### PR TITLE
Add "Done" button after sign custom message

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keysign/JoinKeysignDoneSummary.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/JoinKeysignDoneSummary.swift
@@ -14,7 +14,6 @@ struct JoinKeysignDoneSummary: View {
     @Binding var moveToHome: Bool
     
     @Environment(\.openURL) var openURL
-    
     let summaryViewModel = JoinKeysignSummaryViewModel()
     
     var body: some View {
@@ -33,9 +32,7 @@ struct JoinKeysignDoneSummary: View {
                 } else if viewModel.customMessagePayload == nil {
                     sendContent
                 } else {
-                    ScrollView {
-                        summary
-                    }
+                    summary
                 }
             }
         }
@@ -43,17 +40,26 @@ struct JoinKeysignDoneSummary: View {
     
     var summary: some View {
         VStack {
-            if let approveTxid = viewModel.approveTxid {
-                card(title: NSLocalizedString("Approve", comment: ""), txid: approveTxid)
+            ScrollView {
+                VStack {
+                    if let approveTxid = viewModel.approveTxid {
+                        card(title: NSLocalizedString("Approve", comment: ""), txid: approveTxid)
+                    }
+                    content
+                }
+                .padding(.vertical, 12)
+                .background(Theme.colors.bgSecondary)
+                .cornerRadius(12)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 24)
             }
             
-            content
+            PrimaryButton(title: "done") {
+                onDoneButtonPressed()
+            }
         }
-        .padding(.vertical, 12)
-        .background(Theme.colors.bgSecondary)
-        .cornerRadius(12)
-        .padding(.horizontal, 16)
-        .padding(.bottom, 24)
+        .padding(16)
+        .frame(maxHeight: .infinity, alignment: .bottom)
     }
     
     var content: some View {
@@ -124,6 +130,11 @@ struct JoinKeysignDoneSummary: View {
                 isVerticalStacked: true
             )
         }
+        
+    }
+    
+    private func onDoneButtonPressed() {
+        moveToHome = true
     }
     
     var transactionLink: some View {


### PR DESCRIPTION
## Description

Currently after sign a custom message , there is no "Done" button , on MacOS we have to user the back button , While on IOS , we can't get out of the screen without kill the app 

This PR add a done button , and when click will navigate user to the vault detail screen

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Summary now always appears in a dedicated scrollable section for easier reading.
  - Optional approve card is displayed above the summary when available.
  - Tapping Done reliably returns you to the home screen.

- Style
  - Refreshed layout with padded, rounded summary card and background for improved readability.
  - Primary action (Done) placed outside the scroll area for consistent access.
  - Overall spacing and alignment refined for a cleaner, more stable presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->