### PR TITLE
fix: vault share in downloaded image displays incorrect share count

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/VaultDetail/VaultPairDetailCard.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultDetail/VaultPairDetailCard.swift
@@ -13,8 +13,6 @@ struct VaultPairDetailCard: View {
     let isForSharing: Bool
     let onKeyCopy: (() -> Void)?
 
-    @State var deviceIndex: Int = 0
-
     init(vault: Vault, devicesInfo: [DeviceInfo], isForSharing: Bool = false, onKeyCopy: (() -> Void)? = nil) {
         self.vault = vault
         self.devicesInfo = devicesInfo
@@ -167,11 +165,6 @@ struct VaultPairDetailCard: View {
                 )
             }
             .frame(maxWidth: .infinity, maxHeight: 75, alignment: .center)
-            .onLoad {
-                if isLocalPary {
-                    deviceIndex = device.Index + 1
-                }
-            }
         }
     }
 
@@ -193,7 +186,8 @@ struct VaultPairDetailCard: View {
         let part = NSLocalizedString("share", comment: "")
         let of = NSLocalizedString("of", comment: "")
         let space = " "
-        let vaultIndex = "\(deviceIndex)"
+        let index = vault.signers.firstIndex(of: vault.localPartyID).map { $0 + 1 } ?? 0
+        let vaultIndex = "\(index)"
         let totalCount = "\(vault.signers.count)"
 
         return part + space + vaultIndex + space + of + space + totalCount


### PR DESCRIPTION
## Summary
- Fixed vault share count showing "Share 0 of 2" instead of correct count in downloaded/shared vault details image
- Root cause: `deviceIndex` @State variable defaulted to 0 and was only updated via `.onLoad` which doesn't fire reliably during `ImageRenderer` rendering
- Changed `titlePartText()` to compute the index directly from vault data instead of relying on state

## Issue
Closes #3956

## Changes
- `VultisigApp/Views/Vault/VaultDetail/VaultPairDetailCard.swift` — Removed `@State var deviceIndex` and its `.onLoad` setter in `signerCell`. Compute share index directly from `vault.signers.firstIndex(of: vault.localPartyID)` in `titlePartText()`

## CLAUDE.md Rules Applied
- Rule #1: Design System (Theme.colors.*, Theme.fonts.*)
- Rule #9: SwiftLint passes with no new warnings

## Self-Review Checklist
- [x] No hardcoded colors/fonts — using Theme.colors.* and Theme.fonts.*
- [x] SwiftLint passes with no new warnings
- [x] Build succeeds

## Test Plan
- [ ] Manual testing: Navigate to Settings → Vault Details → Tap Share → Save image → Verify image shows correct share count (e.g., "Share 1 of 2" not "Share 0 of 2")
- [ ] Verify on-screen vault details still shows correct share count

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal state management in vault display by simplifying device index calculations and removing unnecessary lifecycle logic. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->