### PR TITLE
fix(swap): display correct 5 bps referral discount instead of 35 bps

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
@@ -16,6 +16,8 @@ class THORChainSwaps {
 #endif
     }
 
+    static let standardAffiliateFeeRateBp = 50
+
     static var referredAffiliateFeeRateBp: Int {
         return 35
     }

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
@@ -16,8 +16,6 @@ class THORChainSwaps {
 #endif
     }
 
-    static let standardAffiliateFeeRateBp = 50
-
     static var referredAffiliateFeeRateBp: Int {
         return 35
     }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -529,8 +529,8 @@ struct SwapCryptoLogic {
         let vultTier = await VultTierService().fetchDiscountTier(for: vault)
 
         let vultDiscountBps = vultTier?.bpsDiscount ?? 0
-        // Referral discount only applies if user was referred (has a referredCode)
-        let referralDiscountBps = referredCode.isEmpty ? 0 : THORChainSwaps.referredAffiliateFeeRateBp
+        // Referral discount = normal fee - referred fee - referrer share (e.g. 50 - 35 - 10 = 5 bps)
+        let referralDiscountBps = referredCode.isEmpty ? 0 : max(0, THORChainSwaps.affiliateFeeRateBp - THORChainSwaps.referredAffiliateFeeRateBp - (Int(THORChainSwaps.referredUserFeeRateBp) ?? 0))
 
         await MainActor.run {
             tx.vultDiscountBps = vultDiscountBps

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -530,7 +530,7 @@ struct SwapCryptoLogic {
 
         let vultDiscountBps = vultTier?.bpsDiscount ?? 0
         // Referral discount = normal fee - referred fee - referrer share (e.g. 50 - 35 - 10 = 5 bps)
-        let referralDiscountBps = referredCode.isEmpty ? 0 : max(0, THORChainSwaps.standardAffiliateFeeRateBp - THORChainSwaps.referredAffiliateFeeRateBp - (Int(THORChainSwaps.referredUserFeeRateBp) ?? 0))
+        let referralDiscountBps = referredCode.isEmpty ? 0 : max(0, THORChainSwaps.affiliateFeeRateBp - THORChainSwaps.referredAffiliateFeeRateBp - (Int(THORChainSwaps.referredUserFeeRateBp) ?? 0))
 
         await MainActor.run {
             tx.vultDiscountBps = vultDiscountBps

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -530,7 +530,7 @@ struct SwapCryptoLogic {
 
         let vultDiscountBps = vultTier?.bpsDiscount ?? 0
         // Referral discount = normal fee - referred fee - referrer share (e.g. 50 - 35 - 10 = 5 bps)
-        let referralDiscountBps = referredCode.isEmpty ? 0 : max(0, THORChainSwaps.affiliateFeeRateBp - THORChainSwaps.referredAffiliateFeeRateBp - (Int(THORChainSwaps.referredUserFeeRateBp) ?? 0))
+        let referralDiscountBps = referredCode.isEmpty ? 0 : max(0, THORChainSwaps.standardAffiliateFeeRateBp - THORChainSwaps.referredAffiliateFeeRateBp - (Int(THORChainSwaps.referredUserFeeRateBp) ?? 0))
 
         await MainActor.run {
             tx.vultDiscountBps = vultDiscountBps


### PR DESCRIPTION
## Summary
- Fixed referral discount display showing 35 bps (Vultisig's affiliate rate) instead of the actual user savings of 5 bps
- The discount is now correctly calculated as: `affiliateFeeRateBp(50) - referredAffiliateFeeRateBp(35) - referredUserFeeRateBp(10) = 5`

## Test Plan
- [ ] Add a referral code in the app
- [ ] Navigate to swap view and quote a swap
- [ ] Verify discount shows "5 bps" not "35 bps"
- [ ] SwiftLint passes

## Related
- Closes #4113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of referral discount calculations applied during swap quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->