### PR TITLE
fix(thorchain): populate secured asset dropdown with all holdings

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1074,6 +1074,7 @@
 "Withdraw RUJI" = "RUJI abheben";
 "Withdraw Secured Asset" = "Gesicherten Vermögenswert abheben";
 "withdrawAmount" = "%@ abheben";
+"withdrawBelowOutboundFee" = "Betrag unter Ausgangsgebühr — mindestens %@ %@ abheben, um Netzwerkkosten zu decken";
 "withdrawPercentage" = "Abhebungsprozentsatz";
 "withdrawSecuredAssetError" = "To withdraw %@, you need to add the %@ coin to your vault first. Go to vault settings and add %@ to continue.";
 "wrongPassword" = "Falsches Passwort";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1090,6 +1090,7 @@
 "Withdraw RUJI" = "Withdraw RUJI";
 "Withdraw Secured Asset" = "Withdraw Secured Asset";
 "withdrawAmount" = "Withdraw %@";
+"withdrawBelowOutboundFee" = "Amount below outbound fee — withdraw at least %@ %@ to cover network costs";
 "withdrawPercentage" = "Withdraw Percentage";
 "withdrawSecuredAssetError" = "To withdraw %@, you need to add the %@ coin to your vault first. Go to vault settings and add %@ to continue.";
 "wrongPassword" = "Wrong password";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1074,6 +1074,7 @@
 "Withdraw RUJI" = "Retirar RUJI";
 "Withdraw Secured Asset" = "Retirar activo asegurado";
 "withdrawAmount" = "Retirar %@";
+"withdrawBelowOutboundFee" = "Monto por debajo de la tarifa de salida — retira al menos %@ %@ para cubrir los costos de red";
 "withdrawPercentage" = "Porcentaje de retiro";
 "withdrawSecuredAssetError" = "To withdraw %@, you need to add the %@ coin to your vault first. Go to vault settings and add %@ to continue.";
 "wrongPassword" = "Contraseña incorrecta";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1074,6 +1074,7 @@
 "Withdraw RUJI" = "Povuci RUJI";
 "Withdraw Secured Asset" = "Povuci osiguranu imovinu";
 "withdrawAmount" = "Podignite %@";
+"withdrawBelowOutboundFee" = "Iznos ispod izlazne naknade — podignite barem %@ %@ za pokriće mrežnih troškova";
 "withdrawPercentage" = "Postotak povlačenja";
 "withdrawSecuredAssetError" = "Za povlačenje %@, prvo morate dodati %@ kovanicu u svoj trezor. Idite u postavke trezora i dodajte %@ za nastavak.";
 "wrongPassword" = "Pogrešna lozinka";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1074,6 +1074,7 @@
 "Withdraw RUJI" = "Preleva RUJI";
 "Withdraw Secured Asset" = "Preleva asset garantito";
 "withdrawAmount" = "Preleva %@";
+"withdrawBelowOutboundFee" = "Importo inferiore alla commissione in uscita — preleva almeno %@ %@ per coprire i costi di rete";
 "withdrawPercentage" = "Percentuale di prelievo";
 "withdrawSecuredAssetError" = "Per prelevare %@, devi prima aggiungere la moneta %@ al tuo vault. Vai nelle impostazioni del vault e aggiungi %@ per continuare.";
 "wrongPassword" = "Password errata";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1090,6 +1090,7 @@
 "Withdraw RUJI" = "RUJI 출금";
 "Withdraw Secured Asset" = "보안 자산 출금";
 "withdrawAmount" = "%@ 출금";
+"withdrawBelowOutboundFee" = "출금 금액이 출금 수수료보다 낮음 — 네트워크 비용을 충당하려면 최소 %@ %@을(를) 출금하세요";
 "withdrawPercentage" = "출금 비율";
 "withdrawSecuredAssetError" = "%@을(를) 출금하려면 먼저 볼트에 %@ 코인을 추가해야 합니다. 볼트 설정으로 이동하여 %@을(를) 추가하고 계속하세요.";
 "wrongPassword" = "잘못된 비밀번호";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1074,6 +1074,7 @@
 "Withdraw RUJI" = "Sacar RUJI";
 "Withdraw Secured Asset" = "Sacar Ativo Segurado";
 "withdrawAmount" = "Retirar %@";
+"withdrawBelowOutboundFee" = "Valor abaixo da taxa de saída — retire pelo menos %@ %@ para cobrir os custos da rede";
 "withdrawPercentage" = "Porcentagem de saque";
 "withdrawSecuredAssetError" = "To withdraw %@, you need to add the %@ coin to your vault first. Go to vault settings and add %@ to continue.";
 "wrongPassword" = "Senha incorreta";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1075,6 +1075,7 @@
 "Withdraw RUJI" = "提取 RUJI";
 "Withdraw Secured Asset" = "提取担保资产";
 "withdrawAmount" = "提取 %@";
