### PR TITLE
Mac support/keygen views

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -2369,7 +2369,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.vultisig.wallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.vultisigTEST.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
@@ -2424,7 +2424,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.vultisig.wallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.vultisigTEST.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;

--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -2369,7 +2369,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.vultisigTEST.wallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.vultisig.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
@@ -2424,7 +2424,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.vultisigTEST.wallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.vultisig.wallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;

--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/twostraws/CodeScanner",
       "state" : {
-        "revision" : "944a6a1ca030dbd890e647a678e718fc2115d35c",
-        "version" : "2.4.1"
+        "revision" : "34da57fb63b47add20de8a85da58191523ccce57",
+        "version" : "2.5.0"
       }
     },
     {

--- a/VultisigApp/VultisigApp/View Models/ShareSheetViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/ShareSheetViewModel.swift
@@ -20,6 +20,10 @@ class ShareSheetViewModel: ObservableObject {
         if let uiImage = renderer.uiImage {
             renderedImage = Image(uiImage: uiImage)
         }
+#elseif os(macOS)
+        if let nsImage = renderer.nsImage {
+            renderedImage = Image(nsImage: nsImage)
+        }
 #endif
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/Cells/NetworkPromptCell.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Cells/NetworkPromptCell.swift
@@ -19,6 +19,8 @@ struct NetworkPromptCell: View {
             } else {
                 padCell
             }
+#elseif os(macOS)
+            padCell
 #endif
         }
     }

--- a/VultisigApp/VultisigApp/Views/Components/Cells/PeerCell.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Cells/PeerCell.swift
@@ -22,7 +22,11 @@ struct PeerCell: View {
             cell
             check
         }
+#if os(iOS)
         .scaleEffect(isPhone ? 0.7 : 1)
+#elseif os(macOS)
+        .scaleEffect(0.7)
+#endif
         .clipped()
         .onAppear {
             setData()

--- a/VultisigApp/VultisigApp/Views/Components/InstructionPrompt.swift
+++ b/VultisigApp/VultisigApp/Views/Components/InstructionPrompt.swift
@@ -18,6 +18,8 @@ struct InstructionPrompt: View {
             } else {
                 padContent
             }
+#elseif os(macOS)
+            padContent
 #endif
         }
         .frame(maxWidth: .infinity)

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationBackButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationBackButton.swift
@@ -17,9 +17,11 @@ struct NavigationBackButton: View {
             dismiss()
         }) {
             Image(systemName: "chevron.backward")
-                .font(.body18Menlo)
 #if os(iOS)
+                .font(.body18MenloBold)
                 .foregroundColor(tint)
+#elseif os(macOS)
+                .font(.body18Menlo)
 #endif
         }
     }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationBackSheetButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationBackSheetButton.swift
@@ -16,9 +16,11 @@ struct NavigationBackSheetButton: View {
             showSheet.toggle()
         }) {
             Image(systemName: "chevron.backward")
-                .font(.body18Menlo)
 #if os(iOS)
+                .font(.body18MenloBold)
                 .foregroundColor(tint)
+#elseif os(macOS)
+                .font(.body18Menlo)
 #endif
         }
     }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationBlankBackButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationBlankBackButton.swift
