### PR TITLE
fix: Defi balances adjustments

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -340,6 +340,8 @@
 		13C02C5D2EA667AC00C12071 /* DefiTHORChainStakedPositionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C02C5C2EA6679C00C12071 /* DefiTHORChainStakedPositionView.swift */; };
 		13C02C5F2EA667DB00C12071 /* StakePosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C02C5E2EA667D600C12071 /* StakePosition.swift */; };
 		13C02C612EA6699C00C12071 /* AmountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C02C602EA6699900C12071 /* AmountFormatter.swift */; };
+		13C0F79A2EC60C3A00C2A3B8 /* DefiBalanceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C0F7992EC60C3700C2A3B8 /* DefiBalanceService.swift */; };
+		13C0F79F2EC60FE500C2A3B8 /* DefiPositionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C0F79E2EC60FDA00C2A3B8 /* DefiPositionsService.swift */; };
 		13C232692E68A95900DB42D0 /* AddressQRCodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C232682E68A95100DB42D0 /* AddressQRCodeScannerView.swift */; };
 		13C320032E61F8DB00255138 /* ReferralVaultSelectionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C320022E61F8D500255138 /* ReferralVaultSelectionScreen.swift */; };
 		13C7C1DC2E86DD8F00A529FD /* TokenSelectionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C7C1DB2E86DD8900A529FD /* TokenSelectionScreen.swift */; };
@@ -1521,6 +1523,8 @@
 		13C02C5C2EA6679C00C12071 /* DefiTHORChainStakedPositionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefiTHORChainStakedPositionView.swift; sourceTree = "<group>"; };
 		13C02C5E2EA667D600C12071 /* StakePosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakePosition.swift; sourceTree = "<group>"; };
 		13C02C602EA6699900C12071 /* AmountFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountFormatter.swift; sourceTree = "<group>"; };
+		13C0F7992EC60C3700C2A3B8 /* DefiBalanceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefiBalanceService.swift; sourceTree = "<group>"; };
+		13C0F79E2EC60FDA00C2A3B8 /* DefiPositionsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefiPositionsService.swift; sourceTree = "<group>"; };
 		13C232682E68A95100DB42D0 /* AddressQRCodeScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressQRCodeScannerView.swift; sourceTree = "<group>"; };
 		13C320022E61F8D500255138 /* ReferralVaultSelectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralVaultSelectionScreen.swift; sourceTree = "<group>"; };
 		13C7C1DB2E86DD8900A529FD /* TokenSelectionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSelectionScreen.swift; sourceTree = "<group>"; };
@@ -3217,6 +3221,8 @@
 		1385E63B2EC271E500CE634F /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				13C0F79E2EC60FDA00C2A3B8 /* DefiPositionsService.swift */,
+				13C0F7992EC60C3700C2A3B8 /* DefiBalanceService.swift */,
 				1385E63C2EC271F100CE634F /* DefiPositionsStorageService.swift */,
 			);
 			path = Service;
@@ -6328,6 +6334,7 @@
 				A623A09F2BF09FEE00AA2F8D /* NewWalletNameView.swift in Sources */,
 				13A9641C2EBBEB020025FB7A /* RUJIWithdrawRewardsTransactionBuilder.swift in Sources */,
 				A6C0D5652BB3BD0F00156689 /* UTXOTransactionCell.swift in Sources */,
+				13C0F79A2EC60C3A00C2A3B8 /* DefiBalanceService.swift in Sources */,
 				A65649F82B96701300E4B329 /* UTXOTransactionMempoolPreviousOutput.swift in Sources */,
 				13AC28082E61E294001CB9AA /* ScreenEdgeInsets.swift in Sources */,
 				137B2C892E3A84460074F648 /* Screen.swift in Sources */,
@@ -6519,6 +6526,7 @@
 				A6966D312BA4048800903CA4 /* SwapCryptoDetailsView.swift in Sources */,
 				13A657AC2EA283FA00323E4C /* THORChainPositionType.swift in Sources */,
 				139450602EC37BAE006AEE94 /* RemoveLPTransactionBuilder.swift in Sources */,
