### PR TITLE
fix: update selectedTab logic for FastVaultEmailView based on signer count

### DIFF
--- a/VultisigApp/VultisigApp/Views/UpgradeFromGG20/VaultShareBackupsView.swift
+++ b/VultisigApp/VultisigApp/Views/UpgradeFromGG20/VaultShareBackupsView.swift
@@ -64,7 +64,7 @@ struct VaultShareBackupsView: View {
             FastVaultEmailView(
                 tssType: .Migrate,
                 vault: vault,
-                selectedTab: .fast,
+                selectedTab: vault.signers.count == 2 ? .fast : .active,
                 fastVaultExist: true
             )
         }


### PR DESCRIPTION

## Description

Allow active vault to upgrade to DKLS vault

Fixes #2742

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The default tab in the vault backup sharing screen now adapts to your setup: with two signers, it opens the Fast tab; otherwise, it starts on the Active tab. This streamlines navigation and aligns the starting point with typical workflows for different signer counts. The secure vault migration flow remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->