### PR TITLE
Swipe and dismiss disabled for FastBackupVaultOverview

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/ServerBackupVerificationView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/ServerBackupVerificationView.swift
@@ -58,6 +58,7 @@ struct ServerBackupVerificationView: View {
         .onDisappear {
             animationVM.stop()
         }
+        .interactiveDismissDisabled()
     }
     
     var title: some View {

--- a/VultisigApp/VultisigApp/iOS/View/FastBackupVaultOverview+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/FastBackupVaultOverview+iOS.swift
@@ -17,6 +17,9 @@ extension FastBackupVaultOverview {
     var textTabView: some View {
         text
             .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+            .onAppear {
+                  UIScrollView.appearance().isScrollEnabled = false
+            }
     }
     
     var button: some View {


### PR DESCRIPTION
Disabled swipe and dismiss to skip fast vault verification, Fixes #1862