### PR TITLE
Amount format fix

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/Send/SendCryptoDoneSummary.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendCryptoDoneSummary.swift
@@ -150,7 +150,7 @@ struct SendCryptoDoneSummary: View {
     }
     
     private func getSendAmount(for tx: SendTransaction) -> String {
-        tx.amount.formatCurrencyWithSeparators() + " " + tx.coin.ticker
+        tx.amount.formatToDecimal(digits: 8) + " " + tx.coin.ticker
     }
     
     private func getSendFiatAmount(for tx: SendTransaction) -> String {


### PR DESCRIPTION
Asset amount decimal place on send view fixed, Fixes #2040

**Screenshot**
![Simulator Screenshot - iPhone 15 Pro - 2025-04-25 at 02 37 22](https://github.com/user-attachments/assets/b3d5c765-2640-4967-9942-097e550adae7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the display format of cryptocurrency amounts to show up to 8 decimal places for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->