### PR TITLE
Round up the number when convert it from to Decimal  to BigInt

### DIFF
--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -216,8 +216,11 @@ class Coin: ObservableObject, Codable, Hashable {
     }
     
     func raw(for value: Decimal) -> BigInt {
-        let decimal = value * pow(10, decimals)
-        return BigInt(decimal.description) ?? BigInt.zero
+        var decimal = value * pow(10, decimals)
+        
+        var result = Decimal()
+        NSDecimalRound(&result, &decimal, 0,.up)
+        return BigInt(result.description) ?? BigInt(0)
     }
     
     func fiat(value: BigInt) -> Decimal {


### PR DESCRIPTION
## Description

When user input 0.0087 , which is a quite small number , so when convert it to decimal , it becomes `0.008699999999999999` 
Fetching quote for SOL to PYTHIA with amount 0.008699999999999999 , when convert it to the chain's BigInt value , we round it up

Fixes #2427 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when converting decimal values to integers, ensuring values are always rounded up as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->