### PR TITLE
fix: updated sheet presentation for macOS on Send flow

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		1390D8C82E394527003F3E20 /* SecurityScannerSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1390D8C72E39450D003F3E20 /* SecurityScannerSettingsService.swift */; };
 		1390D8CC2E394778003F3E20 /* SecurityScannerServiceFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1390D8CB2E394770003F3E20 /* SecurityScannerServiceFactory.swift */; };
 		139880502E39007C00EC5D3F /* CosmosCoin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1398804F2E39007900EC5D3F /* CosmosCoin.swift */; };
+		139B400C2E42466F00238C2C /* MacOSOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B400B2E42466800238C2C /* MacOSOverlay.swift */; };
 		13B26D3F2E32B506000D3B3A /* SendFormExpandableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B26D3E2E32B501000D3B3A /* SendFormExpandableSection.swift */; };
 		13B676442E37C9B0002F016C /* SendCryptoTransactionHashRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B676432E37C99B002F016C /* SendCryptoTransactionHashRowView.swift */; };
 		13B676462E37CA5F002F016C /* SendCryptoTransactionDetailsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B676452E37CA56002F016C /* SendCryptoTransactionDetailsRow.swift */; };
@@ -1054,6 +1055,7 @@
 		1390D8C72E39450D003F3E20 /* SecurityScannerSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityScannerSettingsService.swift; sourceTree = "<group>"; };
 		1390D8CB2E394770003F3E20 /* SecurityScannerServiceFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityScannerServiceFactory.swift; sourceTree = "<group>"; };
 		1398804F2E39007900EC5D3F /* CosmosCoin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CosmosCoin.swift; sourceTree = "<group>"; };
+		139B400B2E42466800238C2C /* MacOSOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSOverlay.swift; sourceTree = "<group>"; };
 		13B26D3E2E32B501000D3B3A /* SendFormExpandableSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendFormExpandableSection.swift; sourceTree = "<group>"; };
 		13B676432E37C99B002F016C /* SendCryptoTransactionHashRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCryptoTransactionHashRowView.swift; sourceTree = "<group>"; };
 		13B676452E37CA56002F016C /* SendCryptoTransactionDetailsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCryptoTransactionDetailsRow.swift; sourceTree = "<group>"; };
@@ -2058,6 +2060,7 @@
 		049BBB4E2B71E37B004C231F /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				139B400A2E42466400238C2C /* Covers */,
 				13DD3B182E3CFE6600D46FA0 /* Picker */,
 				13DD3B152E3CFE4800D46FA0 /* ScrollView */,
 				13DF05732E3CEF580000188C /* TextField */,
@@ -2253,6 +2256,14 @@
 				A6SEC0072E1234567890AB02 /* BlockaidScannerService.swift */,
 			);
 			path = Blockaid;
