### PR TITLE
fix: update AZTEC decimals from 8 to 4

### DIFF
--- a/VultisigApp/VultisigApp/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Stores/TokensStore.swift
@@ -1214,7 +1214,7 @@ class TokensStore {
             chain: .mayaChain,
             ticker: "AZTEC",
             logo: "aztec",
-            decimals: 8,
+            decimals: 4,
             priceProviderId: "",
             contractAddress: "aztec",
             isNativeToken: false


### PR DESCRIPTION
## Summary
- Updates AZTEC (MayaChain) token decimals from 8 to 4 in `TokensStore.swift`

## Test plan
- [ ] Verify AZTEC balance displays correctly with 4 decimal places
- [ ] Verify AZTEC send/swap amounts calculate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AZTEC token decimal precision on the Maya Chain network from 8 to 4 decimals. This adjustment ensures proper token representation and value calculations within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->