### PR TITLE
fix: reorder available actions to prioritize swap

### DIFF
--- a/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
+++ b/VultisigApp/VultisigApp/Services/Actions/Coin+ChainAction.swift
@@ -25,8 +25,13 @@ extension CoinAction {
 
 extension Chain {
     var defaultActions: [CoinAction] {
-        var actions: [CoinAction] = [.send] // always include send
         
+        var actions: [CoinAction] = []
+        
+        if CoinAction.swapChains.contains(self) {
+            actions.append(.swap)
+        }
+        actions.append(.send) // always include send
         let hasBuyEnabledSet = UserDefaults.standard.value(forKey: "BuyEnabled")
         // when hasBuyEnabledSet has not been set , set it to true
         if hasBuyEnabledSet == nil {
@@ -41,9 +46,6 @@ extension Chain {
             actions.append(.sell)
         }
         
-        if CoinAction.swapChains.contains(self) {
-            actions.append(.swap)
-        }
         if CoinAction.memoChains.contains(self) {
             actions.append(.memo)
         }

--- a/VultisigApp/VultisigApp/View Models/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/VaultDetailViewModel.swift
@@ -26,7 +26,7 @@ class VaultDetailViewModel: ObservableObject {
     private var updateBalanceTask: Task<Void, Never>?
     
     var availableActions: [CoinAction] {
-        [.send,.buy,.swap, .receive].filtered
+        [.swap,.send,.buy,.receive].filtered
     }
     
     func updateBalance(vault: Vault) {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #3127 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Swap now only appears on supported chains, eliminating inconsistent or duplicate action availability.

- Refactor
  - Reordered available actions to prioritize Swap, followed by Send, Buy, and Receive for a more consistent, user-friendly layout across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->