### PR TITLE
ton stake func

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -615,6 +615,8 @@
 		B5A97CF72BF42BE1007574D7 /* TransactionMemoVerifyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A97CF62BF42BE1007574D7 /* TransactionMemoVerifyView.swift */; };
 		B5A97CF92BF42E72007574D7 /* TransactionMemoAddressTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A97CF82BF42E72007574D7 /* TransactionMemoAddressTextField.swift */; };
 		B5A97CFC2BF4365E007574D7 /* TransactionMemoInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A97CFB2BF4365E007574D7 /* TransactionMemoInstance.swift */; };
+		B5B5E2782CCADD69001167C3 /* TransactionMemoStake.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B5E2772CCADD69001167C3 /* TransactionMemoStake.swift */; };
+		B5B5E27A2CCADE85001167C3 /* TransactionMemoUnstake.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B5E2792CCADE85001167C3 /* TransactionMemoUnstake.swift */; };
 		B5C4A42C2C62EC6500AF9B8B /* AddressService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C4A42B2C62EC6500AF9B8B /* AddressService.swift */; };
 		B5CA1A062C16C39700789B11 /* AsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CA1A052C16C39700789B11 /* AsyncImageView.swift */; };
 		B5E476AB2C1A13D7005DB485 /* dydx.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E476AA2C1A13D7005DB485 /* dydx.swift */; };
@@ -1347,6 +1349,8 @@
 		B5A97CF62BF42BE1007574D7 /* TransactionMemoVerifyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionMemoVerifyView.swift; sourceTree = "<group>"; };
 		B5A97CF82BF42E72007574D7 /* TransactionMemoAddressTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionMemoAddressTextField.swift; sourceTree = "<group>"; };
 		B5A97CFB2BF4365E007574D7 /* TransactionMemoInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionMemoInstance.swift; sourceTree = "<group>"; };
+		B5B5E2772CCADD69001167C3 /* TransactionMemoStake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionMemoStake.swift; sourceTree = "<group>"; };
+		B5B5E2792CCADE85001167C3 /* TransactionMemoUnstake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionMemoUnstake.swift; sourceTree = "<group>"; };
 		B5C4A42B2C62EC6500AF9B8B /* AddressService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressService.swift; sourceTree = "<group>"; };
 		B5CA1A052C16C39700789B11 /* AsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImageView.swift; sourceTree = "<group>"; };
 		B5E476AA2C1A13D7005DB485 /* dydx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydx.swift; sourceTree = "<group>"; };
@@ -2788,7 +2792,9 @@
 				B50E399A2BF5AB2100B9A269 /* TransactionMemoAddressable.swift */,
 				B50E399C2BF5AB4B00B9A269 /* TransactionMemoContractTypeEnum.swift */,
 				B53D8CC72BF7F21500B795D3 /* TransactionMemoBond.swift */,
+				B5B5E2772CCADD69001167C3 /* TransactionMemoStake.swift */,
 				B53D8CC92BF7F22500B795D3 /* TransactionMemoUnbond.swift */,
+				B5B5E2792CCADE85001167C3 /* TransactionMemoUnstake.swift */,
 				B53D8CCB2BF7F22F00B795D3 /* TransactionMemoLeave.swift */,
 				B51119322C0072620020B711 /* TransactionMemoCustom.swift */,
 				B590DF852C2E70B800ED934E /* TransactionMemoVote.swift */,
@@ -3529,6 +3535,7 @@
 				A51AE8C62C958A0200EF9A7A /* FastVaultEnterPasswordView+macOS.swift in Sources */,
 				A69FBBC42C8BB5AD00A4B78B /* NoCameraPermissionView+iOS.swift in Sources */,
 				A66A0BD92BA12DF50021A483 /* RenameVaultView.swift in Sources */,
+				B5B5E2782CCADD69001167C3 /* TransactionMemoStake.swift in Sources */,
 				A65617F72CB492B200E9CF19 /* FolderDetailRemainingVaultCell.swift in Sources */,
 				A633B1252B993FE7003D1738 /* FilledButton.swift in Sources */,
 				46F47CBB2B870EE900D964EA /* UTXOTransactionMempool.swift in Sources */,
