### PR TITLE
Removed dismiss on Folder cell selection

### DIFF
--- a/VultisigApp/VultisigApp/Views/Folder/FolderDetailView.swift
+++ b/VultisigApp/VultisigApp/Views/Folder/FolderDetailView.swift
@@ -290,7 +290,6 @@ struct FolderDetailView: View {
     
     private func handleSelection(for vault: Vault) {
         viewModel.setSelectedVault(vault)
-        dismiss()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
             showVaultsList = false


### PR DESCRIPTION
Fixed the bug that repeatedly show Backup View on Folder cell tap, Fixes #1484