### PR TITLE
fix: disable percentage buttons during loading and fee calculation in…

### DIFF
--- a/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
+++ b/VultisigApp/VultisigApp/Views/Components/Send/SendDetailsAmountTab.swift
@@ -101,30 +101,36 @@ struct SendDetailsAmountTab: View {
     }
     
     var percentageButtons: some View {
-        HStack(spacing: 12) {
+        let isDisabled = sendCryptoViewModel.isLoading || tx.isCalculatingFee
+        
+        return HStack(spacing: 12) {
             Button {
                 sendCryptoViewModel.setMaxValues(tx: tx, percentage: 25)
             } label: {
                 getPercentageButtons(for: "25%")
             }
+            .disabled(isDisabled)
             
             Button {
                 sendCryptoViewModel.setMaxValues(tx: tx, percentage: 50)
             } label: {
                 getPercentageButtons(for: "50%")
             }
+            .disabled(isDisabled)
             
             Button {
                 sendCryptoViewModel.setMaxValues(tx: tx, percentage: 75)
             } label: {
                 getPercentageButtons(for: "75%")
             }
+            .disabled(isDisabled)
             
             Button {
                 sendCryptoViewModel.setMaxValues(tx: tx)
             } label: {
                 getPercentageButtons(for: "Max")
             }
+            .disabled(isDisabled)
         }
     }
     
@@ -154,13 +160,16 @@ struct SendDetailsAmountTab: View {
     }
     
     private func getPercentageButtons(for value: String) -> some View {
-        Text(value)
-            .foregroundColor(Theme.colors.textPrimary)
+        let isDisabled = sendCryptoViewModel.isLoading || tx.isCalculatingFee
+        
+        return Text(value)
+            .foregroundColor(isDisabled ? Theme.colors.textExtraLight : Theme.colors.textPrimary)
             .padding(4)
             .frame(maxWidth: .infinity)
             .overlay(
                 RoundedRectangle(cornerRadius: 32)
-                    .stroke(Theme.colors.bgTertiary, lineWidth: 1)
+                    .stroke(isDisabled ? Theme.colors.bgTertiary.opacity(0.5) : Theme.colors.bgTertiary, lineWidth: 1)
             )
+            .opacity(isDisabled ? 0.5 : 1.0)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Percentage amount buttons (25%, 50%, 75%, Max) are now disabled during loading and fee calculation, preventing unintended interactions while operations are in progress.
  * Enhanced visual feedback for disabled state with adjusted colors and reduced opacity for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->