### PR TITLE
fix: select RUJI entry from stakingV2 array instead of first (#3958)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -64,7 +64,9 @@ private extension THORChainStakingService {
         let response = try await httpClient.request(target, responseType: AccountRootData.self)
         let decoded = response.data
 
-        guard let stake = decoded.data.node?.stakingV2?.first else {
+        guard let stake = decoded.data.node?.stakingV2?.first(where: {
+            $0.bonded.asset.metadata?.symbol.uppercased() == "RUJI"
+        }) else {
             return .empty
         }
 


### PR DESCRIPTION
## Summary
- Closes #3958
- The Ruji GraphQL `stakingV2` field returns one entry per pool the account participates in (single-sided RUJI and dual RUJI-RUNE LP). Taking `.first` could surface the wrong pool, so a successful RUJI stake did not reflect in the Vault DeFi tab.
- Filter the array by `bonded.asset.metadata.symbol == "RUJI"` to pick the single-sided RUJI position the DeFi tab tracks.

## Test plan
- [ ] Stake RUJI single-sided on a vault and confirm the position appears in DeFi → THORChain on both iOS and macOS.
- [ ] Verify no regression for accounts with only dual RUJI-RUNE LP staking (should still show empty for single-sided RUJI, which is the correct behavior).
- [ ] Verify accounts with both single and dual stakes show the correct single-sided bonded amount and pending rewards.

> Note: Android (`ThorChainApi.kt:482`) and Windows (`rujiStakeService.ts:62`) have the same bug and should track parallel issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RUJI staking selection to accurately identify and parse the correct staking data, including bonded amounts, pending rewards, and APR calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->