### PR TITLE
fix: hide reshare option when vault has MLDSA key

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/Settings/VaultAdvancedSettingsScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/Settings/VaultAdvancedSettingsScreen.swift
@@ -34,7 +34,7 @@ struct VaultAdvancedSettingsScreen: View {
 
     @ViewBuilder
     var reshareVaultRow: some View {
-        if !vault.isFastVault {
+        if !vault.isFastVault && vault.publicKeyMLDSA44 == nil {
             Button {
                 router.navigate(to: VaultRoute.reshare(vault: vault))
             } label: {


### PR DESCRIPTION
## Summary
- Hide the reshare option in vault advanced settings when the vault has an MLDSA key (`publicKeyMLDSA44 != nil`)
- MLDSA keys do not support reshare yet, so the option should not be visible for those vaults

## Test Plan
- [ ] Open a vault without an MLDSA key → reshare option is visible (existing fast vault excluded)
- [ ] Generate an MLDSA key for a vault → reshare option is hidden
- [ ] SwiftLint passes (no new violations)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vault reshare option visibility to properly account for additional vault configurations, improving the accuracy of when the reshare feature appears in vault settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->