### PR TITLE
fix: Share sheet dismissal on Backup without password

### DIFF
--- a/VultisigApp/VultisigApp/iOS/View/PasswordBackupOptionsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PasswordBackupOptionsView+iOS.swift
@@ -27,6 +27,7 @@ extension PasswordBackupOptionsView {
         .sheet(isPresented: $showSkipShareSheet) {
             if let fileURL = backupViewModel.encryptedFileURLWithoutPassowrd {
                 ShareSheetViewController(activityItems: [fileURL]) { didSave in
+                    showSkipShareSheet = false
                     if didSave {
                         fileSaved()
                         dismissView()


### PR DESCRIPTION
## Description

The app becomes unresponsive (freezes) on the home screen after attempting to initiate a backup of the vault share. This issue occurs regardless of whether the user chooses to add a password to the backup or proceeds with a backup without a password.

Fixes #2412

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context