### PR TITLE
Fix: Correctly use asset ticker for secured asset withdrawals

### DIFF
--- a/VultisigApp/VultisigApp/Chains/thorchain.swift
+++ b/VultisigApp/VultisigApp/Chains/thorchain.swift
@@ -330,8 +330,8 @@ enum THORChainHelper {
             return "BSC"
         }
         
-        // For other secured assets, use the coin's chain ticker
-        return coin.chain.ticker.uppercased()
+        // For other secured assets, use the coin's ticker THOR-DOGE will return DOGE
+        return ticker
     }
     
     static func getFee(keysignPayload: KeysignPayload) throws -> WalletCore.CosmosFee {


### PR DESCRIPTION
This PR fixes an issue where secured asset withdrawals were using the chain ticker (e.g. RUNE) instead of the asset ticker (e.g. DOGE), resulting in incorrect transaction messages.

Tx
https://runescan.io/tx/79EC8F18D2602FF18D07F02E5DE7C6DECEBE1F7934CA4AE450E0B7AB319D4CF2

Tests
https://runescan.io/address/thor103xklz882ffz6vwjwcrawwt8tn57ngrhpfq3cl

Fixes https://github.com/vultisig/vultisig-ios/issues/3637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected THORChain deposit handling to display accurate asset ticker symbols for secured assets (excluding BNB), improving transaction clarity and symbol representation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->