### PR TITLE
Fix the buttons width for MAC and IOS

### DIFF
--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoVerifyView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoVerifyView.swift
@@ -104,23 +104,7 @@ var fields: some View {
         }
     }
     
-    var fastVaultButton: some View {
-        Button {
-            fastPasswordPresented = true
-        } label: {
-            FilledButton(title: NSLocalizedString("fastSign", comment: ""))
-        }
-        .disabled(!sendCryptoVerifyViewModel.isValidForm)
-        .opacity(!sendCryptoVerifyViewModel.isValidForm ? 0.5 : 1)
-        .padding(.horizontal, 16)
-        .sheet(isPresented: $fastPasswordPresented) {
-            FastVaultEnterPasswordView(
-                password: $tx.fastVaultPassword,
-                vault: vault,
-                onSubmit: { signPressed() }
-            )
-        }
-    }
+    
     
     private func setData() {
         isButtonDisabled = false

--- a/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoVerifyView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoVerifyView+iOS.swift
@@ -30,5 +30,23 @@ extension SendCryptoVerifyView {
         .padding(.horizontal, 16)
         .padding(.bottom, idiom == .pad ? 30 : 0)
     }
+    
+    var fastVaultButton: some View {
+        Button {
+            fastPasswordPresented = true
+        } label: {
+            FilledButton(title: NSLocalizedString("fastSign", comment: ""))
+        }
+        .disabled(!sendCryptoVerifyViewModel.isValidForm)
+        .opacity(!sendCryptoVerifyViewModel.isValidForm ? 0.5 : 1)
+        .padding(.horizontal, 16)
+        .sheet(isPresented: $fastPasswordPresented) {
+            FastVaultEnterPasswordView(
+                password: $tx.fastVaultPassword,
+                vault: vault,
+                onSubmit: { signPressed() }
+            )
+        }
+    }
 }
 #endif

--- a/VultisigApp/VultisigApp/macOS/View/Send/SendCryptoVerifyView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Send/SendCryptoVerifyView+macOS.swift
@@ -28,5 +28,23 @@ extension SendCryptoVerifyView {
         .opacity(!sendCryptoVerifyViewModel.isValidForm ? 0.5 : 1)
         .padding(.horizontal, 40)
     }
+    
+    var fastVaultButton: some View {
+        Button {
+            fastPasswordPresented = true
+        } label: {
+            FilledButton(title: NSLocalizedString("fastSign", comment: ""))
+        }
+        .disabled(!sendCryptoVerifyViewModel.isValidForm)
+        .opacity(!sendCryptoVerifyViewModel.isValidForm ? 0.5 : 1)
+        .padding(.horizontal, 40)
+        .sheet(isPresented: $fastPasswordPresented) {
+            FastVaultEnterPasswordView(
+                password: $tx.fastVaultPassword,
+                vault: vault,
+                onSubmit: { signPressed() }
+            )
+        }
+    }
 }
 #endif


### PR DESCRIPTION
<img width="465" alt="image" src="https://github.com/user-attachments/assets/f3b543cd-48ae-42dd-bb4d-8c02b19af172" />

<img width="987" alt="image" src="https://github.com/user-attachments/assets/302bdb1b-28b4-4ad6-a623-a5ec8f3c7081" />

Tx test

https://solscan.io/tx/3T5nZpDGAjLqsYgoDaiXDQnRR2BTmFixrrBEP7vfpRM6RLuHogHn3aZFZw7uU4fTXS912uw1jbU4oHyxfcMf9KjQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fast vault signing is now accessible via a dedicated "fastSign" button available for both iOS and macOS users.
  - The button visually adapts based on input validation—appearing disabled with reduced opacity when incomplete—and, when tapped, presents a secure password entry screen for swift authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->