### PR TITLE
fix: settings padding botom and separators

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		13A8990B2E44F547006F75F0 /* RedactedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A8990A2E44F544006F75F0 /* RedactedText.swift */; };
 		13AB0C072E5CA17100F52F24 /* ReferralCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13AB0C052E5CA17100F52F24 /* ReferralCode.swift */; };
 		13AB0C082E5CA17100F52F24 /* ReferredCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13AB0C062E5CA17100F52F24 /* ReferredCode.swift */; };
+		13AC28082E61E294001CB9AA /* ScreenEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13AC28072E61E293001CB9AA /* ScreenEdgeInsets.swift */; };
 		13AF0D182E4CE655004D4FD2 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13AF0D172E4CE652004D4FD2 /* NavigationRouter.swift */; };
 		13AF0D1A2E4CE672004D4FD2 /* NavigationRouter+EnvironmentKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13AF0D192E4CE672004D4FD2 /* NavigationRouter+EnvironmentKey.swift */; };
 		13AF0D1D2E4CE73B004D4FD2 /* SendRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13AF0D1C2E4CE738004D4FD2 /* SendRoute.swift */; };
@@ -1107,6 +1108,7 @@
 		13A8990A2E44F544006F75F0 /* RedactedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedactedText.swift; sourceTree = "<group>"; };
 		13AB0C052E5CA17100F52F24 /* ReferralCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralCode.swift; sourceTree = "<group>"; };
 		13AB0C062E5CA17100F52F24 /* ReferredCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferredCode.swift; sourceTree = "<group>"; };
+		13AC28072E61E293001CB9AA /* ScreenEdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenEdgeInsets.swift; sourceTree = "<group>"; };
 		13AF0D172E4CE652004D4FD2 /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
 		13AF0D192E4CE672004D4FD2 /* NavigationRouter+EnvironmentKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationRouter+EnvironmentKey.swift"; sourceTree = "<group>"; };
 		13AF0D1C2E4CE738004D4FD2 /* SendRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendRoute.swift; sourceTree = "<group>"; };
@@ -2574,6 +2576,7 @@
 		13DD54992E56556D007335DA /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				13AC28072E61E293001CB9AA /* ScreenEdgeInsets.swift */,
 				13DD549C2E56559D007335DA /* ScreenToolbarModifier.swift */,
 				13DD549A2E56557C007335DA /* ScreenToolbar+EnvironmentKey.swift */,
 				137B2C882E3A84440074F648 /* Screen.swift */,
@@ -4904,6 +4907,7 @@
 				A623A09F2BF09FEE00AA2F8D /* NewWalletNameView.swift in Sources */,
 				A6C0D5652BB3BD0F00156689 /* UTXOTransactionCell.swift in Sources */,
 				A65649F82B96701300E4B329 /* UTXOTransactionMempoolPreviousOutput.swift in Sources */,
+				13AC28082E61E294001CB9AA /* ScreenEdgeInsets.swift in Sources */,
 				137B2C892E3A84460074F648 /* Screen.swift in Sources */,
 				46F8F7212B99FDB70099454E /* TransactionBroadcastResponse.swift in Sources */,
 				131603452E609D74001ED972 /* FileExporterSheet.swift in Sources */,

