### PR TITLE
fix: add block_id fallback filter for Dash Blockchair UTXO path

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Models/Blockchair/Blockchair.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Models/Blockchair/Blockchair.swift
@@ -34,5 +34,6 @@ struct Blockchair: Codable {
         let transactionHash: String?
         let index: Int?
         let value: Int?
+        let blockId: Int?
 	}
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayloadFactory.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayloadFactory.swift
@@ -107,11 +107,13 @@ struct KeysignPayloadFactory {
             )
         } else {
             // Existing Blockchair path for all other UTXO chains
+            let isDash = keysignPayload.coin.chain == .dash
             let info = await utxo.getByKey(key: keysignPayload.coin.blockchairKey)?.utxo?.compactMap { item -> UtxoInfo? in
                 guard
                     let txHash = item.transactionHash, !txHash.isEmpty,
                     let value = item.value,
-                    let index = item.index, index >= 0
+                    let index = item.index, index >= 0,
+                    !isDash || (item.blockId ?? 0) > 0
                 else {
                     return nil
                 }


### PR DESCRIPTION
## Summary
- Add `blockId` field to `BlockchairUtxo` model
- Filter out unconfirmed UTXOs (`blockId <= 0`) for Dash in the Blockchair path
- Safety net in case Dash RPC (from #4103) is unavailable and code falls back to Blockchair

## Context
PR #4103 switched Dash UTXO fetching to native RPC (`getaddressutxos`) which only returns confirmed UTXOs. This is a defense-in-depth addition: if Dash ever routes through the Blockchair path, unconfirmed UTXOs are filtered out to prevent `tx-txlock-conflict`.

## Changes
- `Blockchair.swift`: Added `blockId: Int?` to `BlockchairUtxo`
- `KeysignPayloadFactory.swift`: Added `!isDash || (item.blockId ?? 0) > 0` guard in Blockchair compactMap

## Test plan
- [ ] Verify Dash sends still work (primary RPC path)
- [ ] Verify other UTXO chain sends unaffected (BTC/LTC/DOGE/BCH/ZEC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)