### PR TITLE
current locale

### DIFF
--- a/VultisigApp/VultisigApp/Extensions/DecimalExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/DecimalExtension.swift
@@ -41,9 +41,6 @@ extension Decimal {
         let value = abbrevation.value
         let prefix = abbrevation.prefix
         
-//        formatter.maximumFractionDigits = 2
-//        formatter.minimumFractionDigits = 0
-        
         let number = NSDecimalNumber(decimal: value)
         
         if let formattedNumber = formatter.string(from: number) {

--- a/VultisigApp/VultisigApp/Extensions/DecimalExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/DecimalExtension.swift
@@ -26,11 +26,11 @@ extension Decimal {
             formatter.currencyCode = SettingsCurrency.current.rawValue
         } else {
             formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 2
-            formatter.minimumFractionDigits = 2
-            formatter.decimalSeparator = "."
-            formatter.groupingSeparator = ","
         }
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        formatter.decimalSeparator = Locale.current.decimalSeparator ?? "."
+        formatter.groupingSeparator = Locale.current.groupingSeparator ?? ","
         
         if !useAbbreviation {
             let number = NSDecimalNumber(decimal: self)
@@ -41,8 +41,8 @@ extension Decimal {
         let value = abbrevation.value
         let prefix = abbrevation.prefix
         
-        formatter.maximumFractionDigits = 2
-        formatter.minimumFractionDigits = 0
+//        formatter.maximumFractionDigits = 2
+//        formatter.minimumFractionDigits = 0
         
         let number = NSDecimalNumber(decimal: value)
         
@@ -58,8 +58,8 @@ extension Decimal {
         formatter.numberStyle = .decimal
         formatter.maximumFractionDigits = digits
         formatter.minimumFractionDigits = 0
-        formatter.groupingSeparator = ","
-        formatter.decimalSeparator = "."
+        formatter.decimalSeparator = Locale.current.decimalSeparator ?? "."
+        formatter.groupingSeparator = Locale.current.groupingSeparator ?? ","
         
         let abbrevation = getAbbrevationValues()
         let value = abbrevation.value

--- a/VultisigApp/VultisigApp/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/StringExtension.swift
@@ -91,18 +91,12 @@ extension String {
 
 extension String {
     func toDecimal() -> Decimal {
-        if self.isEmpty {
-            return .zero
-        }
-        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
-        let cleaned = trimmed.replacingOccurrences(of: ",", with: "")
-        
-        if let decimal = Decimal(string: cleaned) {
-            return decimal
-        } else {
+        guard let number = parseInput() else {
             print("Failed to convert to Decimal: \(self)")
             return .zero
         }
+        
+        return number
     }
     
     func formatToFiat(includeCurrencySymbol: Bool = true) -> String {

--- a/VultisigApp/VultisigApp/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/StringExtension.swift
@@ -63,14 +63,8 @@ extension String {
 
 extension String {
     func formatCurrency() -> String {
-        let currency = SettingsCurrency.current
         let decimalPoint = getCurrentDecimalPoint()
-        
-        if currency.usesEuropeanFormat || decimalPoint == "," {
-            return self.replacingOccurrences(of: ",", with: ".")
-        } else {
-            return self.replacingOccurrences(of: ",", with: "").replacingOccurrences(of: ",", with: ".")
-        }
+        return self.replacingOccurrences(of: ",", with: decimalPoint)
     }
     
     func formatCurrencyWithSeparators() -> String {
@@ -78,21 +72,11 @@ extension String {
             return self
         }
         
-        let currency = SettingsCurrency.current
-        let decimalPoint = getCurrentDecimalPoint()
-        
         let outputFormatter = NumberFormatter()
         outputFormatter.numberStyle = .decimal
+        outputFormatter.locale = Locale.current // Use system locale
         outputFormatter.minimumFractionDigits = 0
         outputFormatter.maximumFractionDigits = 8
-        
-        if (currency.usesEuropeanFormat || decimalPoint == ",") {
-            outputFormatter.decimalSeparator = ","
-            outputFormatter.groupingSeparator = "."
-        } else {
-            outputFormatter.decimalSeparator = "."
-            outputFormatter.groupingSeparator = ","
-        }
         
         return outputFormatter.string(for: number) ?? self
     }
@@ -106,6 +90,7 @@ extension String {
     
     private func getCurrentDecimalPoint() -> String {
         let formatter = NumberFormatter()
+        formatter.locale = Locale.current // Ensure it uses system locale
         return formatter.decimalSeparator ?? "."
     }
 }
@@ -127,17 +112,10 @@ extension String {
         guard let decimalValue = Decimal(string: self) else { return "" }
         
         let formatter = NumberFormatter()
-        
-        if includeCurrencySymbol {
-            formatter.numberStyle = .currency
-            formatter.currencyCode = SettingsCurrency.current.rawValue
-        } else {
-            formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 2
-            formatter.minimumFractionDigits = 2
-            formatter.decimalSeparator = "."
-            formatter.groupingSeparator = ""
-        }
+        formatter.locale = Locale.current // Use system locale
+        formatter.numberStyle = includeCurrencySymbol ? .currency : .decimal
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
         
         let number = NSDecimalNumber(decimal: decimalValue)
         return formatter.string(from: number) ?? ""
@@ -170,19 +148,11 @@ extension String {
     }
     
     func isValidDecimal() -> Bool {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale.current
+        formatter.numberStyle = .decimal
         
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .decimal
-        numberFormatter.locale = Locale.current // Use the current locale for decimal separator
-        
-        // Check for both dot and comma as decimal separators
-        let dotSeparator = numberFormatter.decimalSeparator == "."
-        let modifiedSelf = dotSeparator ? self : self.replacingOccurrences(of: ".", with: ",")
-        
-        let number = numberFormatter.number(from: modifiedSelf) != nil
-        
-        return number
-        
+        return formatter.number(from: self) != nil
     }
 
     var isValidEmail: Bool {

--- a/VultisigApp/VultisigApp/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/StringExtension.swift
@@ -72,13 +72,7 @@ extension String {
             return self
         }
         
-        let outputFormatter = NumberFormatter()
-        outputFormatter.numberStyle = .decimal
-        outputFormatter.locale = Locale.current // Use system locale
-        outputFormatter.minimumFractionDigits = 0
-        outputFormatter.maximumFractionDigits = 8
-        
-        return outputFormatter.string(for: number) ?? self
+        return number.formatToFiat(includeCurrencySymbol: false, useAbbreviation: false)
     }
     
     private func parseInput() -> Decimal? {
@@ -109,30 +103,19 @@ extension String {
     }
     
     func formatToFiat(includeCurrencySymbol: Bool = true) -> String {
-        guard let decimalValue = Decimal(string: self) else { return "" }
+        guard let number = parseInput() else {
+            return self
+        }
         
-        let formatter = NumberFormatter()
-        formatter.locale = Locale.current // Use system locale
-        formatter.numberStyle = includeCurrencySymbol ? .currency : .decimal
-        formatter.maximumFractionDigits = 2
-        formatter.minimumFractionDigits = 2
-        
-        let number = NSDecimalNumber(decimal: decimalValue)
-        return formatter.string(from: number) ?? ""
+        return number.formatToFiat(includeCurrencySymbol: includeCurrencySymbol, useAbbreviation: false)
     }
     
     func formatToDecimal(digits: Int) -> String {
-        guard let decimalValue = Decimal(string: self) else { return "" }
+        guard let number = parseInput() else {
+            return self
+        }
         
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = digits
-        formatter.minimumFractionDigits = 0
-        formatter.groupingSeparator = ""
-        formatter.decimalSeparator = "."
-        
-        let number = NSDecimalNumber(decimal: decimalValue)
-        return formatter.string(from: number) ?? ""
+        return number.formatToDecimal(digits: digits)
     }
     
     func toBigInt() -> BigInt {

--- a/VultisigApp/VultisigApp/Views/Components/AddressBook/AddressBookChainSelector.swift
+++ b/VultisigApp/VultisigApp/Views/Components/AddressBook/AddressBookChainSelector.swift
@@ -40,7 +40,7 @@ struct AddressBookChainSelector: View {
     var cell: some View {
         HStack(spacing: 12) {
             image
-            Text("\(selected?.ticker ?? "")")
+            Text("\(selected?.chain.name ?? "")")
             Spacer()
             Image(systemName: "chevron.down")
         }
@@ -50,7 +50,7 @@ struct AddressBookChainSelector: View {
     }
     
     var image: some View {
-        Image(selected?.logo ?? "")
+        Image(selected?.chain.logo ?? "")
             .resizable()
             .frame(width: 32, height: 32)
             .cornerRadius(30)
@@ -70,20 +70,20 @@ struct AddressBookChainSelector: View {
         }
     }
     
-    private func getCell(for chain: CoinMeta?) -> some View {
+    private func getCell(for coin: CoinMeta?) -> some View {
         HStack(spacing: 12) {
-            Image(chain?.logo ?? "")
+            Image(coin?.chain.logo ?? "")
                 .resizable()
                 .frame(width: 32, height: 32)
                 .cornerRadius(30)
             
-            Text(chain?.ticker ?? "")
+            Text(coin?.chain.name ?? "")
                 .font(.body16Menlo)
                 .foregroundColor(.neutral0)
 
             Spacer()
             
-            if selected == chain {
+            if selected == coin {
                 Image(systemName: "checkmark")
                     .font(.body16Menlo)
                     .foregroundColor(.neutral0)
@@ -92,13 +92,13 @@ struct AddressBookChainSelector: View {
         .frame(height: 48)
     }
 
-    private func handleSelection(for chain: CoinMeta?) {
-        guard let chain else {
+    private func handleSelection(for coin: CoinMeta?) {
+        guard let coin else {
             return
         }
         
         isExpanded = false
-        selected = chain
+        selected = coin
     }
 }
 

--- a/VultisigApp/VultisigApp/Views/Components/Cells/ChainCell.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Cells/ChainCell.swift
@@ -91,7 +91,7 @@ struct ChainCell: View {
     }
     
     var quantity: some View {
-        Text(homeViewModel.hideVaultBalance ? "****" : group.nativeCoin.balanceString.formatCurrencyWithSeparators())
+        Text(homeViewModel.hideVaultBalance ? "****" : group.nativeCoin.balanceString)
             .font(.body12Menlo)
             .foregroundColor(.neutral100)
     }

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoVerifyView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoVerifyView.swift
@@ -177,7 +177,7 @@ var fields: some View {
     }
     
     private func getAmount() -> String {
-        tx.amount.formatCurrencyWithSeparators() + " " + tx.coin.ticker
+        tx.amount.formatToDecimal(digits: 8) + " " + tx.coin.ticker
     }
     
     private func getFiatAmount() -> String {


### PR DESCRIPTION
I’ve made a few changes to ensure the code formats numbers consistently. First, I’ve moved the number formatting logic to a single location using the Decimal extension. The string extension will now call the Decimal extension to format numbers correctly.

Next, I’ve updated the views to call the formatters correctly. Now, the views are consistent and read from my system OS (iOS/MACOS).

I’ve also used the Locale.current. to ensure that the formatting is based on the current locale.


![image](https://github.com/user-attachments/assets/5db79bef-7b12-46ec-8b3a-d35dc7fa0e28)
![image](https://github.com/user-attachments/assets/ac376cf9-6ad8-4304-8207-d62470a9625d)
![image](https://github.com/user-attachments/assets/74a544d1-27b3-4779-907c-5f1c3fc195a4)
![image](https://github.com/user-attachments/assets/136a2b74-6d55-40cf-9d27-e26dd83d71e4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the display of numbers and currency values to dynamically use locale settings, ensuring accurate formatting across regions.
  - Streamlined fee calculation logic for clearer, more reliable financial representations.
  - Updated balance displays to present plain numeric values for improved readability.
- **Bug Fixes**
  - Improved error handling and logic in the network fee calculation method.
- **New Features**
  - Simplified methods for formatting currency and decimals, reducing complexity and improving usability.
  - Adjusted transaction amount formatting to display with enhanced precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->