### PR TITLE
fix(send): right-align memo value on Verify screen

### DIFF
--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -189,7 +189,8 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
                             .foregroundStyle(color ?? Theme.colors.textPrimary)
                             .lineLimit(isMultiLine ? nil : 1)
                             .truncationMode(.middle)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .multilineTextAlignment(.trailing)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .trailing)

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -163,6 +163,27 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
                         .foregroundStyle(Theme.colors.textTertiary)
                 }
                 .frame(maxWidth: .infinity, alignment: .trailing)
+            } else if let bracketValue {
+                HStack(spacing: 4) {
+                    if let image {
+                        Image(image)
+                            .resizable()
+                            .frame(width: 16, height: 16)
+                    }
+                    HStack(spacing: 4) {
+                        Text(value)
+                            .foregroundStyle(color ?? Theme.colors.textPrimary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .layoutPriority(1)
+                        Text("(\(bracketValue))")
+                            .foregroundStyle(Theme.colors.textTertiary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
             } else {
                 HStack(spacing: 4) {
                     if let image {
@@ -170,28 +191,12 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
                             .resizable()
                             .frame(width: 16, height: 16)
                     }
-
-                    if let bracketValue {
-                        HStack(spacing: 4) {
-                            Text(value)
-                                .foregroundStyle(color ?? Theme.colors.textPrimary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                                .layoutPriority(1)
-                            Text("(\(bracketValue))")
-                                .foregroundStyle(Theme.colors.textTertiary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    } else {
-                        Text(value)
-                            .foregroundStyle(color ?? Theme.colors.textPrimary)
-                            .lineLimit(isMultiLine ? nil : 1)
-                            .truncationMode(.middle)
-                            .multilineTextAlignment(.trailing)
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                    }
+                    Text(value)
+                        .foregroundStyle(color ?? Theme.colors.textPrimary)
+                        .lineLimit(isMultiLine ? nil : 1)
+                        .truncationMode(.middle)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: image == nil ? .infinity : nil, alignment: .trailing)
                 }
                 .frame(maxWidth: .infinity, alignment: .trailing)
             }


### PR DESCRIPTION
## Summary

On the Send Verify screen, the memo row's text was left-aligned while the network row's text was right-aligned. The parent `HStack` in `getValueCell()` already uses `.trailing`, but the inner `Text` forced `.leading` alignment via `.frame(maxWidth: .infinity, alignment: .leading)`, which overrode the trailing alignment for the memo (and any other single-value cell using this code path).

## Changes

- `VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift`
  - Change inner `Text` frame alignment from `.leading` to `.trailing`
  - Add `.multilineTextAlignment(.trailing)` so wrapped memo lines align on the right as well

All other callers of `getValueCell()` (`from`, `to`, `network`, `functionSignature`, memo dictionary entries) should display values on the trailing edge, matching the rest of the summary.

Closes #4152

## Test plan

- [ ] Open Send, fill a memo, and reach the Verify Summary screen
- [ ] Confirm the memo text is right-aligned, matching the network row
- [ ] Verify a long memo that wraps to multiple lines also right-aligns each line
- [ ] Confirm `from`, `to`, `network`, and any other single-value rows remain right-aligned

## Verification

- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` -> 0 violations
- `xcodebuild -project VultisigApp/VultisigApp.xcodeproj -scheme VultisigApp -destination 'generic/platform=iOS' -quiet build` -> success

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text alignment in the transaction verification summary view. Values are now right-aligned within their container for enhanced readability and visual consistency across single and multi-line text displays. This adjustment provides better visual presentation during the verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->