### PR TITLE
fix: macOS amount field

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/TextFields/SendCryptoAmountTextField.swift
+++ b/VultisigApp/VultisigApp/Views/Components/TextFields/SendCryptoAmountTextField.swift
@@ -53,7 +53,6 @@ struct SendCryptoAmountTextField: View {
         ))
         .frame(maxWidth: .infinity)
         .multilineTextAlignment(.center)
-        .lineLimit(1)
     }
     
     var maxButton: some View {


### PR DESCRIPTION
## Description

- Remove lineLimit to prevent textfield getting cutoff

Fixes #2614

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

https://github.com/user-attachments/assets/db7a4bd5-ac4c-4681-971b-f8ec4633d3cf



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the crypto amount input field to allow more flexible text entry by removing the single-line restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->