### PR TITLE
Fix the issue that on IOS fastvault backup fail and cause the screen go back to set password screen

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/BackupSetupView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/BackupSetupView.swift
@@ -15,13 +15,8 @@ struct BackupSetupView: View {
 
     @State var navigationLinkActive = false
 
-    @State var showSkipShareSheet = false
-    @State var showSaveShareSheet = false
-
     @State var animation: RiveViewModel?
-
-    @Environment(\.dismiss) var dismiss
-    
+   
     var body: some View {
         mainContent
             .navigationDestination(isPresented: $navigationLinkActive) {

--- a/VultisigApp/VultisigApp/Views/Vault/PasswordBackupOptionsView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/PasswordBackupOptionsView.swift
@@ -92,10 +92,12 @@ struct PasswordBackupOptionsView: View {
     }
     
     func dismissView() {
-        if isNewVault {
-            navigationLinkActive = true
-        } else {
-            homeLinkActive = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            if isNewVault {
+                navigationLinkActive = true
+            } else {
+                homeLinkActive = true
+            }
         }
     }
 }

--- a/VultisigApp/VultisigApp/iOS/Native/ShareSheetViewController.swift
+++ b/VultisigApp/VultisigApp/iOS/Native/ShareSheetViewController.swift
@@ -47,7 +47,9 @@ private struct ShareSheetViewController: UIViewControllerRepresentable {
             if let error = error {
                 print("Error sharing: \(error.localizedDescription)")
             }
-            isPresented = false
+            DispatchQueue.main.async {
+                isPresented = false
+            }
             // Added delay on completion execution to wait for sheet dismissal for smoother experience
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 context.coordinator.completion?(completed)

--- a/VultisigApp/VultisigApp/iOS/Native/ShareSheetViewController.swift
+++ b/VultisigApp/VultisigApp/iOS/Native/ShareSheetViewController.swift
@@ -18,6 +18,7 @@ extension View {
             )
             .presentationDetents([.medium])
             .ignoresSafeArea(.all)
+            
         }
     }
 }
@@ -29,9 +30,11 @@ private struct ShareSheetViewController: UIViewControllerRepresentable {
     var completion: ((Bool) -> Void)?
     
     class Coordinator: NSObject {
-        // Strong reference to the UIActivityViewController
-        var activityViewController: UIActivityViewController?
+        // Weak reference to prevent retain cycles
+        weak var activityViewController: UIActivityViewController?
         var completion: ((Bool) -> Void)?
+        var hasCompleted: Bool = false
+        
         init(completion: ((Bool) -> Void)? = nil) {
             self.completion = completion
         }
@@ -40,26 +43,45 @@ private struct ShareSheetViewController: UIViewControllerRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(completion: self.completion)
     }
+    
     func makeUIViewController(context: UIViewControllerRepresentableContext<ShareSheetViewController>) -> UIActivityViewController {
         let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: applicationActivities)
         context.coordinator.activityViewController = controller
+        
+        // Configure the controller
+        controller.excludedActivityTypes = [
+            .assignToContact,
+            .addToReadingList,
+            .openInIBooks,
+            .markupAsPDF
+        ]
+        
         controller.completionWithItemsHandler = { _, completed, _, error in
+            // Prevent multiple completion calls
+            guard !context.coordinator.hasCompleted  else { return }
+            context.coordinator.hasCompleted = true
+            
             if let error = error {
                 print("Error sharing: \(error.localizedDescription)")
             }
+            
+            // Dismiss the sheet first
             DispatchQueue.main.async {
-                isPresented = false
+                self.isPresented = false
             }
-            // Added delay on completion execution to wait for sheet dismissal for smoother experience
+            
+            // Use a longer delay to ensure navigation state is completely stable
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 context.coordinator.completion?(completed)
+                context.coordinator.activityViewController = nil
             }
-            context.coordinator.activityViewController = nil
         }
         
         return controller
     }
     
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: UIViewControllerRepresentableContext<ShareSheetViewController>) {}
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: UIViewControllerRepresentableContext<ShareSheetViewController>) {
+        // No updates needed
+    }
 }
 #endif


### PR DESCRIPTION
## Description
* Removed unused state variables in BackupSetupView for cleaner code.
* Updated dismissView in PasswordBackupOptionsView to use a delayed navigation approach for smoother transitions.
* Improved ShareSheetViewController to prevent multiple completion calls and added configuration for excluded activity types.

Fixes #2607 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context