### PR TITLE
Bug chain search search works only by network name 2104

### DIFF
--- a/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnbond.swift
+++ b/VultisigApp/VultisigApp/Model/TransactionMemo/TransactionMemoUnbond.swift
@@ -18,7 +18,7 @@ class TransactionMemoUnbond: TransactionMemoAddressable, ObservableObject {
     
     // Internal
     @Published var nodeAddressValid: Bool = false
-    @Published var amountValid: Bool = false
+    @Published var amountValid: Bool = true // if ZERO it will unbond all.
     @Published var providerValid: Bool = true
     
     private var cancellables = Set<AnyCancellable>()
@@ -108,8 +108,8 @@ class TransactionMemoUnbond: TransactionMemoAddressable, ObservableObject {
                 ),
                 format: .number,
                 isValid: Binding(
-                    get: { self.amountValid },
-                    set: { self.amountValid = $0 }
+                    get: { true },
+                    set: { _ in }
                 )
             )
 

--- a/VultisigApp/VultisigApp/View Models/CoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/CoinSelectionViewModel.swift
@@ -16,11 +16,17 @@ class CoinSelectionViewModel: ObservableObject {
     @Published var selection = Set<CoinMeta>()
 
     var filteredChains: [String] {
-        return searchText.isEmpty 
-            ? groupedAssets.keys.sorted()
-            : groupedAssets.keys
-                .filter { $0.lowercased().contains(searchText.lowercased()) }
+        if searchText.isEmpty {
+            return groupedAssets.keys.sorted()
+        } else {
+            return groupedAssets
+                .filter { (chain, tokens) in
+                    chain.lowercased().contains(searchText.lowercased()) ||
+                    tokens.contains { $0.ticker.lowercased().contains(searchText.lowercased()) }
+                }
+                .map { $0.key }
                 .sorted()
+        }
     }
 
     let actionResolver = CoinActionResolver()


### PR DESCRIPTION
This fixes the issue https://github.com/vultisig/vultisig-ios/issues/2104

By token
<img width="459" alt="image" src="https://github.com/user-attachments/assets/4bb1c55e-0601-4bcb-b081-d18d91592b9c" />

By chain name
<img width="465" alt="image" src="https://github.com/user-attachments/assets/7b255bb1-b6c7-4e31-94b7-81fb23787f8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced coin selection search to include both chain names and token tickers, making it easier to find chains and tokens.
- **Bug Fixes**
  - Disabled validation state tracking for the unbond amount input, ensuring smoother user experience when unbonding all tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->