### PR TITLE
fix: prioritize current locale over US locale in number parsing for b…

### DIFF
--- a/VultisigApp/VultisigApp/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Extensions/StringExtension.swift
@@ -72,17 +72,8 @@ extension String {
     func parseInput(locale: Locale = Locale.current) -> Decimal? {
         let usLocale = Locale(identifier: "en_US")
         
-        // Attempt 1: Try parsing with "en_US" locale
-        let formatterUS = NumberFormatter()
-        formatterUS.locale = usLocale
-        formatterUS.numberStyle = .decimal
-        
-        if let number = formatterUS.number(from: self) {
-            return number.decimalValue
-        }
-        
-        // Attempt 2: Try parsing with the user's current (or provided default) locale
-        // This is only attempted if the US locale parsing failed and the defaultLocale is different from usLocale
+        // Attempt 1: Try parsing with the user's current (or provided default) locale first
+        // This ensures comma-based locales (Europe/Brazil) work correctly
         if locale.identifier != usLocale.identifier {
             let formatterCurrent = NumberFormatter()
             formatterCurrent.locale = locale
@@ -91,6 +82,15 @@ extension String {
             if let number = formatterCurrent.number(from: self) {
                 return number.decimalValue
             }
+        }
+        
+        // Attempt 2: Fallback to parsing with "en_US" locale
+        let formatterUS = NumberFormatter()
+        formatterUS.locale = usLocale
+        formatterUS.numberStyle = .decimal
+        
+        if let number = formatterUS.number(from: self) {
+            return number.decimalValue
         }
         
         // If both attempts fail


### PR DESCRIPTION
This fixes
https://github.com/vultisig/vultisig-ios/issues/2268

<img width="1690" alt="image" src="https://github.com/user-attachments/assets/ca3fc561-90c4-4f1f-adf0-7ceda1c24946" />

Tests
**Error while parsing the fix** 

```
newValue before converted 0,012929912559973
newValueDecimal after converted 0.012929912559973
newValueFiat 31.40869709505841295
truncatedValueFiat 31.4
newValue before converted 0,01292991255997
newValueDecimal after converted 0.01292991255997
newValueFiat 31.4086970950511255
truncatedValueFiat 31.4
newValue before converted 0,0129299125599
newValueDecimal after converted 0.0129299125599
newValueFiat 31.408697094881085
truncatedValueFiat 31.4
newValue before converted 0,012929912559
newValueDecimal after converted 0.012929912559
newValueFiat 31.40869709269485
truncatedValueFiat 31.4
newValue before converted 0,01292991255
newValueDecimal after converted 0.01292991255
newValueFiat 31.4086970708325
truncatedValueFiat 31.4
newValue before converted 0,0129299125
newValueDecimal after converted 0.0129299125
newValueFiat 31.408696949375
truncatedValueFiat 31.4
newValue before converted 0,012929912
newValueDecimal after converted 0.012929912
newValueFiat 31.4086957348
truncatedValueFiat 31.4
newValue before converted 0,01292991
newValueDecimal after converted 0.01292991
newValueFiat 31.4086908765
truncatedValueFiat 31.4
newValue before converted 0,0129299
newValueDecimal after converted 0.0129299
newValueFiat 31.408666585
truncatedValueFiat 31.4
newValue before converted 0,012929
newValueDecimal after converted 0.012929
newValueFiat 31.40648035
truncatedValueFiat 31.4
newValue before converted 0,01292
newValueDecimal after converted 0.01292
newValueFiat 31.384618
truncatedValueFiat 31.38
newValue before converted 0,0129
newValueDecimal after converted 0.0129
newValueFiat 31.336035
truncatedValueFiat 31.33
newValue before converted 0,012
newValueDecimal after converted 12
newValueFiat 29149.8
truncatedValueFiat 29149.8
```

**After Solution**

```
newValue before converted 
Failed to convert to Decimal: 
newValueDecimal after converted 0
Failed to convert to Decimal: 
newValue before converted 0,012939473567893
newValueDecimal after converted 0.012939473567893
newValueFiat 31.44563805942924753
truncatedValueFiat 31.44
newValue before converted 0,01293947356789
newValueDecimal after converted 0.01293947356789
newValueFiat 31.4456380594219569
truncatedValueFiat 31.44
newValue before converted 0,0129394735678
newValueDecimal after converted 0.0129394735678
newValueFiat 31.445638059203238
truncatedValueFiat 31.44
newValue before converted 0,012939473567
newValueDecimal after converted 0.012939473567
newValueFiat 31.44563805725907
truncatedValueFiat 31.44
newValue before converted 0,0129394
newValueDecimal after converted 0.0129394
newValueFiat 31.445459274
truncatedValueFiat 31.44
newValue before converted 0,012939
newValueDecimal after converted 0.012939
newValueFiat 31.44448719
truncatedValueFiat 31.44
newValue before converted 0,01293
newValueDecimal after converted 0.01293
newValueFiat 31.4226153
truncatedValueFiat 31.42
newValue before converted 0,0129
newValueDecimal after converted 0.0129
newValueFiat 31.349709
truncatedValueFiat 31.34
newValue before converted 0,012
newValueDecimal after converted 0.012
newValueFiat 29.16252
truncatedValueFiat 29.16
newValue before converted 0,01
newValueDecimal after converted 0.01
newValueFiat 24.3021
truncatedValueFiat 24.3
newValue before converted 0,012
newValueDecimal after converted 0.012
newValueFiat 29.16252
truncatedValueFiat 29.16
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved number input parsing to better support international formats by prioritizing the user's locale before falling back to US formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->