### PR TITLE
allow zero to unbond all

### DIFF
--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnbond.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnbond.swift
@@ -18,7 +18,7 @@ class TransactionMemoUnbond: TransactionMemoAddressable, ObservableObject {
     
     // Internal
     @Published var nodeAddressValid: Bool = false
-    @Published var amountValid: Bool = false
+    @Published var amountValid: Bool = true // if ZERO it will unbond all.
     @Published var providerValid: Bool = true
     
     private var cancellables = Set<AnyCancellable>()
@@ -108,8 +108,8 @@ class TransactionMemoUnbond: TransactionMemoAddressable, ObservableObject {
                 ),
                 format: .number,
                 isValid: Binding(
-                    get: { self.amountValid },
-                    set: { self.amountValid = $0 }
+                    get: { true },
+                    set: { _ in }
                 )
             )
 


### PR DESCRIPTION
It allows to set the amount as zero, so you can unbond everything at once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the unbond amount input field to always appear valid, regardless of user input. The amount is now always accepted, including zero, which represents unbonding all.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->