### PR TITLE
PeerDiscoveryView grid layout fixed

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -214,7 +214,8 @@ struct PeerDiscoveryView: View {
     }
     
     func setData(_ proxy: GeometryProxy) {
-        let screenWidth = proxy.size.width
+        screenWidth = proxy.size.width
+        screenHeight = proxy.size.height
         
         if screenWidth<380 {
             isPhoneSE = true

--- a/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
@@ -176,7 +176,6 @@ extension PeerDiscoveryView {
     
     private func updateScreenSize() {
         screenWidth = UIScreen.main.bounds.size.width
-        screenHeight = UIScreen.main.bounds.size.height
         
         if screenWidth>1100 && idiom == .pad {
             isLandscape = true

--- a/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
@@ -13,8 +13,15 @@ extension PeerDiscoveryView {
         ZStack {
             GeometryReader { proxy in
                 Background()
+                    .clipped()
                     .onAppear {
                         setData(proxy)
+                    }
+                    .onChange(of: proxy.size.width) { oldValue, newValue in
+                        screenWidth = proxy.size.width
+                    }
+                    .onChange(of: proxy.size.height) { oldValue, newValue in
+                        screenHeight = proxy.size.height
                     }
             }
             
@@ -60,7 +67,6 @@ extension PeerDiscoveryView {
             qrCodeImage?
                 .resizable()
                 .background(Color.blue600)
-                .aspectRatio(contentMode: .fill)
                 .padding(3)
                 .background(Color.neutral0)
                 .cornerRadius(12)
@@ -74,6 +80,8 @@ extension PeerDiscoveryView {
         .cornerRadius(10)
         .shadow(radius: 5)
         .padding(40)
+        .aspectRatio(contentMode: .fit)
+        .frame(maxWidth: getMinSize(), maxHeight: getMinSize())
     }
     
     var outline: some View {
@@ -147,6 +155,10 @@ extension PeerDiscoveryView {
             displayScale: displayScale,
             type: .Keygen
         )
+    }
+    
+    func getMinSize() -> CGFloat {
+        min(screenWidth/2, screenHeight/1.2)
     }
 }
 #endif


### PR DESCRIPTION
PeerDiscoveryView grid layout fixed, Fixes #1596

Screenshots:
<img width="1913" alt="Screenshot 2024-11-27 at 7 39 53 PM" src="https://github.com/user-attachments/assets/4bdd88ff-fd0b-4970-be27-567b5f05bf49">
<img width="892" alt="Screenshot 2024-11-27 at 7 39 46 PM" src="https://github.com/user-attachments/assets/7c6f36bb-6139-417c-b11d-e56b06e6ff16">
<img width="1824" alt="Screenshot 2024-11-27 at 7 39 34 PM" src="https://github.com/user-attachments/assets/7aa9ab46-bf73-4294-b22f-b28c870f2606">
