### PR TITLE
feat: add ZCash support for Maya chain swaps

### DIFF
--- a/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
@@ -12,7 +12,7 @@ extension CoinAction {
     static var swapChains: [Chain] = [
         .solana,.bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash,
         .thorChain, .mayaChain, .ethereum, .avalanche, .base, .arbitrum,
-        .polygon, .polygonV2, .optimism, .bscChain, .gaiaChain, .kujira, .zksync
+        .polygon, .polygonV2, .optimism, .bscChain, .gaiaChain, .kujira, .zksync, .zcash
     ]
     
     static var memoChains: [Chain] = [

--- a/VultisigApp/VultisigApp/Services/Actions/Coin+Swaps.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/Coin+Swaps.swift
@@ -73,7 +73,9 @@ extension Coin {
             return [.thorchain]
         case .blast, .solana:
             return [.lifi]
-        case .sui, .polkadot, .dydx, .cronosChain, .ton, .osmosis, .terra, .terraClassic, .noble, .ripple, .akash, .tron,.ethereumSepolia, .zcash:
+        case .zcash:
+            return [.mayachain]
+        case .sui, .polkadot, .dydx, .cronosChain, .ton, .osmosis, .terra, .terraClassic, .noble, .ripple, .akash, .tron,.ethereumSepolia:
             return []
         }
     }


### PR DESCRIPTION
https://www.xscanner.org/tx/1DEB75CC80F1AF15D402D62D39EB1B151A0360A7EFF97DF060E0C6DA37A7BDCD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled swap functionality for Zcash, allowing users to perform swaps with this blockchain.
  - Zcash swaps are now supported via the MayaChain provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->