+			sourceTree = "<group>";
+		};
+		139B400A2E42466400238C2C /* Covers */ = {
+			isa = PBXGroup;
+			children = (
+				139B400B2E42466800238C2C /* MacOSOverlay.swift */,
+			);
+			path = Covers;
 			sourceTree = "<group>";
 		};
 		13D764362E4102F100F048DE /* Swap */ = {
@@ -4461,6 +4472,7 @@
 				A6F9F7DB2B9BA2DE00790258 /* ChainCell.swift in Sources */,
 				A6386D8E2C8C274C00DDD58E /* BackupVaultNowView+macOS.swift in Sources */,
 				A686965A2C1F72FF004EDE0B /* HiddenTextField.swift in Sources */,
+				139B400C2E42466F00238C2C /* MacOSOverlay.swift in Sources */,
 				B52FD1CE2CDDA7740031FB71 /* TerraService.swift in Sources */,
 				A6386D9C2C90224300DDD58E /* SendCryptoSigningErrorView+macOS.swift in Sources */,
 				049BBB682B71E9C5004C231F /* WifiInstruction.swift in Sources */,

--- a/VultisigApp/VultisigApp/Views/Components/Covers/MacOSOverlay.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Covers/MacOSOverlay.swift
@@ -1,0 +1,21 @@
+//
+//  MacOSOverlay.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 05/08/2025.
+//
+
+import SwiftUI
+
+struct MacOSOverlay: View {
+    var body: some View {
+        ZStack(alignment: .top) {
+            Color.black
+                .frame(height: 200)
+                .offset(y: -200)
+            
+            Color.black
+        }
+        .opacity(0.8)
+    }
+}

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAssetTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAssetTab.swift
@@ -23,27 +23,6 @@ struct SendDetailsAssetTab: View {
             .onChange(of: tx.coin, { oldValue, newValue in
                 setData()
             })
-            // chain selector
-            .sheet(isPresented: $viewModel.showChainPickerSheet, content: {
-                if let vault = homeViewModel.selectedVault {
-                    SwapChainPickerView(
-                        vault: vault,
-                        showSheet: $viewModel.showChainPickerSheet,
-                        selectedChain: $viewModel.selectedChain
-                    )
-                }
-            })
-            // coin selector
-            .sheet(isPresented: $viewModel.showCoinPickerSheet, content: {
-                if let vault = homeViewModel.selectedVault {
-                    SwapCoinPickerView(
-                        vault: vault,
-                        showSheet: $viewModel.showCoinPickerSheet,
-                        selectedCoin: $tx.coin,
-                        selectedChain: viewModel.selectedChain
-                    )
-                }
-            })
             .onChange(of: viewModel.showCoinPickerSheet) { oldValue, newValue in
                 handleAssetSelection(oldValue, newValue)
             }
@@ -194,6 +173,7 @@ struct SendDetailsAssetTab: View {
         viewModel.assetSetupDone = true
     }
 }
+
 
 #Preview {
     SendDetailsAssetTab(

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDetailsView.swift
@@ -127,6 +127,23 @@ struct SendCryptoDetailsView: View {
         }
     }
     
+    var chainPicker: some View {
+        SwapChainPickerView(
+            vault: vault,
+            showSheet: $sendDetailsViewModel.showChainPickerSheet,
+            selectedChain: $sendDetailsViewModel.selectedChain
+        )
+    }
+
+    var coinPicker: some View {
+        SwapCoinPickerView(
+            vault: vault,
+            showSheet: $sendDetailsViewModel.showCoinPickerSheet,
+            selectedCoin: $tx.coin,
+            selectedChain: sendDetailsViewModel.selectedChain
+        )
+    }
+    
     func onChange(focusedField: Field?) {
         if focusedField == .toAddress {
             handleScroll(newValue: .address, oldValue: .asset, delay: 0.2)

--- a/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoDetailsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoDetailsView+iOS.swift
@@ -24,6 +24,12 @@ extension SendCryptoDetailsView {
                     }
                 }
             }
+            .sheet(isPresented: $sendDetailsViewModel.showChainPickerSheet) {
+                chainPicker
+            }
+            .sheet(isPresented: $sendDetailsViewModel.showCoinPickerSheet) {
+                coinPicker
+            }
     }
     
     var view: some View {

--- a/VultisigApp/VultisigApp/macOS/View/Send/SendCryptoDetailsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Send/SendCryptoDetailsView+macOS.swift
@@ -10,7 +10,15 @@ import SwiftUI
 
 extension SendCryptoDetailsView {
     var container: some View {
-        content
+        ZStack(alignment: .top) {
+            content
+            overlay
+                .showIf(sendDetailsViewModel.showCoinPickerSheet || sendDetailsViewModel.showChainPickerSheet)
+            chainPicker
+                .showIf(sendDetailsViewModel.showChainPickerSheet)
+            coinPicker
+                .showIf(sendDetailsViewModel.showCoinPickerSheet)
+        }
     }
     
     var view: some View {
@@ -32,6 +40,16 @@ extension SendCryptoDetailsView {
         Task {
             await getBalance()
         }
+    }
+    
+    var overlay: some View {
+        MacOSOverlay()
+            .onTapGesture(perform: closeSheets)
+    }
+    
+    func closeSheets() {
+        sendDetailsViewModel.showCoinPickerSheet = false
+        sendDetailsViewModel.showCoinPickerSheet = false
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/macOS/View/Send/SendCryptoDetailsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Send/SendCryptoDetailsView+macOS.swift
@@ -49,7 +49,7 @@ extension SendCryptoDetailsView {
     
     func closeSheets() {
         sendDetailsViewModel.showCoinPickerSheet = false
-        sendDetailsViewModel.showCoinPickerSheet = false
+        sendDetailsViewModel.showChainPickerSheet = false
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
@@ -15,7 +15,8 @@ extension SwapCryptoDetailsView {
             view
             
             if showSheet() {
-                overlay
+                MacOSOverlay()
+                    .onTapGesture(perform: closeSheets)
             }
             
             VStack {
@@ -80,20 +81,6 @@ extension SwapCryptoDetailsView {
                 summary
             }
             .padding(.horizontal, 16)
-        }
-    }
-    
-    var overlay: some View {
-        ZStack(alignment: .top) {
-            Color.black
-                .frame(height: 200)
-                .offset(y: -200)
-            
-            Color.black
-        }
-        .opacity(0.8)
-        .onTapGesture {
-            closeSheets()
         }
     }
     


### PR DESCRIPTION
## Description

Fixes #2675

- Updated sheet presentation for macOS on Send flow

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [x] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new visual overlay component for macOS, providing a translucent background effect when displaying modal sheets.
  * Added modal sheet presentation for chain and coin pickers in the send flow on both iOS and macOS.

* **Refactor**
  * Reorganized picker sheet logic to use reusable components for improved consistency across platforms.
  * Updated macOS and swap views to utilize the new overlay component for sheet dismissals.

* **Style**
  * Enhanced visual experience with a partially transparent overlay during modal interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->