### PR TITLE
fix: display Circle USDC balance in DeFi main list

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/DefiCircleRow.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/DefiCircleRow.swift
@@ -11,7 +11,11 @@ struct DefiCircleRow: View {
     let vault: Vault
     @EnvironmentObject var homeViewModel: HomeViewModel
     
-    @State private var balanceText: String = "..."
+    @State private var circleBalance: Decimal? = nil
+    @State private var isLoading: Bool = true
+    @State private var hasError: Bool = false
+    
+    private let logic = CircleViewLogic()
     
     var body: some View {
         HStack {
@@ -43,20 +47,7 @@ struct DefiCircleRow: View {
             Spacer()
             
             HStack(spacing: 8) {
-                VStack(alignment: .trailing, spacing: 4) {
-                    if let _ = vault.circleWalletAddress {
-                        Text("USDC")
-                            .font(Theme.fonts.priceBodyS)
-                            .foregroundStyle(Theme.colors.textPrimary)
-                        Text(NSLocalizedString("circleRowYieldAccount", comment: "Yield Account"))
-                            .font(Theme.fonts.caption12)
-                            .foregroundStyle(Theme.colors.textTertiary)
-                    } else {
-                        Text(NSLocalizedString("circleRowGetStarted", comment: "Get Started"))
-                            .font(Theme.fonts.priceBodyS)
-                            .foregroundStyle(Theme.colors.primaryAccent4)
-                    }
-                }
+                rightSideContent
                 Icon(named: "chevron-right-small", color: Theme.colors.textPrimary, size: 16)
             }
         }
@@ -65,5 +56,79 @@ struct DefiCircleRow: View {
         .background(Theme.colors.bgSurface1)
         .cornerRadius(10)
         .buttonStyle(.plain)
+        .task {
+            await loadBalance()
+        }
+    }
+    
+    @ViewBuilder
+    private var rightSideContent: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            if vault.circleWalletAddress != nil {
+                // Wallet exists - show balance or loading/error state
+                if isLoading {
+                    // Loading state
+                    Text("...")
+                        .font(Theme.fonts.priceBodyS)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                    Text(NSLocalizedString("circleRowYieldAccount", comment: "Yield Account"))
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                } else if hasError {
+                    // Error state - show dash
+                    Text("-- USDC")
+                        .font(Theme.fonts.priceBodyS)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                    Text(NSLocalizedString("circleRowYieldAccount", comment: "Yield Account"))
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                } else if let balance = circleBalance, balance > 0 {
+                    // Has positive balance - show amount
+                    Text("\(balance.formatted()) USDC")
+                        .font(Theme.fonts.priceBodyS)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                    Text("$\(balance.formatted())")
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                } else {
+                    // Balance is zero or nil - show Yield Account
+                    Text("0 USDC")
+                        .font(Theme.fonts.priceBodyS)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                    Text(NSLocalizedString("circleRowYieldAccount", comment: "Yield Account"))
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                }
+            } else {
+                // No wallet - show Get Started
+                Text(NSLocalizedString("circleRowGetStarted", comment: "Get Started"))
+                    .font(Theme.fonts.priceBodyS)
+                    .foregroundStyle(Theme.colors.primaryAccent4)
+            }
+        }
+    }
+    
+    private func loadBalance() async {
+        guard let address = vault.circleWalletAddress else {
+            await MainActor.run {
+                isLoading = false
+            }
+            return
+        }
+        
+        do {
+            let (usdcBalance, _) = try await logic.fetchData(address: address, vault: vault)
+            await MainActor.run {
+                circleBalance = usdcBalance
+                isLoading = false
+                hasError = false
+            }
+        } catch {
+            print("DefiCircleRow: Error loading balance: \(error.localizedDescription)")
+            await MainActor.run {
+                isLoading = false
+                hasError = true
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3661 - Display total Circle balance on DeFi main view

## Changes

The Circle row in the DeFi main list now displays the actual USDC balance from the Circle smart contract account instead of static text.

### Before
- Showed "USDC" and "Yield Account" text

### After
- **Loading state**: Shows "..." with "Yield Account" subtitle
- **Error state**: Shows "-- USDC" with "Yield Account" subtitle  
- **Zero balance**: Shows "0 USDC" with "Yield Account" subtitle
- **Positive balance**: Shows "{amount} USDC" with "${amount}" fiat equivalent

## Implementation

- Added async balance fetching using `CircleViewLogic.fetchData()`
- Added proper state management with `isLoading` and `hasError` flags
- Extracted right-side content to a computed property for cleaner code

## Testing

- Build verified on iOS Simulator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Circle balance display with loading indicator while data is being retrieved.
  * Added error state handling with appropriate messaging when balance retrieval fails.
  * Improved balance presentation with conditional rendering based on loading, error, and balance states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<img width="1187" height="1069" alt="image" src="https://github.com/user-attachments/assets/67d2e392-fffb-49fe-afe6-974b65144e4f" />

<img width="1176" height="1064" alt="image" src="https://github.com/user-attachments/assets/f0bfc594-843c-4de0-9f7e-eba11df0f305" />

<img width="1182" height="1066" alt="image" src="https://github.com/user-attachments/assets/a7a40609-4faf-4c68-8db1-a9f538d3f426" />

<img width="1179" height="1063" alt="image" src="https://github.com/user-attachments/assets/072d729f-3834-46fc-8141-f865739abac4" />

<img width="1186" height="1067" alt="image" src="https://github.com/user-attachments/assets/6c2f14c7-0033-45d9-9c7c-01bde0a7c085" />
