### PR TITLE
Padding added

### DIFF
--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDoneView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDoneView.swift
@@ -53,7 +53,7 @@ struct SwapCryptoDoneView: View {
             trackButton
             doneButton
         }
-        .padding(.top)
+        .padding(.vertical)
         .padding(.horizontal, 18)
         .background(Color.backgroundBlue)
     }


### PR DESCRIPTION
## Description

Padding added for buttons on Swap Done View for macOS

Fixes #2216

## Which feature is affected?
- [ ] Swap flow - Swap done view

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots:
<img width="913" alt="Screenshot 2025-05-13 at 11 09 42 PM" src="https://github.com/user-attachments/assets/973de8ab-f525-4129-8ee5-114018acc4dc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved vertical spacing for buttons in the swap confirmation view for a more balanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->