### PR TITLE
ci: upload unsigned macOS and iOS simulator build artifacts

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -72,9 +72,9 @@ jobs:
       - name: Package macOS artifact
         working-directory: VultisigApp
         run: |
-          app_path=$(find build-macos/Build/Products -maxdepth 3 -type d -name "*.app" | head -n 1)
+          app_path=$(find build-macos/Build/Products -maxdepth 3 -type d -name "VultisigApp.app")
           if [ -z "$app_path" ]; then
-            echo "No .app found under build-macos/Build/Products"
+            echo "No VultisigApp.app found under build-macos/Build/Products"
             exit 1
           fi
           echo "Zipping $app_path"
@@ -115,9 +115,9 @@ jobs:
       - name: Package iOS simulator artifact
         working-directory: VultisigApp
         run: |
-          app_path=$(find build-ios/Build/Products -maxdepth 3 -type d -name "*.app" | head -n 1)
+          app_path=$(find build-ios/Build/Products -maxdepth 3 -type d -name "VultisigApp.app")
           if [ -z "$app_path" ]; then
-            echo "No .app found under build-ios/Build/Products"
+            echo "No VultisigApp.app found under build-ios/Build/Products"
             exit 1
           fi
           echo "Zipping $app_path"

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -45,19 +45,20 @@ jobs:
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          
+
           # Print environment info
           echo "Xcode version:"
           xcodebuild -version
           echo "Swift version:"
           swift --version
-          
+
           # Clean, build and analyze for macOS
           echo "Building and analyzing for macOS - scheme: $scheme"
           xcodebuild clean build analyze \
             -scheme "$scheme" \
             -"$filetype_parameter" "$file_to_build" \
             -destination 'platform=macOS,arch=x86_64' \
+            -derivedDataPath build-macos \
             -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \
@@ -68,6 +69,26 @@ jobs:
             ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT=YES \
             | xcpretty -c && exit ${PIPESTATUS[0]}
 
+      - name: Package macOS artifact
+        working-directory: VultisigApp
+        run: |
+          app_path=$(find build-macos/Build/Products -maxdepth 3 -type d -name "*.app" | head -n 1)
+          if [ -z "$app_path" ]; then
+            echo "No .app found under build-macos/Build/Products"
+            exit 1
+          fi
+          echo "Zipping $app_path"
+          ditto -c -k --sequesterRsrc --keepParent "$app_path" VultisigApp-macOS.zip
+          ls -lh VultisigApp-macOS.zip
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VultisigApp-macOS-unsigned
+          path: VultisigApp/VultisigApp-macOS.zip
+          retention-days: 14
+          if-no-files-found: error
+
       - name: Build and Test for iOS
         working-directory: VultisigApp
         env:
@@ -76,16 +97,37 @@ jobs:
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          
+
           # Build and test for iOS in one command
           echo "Building and testing for iOS - scheme: $scheme"
           xcodebuild build analyze test \
             -scheme "$scheme" \
             -"$filetype_parameter" "$file_to_build" \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.1' \
+            -derivedDataPath build-ios \
             -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \
             ONLY_ACTIVE_ARCH=YES \
             ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT=YES \
             | xcpretty -c && exit ${PIPESTATUS[0]}
+
+      - name: Package iOS simulator artifact
+        working-directory: VultisigApp
+        run: |
+          app_path=$(find build-ios/Build/Products -maxdepth 3 -type d -name "*.app" | head -n 1)
+          if [ -z "$app_path" ]; then
+            echo "No .app found under build-ios/Build/Products"
+            exit 1
+          fi
+          echo "Zipping $app_path"
+          ditto -c -k --sequesterRsrc --keepParent "$app_path" VultisigApp-iOS-Simulator.zip
+          ls -lh VultisigApp-iOS-Simulator.zip
+
+      - name: Upload iOS simulator artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: VultisigApp-iOS-Simulator-unsigned
+          path: VultisigApp/VultisigApp-iOS-Simulator.zip
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -72,9 +72,10 @@ jobs:
       - name: Package macOS artifact
         working-directory: VultisigApp
         run: |
-          app_path=$(find build-macos/Build/Products -maxdepth 3 -type d -name "VultisigApp.app")
-          if [ -z "$app_path" ]; then
-            echo "No VultisigApp.app found under build-macos/Build/Products"
+          app_path="build-macos/Build/Products/Debug/VultisigApp.app"
+          if [ ! -d "$app_path" ]; then
+            echo "No VultisigApp.app found at $app_path"
+            find build-macos/Build/Products -maxdepth 3 -type d -name "VultisigApp.app" || true
             exit 1
           fi
           echo "Zipping $app_path"
@@ -115,9 +116,10 @@ jobs:
       - name: Package iOS simulator artifact
         working-directory: VultisigApp
         run: |
-          app_path=$(find build-ios/Build/Products -maxdepth 3 -type d -name "VultisigApp.app")
-          if [ -z "$app_path" ]; then
-            echo "No VultisigApp.app found under build-ios/Build/Products"
+          app_path="build-ios/Build/Products/Debug-iphonesimulator/VultisigApp.app"
+          if [ ! -d "$app_path" ]; then
+            echo "No VultisigApp.app found at $app_path"
+            find build-ios/Build/Products -maxdepth 3 -type d -name "VultisigApp.app" || true
             exit 1
           fi
           echo "Zipping $app_path"


### PR DESCRIPTION
## Summary
- Adds `-derivedDataPath` to both `xcodebuild` invocations so the built products land in a predictable location.
- Packages the macOS `.app` and iOS-simulator `.app` with `ditto` and uploads them via `actions/upload-artifact@v4` (14-day retention).
- Every CI run on `main`, PRs, and the merge queue now produces downloadable dev builds for QA/reproduction.

Artifacts are **unsigned** — CI already sets `CODE_SIGNING_ALLOWED=NO`, so the macOS `.app` won't launch on a normal Mac without ad-hoc signing, and the iOS build is a simulator `.app`, not an installable `.ipa`. A signed/notarized pipeline needs certs in GitHub secrets and is intentionally out of scope.

## Test plan
- [ ] CI workflow runs green on this PR
- [ ] `VultisigApp-macOS-unsigned` artifact appears on the run summary and unzips to a `.app`
- [ ] `VultisigApp-iOS-Simulator-unsigned` artifact appears and unzips to a simulator `.app`
- [ ] Downloaded macOS `.app` launches after `codesign --force --deep --sign - <path>` (ad-hoc)
- [ ] Downloaded iOS simulator `.app` installs via `xcrun simctl install booted <path>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now writes macOS and iOS Simulator build outputs to isolated build directories.
  * CI packages the discovered app builds into platform-specific zip archives (macOS and iOS Simulator).
  * Artifact upload steps publish these archives with retention control and strict error handling — workflows fail if expected builds are not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->