### PR TITLE
Enhance percentage calculation precision in SwapCryptoDetailsView

### DIFF
--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -207,22 +207,25 @@ struct SwapCryptoDetailsView: View {
 extension SwapCryptoDetailsView {
     public func handlePercentageSelection(_ percentage: Int) {
         swapViewModel.showAllPercentageButtons = false
+        // Use coin's decimals for proper precision
+        let decimalsToUse = max(4, tx.fromCoin.decimals)
+        
         switch percentage {
         case 25:
-            tx.fromAmount = (tx.fromCoin.balanceDecimal * 0.25).formatToDecimal(digits: 4)
+            tx.fromAmount = (tx.fromCoin.balanceDecimal * 0.25).formatToDecimal(digits: decimalsToUse)
             handleFromCoinUpdate()
         case 50:
-            tx.fromAmount = (tx.fromCoin.balanceDecimal * 0.5).formatToDecimal(digits: 4)
+            tx.fromAmount = (tx.fromCoin.balanceDecimal * 0.5).formatToDecimal(digits: decimalsToUse)
             handleFromCoinUpdate()
         case 75:
-            tx.fromAmount = (tx.fromCoin.balanceDecimal * 0.75).formatToDecimal(digits: 4)
+            tx.fromAmount = (tx.fromCoin.balanceDecimal * 0.75).formatToDecimal(digits: decimalsToUse)
             handleFromCoinUpdate()
         case 100:
-            tx.fromAmount = tx.fromCoin.balanceDecimal.formatToDecimal(digits: 4)
+            tx.fromAmount = tx.fromCoin.balanceDecimal.formatToDecimal(digits: decimalsToUse)
             handleFromCoinUpdate()
             let amountLessFee = tx.fromCoin.rawBalance.toBigInt() - tx.fee
             let amountLessFeeDecimal = amountLessFee.toDecimal(decimals: tx.fromCoin.decimals) / pow(10, tx.fromCoin.decimals)
-            tx.fromAmount = amountLessFeeDecimal.formatToDecimal(digits: 4)
+            tx.fromAmount = amountLessFeeDecimal.formatToDecimal(digits: decimalsToUse)
         default:
             break
         }

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -208,7 +208,13 @@ extension SwapCryptoDetailsView {
     public func handlePercentageSelection(_ percentage: Int) {
         swapViewModel.showAllPercentageButtons = false
         // Use coin's decimals for proper precision
-        let decimalsToUse = max(4, tx.fromCoin.decimals)
+        // For EVM chains, cap at 9 decimals to avoid impractical precision
+        let decimalsToUse: Int
+        if tx.fromCoin.chainType == .EVM {
+            decimalsToUse = min(9, max(4, tx.fromCoin.decimals))
+        } else {
+            decimalsToUse = max(4, tx.fromCoin.decimals)
+        }
         
         switch percentage {
         case 25:

--- a/VultisigApp/VultisigAppTests/Services/SwapPercentageTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapPercentageTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import BigInt
+@testable import VultisigApp
+
+class SwapPercentageTests: XCTestCase {
+    
+    func testBTCPercentageCalculation() {
+        // Create a mock Bitcoin coin with 8 decimals
+        let btcMeta = CoinMeta(
+            chain: .bitcoin,
+            ticker: "BTC",
+            logo: "btc",
+            decimals: 8,
+            priceProviderId: "bitcoin",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        
+        let btcCoin = Coin(asset: btcMeta, address: "test", hexPublicKey: "test")
+        
+        // Set a small balance: 0.00021322 BTC (21322 satoshis)
+        btcCoin.rawBalance = "21322"
+        
+        // Test 25% calculation
+        let balance = btcCoin.balanceDecimal
+        let twentyFivePercent = balance * 0.25
+        let formattedAmount = twentyFivePercent.formatToDecimal(digits: 8)
+        
+        // Should be 0.00005330 BTC, not 0.0001
+        XCTAssertEqual(formattedAmount, "0.00005330", "25% of 0.00021322 BTC should be 0.00005330")
+        
+        // Test with the actual implementation's logic (using max(4, decimals))
+        let decimalsToUse = max(4, btcCoin.decimals)
+        XCTAssertEqual(decimalsToUse, 8, "For BTC, should use 8 decimals")
+        
+        // Test all percentages
+        let testCases: [(percentage: Double, expected: String)] = [
+            (0.25, "0.00005330"),
+            (0.50, "0.00010661"),
+            (0.75, "0.00015991"),
+            (1.00, "0.00021322")
+        ]
+        
+        for testCase in testCases {
+            let calculatedAmount = (balance * testCase.percentage).formatToDecimal(digits: decimalsToUse)
+            XCTAssertEqual(
+                calculatedAmount, 
+                testCase.expected, 
+                "\(Int(testCase.percentage * 100))% of 0.00021322 BTC should be \(testCase.expected)"
+            )
+        }
+    }
+    
+    func testETHPercentageCalculation() {
+        // Create a mock Ethereum coin with 18 decimals
+        let ethMeta = CoinMeta(
+            chain: .ethereum,
+            ticker: "ETH",
+            logo: "eth",
+            decimals: 18,
+            priceProviderId: "ethereum",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        
+        let ethCoin = Coin(asset: ethMeta, address: "test", hexPublicKey: "test")
+        
+        // Set balance: 0.00894077 ETH
+        ethCoin.rawBalance = "8940770000000000" // in wei
+        
+        let balance = ethCoin.balanceDecimal
+        let decimalsToUse = max(4, ethCoin.decimals)
+        
+        // For ETH with 18 decimals, we should maintain high precision
+        XCTAssertEqual(decimalsToUse, 18, "For ETH, should use 18 decimals")
+        
+        // Test 25% calculation
+        let twentyFivePercent = (balance * 0.25).formatToDecimal(digits: decimalsToUse)
+        XCTAssertEqual(twentyFivePercent, "0.00223519", "25% calculation should maintain precision")
+    }
+    
+    func testLowDecimalCoin() {
+        // Test with a coin that has less than 4 decimals (e.g., USDC with 6 decimals)
+        let usdcMeta = CoinMeta(
+            chain: .ethereum,
+            ticker: "USDC",
+            logo: "usdc",
+            decimals: 6,
+            priceProviderId: "usd-coin",
+            contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            isNativeToken: false
+        )
+        
+        let usdcCoin = Coin(asset: usdcMeta, address: "test", hexPublicKey: "test")
+        usdcCoin.rawBalance = "1000000" // 1 USDC
+        
+        let decimalsToUse = max(4, usdcCoin.decimals)
+        XCTAssertEqual(decimalsToUse, 6, "For USDC, should use 6 decimals")
+    }
+} 


### PR DESCRIPTION
This fixes https://github.com/vultisig/vultisig-ios/issues/2349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of displayed amounts when selecting percentage options for crypto swaps, ensuring correct decimal precision based on the selected coin.

* **Tests**
  * Added tests to verify correct percentage calculations and formatting for cryptocurrencies with different decimal precisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->