### PR TITLE
fix: Cursor jumps to 4th box when paste is denied on OTP screen

### DIFF
--- a/VultisigApp/VultisigApp/iOS/View/ServerBackupVerificationView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/ServerBackupVerificationView+iOS.swift
@@ -34,8 +34,8 @@ extension ServerBackupVerificationView {
         }
         .padding(.horizontal, 16)
     }
-
-
+    
+    
     var textField: some View {
         HStack(spacing: 8) {
             field
@@ -71,13 +71,18 @@ extension ServerBackupVerificationView {
             }
         }
     }
-
+    
     func pasteCode() {
-        guard let clipboardContent = UIPasteboard.general.string, clipboardContent.count == Self.codeLength else {
+        guard
+            let raw = UIPasteboard.general.string?.trimmingCharacters(in: .whitespacesAndNewlines),
+            raw.count == Self.codeLength,
+            raw.unicodeScalars.allSatisfy(CharacterSet.decimalDigits.contains)
+        else {
             return
         }
         
-        otp = clipboardContent.map { String($0) }
+        otp = raw.map(String.init)
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             focusedField = Self.codeLength - 1
         }

--- a/VultisigApp/VultisigApp/iOS/View/ServerBackupVerificationView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/ServerBackupVerificationView+iOS.swift
@@ -73,10 +73,11 @@ extension ServerBackupVerificationView {
     }
 
     func pasteCode() {
-        if let clipboardContent = UIPasteboard.general.string, clipboardContent.count == Self.codeLength {
-            otp = clipboardContent.map { String($0) }
+        guard let clipboardContent = UIPasteboard.general.string, clipboardContent.count == Self.codeLength else {
+            return
         }
         
+        otp = clipboardContent.map { String($0) }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             focusedField = Self.codeLength - 1
         }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #2846

- Prevent focusing last field when clipboard otp is empty

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined paste handling for verification codes on iOS by validating clipboard input early and skipping invalid data.
  - No changes to visible behavior, interactions, or public APIs.
  - Improves internal readability and reduces unnecessary processing while preserving the same user experience and timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->