### PR TITLE
fix(circle): Ensure Available Balance uses EOA coin

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleViewLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleViewLogic.swift
@@ -161,7 +161,11 @@ struct CircleViewLogic {
 
     static func getWalletUSDCBalance(vault: Vault) -> Decimal {
         let (chain, _) = getChainDetails(vault: vault)
-        if let usdcCoin = vault.coins.first(where: { $0.chain == chain && $0.ticker == "USDC" }) {
+        guard let ethCoin = vault.coins.first(where: { $0.chain == chain && $0.isNativeToken }) else {
+            return .zero
+        }
+        
+        if let usdcCoin = vault.coins.first(where: { $0.chain == chain && $0.ticker == "USDC" && $0.address == ethCoin.address }) {
             return usdcCoin.balanceDecimal
         }
         return .zero


### PR DESCRIPTION
Fixes an issue where the Circle Dashboard would sometimes display the Circle Account (MSCA) balance instead of the User's Wallet (EOA) available balance by explicitly filtering for the coin matching the Native Coin address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USDC balance retrieval by enhancing error handling for missing blockchain tokens and refining lookup logic to ensure more reliable balance detection across supported chains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->