### PR TITLE
Refactor the way how we get block explorer URL

### DIFF
--- a/VultisigApp/VultisigApp/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Utils/Endpoint.swift
@@ -399,141 +399,138 @@ class Endpoint {
     
     static let tronEvmServiceRpc = "https://api.trongrid.io/jsonrpc"
     
-    static func getExplorerURL(chainTicker: String, txid: String) -> String {
-        switch chainTicker {
-        case "BTC":
+    static func getExplorerURL(chain: Chain, txid: String) -> String {
+        switch chain {
+        case .bitcoin:
             return "https://mempool.space/tx/\(txid)"
-        case "BCH":
+        case .bitcoinCash:
             return "https://blockchair.com/bitcoin-cash/transaction/\(txid)"
-        case "LTC":
+        case .litecoin:
             return "https://blockchair.com/litecoin/transaction/\(txid)"
-        case "DOGE":
+        case .dogecoin:
             return "https://blockchair.com/dogecoin/transaction/\(txid)"
-        case "DASH":
+        case .dash:
             return "https://blockchair.com/dash/transaction/\(txid)"
-        case "RUNE":
+        case .thorChain:
             return "https://thorchain.net/tx/\(txid.stripHexPrefix())"
-        case "SOL":
+        case .solana:
             return "https://solscan.io/tx/\(txid)"
-        case "ETH":
+        case .ethereum:
             return "https://etherscan.io/tx/\(txid)"
-        case "UATOM":
+        case .gaiaChain:
             return "https://www.mintscan.io/cosmos/tx/\(txid)"
-        case "ADYDX":
+        case .dydx:
             return "https://www.mintscan.io/dydx/tx/\(txid)"
-        case "UKUJI":
+        case .kujira:
             return "https://finder.kujira.network/kaiyo-1/tx/\(txid)"
-        case "AVAX":
+        case .avalanche:
             return "https://snowtrace.io/tx/\(txid)"
-        case "BNB":
+        case .bscChain:
             return "https://bscscan.com/tx/\(txid)"
-        case "CACAO":
+        case .mayaChain:
             return "https://www.mayascan.org/tx/\(txid)"
-        case "ARB":
+        case .arbitrum:
             return "https://arbiscan.io/tx/\(txid)"
-        case "BASE":
+        case .base:
             return "https://basescan.org/tx/\(txid)"
-        case "OP":
+        case .optimism:
             return "https://optimistic.etherscan.io/tx/\(txid)"
-        case "MATIC":
+        case .polygon,.polygonV2:
             return "https://polygonscan.com/tx/\(txid)"
-        case "BLAST":
+        case .blast:
             return "https://blastscan.io/tx/\(txid)"
-        case "CRO":
+        case .cronosChain:
             return "https://cronoscan.com/tx/\(txid)"
-        case "SUI":
+        case .sui:
             return "https://suiscan.xyz/mainnet/tx/\(txid)"
-        case "DOT":
+        case .polkadot:
             return "https://polkadot.subscan.io/extrinsic/\(txid)"
-        case "ZK":
+        case .zksync:
             return "https://explorer.zksync.io/tx/\(txid)"
-        case "TON":
+        case .ton:
             return "https://tonviewer.com/transaction/\(txid)"
-        case "UOSMO":
+        case .osmosis:
             return "https://www.mintscan.io/osmosis/tx/\(txid)"
-        case "ULUNA":
+        case .terra:
             return "https://www.mintscan.io/terra/tx/\(txid)"
-        case "ULUNC":
+        case .terraClassic:
             return "https://finder.terra.money/classic/tx/\(txid)"
-        case "USDC":
+        case .noble:
             return "https://www.mintscan.io/noble/tx/\(txid)"
-        case "XRP":
+        case .ripple:
             return "https://xrpscan.com/tx/\(txid)"
-        case "UAKT":
+        case .akash:
             return "https://www.mintscan.io/akash/tx/\(txid)"
-        case "TRX":
+        case .tron:
             return "https://tronscan.org/#/transaction/\(txid)"
-        default:
-            return ""
         }
     }
     
-    static func getExplorerByAddressURL(chainTicker:String, address:String) -> String? {
-        switch chainTicker {
-        case "BTC":
+    static func getExplorerByAddressURL(chain: Chain, address:String) -> String? {
+        switch chain {
+        case .bitcoin:
             return "https://mempool.space/address/\(address)"
-        case "BCH":
+        case .bitcoinCash:
             return "https://blockchair.com/bitcoin-cash/address/\(address)"
-        case "LTC":
+        case .litecoin:
             return "https://blockchair.com/litecoin/address/\(address)"
-        case "DOGE":
+        case .dogecoin:
             return "https://blockchair.com/dogecoin/address/\(address)"
-        case "DASH":
+        case .dash:
             return "https://blockchair.com/dash/address/\(address)"
-        case "RUNE":
+        case .thorChain:
             return "https://runescan.io/address/\(address)"
-        case "SOL":
+        case .solana:
             return "https://solscan.io/account/\(address)"
-        case "ETH":
+        case .ethereum:
             return "https://etherscan.io/address/\(address)"
-        case "UATOM":
+        case .gaiaChain:
             return "https://www.mintscan.io/cosmos/address/\(address)"
-        case "ADYDX":
+        case .dydx:
             return "https://www.mintscan.io/dydx/address/\(address)"
-        case "UKUJI":
+        case .kujira:
             return "https://finder.kujira.network/kaiyo-1/address/\(address)"
-        case "AVAX":
+        case .avalanche:
             return "https://snowtrace.io/address/\(address)"
-        case "BNB":
+        case .bscChain:
             return "https://bscscan.com/address/\(address)"
-        case "CACAO":
+        case .mayaChain:
             return "https://www.mayascan.org/address/\(address)"
-        case "ARB":
+        case .arbitrum:
             return "https://arbiscan.io/address/\(address)"
-        case "BASE":
+        case .base:
             return "https://basescan.org/address/\(address)"
-        case "OP":
+        case .optimism:
             return "https://optimistic.etherscan.io/address/\(address)"
-        case "MATIC":
+        case .polygon,.polygonV2:
             return "https://polygonscan.com/address/\(address)"
-        case "BLAST":
+        case .blast:
             return "https://blastscan.io/address/\(address)"
-        case "CRO":
+        case .cronosChain:
             return "https://cronoscan.com/address/\(address)"
-        case "SUI":
+        case .sui:
             return "https://suiscan.xyz/mainnet/address/\(address)"
-        case "DOT":
+        case .polkadot:
             return "https://polkadot.subscan.io/account/\(address)"
-        case "ZK":
+        case .zksync:
             return "https://explorer.zksync.io/address/\(address)"
-        case "TON":
+        case .ton:
             return "https://tonviewer.com/\(address)"
-        case "UOSMO":
+        case .osmosis:
             return "https://www.mintscan.io/osmosis/address/\(address)"
-        case "ULUNA":
+        case .terra:
             return "https://www.mintscan.io/terra/address/\(address)"
-        case "ULUNC":
+        case .terraClassic:
             return "https://finder.terra.money/classic/address/\(address)"
-        case "USDC":
+        case .noble:
             return "https://www.mintscan.io/noble/address/\(address)"
-        case "XRP":
+        case .ripple:
             return "https://xrpscan.com/account/\(address)"
-        case "UAKT":
+        case .akash:
             return "https://www.mintscan.io/akash/address/\(address)"
-        case "TRX":
+        case .tron:
             return "https://tronscan.org/#/address/\(address)"
-        default:
-            return nil
+        
         }
     }
     

--- a/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
@@ -85,7 +85,7 @@ class KeysignViewModel: ObservableObject {
     
     func getTransactionExplorerURL(txid: String) -> String {
         guard let keysignPayload else { return .empty }
-        return Endpoint.getExplorerURL(chainTicker: keysignPayload.coin.chain.ticker, txid: txid)
+        return Endpoint.getExplorerURL(chain: keysignPayload.coin.chain, txid: txid)
     }
     
     func getSwapProgressURL(txid: String) -> String? {

--- a/VultisigApp/VultisigApp/Views/Components/Cells/UTXOTransactionCell.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Cells/UTXOTransactionCell.swift
@@ -32,7 +32,7 @@ struct UTXOTransactionCell: View {
     
     var transactionIDCell: some View {
         let id = transaction.txid
-        let url = Endpoint.getExplorerURL(chainTicker: tx.coin.ticker, txid: id)
+        let url = Endpoint.getExplorerURL(chain: tx.coin.chain, txid: id)
         let image = transaction.isSent ? "arrow.up.circle" : "arrow.down.circle"
         
         return TransactionCell(
@@ -55,7 +55,7 @@ struct UTXOTransactionCell: View {
             address = id
         }
         
-        let url = Endpoint.getExplorerByAddressURL(chainTicker: tx.coin.ticker, address: address) ?? ""
+        let url = Endpoint.getExplorerByAddressURL(chain: tx.coin.chain, address: address) ?? ""
         
         return TransactionCell(
             title: "from",
@@ -76,7 +76,7 @@ struct UTXOTransactionCell: View {
             address = transaction.receivedFrom.first ?? ""
         }
         
-        let url = Endpoint.getExplorerByAddressURL(chainTicker: tx.coin.ticker, address: address) ?? ""
+        let url = Endpoint.getExplorerByAddressURL(chain: tx.coin.chain, address: address) ?? ""
         
         return TransactionCell(
             title: "to",

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDoneView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDoneView.swift
@@ -188,7 +188,7 @@ struct SendCryptoDoneView: View {
     }
 
     func explorerLink(hash: String) -> String {
-        return Endpoint.getExplorerURL(chainTicker: chain.ticker, txid: hash)
+        return Endpoint.getExplorerURL(chain: chain, txid: hash)
     }
     
     private func shareLink(hash: String) {

--- a/VultisigApp/VultisigApp/Views/Transactions/TransactionsView.swift
+++ b/VultisigApp/VultisigApp/Views/Transactions/TransactionsView.swift
@@ -37,7 +37,7 @@ struct TransactionsView: View {
         VStack{
             Spacer()
             ErrorMessage(text: "cannotFindTransactions")
-            if let coin = group.coins.first , let explorerUrl = Endpoint.getExplorerByAddressURL(chainTicker:coin.chain.ticker,address:coin.address) {
+            if let coin = group.coins.first , let explorerUrl = Endpoint.getExplorerByAddressURL(chain:coin.chain,address:coin.address) {
                 if let url = URL(string: explorerUrl) {
                     Link("checkExplorer",destination: url)
                         .font(.body16MenloBold)


### PR DESCRIPTION
## Description

This pull request refactors the `Endpoint` utility and updates its usage across the codebase to replace `chainTicker` (a `String`) with `chain` (a `Chain` enum). This change improves type safety and reduces the risk of errors caused by incorrect string values.

### Refactor of `Endpoint` utility:

* Updated `Endpoint.getExplorerURL` and `Endpoint.getExplorerByAddressURL` to use the `Chain` enum instead of `chainTicker` strings. This involved replacing all string-based chain identifiers with corresponding `Chain` enum cases, improving type safety and maintainability.


## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated various components to use a strongly typed chain parameter when generating explorer URLs, improving reliability and consistency across transaction and address explorer links.
  - No changes to user-facing logic or the appearance of explorer links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->