### PR TITLE
Add backoff to download setup message

### DIFF
--- a/VultisigApp/VultisigApp/Tss/DKLSMessenger.swift
+++ b/VultisigApp/VultisigApp/Tss/DKLSMessenger.swift
@@ -66,6 +66,8 @@ final class DKLSMessenger {
                 return try await downloadSetupMessage(additionalHeader)
             } catch {
                 print("fail to download setup message,error \(error), attempt: \(attempt)")
+                //backoff 1s
+                try await Task.sleep(for: .seconds(1))
             }
             attempt = attempt + 1
         } while attempt < 10


### PR DESCRIPTION
## Description

This PR add a 1 second backoff when we failed to download setup message , so we don't poll relay server too hard

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context