### PR TITLE
fix: set rounding mode to down in decimal formatters 

### DIFF
--- a/VultisigApp/VultisigApp/Extensions/DecimalExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/DecimalExtension.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Foundation
 import SwiftUI
 import BigInt
 
@@ -31,6 +30,7 @@ extension Decimal {
         formatter.minimumFractionDigits = 2
         formatter.decimalSeparator = Locale.current.decimalSeparator ?? "."
         formatter.groupingSeparator = Locale.current.groupingSeparator ?? ","
+        formatter.roundingMode = .down
         
         let number = NSDecimalNumber(decimal: self)
         return formatter.string(from: number) ?? ""
@@ -42,6 +42,7 @@ extension Decimal {
         formatter.locale = locale
         formatter.maximumFractionDigits = 8
         formatter.minimumFractionDigits = 4
+        formatter.roundingMode = .down
         return formatter.string(from: self as NSDecimalNumber) ?? ""
     }
     
@@ -52,6 +53,7 @@ extension Decimal {
         formatter.minimumFractionDigits = 0
         formatter.decimalSeparator = Locale.current.decimalSeparator ?? "."
         formatter.groupingSeparator = Locale.current.groupingSeparator ?? ","
+        formatter.roundingMode = .down
         
         // Convert Decimal to NSDecimalNumber before using with NumberFormatter
         let number = NSDecimalNumber(decimal: self)
@@ -59,8 +61,6 @@ extension Decimal {
         return formatter.string(from: number) ?? ""
     }
     
-
-
     init(_ bigInt: BigInt) {
         self = .init(string: bigInt.description) ?? 0
     }

--- a/VultisigApp/VultisigApp/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/StringExtension.swift
@@ -69,26 +69,6 @@ extension String {
 
 // MARK: - Amount Formatter
 extension String {
-    
-    private func getCurrentDecimalPoint() -> String {
-        let formatter = NumberFormatter()
-        formatter.locale = Locale.current // Ensure it uses system locale
-        return formatter.decimalSeparator ?? "."
-    }
-    
-    func formatCurrency() -> String {
-        let decimalPoint = getCurrentDecimalPoint()
-        return self.replacingOccurrences(of: ",", with: decimalPoint)
-    }
-    
-    func formatCurrencyWithSeparators() -> String {
-        guard let number = parseInput() else {
-            return self
-        }
-        
-        return number.formatToFiat(includeCurrencySymbol: false, useAbbreviation: false)
-    }
-    
     func parseInput(locale: Locale = Locale.current) -> Decimal? {
         let usLocale = Locale(identifier: "en_US")
         

--- a/VultisigApp/VultisigApp/View Models/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/JoinKeysignViewModel.swift
@@ -64,7 +64,7 @@ class JoinKeysignViewModel: ObservableObject {
             return .empty
         }
 
-        return "\(String(describing: fromCoin.decimal(for: amount)).formatCurrencyWithSeparators()) \(fromCoin.ticker)"
+        return "\(fromCoin.decimal(for: amount).formatDecimalToLocale()) \(fromCoin.ticker)"
     }
     
     func setData(vault: Vault, serviceDelegate: ServiceDelegate, isCameraPermissionGranted: Bool) {

--- a/VultisigApp/VultisigApp/View Models/SendSummaryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendSummaryViewModel.swift
@@ -11,17 +11,17 @@ import Foundation
 class SendSummaryViewModel: ObservableObject {
     func getFromAmount(_ tx: SwapTransaction, selectedCurrency: SettingsCurrency) -> String {
         if tx.fromCoin.chain == tx.toCoin.chain {
-            return "\(tx.fromAmount.formatCurrencyWithSeparators()) \(tx.fromCoin.ticker)"
+            return "\(tx.fromAmount) \(tx.fromCoin.ticker)"
         } else {
-            return "\(tx.fromAmount.formatCurrencyWithSeparators()) \(tx.fromCoin.ticker) (\(tx.fromCoin.chain.ticker))"
+            return "\(tx.fromAmount) \(tx.fromCoin.ticker) (\(tx.fromCoin.chain.ticker))"
         }
     }
 
     func getToAmount(_ tx: SwapTransaction, selectedCurrency: SettingsCurrency) -> String {
         if tx.fromCoin.chain == tx.toCoin.chain {
-            return "\(tx.toAmountDecimal.description.formatCurrencyWithSeparators()) \(tx.toCoin.ticker)"
+            return "\(tx.toAmountDecimal.formatDecimalToLocale()) \(tx.toCoin.ticker)"
         } else {
-            return "\(tx.toAmountDecimal.description.formatCurrencyWithSeparators()) \(tx.toCoin.ticker) (\(tx.toCoin.chain.ticker))"
+            return "\(tx.toAmountDecimal.formatDecimalToLocale()) \(tx.toCoin.ticker) (\(tx.toCoin.chain.ticker))"
         }
     }
     


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved number formatting consistency by ensuring all decimal values are truncated (rounded down) instead of rounded to the nearest value when displayed.
  - Updated currency and amount display formatting for clearer and locale-appropriate numeric representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->