### PR TITLE
feat: add memo support to Tron transaction

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -19,9 +19,6 @@
 		1334C7462E301E8800CBAA3E /* SendCryptoDoneContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1334C7452E301E8700CBAA3E /* SendCryptoDoneContent.swift */; };
 		13417B8A2E3BB1D000A66EE5 /* FunctionCallStakeRuji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13417B892E3BB1CA00A66EE5 /* FunctionCallStakeRuji.swift */; };
 		13417B8C2E3BB1DB00A66EE5 /* FunctionCallUnstakeRuji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13417B8B2E3BB1D200A66EE5 /* FunctionCallUnstakeRuji.swift */; };
-		BU61YTK5IM2CA6CN47V4L8BG /* FunctionCallAddThorLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = BWXBB99J8F32LB10N1PT9BIH /* FunctionCallAddThorLP.swift */; };
-		GVTXGPZR8J4TTJM9OSTSZLYW /* FunctionCallRemoveThorLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = T94FUQJYPRAV7FIDJNMPFKAH /* FunctionCallRemoveThorLP.swift */; };
-		F6MAHZO7QADAUEOCUKP14KWW /* ThorchainLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = VX9GYT3ZT7ENIW24C32BA8O7 /* ThorchainLP.swift */; };
 		13417B8E2E3BB1EE00A66EE5 /* FunctionCallWithdrawRujiRewards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13417B8D2E3BB1DE00A66EE5 /* FunctionCallWithdrawRujiRewards.swift */; };
 		135677A62E391A6E002C10A2 /* SecurityScannerTransactionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135677A52E391A68002C10A2 /* SecurityScannerTransactionFactory.swift */; };
 		135677A82E391AC9002C10A2 /* SecurityScannerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135677A72E391AC3002C10A2 /* SecurityScannerModels.swift */; };
@@ -873,6 +870,7 @@
 		B5F758192BD8E65D0097B5BB /* SuiConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F758182BD8E65D0097B5BA /* SuiConstants.swift */; };
 		B5F7581A2BD8E7230097B5B9 /* SuiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F758192BD8E7230097B5B9 /* SuiService.swift */; };
 		B5F7581D2BD8FDA20097B5B9 /* SuiCoin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F7581C2BD8FDA20097B5B9 /* SuiCoin.swift */; };
+		BU61YTK5IM2CA6CN47V4L8BG /* FunctionCallAddThorLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = BWXBB99J8F32LB10N1PT9BIH /* FunctionCallAddThorLP.swift */; };
 		CF711D753DDB0FC62425A9DA /* KyberSwapQuote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7878748BB9E16298184860 /* KyberSwapQuote.swift */; };
 		D70D65FC2DF48824001C4492 /* RuneBondCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70D65FB2DF48824001C4492 /* RuneBondCell.swift */; };
 		D7620B1D2DF6BFD700294396 /* FunctionCallNodeMaintenance.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7620B1C2DF6BFD700294396 /* FunctionCallNodeMaintenance.swift */; };
@@ -991,6 +989,8 @@
 		DEFF58FC2BCFB384005DFDF9 /* MayaChainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFF58FB2BCFB384005DFDF9 /* MayaChainService.swift */; };
 		DEFF58FE2BD13E5D005DFDF9 /* ThreadSafeDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFF58FD2BD13E5D005DFDF9 /* ThreadSafeDictionary.swift */; };
 		DEFF59012BD238CF005DFDF9 /* SignedTransactionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFF59002BD238CF005DFDF9 /* SignedTransactionResult.swift */; };
