### PR TITLE
fix: clear orphaned sheet blur counter on splash-to-content transition

### DIFF
--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
     @EnvironmentObject var deeplinkViewModel: DeeplinkViewModel
     @EnvironmentObject var pushNotificationManager: PushNotificationManager
+    @Environment(\.sheetPresentedCounterManager) var sheetPresentedCounterManager
 
     @State private var rootRoute: RootRoute?
     @State private var deeplinkError: Error?
@@ -100,6 +101,14 @@ struct ContentView: View {
             guard newValue else { return }
             navigateToHome()
             appViewModel.restartNavigation = false
+        }
+        .onChange(of: appViewModel.showSplashView) { oldValue, newValue in
+            // Clear any orphaned sheet blur counter when transitioning from splash to main content.
+            // No sheets can be presenting at this moment (home screen hasn't loaded yet),
+            // so any counter > 0 is stale from a previous session's view lifecycle.
+            if oldValue && !newValue {
+                sheetPresentedCounterManager.resetCounter()
+            }
         }
         .withError(error: $deeplinkError, errorType: .warning) {
             // Retry action - clear error to allow user to try again

--- a/VultisigApp/VultisigApp/Components/Sheet/SheetPresentedCounterManager/SheetPresentedCounterManager.swift
+++ b/VultisigApp/VultisigApp/Components/Sheet/SheetPresentedCounterManager/SheetPresentedCounterManager.swift
@@ -21,6 +21,7 @@ class SheetPresentedCounterManager: ObservableObject {
     }
 
     func resetCounter() {
+        guard self.counter != 0 else { return }
         self.counter = 0
     }
 }


### PR DESCRIPTION
Closes #4070

## Problem

After not using the Vultisig iOS app for an extended period (months), opening the app and completing Face ID authentication can leave the portfolio screen stuck behind an uninteractable blur overlay — a 40% black tint with 6px Gaussian blur covering the entire screen. No sheet or dialog is visible in the foreground, and there is no way to dismiss it. The user must force-quit and reopen the app.

## Root cause

The blur is applied by `SheetPresentedViewModifier`, which overlays the `NavigationStack` content whenever `SheetPresentedCounterManager.counter > 0`. This counter is incremented when a `crossPlatformSheet` presents, and decremented when it dismisses. The counter resets to 0 when the app enters the background (`didEnterBackgroundNotification`).

After a long idle period, the app goes through an auth cycle on return to foreground: `enableAuth()` toggles `showSplashView`, triggering view destruction and recreation of the container hierarchy. During this SwiftUI view lifecycle churn, the counter can become orphaned — incremented by a sheet modifier on a view that is subsequently destroyed before the matching decrement fires. The exact SwiftUI lifecycle edge case is difficult to reproduce deterministically, but the symptom (counter stuck above zero with no visible sheet) was confirmed on a physical device.

## Fix

This is a **defensive fix**. It resets `SheetPresentedCounterManager` when `showSplashView` transitions from `true` to `false` in `ContentView`. This is the boundary between the splash/auth screen and the main content. At this exact moment:

- The splash screen (`WelcomeView`) is being dismissed — it contains no `crossPlatformSheet` modifiers
- The main content (home screen, sheets) hasn't loaded yet
- Therefore `counter` must be 0; any value > 0 is orphaned

All 8 code paths that set `showSplashView = false` were verified safe for a counter reset — in every case either the splash view was showing (no sheets possible) or the navigation stack is being reset (destroying any existing sheets).

## Test plan

> **Note:** Debug builds skip Face ID (`isRunningOnPhysicalDevice()` returns `false` for `#elseif DEBUG`). To test on a physical device, temporarily apply this **unstaged** change to `AppViewModel.swift`:
> ```diff
>      func isRunningOnPhysicalDevice() -> Bool {
>          #if targetEnvironment(simulator)
>          return false
> -        #elseif DEBUG
> -        return false
>          #else
>          return true
>          #endif
>      }
> ```

**Reproduce the stuck blur (without the fix):**
1. Revert the `ContentView.swift` change from this PR
2. In `HomeScreen.swift`, temporarily add to the body:
   ```swift
   .onAppear {
       DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
           SheetPresentedCounterManagerKey.defaultValue.increment()
       }
   }
   ```
3. Build and run on a physical device — after 2 seconds the portfolio blurs with no visible sheet and no way to dismiss

**Verify the fix clears orphaned blur:**
1. Apply the `ContentView.swift` change from this PR
2. Keep the same temporary `HomeScreen.swift` hack from above
3. Also temporarily change `AppViewModel.swift` interval from `60*5` to `5` for faster testing
4. Build and run — blur appears after 2 seconds
5. Background the app, wait >5 seconds, reopen — Face ID triggers and blur clears on auth completion

**Verify no regressions:**
- [ ] Open any sheet (vault selector, send, settings) — blur appears behind it, clears on dismiss
- [ ] Open a sheet, background the app, reopen — no stuck blur
- [ ] Normal app launch with Face ID — no flash of blur
- [ ] App launch with no vaults — create vault flow works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
