### PR TITLE
Mac os swap popup

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -203,6 +203,8 @@
 		A61BC81B2BA26D9900484689 /* ChainSelectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61BC81A2BA26D9900484689 /* ChainSelectionCell.swift */; };
 		A62268FE2DC0005800F378E0 /* SwapChainPickerView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62268FD2DC0005800F378E0 /* SwapChainPickerView+iOS.swift */; };
 		A62269002DC0007300F378E0 /* SwapChainPickerView+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62268FF2DC0007300F378E0 /* SwapChainPickerView+macOS.swift */; };
+		A62269022DC000E400F378E0 /* SwapCoinPickerView+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62269012DC000E400F378E0 /* SwapCoinPickerView+macOS.swift */; };
+		A62269042DC000F200F378E0 /* SwapCoinPickerView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62269032DC000F200F378E0 /* SwapCoinPickerView+iOS.swift */; };
 		A622C8322C9BB26F00908332 /* VultisigApp+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A622C8312C9BB26F00908332 /* VultisigApp+iOS.swift */; };
 		A622C8342C9BB28000908332 /* VultisigApp+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A622C8332C9BB28000908332 /* VultisigApp+macOS.swift */; };
 		A622C8362C9BB76A00908332 /* CoinPickerView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A622C8352C9BB76A00908332 /* CoinPickerView+iOS.swift */; };
@@ -1085,6 +1087,8 @@
 		A61BC81A2BA26D9900484689 /* ChainSelectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainSelectionCell.swift; sourceTree = "<group>"; };
 		A62268FD2DC0005800F378E0 /* SwapChainPickerView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwapChainPickerView+iOS.swift"; sourceTree = "<group>"; };
 		A62268FF2DC0007300F378E0 /* SwapChainPickerView+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwapChainPickerView+macOS.swift"; sourceTree = "<group>"; };
+		A62269012DC000E400F378E0 /* SwapCoinPickerView+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwapCoinPickerView+macOS.swift"; sourceTree = "<group>"; };
+		A62269032DC000F200F378E0 /* SwapCoinPickerView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwapCoinPickerView+iOS.swift"; sourceTree = "<group>"; };
 		A622C8312C9BB26F00908332 /* VultisigApp+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VultisigApp+iOS.swift"; sourceTree = "<group>"; };
 		A622C8332C9BB28000908332 /* VultisigApp+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VultisigApp+macOS.swift"; sourceTree = "<group>"; };
 		A622C8352C9BB76A00908332 /* CoinPickerView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoinPickerView+iOS.swift"; sourceTree = "<group>"; };
@@ -2906,6 +2910,7 @@
 				A6505AFA2CA67A880002FBF4 /* Send */,
 				A6505AF92CA67A7D0002FBF4 /* Settings */,
 				A6505AF82CA67A720002FBF4 /* Onboarding */,
+				A62269032DC000F200F378E0 /* SwapCoinPickerView+iOS.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2965,6 +2970,7 @@
 				A6BB9BD42DA9EAA20085E117 /* UpgradeYourVaultView+macOS.swift */,
 				A601D3A82DB9F087004B6A0A /* JoinSwapDoneSummary+macOS.swift */,
 				A62268FF2DC0007300F378E0 /* SwapChainPickerView+macOS.swift */,
+				A62269012DC000E400F378E0 /* SwapCoinPickerView+macOS.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -4008,6 +4014,7 @@
 				A69FBBC82C8BB76000A4B78B /* CoverView+macOS.swift in Sources */,
 				A6C6711D2CA3BADA00F59B6A /* CachedAsyncImage+macOS.swift in Sources */,
 				DE1572AC2B7174D3009BC7C5 /* Utils.swift in Sources */,
