### PR TITLE
fix(thorchain): surface Rujira unmerge balance and expand token dropdown

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
@@ -333,6 +333,14 @@ extension ThorchainService {
         let price: Decimal
     }
 
+    /// A single merge account entry as returned by the RUJIRA GraphQL API,
+    /// keyed by the canonical symbol (e.g. "KUJI", "RKUJI", "FUZN").
+    struct RujiMergeAccount {
+        let symbol: String
+        let shares: String
+        let sizeAmount: String
+    }
+
     /// Structure representing a RUJI Stake balance result
     struct RujiStakeBalance {
         let stakeAmount: BigInt
@@ -343,12 +351,10 @@ extension ThorchainService {
         static let empty = RujiStakeBalance(stakeAmount: .zero, stakeTicker: "", rewardsAmount: .zero, rewardsTicker: "")
     }
 
-    /// Fetch merged RUJI balance for a specific token
-    /// - Parameters:
-    ///   - thorAddress: The THORChain address to query
-    ///   - tokenSymbol: The token symbol to check (e.g., "THOR.KUJI", "THOR.RKUJI")
-    /// - Returns: A tuple containing (ruji amount, shares, price per share)
-    func fetchRujiMergeBalance(thorAddr: String, tokenSymbol: String) async throws -> RujiBalance {
+    /// Fetch every merge account tied to the given THORChain address.
+    /// - Parameter thorAddr: The THORChain address to query.
+    /// - Returns: All merge accounts keyed by their canonical asset symbol.
+    func fetchAllRujiMergeBalances(thorAddr: String) async throws -> [RujiMergeAccount] {
         let id = "Account:\(thorAddr)".data(using: .utf8)?.base64EncodedString() ?? ""
 
         guard let url = URL(string: Endpoint.fetchThorchainMergedAssets()) else {
@@ -356,37 +362,55 @@ extension ThorchainService {
         }
 
         let query = String(format: Self.mergedAssetsQuery, id)
-
-        let requestBody: [String: Any] = ["query": query]
-
-        let bodyData = try JSONSerialization.data(withJSONObject: requestBody)
+        let bodyData = try JSONSerialization.data(withJSONObject: ["query": query])
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = bodyData
 
         let (data, _) = try await URLSession.shared.data(for: request)
-
         let decoded = try JSONDecoder().decode(AccountRootData.self, from: data)
 
-        // Find the account matching the selected token
-        let cleanTokenSymbol = tokenSymbol.lowercased().replacingOccurrences(of: "thor.", with: "")
+        return decoded.data.node?.merge?.accounts.map { account in
+            RujiMergeAccount(
+                symbol: account.pool.mergeAsset.metadata.symbol,
+                shares: account.shares,
+                sizeAmount: account.size.amount
+            )
+        } ?? []
+    }
 
-        let acc = decoded.data.node?.merge?.accounts.first { account in
-            account.pool.mergeAsset.metadata.symbol.lowercased() == cleanTokenSymbol
-        }
+    /// Fetch merged RUJI balance for a specific token.
+    /// - Parameters:
+    ///   - thorAddr: The THORChain address to query.
+    ///   - tokenSymbol: The token symbol to check (e.g. "THOR.KUJI", "KUJI").
+    /// - Returns: The matching balance or a zero balance when no position exists.
+    func fetchRujiMergeBalance(thorAddr: String, tokenSymbol: String) async throws -> RujiBalance {
+        let accounts = try await fetchAllRujiMergeBalances(thorAddr: thorAddr)
+        let target = Self.normalizeRujiSymbol(tokenSymbol)
 
-        guard let acc = acc else {
+        guard let match = accounts.first(where: { Self.normalizeRujiSymbol($0.symbol) == target }) else {
+            let available = accounts.map(\.symbol).joined(separator: ", ")
+            logger.warning("No RUJI merge account matched \(tokenSymbol, privacy: .public); available symbols: [\(available, privacy: .public)]")
             return RujiBalance(ruji: 0, shares: "0", price: 0)
         }
 
-        let shares = acc.shares
-        let ruji = Decimal(string: acc.size.amount) ?? 0
-        // Calculate price per share based on user's own position
+        let shares = match.shares
+        let ruji = Decimal(string: match.sizeAmount) ?? 0
         let sharesDecimal = Decimal(string: shares) ?? 1
         let price = sharesDecimal > 0 ? ruji / sharesDecimal : 0
 
         return RujiBalance(ruji: ruji, shares: shares, price: price)
+    }
+
+    /// Normalize a RUJI merge token identifier (e.g. `"THOR.KUJI"`, `"kuji"`, `"KUJI"`)
+    /// into a canonical uppercase ticker suitable for equality comparisons.
+    static func normalizeRujiSymbol(_ symbol: String) -> String {
+        var normalized = symbol.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        if normalized.hasPrefix("THOR.") {
+            normalized.removeFirst("THOR.".count)
+        }
+        return normalized
     }
 
     func fetchRujiStakeBalance(thorAddr: String) async throws -> RujiStakeBalance {

--- a/VultisigApp/VultisigApp/Components/GenericSelectorDropDown.swift
+++ b/VultisigApp/VultisigApp/Components/GenericSelectorDropDown.swift
@@ -15,14 +15,14 @@ struct GenericSelectorDropDown<T: Identifiable & Equatable>: View {
         VStack(alignment: .leading, spacing: 0) {
             selectedCell
 
-            if isActive && isExpanded {
+            if canExpand && isExpanded {
                 cells
             }
         }
         .padding(.horizontal, 12)
         .background(Theme.colors.bgSurface1)
         .cornerRadius(10)
-        .disabled(!isActive)
+        .disabled(items.isEmpty)
     }
 
     var selectedCell: some View {
@@ -47,7 +47,7 @@ struct GenericSelectorDropDown<T: Identifiable & Equatable>: View {
 
             Spacer()
 
-            if isActive {
+            if canExpand {
                 Image(systemName: "chevron.down")
             }
         }
@@ -87,8 +87,8 @@ struct GenericSelectorDropDown<T: Identifiable & Equatable>: View {
         .frame(height: 48)
     }
 
-    var isActive: Bool {
-        return items.count > 1
+    var canExpand: Bool {
+        return !items.isEmpty
     }
 
     private func handleSelection(for item: T) {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosUnmerge.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosUnmerge.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 import Foundation
 import Combine
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-cosmos-unmerge")
 
 /**
  * THORCHAIN - FUNCTION: "EXECUTE CONTRACT - UNMERGE"
@@ -57,22 +60,39 @@ class FunctionCallCosmosUnmerge: ObservableObject {
 
     func initialize() {
         setupValidation()
-        loadAvailableTokens()
+        loadStaticMergeTokens()
         preSelectToken()
+
+        Task { @MainActor in
+            await loadOnChainMergeTokens()
+        }
     }
 
-    private func loadAvailableTokens() {
-        // Find available merge tokens that have balances
-        let availableTokens = ThorchainMergeTokens.tokensToMerge.filter { tokenInfo in
-            vault.coins.contains { coin in
-                coin.chain == .thorChain &&
-                !coin.isNativeToken &&
-                coin.ticker.lowercased() == tokenInfo.denom.lowercased().replacingOccurrences(of: "thor.", with: "")
-            }
+    private func loadStaticMergeTokens() {
+        // Show every known kujira-migration token by default so the user can
+        // pick any asset they may hold a merged position in, even when the
+        // coin hasn't been added to the vault yet.
+        tokens = ThorchainMergeTokens.tokensToMerge.map { tokenInfo in
+            IdentifiableString(value: tokenInfo.denom.uppercased())
         }
+    }
 
-        for token in availableTokens {
-            tokens.append(.init(value: token.denom.uppercased()))
+    @MainActor
+    private func loadOnChainMergeTokens() async {
+        let thorAddress = vault.coins.first(where: { $0.chain == .thorChain })?.address ?? ""
+        guard !thorAddress.isEmpty else { return }
+
+        do {
+            let accounts = try await ThorchainService.shared.fetchAllRujiMergeBalances(thorAddr: thorAddress)
+            let existing = Set(tokens.map { ThorchainService.normalizeRujiSymbol($0.value) })
+
+            for account in accounts {
+                let ticker = ThorchainService.normalizeRujiSymbol(account.symbol)
+                guard !ticker.isEmpty, !existing.contains(ticker) else { continue }
+                tokens.append(IdentifiableString(value: "THOR.\(ticker)"))
+            }
+        } catch {
+            logger.error("Failed to fetch on-chain merge accounts: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -134,7 +154,7 @@ class FunctionCallCosmosUnmerge: ObservableObject {
             let thorAddress = vault.coins.first(where: { $0.chain == .thorChain })?.address ?? ""
 
             guard !thorAddress.isEmpty else {
-                print("ERROR: No THORChain address found in vault")
+                logger.error("No THORChain address found in vault")
                 balanceLabel = NSLocalizedString("noThorAddressFound", comment: "")
                 amount = 0
                 totalShares = "0"
@@ -163,7 +183,7 @@ class FunctionCallCosmosUnmerge: ObservableObject {
             updateBalanceLabel()
             objectWillChange.send() // Force UI update after setting values
         } catch {
-            print("Error fetching merged balance: \(error)")
+            logger.error("Error fetching merged balance: \(error.localizedDescription, privacy: .public)")
             balanceLabel = NSLocalizedString("errorLoadingBalance", comment: "")
             amount = 0
             availableBalance = 0


### PR DESCRIPTION
## Summary

Fixes the two Rujira unmerge bugs reported in #4169:

1. **Balance now loads correctly.** `ThorchainService.fetchRujiMergeBalance` was comparing `account.pool.mergeAsset.metadata.symbol.lowercased()` against a denom with `thor.` stripped, which silently returned zero whenever the GraphQL symbol came back in a different case or format than the static merge list. Both sides are now normalized through `normalizeRujiSymbol`, and a mismatch logs the available symbols so future surprises are traceable instead of silent.
2. **Dropdown shows every mergeable token.** `FunctionCallCosmosUnmerge.loadAvailableTokens` intersected the static list with `vault.coins`, so a user holding a merge position for a token that wasn't in their vault saw nothing. The picker now seeds with all six kujira-migration tokens and unions on-chain balances from the new `fetchAllRujiMergeBalances`, mirroring the Windows flow.
3. **Single-item dropdown is tappable.** `GenericSelectorDropDown` gated `.disabled` on `items.count > 1`, making the whole control un-tappable when only one token was present. It now only disables when the list is empty.
4. Replaced `print` with `OSLog` Logger per project rules.

## Test Plan
- [ ] SwiftLint passes (verified locally on changed files)
- [ ] Open Function Call → Unmerge with a vault that holds a merge position for a token not added to the vault; confirm the token appears and balance loads
- [ ] Open Function Call → Unmerge with a vault that holds a single mergeable token; confirm the dropdown can be tapped/expanded
- [ ] Switch tokens in the dropdown and confirm balance refreshes to the correct `shares` / RUJI value

## Related
- Closes #4169

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved THORChain merge account symbol matching with automatic normalization.
  * Enhanced merge balance detection to log available symbols when no match is found.
  * Fixed dropdown control enabled state based on actual item availability.

* **New Features**
  * Added automatic on-chain merge token discovery that supplements pre-configured static tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->