### PR TITLE
refactor:  Hide reshare for fast vault

### DIFF
--- a/VultisigApp/VultisigApp/iOS/View/EditVaultView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/EditVaultView+iOS.swift
@@ -31,10 +31,10 @@ extension EditVaultView {
                     migrateVault
                 }
                 
-                reshareVault
-                
                 if vault.isFastVault {
                     biometrySelectionCell
+                } else {
+                    reshareVault
                 }
                 
                 customMessage

--- a/VultisigApp/VultisigApp/macOS/View/EditVaultView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/EditVaultView+macOS.swift
@@ -36,10 +36,10 @@ extension EditVaultView {
                     migrateVault
                 }
                 
-                reshareVault
-                
                 if vault.isFastVault {
                     biometrySelectionCell
+                } else {
+                    reshareVault
                 }
                 
                 customMessage


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2706 
## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Edit Vault now correctly adapts options by vault type on iOS and macOS: Fast Vaults show biometric selection and hide the reshare option; standard vaults continue to show reshare. This clarifies available actions and prevents irrelevant options from appearing.
  - No changes to migration, custom messages, on-chain security, or delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->