### PR TITLE
Maya token we should set it's contractAddress to maya

### DIFF
--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -1089,7 +1089,7 @@ class TokensStore {
             logo: "maya",
             decimals: 4,
             priceProviderId: "maya",
-            contractAddress: "",
+            contractAddress: "maya",
             isNativeToken: false
         ),
         CoinMeta(


### PR DESCRIPTION
## Description

After this change , user should disable MAYA token and re-enable it to make the change take effect

Fixes #2447 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
https://www.mayascan.org/address/maya18altpx2gwt4c4ejr5uzda4kyzsudyn9q5dhl9c
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the contract address for the "MAYA" token on the mayaChain to ensure accurate token information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->