### PR TITLE
Search Bar tint fix

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/ChainSelectionView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/ChainSelectionView.swift
@@ -79,6 +79,7 @@ struct ChainSelectionView: View {
             .disableAutocorrection(true)
             .padding(.horizontal, 8)
             .borderlessTextFieldStyle()
+            .colorScheme(.dark)
     }
 
     private func setData() {

--- a/VultisigApp/VultisigApp/Views/Vault/TokenSelectionView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/TokenSelectionView.swift
@@ -63,6 +63,7 @@ struct TokenSelectionView: View {
         }
         .background(Color.blue600)
         .cornerRadius(12)
+        .colorScheme(.dark)
     }
     
     func errorView(error: Error) -> some View {
@@ -99,7 +100,11 @@ struct TokenSelectionView: View {
                         }
                 }
 
-                Section(header: Text(NSLocalizedString("tokens", comment:"Tokens"))) {
+                Section(
+                    header:
+                        Text(NSLocalizedString("tokens", comment:"Tokens"))
+                        .foregroundColor(.neutral0)
+                ) {
                     ForEach(tokenViewModel.preExistTokens, id: \.self) { asset in
                         TokenSelectionCell(chain: group.chain, address: address, asset: asset, isSelected: isTokenSelected(asset: asset))
                             .listRowBackground(Color.clear)


### PR DESCRIPTION
Search bar tint fixed for token and Chain Selection, Fixes #1941

**Screenshot**
![Simulator Screenshot - iPhone 15 Pro - 2025-03-18 at 00 45 49](https://github.com/user-attachments/assets/fc12f36b-6e48-493b-b4d2-6966bb7209a1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated search fields to consistently use a dark theme for improved visual appeal.
  - Enhanced the token section header with a neutral text color for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->