### PR TITLE
Refactor: remove vault from `getPreSignedInputData`

### DIFF
--- a/VultisigApp/VultisigApp/Chains/THORChainSwaps.swift
+++ b/VultisigApp/VultisigApp/Chains/THORChainSwaps.swift
@@ -41,7 +41,7 @@ class THORChainSwaps {
         case .gaiaChain:
             return try ATOMHelper().getSwapPreSignedInputData(keysignPayload:keysignPayload)
         case .ripple:
-            return try RippleHelper.getSwapPreSignedInputData(keysignPayload: keysignPayload, vault: ApplicationState.shared.currentVault!)
+            return try RippleHelper.getSwapPreSignedInputData(keysignPayload: keysignPayload)
         default:
             throw HelperError.runtimeError("not support yet")
         }
@@ -66,7 +66,7 @@ class THORChainSwaps {
             }
             return preSigningOutput.hashPublicKeys.map { $0.dataHash.hexString }
         case .ripple:
-            return try RippleHelper.getPreSignedImageHash(keysignPayload: keysignPayload, vault: ApplicationState.shared.currentVault!)
+            return try RippleHelper.getPreSignedImageHash(keysignPayload: keysignPayload)
         default:
             throw HelperError.runtimeError("not support yet")
         }
@@ -137,7 +137,7 @@ class THORChainSwaps {
         case .gaiaChain:
             return try ATOMHelper().getSignedTransaction(vaultHexPubKey: vaultHexPublicKey, vaultHexChainCode: vaultHexChainCode, inputData: inputData, signatures: signatures)
         case .ripple:
-            return try RippleHelper.getSignedTransaction(vaultHexPubKey: vaultHexPublicKey, keysignPayload: keysignPayload, signatures: signatures, vault: ApplicationState.shared.currentVault!)
+            return try RippleHelper.getSignedTransaction(vaultHexPubKey: vaultHexPublicKey, keysignPayload: keysignPayload, signatures: signatures)
         default:
             throw HelperError.runtimeError("not support")
         }

--- a/VultisigApp/VultisigApp/Services/Keysign/KeysignMessageFactory.swift
+++ b/VultisigApp/VultisigApp/Services/Keysign/KeysignMessageFactory.swift
@@ -87,7 +87,7 @@ struct KeysignMessageFactory {
         case .ton:
             return try TonHelper.getPreSignedImageHash(keysignPayload: payload)
         case .ripple:
-            return try RippleHelper.getPreSignedImageHash(keysignPayload: payload, vault: vault)
+            return try RippleHelper.getPreSignedImageHash(keysignPayload: payload)
         case .akash:
             return try AkashHelper().getPreSignedImageHash(keysignPayload: payload)
         case .tron:

--- a/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
@@ -399,7 +399,7 @@ class KeysignViewModel: ObservableObject {
             let transaction = try TonHelper.getSignedTransaction(vaultHexPubKey: vault.pubKeyEdDSA, keysignPayload: keysignPayload, signatures: signatures)
             return .regular(transaction)
         case .Ripple:
-            let transaction = try RippleHelper.getSignedTransaction(vaultHexPubKey: vault.pubKeyECDSA,keysignPayload: keysignPayload, signatures: signatures, vault: vault)
+            let transaction = try RippleHelper.getSignedTransaction(vaultHexPubKey: vault.pubKeyECDSA,keysignPayload: keysignPayload, signatures: signatures)
             return .regular(transaction)
         case .Tron:
             let transaction = try TronHelper.getSignedTransaction(vaultHexPubKey: vault.pubKeyECDSA, keysignPayload: keysignPayload, signatures: signatures, vault: vault)


### PR DESCRIPTION
## Description

vault get passed into `getPreSignedInputData` , and only to get the publicKey , however , we already have the public key in keysingPayload.Coin

Remove vault from `getPreSignedInputData` thus we don't need to pass vault around

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here https://xrpscan.com/tx/A93BF53127C22C5C5A96B2A85B9E4464FBA5093E23EC4E80B71E2A141038A84C
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified Ripple transaction processing by removing the need to pass a vault parameter in related actions.
  - Improved error handling for invalid public key data during Ripple transaction signing.
  - Streamlined method calls across the app for Ripple-related operations, reducing parameter complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->