### PR TITLE
fix: double Face ID prompt on app launch

### DIFF
--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -147,6 +147,10 @@ struct ContentView: View {
             return
         }
 
+        guard !appViewModel.didUserCancelAuthentication else {
+            return
+        }
+
         guard !appViewModel.showOnboarding && !vaults.isEmpty else {
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                 appViewModel.showSplashView = false

--- a/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
@@ -30,6 +30,7 @@ class AppViewModel: ObservableObject {
     @Published var showCamera: Bool = false
 
     private let logic = AccountLogic()
+    private var didTriggerAuthThisSession = false
 
     static let shared = AppViewModel()
 
@@ -65,6 +66,8 @@ class AppViewModel: ObservableObject {
     }
 
     func authenticateUser() {
+        didTriggerAuthThisSession = true
+
         #if DEBUG
         if CommandLine.arguments.contains("-skipAuthentication") {
             isAuthenticated = true
@@ -133,6 +136,7 @@ class AppViewModel: ObservableObject {
 
     func revokeAuth() {
         showCover = true
+        didTriggerAuthThisSession = false
         let formatter = ISO8601DateFormatter()
         lastRecordedTime = formatter.string(from: Date())
     }
@@ -144,7 +148,7 @@ class AppViewModel: ObservableObject {
         let interval = Date().timeIntervalSince(date)
         lastRecordedTime = formatter.string(from: Date())
 
-        if interval>60*5 {
+        if interval>60*5 && !didTriggerAuthThisSession {
             resetLogin()
             continueLogin()
         }


### PR DESCRIPTION
## Summary
- Fixes #4071
- On cold start after > 5 min idle, `enableAuth()` races with the Face ID already triggered by the splash view's `onAppear`, causing a double Face ID prompt
- After cancellation, `onAppear` could re-trigger Face ID automatically instead of showing the "try again" button

## Changes

**AppViewModel.swift** — Add in-memory `didTriggerAuthThisSession` flag, set synchronously in `authenticateUser()` before the async Face ID starts, checked in `enableAuth()`:
```diff
-        if interval>60*5 {
+        if interval>60*5 && !didTriggerAuthThisSession {
```
Reset in `revokeAuth()` so warm-start re-auth after 5 min still works.

**ContentView.swift** — Guard against `onAppear` re-triggering Face ID after the user cancels:
```diff
+        guard !appViewModel.didUserCancelAuthentication else {
+            return
+        }
```
The "try again" button in WelcomeView calls `viewModel.authenticateUser()` directly on AppViewModel, bypassing this guard.

## Test plan

To test on a physical device from Xcode, apply these two temporary patches:

**1. Enable Face ID in debug builds** (in `AccountLogic.isRunningOnPhysicalDevice()`):
```diff
     func isRunningOnPhysicalDevice() -> Bool {
         #if targetEnvironment(simulator)
         return false
-        #elseif DEBUG
-        return false
         #else
         return true
         #endif
     }
```

**2. Shorten 5-min timeout to 5 seconds** (in `enableAuth()`):
```diff
-        if interval>60*5 && !didTriggerAuthThisSession {
+        if interval>5 && !didTriggerAuthThisSession {
```

Then:
- [ ] Build and run — verify Face ID prompts **once** (not twice)
- [ ] Force quit, wait 6+ seconds, reopen — verify Face ID prompts **once**
- [ ] Cancel Face ID — verify "Try again" button appears (not stuck on spinner)
- [ ] Tap "Try again" — verify Face ID prompts again and works
- [ ] Background the app, wait 6+ seconds, reopen — verify Face ID re-prompts
- [ ] Revert both test patches before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication behavior to properly respect user cancellations, preventing subsequent authentication attempts in the same session.
  * Improved session-based authentication handling to eliminate redundant re-authentication prompts based on time intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->