### PR TITLE
[TON]: Fix Max Transfer (Co-Signing) and Prevent Balance Burn on Failure

### DIFF
--- a/VultisigApp/VultisigApp/Chains/Ton.swift
+++ b/VultisigApp/VultisigApp/Chains/Ton.swift
@@ -33,9 +33,10 @@ enum TonHelper {
             throw HelperError.runtimeError("invalid hex public key")
         }
         
-        var sendMode = UInt32(TheOpenNetworkSendMode.payFeesSeparately.rawValue | TheOpenNetworkSendMode.ignoreActionPhaseErrors.rawValue)
+        let baseMode = TheOpenNetworkSendMode.ignoreActionPhaseErrors.rawValue
+        var sendMode = UInt32(TheOpenNetworkSendMode.payFeesSeparately.rawValue | baseMode)
         if sendMaxAmount {
-            sendMode = UInt32(TheOpenNetworkSendMode.attachAllContractBalance.rawValue)
+            sendMode = UInt32(TheOpenNetworkSendMode.attachAllContractBalance.rawValue | baseMode)
         }
         
         let transfer = TheOpenNetworkTransfer.with {


### PR DESCRIPTION
## Description

- Always include `IGNORE_ACTION_PHASE_ERRORS_VALUE` to prevent validators from retrying until funds are depleted (during error).
- The missing flag caused co-signing with Android to fail when sending the max amount.
- Additionally, Android was missing the mapping for the isMax parameter (already fixed): https://github.com/vultisig/vultisig-android/pull/2218

Tx sucessfull
https://tonviewer.com/transaction/34ecf8d00c327e6a299f2ccd7471220b93cafbdb4da3620f1dc15195436d0e37

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of transaction modes to ensure consistent behavior when sending assets, with no visible changes to the user interface or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->