### PR TITLE
[FIX] Remove MATIC from Ploygon chain #2351

### DIFF
--- a/VultisigApp/VultisigApp/Model/Chain+extensions.swift
+++ b/VultisigApp/VultisigApp/Model/Chain+extensions.swift
@@ -24,7 +24,7 @@ extension Chain {
         switch self {
         case .kujira,.blast,.terra,.terraClassic,.osmosis,.akash,.noble,.mayaChain:
             return false
-        case .thorChain,.solana,.ethereum, .avalanche, .base , .arbitrum, .polygon, .polygonV2, .optimism,.bscChain,.bitcoin,.bitcoinCash,.litecoin,.dogecoin,.dash,.cardano,.gaiaChain,
+        case .thorChain,.solana,.ethereum, .avalanche, .base , .arbitrum, .polygonV2, .optimism,.bscChain,.bitcoin,.bitcoinCash,.litecoin,.dogecoin,.dash,.cardano,.gaiaChain,
                 .cronosChain,.sui,.polkadot,.zksync,.dydx,.ton,.ripple,.tron,.ethereumSepolia,.zcash,.mantle:
             return true
         }
@@ -41,8 +41,6 @@ extension Chain {
             return "ETH"
         case .bscChain:
             return "BSC"
-        case .polygon:
-            return "MATIC"
         case .avalanche:
             return "AVAX-C"
         case .arbitrum:

--- a/VultisigApp/VultisigApp/Model/Chain.swift
+++ b/VultisigApp/VultisigApp/Model/Chain.swift
@@ -14,7 +14,6 @@ enum Chain: String, Codable, Hashable, CaseIterable {
     case base
     case blast
     case arbitrum
-    case polygon
     case polygonV2
     case optimism
     case bscChain
@@ -68,7 +67,6 @@ enum Chain: String, Codable, Hashable, CaseIterable {
         case .arbitrum: return "Arbitrum"
         case .base: return "Base"
         case .optimism: return "Optimism"
-        case .polygon: return "Polygon"
         case .polygonV2: return "Polygon"
         case .blast: return "Blast"
         case .cronosChain: return "CronosChain"
@@ -93,7 +91,7 @@ enum Chain: String, Codable, Hashable, CaseIterable {
         switch self {
         case .thorChain: return "RUNE"
         case .solana: return "SOL"
-        case .ethereum,.avalanche,.base,.blast,.arbitrum,.polygon, .polygonV2,.optimism,.bscChain,.cronosChain, .zksync, .ethereumSepolia, .mantle: return "Gwei"
+        case .ethereum,.avalanche,.base,.blast,.arbitrum, .polygonV2,.optimism,.bscChain,.cronosChain, .zksync, .ethereumSepolia, .mantle: return "Gwei"
         case .bitcoin: return "BTC/vbyte"
         case .bitcoinCash: return "BCH/vbyte"
         case .litecoin: return "LTC/vbyte"
@@ -137,7 +135,6 @@ enum Chain: String, Codable, Hashable, CaseIterable {
         case .arbitrum: return "ARB"
         case .base: return "BASE" //Base does not have a coin
         case .optimism: return "OP"
-        case .polygon: return "MATIC"
         case .polygonV2: return "POL"
         case .blast: return "BLAST"
         case .cronosChain: return "CRO"
@@ -177,7 +174,6 @@ enum Chain: String, Codable, Hashable, CaseIterable {
         case .arbitrum: return "ARB"
         case .base: return "BASE"
         case .optimism: return "OP"
-        case .polygon: return "MATIC"
         case .polygonV2: return "POL"
         case .blast: return "BLAST"
         case .cronosChain: return "CRO"
@@ -210,7 +206,7 @@ enum Chain: String, Codable, Hashable, CaseIterable {
     
     var chainType: ChainType {
         switch self {
-        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygon, .polygonV2, .blast, .cronosChain, .zksync,.ethereumSepolia, .mantle:
+        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygonV2, .blast, .cronosChain, .zksync,.ethereumSepolia, .mantle:
             return .EVM
         case .thorChain,.mayaChain:
             return .THORChain
@@ -251,8 +247,6 @@ enum Chain: String, Codable, Hashable, CaseIterable {
             return "blast"
         case .arbitrum:
             return "arbitrum"
-        case .polygon:
-            return "matic"
         case .polygonV2:
             return "matic"
         case .optimism:
@@ -322,8 +316,6 @@ enum Chain: String, Codable, Hashable, CaseIterable {
             return 81457
         case .arbitrum:
             return 42161
-        case .polygon:
-            return 137
         case .polygonV2:
             return 137 // TODO: find the new id
         case .optimism:
@@ -376,8 +368,6 @@ enum Chain: String, Codable, Hashable, CaseIterable {
             return CoinType.thorchain
         case .arbitrum:
             return CoinType.arbitrum
-        case .polygon:
-            return CoinType.polygon
         case .polygonV2:
             return CoinType.polygon
         case .base:
@@ -446,7 +436,7 @@ enum Chain: String, Codable, Hashable, CaseIterable {
                 .bscChain,
                 .ethereum,
                 .optimism,
-                .polygon,
+                .polygonV2,
                 .arbitrum,
                 .blast,
                 .cronosChain,
@@ -455,7 +445,7 @@ enum Chain: String, Codable, Hashable, CaseIterable {
                 .zcash,
                 .mantle:
             return true
-        case .polygonV2,
+        case 
             .cardano,
             .sui,
             .polkadot,
@@ -478,7 +468,7 @@ enum Chain: String, Codable, Hashable, CaseIterable {
             return .THORChain
         case .solana:
             return .Solana
-        case .ethereum,.avalanche,.base,.blast,.arbitrum,.polygon, .polygonV2,.optimism,.bscChain,.cronosChain, .zksync, .ethereumSepolia, .mantle:
+        case .ethereum,.avalanche,.base,.blast,.arbitrum, .polygonV2,.optimism,.bscChain,.cronosChain, .zksync, .ethereumSepolia, .mantle:
             return .EVM
         case .bitcoin,.bitcoinCash,.litecoin,.dogecoin,.dash, .zcash:
             return .UTXO

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -139,7 +139,7 @@ class Coin: ObservableObject, Codable, Hashable {
             }
         case .arbitrum:
             return "120000"
-        case .base,.blast,.optimism,.cronosChain, .polygon, .polygonV2:
+        case .base,.blast,.optimism,.cronosChain, .polygonV2:
             if self.isNativeToken {
                 return "40000"
             } else {

--- a/VultisigApp/VultisigApp/Services/1inch/OneInchService.swift
+++ b/VultisigApp/VultisigApp/Services/1inch/OneInchService.swift
@@ -22,7 +22,7 @@ struct OneInchService {
     
     private var supportedChain: [Chain] {
         return [
-            .ethereum,.arbitrum,.avalanche,.bscChain,.solana,.optimism,.polygon,.polygonV2,.zksync,.base
+            .ethereum,.arbitrum,.avalanche,.bscChain,.solana,.optimism,.polygonV2,.zksync,.base
         ]
     }
     func isChainSupported(chain: Chain) -> Bool {

--- a/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
@@ -12,7 +12,7 @@ extension CoinAction {
     static var swapChains: [Chain] = [
         .solana,.bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash,
         .thorChain, .mayaChain, .ethereum, .avalanche, .base, .arbitrum,.blast,.mantle,
-        .polygon, .polygonV2, .optimism, .bscChain, .gaiaChain, .kujira, .zksync, .zcash, .ripple,
+        .polygonV2, .optimism, .bscChain, .gaiaChain, .kujira, .zksync, .zcash, .ripple,
         .cronosChain
     ]
     

--- a/VultisigApp/VultisigApp/Services/Actions/Coin+Swaps.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/Coin+Swaps.swift
@@ -67,7 +67,7 @@ extension Coin {
                 return [.thorchain, .oneinch(chain), .lifi] // KyberSwap not supported
             }
             return [.oneinch(chain), .lifi] // KyberSwap not supported
-        case .optimism, .polygon, .polygonV2, .mantle:
+        case .optimism, .polygonV2, .mantle:
             return [.lifi, .oneinch(chain), .kyberswap(chain)] // KyberSwap supported
         case .zksync:
             return [.oneinch(chain), .lifi] // KyberSwap not supported on zkSync

--- a/VultisigApp/VultisigApp/Services/BalanceService.swift
+++ b/VultisigApp/VultisigApp/Services/BalanceService.swift
@@ -147,7 +147,7 @@ private extension BalanceService {
         case .sui:
             return try await sui.getBalance(coin: coin)
             
-        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygon, .polygonV2, .blast, .cronosChain, .zksync, .ethereumSepolia, .mantle:
+        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygonV2, .blast, .cronosChain, .zksync, .ethereumSepolia, .mantle:
             let service = try EvmServiceFactory.getService(forChain: coin.chain)
             return try await service.getBalance(coin: coin)
             

--- a/VultisigApp/VultisigApp/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Services/BlockChainService.swift
@@ -324,7 +324,7 @@ private extension BlockChainService {
             let gasInfo = try await dot.getGasInfo(fromAddress: coin.address)
             return .Polkadot(recentBlockHash: gasInfo.recentBlockHash, nonce: UInt64(gasInfo.nonce), currentBlockNumber: gasInfo.currentBlockNumber, specVersion: gasInfo.specVersion, transactionVersion: gasInfo.transactionVersion, genesisHash: gasInfo.genesisHash)
             
-        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygon, .polygonV2, .blast, .cronosChain,.ethereumSepolia, .mantle:
+        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygonV2, .blast, .cronosChain,.ethereumSepolia, .mantle:
             let service = try EvmServiceFactory.getService(forChain: coin.chain)
             let baseFee = try await service.getBaseFee()
             let (_, defaultPriorityFee, nonce) = try await service.getGasInfo(fromAddress: coin.address, mode: feeMode)

--- a/VultisigApp/VultisigApp/Services/CryptoPriceService.swift
+++ b/VultisigApp/VultisigApp/Services/CryptoPriceService.swift
@@ -223,7 +223,7 @@ private extension CryptoPriceService {
             return "blast"
         case .arbitrum:
             return "arbitrum-one"
-        case .polygon, .polygonV2:
+        case .polygonV2:
             return "polygon-pos"
         case .optimism:
             return "optimistic-ethereum"

--- a/VultisigApp/VultisigApp/Services/Evm/EvmServiceFactory.swift
+++ b/VultisigApp/VultisigApp/Services/Evm/EvmServiceFactory.swift
@@ -23,7 +23,7 @@ class EvmServiceFactory {
             return BaseService.shared
         case .arbitrum:
             return ArbitrumService.shared
-        case .polygon, .polygonV2:
+        case .polygonV2:
             return PolygonService.shared
         case .optimism:
             return OptimismService.shared

--- a/VultisigApp/VultisigApp/Services/Keysign/KeysignMessageFactory.swift
+++ b/VultisigApp/VultisigApp/Services/Keysign/KeysignMessageFactory.swift
@@ -55,7 +55,7 @@ struct KeysignMessageFactory {
             return try utxoHelper.getPreSignedImageHash(keysignPayload: payload)
         case .cardano:
             return try CardanoHelper.getPreSignedImageHash(keysignPayload: payload)
-        case .ethereum, .arbitrum, .base, .optimism, .polygon, .polygonV2, .avalanche, .bscChain, .blast, .cronosChain, .zksync, .ethereumSepolia, .mantle:
+        case .ethereum, .arbitrum, .base, .optimism, .polygonV2, .avalanche, .bscChain, .blast, .cronosChain, .zksync, .ethereumSepolia, .mantle:
             if payload.coin.isNativeToken {
                 return try EVMHelper.getHelper(coin: payload.coin).getPreSignedImageHash(keysignPayload: payload)
             } else {

--- a/VultisigApp/VultisigApp/Services/Keysign/Swap/THORChainSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Services/Keysign/Swap/THORChainSwapPayload.swift
@@ -82,7 +82,7 @@ private extension THORChainSwapPayload {
                 $0.chain = .doge
             case .gaiaChain:
                 $0.chain = .atom
-            case .solana, .sui, .dash, .kujira, .mayaChain, .arbitrum, .base, .optimism, .polygon, .polygonV2, .blast, .cronosChain, .polkadot, .zksync, .dydx, .ton, .osmosis, .terra, .terraClassic, .noble, .ripple, .akash, .tron, .ethereumSepolia, .zcash, .cardano, .mantle: break
+            case .solana, .sui, .dash, .kujira, .mayaChain, .arbitrum, .base, .optimism, .polygonV2, .blast, .cronosChain, .polkadot, .zksync, .dydx, .ton, .osmosis, .terra, .terraClassic, .noble, .ripple, .akash, .tron, .ethereumSepolia, .zcash, .cardano, .mantle: break
             }
             
             $0.symbol = coin.ticker

--- a/VultisigApp/VultisigApp/Services/KyberSwap/KyberSwapQuote.swift
+++ b/VultisigApp/VultisigApp/Services/KyberSwap/KyberSwapQuote.swift
@@ -36,7 +36,7 @@ struct KyberSwapQuote: Codable, Hashable {
         let gasMultiplierTimes10: Int64
         
         switch chain {
-        case .ethereum, .arbitrum, .optimism, .base, .polygon, .avalanche, .bscChain:
+        case .ethereum, .arbitrum, .optimism, .base, .polygonV2, .avalanche, .bscChain:
             gasMultiplierTimes10 = 20
         default:
             gasMultiplierTimes10 = 16

--- a/VultisigApp/VultisigApp/Services/KyberSwap/KyberSwapService.swift
+++ b/VultisigApp/VultisigApp/Services/KyberSwap/KyberSwapService.swift
@@ -202,7 +202,7 @@ struct KyberSwapService {
             return "ethereum"
         case .bscChain:
             return "bsc"
-        case .polygon:
+        case .polygonV2:
             return "polygon"
         case .arbitrum:
             return "arbitrum"

--- a/VultisigApp/VultisigApp/Services/Security/Providers/Blockaid/BlockaidRpcClient.swift
+++ b/VultisigApp/VultisigApp/Services/Security/Providers/Blockaid/BlockaidRpcClient.swift
@@ -166,7 +166,7 @@ private extension Chain {
             return "ethereum"
         case .optimism:
             return "optimism"
-        case .polygon, .polygonV2:
+        case .polygonV2:
             return "polygon"
         case .sui:
             return "sui"
@@ -177,4 +177,3 @@ private extension Chain {
         }
     }
 }
-

--- a/VultisigApp/VultisigApp/Services/Security/Providers/Blockaid/BlockaidScannerService.swift
+++ b/VultisigApp/VultisigApp/Services/Security/Providers/Blockaid/BlockaidScannerService.swift
@@ -22,7 +22,7 @@ class BlockaidScannerService: BlockaidScannerServiceProtocol {
         let chain = transaction.chain
         
         switch chain {
-        case .arbitrum, .avalanche, .base, .blast, .bscChain, .ethereum, .optimism, .polygon, .polygonV2:
+        case .arbitrum, .avalanche, .base, .blast, .bscChain, .ethereum, .optimism, .polygonV2:
             return try await scanEvmTransaction(transaction)
         case .bitcoin:
             return try await scanBitcoinTransaction(transaction)
@@ -135,7 +135,6 @@ private extension BlockaidScannerService {
             .bscChain,
             .ethereum,
             .optimism,
-            .polygon,
             .polygonV2,
             .sui,
             .solana,

--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -1291,7 +1291,7 @@ class TokensStore {
             isNativeToken: true
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "AVAX",
             logo: "avax",
             decimals: 18,
@@ -1300,7 +1300,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "BNB",
             logo: "bsc",
             decimals: 18,
@@ -1309,7 +1309,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "BUSD",
             logo: "busd",
             decimals: 18,
@@ -1318,7 +1318,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "FOX",
             logo: "fox",
             decimals: 18,
@@ -1327,7 +1327,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "LINK",
             logo: "link",
             decimals: 18,
@@ -1336,7 +1336,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "POL",
             logo: "matic",
             decimals: 18,
@@ -1345,7 +1345,7 @@ class TokensStore {
             isNativeToken: true
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "SHIB",
             logo: "shib",
             decimals: 18,
@@ -1354,7 +1354,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "SOL",
             logo: "sol",
             decimals: 9,
@@ -1363,7 +1363,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "USDC",
             logo: "usdc",
             decimals: 6,
@@ -1372,7 +1372,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "USDC.e",
             logo: "USDC.e",
             decimals: 6,
@@ -1381,7 +1381,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "USDT",
             logo: "usdt",
             decimals: 6,
@@ -1390,7 +1390,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "WBTC",
             logo: "wbtc",
             decimals: 8,
@@ -1399,7 +1399,7 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
-            chain: .polygon,
+            chain: .polygonV2,
             ticker: "WETH",
             logo: "weth",
             decimals: 18,

--- a/VultisigApp/VultisigApp/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Utils/Endpoint.swift
@@ -658,7 +658,7 @@ class Endpoint {
             return "https://basescan.org/tx/\(txid)"
         case .optimism:
             return "https://optimistic.etherscan.io/tx/\(txid)"
-        case .polygon,.polygonV2:
+        case .polygonV2:
             return "https://polygonscan.com/tx/\(txid)"
         case .blast:
             return "https://blastscan.io/tx/\(txid)"
@@ -735,7 +735,7 @@ class Endpoint {
             return "https://basescan.org/address/\(address)"
         case .optimism:
             return "https://optimistic.etherscan.io/address/\(address)"
-        case .polygon,.polygonV2:
+        case .polygonV2:
             return "https://polygonscan.com/address/\(address)"
         case .blast:
             return "https://blastscan.io/address/\(address)"
@@ -810,7 +810,7 @@ class Endpoint {
             return "https://basescan.org/address/\(address)" // Hypothetical URL
         case .optimism:
             return "https://optimistic.etherscan.io/address/\(address)"
-        case .polygon, .polygonV2:
+        case .polygonV2:
             return "https://polygonscan.com/address/\(address)"
         case .blast:
             return "https://blastscan.io/address/\(address)"

--- a/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeysignViewModel.swift
@@ -496,7 +496,7 @@ class KeysignViewModel: ObservableObject {
                     case .failure(let error):
                         throw error
                     }
-                case .ethereum, .avalanche,.arbitrum, .bscChain, .base, .optimism, .polygon, .polygonV2, .blast, .cronosChain, .zksync, .ethereumSepolia, .mantle:
+                case .ethereum, .avalanche,.arbitrum, .bscChain, .base, .optimism, .polygonV2, .blast, .cronosChain, .zksync, .ethereumSepolia, .mantle:
                     let service = try EvmServiceFactory.getService(forChain: keysignPayload.coin.chain)
                     self.txid = try await service.broadcastTransaction(hex: tx.rawTransaction)
                 case .bitcoin:

--- a/VultisigApp/VultisigApp/View Models/SendCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendCryptoViewModel.swift
@@ -109,7 +109,7 @@ class SendCryptoViewModel: ObservableObject {
                 
                 isLoading = false
             }
-        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygon, .polygonV2, .blast, .cronosChain, .zksync,.ethereumSepolia, .mantle:
+        case .ethereum, .avalanche, .bscChain, .arbitrum, .base, .optimism, .polygonV2, .blast, .cronosChain, .zksync,.ethereumSepolia, .mantle:
             Task {
                 do {
                     if tx.coin.isNativeToken {

--- a/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
@@ -103,7 +103,7 @@ final class ChainHelperTests: XCTestCase {
             let utxoHelper = UTXOChainsHelper(coin: chain.coinType, vaultHexPublicKey: hexPublicKey, vaultHexChainCode: hexChainCode)
             let imageHash = try utxoHelper.getPreSignedImageHash(keysignPayload: keysignPayload)
             result += imageHash
-        case .ethereum,.arbitrum,.optimism,.polygon,.base,.bscChain,.avalanche,.mantle:
+        case .ethereum,.arbitrum,.optimism,.base,.bscChain,.avalanche,.mantle:
             let chain = keysignPayload.coin.chain
             if keysignPayload.coin.contractAddress.isEmpty {
                 let evmHelper = EVMHelper.getHelper(coin: keysignPayload.coin)


### PR DESCRIPTION
Tests SWAP and SEND
https://polygonscan.com/tx/0x81c20eca9ae29c5344e22db5ca97e435be95af03eb5762ad0eabb240ed16d765
https://polygonscan.com/address/0x245b8d996d6ef17fd48622048370945d4328f7d0
https://scan.li.fi/tx/0x31cc875b0084b0305470aa4d71b7ac8a81310ab0a5704cf6e2aa89122d436475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Migrated from legacy Polygon (MATIC) to Polygon (POL) across the app.
  - Updated ticker to POL, price source, gas settings, and explorer links.
  - Adjusted swaps, balances, signing, and broadcasting to use the POL network.
- Chores
  - Removed legacy Polygon from supported chains, buy flow, scanners, and third‑party integrations.
  - Updated default assets to reference the POL network.
- Tests
  - Aligned test coverage to reflect the Polygon (POL) migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->