### PR TITLE
Show android devices as phone

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/Cells/PeerCell.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Cells/PeerCell.swift
@@ -90,7 +90,9 @@ struct PeerCell: View {
         } else if idString.contains("ipad") {
             deviceName = "iPad"
         } else {
-            deviceName = "Unknown"
+            // likely it will be android device , let's treat it as phone
+            // android eco-system has too many types of devices, hard to know what phone or tablet it is
+            deviceName = "Phone"
         }
         return deviceName
     }
@@ -106,10 +108,15 @@ struct PeerCell: View {
             return Image("iPadAsset")
                 .resizable()
                 .frame(width: 60, height: 80)
-        } else {
+        } else if idString.contains("mac") {
             return Image("macAsset")
                 .resizable()
                 .frame(width: 100, height: 67)
+        } else {
+            // this could be android device, just show as phone
+            return Image("iPhoneAsset")
+                .resizable()
+                .frame(width: 30, height: 50)
         }
     }
     

--- a/VultisigApp/VultisigApp/Views/Vault/ChainDetailView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/ChainDetailView.swift
@@ -131,7 +131,9 @@ struct ChainDetailView: View {
     }
     
     var cells: some View {
-        ForEach(group.coins, id: \.self) { coin in
+        ForEach(group.coins.sorted(by: {
+            $0.isNativeToken || ($0.balanceInFiatDecimal > $1.balanceInFiatDecimal)
+        }), id: \.self) { coin in
             getCoinCell(coin)
         }
     }


### PR DESCRIPTION
fixes #632 

Android eco-system is quite big, and too many brands , the device id/name can by anything , it is hard for us to build a comprehensive  list in our app to detect that , thus treat all android device / unknow name device as phone

fixes #648 
Sort coins in a selected chain by it's balance, and also pin native token on top