### PR TITLE
Fix an reshare issue

### DIFF
--- a/Mediator/Sources/Mediator/Mediator.swift
+++ b/Mediator/Sources/Mediator/Mediator.swift
@@ -138,16 +138,17 @@ public final class Mediator {
         guard let participantID = req.params[":participantKey"] else {
             return HttpResponse.badRequest(.text("participantKey is empty"))
         }
-        let cleanSessionID = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
-        let cleanParticipantKey = participantID.trimmingCharacters(in: .whitespacesAndNewlines)
-        let messageID = req.headers["message_id"]
-        // make sure the keyprefix endwith `-` so it doesn't clash with the participant key
-        var keyPrefix = "\(cleanSessionID)-\(cleanParticipantKey)-"
-        if let messageID {
-            keyPrefix = "\(cleanSessionID)-\(cleanParticipantKey)-\(messageID)-"
-        }
-        let encoder = JSONEncoder()
         do {
+            let cleanSessionID = sessionID.trimmingCharacters(in: .whitespacesAndNewlines)
+            let cleanParticipantKey = participantID.trimmingCharacters(in: .whitespacesAndNewlines)
+            let messageID = req.headers["message_id"]
+            // make sure the keyprefix endwith `-` so it doesn't clash with the participant key
+            var keyPrefix = "\(cleanSessionID)-\(cleanParticipantKey)-"
+            if let messageID {
+                keyPrefix = "\(cleanSessionID)-\(cleanParticipantKey)-\(messageID)-"
+            }
+            let encoder = JSONEncoder()
+            
             // get all the messages
             let messages = try self.cache.allKeys.filter{
                 $0.hasPrefix(keyPrefix)

--- a/VultisigApp/VultisigApp/States/Keygen/ReshareMessage.swift
+++ b/VultisigApp/VultisigApp/States/Keygen/ReshareMessage.swift
@@ -13,4 +13,5 @@ struct ReshareMessage: Codable {
     let oldParties: [String]
     let encryptionKeyHex: String
     let useVultisigRelay: Bool
+    let oldResharePrefix: String
 }

--- a/VultisigApp/VultisigApp/View Models/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/JoinKeygenViewModel.swift
@@ -41,6 +41,7 @@ class JoinKeygenViewModel: ObservableObject {
     @Published var serviceName = ""
     @Published var errorMessage = ""
     @Published var serverAddress: String? = nil
+    @Published var oldResharePrefix: String = ""
     var encryptionKeyHex: String = ""
     var vaults: [Vault] = []
     
@@ -186,6 +187,7 @@ class JoinKeygenViewModel: ObservableObject {
                 serviceName = reshareMsg.serviceName
                 encryptionKeyHex = reshareMsg.encryptionKeyHex
                 useVultisigRelay = reshareMsg.useVultisigRelay
+                oldResharePrefix = reshareMsg.oldResharePrefix
                 // this means the vault is new , and it join the reshare to become the new committee
                 if vault.pubKeyECDSA.isEmpty {
                     if !reshareMsg.pubKeyECDSA.isEmpty {

--- a/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
@@ -83,7 +83,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         self.mediator.start(name: self.serviceName)
         self.logger.info("mediator server started")
         self.startSession()
-        self.participantDiscovery?.getParticipants(serverAddr: self.serverAddr, 
+        self.participantDiscovery?.getParticipants(serverAddr: self.serverAddr,
                                                    sessionID: self.sessionID,
                                                    localParty: self.localPartyID,
                                                    pubKeyECDSA: vault.pubKeyECDSA)
@@ -120,7 +120,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         self.mediator.stop()
     }
     
-   
+    
     private func startSession() {
         let urlString = "\(self.serverAddr)/\(self.sessionID)"
         let body = [self.localPartyID]
@@ -170,7 +170,8 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                     pubKeyECDSA: vault.pubKeyECDSA,
                     oldParties: vault.signers,
                     encryptionKeyHex: encryptionKeyHex,
-                    useVultisigRelay: VultisigRelay.IsRelayEnabled
+                    useVultisigRelay: VultisigRelay.IsRelayEnabled,
+                    oldResharePrefix: vault.resharePrefix ?? ""
                 )
                 data = try jsonEncoder.encode(PeerDiscoveryPayload.Reshare(reshareMsg))
                 let json = String(decoding: data, as: UTF8.self)

--- a/VultisigApp/VultisigApp/View Models/KeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeygenViewModel.swift
@@ -29,6 +29,7 @@ class KeygenViewModel: ObservableObject {
     var mediatorURL: String
     var sessionID: String
     var encryptionKeyHex: String
+    var oldResharePrefix: String
     
     @Published var isLinkActive = false
     @Published var keygenError: String = ""
@@ -47,9 +48,17 @@ class KeygenViewModel: ObservableObject {
         self.mediatorURL = ""
         self.sessionID = ""
         self.encryptionKeyHex = ""
+        self.oldResharePrefix = ""
     }
     
-    func setData(vault: Vault, tssType: TssType, keygenCommittee: [String], vaultOldCommittee: [String], mediatorURL: String, sessionID: String, encryptionKeyHex: String) {
+    func setData(vault: Vault,
+                 tssType: TssType,
+                 keygenCommittee: [String],
+                 vaultOldCommittee: [String],
+                 mediatorURL: String,
+                 sessionID: String,
+                 encryptionKeyHex: String,
+                 oldResharePrefix:String) {
         self.vault = vault
         self.tssType = tssType
         self.keygenCommittee = keygenCommittee
@@ -57,6 +66,7 @@ class KeygenViewModel: ObservableObject {
         self.mediatorURL = mediatorURL
         self.sessionID = sessionID
         self.encryptionKeyHex = encryptionKeyHex
+        self.oldResharePrefix = oldResharePrefix
         messagePuller = MessagePuller(encryptionKeyHex: encryptionKeyHex,pubKey: vault.pubKeyECDSA)
     }
     
@@ -148,7 +158,7 @@ class KeygenViewModel: ObservableObject {
                 reshareReq.pubKey = self.vault.pubKeyECDSA
                 reshareReq.oldParties = self.vaultOldCommittee.joined(separator: ",")
                 reshareReq.newParties = self.keygenCommittee.joined(separator: ",")
-                reshareReq.resharePrefix = self.vault.resharePrefix ?? ""
+                reshareReq.resharePrefix = self.vault.resharePrefix ?? self.oldResharePrefix
                 reshareReq.chainCodeHex = self.vault.hexChainCode
                 self.logger.info("chaincode:\(self.vault.hexChainCode)")
                 

--- a/VultisigApp/VultisigApp/Views/Keygen/JoinKeygenView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/JoinKeygenView.swift
@@ -106,7 +106,8 @@ struct JoinKeygenView: View {
             vaultOldCommittee: self.viewModel.oldCommittee.filter { self.viewModel.keygenCommittee.contains($0) },
             mediatorURL: viewModel.serverAddress!,
             sessionID: self.viewModel.sessionID!,
-            encryptionKeyHex: viewModel.encryptionKeyHex)
+            encryptionKeyHex: viewModel.encryptionKeyHex,
+            oldResharePrefix: viewModel.oldResharePrefix)
     }
     
     var keygenErrorText: some View {

--- a/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
@@ -184,7 +184,8 @@ struct KeygenView: View {
             vaultOldCommittee: vaultOldCommittee,
             mediatorURL: mediatorURL,
             sessionID: sessionID,
-            encryptionKeyHex: encryptionKeyHex
+            encryptionKeyHex: encryptionKeyHex,
+            oldResharePrefix: oldResharePrefix
         )
     }
 }

--- a/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
@@ -21,6 +21,7 @@ struct KeygenView: View {
     let mediatorURL: String
     let sessionID: String
     let encryptionKeyHex: String
+    let oldResharePrefix: String
     @StateObject var viewModel = KeygenViewModel()
     
     let progressTotalCount: Double = 4
@@ -198,7 +199,8 @@ struct KeygenView: View {
             vaultOldCommittee: [],
             mediatorURL: "",
             sessionID: "",
-            encryptionKeyHex: ""
+            encryptionKeyHex: "",
+            oldResharePrefix: ""
         )
     }
 }

--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -259,7 +259,8 @@ struct PeerDiscoveryView: View {
             },
             mediatorURL: viewModel.serverAddr,
             sessionID: viewModel.sessionID,
-            encryptionKeyHex: viewModel.encryptionKeyHex ?? "")
+            encryptionKeyHex: viewModel.encryptionKeyHex ?? "",
+            oldResharePrefix: vault.resharePrefix ?? "")
     }
     
     var failureText: some View {


### PR DESCRIPTION
resolve #484

The issue: If we create a 2/2 vault , use reshare to grow it to 2/3 , and reshare back down to 2/2, it won't be able to grow to 2/3 again
Because the old reshare prefix has not been added to QR Code , and pass down to the pairing device

This PR will fix the issue