### PR TITLE
Tweak QR code creation to reduce memory footprint

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -1154,7 +1154,6 @@
 		13BD8D3D2E3D49AD0013B67E /* ThemeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeProtocol.swift; sourceTree = "<group>"; };
 		13C232682E68A95100DB42D0 /* AddressQRCodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressQRCodeScannerView.swift; sourceTree = "<group>"; };
 		13C320022E61F8D500255138 /* ReferralVaultSelectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralVaultSelectionScreen.swift; sourceTree = "<group>"; };
-		13CCEC062E54D3B100F28937 /* SettingsOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsOption.swift; sourceTree = "<group>"; };
 		13CCEC0B2E54EE2800F28937 /* SettingsSectionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionContainerView.swift; sourceTree = "<group>"; };
 		13CCEC0E2E55010C00F28937 /* InfoBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBannerView.swift; sourceTree = "<group>"; };
 		13D178F82E5753DB00007B48 /* AddressBookChainSelectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressBookChainSelectionScreen.swift; sourceTree = "<group>"; };
@@ -4124,7 +4123,6 @@
 			isa = PBXGroup;
 			children = (
 				4600167D2B71A12D00CE17C7 /* Tss.xcframework */,
-				13CCEC062E54D3B100F28937 /* SettingsOption.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";

--- a/VultisigApp/VultisigApp/Utils/Utils.swift
+++ b/VultisigApp/VultisigApp/Utils/Utils.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 enum Utils {
     static let logger = Logger(subsystem: "util", category: "network")
+    static let context = CIContext()
     public static func sendRequest<T: Codable>(urlString: String, method: String,headers: [String: String], body: T?, completion: @escaping (Bool) -> Void) {
         logger.debug("url:\(urlString)")
         guard let url = URL(string: urlString) else {
@@ -456,9 +457,11 @@ enum Utils {
     }
     
     public static func generateQRCodeImage(from string: String, tint: Color = .white, background: Color = .clear) -> Image {
-        let context = CIContext()
         let filter = CIFilter.qrCodeGenerator()
         filter.message = Data(string.utf8)
+        defer {
+            context.clearCaches()
+        }
         
 #if os(iOS)
         let tintColor = UIColor(tint)
@@ -482,7 +485,7 @@ enum Utils {
         let tintColor = NSColor(tint)
         let backgroundColor = NSColor(background)
         
-        let scale: CGFloat = 100
+        let scale = 1024 / filter.outputImage!.extent.size.width
         let transform = CGAffineTransform(scaleX: scale, y: scale)
         
         if let outputImage = filter.outputImage?.samplingNearest()

--- a/VultisigApp/VultisigApp/View Models/ShareSheetViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/ShareSheetViewModel.swift
@@ -42,4 +42,9 @@ class ShareSheetViewModel: ObservableObject {
         setImage(renderer)
         self.qrCodeData = qrCodeData
     }
+    func clear() {
+        print("clear image reference")
+        renderedImage = nil
+        qrCodeData = nil
+    }
 }

--- a/VultisigApp/VultisigApp/Views/Keysign/KeysignDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/KeysignDiscoveryView.swift
@@ -81,6 +81,8 @@ struct KeysignDiscoveryView: View {
         }
         .onDisappear {
             viewModel.stopDiscovery()
+            shareSheetViewModel.clear()
+            self.qrCodeImage = nil
         }
         .onChange(of: selectedNetwork) { _, newValue in
             VultisigRelay.IsRelayEnabled = newValue == .Internet


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Improvements
  - Faster, more memory-efficient QR code generation with shared processing and automatic cache clearing.
  - Sharper, consistently sized QR codes on macOS via dynamic scaling.

- Bug Fixes
  - QR image and share data are now cleared when leaving Keysign Discovery, preventing stale or incorrect visuals on return.

- Chores
  - Cleaned up project configuration by removing an unused file reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->