### PR TITLE
fix: vault share image shows correct share count

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/VaultDetail/VaultPairDetailCard.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultDetail/VaultPairDetailCard.swift
@@ -193,7 +193,8 @@ struct VaultPairDetailCard: View {
         let part = NSLocalizedString("share", comment: "")
         let of = NSLocalizedString("of", comment: "")
         let space = " "
-        let vaultIndex = "\(deviceIndex)"
+        let computedIndex = (vault.signers.firstIndex(of: vault.localPartyID) ?? -1) + 1
+        let vaultIndex = "\(computedIndex)"
         let totalCount = "\(vault.signers.count)"
 
         return part + space + vaultIndex + space + of + space + totalCount


### PR DESCRIPTION
## Summary
- Fixed "Share 0 of 2" displaying instead of "Share 1 of 2" in the vault details shared image
- Root cause: `titlePartText()` relied on `@State deviceIndex` set via `onLoad` in `signerCell`, but `ImageRenderer` doesn't trigger `onLoad`
- Now computes the index directly from `vault.signers.firstIndex(of: vault.localPartyID)`

## Test plan
- [ ] Go to Settings > Vault Details > tap Share icon
- [ ] Save the generated image and verify it shows correct share count (e.g., "Share 1 of 2")
- [ ] Verify the vault details screen still shows correct share count

Closes #3956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed vault pair detail card index calculation to accurately display each participant's position within the vault's signer group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->