### PR TITLE
Random top padding bug on HomeView fixed

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/HomeView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/HomeView.swift
@@ -35,13 +35,7 @@ struct HomeView: View {
     @Environment(\.modelContext) private var modelContext
     
     var body: some View {
-        ZStack {
-            content
-            
-            if isLoading {
-                Loader()
-            }
-        }
+        container
     }
     
     var navigationTitle: some View {

--- a/VultisigApp/VultisigApp/iOS/View/HomeView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/HomeView+iOS.swift
@@ -9,6 +9,17 @@
 import SwiftUI
 
 extension HomeView {
+    var container: some View {
+        ZStack {
+            content
+            
+            if isLoading {
+                Loader()
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
     var content: some View {
         ZStack {
             Background()

--- a/VultisigApp/VultisigApp/macOS/View/HomeView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/HomeView+macOS.swift
@@ -9,6 +9,16 @@
 import SwiftUI
 
 extension HomeView {
+    var container: some View {
+        ZStack {
+            content
+            
+            if isLoading {
+                Loader()
+            }
+        }
+    }
+    
     var content: some View {
         ZStack {
             Background()


### PR DESCRIPTION
Random top padding bug on HomeView fixed, Fixes #1881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - On iOS and macOS, the Home screen now displays a clear loading overlay while content loads.
  - The iOS navigation bar now shows the title in a streamlined inline style.

- **Refactor**
  - Simplified the Home screen layout for a more focused and efficient display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->