### PR TITLE
feat: show Tron Bandwidth & Energy resources card on Chain/Coin detail screens

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -58,8 +58,8 @@
 		13194DB22EF5908500BEC93C /* CircleRouteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13194DAE2EF5908500BEC93C /* CircleRouteBuilder.swift */; };
 		13194DB32EF5908500BEC93C /* CircleRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13194DAF2EF5908500BEC93C /* CircleRouter.swift */; };
 		131F96E62E7887CF0018BA7B /* Satoshi-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 131F96E22E7887CF0018BA7B /* Satoshi-Medium.otf */; };
-		13204DD52EEB129E00297D01 /* OnboardingVaultSetupInformationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13204DD42EEB129800297D01 /* OnboardingVaultSetupInformationScreen.swift */; };
-		13204DD72EEB1B3D00297D01 /* KeyImportOverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13204DD62EEB1B3600297D01 /* KeyImportOverviewScreen.swift */; };
+		13204DD52EEB129E00297D01 /* OnboardingYourVaultSetupScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13204DD42EEB129800297D01 /* OnboardingYourVaultSetupScreen.swift */; };
+		13204DD72EEB1B3D00297D01 /* OnboardingOverviewScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13204DD62EEB1B3600297D01 /* OnboardingOverviewScreen.swift */; };
 		13204DDC2EEB1CCA00297D01 /* OnboardingInformationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13204DDB2EEB1CC300297D01 /* OnboardingInformationRowView.swift */; };
 		1321A82C2ED0A4ED004CBB99 /* DefiChainBondedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1321A8162ED0A4ED004CBB99 /* DefiChainBondedView.swift */; };
 		1321A82D2ED0A4ED004CBB99 /* DefiChainLPsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1321A8262ED0A4ED004CBB99 /* DefiChainLPsViewModel.swift */; };
@@ -1396,8 +1396,8 @@
 		13194DAE2EF5908500BEC93C /* CircleRouteBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleRouteBuilder.swift; sourceTree = "<group>"; };
 		13194DAF2EF5908500BEC93C /* CircleRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleRouter.swift; sourceTree = "<group>"; };
 		131F96E22E7887CF0018BA7B /* Satoshi-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Satoshi-Medium.otf"; sourceTree = "<group>"; };
-		13204DD42EEB129800297D01 /* OnboardingVaultSetupInformationScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingVaultSetupInformationScreen.swift; sourceTree = "<group>"; };
-		13204DD62EEB1B3600297D01 /* KeyImportOverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyImportOverviewScreen.swift; sourceTree = "<group>"; };
+		13204DD42EEB129800297D01 /* OnboardingYourVaultSetupScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingYourVaultSetupScreen.swift; sourceTree = "<group>"; };
+		13204DD62EEB1B3600297D01 /* OnboardingOverviewScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingOverviewScreen.swift; sourceTree = "<group>"; };
 		13204DDB2EEB1CC300297D01 /* OnboardingInformationRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInformationRowView.swift; sourceTree = "<group>"; };
 		1321A80C2ED0A4ED004CBB99 /* BondNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BondNode.swift; sourceTree = "<group>"; };
 		1321A80D2ED0A4ED004CBB99 /* BondPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BondPosition.swift; sourceTree = "<group>"; };
@@ -4526,8 +4526,8 @@
 			children = (
 				132E015D2F1AA2E6007E717C /* Components */,
 				132E015F2F1AA2E6007E717C /* DeviceCount */,
-				13204DD62EEB1B3600297D01 /* KeyImportOverviewScreen.swift */,
-				13204DD42EEB129800297D01 /* OnboardingVaultSetupInformationScreen.swift */,
+				13204DD62EEB1B3600297D01 /* OnboardingOverviewScreen.swift */,
+				13204DD42EEB129800297D01 /* OnboardingYourVaultSetupScreen.swift */,
 				13C286702EE8B823004D8AC8 /* KeyImportOnboardingScreen.swift */,
 				13C2866F2EE8B80F004D8AC8 /* ChainsSetup */,
 			);
@@ -7224,7 +7224,7 @@
 				DE15729F2B70F284009BC7C5 /* KeysignDiscoveryView.swift in Sources */,
 				135C27B52F44C00F006315FF /* NavigationStackVisibilityModifier.swift in Sources */,
 				134A9FC32E959FB700030C56 /* CarouselBannerType.swift in Sources */,
