### PR TITLE
MacCheckUpdate URL updated

### DIFF
--- a/VultisigApp/VultisigApp/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Utils/Endpoint.swift
@@ -31,6 +31,7 @@ class Endpoint {
     
     static let updateVersionCheck = "https://api.github.com/repos/vultisig/vultisig-ios/releases"
     static let githubMacUpdateBase = "https://github.com/vultisig/vultisig-ios/releases/tag/"
+    static let githubMacDownloadBase = "https://github.com/vultisig/vultisig-ios/releases/download/"
     
     static let FastVaultBackupVerification = vultisigApiProxy + "/vault/verify/"
     

--- a/VultisigApp/VultisigApp/View Models/MacCheckUpdateViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/MacCheckUpdateViewModel.swift
@@ -15,6 +15,7 @@ class MacCheckUpdateViewModel: ObservableObject {
     
     @Published var latestVersion: String = ""
     @Published var latestVersionBase: String = ""
+    @Published var latestPackageName: String = ""
     @Published var currentVersion: String = ""
     
     func resetData() {
@@ -99,6 +100,7 @@ class MacCheckUpdateViewModel: ObservableObject {
     func showDetailView(latest: String, current: String, isAutoCheck: Bool) {
         DispatchQueue.main.async {
             self.latestVersionBase = latest
+            self.latestPackageName = "/VultisigApp.\(latest).signed.pkg"
             self.latestVersion = latest.replacingOccurrences(of: "v", with: "Version ")
             self.currentVersion = current.replacingOccurrences(of: "v", with: "Version ")
             

--- a/VultisigApp/VultisigApp/Views/Update Check/MacCheckUpdateView.swift
+++ b/VultisigApp/VultisigApp/Views/Update Check/MacCheckUpdateView.swift
@@ -92,7 +92,7 @@ struct MacCheckUpdateView: View {
     }
     
     var updateAppMessage: some View {
-        let url = Endpoint.githubMacUpdateBase + macCheckUpdateViewModel.latestVersionBase
+        let url = Endpoint.githubMacDownloadBase + macCheckUpdateViewModel.latestVersionBase + macCheckUpdateViewModel.latestPackageName
         
         return UpdateCheckUpdateNowView(
             latestVersion: macCheckUpdateViewModel.latestVersion,

--- a/VultisigApp/VultisigApp/macOS/View/HomeView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/HomeView+macOS.swift
@@ -28,7 +28,7 @@ extension HomeView {
             NSLocalizedString("newUpdateAvailable", comment: ""),
             isPresented: $macCheckUpdateViewModel.showUpdateAlert
         ) {
-            Link(destination: URL(string: Endpoint.githubMacUpdateBase + macCheckUpdateViewModel.latestVersionBase)!) {
+            Link(destination: URL(string: Endpoint.githubMacDownloadBase + macCheckUpdateViewModel.latestVersionBase + macCheckUpdateViewModel.latestPackageName)!) {
                 Text(NSLocalizedString("updateNow", comment: ""))
             }
             


### PR DESCRIPTION
URL updated for Mac to auto download update package, Fixes #1917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the update flow so that links now direct users to a dedicated download page for releases.
  - Introduced dynamic construction of package download names based on the latest version, ensuring users are routed to the correct release asset.
  - Enhanced the overall user experience by providing clear, direct download links during the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->