### PR TITLE
feat: scrollable address field for iOS

### DIFF
--- a/VultisigApp/VultisigApp/Views/Address Book/AddAddressBookScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Address Book/AddAddressBookScreen.swift
@@ -70,7 +70,12 @@ struct AddAddressBookScreen: View {
     }
     
     var addressField: some View {
-        AddressBookTextField(title: "address", text: $address, showActions: true)
+        AddressBookTextField(
+            title: "address",
+            text: $address,
+            showActions: true,
+            isScrollable: true
+        )
     }
     
     var button: some View {

--- a/VultisigApp/VultisigApp/Views/Address Book/EditAddressBookScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Address Book/EditAddressBookScreen.swift
@@ -67,7 +67,12 @@ struct EditAddressBookScreen: View {
     }
     
     var addressField: some View {
-        AddressBookTextField(title: "address", text: $address, showActions: true)
+        AddressBookTextField(
+            title: "address",
+            text: $address,
+            showActions: true,
+            isScrollable: true
+        )
     }
     
     var button: some View {

--- a/VultisigApp/VultisigApp/Views/Components/AddressBook/AddressBookTextField.swift
+++ b/VultisigApp/VultisigApp/Views/Components/AddressBook/AddressBookTextField.swift
@@ -12,6 +12,7 @@ struct AddressBookTextField: View {
     let title: String
     @Binding var text: String
     var showActions = false
+    var isScrollable = false
     
     @State var showScanner = false
     @State var showImagePicker = false

--- a/VultisigApp/VultisigApp/Views/Components/TextField/CommonTextField.swift
+++ b/VultisigApp/VultisigApp/Views/Components/TextField/CommonTextField.swift
@@ -14,6 +14,7 @@ struct CommonTextField<TrailingView: View>: View {
     let placeholder: String
     @Binding var isSecure: Bool
     @Binding var error: String?
+    let isScrollable: Bool
     
     let trailingView: () -> TrailingView
     
@@ -23,6 +24,7 @@ struct CommonTextField<TrailingView: View>: View {
         placeholder: String,
         isSecure: Binding<Bool> = .constant(false),
         error: Binding<String?> = .constant(nil),
+        isScrollable: Bool = false,
         @ViewBuilder trailingView: @escaping () -> TrailingView
     ) {
         self._text = text
@@ -30,6 +32,7 @@ struct CommonTextField<TrailingView: View>: View {
         self.placeholder = placeholder
         self._isSecure = isSecure
         self._error = error
+        self.isScrollable = isScrollable
         self.trailingView = trailingView
     }
     
@@ -60,18 +63,12 @@ struct CommonTextField<TrailingView: View>: View {
             
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
-                    Group {
-                        if isSecure {
-                            SecureField(placeholder.localized, text: $text)
-                        } else {
-                            TextField(placeholder.localized, text: $text)
-                        }
-                    }
-                    .font(Theme.fonts.bodyMRegular)
-                    .foregroundColor(Theme.colors.textPrimary)
-                    .submitLabel(.done)
-                    .colorScheme(.dark)
-                    .frame(maxWidth: .infinity)
+                    textFieldContainer
+                        .font(Theme.fonts.bodyMRegular)
+                        .foregroundColor(Theme.colors.textPrimary)
+                        .submitLabel(.done)
+                        .colorScheme(.dark)
+                        .frame(maxWidth: .infinity)
                     
                     clearButton
                         .showIf(isEnabled)
@@ -118,5 +115,29 @@ struct CommonTextField<TrailingView: View>: View {
     
     var borderColor: Color {
         error != nil ? Theme.colors.alertError : Theme.colors.border
+    }
+    
+    @ViewBuilder
+    var textFieldContainer: some View {
+        if isScrollable {
+            ScrollView(.horizontal, showsIndicators: false) {
+                textField
+                    .frame(minWidth: 200)
+            }
+        } else {
+            textField
+        }
+    }
+    
+    @ViewBuilder
+    var textField: some View {
+        Group {
+            if isSecure {
+                SecureField(placeholder.localized, text: $text)
+            } else {
+                TextField(placeholder.localized, text: $text)
+            }
+        }
+        .frame(height: 56)
     }
 }

--- a/VultisigApp/VultisigApp/iOS/Components/AddressBookTextField+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/Components/AddressBookTextField+iOS.swift
@@ -14,7 +14,8 @@ extension AddressBookTextField {
         CommonTextField(
             text: $text,
             label: title.localized,
-            placeholder: "typeHere".localized
+            placeholder: "typeHere".localized,
+            isScrollable: isScrollable
         ) {
             if showActions {
                 HStack(spacing: 8) {

--- a/VultisigApp/VultisigApp/iOS/Components/SendCryptoAddressTextField+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/Components/SendCryptoAddressTextField+iOS.swift
@@ -32,7 +32,7 @@ extension SendCryptoAddressTextField {
     }
     
     var field: some View {
-        HStack(spacing: 0) {
+        ScrollView(.horizontal, showsIndicators: false) {
             TextField(NSLocalizedString("enterAddressHere", comment: "").capitalized, text: Binding<String>(
                 get: { tx.toAddress },
                 set: { newValue in
@@ -64,9 +64,12 @@ extension SendCryptoAddressTextField {
             .keyboardType(.default)
             .textInputAutocapitalization(.never)
             .textContentType(.oneTimeCode)
+            .frame(minWidth: 200)
+            .frame(height: 48)
         }
         .padding(.horizontal, 12)
     }
+    
     var scanButton: some View {
         Button {
             showScanner.toggle()


### PR DESCRIPTION
## Description

Fixes #2909

- Added `ScrollView` to address field for Send and Address Book on iOS

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context