### PR TITLE
Fix local mode switch

### DIFF
--- a/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
@@ -31,7 +31,12 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
     @Published var localPartyID = ""
     @Published var selections = Set<String>()
     @Published var serverAddr = "http://127.0.0.1:18080"
-    @Published var selectedNetwork = NetworkPromptType.Internet
+    @Published var selectedNetwork = VultisigRelay.IsRelayEnabled ? NetworkPromptType.Internet : NetworkPromptType.Local {
+        didSet {
+            print("selected network changed: \(selectedNetwork)")
+            VultisigRelay.IsRelayEnabled = NetworkPromptType.Internet == selectedNetwork
+        }
+    }
     
     private var cancellables = Set<AnyCancellable>()
     private let mediator = Mediator.shared

--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -69,7 +69,6 @@ struct PeerDiscoveryView: View {
                     .presentationDetents([.height(450)])
             }
             .onChange(of: viewModel.selectedNetwork) {
-                print("selected network changed: \(viewModel.selectedNetwork)")
                 viewModel.restartParticipantDiscovery()
                 setData()
             }

--- a/VultisigApp/VultisigApp/Views/Keysign/KeysignDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/KeysignDiscoveryView.swift
@@ -23,7 +23,7 @@ struct KeysignDiscoveryView: View {
     @State var screenWidth: CGFloat = 0
     @State var screenHeight: CGFloat = 0
     @State var qrCodeImage: Image? = nil
-    @State var selectedNetwork = NetworkPromptType.Internet
+    @State var selectedNetwork = VultisigRelay.IsRelayEnabled ? NetworkPromptType.Internet : NetworkPromptType.Local
     @State var previewType: QRShareSheetType = .Send
     
     @State var qrSize: CGFloat = .zero
@@ -69,6 +69,14 @@ struct KeysignDiscoveryView: View {
         }
         .onDisappear {
             viewModel.stopDiscovery()
+        }
+        .onChange(of: selectedNetwork) { _, newValue in
+            VultisigRelay.IsRelayEnabled = newValue == .Internet
+            
+            viewModel.restartParticipantDiscovery()
+            Task {
+                await setData()
+            }
         }
     }
     

--- a/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
@@ -95,7 +95,6 @@ extension PeerDiscoveryView {
     var networkPrompts: some View {
         NetworkPrompts(selectedNetwork: $viewModel.selectedNetwork)
             .onChange(of: viewModel.selectedNetwork) {
-                print("selected network changed: \(viewModel.selectedNetwork)")
                 viewModel.restartParticipantDiscovery()
                 setData()
             }


### PR DESCRIPTION
## Description

Fixed local mode switching on iOS because it didn't switch QR code.

## Which feature is affected?
- [ ] Keygen peer discovery
- [ ] Keysign peer discovery


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Network selection in peer and participant discovery views now dynamically synchronizes with the relay connection state, ensuring consistent behavior when switching between Internet and Local modes.

- **Bug Fixes**
  - Improved reliability of participant discovery and data refresh when changing network selection.

- **Style**
  - Removed debug print statements for a cleaner user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->