### PR TITLE
Fast overview text update

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -572,3 +572,5 @@
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";
 "startUsingVault" = "Tresor nutzen";
 "loadingDetails" = "Lade Details";
+"backupPart1" = "Backup Teil 1";
+"backupPart2" = "Backup Teil 2";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -601,3 +601,5 @@
 "migrationFailed" = "Failed to migration GG20 vault to DKLS";
 "migrateVault" = "Migrate GG20 vault to DKLS";
 "loadingDetails" = "Loading details";
+"backupPart1" = "Backup Part 1";
+"backupPart2" = "Backup Part 2";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -555,3 +555,5 @@
 "keysignDiscoveryDisclaimerDevice" = "-se requiere escanear el dispositivo.";
 "startUsingVault" = "Usar Bóveda";
 "loadingDetails" = "Cargando detalles";
+"backupPart1" = "Copia de seguridad Parte 1";
+"backupPart2" = "Copia de seguridad Parte 2";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -555,3 +555,5 @@
 "keysignDiscoveryDisclaimerDevice" = "-potrebno skeniranje uređaja.";
 "startUsingVault" = "Koristi trezor";
 "loadingDetails" = "Učitavanje detalja";
+"backupPart1" = "Sigurnosna kopija Dio 1";
+"backupPart2" = "Sigurnosna kopija Dio 2";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -555,3 +555,5 @@
 "keysignDiscoveryDisclaimerDevice" = "-scansione del dispositivo richiesta.";
 "startUsingVault" = "Usa il Vault";
 "loadingDetails" = "Caricamento dettagli";
+"backupPart1" = "Backup Parte 1";
+"backupPart2" = "Backup Parte 2";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -556,3 +556,5 @@
 "keysignDiscoveryDisclaimerDevice" = "-é necessário escanear o dispositivo.";
 "startUsingVault" = "Usar Cofre";
 "loadingDetails" = "Carregando detalhes";
+"backupPart1" = "Backup Parte 1";
+"backupPart2" = "Backup Parte 2";

--- a/VultisigApp/VultisigApp/Views/Vault/FastBackupVaultOverview.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/FastBackupVaultOverview.swift
@@ -66,7 +66,7 @@ struct FastBackupVaultOverview: View {
     }
     
     var headerTitle: some View {
-        Text(NSLocalizedString("vaultOverview", comment: ""))
+        Text(NSLocalizedString(getTitle(), comment: ""))
             .foregroundColor(.neutral0)
             .font(.body18BrockmannMedium)
     }
@@ -149,6 +149,17 @@ struct FastBackupVaultOverview: View {
     
     private func animate(index: Int) {
         animationVM?.setInput("Index", value: Double(index))
+    }
+    
+    private func getTitle() -> String {
+        switch tabIndex {
+        case 2:
+            "backupPart1"
+        case 3:
+            "backupPart2"
+        default:
+            "vaultOverview"
+        }
     }
 }
 


### PR DESCRIPTION
Title updated for fast vault overview, Fixes #1958

The text for 4th slide is the same as Figma but I did update the title for each slide.

**Screenshot**
![Simulator Screenshot - iPhone 16 - 2025-03-21 at 18 14 35](https://github.com/user-attachments/assets/6337df35-f9ae-47e3-a3e0-08c44b849359)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded localization support by adding backup-related text in multiple languages (English, German, Spanish, Croatian, Italian, Portuguese).
  - Enhanced the backup overview interface with a dynamic header that adapts its title based on the current backup step, providing a more intuitive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->