### PR TITLE
fix TON broadcast , parse error appropriately

### DIFF
--- a/VultisigApp/VultisigApp/Chains/Ton.swift
+++ b/VultisigApp/VultisigApp/Chains/Ton.swift
@@ -104,7 +104,8 @@ enum TonHelper {
                                                                              publicKeys: publicKeys)
         
         let output = try TheOpenNetworkSigningOutput(serializedBytes: compileWithSignature)
-        
+        print("Ton signed transaction output: \(output)")
+        print("Ton signed transaction output encoded: \(output.hash.hexString)")
         let result = SignedTransactionResult(rawTransaction: output.encoded,
                                              transactionHash: output.hash.hexString)
         

--- a/VultisigApp/VultisigApp/Chains/Ton.swift
+++ b/VultisigApp/VultisigApp/Chains/Ton.swift
@@ -104,7 +104,6 @@ enum TonHelper {
                                                                              publicKeys: publicKeys)
         
         let output = try TheOpenNetworkSigningOutput(serializedBytes: compileWithSignature)
-        print("Ton signed transaction output: \(output)")
         print("Ton signed transaction output encoded: \(output.hash.hexString)")
         let result = SignedTransactionResult(rawTransaction: output.encoded,
                                              transactionHash: output.hash.hexString)

--- a/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
@@ -549,7 +549,11 @@ class KeysignViewModel: ObservableObject {
                     
                 case .ton:
                     let base64Hash = try await TonService.shared.broadcastTransaction(tx.rawTransaction)
-                    self.txid = Data(base64Encoded: base64Hash)?.hexString ?? .empty
+                    if base64Hash.isEmpty {
+                        self.txid = tx.transactionHash
+                    } else {
+                        self.txid = Data(base64Encoded: base64Hash)?.hexString ?? tx.transactionHash
+                    }
                 case .ripple:
                     self.txid = try await RippleService.shared.broadcastTransaction(tx.rawTransaction)
                     
@@ -600,7 +604,7 @@ class KeysignViewModel: ObservableObject {
             errMessage = "Failed to broadcast transaction,\(errDetail)"
         case RpcEvmServiceError.rpcError(let code, let message):
             print("code:\(code), message:\(message)")
-            if message == "already known" 
+            if message == "already known"
                 || message == "replacement transaction underpriced"
                 || message.contains("This transaction has already been processed")
             {

--- a/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
@@ -549,7 +549,7 @@ class KeysignViewModel: ObservableObject {
                     
                 case .ton:
                     let base64Hash = try await TonService.shared.broadcastTransaction(tx.rawTransaction)
-                    self.txid = Data(base64Encoded: base64Hash)?.hexString ?? ""
+                    self.txid = Data(base64Encoded: base64Hash)?.hexString ?? .empty
                 case .ripple:
                     self.txid = try await RippleService.shared.broadcastTransaction(tx.rawTransaction)
                     


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2781 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when broadcasting TON transactions with clearer success handling and more robust error interpretation.
  - Duplicate-message server responses are handled gracefully to avoid false failures.
  - Fixed fallback logic for transaction ID selection to prefer valid decoded IDs before falling back.

- Refactor
  - Replaced legacy networking path with a direct request flow for TON broadcasts, improving response validation and logging.

- Chores
  - Added additional debug logging around signing output to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->