### PR TITLE
feat: redesign password verify reminder to show vault name (#4136)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -137,8 +137,6 @@
 "balanceInParentheses" = "( Balance: %@ %@ )";
 "beforeYouStart" = "Bevor Sie beginnen...";
 "biometricsFastSigning" = "Biometrie schnell unterschreiben";
-"biweeklyPasswordVerifyDescription" = "Wir werden Sie regelmäßig bitten, Ihr Fast-Sign-Passwort zu bestätigen, damit Sie es sich immer merken";
-"biweeklyPasswordVerifyTitle" = "Überprüfe dein Server-Share-\nPasswort";
 "bond" = "Binden";
 "Bond" = "Bond";
 "bonded" = "Gebunden";
@@ -1046,6 +1044,8 @@
 "verify" = "Verifizieren";
 "verifyingCodePleaseWait" = "Code wird überprüft, bitte warten";
 "verifyPassword" = "Passwort bestätigen";
+"verifyPasswordPeriodicReminder" = "Wir bitten dich regelmäßig um eine Bestätigung, damit du dein Passwort nicht vergisst.";
+"verifyYourPasswordFor" = "Überprüfe dein Passwort für:";
 "via" = "über";
 "view" = "Ansehen";
 "viewOnExplorer" = "Im Explorer anzeigen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -145,8 +145,6 @@
 "balanceInParentheses" = "( Balance: %@ %@ )";
 "beforeYouStart" = "Before you start...";
 "biometricsFastSigning" = "Biometrics Fast Signing";
-"biweeklyPasswordVerifyDescription" = "We will periodically ask you to verify your fast sign password so you will always remember it";
-"biweeklyPasswordVerifyTitle" = "Verify your Server Share Password";
 "bond" = "Bond";
 "Bond" = "Bond";
 "bonded" = "Bonded";
@@ -1062,6 +1060,8 @@
 "verify" = "Verify";
 "verifyingCodePleaseWait" = "Verifying code, please wait";
 "verifyPassword" = "Verify Password";
+"verifyPasswordPeriodicReminder" = "We periodically ask for a verification so you don't forget your password.";
+"verifyYourPasswordFor" = "Verify your password for:";
 "via" = "via";
 "view" = "View";
 "viewOnExplorer" = "View on Explorer";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -137,8 +137,6 @@
 "balanceInParentheses" = "( Balance: %@ %@ )";
 "beforeYouStart" = "Antes de comenzar...";
 "biometricsFastSigning" = "Biometría Firma rápida";
-"biweeklyPasswordVerifyDescription" = "Periódicamente te pediremos que verifiques tu contraseña de Fast Sign para que siempre la recuerdes";
-"biweeklyPasswordVerifyTitle" = "Verifica la Contraseña de tu\nParte del Servidor";
 "bond" = "Vincular";
 "Bond" = "Bond";
 "bonded" = "Vinculado";
@@ -1046,6 +1044,8 @@
 "verify" = "Verificar";
 "verifyingCodePleaseWait" = "Verificando código, por favor espera";
 "verifyPassword" = "Verificar contraseña";
+"verifyPasswordPeriodicReminder" = "Te pedimos una verificación periódica para que no olvides tu contraseña.";
+"verifyYourPasswordFor" = "Verifica tu contraseña para:";
 "via" = "vía";
 "view" = "Ver";
 "viewOnExplorer" = "Ver en Explorer";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -137,8 +137,6 @@
 "balanceInParentheses" = "( Balance: %@ %@ )";
 "beforeYouStart" = "Prije nego započnete...";
 "biometricsFastSigning" = "Biometrija brzo potpisivanje";
-"biweeklyPasswordVerifyDescription" = "Povremeno ćemo vas tražiti da potvrdite svoju Fast Sign lozinku kako biste je uvijek zapamtili";
-"biweeklyPasswordVerifyTitle" = "Provjeri lozinku za svoj\nServer Share";
 "bond" = "Veži";
 "Bond" = "Bond";
 "bonded" = "Vezano";
@@ -1046,6 +1044,8 @@
 "verify" = "Provjeri";
 "verifyingCodePleaseWait" = "Provjera koda, pričekajte";
 "verifyPassword" = "Potvrdite lozinku";
+"verifyPasswordPeriodicReminder" = "Povremeno tražimo potvrdu kako ne biste zaboravili svoju lozinku.";
+"verifyYourPasswordFor" = "Potvrdi svoju lozinku za:";
 "via" = "putem";
 "view" = "Pogledaj";
 "viewOnExplorer" = "Prikaži u Exploreru";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -137,8 +137,6 @@
 "balanceInParentheses" = "( Saldo: %@ %@ )";
 "beforeYouStart" = "Prima di iniziare...";
 "biometricsFastSigning" = "Biometria Firma rapida";
-"biweeklyPasswordVerifyDescription" = "Ti chiederemo periodicamente di verificare la tua password Fast Sign, così non la dimenticherai mai";
-"biweeklyPasswordVerifyTitle" = "Verifica la Password della tua\nQuota Server";
 "bond" = "Vincola";
 "Bond" = "Bond";
 "bonded" = "Vincolato";
@@ -1046,6 +1044,8 @@
 "verify" = "Verifica";
 "verifyingCodePleaseWait" = "Verifica del codice in corso, attendere";
 "verifyPassword" = "Verifica la password";
+"verifyPasswordPeriodicReminder" = "Ti chiediamo periodicamente una verifica affinché tu non dimentichi la tua password.";
+"verifyYourPasswordFor" = "Verifica la tua password per:";
 "via" = "tramite";
 "view" = "Visualizza";
 "viewOnExplorer" = "Visualizza su Explorer";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -145,8 +145,6 @@
 "balanceInParentheses" = "( 잔액: %@ %@ )";
 "beforeYouStart" = "시작하기 전에...";
 "biometricsFastSigning" = "생체인식 빠른 서명";
-"biweeklyPasswordVerifyDescription" = "빠른 서명 비밀번호를 기억할 수 있도록 주기적으로 확인을 요청합니다";
-"biweeklyPasswordVerifyTitle" = "서버 공유 비밀번호를 확인하세요";
 "bond" = "본드";
 "Bond" = "본드";
 "bonded" = "본딩됨";
@@ -1062,6 +1060,8 @@
 "verify" = "확인";
 "verifyingCodePleaseWait" = "코드 확인 중, 잠시 기다려 주세요";
 "verifyPassword" = "비밀번호 확인";
+"verifyPasswordPeriodicReminder" = "비밀번호를 잊지 않도록 주기적으로 확인을 요청합니다.";
+"verifyYourPasswordFor" = "다음의 비밀번호를 확인하세요:";
 "via" = "경유";
 "view" = "보기";
 "viewOnExplorer" = "탐색기에서 보기";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -137,8 +137,6 @@
 "balanceInParentheses" = "( Balance: %@ %@ )";
 "beforeYouStart" = "Antes de começar...";
 "biometricsFastSigning" = "Biometria assinatura rápida";
-"biweeklyPasswordVerifyDescription" = "Periodicamente pediremos que verifique sua senha do Fast Sign para que você sempre se lembre dela";
-"biweeklyPasswordVerifyTitle" = "Verifique a Senha da sua\nParte do Servidor";
 "bond" = "Vincular";
 "Bond" = "Bond";
 "bonded" = "Vinculado";
@@ -1046,6 +1044,8 @@
 "verify" = "Verificar";
 "verifyingCodePleaseWait" = "Verificando código, aguarde";
 "verifyPassword" = "Verificar senha";
+"verifyPasswordPeriodicReminder" = "Pedimos uma verificação periódica para que você não esqueça sua senha.";
+"verifyYourPasswordFor" = "Verifique sua senha para:";
 "via" = "via";
 "view" = "Ver";
 "viewOnExplorer" = "Ver no Explorer";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -137,8 +137,6 @@
 "balanceInParentheses" = "( 余额: %@ %@ )";
 "beforeYouStart" = "开始之前...";
 "biometricsFastSigning" = "生物识别快速签名";
-"biweeklyPasswordVerifyDescription" = "我们会定期要求您验证快速签名密码，以便您始终记住它";
-"biweeklyPasswordVerifyTitle" = "验证您的服务器份额密码";
 "bond" = "绑定";
 "Bond" = "绑定";
 "bonded" = "已绑定";
@@ -1047,6 +1045,8 @@
 "verify" = "验证";
 "verifyingCodePleaseWait" = "正在验证代码，请稍候";
 "verifyPassword" = "验证密码";
+"verifyPasswordPeriodicReminder" = "我们会定期请您进行验证，以免您忘记密码。";
+"verifyYourPasswordFor" = "验证您的密码：";
 "via" = "通过";
 "view" = "查看";
 "viewOnExplorer" = "在浏览器中查看";

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/Modifiers/BiweeklyPasswordVerificationViewModifier.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/Modifiers/BiweeklyPasswordVerificationViewModifier.swift
@@ -13,13 +13,24 @@ struct BiweeklyPasswordVerificationViewModifier: ViewModifier {
     @State var shouldShow: Bool = false
     @AppStorage("biweeklyPasswordVerifyDate") private var biweeklyPasswordVerifyDate: Double?
 
+    private let keychain = DefaultKeychainService.shared
+
+    private var hasHint: Bool {
+        guard let hint = keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA) else { return false }
+        return !hint.isEmpty
+    }
+
+    private var sheetHeight: CGFloat {
+        hasHint ? 420 : 360
+    }
+
     func body(content: Content) -> some View {
         content
             .crossPlatformSheet(isPresented: $shouldShow) {
                 PasswordVerifyReminderView(vault: vault, isSheetPresented: $shouldShow)
-                    .presentationDetents([.height(260)])
+                    .presentationDetents([.height(sheetHeight)])
                 #if os(macOS)
-                    .frame(width: 400, height: 260)
+                    .frame(width: 400, height: sheetHeight)
                 #endif
             }
             .onLoad {

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/PasswordVerifyReminderView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/PasswordVerifyReminderView.swift
@@ -5,201 +5,150 @@
 //  Created by Amol Kumar on 2025-04-25.
 //
 
+import OSLog
 import SwiftUI
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "password-verify-reminder")
 
 struct PasswordVerifyReminderView: View {
     let vault: Vault
     @Binding var isSheetPresented: Bool
 
-    @AppStorage("biweeklyPasswordVerifyDate") var biweeklyPasswordVerifyDate: Double?
+    @AppStorage("biweeklyPasswordVerifyDate") private var biweeklyPasswordVerifyDate: Double?
 
-    @State var showError = false
-    @State var errorText = ""
-
-    @State var isLoading = false
-    @State var verifyPassword = ""
-    @State var isPasswordVisible = false
+    @State private var password = ""
+    @State private var errorMessage: String?
+    @State private var isLoading = false
+    @State private var isHintVisible = false
 
     private let fastVaultService: FastVaultService = .shared
+    private let keychain = DefaultKeychainService.shared
+
+    private var hint: String? {
+        keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA)
+    }
 
     var body: some View {
-        ZStack {
-            Background()
-            view
+        VStack(spacing: 16) {
+            Icon(
+                named: "focus-lock",
+                color: Theme.colors.primaryAccent4,
+                size: 32
+            )
+            .padding(.top, 24)
 
-            if isLoading {
-                loader
+            VStack(spacing: 12) {
+                Text("verifyYourPasswordFor".localized)
+                    .font(Theme.fonts.title3)
+                    .foregroundStyle(Theme.colors.textPrimary)
+
+                Text(vault.name)
+                    .font(Theme.fonts.title2)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
-        }
-        .animation(.easeInOut, value: showError)
-        .onDisappear {
-            handleCloseTap()
-        }
-    }
+            .multilineTextAlignment(.center)
 
-    var loader: some View {
-        ZStack {
-            overlay
+            Text("verifyPasswordPeriodicReminder".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
 
-            ProgressView()
-                .preferredColorScheme(.dark)
-        }
-    }
+            SecureTextField(
+                value: $password,
+                placeholder: "enterPassword".localized,
+                error: $errorMessage
+            )
+            .padding(.top, 4)
 
-    var overlay: some View {
-        Color.black
-            .ignoresSafeArea()
-            .opacity(0.3)
-    }
+            if let hint, !hint.isEmpty {
+                hintSection(hint: hint)
+            }
 
-    var view: some View {
-        VStack(spacing: 12) {
-            header
-            separator
-            description
-            field
             Spacer(minLength: 0)
-            verifyButton
+
+            PrimaryButton(title: "done".localized) {
+                Task { await verifyPassword() }
+            }
+            .disabled(password.isEmpty || isLoading)
         }
         .padding(.horizontal, 16)
-        .padding(.top, 24)
-        .padding(.bottom, 12)
-        .blur(radius: isLoading ? 1 : 0)
+        .padding(.bottom, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.colors.bgPrimary)
+        .overlay {
+            if isLoading {
+                loadingOverlay
+            }
+        }
+        .onDisappear(perform: resetVerificationTimer)
     }
 
-    var separator: some View {
-        LinearSeparator()
-            .opacity(0.8)
-    }
-
-    var header: some View {
-        Text(NSLocalizedString("biweeklyPasswordVerifyTitle", comment: ""))
-            .multilineTextAlignment(.center)
-            .foregroundColor(Theme.colors.textSecondary)
-            .font(Theme.fonts.bodySMedium)
-            .frame(maxWidth: .infinity)
-            .overlay(alignment: .trailing) {
-                Button(action: handleCloseTap) {
-                    Image(systemName: "xmark")
+    private func hintSection(hint: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isHintVisible.toggle()
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text("showHint".localized)
+                        .font(Theme.fonts.caption12)
                         .foregroundStyle(Theme.colors.textTertiary)
-                        .font(Theme.fonts.bodySMedium)
+
+                    Icon(
+                        named: "chevron-down",
+                        color: Theme.colors.textTertiary,
+                        size: 16
+                    )
+                    .rotationEffect(.degrees(isHintVisible ? 180 : 0))
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("close".localized)
             }
+            .buttonStyle(.plain)
+
+            Text(hint)
+                .font(Theme.fonts.caption12.italic())
+                .foregroundStyle(Theme.colors.textTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .opacity(isHintVisible ? 1 : 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    var description: some View {
-        Text(NSLocalizedString("biweeklyPasswordVerifyDescription", comment: ""))
-            .multilineTextAlignment(.center)
-            .foregroundColor(Theme.colors.textTertiary)
-            .font(Theme.fonts.caption12)
-            .padding(.horizontal, 28)
-    }
-
-    var field: some View {
+    private var loadingOverlay: some View {
         ZStack {
-            textField
-
-            if showError {
-                errorContent
-                    .offset(y: 48)
-            }
-        }
-        .padding(.bottom)
-    }
-
-    var textField: some View {
-        HStack {
-            if isPasswordVisible {
-                TextField(NSLocalizedString("verifyPassword", comment: "").capitalized, text: $verifyPassword)
-                    .borderlessTextFieldStyle()
-            } else {
-                SecureField(NSLocalizedString("verifyPassword", comment: "").capitalized, text: $verifyPassword)
-                    .borderlessTextFieldStyle()
-            }
-
-            hideButton
-        }
-        .colorScheme(.dark)
-        .foregroundColor(Theme.colors.textPrimary)
-        .font(Theme.fonts.bodySMedium)
-        .borderlessTextFieldStyle()
-        .frame(height: 56)
-        .padding(.horizontal, 24)
-        .background(Theme.colors.bgSurface1)
-        .cornerRadius(12)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(showError ? Theme.colors.alertError : Color.clear, lineWidth: 1)
-        )
-    }
-
-    var hideButton: some View {
-        Button(
-            action: {
-                withAnimation {
-                    isPasswordVisible.toggle()
-                }
-            },
-            label: {
-                Image(systemName: isPasswordVisible ? "eye" : "eye.slash")
-                    .foregroundColor(Theme.colors.textPrimary)
-            }
-        )
-        .buttonStyle(.plain)
-        .contentTransition(.symbolEffect(.replace))
-    }
-
-    var verifyButton: some View {
-        PrimaryButton(title: "verify") {
-            handleButtonTap()
+            Color.black.opacity(0.3).ignoresSafeArea()
+            ProgressView().preferredColorScheme(.dark)
         }
     }
 
-    var errorContent: some View {
-        Text(NSLocalizedString(errorText, comment: ""))
-            .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.alertError)
-            .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func verifyPasswordIsValid() async {
-        guard !verifyPassword.isEmpty else {
-            errorText = "emptyField"
-            showError = true
-            isLoading = false
+    private func verifyPassword() async {
+        guard !password.isEmpty else {
+            errorMessage = "emptyField".localized
             return
         }
 
-        showError = false
+        errorMessage = nil
+        isLoading = true
+        defer { isLoading = false }
 
         let isValid = await fastVaultService.get(
             pubKeyECDSA: vault.pubKeyECDSA,
-            password: verifyPassword
+            password: password
         )
 
         if isValid {
-            handleCloseTap()
+            logger.info("Password verification succeeded")
+            isSheetPresented = false
         } else {
-            errorText = "incorrectPassword"
-            showError = true
+            errorMessage = "incorrectPasswordTryAgain".localized
         }
-
-        isLoading = false
     }
 
-    private func handleCloseTap() {
-        let calendar = Calendar.current
-        let startOfToday = calendar.startOfDay(for: Date())
+    private func resetVerificationTimer() {
+        let startOfToday = Calendar.current.startOfDay(for: Date())
         biweeklyPasswordVerifyDate = startOfToday.timeIntervalSince1970
-        isSheetPresented = false
-    }
-
-    private func handleButtonTap() {
-        Task {
-            isLoading = true
-            await verifyPasswordIsValid()
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Rewrite `PasswordVerifyReminderView` using design-system components (`Icon`, `SecureTextField`, `PrimaryButton`, `Theme.*`) to match the [latest Figma](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=73241-81243).
- Surface the vault name in the title block (`"Verify your password for:" / vault.name`) — the ask from #4136.
- Add a "Show hint" reveal when the vault has a stored fast-sign hint (mirrors `FastVaultEnterPasswordView`).
- Scale the sheet detent with hint presence (360pt / 420pt) in `BiweeklyPasswordVerificationViewModifier`.
- Replace legacy `biweeklyPasswordVerifyTitle` / `biweeklyPasswordVerifyDescription` keys with `verifyYourPasswordFor` / `verifyPasswordPeriodicReminder` in all 8 locales.

Closes #4136.

## Test plan
- [ ] Fast vault with no stored hint: sheet opens at 360pt, shows vault name, no "Show hint" row.
- [ ] Fast vault with stored hint: sheet opens at 420pt, "Show hint" row toggles the italic hint text.
- [ ] Wrong password shows inline `incorrectPasswordTryAgain` error; correct password dismisses the sheet.
- [ ] Swiping the sheet down resets the 15-day timer (same as verifying).
- [ ] macOS presentation still fits in the 400 × `sheetHeight` window.
- [ ] All 8 locales render the new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hint support for password verification during periodic reminder prompts.

* **Localization**
  * Updated password verification reminder strings across multiple languages (English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Chinese).

* **UI/UX Improvements**
  * Redesigned password verification reminder interface with simplified layout and improved hint visibility toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->