### PR TITLE
Fix: Increase Blast gas limit to 200k

### DIFF
--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -173,7 +173,9 @@ class Coin: ObservableObject, Codable, Hashable {
             } else {
                 return "150000" // Increased from 120000
             }
-        case .blast, .optimism, .cronosChain, .polygon, .polygonV2:
+        case .blast:
+            return "200000"
+        case .optimism, .cronosChain, .polygon, .polygonV2:
             if self.isNativeToken {
                 return "40000"
             } else {


### PR DESCRIPTION
Increase default gas limit for Blast ERC20 tokens to 200k to prevent 'exceeds block gas limit' errors. Fixes #3694.

Tests
I've increased the fee for Blast, it should cover for both ERC20 and ETH on Blast

SEND ETH
https://blastscan.io/tx/0xbf9a56de9962d7bc6d4a30cfc4869f79bf0662e8238173f5525b2acb21ffd228

SWAP LIFI
https://scan.li.fi/tx/0xfc02bad1ba9b201693cfdc096935fe7eff28e5dd5c61ac57f6f97dcf05e19ab8

SEND USDB
https://blastscan.io/tx/0xf044770d862febc8092a72817fa1485241ccb81a76755b40b094195e35e35ef6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted transaction fee calculation for Blast network to ensure consistent gas limits across all transaction types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->