### PR TITLE
Migrate error state added

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
@@ -75,7 +75,11 @@ struct KeygenView: View {
                 .opacity(tssType == .Migrate ? 0 : 1)
             
             if tssType == .Migrate {
-                migrateView
+                if viewModel.status == .KeygenFailed {
+                    migrationFailedText
+                } else {
+                    migrateView
+                }
             }
         }
     }
@@ -161,6 +165,25 @@ struct KeygenView: View {
         }
     }
     
+    var migrationFailedText: some View {
+        VStack(spacing: 32) {
+            Spacer()
+            ErrorMessage(text: viewModel.keygenError)
+            Spacer()
+            appVersion
+            migrateRetryButton
+        }
+        .padding(32)
+    }
+    
+    var migrateRetryButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            FilledButton(title: "retry")
+        }
+    }
+    
     var doneText: some View {
         VStack(spacing: 18) {
             vaultCreatedAnimationVM?.view()
@@ -202,6 +225,7 @@ struct KeygenView: View {
             showProgressRing = false
         }
     }
+    
     var migrateFailedText: some View {
         VStack(spacing: 18) {
             Text(NSLocalizedString("migrationFailed", comment: "migration failed"))


### PR DESCRIPTION
Migrate error state added to replace blank view, Fixes #2060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new error message and retry button specifically for migration failures during key generation. The error message displays details and app version, and the retry button allows users to dismiss the error view.
- **Improvements**
  - Enhanced the migration flow by conditionally showing the new error message and retry option only when a migration-related key generation failure occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->