### PR TITLE
Disable info screen for reshare/migrate

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -220,8 +220,15 @@ struct PeerDiscoveryView: View {
             showInfoSheet = false
             return
         }
+        switch self.tssType {
+        case .Keygen:
+            showInfoSheet = true
+        case .Reshare:
+            showInfoSheet = false
+        case .Migrate:
+            showInfoSheet = false
+        }
         
-        showInfoSheet = true
     }
 }
 

--- a/VultisigApp/VultisigApp/Views/Reshare/ReshareView.swift
+++ b/VultisigApp/VultisigApp/Views/Reshare/ReshareView.swift
@@ -58,9 +58,6 @@ struct ReshareView: View {
     var buttons: some View {
         VStack(spacing: 12) {
             startReshareButton
-            if vault.libType == .GG20 {
-                startReshareVultisignerButton
-            }
             joinReshareButton
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the application so that additional details are shown only during key generation operations.
	- Streamlined the reshare interface by removing an extra action button for certain vault configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->