### PR TITLE
 blockchair recommendation

### DIFF
--- a/VultisigApp/VultisigApp/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Utils/Endpoint.swift
@@ -135,7 +135,7 @@ class Endpoint {
     }
     
     static func blockchairDashboard(_ address: String, _ coinName: String) -> URL {
-        "\(vultisigApiProxy)/blockchair/\(coinName)/dashboards/address/\(address)".asUrl
+        "\(vultisigApiProxy)/blockchair/\(coinName)/dashboards/address/\(address)?state=latest".asUrl
     }
     
     static func ethereumLabelTxHash(_ value: String) -> String {


### PR DESCRIPTION
Blockchair recommend us to add this flag &state=latest when calling the endpoint to get the dashboard balance. This should bring only the confirmed balance, then it should from now also match with the new version.