### PR TITLE
feat: Swap chain and asset pickers sheet style

### DIFF
--- a/VultisigApp/VultisigApp/Views/Swap/SwapChainPickerView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapChainPickerView.swift
@@ -59,16 +59,19 @@ struct SwapChainPickerView: View {
         .padding(16)
     }
     
+    @ViewBuilder
     var backButton: some View {
-        Button {
-            showSheet = false
-        } label: {
-            NavigationBlankBackButton()
-        }
+        #if os(macOS)
+            Button {
+                showSheet = false
+            } label: {
+                NavigationBlankBackButton()
+            }
+        #endif
     }
     
     var title: some View {
-        Text(NSLocalizedString("selectNetwork", comment: ""))
+        Text(NSLocalizedString("selectChain", comment: ""))
             .foregroundColor(Theme.colors.textPrimary)
             .font(Theme.fonts.bodyLMedium)
     }

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCoinPickerView.swift
@@ -42,11 +42,15 @@ struct SwapCoinPickerView: View {
     }
     
     var backButton: some View {
-        Button {
-            showSheet = false
-        } label: {
-            NavigationBlankBackButton()
-        }
+        #if os(macOS)
+            Button {
+                showSheet = false
+            } label: {
+                NavigationBlankBackButton()
+            }
+        #else
+            Spacer()
+        #endif
     }
     
     var title: some View {

--- a/VultisigApp/VultisigApp/iOS/Extension/ViewExtension+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/Extension/ViewExtension+iOS.swift
@@ -24,5 +24,13 @@ extension View {
         let resign = #selector(UIResponder.resignFirstResponder)
         UIApplication.shared.sendAction(resign, to: nil, from: nil, for: nil)
     }
+    
+    func sheetStyle() -> some View {
+        self
+            .padding(.top, 8)
+            .presentationBackground(Theme.colors.bgPrimary)
+            .presentationDragIndicator(.visible)
+            .presentationDetents([.large])
+    }
 }
 #endif

--- a/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoDetailsView+iOS.swift
@@ -21,6 +21,7 @@ extension SwapCryptoDetailsView {
                 showSheet: $swapViewModel.showFromChainSelector,
                 selectedChain: $swapViewModel.fromChain
             )
+            .sheetStyle()
         })
         .sheet(isPresented: $swapViewModel.showToChainSelector, content: {
             SwapChainPickerView(
@@ -29,6 +30,7 @@ extension SwapCryptoDetailsView {
                 showSheet: $swapViewModel.showToChainSelector,
                 selectedChain: $swapViewModel.toChain
             )
+            .sheetStyle()
         })
         .sheet(isPresented: $swapViewModel.showFromCoinSelector, content: {
             SwapCoinPickerView(
@@ -37,6 +39,7 @@ extension SwapCryptoDetailsView {
                 selectedCoin: $tx.fromCoin,
                 selectedChain: swapViewModel.fromChain
             )
+            .sheetStyle()
         })
         .sheet(isPresented: $swapViewModel.showToCoinSelector, content: {
             SwapCoinPickerView(
@@ -45,6 +48,7 @@ extension SwapCryptoDetailsView {
                 selectedCoin: $tx.toCoin,
                 selectedChain: swapViewModel.toChain
             )
+            .sheetStyle()
         })
     }
     


### PR DESCRIPTION
## Description

Fixes #2313

- Removed back button for iOS and added sheet style for chain and asset pickers

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context