### PR TITLE
fix: display swap fee for 1Inch/KyberSwap using native gas token

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapService.swift
@@ -187,7 +187,7 @@ struct KyberSwapService {
                 gasPrice: buildResponse.tx.gasPrice,
                 gas: buildResponse.tx.gas,
                 swapFee: affiliateFeeAmount.description,
-                swapFeeTokenContract: ""
+                swapFeeTokenContract: routeResponse.data.routeSummary.tokenOut
             )
         )
 

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -48,6 +48,7 @@ struct SwapDetailsSummary: View {
 
                             expandableFees
                         }
+                        .padding(.top, 16)
                     }
                 } else {
                     totalFeesLabel(showChevron: false)

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendSummaryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendSummaryViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Amol Kumar on 2024-11-19.
 //
 
+import BigInt
 import Foundation
 
 @MainActor
@@ -30,11 +31,20 @@ class SendSummaryViewModel: ObservableObject {
     }
 
     func swapFeeString(_ tx: SwapTransaction) -> String {
+        let fromCoin = feeCoin(tx: tx)
+        let networkFee = fromCoin.fiat(value: tx.fee)
+
+        if let swapFeeBigInt = tx.quote?.evmSwapFeeBigInt {
+            let nativeCoin = feeCoin(tx: tx)
+            let feeDecimal = nativeCoin.decimal(for: swapFeeBigInt)
+            let swapFee = nativeCoin.fiat(decimal: feeDecimal)
+            return (swapFee + networkFee).formatToFiat(includeCurrencySymbol: true)
+        }
+
         guard let inboundFeeDecimal = tx.inboundFeeDecimal else { return .empty }
 
-        let fromCoin = feeCoin(tx: tx)
         let inboundFee = tx.toCoin.raw(for: inboundFeeDecimal)
-        let fee = tx.toCoin.fiat(value: inboundFee) + fromCoin.fiat(value: tx.fee)
+        let fee = tx.toCoin.fiat(value: inboundFee) + networkFee
         return fee.formatToFiat(includeCurrencySymbol: true)
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -228,8 +228,8 @@ struct SwapCryptoLogic {
 
         switch quote {
         case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
-            guard let affiliateFeeString = q.fees.affiliate else { return .empty }
-            let feeAmount = affiliateFeeString.toDecimal()
+            let feeAmount = q.fees.affiliate.toDecimal()
+            guard feeAmount > 0 else { return .empty }
             let feeDecimal = feeAmount / pow(10, 8)
             let fiatValue = tx.toCoin.fiat(decimal: feeDecimal)
             return fiatValue.formatToFiat(includeCurrencySymbol: true)

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -436,15 +436,7 @@ struct SwapCryptoLogic {
     }
 
     private func evmSwapFeeFiat(tx: SwapTransaction) -> Decimal? {
-        guard let quote = tx.quote else { return nil }
-        let evmQuote: EVMQuote
-        switch quote {
-        case .oneinch(let q, _), .kyberswap(let q, _):
-            evmQuote = q
-        default:
-            return nil
-        }
-        guard let swapFeeBigInt = BigInt(evmQuote.tx.swapFee), swapFeeBigInt > 0 else { return nil }
+        guard let swapFeeBigInt = tx.quote?.evmSwapFeeBigInt else { return nil }
         let nativeCoin = feeCoin(tx: tx)
         let feeDecimal = nativeCoin.decimal(for: swapFeeBigInt)
         let fiatValue = nativeCoin.fiat(decimal: feeDecimal)

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -408,11 +408,24 @@ struct SwapCryptoLogic {
 
     private func evmSwapFeeFiat(tx: SwapTransaction) -> Decimal? {
         guard let swapFeeBigInt = tx.quote?.evmSwapFeeBigInt else { return nil }
-        let nativeCoin = feeCoin(tx: tx)
-        let feeDecimal = nativeCoin.decimal(for: swapFeeBigInt)
-        let fiatValue = nativeCoin.fiat(decimal: feeDecimal)
+        let coin = swapFeeCoin(tx: tx)
+        let feeDecimal = coin.decimal(for: swapFeeBigInt)
+        let fiatValue = coin.fiat(decimal: feeDecimal)
         guard !fiatValue.isZero else { return nil }
         return fiatValue
+    }
+
+    private func swapFeeCoin(tx: SwapTransaction) -> Coin {
+        guard let contract = tx.quote?.swapFeeTokenContract else {
+            return feeCoin(tx: tx)
+        }
+        if contract.caseInsensitiveCompare(tx.fromCoin.contractAddress) == .orderedSame {
+            return tx.fromCoin
+        }
+        if contract.caseInsensitiveCompare(tx.toCoin.contractAddress) == .orderedSame {
+            return tx.toCoin
+        }
+        return feeCoin(tx: tx)
     }
 
     func getDefaultCoin(for chain: Chain, vault: Vault) -> Coin? {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -348,9 +348,8 @@ struct SwapCryptoLogic {
         let baseFeeFiat = inputFiat * 0.0050
 
         // Actual Fee from Quote
-        // Re-calculate local to avoid string parsing
-        var actualFeeFiat: Decimal = 0
-        if let quote = tx.quote {
+        var actualFeeFiat = evmSwapFeeFiat(tx: tx) ?? 0
+        if actualFeeFiat == 0, let quote = tx.quote {
             switch quote {
             case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
                 let feeAmt = q.fees.affiliate.toDecimal() / pow(10, 8)

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -150,6 +150,10 @@ struct SwapCryptoLogic {
     }
 
     func swapFeeString(tx: SwapTransaction) -> String {
+        if let evmFee = evmSwapFeeFiat(tx: tx) {
+            return evmFee.formatToFiat(includeCurrencySymbol: true)
+        }
+
         guard let inboundFeeDecimal = tx.inboundFeeDecimal, !inboundFeeDecimal.isZero else { return .empty }
 
         let inboundFee = tx.toCoin.raw(for: inboundFeeDecimal)
@@ -186,12 +190,18 @@ struct SwapCryptoLogic {
     }
 
     func totalFeeString(tx: SwapTransaction) -> String {
+        let fromCoin = feeCoin(tx: tx)
+        let networkFee = fromCoin.fiat(gas: tx.fee)
+
+        if let evmFee = evmSwapFeeFiat(tx: tx) {
+            let totalFee = evmFee + networkFee
+            return totalFee.formatToFiat(includeCurrencySymbol: true)
+        }
+
         guard let inboundFeeDecimal = tx.inboundFeeDecimal else { return .empty }
 
-        let fromCoin = feeCoin(tx: tx)
         let inboundFee = tx.toCoin.raw(for: inboundFeeDecimal)
         let providerFee = tx.toCoin.fiat(value: inboundFee)
-        let networkFee = fromCoin.fiat(gas: tx.fee)
         let totalFee = providerFee + networkFee
         return totalFee.formatToFiat(includeCurrencySymbol: true)
     }
@@ -423,6 +433,23 @@ struct SwapCryptoLogic {
         // Fees are always paid in native token
         guard !tx.fromCoin.isNativeToken else { return tx.fromCoin }
         return tx.fromCoins.first(where: { $0.chain == tx.fromCoin.chain && $0.isNativeToken }) ?? tx.fromCoin
+    }
+
+    private func evmSwapFeeFiat(tx: SwapTransaction) -> Decimal? {
+        guard let quote = tx.quote else { return nil }
+        let evmQuote: EVMQuote
+        switch quote {
+        case .oneinch(let q, _), .kyberswap(let q, _):
+            evmQuote = q
+        default:
+            return nil
+        }
+        guard let swapFeeBigInt = BigInt(evmQuote.tx.swapFee), swapFeeBigInt > 0 else { return nil }
+        let nativeCoin = feeCoin(tx: tx)
+        let feeDecimal = nativeCoin.decimal(for: swapFeeBigInt)
+        let fiatValue = nativeCoin.fiat(decimal: feeDecimal)
+        guard !fiatValue.isZero else { return nil }
+        return fiatValue
     }
 
     func getDefaultCoin(for chain: Chain, vault: Vault) -> Coin? {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -222,36 +222,20 @@ struct SwapCryptoLogic {
     func baseAffiliateFee(tx: SwapTransaction) -> String {
         guard let quote = tx.quote else { return .empty }
 
-        // 1. Get Affiliate Fee directly from quote
-        // Determine which quote type we have and extract fee string
-        var affiliateFeeString: String?
-        let feeDecimals = 8 // Default to 8 (THORChain standard)
-        let feeCoin: Coin = tx.toCoin // Assumption based on existing pattern (fees in output asset)
+        if let evmFee = evmSwapFeeFiat(tx: tx) {
+            return evmFee.formatToFiat(includeCurrencySymbol: true)
+        }
 
         switch quote {
         case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
-            affiliateFeeString = q.fees.affiliate
-        // Verify if fee asset matches toCoin or fromCoin if needed, currently assuming toCoin as per SwapQuote.swift
-        case let .kyberswap(q, _):
-            guard let swapFeeBigInt = BigInt(q.tx.swapFee), swapFeeBigInt > 0 else { return .empty }
-            let feeDecimal = feeCoin.decimal(for: swapFeeBigInt)
-            let fiatValue = feeCoin.fiat(decimal: feeDecimal)
+            guard let affiliateFeeString = q.fees.affiliate else { return .empty }
+            let feeAmount = affiliateFeeString.toDecimal()
+            let feeDecimal = feeAmount / pow(10, 8)
+            let fiatValue = tx.toCoin.fiat(decimal: feeDecimal)
             return fiatValue.formatToFiat(includeCurrencySymbol: true)
         default:
-            return .empty // Other providers might not have affiliate fees structured same way
-        }
-
-        guard let affiliateFeeString = affiliateFeeString else {
             return .empty
         }
-        let feeAmount = affiliateFeeString.toDecimal()
-
-        // 2. Convert to Fiat
-        // If fee is in 'toCoin' units (e.g. 1e8)
-        let feeDecimal = feeAmount / pow(10, feeDecimals)
-        let fiatValue = feeCoin.fiat(decimal: feeDecimal)
-
-        return fiatValue.formatToFiat(includeCurrencySymbol: true)
     }
 
     func swapFeeLabel(tx: SwapTransaction) -> String {
@@ -264,35 +248,23 @@ struct SwapCryptoLogic {
 
         guard let quote = tx.quote else { return "swapFee".localized }
 
-        // Get affiliate fee fiat value
-        let affiliateFeeString = baseAffiliateFee(tx: tx)
-        guard !affiliateFeeString.isEmpty else { return String(format: "swapFeePercentage".localized, 0.0) }
-
-        // We need raw numbers for math, reusing logic for efficiency
-        var feeAmt: Decimal = 0
-        switch quote {
-        case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
-            feeAmt = q.fees.affiliate.toDecimal() / pow(10, 8)
-        case let .kyberswap(q, _):
-            if let swapFeeBigInt = BigInt(q.tx.swapFee), swapFeeBigInt > 0 {
-                feeAmt = tx.toCoin.decimal(for: swapFeeBigInt)
+        let feeFiat: Decimal
+        if let evmFee = evmSwapFeeFiat(tx: tx) {
+            feeFiat = evmFee
+        } else {
+            switch quote {
+            case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
+                let feeAmt = q.fees.affiliate.toDecimal() / pow(10, 8)
+                feeFiat = tx.toCoin.fiat(decimal: feeAmt)
+            default:
+                return String(format: "swapFeePercentage".localized, 0.0)
             }
-        default:
-            break
         }
 
-        // Calculate BPS: (Fee Amt / Expected Output Amount * ?? )
-        // Usually Swap Fee is on INPUT.
-        // Let's use currency values for comparsion to handle asset mismatch
-        let feeFiat = tx.toCoin.fiat(decimal: feeAmt)
-
         let inputFiat = tx.fromCoin.fiat(decimal: tx.fromAmountDecimal)
-
         guard inputFiat > 0 else { return "swapFee".localized }
 
-        let rate = (feeFiat / inputFiat)
-        let percentage = rate * 100
-
+        let percentage = (feeFiat / inputFiat) * 100
         return String(format: "swapFeePercentage".localized, NSDecimalNumber(decimal: percentage).doubleValue)
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -90,9 +90,8 @@ enum SwapQuote: Hashable {
             let toAmountBigInt = BigInt(quote.dstAmount) ?? .zero
             let toAmountDecimal = toCoin.decimal(for: toAmountBigInt)
             return toAmountDecimal * (integratorFee ?? 0)
-        case .oneinch(let quote, _), .kyberswap(let quote, _):
-            guard let swapFeeBigInt = BigInt(quote.tx.swapFee), swapFeeBigInt > 0 else { return .zero }
-            return toCoin.decimal(for: swapFeeBigInt)
+        case .oneinch, .kyberswap:
+            return .zero
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -106,6 +106,16 @@ enum SwapQuote: Hashable {
         }
     }
 
+    var swapFeeTokenContract: String? {
+        switch self {
+        case .oneinch(let quote, _), .kyberswap(let quote, _), .lifi(let quote, _, _):
+            let contract = quote.tx.swapFeeTokenContract
+            return contract.isEmpty ? nil : contract
+        default:
+            return nil
+        }
+    }
+
     var memo: String? {
         switch self {
         case .thorchain(let quote), .thorchainChainnet(let quote), .thorchainStagenet(let quote), .mayachain(let quote):

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -90,8 +90,9 @@ enum SwapQuote: Hashable {
             let toAmountBigInt = BigInt(quote.dstAmount) ?? .zero
             let toAmountDecimal = toCoin.decimal(for: toAmountBigInt)
             return toAmountDecimal * (integratorFee ?? 0)
-        case .oneinch, .kyberswap:
-            return .zero
+        case .oneinch(let quote, _), .kyberswap(let quote, _):
+            guard let swapFeeBigInt = BigInt(quote.tx.swapFee), swapFeeBigInt > 0 else { return .zero }
+            return toCoin.decimal(for: swapFeeBigInt)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -98,7 +98,7 @@ enum SwapQuote: Hashable {
 
     var evmSwapFeeBigInt: BigInt? {
         switch self {
-        case .oneinch(let quote, _), .kyberswap(let quote, _):
+        case .oneinch(let quote, _), .kyberswap(let quote, _), .lifi(let quote, _, _):
             guard let fee = BigInt(quote.tx.swapFee), fee > 0 else { return nil }
             return fee
         default:

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -91,7 +91,18 @@ enum SwapQuote: Hashable {
             let toAmountDecimal = toCoin.decimal(for: toAmountBigInt)
             return toAmountDecimal * (integratorFee ?? 0)
         case .oneinch, .kyberswap:
+            // Fee is in native gas token, not toCoin — handled via evmSwapFeeBigInt
             return .zero
+        }
+    }
+
+    var evmSwapFeeBigInt: BigInt? {
+        switch self {
+        case .oneinch(let quote, _), .kyberswap(let quote, _):
+            guard let fee = BigInt(quote.tx.swapFee), fee > 0 else { return nil }
+            return fee
+        default:
+            return nil
         }
     }
 


### PR DESCRIPTION
## Summary
- Swap Fee showed **$0.00** for 1Inch and KyberSwap quotes because `SwapQuote.inboundFeeDecimal()` returned `.zero` for these providers
- Added `SwapQuote.evmSwapFeeBigInt` to extract the raw fee from `EVMQuote.tx.swapFee`
- Added `SwapCryptoLogic.evmSwapFeeFiat()` that converts the fee using the **native gas token** (e.g. ETH), not `toCoin` (e.g. DAI), for correct fiat display
- Unified all callers to use the same fee path:
  - `swapFeeString()` / `totalFeeString()` in `SwapCryptoLogic`
  - `baseAffiliateFee()` — was using `tx.toCoin` for KyberSwap, ignored 1Inch
  - `swapFeeLabel()` — was using `tx.toCoin` for KyberSwap, ignored 1Inch
  - `SendSummaryViewModel.swapFeeString()` — was using `tx.inboundFeeDecimal` (always zero for EVM DEX)
  
## Swap Tx Hash:
  - https://etherscan.io/tx/0x56c0e5dbbbbe37e6cabb17bbdd6e0b5ac91ac2d67e1a3d26b7e9db9334cc6eab
  
##   Approval Tx Hash:
  - https://etherscan.io/tx/0x76589101c700f8c552a71a1a0510b68513ce3ca41bc291bcdf56c28874999a1d
  
  ## Screenshots
  # Before:

### <img width="1210" height="477" alt="image" src="https://github.com/user-attachments/assets/cd44adbd-c585-46ba-af2e-0edb01948ea2" />
### <img width="970" height="459" alt="image" src="https://github.com/user-attachments/assets/0b6d8c5d-45f5-4b07-a5b9-cb0940281aa0" />

 # After:

### <img width="1206" height="551" alt="image" src="https://github.com/user-attachments/assets/7fbd093e-490b-469d-9ed6-f70ae724ec00" />
### <img width="1201" height="488" alt="image" src="https://github.com/user-attachments/assets/f4d29782-9d88-4298-9c36-16e3ee2e68a4" />

## Test plan
- [ ] Initiate a swap via 1Inch provider — verify Swap Fee, Swap Fee %, and Max Total Fee show correct values
- [ ] Initiate a swap via KyberSwap provider — verify the same
- [ ] Verify LI.FI and THORChain swap fees are unaffected
- [ ] Verify the Send summary screen shows the correct combined fee for EVM DEX swaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap fee display now correctly shows fiat amounts when provider-specific EVM swap fees are present.
  * Total fee calculation reliably combines provider swap fees with network gas fees across views.
  * Affiliate fee and percentage display made more accurate across providers and quote types.

* **New Features**
  * App detects provider EVM swap fees and includes them in displayed fiat fee totals when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->