### PR TITLE
disableEstimatie from 1inch quote endpoint

### DIFF
--- a/VultisigApp/VultisigApp/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Utils/Endpoint.swift
@@ -189,7 +189,7 @@ class Endpoint {
         ? "&referrer=\(referrer)&fee=\(fee)"
         : "&referrer=\(referrer)&fee=0"
         
-        return "\(vultisigApiProxy)/1inch/swap/v6.1/\(chain)/swap?src=\(source)&dst=\(destination)&amount=\(amount)&from=\(from)&slippage=\(slippage)&includeGas=true\(isAffiliateParams)".asUrl
+        return "\(vultisigApiProxy)/1inch/swap/v6.1/\(chain)/swap?src=\(source)&dst=\(destination)&amount=\(amount)&from=\(from)&slippage=\(slippage)&includeGas=true&disableEstimate=true\(isAffiliateParams)".asUrl
     }
     
     static func fetchLiFiQuote(fromChain: String, toChain: String, fromToken: String, toAddress: String, toToken: String, fromAmount: String, fromAddress: String, integrator: String?, fee: String?) -> URL {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2743 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of 1inch swap quotes, reducing intermittent errors during quote retrieval.
  - Faster quote generation for a smoother swap flow, especially under varying network conditions.
  - Optimized request handling behind the scenes; no user action or settings changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->