### PR TITLE
fix:  Send token setup from details screen

### DIFF
--- a/VultisigApp/VultisigApp/View Models/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendDetailsViewModel.swift
@@ -30,7 +30,12 @@ class SendDetailsViewModel: ObservableObject {
     }
     
     func onLoad() {
-        selectedTab = hasPreselectedCoin ? .address : .asset
+        if hasPreselectedCoin {
+            assetSetupDone = true
+            selectedTab = .address
+        } else {
+            selectedTab = .asset
+        }
     }
     
     func onSelect(tab: SendDetailsFocusedTab) {


### PR DESCRIPTION
## Description

- Setting assetSetupDone to true on load if token has been preselected

Fixes #2613

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

https://github.com/user-attachments/assets/eb94a39d-5a38-4695-a98c-6ebff8c264d8




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization of the send details screen to ensure correct state when a coin is preselected, providing a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->