### PR TITLE
fix(defi): parallelize bond metrics and prevent data wipe on fetch failure

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
@@ -24,11 +24,7 @@ struct THORChainBondInteractor: BondInteractor {
 
             // Parallelize per-node metric calculations
             let activeNodes: [BondPosition] = await withTaskGroup(of: BondPosition?.self) { group in
-                var bondedNodeAddresses: Set<String> = []
-
                 for node in bondedNodes.nodes {
-                    bondedNodeAddresses.insert(node.address)
-
                     group.addTask {
                         do {
                             let myBondMetrics = try await thorchainAPIService.calculateBondMetrics(
@@ -104,7 +100,7 @@ private extension THORChainBondInteractor {
         do {
             try DefiPositionsStorageService().upsert(positions, for: vault)
         } catch {
-            logger.error("An error occured while saving bond positions: \(error)")
+            logger.error("An error occurred while saving bond positions: \(error)")
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
@@ -19,73 +19,75 @@ struct THORChainBondInteractor: BondInteractor {
             return ([], [])
         }
         do {
-            // Fetch network-wide bond info once (APY and next churn date)
             let networkInfo = try await thorchainAPIService.getNetworkBondInfo()
-
-            // Fetch bonded nodes for this address
             let bondedNodes = try await thorchainAPIService.getBondedNodes(address: runeCoin.address)
 
-            // Map each bonded node to ActiveBondedNode with metrics
-            var activeNodes: [BondPosition] = []
-            var bondedNodeAddresses: Set<String> = []
+            // Parallelize per-node metric calculations
+            let activeNodes: [BondPosition] = await withTaskGroup(of: BondPosition?.self) { group in
+                var bondedNodeAddresses: Set<String> = []
 
-            for node in bondedNodes.nodes {
-                bondedNodeAddresses.insert(node.address)
+                for node in bondedNodes.nodes {
+                    bondedNodeAddresses.insert(node.address)
 
-                do {
-                    // Calculate metrics for this node using shared network info
-                    let myBondMetrics = try await thorchainAPIService.calculateBondMetrics(
-                        nodeAddress: node.address,
-                        myBondAddress: runeCoin.address
-                    )
-
-                    // Parse node state from API status
-                    let nodeState = BondNodeState(fromAPIStatus: myBondMetrics.nodeStatus) ?? .standby
-
-                    // Create BondNode
-                    let bondNode = BondNode(
-                        coin: runeCoin.toCoinMeta(),
-                        address: node.address,
-                        state: nodeState
-                    )
-
-                    // Create ActiveBondedNode with calculated metrics
-                    // Use per-node APY calculated from actual rewards (matching JS implementation)
-                    let activeNode = BondPosition(
-                        node: bondNode,
-                        amount: myBondMetrics.myBond,
-                        apy: myBondMetrics.apy,
-                        nextReward: myBondMetrics.myAward,
-                        nextChurn: networkInfo.nextChurnDate,
-                        vault: vault
-                    )
-
-                    activeNodes.append(activeNode)
-                } catch {
-                    logger.error("Error calculating metrics for node \(node.address): \(error)")
-                    // Continue with other nodes even if one fails
+                    group.addTask {
+                        do {
+                            let myBondMetrics = try await thorchainAPIService.calculateBondMetrics(
+                                nodeAddress: node.address,
+                                myBondAddress: runeCoin.address
+                            )
+                            let nodeState = BondNodeState(fromAPIStatus: myBondMetrics.nodeStatus) ?? .standby
+                            let bondNode = BondNode(
+                                coin: runeCoin.toCoinMeta(),
+                                address: node.address,
+                                state: nodeState
+                            )
+                            return BondPosition(
+                                node: bondNode,
+                                amount: myBondMetrics.myBond,
+                                apy: myBondMetrics.apy,
+                                nextReward: myBondMetrics.myAward,
+                                nextChurn: networkInfo.nextChurnDate,
+                                vault: vault
+                            )
+                        } catch {
+                            logger.error("Error calculating metrics for node \(node.address): \(error)")
+                            return nil
+                        }
+                    }
                 }
+
+                var results: [BondPosition] = []
+                for await result in group {
+                    if let position = result {
+                        results.append(position)
+                    }
+                }
+                return results
             }
 
-            // Filter available nodes to exclude already bonded nodes
+            let bondedNodeAddresses = Set(bondedNodes.nodes.map(\.address))
             let availableNodesList = vultiNodeAddresses
                 .filter { !bondedNodeAddresses.contains($0) }
                 .map { BondNode(coin: runeCoin.toCoinMeta(), address: $0, state: .active) }
 
-            // Create local copies to safely pass to MainActor
             let finalActiveNodes = activeNodes
             let finalAvailableNodes = Array(availableNodesList)
 
-            await savePositions(positions: finalActiveNodes, vault: vault)
+            // Only persist when we have data — avoid wiping stored positions on transient failures
+            if !finalActiveNodes.isEmpty || bondedNodes.nodes.isEmpty {
+                await savePositions(positions: finalActiveNodes, vault: vault)
+            }
+
             return (finalActiveNodes, finalAvailableNodes)
         } catch {
+            logger.error("Error fetching bond positions: \(error)")
             return ([], [])
         }
     }
 
     func canUnbond() async -> Bool {
         guard let network = try? await thorchainAPIService.getNetwork() else {
-            return false // Fail-safe: don't allow unbond if can't verify network status
+            return false
         }
         return !network.vaults_migrating
     }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainBondViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainBondViewModel.swift
@@ -29,7 +29,7 @@ final class DefiChainBondViewModel: ObservableObject {
     }
 
     var hasBondPositions: Bool {
-        vault.defiPositions.contains { $0.chain == chain && !$0.bonds.isEmpty }
+        vault.bondPositions.contains { $0.node.coin.chain == chain }
     }
     private let interactor: BondInteractor?
     private let chain: Chain


### PR DESCRIPTION
## Summary
Three fixes for THORChain bond page:

1. **Parallelize per-node `calculateBondMetrics` calls** with `TaskGroup` instead of sequential loop — prevents UI hang on macOS with multiple bonded nodes (each node required 2 sequential API calls; N nodes = 2N serial calls)

2. **Only persist positions when we have results** or the user genuinely has no bonds — prevents `savePositions([])` from wiping stored bond data on transient network failures, which caused zeros after refresh

3. **Fix `hasBondPositions`** to check `vault.bondPositions` instead of `vault.defiPositions` — was checking the wrong data source, causing bond display to show empty state even when data existed

## Test Plan
- [ ] Navigate to THORChain DeFi Bond page — no hang on macOS
- [ ] Refresh Bond page — correct RUNE amounts persist
- [ ] Bond page with multiple nodes loads quickly (parallel)
- [ ] If network is temporarily unavailable, existing bond data is preserved
- [ ] SwiftLint passes

## Related
- Closes #3984
- Closes #4153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bond position identification for more accurate detection.
  * Improved persistence handling of bond position data.

* **Performance**
  * Optimized bond metrics calculations using parallel processing to enable faster data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->