### PR TITLE
feat: share QR code with caption for messaging apps

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -19,8 +19,8 @@
 		132666CE2E429FFE007FDAC5 /* THORChainAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132666CD2E429FF2007FDAC5 /* THORChainAPIService.swift */; };
 		132666D12E42A054007FDAC5 /* THORName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132666D02E42A051007FDAC5 /* THORName.swift */; };
 		132666D32E42A50B007FDAC5 /* LastBlockResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132666D22E42A506007FDAC5 /* LastBlockResponse.swift */; };
-		1326EBBB2E463C59008A3F8F /* ReferralCodeMemoFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1326EBBA2E463C58008A3F8F /* ReferralCodeMemoFactory.swift */; };
 		1326EBB92E4637FE008A3F8F /* SendCryptoDoneHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1326EBB82E4637F5008A3F8F /* SendCryptoDoneHeaderView.swift */; };
+		1326EBBB2E463C59008A3F8F /* ReferralCodeMemoFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1326EBBA2E463C58008A3F8F /* ReferralCodeMemoFactory.swift */; };
 		1334C73A2E2FE56500CBAA3E /* SendCryptoVerifySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1334C7392E2FE56400CBAA3E /* SendCryptoVerifySummary.swift */; };
 		1334C73C2E2FE57600CBAA3E /* SendCryptoVerifySummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1334C73B2E2FE57200CBAA3E /* SendCryptoVerifySummaryView.swift */; };
 		1334C73F2E3007A000CBAA3E /* OnLoad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1334C73E2E30079F00CBAA3E /* OnLoad.swift */; };
@@ -30,6 +30,7 @@
 		13417B8A2E3BB1D000A66EE5 /* FunctionCallStakeRuji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13417B892E3BB1CA00A66EE5 /* FunctionCallStakeRuji.swift */; };
 		13417B8C2E3BB1DB00A66EE5 /* FunctionCallUnstakeRuji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13417B8B2E3BB1D200A66EE5 /* FunctionCallUnstakeRuji.swift */; };
 		13417B8E2E3BB1EE00A66EE5 /* FunctionCallWithdrawRujiRewards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13417B8D2E3BB1DE00A66EE5 /* FunctionCallWithdrawRujiRewards.swift */; };
+		1344CB212E4A6366006F67B4 /* CrossPlatformShareButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1344CB202E4A6365006F67B4 /* CrossPlatformShareButton.swift */; };
 		134E8D7F2E451F6F0086EBC4 /* PreferredAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134E8D7E2E451F6C0086EBC4 /* PreferredAsset.swift */; };
 		134E8D812E451F800086EBC4 /* PreferredAssetFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134E8D802E451F7A0086EBC4 /* PreferredAssetFactory.swift */; };
 		134E8D832E45300C0086EBC4 /* THORChainAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134E8D822E4530060086EBC4 /* THORChainAPIError.swift */; };
