### PR TITLE
Use chain not coin info for address book

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/AddressBook/AddressBookChainSelector.swift
+++ b/VultisigApp/VultisigApp/Views/Components/AddressBook/AddressBookChainSelector.swift
@@ -40,7 +40,7 @@ struct AddressBookChainSelector: View {
     var cell: some View {
         HStack(spacing: 12) {
             image
-            Text("\(selected?.chain.ticker ?? "")")
+            Text("\(selected?.chain.name ?? "")")
             Spacer()
             Image(systemName: "chevron.down")
         }
@@ -77,7 +77,7 @@ struct AddressBookChainSelector: View {
                 .frame(width: 32, height: 32)
                 .cornerRadius(30)
             
-            Text(coin?.chain.ticker ?? "")
+            Text(coin?.chain.name ?? "")
                 .font(.body16Menlo)
                 .foregroundColor(.neutral0)
 

--- a/VultisigApp/VultisigApp/Views/Components/AddressBook/AddressBookChainSelector.swift
+++ b/VultisigApp/VultisigApp/Views/Components/AddressBook/AddressBookChainSelector.swift
@@ -40,7 +40,7 @@ struct AddressBookChainSelector: View {
     var cell: some View {
         HStack(spacing: 12) {
             image
-            Text("\(selected?.ticker ?? "")")
+            Text("\(selected?.chain.ticker ?? "")")
             Spacer()
             Image(systemName: "chevron.down")
         }
@@ -50,7 +50,7 @@ struct AddressBookChainSelector: View {
     }
     
     var image: some View {
-        Image(selected?.logo ?? "")
+        Image(selected?.chain.logo ?? "")
             .resizable()
             .frame(width: 32, height: 32)
             .cornerRadius(30)
@@ -70,20 +70,20 @@ struct AddressBookChainSelector: View {
         }
     }
     
-    private func getCell(for chain: CoinMeta?) -> some View {
+    private func getCell(for coin: CoinMeta?) -> some View {
         HStack(spacing: 12) {
-            Image(chain?.logo ?? "")
+            Image(coin?.chain.logo ?? "")
                 .resizable()
                 .frame(width: 32, height: 32)
                 .cornerRadius(30)
             
-            Text(chain?.ticker ?? "")
+            Text(coin?.chain.ticker ?? "")
                 .font(.body16Menlo)
                 .foregroundColor(.neutral0)
 
             Spacer()
             
-            if selected == chain {
+            if selected == coin {
                 Image(systemName: "checkmark")
                     .font(.body16Menlo)
                     .foregroundColor(.neutral0)
@@ -92,13 +92,13 @@ struct AddressBookChainSelector: View {
         .frame(height: 48)
     }
 
-    private func handleSelection(for chain: CoinMeta?) {
-        guard let chain else {
+    private func handleSelection(for coin: CoinMeta?) {
+        guard let coin else {
             return
         }
         
         isExpanded = false
-        selected = chain
+        selected = coin
     }
 }
 


### PR DESCRIPTION
I've changed to use the chain while adding addresses to address book since it is per chain not coin. 

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/8929223f-47b1-4923-b106-b7a0d3de3095" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the address book selection experience so that ticker symbols and logos display accurately and consistently.
  - Enhanced naming conventions to streamline how coin information is referenced during selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->