### PR TITLE
Fix: Secured USDC withdrawal from THORChain

### DIFF
--- a/VultisigApp/VultisigApp/Chains/thorchain.swift
+++ b/VultisigApp/VultisigApp/Chains/thorchain.swift
@@ -301,7 +301,21 @@ enum THORChainHelper {
     }
 
     private static func getTicker(coin: Coin) -> String {
-        coin.isNativeToken ? "RUNE" : getNotNativeTicker(coin: coin)
+        if coin.isNativeToken {
+            return "RUNE"
+        }
+
+        // For secured assets, we need the symbol that THORChain expects (including contract address for ERC20)
+        // For trade assets, this is the part after the first dash in the denom
+        if isSecuredAsset(coin: coin) && coin.contractAddress.contains("-") {
+            let parts = coin.contractAddress.split(separator: "-")
+            if parts.count >= 2 {
+                // Return everything after the first dash (e.g., "BTC" from "BTC-BTC" or "USDC-0xA0b86991c6218b36c1d19D4a2e9Eb0ce3606eB48" from "ETH-USDC-0xA0b86991c6218b36c1d19D4a2e9Eb0ce3606eB48")
+                return String(coin.contractAddress.dropFirst(parts[0].count + 1)).uppercased()
+            }
+        }
+
+        return getNotNativeTicker(coin: coin)
     }
 
     private static func getNotNativeTicker(coin: Coin) -> String {
@@ -310,7 +324,7 @@ enum THORChainHelper {
 
     /// Returns the list of secured asset tickers
     private static var securedAssetsTickers: [String] {
-        return ["BTC", "ETH", "BCH", "LTC", "DOGE", "AVAX", "BNB"]
+        return ["BTC", "ETH", "BCH", "LTC", "DOGE", "AVAX", "BNB", "USDC", "USDT", "DAI", "GUSD", "USDP", "LINK", "AAVE", "WBTC"]
     }
 
     /// Checks if a coin is a secured asset
@@ -319,22 +333,33 @@ enum THORChainHelper {
     }
 
     /// Gets the appropriate chain name for a coin in THORChain context
-    /// - For secured assets: returns the chain ticker (e.g., "BTC", "ETH", "DOGE")
-    /// - For BNB secured assets: returns "BSC"
+    /// - For secured assets: returns the native chain ticker (e.g., "BTC", "ETH", "AVAX")
     /// - For non-secured assets: returns "THOR"
     private static func getChainName(coin: Coin) -> String {
         guard isSecuredAsset(coin: coin) else {
             return "THOR"
         }
 
+        // For secured assets, try to parse the native chain from the contractAddress (denom)
+        // Trade assets on THORChain have denoms like "BTC-BTC" or "ETH-USDC-0xA0b86991c6218b36c1d19D4a2e9Eb0ce3606eB48"
+        if coin.contractAddress.contains("-") {
+            let parts = coin.contractAddress.split(separator: "-")
+            if !parts.isEmpty {
+                let chainPart = String(parts[0]).uppercased()
+                // THORChain uses "BSC" for BNB chain assets, but some denoms might use "BNB"
+                if chainPart == "BNB" || chainPart == "BSC" {
+                    return "BSC"
+                }
+                return chainPart
+            }
+        }
+
         let ticker = coin.ticker.uppercased()
 
-        // BNB uses BSC chain
+        // Fallback for older coins that might not have the dash-format contractAddress
         if ticker == "BNB" {
             return "BSC"
         }
-
-        // For other secured assets, use the coin's ticker THOR-DOGE will return DOGE
         return ticker
     }
 

--- a/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Model/FunctionCall/FunctionCallWithdrawSecuredAsset.swift
@@ -74,22 +74,29 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
         loadError = nil
 
         // Supported secured asset tickers
-        let supportedTickers = ["BTC", "ETH", "BCH", "LTC", "DOGE", "AVAX", "BNB"]
+        let supportedTickers = ["BTC", "ETH", "BCH", "LTC", "DOGE", "AVAX", "BNB", "USDC", "USDT", "DAI", "GUSD", "USDP", "LINK", "AAVE", "WBTC"]
 
         // Get secured assets that actually exist in the vault
-        // They might be stored as "DOGE" or "DOGE-DOGE" format
         let securedAssetsInVault = vault.coins.filter { coin in
-            guard coin.chain == .thorChain && coin.balanceDecimal > 0 else { return false }
+            guard coin.chain == .thorChain && coin.balanceDecimal > 0 && !coin.isNativeToken else { return false }
 
             let ticker = coin.ticker.uppercased()
-            // Check if it matches a supported ticker directly (e.g., "DOGE")
+            let denom = coin.contractAddress.uppercased()
+            
+            // Check if it matches a supported ticker directly (e.g., "BTC")
             if supportedTickers.contains(ticker) {
                 return true
             }
-            // Check if it's in dash format (e.g., "DOGE-DOGE")
-            for supported in supportedTickers {
-                if ticker == "\(supported)-\(supported)" {
-                    return true
+            
+            // Check if it's in dash format (e.g., "BTC-BTC" or "ETH-USDC-0xA0b86991c6218b36c1d19D4a2e9Eb0ce3606eB48")
+            if denom.contains("-") {
+                let parts = denom.split(separator: "-")
+                if parts.count >= 2 {
+                    // Check if the symbol part (e.g., "USDC" or "BTC") is supported
+                    let actualTicker = String(parts[1]).uppercased()
+                    if supportedTickers.contains(actualTicker) {
+                        return true
+                    }
                 }
             }
             return false
@@ -107,16 +114,8 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
             } else {
 
                 let vaultAssets = securedAssetsInVault.map { coin in
-                    let ticker = coin.ticker.uppercased()
-
-                    if ticker.contains("-") {
-                        let parts = ticker.split(separator: "-")
-                        if parts.count == 2 && parts[0] == parts[1] {
-                            return IdentifiableString(value: String(parts[0]))
-                        }
-                    }
-                    // Otherwise use the ticker as is
-                    return IdentifiableString(value: coin.ticker)
+                    // Store the contractAddress (denom) in the value to uniquely identify the coin
+                    return IdentifiableString(value: coin.contractAddress)
                 }
                 assetList.append(contentsOf: vaultAssets)
                 self.availableSecuredAssets = assetList
@@ -136,26 +135,24 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
             securedAssetValid = false
             destinationAddress = ""
             destinationAddressValid = false
+            selectedSecuredAssetCoin = nil
             return
         }
 
         // Valid asset selected
         securedAssetValid = true
 
-        // Update destination address based on selected asset
+        // Update destination address based on selected asset (using the contractAddress/denom)
         updateDestinationAddressForAsset(asset.value)
 
         // Update the tx.coin to the selected secured asset for balance validation
         updateTxCoinForSelectedAsset(asset.value)
     }
 
-    private func updateDestinationAddressForAsset(_ assetName: String) {
-        // assetName is just the ticker (e.g., "BTC", "ETH", "DOGE")
-        let ticker = assetName.uppercased()
-
-        // Map secured asset ticker to its native chain
+    private func updateDestinationAddressForAsset(_ denom: String) {
+        // Map secured asset denom to its native chain
         // When withdrawing, we need to send to the original chain address
-        let targetChain = getChainForSecuredAsset(ticker)
+        let targetChain = getChainForSecuredAsset(denom)
 
         // Find the corresponding native coin in vault to get the user's own address for that chain
         if let coin = vault.coins.first(where: {
@@ -168,55 +165,81 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
             // If no coin exists for that chain in the vault, show error
             destinationAddress = ""
             destinationAddressValid = false
-            customErrorMessage = String(format: NSLocalizedString("withdrawSecuredAssetError", comment: ""), ticker, ticker, targetChain.name)
+            customErrorMessage = String(format: NSLocalizedString("withdrawSecuredAssetError", comment: ""), formatAssetName(denom), formatAssetName(denom), targetChain.name)
         }
     }
 
-    /// Maps a secured asset ticker to its native blockchain chain
-    private func getChainForSecuredAsset(_ ticker: String) -> Chain {
-        switch ticker.uppercased() {
-        case "BTC":
-            return .bitcoin
-        case "ETH":
-            return .ethereum
-        case "BCH":
-            return .bitcoinCash
-        case "LTC":
-            return .litecoin
-        case "DOGE":
-            return .dogecoin
-        case "AVAX":
-            return .avalanche
-        case "BNB":
-            return .bscChain
-        default:
-            // Fallback to THORChain if unknown (shouldn't happen)
-            return .thorChain
+    /// Maps a secured asset denom (contractAddress) to its native blockchain chain
+    private func getChainForSecuredAsset(_ denom: String) -> Chain {
+        let cleanDenom = denom.uppercased()
+        
+        if cleanDenom.contains("-") {
+            let parts = cleanDenom.split(separator: "-")
+            if !parts.isEmpty {
+                let chainPart = String(parts[0])
+                switch chainPart {
+                case "BTC": return .bitcoin
+                case "ETH": return .ethereum
+                case "BCH": return .bitcoinCash
+                case "LTC": return .litecoin
+                case "DOGE": return .dogecoin
+                case "AVAX": return .avalanche
+                case "BNB", "BSC": return .bscChain
+                default: break
+                }
+            }
+        }
+        
+        // Fallback to ticker-based mapping for older coins or non-dash denoms
+        let ticker = denom.uppercased()
+        switch ticker {
+        case "BTC": return .bitcoin
+        case "ETH": return .ethereum
+        case "BCH": return .bitcoinCash
+        case "LTC": return .litecoin
+        case "DOGE": return .dogecoin
+        case "AVAX": return .avalanche
+        case "BNB": return .bscChain
+        default: return .thorChain
         }
     }
 
-    private func updateTxCoinForSelectedAsset(_ assetName: String) {
-        // assetName is just the ticker (e.g., "BTC", "ETH", "DOGE")
-        let ticker = assetName.uppercased()
-
-        // Find the secured asset coin - it could be stored as "DOGE" or "DOGE-DOGE"
+    private func updateTxCoinForSelectedAsset(_ denom: String) {
+        // Find the secured asset coin by its contractAddress (denom)
         if let securedAssetCoin = vault.coins.first(where: {
-            guard $0.chain == .thorChain else { return false }
-            let coinTicker = $0.ticker.uppercased()
-            // Check if it matches the ticker directly or in the "TICKER-TICKER" format
-            return coinTicker == ticker || coinTicker == "\(ticker)-\(ticker)"
+            $0.chain == .thorChain && $0.contractAddress.uppercased() == denom.uppercased()
         }) {
             selectedSecuredAssetCoin = securedAssetCoin
-
             // Set the coin and ensure isNativeToken is false for secured assets
             // This will make getTicker() use getNotNativeTicker() which handles secured assets correctly
-            let correctedCoin = securedAssetCoin
-            correctedCoin.isNativeToken = false
-
-            tx.coin = correctedCoin
+            tx.coin = securedAssetCoin
         } else {
             selectedSecuredAssetCoin = nil
         }
+    }
+    
+    /// Formats a secured asset denom for display (e.g., "ETH-USDC-0xA0b86991c6218b36c1d19D4a2e9Eb0ce3606eB48" -> "USDC (ETH)")
+    func formatAssetName(_ denom: String) -> String {
+        if denom == Self.INITIAL_ITEM_FOR_DROPDOWN_TEXT {
+            return denom
+        }
+        
+        let cleanDenom = denom.uppercased()
+        if cleanDenom.contains("-") {
+            let parts = cleanDenom.split(separator: "-")
+            if parts.count >= 2 {
+                let chainPart = String(parts[0])
+                let symbolPart = String(parts[1])
+                
+                if chainPart == symbolPart {
+                    return chainPart
+                } else {
+                    return "\(symbolPart) (\(chainPart))"
+                }
+            }
+        }
+        
+        return denom
     }
 
     private func setupValidation() {
@@ -404,7 +427,7 @@ struct SecuredAssetSelectorSection: View {
                 set: { model.selectedSecuredAsset = $0 }
             ),
             mandatoryMessage: "*",
-            descriptionProvider: { $0.value },
+            descriptionProvider: { model.formatAssetName($0.value) },
             onSelect: { asset in
                 model.selectSecuredAsset(asset)
             }

--- a/VultisigApp/VultisigAppTests/TestData/thorchain.json
+++ b/VultisigApp/VultisigAppTests/TestData/thorchain.json
@@ -333,5 +333,38 @@
             "lib_type": "DKLS"
         },
         "expected_image_hash": ["815f5f2cc595263c742dd3e2d37cb9c90a659e7bae427d31b0fa6fd950c5a8ba"]
+    },
+    {
+        "name": "Withdraw Secured USDC ETH",
+        "keysign_payload": {
+            "coin": {
+                "chain": "THORChain",
+                "ticker": "USDC",
+                "address": "thor18altpx2gwt4c4ejr5uzda4kyzsudyn9q56fnng",
+                "decimals": 8,
+                "price_provider_id": "usdc",
+                "is_native_token": false,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address":"ETH-USDC-0xA0b86991c6218b36c1d19D4a2e9Eb0ce3606eB48",
+                "logo": "usdc.png"
+            },
+            "to_address": "",
+            "to_amount": "100000000",
+            "BlockchainSpecific": {
+                "ThorchainSpecific": {
+                    "account_number": 123456,
+                    "sequence": 1,
+                    "fee": 200000,
+                    "is_deposit": true,
+                    "transaction_type": 0
+                }
+            },
+            "memo": "SECURE-:0x1234567890123456789012345678901234567890",
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": ["180f19d10e4a98474d02c6e45ab60e23358255b4e8a2c60fc0528c7ac78c230d"]
     }
 ]


### PR DESCRIPTION
This PR adds support for withdrawing Secured USDC and other ERC-20 secured assets from THORChain back to their native chains.

### Changes:
- Expanded supported secured asset tickers in `thorchain.swift`.
- Updated `getChainName` and `getTicker` to handle trade assets (ERC-20) by parsing the `contractAddress` (denom).
- Improved asset selection in `FunctionCallWithdrawSecuredAsset.swift` to support ERC-20 denoms and provide better display names.
- Added a test case for Secured USDC ETH withdrawal.

Verified with `ChainHelperTests`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded secured asset support on THORChain, now including USDC, USDT, DAI, GUSD, USDP, LINK, AAVE, and WBTC for withdrawals.
  * Enhanced chain detection and asset identification for secured asset transactions.
  * Improved asset naming and display for better clarity during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->