### PR TITLE
fix: Swap Overview and Error layout issues

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keysign/ErrorView.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/ErrorView.swift
@@ -15,38 +15,37 @@ struct ErrorView: View {
     var action: () -> Void
     
     var body: some View {
-        Screen {
-            VStack {
-                Spacer()
-                VStack(spacing: 12) {
-                    ZStack {
-                        Image("CirclesBackground")
-                        Image(systemName: icon)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 24, height: 24)
-                            .foregroundStyle(color)
-                    }
-                    .padding(.bottom, 12)
-                    Text(title)
+        VStack {
+            Spacer()
+            VStack(spacing: 12) {
+                ZStack {
+                    Image("CirclesBackground")
+                    Image(systemName: icon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 24, height: 24)
                         .foregroundStyle(color)
-                        .font(Theme.fonts.title2)
-                    Text(description)
-                        .foregroundStyle(Theme.colors.textExtraLight)
-                        .font(Theme.fonts.bodySMedium)
-                        .frame(maxWidth: .infinity, maxHeight: description.isNotEmpty ? 40 : 0, alignment: .top)
-                    PrimaryButton(
-                        title: buttonTitle,
-                        type: .secondary,
-                        action: action
-                    )
                 }
-                Spacer()
-                Text(Bundle.main.appVersionString)
+                .padding(.bottom, 12)
+                Text(title)
+                    .foregroundStyle(color)
+                    .font(Theme.fonts.title2)
+                Text(description)
                     .foregroundStyle(Theme.colors.textExtraLight)
-                    .font(Theme.fonts.caption12)
+                    .font(Theme.fonts.bodySMedium)
+                    .frame(maxWidth: .infinity, maxHeight: description.isNotEmpty ? 40 : 0, alignment: .top)
+                PrimaryButton(
+                    title: buttonTitle,
+                    type: .secondary,
+                    action: action
+                )
             }
+            Spacer()
+            Text(Bundle.main.appVersionString)
+                .foregroundStyle(Theme.colors.textExtraLight)
+                .font(Theme.fonts.caption12)
         }
+        .padding(.vertical, 12)
     }
 }
 private extension ErrorView {

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -107,7 +107,6 @@ struct SwapCryptoDetailsView: View {
         } label: {
             swapLabel
         }
-        .padding(8)
         .background(Theme.colors.bgPrimary)
         .cornerRadius(60)
         .overlay(

--- a/VultisigApp/VultisigApp/macOS/View/Swap/SwapVerifyView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Swap/SwapVerifyView+macOS.swift
@@ -12,6 +12,7 @@ extension SwapVerifyView {
     var container: some View {
         content
             .padding(.horizontal, 25)
+            .padding(.vertical, 12)
     }
     
     var fields: some View {


### PR DESCRIPTION
## Description

Fixes #2806

- Updated padding on swap overview for macOS
- Removed Screen wrapping on ErrorView

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated error screen layout with improved spacing and typography for better readability; app version text now styled consistently.
  * Reorganized error screen content for clearer visual hierarchy.
  * Tightened spacing around the swap action button for a cleaner appearance.
  * Added vertical padding to the macOS swap verification view for more balanced spacing.

* **Chores**
  * No changes to functionality or public interfaces; adjustments are visual/layout only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->