### PR TITLE
PeerDiscoveryView fix for iPhone SE

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -126,13 +126,6 @@ struct PeerDiscoveryView: View {
         }
     }
     
-    var portraitContent: some View {
-        VStack(spacing: 0) {
-            qrCode
-            list
-        }
-    }
-    
     var qrCode: some View {
         VStack(spacing: 0) {
             paringBarcode

--- a/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
@@ -53,6 +53,22 @@ extension PeerDiscoveryView {
         states
     }
     
+    var portraitContent: some View {
+        ZStack {
+            if isPhoneSE {
+                ScrollView {
+                    qrCode
+                    list
+                }
+            } else {
+                VStack(spacing: 0) {
+                    qrCode
+                    list
+                }
+            }
+        }
+    }
+    
     var landscapeContent: some View {
         HStack {
             qrCode
@@ -78,7 +94,7 @@ extension PeerDiscoveryView {
             .frame(maxWidth: 500, maxHeight: 500)
             .aspectRatio(contentMode: .fill)
             .padding(16)
-            .background(Color.blue600)
+            .background(Color.clear)
             .cornerRadius(38)
             .padding(2)
     }
@@ -91,13 +107,27 @@ extension PeerDiscoveryView {
         VStack {
             listTitle
             
-            ScrollView {
-                LazyVGrid(columns: phoneColumns, spacing: 18) {
-                    ThisDevicePeerCell(deviceName: idiom == .phone ? "iPhone" : "iPad")
-                    devices
-                    EmptyPeerCell(counter: participantDiscovery.peersFound.count)
+            ZStack {
+                if isPhoneSE {
+                    VStack {
+                        LazyVGrid(columns: phoneColumns, spacing: 18) {
+                            ThisDevicePeerCell(deviceName: idiom == .phone ? "iPhone" : "iPad")
+                            devices
+                            EmptyPeerCell(counter: participantDiscovery.peersFound.count)
+                        }
+                        .padding(.horizontal, 18)
+                    }
+                } else {
+                    ScrollView {
+                        LazyVGrid(columns: phoneColumns, spacing: 18) {
+                            ThisDevicePeerCell(deviceName: idiom == .phone ? "iPhone" : "iPad")
+                            devices
+                            EmptyPeerCell(counter: participantDiscovery.peersFound.count)
+                        }
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 24)
+                    }
                 }
-                .padding(.horizontal, 18)
             }
         }
     }

--- a/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
@@ -46,6 +46,13 @@ extension PeerDiscoveryView {
         )
     }
     
+    var portraitContent: some View {
+        VStack(spacing: 0) {
+            qrCode
+            list
+        }
+    }
+    
     var landscapeContent: some View {
         HStack {
             qrCode


### PR DESCRIPTION
PeerDiscoveryView fix for iPhone SE, Fixes #1924
Made the entire view scrollable for iPhone SE.

**Screenshot**
![Simulator Screenshot - iPhone SE (3rd generation) - 2025-03-11 at 00 16 10](https://github.com/user-attachments/assets/5b5a1fe0-08fe-4af3-8130-b8bd784504bf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the Peer Discovery view for improved responsiveness across devices. Users on smaller devices now see a scrollable layout for easier navigation, while others enjoy a neatly stacked presentation.
  - Updated visual styling for the QR code display, offering a clearer and more consistent appearance.
  - macOS users now have a dedicated portrait layout for a more natural viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->