-				13204DD72EEB1B3D00297D01 /* KeyImportOverviewScreen.swift in Sources */,
+				13204DD72EEB1B3D00297D01 /* OnboardingOverviewScreen.swift in Sources */,
 				13D7643A2E4127B100F048DE /* Array.swift in Sources */,
 				A601D3AB2DBB687E004B6A0A /* PasswordVerifyReminderView.swift in Sources */,
 				DE64A4C82BA7EBEC00C342E3 /* JoinKeygenViewModel.swift in Sources */,
@@ -7400,7 +7400,7 @@
 				13DD3B1A2E3CFE7D00D46FA0 /* FlatPicker.swift in Sources */,
 				135B6BBF2EA1470F00DD7140 /* ChainNotFoundEmptyStateView.swift in Sources */,
 				135677A62E391A6E002C10A2 /* SecurityScannerTransactionFactory.swift in Sources */,
-				13204DD52EEB129E00297D01 /* OnboardingVaultSetupInformationScreen.swift in Sources */,
+				13204DD52EEB129E00297D01 /* OnboardingYourVaultSetupScreen.swift in Sources */,
 				A6BFE1BD2D945AA5000B73C0 /* SwapFromToField.swift in Sources */,
 				A65649F52B966F3E00E4B329 /* DecodableDefault.swift in Sources */,
 				DE491CEF2B708260007C88D5 /* KeygenView.swift in Sources */,

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/OnboardingOverviewScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/OnboardingOverviewScreen.swift
@@ -1,5 +1,5 @@
 //
-//  KeyImportOverviewScreen.swift
+//  OnboardingOverviewScreen.swift
 //  VultisigApp
 //
 //  Created by Gaston Mazzeo on 11/12/2025.
@@ -8,7 +8,8 @@
 import SwiftUI
 import RiveRuntime
 
