### PR TITLE
fix(data): add @MainActor to VaultDefiChainsService for SwiftData thread safety

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
@@ -5,6 +5,10 @@
 //  Created by Gaston Mazzeo on 21/11/2025.
 //
 
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-bond-interactor")
+
 struct THORChainBondInteractor: BondInteractor {
     private let thorchainAPIService = THORChainAPIService()
 
@@ -58,7 +62,7 @@ struct THORChainBondInteractor: BondInteractor {
 
                     activeNodes.append(activeNode)
                 } catch {
-                    print("Error calculating metrics for node \(node.address): \(error)")
+                    logger.error("Error calculating metrics for node \(node.address): \(error)")
                     // Continue with other nodes even if one fails
                 }
             }
@@ -98,7 +102,7 @@ private extension THORChainBondInteractor {
         do {
             try DefiPositionsStorageService().upsert(positions, for: vault)
         } catch {
-            print("An error occured while saving staked positions: \(error)")
+            logger.error("An error occured while saving bond positions: \(error)")
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Home/Service/VaultDefiChainsService.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Service/VaultDefiChainsService.swift
@@ -5,13 +5,17 @@
 //  Created by Gaston Mazzeo on 16/10/2025.
 //
 
+import OSLog
 import SwiftUI
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "vault-defi-chains-service")
 
 // Enables Defi chains for the first time for vaults that were created before Defi features where released
 // TODO: - To be removed after release
 struct VaultDefiChainsService {
     @AppStorage("enabled_vaults_4") private var enabledVaults: [String] = []
 
+    @MainActor
     func enableDefiChainsIfNeeded(for vault: Vault) async {
         guard !enabledVaults.contains(vault.pubKeyECDSA) else {
             return
@@ -36,7 +40,7 @@ struct VaultDefiChainsService {
             try await Storage.shared.save()
             enabledVaults.append(vault.pubKeyECDSA)
         } catch {
-            print("Failed to save DeFi chains for vault: \(error)")
+            logger.error("Failed to save DeFi chains for vault: \(error)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- `VaultDefiChainsService.enableDefiChainsIfNeeded` was modifying SwiftData model properties (`vault.defiChains`, `vault.defiPositions`, `vault.stakePositions`) and calling `Storage.shared.save()` from a background async context
- Added `@MainActor` to ensure all SwiftData mutations happen on the main thread
- Replaced `print()` with `Logger` in touched files per logging rules

## Test Plan
- [ ] DeFi tab loads without threading warnings in console
- [ ] DeFi chains are properly enabled for existing vaults
- [ ] SwiftLint passes

## Related
- Closes #4038

🤖 Generated with [Claude Code](https://claude.com/claude-code)