### PR TITLE
Tooltip removed for Migration

### DIFF
--- a/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
@@ -136,7 +136,12 @@ extension PeerDiscoveryView {
             if viewModel.selectedNetwork == .Local {
                 LocalModeDisclaimer()
             } else if showDisclaimer {
-                PeerDiscoveryScanDeviceDisclaimer(showAlert: $showDisclaimer)
+                if tssType != .Migrate {
+                    PeerDiscoveryScanDeviceDisclaimer(showAlert: $showDisclaimer)
+                } else {
+                    Spacer()
+                        .frame(height: 24)
+                }
             }
         }
         .padding(.horizontal, idiom == .pad ? 24 : 12)

--- a/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
@@ -76,11 +76,16 @@ extension PeerDiscoveryView {
     }
     
     var scrollList: some View {
-        LazyVGrid(columns: adaptiveColumnsMac, spacing: 8) {
-            ThisDevicePeerCell(deviceName: "Mac")
-            devices
-            EmptyPeerCell(counter: participantDiscovery.peersFound.count)
+        VStack {
+            listTitle
+            
+            LazyVGrid(columns: adaptiveColumnsMac, spacing: 8) {
+                ThisDevicePeerCell(deviceName: "Mac")
+                devices
+                EmptyPeerCell(counter: participantDiscovery.peersFound.count)
+            }
         }
+        .frame(maxWidth: .infinity)
     }
     
     var networkPrompts: some View {
@@ -126,7 +131,12 @@ extension PeerDiscoveryView {
             if viewModel.selectedNetwork == .Local {
                 LocalModeDisclaimer()
             } else if showDisclaimer {
-                PeerDiscoveryScanDeviceDisclaimer(showAlert: $showDisclaimer)
+                if tssType != .Migrate {
+                    PeerDiscoveryScanDeviceDisclaimer(showAlert: $showDisclaimer)
+                } else {
+                    Spacer()
+                        .frame(height: 24)
+                }
             }
         }
         .padding(.leading, 24)


### PR DESCRIPTION
## Description

Tooltip removed from PeerDiscoveryView for migration

Fixes #2140

## Which feature is affected?
- [ ] Migration PeerDiscoveryView - Open the Discovery via the migration disclaimer and the tooltip should not appear for PeerDiscoveryView

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots:
![Simulator Screenshot - iPhone 15 Pro - 2025-05-06 at 13 40 53](https://github.com/user-attachments/assets/30530e9a-f27c-45a8-8596-023de2403039)
<img width="905" alt="Screenshot 2025-05-06 at 1 45 16 PM" src="https://github.com/user-attachments/assets/48027b7d-4c21-4054-9059-337fc6f27da1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a title above the peer device grid in the macOS version for improved clarity.
- **Bug Fixes**
  - Updated the disclaimer display so it is now hidden when a specific migration type is selected, maintaining layout spacing for consistency across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->