### PR TITLE
Use ThreadSafeDictionary to cache inbound address and network info

### DIFF
--- a/VultisigApp/VultisigApp/Services/Thorchain/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Services/Thorchain/ThorchainService.swift
@@ -11,8 +11,8 @@ class ThorchainService: ThorchainSwapProvider {
     var network: String = ""
     static let shared = ThorchainService()
     
-    private var cacheFeePrice: [String: (data: ThorchainNetworkInfo, timestamp: Date)] = [:]
-    private var cacheInboundAddresses: [String: (data: [InboundAddress], timestamp: Date)] = [:]
+    private var cacheFeePrice = ThreadSafeDictionary<String,(data: ThorchainNetworkInfo, timestamp: Date)>()
+    private var cacheInboundAddresses = ThreadSafeDictionary<String,(data: [InboundAddress], timestamp: Date)>()
     
     private init() {}
     
@@ -157,7 +157,7 @@ class ThorchainService: ThorchainSwapProvider {
         let urlString = Endpoint.fetchThorchainNetworkInfoNineRealms
         let data = try await Utils.asyncGetRequest(urlString: urlString, headers: [:])
         let thorchainNetworkInfo = try JSONDecoder().decode(ThorchainNetworkInfo.self, from: data)
-        self.cacheFeePrice[cacheKey] = (data: thorchainNetworkInfo, timestamp: Date())
+        self.cacheFeePrice.set(cacheKey,(data: thorchainNetworkInfo, timestamp: Date()))
         return UInt64(thorchainNetworkInfo.native_tx_fee_rune) ?? 0
     }
     
@@ -176,7 +176,7 @@ class ThorchainService: ThorchainSwapProvider {
             let urlString = Endpoint.fetchThorchainInboundAddressesNineRealms
             let data = try await Utils.asyncGetRequest(urlString: urlString, headers: [:])
             let inboundAddresses = try JSONDecoder().decode([InboundAddress].self, from: data)
-            self.cacheInboundAddresses[cacheKey] = (data: inboundAddresses, timestamp: Date())
+            self.cacheInboundAddresses.set(cacheKey,(data: inboundAddresses, timestamp: Date()))
             return inboundAddresses
         } catch {
             print("JSON decoding error: \(error.localizedDescription)")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal caching mechanism for Thorchain network information and inbound addresses to enhance reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->