### PR TITLE
[UPDATE] Copy text on fast vault signing

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -259,7 +259,7 @@
 "reviewConditionsMessage" = "Bitte überprüfe und stimme allen aufgeführten Bedingungen zu.";
 "function" = "Funktion";
 "enterPassword" = "Passwort eingeben";
-"fastVaultEnterDisclaimer" = "Dieses Passwort entschlüsselt Ihren Tresor.";
+"fastVaultEnterDisclaimer" = "Dieses Passwort entschlüsselt deinen Tresor zum Signieren.";
 "fastVaultSetDisclaimer" = "Dieses Passwort verschlüsselt dein FastSign Share";
 "passwordProtectBackup" = "Sichern Sie Ihre Sicherung mit einem Passwort";
 "errorSavingFile" = "Fehler beim Speichern der Datei";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -263,7 +263,7 @@
 "reviewConditionsMessage" = "Kindly review and agree to all the listed conditions.";
 "function" = "Function";
 "enterPassword" = "Enter Password";
-"fastVaultEnterDisclaimer" = "This password decrypts your vault.";
+"fastVaultEnterDisclaimer" = "This password decrypts your Vault for signing.";
 "passwordProtectBackup" = "Password protect your backup";
 "errorSavingFile" = "Error saving file";
 "invalidVaultData" = "Invalid vault data";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "reviewConditionsMessage" = "Por favor, revise y acepte todas las condiciones listadas.";
 "function" = "función";
 "enterPassword" = "Introduce la contraseña";
-"fastVaultEnterDisclaimer" = "Esta contraseña descifra tu bóveda.";
+"fastVaultEnterDisclaimer" = "Esta contraseña descifra tu Bóveda para firmar.";
 "fastVaultSetDisclaimer" = "Esta contraseña encripta su FastSign Share";
 "passwordProtectBackup" = "Protege tu copia de seguridad con una contraseña";
 "errorSavingFile" = "Error al guardar el archivo";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "reviewConditionsMessage" = "Molimo pregledajte i prihvatite sve navedene uvjete.";
 "function" = "funkcija";
 "enterPassword" = "Unesite lozinku";
-"fastVaultEnterDisclaimer" = "Ova lozinka dešifrira vaš trezor.";
+"fastVaultEnterDisclaimer" = "Ova lozinka dešifrira tvoj trezor za potpisivanje.";
 "fastVaultSetDisclaimer" = "Ova lozinka šifrira vaš FastSign Share";
 "passwordProtectBackup" = "Zaštitite svoju sigurnosnu kopiju lozinkom";
 "errorSavingFile" = "Pogreška pri spremanju datoteke";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "reviewConditionsMessage" = "Si prega di rivedere e accettare tutte le condizioni elencate.";
 "function" = "funzione";
 "enterPassword" = "Inserisci la password";
-"fastVaultEnterDisclaimer" = "Questa password decifra il tuo caveau.";
+"fastVaultEnterDisclaimer" = "Questa password decritta il tuo Vault per la firma.";
 "fastVaultSetDisclaimer" = "Questa password crittografa la tua condivisione FastSign";
 "passwordProtectBackup" = "Proteggi il tuo backup con una password";
 "errorSavingFile" = "Errore nel salvataggio del file";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -242,7 +242,7 @@
 "reviewConditionsMessage" = "Por favor, reveja e concorde com todas as condições listadas.";
 "function" = "função";
 "enterPassword" = "Digite a senha";
-"fastVaultEnterDisclaimer" = "Esta senha descriptografa seu cofre.";
+"fastVaultEnterDisclaimer" = "Esta senha descriptografa seu Cofre para assinatura.";
 "fastVaultSetDisclaimer" = "Esta palavra-passe encripta o seu FastSign Share";
 "passwordProtectBackup" = "Proteja seu backup com uma senha";
 "errorSavingFile" = "Erro ao salvar o arquivo";


### PR DESCRIPTION
https://github.com/vultisig/vultisig-ios/issues/1982

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised user-facing password disclaimer messages in multiple languages to clarify that the password now decrypts the vault for signing. These updates also adjust the tone from formal to more informal, enhancing clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->