### PR TITLE
fix: smooth swap fee dropdown animation

### DIFF
--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -39,32 +39,34 @@ struct SwapDetailsSummary: View {
             if swapViewModel.showTotalFees(tx: tx) {
                 if hasExpandableFees {
                     ExpandableView(isExpanded: $showFees) {
-                        totalFeesLabel
+                        totalFeesLabel()
                     } content: {
                         HStack {
                             Rectangle()
                                 .frame(width: 1)
-                                .foregroundColor(Theme.colors.primaryAccent4)
+                                .foregroundStyle(Theme.colors.primaryAccent4)
 
                             expandableFees
                         }
                     }
                 } else {
-                    totalFeesLabel
+                    totalFeesLabel(showChevron: false)
                 }
             }
         }
         .padding(.top, 8)
     }
 
-    var totalFeesLabel: some View {
+    private func totalFeesLabel(showChevron: Bool = true) -> some View {
         HStack {
             getSummaryCell(
                 leadingText: "totalFee",
                 trailingText: "\(swapViewModel.totalFeeString(tx: tx))"
             )
 
-            chevron
+            if showChevron {
+                chevron
+            }
         }
     }
 

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -25,7 +25,6 @@ struct SwapDetailsSummary: View {
 
     var body: some View {
         content
-            .animation(.easeInOut, value: showFees)
     }
 
     var content: some View {
@@ -38,22 +37,24 @@ struct SwapDetailsSummary: View {
             }
 
             if swapViewModel.showTotalFees(tx: tx) {
-                totalFees
-            }
+                if hasExpandableFees {
+                    ExpandableView(isExpanded: $showFees) {
+                        totalFeesLabel
+                    } content: {
+                        HStack {
+                            Rectangle()
+                                .frame(width: 1)
+                                .foregroundColor(Theme.colors.primaryAccent4)
 
-            if hasExpandableFees {
-                otherFees
+                            expandableFees
+                        }
+                    }
+                } else {
+                    totalFeesLabel
+                }
             }
         }
         .padding(.top, 8)
-    }
-
-    var totalFees: some View {
-        Button {
-            showFees.toggle()
-        } label: {
-            totalFeesLabel
-        }
     }
 
     var totalFeesLabel: some View {
@@ -72,18 +73,7 @@ struct SwapDetailsSummary: View {
             .font(Theme.fonts.caption12)
             .foregroundColor(Theme.colors.textPrimary)
             .rotationEffect(Angle(degrees: showFees ? 0 : 180))
-    }
-
-    var otherFees: some View {
-        HStack {
-            Rectangle()
-                .frame(width: 1)
-                .foregroundColor(Theme.colors.primaryAccent4)
-
-            expandableFees
-        }
-        .frame(maxHeight: showFees ? nil : 0)
-        .clipped()
+            .animation(.easeInOut, value: showFees)
     }
 
     var expandableFees: some View {

--- a/VultisigApp/VultisigApp/Core/Stores/SettingsOptionsStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/SettingsOptionsStore.swift
@@ -62,8 +62,7 @@ enum SettingsLanguage: String, CaseIterable {
     static var current: SettingsLanguage {
         get {
             if let langString = UserDefaults.standard.string(forKey: "lang"),
-               let lang = SettingsLanguage(rawValue: langString)
-            {
+               let lang = SettingsLanguage(rawValue: langString) {
                 return lang
             } else {
                 return .English
@@ -96,8 +95,7 @@ enum SettingsCurrency: String, CaseIterable {
     static var current: SettingsCurrency {
         get {
             if let currencyString = UserDefaults.standard.string(forKey: "currency"),
-               let currency = SettingsCurrency(rawValue: currencyString)
-            {
+               let currency = SettingsCurrency(rawValue: currencyString) {
                 return currency
             } else {
                 return .USD
@@ -143,8 +141,7 @@ enum SettingsAPRPeriod: String, CaseIterable {
     static var current: SettingsAPRPeriod {
         get {
             if let periodString = UserDefaults.standard.string(forKey: "aprPeriod"),
-               let period = SettingsAPRPeriod(rawValue: periodString)
-            {
+               let period = SettingsAPRPeriod(rawValue: periodString) {
                 return period
             } else {
                 return .oneMonth // Default to 30d (industry standard)


### PR DESCRIPTION
## Summary
- Replace `frame(maxHeight: nil/0).clipped()` with `ExpandableView` in `SwapDetailsSummary` — SwiftUI cannot smoothly animate to/from `nil` height, causing the jumpy motion
- `ExpandableView` uses `withAnimation(.easeInOut)` + `.transition(.verticalGrowAndFade)` (asymmetric spring fade) for fluid expand/collapse
- Add `.animation(.easeInOut, value: showFees)` to the chevron so its rotation stays in sync
- Remove the now-redundant `totalFees` Button wrapper and `otherFees` computed vars

## Issue
Closes #4116

## Test Plan
- [ ] Navigate to swap screen, tap the total fee row to expand/collapse fee details
- [ ] Expand animation is smooth (fade-in with slight delay)
- [ ] Collapse animation is smooth (fast fade-out)
- [ ] Chevron rotates smoothly in sync with the panel
- [ ] SwiftLint passes (0 new violations)
- [ ] `xcodebuild -scheme Vultisig build` succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned the swap fee details area to use a single expandable view with targeted animation for the chevron, yielding clearer expand/collapse behavior and smoother visual feedback.

* **Style**
  * Minor internal formatting cleanups in settings getters for a more consistent code layout; no behavior or user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->