### PR TITLE
Tweak keygen in local mode,  using ip address to access mediator for better stability

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/xcshareddata/xcschemes/VultisigApp.xcscheme
+++ b/VultisigApp/VultisigApp.xcodeproj/xcshareddata/xcschemes/VultisigApp.xcscheme
@@ -74,7 +74,7 @@
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"
             value = "disable"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/VultisigApp/VultisigApp/Tss/ServiceDelegate.swift
+++ b/VultisigApp/VultisigApp/Tss/ServiceDelegate.swift
@@ -16,7 +16,10 @@ final class ServiceDelegate: NSObject, NetServiceDelegate, ObservableObject {
         if let addresses = sender.addresses {
             for addressData in addresses {
                 addressData.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
-                    let sockaddrPtr = pointer.baseAddress!.assumingMemoryBound(to: sockaddr.self)
+                    guard let baseAddress = pointer.baseAddress else {
+                        return
+                    }
+                    let sockaddrPtr = baseAddress.assumingMemoryBound(to: sockaddr.self)
                     if sockaddrPtr.pointee.sa_family == sa_family_t(AF_INET) {
                         var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
                         if getnameinfo(sockaddrPtr, socklen_t(addressData.count), &hostBuffer, socklen_t(hostBuffer.count), nil, 0, NI_NUMERICHOST) == 0 {

--- a/VultisigApp/VultisigApp/Tss/ServiceDelegate.swift
+++ b/VultisigApp/VultisigApp/Tss/ServiceDelegate.swift
@@ -12,8 +12,24 @@ final class ServiceDelegate: NSObject, NetServiceDelegate, ObservableObject {
     @Published var serverURL: String?
 
     public func netServiceDidResolveAddress(_ sender: NetService) {
+        var ipAddress: String?
+        if let addresses = sender.addresses {
+            for addressData in addresses {
+                addressData.withUnsafeBytes { (pointer: UnsafeRawBufferPointer) in
+                    let sockaddrPtr = pointer.baseAddress!.assumingMemoryBound(to: sockaddr.self)
+                    if sockaddrPtr.pointee.sa_family == sa_family_t(AF_INET) {
+                        var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                        if getnameinfo(sockaddrPtr, socklen_t(addressData.count), &hostBuffer, socklen_t(hostBuffer.count), nil, 0, NI_NUMERICHOST) == 0 {
+                            ipAddress = String(cString: hostBuffer)
+                        }
+                    }
+                }
+                if ipAddress != nil { break }
+            }
+        }
+        print("Resolved service address: \(ipAddress ?? "unknown")")
         logger.info("Service found: \(sender.name), \(sender.hostName ?? ""), port \(sender.port) in domain \(sender.domain)")
-        serverURL = "http://\(sender.hostName ?? ""):\(sender.port)"
+        serverURL = "http://\(ipAddress ?? sender.hostName ?? ""):\(sender.port)"
     }
     
     public func netService(_ sender: NetService, didNotResolve errorDict: [String : NSNumber]) {

--- a/VultisigApp/VultisigApp/View Models/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/JoinKeygenViewModel.swift
@@ -102,7 +102,8 @@ class JoinKeygenViewModel: ObservableObject {
                 DispatchQueue.main.async {
                     self.status = .WaitingForKeygenToStart
                 }
-                
+            } else {
+                self.logger.error("Failed to join the key generation committee.")
             }
         }
     }


### PR DESCRIPTION

## Description

When Resolve service using mDNS , resolve it to IpAddress , sometimes using hostname will have DNS issue

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of network service discovery by extracting and using the IPv4 address directly when resolving services.
  - Added error logging for failures when joining the key generation committee.

- **Chores**
  - Updated app launch configuration to disable a specific environment variable in the Xcode project scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->