### PR TITLE
Replace "X/RUJI" with "RUJI"

### DIFF
--- a/VultisigApp/VultisigApp/Chains/thorchain.swift
+++ b/VultisigApp/VultisigApp/Chains/thorchain.swift
@@ -42,8 +42,8 @@ enum THORChainHelper {
                     $0.coins = [TW_Cosmos_Proto_THORChainCoin.with {
                         $0.asset = TW_Cosmos_Proto_THORChainAsset.with {
                             $0.chain = "THOR"
-                            $0.symbol = swapPayload.fromCoin.ticker.uppercased()
-                            $0.ticker = swapPayload.fromCoin.ticker.uppercased()
+                            $0.symbol = swapPayload.fromCoin.ticker.uppercased().replacingOccurrences(of: "X/RUJI", with: "RUJI")
+                            $0.ticker = swapPayload.fromCoin.ticker.uppercased().replacingOccurrences(of: "X/RUJI", with: "RUJI")
                             $0.synth = false
                         }
                         $0.amount = String(swapPayload.fromAmount)
@@ -140,8 +140,8 @@ enum THORChainHelper {
             thorChainCoin = TW_Cosmos_Proto_THORChainCoin.with {
                 $0.asset = TW_Cosmos_Proto_THORChainAsset.with {
                     $0.chain = "THOR"
-                    $0.symbol = keysignPayload.coin.isNativeToken ? "RUNE" : keysignPayload.coin.ticker.uppercased()
-                    $0.ticker = keysignPayload.coin.isNativeToken ? "RUNE" : keysignPayload.coin.ticker.uppercased()
+                    $0.symbol = keysignPayload.coin.isNativeToken ? "RUNE" : keysignPayload.coin.ticker.uppercased().replacingOccurrences(of: "X/RUJI", with: "RUJI")
+                    $0.ticker = keysignPayload.coin.isNativeToken ? "RUNE" : keysignPayload.coin.ticker.uppercased().replacingOccurrences(of: "X/RUJI", with: "RUJI")
                     $0.synth = false
                 }
                 if keysignPayload.toAmount > 0 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of coin ticker symbols to ensure consistent display by removing the "X/" prefix from "X/RUJI" tickers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->