@@ -1044,8 +1045,8 @@
 		132666CD2E429FF2007FDAC5 /* THORChainAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = THORChainAPIService.swift; sourceTree = "<group>"; };
 		132666D02E42A051007FDAC5 /* THORName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = THORName.swift; sourceTree = "<group>"; };
 		132666D22E42A506007FDAC5 /* LastBlockResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastBlockResponse.swift; sourceTree = "<group>"; };
-		1326EBBA2E463C58008A3F8F /* ReferralCodeMemoFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralCodeMemoFactory.swift; sourceTree = "<group>"; };
 		1326EBB82E4637F5008A3F8F /* SendCryptoDoneHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCryptoDoneHeaderView.swift; sourceTree = "<group>"; };
+		1326EBBA2E463C58008A3F8F /* ReferralCodeMemoFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralCodeMemoFactory.swift; sourceTree = "<group>"; };
 		1334C7392E2FE56400CBAA3E /* SendCryptoVerifySummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCryptoVerifySummary.swift; sourceTree = "<group>"; };
 		1334C73B2E2FE57200CBAA3E /* SendCryptoVerifySummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendCryptoVerifySummaryView.swift; sourceTree = "<group>"; };
 		1334C73E2E30079F00CBAA3E /* OnLoad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLoad.swift; sourceTree = "<group>"; };
@@ -1055,6 +1056,7 @@
 		13417B892E3BB1CA00A66EE5 /* FunctionCallStakeRuji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallStakeRuji.swift; sourceTree = "<group>"; };
 		13417B8B2E3BB1D200A66EE5 /* FunctionCallUnstakeRuji.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallUnstakeRuji.swift; sourceTree = "<group>"; };
 		13417B8D2E3BB1DE00A66EE5 /* FunctionCallWithdrawRujiRewards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionCallWithdrawRujiRewards.swift; sourceTree = "<group>"; };
+		1344CB202E4A6365006F67B4 /* CrossPlatformShareButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrossPlatformShareButton.swift; sourceTree = "<group>"; };
 		134E8D7E2E451F6C0086EBC4 /* PreferredAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredAsset.swift; sourceTree = "<group>"; };
 		134E8D802E451F7A0086EBC4 /* PreferredAssetFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferredAssetFactory.swift; sourceTree = "<group>"; };
 		134E8D822E4530060086EBC4 /* THORChainAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = THORChainAPIError.swift; sourceTree = "<group>"; };
@@ -2119,6 +2121,7 @@
 		049BBB4E2B71E37B004C231F /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				1344CB202E4A6365006F67B4 /* CrossPlatformShareButton.swift */,
 				1378B0492E462AD2005CC32D /* Loaders */,
 				13A899092E44F540006F75F0 /* Text */,
 				132666C52E42954F007FDAC5 /* Icon.swift */,
@@ -4765,6 +4768,7 @@
 				A6386D902C8C290F00DDD58E /* SwapVerifyView+iOS.swift in Sources */,
 				A6C670B32C9D12CF00F59B6A /* VaultPairDetailView+macOS.swift in Sources */,
 				A51AE8C22C931C6000EF9A7A /* FastVaultEnterPasswordView.swift in Sources */,
+				1344CB212E4A6366006F67B4 /* CrossPlatformShareButton.swift in Sources */,
 				A6F7B7392D4EF7BB00AC8104 /* FastBackupVaultOverview.swift in Sources */,
 				B5D1B9FC2DF66B4400D82EFB /* CoinFactory+Cardano.swift in Sources */,
 				A500603F2C10E3EA008237D9 /* ThorchainSwapProvider.swift in Sources */,

--- a/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
@@ -235,10 +235,16 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         }
     }
     
-    func getQrImage(size: CGFloat) -> Image {
-        guard let encryptionKeyHex else {return Image(systemName: "xmark")}
-        let jsonData: String
+    func getQRCodeData(size: CGFloat) -> (String, Image)? {
+        guard let qrCodeData = generateQRdata() else {
+            return nil
+        }
+        return (qrCodeData, Utils.generateQRCodeImage(from: qrCodeData))
+    }
+    
+    private func generateQRdata() -> String? {
         do {
+            guard let encryptionKeyHex else { return nil }
             switch tssType {
             case .Keygen:
                 let keygenMsg = KeygenMessage(
@@ -251,7 +257,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                     libType: vault.libType ?? .GG20
                 )
                 let data = try ProtoSerializer.serialize(keygenMsg)
-                jsonData = "https://vultisig.com?type=NewVault&tssType=\(TssType.Keygen.rawValue)&jsonData=\(data)"
+                return "https://vultisig.com?type=NewVault&tssType=\(TssType.Keygen.rawValue)&jsonData=\(data)"
             case .Reshare, .Migrate:
                 let reshareMsg = ReshareMessage(
                     sessionID: sessionID,
@@ -266,12 +272,11 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                     libType: vault.libType ?? .GG20
                 )
                 let data = try ProtoSerializer.serialize(reshareMsg)
-                jsonData = "https://vultisig.com?type=NewVault&tssType=\(tssType.rawValue)&jsonData=\(data)"
+                return "https://vultisig.com?type=NewVault&tssType=\(tssType.rawValue)&jsonData=\(data)"
             }
-            return Utils.generateQRCodeImage(from: jsonData)
         } catch {
             logger.error("fail to encode keygen message to json,error:\(error.localizedDescription)")
-            return Image(systemName: "xmark")
+            return nil
         }
     }
 }

