### PR TITLE
feat: Add address to address book on complete view

### DIFF
--- a/VultisigApp/VultisigApp/Features/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/ChainDetail/ChainDetailScreen.swift
@@ -70,7 +70,7 @@ struct ChainDetailScreen: View {
                 isPresented: $showManageTokens
             )
         }
-        .onLoad{
+        .onLoad {
             viewModel.refresh(group: group)
         }
         .navigationDestination(isPresented: $showAction) {

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -883,3 +883,4 @@
 "youreSwapping" = "You’re swapping";
 "yourFriendsReferralCode" = "Your Friend Referral Code";
 "yourReferralCode" = "Your Referral Code";
+"addToAddressBook" = "Add to Address Book";

--- a/VultisigApp/VultisigApp/Views/Address Book/AddAddressBookScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Address Book/AddAddressBookScreen.swift
@@ -10,7 +10,9 @@ import SwiftData
 import WalletCore
 
 struct AddAddressBookScreen: View {
-    let count: Int
+    var onDismiss: (() -> Void)?
+    
+    @Query var savedAddresses: [AddressBookItem]
     
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
     @EnvironmentObject var homeViewModel: HomeViewModel
@@ -26,6 +28,12 @@ struct AddAddressBookScreen: View {
     
     @Environment(\.dismiss) var dismiss
     @Environment(\.modelContext) var modelContext
+    
+    init(address: String? = nil, chain: AddressBookChainType? = nil, onDismiss: (() -> Void)? = nil) {
+        self.address = address ?? ""
+        self.selectedChain = chain ?? .evm
+        self.onDismiss = onDismiss
+    }
     
     var body: some View {
         Screen(title: "addAddress".localized) {
@@ -131,12 +139,16 @@ struct AddAddressBookScreen: View {
             title: title,
             address: address,
             coinMeta: coin,
-            order: count
+            order: savedAddresses.count
         )
         
         DispatchQueue.main.asyncAfter(deadline: .now()) {
             modelContext.insert(data)
-            dismiss()
+            if let onDismiss {
+                onDismiss()
+            } else {
+                dismiss()
+            }
         }
     }
     
@@ -160,7 +172,7 @@ struct AddAddressBookScreen: View {
 }
 
 #Preview {
-    AddAddressBookScreen(count: 0)
+    AddAddressBookScreen()
         .environmentObject(CoinSelectionViewModel())
         .environmentObject(HomeViewModel())
 }

--- a/VultisigApp/VultisigApp/Views/Address Book/AddAddressBookScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Address Book/AddAddressBookScreen.swift
@@ -18,8 +18,8 @@ struct AddAddressBookScreen: View {
     @EnvironmentObject var homeViewModel: HomeViewModel
     
     @State var title = ""
-    @State var address = ""
-    @State var selectedChain = AddressBookChainType.evm
+    @State var address: String
+    @State var selectedChain: AddressBookChainType
     
     @State var alertTitle = ""
     @State var alertMessage = ""

--- a/VultisigApp/VultisigApp/Views/Address Book/AddressBookView.swift
+++ b/VultisigApp/VultisigApp/Views/Address Book/AddressBookView.swift
@@ -104,7 +104,7 @@ struct AddressBookView: View {
     
     var addAddressButton: some View {
         PrimaryNavigationButton(title: "addAddress") {
-            AddAddressBookScreen(count: savedAddresses.count)
+            AddAddressBookScreen()
         }
     }
     

--- a/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallView.swift
+++ b/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallView.swift
@@ -122,7 +122,15 @@ struct FunctionCallView: View {
     var doneView: some View {
         ZStack {
             if let hash = functionCallViewModel.hash, let chain = keysignPayload?.coin.chain  {
-                SendCryptoDoneView(vault: vault, hash: hash, approveHash: nil, chain: chain, sendTransaction: tx, swapTransaction: nil)
+                SendCryptoDoneView(
+                    vault: vault,
+                    hash: hash,
+                    approveHash: nil,
+                    chain: chain,
+                    sendTransaction: tx,
+                    swapTransaction: nil,
+                    isSend: false
+                )
             } else {
                 SendCryptoSigningErrorView(errorString: functionCallViewModel.errorMessage)
             }

--- a/VultisigApp/VultisigApp/Views/Keysign/JoinKeysignDoneSummary.swift
+++ b/VultisigApp/VultisigApp/Views/Keysign/JoinKeysignDoneSummary.swift
@@ -91,6 +91,7 @@ struct JoinKeysignDoneSummary: View {
                     hash: viewModel.txid,
                     explorerLink: viewModel.getTransactionExplorerURL(txid: viewModel.txid),
                     memo: viewModel.memo ?? "",
+                    isSend: true,
                     fromAddress: keysignPayload.coin.address,
                     toAddress: keysignPayload.toAddress,
                     fee: (fees.feeCrypto, fees.feeFiat)

--- a/VultisigApp/VultisigApp/Views/Referral/ReferralTransactionOverviewView.swift
+++ b/VultisigApp/VultisigApp/Views/Referral/ReferralTransactionOverviewView.swift
@@ -24,6 +24,7 @@ struct ReferralTransactionOverviewView: View {
                     hash: hash,
                     explorerLink: Endpoint.getExplorerURL(chain: sendTx.coin.chain, txid: hash),
                     memo: sendTx.memo,
+                    isSend: false,
                     fromAddress: sendTx.fromAddress,
                     toAddress: sendTx.toAddress,
                     fee: (sendTx.gasInReadable, referralViewModel.totalFeeFiat)

--- a/VultisigApp/VultisigApp/Views/Send/Screens/SendDoneScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Send/Screens/SendDoneScreen.swift
@@ -22,6 +22,7 @@ struct SendDoneScreen: View {
                 chain: chain,
                 sendTransaction: tx,
                 swapTransaction: nil,
+                isSend: true,
                 contentPadding: 0
             )
         }

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDone/SendCryptoDoneContent.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDone/SendCryptoDoneContent.swift
@@ -12,6 +12,7 @@ struct SendCryptoContent {
     let hash: String
     let explorerLink: String
     let memo: String
+    let isSend: Bool
     
     let fromAddress: String
     let toAddress: String

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDone/SendCryptoDoneContentView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDone/SendCryptoDoneContentView.swift
@@ -13,6 +13,7 @@ struct SendCryptoDoneContentView: View {
     @Binding var showAlert: Bool
     var onDone: () -> Void = {}
     
+    @State var navigateToTransactionDetails = false
     @State var navigateToHome = false
     @State var animationVM: RiveViewModel? = nil
     @EnvironmentObject var homeViewModel: HomeViewModel
@@ -59,6 +60,12 @@ struct SendCryptoDoneContentView: View {
                 onDoneButtonPressed()
             }
         }
+        .navigationDestination(isPresented: $navigateToTransactionDetails) {
+            SendCryptoSecondaryDoneView(
+                input: input,
+                onDone: onDoneButtonPressed
+            )
+        }
         .navigationDestination(isPresented: $navigateToHome) {
             if let vault = homeViewModel.selectedVault {
                 HomeScreen(initialVault: vault)
@@ -75,17 +82,17 @@ struct SendCryptoDoneContentView: View {
     }
     
     var transactionDetailsButton: some View {
-        NavigationLink {
-            SendCryptoSecondaryDoneView(input: input) {
-                onDoneButtonPressed()
-            }
+        Button {
+            navigateToTransactionDetails = true
         } label: {
             HStack {
                 Text(NSLocalizedString("transactionDetails", comment: ""))
                 Spacer()
                 Image(systemName: "chevron.right")
             }
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
     }
     
     var animation: some View {
@@ -112,6 +119,7 @@ struct SendCryptoDoneContentView: View {
         approveHash: "",
         chain: .thorChain,
         sendTransaction: nil,
-        swapTransaction: nil
+        swapTransaction: nil,
+        isSend: true
     )
 }

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDone/SendCryptoTransactionDetailsRow.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDone/SendCryptoTransactionDetailsRow.swift
@@ -7,13 +7,78 @@
 
 import SwiftUI
 
-struct SendCryptoTransactionDetailsRow: View {
+struct SendCryptoTransactionDetailsRow<AccessoryView: View>: View {
     let title: String
     let description: String
     let secondaryDescription: String?
     let bracketValue: String?
     let icon: String?
+    let accessoryView: (() -> AccessoryView)
     
+    init(
+        title: String,
+        description: String,
+        secondaryDescription: String? = nil,
+        bracketValue: String? = nil,
+        icon: String? = nil,
+        @ViewBuilder accessoryView: @escaping () -> AccessoryView
+    ) {
+        self.title = title
+        self.description = description
+        self.secondaryDescription = secondaryDescription
+        self.bracketValue = bracketValue
+        self.icon = icon
+        self.accessoryView = accessoryView
+    }
+    
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 16) {
+            HStack(spacing: 2) {
+                Text(NSLocalizedString(title, comment: ""))
+                    .foregroundColor(Theme.colors.textExtraLight)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                
+                Spacer()
+                
+                if let icon {
+                    Image(icon)
+                        .resizable()
+                        .frame(width: 16, height: 16)
+                        .cornerRadius(32)
+                }
+                
+                VStack(alignment: .trailing, spacing: 2) {
+                    HStack(spacing: 2) {
+                        Text(description)
+                            .foregroundColor(Theme.colors.textPrimary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        
+                        if let bracketValue {
+                            Text("(\(bracketValue))")
+                                .foregroundColor(Theme.colors.textExtraLight)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                    
+                    if let secondaryDescription {
+                        Text(secondaryDescription)
+                            .foregroundColor(Theme.colors.textExtraLight)
+                            .lineLimit(1)
+                    }
+                    
+                }
+            }
+            accessoryView()
+        }
+        .font(Theme.fonts.bodySMedium)
+        .foregroundColor(Theme.colors.textPrimary)
+    }
+}
+
+extension SendCryptoTransactionDetailsRow where AccessoryView == EmptyView {
     init(
         title: String,
         description: String,
@@ -26,48 +91,7 @@ struct SendCryptoTransactionDetailsRow: View {
         self.secondaryDescription = secondaryDescription
         self.bracketValue = bracketValue
         self.icon = icon
-    }
-    
-    var body: some View {
-        HStack(spacing: 2) {
-            Text(NSLocalizedString(title, comment: ""))
-                .foregroundColor(Theme.colors.textExtraLight)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            
-            Spacer()
-            
-            if let icon {
-                Image(icon)
-                    .resizable()
-                    .frame(width: 16, height: 16)
-                    .cornerRadius(32)
-            }
-            
-            VStack(alignment: .trailing, spacing: 2) {
-                HStack(spacing: 2) {
-                    Text(description)
-                        .foregroundColor(Theme.colors.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    
-                    if let bracketValue {
-                        Text("(\(bracketValue))")
-                            .foregroundColor(Theme.colors.textExtraLight)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
-                }
-                
-                if let secondaryDescription {
-                    Text(secondaryDescription)
-                        .foregroundColor(Theme.colors.textExtraLight)
-                        .lineLimit(1)
-                }
-            }
-        }
-        .font(Theme.fonts.bodySMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        self.accessoryView = { EmptyView() }
     }
 }
 

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoDoneView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoDoneView.swift
@@ -12,6 +12,7 @@ struct SendCryptoDoneView: View {
     let hash: String
     let approveHash: String?
     let chain: Chain
+    let isSend: Bool
 
     var progressLink: String? = nil
     
@@ -37,6 +38,7 @@ struct SendCryptoDoneView: View {
         progressLink: String? = nil,
         sendTransaction: SendTransaction?,
         swapTransaction: SwapTransaction?,
+        isSend: Bool,
         contentPadding: CGFloat = 16
     ) {
         self.vault = vault
@@ -46,6 +48,7 @@ struct SendCryptoDoneView: View {
         self.progressLink = progressLink
         self.sendTransaction = sendTransaction
         self.swapTransaction = swapTransaction
+        self.isSend = isSend
         self.contentPadding = contentPadding
     }
     
@@ -74,6 +77,7 @@ struct SendCryptoDoneView: View {
                 hash: hash,
                 explorerLink: explorerLink(),
                 memo: tx.memo,
+                isSend: isSend,
                 fromAddress: tx.fromAddress,
                 toAddress: tx.toAddress,
                 fee: (tx.gasInReadable, sendSummaryViewModel.feesInReadable(tx: tx, vault: vault))
@@ -136,7 +140,8 @@ struct SendCryptoDoneView: View {
         chain: .thorChain,
         progressLink: "https://blockstream.info/tx/",
         sendTransaction: nil,
-        swapTransaction: SwapTransaction()
+        swapTransaction: SwapTransaction(),
+        isSend: true
     )
     .environmentObject(SettingsViewModel())
 }

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoSecondaryDoneView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoSecondaryDoneView.swift
@@ -59,11 +59,14 @@ struct SendCryptoSecondaryDoneView: View {
                 separator
             }
             
+            // TODO: - Here
             Group {
                 SendCryptoTransactionDetailsRow(
                     title: "to",
                     description: input.toAddress
-                )
+                ) {
+                    addToAddressBookButton
+                }
                 separator
             }
             .showIf(input.toAddress.isNotEmpty)
@@ -110,6 +113,25 @@ struct SendCryptoSecondaryDoneView: View {
         PrimaryButton(title: "done") {
             onDone()
         }
+    }
+    
+    var addToAddressBookButton: some View {
+        Button {
+            
+        } label: {
+            HStack(spacing: 6) {
+                Icon(named: "plus", color: Theme.colors.alertSuccess, size: 16)
+                
+                Text("addToAddressBook".localized)
+                    .font(Theme.fonts.caption10)
+                    .foregroundStyle(Theme.colors.alertSuccess)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .overlay(RoundedRectangle(cornerRadius: 99).stroke(Theme.colors.alertSuccess, lineWidth: 0.5))
+            .fixedSize()
+        }
+        .buttonStyle(.plain)
     }
     
     func openLink() {

--- a/VultisigApp/VultisigApp/Views/Send/SendCryptoSecondaryDoneView.swift
+++ b/VultisigApp/VultisigApp/Views/Send/SendCryptoSecondaryDoneView.swift
@@ -6,13 +6,20 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct SendCryptoSecondaryDoneView: View {
     let input: SendCryptoContent
     let onDone: () -> Void
     
+    @State var navigateToAddressBook = false
     @Environment(\.openURL) var openURL
     @EnvironmentObject var homeViewModel: HomeViewModel
+    @Query var savedAddresses: [AddressBookItem]
+
+    var showAddressBookButton: Bool {
+        input.isSend && !savedAddresses.map(\.address).contains(input.toAddress)
+    }
     
     var body: some View {
         Screen(title: "transactionDetails".localized) {
@@ -26,6 +33,14 @@ struct SendCryptoSecondaryDoneView: View {
                 }
                 
                 continueButton
+            }
+        }
+        .navigationDestination(isPresented: $navigateToAddressBook) {
+            AddAddressBookScreen(
+                address: input.toAddress,
+                chain: .init(coinMeta: input.coin.toCoinMeta())
+            ) {
+                onDone()
             }
         }
     }
@@ -66,6 +81,7 @@ struct SendCryptoSecondaryDoneView: View {
                     description: input.toAddress
                 ) {
                     addToAddressBookButton
+                        .showIf(showAddressBookButton)
                 }
                 separator
             }
@@ -82,10 +98,10 @@ struct SendCryptoSecondaryDoneView: View {
             
             
             SendCryptoTransactionDetailsRow(
-                    title: "network",
-                    description: input.coin.chain.name,
-                    icon: input.coin.chain.logo
-                )
+                title: "network",
+                description: input.coin.chain.name,
+                icon: input.coin.chain.logo
+            )
             
             separator
             
@@ -117,7 +133,7 @@ struct SendCryptoSecondaryDoneView: View {
     
     var addToAddressBookButton: some View {
         Button {
-            
+            navigateToAddressBook = true
         } label: {
             HStack(spacing: 6) {
                 Icon(named: "plus", color: Theme.colors.alertSuccess, size: 16)
@@ -150,6 +166,7 @@ struct SendCryptoSecondaryDoneView: View {
             hash: "44B447A6A8BCABCCEC6E3EE9DE366EA4E0CDFC2C0BFB59D51E1A12D27B0C51AB",
             explorerLink: "https://thorchain.net/tx/44B447A6A8BCABCCEC6E3EE9DE366EA4E0CDFC2C0BFB59D51E1A12D27B0C51AB",
             memo: "test",
+            isSend: true,
             fromAddress: "thor1kkmnmgvd85puk8zsvqfxx36cqy9mxqret39t8z",
             toAddress: "thor1kkmnmgvd85puk8zsvqfxx36cqy9mxqret39t8z",
             fee: ("0.001 RUNE", "US$ 0.00")

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoView.swift
@@ -118,7 +118,8 @@ struct SwapCryptoView: View {
                     chain: tx.fromCoin.chain,
                     progressLink: swapViewModel.progressLink(tx: tx, hash: hash),
                     sendTransaction: nil,
-                    swapTransaction: tx
+                    swapTransaction: tx,
+                    isSend: false
                 )
             } else {
                 SendCryptoSigningErrorView(errorString: swapViewModel.error?.localizedDescription ?? "Error")


### PR DESCRIPTION
## Description

Fixes #3088

- Updated Send flow to show `Add to address book` button on transaction details screen if the address is not added yet

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context