### PR TITLE
fix: invalidate SPM cache on Package.resolved change; skip app-store asset thinning in CI

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set Default Scheme
         working-directory: VultisigApp
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.0.1.app
+          sudo xcode-select -s /Applications/Xcode_26.2.app
           mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
           xcrun --find xcodebuild
           scheme_list=$(xcodebuild -list -json | tr -d "\n")

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -23,9 +23,9 @@ jobs:
           path: |
             VultisigApp/.build
             VultisigApp/SourcePackages
-          key: ${{ runner.os }}-spm-
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-spm-   
+            ${{ runner.os }}-spm-
       - name: Set Default Scheme
         working-directory: VultisigApp
         run: |
@@ -65,6 +65,7 @@ jobs:
             DEBUG_INFORMATION_FORMAT=dwarf \
             SWIFT_COMPILATION_MODE=wholemodule \
             OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" \
+            ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT=YES \
             | xcpretty -c && exit ${PIPESTATUS[0]}
 
       - name: Build and Test for iOS
@@ -86,4 +87,5 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \
             ONLY_ACTIVE_ARCH=YES \
+            ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT=YES \
             | xcpretty -c && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- Use content-hashed cache key (`hashFiles('**/Package.resolved')`) so SPM cache is invalidated when dependencies change, preventing stale artifact reuse across dependency updates
- Add `ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT=YES` to both macOS and iOS build steps to fix `CompileAssetCatalogVariant` failures for third-party packages (e.g. CodeScanner) in simulator/CI context

## Root Cause
The CI was failing with `CompileAssetCatalogVariant thinned ... CodeScanner` because the asset catalog compiler was applying app-store thinning rules in a context (simulator/CI) where that is not supported. Additionally, the SPM cache key had no hash, meaning a stale cache could persist even after `Package.resolved` changed.

## Test Plan
- [ ] CI passes on this branch
- [ ] No `CompileAssetCatalogVariant` errors in build log
- [ ] SPM cache key changes when `Package.resolved` is updated

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains infrastructure and build process updates with no end-user-facing changes. Internal development workflows have been updated to improve build consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->