### PR TITLE
Local mode label on Keysign View updated

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -623,3 +623,5 @@
 "close" = "Schließen";
 "vaultTypeDoesnotMatch" = "Tresortyp stimmt nicht überein";
 "failedToLoadFileData" = "Fehler beim Laden der Dateidaten"; 
+"wantToCreateVaultPrivately" = "Möchtest du den Tresor privat erstellen?";
+"wantToSignPrivately" = "Möchtest du privat signieren?";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -654,3 +654,5 @@
 "close" = "Close";
 "vaultTypeDoesnotMatch" = "Vault type doesn't match";
 "failedToLoadFileData" = "Failed to load file data";
+"wantToCreateVaultPrivately" = "Want to create vault privately?";
+"wantToSignPrivately" = "Want to sign privately?";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -606,3 +606,5 @@
 "close" = "Cerrar";
 "vaultTypeDoesnotMatch" = " El tipo de bóveda no coincide";
 "failedToLoadFileData" = "Error al cargar los datos del archivo";
+"wantToCreateVaultPrivately" = "¿Quieres crear la bóveda en privado?";
+"wantToSignPrivately" = "¿Quieres firmar en privado?";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -606,3 +606,5 @@
 "close" = "Zatvori";
 "vaultTypeDoesnotMatch" = " Vrsta trezora se ne podudara";
 "failedToLoadFileData" = "Greška pri učitavanju podataka datoteke";
+"wantToCreateVaultPrivately" = "Želite li stvoriti trezor privatno?";
+"wantToSignPrivately" = "Želite li potpisivati privatno?";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -606,3 +606,5 @@
 "close" = "Chiudi";
 "vaultTypeDoesnotMatch" = " Il tipo di cassaforte non corrisponde";
 "failedToLoadFileData" = "Impossibile caricare i dati del file";
+"wantToCreateVaultPrivately" = "Vuoi creare il vault in privato?";
+"wantToSignPrivately" = "Vuoi firmare in privato?";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -607,3 +607,5 @@
 "close" = "Fechar";
 "vaultTypeDoesnotMatch" = "O tipo de cofre não corresponde";
 "failedToLoadFileData" = "Falha ao carregar dados do arquivo";
+"wantToCreateVaultPrivately" = "Deseja criar o cofre de forma privada?";
+"wantToSignPrivately" = "Deseja assinar de forma privada?";

--- a/VultisigApp/VultisigApp/Views/Components/SwitchToLocalLink.swift
+++ b/VultisigApp/VultisigApp/Views/Components/SwitchToLocalLink.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SwitchToLocalLink: View {
+    let isForKeygen: Bool
     @Binding var selectedNetwork: NetworkPromptType
     
     var body: some View {
@@ -32,7 +33,11 @@ struct SwitchToLocalLink: View {
     
     var switchToLocalLabel: some View {
         HStack {
-            Text(NSLocalizedString("privatePairingMode", comment: ""))
+            if isForKeygen {
+                Text(NSLocalizedString("wantToCreateVaultPrivately", comment: ""))
+            } else {
+                Text(NSLocalizedString("wantToSignPrivately", comment: ""))
+            }
             
             Text(NSLocalizedString("switchToLocalMode", comment: ""))
             .underline()
@@ -57,5 +62,5 @@ struct SwitchToLocalLink: View {
 }
 
 #Preview {
-    SwitchToLocalLink(selectedNetwork: .constant(.Internet))
+    SwitchToLocalLink(isForKeygen: true, selectedNetwork: .constant(.Internet))
 }

--- a/VultisigApp/VultisigApp/iOS/View/Keysign/KeysignDiscoveryView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Keysign/KeysignDiscoveryView+iOS.swift
@@ -103,7 +103,7 @@ extension KeysignDiscoveryView {
     }
     
     var switchLink: some View {
-        SwitchToLocalLink(selectedNetwork: $selectedNetwork)
+        SwitchToLocalLink(isForKeygen: false, selectedNetwork: $selectedNetwork)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
@@ -147,7 +147,7 @@ extension PeerDiscoveryView {
     }
     
     var switchLink: some View {
-        SwitchToLocalLink(selectedNetwork: $viewModel.selectedNetwork)
+        SwitchToLocalLink(isForKeygen: true, selectedNetwork: $viewModel.selectedNetwork)
     }
 
     var isShareButtonVisible: Bool {

--- a/VultisigApp/VultisigApp/macOS/View/Keysign/KeysignDiscoveryView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Keysign/KeysignDiscoveryView+macOS.swift
@@ -109,8 +109,8 @@ extension KeysignDiscoveryView {
     }
     
     var switchLink: some View {
-        SwitchToLocalLink(selectedNetwork: $selectedNetwork)
-            .padding(.bottom, 8)
+        SwitchToLocalLink(isForKeygen: false, selectedNetwork: $selectedNetwork)
+            .padding(.bottom, 24)
     }
     
     func getMinSize() -> CGFloat {

--- a/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
@@ -144,7 +144,7 @@ extension PeerDiscoveryView {
     }
     
     var switchLink: some View {
-        SwitchToLocalLink(selectedNetwork: $viewModel.selectedNetwork)
+        SwitchToLocalLink(isForKeygen: true, selectedNetwork: $viewModel.selectedNetwork)
             .padding(.bottom, 24)
     }
     


### PR DESCRIPTION
## Description

Local mode label on Keysign View replaced to display "Want to sign privately" instead.

Fixes #2159

## Which feature is affected?
- [ ] Sign a transaction ( Send / Swap) - Switch to Local Mode label should say "Want to sign privately".

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots:
<img width="1091" alt="Screenshot 2025-05-13 at 5 11 37 PM" src="https://github.com/user-attachments/assets/7491906a-8843-43c1-b0ed-a2ad602a64b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized prompts in English, German, Spanish, Croatian, Italian, and Portuguese for private vault creation and private signing.
  - Updated interface to display context-specific prompts for private actions during vault creation and signing processes.

- **Style**
  - Increased padding for the switch link component in the macOS key signing view for improved visual spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->