### PR TITLE
Remove 100% pct button

### DIFF
--- a/VultisigApp/VultisigApp/View Models/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendDetailsViewModel.swift
@@ -30,7 +30,12 @@ class SendDetailsViewModel: ObservableObject {
     }
     
     func onLoad() {
-        selectedTab = hasPreselectedCoin ? .address : .asset
+        if hasPreselectedCoin {
+            assetSetupDone = true
+            selectedTab = .address
+        } else {
+            selectedTab = .asset
+        }
     }
     
     func onSelect(tab: SendDetailsFocusedTab) {

--- a/VultisigApp/VultisigApp/Views/Components/Swap/SwapFromToField.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Swap/SwapFromToField.swift
@@ -59,19 +59,9 @@ struct SwapFromToField: View {
     }
     
     var balance: some View {
-        Button {
-            if title == "from" {
-                // Use the same logic as 100% percentage handler
-                handlePercentageSelection?(100)
-            }
-        } label: {
-            Text("\(coin.balanceString) \(coin.ticker)")
-                .font(.body12BrockmannMedium)
-                .foregroundColor(title == "from" ? .turquoise600 : .extraLightGray)
-                .underline(title == "from")
-        }
-        .disabled(title != "from")
-        .buttonStyle(BorderlessButtonStyle())
+        Text("\(coin.balanceString) \(coin.ticker)")
+            .font(.body12BrockmannMedium)
+            .foregroundColor(.extraLightGray)
     }
     
     var unevenRectangle: some View {

--- a/VultisigApp/VultisigApp/Views/Components/Swap/SwapPercentageButtons.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Swap/SwapPercentageButtons.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SwapPercentageButtons: View {
-    let buttonOptions = [25, 50, 75, 100]
+    let buttonOptions = [25, 50, 75]
     
     @State private var selectedPercentage: Int? = nil
     

--- a/VultisigApp/VultisigApp/Views/Components/Swap/SwapPercentageButtons.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Swap/SwapPercentageButtons.swift
@@ -8,7 +8,11 @@
 import SwiftUI
 
 struct SwapPercentageButtons: View {
-    let buttonOptions = [25, 50, 75]
+    let show100: Bool
+    
+    var buttonOptions: [Int] {
+        show100 ? [25, 50, 75, 100] : [25, 50, 75]
+    }
     
     @State private var selectedPercentage: Int? = nil
     

--- a/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
@@ -71,7 +71,10 @@ extension SwapCryptoDetailsView {
     }
     
     var percentageButtons: some View {
-        SwapPercentageButtons(showAllPercentageButtons: $swapViewModel.showAllPercentageButtons) { percentage in
+        SwapPercentageButtons(
+            show100: !tx.fromCoin.isNativeToken,
+            showAllPercentageButtons: $swapViewModel.showAllPercentageButtons
+        ) { percentage in
             handlePercentageSelection(percentage)
         }
         .opacity(keyboardObserver.keyboardHeight == 0 ? 0 : 1)

--- a/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
@@ -66,7 +66,10 @@ extension SwapCryptoDetailsView {
     }
     
     var percentageButtons: some View {
-        SwapPercentageButtons(showAllPercentageButtons: $swapViewModel.showAllPercentageButtons) { percentage in
+        SwapPercentageButtons(
+            show100: !tx.fromCoin.isNativeToken,
+            showAllPercentageButtons: $swapViewModel.showAllPercentageButtons
+        ) { percentage in
             handlePercentageSelection(percentage)
         }
     }


### PR DESCRIPTION
We removed the 100% percent button because it will fail to quote 100% of the time since we depend on the quote to subtract the fees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The balance display in the swap interface is now shown as static text instead of a button.
  * The "100%" percentage selection button is now conditionally shown based on the type of token being swapped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->