### PR TITLE
fix: disable delete vault button instead of using alert

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/VaultDeletionConfirmView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultDeletionConfirmView.swift
@@ -16,13 +16,16 @@ struct VaultDeletionConfirmView: View {
     @State var canLoseFundCheck = false
     @State var vaultBackupCheck = false
     
-    @State var showAlert = false
     @State var navigateBackToHome = false
     @State var navigateToCreateVault = false
     @State var nextSelectedVault: Vault? = nil
     
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject var homeViewModel: HomeViewModel
+    
+    var buttonEnabled: Bool {
+        permanentDeletionCheck && canLoseFundCheck && vaultBackupCheck
+    }
     
     var body: some View {
         Screen(title: "deleteVaultTitle".localized) {
@@ -43,9 +46,6 @@ struct VaultDeletionConfirmView: View {
         }
         .navigationDestination(isPresented: $navigateBackToHome) {
             HomeView(selectedVault: nextSelectedVault, showVaultsList: true)
-        }
-        .alert(isPresented: $showAlert) {
-            alert
         }
     }
     
@@ -80,6 +80,7 @@ struct VaultDeletionConfirmView: View {
         PrimaryButton(title: "deleteVaultTitle", type: .alert) {
             delete()
         }
+        .disabled(!buttonEnabled)
     }
     
     var details: some View {
@@ -87,11 +88,6 @@ struct VaultDeletionConfirmView: View {
     }
     
     func delete() {
-        
-        guard allFieldsChecked() else {
-            showAlert = true
-            return
-        }
         homeViewModel.selectedVault = nil
         ApplicationState.shared.currentVault = nil
         
@@ -120,18 +116,6 @@ struct VaultDeletionConfirmView: View {
         } else {
             navigateToCreateVault = true
         }
-    }
-    
-    func allFieldsChecked() -> Bool {
-        permanentDeletionCheck && canLoseFundCheck && vaultBackupCheck
-    }
-    
-    var alert: Alert {
-        Alert(
-            title: Text(NSLocalizedString("reviewConditions", comment: "")),
-            message: Text(NSLocalizedString("reviewConditionsMessage", comment: "")),
-            dismissButton: .default(Text(NSLocalizedString("ok", comment: "")))
-        )
     }
     
     var backgroundView: some View {


### PR DESCRIPTION
## Description

Fixes #2827

- fix: disable delete vault button instead of using alert

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete Vault button is now enabled only after all required confirmations (permanent deletion, potential fund loss, and backup acknowledgment) are checked.
  * Streamlined deletion flow: no additional alert dialog; deletion proceeds once the button is enabled.
  * Post-deletion navigation remains consistent: returns to Home if another vault exists, or opens Create Vault when none remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->