### PR TITLE
Mac os single vault

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/VaultDeletionConfirmView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultDeletionConfirmView.swift
@@ -59,7 +59,7 @@ struct VaultDeletionConfirmView: View {
         }
     }
     
-    private func allFieldsChecked() -> Bool {
+    func allFieldsChecked() -> Bool {
         permanentDeletionCheck && canLoseFundCheck && vaultBackupCheck
     }
     

--- a/VultisigApp/VultisigApp/Views/Vault/VaultDeletionConfirmView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultDeletionConfirmView.swift
@@ -18,6 +18,7 @@ struct VaultDeletionConfirmView: View {
     
     @State var showAlert = false
     @State var navigateBackToHome = false
+    @State var navigateToCreateVault = false
     
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject var homeViewModel: HomeViewModel
@@ -26,6 +27,9 @@ struct VaultDeletionConfirmView: View {
     
     var body: some View {
         content
+            .navigationDestination(isPresented: $navigateToCreateVault) {
+                CreateVaultView(selectedVault: nil, showBackButton: false)
+            }
     }
     
     var details: some View {
@@ -33,6 +37,8 @@ struct VaultDeletionConfirmView: View {
     }
     
     func delete() {
+        let vaultCount = vaults.count
+        
         guard allFieldsChecked() else {
             showAlert = true
             return
@@ -45,7 +51,12 @@ struct VaultDeletionConfirmView: View {
             print("Error: \(error)")
         }
         ApplicationState.shared.currentVault = nil
-        navigateBackToHome = true
+        
+        if vaultCount > 1 {
+            navigateBackToHome = true
+        } else {
+            navigateToCreateVault = true
+        }
     }
     
     private func allFieldsChecked() -> Bool {

--- a/VultisigApp/VultisigApp/iOS/View/Vault/VaultDeletionConfirmView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/VaultDeletionConfirmView+iOS.swift
@@ -78,8 +78,12 @@ extension VaultDeletionConfirmView {
         Button {
             delete()
         } label: {
-            FilledButton(title: "deleteVaultTitle", background: Color.alertRed)
-                .padding(18)
+            FilledButton(
+                title: "deleteVaultTitle",
+                textColor: allFieldsChecked() ? .backgroundBlue : .disabledText,
+                background: allFieldsChecked() ? Color.alertRed : .disabledButtonBackground
+            )
+            .padding(18)
         }
     }
 }

--- a/VultisigApp/VultisigApp/macOS/View/EditVaultView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/EditVaultView+macOS.swift
@@ -45,7 +45,8 @@ extension EditVaultView {
                 customMessage
                 deleteVault
             }
-            .padding(.horizontal, 25)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 40)
         }
     }
 }

--- a/VultisigApp/VultisigApp/macOS/View/Vault/VaultDeletionConfirmView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Vault/VaultDeletionConfirmView+macOS.swift
@@ -74,7 +74,11 @@ extension VaultDeletionConfirmView {
         Button {
             delete()
         } label: {
-            FilledButton(title: "deleteVaultTitle", background: Color.alertRed)
+            FilledButton(
+                title: "deleteVaultTitle",
+                textColor: allFieldsChecked() ? .backgroundBlue : .disabledText,
+                background: allFieldsChecked() ? Color.alertRed : .disabledButtonBackground
+            )
         }
         .padding(.top, 25)
         .padding(.bottom, 40)


### PR DESCRIPTION
## Description

Deletion logic updated to handle single vault deletion.

Fixes #2198

## Which feature is affected?
- [ ] Delete vault (when only only vault exists) - moves back to create vault view

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved navigation after vault deletion: if no vaults remain, users are now directed to the vault creation screen.

- **Style**
  - Updated delete button appearance on both iOS and macOS to visually indicate when all required fields are checked, enhancing clarity and usability.
  - Adjusted padding in the Edit Vault view on macOS for better layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->