### PR TITLE
Decimal places for sRuji

### DIFF
--- a/VultisigApp/VultisigApp/Services/Thorchain/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Services/Thorchain/ThorchainService.swift
@@ -789,7 +789,7 @@ extension ThorchainService {
         }
         
         for unit in denomUnits {
-            if unit.denom == display {
+            if unit.denom == display && unit.exponent > 0 {
                 return unit.exponent
             }
         }


### PR DESCRIPTION
Sometimes the decimal place is in the second item of the Array, not in the first. So we should check if zero. 

<img width="400" height="88" alt="image" src="https://github.com/user-attachments/assets/1ae80225-dfa9-4164-ba8a-0d10d3d9af6c" />


https://thornode.ninerealms.com/cosmos/bank/v1beta1/balances/thor103xklz882ffz6vwjwcrawwt8tn57ngrhpfq3cl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal parsing for THORChain assets to ensure only valid positive exponents are used, preventing incorrect precision.
  * Fixes occasional misdisplayed balances, rounding errors, and inaccurate amounts in transaction flows and quotes.
  * Enhances consistency of token value formatting across the app.
  * No visible UI changes; behavior is more accurate for affected assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->