--- a/VultisigApp/VultisigApp/View Models/ShareSheetViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/ShareSheetViewModel.swift
@@ -10,9 +10,11 @@ import SwiftUI
 @MainActor
 class ShareSheetViewModel: ObservableObject {
     @Published var renderedImage: Image? = nil
+    @Published var qrCodeData: String?
     
     func render(
         qrCodeImage: Image,
+        qrCodeData: String?,
         displayScale: CGFloat,
         type: QRShareSheetType,
         addressData: String = "",
@@ -38,5 +40,6 @@ class ShareSheetViewModel: ObservableObject {
 
         renderer.scale = displayScale
         setImage(renderer)
+        self.qrCodeData = qrCodeData
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/CrossPlatformShareButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/CrossPlatformShareButton.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-// MARK: - CrossPlatformShareButton
 public struct CrossPlatformShareButton<Label: View>: View {
     private let image: Image
     private let caption: String
@@ -35,7 +34,6 @@ public struct CrossPlatformShareButton<Label: View>: View {
     }
 }
 
-// MARK: - Rendering helpers (Image -> platform image data)
 @MainActor
 private func renderPNGData(from image: Image, scale: CGFloat) -> Data? {
     let renderer = ImageRenderer(content: image) // no resizing
@@ -52,7 +50,6 @@ private func renderPNGData(from image: Image, scale: CGFloat) -> Data? {
     #endif
 }
 
-// MARK: - iOS
 #if os(iOS)
 import UIKit
 
@@ -118,7 +115,6 @@ private struct ActivityViewController: UIViewControllerRepresentable {
 #endif
 
 
-// MARK: - macOS
 #if os(macOS)
 import AppKit
 

--- a/VultisigApp/VultisigApp/Views/Components/CrossPlatformShareButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/CrossPlatformShareButton.swift
@@ -93,7 +93,6 @@ private struct IOSShareButton<Label: View>: View {
             cachedImage = ui // cache for next time
         }
 
-        UIPasteboard.general.string = caption
         payload = SharePayload(items: items)
     }
 }

--- a/VultisigApp/VultisigApp/Views/Components/CrossPlatformShareButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/CrossPlatformShareButton.swift
@@ -1,0 +1,185 @@
+//
+//  CrossPlatformShareButton.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 11/08/2025.
+//
+
+import SwiftUI
+
+// MARK: - CrossPlatformShareButton
+public struct CrossPlatformShareButton<Label: View>: View {
+    private let image: Image
+    private let caption: String
+    private let scale: CGFloat
+    private let label: () -> Label
+
+    public init(
+        image: Image,
+        caption: String,
+        scale: CGFloat = 2,
+        @ViewBuilder label: @escaping () -> Label
+    ) {
+        self.image = image
+        self.caption = caption
+        self.scale = scale
+        self.label = label
+    }
+
+    public var body: some View {
+        #if os(iOS)
+        IOSShareButton(image: image, caption: caption, scale: scale, label: { label() })
+        #elseif os(macOS)
+        MacShareButton(image: image, caption: caption, scale: scale, label: { label() })
+        #endif
+    }
+}
+
+// MARK: - Rendering helpers (Image -> platform image data)
+@MainActor
+private func renderPNGData(from image: Image, scale: CGFloat) -> Data? {
+    let renderer = ImageRenderer(content: image) // no resizing
+    renderer.scale = scale
+    #if os(iOS)
+    return renderer.uiImage?.pngData()
+    #elseif os(macOS)
+    guard
+        let nsImage = renderer.nsImage,
+        let tiff = nsImage.tiffRepresentation,
+        let rep = NSBitmapImageRep(data: tiff)
+    else { return nil }
+    return rep.representation(using: .png, properties: [:])
+    #endif
+}
+
+// MARK: - iOS
+#if os(iOS)
+import UIKit
+
+private struct SharePayload: Identifiable {
+    let id = UUID()
+    let items: [Any]
+}
+
+private struct IOSShareButton<Label: View>: View {
+    let image: Image
+    let caption: String
+    let scale: CGFloat
+    @ViewBuilder var label: () -> Label
+
+    @State private var cachedImage: UIImage?
+    @State private var payload: SharePayload?
+
+    var body: some View {
+        Button(action: share, label: label)
+            .task {
+                if cachedImage == nil,
+                   let png = renderPNGData(from: image, scale: scale),
+                   let ui = UIImage(data: png) {
+                    cachedImage = ui
+                }
+            }
+            .sheet(item: $payload) { payload in
+                ActivityViewController(items: payload.items)
+                    .ignoresSafeArea()
+            }
+    }
+
+    private func share() {
+        // Build from cached pieces (fast), with a safe fallback
+        var items: [Any] = [caption]
+        if let ui = cachedImage {
+            items.insert(ui, at: 0) // [image, text]
+        } else if let png = renderPNGData(from: image, scale: scale),
+                  let ui = UIImage(data: png) {
+            items.insert(ui, at: 0)
+            cachedImage = ui // cache for next time
+        }
+
+        UIPasteboard.general.string = caption
+        payload = SharePayload(items: items)
+    }
+}
+
+private struct ActivityViewController: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let vc = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        vc.popoverPresentationController?.sourceView = UIApplication.shared
+            .connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+            .first
+        return vc
+    }
+
+    func updateUIViewController(_ vc: UIActivityViewController, context: Context) {}
+}
+#endif
+
+
+// MARK: - macOS
+#if os(macOS)
+import AppKit
+
+private struct MacShareButton<Label: View>: NSViewRepresentable {
+    let image: Image
+    let caption: String
+    let scale: CGFloat
+    @ViewBuilder var label: () -> Label
+
+    func makeNSView(context: Context) -> NSButton {
+        let hosting = NSHostingView(rootView: AnyView(label()))
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+
+        let button = NSButton()
+        button.bezelStyle = .texturedRounded
+        button.title = ""
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.share)
+
+        button.addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: button.leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: button.trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: button.topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: button.bottomAnchor)
+        ])
+
+        context.coordinator.button = button
+        return button
+    }
+
+    func updateNSView(_ nsView: NSButton, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(image: image, caption: caption, scale: scale)
+    }
+
+    final class Coordinator: NSObject {
+        let image: Image
+        let caption: String
+        let scale: CGFloat
+        weak var button: NSButton?
+
+        init(image: Image, caption: String, scale: CGFloat) {
+            self.image = image
+            self.caption = caption
+            self.scale = scale
+        }
+
+        @MainActor @objc func share() {
+            var items: [Any] = [caption]
+            if let png = renderPNGData(from: image, scale: scale),
+               let ns = NSImage(data: png) {
+                items.insert(ns, at: 0)
+            }
+
+            let picker = NSSharingServicePicker(items: items)
+            if let button = button {
+                picker.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            }
+        }
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Header/AddressQRCodeHeader.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Header/AddressQRCodeHeader.swift
@@ -39,7 +39,7 @@ struct AddressQRCodeHeader: View {
         NavigationQRShareButton(
             vault: vault,
             type: .Address,
-            renderedImage: shareSheetViewModel.renderedImage,
+            viewModel: shareSheetViewModel,
             title: groupedChain.name
         )
     }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Header/PeerDiscoveryHeader.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Header/PeerDiscoveryHeader.swift
@@ -45,7 +45,7 @@ struct PeerDiscoveryHeader: View {
                 NavigationQRShareButton(
                     vault: vault, 
                     type: .Keygen,
-                    renderedImage: shareSheetViewModel.renderedImage
+                    viewModel: shareSheetViewModel
                 )
             }
         }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Header/SendCryptoHeader.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Header/SendCryptoHeader.swift
