### PR TITLE
Back button added to PasswordBackupOptionsView for Mac

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/PasswordBackupOptionsView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/PasswordBackupOptionsView.swift
@@ -36,15 +36,6 @@ struct PasswordBackupOptionsView: View {
         }
     }
     
-    var content: some View {
-        VStack(spacing: 36) {
-            icon
-            textContent
-            buttons
-        }
-        .padding(24)
-    }
-    
     var icon: some View {
         Image(systemName: "person.badge.key")
             .font(.body28BrockmannMedium)

--- a/VultisigApp/VultisigApp/iOS/View/PasswordBackupOptionsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PasswordBackupOptionsView+iOS.swift
@@ -9,6 +9,15 @@
 import SwiftUI
 
 extension PasswordBackupOptionsView {
+    var content: some View {
+        VStack(spacing: 36) {
+            icon
+            textContent
+            buttons
+        }
+        .padding(24)
+    }
+    
     var withoutPasswordButton: some View {
         Button {
             showSkipShareSheet = true

--- a/VultisigApp/VultisigApp/macOS/View/PasswordBackupOptionsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/PasswordBackupOptionsView+macOS.swift
@@ -9,6 +9,26 @@
 import SwiftUI
 
 extension PasswordBackupOptionsView {
+    var content: some View {
+        VStack(spacing: 36) {
+            header
+            Spacer()
+            
+            VStack(spacing: 36) {
+                icon
+                textContent
+                buttons
+            }
+            .padding(24)
+            
+            Spacer()
+        }
+    }
+    
+    var header: some View {
+        GeneralMacHeader(title: "")
+    }
+    
     var withoutPasswordButton: some View {
         Button {
             showSkipShareSheet = true


### PR DESCRIPTION
Back button added to PasswordBackupOptionsView for Mac, Fixes #2019

**Screenshot**
<img width="1064" alt="Screenshot 2025-03-31 at 11 34 19 PM" src="https://github.com/user-attachments/assets/4705d4f3-35db-4eb4-ac04-877ceeb494d1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Password Backup Options screen for a cleaner, more organized appearance on both iOS and macOS.
  - The layout now features improved spacing and structure, offering a more modern and consistent user interface.
  - On macOS, a new header has been introduced to enhance visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->