+"withdrawBelowOutboundFee" = "金额低于出站费用 — 请至少提取 %@ %@ 以支付网络费用";
 "withdrawPercentage" = "提取百分比";
 "withdrawSecuredAssetError" = "要提取 %@，您需要先将 %@ 代币添加到您的保险库。请前往保险库设置并添加 %@ 以继续。";
 "wrongPassword" = "密码错误";

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
@@ -61,7 +61,9 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
     func initialize() {
         setupValidation()
         prefillAddresses()
-        loadAvailableSecuredAssets()
+        Task { @MainActor in
+            await loadAvailableSecuredAssets()
+        }
     }
 
     private func prefillAddresses() {
@@ -72,42 +74,49 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
 
     // MARK: - Load Available Secured Assets
 
-    func loadAvailableSecuredAssets() {
+    @MainActor
+    func loadAvailableSecuredAssets() async {
         isLoadingAssets = true
         loadError = nil
 
+        // Secured-asset balances live as cosmos-bank denoms on the user's THOR
+        // address, not as entries in `vault.coins` until a discovery pass
+        // persists them. Trigger the same discovery path the chain detail
+        // screen uses so USDC / USDT / etc. acquired after the last visit are
+        // picked up before we build the dropdown.
+        let thorChains: Set<Chain> = [.thorChain, .thorChainChainnet, .thorChainStagenet]
+        let thorNative = vault.coins.first { coin in
+            thorChains.contains(coin.chain) && coin.isNativeToken
+        }
+        if let thorNative {
+            await CoinService.addDiscoveredTokens(nativeToken: thorNative, to: vault)
+        }
+
         // A secured asset is any non-native THORChain coin whose on-chain denom is
         // formatted as `<l1chain>-<symbol>[-<contract>]` (see THORChainHelper).
-        // Rely on the shared helper rather than a hand-rolled ticker allow-list so
-        // every secured asset held in the vault (USDC, USDT, WBTC, ...) is offered.
         let securedAssetsInVault = vault.coins
             .filter { THORChainHelper.isSecuredAsset(coin: $0) && $0.balanceDecimal > 0 }
             .sorted { displayName(for: $0) < displayName(for: $1) }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        var assetList = [IdentifiableString(value: NSLocalizedString("selectSecuredAssetToWithdraw", comment: ""))]
+        var lookup: [UUID: Coin] = [:]
 
-            // Always start with "Select asset" placeholder to ensure dropdown works
-            var assetList = [IdentifiableString(value: NSLocalizedString("selectSecuredAssetToWithdraw", comment: ""))]
-            var lookup: [UUID: Coin] = [:]
-
-            if securedAssetsInVault.isEmpty {
-                // Keep just the placeholder
-                self.availableSecuredAssets = assetList
-                self.securedAssetLookup = lookup
-                self.loadError = NSLocalizedString("noSecuredAssets", comment: "")
-            } else {
-                let vaultAssets = securedAssetsInVault.map { coin -> IdentifiableString in
-                    let item = IdentifiableString(value: self.displayName(for: coin))
-                    lookup[item.id] = coin
-                    return item
-                }
-                assetList.append(contentsOf: vaultAssets)
-                self.availableSecuredAssets = assetList
-                self.securedAssetLookup = lookup
-                self.loadError = nil
+        if securedAssetsInVault.isEmpty {
+            availableSecuredAssets = assetList
+            securedAssetLookup = lookup
+            loadError = NSLocalizedString("noSecuredAssets", comment: "")
+        } else {
+            let vaultAssets = securedAssetsInVault.map { coin -> IdentifiableString in
+                let item = IdentifiableString(value: displayName(for: coin))
+                lookup[item.id] = coin
+                return item
             }
-            self.isLoadingAssets = false
+            assetList.append(contentsOf: vaultAssets)
+            availableSecuredAssets = assetList
+            securedAssetLookup = lookup
+            loadError = nil
         }
+        isLoadingAssets = false
     }
 
     /// Human-readable label for a secured asset (e.g. "ETH.USDC", "BTC.BTC").
@@ -358,9 +367,7 @@ struct SecuredAssetSelectorSection: View {
                 Spacer()
 
                 Button {
-                    model.loadError = nil
-                    model.isLoadingAssets = true
-                    model.loadAvailableSecuredAssets()
+                    Task { await model.loadAvailableSecuredAssets() }
                 } label: {
                     Text(NSLocalizedString("retry", comment: ""))
                         .font(.caption)

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
@@ -36,8 +36,33 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
 
     /// Maps a dropdown item's id to the underlying secured asset coin in the vault.
     private var securedAssetLookup: [UUID: Coin] = [:]
+    /// Set by `updateDestinationAddress` when the vault lacks the L1 native
+    /// coin; read by `updateErrorMessage` so destination issues take priority
+    /// over amount/fee complaints.
+    private var destinationError: String?
 
     private var cancellables = Set<AnyCancellable>()
+
+    private static let thorChains: Set<Chain> = [.thorChain, .thorChainChainnet, .thorChainStagenet]
+
+    // MARK: - Coin helpers
+
+    private func nativeCoin(for chain: Chain) -> Coin? {
+        vault.coins.first { $0.chain == chain && $0.isNativeToken }
+    }
+
+    private var thorNative: Coin? {
+        vault.coins.first { Self.thorChains.contains($0.chain) && $0.isNativeToken }
+    }
+
+    /// Short symbol (e.g. "USDC") — `securedAssetSymbol` keeps the trailing
+    /// contract suffix for signing, which isn't what we want for labels.
+    private func shortSymbol(for coin: Coin) -> String {
+        THORChainHelper.securedAssetSymbol(coin: coin)
+            .split(separator: "-")
+            .first
+            .map(String.init) ?? coin.ticker.uppercased()
+    }
 
     // Domain models
     var tx: SendTransaction
@@ -82,57 +107,61 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
     func loadAvailableSecuredAssets() async {
         isLoadingAssets = true
         loadError = nil
-
-        let thorChains: Set<Chain> = [.thorChain, .thorChainChainnet, .thorChainStagenet]
-        guard let thorNative = vault.coins.first(where: { coin in
-            thorChains.contains(coin.chain) && coin.isNativeToken
-        }) else {
-            setPickerEmpty(reason: NSLocalizedString("noSecuredAssets", comment: ""))
-            return
-        }
-
-        // Secured-asset balances live as cosmos-bank denoms on the user's THOR
-        // address and are not present in vault.coins until explicitly enabled.
-        // Fetch the live bank balances so we see every secured asset the user
-        // holds (USDC, USDT, WBTC, ...) even on first use, then persist each
-        // via CoinService.addIfNeeded so the signing flow has a proper Coin.
         do {
-            let service = ThorchainServiceFactory.getService(for: thorNative.chain)
-            let balances = try await service.fetchBalances(thorNative.address)
-
-            var persisted: [Coin] = []
-            for balance in balances where Self.isSecuredDenom(balance.denom) {
-                guard let coin = try persistSecuredAsset(balance: balance, chain: thorNative.chain) else {
-                    continue
-                }
-                coin.rawBalance = balance.amount
-                persisted.append(coin)
-            }
-
-            let securedAssets = persisted
-                .filter { $0.balanceDecimal > 0 }
-                .sorted { displayName(for: $0) < displayName(for: $1) }
-
-            guard !securedAssets.isEmpty else {
-                setPickerEmpty(reason: NSLocalizedString("noSecuredAssets", comment: ""))
-                return
-            }
-
-            var assetList = [IdentifiableString(value: NSLocalizedString("selectSecuredAssetToWithdraw", comment: ""))]
-            var lookup: [UUID: Coin] = [:]
-            for coin in securedAssets {
-                let item = IdentifiableString(value: displayName(for: coin))
-                lookup[item.id] = coin
-                assetList.append(item)
-            }
-            availableSecuredAssets = assetList
-            securedAssetLookup = lookup
-            loadError = nil
-            isLoadingAssets = false
+            let assets = try await fetchSecuredAssetCoins()
+            applyPicker(securedAssets: assets)
         } catch {
             logger.error("Failed to fetch THORChain balances: \(error.localizedDescription)")
             setPickerEmpty(reason: NSLocalizedString("noSecuredAssets", comment: ""))
         }
+    }
+
+    /// Pulls live cosmos-bank balances from the user's THOR address, persists
+    /// any secured-asset denoms that aren't yet in the vault, and returns the
+    /// set of coins with a non-zero balance sorted for display.
+    ///
+    /// Secured-asset balances live as cosmos-bank denoms and aren't present in
+    /// `vault.coins` until explicitly enabled, so fetching from the network
+    /// ensures USDC / USDT / WBTC etc. show up on first use. `addIfNeeded`
+    /// skips the spam/hidden filters that `addDiscoveredTokens` would apply.
+    @MainActor
+    private func fetchSecuredAssetCoins() async throws -> [Coin] {
+        guard let thorNative else { return [] }
+
+        let service = ThorchainServiceFactory.getService(for: thorNative.chain)
+        let balances = try await service.fetchBalances(thorNative.address)
+
+        var persisted: [Coin] = []
+        for balance in balances where Self.isSecuredDenom(balance.denom) {
+            guard let coin = try persistSecuredAsset(balance: balance, chain: thorNative.chain) else {
+                continue
+            }
+            coin.rawBalance = balance.amount
+            persisted.append(coin)
+        }
+
+        return persisted
+            .filter { $0.balanceDecimal > 0 }
+            .sorted { displayName(for: $0) < displayName(for: $1) }
+    }
+
+    @MainActor
+    private func applyPicker(securedAssets: [Coin]) {
+        guard !securedAssets.isEmpty else {
+            setPickerEmpty(reason: NSLocalizedString("noSecuredAssets", comment: ""))
+            return
+        }
+        var assetList = [IdentifiableString(value: NSLocalizedString("selectSecuredAssetToWithdraw", comment: ""))]
+        var lookup: [UUID: Coin] = [:]
+        for coin in securedAssets {
+            let item = IdentifiableString(value: displayName(for: coin))
+            lookup[item.id] = coin
+            assetList.append(item)
+        }
+        availableSecuredAssets = assetList
+        securedAssetLookup = lookup
+        loadError = nil
+        isLoadingAssets = false
     }
 
     private static func isSecuredDenom(_ denom: String) -> Bool {
@@ -169,15 +198,8 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
     }
 
     /// Human-readable label for a secured asset (e.g. "ETH.USDC", "BTC.BTC").
-    /// Uses the L1 chain + symbol (without the trailing contract address suffix
-    /// that `securedAssetSymbol` preserves) so labels stay short and unique.
     private func displayName(for coin: Coin) -> String {
-        let chain = THORChainHelper.securedAssetChain(coin: coin)
-        let symbol = THORChainHelper.securedAssetSymbol(coin: coin)
-            .split(separator: "-")
-            .first
-            .map(String.init) ?? coin.ticker.uppercased()
-        return "\(chain).\(symbol)"
+        "\(THORChainHelper.securedAssetChain(coin: coin)).\(shortSymbol(for: coin))"
     }
 
     // MARK: - Asset Selection
@@ -225,7 +247,7 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
 
         let l1ChainCode = THORChainHelper.securedAssetChain(coin: securedAssetCoin)
         guard let l1Chain = chain(forSwapAsset: l1ChainCode),
-              let nativeCoin = vault.coins.first(where: { $0.chain == l1Chain && $0.isNativeToken }) else {
+              let native = nativeCoin(for: l1Chain) else {
             return
         }
 
@@ -240,7 +262,7 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
         // outbound_fee is denominated in the L1 native asset at 8 decimals across
         // all THORChain-supported chains.
         let feeNativeAmount = feeBaseUnits / pow(10, 8)
-        let feeFiat = RateProvider.shared.fiatBalance(value: feeNativeAmount, coin: nativeCoin)
+        let feeFiat = RateProvider.shared.fiatBalance(value: feeNativeAmount, coin: native)
         let unitFiat = RateProvider.shared.fiatBalance(value: 1, coin: securedAssetCoin)
 
         guard feeFiat > 0, unitFiat > 0 else {
@@ -257,30 +279,24 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
     private func updateDestinationAddress(for securedAssetCoin: Coin) {
         // The L1 chain is encoded in the secured asset's denom (e.g. "eth-usdc-0x...").
         let l1Chain = THORChainHelper.securedAssetChain(coin: securedAssetCoin)
-        let displayTicker = displayName(for: securedAssetCoin)
-            .split(separator: ".")
-            .last
-            .map(String.init) ?? securedAssetCoin.ticker.uppercased()
         let targetChain = chain(forSwapAsset: l1Chain)
 
-        // Find the corresponding native coin in vault to get the user's own address for that chain
-        if let targetChain,
-           let coin = vault.coins.first(where: { $0.chain == targetChain && $0.isNativeToken }) {
+        if let targetChain, let coin = nativeCoin(for: targetChain) {
             destinationAddress = coin.address
             destinationAddressValid = true
-            customErrorMessage = nil
+            destinationError = nil
         } else {
-            // If no coin exists for that chain in the vault, show error
             destinationAddress = ""
             destinationAddressValid = false
             let chainName = targetChain?.name ?? l1Chain
-            customErrorMessage = String(
+            destinationError = String(
                 format: NSLocalizedString("withdrawSecuredAssetError", comment: ""),
-                displayTicker,
+                shortSymbol(for: securedAssetCoin),
                 l1Chain,
                 chainName
             )
         }
+        updateErrorMessage()
     }
 
     /// Maps a THORChain swap-asset chain code (e.g. "ETH", "AVAX") to the local `Chain` enum.
@@ -324,40 +340,44 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
     }
 
     private func validateAmount() {
-        guard amount > 0 else {
-            amountValid = false
-            // Only set amount error if there's no destination address error
-            if destinationAddressValid {
-                customErrorMessage = NSLocalizedString("enterValidAmount", comment: "")
-            }
-            return
-        }
+        amountValid = computeAmountValid()
+        updateErrorMessage()
+    }
 
-        if let secured = selectedSecuredAssetCoin {
-            let balanceOK = amount <= secured.balanceDecimal
-            let feeOK = minimumWithdrawAmount == 0 || amount >= minimumWithdrawAmount
-            amountValid = balanceOK && feeOK
-            // Only update error message if there's no destination address error
-            if destinationAddressValid {
-                if !balanceOK {
-                    customErrorMessage = NSLocalizedString("insufficientBalanceForFunctions", comment: "")
-                } else if !feeOK {
-                    customErrorMessage = String(
-                        format: NSLocalizedString("withdrawBelowOutboundFee", comment: ""),
-                        minimumWithdrawAmount.formatForDisplay(),
-                        secured.ticker.uppercased()
-                    )
-                } else {
-                    customErrorMessage = nil
-                }
-            }
-        } else {
-            amountValid = false
-            // Only set this error if there's no destination address error
-            if destinationAddressValid {
-                customErrorMessage = NSLocalizedString("selectSecuredAssetToSeeBalance", comment: "")
-            }
+    private func computeAmountValid() -> Bool {
+        guard amount > 0, let secured = selectedSecuredAssetCoin else { return false }
+        guard amount <= secured.balanceDecimal else { return false }
+        if minimumWithdrawAmount > 0, amount < minimumWithdrawAmount { return false }
+        return true
+    }
+
+    /// Destination errors take priority over amount/fee errors — matches the
+    /// original behavior that suppressed amount messages while destination was
+    /// broken, but without scattering `customErrorMessage` writes across three
+    /// methods.
+    private func updateErrorMessage() {
+        customErrorMessage = destinationError ?? amountErrorMessage()
+    }
+
+    private func amountErrorMessage() -> String? {
+        guard destinationAddressValid else { return nil }
+        guard amount > 0 else {
+            return NSLocalizedString("enterValidAmount", comment: "")
         }
+        guard let secured = selectedSecuredAssetCoin else {
+            return NSLocalizedString("selectSecuredAssetToSeeBalance", comment: "")
+        }
+        if amount > secured.balanceDecimal {
+            return NSLocalizedString("insufficientBalanceForFunctions", comment: "")
+        }
+        if minimumWithdrawAmount > 0, amount < minimumWithdrawAmount {
+            return String(
+                format: NSLocalizedString("withdrawBelowOutboundFee", comment: ""),
+                minimumWithdrawAmount.formatForDisplay(),
+                secured.ticker.uppercased()
+            )
+        }
+        return nil
     }
 
     var description: String {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
@@ -32,6 +32,7 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
     @Published var isLoadingAssets: Bool = true
     @Published var loadError: String? = nil
     @Published var selectedSecuredAssetCoin: Coin? = nil  // Track the actual secured asset coin
+    @Published var minimumWithdrawAmount: Decimal = 0
 
     /// Maps a dropdown item's id to the underlying secured asset coin in the vault.
     private var securedAssetLookup: [UUID: Coin] = [:]
@@ -209,6 +210,48 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
 
         // Update destination address based on the L1 chain encoded in the denom
         updateDestinationAddress(for: securedAssetCoin)
+
+        Task { @MainActor in
+            await refreshOutboundFeeThreshold(for: securedAssetCoin)
+        }
+    }
+
+    /// Queries the L1 chain's outbound_fee from THORChain's inbound_addresses and
+    /// converts it into the selected secured asset's units so we can reject
+    /// amounts THORChain would refuse with "not enough asset to pay for fees".
+    @MainActor
+    private func refreshOutboundFeeThreshold(for securedAssetCoin: Coin) async {
+        minimumWithdrawAmount = 0
+
+        let l1ChainCode = THORChainHelper.securedAssetChain(coin: securedAssetCoin)
+        guard let l1Chain = chain(forSwapAsset: l1ChainCode),
+              let nativeCoin = vault.coins.first(where: { $0.chain == l1Chain && $0.isNativeToken }) else {
+            return
+        }
+
+        let inboundChainName = ThorchainService.getInboundChainName(for: l1Chain)
+        let addresses = await ThorchainService.shared.fetchThorchainInboundAddress()
+        guard let inbound = addresses.first(where: { $0.chain.uppercased() == inboundChainName.uppercased() }),
+              let feeRaw = inbound.outbound_fee,
+              let feeBaseUnits = Decimal(string: feeRaw) else {
+            return
+        }
+
+        // outbound_fee is denominated in the L1 native asset at 8 decimals across
+        // all THORChain-supported chains.
+        let feeNativeAmount = feeBaseUnits / pow(10, 8)
+        let feeFiat = RateProvider.shared.fiatBalance(value: feeNativeAmount, coin: nativeCoin)
+        let unitFiat = RateProvider.shared.fiatBalance(value: 1, coin: securedAssetCoin)
+
+        guard feeFiat > 0, unitFiat > 0 else {
+            return
+        }
+
+        // Small buffer so a price tick between check and broadcast doesn't flip
+        // the tx from accepted to "not enough asset to pay for fees".
+        let buffer: Decimal = 1.2
+        minimumWithdrawAmount = (feeFiat * buffer) / unitFiat
+        validateAmount()
     }
 
     private func updateDestinationAddress(for securedAssetCoin: Coin) {
@@ -291,10 +334,22 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
         }
 
         if let secured = selectedSecuredAssetCoin {
-            amountValid = amount <= secured.balanceDecimal
+            let balanceOK = amount <= secured.balanceDecimal
+            let feeOK = minimumWithdrawAmount == 0 || amount >= minimumWithdrawAmount
+            amountValid = balanceOK && feeOK
             // Only update error message if there's no destination address error
             if destinationAddressValid {
-                customErrorMessage = amountValid ? nil : NSLocalizedString("insufficientBalanceForFunctions", comment: "")
+                if !balanceOK {
+                    customErrorMessage = NSLocalizedString("insufficientBalanceForFunctions", comment: "")
+                } else if !feeOK {
+                    customErrorMessage = String(
+                        format: NSLocalizedString("withdrawBelowOutboundFee", comment: ""),
+                        minimumWithdrawAmount.formatForDisplay(),
+                        secured.ticker.uppercased()
+                    )
+                } else {
+                    customErrorMessage = nil
+                }
             }
         } else {
             amountValid = false

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
@@ -30,6 +30,9 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
     @Published var loadError: String? = nil
     @Published var selectedSecuredAssetCoin: Coin? = nil  // Track the actual secured asset coin
 
+    /// Maps a dropdown item's id to the underlying secured asset coin in the vault.
+    private var securedAssetLookup: [UUID: Coin] = [:]
+
     private var cancellables = Set<AnyCancellable>()
 
     // Domain models
@@ -73,57 +76,50 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
         isLoadingAssets = true
         loadError = nil
 
-        // Supported secured asset tickers
-        let supportedTickers = ["BTC", "ETH", "BCH", "LTC", "DOGE", "AVAX", "BNB"]
-
-        // Get secured assets that actually exist in the vault
-        // They might be stored as "DOGE" or "DOGE-DOGE" format
-        let securedAssetsInVault = vault.coins.filter { coin in
-            guard coin.chain == .thorChain && coin.balanceDecimal > 0 else { return false }
-
-            let ticker = coin.ticker.uppercased()
-            // Check if it matches a supported ticker directly (e.g., "DOGE")
-            if supportedTickers.contains(ticker) {
-                return true
-            }
-            // Check if it's in dash format (e.g., "DOGE-DOGE")
-            for supported in supportedTickers {
-                if ticker == "\(supported)-\(supported)" {
-                    return true
-                }
-            }
-            return false
-        }
+        // A secured asset is any non-native THORChain coin whose on-chain denom is
+        // formatted as `<l1chain>-<symbol>[-<contract>]` (see THORChainHelper).
+        // Rely on the shared helper rather than a hand-rolled ticker allow-list so
+        // every secured asset held in the vault (USDC, USDT, WBTC, ...) is offered.
+        let securedAssetsInVault = vault.coins
+            .filter { THORChainHelper.isSecuredAsset(coin: $0) && $0.balanceDecimal > 0 }
+            .sorted { displayName(for: $0) < displayName(for: $1) }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
 
             // Always start with "Select asset" placeholder to ensure dropdown works
             var assetList = [IdentifiableString(value: NSLocalizedString("selectSecuredAssetToWithdraw", comment: ""))]
+            var lookup: [UUID: Coin] = [:]
 
             if securedAssetsInVault.isEmpty {
                 // Keep just the placeholder
                 self.availableSecuredAssets = assetList
+                self.securedAssetLookup = lookup
                 self.loadError = NSLocalizedString("noSecuredAssets", comment: "")
             } else {
-
-                let vaultAssets = securedAssetsInVault.map { coin in
-                    let ticker = coin.ticker.uppercased()
-
-                    if ticker.contains("-") {
-                        let parts = ticker.split(separator: "-")
-                        if parts.count == 2 && parts[0] == parts[1] {
-                            return IdentifiableString(value: String(parts[0]))
-                        }
-                    }
-                    // Otherwise use the ticker as is
-                    return IdentifiableString(value: coin.ticker)
+                let vaultAssets = securedAssetsInVault.map { coin -> IdentifiableString in
+                    let item = IdentifiableString(value: self.displayName(for: coin))
+                    lookup[item.id] = coin
+                    return item
                 }
                 assetList.append(contentsOf: vaultAssets)
                 self.availableSecuredAssets = assetList
+                self.securedAssetLookup = lookup
                 self.loadError = nil
             }
             self.isLoadingAssets = false
         }
+    }
+
+    /// Human-readable label for a secured asset (e.g. "ETH.USDC", "BTC.BTC").
+    /// Uses the L1 chain + symbol (without the trailing contract address suffix
+    /// that `securedAssetSymbol` preserves) so labels stay short and unique.
+    private func displayName(for coin: Coin) -> String {
+        let chain = THORChainHelper.securedAssetChain(coin: coin)
+        let symbol = THORChainHelper.securedAssetSymbol(coin: coin)
+            .split(separator: "-")
+            .first
+            .map(String.init) ?? coin.ticker.uppercased()
+        return "\(chain).\(symbol)"
     }
 
     // MARK: - Asset Selection
@@ -136,31 +132,40 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
             securedAssetValid = false
             destinationAddress = ""
             destinationAddressValid = false
+            selectedSecuredAssetCoin = nil
             return
         }
 
-        // Valid asset selected
+        // Resolve the underlying secured asset coin via the stable id mapping so
+        // tokens that share a symbol across chains (e.g. USDC on ETH vs AVAX) stay
+        // addressable independently.
+        guard let securedAssetCoin = securedAssetLookup[asset.id] else {
+            securedAssetValid = false
+            selectedSecuredAssetCoin = nil
+            return
+        }
+
         securedAssetValid = true
 
-        // Update destination address based on selected asset
-        updateDestinationAddressForAsset(asset.value)
-
         // Update the tx.coin to the selected secured asset for balance validation
-        updateTxCoinForSelectedAsset(asset.value)
+        updateTxCoin(for: securedAssetCoin)
+
+        // Update destination address based on the L1 chain encoded in the denom
+        updateDestinationAddress(for: securedAssetCoin)
     }
 
-    private func updateDestinationAddressForAsset(_ assetName: String) {
-        // assetName is just the ticker (e.g., "BTC", "ETH", "DOGE")
-        let ticker = assetName.uppercased()
-
-        // Map secured asset ticker to its native chain
-        // When withdrawing, we need to send to the original chain address
-        let targetChain = getChainForSecuredAsset(ticker)
+    private func updateDestinationAddress(for securedAssetCoin: Coin) {
+        // The L1 chain is encoded in the secured asset's denom (e.g. "eth-usdc-0x...").
+        let l1Chain = THORChainHelper.securedAssetChain(coin: securedAssetCoin)
+        let displayTicker = displayName(for: securedAssetCoin)
+            .split(separator: ".")
+            .last
+            .map(String.init) ?? securedAssetCoin.ticker.uppercased()
+        let targetChain = chain(forSwapAsset: l1Chain)
 
         // Find the corresponding native coin in vault to get the user's own address for that chain
-        if let coin = vault.coins.first(where: {
-            $0.chain == targetChain && $0.isNativeToken
-        }) {
+        if let targetChain,
+           let coin = vault.coins.first(where: { $0.chain == targetChain && $0.isNativeToken }) {
             destinationAddress = coin.address
             destinationAddressValid = true
             customErrorMessage = nil
@@ -168,55 +173,29 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
             // If no coin exists for that chain in the vault, show error
             destinationAddress = ""
             destinationAddressValid = false
-            customErrorMessage = String(format: NSLocalizedString("withdrawSecuredAssetError", comment: ""), ticker, ticker, targetChain.name)
+            let chainName = targetChain?.name ?? l1Chain
+            customErrorMessage = String(
+                format: NSLocalizedString("withdrawSecuredAssetError", comment: ""),
+                displayTicker,
+                l1Chain,
+                chainName
+            )
         }
     }
 
-    /// Maps a secured asset ticker to its native blockchain chain
-    private func getChainForSecuredAsset(_ ticker: String) -> Chain {
-        switch ticker.uppercased() {
-        case "BTC":
-            return .bitcoin
-        case "ETH":
-            return .ethereum
-        case "BCH":
-            return .bitcoinCash
-        case "LTC":
-            return .litecoin
-        case "DOGE":
-            return .dogecoin
-        case "AVAX":
-            return .avalanche
-        case "BNB":
-            return .bscChain
-        default:
-            // Fallback to THORChain if unknown (shouldn't happen)
-            return .thorChain
-        }
+    /// Maps a THORChain swap-asset chain code (e.g. "ETH", "AVAX") to the local `Chain` enum.
+    private func chain(forSwapAsset swapAsset: String) -> Chain? {
+        Chain.allCases.first { $0.swapAsset.uppercased() == swapAsset.uppercased() }
     }
 
-    private func updateTxCoinForSelectedAsset(_ assetName: String) {
-        // assetName is just the ticker (e.g., "BTC", "ETH", "DOGE")
-        let ticker = assetName.uppercased()
+    private func updateTxCoin(for securedAssetCoin: Coin) {
+        selectedSecuredAssetCoin = securedAssetCoin
 
-        // Find the secured asset coin - it could be stored as "DOGE" or "DOGE-DOGE"
-        if let securedAssetCoin = vault.coins.first(where: {
-            guard $0.chain == .thorChain else { return false }
-            let coinTicker = $0.ticker.uppercased()
-            // Check if it matches the ticker directly or in the "TICKER-TICKER" format
-            return coinTicker == ticker || coinTicker == "\(ticker)-\(ticker)"
-        }) {
-            selectedSecuredAssetCoin = securedAssetCoin
+        // Ensure isNativeToken is false for secured assets so getTicker() routes
+        // through getNotNativeTicker() which handles secured assets correctly.
+        securedAssetCoin.isNativeToken = false
 
-            // Set the coin and ensure isNativeToken is false for secured assets
-            // This will make getTicker() use getNotNativeTicker() which handles secured assets correctly
-            let correctedCoin = securedAssetCoin
-            correctedCoin.isNativeToken = false
-
-            tx.coin = correctedCoin
-        } else {
-            selectedSecuredAssetCoin = nil
-        }
+        tx.coin = securedAssetCoin
     }
 
     private func setupValidation() {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 import Foundation
 import Combine
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-withdraw-secured-asset")
 
 // MARK: - Main ViewModel
 
@@ -79,43 +82,88 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
         isLoadingAssets = true
         loadError = nil
 
-        // Secured-asset balances live as cosmos-bank denoms on the user's THOR
-        // address, not as entries in `vault.coins` until a discovery pass
-        // persists them. Trigger the same discovery path the chain detail
-        // screen uses so USDC / USDT / etc. acquired after the last visit are
-        // picked up before we build the dropdown.
         let thorChains: Set<Chain> = [.thorChain, .thorChainChainnet, .thorChainStagenet]
-        let thorNative = vault.coins.first { coin in
+        guard let thorNative = vault.coins.first(where: { coin in
             thorChains.contains(coin.chain) && coin.isNativeToken
+        }) else {
+            setPickerEmpty(reason: NSLocalizedString("noSecuredAssets", comment: ""))
+            return
         }
-        if let thorNative {
-            await CoinService.addDiscoveredTokens(nativeToken: thorNative, to: vault)
-        }
 
-        // A secured asset is any non-native THORChain coin whose on-chain denom is
-        // formatted as `<l1chain>-<symbol>[-<contract>]` (see THORChainHelper).
-        let securedAssetsInVault = vault.coins
-            .filter { THORChainHelper.isSecuredAsset(coin: $0) && $0.balanceDecimal > 0 }
-            .sorted { displayName(for: $0) < displayName(for: $1) }
+        // Secured-asset balances live as cosmos-bank denoms on the user's THOR
+        // address and are not present in vault.coins until explicitly enabled.
+        // Fetch the live bank balances so we see every secured asset the user
+        // holds (USDC, USDT, WBTC, ...) even on first use, then persist each
+        // via CoinService.addIfNeeded so the signing flow has a proper Coin.
+        do {
+            let service = ThorchainServiceFactory.getService(for: thorNative.chain)
+            let balances = try await service.fetchBalances(thorNative.address)
 
-        var assetList = [IdentifiableString(value: NSLocalizedString("selectSecuredAssetToWithdraw", comment: ""))]
-        var lookup: [UUID: Coin] = [:]
+            var persisted: [Coin] = []
+            for balance in balances where Self.isSecuredDenom(balance.denom) {
+                guard let coin = try persistSecuredAsset(balance: balance, chain: thorNative.chain) else {
+                    continue
+                }
+                coin.rawBalance = balance.amount
+                persisted.append(coin)
+            }
 
-        if securedAssetsInVault.isEmpty {
-            availableSecuredAssets = assetList
-            securedAssetLookup = lookup
-            loadError = NSLocalizedString("noSecuredAssets", comment: "")
-        } else {
-            let vaultAssets = securedAssetsInVault.map { coin -> IdentifiableString in
+            let securedAssets = persisted
+                .filter { $0.balanceDecimal > 0 }
+                .sorted { displayName(for: $0) < displayName(for: $1) }
+
+            guard !securedAssets.isEmpty else {
+                setPickerEmpty(reason: NSLocalizedString("noSecuredAssets", comment: ""))
+                return
+            }
+
+            var assetList = [IdentifiableString(value: NSLocalizedString("selectSecuredAssetToWithdraw", comment: ""))]
+            var lookup: [UUID: Coin] = [:]
+            for coin in securedAssets {
                 let item = IdentifiableString(value: displayName(for: coin))
                 lookup[item.id] = coin
-                return item
+                assetList.append(item)
             }
-            assetList.append(contentsOf: vaultAssets)
             availableSecuredAssets = assetList
             securedAssetLookup = lookup
             loadError = nil
+            isLoadingAssets = false
+        } catch {
+            logger.error("Failed to fetch THORChain balances: \(error.localizedDescription)")
+            setPickerEmpty(reason: NSLocalizedString("noSecuredAssets", comment: ""))
         }
+    }
+
+    private static func isSecuredDenom(_ denom: String) -> Bool {
+        let lower = denom.lowercased()
+        guard lower != "rune" else { return false }
+        guard !lower.hasPrefix("x/") else { return false }
+        return lower.contains("-")
+    }
+
+    @MainActor
+    private func persistSecuredAsset(balance: CosmosBalance, chain: Chain) throws -> Coin? {
+        let info = THORChainTokenMetadataFactory.create(asset: balance.denom)
+        let ticker = info.ticker.uppercased()
+        let localAsset = TokensStore.TokenSelectionAssets.first {
+            $0.ticker.caseInsensitiveCompare(ticker) == .orderedSame
+        }
+        let coinMeta = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: localAsset?.logo ?? info.logo,
+            decimals: info.decimals,
+            priceProviderId: localAsset?.priceProviderId ?? "",
+            contractAddress: balance.denom,
+            isNativeToken: false
+        )
+        return try CoinService.addIfNeeded(asset: coinMeta, to: vault, priceProviderId: coinMeta.priceProviderId)
+    }
+
+    private func setPickerEmpty(reason: String) {
+        availableSecuredAssets = [IdentifiableString(value: NSLocalizedString("selectSecuredAssetToWithdraw", comment: ""))]
+        securedAssetLookup = [:]
+        loadError = reason
         isLoadingAssets = false
     }
 

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallVerifyViewModel.swift
@@ -37,17 +37,20 @@ class FunctionCallVerifyViewModel: ObservableObject {
 
             let keysignPayloadFactory = KeysignPayloadFactory()
 
-            // LP adds are deposits, not swaps. Native RUNE/CACAO build their deposit
-            // from the memo in THORChainHelper and need no payload. ERC20 LP adds still
-            // ride the legacy swap-signing path — EVMHelper.getSwapPreSignedInputData
-            // requires a THORChainSwapPayload to build the router's depositWithExpiry
-            // call, so we synthesize one for that case only. TODO: replace with a
-            // dedicated deposit payload across iOS/Android/Windows.
+            // LP adds and SECURE+ mints are deposits, not swaps. Native RUNE/CACAO
+            // build their deposit from the memo in THORChainHelper and need no
+            // payload. ERC20 deposits still ride the legacy swap-signing path —
+            // EVMHelper.getSwapPreSignedInputData requires a THORChainSwapPayload
+            // to build the router's depositWithExpiry call (which is what carries
+            // the memo to THORChain), so we synthesize one for those cases. The
+            // router routes by memo, so the same shim works for both. TODO:
+            // replace with a dedicated deposit payload across iOS/Android/Windows.
             var approvePayload: ERC20ApprovePayload?
             var swapPayload: SwapPayload?
-            if tx.memoFunctionDictionary.get("pool") != nil,
-               tx.coin.shouldApprove,
-               !tx.toAddress.isEmpty {
+            let isLPAdd = tx.memoFunctionDictionary.get("pool") != nil
+            let isSecuredAssetMint = tx.memo.hasPrefix("SECURE+")
+            let isRouterDeposit = isLPAdd || isSecuredAssetMint
+            if isRouterDeposit, tx.coin.shouldApprove, !tx.toAddress.isEmpty {
                 let inboundAddresses = await ThorchainService.shared.fetchThorchainInboundAddress()
                 let chainName = ThorchainService.getInboundChainName(for: tx.coin.chain)
                 guard let inbound = inboundAddresses.first(where: { $0.chain.uppercased() == chainName.uppercased() }) else {


### PR DESCRIPTION
## Summary

Closes #3863.

Fixing ERC-20 secured asset withdrawal surfaced three distinct bugs plus a UX gap. This PR addresses all four end-to-end, so a user can now mint a secured asset from an ERC-20 token (e.g. USDC on Ethereum) and withdraw it back — exactly what the issue reported as broken.

### 1. Withdraw picker only surfaced a hardcoded list of native L1 tickers
The dropdown filtered `vault.coins` against `["BTC","ETH","BCH","LTC","DOGE","AVAX","BNB"]`, silently excluding every ERC-20 secured asset (USDC, USDT, WBTC, …). Replaced with `THORChainHelper.isSecuredAsset(coin:)` and a stable `UUID -> Coin` lookup so rows display as `<L1CHAIN>.<SYMBOL>` (e.g. `ETH.USDC`, `AVAX.USDC`) and multi-chain tokens sharing a symbol stay addressable independently. Withdrawal target chain now derives from the denom's L1 prefix via `Chain.allCases.swapAsset` instead of a ticker switch.

### 2. vault.coins didn't contain the secured asset until discovery ran
Even with the picker fixed, secured balances live as cosmos-bank denoms on the user's THOR address and aren't in `vault.coins` until something persists them. Rather than relying on `CoinService.addDiscoveredTokens` (whose spam / hidden-token filters can drop legitimate secured assets), the picker now fetches bank balances directly via `ThorchainServiceFactory.getService(for:).fetchBalances(address)`, filters denoms by the `<chain>-<symbol>(-<contract>)?` shape, materializes each via `CoinService.addIfNeeded` (bypassing the filters), and hydrates `rawBalance` from the fetched amount.

### 3. SECURE+ ERC-20 mints never went through the THORChain router
`FunctionCallVerifyViewModel` synthesized the `THORChainSwapPayload` + `ERC20ApprovePayload` (which trigger the EVM signer to build `router.depositWithExpiry` plus the prior approve tx) only when the memo dict carried a `pool` key — i.e. only for `addThorLP`. SECURE+ from ERC-20 sources fell through to a plain ERC-20 `transfer(router, amount)`: no approval issued, router never saw `depositWithExpiry`, THORChain never credited the secured asset, funds stranded at the router contract. Widened the gate to also fire on memos prefixed with `SECURE+`, reusing the same shim. Router routes by memo, so no other plumbing changes needed.

### 4. THORChain rejects withdrawals whose value is below the outbound fee
THORChain's response is `not enough asset to pay for fees` and the funds sit until someone retries with a larger amount. Now fetches `outbound_fee` from `inbound_addresses` for the selected asset's L1 chain, converts it into the selected asset's units via fiat rates (`feeNative × fiatRate(native) / fiatRate(asset)`) with a 1.2x buffer for price drift, and surfaces the minimum as a validation error (`withdrawBelowOutboundFee`) when the user enters less — blocking submit.

### 5. Refactor pass on `FunctionCallWithdrawSecuredAsset`
Same behavior, shorter functions. Extracted `nativeCoin(for:)` / `thorNative` / `shortSymbol(for:)`, introduced a single priority-based `updateErrorMessage()` so `customErrorMessage` has one writer, split `validateAmount` into pure `computeAmountValid` + `amountErrorMessage` helpers, split the 55-line `loadAvailableSecuredAssets` into `fetchSecuredAssetCoins` + `applyPicker`.

## Proof (mainnet, end-to-end)

- **Secure USDC on Ethereum (mint):** [etherscan.io/tx/0x6eb4c36b...](https://etherscan.io/tx/0x6eb4c36bd51261ec3d199dd442fc7de80083bf25f465252bc93b352c84b939fc)
- **Withdraw secured USDC:** [thorchain.net/tx/7DDAA1A8...](https://thorchain.net/tx/7DDAA1A8C17580B587598107D7C31031908E5ED6BF33DD9CEDD2D09D0E86E2F8)

## Test plan

- [x] Secure USDC on Ethereum: vault holds USDC on ETH → Function Call → Secured Assets → approve tx + router `depositWithExpiry` with memo `SECURE+:<thor-addr>` → THORChain credits `eth-usdc-0xa0b...` denom.
- [x] Withdraw secured USDC: vault with freshly credited secured USDC → Function Call → Withdraw Secured Asset → `ETH.USDC` row appears with live balance (without visiting THORChain detail screen first) → select → destination auto-fills with vault's ETH address → broadcasts `MsgDeposit` with the secured-asset coin and `SECURE-:<eth-addr>` memo → THORChain unwraps and pays USDC to the ETH address.
- [ ] Multi-chain secured asset: vault holds secured USDC on ETH and AVAX → both rows appear separately, each routes to its chain's native address.
- [ ] Native secured asset regression: vault with only secured BTC → `BTC.BTC` row, destination prefills BTC address, withdrawal path unchanged.
- [ ] Below-fee guard: select `ETH.USDC`, enter 0.1 → error `Amount below outbound fee — withdraw at least X USDC to cover network costs` appears, submit disabled. Enter a value above the threshold → error clears, submit enabled.
- [ ] Error path: secured asset whose native chain isn't in the vault → existing `withdrawSecuredAssetError` surfaces with correct chain/symbol substitutions.
- [ ] SwiftLint + xcodebuild clean (verified).

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added outbound fee threshold enforcement for secured asset withdrawals. The app now calculates minimum withdrawal amounts required to cover network costs and displays error messages when amounts fall below the threshold.

* **Localization**
  * Added withdrawal fee threshold error messages translated into multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->