### PR TITLE
FastVaultSetHintView: keep placeholder visible while focused and gate navigation on non-empty hint

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/FastVaultSetHintView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/FastVaultSetHintView.swift
@@ -57,7 +57,10 @@ struct FastVaultSetHintView: View {
                     .autocorrectionDisabled()
                     .focused($isFocused)
                     .onSubmit {
-                        isLinkActive = true
+                        let hasInput = !hint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        if hasInput {
+                            isLinkActive = true
+                        }
                     }
                 
                 if !hint.isEmpty {
@@ -67,7 +70,7 @@ struct FastVaultSetHintView: View {
                     }
                 }
             }
-            if hint.isEmpty && !isFocused {
+            if hint.isEmpty {
                 VStack {
                     HStack {
                         Text(NSLocalizedString("enterHint", comment: ""))
@@ -114,6 +117,8 @@ struct FastVaultSetHintView: View {
             PrimaryButton(title: "next") {
                 isLinkActive = true
             }
+            .disabled(hint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .opacity(hint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0.5 : 1)
         }
         .padding(.top, 16)
         .padding(.bottom, 40)


### PR DESCRIPTION
### Title
FastVaultSetHintView: keep placeholder visible while focused and gate navigation on non-empty hint

### Summary
Fixes the “Add an optional hint” screen so that:
- Placeholder remains visible while the field is empty (even when focused)
- Next/keyboard Submit only navigates when the hint has non‑whitespace content
- Aligns behavior so “Next” ≠ “Skip” when the field is empty

Closes [Issue #2566](https://github.com/vultisig/vultisig-ios/issues/2566).

### Context
- Reported bug: placeholder disappeared on focus and “Next” advanced even with no input, effectively behaving like “Skip”.
- Expected: placeholder stays until the user types; “Next” is disabled until there’s input. See [#2566](https://github.com/vultisig/vultisig-ios/issues/2566).

### Changes
- FastVaultSetHintView.swift
  - Placeholder logic: show when `hint.isEmpty` (removes `&& !isFocused`) to keep the instruction visible during focus and avoid flicker.
  - Submit behavior: guard navigation in `.onSubmit` with a trimmed non‑empty check.
  - Button state: disable and dim “Next” when the trimmed hint is empty.

### Rationale
- Placeholder visibility: Users saw a “blank” text area upon focus which was confusing; keeping the placeholder until typing improves clarity and accessibility.
- Navigation gating: Ensures “Next” is only possible with actual input; prevents “Next” acting as “Skip”.
- UI consistency: Button disabled state now matches the submit behavior; clearer affordance.

### Before vs After
- Before:
  - Placeholder disappeared on focus (even with empty text)
  - “Next” and keyboard “Done” navigated with empty input
- After:
  - Placeholder stays while empty, even focused
  - “Next” and “Done” only navigate when there’s non‑whitespace text
  - “Skip” remains the path for proceeding without a hint

### User Impact
- Clearer guidance on the field’s purpose
- Impossible to accidentally proceed via “Next” without providing a hint
- Still easy to proceed without a hint via “Skip”

### Accessibility
- Placeholder remains as instructional text when the control is focused but empty, improving comprehension and VoiceOver reading.
- Disabled state communicates affordance via color and opacity.

### Risk / Scope
- Low. Changes are isolated to `VultisigApp/Views/Keygen/FastVaultSetHintView.swift`.
- No changes to shared components; only uses existing button disabled styling.

### Test Plan
- Navigate to Add an optional hint:
  - With empty field, focus the editor → placeholder remains visible
  - Tap “Next” or “Done” with no text → no navigation; button appears disabled
  - Type spaces only → still disabled; no navigation on “Done”
  - Type valid text → “Next” enabled; “Done” navigates
  - Tap “Skip” at any time → navigates and saves `hint = nil`
- Regression:
  - From Settings > Vault Settings > Enable Biometrics for Fast Sign > Optional: Password hint, flow remains unaffected

### Screenshots
- Optional: attach before/after images showing placeholder on focus and disabled “Next”.

### Linked Issue
- [#2566](https://github.com/vultisig/vultisig-ios/issues/2566)

### Checklist
- [x] Behavior matches expected UX from #2566
- [x] Lints pass
- [x] No new strings or localization changes
- [x] Manual test on iOS with software keyboard

Impacted file:
- `VultisigApp/Views/Keygen/FastVaultSetHintView.swift`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevented progression without a hint: Next button is disabled and dimmed until non-empty input is provided.
  - Submission now only proceeds when the hint contains non-whitespace characters.
  - Hint placeholder now appears whenever the field is empty, improving clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->