### PR TITLE
fix: Wrong referral code on edit screen

### DIFF
--- a/VultisigApp/VultisigApp/View Models/Referral/EditReferralViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/Referral/EditReferralViewModel.swift
@@ -16,9 +16,12 @@ class EditReferralViewModel: ObservableObject {
     @Published var preferredAsset: PreferredAsset?
     var initialPreferredAsset: PreferredAsset?
 
-    @AppStorage("savedGeneratedReferralCode") var savedGeneratedReferralCode: String = ""
     let thornameDetails: THORName
     let currentBlockHeight: UInt64
+    
+    var referralCode: String {
+        thornameDetails.name.uppercased()
+    }
     
     var totalFeeAmountText: String {
         "\(totalFeeAmount) RUNE"
@@ -118,7 +121,7 @@ private extension EditReferralViewModel {
         tx.transactionType = fnCallInstance.getTransactionType()
         
         let memo = ReferralCodeMemoFactory.createEdit(
-            referralCode: savedGeneratedReferralCode,
+            referralCode: referralCode,
             nativeCoin: nativeCoin,
             preferredAsset: preferredAsset,
             preferredAssetCoin: preferredAssetCoin

--- a/VultisigApp/VultisigApp/Views/Referral/EditReferralDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Referral/EditReferralDetailsView.swift
@@ -68,7 +68,7 @@ struct EditReferralDetailsView: View {
                 .font(Theme.fonts.bodySMedium)
                 .frame(maxWidth: .infinity, alignment: .leading)
             ReferralTextField(
-                text: $viewModel.savedGeneratedReferralCode,
+                text: .constant(viewModel.referralCode),
                 placeholderText: .empty,
                 action: .Copy,
                 isDisabled: true


### PR DESCRIPTION
## Description

- Removed UserDefaults generate code leftover

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Referral code is now automatically derived from your THORName and displayed in uppercase for consistency.
  * The referral code field in Edit Referral is read-only and always reflects the current derived value.
  * Removed local persistence of referral codes to prevent stale values.
  * Actions that include a referral (memos, shares) now use the displayed derived code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->