### PR TITLE
Navigation title

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/TokenSelectionView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/TokenSelectionView.swift
@@ -139,3 +139,12 @@ struct TokenSelectionView: View {
         }
     }
 }
+
+#Preview {
+    TokenSelectionView(
+        chainDetailView: ChainDetailView(group: GroupedChain.example, vault: Vault.example),
+        vault: Vault.example,
+        group: GroupedChain.example
+    )
+    .environmentObject(CoinSelectionViewModel())
+}

--- a/VultisigApp/VultisigApp/Views/Vault/TokenSelectionView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/TokenSelectionView.swift
@@ -86,34 +86,32 @@ struct TokenSelectionView: View {
     }
 
     var list: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                if !tokenViewModel.selectedTokens.isEmpty {
-                    Section(header: Text(NSLocalizedString("Selected", comment:"Selected")).background(Color.backgroundBlue)) {
-                        ForEach(tokenViewModel.selectedTokens, id: \.self) { asset in
-                            TokenSelectionCell(chain: group.chain, address: address, asset: asset, isSelected: isTokenSelected(asset: asset))
-                                .listRowBackground(Color.clear)
-                                .listRowSeparator(.hidden)
-                        }
+        VStack(alignment: .leading, spacing: 24) {
+            if !tokenViewModel.selectedTokens.isEmpty {
+                Section(header: Text(NSLocalizedString("Selected", comment:"Selected")).background(Color.backgroundBlue)) {
+                    ForEach(tokenViewModel.selectedTokens, id: \.self) { asset in
+                        TokenSelectionCell(chain: group.chain, address: address, asset: asset, isSelected: isTokenSelected(asset: asset))
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
                     }
                 }
-                
-                if tokenViewModel.searchText.isEmpty {
-                    Section(header: Text(NSLocalizedString("tokens", comment:"Tokens"))) {
-                        ForEach(tokenViewModel.preExistTokens, id: \.self) { asset in
+            }
+            
+            if tokenViewModel.searchText.isEmpty {
+                Section(header: Text(NSLocalizedString("tokens", comment:"Tokens"))) {
+                    ForEach(tokenViewModel.preExistTokens, id: \.self) { asset in
+                        TokenSelectionCell(chain: group.chain, address: address, asset: asset, isSelected: isTokenSelected(asset: asset))
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                    }
+                }
+            } else {
+                Section(header: Text(NSLocalizedString("searchResult", comment:"Search Result"))) {
+                    if !tokenViewModel.searchedTokens.isEmpty {
+                        ForEach(tokenViewModel.searchedTokens, id: \.self) { asset in
                             TokenSelectionCell(chain: group.chain, address: address, asset: asset, isSelected: isTokenSelected(asset: asset))
                                 .listRowBackground(Color.clear)
                                 .listRowSeparator(.hidden)
-                        }
-                    }
-                } else {
-                    Section(header: Text(NSLocalizedString("searchResult", comment:"Search Result"))) {
-                        if !tokenViewModel.searchedTokens.isEmpty {
-                            ForEach(tokenViewModel.searchedTokens, id: \.self) { asset in
-                                TokenSelectionCell(chain: group.chain, address: address, asset: asset, isSelected: isTokenSelected(asset: asset))
-                                    .listRowBackground(Color.clear)
-                                    .listRowSeparator(.hidden)
-                            }
                         }
                     }
                 }

--- a/VultisigApp/VultisigApp/iOS/View/Address/AddAddressBookView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Address/AddAddressBookView+iOS.swift
@@ -15,6 +15,7 @@ extension AddAddressBookView {
             main
         }
         .navigationTitle(NSLocalizedString("addAddress", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Address/AddressBookView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Address/AddressBookView+iOS.swift
@@ -15,6 +15,7 @@ extension AddressBookView {
             main
         }
         .navigationTitle(NSLocalizedString("addressBook", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             if savedAddresses.count != 0 {
                 ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {

--- a/VultisigApp/VultisigApp/iOS/View/Address/AddressQRCodeView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Address/AddressQRCodeView+iOS.swift
@@ -17,8 +17,8 @@ extension AddressQRCodeView {
             main
         }
         .navigationBarBackButtonHidden(true)
-        .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(NSLocalizedString("address", comment: "AddressQRCodeView title"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarLeading.getPlacement()) {
                 NavigationBackSheetButton(showSheet: $showSheet)

--- a/VultisigApp/VultisigApp/iOS/View/Address/EditAddressBookView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Address/EditAddressBookView+iOS.swift
@@ -15,6 +15,7 @@ extension EditAddressBookView {
             main
         }
         .navigationTitle(NSLocalizedString("editAddress", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/BackupPasswordSetupView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/BackupPasswordSetupView+iOS.swift
@@ -15,6 +15,7 @@ extension BackupPasswordSetupView {
             main
         }
         .navigationTitle(NSLocalizedString("backup", comment: "Backup"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/ChainDetailView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/ChainDetailView+iOS.swift
@@ -21,6 +21,7 @@ extension ChainDetailView {
             PopupCapsule(text: "addressCopied", showPopup: $showAlert)
         }
         .navigationTitle(NSLocalizedString(group.name, comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
                 NavigationRefreshButton() {

--- a/VultisigApp/VultisigApp/iOS/View/ChainSelectionView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/ChainSelectionView+iOS.swift
@@ -18,6 +18,7 @@ extension ChainSelectionView {
         }
         .navigationBarBackButtonHidden(true)
         .navigationTitle(NSLocalizedString("chooseChains", comment: "Choose Chains"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarLeading.getPlacement()) {
                 NavigationBackSheetButton(showSheet: $showChainSelectionSheet)

--- a/VultisigApp/VultisigApp/iOS/View/CoinDetailView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/CoinDetailView+iOS.swift
@@ -19,6 +19,7 @@ extension CoinDetailView {
             }
         }
         .navigationTitle(NSLocalizedString(coin.ticker, comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
                 NavigationRefreshButton() {

--- a/VultisigApp/VultisigApp/iOS/View/CoinPickerView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/CoinPickerView+iOS.swift
@@ -16,6 +16,7 @@ extension CoinPickerView {
         }
         .navigationBarBackButtonHidden(true)
         .navigationTitle(NSLocalizedString("chooseTokens", comment: "Choose Tokens"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarLeading.getPlacement()) {
                 Button(action: {

--- a/VultisigApp/VultisigApp/iOS/View/CreateFolderView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/CreateFolderView+iOS.swift
@@ -15,6 +15,7 @@ extension CreateFolderView {
             button
         }
         .navigationTitle(NSLocalizedString("createFolder", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/iOS/View/EditVaultView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/EditVaultView+iOS.swift
@@ -16,6 +16,7 @@ extension EditVaultView {
     var navigation: some View {
         base
             .navigationTitle(NSLocalizedString("editVault", comment: "Edit Vault View title"))
+            .navigationBarTitleDisplayMode(.inline)
     }
     
     var view: some View {

--- a/VultisigApp/VultisigApp/iOS/View/ImportWalletView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/ImportWalletView+iOS.swift
@@ -15,6 +15,7 @@ extension ImportWalletView {
             main
         }
         .navigationTitle(NSLocalizedString("import", comment: "Import title"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
                 NavigationHelpButton()

--- a/VultisigApp/VultisigApp/iOS/View/Keygen/JoinKeygenView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Keygen/JoinKeygenView+iOS.swift
@@ -16,6 +16,7 @@ extension JoinKeygenView {
             main
         }
         .navigationTitle(NSLocalizedString("joinKeygen", comment: "Join keygen/reshare"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
                 NavigationHelpButton()

--- a/VultisigApp/VultisigApp/iOS/View/Keygen/KeygenView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Keygen/KeygenView+iOS.swift
@@ -17,6 +17,7 @@ extension KeygenView {
             instructions
         }
         .navigationTitle(NSLocalizedString("joinKeygen", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(isPresented: $viewModel.isLinkActive) {
             BackupVaultNowView(vault: vault)
         }

--- a/VultisigApp/VultisigApp/iOS/View/Keysign/JoinKeysignView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Keysign/JoinKeysignView+iOS.swift
@@ -15,6 +15,7 @@ extension JoinKeysignView {
             main
         }
         .navigationTitle(NSLocalizedString("joinKeySign", comment: "Join Keysign"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             
             ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {

--- a/VultisigApp/VultisigApp/iOS/View/NewWalletNameView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/NewWalletNameView+iOS.swift
@@ -15,6 +15,7 @@ extension NewWalletNameView {
             main
         }
         .navigationTitle(NSLocalizedString(header, comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
                 NavigationHelpButton()

--- a/VultisigApp/VultisigApp/iOS/View/RegisterVaultView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/RegisterVaultView+iOS.swift
@@ -15,6 +15,7 @@ extension RegisterVaultView {
             content
         }
         .navigationTitle(NSLocalizedString("registerVault", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var content: some View {

--- a/VultisigApp/VultisigApp/iOS/View/RenameVaultView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/RenameVaultView+iOS.swift
@@ -15,6 +15,7 @@ extension RenameVaultView {
             main
         }
         .navigationTitle(NSLocalizedString("renameVault", comment: "Edit Rename Vault View title"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoView+iOS.swift
@@ -12,6 +12,7 @@ extension SendCryptoView {
     var container: some View {
         content
             .navigationTitle(NSLocalizedString(sendCryptoViewModel.currentTitle, comment: "SendCryptoView title"))
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 if sendCryptoViewModel.currentIndex != 1 {
                     ToolbarItem(placement: Placement.topBarLeading.getPlacement()) {

--- a/VultisigApp/VultisigApp/iOS/View/Settings/SettingsCurrencySelectionView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Settings/SettingsCurrencySelectionView+iOS.swift
@@ -19,6 +19,7 @@ extension SettingsCurrencySelectionView {
             }
         }
         .navigationTitle(NSLocalizedString("currency", comment: "Currency"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Settings/SettingsDefaultChainView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Settings/SettingsDefaultChainView+iOS.swift
@@ -12,6 +12,7 @@ extension SettingsDefaultChainView {
     var container: some View {
         content
             .navigationTitle(NSLocalizedString("defaultChains", comment: ""))
+            .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Settings/SettingsFAQView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Settings/SettingsFAQView+iOS.swift
@@ -15,6 +15,7 @@ extension SettingsFAQView {
             main
         }
         .navigationTitle(NSLocalizedString("faq", comment: "FAQ"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Settings/SettingsLanguageSelectionView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Settings/SettingsLanguageSelectionView+iOS.swift
@@ -15,6 +15,7 @@ extension SettingsLanguageSelectionView {
             main
         }
         .navigationTitle(NSLocalizedString("language", comment: "Language"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Settings/SettingsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Settings/SettingsView+iOS.swift
@@ -15,6 +15,7 @@ extension SettingsView {
             main
         }
         .navigationTitle(NSLocalizedString("settings", comment: "Settings"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/SetupQRCodeView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/SetupQRCodeView+iOS.swift
@@ -15,6 +15,7 @@ extension SetupQRCodeView {
             main
         }
         .navigationTitle(NSLocalizedString("setup", comment: "Setup title"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
                 NavigationHelpButton()

--- a/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoView+iOS.swift
@@ -23,6 +23,7 @@ extension SwapCryptoView {
         }
         .navigationBarBackButtonHidden(swapViewModel.currentIndex != 1 ? true : false)
         .navigationTitle(NSLocalizedString(swapViewModel.currentTitle, comment: "SendCryptoView title"))
+        .navigationBarTitleDisplayMode(.inline)
         .ignoresSafeArea(.keyboard)
         .toolbar {
             if swapViewModel.currentIndex != 1 {

--- a/VultisigApp/VultisigApp/iOS/View/TokenSelectionView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/TokenSelectionView+iOS.swift
@@ -36,13 +36,6 @@ extension TokenSelectionView {
                         .foregroundColor(Color.neutral0)
                 }
             }
-            ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
-                saveButton
-            }
-            
-            ToolbarItem(placement: Placement.principal.getPlacement()) {
-                searchBar
-            }
         }
     }
     
@@ -58,14 +51,18 @@ extension TokenSelectionView {
         }
         .background(Color.clear)
         .padding(.horizontal, 25)
+        .padding(.top, 25)
     }
     
     var view: some View {
         VStack(alignment: .leading, spacing: 0) {
+            searchBar
+                .padding(.horizontal, 25)
+            
             addCustomTokenButton
             scrollView
+            saveButton
         }
-        .padding(.bottom, 50)
     }
     
     var scrollView: some View {
@@ -95,9 +92,10 @@ extension TokenSelectionView {
             self.chainDetailView.sheetType = nil
             dismiss()
         }) {
-            Text("Save")
-                .foregroundColor(.blue)
+            FilledButton(title: "save")
         }
+        .padding(.horizontal, 25)
+        .padding(.vertical, 12)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/iOS/View/TokenSelectionView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/TokenSelectionView+iOS.swift
@@ -24,6 +24,7 @@ extension TokenSelectionView {
         }
         .navigationBarBackButtonHidden(true)
         .navigationTitle(NSLocalizedString("chooseTokens", comment: "Choose Tokens"))
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: Placement.topBarLeading.getPlacement()) {
                 Button(action: {

--- a/VultisigApp/VultisigApp/iOS/View/TokenSelectionView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/TokenSelectionView+iOS.swift
@@ -66,10 +66,12 @@ extension TokenSelectionView {
     }
     
     var scrollView: some View {
-        list
-            .scrollContentBackground(.hidden)
-            .padding(.horizontal, 25)
-            .listStyle(.grouped)
+        ScrollView {
+            list
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, 25)
+                .listStyle(.grouped)
+        }
     }
 
     var textField: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Transaction/TransactionsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Transaction/TransactionsView+iOS.swift
@@ -15,6 +15,7 @@ extension TransactionsView {
             main
         }
         .navigationTitle(NSLocalizedString("transactions", comment: "Transactions"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultEmailView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultEmailView+iOS.swift
@@ -15,6 +15,7 @@ extension FastVaultEmailView {
             main
         }
         .navigationTitle(NSLocalizedString("email", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultEnterPasswordView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultEnterPasswordView+iOS.swift
@@ -20,8 +20,8 @@ extension FastVaultEnterPasswordView {
             }
             .navigationBarItems(leading: backButton)
             .navigationBarTitleTextColor(.neutral0)
-            .navigationBarTitleDisplayMode(.inline)
             .navigationTitle(NSLocalizedString("password", comment: ""))
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
 

--- a/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultSetPasswordView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultSetPasswordView+iOS.swift
@@ -20,6 +20,7 @@ extension FastVaultSetPasswordView {
             }
         }
         .navigationTitle(NSLocalizedString("password", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Vault/VaultDeletionConfirmView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/VaultDeletionConfirmView+iOS.swift
@@ -17,6 +17,7 @@ extension VaultDeletionConfirmView {
             main
         }
         .navigationTitle(NSLocalizedString("deleteVaultTitle", comment: "Delete Vault"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Vault/VaultDetailQRCodeView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/VaultDetailQRCodeView+iOS.swift
@@ -17,6 +17,7 @@ extension VaultDetailQRCodeView {
             main
         }
         .navigationTitle(NSLocalizedString("shareVaultQR", comment: ""))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/iOS/View/Vault/VaultPairDetailView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/VaultPairDetailView+iOS.swift
@@ -15,6 +15,7 @@ extension VaultPairDetailView {
             main
         }
         .navigationTitle(NSLocalizedString("vaultDetailsTitle", comment: "View your vault details"))
+        .navigationBarTitleDisplayMode(.inline)
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/macOS/View/TokenSelectionView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/TokenSelectionView+macOS.swift
@@ -50,16 +50,20 @@ extension TokenSelectionView {
         VStack(alignment: .leading, spacing: 0) {
             search
             addCustomTokenButton
+            Separator()
             scrollView
         }
     }
     
     var scrollView: some View {
-        list
-            .scrollContentBackground(.hidden)
-            .padding(.horizontal, 40)
-            .padding(.bottom, 50)
-            .colorScheme(.dark)
+        ScrollView {
+            list
+                .scrollContentBackground(.hidden)
+                .padding(.top, 24)
+                .padding(.horizontal, 40)
+                .padding(.bottom, 50)
+                .colorScheme(.dark)
+        }
     }
     
     var textField: some View {
@@ -81,7 +85,7 @@ extension TokenSelectionView {
             dismiss()
         }) {
             Text("Save")
-                .foregroundColor(.blue)
+                .foregroundColor(Color.neutral0)
         }
         .padding(.horizontal, 32)
         .frame(height: 44)


### PR DESCRIPTION
Fixed the following:
- Fixed navigation title to be of type inline for all views, Fixes #1507
- Updated TokenSelectionView to move the search bar from the navigation bar.

iOS:
![Simulator Screenshot - iPhone 15 Pro - 2024-11-07 at 01 17 08](https://github.com/user-attachments/assets/4e7c8140-12a6-4e60-a050-4f6f38c5c9c2)

macOS:
<img width="1115" alt="Screenshot 2024-11-07 at 1 16 17 AM" src="https://github.com/user-attachments/assets/7fd3abee-bfe9-40f3-8d42-8276dd2afe2e">
