### PR TITLE
fix: Screen Navigation Bar improvements on macOS

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/Navigation Header/GeneralMacHeader.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Navigation Header/GeneralMacHeader.swift
@@ -15,7 +15,7 @@ struct GeneralMacHeader: View {
     var showActions: Bool = true
     
     var body: some View {
-        HStack {
+        HStack(alignment: .center) {
             HStack {
                 if showActions {
                     leadingAction
@@ -30,8 +30,8 @@ struct GeneralMacHeader: View {
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
         }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 40)
+        .padding(.horizontal, 24)
+        .frame(height: 40)
         .background(Theme.colors.bgPrimary)
     }
     

--- a/VultisigApp/VultisigApp/Views/Send/Screens/SendPairScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Send/Screens/SendPairScreen.swift
@@ -34,15 +34,13 @@ struct SendPairScreen: View {
         .navigationDestination(item: $keysignInput) { input in
             SendRouteBuilder().buildKeysignScreen(input: input, tx: tx)
         }
-        .toolbar {
+        .screenToolbar {
             if fastVaultPassword == nil {
-                ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
-                    NavigationQRShareButton(
-                        vault: vault,
-                        type: .Keysign,
-                        viewModel: shareSheetViewModel
-                    )
-                }
+                NavigationQRShareButton(
+                    vault: vault,
+                    type: .Keysign,
+                    viewModel: shareSheetViewModel
+                )
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes #2838

- Added fixed height for macOS navigation bar header
- Used new `screenToolbar` modifier on SendPairScreen for cross-platform support

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Mac header spacing tightened with a consistent, shorter height and centered alignment for a cleaner look.

* **Refactor**
  * Updated the Send Pair screen to use the app’s standardized screen toolbar.
  * QR Share button remains available when appropriate (unchanged visibility), with placement now following the default toolbar behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->