### PR TITLE
fix(maya): align MAYA.AZTEC decimals between iOS and macOS

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -213,6 +213,34 @@ struct CoinService {
         return tokens
     }
 
+    /// Migrate stale `decimals` values for tokens whose registered precision changed
+    /// between releases. Fixes legacy persisted coins where the stored decimals no
+    /// longer matches `TokensStore.TokenSelectionAssets` (the canonical source).
+    ///
+    /// Known case (issue #4171): MAYA.AZTEC shipped briefly with `decimals = 8` and
+    /// was later corrected to `decimals = 4` (PR #3943). Vaults created while the
+    /// bad value was live kept the stale 8 in SwiftData, so balances render with
+    /// 4 fewer visible digits on platforms where the user never re-added the token.
+    static func migrateStaleCoinDecimals(vault: Vault) {
+        // Tokens whose decimals were corrected in-place in `TokensStore`.
+        // Keyed by (chain, ticker, contractAddress) — all compared case-insensitively.
+        let knownDecimalFixes: [(chain: Chain, ticker: String, contractAddress: String, expectedDecimals: Int)] = [
+            (.mayaChain, "AZTEC", "aztec", 4)
+        ]
+
+        for fix in knownDecimalFixes {
+            let staleCoins = vault.coins.filter { coin in
+                coin.chain == fix.chain
+                    && coin.ticker.caseInsensitiveCompare(fix.ticker) == .orderedSame
+                    && coin.contractAddress.caseInsensitiveCompare(fix.contractAddress) == .orderedSame
+                    && coin.decimals != fix.expectedDecimals
+            }
+            for coin in staleCoins {
+                coin.decimals = fix.expectedDecimals
+            }
+        }
+    }
+
     /// Migrate coins and hidden tokens that reference old contract addresses from PR #3837.
     /// Old addresses (e.g. "x/staking-x/tcy") are updated to new ones (e.g. "x/staking-tcy").
     /// If both old and new coins exist, the old duplicate is removed.
@@ -255,6 +283,7 @@ struct CoinService {
 
     static func addDiscoveredTokens(nativeToken: Coin, to vault: Vault) async {
         migrateOldContractAddresses(vault: vault)
+        migrateStaleCoinDecimals(vault: vault)
 
         do {
             let tokens = try await fetchDiscoveredTokens(nativeCoin: nativeToken.toCoinMeta(), address: nativeToken.address)


### PR DESCRIPTION
## Summary
- Add targeted migration `CoinService.migrateStaleCoinDecimals(vault:)` that reconciles persisted `Coin.decimals` against the canonical `TokensStore` value for known tokens whose precision changed between releases.
- Fix case registered today: MAYA.AZTEC (chain `.mayaChain`, ticker `AZTEC`, contract `aztec`) → `decimals = 4`.
- Hook the migration into `addDiscoveredTokens(nativeToken:to:)` so it runs alongside the existing `migrateOldContractAddresses` every time the Maya chain detail screen refreshes (and from any other discovery path).

## Root cause
MAYA.AZTEC was briefly registered in `TokensStore` with `decimals = 8` before being corrected to `decimals = 4` in PR #3943. Vaults created while the bad value was live kept `decimals = 8` in SwiftData, and the app never reconciled persisted `Coin` metadata against `TokensStore` on subsequent launches. Because the balance display computes `rawBalance / 10^decimals`, an over-inflated exponent renders the amount 10,000× smaller (i.e. "missing 4 decimal places"). The user's confirmed workaround — disabling and re-enabling the Maya chain on macOS — fixed it precisely because that path recreates the token from `TokensStore` with the corrected precision. iOS users just happened to not hit the stale-persisted state on the tested devices; the bug is data-state, not formatting, and macOS was simply where it surfaced.

## Test Plan
- [ ] Build macOS: `xcodebuild -scheme VultisigApp -destination 'platform=macOS' build` succeeds (verified locally)
- [ ] Reproduce pre-fix: create a vault with Maya enabled on an installation that had `AZTEC decimals=8` persisted (or manually set it in a debug path); confirm balance row shows 4 fewer digits than the Maya API-returned value.
- [ ] Apply fix, relaunch the app, open the Maya chain detail screen; confirm `updateBalances` triggers `addDiscoveredTokens` → `migrateStaleCoinDecimals`, and the stored `Coin.decimals` for AZTEC flips to `4`.
- [ ] Confirm AZTEC balance matches iOS display (e.g. `1.2345 AZTEC` instead of `0.00012345`).
- [ ] Confirm the migration is idempotent — opening the screen again does not mutate state.
- [ ] Regression: on a clean install (no stale data), verify AZTEC still displays 4 decimals and no other token metadata is altered.
- [ ] SwiftLint: `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` reports no new warnings (verified — 0 new, 5 pre-existing unrelated).

Closes #4171

Co-Authored-By: Claude <noreply@anthropic.com>