### PR TITLE
fix: Prevent Fast Vault password persistence and improve error report…

### DIFF
--- a/VultisigApp/VultisigApp/View Models/KeysignDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/KeysignDiscoveryViewModel.swift
@@ -142,7 +142,11 @@ class KeysignDiscoveryViewModel: ObservableObject {
                 vaultPassword: fastVaultPassword
             ) { isSuccess in
                 if !isSuccess {
+                    self.logger.error("Fast Vault signing failed")
                     self.status = .FailToStart
+                    self.errorMessage = "Fast Vault signing failed. Please check your password or try Paired Sign by long-pressing the button."
+                } else {
+                    self.logger.info("Fast Vault signing initiated successfully")
                 }
             }
             

--- a/VultisigApp/VultisigApp/View Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/View Models/SendTransaction.swift
@@ -217,6 +217,7 @@ class SendTransaction: ObservableObject, Hashable {
         self.wasmContractPayload = nil  // Clear contract payload
         self.transactionType = .unspecified  // Reset transaction type
         self.memoFunctionDictionary = ThreadSafeDictionary()  // Clear memo functions
+        self.fastVaultPassword = .empty  // Clear password state
     }
     
     func parseCryptoURI(_ uri: String) {

--- a/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallVerifyScreen.swift
@@ -38,6 +38,10 @@ struct FunctionCallVerifyScreen: View {
         }
         .onDisappear {
             depositVerifyViewModel.isLoading = false
+            // Clear password if navigating back (not forward to keysign)
+            if keysignPayload == nil {
+                tx.fastVaultPassword = .empty
+            }
         }
         .alert(item: $error) { error in
             Alert(
@@ -101,6 +105,8 @@ struct FunctionCallVerifyScreen: View {
                     title: NSLocalizedString("signTransaction", comment: "")) {
                         fastPasswordPresented = true
                     } longPressAction: {
+                        // Clear password for paired sign (long press)
+                        tx.fastVaultPassword = .empty
                         onSignPress()
                     }
                     .crossPlatformSheet(isPresented: $fastPasswordPresented) {

--- a/VultisigApp/VultisigApp/Views/Keygen/FastVaultEnterPasswordView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/FastVaultEnterPasswordView.swift
@@ -121,7 +121,11 @@ struct FastVaultEnterPasswordView: View {
                 onSubmit?()
                 dismiss()
             },
-            onError: nil)
+            onError: { error in
+                // Log authentication error - don't fail silently
+                print("Fast Vault authentication error: \(error.localizedDescription)")
+                // Error is shown by system dialog, no need to show another alert
+            })
     }
 }
 

--- a/VultisigApp/VultisigApp/Views/Send/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Send/Screens/SendVerifyScreen.swift
@@ -50,6 +50,10 @@ struct SendVerifyScreen: View {
         }
         .onDisappear {
             sendCryptoVerifyViewModel.isLoading = false
+            // Clear password if navigating back (not forward to keysign)
+            if keysignPayload == nil {
+                tx.fastVaultPassword = .empty
+            }
         }
         .navigationDestination(item: $keysignPayload) { payload in
             SendRouteBuilder().buildPairScreen(
@@ -133,6 +137,8 @@ struct SendVerifyScreen: View {
                 LongPressPrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
                     fastPasswordPresented = true
                 } longPressAction: {
+                    // Clear password for paired sign (long press)
+                    tx.fastVaultPassword = .empty
                     onSignPress()
                 }
                 .crossPlatformSheet(isPresented: $fastPasswordPresented) {

--- a/VultisigApp/VultisigApp/Views/Swap/SwapVerifyView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapVerifyView.swift
@@ -32,6 +32,10 @@ struct SwapVerifyView: View {
         }
         .onDisappear {
             swapViewModel.isLoading = false
+            // Clear password if navigating back (not forward to keysign)
+            if swapViewModel.keysignPayload == nil {
+                tx.fastVaultPassword = .empty
+            }
         }
         .onLoad {
             referredViewModel.setData()
@@ -200,6 +204,8 @@ struct SwapVerifyView: View {
             LongPressPrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
                 fastPasswordPresented = true
             } longPressAction: {
+                // Clear password for paired sign (long press)
+                tx.fastVaultPassword = .empty
                 onSignPress()
             }
             .disabled(signButtonDisabled)


### PR DESCRIPTION
# Fix Mac Fast Sign Infinite Loop & Mode Switching Bug
https://github.com/vultisig/vultisig-ios/issues/3516

## Description
This PR fixes a critical bug on macOS where the Fast Sign flow would enter an infinite authentication loop, and users were unable to switch from "Fast Sign" (tap) to "Paired Sign" (long press) once a password had been entered.

## The Problem
The core issue was caused by persistent state in the `SendTransaction` object (specifically `fastVaultPassword`) acting like a "zombie" state:

1.  **State Persistence**: When a user attempted Fast Sign, the `fastVaultPassword` was set in the transaction model. If the signing failed or the user navigated back, this password **remained set** in the model.
2.  **Mode Switching Failure**: The "Sign" button logic checks for the presence of `fastVaultPassword` to decide whether to execute the Fast Sign flow or the Paired Sign flow. Because the password wasn't being cleared, even when the user explicitly Long Pressed for "Paired Sign", the app detected the existing password and forced the "Fast Sign" logic again.
3.  **Infinite Loop**: This created a loop where the app would repeatedly prompt for authentication or fail silently, as it kept trying to use the stale or rejected Fast Sign state instead of resetting or allowing the user to switch modes.

## The Solution
We implemented a strict state cleanup strategy to ensure the "clipboard" is wiped clean when necessary:

1.  **Explicit Clear on Mode Switch**: Added logic to explicitly set `tx.fastVaultPassword = .empty` when the user triggers the **Long Press** action. This forces the app to recognize the user's intent to use Paired Sign.
2.  **Navigation Cleanup**: Added `onDisappear` cleanup to clear the password when the user navigates back from the Verify screen, preventing dirty state from affecting future attempts.
3.  **Transaction Reset**: Updated the `SendTransaction.reset()` method to ensure the password field is cleared when a transaction is fully reset.
4.  **Error Handling**: Added missing error logging to the `BiometryService` and `KeysignDiscoveryViewModel` to prevent silent failures during the authentication process.

## Changes
- **Verify Screens** (`SendVerifyScreen`, `SwapVerifyView`, `FunctionCallVerifyScreen`): Added password clearing logic to the `LongPressPrimaryButton` action and `onDisappear`.
- **FastVaultEnterPasswordView**: Added error callback to `biometryService.authenticate` to log failures instead of ignoring them.
- **KeysignDiscoveryViewModel**: Added user-facing error messages when Fast Vault signing fails.
- **SendTransaction**: Added `fastVaultPassword = .empty` to the `reset()` method.

## How to Test
1.  **Verify Mode Switching**:
    *   Start a Fast Vault transaction.
    *   Tap "Sign" and enter the password (do not complete signing).
    *   Go back or stay on screen.
    *   **Long Press** "Sign".
    *   **Result**: The app should correctly initiate the **Paired Sign** flow (QR code) instead of looping back to Fast Sign.

2.  **Verify Fast Sign Loop**:
    *   Attempt Fast Sign on macOS.
    *   **Result**: If authentication fails or is cancelled, the app should now handle the state correctly without entering an infinite loop of password prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for Fast Vault signing failures, guiding users toward recovery options
  * Ensured password state is properly cleared during screen navigation and paired signing workflows
  * Enhanced error logging for biometric authentication to support better issue diagnosis and troubleshooting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->