### PR TITLE
TCY native token price

### DIFF
--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -1547,7 +1547,7 @@ class TokensStore {
             ticker: "TCY",
             logo: "tcy",
             decimals: 8,
-            priceProviderId: "tcy",
+            priceProviderId: "",
             contractAddress: "tcy",
             isNativeToken: false
         ),


### PR DESCRIPTION
this fixes the tcy token price, it does not come from cg so we can't allow any provider id
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/170107b3-df70-439b-b6f7-9a0002d70443" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the price provider information for the "TCY" token on ThorChain to improve accuracy in token data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->