### PR TITLE
Verify password prompt dimises for 15 days on close tap

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/PasswordVerifyReminderView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/PasswordVerifyReminderView.swift
@@ -15,7 +15,6 @@ struct PasswordVerifyReminderView: View {
     
     @State var showError = false
     @State var errorText = ""
-    @State var passwordVerified = false
     
     @State var isLoading = false
     @State var verifyPassword = ""
@@ -53,26 +52,12 @@ struct PasswordVerifyReminderView: View {
     var view: some View {
         VStack(spacing: 28) {
             header
-            
-            if passwordVerified {
-                passwordVerifiedText
-                closeFilledButton
-            } else {
-                field
-                verifyButton
-            }
+            field
+            verifyButton
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 24)
         .blur(radius: isLoading ? 1 : 0)
-    }
-    
-    var passwordVerifiedText: some View {
-        Text(NSLocalizedString("passwordVerifiedSuccessfully", comment: ""))
-            .font(.body16BrockmannMedium)
-            .foregroundColor(.extraLightGray)
-            .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.vertical, 24)
     }
 
     var header: some View {
@@ -177,15 +162,6 @@ struct PasswordVerifyReminderView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
     }
     
-    var closeFilledButton: some View {
-        Button {
-            handleCloseTap()
-        } label: {
-            FilledButton(title: "close")
-        }
-        .buttonStyle(.plain)
-    }
-    
     private func verifyPasswordIsValid() async {
         guard !verifyPassword.isEmpty else {
             errorText = "emptyField"
@@ -202,11 +178,7 @@ struct PasswordVerifyReminderView: View {
         )
         
         if isValid {
-            passwordVerified = true
-            // Store the verification time using a fixed reference point
-            let calendar = Calendar.current
-            let startOfToday = calendar.startOfDay(for: Date())
-            biweeklyPasswordVerifyDate = startOfToday.timeIntervalSince1970
+            handleCloseTap()
         } else {
             errorText = "incorrectPassword"
             showError = true

--- a/VultisigApp/VultisigApp/Views/Vault/PasswordVerifyReminderView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/PasswordVerifyReminderView.swift
@@ -151,7 +151,7 @@ struct PasswordVerifyReminderView: View {
     
     var closeButton: some View {
         Button {
-            isSheetPresented = false
+            handleCloseTap()
         } label: {
             Image(systemName: "xmark")
         }
@@ -179,7 +179,7 @@ struct PasswordVerifyReminderView: View {
     
     var closeFilledButton: some View {
         Button {
-            isSheetPresented = false
+            handleCloseTap()
         } label: {
             FilledButton(title: "close")
         }
@@ -213,5 +213,12 @@ struct PasswordVerifyReminderView: View {
         }
         
         isLoading = false
+    }
+    
+    private func handleCloseTap() {
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: Date())
+        biweeklyPasswordVerifyDate = startOfToday.timeIntervalSince1970
+        isSheetPresented = false
     }
 }


### PR DESCRIPTION
## Description

Verify password prompt logic updated to show it after 15 days for close button tap as well.

Fixes #2339 & #2299

## Which feature is affected?
- [ ] Verify password prompt for Fast Vault

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the password verification reminder by removing the intermediate verification state and related messages.
  - Centralized the closing action to update the next verification date and dismiss the reminder consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->