### PR TITLE
fix: crash when amount section gets opened during send flow

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
@@ -20,9 +20,13 @@ struct SendDetailsAmountTab: View {
         content
             .padding(.bottom, 100)
             .clipped()
-            .onChange(of: isExpanded) { oldValue, newValue in
-                Task {
-                    setData(oldValue, newValue)
+            .onChange(of: isExpanded) { _, newValue in
+                guard newValue else {
+                    return
+                }
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    focusedField = .amount
                 }
             }
     }
@@ -157,12 +161,5 @@ struct SendDetailsAmountTab: View {
                 RoundedRectangle(cornerRadius: 32)
                     .stroke(Theme.colors.bgTertiary, lineWidth: 1)
             )
-    }
-    
-    private func setData(_ oldValue: Bool, _ newValue: Bool) {
-        guard oldValue != newValue, !newValue else {
-            focusedField = .amount
-            return
-        }
     }
 }


### PR DESCRIPTION
## Description

Fixes #2933

- fix: crash when amount section gets opened during send flow

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Send amount section behavior: the amount field now auto-focuses when the section is expanded, making it faster to start typing.
  * Prevented unintended focus changes when collapsing the section for a smoother experience.
  * Added a brief delay before focusing to ensure reliable keyboard appearance and a more stable interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->