### PR TITLE
Display the balance for the unbound fn

### DIFF
--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnbond.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnbond.swift
@@ -23,6 +23,8 @@ class TransactionMemoUnbond: TransactionMemoAddressable, ObservableObject {
     
     private var cancellables = Set<AnyCancellable>()
     
+    private var tx: SendTransaction
+    
     var addressFields: [String: String] {
         get {
             var fields = ["nodeAddress": nodeAddress]
@@ -41,11 +43,21 @@ class TransactionMemoUnbond: TransactionMemoAddressable, ObservableObject {
         }
     }
     
-    required init() {
+    required init(
+        tx: SendTransaction, transactionMemoViewModel: TransactionMemoViewModel
+    ) {
+        self.tx = tx
         setupValidation()
     }
     
-    init(nodeAddress: String, amount: Double = 0.0, provider: String = "") {
+    var balance: String {
+        let balance = tx.coin.balanceDecimal.description
+        
+        return "( Balance: \(balance) \(tx.coin.ticker.uppercased()) )"
+    }
+    
+    init(nodeAddress: String, amount: Double = 0.0, provider: String = "", tx: SendTransaction, transactionMemoViewModel: TransactionMemoViewModel) {
+        self.tx = tx
         self.nodeAddress = nodeAddress
         self.amount = amount
         self.provider = provider
@@ -98,7 +110,7 @@ class TransactionMemoUnbond: TransactionMemoAddressable, ObservableObject {
             )
 
             StyledFloatingPointField(
-                placeholder: "Amount",
+                placeholder: "Amount \(balance)",
                 value: Binding(
                     get: { self.amount },
                     set: { self.amount = $0 }

--- a/VultisigApp/VultisigApp/Views/TransactionMemo/TransactionMemoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/TransactionMemo/TransactionMemoDetailsView.swift
@@ -42,7 +42,7 @@ struct TransactionMemoDetailsView: View {
                 case .bond:
                     txMemoInstance = .bond(TransactionMemoBond(tx: tx, transactionMemoViewModel: transactionMemoViewModel))
                 case .unbond:
-                    txMemoInstance = .unbond(TransactionMemoUnbond())
+                    txMemoInstance = .unbond(TransactionMemoUnbond(tx: tx, transactionMemoViewModel: transactionMemoViewModel))
                 case .bondMaya:
 
                     DispatchQueue.main.async {


### PR DESCRIPTION
<img width="451" alt="image" src="https://github.com/user-attachments/assets/fa2ae423-2f18-4709-8d11-bafe94c2ea12" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The unbonding transaction interface now displays real-time balance feedback by showing a formatted balance (including coin ticker) as part of the input field.
	- The transaction processing workflow for unbonding operations has been enhanced with improved data integration, ensuring users have immediate and clear context during transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->