@@ -3879,6 +3886,7 @@
 				A6505ACE2CA668460002FBF4 /* OutlinedDisclaimer+macOS.swift in Sources */,
 				A6386D9E2C90225000DDD58E /* SendCryptoSigningErrorView+iOS.swift in Sources */,
 				A5D49F582BE26C63001766C8 /* CoinActionResolver.swift in Sources */,
+				B5B5E27A2CCADE85001167C3 /* TransactionMemoUnstake.swift in Sources */,
 				DE8BDCCB2C47E34300A1EDA6 /* Vault+ProtoMappable.swift in Sources */,
 				B5A97CF12BF41903007574D7 /* TransactionMemoVerifyViewModel.swift in Sources */,
 				A69FBBCE2C8BBA1900A4B78B /* TransactionMemoVerifyView+macOS.swift in Sources */,

--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoInstance.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoInstance.swift
@@ -18,6 +18,8 @@ enum TransactionMemoInstance {
     case vote(TransactionMemoVote)
     case addPool(TransactionMemoAddPool)
     case withdrawPool(TransactionMemoWithdrawPool)
+    case stake(TransactionMemoStake)
+    case unstake(TransactionMemoUnstake)
     
     var view: AnyView {
         switch self {
@@ -34,6 +36,10 @@ enum TransactionMemoInstance {
         case .addPool(let memo):
             return memo.getView()
         case .withdrawPool(let memo):
+            return memo.getView()
+        case .stake(let memo):
+            return memo.getView()
+        case .unstake(let memo):
             return memo.getView()
         }
     }
@@ -54,6 +60,10 @@ enum TransactionMemoInstance {
             return memo.description
         case .withdrawPool(let memo):
             return memo.description
+        case .stake(let memo):
+            return memo.description
+        case .unstake(let memo):
+            return memo.description
         }
     }
     
@@ -73,6 +83,10 @@ enum TransactionMemoInstance {
             return memo.amount
         case .withdrawPool(_):
             return .zero
+        case .stake(let memo):
+            return memo.amount
+        case .unstake(let memo):
+            return 1 // You must send 1 TON to unstake with a "w" memo
         }
     }
     
@@ -91,6 +105,10 @@ enum TransactionMemoInstance {
         case .addPool(let memo):
             return memo.toDictionary()
         case .withdrawPool(let memo):
+            return memo.toDictionary()
+        case .stake(let memo):
+            return memo.toDictionary()
+        case .unstake(let memo):
             return memo.toDictionary()
         }
     }
@@ -120,6 +138,10 @@ enum TransactionMemoInstance {
             return memo.isTheFormValid
         case .withdrawPool(let memo):
             return memo.isTheFormValid
+        case .stake(let memo):
+            return memo.isTheFormValid
+        case .unstake(let memo):
+            return memo.isTheFormValid
         }
     }
     
@@ -129,6 +151,8 @@ enum TransactionMemoInstance {
             return .bond(TransactionMemoBond())
         case .dydx:
             return .vote(TransactionMemoVote())
+        case .ton:
+            return .stake(TransactionMemoStake())
         default:
             return .custom(TransactionMemoCustom())
         }

--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoInstance.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoInstance.swift
@@ -86,7 +86,18 @@ enum TransactionMemoInstance {
         case .stake(let memo):
             return memo.amount
         case .unstake(let memo):
-            return 1 // You must send 1 TON to unstake with a "w" memo
+            return memo.amount // You must send 1 TON to unstake with a "w" memo
+        }
+    }
+    
+    var toAddress: String? {
+        switch self {
+        case .stake(let memo):
+            return memo.nodeAddress
+        case .unstake(let memo):
+            return memo.nodeAddress
+        default:
+            return nil
         }
     }
     

--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoStake.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoStake.swift
@@ -1,42 +1,30 @@
 //
-//  TransactionMemoBond.swift
+//  TransactionMemoStake.swift
 //  VultisigApp
 //
