### PR TITLE
#1975

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -362,7 +362,7 @@
 "keygenInstructionsCar7DescriptionPart3" = " zu und verbessere so die Flexibilität, ohne die Sicherheit zu vernachlässigen.";
 "noSavedAddressesForChain" = "Keine gespeicherten Adressen für diese Kette gefunden.";
 "editAddress" = "Adresse bearbeiten";
-"validAddressDomainError" = "Wir konnten die Adresse dieses Domain-Dienstes in dieser Kette nicht auflösen.";
+"validAddressDomainError" = "Bitte gib eine gültige Adresse für die ausgewählte Blockchain ein.";
 "privacyPolicy" = "Datenschutzerklärung";
 "termsOfService" = "Nutzungsbedingungen";
 "legal" = "Rechtliches";

--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -412,7 +412,7 @@
 "invalidAddress" = "Ungültige Adresse";
 "emptyAddressField" = "Leeres Adressfeld.";
 "nonNegativeFeeError" = "Nicht genug Gas, um die Transaktion abzudecken.";
-"part" = "Teil";
+"part" = "Anteil";
 "devices" = "Geräte";
 "signers" = "Unterzeichner";
 "vaultPart" = "Tresorteil";
@@ -556,7 +556,7 @@
 "FastVaultOverview1Text2" = "";
 "FastVaultOverview1Text3" = " Anteile, ";
 "FastVaultOverview1Text4" = "sichere sie jetzt";
-"FastVaultOverview2Text1" = "Teil 1 der Vault-Anteile wird ";
+"FastVaultOverview2Text1" = "Anteil 1 der Tresoranteile wird ";
 "FastVaultOverview2Text2" = "vom Server gespeichert.";
 "FastVaultOverview2Text3" = "";
 "FastVaultOverview2Text4" = "";
@@ -572,8 +572,8 @@
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";
 "startUsingVault" = "Tresor nutzen";
 "loadingDetails" = "Lade Details";
-"backupPart1" = "Backup Teil 1";
-"backupPart2" = "Backup Teil 2";
+"backupPart1" = "Sicherungsanteil 1";
+"backupPart2" = "Sicherungsanteil 2";
 "vultiserverPassword" = "Vultiserver-Passwort";
 "doYouWantToAddPassword" = "Möchten Sie ein Passwort für Ihre Geräte-Tresoranteile hinzufügen?";
 "doYouWantToAddPasswordDescription" = "Wir empfehlen, kein Backup-Passwort für Geräte-Tresoranteile zu setzen – Ihre Daten sind sicher, wenn die Backups an verschiedenen Orten gespeichert werden, was bereits einen hohen Schutz bietet. Denken Sie daran, dass Backup-Passwörter nicht wiederhergestellt werden können, wenn Sie sie vergessen. Ihre Wahl!";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -367,7 +367,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", enhancing flexibility without compromising security.";
 "noSavedAddressesForChain" = "No Saved Addresses found for this chain.";
 "editAddress" = "Edit Address";
-"validAddressDomainError" = "We were unable to resolve the address of this domain service on this chain.";
+"validAddressDomainError" = "Please enter a valid address for the selected blockchain.";
 "privacyPolicy" = "Privacy Policy";
 "termsOfService" = "Terms of Service";
 "legal" = "Legal";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -274,7 +274,7 @@
 "findCustomTokens" = "Find Your Custom Token";
 "customToken" = "Custom Token";
 "details" = "Details";
-"vaultType" = "Vault Part";
+"vaultType" = "Vault Share";
 "ECDSAKey" = "ECDSA Key";
 "EdDSAKey" = "EdDSA Key";
 "Selected" = "Selected";
@@ -422,10 +422,10 @@
 "invalidAddress" = "Invalid Address";
 "emptyAddressField" = "Empty address field.";
 "nonNegativeFeeError" = "Not enough gas to cover transaction.";
-"part" = "Part";
+"part" = "Share";
 "devices" = "Devices";
 "signers" = "Signers";
-"vaultPart" = "Vault Part";
+"vaultPart" = "Vault Share";
 "name" = "Name";
 "fastVaultSetDisclaimer" = "This Password encrypts your Vault Share received via email";
 "fastVaultEmailDisclaimer" = "This email is only used to send the backup";
@@ -583,7 +583,7 @@
 "FastVaultOverview1Text2" = "";
 "FastVaultOverview1Text3" = " shares, ";
 "FastVaultOverview1Text4" = "back them up  now";