+		F6MAHZO7QADAUEOCUKP14KWW /* ThorchainLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = VX9GYT3ZT7ENIW24C32BA8O7 /* ThorchainLP.swift */; };
+		GVTXGPZR8J4TTJM9OSTSZLYW /* FunctionCallRemoveThorLP.swift in Sources */ = {isa = PBXBuildFile; fileRef = T94FUQJYPRAV7FIDJNMPFKAH /* FunctionCallRemoveThorLP.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1024,9 +1024,6 @@
 		1334C7452E301E8700CBAA3E /* SendCryptoDoneContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCryptoDoneContent.swift; sourceTree = "<group>"; };
 		13417B892E3BB1CA00A66EE5 /* FunctionCallStakeRuji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallStakeRuji.swift; sourceTree = "<group>"; };
 		13417B8B2E3BB1D200A66EE5 /* FunctionCallUnstakeRuji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallUnstakeRuji.swift; sourceTree = "<group>"; };
-		BWXBB99J8F32LB10N1PT9BIH /* FunctionCallAddThorLP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallAddThorLP.swift; sourceTree = "<group>"; };
-		T94FUQJYPRAV7FIDJNMPFKAH /* FunctionCallRemoveThorLP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallRemoveThorLP.swift; sourceTree = "<group>"; };
-		VX9GYT3ZT7ENIW24C32BA8O7 /* ThorchainLP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThorchainLP.swift; sourceTree = "<group>"; };
 		13417B8D2E3BB1DE00A66EE5 /* FunctionCallWithdrawRujiRewards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallWithdrawRujiRewards.swift; sourceTree = "<group>"; };
 		135677A52E391A68002C10A2 /* SecurityScannerTransactionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityScannerTransactionFactory.swift; sourceTree = "<group>"; };
 		135677A72E391AC3002C10A2 /* SecurityScannerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityScannerModels.swift; sourceTree = "<group>"; };
@@ -1878,6 +1875,7 @@
 		B5F758182BD8E65D0097B5BA /* SuiConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuiConstants.swift; sourceTree = "<group>"; };
 		B5F758192BD8E7230097B5B9 /* SuiService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuiService.swift; sourceTree = "<group>"; };
 		B5F7581C2BD8FDA20097B5B9 /* SuiCoin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuiCoin.swift; sourceTree = "<group>"; };
+		BWXBB99J8F32LB10N1PT9BIH /* FunctionCallAddThorLP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallAddThorLP.swift; sourceTree = "<group>"; };
 		CD36D5BDFA9CBF0B16709643 /* KyberSwapService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KyberSwapService.swift; sourceTree = "<group>"; };
 		D70D65FB2DF48824001C4492 /* RuneBondCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuneBondCell.swift; sourceTree = "<group>"; };
 		D7620B1C2DF6BFD700294396 /* FunctionCallNodeMaintenance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallNodeMaintenance.swift; sourceTree = "<group>"; };
@@ -1998,6 +1996,8 @@
 		E7DBBE9179D24F73ADF22596 /* ExtensionMemoServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionMemoServiceTests.swift; sourceTree = "<group>"; };
 		E8C796F13B6313681B4F992A /* KyberSwapToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KyberSwapToken.swift; sourceTree = "<group>"; };
 		FCB0CAFF343CC6FF8986E07F /* HiddenToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HiddenToken.swift; sourceTree = "<group>"; };
+		T94FUQJYPRAV7FIDJNMPFKAH /* FunctionCallRemoveThorLP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallRemoveThorLP.swift; sourceTree = "<group>"; };
+		VX9GYT3ZT7ENIW24C32BA8O7 /* ThorchainLP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThorchainLP.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -2016,6 +2016,7 @@
 				thorchain.json,
 				thorchainswap.json,
 				ton.json,
+				tron.json,
 				utxo.json,
 				xrp.json,
 			);
@@ -2275,6 +2276,14 @@
 			path = Blockaid;
 			sourceTree = "<group>";
 		};
+		139B400A2E42466400238C2C /* Covers */ = {
+			isa = PBXGroup;
+			children = (
+				139B400B2E42466800238C2C /* MacOSOverlay.swift */,
+			);
+			path = Covers;
+			sourceTree = "<group>";
+		};
 		13BD8D262E3D49600013B67E /* DesignSystem */ = {
 			isa = PBXGroup;
 			children = (
@@ -2320,14 +2329,6 @@
 				13BD8D3D2E3D49AD0013B67E /* ThemeProtocol.swift */,
 			);
 			path = Theme;
-			sourceTree = "<group>";
-		};
-		139B400A2E42466400238C2C /* Covers */ = {
-			isa = PBXGroup;
-			children = (
-				139B400B2E42466800238C2C /* MacOSOverlay.swift */,
-			);
-			path = Covers;
 			sourceTree = "<group>";
 		};
 		13D764362E4102F100F048DE /* Swap */ = {
@@ -4910,9 +4911,9 @@
 				A60CA7EB2BB1020900FDEB5C /* DetectOrientation.swift in Sources */,
 				B5C4A42C2C62EC6500AF9B8B /* AddressService.swift in Sources */,
 				13417B8A2E3BB1D000A66EE5 /* FunctionCallStakeRuji.swift in Sources */,
-			BU61YTK5IM2CA6CN47V4L8BG /* FunctionCallAddThorLP.swift in Sources */,
-			GVTXGPZR8J4TTJM9OSTSZLYW /* FunctionCallRemoveThorLP.swift in Sources */,
-			F6MAHZO7QADAUEOCUKP14KWW /* ThorchainLP.swift in Sources */,
+				BU61YTK5IM2CA6CN47V4L8BG /* FunctionCallAddThorLP.swift in Sources */,
+				GVTXGPZR8J4TTJM9OSTSZLYW /* FunctionCallRemoveThorLP.swift in Sources */,
+				F6MAHZO7QADAUEOCUKP14KWW /* ThorchainLP.swift in Sources */,
 				A6E0C94F2DF49E2700A01543 /* CreateReferralDetailsView+macOS.swift in Sources */,
 				A6C670CB2C9E8BAB00F59B6A /* VultExtensionViewModel.swift in Sources */,
 				D9AD8EDE2B6730430009F8D5 /* WelcomeView.swift in Sources */,

--- a/VultisigApp/VultisigApp/Chains/Tron.swift
+++ b/VultisigApp/VultisigApp/Chains/Tron.swift
@@ -96,6 +96,9 @@ enum TronHelper {
                         )!
                     }
                     $0.expiration = Int64(expiration)
+                    if let memo = keysignPayload.memo {
+                        $0.memo = memo
+                    }
                 }
             }
             

