### PR TITLE
fix: correctly format insufficientGasTokenError with token names

### DIFF
--- a/VultisigApp/VultisigApp/View Models/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/View Models/SendCryptoVerifyLogic.swift
@@ -33,10 +33,10 @@ struct SendCryptoVerifyLogic {
     private func calculateEVMFee(tx: SendTransaction) async throws -> FeeResult {
         let service = try EthereumFeeService(chain: tx.coin.chain)
         
-        let gasLimit = tx.coin.isNativeToken ? 
-            BigInt(EVMHelper.defaultETHTransferGasUnit) : 
-            BigInt(EVMHelper.defaultERC20TransferGasUnit)
-            
+        let gasLimit = tx.coin.isNativeToken ?
+        BigInt(EVMHelper.defaultETHTransferGasUnit) :
+        BigInt(EVMHelper.defaultERC20TransferGasUnit)
+        
         let feeInfo = try await service.calculateFees(
             chain: tx.coin.chain,
             limit: gasLimit,
@@ -183,12 +183,14 @@ struct SendCryptoVerifyLogic {
                 if let nativeToken = vault.coins.nativeCoin(chain: tx.coin.chain) {
                     let nativeBalance = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
                     if tx.fee > nativeBalance {
-                        // Using a generic error message since checking gas specifically might require a new error string key 
-                        // or we can reuse existing logic if available. 
-                        // The user complained about "walletBalanceExceededError" being shown wrongly, 
+                        // Using a generic error message since checking gas specifically might require a new error string key
+                        // or we can reuse existing logic if available.
+                        // The user complained about "walletBalanceExceededError" being shown wrongly,
                         // so returning it for actual insufficient gas is acceptable or we can use "notEnoughGas" if it exists.
                         // But keeping it consistent with the function signature.
-                        return BalanceValidationResult(isValid: false, errorMessage: "insufficientGasTokenError")
+                        let nativeToken = vault.coins.nativeCoin(chain: tx.coin.chain)
+                        let errorMessage = String(format: "insufficientGasTokenError".localized, nativeToken?.ticker ?? "Native Token", tx.coin.ticker)
+                        return BalanceValidationResult(isValid: false, errorMessage: errorMessage)
                     }
                 }
             }


### PR DESCRIPTION
Fixes #3668

The error message was showing raw placeholders '%@' instead of the actual token names. Now properly formats the localized string with the native token ticker and the sending token ticker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when there are insufficient funds to cover gas fees—now displays relevant token information in your system language for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->