### PR TITLE
Fix: Swap UI issues - tooltip offset and duplicate percentage buttons

### DIFF
--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -58,9 +58,6 @@ struct SwapCryptoDetailsView: View {
     var screenContainer: some View {
         ZStack(alignment: .bottom) {
             screenContent
-            #if os(iOS)
-            percentageButtons
-            #endif
         }
     }
 

--- a/VultisigApp/VultisigApp/Views/Swap/SwapErrorTooltipView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapErrorTooltipView.swift
@@ -15,7 +15,11 @@ struct SwapErrorTooltipView: View {
     private let circleIconSize: CGFloat = 20
     private let circleIconPadding: CGFloat = 7
     private var circleSize: CGFloat { circleIconSize + circleIconPadding * 2 }
+    #if os(macOS)
+    private let tooltipGap: CGFloat = 30  // Slightly more offset on macOS
+    #else
     private let tooltipGap: CGFloat = 24
+    #endif
 
     var body: some View {
         warningIcon


### PR DESCRIPTION
## Summary

This PR fixes two UI issues in the Swap screen:

### 1. Error Tooltip Offset on macOS (closes #3686)

The swap error tooltip was not positioned correctly on macOS. Added platform-specific offset adjustment:
- **macOS:** 30px offset
- **iOS:** 24px offset (unchanged)

**File:** `SwapErrorTooltipView.swift`

### 2. Duplicate Percentage Buttons on iOS

The percentage buttons (25%, 50%, 75%) were appearing twice on the iOS swap screen:
- Once in `screenContainer` (ZStack overlay)
- Once in the keyboard toolbar

Removed the duplicate from `screenContainer` since the buttons should only appear in the keyboard toolbar on iOS.

**File:** `SwapCryptoDetailsView.swift`

## Testing

- [x] Build succeeds on iOS
- [x] Build succeeds on macOS
- [x] Manual verification of tooltip positioning on macOS
- [x] Manual verification of percentage buttons on iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed percentage selection buttons from the swap interface
  * Adjusted error tooltip spacing on macOS for improved alignment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes IOS
<img width="525" height="1087" alt="image" src="https://github.com/user-attachments/assets/44f9eb7b-ad33-45af-98fb-a22b1d30db37" />

MAC
<img width="2041" height="1252" alt="image" src="https://github.com/user-attachments/assets/ebe99ada-21ef-4bf0-8fb1-3aebd56fe35b" />

Percentage button was duplicated and also fixed
<img width="517" height="1102" alt="image" src="https://github.com/user-attachments/assets/a8431eae-30bf-467a-85ef-43868e3ad155" />
