### PR TITLE
feat: add refresh functionality to SendCryptoDetailsView (#2718)

### DIFF
--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDetailsView.swift
@@ -118,6 +118,9 @@ struct SendCryptoDetailsView: View {
                 }
                 .padding(16)
             }
+            .refreshable {
+                await onRefresh()
+            }
             .onLoad {
                 scrollProxy = proxy
             }
@@ -224,6 +227,12 @@ struct SendCryptoDetailsView: View {
     }
     
     func getBalance() async {
+        await BalanceService.shared.updateBalance(for: tx.coin)
+        coinBalance = tx.coin.balanceString
+    }
+
+    private func onRefresh() async {
+        await sendCryptoViewModel.loadGasInfoForSending(tx: tx)
         await BalanceService.shared.updateBalance(for: tx.coin)
         coinBalance = tx.coin.balanceString
     }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pull-to-refresh on the Send details screen to manually refresh network fees and wallet balance across tabs.

* **Improvements**
  * Faster, more reliable fee and balance updates when network conditions change—reduces need to navigate away and speeds confirmation before sending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->