### PR TITLE
fix(chain-selection): fix race condition when adding multiple chains

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/ChainSelection/VaultSelectChainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainSelection/VaultSelectChainScreen.swift
@@ -64,13 +64,12 @@ private extension VaultSelectChainScreen {
     func onSaveInternal() {
         isLoading = true
         Task {
+            await saveAssets()
             await MainActor.run {
                 isLoading = false
                 onSave()
                 isPresented.toggle()
             }
-            await saveAssets()
-
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #3777

## Problem

When selecting multiple chains at the same time in the chain selection screen, some chains would sometimes not get added.

## Root Cause

In `VaultSelectChainScreen.onSaveInternal()`, the sheet was being dismissed and `onSave()` was being called **before** `saveAssets()` completed. This caused a race condition where the vault refresh would load the old state before the new chains were persisted.

```swift
// BEFORE (buggy):
func onSaveInternal() {
    isLoading = true
    Task {
        await MainActor.run {
            isLoading = false
            onSave()             // ❌ Triggers refresh...
            isPresented.toggle() // ❌ ...and dismisses sheet BEFORE save
        }
        await saveAssets()       // ❌ Save happens AFTER dismiss
    }
}
```

## Solution

Reordered the operations to await `saveAssets()` first, matching the correct pattern already used in `DefiSelectChainScreen`:

```swift
// AFTER (fixed):
func onSaveInternal() {
    isLoading = true
    Task {
        await saveAssets()       // ✅ Save FIRST
        await MainActor.run {
            isLoading = false
            onSave()             // ✅ Then trigger refresh
            isPresented.toggle() // ✅ Then dismiss
        }
    }
}
```

## Testing

- [x] Build succeeded
- [ ] Manual test: Select 5+ chains quickly and verify all appear after save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved asset saving timing during wallet chain selection operations to ensure data persistence occurs at the correct stage of the workflow, enhancing reliability of asset management when switching blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->