@@ -12,9 +12,11 @@ struct NavigationBlankBackButton: View {
     
     var body: some View {
         Image(systemName: "chevron.backward")
-            .font(.body18Menlo)
 #if os(iOS)
-                .foregroundColor(tint)
+            .font(.body18MenloBold)
+            .foregroundColor(tint)
+#elseif os(macOS)
+            .font(.body18Menlo)
 #endif
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationEditButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationEditButton.swift
@@ -12,9 +12,11 @@ struct NavigationEditButton: View {
     
     var body: some View {
         Image(systemName: "square.and.pencil")
-            .font(.body18Menlo)
 #if os(iOS)
-                .foregroundColor(tint)
+            .font(.body18MenloBold)
+            .foregroundColor(tint)
+#elseif os(macOS)
+            .font(.body18Menlo)
 #endif
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationHelpButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationHelpButton.swift
@@ -18,9 +18,11 @@ struct NavigationHelpButton: View {
     
     var image: some View {
         Image(systemName: "questionmark.circle")
-            .font(.body18Menlo)
 #if os(iOS)
-                .foregroundColor(tint)
+            .font(.body18MenloBold)
+            .foregroundColor(tint)
+#elseif os(macOS)
+            .font(.body18Menlo)
 #endif
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationHomeEditButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationHomeEditButton.swift
@@ -50,9 +50,12 @@ struct NavigationHomeEditButton: View {
     
     var doneButton: some View {
         Text(NSLocalizedString("done", comment: ""))
-            .font(.body18Menlo)
 #if os(iOS)
-                .foregroundColor(tint)
+            .font(.body18MenloBold)
+            .foregroundColor(tint)
+        
+#elseif os(macOS)
+            .font(.body18Menlo)
 #endif
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationMenuButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationMenuButton.swift
@@ -12,9 +12,11 @@ struct NavigationMenuButton: View {
     
     var body: some View {
         Image("MenuIcon")
-            .font(.body18Menlo)
 #if os(iOS)
-                .foregroundColor(tint)
+            .font(.body18MenloBold)
+            .foregroundColor(tint)
+#elseif os(macOS)
+            .font(.body18Menlo)
 #endif
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationQRShareButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationQRShareButton.swift
@@ -33,9 +33,11 @@ struct NavigationQRShareButton: View {
     
     var content: some View {
         Image(systemName: "arrow.up.doc")
-            .font(.body16Menlo)
 #if os(iOS)
-                .foregroundColor(tint)
+            .font(.body18MenloBold)
+            .foregroundColor(tint)
+#elseif os(macOS)
+            .font(.body18Menlo)
 #endif
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationRefreshButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationRefreshButton.swift
@@ -14,9 +14,11 @@ struct NavigationRefreshButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: "arrow.clockwise.circle")
-                .font(.body18Menlo)
 #if os(iOS)
+                .font(.body18MenloBold)
                 .foregroundColor(tint)
+#elseif os(macOS)
+                .font(.body18Menlo)
 #endif
         }
     }

--- a/VultisigApp/VultisigApp/Views/Components/NetworkPrompts.swift
+++ b/VultisigApp/VultisigApp/Views/Components/NetworkPrompts.swift
@@ -11,16 +11,10 @@ struct NetworkPrompts: View {
     @Binding var selectedNetwork: NetworkPromptType
     
     private let gridRows = [
-            GridItem(.adaptive(minimum: 150))
+        GridItem(.adaptive(minimum: 150))
     ]
     
     var body: some View {
-        ZStack {
-            layout
-        }
-    }
-    
-    var layout: some View {
         HStack(spacing: 12) {
             cells
         }

--- a/VultisigApp/VultisigApp/Views/Keygen/KeyGenSummaryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/KeyGenSummaryView.swift
@@ -41,6 +41,7 @@ struct KeyGenSummaryView: View {
             .padding(.top, 30)
             .padding(.horizontal, 22)
             .foregroundColor(.neutral0)
+            .scrollIndicators(.hidden)
         }
     }
     

--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -216,7 +216,7 @@ struct PeerDiscoveryView: View {
     }
     
     var gridList: some View {
-        ScrollView(showsIndicators: false) {
+        ScrollView {
             LazyVGrid(columns: columns, spacing: 8) {
                 devices
             }
@@ -224,6 +224,7 @@ struct PeerDiscoveryView: View {
         .padding(idiom == .phone ? 0 : 20)
 #endif
         }
+        .scrollIndicators(.hidden)
     }
     
     var networkPrompts: some View {

--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -111,12 +111,19 @@ struct PeerDiscoveryView: View {
         HStack {
             qrCode
             
-            VStack{
+#if os(iOS)
+            VStack {
                 list
                     .padding(20)
-                
                 vaultDetail
             }
+#elseif os(macOS)
+            VStack {
+                vaultDetail
+                list
+            }
+            .padding(40)
+#endif
         }
     }
     
@@ -263,7 +270,7 @@ struct PeerDiscoveryView: View {
         .padding(.bottom, 10)
         .disabled(viewModel.selections.count < 2)
         .opacity(viewModel.selections.count < 2 ? 0.8 : 1)
-        .background(Color.backgroundBlue.opacity(0.95))
+        .grayscale(viewModel.selections.count < 2 ? 1 : 0)
 #if os(macOS)
         .padding(.bottom, 30)
 #endif

--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -216,11 +216,13 @@ struct PeerDiscoveryView: View {
     }
     
     var gridList: some View {
-        ScrollView {
-            LazyVGrid(columns: columns, spacing: 32) {
+        ScrollView(showsIndicators: false) {
+            LazyVGrid(columns: columns, spacing: 8) {
                 devices
             }
-            .padding(.vertical, 16)
+#if os(iOS)
+        .padding(idiom == .phone ? 0 : 20)
+#endif
         }
     }
     

--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -16,7 +16,7 @@ struct PeerDiscoveryView: View {
     @StateObject var shareSheetViewModel = ShareSheetViewModel()
     
     @State var qrCodeImage: Image? = nil
-    @State var isLandscape: Bool = false
+    @State var isLandscape: Bool = true
     
     @Environment(\.displayScale) var displayScale
     
@@ -114,6 +114,7 @@ struct PeerDiscoveryView: View {
             VStack{
                 list
                     .padding(20)
+                
                 vaultDetail
             }
         }
@@ -178,6 +179,9 @@ struct PeerDiscoveryView: View {
         }
         .cornerRadius(10)
         .shadow(radius: 5)
+#if os(macOS)
+        .padding(40)
+#endif
     }
     
     var deviceList: some View {
@@ -260,6 +264,9 @@ struct PeerDiscoveryView: View {
         .disabled(viewModel.selections.count < 2)
         .opacity(viewModel.selections.count < 2 ? 0.8 : 1)
         .background(Color.backgroundBlue.opacity(0.95))
+#if os(macOS)
+        .padding(.bottom, 30)
+#endif
     }
     
     var keygenView: some View {
@@ -293,8 +300,6 @@ struct PeerDiscoveryView: View {
     private func setData() {
 #if os(iOS)
         isLandscape = (orientation == .landscapeLeft || orientation == .landscapeRight) && idiom == .pad
-#elseif os(macOS)
-        isLandscape = true
 #endif
         
         qrCodeImage = viewModel.getQrImage(size: 100)


### PR DESCRIPTION
Updated the following views for Mac:
- Peer Discovery View
- Share sheet to handle NSImage
- KeyGenSummaryView
- Updated Navigation Items to have bold with for iOS and regular for macOS
- Updated NetworkPrompt and WifiInstructions to show up on Mac.