-"FastVaultOverview2Text1" = "Part 1 of the vault shares will be ";
+"FastVaultOverview2Text1" = "Share 1 of the vault shares will be ";
 "FastVaultOverview2Text2" = "held by the server.";
 "FastVaultOverview2Text3" = "";
 "FastVaultOverview2Text4" = "";
@@ -601,8 +601,8 @@
 "migrationFailed" = "Failed to migration GG20 vault to DKLS";
 "migrateVault" = "Migrate GG20 vault to DKLS";
 "loadingDetails" = "Loading details";
-"backupPart1" = "Backup Part 1";
-"backupPart2" = "Backup Part 2";
+"backupPart1" = "Backup Share 1";
+"backupPart2" = "Backup Share 2";
 "vultiserverPassword" = "Vultiserver Password";
 "doYouWantToAddPassword" = "Do you want to add a password to your device vault shares? ";
 "doYouWantToAddPasswordDescription" = "We recommend that you do not set a backup password for device vault shares-your data is safe if the backups are properly stored in different locations, which is already a significant protection. Remember, backup passwords can't be recovered if you forget them. Your choice!";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -345,7 +345,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", mejorando la flexibilidad sin comprometer la seguridad.";
 "noSavedAddressesForChain" = "No se encontraron direcciones guardadas para esta cadena.";
 "editAddress" = "Editar dirección";
-"validAddressDomainError" = "No pudimos resolver la dirección de este dominio de servicio en esta cadena.";
+"validAddressDomainError" = "Por favor, introduce una dirección válida para la cadena de bloques seleccionada.";
 "privacyPolicy" = "Política de Privacidad";
 "termsOfService" = "Términos de Servicio";
 "legal" = "Legal";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -254,7 +254,7 @@
 "findCustomTokens" = "Encuentra Tu Token Personalizado";
 "customToken" = "Token Personalizado";
 "details" = "Detalles";
-"vaultType" = "Parte del Cofre";
+"vaultType" = "Participación del Bóveda";
 "ECDSAKey" = "Clave ECDSA";
 "EdDSAKey" = "Clave EdDSA";
 "Selected" = "Seleccionado";
@@ -395,7 +395,7 @@
 "invalidAddress" = "Dirección no válida";
 "emptyAddressField" = "Campo de dirección vacío.";
 "nonNegativeFeeError" = "No hay suficiente gas para cubrir la transacción.";
-"part" = "Parte";
+"part" = "Participación";
 "devices" = "Dispositivos";
 "signers" = "Firmantes";
 "vaultPart" = "Parte del cofre";
@@ -539,7 +539,7 @@
 "FastVaultOverview1Text2" = "";
 "FastVaultOverview1Text3" = " partes, ";
 "FastVaultOverview1Text4" = "haz una copia de seguridad ahora";
-"FastVaultOverview2Text1" = "La parte 1 de las partes del vault será ";
+"FastVaultOverview2Text1" = "La participación 1 de las participaciones del bóveda será ";
 "FastVaultOverview2Text2" = "almacenada por el servidor.";
 "FastVaultOverview2Text3" = "";
 "FastVaultOverview2Text4" = "";
@@ -555,8 +555,8 @@
 "keysignDiscoveryDisclaimerDevice" = "-se requiere escanear el dispositivo.";
 "startUsingVault" = "Usar Bóveda";
 "loadingDetails" = "Cargando detalles";
-"backupPart1" = "Copia de seguridad Parte 1";
-"backupPart2" = "Copia de seguridad Parte 2";
+"backupPart1" = "Copia de Seguridad 1";
+"backupPart2" = "Copia de Seguridad 2";
 "vultiserverPassword" = "Contraseña de Vultiserver";
 "doYouWantToAddPassword" = "¿Quieres agregar una contraseña a las copias de seguridad de tu dispositivo?";
 "doYouWantToAddPasswordDescription" = "Recomendamos no establecer una contraseña de respaldo para las copias de seguridad del dispositivo: tus datos están seguros si los respaldos se almacenan en diferentes ubicaciones, lo que ya brinda una protección significativa. Recuerda, las contraseñas de respaldo no se pueden recuperar si las olvidas. ¡Tú decides!";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -345,7 +345,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", povećavajući fleksibilnost bez ugrožavanja sigurnosti.";
 "noSavedAddressesForChain" = "Nema spremljenih adresa za ovaj lanac.";
 "editAddress" = "Uredi adresu";