-//  Created by Enrique Souza Soares on 17/05/24.
-//
+//  Created by Enrique Souza Soares on 24/10/24.
 
 import SwiftUI
 import Foundation
 import Combine
 
 class TransactionMemoStake: TransactionMemoAddressable, ObservableObject {
-    @Published var amount: Double = 0.0
-    @Published var nodeAddress: String = ""
-    @Published var provider: String = ""
-    @Published var fee: Int64 = .zero
+    @Published var amount: Double = 1003
+    @Published var nodeAddress: String = "Ef8t6cZkqFuHjJ_a_ydEK_tu3LHWRA4JZXRyewLY4j8FZ6B5"
     
     // Internal
-    @Published var amountValid: Bool = false
-    @Published var nodeAddressValid: Bool = false
-    @Published var providerValid: Bool = true
-    @Published var feeValid: Bool = true
-    
-    @Published var isTheFormValid: Bool = false
+    @Published var amountValid: Bool = true
+    @Published var nodeAddressValid: Bool = true
+    @Published var isTheFormValid: Bool = true
     
     var addressFields: [String: String] {
         get {
-            var fields = ["nodeAddress": nodeAddress]
-            if !provider.isEmpty {
-                fields["provider"] = provider
-            }
+            let fields = ["nodeAddress": nodeAddress]
             return fields
         }
         set {
             if let value = newValue["nodeAddress"] {
                 nodeAddress = value
-            }
-            if let value = newValue["provider"] {
-                provider = value
             }
         }
     }
@@ -48,8 +36,8 @@ class TransactionMemoStake: TransactionMemoAddressable, ObservableObject {
     }
     
     private func setupValidation() {
-        Publishers.CombineLatest4($amountValid, $nodeAddressValid, $providerValid, $feeValid)
-            .map { $0 && $1 && $2 && $3 && (!self.provider.isEmpty ? self.fee != .zero : true) }
+        Publishers.CombineLatest($amountValid, $nodeAddressValid)
+            .map { $0 && $1 }
             .assign(to: \.isTheFormValid, on: self)
             .store(in: &cancellables)
     }
@@ -59,25 +47,12 @@ class TransactionMemoStake: TransactionMemoAddressable, ObservableObject {
     }
     
     func toString() -> String {
-        var memo = "BOND:\(self.nodeAddress)"
-        if !self.provider.isEmpty {
-            memo += ":\(self.provider)"
-        }
-        if self.fee != .zero {
-            if self.provider.isEmpty {
-                memo += "::\(self.fee)"
-            } else {
-                memo += ":\(self.fee)"
-            }
-        }
-        return memo
+        return "d"
     }
     
     func toDictionary() -> ThreadSafeDictionary<String, String> {
         let dict = ThreadSafeDictionary<String, String>()
         dict.set("nodeAddress", self.nodeAddress)
-        dict.set("provider", self.provider)
-        dict.set("fee", "\(self.fee)")
         dict.set("memo", self.toString())
         return dict
     }
@@ -92,29 +67,7 @@ class TransactionMemoStake: TransactionMemoAddressable, ObservableObject {
                     set: { self.nodeAddressValid = $0 }
                 )
             )
