### PR TITLE
fix: Check for `isNativeCoin` for `nativeCoin` property

### DIFF
--- a/VultisigApp/VultisigApp/Model/CoinsGrouped.swift
+++ b/VultisigApp/VultisigApp/Model/CoinsGrouped.swift
@@ -45,7 +45,7 @@ class GroupedChain: ObservableObject, Identifiable, Hashable {
     }
 
     var nativeCoin: Coin {
-        return coins[0]
+        return coins.first(where: { $0.isNativeToken }) ?? coins[0]
     }
 
     init(chain: Chain, address: String, logo: String, count: Int = 0, coins: [Coin]) {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly identifies the native token in a coin group by selecting the flagged native token instead of assuming the first item.
  - Prevents incorrect defaults when the native token isn’t first, improving accuracy for balances, fees, and transaction prompts.
  - Enhances reliability across wallets with mixed coin ordering.
- Tests
  - Updated logic covered by existing flows; no behavioral regressions expected for non-native coins.
- Documentation
  - Clarified behavior around native token selection in grouped coin contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->