-"validAddressDomainError" = "Nismo mogli razrijesti adresu ovog domena usluge u ovom lancu.";
+"validAddressDomainError" = "Unesite valjanu adresu za odabrani blockchain.";
 "privacyPolicy" = "Pravila o privatnosti";
 "termsOfService" = "Uvjeti korištenja";
 "legal" = "Pravno";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -539,7 +539,7 @@
 "FastVaultOverview1Text2" = "";
 "FastVaultOverview1Text3" = " dijelova, ";
 "FastVaultOverview1Text4" = "sigurnosno ih kopirajte sada";
-"FastVaultOverview2Text1" = "Dio 1 dijelova trezora bit će ";
+"FastVaultOverview2Text1" = "Dio 1 od dijelova trezora će biti ";
 "FastVaultOverview2Text2" = "pohranjen na poslužitelju.";
 "FastVaultOverview2Text3" = "";
 "FastVaultOverview2Text4" = "";
@@ -555,8 +555,8 @@
 "keysignDiscoveryDisclaimerDevice" = "-potrebno skeniranje uređaja.";
 "startUsingVault" = "Koristi trezor";
 "loadingDetails" = "Učitavanje detalja";
-"backupPart1" = "Sigurnosna kopija Dio 1";
-"backupPart2" = "Sigurnosna kopija Dio 2";
+"backupPart1" = "Rezervna Kopija 1";
+"backupPart2" = "Rezervna Kopija 2";
 "vultiserverPassword" = "Vultiserver lozinka";
 "doYouWantToAddPassword" = "Želite li dodati lozinku za sigurnosne kopije trezora na uređaju?";
 "doYouWantToAddPasswordDescription" = "Preporučujemo da ne postavljate lozinku za sigurnosne kopije trezora uređaja – vaši podaci su sigurni ako su sigurnosne kopije pravilno pohranjene na različitim mjestima, što već pruža značajnu zaštitu. Zapamtite, lozinke za sigurnosne kopije ne mogu se vratiti ako ih zaboravite. Vaš izbor!";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -254,7 +254,7 @@
 "findCustomTokens" = "Trova Il Tuo Token Personalizzato";
 "customToken" = "Token Personalizzato";
 "details" = "Dettagli";
-"vaultType" = "Parte della Cassaforte";
+"vaultType" = "Quota della Cassaforte";
 "ECDSAKey" = "Chiave ECDSA";
 "EdDSAKey" = "Chiave EdDSA";
 "Selected" = "Selezionato";
@@ -395,7 +395,7 @@
 "invalidAddress" = "Indirizzo non valido";
 "emptyAddressField" = "Campo indirizzo vuoto.";
 "nonNegativeFeeError" = "Non abbastanza gas per coprire la transazione.";
-"part" = "Parte";
+"part" = "Quota";
 "devices" = "Dispositivi";
 "signers" = "Firmatari";
 "vaultPart" = "Parte della cassaforte";
@@ -539,7 +539,7 @@
 "FastVaultOverview1Text2" = "";
 "FastVaultOverview1Text3" = " quote, ";
 "FastVaultOverview1Text4" = "esegui il backup ora";
-"FastVaultOverview2Text1" = "La parte 1 delle quote del vault sarà ";
+"FastVaultOverview2Text1" = "La quota 1 delle quote della cassaforte sarà ";
 "FastVaultOverview2Text2" = "conservata dal server.";
 "FastVaultOverview2Text3" = "";
 "FastVaultOverview2Text4" = "";
@@ -555,8 +555,8 @@
 "keysignDiscoveryDisclaimerDevice" = "-scansione del dispositivo richiesta.";
 "startUsingVault" = "Usa il Vault";
 "loadingDetails" = "Caricamento dettagli";
-"backupPart1" = "Backup Parte 1";
-"backupPart2" = "Backup Parte 2";
+"backupPart1" = "Copia di Backup 1";
+"backupPart2" = "Copia di Backup 2";
 "vultiserverPassword" = "Password Vultiserver";
 "doYouWantToAddPassword" = "Vuoi aggiungere una password ai tuoi vault share del dispositivo?";
 "doYouWantToAddPasswordDescription" = "Ti consigliamo di non impostare una password di backup per i vault share del dispositivo: i tuoi dati sono sicuri se i backup sono archiviati in posizioni diverse, il che fornisce già una protezione significativa. Ricorda, le password di backup non possono essere recuperate se le dimentichi. A te la scelta!";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -345,7 +345,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", migliorando la flessibilità senza compromettere la sicurezza.";
 "noSavedAddressesForChain" = "Nessun indirizzo salvato trovato per questa catena.";
 "editAddress" = "Modifica indirizzo";
