### PR TITLE
fix: vault share shows 'Share 0 of N' in exported image

### DIFF
--- a/VultisigApp/VultisigApp/Views/Vault/VaultDetail/VaultPairDetailCard.swift
+++ b/VultisigApp/VultisigApp/Views/Vault/VaultDetail/VaultPairDetailCard.swift
@@ -193,8 +193,8 @@ struct VaultPairDetailCard: View {
         let part = NSLocalizedString("share", comment: "")
         let of = NSLocalizedString("of", comment: "")
         let space = " "
-        let index = devicesInfo.first(where: { $0.Signer == vault.localPartyID })?.Index ?? 0
-        let vaultIndex = "\(index + 1)"
+        let matchedIndex = devicesInfo.first(where: { $0.Signer == vault.localPartyID })?.Index
+        let vaultIndex = matchedIndex.map { "\($0 + 1)" } ?? "0"
         let totalCount = "\(vault.signers.count)"
 
         return part + space + vaultIndex + space + of + space + totalCount


### PR DESCRIPTION
## What

Fixes the vault share index displaying as "Share 0 of 2" in the downloaded/shared image from Vault Details.

## Why

`VaultPairDetailCard` uses a `@State var deviceIndex = 0` that gets updated via `onLoad` in the signer cell. When `ImageRenderer` captures the card for sharing, the `onLoad` closures don't execute during the render pass, so `deviceIndex` stays at `0`.

## How

Replaced the `@State`-dependent lookup with a direct computation from `devicesInfo` in `titlePartText()`, matching `vault.localPartyID` to find the correct index.

Closes #3956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vault position numbering so the displayed vault part index now correctly reflects the matched device information (falls back to 0 when no match), ensuring accurate "part of total" labels in vault details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->