### PR TITLE
fix: prevent back navigation loop on Join Keygen screen (#3828)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -406,6 +406,10 @@ extension HomeScreen {
         switch type {
         case .NewVault:
             moveToCreateVaultView()
+            // Clear fields that CreateVaultView also checks, preventing double navigation.
+            // Keep receivedUrl intact — JoinKeygenView reads it for QR data.
+            deeplinkViewModel.tssType = nil
+            deeplinkViewModel.jsonData = nil
         case .SignTransaction:
             moveToVaultsView()
         case .Send:


### PR DESCRIPTION
## Summary

Fixes #3828 — Back navigation loops on "Join Keygen" screen during QR join flow.

## Root Cause

When `CreateVaultView` is pushed from `HomeScreen` ("Create Vault" button), both views coexist in the navigation stack. Scanning a keygen QR triggers:

1. **`HomeScreen`** receives the `ProcessDeeplink` notification → navigates to `JoinKeygenView` (first push)
2. **`CreateVaultView+iOS`** detects the scanner sheet dismissal → checks `deeplinkViewModel.tssType/jsonData` (still set) → navigates to `JoinKeygenView` again (second push)

Result: two `JoinKeygenView` instances on the stack, causing the back button to loop.

## Fix

After `HomeScreen` handles the `.NewVault` deeplink type, clear `tssType` and `jsonData` from `deeplinkViewModel`. This ensures `CreateVaultView`'s guard condition fails, preventing the duplicate push.

`receivedUrl` is intentionally preserved — `JoinKeygenView.setData()` needs it to extract QR data.

## Testing

- Scan keygen QR from Create Vault screen → Back button returns to Create Vault (not another Join Keygen)
- Scan keygen QR from Home screen camera → Back button returns to Home (unchanged behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deeplink handling for vault creation to prevent double navigation and ensure proper QR code scanning during the vault setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->