### PR TITLE
Fix: Correct referral program typo and improve English copy

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -715,7 +715,7 @@
 "sendOverview" = "Send overview";
 "whitespaceNotAllowed" = "Whitespace character is not allowed";
 "referralProgram" = "Referral Program";
-"referralProgramTooltipDescription" = "The referral programm is applied for THORChain swaps and is on a best effort basis. You need to register a THORName to use the Vultisig referral. The registration fee is 10 RUNE and 1 RUNE for each year, which is paid to the THORChain network.";
+"referralProgramTooltipDescription" = "The referral program applies to THORChain swaps and operates on a best-effort basis. To use the Vultisig referral, you must register a THORName. The registration fee is 10 RUNE plus 1 RUNE per year, paid to the THORChain network.";
 "insufficientBalance" = "Insufficient Balance";
 "verifyBoxCheck" = "Please check all the boxes";
 "expirationDate" = "Expiration date";


### PR DESCRIPTION
This PR corrects a typo in the English localization file:

- Changed "programm" → "program"
- Reworded the entire string for improved grammar and clarity:
  > "The referral program applies to THORChain swaps and operates on a best-effort basis. To use the Vultisig referral, you must register a THORName. The registration fee is 10 RUNE plus 1 RUNE per year, paid to the THORChain network."

Other languages were reviewed but left unchanged, as their use of "program" (e.g. programma, Programm, programa) is accurate in context.

Only the `en.lproj/Localizable.strings` file was modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the English description for the referral program tooltip, correcting typos and clarifying the program's applicability and fee structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->