### PR TITLE
fix: updated thorname fee calculation for new names

### DIFF
--- a/VultisigApp/VultisigApp/View Models/Referral/ReferralViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/Referral/ReferralViewModel.swift
@@ -117,8 +117,16 @@ class ReferralViewModel: ObservableObject {
     }
     
     func getTotalFee() -> Decimal {
-        let amount = registrationFee + (feePerBlock * Decimal(ReferralExpiryDataCalculator.blockPerYear * UInt64(expireInCount)))
-        return amount / 100_000_000
+        let amount: Decimal
+        if expireInCount > 1 {
+            amount = (feePerBlock * Decimal(ReferralExpiryDataCalculator.blockPerYear * UInt64(expireInCount - 1)))
+        } else {
+            // Registration comes with 1 free year, but sending exactly 10 RUNE fails
+            // So we need to send a little bit more
+            amount = feePerBlock
+        }
+        
+        return (registrationFee + amount) / 100_000_000
     }
     
     func getFiatAmount(for amount: Decimal) -> String {
@@ -286,11 +294,7 @@ class ReferralViewModel: ObservableObject {
         let amount = totalFee + gas
         let vaultAmount = nativeCoin?.balanceDecimal ?? 0
         
-        if vaultAmount >= amount {
-            return true
-        } else {
-            return false
-        }
+        return vaultAmount >= amount
     }
     
     func fetchReferralCodeDetails(vaults: [Vault]) async {


### PR DESCRIPTION
## Description

- Updated thorname fee calculation for new names:
  - If user sets 1 year, we need to send a bit more than 10 RUNE for registration
  - If user sets > 1 years, we need to send 10 + N-1 years.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee calculation logic for referrals to ensure accurate total fees based on expiration period.
  * Enhanced gas check for transactions to simplify and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->