### PR TITLE
Kuji on Osmosis

### DIFF
--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -1265,11 +1265,11 @@ class TokensStore {
         ),
         CoinMeta(
             chain: .osmosis,
-            ticker: "LVN",
-            logo: "levana",
+            ticker: "KUJI",
+            logo: "kuji",
             decimals: 6,
-            priceProviderId: "levana-protocol",
-            contractAddress: "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
+            priceProviderId: "kujira",
+            contractAddress: "ibc/93B87B73E634D3BD3CD782F52C99883F340CE6027F37718E0E04D552272DA8A9",
             isNativeToken: false
         ),
         CoinMeta(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Osmosis token listing: replaced the obsolete LVN entry with KUJI (Kujira).
  * App now shows the correct KUJI ticker, icon, price source, and IBC address.
  * KUJI will appear in searches and portfolio views; LVN will no longer be listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->