### PR TITLE
Add new CoinMeta entries for ThorChain tokens in TokensStore

### DIFF
--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class TokensStore {
-
+    
     static let TokenSelectionAssets = [
         CoinMeta(
             chain: .akash,
@@ -1576,6 +1576,51 @@ class TokensStore {
             decimals: 8,
             priceProviderId: "",
             contractAddress: "x/ruji",
+            isNativeToken: false
+        ),
+        CoinMeta(
+            chain: .thorChain,
+            ticker: "KUJI",
+            logo: "kuji",
+            decimals: 8,
+            priceProviderId: "kujira",
+            contractAddress: "thor.kuji",
+            isNativeToken: false
+        ),
+        CoinMeta(
+            chain: .thorChain,
+            ticker: "FUZN",
+            logo: "fuzn",
+            decimals: 8,
+            priceProviderId: "fuzion",
+            contractAddress: "thor.fuzn",
+            isNativeToken: false
+        ),
+        CoinMeta(
+            chain: .thorChain,
+            ticker: "NSTK",
+            logo: "nstk",
+            decimals: 8,
+            priceProviderId: "unstake-fi",
+            contractAddress: "thor.nstk",
+            isNativeToken: false
+        ),
+        CoinMeta(
+            chain: .thorChain,
+            ticker: "WINK",
+            logo: "wink",
+            decimals: 8,
+            priceProviderId: "winkhub",
+            contractAddress: "thor.wink",
+            isNativeToken: false
+        ),
+        CoinMeta(
+            chain: .thorChain,
+            ticker: "LVN",
+            logo: "levana",
+            decimals: 8,
+            priceProviderId: "levana-protocol",
+            contractAddress: "thor.lvn",
             isNativeToken: false
         ),
         CoinMeta(


### PR DESCRIPTION
- Introduced new tokens: KUJI, FUZN, NSTK, WINK, and LVN, each with their respective properties including ticker, logo, decimals, price provider ID, and contract address.
- Enhanced the token selection assets to support additional cryptocurrencies on the ThorChain.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context