### PR TITLE
fix: save user notifications settings under user defaults to track be tween sessions

### DIFF
--- a/VultisigApp/VultisigApp/Services/Notification/PushNotificationManager.swift
+++ b/VultisigApp/VultisigApp/Services/Notification/PushNotificationManager.swift
@@ -21,6 +21,7 @@ class PushNotificationManager: ObservableObject, PushNotificationManaging {
     var hadVaultsOnStartup = false
 
     @AppStorage("hasSeenNotificationPrompt") var hasSeenNotificationPrompt: Bool = false
+    @AppStorage("notificationsEnabled") var isNotificationsEnabled: Bool = false
 
     private let keychainService: KeychainService
     private let notificationService: NotificationServicing

--- a/VultisigApp/VultisigApp/Services/Notification/PushNotificationManaging.swift
+++ b/VultisigApp/VultisigApp/Services/Notification/PushNotificationManaging.swift
@@ -10,6 +10,7 @@ protocol PushNotificationManaging: AnyObject {
     var isPermissionGranted: Bool { get set }
     var deviceToken: String? { get }
     var hasSeenNotificationPrompt: Bool { get set }
+    var isNotificationsEnabled: Bool { get set }
     var hadVaultsOnStartup: Bool { get set }
     var foregroundNotification: ForegroundNotificationData? { get set }
 

--- a/VultisigApp/VultisigApp/Views/Settings/Notifications/NotificationsSettingsScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/Notifications/NotificationsSettingsScreen.swift
@@ -112,6 +112,7 @@ struct NotificationsSettingsScreen: View {
                 let status = await pushNotificationManager.authorizationStatus()
                 if status == .denied {
                     notificationsEnabled = false
+                    pushNotificationManager.isNotificationsEnabled = false
                     showSettingsAlert = true
                     return
                 }
@@ -119,13 +120,16 @@ struct NotificationsSettingsScreen: View {
                 let granted = await pushNotificationManager.requestPermission()
                 if granted {
                     notificationsEnabled = true
+                    pushNotificationManager.isNotificationsEnabled = true
                     pushNotificationManager.setAllVaultsOptIn(vaults, enabled: true)
                 } else {
                     notificationsEnabled = false
+                    pushNotificationManager.isNotificationsEnabled = false
                 }
             }
         } else {
-            notificationsEnabled = enabled
+            notificationsEnabled = false
+            pushNotificationManager.isNotificationsEnabled = false
             pushNotificationManager.setAllVaultsOptIn(vaults, enabled: false)
             pushNotificationManager.unregisterForRemoteNotifications()
         }
@@ -140,12 +144,18 @@ struct NotificationsSettingsScreen: View {
         }
         #endif
     }
-    
+
     @MainActor
     func checkForPermissions() async {
+        let userEnabled = pushNotificationManager.isNotificationsEnabled
         await pushNotificationManager.checkPermissionStatus()
-        let isEnabled = pushNotificationManager.isPermissionGranted
-        onNotificationsEnabled(isEnabled)
+        let osGranted = pushNotificationManager.isPermissionGranted
+
+        if userEnabled && !osGranted {
+            onNotificationsEnabled(false)
+        } else {
+            notificationsEnabled = userEnabled
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. 

Fixes #3950

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context