### PR TITLE
fix:  Image too wide on Vault share QR

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/VaultDetailMacQRCode.swift
+++ b/VultisigApp/VultisigApp/Views/Components/VaultDetailMacQRCode.swift
@@ -23,7 +23,11 @@ struct VaultDetailMacQRCode: View {
         }
         .padding(22)
         .frame(width: 960, height: 1400)
-        .background(LinearGradient.primaryGradientLinear)
+        .background(
+            RoundedRectangle(cornerRadius: 24)
+                .fill(Theme.colors.bgSecondary.opacity(0.6))
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
     }
     
     var qrCodeContent: some View {
@@ -39,9 +43,12 @@ struct VaultDetailMacQRCode: View {
             .resizable()
             .frame(width: 700, height: 700)
             .scaledToFit()
-            .padding(3)
-            .cornerRadius(10)
             .foregroundColor(Theme.colors.textPrimary)
+            .padding(24)
+            .overlay(
+                RoundedRectangle(cornerRadius: 24)
+                    .stroke(Theme.colors.borderLight, lineWidth: 1)
+            )
     }
     
     var logo: some View {

--- a/VultisigApp/VultisigApp/Views/Components/VaultDetailQRCode.swift
+++ b/VultisigApp/VultisigApp/Views/Components/VaultDetailQRCode.swift
@@ -14,10 +14,8 @@ struct VaultDetailQRCode: View {
     
     var body: some View {
         VStack(spacing: 12) {
-            VStack(spacing: 8) {
-                name
-                uid
-            }
+            name
+            uid
             qrCodeContent
             webLink
         }
@@ -27,6 +25,7 @@ struct VaultDetailQRCode: View {
                 .fill(Theme.colors.bgSecondary.opacity(0.6))
                 .stroke(Theme.colors.borderLight, lineWidth: 1)
         )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     
     var qrCodeContent: some View {

--- a/VultisigApp/VultisigApp/Views/Vault/VaultDetailQRCodeView.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultDetailQRCodeView.swift
@@ -17,17 +17,15 @@ struct VaultDetailQRCodeView: View {
     @Environment(\.displayScale) var displayScale
     
     var body: some View {
-        Screen(title: "shareVaultQR".localized) {
+        Screen(title: "shareVaultQR".localized, edgeInsets: .init(bottom: .zero)) {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 15) {
-                    Spacer()
                     qrCode
                     InfoBannerView(
                         description: "shareVaultQRInformation".localized,
                         type: .info,
                         leadingIcon: "circle-info"
                     )
-                    Spacer()
                     buttons
                 }
                 .onLoad {

--- a/VultisigApp/VultisigApp/iOS/View Model/VaultDetailQRCodeViewModel+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View Model/VaultDetailQRCodeViewModel+iOS.swift
@@ -10,8 +10,13 @@ import SwiftUI
 
 extension VaultDetailQRCodeViewModel {
     func render(vault: Vault, displayScale: CGFloat) {
-        let renderer = ImageRenderer(content: VaultDetailQRCode(vault: vault))
-
+        let screenSize = UIScreen.main.bounds.size
+        
+        // Create a scaled version that fills the screen while maintaining aspect ratio
+        let qrCodeView = VaultDetailQRCode(vault: vault)
+        
+        let renderer = ImageRenderer(content: qrCodeView)
+        renderer.proposedSize = ProposedViewSize(screenSize)
         renderer.scale = displayScale
         
         if let uiImage = renderer.uiImage {
@@ -41,12 +46,7 @@ extension VaultDetailQRCodeViewModel {
     }
     
     func renderImage(image: Image) -> UIImage {
-        let controller = UIHostingController(
-            rootView:
-                image
-                    .frame(width: 278, height: 402)
-                    .offset(y: -30)
-        )
+        let controller = UIHostingController(rootView: image)
         let view = controller.view
 
         let targetSize = controller.view.intrinsicContentSize

--- a/VultisigApp/VultisigApp/iOS/View/Vault/VaultDetailQRCodeView+iOS.swift
+++ b/VultisigApp/VultisigApp/iOS/View/Vault/VaultDetailQRCodeView+iOS.swift
@@ -12,7 +12,7 @@ extension VaultDetailQRCodeView {
     private var idiom : UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     
     var buttons: some View {
-        VStack(spacing: 15) {
+        VStack(spacing: 16) {
             shareButton
             saveButton
         }

--- a/VultisigApp/VultisigApp/macOS/View/Vault/VaultDetailQRCodeView+macOS.swift
+++ b/VultisigApp/VultisigApp/macOS/View/Vault/VaultDetailQRCodeView+macOS.swift
@@ -14,11 +14,10 @@ extension VaultDetailQRCodeView {
     }
     
     var buttons: some View {
-        HStack(spacing: 22) {
+        HStack(spacing: 16) {
             shareButton
             saveButton
         }
-        .padding(.horizontal, 25)
     }
 }
 #endif


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #3017

- Adjusted size for QR code view rendering for sharing
- Updated style for macOS QR Code sharing

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

<img width="200" alt="Simulator Screenshot - iPhone 16e - 2025-09-30 at 10 33 40" src="https://github.com/user-attachments/assets/715e5756-d2d4-49f9-91b3-0b4b9c66a886" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Refreshed QR code view with a rounded, framed container and increased padding for clearer emphasis.
  * Harmonized spacing across iOS and macOS, reducing unnecessary padding and aligning buttons more consistently.
  * View now expands to fill available space for a cleaner, more balanced layout.

* Refactor
  * Replaced spacers with explicit screen insets for predictable vertical spacing.
  * Improved share/save rendering by sizing content to the full screen for more reliable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->