### PR TITLE
Empty notification after going back from verify view #2010

### DIFF
--- a/VultisigApp/VultisigApp/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/StringExtension.swift
@@ -128,11 +128,23 @@ extension String {
     }
     
     func isValidDecimal() -> Bool {
+        if self.isEmpty {
+            return false
+        }
+        
+        let currentLocale = Locale.current
+        let localeDecimalSeparator = currentLocale.decimalSeparator ?? "."
+        
+        var normalizedString = self
+        if localeDecimalSeparator != "." && self.contains(".") && !self.contains(localeDecimalSeparator) {
+            normalizedString = self.replacingOccurrences(of: ".", with: localeDecimalSeparator)
+        }
+        
         let formatter = NumberFormatter()
-        formatter.locale = Locale.current
+        formatter.locale = currentLocale
         formatter.numberStyle = .decimal
         
-        return formatter.number(from: self) != nil
+        return formatter.number(from: normalizedString) != nil
     }
 
     var isValidEmail: Bool {


### PR DESCRIPTION
[BUG] Empty notification after going back from verify view #2010


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced decimal number validation to immediately reject empty inputs.
	- Improved handling of locale-specific decimal separators to ensure accurate number formatting and conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->