### PR TITLE
fix(data): prevent duplicate coins from SwiftData inverse relationship sync

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -168,6 +168,12 @@ struct CoinService {
         // otherwise it report an error "Illegal attempt to map a relationship containing temporary objects to its identifiers."
         Storage.shared.insert([newCoin])
         try Storage.shared.save()
+
+        // Guard against SwiftData inverse relationship auto-populating vault.coins
+        guard !vault.coins.contains(where: { $0.id == newCoin.id }) else {
+            return vault.coins.first(where: { $0.id == newCoin.id })
+        }
+
         vault.coins.append(newCoin)
         return newCoin
     }

--- a/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
@@ -50,7 +50,11 @@ class VaultDefaultCoinService {
             for coin in coins {
                 if coin.isNativeToken {
                     self.context.insert(coin)
-                    vault.coins.append(coin)
+
+                    // Only append if SwiftData inverse relationship didn't auto-populate
+                    if !vault.coins.contains(where: { $0.id == coin.id }) {
+                        vault.coins.append(coin)
+                    }
 
                     Task {
                         await CoinService.addDiscoveredTokens(nativeToken: coin, to: vault)


### PR DESCRIPTION
## Summary
- After `insert()` + `save()`, SwiftData may auto-populate `vault.coins` via the inverse relationship on `Coin`
- The subsequent `append()` then creates a duplicate entry
- Added guard checks in `CoinService.addToChain` and `VaultDefaultCoinService.setDefaultCoins` to skip the append if the coin is already present

## Test Plan
- [ ] Add a new chain/token to vault — no duplicate coins appear
- [ ] Create a new vault — default coins don't duplicate
- [ ] SwiftLint passes

## Related
- Closes #4090
- Related to #4089 (crash fix for duplicate coins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)