### PR TITLE
Remove the loader

### DIFF
--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoView.swift
@@ -32,10 +32,6 @@ struct SendCryptoView: View {
         ZStack {
             Background()
             main
-            
-            if sendCryptoViewModel.isLoading || sendCryptoVerifyViewModel.isLoading {
-                loader
-            }
         }
         .ignoresSafeArea(.keyboard)
         .onAppear {
@@ -180,10 +176,6 @@ struct SendCryptoView: View {
 
     var errorView: some View {
         SendCryptoSigningErrorView()
-    }
-    
-    var loader: some View {
-        Loader()
     }
     
     private func setData() async {

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoView.swift
@@ -69,7 +69,6 @@ struct SendCryptoView: View {
             
             tabView
         }
-        .blur(radius: sendCryptoViewModel.isLoading ? 1 : 0)
     }
     
     var tabView: some View {


### PR DESCRIPTION
I removed the loader as suggested. It still gets blur, but no loader. We should get used with a top limit between 1 and 5 secs to load all info. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Removed the transient loading indicator from the send crypto screen, resulting in a cleaner and more direct user experience without the previous visual feedback during loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->