### PR TITLE
Maya fees + amount decimals

### DIFF
--- a/VultisigApp/VultisigApp/Chains/maya.swift
+++ b/VultisigApp/VultisigApp/Chains/maya.swift
@@ -11,7 +11,7 @@ import WalletCore
 import CryptoSwift
 
 enum MayaChainHelper {
-    static let MayaChainGas: UInt64 = 2000000
+    static let MayaChainGas: UInt64 = 2000000000
     
     static func getMayaCoin(hexPubKey: String, hexChainCode: String, coinTicker: String) -> Result<Coin, Error> {
         let derivePubKey = PublicKeyHelper.getDerivedPubKey(hexPubKey: hexPubKey,
@@ -40,7 +40,7 @@ enum MayaChainHelper {
     }
     
     static func getSwapPreSignedInputData(keysignPayload: KeysignPayload, signingInput: CosmosSigningInput) -> Result<Data, Error> {
-        guard case .THORChain(let accountNumber, let sequence) = keysignPayload.chainSpecific else {
+        guard case .MayaChain(let accountNumber, let sequence) = keysignPayload.chainSpecific else {
             return .failure(HelperError.runtimeError("fail to get account number and sequence"))
         }
         guard let pubKeyData = Data(hexString: keysignPayload.coin.hexPublicKey) else {
@@ -53,12 +53,13 @@ enum MayaChainHelper {
         input.mode = .sync
         // THORChain fee is 0.02 RUNE
         input.fee = CosmosFee.with {
-            $0.gas = 20000000
+            $0.gas = MayaChainGas
             $0.amounts = [CosmosAmount.with {
                 $0.denom = "cacao"
-                $0.amount = "2000000000"
+                $0.amount = MayaChainGas.description
             }]
         }
+        print(input.debugDescription)
         // memo has been set
         // deposit message has been set
         do {
@@ -78,7 +79,7 @@ enum MayaChainHelper {
         guard let toAddress = AnyAddress(string: keysignPayload.toAddress, coin: .thorchain,hrp: "maya") else {
             return .failure(HelperError.runtimeError("\(keysignPayload.toAddress) is invalid"))
         }
-        guard case .THORChain(let accountNumber, let sequence) = keysignPayload.chainSpecific else {
+        guard case .MayaChain(let accountNumber, let sequence) = keysignPayload.chainSpecific else {
             return .failure(HelperError.runtimeError("fail to get account number and sequence"))
         }
         guard let pubKeyData = Data(hexString: keysignPayload.coin.hexPublicKey) else {
@@ -110,10 +111,12 @@ enum MayaChainHelper {
                 $0.gas = MayaChainGas
                 $0.amounts = [CosmosAmount.with {
                     $0.denom = "cacao"
-                    $0.amount = "2000000"
+                    $0.amount = MayaChainGas.description
                 }]
             }
         }
+        
+        print(input.debugDescription)
         
         do {
             let inputData = try input.serializedData()

--- a/VultisigApp/VultisigApp/Extensions/TssExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/TssExtension.swift
@@ -75,7 +75,7 @@ extension TssKeysignResponse {
     
     func fromJson(json: Data) throws -> TssKeysignResponse {
         let resp = try JSONDecoder().decode(KeysignSignature.self,from: json)
-        var tssKeysignResp =  TssKeysignResponse()
+        let tssKeysignResp =  TssKeysignResponse()
         tssKeysignResp.msg = resp.msg
         tssKeysignResp.r = resp.r
         tssKeysignResp.s = resp.s

--- a/VultisigApp/VultisigApp/Services/Actions/CoinActionResolver.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/CoinActionResolver.swift
@@ -47,7 +47,7 @@ private extension CoinActionResolver {
     private func fetchConfig() async throws -> Config {
         let url = URL(string: "https://api.voltix.org/actions/default.json")!
 
-        let (data, _) = try await URLSession.shared.data(from: url)
+        let (_, _) = try await URLSession.shared.data(from: url)
 
         let jsonData = try Data(contentsOf: url)
         let config = try JSONDecoder().decode(Config.self, from: jsonData)

--- a/VultisigApp/VultisigApp/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Services/BlockChainService.swift
@@ -64,7 +64,7 @@ final class BlockChainService {
             guard let sequence = UInt64(account?.sequence ?? "0") else {
                 throw Errors.failToGetSequenceNo
             }
-            return .THORChain(accountNumber: accountNumber, sequence: sequence)
+            return .MayaChain(accountNumber: accountNumber, sequence: sequence)
         case .solana:
             async let recentBlockHashPromise = sol.fetchRecentBlockhash()
             async let highPriorityFeePromise = sol.fetchHighPriorityFee(account: coin.address)

--- a/VultisigApp/VultisigApp/Services/KeysignPayloadFactory.swift
+++ b/VultisigApp/VultisigApp/Services/KeysignPayloadFactory.swift
@@ -39,7 +39,7 @@ struct KeysignPayloadFactory {
 
         var utxos: [UtxoInfo] = []
 
-        if case let .UTXO(byteFee, sendMaxAmount) = chainSpecific {
+        if case let .UTXO(byteFee, _) = chainSpecific {
             let totalAmountNeeded = amount + BigInt(byteFee)
 
             guard let info = utxo.blockchairData.get(coin.blockchairKey)?.selectUTXOsForPayment(amountNeeded: Int64(totalAmountNeeded)).map({

--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -15,9 +15,9 @@ class TokensStore {
         
         Coin(chain: Chain.thorChain, ticker: "RUNE", logo: "rune", address: "", priceRate: 0.0, chainType: ChainType.THORChain, decimals: "8", hexPublicKey: "", feeUnit: "Rune", priceProviderId: "thorchain", contractAddress: "", rawBalance: "0", isNativeToken: true, feeDefault: "0.02"),
         
-        Coin(chain: Chain.mayaChain, ticker: "CACAO", logo: "cacao", address: "", priceRate: 0.0, chainType: ChainType.THORChain, decimals: "10", hexPublicKey: "", feeUnit: "cacao", priceProviderId: "cacao", contractAddress: "", rawBalance: "0", isNativeToken: true, feeDefault: "0.02"),
+        Coin(chain: Chain.mayaChain, ticker: "CACAO", logo: "cacao", address: "", priceRate: 0.0, chainType: ChainType.THORChain, decimals: "10", hexPublicKey: "", feeUnit: "cacao", priceProviderId: "cacao", contractAddress: "", rawBalance: "0", isNativeToken: true, feeDefault: "2000000000"),
         
-        Coin(chain: Chain.mayaChain, ticker: "MAYA", logo: "maya", address: "", priceRate: 0.0, chainType: ChainType.THORChain, decimals: "4", hexPublicKey: "", feeUnit: "cacao", priceProviderId: "maya", contractAddress: "", rawBalance: "0", isNativeToken: false, feeDefault: "0.02"),
+        Coin(chain: Chain.mayaChain, ticker: "MAYA", logo: "maya", address: "", priceRate: 0.0, chainType: ChainType.THORChain, decimals: "4", hexPublicKey: "", feeUnit: "cacao", priceProviderId: "maya", contractAddress: "", rawBalance: "0", isNativeToken: false, feeDefault: "200"),
         
         Coin(chain: Chain.ethereum, ticker: "ETH", logo: "eth", address: "", priceRate: 0.0, chainType: ChainType.EVM, decimals: "18", hexPublicKey: "", feeUnit: "Gwei", priceProviderId: "ethereum", contractAddress: "", rawBalance: "0", isNativeToken: true, feeDefault: "23000"),
         

--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -17,7 +17,7 @@ class TokensStore {
         
         Coin(chain: Chain.mayaChain, ticker: "CACAO", logo: "cacao", address: "", priceRate: 0.0, chainType: ChainType.THORChain, decimals: "10", hexPublicKey: "", feeUnit: "cacao", priceProviderId: "cacao", contractAddress: "", rawBalance: "0", isNativeToken: true, feeDefault: "2000000000"),
         
-        Coin(chain: Chain.mayaChain, ticker: "MAYA", logo: "maya", address: "", priceRate: 0.0, chainType: ChainType.THORChain, decimals: "4", hexPublicKey: "", feeUnit: "cacao", priceProviderId: "maya", contractAddress: "", rawBalance: "0", isNativeToken: false, feeDefault: "200"),
+        Coin(chain: Chain.mayaChain, ticker: "MAYA", logo: "maya", address: "", priceRate: 0.0, chainType: ChainType.THORChain, decimals: "4", hexPublicKey: "", feeUnit: "cacao", priceProviderId: "maya", contractAddress: "", rawBalance: "0", isNativeToken: false, feeDefault: "2000000000"),
         
         Coin(chain: Chain.ethereum, ticker: "ETH", logo: "eth", address: "", priceRate: 0.0, chainType: ChainType.EVM, decimals: "18", hexPublicKey: "", feeUnit: "Gwei", priceProviderId: "ethereum", contractAddress: "", rawBalance: "0", isNativeToken: true, feeDefault: "23000"),
         

--- a/VultisigApp/VultisigApp/View Models/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/JoinKeygenViewModel.swift
@@ -154,7 +154,7 @@ class JoinKeygenViewModel: ObservableObject {
             }
             handleQrCodeSuccessResult(scanData: jsonData)
             
-        case .failure(let error):
+        case .failure(_):
             errorMessage = "Unable to scan the QR code. Please import an image using the button below."
             status = .FailToStart
             return

--- a/VultisigApp/VultisigApp/View Models/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendCryptoVerifyViewModel.swift
@@ -34,23 +34,9 @@ class SendCryptoVerifyViewModel: ObservableObject {
     }
     
     func amount(for coin: Coin, tx: SendTransaction) -> BigInt {
-        switch coin.chain {
-        case .thorChain:
-            return tx.amountInSats
-        case .mayaChain, .polkadot, .gaiaChain, .kujira:
-            return tx.amountInCoinDecimal
-        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygon, .blast, .cronosChain:
-            if coin.isNativeToken {
-                return tx.amountInWei
-            } else {
-                return tx.amountInTokenWei
-            }
-        case .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash:
-            return tx.amountInSats
-        case .solana, .sui:
-            return tx.amountInLamports
-            
-        }
+
+        return tx.amountInCoinDecimal
+
     }
     func validateForm(tx: SendTransaction, vault: Vault) async -> KeysignPayload? {
         

--- a/VultisigApp/VultisigApp/View Models/SendCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendCryptoViewModel.swift
@@ -246,7 +246,7 @@ class SendCryptoViewModel: ObservableObject, TransferViewModel {
     }
     
     private func getTransactionPlan(tx: SendTransaction, key:String) -> TW_Bitcoin_Proto_TransactionPlan? {
-        guard let utxoInfo = utxo.blockchairData.get(key)?.selectUTXOsForPayment(amountNeeded: Int64(tx.amountInSats)).map({
+        guard let utxoInfo = utxo.blockchairData.get(key)?.selectUTXOsForPayment(amountNeeded: Int64(tx.amountInCoinDecimal)).map({
             UtxoInfo(
                 hash: $0.transactionHash ?? "",
                 amount: Int64($0.value ?? 0),
@@ -266,7 +266,7 @@ class SendCryptoViewModel: ObservableObject, TransferViewModel {
             coin: tx.coin,
             toAddress: tx.toAddress,
             toAmount: BigInt(totalSelectedAmount),
-            chainSpecific: BlockChainSpecific.UTXO(byteFee: BigInt(tx.feeInSats), sendMaxAmount: tx.sendMaxAmount),
+            chainSpecific: BlockChainSpecific.UTXO(byteFee: tx.gas.toBigInt(), sendMaxAmount: tx.sendMaxAmount),
             utxos: utxoInfo,
             memo: tx.memo,
             swapPayload: nil,

--- a/VultisigApp/VultisigApp/View Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/View Models/SendTransaction.swift
@@ -100,28 +100,7 @@ class SendTransaction: ObservableObject, Hashable {
         }
         return BigInt.zero
     }
-    
-    var amountInTokenWei: BigInt {
-        let decimals = Double(coin.decimals) ?? Double(EVMHelper.ethDecimals) // The default is always in WEI unless the token has a different one like UDSC
         
-        return BigInt(amountDecimal * pow(10, decimals))
-    }
-    
-    //TODO: Remove and only use the RAW BigInt
-    var amountInLamports: BigInt {
-        BigInt(amountDecimal * 1_000_000_000)
-    }
-    
-    //TODO: Remove and only use the RAW BigInt
-    var amountInSats: BigInt {
-        BigInt(amountDecimal * 100_000_000)
-    }
-    
-    //TODO: Remove and only use the RAW fee
-    var feeInSats: Int64 {
-        Int64(gas) ?? Int64(20) // Assuming that the gas is in sats
-    }
-    
     var amountDecimal: Double {
         let amountString = amount.replacingOccurrences(of: ",", with: ".")
         return Double(amountString) ?? 0
@@ -253,7 +232,6 @@ class SendTransaction: ObservableObject, Hashable {
             "gas: \(gas)",
             "coin: \(coin.toString())",
             "fromAddress: \(fromAddress)",
-            "feeInSats: \(feeInSats)",
             "amountDecimal: \(amountDecimal)",
             "amountInCoinDecimal: \(amountInCoinDecimal)",
             "gasDecimal: \(gasDecimal)"

--- a/VultisigApp/VultisigApp/View Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/View Models/SendTransaction.swift
@@ -35,10 +35,6 @@ class SendTransaction: ObservableObject, Hashable {
         coin.address
     }
     
-    var amountInWei: BigInt {
-        BigInt(amountDecimal * pow(10, Double(EVMHelper.ethDecimals)))
-    }
-    
     var isAmountExceeded: Bool {
         
         let totalBalance = BigInt(coin.rawBalance) ?? BigInt.zero
@@ -153,6 +149,7 @@ class SendTransaction: ObservableObject, Hashable {
             }
             return "\(gasDecimal / weiPerGWeiDecimal) \(coin.feeUnit)"
         }
+        
         return "\((gasDecimal / pow(10,decimals)).formatToDecimal(digits: decimals).description) \(coin.feeUnit)"
     }
     
@@ -247,10 +244,6 @@ class SendTransaction: ObservableObject, Hashable {
             "gas: \(gas)",
             "coin: \(coin.toString())",
             "fromAddress: \(fromAddress)",
-            "amountInWei: \(amountInWei)",
-            "amountInTokenWei: \(amountInTokenWei)",
-            "amountInLamports: \(amountInLamports)",
-            "amountInSats: \(amountInSats)",
             "feeInSats: \(feeInSats)",
             "amountDecimal: \(amountDecimal)",
             "amountInCoinDecimal: \(amountInCoinDecimal)",

--- a/VultisigApp/VultisigApp/Views/Keysign/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/KeysignPayload.swift
@@ -19,6 +19,7 @@ enum BlockChainSpecific: Codable, Hashable {
     case UTXO(byteFee: BigInt, sendMaxAmount: Bool) // byteFee
     case Ethereum(maxFeePerGasWei: BigInt, priorityFeeWei: BigInt, nonce: Int64, gasLimit: BigInt) // maxFeePerGasWei, priorityFeeWei, nonce , gasLimit
     case THORChain(accountNumber: UInt64, sequence: UInt64)
+    case MayaChain(accountNumber: UInt64, sequence: UInt64)
     case Cosmos(accountNumber: UInt64, sequence: UInt64, gas: UInt64)
     case Solana(recentBlockHash: String, priorityFee: BigInt) // priority fee is in microlamports
     case Sui(referenceGasPrice: BigInt, coins: [[String:String]])
@@ -32,6 +33,8 @@ enum BlockChainSpecific: Codable, Hashable {
             return maxFeePerGas
         case .THORChain:
             return 2_000_000
+        case .MayaChain:
+            return MayaChainHelper.MayaChainGas.description.toBigInt() //Maya uses 10e10
         case .Cosmos:
             return 7500
         case .Solana:

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoViewModel.swift
@@ -355,43 +355,13 @@ private extension SwapCryptoViewModel {
     }
     
     func amount(for coin: Coin, tx: SwapTransaction) -> Int64 {
-        switch coin.chain {
-        case .thorChain:
-            return tx.amountInSats
-        case .mayaChain, .polkadot:
-            return tx.amountInCoinDecimal
-        case .ethereum, .avalanche,.arbitrum, .bscChain, .base, .optimism, .polygon, .blast, .cronosChain:
-            if coin.isNativeToken {
-                return Int64(tx.amountInWei)
-            } else {
-                return Int64(tx.amountInTokenWei)
-            }
-        case .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash:
-            return tx.amountInSats
-        case .gaiaChain, .kujira:
-            return tx.amountInCoinDecimal
-        case .solana, .sui:
-            return tx.amountInLamports
-        }
+        return tx.amountInCoinDecimal
     }
     
     func swapFromAmount(tx: SwapTransaction) -> BigInt {
-        switch tx.fromCoin.chain {
-        case .thorChain, .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash:
-            return BigInt(tx.amountInSats)
-        case .mayaChain, .polkadot:
-            return BigInt(tx.amountInCoinDecimal)
-        case .ethereum, .avalanche,.arbitrum, .bscChain, .base, .optimism, .polygon, .blast, .cronosChain:
-            if tx.fromCoin.isNativeToken {
-                return BigInt(tx.amountInWei)
-            } else {
-                return BigInt(tx.amountInTokenWei)
-            }
-        case .gaiaChain, .kujira:
-            return BigInt(tx.amountInCoinDecimal)
-        case .solana, .sui:
-            return BigInt(tx.amountInLamports)
-        }
+        
+        return BigInt(tx.amountInCoinDecimal)
+        
     }
 
     func swapToAmountDecimal(quote: ThorchainSwapQuote) -> Decimal {

--- a/VultisigApp/VultisigApp/Views/Swap/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapTransaction.swift
@@ -47,35 +47,14 @@ class SwapTransaction: ObservableObject {
     }
 }
 
-// TODO: Refactor amount conversions
-
 extension SwapTransaction {
-
-    var amountInWei: BigInt {
-        BigInt(amountDecimal * pow(10, Double(EVMHelper.ethDecimals)))
-    }
-
-    var amountInTokenWei: BigInt {
-        let decimals = Double(fromCoin.decimals) ?? Double(EVMHelper.ethDecimals) // The default is always in WEI unless the token has a different one like UDSC
-
-        return BigInt(amountDecimal * pow(10, decimals))
-    }
-
-    var amountInLamports: Int64 {
-        Int64(amountDecimal * 1_000_000_000)
-    }
-
-    var amountInSats: Int64 {
-        Int64(amountDecimal * 100_000_000)
-    }
-
     var amountDecimal: Double {
         let amountString = fromAmount.replacingOccurrences(of: ",", with: ".")
-        return Double(amountString) ?? 0
+        return Double(amountString) ?? .zero
     }
     var amountInCoinDecimal: Int64 {
         let amountDouble = amountDecimal
-        let decimals = Int(fromCoin.decimals) ?? 8
+        let decimals = Int(fromCoin.decimals) ?? .zero
         return Int64(amountDouble * pow(10,Double(decimals)))
     }
 }


### PR DESCRIPTION
This PR has the intention to remove and clean up the code that is currently using computed vars for imports, sats, and wei, we should only use the amount in decimals coin where it will power up the amount to the power of the coin. 

Also, this PR will fix the Maya chain fee for both tokens and coin.