### PR TITLE
Fix ERC20 failed to estimate gas issue

### DIFF
--- a/VultisigApp/VultisigApp/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Services/BlockChainService.swift
@@ -185,7 +185,7 @@ private extension BlockChainService {
         
         let estimateGasLimit = tx.coin.isNativeToken ?
         try await estimateGasLimit(tx: tx, gasPrice: gasPrice, priorityFee: priorityFee, nonce: nonce) :
-        try await estimateERC20GasLimit(tx: tx, gasPrice: gasPrice, priorityFee: priorityFee, nonce: nonce)
+        await estimateERC20GasLimit(tx: tx, gasPrice: gasPrice, priorityFee: priorityFee, nonce: nonce)
         
         let defaultGasLimit = BigInt(EVMHelper.defaultERC20TransferGasUnit)
         let gasLimit = max(defaultGasLimit, estimateGasLimit)

--- a/VultisigApp/VultisigApp/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Services/BlockChainService.swift
@@ -448,15 +448,20 @@ private extension BlockChainService {
         gasPrice: BigInt,
         priorityFee: BigInt,
         nonce: Int64
-    ) async throws -> BigInt {
-        let service = try EvmServiceFactory.getService(forChain: tx.coin.chain)
-        let gas = try await service.estimateGasForERC20Transfer(
-            senderAddress: tx.coin.address,
-            contractAddress: tx.coin.contractAddress,
-            recipientAddress: .anyAddress,
-            value: BigInt(stringLiteral: tx.coin.rawBalance)
-        )
-        return gas
+    ) async  -> BigInt {
+        do{
+            let service = try EvmServiceFactory.getService(forChain: tx.coin.chain)
+            let gas = try await service.estimateGasForERC20Transfer(
+                senderAddress: tx.coin.address,
+                contractAddress: tx.coin.contractAddress,
+                recipientAddress: .anyAddress,
+                value: BigInt(stringLiteral: tx.coin.rawBalance)
+            )
+            return gas
+        } catch {
+            print("failed to estimate ERC20 transfer gas limit : \(error)")
+            return 0
+        }
     }
     
     func estimateGasLimit(


### PR DESCRIPTION
Sometimes the method call to estimate_gas failed with an error , when it happens we just use the default gas limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved transaction gas estimation reliability by incorporating internal error handling. In the event of an estimation issue, the system now uses a safe fallback value to prevent disruptions and ensure smoother transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->