### PR TITLE
disable pct button if selected

### DIFF
--- a/VultisigApp/VultisigApp/View Models/SwapCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SwapCryptoViewModel.swift
@@ -39,7 +39,8 @@ class SwapCryptoViewModel: ObservableObject, TransferViewModel {
     @Published var showToChainSelector = false
     @Published var showFromCoinSelector = false
     @Published var showToCoinSelector = false
-
+    @Published var showAllPercentageButtons = true
+    
     var progress: Double {
         return Double(currentIndex) / Double(titles.count)
     }

--- a/VultisigApp/VultisigApp/Views/Components/Swap/SwapFromToField.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Swap/SwapFromToField.swift
@@ -111,6 +111,7 @@ struct SwapFromToField: View {
         SwapCryptoAmountTextField(amount: $amount) { _ in
             if title=="from" {
                 swapViewModel.updateFromAmount(tx: tx, vault: vault)
+                swapViewModel.showAllPercentageButtons = true
             }
         }
         .disabled(title=="to")

--- a/VultisigApp/VultisigApp/Views/Components/Swap/SwapPercentageButtons.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Swap/SwapPercentageButtons.swift
@@ -10,6 +10,10 @@ import SwiftUI
 struct SwapPercentageButtons: View {
     let buttonOptions = [25, 50, 75, 100]
     
+    @State private var selectedPercentage: Int? = nil
+    
+    @Binding var showAllPercentageButtons: Bool
+    
     let onTap: (Int) -> Void
     
     var body: some View {
@@ -36,19 +40,21 @@ struct SwapPercentageButtons: View {
     
     private func getPercentageButton(for option: Int) -> some View {
         Button(action: {
+            self.selectedPercentage = option
             onTap(option)
         }) {
-            getPercentageCell(for: "\(option)")
+            getPercentageCell(for: "\(option)", isSelected: self.selectedPercentage == option && !self.showAllPercentageButtons)
         }
+        .disabled(self.selectedPercentage == option && !self.showAllPercentageButtons)
     }
     
-    private func getPercentageCell(for text: String) -> some View {
+    private func getPercentageCell(for text: String, isSelected: Bool) -> some View {
         Text(text + "%")
             .font(.body12BrockmannMedium)
-            .foregroundColor(.neutral0)
+            .foregroundColor(isSelected ? Color.white : .neutral0)
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
-            .background(Color.blue600)
+            .background(isSelected ? Color.blue800 : Color.blue600)
             .cornerRadius(32)
     }
 }

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -203,6 +203,7 @@ struct SwapCryptoDetailsView: View {
 
 extension SwapCryptoDetailsView {
     public func handlePercentageSelection(_ percentage: Int) {
+        swapViewModel.showAllPercentageButtons = false
         switch percentage {
         case 25:
             tx.fromAmount = (tx.fromCoin.balanceDecimal * 0.25).formatToDecimal(digits: 4)

--- a/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
@@ -75,7 +75,7 @@ extension SwapCryptoDetailsView {
     }
     
     var percentageButtons: some View {
-        SwapPercentageButtons { percentage in
+        SwapPercentageButtons(showAllPercentageButtons: $swapViewModel.showAllPercentageButtons) { percentage in
             handlePercentageSelection(percentage)
         }
         .opacity(keyboardObserver.keyboardHeight == 0 ? 0 : 1)

--- a/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
@@ -75,7 +75,7 @@ extension SwapCryptoDetailsView {
     }
     
     var percentageButtons: some View {
-        SwapPercentageButtons { percentage in
+        SwapPercentageButtons(showAllPercentageButtons: $swapViewModel.showAllPercentageButtons) { percentage in
             handlePercentageSelection(percentage)
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added visual feedback for selected percentage buttons in the swap interface, allowing users to clearly see which percentage is active.
	- Enhanced interaction by disabling already selected percentage buttons when appropriate.
- **Improvements**
	- Updated swap views to provide more intuitive control over percentage button visibility and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->