### PR TITLE
fix: catch gas estimation errors in EVM swap and fall back to nil

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -705,7 +705,12 @@ private extension BlockChainService {
             return BigInt(EVMHelper.defaultERC20TransferGasUnit)
         case .oneinch(let quote, _), .kyberswap(let quote, _), .lifi(let quote, _, _):
             if tx.fromCoin.isNativeToken {
-                return try await service.estimateGasLimitForSwap(senderAddress: tx.fromCoin.address, toAddress: quote.tx.to, value: tx.amountInCoinDecimal, data: quote.tx.data)
+                do {
+                    return try await service.estimateGasLimitForSwap(senderAddress: tx.fromCoin.address, toAddress: quote.tx.to, value: tx.amountInCoinDecimal, data: quote.tx.data)
+                } catch {
+                    // If estimation fails, return nil to fall back to default gas limit
+                    return nil
+                }
             }
             return nil
         case .none:


### PR DESCRIPTION
## Summary
- Wrap `estimateGasLimitForSwap` in a `do/catch` for the native-token OneInch/KyberSwap/LiFi path
- On failure, return `nil` so the caller applies the default gas limit instead of propagating the error and failing the swap

## Test Plan
- [ ] Swap a native EVM token (ETH/BNB/AVAX) via 1inch/KyberSwap/LiFi — swap proceeds normally when estimation succeeds
- [ ] Simulate a gas estimation failure (e.g. RPC error) — swap falls back to default gas limit instead of throwing
- [ ] SwiftLint passes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gas limit estimation reliability for native token swap transactions. When gas estimation encounters errors, the system now gracefully falls back to default limits instead of interrupting the swap process, enhancing transaction stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->