### PR TITLE
Tron fee to match android

### DIFF
--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -202,7 +202,7 @@ class Coin: ObservableObject, Codable, Hashable {
         case .akash:
             return "3000" // 0.003 AKT Cosmos station uses something like that
         case .tron:
-            return "800000"
+            return "100000" // 0.1 TRX = 100000 SUN
         }
     }
     

--- a/VultisigApp/VultisigApp/Services/Actions/Coin+Swaps.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/Coin+Swaps.swift
@@ -58,9 +58,9 @@ extension Coin {
             }
         case .arbitrum:
             if mayaArbTokens.contains(ticker) {
-                return [.mayachain, .kyberswap(chain), .oneinch(chain), .lifi]
+                return [.mayachain, .oneinch(chain), .lifi, .kyberswap(chain), ]
             } else {
-                return [.kyberswap(chain), .oneinch(chain), .lifi]
+                return [.oneinch(chain), .lifi, .kyberswap(chain), ]
             }
         case .base:
             if thorBaseTokens.contains(ticker) {

--- a/VultisigApp/VultisigApp/Services/Tron/TronService.swift
+++ b/VultisigApp/VultisigApp/Services/Tron/TronService.swift
@@ -78,7 +78,7 @@ class TronService: RpcService {
         let oneHourMillis = Int64(60 * 60 * 1000)
         let expiration = nowMillis + oneHourMillis
         
-        var estimation = "800000" // If a TRX we will charge Fee: 800000 SUN = 0.8 TRX MEXC charges it. So probably safer
+        var estimation = "100000" // 0.1 TRX = 100000 SUN (default fee for native TRX transfers)
         if !coin.isNativeToken {
             // 0x9c9d70d46934c98fd3d7c302c4e0b924da7a4fdf
             // Tron does not have a 0x... it can be any address


### PR DESCRIPTION
- Changed TRX fee estimation from "800000" to "100000" to reflect accurate transfer costs.
- Adjusted the order of swap actions for Arbitrum and Base cases to enhance consistency and readability.

https://tronscan.org/#/transaction/1d679e21af3c673aa377798d0b4e8fed839bebda34aa03ed574bd461a5ccf59e

The error on IOS does not happen. The tx works fine. The biggest issue is that I've spent 18 USD to send 1 USD.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default fee for TRON transactions to 0.1 TRX for improved accuracy.
  * Adjusted the order of swap providers for the Arbitrum chain to enhance user experience when selecting swap options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->