### PR TITLE
fix(thorchain): show specific error when THORChain disabled on LP add

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -374,6 +374,8 @@
 "foregroundNotificationGeneric" = "Transaktion wartet auf Genehmigung";
 "foregroundNotificationSend" = "Senden %@";
 "foregroundNotificationSwap" = "Tausch %@ → %@";
+"formInvalid" = "Formular ungültig";
+"formInvalidMessage" = "Das Formular ist nicht gültig. Bitte korrigiere die mit einem roten Stern markierten Felder.";
 "foundActiveChainsSubtitle" = "Jede zusätzliche Chain verdoppelt ungefähr die Zeit zur Generierung Ihres Tresors. Geschätzte Zeit für alle ausgewählten Chains: %d Minuten";
 "foundActiveChainsSubtitleHighlight" = "%d Minuten";
 "foundActiveChainsTitle" = "Wir haben %d aktive Chains gefunden";
@@ -884,6 +886,7 @@
 "thisVaultOnly" = "Nur dieses Gewölbe";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorchainNotEnabledForLP" = "THORChain ist in diesem Vault nicht aktiviert. Aktiviere THORChain, um Liquidität hinzuzufügen.";
 "thresholdNotReachedMessage" = "Schwelle nicht erreicht.\nEs fehlen genügend Anfangsgeräte.";
 "timeout" = "Zeitüberschreitung";
 "title" = "Titel";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -380,6 +380,8 @@
 "foregroundNotificationGeneric" = "Transaction pending approval";
 "foregroundNotificationSend" = "Send %@";
 "foregroundNotificationSwap" = "Swap %@ → %@";
+"formInvalid" = "Form Invalid";
+"formInvalidMessage" = "The form is not valid. Please fix the fields marked with a red star.";
 "foundActiveChainsSubtitle" = "Each extra chain increases the time to generate your vault and possibility of an timeout.";
 "foundActiveChainsTitle" = "We found %d active chains";
 "from" = "From";
@@ -894,6 +896,7 @@
 "thisVaultOnly" = "This Vault Only";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorchainNotEnabledForLP" = "THORChain is not enabled on this vault. Enable THORChain to add liquidity.";
 "thresholdNotReachedMessage" = "Threshold not reached.\nMissing enough initial devices.";
 "timeout" = "Timeout";
 "title" = "Title";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -374,6 +374,8 @@
 "foregroundNotificationGeneric" = "Transacción pendiente de aprobación";
 "foregroundNotificationSend" = "Enviar %@";
 "foregroundNotificationSwap" = "Intercambiar %@ → %@";
+"formInvalid" = "Formulario inválido";
+"formInvalidMessage" = "El formulario no es válido. Corrige los campos marcados con una estrella roja.";
 "foundActiveChainsSubtitle" = "Cada cadena adicional duplica aproximadamente el tiempo para generar tu bóveda. Tiempo estimado para todas las cadenas seleccionadas: %d minutos";
 "foundActiveChainsSubtitleHighlight" = "%d minutos";
 "foundActiveChainsTitle" = "Encontramos %d cadenas activas";
@@ -884,6 +886,7 @@
 "thisVaultOnly" = "Solo esta bóveda";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorchainNotEnabledForLP" = "THORChain no está habilitado en esta bóveda. Habilita THORChain para añadir liquidez.";
 "thresholdNotReachedMessage" = "Umbral no alcanzado.\nFaltan suficientes dispositivos iniciales.";
 "timeout" = "Tiempo de espera agotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -374,6 +374,8 @@
 "foregroundNotificationGeneric" = "Transakcija čeka odobrenje";
 "foregroundNotificationSend" = "Pošalji %@";
 "foregroundNotificationSwap" = "Zamijeni %@ → %@";
+"formInvalid" = "Obrazac nije valjan";
+"formInvalidMessage" = "Obrazac nije valjan. Ispravite polja označena crvenom zvjezdicom.";
 "foundActiveChainsSubtitle" = "Svaki dodatni chain otprilike udvostručuje vrijeme za generiranje vašeg trezora. Procijenjeno vrijeme za sve odabrane chainove: %d minuta";
 "foundActiveChainsSubtitleHighlight" = "%d minuta";
 "foundActiveChainsTitle" = "Pronašli smo %d aktivnih chainova";
@@ -884,6 +886,7 @@
 "thisVaultOnly" = "Samo ovaj trezor";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorchainNotEnabledForLP" = "THORChain nije omogućen na ovom trezoru. Omogućite THORChain za dodavanje likvidnosti.";
 "thresholdNotReachedMessage" = "Prag nije dosegnut.\nNedostaje dovoljno početnih uređaja.";
 "timeout" = "Isteklo vrijeme";
 "title" = "Naslov";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -374,6 +374,8 @@
 "foregroundNotificationGeneric" = "Transazione in attesa di approvazione";
 "foregroundNotificationSend" = "Invia %@";
 "foregroundNotificationSwap" = "Scambia %@ → %@";
