### PR TITLE
Update FocusState and handle "onSubmit"

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/FastVaultEmailView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/FastVaultEmailView.swift
@@ -20,9 +20,14 @@ struct FastVaultEmailView: View {
     
     @State var isEmptyEmail: Bool = false
     @State var isInvalidEmail: Bool = false
-
+    @FocusState var isEmailFocused: Bool
+    
     var body: some View {
-        content
+        content.onAppear(){
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                isEmailFocused = true
+            }
+        }
     }
 
     var emailField: some View {
@@ -41,6 +46,7 @@ struct FastVaultEmailView: View {
         .padding(.horizontal, 16)
         .animation(.easeInOut, value: isEmptyEmail)
         .animation(.easeInOut, value: isInvalidEmail)
+        
     }
 
     var emptyEmailLabel: some View {
@@ -89,7 +95,7 @@ struct FastVaultEmailView: View {
         }
     }
     
-    private func handleTap() {
+    func handleTap() {
         guard isEmptyEmailCheck() else {
             isEmptyEmail = true
             return

--- a/VultisigApp/VultisigApp/Views/Keygen/FastVaultSetHintView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/FastVaultSetHintView.swift
@@ -14,31 +14,37 @@ struct FastVaultSetHintView: View {
     let fastVaultEmail: String
     let fastVaultPassword: String
     let fastVaultExist: Bool
-
+    
     @State var hint: String = ""
     @State var isLinkActive = false
-
+    @FocusState var isFocused: Bool
+    
     var body: some View {
         content
+            .onAppear(){
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    isFocused = true
+                }
+            }
     }
-
+    
     var hintField: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text(NSLocalizedString("setPasswordHintTitle", comment: ""))
                 .font(.body34BrockmannMedium)
                 .foregroundColor(.neutral0)
                 .padding(.top, 16)
-
+            
             Text(NSLocalizedString("setPasswordHintSubtitle", comment: ""))
                 .font(.body14BrockmannMedium)
                 .foregroundColor(.extraLightGray)
-
+            
             hintTextfield
         }
         .padding(.top, 24)
         .padding(.horizontal, 16)
     }
-
+    
     var hintTextfield: some View {
         ZStack {
             HStack {
@@ -49,7 +55,13 @@ struct FastVaultSetHintView: View {
                     .font(.body16BrockmannMedium)
                     .submitLabel(.done)
                     .autocorrectionDisabled()
-
+                    .focused($isFocused)
+                    .onSubmit {
+                        
+                        isLinkActive = true
+                        
+                    }
+                
                 if !hint.isEmpty {
                     VStack {
                         clearButton
@@ -67,7 +79,7 @@ struct FastVaultSetHintView: View {
                             .padding(.leading, 5)
                         Spacer()
                     }
-
+                    
                     Spacer()
                 }
             }
@@ -82,7 +94,7 @@ struct FastVaultSetHintView: View {
                 .stroke(Color.blue200, lineWidth: 1)
         )
     }
-
+    
     var clearButton: some View {
         Button {
             hint = ""
@@ -91,7 +103,7 @@ struct FastVaultSetHintView: View {
                 .foregroundColor(.neutral500)
         }
     }
-
+    
     var buttons: some View {
         HStack(spacing: 8) {
             Button(action: {
@@ -110,7 +122,7 @@ struct FastVaultSetHintView: View {
         .padding(.bottom, 40)
         .padding(.horizontal, 16)
     }
-
+    
     var fastSignConfig: FastSignConfig {
         return FastSignConfig(
             email: fastVaultEmail,

--- a/VultisigApp/VultisigApp/Views/Keygen/FastVaultSetHintView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/FastVaultSetHintView.swift
@@ -57,9 +57,7 @@ struct FastVaultSetHintView: View {
                     .autocorrectionDisabled()
                     .focused($isFocused)
                     .onSubmit {
-                        
                         isLinkActive = true
-                        
                     }
                 
                 if !hint.isEmpty {
@@ -69,7 +67,7 @@ struct FastVaultSetHintView: View {
                     }
                 }
             }
-            if hint.isEmpty {
+            if hint.isEmpty && !isFocused {
                 VStack {
                     HStack {
                         Text(NSLocalizedString("enterHint", comment: ""))

--- a/VultisigApp/VultisigApp/Views/New Wallet/NewWalletNameView.swift
+++ b/VultisigApp/VultisigApp/Views/New Wallet/NewWalletNameView.swift
@@ -17,6 +17,7 @@ struct NewWalletNameView: View {
     @State var didSet = false
     @State var isLinkActive = false
     @State var showAlert = false
+    @FocusState private var isNameFocused: Bool
     
     @Query var vaults: [Vault]
     
@@ -30,6 +31,9 @@ struct NewWalletNameView: View {
             Spacer()
             button
         }
+        .onAppear() {
+            isNameFocused = true
+        }
         .alert(isPresented: $showAlert) {
             alert
         }
@@ -41,6 +45,10 @@ struct NewWalletNameView: View {
                 .font(.body16BrockmannMedium)
                 .foregroundColor(.neutral0)
                 .submitLabel(.done)
+                .focused($isNameFocused)
+                .onSubmit {
+                    verifyVault()
+                }
             
             if !name.isEmpty {
                 clearButton

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDetailsView.swift
@@ -42,6 +42,7 @@ struct SendCryptoDetailsView: View {
         }
         .gesture(DragGesture())
         .onFirstAppear {
+            focusedField = .toAddress
             setData()
         }
         .onChange(of: tx.coin) { oldValue, newValue in

--- a/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultEmailView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/FastVaultEmailView+iOS.swift
@@ -50,7 +50,10 @@ extension FastVaultEmailView {
             .font(.body16Menlo)
             .foregroundColor(.neutral0)
             .submitLabel(.done)
-            
+            .focused($isEmailFocused)
+            .onSubmit {
+                handleTap()
+            }
             if !email.isEmpty {
                 clearButton
             }

--- a/VultisigApp/VultisigApp/macOS/View/FastVaultEmailView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/FastVaultEmailView+macOS.swift
@@ -55,6 +55,10 @@ extension FastVaultEmailView {
             .font(.body16Menlo)
             .foregroundColor(.neutral0)
             .submitLabel(.done)
+            .focused($isEmailFocused)
+            .onSubmit {
+                handleTap()
+            }
             
             if !email.isEmpty {
                 clearButton


### PR DESCRIPTION
## Description

Automatically set FocusState to the input field when creating vault , and also handle the "onSubmit" event , so user can user their keyboard , especially when on MacOS

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Input fields in various views (email, hint, password, wallet name, and crypto address) now automatically receive keyboard focus when the view appears, streamlining the user experience.
  - Users can now submit forms directly from the keyboard (e.g., pressing return/done) in email, password, and wallet name fields for faster navigation and submission.

- **Refactor**
  - Improved and unified form submission logic in password-related views for better keyboard navigation and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->