### PR TITLE
fix: incorrect device count shown on QR scan page during Secure Vault creation

### DIFF
--- a/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/PeerDiscoveryScreen.swift
@@ -67,20 +67,11 @@ struct PeerDiscoveryScreen: View {
 
     var totalDeviceCount: Int {
         switch tssType {
-        case .Keygen:
-            switch selectedTab {
-            case .fast:
-                return 2
-            case .active:
-                return 4
-            case .secure:
-                return 3
-            }
         case .Reshare:
             return vault.signers.count
         case .Migrate:
             return vault.signers.count
-        case .KeyImport:
+        case .KeyImport, .Keygen:
             if let setupType {
                 switch setupType {
                 case .fast:


### PR DESCRIPTION
… creation

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #3882 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified peer discovery device count logic by consolidating the Keygen and KeyImport flows for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->