### PR TITLE
Id refresh removed from ContentView

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/xcshareddata/xcschemes/VultisigApp.xcscheme
+++ b/VultisigApp/VultisigApp.xcodeproj/xcshareddata/xcschemes/VultisigApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/VultisigApp/VultisigApp/ContentView.swift
+++ b/VultisigApp/VultisigApp/ContentView.swift
@@ -30,8 +30,6 @@ struct ContentView: View {
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarTitleTextColor(.neutral0)
         }
-        //This fixes the issue of pasting the address when sending a transaction
-        //.id(deeplinkViewModel.viewID)
         .onOpenURL { incomingURL in
             deeplinkViewModel.extractParameters(incomingURL, vaults: vaults)
         }

--- a/VultisigApp/VultisigApp/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/VultisigApp.swift
@@ -39,7 +39,6 @@ struct VultisigApp: App {
                 continueLogin()
             case .inactive, .background:
                 resetLogin()
-                deeplinkViewModel.viewID = UUID()
             default:
                 break
             }


### PR DESCRIPTION
The id refresh method had been removed due to multiple bugs being introduced because of that.
FaceId path would be replaced completely while addressing the Issue #427.