### PR TITLE
fix: replace top 3 asyncAfter crash sources with cancellable Tasks [macOS]

### DIFF
--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
 
     @State private var rootRoute: RootRoute?
     @State private var deeplinkError: Error?
+    @State private var dismissSplashTask: Task<Void, Never>?
 
     init(navigationRouter: NavigationRouter) {
         self.navigationRouter = navigationRouter
@@ -161,7 +162,10 @@ struct ContentView: View {
         }
 
         guard !appViewModel.showOnboarding && !vaults.isEmpty else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            dismissSplashTask?.cancel()
+            dismissSplashTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
                 appViewModel.showSplashView = false
             }
             return

--- a/VultisigApp/VultisigApp/Components/Sheet/CrossPlatformSheet.swift
+++ b/VultisigApp/VultisigApp/Components/Sheet/CrossPlatformSheet.swift
@@ -27,6 +27,7 @@ private struct CrossPlatformSheet<SheetContent: View>: ViewModifier {
 
     @State var counter: Int = 0
     @State private var internalIsPresented: Bool = false
+    @State private var dismissTask: Task<Void, Never>?
 
     init(isPresented: Binding<Bool>, isDismissable: Bool = true, @ViewBuilder sheetContent: @escaping () -> SheetContent) {
         self._isPresented = isPresented
@@ -79,7 +80,10 @@ private struct CrossPlatformSheet<SheetContent: View>: ViewModifier {
         }
         .onChange(of: internalIsPresented) { _, newValue in
             guard !newValue else { return }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            dismissTask?.cancel()
+            dismissTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(300))
+                guard !Task.isCancelled else { return }
                 isPresented = false
             }
         }
@@ -121,6 +125,7 @@ private struct PlatformSheetWithItem<Item: Identifiable & Equatable, SheetConten
 
     @State var counter: Int = 0
     @State private var internalItem: Item?
+    @State private var dismissTask: Task<Void, Never>?
 
     init(item: Binding<Item?>, @ViewBuilder sheetContent: @escaping (Item) -> SheetContent) {
         self._item = item
@@ -171,7 +176,10 @@ private struct PlatformSheetWithItem<Item: Identifiable & Equatable, SheetConten
         }
         .onChange(of: internalItem) { _, newValue in
             guard newValue == nil else { return }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            dismissTask?.cancel()
+            dismissTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(300))
+                guard !Task.isCancelled else { return }
                 item = nil
             }
         }

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Screens/VaultManagementSheet.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Screens/VaultManagementSheet.swift
@@ -106,13 +106,18 @@ struct VaultManagementSheet: View {
 
 private extension VaultManagementSheet {
     // This is to support detents animation
+    @State private var detentAnimationTask: Task<Void, Never>?
+
     func updateDetents(isEditing: Bool) {
+        detentAnimationTask?.cancel()
         updateDetents(whileAnimation: true)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        detentAnimationTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
             detentSelection = isEditing ? .large : detents[safe: 0] ?? .medium
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                updateDetents(whileAnimation: false)
-            }
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            updateDetents(whileAnimation: false)
         }
     }
     func updateDetents(whileAnimation: Bool) {

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Screens/VaultManagementSheet.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Screens/VaultManagementSheet.swift
@@ -71,6 +71,12 @@ struct VaultManagementSheet: View {
             updateDetents(whileAnimation: false)
             detentSelection = detents[safe: 0] ?? .medium
         }
+        .onDisappear {
+            // Cancel the sleeping detent animation Task so it can't wake up
+            // and mutate detentSelection after the sheet has been dismissed.
+            detentAnimationTask?.cancel()
+            detentAnimationTask = nil
+        }
     }
 
     var mainSheetView: some View {

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Screens/VaultManagementSheet.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Screens/VaultManagementSheet.swift
@@ -30,6 +30,7 @@ struct VaultManagementSheet: View {
 
     @State private var sheetType = VaultSheetType.main
     @State private var shouldUseMoveTransition = true
+    @State private var detentAnimationTask: Task<Void, Never>?
 
     @Binding var isPresented: Bool
     let availableHeight: CGFloat
@@ -106,8 +107,6 @@ struct VaultManagementSheet: View {
 
 private extension VaultManagementSheet {
     // This is to support detents animation
-    @State private var detentAnimationTask: Task<Void, Never>?
-
     func updateDetents(isEditing: Bool) {
         detentAnimationTask?.cancel()
         updateDetents(whileAnimation: true)


### PR DESCRIPTION
## Summary
- Replace `DispatchQueue.main.asyncAfter` with cancellable `Task` + `Task.sleep` in the 3 highest-risk crash sites to prevent `EXC_BREAKPOINT` in `-[NSWindow _postWindowNeedsUpdateConstraints]` on macOS Sequoia
- **CrossPlatformSheet.swift**: Both sheet dismiss delays (bool and item variants) now use `@State dismissTask` with cancellation
- **ContentView.swift**: 2s splash view delay now stored in `@State dismissSplashTask` with cancellation guard
- **VaultManagementSheet.swift**: Nested double `asyncAfter` for detent animation replaced with single sequential `Task` in `@State detentAnimationTask`

## Context
The macOS app frequently crashes with `EXC_BREAKPOINT (SIGTRAP)` in `_postWindowNeedsUpdateConstraints` during SwiftUI render cycles. Root cause: `DispatchQueue.main.asyncAfter` closures fire unconditionally — even after the window closes — triggering re-entrant constraint updates on an invalidated NSWindow.

These 3 sites were identified as the highest-probability crash sources from crash report analysis. Remaining ~65 sites are tracked in #4124.

## Test plan
- [ ] macOS: Open and close sheets repeatedly — no crash
- [ ] macOS: Close window during splash screen 2s delay — no crash
- [ ] macOS: Toggle vault management sheet edit mode rapidly — no crash
- [ ] iOS: Verify sheet dismiss, splash, and vault management behavior unchanged
- [ ] SwiftLint passes (verified: 0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of UI dismissal timing for splash screens and sheet components to enhance app responsiveness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->