### PR TITLE
fix: share sheet dismissal improvements

### DIFF
--- a/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/EncryptedBackupViewModel.swift
@@ -17,7 +17,7 @@ class EncryptedBackupViewModel: ObservableObject {
     @Published var showVaultExporter = false
     @Published var showVaultImporter = false
     @Published var encryptedFileURLWithPassowrd: URL? = nil
-    @Published var encryptedFileURLWithoutPassowrd: URL? = nil
+    @Published var encryptedFileURLWithoutPassword: URL? = nil
     @Published var decryptedContent: String? = nil
     @Published var encryptionPassword: String = ""
     @Published var decryptionPassword: String = ""
@@ -42,7 +42,7 @@ class EncryptedBackupViewModel: ObservableObject {
         isFileUploaded = false
         importedFileName = nil
         encryptedFileURLWithPassowrd = nil
-        encryptedFileURLWithoutPassowrd = nil
+        encryptedFileURLWithoutPassword = nil
         decryptedContent = ""
         encryptionPassword = ""
         decryptionPassword = ""
@@ -73,7 +73,7 @@ class EncryptedBackupViewModel: ObservableObject {
             do {
                 try dataToSave.write(to: tempURL)
                 encryptedFileURLWithPassowrd = tempURL
-                encryptedFileURLWithoutPassowrd = tempURL
+                encryptedFileURLWithoutPassword = tempURL
                 print(tempURL.absoluteString)
             } catch {
                 print("Error writing file: \(error.localizedDescription)")

--- a/VultisigApp/VultisigApp/iOS/Native/ShareSheetViewController.swift
+++ b/VultisigApp/VultisigApp/iOS/Native/ShareSheetViewController.swift
@@ -32,6 +32,7 @@ fileprivate struct ShareSheetViewController: UIViewControllerRepresentable {
         let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: applicationActivities)
         controller.completionWithItemsHandler = { activityType, completed, returnedItems, error in
             isPresented = false
+            // Added delay on completion execution to wait for sheet dismissal for smoother experience
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 completion?(completed)
             }

--- a/VultisigApp/VultisigApp/iOS/View/BackupPasswordSetupView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/BackupPasswordSetupView+iOS.swift
@@ -56,7 +56,7 @@ extension BackupPasswordSetupView {
     
     @ViewBuilder
     var skipButton: some View {
-        if let fileURL = backupViewModel.encryptedFileURLWithoutPassowrd {
+        if let fileURL = backupViewModel.encryptedFileURLWithoutPassword {
             Button(action: {
                 showSkipShareSheet = true
             }) {

--- a/VultisigApp/VultisigApp/iOS/View/BackupPasswordSetupView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/BackupPasswordSetupView+iOS.swift
@@ -37,42 +37,36 @@ extension BackupPasswordSetupView {
         }
     }
     
+    @ViewBuilder
     var saveButton: some View {
-        Button(action: {
-            handleProxyTap()
-        }) {
-            FilledButton(title: "save")
-        }
-        .sheet(isPresented: $showSaveShareSheet) {
-            if let fileURL = backupViewModel.encryptedFileURLWithPassowrd {
-                ShareSheetViewController(activityItems: [fileURL]) { didSave in
-                    if didSave {
-                        fileSaved()
-                        dismissView()
-                    }
+        if let fileURL = backupViewModel.encryptedFileURLWithPassowrd {
+            Button(action: {
+                handleProxyTap()
+            }) {
+                FilledButton(title: "save")
+            }
+            .shareSheet(isPresented: $showSaveShareSheet, activityItems: [fileURL]) { didSave in
+                if didSave {
+                    fileSaved()
+                    dismissView()
                 }
-                .presentationDetents([.medium])
-                .ignoresSafeArea(.all)
             }
         }
     }
     
+    @ViewBuilder
     var skipButton: some View {
-        Button(action: {
-            showSkipShareSheet = true
-        }) {
-            OutlineButton(title: "skipPassword")
-        }
-        .sheet(isPresented: $showSkipShareSheet) {
-            if let fileURL = backupViewModel.encryptedFileURLWithoutPassowrd {
-                ShareSheetViewController(activityItems: [fileURL]) { didSave in
-                    if didSave {
-                        fileSaved()
-                        dismissView()
-                    }
+        if let fileURL = backupViewModel.encryptedFileURLWithoutPassowrd {
+            Button(action: {
+                showSkipShareSheet = true
+            }) {
+                OutlineButton(title: "skipPassword")
+            }
+            .shareSheet(isPresented: $showSkipShareSheet, activityItems: [fileURL]) { didSave in
+                if didSave {
+                    fileSaved()
+                    dismissView()
                 }
-                .presentationDetents([.medium])
-                .ignoresSafeArea(.all)
             }
         }
     }

--- a/VultisigApp/VultisigApp/iOS/View/PasswordBackupOptionsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PasswordBackupOptionsView+iOS.swift
@@ -20,7 +20,7 @@ extension PasswordBackupOptionsView {
     
     @ViewBuilder
     var withoutPasswordButton: some View {
-        if let fileURL = backupViewModel.encryptedFileURLWithoutPassowrd {
+        if let fileURL = backupViewModel.encryptedFileURLWithoutPassword {
             Button {
                 showSkipShareSheet = true
             } label: {

--- a/VultisigApp/VultisigApp/iOS/View/PasswordBackupOptionsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PasswordBackupOptionsView+iOS.swift
@@ -18,23 +18,19 @@ extension PasswordBackupOptionsView {
         .padding(24)
     }
     
+    @ViewBuilder
     var withoutPasswordButton: some View {
-        Button {
-            showSkipShareSheet = true
-        } label: {
-            withoutPasswordLabel
-        }
-        .sheet(isPresented: $showSkipShareSheet) {
-            if let fileURL = backupViewModel.encryptedFileURLWithoutPassowrd {
-                ShareSheetViewController(activityItems: [fileURL]) { didSave in
-                    showSkipShareSheet = false
-                    if didSave {
-                        fileSaved()
-                        dismissView()
-                    }
+        if let fileURL = backupViewModel.encryptedFileURLWithoutPassowrd {
+            Button {
+                showSkipShareSheet = true
+            } label: {
+                withoutPasswordLabel
+            }
+            .shareSheet(isPresented: $showSkipShareSheet, activityItems: [fileURL])  { didSave in
+                if didSave {
+                    fileSaved()
+                    dismissView()
                 }
-                .presentationDetents([.medium])
-                .ignoresSafeArea(.all)
             }
         }
     }

--- a/VultisigApp/VultisigApp/macOS/View/BackupPasswordSetupView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/BackupPasswordSetupView+macOS.swift
@@ -76,7 +76,7 @@ extension BackupPasswordSetupView {
         }
         .fileExporter(
             isPresented: $showSkipShareSheet,
-            document: EncryptedDataFile(url: backupViewModel.encryptedFileURLWithoutPassowrd),
+            document: EncryptedDataFile(url: backupViewModel.encryptedFileURLWithoutPassword),
             contentType: .data,
             defaultFilename: "\(vault.getExportName())"
         ) { result in

--- a/VultisigApp/VultisigApp/macOS/View/PasswordBackupOptionsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/PasswordBackupOptionsView+macOS.swift
@@ -37,7 +37,7 @@ extension PasswordBackupOptionsView {
         }
         .fileExporter(
             isPresented: $showSkipShareSheet,
-            document: EncryptedDataFile(url: backupViewModel.encryptedFileURLWithoutPassowrd),
+            document: EncryptedDataFile(url: backupViewModel.encryptedFileURLWithoutPassword),
             contentType: .data,
             defaultFilename: "\(vault.getExportName())"
         ) { result in


### PR DESCRIPTION
## Description

- This is a follow-up PR for [#2412](https://github.com/vultisig/vultisig-ios/issues/2412) to provide a more scalable and elegant solution for the share sheet.
- Moved share sheet dismissal to ShareSheetViewController by passing Binding property.
- Created `.shareSheet` View extension to wrap `ShareSheetViewController` creation
- Fixed password typo

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context