### PR TITLE
fix: close button flash in background on Receive QR

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ReceiveQRCodeBottomSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ReceiveQRCodeBottomSheet.swift
@@ -41,19 +41,19 @@ struct ReceiveQRCodeBottomSheet: View {
             .padding(.horizontal, 16)
             .frame(maxWidth: .infinity) // Use maxWidth instead of GeometryReader
             .background(ModalBackgroundView(width: proxy.size.width))
+            .overlay(alignment: .topLeading) {
+                ToolbarButton(image: "x") {
+                    onClose()
+                }
+                .padding(.top, 8)
+                .padding(.leading, 16)
+            }
         }
         .presentationDetents([.height(465)])
         .presentationBackground(Theme.colors.bgSurface1)
         .background(Theme.colors.bgSurface1)
         .presentationDragIndicator(.visible)
         .applySheetSize(700, 450)
-        .crossPlatformToolbar(ignoresTopEdge: true, showsBackButton: false) {
-            CustomToolbarItem(placement: .leading) {
-                ToolbarButton(image: "x") {
-                    onClose()
-                }
-            }
-        }
         .onLoad {
             let qrCodeImage = QRCodeGenerator().generateImage(
                 qrStringData: coin.address,


### PR DESCRIPTION
## Summary
- Fixed Close (X) button briefly appearing in the background when opening the Receive QR sheet from Chain Detail
- Root cause: `crossPlatformToolbar` without a `navigationTitle` doesn't wrap the sheet in its own `NavigationStack`, causing `.toolbar` items to leak to the parent's navigation bar
- Replaced with an overlay close button scoped to the sheet content

## Test plan
- [ ] Open Chain Detail page and tap Receive button
- [ ] Verify no Close (X) button flashes in the background during sheet presentation
- [ ] Verify the close button works correctly within the QR sheet
- [ ] Verify share and copy buttons still work in the QR sheet

Closes #3959

🤖 Generated with [Claude Code](https://claude.com/claude-code)