### PR TITLE
[FIX] - Swaps from Mantle to Major Chains (Solana/Blast/Base/Avalanche) Fail with “Failed to Forward Tx to Sequencer” Error For All Possible Amount #2853

### DIFF
--- a/VultisigApp/VultisigApp/Chains/OneInchSwaps.swift
+++ b/VultisigApp/VultisigApp/Chains/OneInchSwaps.swift
@@ -63,7 +63,14 @@ private extension OneInchSwaps {
         let gasPrice = BigUInt(quote.tx.gasPrice) ?? BigUInt.zero
         // sometimes the `gas` field in oneinch tx is 0
         // when it is 0, we need to override it with defaultETHSwapGasUnit(600000)
-        let normalizedGas = quote.tx.gas == 0 ? EVMHelper.defaultETHSwapGasUnit : quote.tx.gas
+        var normalizedGas = quote.tx.gas == 0 ? EVMHelper.defaultETHSwapGasUnit : quote.tx.gas
+        
+        // For all EVM chains, ensure we use at least the gas limit from keysignPayload
+        // This prevents insufficient gas errors when swap providers return lower values
+        if case .Ethereum(_, _, _, let gasLimit) = keysignPayload.chainSpecific {
+            normalizedGas = max(normalizedGas, Int64(gasLimit))
+        }
+        
         let gas = BigUInt(normalizedGas)
         let helper = EVMHelper.getHelper(coin: keysignPayload.coin)
         let signed = try helper.getPreSignedInputData(signingInput: input, keysignPayload: keysignPayload, gas: gas, gasPrice: gasPrice, incrementNonce: incrementNonce)

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -139,11 +139,18 @@ class Coin: ObservableObject, Codable, Hashable {
             }
         case .arbitrum:
             return "120000"
-        case .base,.blast,.optimism,.cronosChain, .polygon, .polygonV2, .mantle:
+        case .base,.blast,.optimism,.cronosChain, .polygon, .polygonV2:
             if self.isNativeToken {
                 return "40000"
             } else {
                 return "120000"
+            }
+        case .mantle:
+            // Mantle requires much higher gas limits
+            if self.isNativeToken {
+                return "250000000"  // 250M gas
+            } else {
+                return "250000000"  // 250M gas
             }
         case .zksync:
             return "200000"

--- a/VultisigApp/VultisigApp/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Services/BlockChainService.swift
@@ -443,6 +443,10 @@ private extension BlockChainService {
         case .transfer:
             return BigInt(coin.feeDefault) ?? 0
         case .swap:
+            // For Mantle, use the coin's default gas limit for swaps
+            if coin.chain == .mantle {
+                return BigInt(coin.feeDefault) ?? 0
+            }
             return BigInt(EVMHelper.defaultETHSwapGasUnit)
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ethereum swaps now respect provided gas limits during processing.
  - Corrected Mantle gas calculations by applying dedicated default limits for swaps and transfers.
- Refactor
  - Separated Mantle from base-like chains to apply its own gas defaults across token types.
  - Simplified gas handling paths while keeping behavior unchanged for other chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->