### PR TITLE
strip "ethereum:" prefix on metamask address

### DIFF
--- a/VultisigApp/VultisigApp/Utils/Utils.swift
+++ b/VultisigApp/VultisigApp/Utils/Utils.swift
@@ -471,7 +471,7 @@ enum Utils {
             if let cgImage = context.createCGImage(outputImage, from: outputImage.extent) {
                 return Image(uiImage: UIImage(cgImage: cgImage))
                     .interpolation(.none)
-
+                
             }
         }
         
@@ -490,12 +490,12 @@ enum Utils {
                 "inputColor0": CIColor(color: tintColor) ?? .black,
                 "inputColor1": CIColor(color: backgroundColor) ?? .white
             ])
-            .transformed(by: transform) {
-                if let cgImage = context.createCGImage(outputImage, from: outputImage.extent) {
-                    return Image(nsImage: NSImage(cgImage: cgImage, size: CGSize(width: 1024, height: 1024)))
-                        .interpolation(.none)
-                }
+                .transformed(by: transform) {
+            if let cgImage = context.createCGImage(outputImage, from: outputImage.extent) {
+                return Image(nsImage: NSImage(cgImage: cgImage, size: CGSize(width: 1024, height: 1024)))
+                    .interpolation(.none)
             }
+        }
         
         let image = NSImage(systemSymbolName: "xmark.circle", accessibilityDescription: nil) ?? NSImage()
         return Image(nsImage: image)
@@ -518,7 +518,7 @@ enum Utils {
         }
         return Data()
     }