@@ -48,7 +48,7 @@ struct SendCryptoHeader: View {
             NavigationQRShareButton(
                 vault: vault, 
                 type: .Keysign,
-                renderedImage: shareSheetViewModel.renderedImage
+                viewModel: shareSheetViewModel
             )
             .opacity(sendCryptoViewModel.currentIndex == 3 ? 1 : 0)
             .disabled(sendCryptoViewModel.currentIndex != 3)

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Header/SwapCryptoHeader.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Header/SwapCryptoHeader.swift
@@ -49,7 +49,7 @@ struct SwapCryptoHeader: View {
             NavigationQRShareButton(
                 vault: vault, 
                 type: .Keysign,
-                renderedImage: shareSheetViewModel.renderedImage
+                viewModel: shareSheetViewModel
             )
             .disabled(swapViewModel.currentIndex != 3)
         }

--- a/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationQRShareButton.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Items/NavigationQRShareButton.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CoreTransferable
 
 enum NavigationQRType {
     case Keygen
@@ -16,7 +17,7 @@ enum NavigationQRType {
 struct NavigationQRShareButton: View {
     let vault: Vault
     let type: NavigationQRType
-    let renderedImage: Image?
+    let viewModel: ShareSheetViewModel
     var tint: Color = Theme.colors.textPrimary
     
     var title: String = ""
@@ -30,7 +31,7 @@ struct NavigationQRShareButton: View {
     
     var shareLink: some View {
         ZStack {
-            if let image = renderedImage {
+            if let image = viewModel.renderedImage {
                 getLink(image: image)
             } else {
                 ProgressView()
@@ -38,12 +39,13 @@ struct NavigationQRShareButton: View {
         }
     }
     
+    @ViewBuilder
     private func getLink(image: Image) -> some View {
-        ShareLink(
-            item: image,
-            preview: SharePreview(imageName, image: image)
-        ) {
+        CrossPlatformShareButton(image: image, caption: viewModel.qrCodeData ?? .empty) {
             content
+        }
+        .onLoad {
+            setData()
         }
     }
     
@@ -51,9 +53,6 @@ struct NavigationQRShareButton: View {
         Image(systemName: "arrow.up.doc")
             .font(Theme.fonts.bodyLMedium)
             .foregroundColor(tint)
-            .onAppear {
-                setData()
-            }
     }
     
     func setData() {
@@ -84,7 +83,8 @@ struct NavigationQRShareButton: View {
         NavigationQRShareButton(
             vault: Vault.example, 
             type: .Keygen,
-            renderedImage: nil
+            viewModel: ShareSheetViewModel()
         )
     }
 }
+

--- a/VultisigApp/VultisigApp/Views/Keysign/KeysignDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/KeysignDiscoveryView.swift
@@ -167,11 +167,15 @@ struct KeysignDiscoveryView: View {
             onFastKeysign: { startKeysign() }
         )
         
-        qrCodeImage = await viewModel.getQrImage(size: 100)
+        guard let (qrCodeData, qrCodeImage) = await viewModel.getQrImage(size: 100) else {
+            return
+        }
         
-        if let qrCodeImage, let keysignPayload {
+        self.qrCodeImage = qrCodeImage
+        if let keysignPayload {
             shareSheetViewModel.render(
                 qrCodeImage: qrCodeImage,
+                qrCodeData: qrCodeData,
                 displayScale: displayScale,
                 type: previewType,
                 vaultName: vault.name,

--- a/VultisigApp/VultisigApp/Views/Vault/AddressQRCodeView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/AddressQRCodeView.swift
@@ -71,8 +71,9 @@ struct AddressQRCodeView: View {
         }
         
         shareSheetViewModel.render(
-            qrCodeImage: qrCodeImage, 
-            displayScale: displayScale, 
+            qrCodeImage: qrCodeImage,
+            qrCodeData: nil,
+            displayScale: displayScale,
             type: .Address,
             addressData: addressData
         )

--- a/VultisigApp/VultisigApp/iOS/Components/NavigationQRShareButton+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/Components/NavigationQRShareButton+iOS.swift
@@ -28,7 +28,7 @@ extension NavigationQRShareButton {
     }
     
     func shareImage() {
-        guard let image = renderedImage else {
+        guard let image = viewModel.renderedImage else {
             return
         }
         

--- a/VultisigApp/VultisigApp/iOS/View/Address/AddressQRCodeView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Address/AddressQRCodeView+iOS.swift
@@ -27,7 +27,7 @@ extension AddressQRCodeView {
                 NavigationQRShareButton(
                     vault: vault,
                     type: .Address,
-                    renderedImage: shareSheetViewModel.renderedImage,
+                    viewModel: shareSheetViewModel,
                     title: groupedChain.name
                 )
             }

--- a/VultisigApp/VultisigApp/iOS/View/FunctionCall/FunctionCallView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/FunctionCall/FunctionCallView+iOS.swift
@@ -29,7 +29,7 @@ extension FunctionCallView {
                         NavigationQRShareButton(
                             vault: vault,
                             type: .Keysign,
-                            renderedImage: shareSheetViewModel.renderedImage
+                            viewModel: shareSheetViewModel
                         )
                     }
                 }

--- a/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
@@ -31,7 +31,7 @@ extension PeerDiscoveryView {
                     NavigationQRShareButton(
                         vault: vault,
                         type: .Keygen,
-                        renderedImage: shareSheetViewModel.renderedImage
+                        viewModel: shareSheetViewModel
                     )
                 }
             }
@@ -150,16 +150,16 @@ extension PeerDiscoveryView {
     }
 
     func setData() {
-        qrCodeImage = viewModel.getQrImage(size: 100)
-        animationVM = RiveViewModel(fileName: "QRCodeScanned", autoPlay: true)
-        
-        guard let qrCodeImage else {
+        guard let (qrCodeString, qrCodeImage) = viewModel.getQRCodeData(size: 100) else {
             return
         }
         
+        self.qrCodeImage = qrCodeImage
+        animationVM = RiveViewModel(fileName: "QRCodeScanned", autoPlay: true)
         shareSheetViewModel.render(
             qrCodeImage: qrCodeImage,
-            displayScale: displayScale, 
+            qrCodeData: qrCodeString,
+            displayScale: displayScale,
             type: .Keygen
         )
     }

--- a/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Send/SendCryptoView+iOS.swift
@@ -24,7 +24,7 @@ extension SendCryptoView {
                         NavigationQRShareButton(
                             vault: vault,
                             type: .Keysign,
-                            renderedImage: shareSheetViewModel.renderedImage
+                            viewModel: shareSheetViewModel
                         )
                     }
                 }

--- a/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoView+iOS.swift
@@ -37,7 +37,7 @@ extension SwapCryptoView {
                     NavigationQRShareButton(
                         vault: vault,
                         type: .Keysign,
-                        renderedImage: shareSheetViewModel.renderedImage
+                        viewModel: shareSheetViewModel
                     )
                 }
             }

--- a/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
@@ -144,15 +144,14 @@ extension PeerDiscoveryView {
     }
     
     func setData() {
-        qrCodeImage = viewModel.getQrImage(size: 100)
-        animationVM = RiveViewModel(fileName: "QRCodeScanned", autoPlay: true)
-        
-        guard let qrCodeImage else {
+        guard let (qrCodeString, qrCodeImage) = viewModel.getQRCodeData(size: 100) else {
             return
         }
-        
+        self.qrCodeImage = qrCodeImage
+        animationVM = RiveViewModel(fileName: "QRCodeScanned", autoPlay: true)
         shareSheetViewModel.render(
             qrCodeImage: qrCodeImage,
+            qrCodeData: qrCodeString,
             displayScale: displayScale,
             type: .Keygen
         )


### PR DESCRIPTION
## Description

Fixes #2375

- Passing QR image with link data to share through activity controller
- Added `CrossPlatformShareButton` to be able to share image with caption.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context
- Tested with Discord, Telegram and Whatsapp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Cross-platform share button for iOS and macOS with consistent UI.
  - Share sheet now includes QR code data (URL/text) alongside the image.
  - Share payloads for key-sign and peer-discovery include amounts/addresses for Send/Swap flows.

- Refactor
  - QR generation unified to return both data and image; callers now unwrap optional tuple.
  - Share UI switched to accept a share view model instead of a pre-rendered image.
  - QR generation error handling no longer returns placeholder images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->