### PR TITLE
fix: use dynamic ticker for Maya MsgDeposit (#4044)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Maya/Signing/maya.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Maya/Signing/maya.swift
@@ -31,8 +31,8 @@ enum MayaChainHelper {
             mayaChainCoin = TW_Cosmos_Proto_THORChainCoin.with {
                 $0.asset = TW_Cosmos_Proto_THORChainAsset.with {
                     $0.chain = "MAYA"
-                    $0.symbol = "CACAO"
-                    $0.ticker = "CACAO"
+                    $0.symbol = keysignPayload.coin.ticker
+                    $0.ticker = keysignPayload.coin.ticker
                     $0.synth = false
                 }
                 if keysignPayload.toAmount > 0 {


### PR DESCRIPTION
## Summary
- MsgDeposit for MAYA.MAYA was incorrectly sending MAYA.CACAO because symbol/ticker were hardcoded to `"CACAO"`
- Now uses `keysignPayload.coin.ticker` so deposits correctly reflect the actual token (MAYA or CACAO)

## Test plan
- [x] Initiate a deposit for MAYA.MAYA tokens — verify MsgDeposit uses MAYA.MAYA, not MAYA.CACAO 
https://www.explorer.mayachain.info/tx/2CF8166AC5BEA5CF6477A8949043903250940CEDAEF4BBAD59C43BD881D51215
https://mayanode.mayachain.info/cosmos/tx/v1beta1/txs/2CF8166AC5BEA5CF6477A8949043903250940CEDAEF4BBAD59C43BD881D51215
- [ ] Initiate a deposit for MAYA.CACAO tokens — verify MsgDeposit still uses MAYA.CACAO
https://www.explorer.mayachain.info/tx/9FC4D4E4B48A5653267DC4590B8D3E4319FC3F4B435A734E797FD740D0DCB3BA
- [ ] Verify regular (non-deposit) Maya sends are unaffected

Closes #4044

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MAYAChain coin metadata handling to use dynamic ticker values for transaction construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->