-
+    
     public static func detectQRCode(_ image: UIImage?) -> [String] {
         var detectedStrings = [String]()
         guard let image = image, let ciImage = CIImage(image: image) else { return detectedStrings }
@@ -582,11 +582,11 @@ enum Utils {
         
         return detectedStrings
     }
-
+    
     public static func getUniqueIdentifier() -> String {
         let userDefaults = UserDefaults.standard
         let uuidKey = "com.vultisig.wallet"
-
+        
         // Check if a UUID already exists in UserDefaults
         if let uuid = userDefaults.string(forKey: uuidKey) {
             return uuid
@@ -614,7 +614,7 @@ enum Utils {
 #if os(iOS)
             if let imageData = try? Data(contentsOf: url), let selectedImage = UIImage(data: imageData) {
                 let qrStrings = Utils.detectQRCode(selectedImage)
-            
+                
                 if qrStrings.isEmpty {
                     print("No QR codes detected.")
                     throw UtilsQrCodeFromImageError.NoQRCodesDetected
@@ -630,7 +630,7 @@ enum Utils {
 #elseif os(macOS)
             if let imageData = try? Data(contentsOf: url), let selectedImage = NSImage(data: imageData) {
                 let qrStrings = Utils.detectQRCode(selectedImage)
-            
+                
                 if qrStrings.isEmpty {
                     print("No QR codes detected.")
                     throw UtilsQrCodeFromImageError.NoQRCodesDetected
@@ -668,5 +668,14 @@ enum Utils {
 #elseif os(macOS)
         return Host.current().localizedName ?? "Mac"
 #endif
+    }
+    
+    public static func sanitizeAddress(address: String) -> String {
+        let sanitizedAddress = address
+        if sanitizedAddress.hasPrefix("ethereum:") {
+            return String(sanitizedAddress.dropFirst(9))
+        }
+        
+        return sanitizedAddress
     }
 }

--- a/VultisigApp/VultisigApp/View Models/DeeplinkViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/DeeplinkViewModel.swift
@@ -32,7 +32,7 @@ class DeeplinkViewModel: ObservableObject {
         let queryItems = URLComponents(string: url.absoluteString)?.queryItems
         
         if queryItems == nil {
-            address = sanitizeAddress(address: url.absoluteString)
+            address = Utils.sanitizeAddress(address: url.absoluteString)
         }
         
         //Flow Type
@@ -51,14 +51,7 @@ class DeeplinkViewModel: ObservableObject {
         jsonData = queryItems?.first(where: { $0.name == "jsonData" })?.value
     }
     
-    private func sanitizeAddress(address: String) -> String {
-        let sanitizedAddress = address
-        if sanitizedAddress.hasPrefix("ethereum:") {
-            return String(sanitizedAddress.dropFirst(9))
-        }
-        
-        return sanitizedAddress
-    }
+    
     
     static func getJsonData(_ url: URL?) -> String? {
         guard let url else {
@@ -68,16 +61,16 @@ class DeeplinkViewModel: ObservableObject {
         let queryItems = URLComponents(string: url.absoluteString)?.queryItems
         return queryItems?.first(where: { $0.name == "jsonData" })?.value
     }
-
+    
     static func getTssType(_ url: URL?) -> String? {
         guard let url else {
             return nil
         }
-
+        
         let queryItems = URLComponents(string: url.absoluteString)?.queryItems
         return queryItems?.first(where: { $0.name == "tssType" })?.value
     }
-
+    
     func resetData() {
         type = nil
         selectedVault = nil

--- a/VultisigApp/VultisigApp/View Models/DeeplinkViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/DeeplinkViewModel.swift
@@ -32,7 +32,7 @@ class DeeplinkViewModel: ObservableObject {
         let queryItems = URLComponents(string: url.absoluteString)?.queryItems
         
         if queryItems == nil {
-            address = url.absoluteString
+            address = sanitizeAddress(address: url.absoluteString)
         }
         
         //Flow Type
@@ -49,6 +49,15 @@ class DeeplinkViewModel: ObservableObject {
         
         //JsonData
         jsonData = queryItems?.first(where: { $0.name == "jsonData" })?.value
+    }
+    
+    private func sanitizeAddress(address: String) -> String {
+        let sanitizedAddress = address
+        if sanitizedAddress.hasPrefix("ethereum:") {
+            return String(sanitizedAddress.dropFirst(9))
+        }
+        
+        return sanitizedAddress
     }
     
     static func getJsonData(_ url: URL?) -> String? {

--- a/VultisigApp/VultisigApp/iOS/Components/AddressBookTextField+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/Components/AddressBookTextField+iOS.swift
@@ -50,13 +50,13 @@ extension AddressBookTextField {
     var field: some View {
         HStack(spacing: 0) {
             TextField(NSLocalizedString("typeHere", comment: "").capitalized, text: $text)
-            .foregroundColor(.neutral0)
-            .submitLabel(.next)
-            .disableAutocorrection(true)
-            .borderlessTextFieldStyle()
-            .keyboardType(.default)
-            .textInputAutocapitalization(.never)
-            .textContentType(.oneTimeCode)
+                .foregroundColor(.neutral0)
+                .submitLabel(.next)
+                .disableAutocorrection(true)
+                .borderlessTextFieldStyle()
+                .keyboardType(.default)
+                .textInputAutocapitalization(.never)
+                .textContentType(.oneTimeCode)
         }
     }
     
@@ -67,7 +67,7 @@ extension AddressBookTextField {
     func handleScan(result: Result<ScanResult, ScanError>) {
         switch result {
         case .success(let result):
-            text = result.string
+            text = Utils.sanitizeAddress(address: result.string)
             showScanner = false
         case .failure(let err):
             print("fail to scan QR code,error:\(err.localizedDescription)")

--- a/VultisigApp/VultisigApp/iOS/Native/GeneralCodeScannerView.swift
+++ b/VultisigApp/VultisigApp/iOS/Native/GeneralCodeScannerView.swift
@@ -106,6 +106,7 @@ struct GeneralCodeScannerView: View {
     var backButton: some View {
         Button {
             showSheet = false
+            print("back clicked")
         } label: {
             getIcon(for: "xmark")
         }
@@ -128,7 +129,7 @@ struct GeneralCodeScannerView: View {
                 isGalleryPresented: $isGalleryPresented,
                 videoCaptureDevice: AVCaptureDevice.zoomedCameraForQRCode(withMinimumCodeSize: 100),
                 completion: handleScan
-            )
+            ).allowsHitTesting(false)
             
             overlay
         }

--- a/VultisigApp/VultisigApp/iOS/Native/GeneralCodeScannerView.swift
+++ b/VultisigApp/VultisigApp/iOS/Native/GeneralCodeScannerView.swift
@@ -106,7 +106,6 @@ struct GeneralCodeScannerView: View {
     var backButton: some View {
         Button {
             showSheet = false
-            print("back clicked")
         } label: {
             getIcon(for: "xmark")
         }


### PR DESCRIPTION
fixes #2075 #2076 #2080

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Ethereum addresses from deeplinks by automatically removing the "ethereum:" prefix when present.
  - Disabled user interaction with the code scanner view to prevent unintended actions during scanning.
  - Sanitized scanned addresses before displaying them in the address book input field for better data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->