### PR TITLE
Failed to access URL error fixed for macOS

### DIFF
--- a/VultisigApp/VultisigApp/Utils/Utils.swift
+++ b/VultisigApp/VultisigApp/Utils/Utils.swift
@@ -606,12 +606,12 @@ enum Utils {
             let success = url.startAccessingSecurityScopedResource()
             defer { url.stopAccessingSecurityScopedResource() }
             
+#if os(iOS)
             guard success else {
                 print("Failed to access URL")
                 throw UtilsQrCodeFromImageError.URLInaccessible
             }
             
-#if os(iOS)
             if let imageData = try? Data(contentsOf: url), let selectedImage = UIImage(data: imageData) {
                 let qrStrings = Utils.detectQRCode(selectedImage)
                 

--- a/VultisigApp/VultisigApp/macOS/Components/FileQRCodeImporterMac+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/Components/FileQRCodeImporterMac+macOS.swift
@@ -17,7 +17,7 @@ extension FileQRCodeImporterMac {
                 fileCell(name)
             }
         }
-        .onDrop(of: [.data], isTargeted: $isUploading) { providers -> Bool in
+        .onDrop(of: [.fileURL], isTargeted: $isUploading) { providers -> Bool in
             OnDropQRUtils.handleFileQRCodeImporterMacDrop(providers: providers) { result in
                 handleFileImport(result)
             }

--- a/VultisigApp/VultisigApp/macOS/Utils/OnDropQRUtils.swift
+++ b/VultisigApp/VultisigApp/macOS/Utils/OnDropQRUtils.swift
@@ -7,6 +7,7 @@
 
 #if os(macOS)
 import AppKit
+import UniformTypeIdentifiers
 
 enum OnDropQRError: Error {
     case noItems
@@ -48,7 +49,7 @@ class OnDropQRUtils {
         
         for provider in providers {
             dispatchGroup.enter()
-            provider.loadItem(forTypeIdentifier: "public.data", options: nil) { (item, error) in
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { (item, error) in
                 if let error = error {
                     dropError = error
                     dispatchGroup.leave()


### PR DESCRIPTION
## Description

Failed to access URL error fixed for macOS

Fixes #2126

## Which feature is affected?
- [ ] Add vault (macOS) - Scan QR code -> Upload QR code image -> use drag and drop

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved platform compatibility and stability by ensuring certain QR code image access checks are only executed on iOS.
  - Enhanced drag-and-drop functionality on macOS by accepting only file URLs instead of generic data, reducing the chance of invalid drops.
  - Increased reliability of file type detection for dropped items by using a standardized file URL identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->