### PR TITLE
fix: prevent navigationLink being set to false after vault deletion

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/FastVaultSetPasswordView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/FastVaultSetPasswordView.swift
@@ -40,7 +40,7 @@ struct FastVaultSetPasswordView: View {
                     FastVaultSetHintView(tssType: tssType, vault: vault, selectedTab: selectedTab, fastVaultEmail: fastVaultEmail, fastVaultPassword: password, fastVaultExist: fastVaultExist)
                 }
             }
-            .onAppear() {
+            .onLoad {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     isPasswordFieldFocused = true
                 }
@@ -68,9 +68,6 @@ struct FastVaultSetPasswordView: View {
         }
         .padding(.horizontal, 16)
         .padding(.top, 30)
-        .onAppear {
-            isLinkActive = false
-        }
     }
     
     var title: some View {


### PR DESCRIPTION
## Description

Fixes #2629

- Remove NavigationLink update on view appear.

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):
