### PR TITLE
OnboardingSummaryView animation size updated

### DIFF
--- a/VultisigApp/VultisigApp/Views/Onboarding/OnboardingSummaryView+macOS.swift
+++ b/VultisigApp/VultisigApp/Views/Onboarding/OnboardingSummaryView+macOS.swift
@@ -18,7 +18,7 @@ extension OnboardingSummaryView {
                 animationVM?.view()
             }
         }
-        .frame(width: 700, height: 500)
+        .frame(width: 500, height: 400)
     }
 }
 


### PR DESCRIPTION
Backup guide overhang issue fixed for app window on macOS, Fixes #2087

**Screenshot**
<img width="901" alt="Screenshot 2025-05-01 at 3 38 44 PM" src="https://github.com/user-attachments/assets/d3013d93-b5ab-48a0-97cd-4fb99ee2e3be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Reduced the size of the animation displayed during onboarding on macOS for a more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->