+				A62269042DC000F200F378E0 /* SwapCoinPickerView+iOS.swift in Sources */,
 				A6C670EF2CA26F6400F59B6A /* SettingsView+macOS.swift in Sources */,
 				46B60BC02BBB20130043EBBA /* RpcEvmService.swift in Sources */,
 				A6F7B6E72D4B07B500AC8104 /* KeygenProgressBar.swift in Sources */,
@@ -4294,6 +4301,7 @@
 				A675305E2CAFB2CE00B1E344 /* FolderVaultCell.swift in Sources */,
 				A6505AF72CA678B30002FBF4 /* OnDropQRUtils.swift in Sources */,
 				A61BC8122BA2407A00484689 /* SendCryptoView.swift in Sources */,
+				A62269022DC000E400F378E0 /* SwapCoinPickerView+macOS.swift in Sources */,
 				DED05FE42BBB824D00E0496C /* ThorchainAccountValue.swift in Sources */,
 				A6386DA42C90236100DDD58E /* CoinSelectionCell+macOS.swift in Sources */,
 				A60CA7E52BB0D37D00FDEB5C /* ContentView.swift in Sources */,

--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -201,6 +201,8 @@
 		A61BC8162BA256C600484689 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61BC8152BA256C600484689 /* ProgressBar.swift */; };
 		A61BC8192BA2687E00484689 /* TokensStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61BC8182BA2687D00484689 /* TokensStore.swift */; };
 		A61BC81B2BA26D9900484689 /* ChainSelectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61BC81A2BA26D9900484689 /* ChainSelectionCell.swift */; };
+		A62268FE2DC0005800F378E0 /* SwapChainPickerView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62268FD2DC0005800F378E0 /* SwapChainPickerView+iOS.swift */; };
+		A62269002DC0007300F378E0 /* SwapChainPickerView+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62268FF2DC0007300F378E0 /* SwapChainPickerView+macOS.swift */; };
 		A622C8322C9BB26F00908332 /* VultisigApp+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A622C8312C9BB26F00908332 /* VultisigApp+iOS.swift */; };
 		A622C8342C9BB28000908332 /* VultisigApp+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A622C8332C9BB28000908332 /* VultisigApp+macOS.swift */; };
 		A622C8362C9BB76A00908332 /* CoinPickerView+iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A622C8352C9BB76A00908332 /* CoinPickerView+iOS.swift */; };
@@ -1081,6 +1083,8 @@
 		A61BC8152BA256C600484689 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		A61BC8182BA2687D00484689 /* TokensStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokensStore.swift; sourceTree = "<group>"; };
 		A61BC81A2BA26D9900484689 /* ChainSelectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChainSelectionCell.swift; sourceTree = "<group>"; };
+		A62268FD2DC0005800F378E0 /* SwapChainPickerView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwapChainPickerView+iOS.swift"; sourceTree = "<group>"; };
+		A62268FF2DC0007300F378E0 /* SwapChainPickerView+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwapChainPickerView+macOS.swift"; sourceTree = "<group>"; };
 		A622C8312C9BB26F00908332 /* VultisigApp+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VultisigApp+iOS.swift"; sourceTree = "<group>"; };
 		A622C8332C9BB28000908332 /* VultisigApp+macOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VultisigApp+macOS.swift"; sourceTree = "<group>"; };
 		A622C8352C9BB76A00908332 /* CoinPickerView+iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoinPickerView+iOS.swift"; sourceTree = "<group>"; };
@@ -2892,6 +2896,7 @@
 				A6BB9BD02DA9E56A0085E117 /* VaultShareBackupsView+iOS.swift */,
 				A6BB9BD62DA9EAB10085E117 /* UpgradeYourVaultView+iOS.swift */,
 				A601D3A62DB9F078004B6A0A /* JoinSwapDoneSummary+iOS.swift */,
+				A62268FD2DC0005800F378E0 /* SwapChainPickerView+iOS.swift */,
 				A6505B002CA67B560002FBF4 /* Keygen */,
 				A6505AFF2CA67B4F0002FBF4 /* Keysign */,
 				A6505AFD2CA67ADE0002FBF4 /* Transaction */,