-struct KeyImportOverviewScreen: View {
+struct OnboardingOverviewScreen: View {
+    let tssType: TssType
     let vault: Vault
     let email: String?
     let keyImportInput: KeyImportInput?
@@ -35,9 +36,9 @@ struct KeyImportOverviewScreen: View {
                 Spacer()
                 VStack(spacing: 32) {
                     informationView
-                    PrimaryButton(title: "continue") {
+                    PrimaryButton(title: "iUnderstand") {
                         router.navigate(to: KeygenRoute.backupNow(
-                            tssType: .KeyImport,
+                            tssType: tssType,
                             backupType: .single(vault: vault),
                             isNewVault: true
                         ))
@@ -48,7 +49,7 @@ struct KeyImportOverviewScreen: View {
         .onLoad(perform: onLoad)
         .crossPlatformSheet(isPresented: $isVerificationLinkActive) {
             ServerBackupVerificationScreen(
-                tssType: .KeyImport,
+                tssType: tssType,
                 vault: vault,
                 email: email ?? .empty,
                 isPresented: $isVerificationLinkActive,
@@ -56,7 +57,7 @@ struct KeyImportOverviewScreen: View {
                 onBackup: { },
                 onBackToEmailSetup: {
                     router.navigate(to: OnboardingRoute.vaultSetup(
-                        tssType: .KeyImport,
+                        tssType: tssType,
                         keyImportInput: keyImportInput
                     ))
                 }
@@ -117,7 +118,8 @@ struct KeyImportOverviewScreen: View {
 }
 
 #Preview {
-    KeyImportOverviewScreen(
+    OnboardingOverviewScreen(
+        tssType: .Keygen,
         vault: .example,
         email: nil,
         keyImportInput: nil,

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/OnboardingYourVaultSetupScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/OnboardingYourVaultSetupScreen.swift
@@ -1,5 +1,5 @@
 //
-//  OnboardingVaultSetupInformationScreen.swift
+//  OnboardingYourVaultSetupScreen.swift
 //  VultisigApp
 //
 //  Created by Gaston Mazzeo on 11/12/2025.
@@ -8,7 +8,7 @@
 import SwiftUI
 import RiveRuntime
 
-struct OnboardingVaultSetupInformationScreen: View {
+struct OnboardingYourVaultSetupScreen: View {
     let tssType: TssType
     let keyImportInput: KeyImportInput?
     let setupType: KeyImportSetupType
@@ -153,7 +153,7 @@ struct OnboardingVaultSetupInformationScreen: View {
     }
 }
 
-private extension OnboardingVaultSetupInformationScreen {
+private extension OnboardingYourVaultSetupScreen {
     var vaultSetupTitle: String {
         switch setupType {
         case .fast:
@@ -293,7 +293,7 @@ private extension OnboardingVaultSetupInformationScreen {
 }
 
 #Preview {
-    OnboardingVaultSetupInformationScreen(
+    OnboardingYourVaultSetupScreen(
         tssType: .Keygen,
         keyImportInput: nil,
         setupType: .fast

--- a/VultisigApp/VultisigApp/Features/Onboarding/Navigation/OnboardingRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/Navigation/OnboardingRouteBuilder.swift
@@ -35,7 +35,7 @@ struct OnboardingRouteBuilder {
         keyImportInput: KeyImportInput?,
         setupType: KeyImportSetupType
     ) -> some View {
-        OnboardingVaultSetupInformationScreen(
+        OnboardingYourVaultSetupScreen(
             tssType: tssType,
             keyImportInput: keyImportInput,
             setupType: setupType

--- a/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/de.lproj/Localizable.strings
@@ -1372,5 +1372,6 @@
 "noPositionsFound" = "Keine Positionen gefunden";
 "unrelatedQRCode" = "Unbekannter QR-Code";
 "unrelatedQRCodeMessage" = "Es wurde ein nicht zugehöriger QR-Code gescannt.";
+"iUnderstand" = "Ich verstehe";
 "replaceExistingVault" = "Ersetzen";
 "duplicateVaultMessage" = "Ein Tresor namens \"%@\" hat bereits dieselben Schlüssel. Durch das Ersetzen werden seine Daten überschrieben.";

--- a/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/en.lproj/Localizable.strings
@@ -1418,5 +1418,6 @@
 
 "unrelatedQRCode" = "Unrelated QR Code";
 "unrelatedQRCodeMessage" = "Unrelated QR code is scanned.";
+"iUnderstand" = "I understand";
 "replaceExistingVault" = "Replace";
 "duplicateVaultMessage" = "A vault named \"%@\" already has the same keys. Replacing it will overwrite its data.";

--- a/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/es.lproj/Localizable.strings
@@ -1372,5 +1372,6 @@
 "noPositionsFound" = "No se encontraron posiciones";
 "unrelatedQRCode" = "Código QR no relacionado";
 "unrelatedQRCodeMessage" = "Se escaneó un código QR no relacionado.";
+"iUnderstand" = "Entiendo";
 "replaceExistingVault" = "Reemplazar";
 "duplicateVaultMessage" = "Un almacén llamado \"%@\" ya tiene las mismas claves. Reemplazarlo sobrescribirá sus datos.";

--- a/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/hr.lproj/Localizable.strings
@@ -1372,5 +1372,6 @@
 "noPositionsFound" = "Nema pronađenih pozicija";
 "unrelatedQRCode" = "Nepovezani QR kod";
 "unrelatedQRCodeMessage" = "Skeniran je nepovezani QR kod.";
+"iUnderstand" = "Razumijem";
 "replaceExistingVault" = "Zamijeni";
 "duplicateVaultMessage" = "Spremište pod nazivom \"%@\" već ima iste ključeve. Zamjenom će se prebrisati njegovi podatci.";

--- a/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/it.lproj/Localizable.strings
@@ -1372,5 +1372,6 @@
 "noPositionsFound" = "Nessuna posizione trovata";
 "unrelatedQRCode" = "Codice QR non correlato";
 "unrelatedQRCodeMessage" = "È stato scansionato un codice QR non correlato.";
+"iUnderstand" = "Ho capito";
 "replaceExistingVault" = "Sostituisci";
 "duplicateVaultMessage" = "Un caveau chiamato \"%@\" ha già le stesse chiavi. Sostituendolo, i suoi dati verranno sovrascritti.";

--- a/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/pt.lproj/Localizable.strings
@@ -1372,5 +1372,6 @@
 "noPositionsFound" = "Nenhuma posição encontrada";
 "unrelatedQRCode" = "Código QR não relacionado";
 "unrelatedQRCodeMessage" = "Foi escaneado um código QR não relacionado.";
+"iUnderstand" = "Eu entendo";
 "replaceExistingVault" = "Substituir";
 "duplicateVaultMessage" = "Um cofre chamado \"%@\" já possui as mesmas chaves. Substituí-lo sobrescreverá seus dados.";

--- a/VultisigApp/VultisigApp/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1375,5 +1375,6 @@
 "noPositionsFound" = "未找到任何持仓";
 "unrelatedQRCode" = "无关的二维码";
 "unrelatedQRCodeMessage" = "扫描到无关的二维码。";
+"iUnderstand" = "我了解";
 "replaceExistingVault" = "替换";
 "duplicateVaultMessage" = "名为\"%@\"的保险库已拥有相同的密钥。替换将覆盖其数据。";

--- a/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/KeygenView.swift
@@ -92,6 +92,7 @@ struct KeygenView: View {
         case .KeyImport, .Keygen, .Reshare:
             if fastSignConfig != nil {
                 router.navigate(to: KeygenRoute.keyImportOverview(
+                    tssType: tssType,
                     vault: vault,
                     email: fastSignConfig?.email,
                     keyImportInput: keyImportInput,

--- a/VultisigApp/VultisigApp/Views/Keygen/Navigation/KeygenRoute.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/Navigation/KeygenRoute.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum KeygenRoute: Hashable {
     case backupNow(tssType: TssType, backupType: VaultBackupType, isNewVault: Bool)
-    case keyImportOverview(vault: Vault, email: String?, keyImportInput: KeyImportInput?, setupType: KeyImportSetupType)
+    case keyImportOverview(tssType: TssType, vault: Vault, email: String?, keyImportInput: KeyImportInput?, setupType: KeyImportSetupType)
     case peerDiscovery(tssType: TssType, vault: Vault, selectedTab: SetupVaultState, fastSignConfig: FastSignConfig?, keyImportInput: KeyImportInput?, setupType: KeyImportSetupType?)
     case fastVaultEmail(tssType: TssType, vault: Vault, selectedTab: SetupVaultState, fastVaultExist: Bool)
     case fastVaultSetHint(tssType: TssType, vault: Vault, selectedTab: SetupVaultState, fastVaultEmail: String, fastVaultPassword: String, fastVaultExist: Bool)

--- a/VultisigApp/VultisigApp/Views/Keygen/Navigation/KeygenRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/Navigation/KeygenRouteBuilder.swift
@@ -24,12 +24,14 @@ struct KeygenRouteBuilder {
 
     @ViewBuilder
     func buildKeyImportOverviewScreen(
+        tssType: TssType,
         vault: Vault,
         email: String?,
         keyImportInput: KeyImportInput?,
         setupType: KeyImportSetupType
     ) -> some View {
-        KeyImportOverviewScreen(
+        OnboardingOverviewScreen(
+            tssType: tssType,
             vault: vault,
             email: email,
             keyImportInput: keyImportInput,

--- a/VultisigApp/VultisigApp/Views/Keygen/Navigation/KeygenRouter.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/Navigation/KeygenRouter.swift
@@ -19,8 +19,9 @@ struct KeygenRouter {
                 backupType: backupType,
                 isNewVault: isNewVault
             )
-        case .keyImportOverview(let vault, let email, let keyImportInput, let setupType):
+        case .keyImportOverview(let tssType, let vault, let email, let keyImportInput, let setupType):
             viewBuilder.buildKeyImportOverviewScreen(
+                tssType: tssType,
                 vault: vault,
                 email: email,
                 keyImportInput: keyImportInput,

--- a/VultisigApp/VultisigApp/Views/Keygen/ReviewYourVaultsScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Keygen/ReviewYourVaultsScreen.swift
@@ -103,6 +103,7 @@ struct ReviewYourVaultsScreen: View {
 
     private func navigateToOverview() {
         router.navigate(to: KeygenRoute.keyImportOverview(
+            tssType: tssType,
             vault: vault,
             email: email,
             keyImportInput: keyImportInput,


### PR DESCRIPTION
## Summary

Displays the Tron **Bandwidth & Energy** resources card on the Chain Detail and Coin Detail screens when the chain is Tron, matching the existing card from the Tron DeFi dashboard.

### Changes
- **New**: `TronResourcesCardView.swift` — standalone reusable Bandwidth/Energy card extracted from `TronDashboardView`
- **Modified**: `TronDashboardView.swift` — delegates to the new reusable component (~100 lines removed)
- **Modified**: `ChainDetailScreen.swift` + `ChainDetailViewModel.swift` — shows the resources card after action buttons for Tron chains
- **Modified**: `CoinDetailScreen.swift` + `CoinDetailViewModel.swift` — shows the resources card after action buttons for Tron tokens

### How it works
- `TronResourcesCardView` accepts raw data values (bandwidth/energy available/total, loading state), making it reusable across screens
- Resource data is fetched via `TronService.shared.getAccountResource()` on screen load
- The card only renders when the chain is Tron (`viewModel.isTron`)

Closes #3810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TRON bandwidth & energy card with progress indicators and loading state.
  * Info modal explaining Bandwidth and Energy with expandable sections and a "Learn more" link.
  * Automatic loading and refresh of TRON resource metrics on chain and coin detail screens.

* **Refactor**
  * TRON resource UI consolidated into a reusable card component.

* **Documentation**
  * Added localized strings for the TRON Resources info modal (multiple languages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->