### PR TITLE
fix: No differentiation between "share" and "parts" on backup

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -814,6 +814,7 @@
 "allVaults" = "All Vaults";
 "thisVaultOnly" = "This Vault Only";
 "partOf" = "part %d of %d";
+"shareOf" = "share %d of %d";
 "plusMore" = "+%d more";
 "noReferralYetTitle" = "No referral yet.";
 "noReferralYetDescription" = "Turn your vault into a rewards machine. Create your referral now and start earning.";

--- a/VultisigApp/VultisigApp/Views/Vault/Backup/VaultBackupSelectionScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/Backup/VaultBackupSelectionScreen.swift
@@ -115,21 +115,7 @@ struct VaultBackupSelectionScreen: View {
                 .foregroundStyle(Theme.colors.textPrimary)
             Spacer()
             
-            HStack(alignment: .center, spacing: 4) {
-                image(for: vault)
-                    .frame(width: 16, height: 16)
-                Text(partText(for: vault))
-                    .font(Theme.fonts.caption12)
-                    .foregroundStyle(Theme.colors.textExtraLight)
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .cornerRadius(99)
-            .overlay(
-                RoundedRectangle(cornerRadius: 99)
-                    .inset(by: 1)
-                    .stroke(Theme.colors.border, lineWidth: 1)
-            )
+            VaultPartView(vault: vault)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
@@ -141,28 +127,6 @@ struct VaultBackupSelectionScreen: View {
             return "thisVaultOnly".localized
         case .multiple:
             return "allVaults".localized
-        }
-    }
-    
-    func partText(for vault: Vault) -> String {
-        guard let index = vault.signers.firstIndex(of: vault.localPartyID) else {
-            return "-"
-        }
-        return String(format: "partOf".localized, index + 1, vault.signers.count)
-    }
-    
-    @ViewBuilder
-    func image(for vault: Vault) -> some View {
-        if vault.isFastVault {
-            Image("lightning")
-                .resizable()
-                .aspectRatio(1, contentMode: .fit)
-                .foregroundStyle(Theme.colors.alertWarning)
-        } else {
-            Image("shield")
-                .resizable()
-                .aspectRatio(1, contentMode: .fit)
-                .foregroundStyle(Theme.colors.bgButtonPrimary)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Views/Vault/VaultPairView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultPairView.swift
@@ -33,7 +33,8 @@ struct VaultPartView: View {
         guard let index = vault.signers.firstIndex(of: vault.localPartyID) else {
             return "-"
         }
-        return String(format: "partOf".localized, index + 1, vault.signers.count)
+        let partText = vault.libType == .DKLS ? "partOf".localized : "shareOf".localized
+        return String(format: partText, index + 1, vault.signers.count)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Description

Fixes #2914 

- Show `part x of y` for DKLS and `share x of y` for GG20
- Using `VaultPartView` on `VaultBackupSelectionScreen`

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context