### PR TITLE
fix: remove address display from Circle DeFi row

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/DefiCircleRow.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/DefiCircleRow.swift
@@ -32,11 +32,7 @@ struct DefiCircleRow: View {
                         .font(Theme.fonts.bodySMedium)
                         .foregroundStyle(Theme.colors.textPrimary)
 
-                    if let address = vault.circleWalletAddress {
-                        Text(address.truncatedMiddle)
-                            .font(Theme.fonts.caption12)
-                            .foregroundStyle(Theme.colors.textTertiary)
-                    } else {
+                    if vault.circleWalletAddress == nil {
                         Text(NSLocalizedString("circleRowCreateWallet", comment: "Create Wallet"))
                             .font(Theme.fonts.caption12)
                             .foregroundStyle(Theme.colors.textTertiary)


### PR DESCRIPTION
## Summary
- Removed wallet address display from the Circle DeFi row to match Figma design
- "Create Wallet" subtitle still shows when no wallet exists

## Test plan
- [ ] Open DeFi tab and verify Circle row no longer shows the wallet address
- [ ] Verify "Create Wallet" still appears when no Circle wallet exists
- [ ] Verify balance and other right-side content still displays correctly

Closes #3955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Circle DeFi protocol row display to no longer show wallet address information inline under the title. The "Create Wallet" prompt remains visible when a wallet hasn't been created. Wallet details are now displayed in other UI areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->