### PR TITLE
Update continue button logic for Reshare case and adjust vault setup 

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryView.swift
@@ -132,7 +132,7 @@ struct PeerDiscoveryView: View {
     
     func disableContinueButton() -> Bool {
         switch viewModel.tssType {
-        case .Keygen,.Reshare:
+        case .Keygen:
             switch selectedTab {
             case .fast:
                 return viewModel.selections.count < 2
@@ -141,6 +141,9 @@ struct PeerDiscoveryView: View {
             case .secure:
                 return viewModel.selections.count < 2
             }
+        case .Reshare:
+            let requiredCount = vault.getThreshold() + 1
+            return viewModel.selections.count < requiredCount
         case .Migrate:
             return Set(viewModel.selections) != Set(viewModel.vault.signers)
         }

--- a/VultisigApp/VultisigApp/Views/Vault/VaultPairDetailView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultPairDetailView.swift
@@ -88,7 +88,7 @@ struct VaultPairDetailView: View {
     
     @ViewBuilder
     var vaultSetupSection: some View {
-        let title = "\(vault.getThreshold())-\("of".localized)-\(devicesInfo.count) " + "vaultSetup".localized
+        let title = "\(vault.getThreshold()+1)-\("of".localized)-\(devicesInfo.count) " + "vaultSetup".localized
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
                 .font(Theme.fonts.caption12)


### PR DESCRIPTION

## Description

During reshare , only allow user to kick off reshare after 2/3 of devices join

Fixes #2963 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context