+				13C0F79F2EC60FE500C2A3B8 /* DefiPositionsService.swift in Sources */,
 				A5F97C8E2BBF0BCF000C30DF /* BalanceService.swift in Sources */,
 				137B2C872E3A84130074F648 /* OnChainSecurityScreen.swift in Sources */,
 				DEEDAEE12B8AF7EF005170E8 /* evm.swift in Sources */,

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiBalanceService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiBalanceService.swift
@@ -1,0 +1,47 @@
+//
+//  DefiBalanceService.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 13/11/2025.
+//
+
+import Foundation
+
+struct DefiBalanceService {
+    func totalBalanceInFiatString(for chain: Chain, vault: Vault) -> String {
+        let balanceDecimal = totalBalanceInFiat(for: chain, vault: vault)
+        return balanceDecimal.formatToFiat(includeCurrencySymbol: true, useAbbreviation: true)
+    }
+    
+    func totalBalanceInFiat(for chain: Chain, vault: Vault) -> Decimal {
+        switch chain {
+        case .thorChain:
+            thorChainTotalBalanceFiatDecimal(for: vault)
+        default:
+            defaultTotalBalanceFiatDecimal(chain: chain, for: vault)
+        }
+    }
+}
+
+private extension DefiBalanceService {
+    func thorChainTotalBalanceFiatDecimal(for vault: Vault) -> Decimal {
+        guard let runeCoin = vault.runeCoin else { return .zero }
+        let coinBalances = defaultTotalBalanceFiatDecimal(chain: .thorChain, for: vault)
+        let lpBalances: Decimal = vault.lpPositions
+            .map { runeCoin.fiat(decimal: $0.coin1Amount) }
+            .reduce(Decimal.zero, +)
+        return coinBalances + lpBalances
+    }
+    
+    func defaultTotalBalanceFiatDecimal(chain: Chain, for vault: Vault) -> Decimal {
+        let coins = vault.coins
+            .filter { $0.chain == chain }
+            .filter { coin in
+                let coinMeta = coin.toCoinMeta()
+                return vault.stakePositions.map(\.coin).contains(coinMeta) || vault.bondPositions.map(\.node.coin).contains(coinMeta)
+            }
+        
+        let coinBalances = coins.map(\.defiBalanceInFiatDecimal)
+        return coinBalances.reduce(Decimal(0), { $0 + $1 })
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
@@ -1,0 +1,36 @@
+//
+//  DefiPositionsService.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 13/11/2025.
+//
+
+struct DefiPositionsService {
+    func positionCoins(for chain: Chain) -> [CoinMeta] {
+        bondCoins(for: chain) + stakeCoins(for: chain)
+    }
+    
+    func bondCoins(for chain: Chain) -> [CoinMeta] {
+        switch chain {
+        case .thorChain:
+            [TokensStore.rune]
+        default:
+            []
+        }
+    }
+    
+    func stakeCoins(for chain: Chain) -> [CoinMeta] {
+        switch chain {
+        case .thorChain:
+            [
+                TokensStore.tcy,
+                TokensStore.ruji,
+                TokensStore.stcy,
+                TokensStore.yrune,
+                TokensStore.ytcy
+            ]
+        default:
+            []
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/View/DefiChainCellView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/View/DefiChainCellView.swift
@@ -13,11 +13,17 @@ struct DefiChainCellView: View {
     
     @EnvironmentObject var homeViewModel: HomeViewModel
     
+    private let service = DefiBalanceService()
+    
+    var balanceFiat: String {
+        service.totalBalanceInFiatString(for: group.chain, vault: vault)
+    }
+    
     var body: some View {
         GroupedChainCellView(
             group: group,
             vault: vault,
-            fiatBalance: { group.defiBalanceInFiatString },
+            fiatBalance: { balanceFiat },
             cryptoBalance: { group.nativeCoin.defiBalanceStringWithTicker }
         )
         .buttonStyle(.plain)

--- a/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/DefiTHORChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/DefiTHORChainMainScreen.swift
@@ -31,7 +31,7 @@ struct DefiTHORChainMainScreen: View {
     var body: some View {
         ScrollView(showsIndicators: false) {
             LazyVStack(spacing: 16) {
-                DefiTHORChainBalanceView(groupedChain: group)
+                DefiTHORChainBalanceView(vault: vault, groupedChain: group)
                 positionsSegmentedControlView
                 selectedPositionView
             }
@@ -161,6 +161,15 @@ struct DefiTHORChainMainScreen: View {
             coin = TokensStore.rune
         }
         return coin
+    }
+    
+    func stakeCoin(for coin: CoinMeta) -> CoinMeta {
+        switch coin {
+        case TokensStore.stcy:
+            return TokensStore.tcy
+        default:
+            return coin
+        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/View/LPs/DefiTHORChainLPPositionView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/View/LPs/DefiTHORChainLPPositionView.swift
@@ -71,7 +71,7 @@ struct DefiTHORChainLPPositionView: View {
                 .foregroundStyle(Theme.colors.textExtraLight)
             Spacer()
             
-            Text(position.apr.formatted(.percent))
+            Text(position.apr.formatted(.percent.precision(.fractionLength(2))))
                 .font(Theme.fonts.bodyMMedium)
                 .foregroundStyle(Theme.colors.alertSuccess)
         }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/View/Main/DefiTHORChainBalanceView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/View/Main/DefiTHORChainBalanceView.swift
@@ -8,9 +8,15 @@
 import SwiftUI
 
 struct DefiTHORChainBalanceView: View {
+    @ObservedObject var vault: Vault
     let groupedChain: GroupedChain
     
     @EnvironmentObject var homeViewModel: HomeViewModel
+    
+    let service = DefiBalanceService()
+    var balance: String {
+        service.totalBalanceInFiatString(for: .thorChain, vault: vault)
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -23,7 +29,7 @@ struct DefiTHORChainBalanceView: View {
                 .font(Theme.fonts.caption12)
                 .padding(.top, 12)
             
-            HiddenBalanceText(groupedChain.defiBalanceInFiatString)
+            HiddenBalanceText(balance)
                 .foregroundStyle(Theme.colors.textPrimary)
                 .font(Theme.fonts.priceTitle1)
                 .contentTransition(.numericText())
@@ -69,6 +75,6 @@ struct DefiTHORChainBalanceView: View {
         count: 3,
         coins: [Coin.example]
     )
-    DefiTHORChainBalanceView(groupedChain: groupedChain)
+    DefiTHORChainBalanceView(vault: .example, groupedChain: groupedChain)
         .environmentObject(HomeViewModel())
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/ViewModel/DefiTHORChainMainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/ViewModel/DefiTHORChainMainViewModel.swift
@@ -64,14 +64,9 @@ final class DefiTHORChainMainViewModel: ObservableObject {
     }
     
     func setupThorchainPositions() async {
-        let bond = [TokensStore.rune]
-        let staking = [
-            TokensStore.tcy,
-            TokensStore.ruji,
-            TokensStore.stcy,
-            TokensStore.yrune,
-            TokensStore.ytcy
-        ]
+        let positionsService = DefiPositionsService()
+        let bond = positionsService.bondCoins(for: .thorChain)
+        let staking = positionsService.stakeCoins(for: .thorChain)
         let pools = (try? await thorchainService.getPools()) ?? []
         let lps = pools.compactMap { THORChainAssetFactory.createCoin(from: $0.asset) }
         

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -113,7 +113,7 @@ class Coin: ObservableObject, Codable, Hashable {
     }
     
     var defiBalanceString: String {
-        return stakedBalanceDecimal.formatForDisplay()
+        return defiBalanceDecimal.formatForDisplay()
     }
     
     var defiBalanceStringWithTicker: String {
@@ -295,8 +295,7 @@ class Coin: ObservableObject, Codable, Hashable {
     }
     
     var defiBalanceInFiatDecimal: Decimal {
-        let combined = stakedBalanceDecimal
-        let fiat = RateProvider.shared.fiatBalance(value: combined, coin: self)
+        let fiat = RateProvider.shared.fiatBalance(value: defiBalanceDecimal, coin: self)
         return fiat
     }
     
@@ -373,5 +372,27 @@ private extension Coin {
         case isNativeToken
         case hexPublicKey
         case address
+    }
+}
+
+// MARK: - Defi
+
+extension Coin {
+    var defiBalanceDecimal: Decimal {
+        switch chain {
+        case .thorChain:
+            return thorchainDefiBalanceDecimal
+        default:
+            return stakedBalanceDecimal
+        }
+    }
+    
+    var thorchainDefiBalanceDecimal: Decimal {
+        switch ticker.uppercased() {
+        case "STCY", "YRUNE", "YTCY":
+            return balanceDecimal
+        default:
+            return stakedBalanceDecimal
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -30,7 +30,9 @@ final class Vault: ObservableObject, Codable {
     @Relationship(deleteRule: .cascade) var hiddenTokens = [HiddenToken]()
     @Relationship(deleteRule: .cascade) var referralCode: ReferralCode?
     @Relationship(deleteRule: .cascade) var referredCode: ReferredCode?
+    // Visible Defi Positions
     @Relationship(deleteRule: .cascade) var defiPositions: [DefiPositions] = []
+    // Defi Positions Data for caching
     @Relationship(deleteRule: .cascade) var bondPositions: [BondPosition] = []
     @Relationship(deleteRule: .cascade) var stakePositions: [StakePosition] = []
     @Relationship(deleteRule: .cascade) var lpPositions: [LPPosition] = []
@@ -128,7 +130,7 @@ final class Vault: ObservableObject, Codable {
     }
 
     func nativeCoin(for coin: Coin) -> Coin? {
-        return coins.first(where: { $0.chain == coin.chain && $0.isNativeToken })
+        nativeCoin(for: coin.chain)
     }
     
     func nativeCoin(for chain: Chain) -> Coin? {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

- Using balance or stakedBalance based on coin ticker
- Added LPs to total balance
- Added convenience methods to extend Defi tab to other chains

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced improved DeFi balance calculation services for more accurate fiat value display across supported chains.
  * Dynamically load bond and staking positions based on chain configuration.

* **Bug Fixes**
  * Updated APR display to show two decimal places for improved precision.

* **Refactor**
  * Refactored balance display logic in DeFi views for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->