### PR TITLE
fix: resolve SwiftData threading crash in balance updates

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -222,7 +222,7 @@ private extension ChainDetailScreen {
     }
 
     func refresh() {
-        Task.detached {
+        Task {
             await updateBalances()
             await MainActor.run {
                 coinSelectionViewModel.setData(for: vault)

--- a/VultisigApp/VultisigApp/View Models/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/View Models/VaultDetailViewModel.swift
@@ -29,7 +29,7 @@ class VaultDetailViewModel: ObservableObject {
 
     func updateBalance(vault: Vault) {
         updateBalanceTask?.cancel()
-        updateBalanceTask = Task.detached { [weak self] in
+        updateBalanceTask = Task { [weak self] in
             guard let self else { return }
             let updatedGroups = await self.logic.updateBalance(vault: vault)
             if !Task.isCancelled {

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCurrencySelectionView.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCurrencySelectionView.swift
@@ -50,7 +50,7 @@ struct SettingsCurrencySelectionView: View {
 
         // Refresh prices in the background without blocking the UI
         if let currentVault = appViewModel.selectedVault {
-            Task.detached {
+            Task {
                 await BalanceService.shared.updateBalances(vault: currentVault)
             }
         }


### PR DESCRIPTION
Replace Task.detached with Task to maintain proper actor context for SwiftData models (Vault, Coin). Task.detached created tasks without actor isolation, causing SwiftData assertion failures when saving changes because models were accessed from the wrong ModelContext.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #<issue-number>

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved concurrency handling for balance update operations across multiple views to enhance stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->