-            TransactionMemoAddressTextField(
-                memo: self,
-                addressKey: "provider",
-                isOptional: true,
-                isAddressValid: Binding(
-                    get: { self.providerValid },
-                    set: { self.providerValid = $0 }
-                )
-            )
-
-            StyledIntegerField(
-                placeholder: "Operator's Fee",
-                value: Binding(
-                    get: { self.fee },
-                    set: { self.fee = $0 }
-                ),
-                format: .number,
-                isValid: Binding(
-                    get: { self.feeValid },
-                    set: { self.feeValid = $0 }
-                ),
-                isOptional: true
-            )
+            
             StyledFloatingPointField(placeholder: "Amount", value: Binding(
                 get: { self.amount },
                 set: { self.amount = $0 }

--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoStake.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoStake.swift
@@ -1,0 +1,127 @@
+//
+//  TransactionMemoBond.swift
+//  VultisigApp
+//
+//  Created by Enrique Souza Soares on 17/05/24.
+//
+
+import SwiftUI
+import Foundation
+import Combine
+
+class TransactionMemoStake: TransactionMemoAddressable, ObservableObject {
+    @Published var amount: Double = 0.0
+    @Published var nodeAddress: String = ""
+    @Published var provider: String = ""
+    @Published var fee: Int64 = .zero
+    
+    // Internal
+    @Published var amountValid: Bool = false
+    @Published var nodeAddressValid: Bool = false
+    @Published var providerValid: Bool = true
+    @Published var feeValid: Bool = true
+    
+    @Published var isTheFormValid: Bool = false
+    
+    var addressFields: [String: String] {
+        get {
+            var fields = ["nodeAddress": nodeAddress]
+            if !provider.isEmpty {
+                fields["provider"] = provider
+            }
+            return fields
+        }
+        set {
+            if let value = newValue["nodeAddress"] {
+                nodeAddress = value
+            }
+            if let value = newValue["provider"] {
+                provider = value
+            }
+        }
+    }
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    required init() {
+        setupValidation()
+    }
+    
+    private func setupValidation() {
+        Publishers.CombineLatest4($amountValid, $nodeAddressValid, $providerValid, $feeValid)
+            .map { $0 && $1 && $2 && $3 && (!self.provider.isEmpty ? self.fee != .zero : true) }
+            .assign(to: \.isTheFormValid, on: self)
+            .store(in: &cancellables)
+    }
+    
+    var description: String {
+        return toString()
+    }
+    
+    func toString() -> String {
+        var memo = "BOND:\(self.nodeAddress)"
+        if !self.provider.isEmpty {
+            memo += ":\(self.provider)"
+        }
+        if self.fee != .zero {
+            if self.provider.isEmpty {
+                memo += "::\(self.fee)"
+            } else {
+                memo += ":\(self.fee)"
+            }
+        }
+        return memo
+    }
+    
+    func toDictionary() -> ThreadSafeDictionary<String, String> {
+        let dict = ThreadSafeDictionary<String, String>()
+        dict.set("nodeAddress", self.nodeAddress)
+        dict.set("provider", self.provider)
+        dict.set("fee", "\(self.fee)")
+        dict.set("memo", self.toString())
+        return dict
+    }
+    
+    func getView() -> AnyView {
+        AnyView(VStack {
+            TransactionMemoAddressTextField(
+                memo: self,
+                addressKey: "nodeAddress",
+                isAddressValid: Binding(
+                    get: { self.nodeAddressValid },
+                    set: { self.nodeAddressValid = $0 }
+                )
+            )
+            TransactionMemoAddressTextField(
+                memo: self,
+                addressKey: "provider",
+                isOptional: true,
+                isAddressValid: Binding(
+                    get: { self.providerValid },
+                    set: { self.providerValid = $0 }
+                )
+            )
+
+            StyledIntegerField(
+                placeholder: "Operator's Fee",
+                value: Binding(
+                    get: { self.fee },
+                    set: { self.fee = $0 }
+                ),
+                format: .number,
+                isValid: Binding(
+                    get: { self.feeValid },
+                    set: { self.feeValid = $0 }
+                ),
+                isOptional: true
+            )
+            StyledFloatingPointField(placeholder: "Amount", value: Binding(
+                get: { self.amount },
+                set: { self.amount = $0 }
+            ), format: .number, isValid: Binding(
+                get: { self.amountValid },
+                set: { self.amountValid = $0 }
+            ))
+        })
+    }
+}

--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoTypeEnum.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoTypeEnum.swift
@@ -10,7 +10,7 @@ import Foundation
 import Combine
 
 enum TransactionMemoType: String, CaseIterable, Identifiable {
-    case bond, unbond, leave, custom, vote, addPool, withdrawPool
+    case bond, unbond, leave, custom, vote, addPool, withdrawPool, stake, unstake
     
     var id: String { self.rawValue }
     var display: String {
@@ -29,6 +29,10 @@ enum TransactionMemoType: String, CaseIterable, Identifiable {
             return "Remove from RUNEPool"
         case .vote:
             return "Vote"
+        case .stake:
+            return "Stake"
+        case .unstake:
+            return "Unstake"
         }
     }
     
@@ -40,6 +44,8 @@ enum TransactionMemoType: String, CaseIterable, Identifiable {
             return [.bond, .unbond, .leave, .custom]
         case .dydx:
             return [.vote]
+        case .ton:
+            return [.stake, .unstake]
         default:
             return []
         }
@@ -51,6 +57,8 @@ enum TransactionMemoType: String, CaseIterable, Identifiable {
             return .bond
         case .dydx:
             return .vote
+        case .ton:
+            return .stake
         default:
             return .custom
         }

--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnstake.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnstake.swift
@@ -1,9 +1,8 @@
-
 //
-//  TransactionMemoUnbond.swift
+//  TransactionMemoUnstake.swift
 //  VultisigApp
 //
-//  Created by Enrique Souza Soares on 17/05/24.
+//  Created by Enrique Souza Soares on 24/10/24.
 //
 
 import SwiftUI
@@ -11,51 +10,35 @@ import Foundation
 import Combine
 
 class TransactionMemoUnstake: TransactionMemoAddressable, ObservableObject {
-    @Published var isTheFormValid: Bool = false
-    
-    @Published var nodeAddress: String = ""
-    @Published var amount: Double = 0.0
-    @Published var provider: String = ""
+    @Published var amount: Double = 1
+    @Published var nodeAddress: String = "Ef8t6cZkqFuHjJ_a_ydEK_tu3LHWRA4JZXRyewLY4j8FZ6B5"
     
     // Internal
-    @Published var nodeAddressValid: Bool = false
-    @Published var amountValid: Bool = false
-    @Published var providerValid: Bool = true
-    
-    private var cancellables = Set<AnyCancellable>()
+    @Published var amountValid: Bool = true
+    @Published var nodeAddressValid: Bool = true
+    @Published var isTheFormValid: Bool = true
     
     var addressFields: [String: String] {
         get {
-            var fields = ["nodeAddress": nodeAddress]
-            if !provider.isEmpty {
-                fields["provider"] = provider
-            }
+            let fields = ["nodeAddress": nodeAddress]
             return fields
         }
         set {
             if let value = newValue["nodeAddress"] {
                 nodeAddress = value
             }
-            if let value = newValue["provider"] {
-                provider = value
-            }
         }
     }
+    
+    private var cancellables = Set<AnyCancellable>()
     
     required init() {
         setupValidation()
     }
     
-    init(nodeAddress: String, amount: Double = 0.0, provider: String = "") {
-        self.nodeAddress = nodeAddress
-        self.amount = amount
-        self.provider = provider
-        setupValidation()
-    }
-    
     private func setupValidation() {
-        Publishers.CombineLatest3($nodeAddressValid, $amountValid, $providerValid)
-            .map { $0 && $1 && $2 }
+        Publishers.CombineLatest($amountValid, $nodeAddressValid)
+            .map { $0 && $1 }
             .assign(to: \.isTheFormValid, on: self)
             .store(in: &cancellables)
     }
@@ -64,31 +47,19 @@ class TransactionMemoUnstake: TransactionMemoAddressable, ObservableObject {
         return toString()
     }
     
-    var amountInUnits: String {
-        let amountInSats = Int64(self.amount * pow(10, 8))
-        return amountInSats.description
-    }
-    
     func toString() -> String {
-        var memo = "UNBOND:\(self.nodeAddress):\(amountInUnits)"
-        if !self.provider.isEmpty {
-            memo += ":\(self.provider)"
-        }
-        return memo
+        return "w"
     }
     
     func toDictionary() -> ThreadSafeDictionary<String, String> {
         let dict = ThreadSafeDictionary<String, String>()
         dict.set("nodeAddress", self.nodeAddress)
-        dict.set("Unbond amount", "\(self.amount)")
-        dict.set("provider", self.provider)
         dict.set("memo", self.toString())
         return dict
     }
     
     func getView() -> AnyView {
         AnyView(VStack {
-
             TransactionMemoAddressTextField(
                 memo: self,
                 addressKey: "nodeAddress",
@@ -97,29 +68,14 @@ class TransactionMemoUnstake: TransactionMemoAddressable, ObservableObject {
                     set: { self.nodeAddressValid = $0 }
                 )
             )
-
-            StyledFloatingPointField(
-                placeholder: "Amount",
-                value: Binding(
-                    get: { self.amount },
-                    set: { self.amount = $0 }
-                ),
-                format: .number,
-                isValid: Binding(
-                    get: { self.amountValid },
-                    set: { self.amountValid = $0 }
-                )
-            )
-
-            TransactionMemoAddressTextField(
-                memo: self,
-                addressKey: "provider",
-                isOptional: true,
-                isAddressValid: Binding(
-                    get: { self.providerValid },
-                    set: { self.providerValid = $0 }
-                )
-            )
+            
+            StyledFloatingPointField(placeholder: "Amount", value: Binding(
+                get: { self.amount },
+                set: { self.amount = $0 }
+            ), format: .number, isValid: Binding(
+                get: { self.amountValid },
+                set: { self.amountValid = $0 }
+            ))
         })
     }
 }

--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnstake.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnstake.swift
@@ -1,0 +1,125 @@
+
+//
+//  TransactionMemoUnbond.swift
+//  VultisigApp
+//
+//  Created by Enrique Souza Soares on 17/05/24.
+//
+
+import SwiftUI
+import Foundation
+import Combine
+
+class TransactionMemoUnstake: TransactionMemoAddressable, ObservableObject {
+    @Published var isTheFormValid: Bool = false
+    
+    @Published var nodeAddress: String = ""
+    @Published var amount: Double = 0.0
+    @Published var provider: String = ""
+    
+    // Internal
+    @Published var nodeAddressValid: Bool = false
+    @Published var amountValid: Bool = false
+    @Published var providerValid: Bool = true
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    var addressFields: [String: String] {
+        get {
+            var fields = ["nodeAddress": nodeAddress]
+            if !provider.isEmpty {
+                fields["provider"] = provider
+            }
+            return fields
+        }
+        set {
+            if let value = newValue["nodeAddress"] {
+                nodeAddress = value
+            }
+            if let value = newValue["provider"] {
+                provider = value
+            }
+        }
+    }
+    
+    required init() {
+        setupValidation()
+    }
+    
+    init(nodeAddress: String, amount: Double = 0.0, provider: String = "") {
+        self.nodeAddress = nodeAddress
+        self.amount = amount
+        self.provider = provider
+        setupValidation()
+    }
+    
+    private func setupValidation() {
+        Publishers.CombineLatest3($nodeAddressValid, $amountValid, $providerValid)
+            .map { $0 && $1 && $2 }
+            .assign(to: \.isTheFormValid, on: self)
+            .store(in: &cancellables)
+    }
+    
+    var description: String {
+        return toString()
+    }
+    
+    var amountInUnits: String {
+        let amountInSats = Int64(self.amount * pow(10, 8))
+        return amountInSats.description
+    }
+    
+    func toString() -> String {
+        var memo = "UNBOND:\(self.nodeAddress):\(amountInUnits)"
+        if !self.provider.isEmpty {
+            memo += ":\(self.provider)"
+        }
+        return memo
+    }
+    
+    func toDictionary() -> ThreadSafeDictionary<String, String> {
+        let dict = ThreadSafeDictionary<String, String>()
+        dict.set("nodeAddress", self.nodeAddress)
+        dict.set("Unbond amount", "\(self.amount)")
+        dict.set("provider", self.provider)
+        dict.set("memo", self.toString())
+        return dict
+    }
+    
+    func getView() -> AnyView {
+        AnyView(VStack {
+
+            TransactionMemoAddressTextField(
+                memo: self,
+                addressKey: "nodeAddress",
+                isAddressValid: Binding(
+                    get: { self.nodeAddressValid },
+                    set: { self.nodeAddressValid = $0 }
+                )
+            )
+
+            StyledFloatingPointField(
+                placeholder: "Amount",
+                value: Binding(
+                    get: { self.amount },
+                    set: { self.amount = $0 }
+                ),
+                format: .number,
+                isValid: Binding(
+                    get: { self.amountValid },
+                    set: { self.amountValid = $0 }
+                )
+            )
+
+            TransactionMemoAddressTextField(
+                memo: self,
+                addressKey: "provider",
+                isOptional: true,
+                isAddressValid: Binding(
+                    get: { self.providerValid },
+                    set: { self.providerValid = $0 }
+                )
+            )
+        })
+    }
+}

--- a/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
@@ -13,8 +13,10 @@ extension Chain {
         switch self {
         case .thorChain:
             actions = [.send, .swap, .memo]
-        case .solana, .ton:
+        case .solana:
             actions = [.send]
+        case .ton:
+            actions = [.send, .memo]
         case .ethereum:
             actions = [.send, .swap]
         case .avalanche:

--- a/VultisigApp/VultisigApp/Views/Components/TextFields/TransactionMemoAddressTextField.swift
+++ b/VultisigApp/VultisigApp/Views/Components/TextFields/TransactionMemoAddressTextField.swift
@@ -142,6 +142,7 @@ struct TransactionMemoAddressTextField<MemoType: TransactionMemoAddressable>: Vi
         }
         
         isAddressValid = AddressService.validateAddress(address: newValue, chain: .thorChain) ||
-        AddressService.validateAddress(address: newValue, chain: .mayaChain)
+        AddressService.validateAddress(address: newValue, chain: .mayaChain) ||
+        AddressService.validateAddress(address: newValue, chain: .ton)
     }
 }

--- a/VultisigApp/VultisigApp/Views/TransactionMemo/TransactionMemoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/TransactionMemo/TransactionMemoDetailsView.swift
@@ -96,6 +96,11 @@ struct TransactionMemoDetailsView: View {
                     tx.memoFunctionDictionary = txMemoInstance.toDictionary()
                     tx.transactionType = txMemoInstance.getTransactionType()
                     transactionMemoViewModel.moveToNextView()
+                                        
+                    if let toAddress = txMemoInstance.toAddress {
+                        tx.toAddress = toAddress
+                    }
+                    
                 } else {
                     showInvalidFormAlert = true
                 }

--- a/VultisigApp/VultisigApp/Views/TransactionMemo/TransactionMemoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/TransactionMemo/TransactionMemoDetailsView.swift
@@ -44,6 +44,10 @@ struct TransactionMemoDetailsView: View {
                     txMemoInstance = .addPool(TransactionMemoAddPool())
                 case .withdrawPool:
                     txMemoInstance = .withdrawPool(TransactionMemoWithdrawPool())
+                case .stake:
+                    txMemoInstance = .stake(TransactionMemoStake())
+                case .unstake:
+                    txMemoInstance = .unstake(TransactionMemoUnstake())
                 }
             }
     }


### PR DESCRIPTION
Based on TON's specification, I've created a function for TON where you send coins to a POOL with the memo "d" for deposit and "w" for withdrawal;

https://blog.ton.cat/how-to-stake/

All of our transactions are **bounceable**, so if the pool refuses, the amount should be returned. You can see my tests here:
https://tonscan.org/pool/Ef8t6cZkqFuHjJ_a_ydEK_tu3LHWRA4JZXRyewLY4j8FZ6B5

You can also specify the POOL address. Therefore, I left the following POOL address as a default:

Ef8t6cZkqFuHjJ_a_ydEK_tu3LHWRA4JZXRyewLY4j8FZ6B5

The minimum amount for this POOL is **1 003 TON**, so I also left it as a default. 

I also left the same POOL for withdrawal, but to withdraw, we must send 1 TON always, and it will return all funds. There are no other options based on the spec above.