### PR TITLE
fix: update macOS version in CI workflow to Xcode 26.0.0

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build, analyse and test default scheme using xcodebuild command
-    runs-on: macos-14
+    runs-on: macos-26
     
     steps:
       - name: Checkout
@@ -18,7 +18,7 @@ jobs:
       - name: Set Default Scheme
         working-directory: VultisigApp
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app
+          sudo xcode-select -s /Applications/Xcode_26.0.0.app
           mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
           xcrun --find xcodebuild
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
@@ -31,7 +31,7 @@ jobs:
         env:
           scheme: ${{ 'default' }}
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app
+          sudo xcode-select -s /Applications/Xcode_26.0.0.app
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
@@ -62,7 +62,7 @@ jobs:
         env:
           scheme: ${{ 'default' }}
         run: |
-          sudo xcode-select -s /Applications/Xcode_16.2.app
+          sudo xcode-select -s /Applications/Xcode_26.0.0.app
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -72,7 +72,7 @@ jobs:
           xcodebuild build analyze test \
             -scheme "$scheme" \
             -"$filetype_parameter" "$file_to_build" \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.6' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \
             ONLY_ACTIVE_ARCH=NO \

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Cache SwiftPM
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             VultisigApp/.build

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -40,6 +40,10 @@ jobs:
         env:
           scheme: ${{ 'default' }}
         run: |
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo $default | cat >default
+          echo Using default scheme: $default
           # Clean, build and analyze for macOS
           echo "Building and analyzing for macOS - scheme: $scheme"
           xcodebuild clean build analyze \
@@ -59,6 +63,10 @@ jobs:
         env:
           scheme: ${{ 'default' }}
         run: |
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo $default | cat >default
+          echo Using default scheme: $default
           # Build and test for iOS in one command
           echo "Building and testing for iOS - scheme: $scheme"
           xcodebuild build analyze test \

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Cache SwiftPM
         uses: actions/cache@v4

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       
+      - name: Cache SwiftPM
+        uses: actions/cache@v3
+        with:
+          path: |
+            VultisigApp/.build
+            VultisigApp/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('VultisigApp/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-   
       - name: Set Default Scheme
         working-directory: VultisigApp
         run: |
@@ -31,17 +40,6 @@ jobs:
         env:
           scheme: ${{ 'default' }}
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.0.0.app
-          if [ $scheme = default ]; then scheme=$(cat default); fi
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          
-          # Print environment info
-          echo "Xcode version:"
-          xcodebuild -version
-          echo "Swift version:"
-          swift --version
-          
           # Clean, build and analyze for macOS
           echo "Building and analyzing for macOS - scheme: $scheme"
           xcodebuild clean build analyze \
@@ -50,10 +48,9 @@ jobs:
             -destination 'platform=macOS,arch=x86_64' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \
-            ONLY_ACTIVE_ARCH=NO \
+            ONLY_ACTIVE_ARCH=YES \
             DEBUG_INFORMATION_FORMAT=dwarf \
             SWIFT_COMPILATION_MODE=wholemodule \
-            -verbose \
             OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" \
             | xcpretty -c && exit ${PIPESTATUS[0]}
 
@@ -62,11 +59,6 @@ jobs:
         env:
           scheme: ${{ 'default' }}
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.0.0.app
-          if [ $scheme = default ]; then scheme=$(cat default); fi
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          
           # Build and test for iOS in one command
           echo "Building and testing for iOS - scheme: $scheme"
           xcodebuild build analyze test \
@@ -75,6 +67,5 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.6' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \
-            ONLY_ACTIVE_ARCH=NO \
-            -verbose \
+            ONLY_ACTIVE_ARCH=YES \
             | xcpretty -c && exit ${PIPESTATUS[0]}

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -40,10 +40,16 @@ jobs:
         env:
           scheme: ${{ 'default' }}
         run: |
-          scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
-          echo $default | cat >default
-          echo Using default scheme: $default
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          
+          # Print environment info
+          echo "Xcode version:"
+          xcodebuild -version
+          echo "Swift version:"
+          swift --version
+          
           # Clean, build and analyze for macOS
           echo "Building and analyzing for macOS - scheme: $scheme"
           xcodebuild clean build analyze \
@@ -63,10 +69,10 @@ jobs:
         env:
           scheme: ${{ 'default' }}
         run: |
-          scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
-          echo $default | cat >default
-          echo Using default scheme: $default
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          
           # Build and test for iOS in one command
           echo "Building and testing for iOS - scheme: $scheme"
           xcodebuild build analyze test \


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI to a newer macOS/Xcode environment (Xcode 26) and updated the iOS simulator target (iOS 18.6).
  * Added build caching to speed up CI runs and improve consistency.
  * Adjusted CI build/test steps to surface environment info, reduce verbose output, remove redundant selectors, and use active-architecture builds for faster, more reliable CI; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->