### PR TITLE
Mac os keygen error state

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -626,3 +626,4 @@
 "wantToCreateVaultPrivately" = "Möchtest du den Tresor privat erstellen?";
 "wantToSignPrivately" = "Möchtest du privat signieren?";
 "overview" = "Übersicht";
+"keygenFailedErrorMessage" = "Keygen fehlgeschlagen\nBitte versuche es erneut";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -657,3 +657,4 @@
 "wantToCreateVaultPrivately" = "Want to create vault privately?";
 "wantToSignPrivately" = "Want to sign privately?";
 "overview" = "Overview";
+"keygenFailedErrorMessage" = "Keygen failed\nPlease try again";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -609,3 +609,4 @@
 "wantToCreateVaultPrivately" = "¿Quieres crear la bóveda en privado?";
 "wantToSignPrivately" = "¿Quieres firmar en privado?";
 "overview" = "Resumen";
+"keygenFailedErrorMessage" = "Keygen fallido\nPor favor, inténtalo de nuevo";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -609,3 +609,4 @@
 "wantToCreateVaultPrivately" = "Želite li stvoriti trezor privatno?";
 "wantToSignPrivately" = "Želite li potpisivati privatno?";
 "overview" = "Pregled";
+"keygenFailedErrorMessage" = "Keygen nije uspio\nPokušajte ponovno";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -609,3 +609,4 @@
 "wantToCreateVaultPrivately" = "Vuoi creare il vault in privato?";
 "wantToSignPrivately" = "Vuoi firmare in privato?";
 "overview" = "Panoramica";
+"keygenFailedErrorMessage" = "Keygen non riuscito\nRiprova";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -610,3 +610,4 @@
 "wantToCreateVaultPrivately" = "Deseja criar o cofre de forma privada?";
 "wantToSignPrivately" = "Deseja assinar de forma privada?";
 "overview" = "Visão geral";
+"keygenFailedErrorMessage" = "Falha no Keygen\nTente novamente";

--- a/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
@@ -285,9 +285,7 @@ struct KeygenView: View {
     
     var button: some View {
         Button {
-            Task {
-                await setData()
-            }
+            dismiss()
         } label: {
             FilledButton(title: "retry")
         }

--- a/VultisigApp/VultisigApp/macOS/View/Keygen/KeygenView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Keygen/KeygenView+macOS.swift
@@ -29,12 +29,15 @@ extension KeygenView {
                 }
                 states
             }
-            Spacer()
             
             if progressCounter < 4 {
                 if viewModel.status == .KeygenFailed {
+                    errorMessage
+                    Spacer()
                     retryButton
+                        .padding(.bottom)
                 } else {
+                    Spacer()
                     progressContainer
                 }
             }
@@ -43,6 +46,10 @@ extension KeygenView {
     
     var progressContainer: some View {
         KeygenProgressContainer(progressCounter: progressCounter)
+    }
+    
+    var errorMessage: some View {
+        ErrorMessage(text: "keygenFailedErrorMessage")
     }
 }
 #endif


### PR DESCRIPTION
## Description

Error message and retry button fixed for Keygen on macOS

Fixes #2252

## Which feature is affected?
- [ ] Create vault (Fast) error view - Test the retry button when Keygen fails on macOS

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots:
<img width="938" alt="Screenshot 2025-05-20 at 11 39 21 AM" src="https://github.com/user-attachments/assets/0b6919cd-edd9-488b-9542-e69f3db58cbf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a user-facing error message for key generation failures, now localized in English, German, Spanish, Croatian, Italian, and Portuguese.
- **User Interface**
  - Improved error handling in the key generation view, displaying the localized error message and adjusting layout for better visibility.
  - Updated retry button behavior to dismiss the error view immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->