### PR TITLE
Backup Guide animation fix for macOS

### DIFF
--- a/VultisigApp/VultisigApp/Views/Onboarding/OnboardingSummaryView+macOS.swift
+++ b/VultisigApp/VultisigApp/Views/Onboarding/OnboardingSummaryView+macOS.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 extension OnboardingSummaryView {
-
     var animation: some View {
         ZStack {
             if kind == .secure {
@@ -18,7 +17,7 @@ extension OnboardingSummaryView {
                 animationVM?.view()
             }
         }
-        .frame(width: 500, height: 400)
+        .frame(width: 450, height: 350)
     }
 }
 

--- a/VultisigApp/VultisigApp/Views/Onboarding/OnboardingSummaryView.swift
+++ b/VultisigApp/VultisigApp/Views/Onboarding/OnboardingSummaryView.swift
@@ -103,6 +103,8 @@ struct OnboardingSummaryView: View {
     }
     
     private func setData() {
-        animationVM = RiveViewModel(fileName: kind.animation)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            animationVM = RiveViewModel(fileName: kind.animation)
+        }
     }
 }


### PR DESCRIPTION
## Description

Screen being blank on OnboardingSummaryView fixed for Fast Vault on macOS

Fixes #2170

## Which feature is affected?
- [ ] Create vault ( Fast) - Check the OnboardingSummaryView that is displayed after creating the backup.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted animation view size for a more compact display during onboarding.
  - Removed an unnecessary blank line for cleaner code presentation.

- **Refactor**
  - Deferred the loading of onboarding animations slightly to improve display timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->