### PR TITLE
EVM: Ensure priority fee ≤ max fee and keep TSS preimage consistent

### DIFF
--- a/VultisigApp/VultisigApp/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Services/BlockChainService.swift
@@ -335,13 +335,14 @@ private extension BlockChainService {
             let normalizedPriorityFee = max(priorityFee, defaultPriorityFee)
             let normalizedBaseFee = Self.normalizeEVMFee(baseFee)
             let maxFeePerGasWei = normalizedBaseFee + normalizedPriorityFee
-            return .Ethereum(maxFeePerGasWei: maxFeePerGasWei, priorityFeeWei: priorityFee, nonce: nonce, gasLimit: gasLimit)
+            return .Ethereum(maxFeePerGasWei: maxFeePerGasWei, priorityFeeWei: normalizedPriorityFee, nonce: nonce, gasLimit: gasLimit)
             
         case .zksync:
             let service = try EvmServiceFactory.getService(forChain: coin.chain)
             let (gasLimit, _, maxFeePerGas, maxPriorityFeePerGas, nonce) = try await service.getGasInfoZk(fromAddress: coin.address, toAddress: .zeroAddress)
-            
-            return .Ethereum(maxFeePerGasWei: maxFeePerGas, priorityFeeWei: maxPriorityFeePerGas, nonce: nonce, gasLimit: gasLimit)
+            // Ensure priority fee does not exceed max fee
+            let adjustedPriority = maxPriorityFeePerGas > maxFeePerGas ? maxFeePerGas : maxPriorityFeePerGas
+            return .Ethereum(maxFeePerGasWei: maxFeePerGas, priorityFeeWei: adjustedPriority, nonce: nonce, gasLimit: gasLimit)
             
         case .gaiaChain, .kujira, .osmosis, .terra, .terraClassic, .dydx, .noble, .akash:
             let service = try CosmosServiceFactory.getService(forChain: coin.chain)

--- a/VultisigApp/VultisigApp/Services/Evm/RpcEvmService.swift
+++ b/VultisigApp/VultisigApp/Services/Evm/RpcEvmService.swift
@@ -36,7 +36,11 @@ class RpcEvmService: RpcService {
         let priorityFeeMapValue = try await priorityFeeMap
         let nonceValue = try await nonce
 
-        let priorityFee = priorityFeeMapValue[mode] ?? .zero
+        var priorityFee = priorityFeeMapValue[mode] ?? .zero
+        // Ensure priority fee does not exceed the gas price when only legacy gasPrice is available on chain
+        if priorityFee > gasPriceValue {
+            priorityFee = gasPriceValue
+        }
 
         return (gasPriceValue, priorityFee, Int64(nonceValue))
     }


### PR DESCRIPTION
### Title
EVM: Ensure priority fee ≤ max fee and keep TSS preimage consistent

### Summary
- Enforce priorityFeeWei ≤ maxFeePerGasWei at the shared layer so all devices use identical protobuf values.
- Revert any client-side signing changes to avoid diverging preimages across platforms.

### Changes
- BlockChainService: 
  - EVM: use normalizedPriorityFee and set maxFeePerGas = normalizeEVMFee(baseFee) + normalizedPriorityFee.
  - zkSync: clamp priorityFeeWei to min(maxPriorityFeePerGas, maxFeePerGas).
- RpcEvmService:
  - Legacy path: cap priorityFee to ≤ gasPrice.
- Reverted local clamps in evm.swift and erc20.swift.

### Rationale
- Prevent “max priority fee per gas is higher than max fee per gas”.
- Maintain identical TSS preimage across iOS/Android/Windows.

### Files
- BlockChainService.swift
- Services/Evm/RpcEvmService.swift
- Chains/EVM/evm.swift (revert)
- Chains/erc20.swift (revert)

### Testing
- Verify on EVM and zkSync that priorityFeeWei ≤ maxFeePerGasWei.
- Cross-device signing produces identical preimage and tx hash.
- Legacy-only chains: priorityFee ≤ gasPrice.

### Risk
- Low: only reduces priority fee when necessary; no UI/API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Ethereum and zkSync transaction fees to ensure priority fees do not exceed maximum allowed values.
  * Adjusted fee calculations to prevent priority fees from being higher than gas prices on certain chains, enhancing transaction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->