### PR TITLE
Send view label

### DIFF
--- a/VultisigApp/VultisigApp/Services/Keysign/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Services/Keysign/KeysignPayload.swift
@@ -23,6 +23,13 @@ struct KeysignPayload: Codable, Hashable {
         let power = Decimal(sign: .plus, exponent: -coin.decimals, significand: 1)
         return "\(decimalAmount * power) \(coin.ticker)"
     }
+    
+    var toAmountFiatString: String {
+        let newValueFiat = (Decimal(string: toAmount.description) ?? Decimal.zero) * Decimal(coin.price)
+        let truncatedValueFiat = newValueFiat.truncated(toPlaces: 2)
+        let power = Decimal(sign: .plus, exponent: -coin.decimals, significand: 1)
+        return NSDecimalNumber(decimal: truncatedValueFiat * power).stringValue.formatToFiat()
+    }
 
     static let example = KeysignPayload(coin: Coin.example, toAddress: "toAddress", toAmount: 100, chainSpecific: BlockChainSpecific.UTXO(byteFee: 100, sendMaxAmount: false), utxos: [], memo: "Memo", swapPayload: nil, approvePayload: nil, vaultPubKeyECDSA: "12345", vaultLocalPartyID: "iPhone-100")
 }

--- a/VultisigApp/VultisigApp/View Models/KeysignDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeysignDiscoveryViewModel.swift
@@ -16,7 +16,6 @@ enum KeysignDiscoveryStatus {
 }
 
 class KeysignDiscoveryViewModel: ObservableObject {
-    
     private let logger = Logger(subsystem: "keysign-discovery", category: "viewmodel")
     private var cancellables = Set<AnyCancellable>()
     

--- a/VultisigApp/VultisigApp/Views/Keysign/KeysignMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/KeysignMessageConfirmView.swift
@@ -63,8 +63,8 @@ struct KeysignMessageConfirmView: View {
                 amountField
                 Separator()
                 valueField
-
-                Separator()
+//                Separator()
+//                networkFeeField
             }
             .padding(16)
             .background(Color.blue600)
@@ -88,6 +88,10 @@ struct KeysignMessageConfirmView: View {
     var valueField: some View {
         getSummaryCell(title: "value", value: viewModel.keysignPayload?.toAmountFiatString ?? "")
     }
+    
+//    var networkFeeField: some View {
+//        getSummaryCell(title: "networkFee", value: viewModel.keysignPayload?.networkFee ?? "")
+//    }
 
     var amountField: some View {
         getSummaryCell(title: "amount", value: viewModel.keysignPayload?.toAmountString ?? "")

--- a/VultisigApp/VultisigApp/Views/Keysign/KeysignMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/KeysignMessageConfirmView.swift
@@ -49,17 +49,20 @@ struct KeysignMessageConfirmView: View {
                 Separator()
                 toField
                 Separator()
-                amountField
                 
                 if let memo = viewModel.keysignPayload?.memo, !memo.isEmpty {
-                    Separator()
                     getSummaryCell(title: "memo", value: memo)
-                }
-
-                if let decodedMemo = viewModel.decodedMemo {
                     Separator()
-                    functionField(decodedMemo: decodedMemo)
                 }
+                
+                if let decodedMemo = viewModel.decodedMemo {
+                    functionField(decodedMemo: decodedMemo)
+                    Separator()
+                }
+                
+                amountField
+                Separator()
+                valueField
 
                 Separator()
             }
@@ -80,6 +83,10 @@ struct KeysignMessageConfirmView: View {
     
     var toField: some View {
         getPrimaryCell(title: "to", value: viewModel.keysignPayload?.toAddress ?? "")
+    }
+    
+    var valueField: some View {
+        getSummaryCell(title: "value", value: viewModel.keysignPayload?.toAmountFiatString ?? "")
     }
 
     var amountField: some View {
@@ -105,7 +112,7 @@ struct KeysignMessageConfirmView: View {
                 .font(.body20MontserratSemiBold)
                 .foregroundColor(.neutral0)
             Text(value)
-                .font(.body12Menlo)
+                .font(.body13MenloBold)
                 .foregroundColor(.turquoise600)
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Added Fiat value to JoinKeysignVerify View and skeleton for network fee cell, Fixes #1226

**Please Note**
The view still does not show Network Fee. I spent quite an amount of time to understand the payload setup flow in order to add it but couldn't.
So I've added follow up issues so I can come back and update those views once the required parameters are available for KeysignPayload.

Add network fee to KeysignPayload
https://github.com/vultisig/vultisig-ios/issues/1641

Add network Fee cell to Keysign views for pair device
https://github.com/vultisig/vultisig-ios/issues/1642

**Screenshot**
![IMG_B8710B3093C5-1](https://github.com/user-attachments/assets/74c36ff6-c582-43c4-90f9-12b6b03caa13)

