### PR TITLE
fix(wallet): restrict hit area of hide balance button

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainBalanceView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainBalanceView.swift
@@ -19,15 +19,17 @@ struct VaultMainBalanceView: View {
     @EnvironmentObject var homeViewModel: HomeViewModel
 
     var body: some View {
-        Button {
-            homeViewModel.hideVaultBalance.toggle()
-        } label: {
-            VStack(spacing: spacing) {
-                balanceLabel
+        VStack(spacing: spacing) {
+            balanceLabel
+                .allowsHitTesting(false)
+            Button {
+                homeViewModel.hideVaultBalance.toggle()
+            } label: {
                 toggleBalanceVisibilityButton
             }
-            .frame(maxWidth: .infinity)
+            .buttonStyle(PlainButtonStyle())
         }
+        .frame(maxWidth: .infinity)
     }
 
     var balanceLabel: some View {


### PR DESCRIPTION
This PR fixes the issue where tapping outside the 'Hide balance' button area (e.g., on the balance text) would toggle the balance visibility.

### Changes
- Removed the top-level Button wrapper in VaultMainBalanceView.
- Wrapped only the toggle button content in a Button.
- Explicitly disabled hit testing on the balance text using .allowsHitTesting(false).
- Applied .buttonStyle(PlainButtonStyle()) to the toggle button to prevent it from capturing expanding touches.

Fixes #3822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the balance view layout structure for better maintainability and component organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->