### PR TITLE
fix: updated expandable section animation to prevent crash on macOS

### DIFF
--- a/VultisigApp/VultisigApp/Features/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/ChainDetail/ChainDetailScreen.swift
@@ -21,6 +21,7 @@ struct ChainDetailScreen: View {
     @ObservedObject var group: GroupedChain
     let vault: Vault
     @State var vaultAction: VaultAction?
+    @State var showAction: Bool = false
     
     @StateObject var viewModel: ChainDetailViewModel
     
@@ -99,8 +100,10 @@ struct ChainDetailScreen: View {
         .onLoad {
             refresh()
         }
-        .navigationDestination(item: $vaultAction) {
-            VaultActionRouteBuilder().buildActionRoute(action: $0, sendTx: sendTx, vault: vault)
+        .navigationDestination(isPresented: $showAction) {
+            if let vaultAction {
+                VaultActionRouteBuilder().buildActionRoute(action: vaultAction, sendTx: sendTx, vault: vault)
+            }
         }
         .navigationDestination(item: $coinToShow) {
             CoinDetailView(coin: $0, group: group, vault: vault, sendTx: sendTx)
@@ -270,6 +273,7 @@ private extension ChainDetailScreen {
         
         guard let vaultAction else { return }
         self.vaultAction = vaultAction
+        self.showAction = true
     }
     
     func onCopy() {

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -15,6 +15,7 @@ struct HomeScreen: View {
     @State var selectedVault: Vault? = nil
     @State var showVaultSelector: Bool = false
     @State var addressToCopy: GroupedChain?
+    @State var showUpgradeVaultSheet: Bool = false
     
     @State var vaults: [Vault] = []
     @State private var selectedTab: HomeTab = .wallet
@@ -85,7 +86,8 @@ struct HomeScreen: View {
                     vault: selectedVault,
                     routeToPresent: $vaultRoute,
                     showVaultSelector: $showVaultSelector,
-                    addressToCopy: $addressToCopy
+                    addressToCopy: $addressToCopy,
+                    showUpgradeVaultSheet: $showUpgradeVaultSheet
                 )
                 #if os(macOS)
                 .navigationBarBackButtonHidden()
@@ -101,6 +103,9 @@ struct HomeScreen: View {
         .sensoryFeedback(homeViewModel.showAlert ? .stop : .impact, trigger: homeViewModel.showAlert)
         .customNavigationBarHidden(true)
         .withAddressCopy(group: $addressToCopy)
+        .withUpgradeVault(vault: selectedVault, shouldShow: $showUpgradeVaultSheet)
+        .withBiweeklyPasswordVerification(vault: selectedVault)
+        .withMonthlyBackupWarning(vault: selectedVault)
         .onChange(of: selectedTab) { oldValue, newValue in
             if newValue == .camera {
                 selectedTab = oldValue

--- a/VultisigApp/VultisigApp/Features/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/VaultMain/VaultMainScreen.swift
@@ -13,6 +13,7 @@ struct VaultMainScreen: View {
     @Binding var routeToPresent: VaultMainRoute?
     @Binding var showVaultSelector: Bool
     @Binding var addressToCopy: GroupedChain?
+    @Binding var showUpgradeVaultSheet: Bool
     
     @Environment(\.modelContext) var modelContext
     @EnvironmentObject var viewModel: VaultDetailViewModel
@@ -25,7 +26,6 @@ struct VaultMainScreen: View {
     @State var showBalanceInHeader: Bool = false
     @State var showChainSelection: Bool = false
     @State var showSearchHeader: Bool = false
-    @State var showUpgradeVaultSheet: Bool = false
     @State var focusSearch: Bool = false
     @State var scrollProxy: ScrollViewProxy?
     @State var frameHeight: CGFloat = 0
@@ -96,9 +96,6 @@ struct VaultMainScreen: View {
             .sheet(isPresented: $showBackupNow) {
                 VaultBackupNowScreen(tssType: .Keygen, backupType: .single(vault: vault))
             }
-            .withUpgradeVault(vault: vault, shouldShow: $showUpgradeVaultSheet)
-            .withBiweeklyPasswordVerification(vault: vault)
-            .withMonthlyBackupWarning(vault: vault)
             .onAppear(perform: refresh)
             .refreshable { refresh() }
             .onChange(of: homeViewModel.selectedVault?.coins) {
@@ -305,7 +302,8 @@ struct VaultMainScreen: View {
         vault: .example,
         routeToPresent: .constant(nil),
         showVaultSelector: .constant(false),
-        addressToCopy: .constant(nil)
+        addressToCopy: .constant(nil),
+        showUpgradeVaultSheet: .constant(false)
     )
     .environmentObject(HomeViewModel())
     .environmentObject(VaultDetailViewModel())

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAddressTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAddressTab.swift
@@ -37,8 +37,10 @@ struct SendDetailsAddressTab: View {
         SendFormExpandableSection(isExpanded: isExpanded) {
             titleSection
         } content: {
-            separator
-            fields
+            VStack(spacing: 16) {
+                separator
+                fields
+            }
         }
     }
     

--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
@@ -35,16 +35,18 @@ struct SendDetailsAmountTab: View {
         SendFormExpandableSection(isExpanded: isExpanded) {
             titleSection
         } content: {
-            separator
-            amountFieldSection
-            
-            if sendCryptoViewModel.showAmountAlert {
-                errorText
+            VStack(spacing: 16) {
+                separator
+                amountFieldSection
+                
+                if sendCryptoViewModel.showAmountAlert {
+                    errorText
+                }
+                
+                percentageButtons
+                balanceSection
+                additionalOptionsSection
             }
-            
-            percentageButtons
-            balanceSection
-            additionalOptionsSection
         }
     }
     

--- a/VultisigApp/VultisigApp/Views/Components/TextFields/SendCryptoAddressTextField.swift
+++ b/VultisigApp/VultisigApp/Views/Components/TextFields/SendCryptoAddressTextField.swift
@@ -28,7 +28,7 @@ struct SendCryptoAddressTextField: View {
 #endif
     
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             container
             
             if sendCryptoViewModel.showAddressAlert {

--- a/VultisigApp/VultisigApp/Views/Transitions/VerticalGrowAndFade.swift
+++ b/VultisigApp/VultisigApp/Views/Transitions/VerticalGrowAndFade.swift
@@ -7,24 +7,11 @@
 
 import SwiftUI
 
-struct VerticalGrowAndFadeViewModifier: ViewModifier {
-    let y: CGFloat
-    let opacity: Double
-    let anchor: UnitPoint
-    
-    func body(content: Content) -> some View {
-        content
-            .scaleEffect(x: 1, y: y, anchor: anchor)
-            .opacity(opacity)
-            .clipped()
-    }
-}
-
 extension AnyTransition {
     static var verticalGrowAndFade: AnyTransition {
-        .modifier(
-            active: VerticalGrowAndFadeViewModifier(y: 0.0, opacity: 0.0, anchor: .top),
-            identity: VerticalGrowAndFadeViewModifier(y: 1.0, opacity: 1.0, anchor: .top)
+        .asymmetric(
+            insertion: .opacity.animation(.interpolatingSpring(duration: 0.3).delay(0.3)),
+            removal: .opacity.animation(.interpolatingSpring(duration: 0.3)),
         )
     }
 }


### PR DESCRIPTION
## Description

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing and layout consistency (16pt) in Send Address, Amount, and address input fields for clearer readability.
  * Grouped amount sections (percent buttons, balance, options) and aligned error messages within the same block.
  * Updated transition to a smoother fade with spring animation for insert/remove actions.

* **New Features**
  * Home now surfaces upgrade prompts and periodic password/backup verifications tied to selected vaults.
  * Vault main screen accepts external control for showing the upgrade sheet.

* **Refactor**
  * Simplified transition to an asymmetric opacity-based animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->