### PR TITLE
fix: incorrect fee calculation triggers false exceeds balance error on send max (#3797)

### DIFF
--- a/VultisigApp/VultisigApp/View Models/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendCryptoVerifyViewModel.swift
@@ -18,6 +18,7 @@ class SendCryptoVerifyViewModel: ObservableObject {
     @Published var showAlert = false
     @Published var isLoading = false
     @Published var errorMessage = ""
+    @Published var hasBalanceError = false
 
     @Published var showSecurityScannerSheet: Bool = false
     @Published var securityScannerState: SecurityScannerState = .idle
@@ -34,6 +35,7 @@ class SendCryptoVerifyViewModel: ObservableObject {
         tx.isCalculatingFee = true
         isLoading = true
         errorMessage = ""
+        hasBalanceError = false
         // Ensure balance is loaded before validation (protects against stale/empty balances)
         await BalanceService.shared.updateBalance(for: tx.coin)
 
@@ -82,6 +84,7 @@ class SendCryptoVerifyViewModel: ObservableObject {
             errorMessage = result.errorMessage ?? ""
             showAlert = true
             isAmountCorrect = false
+            hasBalanceError = true
         }
     }
 
@@ -90,7 +93,7 @@ class SendCryptoVerifyViewModel: ObservableObject {
     }
 
     var signButtonDisabled: Bool {
-        !isValidForm || isLoading
+        !isValidForm || isLoading || hasBalanceError
     }
 
     func validateForm(tx: SendTransaction, vault: Vault) async throws -> KeysignPayload {

--- a/VultisigApp/VultisigApp/View Models/SendCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/SendCryptoViewModel.swift
@@ -404,6 +404,7 @@ struct SendCryptoLogic {
             }
 
         case .kujira, .gaiaChain, .mayaChain, .thorChain, .thorChainStagenet, .dydx, .osmosis, .terra, .terraClassic, .noble, .akash:
+            tx.sendMaxAmount = percentage == 100
             await balanceService.updateBalance(for: tx.coin)
 
             var gas = BigInt.zero
@@ -413,7 +414,7 @@ struct SendCryptoLogic {
 
             tx.amount = "\(tx.coin.getMaxValue(gas).formatToDecimal(digits: tx.coin.decimals))"
             setPercentageAmount(tx: tx, for: percentage)
-            convertToFiat(newValue: tx.amount, tx: tx)
+            convertToFiat(newValue: tx.amount, tx: tx, setMaxValue: tx.sendMaxAmount)
         case .polkadot:
             do {
                 tx.sendMaxAmount = percentage == 100


### PR DESCRIPTION
## Summary

Fixes #3797 — On Send → THORChain RUNE, selecting Max amount led to incorrect fee handling error in the verify screen: _"The total amount and fee exceed your wallet's balance"_. After tapping OK, the app still allowed signing.

## Root Cause

**Bug 1:** THORChain/Cosmos chains never set `sendMaxAmount = true` in `setMaxValues`, so the verify screen's max-send amount adjustment (subtracting the fee from balance) never triggered.

**Bug 2:** After the error alert, the user could re-check the "Amount Correct" checkbox, bypassing validation and re-enabling the sign button.

## Changes

- **`SendCryptoViewModel.swift`** — Added `tx.sendMaxAmount = percentage == 100` for Cosmos/THORChain chains and passed `setMaxValue` to `convertToFiat`
- **`SendCryptoVerifyViewModel.swift`** — Added `hasBalanceError` flag to permanently block signing when balance validation fails (reset on retry)

## Test Addresses

- https://runescan.io/address/thor103xklz882ffz6vwjwcrawwt8tn57ngrhpfq3cl
- `thor1gka5rqnwjuv2agdefdcs2pndu8cu2dzf3kefgx`
- https://runescan.io/address/thor1gka5rqnwjuv2agdefdcs2pndu8cu2dzf3kefgx

Closes #3797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance and gas validation with enhanced error detection and messaging during transaction verification
  * Better handling of balance-related validation failures during crypto transaction sign-off

* **Enhancements**
  * Optimized maximum transaction amount calculations for select blockchain networks
  * Refined transaction amount-to-fiat conversion calculations for improved accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->