### PR TITLE
Fix chain selection during send

### DIFF
--- a/VultisigApp/VultisigApp/Views/Swap/SwapChainPickerView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapChainPickerView.swift
@@ -17,7 +17,7 @@ struct SwapChainPickerView: View {
     let vault: Vault
     @Binding var showSheet: Bool
     @Binding var selectedChain: Chain?
-
+    
     @State var searchText = ""
     @EnvironmentObject var viewModel: CoinSelectionViewModel
     
@@ -132,7 +132,7 @@ struct SwapChainPickerView: View {
             view
         }
     }
-
+    
     var searchBar: some View {
         SearchTextField(value: $searchText)
             .padding(.bottom, 12)
@@ -160,7 +160,7 @@ struct SwapChainPickerView: View {
                 viewModel.groupedAssets[chainName]?.first?.chain
             }.filter(\.isSwapAvailable)
         case .send:
-            return vault.coins.map { $0.chain }.uniqueBy { $0.chainType }
+            return vault.coins.filter {$0.isNativeToken}.map{$0.chain}
         }
     }
 }


### PR DESCRIPTION
## Description

Currently during send , if we click "chain selection" , it doesn't show up all the chains

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of available chains when sending, now showing only chains with native tokens.
* **Style**
  * Enhanced code formatting for consistency (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->