### PR TITLE
When vault is dkls , we name it different use share2of3

### DIFF
--- a/VultisigApp/VultisigApp/Extensions/VaultExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/VaultExtension.swift
@@ -41,6 +41,13 @@ extension Vault {
             }
         }
         let cleanVaultName = vaultName.replacingOccurrences(of: "/", with: "-")
-        return "\(cleanVaultName)-\(lastFourOfPubKey)-part\(signersOrder)of\(signersCount)" + ".vult"
+        var partName = ""
+        switch self.libType {
+        case .DKLS:
+            partName = "share"
+        default:
+            partName = "part"
+        }
+        return "\(cleanVaultName)-\(lastFourOfPubKey)-\(partName)\(signersOrder)of\(signersCount)" + ".vult"
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Export naming now adapts to your configuration by conditionally applying either a "share" or "part" identifier. This update ensures that file exports more accurately reflect the associated content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->