### PR TITLE
chore: add merge_group trigger to CI workflow

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Add `merge_group` trigger targeting `main` branch to the Xcode build/test workflow
- Enables CI to run when PRs enter GitHub's merge queue

## Test plan
- [ ] Verify workflow runs on merge queue events
- [ ] Confirm existing push and pull_request triggers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow to better support merge queue operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->