### PR TITLE
Fix UTXO balance doesn't show issue

### DIFF
--- a/VultisigApp/VultisigApp/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Utils/Endpoint.swift
@@ -184,7 +184,7 @@ class Endpoint {
     
     static func blockchairDashboard(_ address: String, _ coinName: String) -> URL {
         // ?state=latest
-        "\(vultisigApiProxy)/blockchair/\(coinName)/dashboards/address/\(address)".asUrl
+        "\(vultisigApiProxy)/blockchair/\(coinName)/dashboards/address/\(address)?state=latest".asUrl
     }
     
     static func ethereumLabelTxHash(_ value: String) -> String {


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `Endpoint` class in `VultisigApp/VultisigApp/Utils/Endpoint.swift`. The change ensures that the `blockchairDashboard` method appends the `?state=latest` query parameter to the generated URL, providing more specific API requests.


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault ❎
- [ ] Sending  - Please attach a tx link here ❎
- [ ] Swap - Please attach a tx link for the swap here ❎
- [ ] New Chain / Chain related feature  -  Please attach tx link here ❎

## Checklist

- [ ] I have performed a self-review of my code ✅
- [ ] I have commented my code, particularly in hard-to-understand areas ❎
- [ ] My changes generate no new warnings ❎
- [ ] I have added tests that prove my fix is effective or that my feature works ❎

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the dashboard URL for blockchain data to include the latest state information, ensuring more accurate and up-to-date results when viewing dashboard data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->