### PR TITLE
fix: debounce THORName/ENS resolution to prevent premature parsing

### DIFF
--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
@@ -68,11 +68,6 @@ struct SendDetailsAddressFields: View {
         ) {
             handle(addressResult: $0)
         }
-        .onChange(of: tx.toAddress) { _, newValue in
-            DebounceHelper.shared.debounce {
-                validateAddress(newValue)
-            }
-        }
     }
 
     func handle(addressResult: AddressResult?) {
@@ -108,11 +103,5 @@ struct SendDetailsAddressFields: View {
             }
         }
 
-        // Always validate after potential chain switch
-        validateAddress(tx.toAddress)
-    }
-
-    func validateAddress(_ newValue: String) {
-        sendCryptoViewModel.validateAddress(tx: tx, address: newValue)
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/AddressService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/AddressService.swift
@@ -69,63 +69,49 @@ struct AddressService {
 
     static func resolveInput(_ input: String, chain: Chain) async throws -> String {
         if chain == .mayaChain {
-            let isValid = AnyAddress.isValidBech32(string: input, coin: .thorchain, hrp: "maya")
-
-            if isValid {
-                return input
-            } else {
+            guard AnyAddress.isValidBech32(string: input, coin: .thorchain, hrp: "maya") else {
                 throw Errors.invalidAddress
             }
+            return input
         }
 
         if chain == .thorChainChainnet {
-            let isValid = AnyAddress.isValidBech32(string: input, coin: .thorchain, hrp: "cthor")
-
-            if isValid {
+            if AnyAddress.isValidBech32(string: input, coin: .thorchain, hrp: "cthor") {
                 return input
-            } else {
-                // Try TNS resolution for stagenet
-                let service = ThorchainServiceFactory.getService(for: .thorChainChainnet)
-                return try await service.resolveTNS(name: input, chain: chain)
             }
+            let service = ThorchainServiceFactory.getService(for: .thorChainChainnet)
+            return try await resolveAndValidate(await service.resolveTNS(name: input, chain: chain), chain: chain)
         }
 
         if chain == .thorChainStagenet {
-            let isValid = AnyAddress.isValidBech32(string: input, coin: .thorchain, hrp: "sthor")
-
-            if isValid {
+            if AnyAddress.isValidBech32(string: input, coin: .thorchain, hrp: "sthor") {
                 return input
-            } else {
-                let service = ThorchainServiceFactory.getService(for: .thorChainStagenet)
-                return try await service.resolveTNS(name: input, chain: chain)
             }
+            let service = ThorchainServiceFactory.getService(for: .thorChainStagenet)
+            return try await resolveAndValidate(await service.resolveTNS(name: input, chain: chain), chain: chain)
         }
 
         if chain == .qbtc {
-            let isValid = AnyAddress.isValidBech32(string: input, coin: .cosmos, hrp: "qbtc")
-
-            if isValid {
-                return input
-            } else {
+            guard AnyAddress.isValidBech32(string: input, coin: .cosmos, hrp: "qbtc") else {
                 throw Errors.invalidAddress
             }
-        }
-
-        let isValid = chain.coinType.validate(address: input)
-
-        if isValid {
             return input
-
-        } else if input.isENSNameService() {
-            return try await AddressService.resolveENSDomaninAddress(input: input, chain: chain)
-
-        } else if chain == .thorChain {
-            let service = ThorchainServiceFactory.getService(for: .thorChain)
-            return try await service.resolveTNS(name: input, chain: chain)
-
-        } else {
-            throw Errors.invalidAddress
         }
+
+        if chain.coinType.validate(address: input) {
+            return input
+        }
+
+        if input.isENSNameService() {
+            return try await resolveAndValidate(await resolveENSDomaninAddress(input: input, chain: chain), chain: chain)
+        }
+
+        if chain == .thorChain {
+            let service = ThorchainServiceFactory.getService(for: .thorChain)
+            return try await resolveAndValidate(await service.resolveTNS(name: input, chain: chain), chain: chain)
+        }
+
+        throw Errors.invalidAddress
     }
 
     static func validateAddress(address: String, chain: Chain) -> Bool {
@@ -174,6 +160,14 @@ private extension AddressService {
 
     enum Errors: Error {
         case invalidAddress
+    }
+
+    static func resolveAndValidate(_ resolution: @autoclosure () async throws -> String, chain: Chain) async throws -> String {
+        let resolved = try await resolution()
+        guard validateAddress(address: resolved, chain: chain) else {
+            throw Errors.invalidAddress
+        }
+        return resolved
     }
 
     static func resolveENSDomaninAddress(input: String, chain: Chain) async throws -> String {

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoViewModel.swift
@@ -26,6 +26,10 @@ class SendCryptoViewModel: ObservableObject {
     // Logic delegation
     private let logic = SendCryptoLogic()
 
+    // Address resolution
+    @Published private(set) var addressResolved: Bool?
+    private var addressResolutionTask: Task<Void, Never>?
+
     // State for alerts
     @Published var showAddressAlert: Bool = false
     @Published var showAmountAlert: Bool = false
@@ -60,6 +64,31 @@ class SendCryptoViewModel: ObservableObject {
         tx.isFastVault = await logic.loadFastVault(vault: vault)
     }
 
+    func isValidAddressFormat(tx: SendTransaction) -> Bool {
+        guard !tx.toAddress.isEmpty else { return false }
+        let isValid = AddressService.validateAddress(address: tx.toAddress, chain: tx.coin.chain)
+        if isValid {
+            showAddressAlert = false
+            errorMessage = nil
+        }
+        return isValid
+    }
+
+    func debouncedResolveAddress(tx: SendTransaction) {
+        addressResolutionTask?.cancel()
+        addressResolved = nil
+        addressResolutionTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
+            addressResolved = await validateToAddress(tx: tx)
+        }
+    }
+
+    func cancelAddressResolution() {
+        addressResolutionTask?.cancel()
+        addressResolved = nil
+    }
+
     func setMaxValues(tx: SendTransaction, percentage: Double = 100) {
         errorMessage = ""
         isLoading = true
@@ -76,13 +105,6 @@ class SendCryptoViewModel: ObservableObject {
 
     func convertToFiat(newValue: String, tx: SendTransaction, setMaxValue: Bool = false) {
         logic.convertToFiat(newValue: newValue, tx: tx, setMaxValue: setMaxValue)
-    }
-
-    func validateAddress(tx: SendTransaction, address: String) {
-        guard !isNamespaceResolved else {
-            return
-        }
-        _ = AddressService.validateAddress(address: address, chain: tx.coin.chain)
     }
 
     func validateAmount(amount: String) {
@@ -242,7 +264,6 @@ struct SendCryptoLogic {
 
         do {
             let resolvedAddress = try await AddressService.resolveInput(tx.toAddress, chain: tx.coin.chain)
-            // Mutate tx address on MainActor
             await MainActor.run {
                 tx.toAddress = resolvedAddress
             }
@@ -253,16 +274,6 @@ struct SendCryptoLogic {
             logger.log("Please enter a valid address for the selected blockchain.")
             result.isValid = false
             return result
-        }
-
-        let isValid = AddressService.validateAddress(address: tx.toAddress, chain: tx.coin.chain)
-        if !isValid {
-             result.errorTitle = "error"
-             result.errorMessage = "validAddressError"
-             result.showAddressAlert = true
-             logger.log("Invalid address.")
-             result.isValid = false
-             return result
         }
 
         return result

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
@@ -32,7 +32,6 @@ struct SendDetailsScreen: View {
     @EnvironmentObject var deeplinkViewModel: DeeplinkViewModel
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
     @State var countdownTimer: Timer?
-
     @Environment(\.router) var router
 
     var body: some View {
@@ -74,7 +73,28 @@ struct SendDetailsScreen: View {
                 }
             }
             .onChange(of: tx.toAddress) { _, _ in
-                validateAddress()
+                sendCryptoViewModel.cancelAddressResolution()
+
+                guard !tx.toAddress.isEmpty else {
+                    sendDetailsViewModel.addressSetupDone = false
+                    return
+                }
+
+                if sendCryptoViewModel.isValidAddressFormat(tx: tx) {
+                    sendDetailsViewModel.addressSetupDone = true
+                    sendDetailsViewModel.onSelect(tab: .amount)
+                } else {
+                    sendCryptoViewModel.debouncedResolveAddress(tx: tx)
+                }
+            }
+            .onChange(of: sendCryptoViewModel.addressResolved) { _, resolved in
+                guard let resolved else { return }
+                sendDetailsViewModel.addressSetupDone = resolved
+                if resolved {
+                    sendDetailsViewModel.onSelect(tab: .amount)
+                } else if sendDetailsViewModel.selectedTab == .amount {
+                    sendDetailsViewModel.onSelect(tab: .address)
+                }
             }
             .onDisappear {
                 sendCryptoViewModel.stopMediator()
@@ -361,29 +381,19 @@ private func setMainData() async {
         }
 
         if !tx.toAddress.isEmpty {
-            sendCryptoViewModel.validateAddress(tx: tx, address: tx.toAddress)
-            validateAddress()
+            if sendCryptoViewModel.isValidAddressFormat(tx: tx) {
+                sendDetailsViewModel.addressSetupDone = true
+                sendDetailsViewModel.onSelect(tab: .amount)
+            } else {
+                let resolved = await sendCryptoViewModel.validateToAddress(tx: tx)
+                sendDetailsViewModel.addressSetupDone = resolved
+                if resolved {
+                    sendDetailsViewModel.onSelect(tab: .amount)
+                }
+            }
         }
 
         await sendCryptoViewModel.loadFastVault(tx: tx, vault: vault)
-    }
-
-    private func validateAddress() {
-        Task {
-            guard await sendCryptoViewModel.validateToAddress(tx: tx) else {
-                sendDetailsViewModel.addressSetupDone = false
-                // Only force back to address tab if we're on amount tab
-                // (can't proceed to amount without valid address).
-                // Don't override if user is on asset tab — they should be
-                // free to switch assets even with an invalid address.
-                if sendDetailsViewModel.selectedTab == .amount {
-                    sendDetailsViewModel.onSelect(tab: .address)
-                }
-                return
-            }
-            sendDetailsViewModel.addressSetupDone = true
-            sendDetailsViewModel.onSelect(tab: .amount)
-        }
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Debounce async THORName/ENS resolution (1s) so users can type full names without premature parsing interrupting input
- Run sync address format validation immediately for instant feedback on valid addresses
- Move address validation logic from View to ViewModel (`isValidAddressFormat`, `debouncedResolveAddress`, `cancelAddressResolution`)
- Centralize post-resolution validation in `AddressService.resolveAndValidate` and remove redundant check from `SendCryptoLogic`
- Remove dead code: `SendCryptoViewModel.validateAddress(tx:address:)` and unused onChange in `SendDetailsAddressFields`

Closes #4057

## Test plan
- [ ] Navigate to Send RUNE, type a THORName character by character — input should not be interrupted
- [ ] Paste a valid THORChain address — should proceed to amount tab immediately (no 1s delay)
- [ ] Type a valid THORName and wait 1s — should resolve and proceed to amount tab
- [ ] Type an invalid THORName and wait 1s — should show address error
- [ ] Test ENS resolution on EVM chains (e.g. `vitalik.eth`)
- [ ] Test deeplink with THORName address — should resolve immediately on load
- [ ] Verify Send flow works end-to-end for regular addresses across chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved address validation for resolved addresses (ENS/TNS), ensuring they are properly validated against target chains.

* **Refactor**
  * Enhanced address validation flow: synchronous format validation now occurs immediately, while address resolution is debounced asynchronously for better performance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->