### PR TITLE
Support added to upload vault backup from 3rd party app (Google Drive)

### DIFF
--- a/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
@@ -115,14 +115,8 @@ class EncryptedBackupViewModel: ObservableObject {
     
     // Import
     func importFile(from url: URL) {
-        let success = url.startAccessingSecurityScopedResource()
         defer { url.stopAccessingSecurityScopedResource() }
         
-        guard success else {
-            alertTitle = "Permission denied for accessing the file."
-            showAlert = true
-            return
-        }
         do {
             
             let data = try Data(contentsOf: url)
@@ -267,13 +261,14 @@ class EncryptedBackupViewModel: ObservableObject {
                 .setDefaultCoinsOnce(vault: backupVault.vault, defaultChains: defaultChains)
             modelContext.insert(backupVault.vault)
             selectedVault = backupVault.vault
+            showAlert = false
             isLinkActive = true
         }  catch {
             print("failed to import with new format , fallback to the old format instead. \(error.localizedDescription)")
+            
             // fallback
             do{
-                let vault = try decoder.decode(Vault.self,
-                                               from: vaultData)
+                let vault = try decoder.decode(Vault.self, from: vaultData)
                 
                 if !isVaultUnique(backupVault: vault,vaults:vaults){
                     alertTitle = "vaultAlreadyExists"
@@ -285,6 +280,7 @@ class EncryptedBackupViewModel: ObservableObject {
                     .setDefaultCoinsOnce(vault: vault, defaultChains: defaultChains)
                 modelContext.insert(vault)
                 selectedVault = vault
+                showAlert = false
                 isLinkActive = true
             } catch {
                 logger.error("fail to restore vault: \(error.localizedDescription)")

--- a/VultisigApp/VultisigApp/Views/New Wallet/ImportWalletView.swift
+++ b/VultisigApp/VultisigApp/Views/New Wallet/ImportWalletView.swift
@@ -80,11 +80,7 @@ struct ImportWalletView: View {
     
     var continueButton: some View {
         Button {
-            backupViewModel.restoreVault(
-                modelContext: context,
-                vaults: vaults,
-                defaultChains: settingsDefaultChainViewModel.defaultChains
-            )
+            handleButtonTap()
         } label: {
             FilledButton(
                 title: "continue",
@@ -112,6 +108,18 @@ struct ImportWalletView: View {
     
     private func resetData() {
         backupViewModel.resetData()
+    }
+    
+    private func handleButtonTap() {
+        backupViewModel.restoreVault(
+            modelContext: context,
+            vaults: vaults,
+            defaultChains: settingsDefaultChainViewModel.defaultChains
+        )
+        
+        if !backupViewModel.showAlert {
+            vultExtensionViewModel.showImportView = false
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Support added to upload vault backup from 3rd party app (Google Drive)

Fixes #2066

## Which feature is affected?
- [ ] Upload vault backup - Google Drive app -> Open .VULT backup in Vultisig app

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works