### PR TITLE
fix: adjusted colors for qr code CI filter

### DIFF
--- a/VultisigApp/VultisigApp/Utils/Utils.swift
+++ b/VultisigApp/VultisigApp/Utils/Utils.swift
@@ -455,7 +455,7 @@ enum Utils {
         return data
     }
     
-    public static func generateQRCodeImage(from string: String, tint: Color = Theme.colors.textPrimary, background: Color = .clear) -> Image {
+    public static func generateQRCodeImage(from string: String, tint: Color = .white, background: Color = .clear) -> Image {
         let context = CIContext()
         let filter = CIFilter.qrCodeGenerator()
         filter.message = Data(string.utf8)


### PR DESCRIPTION
## Description

Fixes #2822

- fix: adjusted colors for qr code CI filter

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - QR codes generated in the app now default to a white color, improving contrast and readability across various backgrounds and in dark mode.
  - Screens that already specify a custom QR tint are unaffected, ensuring existing designs remain consistent.
  - Users should notice clearer, more legible QR codes without any action required.
  - This change aims to provide a more consistent visual experience across the app’s QR code displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->