--- a/VultisigApp/VultisigApp/Views/Address Book/AddressBookView.swift
+++ b/VultisigApp/VultisigApp/Views/Address Book/AddressBookView.swift
@@ -21,11 +21,13 @@ struct AddressBookView: View {
     
     @Environment(\.modelContext) var modelContext
     
+    var savedAddressesEmpty: Bool { savedAddresses.isEmpty }
+    
     var body: some View {
-        Screen(title: "addressBook".localized) {
+        Screen(title: "addressBook".localized, edgeInsets: ScreenEdgeInsets(bottom: savedAddressesEmpty ? nil : 0)) {
             VStack {
                 Group {
-                    if savedAddresses.isEmpty {
+                    if savedAddressesEmpty {
                        emptyView
                             .background(BlurredBackground())
                     } else {
@@ -37,7 +39,7 @@ struct AddressBookView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .screenToolbar {
-            if savedAddresses.count != 0 {
+            if !savedAddressesEmpty {
                 navigationButton
             }
         }

--- a/VultisigApp/VultisigApp/Views/Components/Screen/Screen.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Screen/Screen.swift
@@ -9,13 +9,20 @@ import SwiftUI
 
 struct Screen<Content: View>: View {
     let title: String
+    let edgeInsets: ScreenEdgeInsets
     let showNavigationBar: Bool
     
     let content: () -> Content
     
-    init(title: String = "", showNavigationBar: Bool = true, @ViewBuilder content: @escaping () -> Content) {
+    init(
+        title: String = "",
+        showNavigationBar: Bool = true,
+        edgeInsets: ScreenEdgeInsets = .noInsets,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
         self.title = title
         self.showNavigationBar = showNavigationBar
+        self.edgeInsets = edgeInsets
         self.content = content
     }
     
@@ -43,8 +50,10 @@ struct Screen<Content: View>: View {
     
     var contentContainer: some View {
         content()
-            .padding(.vertical, 12)
-            .padding(.horizontal, horizontalPadding)
+            .padding(.top, edgeInsets.top ?? verticalPadding)
+            .padding(.bottom, edgeInsets.bottom ?? verticalPadding)
+            .padding(.leading, edgeInsets.leading ?? horizontalPadding)
+            .padding(.trailing, edgeInsets.trailing ?? horizontalPadding)
     }
     
     var horizontalPadding: CGFloat {
@@ -54,6 +63,8 @@ struct Screen<Content: View>: View {
             return 40
         #endif
     }
+    
+    var verticalPadding: CGFloat { 12 }
 }
 
 #Preview {

--- a/VultisigApp/VultisigApp/Views/Components/Screen/ScreenEdgeInsets.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Screen/ScreenEdgeInsets.swift
@@ -1,0 +1,29 @@
+//
+//  ScreenEdgeInsets.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 29/08/2025.
+//
+
+import SwiftUI
+
+struct ScreenEdgeInsets {
+    let top: CGFloat?
+    let leading: CGFloat?
+    let bottom: CGFloat?
+    let trailing: CGFloat?
+    
+    init(
+        top: CGFloat? = nil,
+        leading: CGFloat? = nil,
+        bottom: CGFloat? = nil,
+        trailing: CGFloat? = nil
+    ) {
+        self.top = top
+        self.leading = leading
+        self.bottom = bottom
+        self.trailing = trailing
+    }
+    
+    static let noInsets = ScreenEdgeInsets()
+}

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCurrencySelectionView.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCurrencySelectionView.swift
@@ -14,7 +14,7 @@ struct SettingsCurrencySelectionView: View {
     @State var isLoading = false
     
     var body: some View {
-        Screen(title: "currency".localized) {
+        Screen(title: "currency".localized, edgeInsets: ScreenEdgeInsets(bottom: 0)) {
             ScrollView(showsIndicators: false) {
                 SettingsSectionContainerView {
                     VStack(spacing: .zero) {
@@ -24,7 +24,8 @@ struct SettingsCurrencySelectionView: View {
                             } label: {
                                 SettingSelectionCell(
                                     title: currency.rawValue,
-                                    isSelected: currency.rawValue == settingsViewModel.selectedCurrency.rawValue
+                                    isSelected: currency.rawValue == settingsViewModel.selectedCurrency.rawValue,
+                                    showSeparator: currency != SettingsCurrency.allCases.last
                                 )
                             }
                         }

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsFAQView.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsFAQView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingsFAQView: View {
     var body: some View {
-        Screen(title: "faq".localized) {
+        Screen(title: "faq".localized, edgeInsets: ScreenEdgeInsets(bottom: 0)) {
             ScrollView(showsIndicators: false) {
                 SettingsSectionContainerView {
                     VStack(spacing: .zero) {

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsLanguageSelectionView.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsLanguageSelectionView.swift
@@ -13,7 +13,7 @@ struct SettingsLanguageSelectionView: View {
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
-        Screen(title: "language".localized) {
+        Screen(title: "language".localized, edgeInsets: ScreenEdgeInsets(bottom: 0)) {
             ScrollView(showsIndicators: false) {
                 SettingsSectionContainerView {
                     VStack(spacing: .zero) {
@@ -24,7 +24,8 @@ struct SettingsLanguageSelectionView: View {
                                 SettingSelectionCell(
                                     title: language.rawValue,
                                     isSelected: language==settingsViewModel.selectedLanguage,
-                                    description: language.description()
+                                    description: language.description(),
+                                    showSeparator: language != SettingsLanguage.allCases.last
                                 )
                             }
                         }

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsMainScreen/SettingsMainScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsMainScreen/SettingsMainScreen.swift
@@ -66,13 +66,14 @@ struct SettingsMainScreen: View {
     ]
     
     var body: some View {
-        Screen(title: "settings".localized) {
+        Screen(title: "settings".localized, edgeInsets: ScreenEdgeInsets(bottom: 0)) {
             ScrollView(showsIndicators: false) {
                 LazyVStack(spacing: 14) {
                     ForEach(groups) { group in
                         groupView(for: group)
                     }
                     appVersion
+                        .padding(.bottom, 12)
                 }
             }
         }

--- a/VultisigApp/VultisigApp/Views/Vault/Settings/VaultAdvancedSettingsScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/Settings/VaultAdvancedSettingsScreen.swift
@@ -48,7 +48,12 @@ struct VaultAdvancedSettingsScreen: View {
         NavigationLink {
             OnChainSecurityScreen()
         } label: {
-            SettingsOptionView(icon: "folder-lock", title: "vaultSettingsSecurityTitle".localized, subtitle: "vaultSettingsSecuritySubtitle".localized)
+            SettingsOptionView(
+                icon: "folder-lock",
+                title: "vaultSettingsSecurityTitle".localized,
+                subtitle: "vaultSettingsSecuritySubtitle".localized,
+                showSeparator: false
+            )
         }
     }
 }


### PR DESCRIPTION
## Description

- Adjusted padding bottom for ScrollViews
- Adjusted separators for Settings list screens

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-edge screen padding for finer layout control.
  - Configurable list separators, showing only between items.
  - Address Book improves empty state handling and toolbar visibility based on saved addresses.

- Style
  - Consistent bottom insets across Settings screens.
  - Extra spacing for app version in Settings.
  - Hidden separator for the “On-chain security” row.

- Chores
  - Added a new layout helper to the project configuration to support per-edge padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->