### PR TITLE
fix: Added countdown timer when user asks for server backup too many times

### DIFF
--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -842,7 +842,7 @@
 "passwordIsRequired" = "Password is required.";
 "emailIsRequired" = "Email is required.";
 "requestServerVaultShareSuccess" = "We’ve sent a copy of your vault share to your email. It should arrive shortly.";
-"requestServerVaultShareTooManyRequestsError" = "You've requested a vault share too many times in a short period of time. Please wait a couple a minutes and try again.";
+"requestServerVaultShareTooManyRequestsError" = "You've requested a vault share too many times in a short period of time. Please wait %@ minutes and try again.";
 "requestServerVaultShareUnknownError" = "We couldn't send a new copy of your vault share. Please wait a couple of minutes and try again.";
 "requestServerVaultShareBadRequestError" = "Password for your vault is incorrect. Please check and try again.";
 "vult" = "$VULT";
@@ -898,3 +898,4 @@
 "custom" = "Custom";
 "customTokenErrorSubtitle" = "Possible reasons: wrong contract, unsupported chain, or token removed from registries.";
 "addingToken" = "Adding Token...";
+"pleaseWaitMinutes" = "Please wait %@ minutes";

--- a/VultisigApp/VultisigApp/Views/Vault/Backup/VaultServerBackupScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/Backup/VaultServerBackupScreen.swift
@@ -31,7 +31,7 @@ struct VaultServerBackupScreen: View {
                 ScrollView(showsIndicators: false) {
                     VStack(spacing: 12) {
                         InfoBannerView(
-                            description: (viewModel.alertError ?? ResendVaultShareError.unknown).localizedDescription,
+                            description: viewModel.alertErrorDescription ?? "",
                             type: .error,
                             leadingIcon: "triangle-alert"
                         )
@@ -134,7 +134,7 @@ struct VaultServerBackupScreen: View {
                 
                 Spacer()
                 
-                PrimaryButton(title: "next".localized) {
+                PrimaryButton(title: viewModel.buttonTitle) {
                     focusedFieldBinding = nil
                     Task {
                         await viewModel.requestServerVaultShare(vault: vault)


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #3016

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

https://github.com/user-attachments/assets/43230496-77f5-489f-93db-838de4795815


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a countdown and dynamic button label during rate limits on server vault backup requests.
  - Displays a contextual alert showing the remaining wait time.
  - Updated localization to support formatted wait-time messages.

- Bug Fixes
  - Prevents submitting backup requests while a wait period is active, reducing repeated errors.
  - Improves clarity of “Too Many Requests” messages with precise wait guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->