--- a/VultisigApp/VultisigApp/Chains/Tron.swift
+++ b/VultisigApp/VultisigApp/Chains/Tron.swift
@@ -42,6 +42,11 @@ enum TronHelper {
                 $0.transaction = TronTransaction.with {
                     $0.contractOneof = .transfer(contract)
                     $0.timestamp = Int64(timestamp)
+                    
+                    if let memo = keysignPayload.memo {
+                        $0.memo = memo
+                    }
+                    
                     $0.blockHeader = TronBlockHeader.with {
                         $0.timestamp = Int64(blockHeaderTimestamp)
                         $0.number = Int64(blockHeaderNumber)

--- a/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
@@ -38,7 +38,7 @@ final class ChainHelperTests: XCTestCase {
         }
         let resourceURL = URL(fileURLWithPath: resourcePath)
         let jsonFiles = try fileManager.contentsOfDirectory(at: resourceURL, includingPropertiesForKeys: nil)
-            .filter { $0.pathExtension == "json"}
+            .filter { $0.pathExtension == "json" }
         
         // Iterate through each JSON file
         for jsonFile in jsonFiles {
@@ -141,6 +141,8 @@ final class ChainHelperTests: XCTestCase {
             result += try KujiraHelper().getPreSignedImageHash(keysignPayload: keysignPayload)
         case .ton:
             result += try TonHelper.getPreSignedImageHash(keysignPayload: keysignPayload)
+        case .tron:
+            result += try TronHelper.getPreSignedImageHash(keysignPayload: keysignPayload)
         default:
             XCTFail("Unsupported chain: \(String(describing: chain.name))")
         }

--- a/VultisigApp/VultisigAppTests/TestData/tron.json
+++ b/VultisigApp/VultisigAppTests/TestData/tron.json
@@ -1,0 +1,73 @@
+[
+    {
+        "name": "Send TRON TRX",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Tron",
+                "ticker": "TRX",
+                "address": "TJZtvvRgRzYTfQLLasVXM4P2TiJRW8UF71",
+                "decimals": 6,
+                "price_provider_id": "tron",
+                "is_native_token": true,
+                "hex_public_key": "04752f79c4b51922b6d096c5a0d026c400b39993578e302a7f5ddc6c5d6c0733942440c89872186bd107bdb6a0fdd45d91d525b581570f0d00a3409ac49abf77a6",
+                "logo": "tron"
+            },
+            "to_address": "TYwbooxVSPe4LZm7U72tuqUNNiQ15BNaLa",
+            "to_amount": "1000000",
+            "BlockchainSpecific": {
+                "TronSpecific": {
+                    "block_header_version" : 32,
+                    "block_header_number" : 74623821,
+                    "timestamp" : 1754530349070,
+                    "block_header_tx_trie_root" : "25eb4a0b57910d8467dd10b9111c51453b998317208e25059262d4a1f7b7c893",
+                    "expiration" : 1754533949070,
+                    "gas_estimation" : 100000,
+                    "block_header_parent_hash" : "000000000472ab4c0c452c67aefd6063256a41a6e525a3223e8a70280a92e8ab",
+                    "block_header_timestamp" : 1754530347000,
+                    "block_header_witness_address" : "41022939a4a06cbc7b384096c1af8657ec435173af"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "0342d6eb3e536bd1d6f57a8388afb09936aa64160c5e2ebee76d791b4844a06770",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": ["9c6f6acf8ab07a42b75e0db2898903008d8f6ef383dd1fcf43953e3eb28fd2d3"]
+    },
+    {
+        "name": "Send TRON TRX with memo",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Tron",
+                "ticker": "TRX",
+                "address": "TJZtvvRgRzYTfQLLasVXM4P2TiJRW8UF71",
+                "decimals": 6,
+                "price_provider_id": "tron",
+                "is_native_token": true,
+                "hex_public_key": "04752f79c4b51922b6d096c5a0d026c400b39993578e302a7f5ddc6c5d6c0733942440c89872186bd107bdb6a0fdd45d91d525b581570f0d00a3409ac49abf77a6",
+                "logo": "tron"
+            },
+            "to_address": "TYwbooxVSPe4LZm7U72tuqUNNiQ15BNaLa",
+            "to_amount": "1000000",
+            "BlockchainSpecific": {
+                "TronSpecific": {
+                    "block_header_version" : 32,
+                    "block_header_number" : 74623821,
+                    "timestamp" : 1754530349070,
+                    "block_header_tx_trie_root" : "25eb4a0b57910d8467dd10b9111c51453b998317208e25059262d4a1f7b7c893",
+                    "expiration" : 1754533949070,
+                    "gas_estimation" : 100000,
+                    "block_header_parent_hash" : "000000000472ab4c0c452c67aefd6063256a41a6e525a3223e8a70280a92e8ab",
+                    "block_header_timestamp" : 1754530347000,
+                    "block_header_witness_address" : "41022939a4a06cbc7b384096c1af8657ec435173af"
+                }
+            },
+            "memo": "helloworld",
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "0342d6eb3e536bd1d6f57a8388afb09936aa64160c5e2ebee76d791b4844a06770",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": ["f75f46b4f037a7824c1c8cff70f4ba546d276408413e24571bb4787d02ef9292"]
+    }
+]


### PR DESCRIPTION
https://tronscan.org/#/transaction/4d2c1e98cd78de3a394d9aeb6ca3aff1c576e102abf8cbc796c0b0a43f521211
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including a memo field when sending native TRX and TRC20 token transfers on the Tron network, allowing users to attach additional information to their transactions.
* **Tests**
  * Introduced new test cases for TRON transaction signing, including memo field scenarios, to ensure accurate transaction processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->