### PR TITLE
fix: remove paired sign long-hold from fast vault verify screens

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
@@ -169,17 +169,8 @@ struct CircleWithdrawView: View {
     @ViewBuilder
     var withdrawButton: some View {
         if isFastVault {
-            VStack {
-                Text(NSLocalizedString("holdForPairedSign", comment: ""))
-                    .foregroundColor(Theme.colors.textTertiary)
-                    .font(Theme.fonts.bodySMedium)
-
-                LongPressPrimaryButton(title: NSLocalizedString("circleWithdrawConfirm", comment: "Continue")) {
-                    fastPasswordPresented = true
-                } longPressAction: {
-                    fastVaultPassword = ""
-                    Task { await handleWithdraw() }
-                }
+            PrimaryButton(title: NSLocalizedString("circleWithdrawConfirm", comment: "Continue")) {
+                fastPasswordPresented = true
             }
             .disabled(isButtonDisabled)
         } else {

--- a/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallVerifyScreen.swift
@@ -87,25 +87,16 @@ struct FunctionCallVerifyScreen: View {
     var pairedSignButton: some View {
         VStack {
             if tx.isFastVault {
-                Text(NSLocalizedString("holdForPairedSign", comment: ""))
-                    .foregroundColor(Theme.colors.textTertiary)
-                    .font(Theme.fonts.bodySMedium)
-
-                LongPressPrimaryButton(
-                    title: NSLocalizedString("signTransaction", comment: "")) {
-                        fastPasswordPresented = true
-                    } longPressAction: {
-                        // Clear password for paired sign (long press)
-                        tx.fastVaultPassword = .empty
-                        onSignPress()
-                    }
-                    .crossPlatformSheet(isPresented: $fastPasswordPresented) {
-                        FastVaultEnterPasswordView(
-                            password: $tx.fastVaultPassword,
-                            vault: vault,
-                            onSubmit: { onSignPress() }
-                        )
-                    }
+                PrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
+                    fastPasswordPresented = true
+                }
+                .crossPlatformSheet(isPresented: $fastPasswordPresented) {
+                    FastVaultEnterPasswordView(
+                        password: $tx.fastVaultPassword,
+                        vault: vault,
+                        onSubmit: { onSignPress() }
+                    )
+                }
             } else {
                 PrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
                     onSignPress()

--- a/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallVerifyView.swift
+++ b/VultisigApp/VultisigApp/Views/FunctionCall/FunctionCallVerifyView.swift
@@ -99,23 +99,16 @@ struct FunctionCallVerifyScreen: View {
     var pairedSignButton: some View {
         VStack {
             if tx.isFastVault {
-                Text(NSLocalizedString("holdForPairedSign", comment: ""))
-                    .foregroundColor(Theme.colors.textExtraLight)
-                    .font(Theme.fonts.bodySMedium)
-
-                LongPressPrimaryButton(
-                    title: NSLocalizedString("signTransaction", comment: "")) {
-                        fastPasswordPresented = true
-                    } longPressAction: {
-                        onSignPress()
-                    }
-                    .crossPlatformSheet(isPresented: $fastPasswordPresented) {
-                        FastVaultEnterPasswordView(
-                            password: $tx.fastVaultPassword,
-                            vault: vault,
-                            onSubmit: { onSignPress() }
-                        )
-                    }
+                PrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
+                    fastPasswordPresented = true
+                }
+                .crossPlatformSheet(isPresented: $fastPasswordPresented) {
+                    FastVaultEnterPasswordView(
+                        password: $tx.fastVaultPassword,
+                        vault: vault,
+                        onSubmit: { onSignPress() }
+                    )
+                }
             } else {
                 PrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
                     onSignPress()

--- a/VultisigApp/VultisigApp/Views/Send/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Views/Send/Screens/SendVerifyScreen.swift
@@ -126,16 +126,8 @@ struct SendVerifyScreen: View {
     var pairedSignButton: some View {
         VStack {
             if tx.isFastVault {
-                Text(NSLocalizedString("holdForPairedSign", comment: ""))
-                    .foregroundColor(Theme.colors.textTertiary)
-                    .font(Theme.fonts.bodySMedium)
-
-                LongPressPrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
+                PrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
                     fastPasswordPresented = true
-                } longPressAction: {
-                    // Clear password for paired sign (long press)
-                    tx.fastVaultPassword = .empty
-                    onSignPress()
                 }
                 .crossPlatformSheet(isPresented: $fastPasswordPresented) {
                     FastVaultEnterPasswordView(

--- a/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Views/Settings/SettingsCustomMessageView.swift
@@ -151,14 +151,8 @@ struct SettingsCustomMessageView: View {
     var signButton: some View {
         VStack(spacing: 16) {
             if isFastVault {
-                Text(NSLocalizedString("holdForPairedSign", comment: ""))
-                    .foregroundColor(Theme.colors.textTertiary)
-                    .font(Theme.fonts.bodySMedium)
-
-                LongPressPrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
+                PrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
                     fastPasswordPresented = true
-                } longPressAction: {
-                    onSignPress()
                 }
                 .disabled(!signButtonEnabled)
                 .crossPlatformSheet(isPresented: $fastPasswordPresented) {

--- a/VultisigApp/VultisigApp/Views/Swap/SwapVerifyView.swift
+++ b/VultisigApp/VultisigApp/Views/Swap/SwapVerifyView.swift
@@ -199,16 +199,8 @@ struct SwapVerifyView: View {
     @ViewBuilder
     var signButton: some View {
         if tx.isFastVault {
-            Text(NSLocalizedString("holdForPairedSign", comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
-                .font(Theme.fonts.bodySMedium)
-
-            LongPressPrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
+            PrimaryButton(title: NSLocalizedString("signTransaction", comment: "")) {
                 fastPasswordPresented = true
-            } longPressAction: {
-                // Clear password for paired sign (long press)
-                tx.fastVaultPassword = .empty
-                onSignPress()
             }
             .disabled(signButtonDisabled)
             .crossPlatformSheet(isPresented: $fastPasswordPresented) {


### PR DESCRIPTION
## Description

Fast vaults use server-assisted signing (password/biometric → api.vultisig.com). The `LongPressPrimaryButton` on verify screens has a long-press action that clears `fastVaultPassword` and routes to the QR/paired signing path, which hangs forever at "Waiting for device to join" since no second device will ever join.

### Root Cause

All verify screens (Send, Swap, FunctionCall, FunctionCallVerify, Circle, Custom Message) render a `LongPressPrimaryButton` for fast vaults with:
- Normal tap → shows password sheet (correct fast sign path)
- Long press → clears password, calls `onSignPress()` directly → paired/QR sign (dead end)

### Fix

Replace `LongPressPrimaryButton` with `PrimaryButton` that shows the password sheet. Remove the "Hold for paired sign" hint text and the long-press action closure.

Secure vault behavior is unchanged — they still use `PrimaryButton` with direct `onSignPress()`.

## Risk

Low — only changes the fast vault branch. Secure vault path untouched.

## Testing

### Engineering
- Verify Send, Swap, Deposit, FunctionCall, Circle, and Custom Message screens show plain button for fast vaults
- Verify tapping the button shows password sheet and completes fast sign
- Verify no "Hold for paired sign" text appears for fast vaults

### Operations
- Test fast vault send flow end-to-end (amount → verify → sign → broadcast)