### PR TITLE
add --version cli flag to Vultisig MacOS app

### DIFF
--- a/VultisigApp/VultisigApp/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/VultisigApp.swift
@@ -26,6 +26,20 @@ struct VultisigApp: App {
     @StateObject var globalStateViewModel = GlobalStateViewModel()
     @StateObject var navigationRouter = NavigationRouter()
     
+    init() {
+#if os(macOS)
+        // Check for --version flag
+        if CommandLine.arguments.contains("--version") {
+            if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+               let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+                print("VultisigApp version \(version) (build \(build))")
+            } else {
+                print("Version information not available")
+            }
+            exit(0) // Exit after printing version
+        }
+#endif
+    }
     var body: some Scene {
         WindowGroup {
             content


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS: Launching the app with the --version flag now prints the app version and build number in one line and exits immediately. This enables quick version checks from Terminal, scripts, and automation without opening the UI. Normal startup behavior is unchanged when the flag is omitted. No impact on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->