### PR TITLE
Remove redundent chain label on swap verify and confirm screen

### DIFF
--- a/VultisigApp/VultisigApp/View Models/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/JoinKeysignViewModel.swift
@@ -396,20 +396,13 @@ class JoinKeysignViewModel: ObservableObject {
     func getFromAmount() -> String {
         guard let payload = keysignPayload?.swapPayload else { return .empty }
         let amount = payload.fromCoin.decimal(for: payload.fromAmount)
-        if payload.fromCoin.chain == payload.toCoin.chain {
-            return "\(amount.formatDecimalToLocale()) \(payload.fromCoin.ticker)"
-        } else {
-            return "\(amount.formatDecimalToLocale()) \(payload.fromCoin.ticker) (\(payload.fromCoin.chain.ticker))"
-        }
+        return "\(amount.formatDecimalToLocale()) \(payload.fromCoin.ticker)"
     }
 
     func getToAmount() -> String {
         guard let payload = keysignPayload?.swapPayload else { return .empty }
         let amount = payload.toAmountDecimal
-        if payload.fromCoin.chain == payload.toCoin.chain {
-            return "\(amount.formatDecimalToLocale()) \(payload.toCoin.ticker)"
-        } else {
-            return "\(amount.formatDecimalToLocale()) \(payload.toCoin.ticker) (\(payload.toCoin.chain.ticker))"
-        }
+        return "\(amount.formatDecimalToLocale()) \(payload.toCoin.ticker)"
+        
     }
 }

--- a/VultisigApp/VultisigApp/Views/Keysign/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/KeysignSwapConfirmView.swift
@@ -164,10 +164,7 @@ struct KeysignSwapConfirmView: View {
         VStack(alignment: .leading, spacing: 4) {
             Group {
                 Text(amount ?? "")
-                    .foregroundColor(.neutral0) +
-                Text(" ") +
-                Text(ticker ?? "")
-                    .foregroundColor(.extraLightGray)
+                    .foregroundColor(.neutral0)
             }
             .font(.body18BrockmannMedium)
             


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2354 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):
![IMG_1DADCF371A8E-1](https://github.com/user-attachments/assets/989f16c7-3994-44bb-904e-bf2b5232fea6)

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the display of swap amounts to show only the amount, removing the coin ticker from the confirmation view.
- **Refactor**
  - Simplified the formatting of amount strings for swaps by always displaying the amount with its ticker, regardless of chain differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->