### PR TITLE
fix: “Next” Button Remains Enabled After Switching from Vault Creation mode

### DIFF
--- a/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
@@ -92,7 +92,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
             self.localPartyID = Utils.getLocalDeviceIdentity()
             self.vault.localPartyID = self.localPartyID
         }
-        self.selections.insert(self.localPartyID)
+        self.restartSelections()
         // ensure when active / fast vault , user is always using internet option
         switch state {
         case .active , .fast:
@@ -137,6 +137,11 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
             self?.startFastVaultKeygenIfNeeded(state: state)
         }
         .store(in: &cancellables)
+    }
+    
+    func restartSelections() {
+        self.selections.removeAll()
+        self.selections.insert(self.localPartyID)
     }
     
     func autoSelectPeer(_ peer: String){
@@ -191,6 +196,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         } else {
             serverAddr = "http://127.0.0.1:18080"
         }
+        self.restartSelections()
         self.participantDiscovery?.peersFound = [String]()
         self.startSession()
         self.participantDiscovery?.getParticipants(

--- a/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeygenPeerDiscoveryViewModel.swift
@@ -38,7 +38,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         }
     }
     
-    private var cancellables = Set<AnyCancellable>()
+    private var peersFoundCancellable: AnyCancellable?
     private let mediator = Mediator.shared
     private let fastVaultService = FastVaultService.shared
     
@@ -130,13 +130,13 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
             }
         }
         
-        participantDiscovery.$peersFound.sink { [weak self] in
-            $0.forEach { peer in
-                self?.autoSelectPeer(peer)
+        peersFoundCancellable = participantDiscovery.$peersFound
+            .sink { [weak self] in
+                $0.forEach { peer in
+                    self?.autoSelectPeer(peer)
+                }
+                self?.startFastVaultKeygenIfNeeded(state: state)
             }
-            self?.startFastVaultKeygenIfNeeded(state: state)
-        }
-        .store(in: &cancellables)
     }
     
     func restartSelections() {

--- a/VultisigApp/VultisigApp/Views/Components/SwitchToLocalLink.swift
+++ b/VultisigApp/VultisigApp/Views/Components/SwitchToLocalLink.swift
@@ -51,12 +51,10 @@ struct SwitchToLocalLink: View {
     }
     
     private func toggleNetwork() {
-        withAnimation {
-            if selectedNetwork == .Internet {
-                selectedNetwork = .Local
-            } else {
-                selectedNetwork = .Internet
-            }
+        if selectedNetwork == .Internet {
+            selectedNetwork = .Local
+        } else {
+            selectedNetwork = .Internet
         }
     }
 }

--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -187,6 +187,7 @@ struct PeerDiscoveryView: View {
         .foregroundColor(Theme.colors.textPrimary)
         .padding(.bottom, 8)
         .padding(.horizontal, 8)
+        .animation(.easeInOut, value: viewModel.selections)
     }
     
     private func showInfo() {

--- a/VultisigApp/VultisigApp/Views/Keysign/ParticipantDiscovery.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/ParticipantDiscovery.swift
@@ -20,6 +20,7 @@ class ParticipantDiscovery: ObservableObject {
     
     func stop() {
         self.task?.cancel()
+        self.task = nil
     }
 
     func getParticipants(serverAddr: String, sessionID: String, localParty: String, pubKeyECDSA: String) {
@@ -47,6 +48,7 @@ class ParticipantDiscovery: ObservableObject {
                                         continue
                                     }
                                     if !self.peersFound.contains(peer) {
+                                        guard !Task.isCancelled else { return }
                                         self.peersFound.append(peer)
                                     }
                                 }

--- a/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/PeerDiscoveryView+iOS.swift
@@ -88,6 +88,7 @@ extension PeerDiscoveryView {
                 EmptyPeerCell(counter: participantDiscovery.peersFound.count)
             }
             .padding(.horizontal, 12)
+            .animation(.easeInOut(duration: 0.2), value: viewModel.selections)
         }
         .frame(maxWidth: .infinity)
     }
@@ -123,6 +124,7 @@ extension PeerDiscoveryView {
         .padding(.top, 20)
         .padding(.bottom, idiom == .phone ? 10 : 30)
         .disabled(isButtonDisabled)
+        .animation(.easeInOut(duration: 0.2), value: isButtonDisabled)
     }
     
     var disclaimer: some View {

--- a/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/PeerDiscoveryView+macOS.swift
@@ -84,6 +84,7 @@ extension PeerDiscoveryView {
                 devices
                 EmptyPeerCell(counter: participantDiscovery.peersFound.count)
             }
+            .animation(.easeInOut(duration: 0.2), value: viewModel.selections)
         }
         .frame(maxWidth: .infinity)
     }
@@ -119,6 +120,7 @@ extension PeerDiscoveryView {
         .padding(.bottom, 10)
         .disabled(isButtonDisabled)
         .padding(.bottom, 10)
+        .animation(.easeInOut(duration: 0.2), value: isButtonDisabled)
     }
     
     var disclaimer: some View {


### PR DESCRIPTION
## Description

Fixes #2728

- Reset devices selection when creation mode changes

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added smooth ease-in-out animations to selection changes, lists, and button enable/disable states on iOS and macOS.
  * Removed animation when switching between Internet and Local networks for snappier toggling.

* **Bug Fixes**
  * Improved reliability when restarting peer discovery by resetting selections to a clean state.
  * Enhanced cancellation handling during participant discovery to prevent stale tasks and partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->