### PR TITLE
fix: prevent default coin on same chain update

### DIFF
--- a/VultisigApp/VultisigApp/View Models/SwapCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SwapCryptoViewModel.swift
@@ -563,12 +563,19 @@ private extension SwapCryptoViewModel {
 
 extension SwapCryptoViewModel {
     func handleFromChainUpdate(tx: SwapTransaction, vault: Vault) {
-        guard let fromChain, let coin = getDefaultCoin(for: fromChain, vault: vault) else { return }
+        guard
+            let fromChain,
+            fromChain != tx.fromCoin.chain,
+            let coin = getDefaultCoin(for: fromChain, vault: vault)
+        else { return }
         tx.fromCoin = coin
     }
     
     func handleToChainUpdate(tx: SwapTransaction, vault: Vault) {
-        guard let toChain, let coin = getDefaultCoin(for: toChain, vault: vault) else { return }
+        guard
+            let toChain,
+            toChain != tx.toCoin.chain,
+            let coin = getDefaultCoin(for: toChain, vault: vault) else { return }
         tx.toCoin = coin
     }
     

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoView.swift
@@ -26,6 +26,11 @@ struct SwapCryptoView: View {
     
     var body: some View {
         content
+            .onLoad {
+                if let fromCoin {
+                    tx.fromCoin = fromCoin
+                }
+            }
             .onAppear {
                 swapViewModel.fetchFees(tx: tx, vault: vault)
             }

--- a/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Swap/SwapCryptoView+iOS.swift
@@ -14,7 +14,7 @@ extension SwapCryptoView {
             Background()
             main
         }
-        .onAppear {
+        .onLoad {
             UIApplication.shared.isIdleTimerDisabled = true
             swapViewModel.load(initialFromCoin: fromCoin, initialToCoin: toCoin, vault: vault, tx: tx)
         }

--- a/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Swap/SwapCryptoView+macOS.swift
@@ -14,7 +14,7 @@ extension SwapCryptoView {
             Background()
             main
         }
-        .onAppear {
+        .onLoad {
             swapViewModel.load(initialFromCoin: fromCoin, initialToCoin: toCoin, vault: vault, tx: tx)
         }
         .task {


### PR DESCRIPTION
## Description

Fixes #2753

- Prevent default coin on same chain update

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional context

Test with ETH.THOR