### PR TITLE
Fix: RUJI/sRUJI 0$ Price Bug on macOS/iOS

### DIFF
--- a/VultisigApp/VultisigApp/Services/CryptoPriceService.swift
+++ b/VultisigApp/VultisigApp/Services/CryptoPriceService.swift
@@ -189,8 +189,17 @@ private extension CryptoPriceService {
                     let rate: Rate = .init(fiat: "usd", crypto: contract, value: price ?? 0.0)
                     rates.append(rate)
                 } else {
-                    let sanitisedContract = contract.uppercased().replacingOccurrences(of: "X/", with: "")
-                    let poolPrice = await thorService.getAssetPriceInUSD(assetName: sanitisedContract)
+                    var sanitisedContract = contract.uppercased().replacingOccurrences(of: "X/", with: "")
+                    
+                    // Handle staking assets mappings to their underlying asset for price
+                    if sanitisedContract.starts(with: "STAKING-") {
+                        sanitisedContract = sanitisedContract.replacingOccurrences(of: "STAKING-", with: "")
+                    }
+                    
+                    // Ensure we have the THOR. prefix for the pool lookup
+                    let assetName = sanitisedContract.contains(".") ? sanitisedContract : "THOR.\(sanitisedContract)"
+                    
+                    let poolPrice = await thorService.getAssetPriceInUSD(assetName: assetName)
                     let poolRate: Rate = .init(fiat: "usd", crypto: contract, value: poolPrice)
                     rates.append(poolRate)
                 }


### PR DESCRIPTION
## Description
Fixes a bug where RUJI and sRUJI staked assets showed 0$ value on macOS/iOS.

## Cause
The fallback price lookup mechanism for Thorchain assets (used when CoinGecko ID is missing or invalid) was incorrectly formatting the asset name. It was sending raw ticker names (e.g. "RUJI") instead of the required pool format "THOR.RUJI". It also failed to map staking assets (prefix "x/staking-") to their underlying pricing assets.

## Changes
- Updated `CryptoPriceService.swift` to:
  - Sanitize contract addresses by removing "X/" and "STAKING-" prefixes.
  - Ensure the "THOR." chain prefix is added to asset names for pool lookups.
  - Correctly map sRUJI/sTCY to their underlying pools (RUJI/TCY).

## Verification
- Verified code compilation.
- The logic aligns with how Thorchain pool endpoints expect asset parameters.

Fix https://github.com/vultisig/vultisig-ios/issues/3423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cryptocurrency price calculations for staking assets.
  * Improved ThorChain pool asset price lookups for better accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->