### PR TITLE
fix: added link for Learn More button during backup setup

### DIFF
--- a/VultisigApp/VultisigApp/Utils/URL.swift
+++ b/VultisigApp/VultisigApp/Utils/URL.swift
@@ -15,4 +15,5 @@ class StaticURL {
     static let PrivacyPolicyURL = URL(string: "https://vultisig.com/privacy")!
     static let TermsOfServiceURL = URL(string: "https://vultisig.com/termofservice")!
     static let VultisigWeb = URL(string: "https://airdrop.vultisig.com/")!
+    static let VultBackupURL = URL(string: "https://docs.vultisig.com/vultisig-vault-user-actions/managing-your-vault/vault-backup")!
 }

--- a/VultisigApp/VultisigApp/Views/Vault/BackupSetupView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/BackupSetupView.swift
@@ -61,9 +61,7 @@ struct BackupSetupView: View {
                 .foregroundColor(Color.extraLightGray)
                 .multilineTextAlignment(.center)
 
-            Button {
-                // TODO: Learn more link
-            } label: {
+            Link(destination: StaticURL.VultBackupURL) {
                 Text(NSLocalizedString("learnMore", comment: ""))
                     .font(.body14BrockmannMedium)
                     .foregroundColor(Color.lightText)


### PR DESCRIPTION
## Description

- Added link for Learn More button during backup setup

Fixes #2523

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a direct link in the backup setup view to access the vault backup documentation.

* **Improvements**
  * Replaced a placeholder button with an active link for easier navigation to backup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->