### PR TITLE
fix: clear invalid email flag when input becomes valid

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/FastVaultEmailView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/FastVaultEmailView.swift
@@ -28,6 +28,10 @@ struct FastVaultEmailView: View {
                 if !newValue.isEmpty {
                     isEmptyEmail = false
                 }
+                
+                if isInvalidEmail && newValue.isValidEmail {
+                    isInvalidEmail = false
+                }
             }
             .onAppear(){
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {


### PR DESCRIPTION
Fix https://github.com/vultisig/vultisig-ios/issues/3526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email validation error messages now automatically clear when a valid email is entered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->