### PR TITLE
fix(keygen): pop to email entry when switching email in fast vault OTP

### DIFF
--- a/VultisigApp/VultisigApp/Core/Navigation/NavigationRouter.swift
+++ b/VultisigApp/VultisigApp/Core/Navigation/NavigationRouter.swift
@@ -11,6 +11,7 @@ typealias NavPath = Hashable
 
 final class NavigationRouter: ObservableObject {
     @Published var navPath: NavigationPath
+    private var history: [any NavPath] = []
 
     init(navPath: NavigationPath = NavigationPath()) {
         self.navPath = navPath
@@ -18,19 +19,35 @@ final class NavigationRouter: ObservableObject {
 
     func replace(to destination: any NavPath) {
         navPath = NavigationPath()
+        history.removeAll()
         navPath.append(destination)
+        history.append(destination)
     }
 
     func navigate(to destination: any NavPath) {
         navPath.append(destination)
+        history.append(destination)
     }
 
     func navigateBack() {
         guard !navPath.isEmpty else { return }
         navPath.removeLast()
+        if !history.isEmpty { history.removeLast() }
+    }
+
+    func navigateBack(matching predicate: (any NavPath) -> Bool) {
+        guard let matchIndex = history.lastIndex(where: predicate) else {
+            navigateBack()
+            return
+        }
+        let removeCount = history.count - 1 - matchIndex
+        guard removeCount > 0 else { return }
+        navPath.removeLast(removeCount)
+        history.removeLast(removeCount)
     }
 
     func navigateToRoot() {
         navPath.removeLast(navPath.count)
+        history.removeAll()
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/KeygenView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/KeygenView.swift
@@ -68,13 +68,7 @@ struct KeygenView: View {
                     otpVerified: $otpVerified,
                     onBackup: { },
                     onBackToEmailSetup: {
-                        router.navigate(to: KeygenRoute.fastVaultPassword(
-                            tssType: tssType,
-                            vault: vault,
-                            selectedTab: .fast,
-                            isExistingVault: true,
-                            singleKeygenType: singleKeygenType
-                        ))
+                        router.navigateBack()
                     }
                 )
             }

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/VaultSetup/VaultSetupScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/VaultSetup/VaultSetupScreen.swift
@@ -105,23 +105,21 @@ struct VaultSetupScreen: View {
             }
         }
         .screenEdgeInsets(.init(leading: 24, trailing: 24))
-        .screenBackButtonHidden(currentStep > 0)
+        .screenBackButtonHidden(true)
         .screenToolbar {
-            if currentStep > 0 {
-                CustomToolbarItem(placement: .leading) {
-                    ToolbarButton(image: "chevron.left") {
-                        navigateToStep(currentStep - 1)
-                    } iconContent: { _ in
-                        Icon(named: "chevron.left", color: Theme.colors.textPrimary, size: 20, isSystem: true)
-                            .offset(x: -1)
-                    }
+            CustomToolbarItem(placement: .leading) {
+                ToolbarButton(image: "chevron.left") {
+                    handleBack()
+                } iconContent: { _ in
+                    Icon(named: "chevron.left", color: Theme.colors.textPrimary, size: 20, isSystem: true)
+                        .offset(x: -1)
                 }
             }
             CustomToolbarItem(placement: .trailing, hideSharedBackground: true) {
                 referralButton
             }
         }
-        .navigationBarBackButtonHidden(currentStep > 0)
+        .navigationBarBackButtonHidden(true)
         .onSubmit {
             onContinue()
         }
@@ -360,6 +358,20 @@ struct VaultSetupScreen: View {
     }
 
     // MARK: - Actions
+
+    private func handleBack() {
+        if currentStep > 0 {
+            navigateToStep(currentStep - 1)
+        } else {
+            router.navigateBack { route in
+                if let onboardingRoute = route as? OnboardingRoute,
+                   case .vaultSetupInformation = onboardingRoute {
+                    return true
+                }
+                return false
+            }
+        }
+    }
 
     private func navigateToStep(_ target: Int) {
         guard canNavigateToStep(target) else { return }


### PR DESCRIPTION
## Summary

- In fast-vault keygen, the OTP verification sheet's **"Use a different email"** button invoked `onBackToEmailSetup`, which incorrectly **pushed** a new `fastVaultPassword` route onto the navigation stack. This caused a loop where the user kept landing back on the OTP screen instead of the email entry screen.
- Replace the push with `router.navigateBack()` so that PeerDiscovery (which hosts `KeygenView` inline) is popped off the stack, leaving the user on the email entry screen that is already on the stack in both entry paths (`FastVaultPasswordScreen` and `VaultSetupScreen`).
- The OTP sheet itself is already dismissed by `ServerBackupVerificationScreen.deleteVault()` (which sets `isPresented = false` before firing the callback), so no extra sheet state reset is needed.

## Test plan

- [ ] Fast vault flow (new vault) via `VaultSetupScreen`: enter name/email/password, continue through keygen until OTP appears. Tap "Use a different email". Verify the app returns to the email step of VaultSetupScreen (not OTP, not a new blank screen).
- [ ] Fast vault flow (existing vault) via `FastVaultPasswordScreen` (single keygen / reshare path): reach OTP, tap "Use a different email", verify user returns to the email step of FastVaultPasswordScreen.
- [ ] Verify no duplicated routes in the back stack after pressing back from the email screen.

Closes #4184

Co-Authored-By: Claude <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced back navigation consistency across key-generation and vault setup flows; back buttons now reliably return to the previous screen in the navigation stack.
  * Updated back button visibility to display consistently during wallet setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->