### PR TITLE
fix: autocompound toggle for TCY staking

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/DefiTHORChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiTHORChain/DefiTHORChainMainScreen.swift
@@ -135,7 +135,7 @@ struct DefiTHORChainMainScreen: View {
     func onStake(position: StakePosition) {
         switch position.type {
         case .stake, .compound:
-            transactionToPresent = .stake(coin: position.coin)
+            transactionToPresent = .stake(coin: stakeCoin(for: position.coin), defaultAutocompound: defaultAutocompound(for: position.coin))
         case .index:
             transactionToPresent = .mint(coin: coin(for: position.coin), yCoin: position.coin)
         }
@@ -144,7 +144,7 @@ struct DefiTHORChainMainScreen: View {
     func onUnstake(position: StakePosition) {
         switch position.type {
         case .stake, .compound:
-            transactionToPresent = .unstake(coin: position.coin)
+            transactionToPresent = .unstake(coin: stakeCoin(for: position.coin), defaultAutocompound: defaultAutocompound(for: position.coin))
         case .index:
             transactionToPresent = .redeem(coin: coin(for: position.coin), yCoin: position.coin)
         }
@@ -169,6 +169,15 @@ struct DefiTHORChainMainScreen: View {
             return TokensStore.tcy
         default:
             return coin
+        }
+    }
+    
+    func defaultAutocompound(for coin: CoinMeta) -> Bool {
+        switch coin {
+        case TokensStore.stcy:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Model/FunctionTransactionType.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Model/FunctionTransactionType.swift
@@ -10,8 +10,8 @@ import Foundation
 enum FunctionTransactionType: Hashable {
     case bond(node: String?)
     case unbond(node: BondNode)
-    case stake(coin: CoinMeta)
-    case unstake(coin: CoinMeta)
+    case stake(coin: CoinMeta, defaultAutocompound: Bool)
+    case unstake(coin: CoinMeta, defaultAutocompound: Bool)
     case withdrawRewards(coin: CoinMeta, rewards: Decimal, rewardsCoin: CoinMeta)
     case mint(coin: CoinMeta, yCoin: CoinMeta)
     case redeem(coin: CoinMeta, yCoin: CoinMeta)

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -43,17 +43,17 @@ struct FunctionTransactionScreen: View {
                         onVerify: onVerify
                     )
                 }
-            case .stake(let coin):
+            case .stake(let coin, let defaultAutocompound):
                 resolvingCoin(coinMeta: coin) {
                     StakeTransactionScreen(
-                        viewModel: StakeTransactionViewModel(coin: $0, vault: vault),
+                        viewModel: StakeTransactionViewModel(coin: $0, vault: vault, defaultAutocompound: defaultAutocompound),
                         onVerify: onVerify
                     )
                 }
-            case .unstake(let coin):
+            case .unstake(let coin, let defaultAutocompound):
                 resolvingCoin(coinMeta: coin) {
                     UnstakeTransactionScreen(
-                        viewModel: UnstakeTransactionViewModel(coin: $0, vault: vault),
+                        viewModel: UnstakeTransactionViewModel(coin: $0, vault: vault, defaultAutocompound: defaultAutocompound),
                         onVerify: onVerify
                     )
                 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Stake/StakeTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Stake/StakeTransactionScreen.swift
@@ -47,7 +47,8 @@ struct StakeTransactionScreen: View {
     StakeTransactionScreen(
         viewModel: StakeTransactionViewModel(
             coin: .example,
-            vault: .example
+            vault: .example,
+            defaultAutocompound: false
         )
     ) { _ in }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Stake/StakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Stake/StakeTransactionViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 final class StakeTransactionViewModel: ObservableObject, Form {
     let coin: Coin
     let vault: Vault
+    let defaultAutocompound: Bool
     
     var supportsAutocompound: Bool {
         coin.supportsAutocompound
@@ -33,14 +34,16 @@ final class StakeTransactionViewModel: ObservableObject, Form {
     var formCancellable: AnyCancellable?
     var cancellables = Set<AnyCancellable>()
     
-    init(coin: Coin, vault: Vault) {
+    init(coin: Coin, vault: Vault, defaultAutocompound: Bool) {
         self.coin = coin
         self.vault = vault
+        self.defaultAutocompound = defaultAutocompound
     }
     
     func onLoad() {
         setupForm()
         amountField.validators.append(AmountBalanceValidator(balance: coin.balanceDecimal))
+        isAutocompound = defaultAutocompound
     }
     
     var transactionBuilder: TransactionBuilder? {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Unstake/UnstakeTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Unstake/UnstakeTransactionScreen.swift
@@ -69,7 +69,8 @@ struct AutocompoundToggle: View {
     UnstakeTransactionScreen(
         viewModel: UnstakeTransactionViewModel(
             coin: .example,
-            vault: .example
+            vault: .example,
+            defaultAutocompound: false
         )
     ) { _ in }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Unstake/UnstakeTransactionViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 final class UnstakeTransactionViewModel: ObservableObject, Form {
     let coin: Coin
     let vault: Vault
+    let defaultAutocompound: Bool
     
     var supportsAutocompound: Bool {
         coin.supportsAutocompound
@@ -31,10 +32,12 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     var formCancellable: AnyCancellable?
     var cancellables = Set<AnyCancellable>()
     
-    init(coin: Coin, vault: Vault) {
+    init(coin: Coin, vault: Vault, defaultAutocompound: Bool) {
         self.coin = coin
         self.vault = vault
+        self.defaultAutocompound = defaultAutocompound
     }
+    
     
     func onLoad() {
         setupForm()
@@ -47,6 +50,7 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
                 viewModel.updateAvailableBalance()
             }
             .store(in: &cancellables)
+        isAutocompound = defaultAutocompound
     }
     
     var transactionBuilder: TransactionBuilder? {


### PR DESCRIPTION
## Description

Fixes #3369

- Redirect to TCY staking screen with auto-compound toggle ON when coming from sTCY

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the staking and unstaking transaction flow to support coin-specific auto-compounding settings. Default auto-compounding behavior is now determined dynamically based on the asset being transacted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->