### PR TITLE
feat: enhance RippleService to fetch server state and calculate available balance

### DIFF
--- a/VultisigApp/VultisigApp/Services/Ripple/RippleService.swift
+++ b/VultisigApp/VultisigApp/Services/Ripple/RippleService.swift
@@ -74,8 +74,8 @@ class RippleService {
         
         // Calculate reserved balance
         let ownerCount = BigInt(accountInfo?.result?.accountData?.ownerCount ?? 0)
-        let reservedBase = BigInt(serverState?.result?.state?.validatedLedger?.reserveBase ?? 10000000) // Default 10 XRP
-        let reserveInc = BigInt(serverState?.result?.state?.validatedLedger?.reserveInc ?? 2000000)   // Default 2 XRP
+        let reservedBase = BigInt(serverState?.result?.state?.validatedLedger?.reserveBase ?? 1000000) // Default 1 XRP
+        let reserveInc = BigInt(serverState?.result?.state?.validatedLedger?.reserveInc ?? 200000)     // Default 0.2 XRP
         
         let reservedBalance = reservedBase + (ownerCount * reserveInc)
         
@@ -101,7 +101,7 @@ class RippleService {
             
             return response
         } catch {
-            print("Error in fetchServerState:")
+            print("Error in fetchServerState: \(error)")
             throw error
         }
     }


### PR DESCRIPTION
Available balance, not reserved
IOS
<img width="474" height="1010" alt="image" src="https://github.com/user-attachments/assets/3df27c30-efb4-4918-b6a0-d39f8501b415" />

MacOS
<img width="913" height="916" alt="image" src="https://github.com/user-attachments/assets/0521ba92-f708-4eea-986e-a73890099913" />

Explorer
Available balance
<img width="1455" height="452" alt="image" src="https://github.com/user-attachments/assets/dc0213ee-d98b-40ed-920d-2b83b1b71e9d" />

<img width="1423" height="385" alt="image" src="https://github.com/user-attachments/assets/35b428cf-70f7-4c84-95fb-22451f46e7dc" />

<img width="1408" height="335" alt="image" src="https://github.com/user-attachments/assets/40142c0c-efa2-45d7-8543-683382c55d0f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved balance display for Ripple accounts by now showing the available balance after accounting for network reserve requirements.

* **Bug Fixes**
  * Ensured that the available balance never displays a negative value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->