### PR TITLE
refactor: Improve token sorting in ChainDetailView by prioritizing na…

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/ChainDetailView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/ChainDetailView.swift
@@ -8,7 +8,12 @@ struct ChainDetailView: View {
     var tokens: [Coin] {
         return vault.coins
             .filter { $0.chain == group.chain }
-            .sorted()
+            .sorted {
+                if $0.isNativeToken != $1.isNativeToken {
+                    return $0.isNativeToken
+                }
+                return $0.balanceDecimal > $1.balanceDecimal
+            }
     }
 
     @StateObject var sendTx = SendTransaction()


### PR DESCRIPTION

## Description

This PR sort the tokens in chain detail view based on the following rules
1. Native Token will show up on the top 
2. The reset tokens will be sorted based on it's balance , higher balance will show up on the top

Fixes #2343 
## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context