### PR TITLE
fix: add .blast to swapChains in CoinAction

### DIFF
--- a/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
@@ -11,7 +11,7 @@ extension CoinAction {
     
     static var swapChains: [Chain] = [
         .solana,.bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash,
-        .thorChain, .mayaChain, .ethereum, .avalanche, .base, .arbitrum,
+        .thorChain, .mayaChain, .ethereum, .avalanche, .base, .arbitrum,.blast,
         .polygon, .polygonV2, .optimism, .bscChain, .gaiaChain, .kujira, .zksync, .zcash, .ripple,
         .cronosChain
     ]


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2745

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for swaps on the Blast network. Users can now initiate and complete token swaps on Blast within the standard swap flow, just like other supported networks. This expands the available chain options for swapping and improves flexibility when managing assets across networks. No additional setup is required—Blast will appear automatically where swap-capable networks are listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->