### PR TITLE
Fix for macOS blank screen on Folder selection

### DIFF
--- a/VultisigApp/VultisigApp/Views/Folder/FolderDetailView.swift
+++ b/VultisigApp/VultisigApp/Views/Folder/FolderDetailView.swift
@@ -194,8 +194,11 @@ struct FolderDetailView: View {
     
     private func handleSelection(for vault: Vault) {
         viewModel.setSelectedVault(vault)
-        showVaultsList = false
         dismiss()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            showVaultsList = false
+        }
     }
     
     private func deleteFolder() {


### PR DESCRIPTION
Fix for macOS blank screen on Folder selection