### PR TITLE
Display Chain name at swap success screen

### DIFF
--- a/VultisigApp/VultisigApp/View Models/SendSummaryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendSummaryViewModel.swift
@@ -25,7 +25,7 @@ class SendSummaryViewModel: ObservableObject {
         if tx.fromCoin.chain == tx.toCoin.chain {
             return "\(formattedAmount) \(tx.toCoin.ticker)"
         } else {
-            return "\(formattedAmount) \(tx.toCoin.ticker) (\(tx.toCoin.chain.ticker))"
+            return "\(formattedAmount) \(tx.toCoin.ticker) (\(tx.toCoin.chain.name))"
         }
     }
     

--- a/VultisigApp/VultisigApp/View Models/SendSummaryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendSummaryViewModel.swift
@@ -15,7 +15,7 @@ class SendSummaryViewModel: ObservableObject {
         if tx.fromCoin.chain == tx.toCoin.chain {
             return "\(formattedAmount) \(tx.fromCoin.ticker)"
         } else {
-            return "\(formattedAmount) \(tx.fromCoin.ticker) (\(tx.fromCoin.chain.ticker))"
+            return "\(formattedAmount) \(tx.fromCoin.ticker) (\(tx.fromCoin.chain.name))"
         }
     }
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2788 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated cross-chain send summaries to show the full chain name (not the ticker) next to both the "From" and "To" amounts for clearer network identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->