### PR TITLE
fix: applied new style for hold for sign for swaps

### DIFF
--- a/VultisigApp/VultisigApp/Views/Swap/SwapVerifyView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapVerifyView.swift
@@ -55,10 +55,9 @@ struct SwapVerifyView: View {
     var content: some View {
         VStack(spacing: 16) {
             fields
-            if tx.isFastVault {
-                fastVaultButton
-            }
-            pairedSignButton
+            signButton
+                .padding(.horizontal, 16)
+                .disabled(!verifyViewModel.isValidForm(shouldApprove: tx.isApproveRequired))
         }
     }
 
@@ -186,40 +185,29 @@ struct SwapVerifyView: View {
         }
     }
 
-    var fastVaultButton: some View {
-        PrimaryButton(title: NSLocalizedString("fastSign", comment: "")) {
-            fastPasswordPresented = true
-        }
-        .disabled(!verifyViewModel.isValidForm(shouldApprove: tx.isApproveRequired))
-        .opacity(verifyViewModel.isValidForm(shouldApprove: tx.isApproveRequired) ? 1 : 0.5)
-        .padding(.horizontal, 24)
-        .sheet(isPresented: $fastPasswordPresented) {
-            FastVaultEnterPasswordView(
-                password: $tx.fastVaultPassword,
-                vault: vault, 
-                onSubmit: { onSignPress() }
-            )
-        }
-    }
-
     @ViewBuilder
-    var pairedSignButton: some View {
-        let isDisabled = !verifyViewModel.isValidForm(shouldApprove: tx.isApproveRequired)
-        
-        if swapViewModel.isLoadingTransaction {
-            ButtonLoader()
-                .padding(.horizontal, 24)
-                .padding(.bottom, 24)
-        } else {
-            PrimaryButton(
-                title: tx.isFastVault ? "Paired sign" : "startTransaction",
-                type: tx.isFastVault ? .secondary : .primary
-            ) {
+    var signButton: some View {
+        if tx.isFastVault {
+            Text(NSLocalizedString("holdForPairedSign", comment: ""))
+                .foregroundColor(.extraLightGray)
+                .font(.body14BrockmannMedium)
+            
+            LongPressPrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
+                fastPasswordPresented = true
+            } longPressAction: {
                 onSignPress()
             }
-            .disabled(isDisabled)
-            .padding(.horizontal, 24)
-            .padding(.bottom, 24)
+            .sheet(isPresented: $fastPasswordPresented) {
+                FastVaultEnterPasswordView(
+                    password: $tx.fastVaultPassword,
+                    vault: vault,
+                    onSubmit: { onSignPress() }
+                )
+            }
+        } else {
+            PrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
+                onSignPress()
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #2671

- Applied new style for hold for sign for swaps

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified the signing interface into a single button with conditional behavior for different transaction types.
  * Improved user experience by streamlining the signing process, including long-press and password entry for certain transactions.

* **Style**
  * Simplified and updated the signing UI for a more consistent look and feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->