-"validAddressDomainError" = "Non è stato possibile risolvere l'indirizzo di questo dominio di servizio in questa catena.";
+"validAddressDomainError" = "Inserisci un indirizzo valido per la blockchain selezionata.";
 "privacyPolicy" = "Informativa sulla privacy";
 "termsOfService" = "Termini di servizio";
 "legal" = "Legale";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -346,7 +346,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", aumentando a flexibilidade sem comprometer a segurança.";
 "noSavedAddressesForChain" = "Nenhum endereço salvo encontrado para esta cadeia.";
 "editAddress" = "Editar endereço";
-"validAddressDomainError" = "Não foi possível resolver o endereço deste domínio de serviço nesta cadeia.";
+"validAddressDomainError" = "Por favor, insira um endereço válido para o blockchain selecionado.";
 "privacyPolicy" = "Política de Privacidade";
 "termsOfService" = "Termos de Serviço";
 "legal" = "Legal";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -556,8 +556,8 @@
 "keysignDiscoveryDisclaimerDevice" = "-é necessário escanear o dispositivo.";
 "startUsingVault" = "Usar Cofre";
 "loadingDetails" = "Carregando detalhes";
-"backupPart1" = "Backup Parte 1";
-"backupPart2" = "Backup Parte 2";
+"backupPart1" = "Cópia de Segurança 1";
+"backupPart2" = "Cópia de Segurança 2";
 "vultiserverPassword" = "Senha do Vultiserver";
 "doYouWantToAddPassword" = "Deseja adicionar uma senha aos seus compartilhamentos de cofre do dispositivo?";
 "doYouWantToAddPasswordDescription" = "Recomendamos que você não defina uma senha de backup para os compartilhamentos de cofre do dispositivo – seus dados estão seguros se os backups forem armazenados corretamente em locais diferentes, o que já fornece uma proteção significativa. Lembre-se de que senhas de backup não podem ser recuperadas se forem esquecidas. Sua escolha!";

--- a/VultisigApp/VultisigApp/View Models/SendCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendCryptoViewModel.swift
@@ -328,7 +328,7 @@ class SendCryptoViewModel: ObservableObject, TransferViewModel {
             errorTitle = "error"
             errorMessage = "validAddressDomainError"
             showAlert = true
-            logger.log("We were unable to resolve the address of this domain service on this chain.")
+            logger.log("Please enter a valid address for the selected blockchain.")
             isValidForm = false
             isLoading = false
             return false

--- a/VultisigApp/VultisigApp/Views/Components/Cells/FolderDetailSelectedVaultCell.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Cells/FolderDetailSelectedVaultCell.swift
@@ -91,7 +91,7 @@ struct FolderDetailSelectedVaultCell: View {
     }
     
     var partAssignedCell: some View {
-        Text("Part \(viewModel.order)of\(viewModel.totalSigners)")
+        Text("Share \(viewModel.order)of\(viewModel.totalSigners)")
             .font(.body14Menlo)
             .foregroundColor(.body)
     }

--- a/VultisigApp/VultisigApp/Views/Vault/VaultPairDetailView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultPairDetailView.swift
@@ -60,7 +60,7 @@ struct VaultPairDetailView: View {
     }
     
     private func getDeviceCell(for device: DeviceInfo) -> some View {
-        let part = "Part \(device.Index+1) of \(vault.signers.count): "
+        let part = "Share \(device.Index+1) of \(vault.signers.count): "
         let signer = device.Signer
         
         return ZStack {


### PR DESCRIPTION
"vaultType" = "Vault Part";
"part" = "Part";
"FastVaultOverview2Text1" = "Part 1 of the vault shares will be ";
"backupPart1" = "Backup Part 1";
"backupPart2" = "Backup Part 2";

They all were renamed to Share.
https://github.com/vultisig/vultisig-ios/issues/1975
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Localization Updates**
  - Updated displayed terminology across multiple languages for vault details and backup instructions. Terms previously labeled as “Part” (and related translations) are now consistently presented as “Share” (or equivalent) to enhance clarity and consistency.
  
- **User Interface**
  - Revised error messaging now prompts users to "Please enter a valid address for the selected blockchain," offering clearer guidance when an invalid address is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->