### PR TITLE
[FIX] - Failed to fetch merge accounts: valueNotFound #2872

### DIFF
--- a/VultisigApp/VultisigApp/Model/MergeAccountResponse.swift
+++ b/VultisigApp/VultisigApp/Model/MergeAccountResponse.swift
@@ -15,7 +15,7 @@ struct MergeAccountResponse: Decodable {
             let merge: AccountMerge?
             
             struct AccountMerge: Decodable {
-                let accounts: [MergeAccount]
+                let accounts: [MergeAccount]?
                 
                 struct MergeAccount: Decodable {
                     let pool: Pool


### PR DESCRIPTION
This fixes the issue https://github.com/vultisig/vultisig-ios/issues/2872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents occasional errors when merging accounts if the service returns no accounts.
  * Improves handling of empty or missing account lists during merge operations, reducing unexpected failures.
  * Enhances overall stability and reliability of account merge flows for users in edge cases where data is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->