### PR TITLE
doritos-fix

### DIFF
--- a/VultisigApp/VultisigApp/Model/Solana/SolanaJupiterTokenInfo.swift
+++ b/VultisigApp/VultisigApp/Model/Solana/SolanaJupiterTokenInfo.swift
@@ -6,13 +6,7 @@ class SolanaJupiterToken: Codable {
     let symbol: String
     let decimals: Int
     let logoURI: URL
-    let tags: [String]
-    let dailyVolume: String?
-    let createdAt: Date
-    let freezeAuthority: String?
-    let mintAuthority: String?
-    let permanentDelegate: String?
-    let mintedAt: Date
+    
     let extensions: SolanaJupiterTokenExtensions
     
     enum CodingKeys: String, CodingKey {
@@ -21,13 +15,7 @@ class SolanaJupiterToken: Codable {
         case symbol
         case decimals
         case logoURI = "logoURI"
-        case tags
-        case dailyVolume = "daily_volume"
-        case createdAt = "created_at"
-        case freezeAuthority = "freeze_authority"
-        case mintAuthority = "mint_authority"
-        case permanentDelegate = "permanent_delegate"
-        case mintedAt = "minted_at"
+
         case extensions
     }
     
@@ -39,19 +27,7 @@ class SolanaJupiterToken: Codable {
         symbol = try container.decode(String.self, forKey: .symbol)
         decimals = try container.decode(Int.self, forKey: .decimals)
         logoURI = try container.decode(URL.self, forKey: .logoURI)
-        tags = try container.decode([String].self, forKey: .tags)
-        dailyVolume = try container.decodeIfPresent(String.self, forKey: .dailyVolume)
-        freezeAuthority = try container.decodeIfPresent(String.self, forKey: .freezeAuthority)
-        mintAuthority = try container.decodeIfPresent(String.self, forKey: .mintAuthority)
-        permanentDelegate = try container.decodeIfPresent(String.self, forKey: .permanentDelegate)
         extensions = try container.decode(SolanaJupiterTokenExtensions.self, forKey: .extensions)
-        
-        // Custom date decoding
-        let createdAtStringOrDouble = try container.decode(StringOrDouble.self, forKey: .createdAt)
-        createdAt = createdAtStringOrDouble.date
-        
-        let mintedAtStringOrDouble = try container.decode(StringOrDouble.self, forKey: .mintedAt)
-        mintedAt = mintedAtStringOrDouble.date
     }
 }
 
@@ -60,38 +36,6 @@ class SolanaJupiterTokenExtensions: Codable {
     
     enum CodingKeys: String, CodingKey {
         case coingeckoId = "coingeckoId"
-    }
-}
-
-enum StringOrDouble: Codable {
-    case string(String)
-    case double(Double)
-    
-    var date: Date {
-        switch self {
-        case .string(let dateString):
-            // Try to decode as an ISO8601 date string
-            let formatter = ISO8601DateFormatter()
-            if let date = formatter.date(from: dateString) {
-                return date
-            } else {
-                // Fallback if the date string is invalid
-                return Date()
-            }
-        case .double(let timestamp):
-            return Date(timeIntervalSince1970: timestamp)
-        }
-    }
-    
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if let stringValue = try? container.decode(String.self) {
-            self = .string(stringValue)
-        } else if let doubleValue = try? container.decode(Double.self) {
-            self = .double(doubleValue)
-        } else {
-            throw DecodingError.typeMismatch(StringOrDouble.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Expected String or Double for date"))
-        }
     }
 }
 


### PR DESCRIPTION
Some properties sometimes do not come, or they just come in a different type on JSON. So I just removed since they wont be used.

Tests:
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/deb6889b-2a02-4ead-a56f-e91e89c867d0">



This PR fixes the following error:

```
declared attribute value type "Array<String>" of attribute named signers
Error in fetchSolanaJupiterTokenInfoList:
Error in fetchTokens: typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "daily_volume", intValue: nil)], debugDescription: "Expected to decode String but found number instead.", underlyingError: nil))
Error in fetchSolanaTokenInfoList:
Error in fetchSolanaJupiterTokenInfoList:
Error in fetchTokens: Error Domain=NSURLErrorDomain Code=-999 "cancelled" UserInfo={_kCFStreamErrorCodeKey=89, NSUnderlyingError=0x60000133df20 {Error Domain=kCFErrorDomainCFNetwork Code=-999 "(null)" UserInfo={NSErrorPeerAddressKey=<CFData 0x600003ccafd0 [0x1f9f3e1c0]>{length = 16, capacity = 16, bytes = 0x100201bbac4090c50000000000000000}, _kCFStreamErrorCodeKey=89, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <BB5B54E7-C379-47DD-99D6-D4660142C3D3>.<16>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <BB5B54E7-C379-47DD-99D6-D4660142C3D3>.<16>"
), NSLocalizedDescription=cancelled, NSErrorFailingURLStringKey=https://tokens.jup.ag/token/FgWto1nfArQTpg3o74sYkti753caPfHNXHG8CkedDpMg, NSErrorFailingURLKey=https://tokens.jup.ag/token/FgWto1nfArQTpg3o74sYkti753caPfHNXHG8CkedDpMg, _kCFStreamErrorDomainKey=1}
Error in fetchSolanaJupiterTokenInfoList:
Error in fetchTokens: typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "daily_volume", intValue: nil)], debugDescription: "Expected to decode String but found number instead.", underlyingError: nil))
```