@@ -2959,6 +2964,7 @@
 				A6BB9BCC2DA9E1D60085E117 /* AllDevicesUpgradeView+macOS.swift */,
 				A6BB9BD42DA9EAA20085E117 /* UpgradeYourVaultView+macOS.swift */,
 				A601D3A82DB9F087004B6A0A /* JoinSwapDoneSummary+macOS.swift */,
+				A62268FF2DC0007300F378E0 /* SwapChainPickerView+macOS.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -3843,6 +3849,7 @@
 				A633B13A2B9A5A22003D1738 /* ImportWalletView.swift in Sources */,
 				A6386D942C8C2A9800DDD58E /* SwapCryptoDetailsView+iOS.swift in Sources */,
 				DE63AE4B2BB4D87F001BBE5C /* BscService.swift in Sources */,
+				A62269002DC0007300F378E0 /* SwapChainPickerView+macOS.swift in Sources */,
 				A6F42CC22C09175B00D0431C /* GeneralCodeScannerView.swift in Sources */,
 				A6386D9A2C901DAA00DDD58E /* SendCryptoVerifyView+macOS.swift in Sources */,
 				A6182F4D2C92944A0059BFDD /* SendCryptoAmountTextField+macOS.swift in Sources */,
@@ -3863,6 +3870,7 @@
 				A6505AD02CA668AF0002FBF4 /* InformationNote+iOS.swift in Sources */,
 				A571F46C2C7E9218000F46D3 /* SendGasSettingsView.swift in Sources */,
 				DE9EB0F02BA2CFB7001747D9 /* ReshareMessage.swift in Sources */,
+				A62268FE2DC0005800F378E0 /* SwapChainPickerView+iOS.swift in Sources */,
 				A69069B52BCF538000F28A8B /* NetworkPrompts.swift in Sources */,
 				A6BB9BCD2DA9E1D60085E117 /* AllDevicesUpgradeView+macOS.swift in Sources */,
 				A6C556F22CE59A3F00E5E44E /* BackupNowDisclaimer+macOS.swift in Sources */,

--- a/VultisigApp/VultisigApp/Views/Swap/SwapChainPickerView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapChainPickerView.swift
@@ -30,10 +30,6 @@ struct SwapChainPickerView: View {
             : chainsArray
             .filter { $0.name.lowercased().contains(searchText.lowercased()) }
     }
