### PR TITLE
fix: resolve sRUJI balance not displaying

### DIFF
--- a/VultisigApp/VultisigApp/Core/Extensions/THORBalanceExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/THORBalanceExtension.swift
@@ -21,10 +21,19 @@ extension [CosmosBalance] {
         for balance in self {
             if coin.isNativeToken && balance.denom.lowercased() == denom {
                 return balance.amount
-            } else if !coin.isNativeToken && balance.denom.lowercased() == coin.contractAddress.lowercased() {
+            } else if !coin.isNativeToken && balance.denom.lowercased() == apiDenom(for: coin) {
                 return balance.amount
             }
         }
         return .zero
+    }
+
+    private func apiDenom(for coin: CoinMeta) -> String {
+        switch coin {
+        case TokensStore.sruji:
+            return "x/staking-x/ruji"
+        default:
+            return coin.contractAddress.lowercased()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- sRUJI balance wasn't showing because the THORChain balance API returns the denom as `x/staking-x/ruji`, which doesn't match the coin's stored `contractAddress`.
- Added an `apiDenom(for:)` mapping in `THORBalanceExtension` so sRUJI lookups hit the correct denom without altering the stored contract address.

Fixes #4129

## Test plan
- [ ] Open a vault holding sRUJI and confirm the balance renders
- [ ] Confirm other THORChain tokens still resolve balances correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)