### PR TITLE
feat: add address validation for token fetching in CustomTokenScreen

### DIFF
--- a/VultisigApp/VultisigApp/Features/TokenSelection/Screens/CustomTokenScreen.swift
+++ b/VultisigApp/VultisigApp/Features/TokenSelection/Screens/CustomTokenScreen.swift
@@ -144,6 +144,13 @@ struct CustomTokenScreen: View {
     
     private func fetchTokenInfo() async {
         guard !contractAddress.isEmpty else { return }
+        
+        // Validate address format before making API calls
+        guard isValidAddress else {
+            error = InvalidAddressError()
+            return
+        }
+        
         isLoading = true
         showTokenInfo = false
         error = nil
@@ -244,6 +251,12 @@ struct CustomTokenScreen: View {
     private struct RateLimitError: LocalizedError {
         var errorDescription: String? {
             return NSLocalizedString("Too many requests. Please close this screen and try again later.", comment: "Rate limit error")
+        }
+    }
+    
+    private struct InvalidAddressError: LocalizedError {
+        var errorDescription: String? {
+            return NSLocalizedString("invalidAddress", comment: "Invalid address error")
         }
     }
     

--- a/VultisigApp/VultisigApp/Views/Swap/SwapCustomTokenView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCustomTokenView.swift
@@ -138,6 +138,13 @@ struct SwapCustomTokenView: View {
     
     private func fetchTokenInfo() async {
         guard !contractAddress.isEmpty else { return }
+        
+        // Validate address format before making API calls
+        guard isValidAddress else {
+            error = InvalidAddressError()
+            return
+        }
+        
         isLoading = true
         showTokenInfo = false
         error = nil
@@ -240,6 +247,12 @@ struct SwapCustomTokenView: View {
     private struct RateLimitError: LocalizedError {
         var errorDescription: String? {
             return NSLocalizedString("Too many requests. Please close this screen and try again later.", comment: "Rate limit error")
+        }
+    }
+    
+    private struct InvalidAddressError: LocalizedError {
+        var errorDescription: String? {
+            return NSLocalizedString("invalidAddress", comment: "Invalid address error")
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom Token and Swap custom token screens now validate the contract address before fetching data. If the address is invalid, an immediate, localized “invalid address” error is shown and the request is stopped.
  * Prevents unnecessary network calls and eliminates misleading loading or partial results for invalid inputs, improving responsiveness and clarity during token lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->