### PR TITLE
Fix: Clear swap error state when dismissing tooltip

### DIFF
--- a/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapCryptoDetailsView.swift
@@ -119,6 +119,7 @@ struct SwapCryptoDetailsView: View {
                     error: error,
                     showTooltip: $showErrorTooltip,
                     onDismissTooltip: {
+                        swapViewModel.error = nil
                         showErrorTooltip = false
                     }
                 )


### PR DESCRIPTION
Fixes #3823. Dismissing the error tooltip in the Swap module now correctly clears the error state in the ViewModel, restoring the UI to its normal state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the swap error state would persist after dismissing the error tooltip, ensuring the error is properly cleared when the notification is dismissed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->