### PR TITLE
fix(send): refresh balance after successful broadcast

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TransactionStatusPoller.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TransactionStatusPoller.swift
@@ -3,16 +3,21 @@
 //  VultisigApp
 //
 
+import Combine
 import Foundation
+import OSLog
 
 @MainActor
-final class TransactionStatusPoller {
+final class TransactionStatusPoller: ObservableObject {
     static let shared = TransactionStatusPoller()
+
+    @Published private(set) var completedTransactionCount: Int = 0
 
     private let service = TransactionStatusService.shared
     private let recorder = TransactionHistoryRecorder.shared
     private var activeTasks: [String: Task<Void, Never>] = [:]
     private var taskTokens: [String: UUID] = [:]
+    private let logger = Logger(subsystem: "com.vultisig.app", category: "tx-status-poller")
 
     private init() {}
 
@@ -43,6 +48,7 @@ final class TransactionStatusPoller {
                             errorMessage: timeoutMessage
                         )
                         onUpdate(.error, timeoutMessage)
+                        self?.completedTransactionCount += 1
                         break
                     }
 
@@ -63,6 +69,7 @@ final class TransactionStatusPoller {
                             errorMessage: errorMessage
                         )
                         onUpdate(historyStatus, errorMessage)
+                        self?.completedTransactionCount += 1
                         break
                     }
 
@@ -95,6 +102,18 @@ final class TransactionStatusPoller {
         guard taskTokens[txHash] == token else { return }
         activeTasks.removeValue(forKey: txHash)
         taskTokens.removeValue(forKey: txHash)
+    }
+
+    /// Start polling all pending transactions for a vault.
+    func pollPendingTransactions(pubKeyECDSA: String) {
+        do {
+            let pending = try StoredPendingTransactionStorage.shared.getAllPending()
+            for tx in pending where tx.pubKeyECDSA == pubKeyECDSA {
+                poll(txHash: tx.txHash, chain: tx.chain, createdAt: tx.createdAt, pubKeyECDSA: pubKeyECDSA) { _, _ in }
+            }
+        } catch {
+            logger.error("Failed to fetch pending transactions: \(error)")
+        }
     }
 
     /// Returns a terminal TransactionHistoryStatus if the result is terminal, nil if still pending.

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -82,6 +82,14 @@ struct HomeScreen: View {
                 presetValuesForDeeplink()
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .agentDidBroadcastTx)) { _ in
+            Task {
+                try? await Task.sleep(for: .seconds(3))
+                await MainActor.run {
+                    shouldRefresh = true
+                }
+            }
+        }
         .onChange(of: deeplinkViewModel.type) { _, newValue in
             if newValue != nil {
                 presetValuesForDeeplink()

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -82,7 +82,8 @@ struct HomeScreen: View {
                 presetValuesForDeeplink()
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .agentDidBroadcastTx)) { _ in
+        .onChange(of: appViewModel.restartNavigation) { _, newValue in
+            guard newValue else { return }
             Task {
                 try? await Task.sleep(for: .seconds(3))
                 await MainActor.run {

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -40,6 +40,7 @@ struct HomeScreen: View {
     @EnvironmentObject var phoneCheckUpdateViewModel: PhoneCheckUpdateViewModel
     @EnvironmentObject var vultExtensionViewModel: VultExtensionViewModel
     @EnvironmentObject var appViewModel: AppViewModel
+    @ObservedObject private var transactionPoller = TransactionStatusPoller.shared
     @Environment(\.modelContext) private var modelContext
 
     var tabs: [HomeTab] {
@@ -84,12 +85,18 @@ struct HomeScreen: View {
         }
         .onChange(of: appViewModel.restartNavigation) { _, newValue in
             guard newValue else { return }
+            if let vault = appViewModel.selectedVault {
+                transactionPoller.pollPendingTransactions(pubKeyECDSA: vault.pubKeyECDSA)
+            }
             Task {
                 try? await Task.sleep(for: .seconds(3))
                 await MainActor.run {
                     shouldRefresh = true
                 }
             }
+        }
+        .onChange(of: transactionPoller.completedTransactionCount) { _, _ in
+            shouldRefresh = true
         }
         .onChange(of: deeplinkViewModel.type) { _, newValue in
             if newValue != nil {
@@ -490,6 +497,7 @@ extension HomeScreen {
         Task { @MainActor in
             await VaultDefiChainsService().enableDefiChainsIfNeeded(for: vault)
         }
+        transactionPoller.pollPendingTransactions(pubKeyECDSA: vault.pubKeyECDSA)
     }
 
     private func handleSendDeeplinkAfterVaultSelection(vault: Vault) {


### PR DESCRIPTION
## Summary
- Trigger a delayed (3s) balance refresh after any transaction completion (send, swap, join keysign, referral)
- Observes `appViewModel.restartNavigation` — the universal exit point all completion screens use via `appViewModel.restart()`
- Allows the blockchain node time to register the pending tx before re-fetching balances

## Test Plan
- [ ] Send any token, tap "Done" → balance updates within ~5 seconds
- [ ] Complete a swap, tap "Done" → balance updates within ~5 seconds
- [ ] Join keysign flow → balance updates after completion
- [ ] No double-refresh or unnecessary API calls
- [ ] SwiftLint passes

## Related
- Closes #4078

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background polling for pending transactions and automatic UI refresh when transactions complete or are detected.
* **Updates**
  * Improved app navigation restart behavior with enhanced refresh timing to ensure smoother transitions when returning to the initial state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->