### PR TITLE
fix(solana): create recipient ATA when missing for SPL transfers

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
@@ -13,6 +13,9 @@ enum SolanaHelper {
     static let defaultFeeInLamports: BigInt = 1000000 // 0.001
     static let defaultPriorityFeePrice: UInt64 = 1_000_000 // Fallback priority fee price in microlamports
     static let priorityFeeLimit: BigInt = 100_000 // Priority fee compute unit limit
+    /// Rent-exempt reserve for a new SPL Associated Token Account (~0.00203928 SOL).
+    /// Required when the recipient has no ATA and we create one alongside the transfer.
+    static let ataRentLamports: BigInt = 2_039_280
 
     static func getPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
         guard keysignPayload.coin.chain.ticker == "SOL" else {
@@ -88,8 +91,12 @@ enum SolanaHelper {
 
             } else if let fromPubKey = fromAddressPubKey, !fromPubKey.isEmpty {
 
-                // Create new account association for either SPL or Token-2022
-                let receiverAddress = SolanaAddress(string: toAddress.description)!
+                // Recipient has no Associated Token Account yet. Derive the deterministic ATA
+                // and let TrustWalletCore emit a `createAssociatedTokenAccount` instruction
+                // alongside the SPL transfer in a single transaction.
+                guard let receiverAddress = SolanaAddress(string: toAddress.description) else {
+                    throw HelperError.runtimeError("Invalid recipient Solana address")
+                }
 
                 let generatedAssociatedAddress: String?
                 if tokenProgramId {

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -423,8 +423,13 @@ private extension BlockChainService {
                     }
                 }
 
-                // Important: Only return nil for toAddressPubKey if we're certain the account doesn't exist
-                // Empty string from RPC doesn't mean the account doesn't exist
+                // If the RPC and the deterministic ATA probe both fail to find a recipient
+                // token account, collapse the empty string to nil. The Solana signing helper
+                // treats a nil `toAddressPubKey` as the signal to emit a
+                // `createAssociatedTokenAccount` instruction alongside the SPL transfer so
+                // the recipient's ATA is created in the same transaction (see
+                // `SolanaHelper.getPreSignedInputData`). The extra ~0.00203 SOL rent for the
+                // new account is surfaced via `BlockChainSpecific.gas` (see `SolanaHelper.ataRentLamports`).
                 let finalToAddress = associatedTokenAddressTo?.isEmpty == true ? nil : associatedTokenAddressTo
 
                 return .Solana(recentBlockHash: recentBlockHash, priorityFee: dynamicPriorityFee, priorityLimit: SolanaHelper.priorityFeeLimit, fromAddressPubKey: associatedTokenAddressFrom, toAddressPubKey: finalToAddress, hasProgramId: isToken2022)

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
@@ -48,7 +48,13 @@ enum BlockChainSpecific: Codable, Hashable {
             return MayaChainHelper.MayaChainGas.description.toBigInt() // Maya uses 10e10
         case .Cosmos(_, _, let gas, _, _):
             return gas.description.toBigInt()
-        case .Solana:
+        case .Solana(_, _, _, let fromAddressPubKey, let toAddressPubKey, _):
+            // Include ATA rent when the recipient's associated token account must be
+            // created alongside the SPL transfer (sender has an ATA, recipient does not).
+            if let from = fromAddressPubKey, !from.isEmpty,
+               toAddressPubKey == nil || toAddressPubKey?.isEmpty == true {
+                return SolanaHelper.defaultFeeInLamports + SolanaHelper.ataRentLamports
+            }
             return SolanaHelper.defaultFeeInLamports
         case .Sui(_, _, let gasBudget):
             return gasBudget


### PR DESCRIPTION
## Summary

Fixes #4079. When sending an SPL token to an address that has no Associated Token Account, the recipient ATA lookup returns nothing and the transfer previously failed silently or risked going to the wrong address. This PR makes the missing-ATA path explicit end-to-end and surfaces the additional rent in the fee display.

- When the recipient has no ATA (both `getTokenAccountsByOwner` and the deterministic probe fail), `BlockChainService` now emits `BlockChainSpecific.Solana` with `toAddressPubKey = nil`. That's the existing contract between `BlockChainService` and `SolanaHelper.getPreSignedInputData`, but the intent was buried in a misleading comment — it's now spelled out.
- `SolanaHelper.getPreSignedInputData` already handles the nil case by building a `SolanaCreateAndTransferToken` message, which TrustWalletCore compiles as a single transaction containing both the `createAssociatedTokenAccount` instruction and the SPL transfer. The recipient's ATA is derived deterministically from the mint's token program (SPL Token or Token-2022), matching the sender's program type. I replaced an unsafe force-unwrap on `SolanaAddress(string:)` with a guarded throw while I was there.
- Added `SolanaHelper.ataRentLamports = 2_039_280` (~0.00203928 SOL) and wired it into `BlockChainSpecific.Solana.gas`/`fee` so that the verify screen's fee display and the `hasEnoughNativeTokensToPayTheFees` check both include the ATA rent only when ATA creation is actually implied (sender has an ATA, recipient does not).

### Diff shape

- `VultisigApp/Blockchain/Solana/Signing/Solana.swift` — add `ataRentLamports`, replace force-unwrap with guarded throw, clarify comment.
- `VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift` — Solana `gas` now returns `defaultFeeInLamports + ataRentLamports` when ATA creation is needed.
- `VultisigApp/Core/Services/BlockChainService.swift` — rewrite the misleading comment so the nil-triggers-ATA-creation contract is obvious to future readers.

No changes to the TSS layer, no project.pbxproj edits, no new user-facing strings (so no localization changes needed).

## Test plan

- [ ] Devnet / testnet: send an SPL token to a brand-new Solana address (no ATA). Verify the transaction succeeds in one step and the recipient ends up with both a freshly created ATA and the transferred tokens.
- [ ] Verify the Send verify screen shows `~0.00303928 SOL` (base 0.001 + rent 0.00203928) when the recipient has no ATA, and `~0.001 SOL` when the recipient already has an ATA.
- [ ] Confirm `hasEnoughNativeTokensToPayTheFees` blocks the send when the sender lacks enough SOL to cover the higher fee+rent.
- [ ] Regression: existing happy path (recipient already has ATA) still uses `tokenTransferTransaction` and shows the default 0.001 SOL fee.
- [ ] Regression: Token-2022 transfer to a recipient with no ATA creates a Token-2022 ATA (the sender's program type is inherited, which is always correct since the mint fixes the program).
- [ ] Native SOL transfers are unaffected (`fromAddressPubKey == nil` → no rent added).
- [ ] Confirm on mainnet against a real token (e.g. USDC) with a throwaway recipient address before release. Mainnet vs testnet considerations: the actual rent-exempt amount is a function of the current rent sysvar; 2_039_280 lamports has been the SPL ATA minimum on mainnet and all clusters for a long time, but if Solana ever changes rent we may need to fetch `getMinimumBalanceForRentExemption(165)` dynamically — flagged for future work, not required here.
- [ ] SwiftLint clean (no new warnings).
- [ ] Build: `xcodebuild -project VultisigApp/VultisigApp.xcodeproj -scheme VultisigApp -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build` succeeds.

Closes #4079

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for invalid recipient Solana addresses with specific error messages.
  * Improved recipient token account resolution for Solana transfers.

* **New Features**
  * Automatic creation of Associated Token Accounts when transferring tokens to recipients without existing accounts.
  * More accurate gas fee estimation accounting for additional costs when creating Associated Token Accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Tx link: https://solscan.io/tx/5kP5pk9LN6UDPA6BYt24Njx252kFjTLCMrsJHLRxTC4nVkWn5jYDzhhPAP5t3hiwC4TLSYKZYrJpswcBRYxsefH6