### PR TITLE
USDC label centered

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositView.swift
@@ -79,12 +79,12 @@ struct CircleDepositView: View {
                 VStack(spacing: 8) {
                     HStack(spacing: 4) {
                         amountTextField
+                            .fixedSize()
 
                         Text("USDC")
                             .font(Theme.fonts.bodyLMedium)
                             .foregroundStyle(Theme.colors.textSecondary)
                     }
-                    .frame(maxWidth: .infinity)
 
                     Text("\(Int(min(percentage, 100)))%")
                         .font(CircleConstants.Fonts.subtitle)

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
@@ -98,12 +98,12 @@ struct CircleWithdrawView: View {
                 VStack(spacing: 8) {
                     HStack(spacing: 4) {
                         amountTextField
+                            .fixedSize()
 
                         Text("USDC")
                             .font(Theme.fonts.bodyLMedium)
                             .foregroundStyle(Theme.colors.textSecondary)
                     }
-                    .frame(maxWidth: .infinity)
 
                     Text("\(Int(min(percentage, 100)))%")
                         .font(CircleConstants.Fonts.subtitle)


### PR DESCRIPTION
https://github.com/vultisig/vultisig-ios/issues/3706

<img width="4112" height="2586" alt="image" src="https://github.com/user-attachments/assets/5fdccdc5-b4b1-4e01-8e4e-b1bf7711d7f8" />
<img width="4112" height="2586" alt="image" src="https://github.com/user-attachments/assets/62d29c1d-79bb-42f0-897e-ad498a82eb57" />
<img width="1004" height="2158" alt="image" src="https://github.com/user-attachments/assets/1d31acb0-2c08-470f-b0fb-228f9f880255" />
<img width="1006" height="2162" alt="image" src="https://github.com/user-attachments/assets/69fed735-b3ac-46d4-948c-ae992612f733" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layout sizing of amount input fields in both Circle deposit and withdrawal screens. The fields now use more appropriate dimensions to fit their content rather than expanding to full width, resulting in improved visual alignment and more consistent presentation. This enhances the overall appearance and usability of both interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->