### PR TITLE
fix: hide Defi tab for 1.27.18

### DIFF
--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -83,7 +83,7 @@ struct HomeScreen: View {
             ZStack(alignment: .top) {
                 VultiTabBar(
                     selectedItem: $selectedTab,
-                    items: [HomeTab.wallet, .defi],
+                    items: [HomeTab.wallet],
                     accessory: .camera,
                 ) { tab in
                     Group {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed the Defi tab from the main navigation, streamlining the interface to focus on core wallet features and simplifying the user experience by eliminating secondary navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->