### PR TITLE
Sign title changed to Overview

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -625,3 +625,4 @@
 "failedToLoadFileData" = "Fehler beim Laden der Dateidaten"; 
 "wantToCreateVaultPrivately" = "Möchtest du den Tresor privat erstellen?";
 "wantToSignPrivately" = "Möchtest du privat signieren?";
+"overview" = "Übersicht";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -656,3 +656,4 @@
 "failedToLoadFileData" = "Failed to load file data";
 "wantToCreateVaultPrivately" = "Want to create vault privately?";
 "wantToSignPrivately" = "Want to sign privately?";
+"overview" = "Overview";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -608,3 +608,4 @@
 "failedToLoadFileData" = "Error al cargar los datos del archivo";
 "wantToCreateVaultPrivately" = "¿Quieres crear la bóveda en privado?";
 "wantToSignPrivately" = "¿Quieres firmar en privado?";
+"overview" = "Resumen";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -608,3 +608,4 @@
 "failedToLoadFileData" = "Greška pri učitavanju podataka datoteke";
 "wantToCreateVaultPrivately" = "Želite li stvoriti trezor privatno?";
 "wantToSignPrivately" = "Želite li potpisivati privatno?";
+"overview" = "Pregled";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -608,3 +608,4 @@
 "failedToLoadFileData" = "Impossibile caricare i dati del file";
 "wantToCreateVaultPrivately" = "Vuoi creare il vault in privato?";
 "wantToSignPrivately" = "Vuoi firmare in privato?";
+"overview" = "Panoramica";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -609,3 +609,4 @@
 "failedToLoadFileData" = "Falha ao carregar dados do arquivo";
 "wantToCreateVaultPrivately" = "Deseja criar o cofre de forma privada?";
 "wantToSignPrivately" = "Deseja assinar de forma privada?";
+"overview" = "Visão geral";

--- a/VultisigApp/VultisigApp/View Models/SettingsCustomMessageViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SettingsCustomMessageViewModel.swift
@@ -25,7 +25,7 @@ class SettingsCustomMessageViewModel: ObservableObject, TransferViewModel {
             case .keysign:
                 return "keysign"
             case .done:
-                return "done"
+                return "overview"
             }
         }
     }

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView+MacOS.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView+MacOS.swift
@@ -18,7 +18,23 @@ extension SettingsCustomMessageView {
     }
 
     var headerMac: some View {
-        GeneralMacHeader(title: viewModel.state.title, showActions: viewModel.state != .initial)
+        GeneralMacHeader(title: viewModel.state.title)
+    }
+    
+    var button: some View {
+        buttonLabel
+            .padding(.horizontal)
+            .padding(.bottom)
+    }
+    
+    var customMessageContent: some View {
+        VStack(spacing: 16) {
+            title(text: "Method").padding(.top, 16.0)
+            textField(title: "Signing method", text: $method)
+            title(text: "Message")
+            textField(title: "Message to sign", text: $message)
+        }
+        .padding()
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView+MacOS.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView+MacOS.swift
@@ -18,7 +18,7 @@ extension SettingsCustomMessageView {
     }
 
     var headerMac: some View {
-        GeneralMacHeader(title: viewModel.state.title)
+        GeneralMacHeader(title: viewModel.state.title, showActions: viewModel.state != .initial)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView+iOS.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView+iOS.swift
@@ -17,6 +17,13 @@ extension SettingsCustomMessageView {
         .navigationTitle(NSLocalizedString(viewModel.state.title, comment: ""))
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(viewModel.state != .initial)
+        .toolbar {
+            if viewModel.state != .initial {
+                ToolbarItem(placement: Placement.topBarLeading.getPlacement()) {
+                    backButton
+                }
+            }
+        }
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView+iOS.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView+iOS.swift
@@ -25,5 +25,18 @@ extension SettingsCustomMessageView {
             }
         }
     }
+    
+    var button: some View {
+        buttonLabel
+    }
+    
+    var customMessageContent: some View {
+        VStack(spacing: 16) {
+            title(text: "Method").padding(.top, 16.0)
+            textField(title: "Signing method", text: $method)
+            title(text: "Message")
+            textField(title: "Message to sign", text: $message)
+        }
+    }
 }
 #endif

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView.swift
@@ -25,13 +25,6 @@ struct SettingsCustomMessageView: View {
             Background()
             main
         }
-        .toolbar {
-            if viewModel.state != .initial {
-                ToolbarItem(placement: Placement.topBarLeading.getPlacement()) {
-                    backButton
-                }
-            }
-        }
     }
 
     var view: some View {
@@ -42,8 +35,7 @@ struct SettingsCustomMessageView: View {
             tabView
         }
     }
-
-    @ViewBuilder
+    
     var tabView: some View {
         ZStack {
             switch viewModel.state {
@@ -65,6 +57,7 @@ struct SettingsCustomMessageView: View {
                 title(text: "Message")
                 textField(title: "Message to sign", text: $message)
             }
+            .padding()
             .padding(.horizontal, 16)
         }
         .safeAreaInset(edge: .bottom) {
@@ -137,6 +130,8 @@ struct SettingsCustomMessageView: View {
         .padding(.bottom, 12)
         .disabled(!buttonEnabled)
         .opacity(buttonEnabled ? 1 : 0.5)
+        .padding(.horizontal)
+        .padding(.bottom)
     }
 
     var backButton: some View {

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView.swift
@@ -51,14 +51,8 @@ struct SettingsCustomMessageView: View {
 
     var customMessage: some View {
         ScrollView {
-            VStack(spacing: 16) {
-                title(text: "Method").padding(.top, 16.0)
-                textField(title: "Signing method", text: $method)
-                title(text: "Message")
-                textField(title: "Message to sign", text: $message)
-            }
-            .padding()
-            .padding(.horizontal, 16)
+            customMessageContent
+                .padding(.horizontal, 16)
         }
         .safeAreaInset(edge: .bottom) {
             if viewModel.state == .initial {
@@ -120,7 +114,7 @@ struct SettingsCustomMessageView: View {
         )
     }
 
-    var button: some View {
+    var buttonLabel: some View {
         return Button {
             viewModel.moveToNextView()
         } label: {
@@ -130,8 +124,6 @@ struct SettingsCustomMessageView: View {
         .padding(.bottom, 12)
         .disabled(!buttonEnabled)
         .opacity(buttonEnabled ? 1 : 0.5)
-        .padding(.horizontal)
-        .padding(.bottom)
     }
 
     var backButton: some View {


### PR DESCRIPTION
## Description

Title for Sign Custom Message changed to "Overview" for done view.

Fixes #2218

## Which feature is affected?
- [ ] Sign Custom Message - Please follow Sign Custom Message flow

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots:
<img width="912" alt="Screenshot 2025-05-14 at 12 19 21 AM" src="https://github.com/user-attachments/assets/480f1f44-8612-47ce-9713-0216bc97aac1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced custom message settings interface on both iOS and macOS with improved input fields and button layout.
  - Added explicit navigation controls for custom message settings on iOS.

- **Localization**
  - Introduced the "overview" translation in German, English, Spanish, Croatian, Italian, and Portuguese.

- **Style**
  - Simplified and unified the layout for custom message settings views across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->