### PR TITLE
Make sure swap is filter based on region

### DIFF
--- a/VultisigApp/VultisigApp/Features/ChainDetail/ViewModel/ChainDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/ChainDetail/ViewModel/ChainDetailViewModel.swift
@@ -29,7 +29,7 @@ final class ChainDetailViewModel: ObservableObject {
     
     func refresh(group: GroupedChain) {
         Task { @MainActor in
-            availableActions = await actionResolver.resolveActions(for: group.chain)
+            availableActions = await actionResolver.resolveActions(for: group.chain).filtered
         }
     }
     

--- a/VultisigApp/VultisigApp/Features/CoinDetail/ViewModel/CoinDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/CoinDetail/ViewModel/CoinDetailViewModel.swift
@@ -19,7 +19,7 @@ final class CoinDetailViewModel: ObservableObject {
     
     func setup() {
         Task { @MainActor in
-            availableActions = await actionResolver.resolveActions(for: coin.chain)
+            availableActions = await actionResolver.resolveActions(for: coin.chain).filtered
         }
     }
 }

--- a/VultisigApp/VultisigApp/View Models/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/VaultDetailViewModel.swift
@@ -27,7 +27,7 @@ class VaultDetailViewModel: ObservableObject {
     private var updateBalanceTask: Task<Void, Never>?
     
     var availableActions: [CoinAction] {
-        [.send,.buy,.swap, .receive]
+        [.send,.buy,.swap, .receive].filtered
     }
     
     @Published var selectedTab: VaultTab = .portfolio


### PR DESCRIPTION
## Description

Make sure swap button is filter out for some region

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Action menus in chain, coin, and vault details now show only relevant options, reducing clutter and preventing unavailable actions from appearing.

* **New Features**
  * Context-aware filtering applied to available actions across details screens for a more accurate and streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->