### PR TITLE
Optimize the backup view to only save backup file when necessary

### DIFF
--- a/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
@@ -78,7 +78,6 @@ class EncryptedBackupViewModel: ObservableObject {
                 encryptedFileURLWithPassowrd = tempURL
                 encryptedFileURLWithoutPassowrd = tempURL
                 print(tempURL.absoluteString)
-                showVaultExporter = true
             } catch {
                 print("Error writing file: \(error.localizedDescription)")
             }

--- a/VultisigApp/VultisigApp/Views/Vault/BackupPasswordSetupView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/BackupPasswordSetupView.swift
@@ -38,6 +38,24 @@ struct BackupPasswordSetupView: View {
                     handleSaveTap()
                 }
             }
+            .fileExporter(isPresented: $backupViewModel.showVaultExporter,
+                          document: EncryptedDataFile(url: backupViewModel.encryptedFileURLWithPassowrd),
+                          contentType: .data,
+                          defaultFilename: "\(vault.getExportName())"
+            ) { result in
+                switch result {
+                case .success(let url):
+                    print("File saved to: \(url)")
+                    fileSaved()
+                    dismiss()
+                case .failure(let error):
+                    print("Error saving file: \(error.localizedDescription)")
+                    backupViewModel.alertTitle = "errorSavingFile"
+                    backupViewModel.alertMessage = error.localizedDescription
+                    backupViewModel.showAlert = true
+                }
+                
+            }
     }
     
     var content: some View {
@@ -101,13 +119,21 @@ struct BackupPasswordSetupView: View {
                 proxySaveButton
             } else {
                 if let fileURL = backupViewModel.encryptedFileURLWithPassowrd {
+                    #if os(iOS)
                     ShareLink(item: fileURL) {
                         FilledButton(title: "save")
                     }
                     .simultaneousGesture(TapGesture().onEnded() {
                         fileSaved()
                     })
-                    .onDisappear()
+                    #elseif  os(macOS)
+                    Button{
+                        backupViewModel.showVaultExporter = true
+                    } label: {
+                        FilledButton(title: "save")
+                    }
+                    
+                    #endif
                 }
             }
         }
@@ -116,12 +142,21 @@ struct BackupPasswordSetupView: View {
     var skipButton: some View {
         ZStack {
             if let fileURL = backupViewModel.encryptedFileURLWithoutPassowrd {
+                #if os(iOS)
                 ShareLink(item: fileURL) {
                     OutlineButton(title: "skip")
                 }
                 .simultaneousGesture(TapGesture().onEnded() {
+                    print("set file saved")
                     fileSaved()
                 })
+                #elseif os(macOS)
+                Button{
+                    backupViewModel.showVaultExporter = true
+                } label: {
+                    OutlineButton(title: "skip")
+                }
+                #endif
             }
         }
     }
@@ -174,6 +209,7 @@ struct BackupPasswordSetupView: View {
     private func fileSaved() {
         vault.isBackedUp = true
     }
+    
 }
 
 #Preview {

--- a/VultisigApp/VultisigApp/Views/Vault/BackupPasswordSetupView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/BackupPasswordSetupView.swift
@@ -28,14 +28,15 @@ struct BackupPasswordSetupView: View {
             }
             .onAppear {
                 backupViewModel.resetData()
-                handleSaveTap()
                 handleSkipTap()
             }
             .onDisappear {
                 backupViewModel.resetData()
             }
             .onChange(of: verifyPassword) { oldValue, newValue in
-                handleSaveTap()
+                if backupViewModel.encryptionPassword == verifyPassword {
+                    handleSaveTap()
+                }
             }
     }
     
@@ -106,6 +107,7 @@ struct BackupPasswordSetupView: View {
                     .simultaneousGesture(TapGesture().onEnded() {
                         fileSaved()
                     })
+                    .onDisappear()
                 }
             }
         }


### PR DESCRIPTION
1. on MacOS , show up the export folder selection dialog ,allow user to save the file to a local folder of their chosen
2. on all systems , only save the .bak file when necessary