### PR TITLE
feat: Send Screen - move to next section when continue button is pressed

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		138574232E2DB765002532BF /* IconButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138574222E2DB765002532BF /* IconButtonStyle.swift */; };
 		138574262E2DB9C6002532BF /* NavigationIconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138574242E2DB9C6002532BF /* NavigationIconButton.swift */; };
 		138574272E2DB9C6002532BF /* IconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138574252E2DB9C6002532BF /* IconButton.swift */; };
+		13B26D3F2E32B506000D3B3A /* SendFormExpandableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B26D3E2E32B501000D3B3A /* SendFormExpandableSection.swift */; };
 		13EFA1CB2E31389D009838EB /* OTPCharTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EFA1CA2E31389C009838EB /* OTPCharTextField.swift */; };
 		3438005C33774BADE4B163FD /* KyberSwapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD36D5BDFA9CBF0B16709643 /* KyberSwapService.swift */; };
 		43E0C072714FC369B3B91499 /* HiddenToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCB0CAFF343CC6FF8986E07F /* HiddenToken.swift */; };
@@ -999,6 +1000,7 @@
 		138574222E2DB765002532BF /* IconButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconButtonStyle.swift; sourceTree = "<group>"; };
 		138574242E2DB9C6002532BF /* NavigationIconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationIconButton.swift; sourceTree = "<group>"; };
 		138574252E2DB9C6002532BF /* IconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconButton.swift; sourceTree = "<group>"; };
+		13B26D3E2E32B501000D3B3A /* SendFormExpandableSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendFormExpandableSection.swift; sourceTree = "<group>"; };
 		13EFA1CA2E31389C009838EB /* OTPCharTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPCharTextField.swift; sourceTree = "<group>"; };
 		4600167D2B71A12D00CE17C7 /* Tss.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:G8Q5XUAJD9:Cortina Ventures PTY LTD"; lastKnownFileType = wrapper.xcframework; path = Tss.xcframework; sourceTree = "<group>"; };
 		4606B3AF2B80465E0045094D /* UTXOTransactionsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTXOTransactionsService.swift; sourceTree = "<group>"; };
@@ -2467,6 +2469,7 @@
 		A617B67A2CEC63F6006E5122 /* Send */ = {
 			isa = PBXGroup;
 			children = (
+				13B26D3E2E32B501000D3B3A /* SendFormExpandableSection.swift */,
 				A617B67B2CEC641B006E5122 /* SendCryptoDoneSummary.swift */,
 				A6D739DB2E0AFF2E0005697D /* LinearSeparator.swift */,
 				A6D739DD2E0B30440005697D /* SendDetailsAssetTab.swift */,
@@ -4998,6 +5001,7 @@
 				A685245F2DFCD47E00FEE2E4 /* ReferralViewModel.swift in Sources */,
 				A594EC2B2D00BE6C00B74EBC /* SettingsCustomMessageViewModel.swift in Sources */,
 				A6F7B6772D42F64D00AC8104 /* OnboardingTextCard.swift in Sources */,
+				13B26D3F2E32B506000D3B3A /* SendFormExpandableSection.swift in Sources */,
 				B5E476AD2C1A556D005DB485 /* DydxService.swift in Sources */,
 				B54B01972BDCEB8E00FDA472 /* Polkadot.swift in Sources */,
 				A6AF960C2C2E2D6400992578 /* GeneralQRImportMacView.swift in Sources */,

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAddressTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAddressTab.swift
@@ -34,7 +34,7 @@ struct SendDetailsAddressTab: View {
     }
     
     var content: some View {
-        SendFormExpandableSecion(isExpanded: isExpanded) {
+        SendFormExpandableSection(isExpanded: isExpanded) {
             titleSection
         } content: {
             separator

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAddressTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAddressTab.swift
@@ -34,20 +34,12 @@ struct SendDetailsAddressTab: View {
     }
     
     var content: some View {
-        VStack(spacing: 16) {
+        SendFormExpandableSecion(isExpanded: isExpanded) {
             titleSection
-                
-            if isExpanded {
-                separator
-                fields
-            }
+        } content: {
+            separator
+            fields
         }
-        .padding(16)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.blue200, lineWidth: 1)
-        )
-        .padding(1)
     }
     
     var titleSection: some View {

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
@@ -28,7 +28,7 @@ struct SendDetailsAmountTab: View {
     }
     
     var content: some View {
-        SendFormExpandableSecion(isExpanded: viewModel.selectedTab == .amount) {
+        SendFormExpandableSection(isExpanded: isExpanded) {
             titleSection
         } content: {
             separator

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
@@ -28,28 +28,20 @@ struct SendDetailsAmountTab: View {
     }
     
     var content: some View {
-        VStack(spacing: 16) {
+        SendFormExpandableSecion(isExpanded: viewModel.selectedTab == .amount) {
             titleSection
-                
-            if isExpanded {
-                separator
-                amountFieldSection
-                
-                if sendCryptoViewModel.showAmountAlert {
-                    errorText
-                }
-                
-                percentageButtons
-                balanceSection
-                additionalOptionsSection
+        } content: {
+            separator
+            amountFieldSection
+            
+            if sendCryptoViewModel.showAmountAlert {
+                errorText
             }
+            
+            percentageButtons
+            balanceSection
+            additionalOptionsSection
         }
-        .padding(16)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.blue200, lineWidth: 1)
-        )
-        .padding(1)        
     }
     
     var titleSection: some View {

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAssetTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAssetTab.swift
@@ -63,7 +63,7 @@ struct SendDetailsAssetTab: View {
     }
     
     var content: some View {
-        SendFormExpandableSecion(isExpanded: isExpanded) {
+        SendFormExpandableSection(isExpanded: isExpanded) {
             titleSection
         } content: {
             separator

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAssetTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAssetTab.swift
@@ -63,20 +63,12 @@ struct SendDetailsAssetTab: View {
     }
     
     var content: some View {
-        VStack(spacing: 16) {
+        SendFormExpandableSecion(isExpanded: isExpanded) {
             titleSection
-            
-            if isExpanded {
-                separator
-                assetSelectionSection
-            }
+        } content: {
+            separator
+            assetSelectionSection
         }
-        .padding(16)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(Color.blue200, lineWidth: 1)
-        )
-        .padding(1)
     }
     
     var titleSection: some View {
@@ -203,5 +195,10 @@ struct SendDetailsAssetTab: View {
 }
 
 #Preview {
-    SendDetailsAssetTab(isExpanded: true, tx: SendTransaction(), viewModel: SendDetailsViewModel(), sendCryptoViewModel: SendCryptoViewModel())
+    SendDetailsAssetTab(
+        isExpanded: true,
+        tx: SendTransaction(),
+        viewModel: SendDetailsViewModel(),
+        sendCryptoViewModel: SendCryptoViewModel()
+    )
 }

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendFormExpandableSection.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendFormExpandableSection.swift
@@ -1,0 +1,70 @@
+//
+//  SendFormExpandableSection.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 24/07/2025.
+//
+
+import SwiftUI
+
+struct SendFormExpandableSecion<Header: View, Content: View>: View {
+    let isExpanded: Bool
+    let header: () -> Header
+    let content: () -> Content
+    
+    @State var opacity: CGFloat = 0
+    @State var height: CGFloat? = 0
+        
+    init(
+        isExpanded: Bool,
+        @ViewBuilder header: @escaping () -> Header,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.isExpanded = isExpanded
+        self.header = header
+        self.content = content
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            header()
+            content()
+                .padding(.top, 16)
+                .clipped()
+                .opacity(opacity)
+                .frame(height: height)
+        }
+        .padding(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.blue200, lineWidth: 1)
+        )
+        .padding(1)
+        .onChange(of: isExpanded) { _, _ in
+            animate()
+        }
+        .onLoad {
+            animate()
+        }
+    }
+    
+    private func animate() {
+        if isExpanded {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                height = nil
+            }
+            
+            withAnimation(.easeInOut(duration: 0.2).delay(0.15)) {
+                opacity = 1
+            }
+        } else {
+            withAnimation(.easeInOut(duration: 0.1)) {
+                opacity = 0
+            }
+            
+            withAnimation {
+                height = 0
+            }
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendFormExpandableSection.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendFormExpandableSection.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct SendFormExpandableSecion<Header: View, Content: View>: View {
+struct SendFormExpandableSection<Header: View, Content: View>: View {
     let isExpanded: Bool
     let header: () -> Header
     let content: () -> Content

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDetailsView.swift
@@ -159,15 +159,22 @@ struct SendCryptoDetailsView: View {
     }
     
     func validateForm() async {
-        await MainActor.run {
-            sendCryptoViewModel.isLoading = true
-        }
-        
-        sendDetailsViewModel.onSelect(tab: .amount)
-        sendCryptoViewModel.validateAmount(amount: tx.amount.description)
-        
-        if await sendCryptoViewModel.validateForm(tx: tx) {
-            sendCryptoViewModel.moveToNextView()
+        switch sendDetailsViewModel.selectedTab {
+        case .asset:
+            sendDetailsViewModel.onSelect(tab: .address)
+            return
+        case .address:
+            sendDetailsViewModel.onSelect(tab: .amount)
+            return
+        case .amount:
+            await MainActor.run {
+                sendCryptoViewModel.isLoading = true
+            }
+            sendCryptoViewModel.validateAmount(amount: tx.amount.description)
+            
+            if await sendCryptoViewModel.validateForm(tx: tx) {
+                sendCryptoViewModel.moveToNextView()
+            }
         }
         
         await MainActor.run {


### PR DESCRIPTION
## Description

- Added behavior to move to next section when continue button is pressed. Except from address to amount when the address hasn't been filled yet

Fixes #[2601](https://github.com/vultisig/vultisig-ios/issues/2601)

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

https://github.com/user-attachments/assets/57190e44-0644-4cfe-92ba-baca4755cb54