-
-    var body: some View {
-        content
-    }
     
     var content: some View {
         ZStack {

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCoinPickerView.swift
@@ -17,18 +17,6 @@ struct SwapCoinPickerView: View {
     @State var searchText = ""
     @State var showChainPickerSheet: Bool = false
     @EnvironmentObject var viewModel: CoinSelectionViewModel
-
-    var body: some View {
-        content
-            .sheet(isPresented: $showChainPickerSheet, content: {
-                SwapChainPickerView(
-                    vault: vault,
-                    showSheet: $showChainPickerSheet,
-                    selectedChain: $selectedChain,
-                    selectedCoin: $selectedCoin
-                )
-            })
-    }
     
     var content: some View {
         ZStack {
@@ -38,6 +26,14 @@ struct SwapCoinPickerView: View {
             }
         }
         .buttonStyle(BorderlessButtonStyle())
+        .sheet(isPresented: $showChainPickerSheet, content: {
+            SwapChainPickerView(
+                vault: vault,
+                showSheet: $showChainPickerSheet,
+                selectedChain: $selectedChain,
+                selectedCoin: $selectedCoin
+            )
+        })
     }
     
     var main: some View {

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCoinPickerView.swift
@@ -18,24 +18,6 @@ struct SwapCoinPickerView: View {
     @State var showChainPickerSheet: Bool = false
     @EnvironmentObject var viewModel: CoinSelectionViewModel
     
-    var content: some View {
-        ZStack {
-            ZStack {
-                Background()
-                main
-            }
-        }
-        .buttonStyle(BorderlessButtonStyle())
-        .sheet(isPresented: $showChainPickerSheet, content: {
-            SwapChainPickerView(
-                vault: vault,
-                showSheet: $showChainPickerSheet,
-                selectedChain: $selectedChain,
-                selectedCoin: $selectedCoin
-            )
-        })
-    }
-    
     var main: some View {
         VStack {
             header

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -53,40 +53,6 @@ struct SwapCryptoDetailsView: View {
             fields
             continueButton
         }
-        .sheet(isPresented: $swapViewModel.showFromChainSelector, content: {
-            SwapChainPickerView(
-                vault: vault,
-                showSheet: $swapViewModel.showFromChainSelector,
-                selectedChain: $swapViewModel.fromChain,
-                selectedCoin: $tx.fromCoin
-            )
-        })
-        .sheet(isPresented: $swapViewModel.showToChainSelector, content: {
-            SwapChainPickerView(
-                vault: vault,
-                showSheet: $swapViewModel.showToChainSelector,
-                selectedChain: $swapViewModel.toChain,
-                selectedCoin: $tx.toCoin
-            )
-        })
-        .sheet(isPresented: $swapViewModel.showFromCoinSelector, content: {
-            SwapCoinPickerView(
-                vault: vault,
-                selectedNetwork: swapViewModel.fromChain,
-                showSheet: $swapViewModel.showFromCoinSelector,
-                selectedCoin: $tx.fromCoin,
-                selectedChain: $swapViewModel.fromChain
-            )
-        })
-        .sheet(isPresented: $swapViewModel.showToCoinSelector, content: {
-            SwapCoinPickerView(
-                vault: vault,
-                selectedNetwork: swapViewModel.toChain,
-                showSheet: $swapViewModel.showToCoinSelector,
-                selectedCoin: $tx.toCoin,
-                selectedChain: $swapViewModel.toChain
-            )
-        })
     }
     
     var swapContent: some View {
@@ -228,6 +194,10 @@ struct SwapCryptoDetailsView: View {
         let fromChain = swapViewModel.fromChain
         swapViewModel.fromChain = swapViewModel.toChain
         swapViewModel.toChain = fromChain
+    }
+    
+    func showSheet() -> Bool {
+        swapViewModel.showFromChainSelector || swapViewModel.showToChainSelector || swapViewModel.showFromCoinSelector || swapViewModel.showToCoinSelector
     }
 }
 

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoView.swift
@@ -12,10 +12,11 @@ struct SwapCryptoView: View {
     let toCoin: Coin?
     let vault: Vault
     
+    @State var keysignView: KeysignView?
+    
     @StateObject var tx = SwapTransaction()
     @StateObject var swapViewModel = SwapCryptoViewModel()
     @StateObject var shareSheetViewModel = ShareSheetViewModel()
-    @State var keysignView: KeysignView?
     
     init(fromCoin: Coin? = nil, toCoin: Coin? = nil, vault: Vault) {
         self.fromCoin = fromCoin

--- a/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
@@ -19,6 +19,40 @@ extension SwapCryptoDetailsView {
                 loader
             }
         }
+        .sheet(isPresented: $swapViewModel.showFromChainSelector, content: {
+            SwapChainPickerView(
+                vault: vault,
+                showSheet: $swapViewModel.showFromChainSelector,
+                selectedChain: $swapViewModel.fromChain,
+                selectedCoin: $tx.fromCoin
+            )
+        })
+        .sheet(isPresented: $swapViewModel.showToChainSelector, content: {
+            SwapChainPickerView(
+                vault: vault,
+                showSheet: $swapViewModel.showToChainSelector,
+                selectedChain: $swapViewModel.toChain,
+                selectedCoin: $tx.toCoin
+            )
+        })
+        .sheet(isPresented: $swapViewModel.showFromCoinSelector, content: {
+            SwapCoinPickerView(
+                vault: vault,
+                selectedNetwork: swapViewModel.fromChain,
+                showSheet: $swapViewModel.showFromCoinSelector,
+                selectedCoin: $tx.fromCoin,
+                selectedChain: $swapViewModel.fromChain
+            )
+        })
+        .sheet(isPresented: $swapViewModel.showToCoinSelector, content: {
+            SwapCoinPickerView(
+                vault: vault,
+                selectedNetwork: swapViewModel.toChain,
+                showSheet: $swapViewModel.showToCoinSelector,
+                selectedCoin: $tx.toCoin,
+                selectedChain: $swapViewModel.toChain
+            )
+        })
     }
     
     var view: some View {

--- a/VultisigApp/VultisigApp/iOS/View/SwapChainPickerView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/SwapChainPickerView+iOS.swift
@@ -1,0 +1,16 @@
+//
+//  SwapChainPickerView+iOS.swift
+//  VultisigApp
+//
+//  Created by Amol Kumar on 2025-04-28.
+//
+
+#if os(iOS)
+import SwiftUI
+
+extension SwapChainPickerView {
+    var body: some View {
+        content
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/iOS/View/SwapCoinPickerView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/SwapCoinPickerView+iOS.swift
@@ -12,5 +12,21 @@ extension SwapCoinPickerView {
     var body: some View {
         content
     }
+    
+    var content: some View {
+        ZStack {
+            Background()
+            main
+        }
+        .buttonStyle(BorderlessButtonStyle())
+        .sheet(isPresented: $showChainPickerSheet, content: {
+            SwapChainPickerView(
+                vault: vault,
+                showSheet: $showChainPickerSheet,
+                selectedChain: $selectedChain,
+                selectedCoin: $selectedCoin
+            )
+        })
+    }
 }
 #endif

--- a/VultisigApp/VultisigApp/iOS/View/SwapCoinPickerView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/SwapCoinPickerView+iOS.swift
@@ -1,0 +1,16 @@
+//
+//  SwapCoinPickerView+iOS.swift
+//  VultisigApp
+//
+//  Created by Amol Kumar on 2025-04-28.
+//
+
+#if os(iOS)
+import SwiftUI
+
+extension SwapCoinPickerView {
+    var body: some View {
+        content
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
@@ -17,6 +17,55 @@ extension SwapCryptoDetailsView {
             if swapViewModel.isLoading {
                 loader
             }
+            
+            if showSheet() {
+                overlay
+            }
+            
+            VStack {
+                Spacer()
+                
+                if swapViewModel.showFromChainSelector {
+                    SwapChainPickerView(
+                        vault: vault,
+                        showSheet: $swapViewModel.showFromChainSelector,
+                        selectedChain: $swapViewModel.fromChain,
+                        selectedCoin: $tx.fromCoin
+                    )
+                }
+                
+                if swapViewModel.showToChainSelector {
+                    SwapChainPickerView(
+                        vault: vault,
+                        showSheet: $swapViewModel.showToChainSelector,
+                        selectedChain: $swapViewModel.toChain,
+                        selectedCoin: $tx.toCoin
+                    )
+                }
+                
+                if swapViewModel.showFromCoinSelector {
+                    SwapCoinPickerView(
+                        vault: vault,
+                        selectedNetwork: swapViewModel.fromChain,
+                        showSheet: $swapViewModel.showFromCoinSelector,
+                        selectedCoin: $tx.fromCoin,
+                        selectedChain: $swapViewModel.fromChain
+                    )
+                }
+                
+                if swapViewModel.showToCoinSelector {
+                    SwapCoinPickerView(
+                        vault: vault,
+                        selectedNetwork: swapViewModel.toChain,
+                        showSheet: $swapViewModel.showToCoinSelector,
+                        selectedCoin: $tx.toCoin,
+                        selectedChain: $swapViewModel.toChain
+                    )
+                }
+                
+                Spacer()
+            }
+            .offset(y: -50)
         }
     }
     
@@ -40,6 +89,27 @@ extension SwapCryptoDetailsView {
             }
             .padding(.horizontal, 16)
         }
+    }
+    
+    var overlay: some View {
+        ZStack(alignment: .top) {
+            Color.black
+                .frame(height: 200)
+                .offset(y: -200)
+            
+            Color.black
+        }
+        .opacity(0.8)
+        .onTapGesture {
+            closeSheets()
+        }
+    }
+    
+    func closeSheets() {
+        swapViewModel.showFromChainSelector = false
+        swapViewModel.showToChainSelector = false
+        swapViewModel.showFromCoinSelector = false
+        swapViewModel.showToCoinSelector = false
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/macOS/View/SwapChainPickerView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/SwapChainPickerView+macOS.swift
@@ -11,8 +11,7 @@ import SwiftUI
 extension SwapChainPickerView {
     var body: some View {
         content
-            .frame(minWidth: 700)
-            .frame(height: 500)
+            .frame(width: 700, height: 450)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/macOS/View/SwapChainPickerView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/SwapChainPickerView+macOS.swift
@@ -1,0 +1,18 @@
+//
+//  SwapChainPickerView+macOS.swift
+//  VultisigApp
+//
+//  Created by Amol Kumar on 2025-04-28.
+//
+
+#if os(macOS)
+import SwiftUI
+
+extension SwapChainPickerView {
+    var body: some View {
+        content
+            .frame(minWidth: 700)
+            .frame(height: 500)
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/macOS/View/SwapCoinPickerView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/SwapCoinPickerView+macOS.swift
@@ -1,0 +1,18 @@
+//
+//  SwapCoinPickerView+macOS.swift
+//  VultisigApp
+//
+//  Created by Amol Kumar on 2025-04-28.
+//
+
+#if os(macOS)
+import SwiftUI
+
+extension SwapCoinPickerView {
+    var body: some View {
+        content
+            .frame(minWidth: 700)
+            .frame(height: 500)
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/macOS/View/SwapCoinPickerView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/SwapCoinPickerView+macOS.swift
@@ -11,8 +11,7 @@ import SwiftUI
 extension SwapCoinPickerView {
     var body: some View {
         content
-            .frame(minWidth: 700)
-            .frame(height: 500)
+            .frame(width: 700, height: 450)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/macOS/View/SwapCoinPickerView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/SwapCoinPickerView+macOS.swift
@@ -13,5 +13,22 @@ extension SwapCoinPickerView {
         content
             .frame(width: 700, height: 450)
     }
+    
+    var content: some View {
+        ZStack {
+            Background()
+            main
+            
+            if showChainPickerSheet {
+                SwapChainPickerView(
+                    vault: vault,
+                    showSheet: $showChainPickerSheet,
+                    selectedChain: $selectedChain,
+                    selectedCoin: $selectedCoin
+                )
+            }
+        }
+        .buttonStyle(BorderlessButtonStyle())
+    }
 }
 #endif


### PR DESCRIPTION
Closing action added to coin and chain selector sheets for Swap on macOS, Fixes #2101

**Screenshot**
<img width="1440" alt="Screenshot 2025-04-28 at 5 03 40 PM" src="https://github.com/user-attachments/assets/d74387d3-61c8-4866-825f-52c9ea3b07f1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated modal picker views for selecting chains and coins during swaps on both iOS and macOS platforms.
  - Added overlays and centralized dismissal for multiple picker modals on macOS for improved usability.

- **Improvements**
  - Enhanced platform-specific user interfaces for swap pickers, ensuring consistent and optimized experiences on both iOS and macOS.
  - Updated modal presentation logic for swap-related views to provide clearer and more intuitive selection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->