+"formInvalid" = "Modulo non valido";
+"formInvalidMessage" = "Il modulo non è valido. Correggi i campi contrassegnati con una stella rossa.";
 "foundActiveChainsSubtitle" = "Ogni chain aggiuntiva raddoppia approssimativamente il tempo per generare il tuo vault. Tempo stimato per tutte le chain selezionate: %d minuti";
 "foundActiveChainsSubtitleHighlight" = "%d minuti";
 "foundActiveChainsTitle" = "Abbiamo trovato %d chain attive";
@@ -884,6 +886,7 @@
 "thisVaultOnly" = "Solo questo Vault";
 "thorAddressAutoFilled" = "Indirizzo THORChain (compilato automaticamente)";
 "thorAddressNotFound" = "Indirizzo THORChain non trovato nel vault. Assicurati di avere RUNE nel tuo vault.";
+"thorchainNotEnabledForLP" = "THORChain non è abilitato in questo vault. Abilita THORChain per aggiungere liquidità.";
 "thresholdNotReachedMessage" = "Soglia non raggiunta.\nMancano dispositivi iniziali sufficienti.";
 "timeout" = "Tempo scaduto";
 "title" = "Titolo";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -380,6 +380,8 @@
 "foregroundNotificationGeneric" = "트랜잭션 승인 대기 중";
 "foregroundNotificationSend" = "%@ 전송";
 "foregroundNotificationSwap" = "%@ → %@ 스왑";
+"formInvalid" = "양식이 유효하지 않음";
+"formInvalidMessage" = "양식이 유효하지 않습니다. 빨간색 별표로 표시된 필드를 수정하세요.";
 "foundActiveChainsSubtitle" = "추가 체인마다 볼트 생성 시간이 늘어나고 타임아웃 가능성이 높아집니다.";
 "foundActiveChainsTitle" = "%d개의 활성 체인을 찾았습니다";
 "from" = "출처";
@@ -894,6 +896,7 @@
 "thisVaultOnly" = "이 볼트만";
 "thorAddressAutoFilled" = "THORChain 주소 (자동 채워짐)";
 "thorAddressNotFound" = "볼트에서 THORChain 주소를 찾을 수 없습니다. RUNE이 볼트에 있는지 확인하세요.";
+"thorchainNotEnabledForLP" = "이 볼트에 THORChain이 활성화되어 있지 않습니다. 유동성을 추가하려면 THORChain을 활성화하세요.";
 "thresholdNotReachedMessage" = "임계값에 도달하지 않았습니다.\n초기 기기가 충분하지 않습니다.";
 "timeout" = "시간 초과";
 "title" = "제목";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -374,6 +374,8 @@
 "foregroundNotificationGeneric" = "Transação pendente de aprovação";
 "foregroundNotificationSend" = "Enviar %@";
 "foregroundNotificationSwap" = "Trocar %@ → %@";
+"formInvalid" = "Formulário inválido";
+"formInvalidMessage" = "O formulário não é válido. Corrija os campos marcados com uma estrela vermelha.";
 "foundActiveChainsSubtitle" = "Cada chain adicional aproximadamente dobra o tempo para gerar seu cofre. Tempo estimado para todas as chains selecionadas: %d minutos";
 "foundActiveChainsSubtitleHighlight" = "%d minutos";
 "foundActiveChainsTitle" = "Encontramos %d chains ativas";
@@ -884,6 +886,7 @@
 "thisVaultOnly" = "Apenas este cofre";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorchainNotEnabledForLP" = "THORChain não está ativado neste vault. Ative o THORChain para adicionar liquidez.";
 "thresholdNotReachedMessage" = "Limite não alcançado.\nFaltam dispositivos iniciais suficientes.";
 "timeout" = "Tempo esgotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -374,6 +374,8 @@
 "foregroundNotificationGeneric" = "交易待审批";
 "foregroundNotificationSend" = "发送 %@";
 "foregroundNotificationSwap" = "兑换 %@ → %@";
+"formInvalid" = "表单无效";
+"formInvalidMessage" = "表单无效。请修正带有红星标记的字段。";
 "foundActiveChainsSubtitle" = "每增加一条链大约会使生成保险库的时间翻倍。所有选定链的预计时间：%d分钟";
 "foundActiveChainsSubtitleHighlight" = "%d分钟";
 "foundActiveChainsTitle" = "我们找到了%d条活跃链";
@@ -884,6 +886,7 @@
 "thisVaultOnly" = "仅此保险库";
 "thorAddressAutoFilled" = "THORChain 地址 (自动填充)";
 "thorAddressNotFound" = "保险库中未找到 THORChain 地址。请确保您的保险库中有 RUNE。";
+"thorchainNotEnabledForLP" = "此保险库未启用 THORChain。请启用 THORChain 以添加流动性。";
 "thresholdNotReachedMessage" = "未达到阈值。\n缺少足够的初始设备";
 "timeout" = "超时";
 "title" = "标题";

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -21,6 +21,7 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     @Published var poolValid: Bool = false
     @Published var isTheFormValid: Bool = false
     @Published var customErrorMessage: String? = nil
