### PR TITLE
feat(maya): add asset selection for custom memos

### DIFF
--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCustom.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCustom.swift
@@ -68,14 +68,20 @@ class FunctionCallCustom: FunctionCallAddressable, ObservableObject {
             }
 
         case .mayaChain:
-            // Load CACAO from TokensStore filtered by MayaChain
-            let mayaChainTokens = TokensStore.TokenSelectionAssets.filter { $0.chain == .mayaChain }
-            for token in mayaChainTokens {
-                let ticker = token.ticker.uppercased()
-                // Add CACAO (native token), MAYA, and AZTEC
+            // Load MayaChain tokens from vault: CACAO, MAYA, AZTEC
+            let mayaChainCoins = vault.coins.filter { $0.chain == .mayaChain }
+
+            for coin in mayaChainCoins {
+                let ticker = coin.ticker.uppercased()
+                // Add CACAO (native), MAYA, and AZTEC
                 if ticker == "CACAO" || ticker == "MAYA" || ticker == "AZTEC" {
                     tokens.append(.init(value: ticker))
                 }
+            }
+
+            // If no tokens found, at least add CACAO
+            if tokens.isEmpty {
+                tokens.append(.init(value: "CACAO"))
             }
 
         default:
@@ -101,7 +107,7 @@ class FunctionCallCustom: FunctionCallAddressable, ObservableObject {
             if coin.chain == .thorChain && coin.ticker.lowercased() == ticker {
                 return coin
             }
-            // Check MayaChain for MAYA
+            // Check MayaChain for CACAO, MAYA, AZTEC
             if coin.chain == .mayaChain && coin.ticker.lowercased() == ticker {
                 return coin
             }


### PR DESCRIPTION
## Summary
- Mirror the Thorchain asset-picker pattern on MayaChain custom memos so the user can choose which asset (CACAO / MAYA / AZTEC) the memo is sent with.
- Source the picker options from `vault.coins` filtered by `.mayaChain` (same shape as the existing Thorchain branch) instead of the global `TokensStore`, so the dropdown only lists assets the user actually holds and `tx.coin` reliably updates when the selection changes.
- Fall back to CACAO when no Maya coins are present in the vault, matching Thorchain's RUNE fallback.

The shared `FunctionCallCustom` view/viewmodel was already wired for Maya in `FunctionCallTypeEnum.getCases(for:)`, so no new views, view models, or routes are introduced — this is a minimal behavioral fix to the existing code path.

## Test Plan
- [ ] Open a vault that holds CACAO + MAYA + AZTEC on MayaChain; open **Function Call** on a Maya coin, switch to **Custom**, and verify the asset dropdown lists all three with the correct balances.
- [ ] Switch between CACAO, MAYA, and AZTEC in the dropdown and confirm the balance label updates and the outbound transaction is built with the selected coin.
- [ ] Open a vault that holds only CACAO on Maya and verify the dropdown still shows CACAO.
- [ ] Sanity-check the Thorchain flow (Function Call → Custom on a THORChain coin) — RUNE / RUJI / TCY picker still behaves as before.
- [ ] Lint: `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — no new warnings.

Closes #3762

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MayaChain token availability by refining token source selection and ensuring proper fallback handling for supported tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->