### PR TITLE
fix: correct sTCY and sRUJI contractAddress to match on-chain denoms (#3788)

### DIFF
--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -1924,7 +1924,7 @@ class TokensStore {
         logo: "xruji", // Use same logo as RUJI
         decimals: 8,
         priceProviderId: "rujira",
-        contractAddress: "x/staking-x/ruji",
+        contractAddress: "x/staking-ruji",
         isNativeToken: false
     )
 
@@ -1934,7 +1934,7 @@ class TokensStore {
         logo: "sTCY", // Use same logo as TCY
         decimals: 8,
         priceProviderId: "tcy",
-        contractAddress: "x/staking-x/tcy",
+        contractAddress: "x/staking-tcy",
         isNativeToken: false
     )
 


### PR DESCRIPTION
## Summary

Fixes #3788 — sTCY transfer balance not reflected in vault on iOS/macOS despite on-chain success.

## Root Cause

The `contractAddress` for **sTCY** and **sRUJI** in `TokensStore.swift` had an extra `x/` segment that didn't match the actual on-chain denoms:

| Token | Before (iOS) | On-chain denom | Android (`Coins.kt`) |
|-------|-------------|---------------|----------------------|
| sTCY | `x/staking-x/tcy` ❌ | `x/staking-tcy` | `x/staking-tcy` ✅ |
| sRUJI | `x/staking-x/ruji` ❌ | `x/staking-ruji` | N/A |

When `BalanceService` fetches balances, it compares the on-chain `denom` with `coin.contractAddress` via `THORBalanceExtension.balance(denom:coin:)`. The mismatch caused the lookup to always return `"0"`.

## Verification

- Queried the live THORChain API for the vault address from the issue (`thor1cafk2rm4djmf7uw0yxn3nxu9kd736mxv7p8x9h`), confirmed the on-chain denom is `x/staking-tcy`.
- Cross-referenced with Android codebase (`Coins.kt:2827`), which correctly uses `x/staking-tcy`.
- Build passes on iOS Simulator.

## Changes

- `TokensStore.swift`: Fixed `contractAddress` for `stcy` (`x/staking-x/tcy` → `x/staking-tcy`) and `sruji` (`x/staking-x/ruji` → `x/staking-ruji`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Corrected contract address paths for RUJI and TCY tokens to ensure accurate blockchain identification. These configuration updates improve token recognition and transaction processing reliability, enhancing overall application stability in wallet operations when handling these specific tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->