### PR TITLE
fix: close button flashing in background when opening Receive QR sheet

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ReceiveQRCodeBottomSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ReceiveQRCodeBottomSheet.swift
@@ -41,13 +41,6 @@ struct ReceiveQRCodeBottomSheet: View {
             .padding(.horizontal, 16)
             .frame(maxWidth: .infinity) // Use maxWidth instead of GeometryReader
             .background(ModalBackgroundView(width: proxy.size.width))
-            .overlay(alignment: .topLeading) {
-                ToolbarButton(image: "x") {
-                    onClose()
-                }
-                .padding(.leading, 16)
-                .padding(.top, 16)
-            }
         }
         .presentationDetents([.height(465)])
         .presentationBackground(Theme.colors.bgSurface1)
@@ -74,6 +67,15 @@ struct ReceiveQRCodeBottomSheet: View {
                 type: .Address,
                 addressData: coin.address
             )
+        }
+        .crossPlatformToolbar(ignoresTopEdge: true, showsBackButton: false) {
+            #if os(macOS)
+            CustomToolbarItem(placement: .leading) {
+                ToolbarButton(image: "x") {
+                    onClose()
+                }
+            }
+            #endif
         }
     }
 


### PR DESCRIPTION
## What

Fixes the close (X) button briefly appearing in the ChainDetailScreen background when opening the Receive QR bottom sheet.

## Why

`ReceiveQRCodeBottomSheet` used `.crossPlatformToolbar` to render its close button on all platforms. Since no `navigationTitle` was provided, `IOSToolbarView` didn't wrap the sheet content in a `NavigationStack`, causing the `.toolbar` item to attach to the parent navigation bar (ChainDetailScreen). This made the X button flash briefly in the background during the sheet transition.

## How

Wrapped the close button in `#if os(macOS)` so it only renders on macOS, where sheets don't have native swipe-to-dismiss. On iOS, the sheet already has a drag indicator and swipe-to-dismiss, so the explicit close button is unnecessary.

SwiftLint: 0 violations ✅

Closes #3959