+    @Published var thorchainNotEnabled: Bool = false
 
     // Pools
     @Published var availablePools: [IdentifiableString] = []
@@ -206,12 +207,16 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
         if tx.coin.chain == .thorChain {
             pairedAddress = ""
             pairedAddressValid = false
+            thorchainNotEnabled = false
         } else if let thorCoin = vault.coins.first(where: { $0.chain == .thorChain && $0.isNativeToken }) {
             pairedAddress = thorCoin.address
             pairedAddressValid = true
+            thorchainNotEnabled = false
         } else {
             pairedAddress = ""
             pairedAddressValid = false
+            thorchainNotEnabled = true
+            customErrorMessage = NSLocalizedString("thorchainNotEnabledForLP", comment: "Error shown when adding a THORChain LP from a non-THORChain asset while THORChain is not enabled on the vault")
         }
     }
 
@@ -313,7 +318,9 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
                 let currentBalance = self.tx.coin.balanceDecimal
                 self.amountValid = amount > 0 && amount <= currentBalance
 
-                if currentBalance < amount {
+                if self.thorchainNotEnabled {
+                    self.customErrorMessage = NSLocalizedString("thorchainNotEnabledForLP", comment: "Error shown when adding a THORChain LP from a non-THORChain asset while THORChain is not enabled on the vault")
+                } else if currentBalance < amount {
                     self.amountValid = false
                     self.customErrorMessage = NSLocalizedString("insufficientBalanceForFunctions", comment: "Error message when user tries to enter amount greater than available balance")
                 } else {
@@ -381,6 +388,10 @@ struct FunctionCallAddThorLPView: View {
 
     var body: some View {
         VStack {
+            if model.thorchainNotEnabled {
+                ThorchainNotEnabledBanner()
+            }
+
             PoolSelectorSection(model: model)
 
             if model.isApprovalRequired {
@@ -496,6 +507,26 @@ struct PoolSelectorSection: View {
             }
 
         )
+    }
+}
+
+struct ThorchainNotEnabledBanner: View {
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(Theme.fonts.bodyMMedium)
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text(NSLocalizedString("thorchainNotEnabledForLP", comment: "Error shown when adding a THORChain LP from a non-THORChain asset while THORChain is not enabled on the vault"))
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .cornerRadius(10)
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
@@ -176,11 +176,11 @@ struct FunctionCallDetailsScreen: View {
 
     var invalidFormAlert: Alert {
         Alert(
-            title: Text("Form Invalid"),
+            title: Text(NSLocalizedString("formInvalid", comment: "")),
             message: Text(
-                fnCallInstance?.customErrorMessage ?? "The form is not valid. Please fix the fields marked with a red star."
+                fnCallInstance?.customErrorMessage ?? NSLocalizedString("formInvalidMessage", comment: "")
             ),
-            dismissButton: .default(Text("OK"))
+            dismissButton: .default(Text(NSLocalizedString("ok", comment: "")))
         )
     }
 


### PR DESCRIPTION
## Summary
- When a user opens **Add THORChain LP** from a non-THORChain asset (e.g. ETH.USDT) on a vault that does not have THORChain enabled, the app previously showed a generic "Form Invalid / please fix the fields marked with a red star" popup even though no field was marked. This made the real cause invisible.
- Detects the missing-THORChain case in `FunctionCallAddThorLP` and now surfaces a localized, specific message. Adds an inline warning banner at the top of the LP form while the condition persists.
- Localizes the reusable Function Call `invalidFormAlert` (title, fallback message, dismiss button) that was previously hardcoded to English.

## Changes
- `FunctionCallAddThorLP.swift` — new `thorchainNotEnabled` state set from `prefillPairedAddress()` with priority over balance errors in the validation sink; new `ThorchainNotEnabledBanner` rendered at the top of the form.
- `FunctionCallDetailsScreen.swift` — alert uses `NSLocalizedString` for title/message/button.
- `Localizable.strings` (all 8 locales) — new keys: `formInvalid`, `formInvalidMessage`, `thorchainNotEnabledForLP`. Files re-sorted via `sort_localizable.py`.

## Test Plan
- [ ] Open a vault that does **not** have THORChain enabled
- [ ] Navigate: ETH → Functions → Add THORChain LP → choose ETH.USDT/USDC
- [ ] The banner appears on the form, and the popup shows the THORChain-not-enabled message (not the generic "Form Invalid" fallback)
- [ ] Enable THORChain on the vault → banner disappears and the flow proceeds normally
- [ ] Verify each locale (en/de/es/hr/it/ko/pt/zh-Hans) renders the new strings
- [ ] SwiftLint passes
- [ ] Build succeeds

## Related
- Closes #4179

Co-Authored-By: Claude <noreply@anthropic.com>