### PR TITLE
Swap cancel error

### DIFF
--- a/VultisigApp/VultisigApp/View Models/SwapCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SwapCryptoViewModel.swift
@@ -431,7 +431,11 @@ private extension SwapCryptoViewModel {
                 throw Errors.insufficientFunds
             }
         } catch {
-            self.error = error
+            if let error = error as? URLError, error.code == .cancelled {
+                print("request cancelled")
+            } else {
+                self.error = error
+            }
         }
     }
     

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -196,11 +196,6 @@ struct SwapCryptoDetailsView: View {
         swapViewModel.fromChain = swapViewModel.toChain
         swapViewModel.toChain = fromChain
         swapViewModel.refreshData(tx: tx, vault: vault)
-//        let fromChain = swapViewModel.fromChain
-//        swapViewModel.fromChain = swapViewModel.toChain
-//        swapViewModel.toChain = fromChain
-//        handleFromCoinUpdate()
-//        handleToCoinUpdate()
     }
     
     func showSheet() -> Bool {

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -189,11 +189,18 @@ struct SwapCryptoDetailsView: View {
     }
     
     private func handleSwapTap() {
+        swapViewModel.error = nil
         buttonRotated.toggle()
         swapViewModel.switchCoins(tx: tx, vault: vault)
         let fromChain = swapViewModel.fromChain
         swapViewModel.fromChain = swapViewModel.toChain
         swapViewModel.toChain = fromChain
+        swapViewModel.refreshData(tx: tx, vault: vault)
+//        let fromChain = swapViewModel.fromChain
+//        swapViewModel.fromChain = swapViewModel.toChain
+//        swapViewModel.toChain = fromChain
+//        handleFromCoinUpdate()
+//        handleToCoinUpdate()
     }
     
     func showSheet() -> Bool {


### PR DESCRIPTION
## Description

Swap validation logic updated to handle cancelled state

Fixes #2255

## Which feature is affected?
- [ ] Swap - Select Polygon and BNB chain. And tap on interchange button.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cancelled network requests during quote updates are no longer shown as errors in the UI.
  - Existing errors are now cleared before initiating a swap action to ensure accurate error display.

- **New Features**
  - Swap details are now refreshed automatically after swapping coins, providing up-to-date information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->