### PR TITLE
fixes for pct and verify

### DIFF
--- a/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallStakeTCY.swift
+++ b/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallStakeTCY.swift
@@ -34,6 +34,7 @@ class FunctionCallStakeTCY: ObservableObject {
     
     private func setupValidation() {
         $amountValid
+            .map { $0 && !self.amount.isZero && self.tx.coin.balanceDecimal >= self.amount }
             .assign(to: \.isTheFormValid, on: self)
             .store(in: &cancellables)
     }

--- a/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
+++ b/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
@@ -86,7 +86,7 @@ class FunctionCallUnstakeTCY: ObservableObject {
     }
     
     func validateAmount() {
-        if let intAmount = Int64(amount), intAmount > 0 {
+        if let intAmount = Int64(amount), intAmount > 0, self.stakedAmount > 0 {
             amountValid = true
         } else {
             amountValid = false

--- a/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
+++ b/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
@@ -95,7 +95,7 @@ class FunctionCallUnstakeTCY: ObservableObject {
         isTheFormValid = amountValid
     }
     
-
+    
     
     struct PercentageButtons: View {
         let action: (Int) -> Void
@@ -123,6 +123,18 @@ class FunctionCallUnstakeTCY: ObservableObject {
 struct UnstakeView: View {
     @ObservedObject var viewModel: FunctionCallUnstakeTCY
     
+    var textField: some View {
+        TextField("Enter percentage", text: $viewModel.amount)
+            .id(viewModel.lastUpdateTime)
+        //.keyboardType(.numberPad)
+            .font(.body16Menlo)
+            .foregroundColor(.neutral0)
+            .padding(12)
+            .background(Color.blue600)
+            .cornerRadius(12)
+            .borderlessTextFieldStyle()
+    }
+    
     var body: some View {
         VStack(spacing: 16) {
             VStack(spacing: 8) {
@@ -146,15 +158,12 @@ struct UnstakeView: View {
                     }
                 }
                 
-                TextField("Enter percentage", text: $viewModel.amount)
-                    .id(viewModel.lastUpdateTime)
-                    .keyboardType(.numberPad)
-                    .font(.body16Menlo)
-                    .foregroundColor(.neutral0)
-                    .padding(12)
-                    .background(Color.blue600)
-                    .cornerRadius(12)
-                    .borderlessTextFieldStyle()
+#if os(iOS)
+                textField.keyboardType(.decimalPad)
+#endif
+#if os(macOS)
+                textField
+#endif
             }
         }
     }

--- a/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
+++ b/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
@@ -11,12 +11,15 @@ import Combine
 class FunctionCallUnstakeTCY: ObservableObject {
     @Published var amount: String = ""
     public var lastUpdateTime: Date = Date()
+    
     @Published var amountValid: Bool = false
     @Published var isTheFormValid: Bool = false
     
-    private var tx: SendTransaction
-    private var stakedAmount: Decimal = .zero
     private var cancellables = Set<AnyCancellable>()
+    
+    private var tx: SendTransaction
+    
+    private var stakedAmount: Decimal = .zero
     
     required init(
         tx: SendTransaction, functionCallViewModel: FunctionCallViewModel, stakedAmount: Decimal
@@ -24,6 +27,10 @@ class FunctionCallUnstakeTCY: ObservableObject {
         self.stakedAmount = stakedAmount
         self.tx = tx
         setupValidation()
+    }
+    
+    var balance: String {
+        return "( Staked Amount: \(self.stakedAmount) \(tx.coin.ticker.uppercased()) )"
     }
     
     private func setupValidation() {
@@ -36,10 +43,6 @@ class FunctionCallUnstakeTCY: ObservableObject {
         $amountValid
             .assign(to: \.isTheFormValid, on: self)
             .store(in: &cancellables)
-    }
-    
-    var balance: String {
-        return "( Staked Amount: \(self.stakedAmount) \(tx.coin.ticker.uppercased()) )"
     }
     
     var description: String {
@@ -61,11 +64,18 @@ class FunctionCallUnstakeTCY: ObservableObject {
         return dict
     }
     
+    var percentageButtons: some View {
+        PercentageButtons { [weak self] percentage in
+            self?.setPercentage(percentage)
+        }
+    }
+    
     func setPercentage(_ percentage: Int) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             
             self.amount = String(percentage)
+            self.validateAmount()
             self.lastUpdateTime = Date()
             self.objectWillChange.send()
         }
@@ -85,11 +95,7 @@ class FunctionCallUnstakeTCY: ObservableObject {
         isTheFormValid = amountValid
     }
     
-    var percentageButtons: some View {
-        PercentageButtons { [weak self] percentage in
-            self?.setPercentage(percentage)
-        }
-    }
+
     
     struct PercentageButtons: View {
         let action: (Int) -> Void

--- a/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
+++ b/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
@@ -126,7 +126,6 @@ struct UnstakeView: View {
     var textField: some View {
         TextField("Enter percentage", text: $viewModel.amount)
             .id(viewModel.lastUpdateTime)
-        //.keyboardType(.numberPad)
             .font(.body16Menlo)
             .foregroundColor(.neutral0)
             .padding(12)

--- a/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
+++ b/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnstakeTCY.swift
@@ -9,17 +9,14 @@ import Foundation
 import Combine
 
 class FunctionCallUnstakeTCY: ObservableObject {
-    @Published var amount: Int64 = .zero
-    
-    // Internal
+    @Published var amount: String = ""
+    public var lastUpdateTime: Date = Date()
     @Published var amountValid: Bool = false
     @Published var isTheFormValid: Bool = false
     
-    private var cancellables = Set<AnyCancellable>()
-    
     private var tx: SendTransaction
-    
     private var stakedAmount: Decimal = .zero
+    private var cancellables = Set<AnyCancellable>()
     
     required init(
         tx: SendTransaction, functionCallViewModel: FunctionCallViewModel, stakedAmount: Decimal
@@ -29,14 +26,20 @@ class FunctionCallUnstakeTCY: ObservableObject {
         setupValidation()
     }
     
-    var balance: String {
-        return "( Staked Amount: \(self.stakedAmount) \(tx.coin.ticker.uppercased()) )"
-    }
-    
     private func setupValidation() {
+        $amount
+            .sink { [weak self] _ in
+                self?.validateAmount()
+            }
+            .store(in: &cancellables)
+        
         $amountValid
             .assign(to: \.isTheFormValid, on: self)
             .store(in: &cancellables)
+    }
+    
+    var balance: String {
+        return "( Staked Amount: \(self.stakedAmount) \(tx.coin.ticker.uppercased()) )"
     }
     
     var description: String {
@@ -44,8 +47,12 @@ class FunctionCallUnstakeTCY: ObservableObject {
     }
     
     func toString() -> String {
-        let basisPoints = self.amount * 100  // Convert to basis points (25% -> 2500)
-        return "tcy-:\(basisPoints)"
+        if let intAmount = Int64(self.amount) {
+            let basisPoints = intAmount * 100
+            return "tcy-:\(basisPoints)"
+        } else {
+            return "tcy-:0"
+        }
     }
     
     func toDictionary() -> ThreadSafeDictionary<String, String> {
@@ -54,26 +61,95 @@ class FunctionCallUnstakeTCY: ObservableObject {
         return dict
     }
     
-    var percentageButtons: some View {
-        SwapPercentageButtons { percentage in
-            self.amount = Int64(percentage)
+    func setPercentage(_ percentage: Int) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            
+            self.amount = String(percentage)
+            self.lastUpdateTime = Date()
+            self.objectWillChange.send()
         }
     }
     
     func getView() -> AnyView {
-        AnyView(VStack {
-            percentageButtons
-            StyledIntegerField(
-                placeholder: "Percentage to Unstake \(self.balance)",
-                value: Binding(
-                    get: { self.amount },
-                    set: { self.amount = $0 }
-                ),
-                format: .number,
-                isValid: Binding(
-                    get: { self.amountValid },
-                    set: { self.amountValid = $0 }
-                ))
-        })
+        return AnyView(UnstakeView(viewModel: self))
+    }
+    
+    func validateAmount() {
+        if let intAmount = Int64(amount), intAmount > 0 {
+            amountValid = true
+        } else {
+            amountValid = false
+        }
+        
+        isTheFormValid = amountValid
+    }
+    
+    var percentageButtons: some View {
+        PercentageButtons { [weak self] percentage in
+            self?.setPercentage(percentage)
+        }
+    }
+    
+    struct PercentageButtons: View {
+        let action: (Int) -> Void
+        
+        var body: some View {
+            HStack(spacing: 8) {
+                ForEach([25, 50, 75, 100], id: \.self) { option in
+                    Button(action: {
+                        action(option)
+                    }) {
+                        Text("\(option)%")
+                            .font(.body12BrockmannMedium)
+                            .foregroundColor(.neutral0)
+                            .padding(.vertical, 8)
+                            .frame(maxWidth: .infinity)
+                            .background(Color.blue600)
+                            .cornerRadius(32)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct UnstakeView: View {
+    @ObservedObject var viewModel: FunctionCallUnstakeTCY
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            VStack(spacing: 8) {
+                viewModel.percentageButtons
+                
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundColor(.blue400)
+            }
+            .frame(maxWidth: .infinity)
+            
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Percentage to Unstake \(viewModel.balance)")
+                        .font(.body14MontserratMedium)
+                        .foregroundColor(.neutral0)
+                    if !viewModel.amountValid {
+                        Text("*")
+                            .font(.body14MontserratMedium)
+                            .foregroundColor(.red)
+                    }
+                }
+                
+                TextField("Enter percentage", text: $viewModel.amount)
+                    .id(viewModel.lastUpdateTime)
+                    .keyboardType(.numberPad)
+                    .font(.body16Menlo)
+                    .foregroundColor(.neutral0)
+                    .padding(12)
+                    .background(Color.blue600)
+                    .cornerRadius(12)
+                    .borderlessTextFieldStyle()
+            }
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendCryptoDoneSummary.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendCryptoDoneSummary.swift
@@ -32,19 +32,24 @@ struct SendCryptoDoneSummary: View {
     
     private func getSendCard(_ tx: SendTransaction) -> some View {
         VStack(spacing: 18) {
-            Separator()
-            getGeneralCell(
-                title: "from",
-                description: tx.fromAddress,
-                isVerticalStacked: true
-            )
             
-            Separator()
-            getGeneralCell(
-                title: "to",
-                description: tx.toAddress,
-                isVerticalStacked: true
-            )
+            if !tx.fromAddress.isEmpty {
+                Separator()
+                getGeneralCell(
+                    title: "from",
+                    description: tx.fromAddress,
+                    isVerticalStacked: true
+                )
+            }
+            
+            if !tx.toAddress.isEmpty {
+                Separator()
+                getGeneralCell(
+                    title: "to",
+                    description: tx.toAddress,
+                    isVerticalStacked: true
+                )
+            }
             
             if !tx.memo.isEmpty {
                 Separator()
@@ -55,17 +60,21 @@ struct SendCryptoDoneSummary: View {
                 )
             }
             
-            Separator()
-            getGeneralCell(
-                title: "amount",
-                description: getSendAmount(for: tx)
-            )
+            if !getSendAmount(for: tx).isEmpty {
+                Separator()
+                getGeneralCell(
+                    title: "amount",
+                    description: getSendAmount(for: tx)
+                )
+            }
             
-            Separator()
-            getGeneralCell(
-                title: "value",
-                description: getSendFiatAmount(for: tx)
-            )
+            if !getSendFiatAmount(for: tx).isEmpty {
+                Separator()
+                getGeneralCell(
+                    title: "value",
+                    description: getSendFiatAmount(for: tx)
+                )
+            }
             
             Separator()
             getGeneralCell(

--- a/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallVerifyView.swift
+++ b/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallVerifyView.swift
@@ -103,13 +103,18 @@ struct FunctionCallVerifyView: View {
                 getDetailsCell(for: "amount", with: getAmount())
             }
             
-            VStack {
-                ForEach(Array(tx.memoFunctionDictionary.allKeysInOrder()), id: \.self) { key in
+            if !tx.memoFunctionDictionary.allKeysInOrder().isEmpty {
+                let validKeys = tx.memoFunctionDictionary.allKeysInOrder().filter { key in
+                    guard let value = tx.memoFunctionDictionary.get(key) else { return false }
+                    return !value.isEmpty && value != "0" && value != "0.0"
+                }
+                
+                ForEach(Array(validKeys.enumerated()), id: \.element) { index, key in
                     if let value = tx.memoFunctionDictionary.get(key) {
-                        if !value.isEmpty && value != "0" && value != "0.0" {
+                        if index > 0 || tx.amountDecimal > 0 || !tx.fromAddress.isEmpty {
                             Separator()
-                            getAddressCell(for: key.toFormattedTitleCase(), with: value)
                         }
+                        getAddressCell(for: key.toFormattedTitleCase(), with: value)
                     }
                 }
             }

--- a/VultisigApp/VultisigApp/Views/Keysign/JoinKeysignDoneSummary.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/JoinKeysignDoneSummary.swift
@@ -44,7 +44,7 @@ struct JoinKeysignDoneSummary: View {
                 card(title: NSLocalizedString("transaction", comment: "Transaction"), txid: viewModel.txid)
                     .padding(.horizontal, -16)
             }
-
+            
             content
         }
         .padding(.vertical, 12)
@@ -77,13 +77,17 @@ struct JoinKeysignDoneSummary: View {
     
     var transactionContent: some View {
         VStack(spacing: 18) {
-            Separator()
-            getGeneralCell(
-                title: "to",
-                description: viewModel.keysignPayload?.toAddress ?? "",
-                isVerticalStacked: true
-            )
             
+            if let address = viewModel.keysignPayload?.toAddress, !address.isEmpty {
+                
+                Separator()
+                getGeneralCell(
+                    title: "to",
+                    description: address,
+                    isVerticalStacked: true
+                )
+                
+            }
             
             if let memo = viewModel.keysignPayload?.memo, !memo.isEmpty {
                 Separator()
@@ -94,24 +98,32 @@ struct JoinKeysignDoneSummary: View {
                 )
             }
             
-            Separator()
-            getGeneralCell(
-                title: "amount",
-                description: viewModel.keysignPayload?.toAmountString ?? "",
-                isVerticalStacked: false
-            )
+            if let amount = viewModel.keysignPayload?.toAmountString, !amount.isEmpty {
+                
+                Separator()
+                getGeneralCell(
+                    title: "amount",
+                    description: amount,
+                    isVerticalStacked: false
+                )
+                
+            }
             
-            Separator()
-            getGeneralCell(
-                title: "value",
-                description: viewModel.keysignPayload?.toAmountFiatString ?? "",
-                isVerticalStacked: false
-            )
+            if let fiat = viewModel.keysignPayload?.toAmountFiatString, !fiat.isEmpty {
+                
+                Separator()
+                getGeneralCell(
+                    title: "value",
+                    description: fiat,
+                    isVerticalStacked: false
+                )
+                
+            }
             
             transactionLink
         }
     }
-
+    
     var signMessageContent: some View {
         VStack(spacing: 18) {
             getGeneralCell(
@@ -119,7 +131,7 @@ struct JoinKeysignDoneSummary: View {
                 description: viewModel.customMessagePayload?.method ?? "",
                 isVerticalStacked: true
             )
-
+            
             Separator()
             getGeneralCell(
                 title: "Message",
@@ -134,7 +146,7 @@ struct JoinKeysignDoneSummary: View {
             )
         }
     }
-
+    
     var transactionLink: some View {
         VStack {
             Separator()
@@ -145,7 +157,7 @@ struct JoinKeysignDoneSummary: View {
             }
         }
     }
-
+    
     private func getGeneralCell(title: String, description: String, isVerticalStacked: Bool = false) -> some View {
         ZStack {
             if isVerticalStacked {
@@ -175,7 +187,7 @@ struct JoinKeysignDoneSummary: View {
     private func card(title: String, txid: String) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             titleSection(title: title, txid: txid)
-
+            
             Text(txid)
                 .font(.body13Menlo)
                 .foregroundColor(.turquoise600)
@@ -242,7 +254,7 @@ struct JoinKeysignDoneSummary: View {
             openURL(url)
         }
     }
-
+    
     private func progressLink(link: String) {
         if !link.isEmpty, let url = URL(string: link) {
             openURL(url)

--- a/VultisigApp/VultisigApp/Views/Keysign/JoinSwapDoneSummary.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/JoinSwapDoneSummary.swift
@@ -169,20 +169,24 @@ struct JoinSwapDoneSummary: View {
                 showCopyButton: true
             )
             
-            separator
-            getCell(
-                title: "from",
-                value: vault.name,
-                bracketValue: summaryViewModel.getFromCoin(keysignViewModel.keysignPayload)?.address,
-                bracketMaxWidth: 120
-            )
+            if ((summaryViewModel.getFromCoin(keysignViewModel.keysignPayload)?.address) != nil) == false {
+                separator
+                getCell(
+                    title: "from",
+                    value: vault.name,
+                    bracketValue: summaryViewModel.getFromCoin(keysignViewModel.keysignPayload)?.address,
+                    bracketMaxWidth: 120
+                )
+            }
             
-            separator
-            getCell(
-                title: "to",
-                value: summaryViewModel.getToCoin(keysignViewModel.keysignPayload)?.address,
-                valueMaxWidth: 120
-            )
+            if summaryViewModel.getToCoin(keysignViewModel.keysignPayload)?.address.isEmpty == false {
+                separator
+                getCell(
+                    title: "to",
+                    value: summaryViewModel.getToCoin(keysignViewModel.keysignPayload)?.address,
+                    valueMaxWidth: 120
+                )
+            }
             
             separator
             getCell(

--- a/VultisigApp/VultisigApp/Views/Keysign/KeysignMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/KeysignMessageConfirmView.swift
@@ -34,10 +34,16 @@ struct KeysignMessageConfirmView: View {
     var summary: some View {
         ScrollView {
             VStack(spacing: 16) {
-                fromField
-                Separator()
-                toField
-                Separator()
+                
+                if ((viewModel.keysignPayload?.coin.address.isEmpty) == nil) {
+                    fromField
+                    Separator()
+                }
+                
+                if ((viewModel.keysignPayload?.toAddress.isEmpty) == nil) {
+                    toField
+                    Separator()
+                }
                 
                 if let memo = viewModel.keysignPayload?.memo, !memo.isEmpty {
                     getSummaryCell(title: "memo", value: memo)
@@ -49,10 +55,16 @@ struct KeysignMessageConfirmView: View {
                     Separator()
                 }
                 
-                amountField
-                Separator()
-                valueField
-                Separator()
+                if ((viewModel.keysignPayload?.toAmountString.isEmpty) == nil) {
+                    amountField
+                    Separator()
+                }
+                
+                if ((viewModel.keysignPayload?.toAmountFiatString.isEmpty) == nil) {
+                    valueField
+                    Separator()
+                }
+                
                 networkFeeField
             }
             .padding(16)
@@ -78,15 +90,15 @@ struct KeysignMessageConfirmView: View {
     var networkFeeField: some View {
         getSummaryCell(title: "networkFee", value: viewModel.getCalculatedNetworkFee())
     }
-
+    
     var amountField: some View {
         getSummaryCell(title: "amount", value: viewModel.keysignPayload?.toAmountString ?? "")
     }
-
+    
     func functionField(decodedMemo: String) -> some View {
         getSummaryCell(title: "function", value: decodedMemo)
     }
-
+    
     var button: some View {
         Button(action: {
             self.viewModel.joinKeysignCommittee()


### PR DESCRIPTION
This should fix the issue when clicking int percentage button the UI was not being notified about it. 

That also fixes the join, verify and done views. 


https://thorchain.net/address/thor103xklz882ffz6vwjwcrawwt8tn57ngrhpfq3cl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced percentage selection buttons (25%, 50%, 75%, 100%) for unstaking amounts.
  - Added real-time validation feedback for unstake amount input.
  - Display now includes a timestamp for the last update.

- **Refactor**
  - Improved input handling by switching the unstake amount field from numeric to string-based entry.
  - Modularized the unstake view for better UI separation and maintainability.
  - Enhanced transaction summary display logic for clearer presentation and separator handling.
  - Strengthened form validation to ensure unstake amount is positive and within available balance before submission.
  - Updated conditional rendering across multiple views to prevent displaying empty or placeholder fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->