### PR TITLE
IOS keyboard

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/TextFields/SendCryptoAmountTextField.swift
+++ b/VultisigApp/VultisigApp/Views/Components/TextFields/SendCryptoAmountTextField.swift
@@ -17,8 +17,12 @@ struct SendCryptoAmountTextField: View {
     
     var body: some View {
         HStack(spacing: 0) {
+#if os(iOS)
+            container.keyboardType(.decimalPad)
+#endif
+#if os(macOS)
             container
-            
+#endif
             if showButton {
                 maxButton
             }


### PR DESCRIPTION
This solves the issue https://github.com/vultisig/vultisig-ios/issues/2169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the crypto amount input field by enabling a decimal keypad for numeric input on iOS devices, while maintaining the original input behavior on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

![image](https://github.com/user-attachments/assets/91d12204-486d-44a3-b05a-46843424b2e0)
