### PR TITLE
fix: LongPressPrimaryButton tap action not firing

### DIFF
--- a/VultisigApp/VultisigApp/Components/Buttons/PrimaryButton/LongPressPrimaryButton.swift
+++ b/VultisigApp/VultisigApp/Components/Buttons/PrimaryButton/LongPressPrimaryButton.swift
@@ -23,7 +23,7 @@ struct LongPressPrimaryButton: View {
             title: title,
             supportsLongPress: true,
             longPressProgress: $progress
-        ) {}
+        ) { action() }
             .onLongPressGesture(
                 minimumDuration: 0,
                 maximumDistance: 0,


### PR DESCRIPTION
## Summary
- `LongPressPrimaryButton` passed an empty closure `{}` to `PrimaryButton`, making the native SwiftUI `Button` tap handler a no-op
- The quick-tap action (password sheet) was only reachable via `.simultaneousGesture(TapGesture())`, which doesn't fire reliably from accessibility tools or UI testing frameworks
- Now passes the actual `action()` closure to `PrimaryButton` so the native button tap path works

## Details
One-line change: `PrimaryButton(...) {}` → `PrimaryButton(...) { action() }`

The `.simultaneousGesture(TapGesture())` remains as a fallback. The long-press hold gesture for paired device signing is unaffected. No user-facing behavior change.

## Test plan
- [x] Tap "Sign transaction" on verify screen → password sheet appears
- [x] Long press "Sign transaction" → paired device QR screen appears (unchanged)
- [x] Full send transaction via Fast Vault (password → keysign → success)
- [x] Build succeeds on simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed long-press button functionality where the button action was not executing properly. The button now correctly triggers its intended action when pressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->