### PR TITLE
fix ubond

### DIFF
--- a/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnbond.swift
+++ b/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallUnbond.swift
@@ -65,7 +65,7 @@ class FunctionCallUnbond: FunctionCallAddressable, ObservableObject {
     
     var amountInUnits: String {
         let amountInSats = self.amount * pow(10, 8)
-        return amountInSats.formatDecimalToLocale()
+        return amountInSats.description
     }
     
     func toString() -> String {


### PR DESCRIPTION
Fix the format for unbound. It was formatting to locale, but we need that only in big integer 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the display format for amounts to use plain numeric strings instead of locale-specific formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->