### PR TITLE
fix: prevent crash loop from duplicate coin IDs

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
@@ -160,8 +160,7 @@ class BalanceService {
     /// Phase 3: Apply balance updates to coins in batch on MainActor
     @MainActor
     private func applyBalanceUpdates(_ updates: [CoinBalanceUpdate], to vault: Vault) throws {
-        // Create lookup dictionary for O(1) access (follows DefiPositionsStorageService pattern)
-        let coinsByID = Dictionary(uniqueKeysWithValues: vault.coins.map { ($0.id, $0) })
+        let coinsByID = Dictionary(vault.coins.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
 
         // Apply all updates
         for update in updates where update.hasUpdates {

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsStorageService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsStorageService.swift
@@ -20,7 +20,7 @@ struct DefiPositionsStorageService {
         )
 
         let existingPositions = try Storage.shared.modelContext.fetch(fetchDescriptor)
-        let existingPositionsByID = Dictionary(uniqueKeysWithValues: existingPositions.map { ($0.id, $0) })
+        let existingPositionsByID = Dictionary(existingPositions.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
 
         for position in positions {
             if let existing = existingPositionsByID[position.id] {
@@ -62,7 +62,7 @@ struct DefiPositionsStorageService {
         }
 
         // Create lookup for existing positions
-        let existingPositionsByID = Dictionary(uniqueKeysWithValues: allExistingPositions.map { ($0.id, $0) })
+        let existingPositionsByID = Dictionary(allExistingPositions.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
         let newPositionIDs = Set(positions.map { $0.id })
 
         // Delete positions that are no longer present
@@ -98,7 +98,7 @@ struct DefiPositionsStorageService {
         )
 
         let existingPositions = try Storage.shared.modelContext.fetch(fetchDescriptor)
-        let existingPositionsByID = Dictionary(uniqueKeysWithValues: existingPositions.map { ($0.id, $0) })
+        let existingPositionsByID = Dictionary(existingPositions.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
 
         for position in positions {
             if let existing = existingPositionsByID[position.id] {


### PR DESCRIPTION
## Summary

- Replace `Dictionary(uniqueKeysWithValues:)` with `Dictionary(_:uniquingKeysWith:)` in `BalanceService.applyBalanceUpdates` and `DefiPositionsStorageService` to prevent fatal crashes when duplicate coin/position IDs exist
- Root cause: vault switching can create duplicate `Coin` entries via a race condition in `addDiscoveredTokens`, and `Dictionary(uniqueKeysWithValues:)` crashes on duplicate keys

## Context

Users report a crash loop after switching wallets — the app crashes immediately on every launch. Both crash logs show identical stacks:

```
_assertionFailure → _NativeDictionary.merge → Dictionary.init(uniqueKeysWithValues:)
  → BalanceService.applyBalanceUpdates → updateBalances → VaultDetailViewModel
```

The underlying data bug (duplicate coins from concurrent `addDiscoveredTokens` during vault switch) should be addressed separately.

## Test plan

- [ ] Verify app launches without crash when vault.coins contains duplicate IDs
- [ ] Verify balance updates still apply correctly to coins
- [ ] Verify DeFi position upserts still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of balance and DeFi position data handling by enhancing duplicate identifier resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->