### PR TITLE
Add support txt files for testing wallet import

### DIFF
--- a/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
@@ -306,7 +306,7 @@ class EncryptedBackupViewModel: ObservableObject {
     private func isValidFormat(_ url: URL) -> Bool {
         let fileExtension = url.pathExtension.lowercased()
         
-        if fileExtension == "dat" || fileExtension == "bak" ||  fileExtension == "vult" {
+        if fileExtension == "dat" || fileExtension == "bak" || fileExtension == "vult" || fileExtension == "txt" {
             return true
         } else {
             return false
@@ -329,7 +329,14 @@ class EncryptedBackupViewModel: ObservableObject {
                     return
                 }
                 
-                importedFileName = url.lastPathComponent
+                if url.pathExtension.lowercased() == "txt" {
+                    let fileName = url.lastPathComponent
+                    let newFileName = fileName.replacingOccurrences(of: ".txt", with: ".vult")
+                    importedFileName = newFileName
+                } else {
+                    importedFileName = url.lastPathComponent
+                }
+                
                 importFile(from: url)
             }
         case .failure(let error):
@@ -343,7 +350,14 @@ class EncryptedBackupViewModel: ObservableObject {
             return
         }
         
-        importedFileName = url.lastPathComponent
+        if url.pathExtension.lowercased() == "txt" {
+            let fileName = url.lastPathComponent
+            let newFileName = fileName.replacingOccurrences(of: ".txt", with: ".vult")
+            importedFileName = newFileName
+        } else {
+            importedFileName = url.lastPathComponent
+        }
+        
         importFile(from: url)
     }
     
@@ -364,7 +378,13 @@ class EncryptedBackupViewModel: ObservableObject {
                                 self.showInvalidFormatAlert()
                                 return
                             }    
-                            self.importedFileName = url.lastPathComponent
+                            if url.pathExtension.lowercased() == "txt" {
+                                let fileName = url.lastPathComponent
+                                let newFileName = fileName.replacingOccurrences(of: ".txt", with: ".vult")
+                                self.importedFileName = newFileName
+                            } else {
+                                self.importedFileName = url.lastPathComponent
+                            }
                             self.importDragDropFile(content: data)
                         }
                     }

--- a/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
@@ -328,15 +328,7 @@ class EncryptedBackupViewModel: ObservableObject {
                     showInvalidFormatAlert()
                     return
                 }
-                
-                if url.pathExtension.lowercased() == "txt" {
-                    let fileName = url.lastPathComponent
-                    let newFileName = fileName.replacingOccurrences(of: ".txt", with: ".vult")
-                    importedFileName = newFileName
-                } else {
-                    importedFileName = url.lastPathComponent
-                }
-                
+                importedFileName = url.lastPathComponent.replacingOccurrences(of: ".txt", with: ".vult")
                 importFile(from: url)
             }
         case .failure(let error):
@@ -349,15 +341,7 @@ class EncryptedBackupViewModel: ObservableObject {
             showInvalidFormatAlert()
             return
         }
-        
-        if url.pathExtension.lowercased() == "txt" {
-            let fileName = url.lastPathComponent
-            let newFileName = fileName.replacingOccurrences(of: ".txt", with: ".vult")
-            importedFileName = newFileName
-        } else {
-            importedFileName = url.lastPathComponent
-        }
-        
+        importedFileName = url.lastPathComponent.replacingOccurrences(of: ".txt", with: ".vult")
         importFile(from: url)
     }
     
@@ -378,13 +362,7 @@ class EncryptedBackupViewModel: ObservableObject {
                                 self.showInvalidFormatAlert()
                                 return
                             }    
-                            if url.pathExtension.lowercased() == "txt" {
-                                let fileName = url.lastPathComponent
-                                let newFileName = fileName.replacingOccurrences(of: ".txt", with: ".vult")
-                                self.importedFileName = newFileName
-                            } else {
-                                self.importedFileName = url.lastPathComponent
-                            }
+                            self.importedFileName = url.lastPathComponent.replacingOccurrences(of: ".txt", with: ".vult")
                             self.importDragDropFile(content: data)
                         }
                     }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Add support txt format for testing needs, due browser stack restrict uploading .vult

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for importing backup files with the ".txt" extension.

- **Bug Fixes**
  - Ensured ".txt" files are consistently renamed and treated as ".vult" files during import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->