### PR TITLE
fix: Balance fetching adjustments

### DIFF
--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -34,6 +34,7 @@ struct HomeScreen: View {
     @State var walletShowPortfolioHeader: Bool = false
     @State var defiShowPortfolioHeader: Bool = false
     @State var showPortfolioHeader: Bool = false
+    @State var shouldRefresh: Bool = false
     
     @EnvironmentObject var vaultDetailViewModel: VaultDetailViewModel
     @EnvironmentObject var deeplinkViewModel: DeeplinkViewModel
@@ -100,7 +101,8 @@ struct HomeScreen: View {
                                 addressToCopy: $addressToCopy,
                                 showUpgradeVaultSheet: $showUpgradeVaultSheet,
                                 showBackupNow: $showBackupNow,
-                                showBalanceInHeader: $walletShowPortfolioHeader
+                                showBalanceInHeader: $walletShowPortfolioHeader,
+                                shouldRefresh: $shouldRefresh
                             )
                         case .defi:
                             DefiMainScreen(
@@ -205,7 +207,7 @@ struct HomeScreen: View {
             showBalance: $showPortfolioHeader,
             vaultSelectorAction: { showVaultSelector.toggle() },
             settingsAction: { vaultRoute = .settings },
-            onRefresh: {}
+            onRefresh: { shouldRefresh = true }
         )
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -76,6 +76,7 @@ struct ChainDetailScreen: View {
         }
         .onLoad {
             viewModel.refresh(group: group)
+            refresh()
         }
         .navigationDestination(isPresented: $showAction) {
             if let vaultAction {

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -15,6 +15,7 @@ struct VaultMainScreen: View {
     @Binding var showUpgradeVaultSheet: Bool
     @Binding var showBackupNow: Bool
     @Binding var showBalanceInHeader: Bool
+    @Binding var shouldRefresh: Bool
     
     @Environment(\.modelContext) var modelContext
     @EnvironmentObject var viewModel: VaultDetailViewModel
@@ -98,6 +99,11 @@ struct VaultMainScreen: View {
             refresh()
         }
         .onChange(of: vault) { oldValue, newValue in
+            refresh()
+        }
+        .onChange(of: shouldRefresh) { oldValue, newValue in
+            guard newValue else { return }
+            shouldRefresh = false
             refresh()
         }
     }
@@ -279,7 +285,8 @@ struct VaultMainScreen: View {
         addressToCopy: .constant(nil),
         showUpgradeVaultSheet: .constant(false),
         showBackupNow: .constant(false),
-        showBalanceInHeader: .constant(false)
+        showBalanceInHeader: .constant(false),
+        shouldRefresh: .constant(false)
     )
     .environmentObject(HomeViewModel())
     .environmentObject(VaultDetailViewModel())

--- a/VultisigApp/VultisigApp/Services/BalanceService.swift
+++ b/VultisigApp/VultisigApp/Services/BalanceService.swift
@@ -100,7 +100,7 @@ private extension BalanceService {
             }
             
             // Handle TCY staked balance (includes both regular and auto-compound)
-            if coin.ticker.localizedCaseInsensitiveContains("tcy") {
+            if coin.ticker.caseInsensitiveCompare("TCY") == .orderedSame {
                 let service = ThorchainServiceFactory.getService(for: coin.chain)
                 let tcyStakedBalance = await service.fetchTcyStakedAmount(address: coin.address)
                 


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes

- fetch balances on ChainDetailScreen onLoad 
- added missing refresh on homescreen for macOS

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual refresh option from the home screen.

* **Bug Fixes**
  * Improved balance calculation accuracy for certain tokens.
  * Fixed automatic chain detail refresh on view load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->