### PR TITLE
fix: THORChain streaming interval 1→0 for Rapid Swaps

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapProvider.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapProvider.swift
@@ -21,7 +21,7 @@ enum SwapProvider: Equatable {
         case .mayachain:
             return 3
         case .thorchain, .thorchainChainnet, .thorchainStagenet:
-            return 1
+            return 0
         default:
             return 0
         }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -211,8 +211,7 @@ private extension SwapService {
                 } else if error.message.localizedCaseInsensitiveContains("invalid symbol") ||
                     error.message.localizedCaseInsensitiveContains("bad to asset") ||
                     error.message.localizedCaseInsensitiveContains("bad from asset") ||
-                    error.message.localizedCaseInsensitiveContains("pool does not exist")
-                {
+                    error.message.localizedCaseInsensitiveContains("pool does not exist") {
                     // This typically means no liquidity pool exists for this token pair
                     throw SwapError.noLiquidityPool
                 } else {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapService.swift
@@ -39,7 +39,7 @@ struct KyberSwapService {
         routeRequest.allHTTPHeaderFields = [
             "accept": "application/json",
             "content-type": "application/json",
-            "x-client-id": KyberSwapService.sourceIdentifier,
+            "x-client-id": KyberSwapService.sourceIdentifier
         ]
 
         let (routeData, _) = try await URLSession.shared.data(for: routeRequest)
@@ -119,7 +119,7 @@ struct KyberSwapService {
         buildRequest.allHTTPHeaderFields = [
             "accept": "application/json",
             "content-type": "application/json",
-            "x-client-id": KyberSwapService.sourceIdentifier,
+            "x-client-id": KyberSwapService.sourceIdentifier
         ]
         buildRequest.httpBody = try JSONEncoder().encode(buildPayload)
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/MayaChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/MayaChainBondInteractor.swift
@@ -80,7 +80,7 @@ struct MayaChainBondInteractor: BondInteractor {
         }
     }
 
-    func canUnbond() async -> Bool {
+    func canUnbond() -> Bool {
         // Maya allows unbonding when vaults are not migrating
         // For now, return true - can be enhanced with actual migration check if needed
         true

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/MayaChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/MayaChainBondInteractor.swift
@@ -80,7 +80,8 @@ struct MayaChainBondInteractor: BondInteractor {
         }
     }
 
-    func canUnbond() -> Bool {
+    // swiftlint:disable:next async_without_await
+    func canUnbond() async -> Bool {
         // Maya allows unbonding when vaults are not migrating
         // For now, return true - can be enhanced with actual migration check if needed
         true

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
@@ -86,7 +86,8 @@ struct THORChainBondInteractor: BondInteractor {
         return !network.vaults_migrating
     }
 
-    func canAddBond(vault _: Vault) -> Bool {
+    // swiftlint:disable:next async_without_await
+    func canAddBond(vault _: Vault) async -> Bool {
         return true
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
@@ -86,7 +86,7 @@ struct THORChainBondInteractor: BondInteractor {
         return !network.vaults_migrating
     }
 
-    func canAddBond(vault: Vault) async -> Bool {
+    func canAddBond(vault _: Vault) -> Bool {
         return true
     }
 }

--- a/VultisigApp/VultisigAppTests/Chains/ThorAddressValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ThorAddressValidationTests.swift
@@ -6,7 +6,7 @@ final class ThorAddressValidationTests: XCTestCase {
     func testThorAddressValidationDebug() {
         let addresses = [
             "thor1prxy0sufdqfve6ygkwu9gswe60cle8gy02ex2w",
-            "thor1rxrvvw4xgscce7sfvc6wdpherra77932szstey",
+            "thor1rxrvvw4xgscce7sfvc6wdpherra77932szstey"
         ]
 
         for address in addresses {

--- a/VultisigApp/VultisigAppTests/Services/KyberSwapServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/KyberSwapServiceTests.swift
@@ -156,7 +156,7 @@ final class KyberSwapServiceTests: XCTestCase {
             routeRequest.allHTTPHeaderFields = [
                 "accept": "application/json",
                 "content-type": "application/json",
-                "x-client-id": "vultisig-ios",
+                "x-client-id": "vultisig-ios"
             ]
 
             let (routeData, _) = try await URLSession.shared.data(for: routeRequest)
@@ -208,7 +208,7 @@ final class KyberSwapServiceTests: XCTestCase {
         // Test different error scenarios
         let testCases = [
             ("Very large amount", "999999999999999999999999999999"), // Should trigger insufficient funds
-            ("Normal amount", "1000000000000000000"), // 1 ETH
+            ("Normal amount", "1000000000000000000") // 1 ETH
         ]
 
         for (testName, amount) in testCases {


### PR DESCRIPTION
## Summary
- Set THORChain `streamingInterval` from `1` to `0` so the protocol decides optimally (Rapid Swaps support)
- MayaChain stays at `3` (unchanged)
- Minor style fixes: trailing commas, brace placement, `async` keyword cleanup in bond interactors

## Issue
Closes #4088

https://runescan.io/tx/C53425D62F43728F0D0F1A61454DD28ACF5BB7689C834EC423739132616E4A45

## Test Plan
- [x] THORChain swaps use `streaming_interval=0` in the quote request
- [x] MayaChain swaps still use `streaming_interval=3`
- [x] SwiftLint passes (no new violations)
- [x] Build succeeds

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved swap streaming performance for THORChain networks by adjusting interval timing.
  * Fixed HTTP header configuration in KyberSwap integration for improved reliability.

* **Chores**
  * Enhanced code quality through linting improvements and test adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->