### PR TITLE
feat: using Screen on SwapCryptoDetailsView to fix padding

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/Screen.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Screen.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 struct Screen<Content: View>: View {
     let title: String
+    let showNavigationBar: Bool
     let content: () -> Content
     
-    init(title: String = "", @ViewBuilder content: @escaping () -> Content) {
+    init(title: String = "", showNavigationBar: Bool = true, @ViewBuilder content: @escaping () -> Content) {
         self.title = title
+        self.showNavigationBar = showNavigationBar
         self.content = content
     }
     
@@ -27,11 +29,14 @@ struct Screen<Content: View>: View {
 #if os(macOS)
         VStack {
             GeneralMacHeader(title: title)
+                .showIf(showNavigationBar)
             contentContainer
         }
 #else
         contentContainer
-            .navigationTitle(title)
+            .if(showNavigationBar) {
+                $0.navigationTitle(title)
+            }
 #endif
     }
     

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -21,25 +21,27 @@ struct SwapCryptoDetailsView: View {
     let vault: Vault
 
     var body: some View {
-        container
-            .onAppear {
-                setData()
-            }
-            .onReceive(timer) { input in
-                swapViewModel.updateTimer(tx: tx, vault: vault, referredCode: referredViewModel.savedReferredCode)
-            }
-            .onChange(of: tx.fromCoin, { _, _ in
-                handleFromCoinUpdate()
-            })
-            .onChange(of: tx.toCoin, { _, _ in
-                handleToCoinUpdate()
-            })
-            .onChange(of: swapViewModel.fromChain) { _, _ in
-                swapViewModel.handleFromChainUpdate(tx: tx, vault: vault)
-            }
-            .onChange(of: swapViewModel.toChain) { _, _ in
-                swapViewModel.handleToChainUpdate(tx: tx, vault: vault)
-            }
+        Screen(showNavigationBar: false) {
+            container
+        }
+        .onAppear {
+            setData()
+        }
+        .onReceive(timer) { input in
+            swapViewModel.updateTimer(tx: tx, vault: vault, referredCode: referredViewModel.savedReferredCode)
+        }
+        .onChange(of: tx.fromCoin, { _, _ in
+            handleFromCoinUpdate()
+        })
+        .onChange(of: tx.toCoin, { _, _ in
+            handleToCoinUpdate()
+        })
+        .onChange(of: swapViewModel.fromChain) { _, _ in
+            swapViewModel.handleFromChainUpdate(tx: tx, vault: vault)
+        }
+        .onChange(of: swapViewModel.toChain) { _, _ in
+            swapViewModel.handleToChainUpdate(tx: tx, vault: vault)
+        }
     }
     
     var content: some View {
@@ -158,7 +160,6 @@ struct SwapCryptoDetailsView: View {
             ButtonLoader()
                 .disabled(true)
                 .opacity(swapViewModel.validateForm(tx: tx) ? 1 : 0.5)
-                .padding(40)
         } else {
             PrimaryButton(title: "continue") {
                 Task {
@@ -167,7 +168,6 @@ struct SwapCryptoDetailsView: View {
             }
             .disabled(isDisabled)
             .opacity(swapViewModel.validateForm(tx: tx) ? 1 : 0.5)
-            .padding(40)
         }
     }
     

--- a/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
@@ -11,7 +11,6 @@ import SwiftUI
 extension SwapCryptoDetailsView {
     var container: some View {
         ZStack(alignment: .bottom) {
-            Background()
             view
             percentageButtons
         }
@@ -86,7 +85,6 @@ extension SwapCryptoDetailsView {
                 swapContent
                 summary
             }
-            .padding(.horizontal, 16)
         }
         .refreshable {
             swapViewModel.refreshData(tx: tx, vault: vault, referredCode: referredViewModel.savedReferredCode)

--- a/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoDetailsView+macOS.swift
@@ -11,7 +11,6 @@ import SwiftUI
 extension SwapCryptoDetailsView {
     var container: some View {
         ZStack(alignment: .top) {
-            Background()
             view
             
             if showSheet() {


### PR DESCRIPTION
## Description

-  Using Screen on SwapCryptoDetailsView to fix padding

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Screens can now hide the navigation/header; Swap Crypto Details opens without a header for a more immersive flow.
* Style
  * Simplified Swap details visuals by removing background elements on iOS and macOS.
  * Adjusted spacing and removed extra padding for a cleaner, more compact layout.
  * Conditional display of titles for a less cluttered appearance when the header is hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->