### PR TITLE
Back button tap area increased

### DIFF
--- a/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoView+iOS.swift
@@ -54,8 +54,9 @@ extension SendCryptoView {
             sendCryptoViewModel.handleBackTap(dismiss)
         } label: {
             NavigationBlankBackButton()
-                .offset(x: -8)
+                .offset(x: -24)
         }
+        .padding(.horizontal, 24)
         .opacity(isDone ? 0 : 1)
         .disabled(isDone)
     }


### PR DESCRIPTION
Send Screen – Back button blocked issue during gas calculation fixed, Fixes #2079

The back button wasn't blocked but instead it had a small tap area and was easy to miss. Increased its width to more accurately register touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the back button's position and spacing in the toolbar for improved alignment and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->