### PR TITLE
Fix thorchain send/swap after hardfork

### DIFF
--- a/VultisigApp/VultisigApp/Model/Cosmos/AccountManager/THORChainAccountNumberResponse.swift
+++ b/VultisigApp/VultisigApp/Model/Cosmos/AccountManager/THORChainAccountNumberResponse.swift
@@ -8,6 +8,5 @@
 import Foundation
 
 class THORChainAccountNumberResponse: Codable {
-    var height: String
     var result: THORChainAccountResult
 }

--- a/VultisigApp/VultisigApp/Model/Cosmos/AccountManager/ThorchainAccountResult.swift
+++ b/VultisigApp/VultisigApp/Model/Cosmos/AccountManager/ThorchainAccountResult.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 class THORChainAccountResult: Codable {
-    var type: String
     var value: THORChainAccountValue?
 }
 

--- a/VultisigApp/VultisigApp/Model/Cosmos/AccountManager/ThorchainAccountValue.swift
+++ b/VultisigApp/VultisigApp/Model/Cosmos/AccountManager/ThorchainAccountValue.swift
@@ -9,17 +9,12 @@ import Foundation
 
 class THORChainAccountValue: Codable {
     var address: String?
-    var publicKey: THORChainAccountValuePublicKey?
+    var publicKey: String?
     var accountNumber: String?
     var sequence: String?
     
     enum CodingKeys: String, CodingKey {
-        case address, publicKey = "public_key", accountNumber = "account_number", sequence
+        case address, publicKey = "pub_key", accountNumber = "account_number", sequence
     }
 }
 
-class THORChainAccountValuePublicKey: Codable {
-    var type: String
-    var value: String
-   
-}


### PR DESCRIPTION
https://thornode.ninerealms.com/auth/accounts/thor1vzltn37rqccwk95tny657au9j2z072dhgstcmn 
The response from this endpoint is different than before after the hard fork , thus we need to adjust it to fetch account number and sequence no

swap: https://thorchain.net/tx/6747192E801B9C6058E54E911300897C45FAB77BEE994C56B2DF0604867FAB74
send: https://thorchain.net/tx/4D089C9D1B267BAD3E00A2448708301C5490AAE6B0101E14C8A2F160CBD18ED4