### PR TITLE
Back link added from ServerBackupVerificationView to EmailSetupView

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/FastVaultEmailView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/FastVaultEmailView.swift
@@ -13,6 +13,7 @@ struct FastVaultEmailView: View {
     let selectedTab: SetupVaultState
 
     var fastVaultExist: Bool = false
+    var backButtonHidden: Bool = false
 
     @State var email: String = ""
     @State var isLinkActive = false

--- a/VultisigApp/VultisigApp/Views/Keygen/ServerBackupVerificationView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/ServerBackupVerificationView.swift
@@ -15,13 +15,13 @@ struct ServerBackupVerificationView: View {
 
     @Binding var isPresented: Bool
     @Binding var tabIndex: Int
+    @Binding var goBackToEmailSetup: Bool
 
     @FocusState private var focusedField: Int?
 
     @State var otp: [String] = Array(repeating: "", count: codeLength)
 
     @State var isLoading: Bool = false
-    @State var isCancelLinkActive: Bool = false
 
     @State var alertDescription = "verificationCodeTryAgain"
     @State var showAlert: Bool = false
@@ -50,9 +50,6 @@ struct ServerBackupVerificationView: View {
             cancelButton
         }
         .animation(.easeInOut, value: showAlert)
-        .navigationDestination(isPresented: $isCancelLinkActive) {
-            HomeView()
-        }
         .onDisappear {
             animationVM?.stop()
         }
@@ -214,6 +211,7 @@ struct ServerBackupVerificationView: View {
             try modelContext.save()
             isLoading = false
             isPresented = false
+            goBackToEmailSetup = true
         } catch {
             print("Error: \(error)")
         }
@@ -225,6 +223,7 @@ struct ServerBackupVerificationView: View {
         vault: Vault.example,
         email: "mail@email.com",
         isPresented: .constant(false),
-        tabIndex: .constant(2)
+        tabIndex: .constant(2),
+        goBackToEmailSetup: .constant(false)
     )
 }

--- a/VultisigApp/VultisigApp/Views/Vault/FastBackupVaultOverview.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/FastBackupVaultOverview.swift
@@ -18,6 +18,7 @@ struct FastBackupVaultOverview: View {
     @State var tabIndex = 0
     @State var isVerificationLinkActive = false
     @State var isBackupLinkActive = false
+    @State var goBackToEmailSetup = false
     
     @State var animationVM: RiveViewModel? = nil
     @State var backupVaultAnimationVM: RiveViewModel? = nil
@@ -33,12 +34,22 @@ struct FastBackupVaultOverview: View {
                 vault: vault,
                 email: email,
                 isPresented: $isVerificationLinkActive,
-                tabIndex: $tabIndex
+                tabIndex: $tabIndex,
+                goBackToEmailSetup: $goBackToEmailSetup
             )
         }
         .navigationDestination(isPresented: $isBackupLinkActive) {
             BackupSetupView(vault: vault, isNewVault: true)
         }
+        .navigationDestination(isPresented: $goBackToEmailSetup, destination: { 
+            FastVaultEmailView(
+                tssType: .Keygen,
+                vault: vault,
+                selectedTab: .fast,
+                backButtonHidden: true,
+                email: email
+            )
+        })
         .onAppear {
             setData()
         }

--- a/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultEmailView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultEmailView+iOS.swift
@@ -14,6 +14,7 @@ extension FastVaultEmailView {
             Background()
             main
         }
+        .navigationBarBackButtonHidden(backButtonHidden)
         .navigationTitle(NSLocalizedString("", comment: ""))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/VultisigApp/VultisigApp/macOS/View/FastVaultEmailView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/FastVaultEmailView+macOS.swift
@@ -27,7 +27,7 @@ extension FastVaultEmailView {
     }
 
     var headerMac: some View {
-        GeneralMacHeader(title: "")
+        GeneralMacHeader(title: "", showActions: !backButtonHidden)
     }
     
     var view: some View {


### PR DESCRIPTION
Return to email change link added to fast vault verification view, Fixes #1996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the email view with improved navigation controls, including the ability to hide or show the back button.
  - Streamlined navigation during backup and verification processes, allowing a smoother transition back to the email setup.
  - Updated the header presentation on macOS to dynamically display action buttons based on the current navigation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->