### PR TITLE
Localization updated

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -570,5 +570,4 @@
 "FastVaultOverview4Text4" = "online.";
 "keysignDiscoveryDisclaimer" = "Scanne den QR-Code, um die Transaktion zu signieren.";
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";
-"startUsingVault" = "Beginnen Sie mit der Nutzung Ihres Tresors";
 "startUsingVault" = "Tresor nutzen";

--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -511,7 +511,6 @@
 "wellDone." = "Gut gemacht.";
 "readyToUseNewWalletStandard." = "Sie sind bereit, einen neuen Wallet-Standard zu verwenden.";
 "secureVaultSummaryDiscalimer" = "Ich habe gelesen und verstanden, was zu tun ist.";
-"startUsingVault" = "Vault verwenden";
 "secureVaultSecureTextDescription" = "Maximale Sicherheit mit mehreren Geräten\nImmer zugänglich mit Geräte-Backups\nSichere beliebige Vermögenswerte";
 "fastVaultSecureTextDescription" = "Nur 1 Gerät erforderlich\nSpeichere kleinere Beträge für den täglichen Gebrauch\nVultiserver unterschreibt sofort";
 "fastSetUp" = "Schnelle Einrichtung mit 1 Gerät";
@@ -571,3 +570,5 @@
 "FastVaultOverview4Text4" = "online.";
 "keysignDiscoveryDisclaimer" = "Scanne den QR-Code, um die Transaktion zu signieren.";
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";
+"startUsingVault" = "Beginnen Sie mit der Nutzung Ihres Tresors";
+"startUsingVault" = "Tresor nutzen";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -538,7 +538,6 @@
 "secureVaultSummaryText3" = "Keep vault shares in different locations";
 "secureVaultSummaryText4" = "All vault shares ensure secure access to your funds";
 "secureVaultSummaryDiscalimer" = "I have read and understand what to do";
-"startUsingVault" = "Start using vault";
 "secureVaultSecureTextDescription" = "Maximum security with multiple devices\nAlways accessible with device backups\nSecure any amount of assets";
 "fastVaultSecureTextDescription" = "Only 1 device needed\nStore smaller funds for daily use\nVultiserver co-signs instantly";
 "fastSetUp" = "Quick, 1 device setup";
@@ -598,3 +597,4 @@
 "FastVaultOverview4Text4" = "online.";
 "keysignDiscoveryDisclaimer" = "Scan QR code to sign transaction. ";
 "keysignDiscoveryDisclaimerDevice" = "-device scan required.";
+"startUsingVault" = "Start using your Vault";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -494,7 +494,6 @@
 "wellDone." = "Bien hecho.";
 "readyToUseNewWalletStandard." = "Estás listo para usar un nuevo estándar de billetera.";
 "secureVaultSummaryDiscalimer" = "He leído y entendido qué hacer.";
-"startUsingVault" = "Empezar a usar la bóveda";
 "secureVaultSecureTextDescription" = "Máxima seguridad con múltiples dispositivos\nSiempre accesible con copias de seguridad de dispositivos\nProtege cualquier cantidad de activos";
 "fastVaultSecureTextDescription" = "Solo se necesita 1 dispositivo\nGuarda fondos pequeños para uso diario\nVultiserver firma instantáneamente";
 "fastSetUp" = "Configuración rápida con 1 dispositivo";
@@ -554,3 +553,4 @@
 "FastVaultOverview4Text4" = "en línea.";
 "keysignDiscoveryDisclaimer" = "Escanea el código QR para firmar la transacción.";
 "keysignDiscoveryDisclaimerDevice" = "-se requiere escanear el dispositivo.";
+"startUsingVault" = "Usar Bóveda";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -494,7 +494,6 @@
 "wellDone." = "Dobro napravljeno.";
 "readyToUseNewWalletStandard." = "Spremni ste za korištenje novog standarda novčanika.";
 "secureVaultSummaryDiscalimer" = "Pročitao/la sam i razumijem što trebam učiniti.";
-"startUsingVault" = "Počnite koristiti trezor";
 "secureVaultSecureTextDescription" = "Maksimalna sigurnost s više uređaja\nUvijek dostupan uz sigurnosne kopije uređaja\nOsiguraj bilo koji iznos imovine";
 "fastVaultSecureTextDescription" = "Potreban je samo 1 uređaj\nPohrani manje iznose za svakodnevnu upotrebu\nVultiserver odmah supotpisuje";
 "fastSetUp" = "Brza postavka s 1 uređajem";
@@ -554,3 +553,4 @@
 "FastVaultOverview4Text4" = "online.";
 "keysignDiscoveryDisclaimer" = "Skenirajte QR kod kako biste potpisali transakciju.";
 "keysignDiscoveryDisclaimerDevice" = "-potrebno skeniranje uređaja.";
+"startUsingVault" = "Koristi trezor";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -494,7 +494,6 @@
 "wellDone." = "Ben fatto.";
 "readyToUseNewWalletStandard." = "Ora sei pronto per usare un nuovo standard di wallet.";
 "secureVaultSummaryDiscalimer" = "Ho letto e capito cosa fare.";
-"startUsingVault" = "Inizia a usare il vault";
 "secureVaultSecureTextDescription" = "Massima sicurezza con più dispositivi\nSempre accessibile con backup del dispositivo\nProteggi qualsiasi importo di asset";
 "fastVaultSecureTextDescription" = "Solo 1 dispositivo necessario\nConserva piccoli fondi per l'uso quotidiano\nVultiserver firma istantaneamente";
 "fastSetUp" = "Configurazione rapida con 1 dispositivo";
@@ -554,3 +553,4 @@
 "FastVaultOverview4Text4" = "online.";
 "keysignDiscoveryDisclaimer" = "Scansiona il codice QR per firmare la transazione.";
 "keysignDiscoveryDisclaimerDevice" = "-scansione del dispositivo richiesta.";
+"startUsingVault" = "Usa il Vault";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -495,7 +495,6 @@
 "wellDone." = "Muito bem.";
 "readyToUseNewWalletStandard." = "Você está pronto para usar um novo padrão de carteira.";
 "secureVaultSummaryDiscalimer" = "Li e entendi o que fazer.";
-"startUsingVault" = "Começar a usar o cofre";
 "secureVaultSecureTextDescription" = "Máxima segurança com vários dispositivos\nSempre acessível com backups de dispositivos\nProteja qualquer quantia de ativos";
 "fastVaultSecureTextDescription" = "Apenas 1 dispositivo necessário\nArmazene pequenos fundos para uso diário\nVultiserver assina instantaneamente";
 "fastSetUp" = "Configuração rápida com 1 dispositivo";
@@ -555,3 +554,4 @@
 "FastVaultOverview4Text4" = "online.";
 "keysignDiscoveryDisclaimer" = "Escaneie o código QR para assinar a transação.";
 "keysignDiscoveryDisclaimerDevice" = "-é necessário escanear o dispositivo.";
+"startUsingVault" = "Usar Cofre";


### PR DESCRIPTION
Backup guide button label updated, Fixes #1939


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Refined user interface text prompting vault usage across multiple languages.
  - German translation updated to "Tresor nutzen".
  - English text personalized to "Start using your Vault".
  - Spanish updated to "Usar Bóveda".
  - Croatian simplified to "Koristi trezor".
  - Italian changed to "Usa il Vault".
  - Portuguese updated to "Usar Cofre".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->