### PR TITLE
fix(fastvault): surface registration errors instead of silent failure

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -560,6 +560,7 @@
 		1F82D177506703CE9B853D00 /* SendAddressResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481C226D2BE5E37744AD54D3 /* SendAddressResolver.swift */; };
 		20F64419F06B1745E7499269 /* GeneralQRImportMacView+macOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99155325EA91C0D8966E2B11 /* GeneralQRImportMacView+macOS.swift */; };
 		21E1CA7DB5C8B9ADB07F0EFE /* TransactionHistoryRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = E681A12253338A5053513178 /* TransactionHistoryRoute.swift */; };
+		22F89C9E92007AE77EBF21FC /* FastVaultAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0637440EAA7101B24C2805 /* FastVaultAPI.swift */; };
 		2353311EA5E3A85FD0708F48 /* PushNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB189371E4AEE3FD55C1FE44 /* PushNotificationManager.swift */; };
 		2587BEE0C4B62870DEAB2199 /* SolanaTransactionStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78CA9F7989A44AB965FF32F3 /* SolanaTransactionStatusProvider.swift */; };
 		267798512F306C9AAD705483 /* UTXOTransactionStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1A1FCF78FFFE8E23B38F0E /* UTXOTransactionStatusResponse.swift */; };
@@ -601,7 +602,6 @@
 		46B60BC02BBB20130043EBBA /* RpcEvmService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B60BBF2BBB20130043EBBA /* RpcEvmService.swift */; };
 		46C8CBBD2BA7753900E68E08 /* Blockchair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C8CBBC2BA7753900E68E08 /* Blockchair.swift */; };
 		46C8CBBF2BA777BF00E68E08 /* BlockchairService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C8CBBE2BA777BF00E68E08 /* BlockchairService.swift */; };
-		475347731FCD706FD03E2747 /* DashService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884FB78FE9A167DB8E5779D8 /* DashService.swift */; };
 		46DE08902BD0D03E00AE8BDE /* CosmosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DE088F2BD0D03E00AE8BDE /* CosmosService.swift */; };
 		46DE08952BD0DCA200AE8BDE /* EvmService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DE08942BD0DCA200AE8BDE /* EvmService.swift */; };
 		46E5BC2B48C51362FE1B0CE7 /* TransactionHistoryRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3649DFEAF4C207AD2307E8B7 /* TransactionHistoryRouter.swift */; };
@@ -610,6 +610,7 @@
 		46F47CBB2B870EE900D964EA /* UTXOTransactionMempool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F47CBA2B870EE900D964EA /* UTXOTransactionMempool.swift */; };
 		46F8F7212B99FDB70099454E /* TransactionBroadcastResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F8F7202B99FDB70099454E /* TransactionBroadcastResponse.swift */; };
 		46F8F7282B9A011B0099454E /* ThorchainBroadcastTransactionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F8F7272B9A011B0099454E /* ThorchainBroadcastTransactionService.swift */; };
+		475347731FCD706FD03E2747 /* DashService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884FB78FE9A167DB8E5779D8 /* DashService.swift */; };
 		49CB6ADB7BAE03968F64D688 /* AgentLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A3AF7D4C4F47BA17581C92 /* AgentLogging.swift */; };
 		4A370C3F7F0151F5BC40FC1F /* AgentTransactionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61CDCEFBC18B3F5073DB943 /* AgentTransactionBuilder.swift */; };
 		4D50FC2F5E9F3BF92C034ADF /* AgentStreamManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE724E2B902EF120C1EE5D8F /* AgentStreamManager.swift */; };
@@ -648,7 +649,7 @@
 		8D8CD1A7DF304D8074C03B4E /* SingleKeygenMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1706BAF79A7E992FFEBF71 /* SingleKeygenMessage.swift */; };
 		8F55CD3B2DC382E500B53E85 /* TokensStore+Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F55CD3A2DC382E400B53E85 /* TokensStore+Token.swift */; };
 		9176AD98C5FADC4D5D92F04E /* TransactionHistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546B9FEB444B04006FF576BE /* TransactionHistoryItem.swift */; };
-		927BE27A46C4476AA7DA2901 /* Services/SuiTokenPriceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927BE27A46C4476AA7DA2902 /* Services/SuiTokenPriceTests.swift */; };
+		927BE27A46C4476AA7DA2901 /* SuiTokenPriceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927BE27A46C4476AA7DA2902 /* SuiTokenPriceTests.swift */; };
 		9358531DB65C84AF807A7CEB /* TransactionHistoryTypePill.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1119DA71589F5CCF4138189 /* TransactionHistoryTypePill.swift */; };
 		9802909F69AF78B4BCE010CE /* CircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35953B42171F515630BA7E9B /* CircleView.swift */; };
 		9976DC2B005ADF44E38FE464 /* CircleApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B3EE2059C84ADD4F8C4F16 /* CircleApiService.swift */; };
@@ -1253,6 +1254,7 @@
 		089EF1D434FDC5673F1F090A /* ReviewYourVaultsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReviewYourVaultsScreen.swift; path = VultisigApp/Features/Keygen/Views/ReviewYourVaultsScreen.swift; sourceTree = SOURCE_ROOT; };
 		0ABEFADAC7EF33E20A932CD6 /* SolanaTransactionStatusResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SolanaTransactionStatusResponse.swift; sourceTree = "<group>"; };
 		0BD426AD3A78890574917DE6 /* CustomMessageDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMessageDecoder.swift; sourceTree = "<group>"; };
+		0C0637440EAA7101B24C2805 /* FastVaultAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FastVaultAPI.swift; sourceTree = "<group>"; };
 		13052B962E8C5511000285D2 /* CrossPlatformToolbarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrossPlatformToolbarModifier.swift; sourceTree = "<group>"; };
 		13052B982E8C5744000285D2 /* MacOSToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSToolbarView.swift; sourceTree = "<group>"; };
 		13052B9A2E8C574C000285D2 /* IOSToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSToolbarView.swift; sourceTree = "<group>"; };
@@ -1834,7 +1836,6 @@
 		46B60BBF2BBB20130043EBBA /* RpcEvmService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RpcEvmService.swift; sourceTree = "<group>"; };
 		46C8CBBC2BA7753900E68E08 /* Blockchair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Blockchair.swift; sourceTree = "<group>"; };
 		46C8CBBE2BA777BF00E68E08 /* BlockchairService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchairService.swift; sourceTree = "<group>"; };
-		884FB78FE9A167DB8E5779D8 /* DashService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashService.swift; sourceTree = "<group>"; };
 		46DE088F2BD0D03E00AE8BDE /* CosmosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CosmosService.swift; sourceTree = "<group>"; };
 		46DE08942BD0DCA200AE8BDE /* EvmService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EvmService.swift; sourceTree = "<group>"; };
 		46E98FFB2BAE407300C53D97 /* DecodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorExtension.swift; sourceTree = "<group>"; };
@@ -1876,11 +1877,12 @@
 		834B4865644FA4A2EACF956E /* TransactionHistoryData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionHistoryData.swift; sourceTree = "<group>"; };
 		84EDDEF72A877329900F12D6 /* CreateMldsaRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMldsaRequest.swift; sourceTree = "<group>"; };
 		85ED8A4004502BBCBEAF924E /* CircleDepositViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleDepositViewModel.swift; sourceTree = "<group>"; };
+		884FB78FE9A167DB8E5779D8 /* DashService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashService.swift; sourceTree = "<group>"; };
 		8922E2B9288FCFE9626B80C1 /* AgentChatViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentChatViewModel.swift; sourceTree = "<group>"; };
 		8BE8825D6F0DBD6E8F28CB49 /* DefiCircleRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefiCircleRow.swift; sourceTree = "<group>"; };
 		8E6A38BCCA67E47B84787AA0 /* ForegroundNotificationParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForegroundNotificationParser.swift; sourceTree = "<group>"; };
 		8F55CD3A2DC382E400B53E85 /* TokensStore+Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TokensStore+Token.swift"; sourceTree = "<group>"; };
-		927BE27A46C4476AA7DA2902 /* Services/SuiTokenPriceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/SuiTokenPriceTests.swift; sourceTree = "<group>"; };
+		927BE27A46C4476AA7DA2902 /* SuiTokenPriceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/SuiTokenPriceTests.swift; sourceTree = "<group>"; };
 		9329F94E8B6ADC49CF18B0B5 /* HomePage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomePage.swift; sourceTree = "<group>"; };
 		93EF791E371FD688E09C0829 /* NotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		95F9E808DB3DFACA1E3B84E4 /* ReferralCodeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralCodeSheet.swift; sourceTree = "<group>"; };
@@ -2472,7 +2474,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		DE2EDA742E324604004713ED /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		DE2EDA742E324604004713ED /* Exceptions for "TestData" folder in "VultisigAppTests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				arb.json,
@@ -2503,7 +2505,18 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		DE2EDA722E3245A4004713ED /* TestData */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (DE2EDA742E324604004713ED /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TestData; sourceTree = "<group>"; };
+		DE2EDA722E3245A4004713ED /* TestData */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				DE2EDA742E324604004713ED /* Exceptions for "TestData" folder in "VultisigAppTests" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = TestData;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -4552,6 +4565,7 @@
 			children = (
 				A51AE8BA2C931C2000EF9A7A /* FastVaultService.swift */,
 				615D365EDC5D083737E59F94 /* FastVaultKeysignService.swift */,
+				0C0637440EAA7101B24C2805 /* FastVaultAPI.swift */,
 			);
 			path = FastVault;
 			sourceTree = "<group>";
@@ -6457,7 +6471,7 @@
 				DE8AD7482BC7A84100339775 /* Utils */,
 				DEF2E2CE2B9DA41A000737B8 /* Chains */,
 				DE49A17A2B65F6DB000F3AFB /* VultisigAppTests.swift */,
-				927BE27A46C4476AA7DA2902 /* Services/SuiTokenPriceTests.swift */,
+				927BE27A46C4476AA7DA2902 /* SuiTokenPriceTests.swift */,
 				FDC8064E13E4758250781597 /* Snapshots */,
 			);
 			path = VultisigAppTests;
@@ -6921,7 +6935,7 @@
 			);
 			mainGroup = DE49A15A2B65F6D9000F3AFB;
 			packageReferences = (
-				D9A22EB52B667C41007281BF /* XCLocalSwiftPackageReference "../Mediator" */,
+				D9A22EB52B667C41007281BF /* XCLocalSwiftPackageReference "Mediator" */,
 				DE49A1B32B6A1088000F3AFB /* XCRemoteSwiftPackageReference "CodeScanner" */,
 				DEEDAEE62B8B50A4005170E8 /* XCRemoteSwiftPackageReference "BigInt" */,
 				DEFF59022BD23A12005DFDF9 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
@@ -8152,6 +8166,7 @@
 				411422942A928D78FADAFCDF /* MacCameraServiceViewModel.swift in Sources */,
 				BD9DB6201E7149E5BC4D9EA7 /* StyledIntegerField.swift in Sources */,
 				9FFDCA67FBEF7610D81CDCC5 /* AccessibilityID.swift in Sources */,
+				22F89C9E92007AE77EBF21FC /* FastVaultAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8169,7 +8184,7 @@
 				DEF4295B2CA66D57004B6D0B /* ERC20Test.swift in Sources */,
 				DE49A17B2B65F6DB000F3AFB /* VultisigAppTests.swift in Sources */,
 				DE214FF62E308EEE00CEEA71 /* ChainHelperTests.swift in Sources */,
-				927BE27A46C4476AA7DA2901 /* Services/SuiTokenPriceTests.swift in Sources */,
+				927BE27A46C4476AA7DA2901 /* SuiTokenPriceTests.swift in Sources */,
 				D2FE6763BED8CC3044A39FBA /* ZipImportDuplicateTests.swift in Sources */,
 				CFF1B0DCBE47EAF6A1C28914 /* CreateVaultSnapshotTests.swift in Sources */,
 				AA15C50444DA9182DE80C9ED /* SnapshotDeviceConfigs.swift in Sources */,
@@ -8198,7 +8213,7 @@
 /* Begin PBXTargetDependency section */
 		B227A2B22F203CF800A32DBE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = B227A2B12F203CF800A32DBE /* SwiftLintBuildToolPlugin */;
+			productRef = B227A2B12F203CF800A32DBE /* plugin:SwiftLintBuildToolPlugin */;
 		};
 		DE49A1782B65F6DB000F3AFB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -8622,7 +8637,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		D9A22EB52B667C41007281BF /* XCLocalSwiftPackageReference "../Mediator" */ = {
+		D9A22EB52B667C41007281BF /* XCLocalSwiftPackageReference "Mediator" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../Mediator;
 		};
@@ -8719,7 +8734,7 @@
 			package = A6D44A592D51950600C66726 /* XCRemoteSwiftPackageReference "rive-ios" */;
 			productName = RiveRuntime;
 		};
-		B227A2B12F203CF800A32DBE /* SwiftLintBuildToolPlugin */ = {
+		B227A2B12F203CF800A32DBE /* plugin:SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B227A2B02F203C8000A32DBE /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -360,6 +360,7 @@
 "fastLoaderTitle" = "Suche nach FastVaultServer";
 "fastModeTitle" = "SCHNELL";
 "fastSetUp" = "Schnelle Einrichtung";
+"fastVaultRegistrationFailed" = "Registrierung beim Vultiserver fehlgeschlagen. Bitte erneut versuchen.";
 "fastVaultSecureTextDescription" = "Nur 1 Gerät erforderlich\nKleine Beträge für schnelle Aktionen speichern\nVultiserver unterzeichnet sofort";
 "fee" = "Gebühr";
 "filterByAsset" = "Nach Asset filtern";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -366,6 +366,7 @@
 "fastLoaderTitle" = "Looking for Vultiserver to connect...";
 "fastModeTitle" = "FAST";
 "fastSetUp" = "Fast set-up";
+"fastVaultRegistrationFailed" = "Failed to register with Vultiserver. Please try again.";
 "fastVaultSecureTextDescription" = "Only 1 device needed\nStore small funds for quick actions\nVultiserver co-signs instantly";
 "fee" = "Fee";
 "filterByAsset" = "Filter by Asset";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -360,6 +360,7 @@
 "fastLoaderTitle" = "Buscando FastVaultServer";
 "fastModeTitle" = "RÁPIDO";
 "fastSetUp" = "Configuración rápida";
+"fastVaultRegistrationFailed" = "Error al registrar con Vultiserver. Por favor, inténtalo de nuevo.";
 "fastVaultSecureTextDescription" = "Solo se necesita 1 dispositivo\nGuarda fondos pequeños para acciones rápidas\nVultiserver cofirma al instante";
 "fee" = "Tarifa";
 "filterByAsset" = "Filtrar por activo";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -360,6 +360,7 @@
 "fastLoaderTitle" = "Tražim FastVaultServer";
 "fastModeTitle" = "BRZO";
 "fastSetUp" = "Brza postavka";
+"fastVaultRegistrationFailed" = "Registracija na Vultiserver nije uspjela. Molimo pokušajte ponovno.";
 "fastVaultSecureTextDescription" = "Potrebno je samo 1 uređaj\nPohrani manja sredstva za brze radnje\nVultiserver trenutno supotpisuje";
 "fee" = "Naknada";
 "filterByAsset" = "Filtriraj po imovini";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -360,6 +360,7 @@
 "fastLoaderTitle" = "Ricerca del FastVaultServer";
 "fastModeTitle" = "VELOCE";
 "fastSetUp" = "Configurazione rapida";
+"fastVaultRegistrationFailed" = "Registrazione su Vultiserver non riuscita. Riprova.";
 "fastVaultSecureTextDescription" = "Solo 1 dispositivo necessario\nConserva piccoli fondi per azioni rapide\nVultiserver cofirma istantaneamente";
 "fee" = "Commissione";
 "filterByAsset" = "Filtra per asset";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -366,6 +366,7 @@
 "fastLoaderTitle" = "연결할 Vultiserver를 찾는 중...";
 "fastModeTitle" = "빠름";
 "fastSetUp" = "빠른 설정";
+"fastVaultRegistrationFailed" = "Vultiserver 등록에 실패했습니다. 다시 시도해 주세요.";
 "fastVaultSecureTextDescription" = "기기 1개만 필요\n빠른 작업을 위한 소액 자금 저장\nVultiserver가 즉시 공동 서명";
 "fee" = "수수료";
 "filterByAsset" = "자산으로 필터링";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -360,6 +360,7 @@
 "fastLoaderTitle" = "Procurando FastVaultServer";
 "fastModeTitle" = "RÁPIDO";
 "fastSetUp" = "Configuração rápida";
+"fastVaultRegistrationFailed" = "Falha ao registrar no Vultiserver. Tente novamente.";
 "fastVaultSecureTextDescription" = "Apenas 1 dispositivo necessário\nArmazene pequenos fundos para ações rápidas\nVultiserver coassina instantaneamente";
 "fee" = "Taxa";
 "filterByAsset" = "Filtrar por ativo";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -360,6 +360,7 @@
 "fastLoaderTitle" = "正在寻找 Vultiserver 连接...";
 "fastModeTitle" = "快速";
 "fastSetUp" = "快速设置";
+"fastVaultRegistrationFailed" = "注册 Vultiserver 失败，请重试。";
 "fastVaultSecureTextDescription" = "只需 1 个设备\n存储小额资金以进行快速操作\nVultiserver 即时共同签名";
 "fee" = "费用";
 "filterByAsset" = "按资产筛选";

--- a/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultAPI.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultAPI.swift
@@ -1,0 +1,113 @@
+//
+//  FastVaultAPI.swift
+//  VultisigApp
+//
+
+import Foundation
+
+enum FastVaultAPI: TargetType {
+    case validateAccess(pubKeyECDSA: String, base64Password: String)
+    case exists(pubKeyECDSA: String)
+    case create(VaultCreateRequest)
+    case batchCreate(BatchKeygenRequest)
+    case keyImport(KeyImportRequest)
+    case batchKeyImport(BatchKeyImportRequest)
+    case reshare(ReshareRequest)
+    case batchReshare(BatchReshareRequest)
+    case sign(KeysignRequest)
+    case migrate(MigrationRequest)
+    case singleKeygen(CreateMldsaRequest)
+    case verifyBackupOTP(pubKeyECDSA: String, code: String)
+
+    var baseURL: URL {
+        guard let url = URL(string: Endpoint.vultisigApiProxy) else {
+            fatalError("Invalid FastVault base URL")
+        }
+        return url
+    }
+
+    var path: String {
+        switch self {
+        case .validateAccess(let pubKey, _):
+            return "/vault/get/\(pubKey)"
+        case .exists(let pubKey):
+            return "/vault/exist/\(pubKey)"
+        case .create:
+            return "/vault/create"
+        case .batchCreate:
+            return "/vault/batch/keygen"
+        case .keyImport:
+            return "/vault/import"
+        case .batchKeyImport:
+            return "/vault/batch/import"
+        case .reshare:
+            return "/vault/reshare"
+        case .batchReshare:
+            return "/vault/batch/reshare"
+        case .sign:
+            return "/vault/sign"
+        case .migrate:
+            return "/vault/migrate"
+        case .singleKeygen:
+            return "/vault/mldsa"
+        case .verifyBackupOTP(let pubKey, let code):
+            return "/vault/verify/\(pubKey)/\(code)"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .validateAccess, .exists, .verifyBackupOTP:
+            return .get
+        case .create, .batchCreate, .keyImport, .batchKeyImport,
+             .reshare, .batchReshare, .sign, .migrate, .singleKeygen:
+            return .post
+        }
+    }
+
+    var task: HTTPTask {
+        switch self {
+        case .validateAccess, .exists, .verifyBackupOTP:
+            return .requestPlain
+        case .create(let req):
+            return .requestCodable(req, .jsonEncoding)
+        case .batchCreate(let req):
+            return .requestCodable(req, .jsonEncoding)
+        case .keyImport(let req):
+            return .requestCodable(req, .jsonEncoding)
+        case .batchKeyImport(let req):
+            return .requestCodable(req, .jsonEncoding)
+        case .reshare(let req):
+            return .requestCodable(req, .jsonEncoding)
+        case .batchReshare(let req):
+            return .requestCodable(req, .jsonEncoding)
+        case .sign(let req):
+            return .requestCodable(req, .jsonEncoding)
+        case .migrate(let req):
+            return .requestCodable(req, .jsonEncoding)
+        case .singleKeygen(let req):
+            return .requestCodable(req, .jsonEncoding)
+        }
+    }
+
+    var headers: [String: String]? {
+        switch self {
+        case .validateAccess(_, let base64Password):
+            return [
+                "Content-Type": "application/json",
+                "x-password": base64Password
+            ]
+        default:
+            return ["Content-Type": "application/json"]
+        }
+    }
+
+    var validationType: ValidationType {
+        switch self {
+        case .validateAccess:
+            return .customCodes([200, 401, 403, 404])
+        default:
+            return .successCodes
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultService.swift
@@ -375,18 +375,15 @@ private extension FastVaultService {
 }
 
 enum FastVaultServiceError: Error, LocalizedError {
-    case invalidSignURL
-    case invalidResponse
+    case missingEncryptionKey
     case signFailed(statusCode: Int, responseBody: String?)
     case registrationFailed(operation: String, statusCode: Int, responseBody: String?)
     case networkFailure(Error)
 
     var errorDescription: String? {
         switch self {
-        case .invalidSignURL:
-            return "FastVault sign URL is invalid"
-        case .invalidResponse:
-            return "FastVault sign returned an invalid response"
+        case .missingEncryptionKey:
+            return "FastVault encryption key is missing"
         case .signFailed(let statusCode, let responseBody):
             return "FastVault sign failed with status \(statusCode): \(describeBody(responseBody))"
         case .registrationFailed(let operation, let statusCode, let responseBody):

--- a/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultService.swift
@@ -53,8 +53,12 @@ final class FastVaultService {
 
     static let shared = FastVaultService()
 
-    private let endpoint = "https://api.vultisig.com/vault"
-    private let logger = Logger(subsystem: "com.vultisig", category: "FastVaultService")
+    private let httpClient: HTTPClientProtocol
+    private let logger = Logger(subsystem: "com.vultisig.app", category: "fast-vault-service")
+
+    init(httpClient: HTTPClientProtocol = HTTPClient()) {
+        self.httpClient = httpClient
+    }
 
     static func localPartyID(sessionID: String) -> String {
         guard let data = sessionID.data(using: .utf8) else {
@@ -66,32 +70,19 @@ final class FastVaultService {
     }
 
     func validateAccess(pubKeyECDSA: String, password: String) async -> FastVaultAccessValidationResult {
-        let urlString = "\(endpoint)/get/\(pubKeyECDSA)"
-
-        guard let url = URL(string: urlString) else {
-            return .networkFailure("FastVault get URL is invalid")
-        }
-
-        guard let pwd = password.data(using: .utf8)?.base64EncodedString() else {
+        guard let encodedPassword = password.data(using: .utf8)?.base64EncodedString() else {
             return .networkFailure("Failed to encode FastVault password")
         }
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.addValue(pwd, forHTTPHeaderField: "x-password")
-
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return .networkFailure("FastVault get returned an invalid response")
-            }
-
-            let responseBody = String(data: data, encoding: .utf8)?
+            let response = try await httpClient.request(
+                FastVaultAPI.validateAccess(pubKeyECDSA: pubKeyECDSA, base64Password: encodedPassword)
+            )
+            let body = String(data: response.data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
 
-            switch httpResponse.statusCode {
-            case 200 ... 299:
+            switch response.response.statusCode {
+            case 200...299:
                 return .valid
             case 401, 403:
                 return .invalidPassword
@@ -99,8 +90,8 @@ final class FastVaultService {
                 return .vaultNotFound
             default:
                 return .requestFailed(
-                    statusCode: httpResponse.statusCode,
-                    responseBody: responseBody
+                    statusCode: response.response.statusCode,
+                    responseBody: body
                 )
             }
         } catch {
@@ -118,10 +109,10 @@ final class FastVaultService {
 
     func exist(pubKeyECDSA: String) async -> Bool {
         do {
-            let urlString = "\(endpoint)/exist/\(pubKeyECDSA)"
-            _ = try await Utils.asyncGetRequest(urlString: urlString, headers: [:])
+            _ = try await httpClient.request(FastVaultAPI.exists(pubKeyECDSA: pubKeyECDSA))
             return true
         } catch {
+            logger.info("FastVault exist check returned false: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -142,13 +133,19 @@ final class FastVaultService {
         encryptionPassword: String,
         email: String,
         lib_type: Int
-    ) {
+    ) async throws {
         let localPartyID = Self.localPartyID(sessionID: sessionID)
-        let req = VaultCreateRequest(name: name, session_id: sessionID, hex_encryption_key: hexEncryptionKey, hex_chain_code: hexChainCode, local_party_id: localPartyID, encryption_password: encryptionPassword, email: email, lib_type: lib_type)
-
-        Utils.sendRequest(urlString: "\(endpoint)/create", method: "POST", headers: [:], body: req) { _ in
-            self.logger.info("Sent FastVault create request successfully")
-        }
+        let req = VaultCreateRequest(
+            name: name,
+            session_id: sessionID,
+            hex_encryption_key: hexEncryptionKey,
+            hex_chain_code: hexChainCode,
+            local_party_id: localPartyID,
+            encryption_password: encryptionPassword,
+            email: email,
+            lib_type: lib_type
+        )
+        try await send(.create(req), operation: "create")
     }
 
     func batchCreate(
@@ -160,7 +157,7 @@ final class FastVaultService {
         email: String,
         lib_type: Int,
         protocols: [String]
-    ) {
+    ) async throws {
         let localPartyID = Self.localPartyID(sessionID: sessionID)
         let req = BatchKeygenRequest(
             name: name,
@@ -173,10 +170,7 @@ final class FastVaultService {
             lib_type: lib_type,
             protocols: protocols
         )
-
-        Utils.sendRequest(urlString: "\(endpoint)/batch/keygen", method: "POST", headers: [:], body: req) { _ in
-            self.logger.info("Sent FastVault batch keygen request successfully")
-        }
+        try await send(.batchCreate(req), operation: "batch keygen")
     }
 
     func keyImport(
@@ -188,13 +182,20 @@ final class FastVaultService {
         email: String,
         lib_type: Int,
         chains: [String]
-    ) {
+    ) async throws {
         let localPartyID = Self.localPartyID(sessionID: sessionID)
-        let req = KeyImportRequest(name: name, session_id: sessionID, hex_encryption_key: hexEncryptionKey, hex_chain_code: hexChainCode, local_party_id: localPartyID, encryption_password: encryptionPassword, email: email, lib_type: lib_type, chains: chains)
-
-        Utils.sendRequest(urlString: "\(endpoint)/import", method: "POST", headers: [:], body: req) { _ in
-            self.logger.info("Sent FastVault import request successfully")
-        }
+        let req = KeyImportRequest(
+            name: name,
+            session_id: sessionID,
+            hex_encryption_key: hexEncryptionKey,
+            hex_chain_code: hexChainCode,
+            local_party_id: localPartyID,
+            encryption_password: encryptionPassword,
+            email: email,
+            lib_type: lib_type,
+            chains: chains
+        )
+        try await send(.keyImport(req), operation: "import")
     }
 
     func batchKeyImport(
@@ -206,7 +207,7 @@ final class FastVaultService {
         lib_type: Int,
         chains: [String],
         protocols: [String]
-    ) {
+    ) async throws {
         let localPartyID = Self.localPartyID(sessionID: sessionID)
         let req = BatchKeyImportRequest(
             name: name,
@@ -219,10 +220,7 @@ final class FastVaultService {
             chains: chains,
             protocols: protocols
         )
-
-        Utils.sendRequest(urlString: "\(endpoint)/batch/import", method: "POST", headers: [:], body: req) { _ in
-            self.logger.info("Sent FastVault batch import request successfully")
-        }
+        try await send(.batchKeyImport(req), operation: "batch import")
     }
 
     func batchReshare(
@@ -233,7 +231,7 @@ final class FastVaultService {
         email: String,
         oldParties: [String],
         protocols: [String]
-    ) {
+    ) async throws {
         let localPartyID = Self.localPartyID(sessionID: sessionID)
         let req = BatchReshareRequest(
             public_key: publicKeyECDSA,
@@ -245,10 +243,7 @@ final class FastVaultService {
             email: email,
             protocols: protocols
         )
-
-        Utils.sendRequest(urlString: "\(endpoint)/batch/reshare", method: "POST", headers: [:], body: req) { _ in
-            self.logger.info("Sent FastVault batch reshare request successfully")
-        }
+        try await send(.batchReshare(req), operation: "batch reshare")
     }
 
     func reshare(
@@ -262,23 +257,22 @@ final class FastVaultService {
         oldParties: [String],
         oldResharePrefix: String,
         lib_type: Int
-    ) {
+    ) async throws {
         let localPartyID = Self.localPartyID(sessionID: sessionID)
-        let req = ReshareRequest(name: name,
-                                 public_key: publicKeyECDSA,
-                                 session_id: sessionID,
-                                 hex_encryption_key: hexEncryptionKey,
-                                 hex_chain_code: hexChainCode,
-                                 local_party_id: localPartyID,
-                                 old_parties: oldParties,
-                                 encryption_password: encryptionPassword,
-                                 email: email,
-                                 old_reshare_prefix: oldResharePrefix,
-                                 lib_type: lib_type)
-
-        Utils.sendRequest(urlString: "\(endpoint)/reshare", method: "POST", headers: [:], body: req) { _ in
-            self.logger.info("Sent FastVault reshare request successfully")
-        }
+        let req = ReshareRequest(
+            name: name,
+            public_key: publicKeyECDSA,
+            session_id: sessionID,
+            hex_encryption_key: hexEncryptionKey,
+            hex_chain_code: hexChainCode,
+            local_party_id: localPartyID,
+            old_parties: oldParties,
+            encryption_password: encryptionPassword,
+            email: email,
+            old_reshare_prefix: oldResharePrefix,
+            lib_type: lib_type
+        )
+        try await send(.reshare(req), operation: "reshare")
     }
 
     func sign(
@@ -291,51 +285,33 @@ final class FastVaultService {
         vaultPassword: String,
         chain: String
     ) async throws {
-        let request = KeysignRequest(public_key: publicKeyEcdsa, messages: keysignMessages, session: sessionID, hex_encryption_key: hexEncryptionKey, derive_path: derivePath, is_ecdsa: isECDSA, vault_password: vaultPassword, chain: chain)
-        guard let url = URL(string: "\(endpoint)/sign") else {
-            throw FastVaultServiceError.invalidSignURL
-        }
-
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.httpBody = try JSONEncoder().encode(request)
-
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw FastVaultServiceError.invalidResponse
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            let responseBody = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            throw FastVaultServiceError.signFailed(
-                statusCode: httpResponse.statusCode,
-                responseBody: responseBody
-            )
+        let request = KeysignRequest(
+            public_key: publicKeyEcdsa,
+            messages: keysignMessages,
+            session: sessionID,
+            hex_encryption_key: hexEncryptionKey,
+            derive_path: derivePath,
+            is_ecdsa: isECDSA,
+            vault_password: vaultPassword,
+            chain: chain
+        )
+        do {
+            _ = try await httpClient.request(FastVaultAPI.sign(request))
+        } catch let HTTPError.statusCode(code, data) {
+            let body = data.flatMap { String(data: $0, encoding: .utf8) }?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw FastVaultServiceError.signFailed(statusCode: code, responseBody: body)
+        } catch {
+            throw FastVaultServiceError.networkFailure(error)
         }
     }
 
     func verifyBackupOTP(ecdsaKey: String, OTPCode: String) async -> Bool {
-        let parameters = "\(ecdsaKey)/\(OTPCode)"
-        let urlString = Endpoint.FastVaultBackupVerification + parameters
-
-        guard let url = URL(string: urlString) else {
-            logger.error("FastVault backup verification URL is invalid")
-            return false
-        }
-
         do {
-            let (_, response) = try await URLSession.shared.data(from: url)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
-
-            if httpResponse.statusCode == 200 {
-                return true
-            } else {
-                return false
-            }
+            _ = try await httpClient.request(
+                FastVaultAPI.verifyBackupOTP(pubKeyECDSA: ecdsaKey, code: OTPCode)
+            )
+            return true
         } catch {
             logger.error("FastVault backup verification failed: \(error.localizedDescription, privacy: .public)")
             return false
@@ -348,7 +324,7 @@ final class FastVaultService {
         hexEncryptionKey: String,
         encryptionPassword: String,
         email: String
-    ) {
+    ) async throws {
         let req = CreateMldsaRequest(
             public_key: publicKeyECDSA,
             session_id: sessionID,
@@ -356,10 +332,7 @@ final class FastVaultService {
             encryption_password: encryptionPassword,
             email: email
         )
-
-        Utils.sendRequest(urlString: "\(endpoint)/mldsa", method: "POST", headers: [:], body: req) { _ in
-            self.logger.info("Sent FastVault MLDSA keygen request successfully")
-        }
+        try await send(.singleKeygen(req), operation: "mldsa keygen")
     }
 
     func migrate(
@@ -367,15 +340,36 @@ final class FastVaultService {
         sessionID: String,
         hexEncryptionKey: String,
         encryptionPassword: String,
-        email: String) {
-        let req = MigrationRequest(public_key: publicKeyECDSA,
-                                 session_id: sessionID,
-                                 hex_encryption_key: hexEncryptionKey,
-                                 encryption_password: encryptionPassword,
-                                 email: email)
+        email: String
+    ) async throws {
+        let req = MigrationRequest(
+            public_key: publicKeyECDSA,
+            session_id: sessionID,
+            hex_encryption_key: hexEncryptionKey,
+            encryption_password: encryptionPassword,
+            email: email
+        )
+        try await send(.migrate(req), operation: "migrate")
+    }
+}
 
-        Utils.sendRequest(urlString: "\(endpoint)/migrate", method: "POST", headers: [:], body: req) { _ in
-            self.logger.info("Sent FastVault migration request successfully")
+private extension FastVaultService {
+    func send(_ target: FastVaultAPI, operation: String) async throws {
+        do {
+            _ = try await httpClient.request(target)
+            logger.info("FastVault \(operation, privacy: .public) request succeeded")
+        } catch let HTTPError.statusCode(code, data) {
+            let body = data.flatMap { String(data: $0, encoding: .utf8) }?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.error("FastVault \(operation, privacy: .public) failed: HTTP \(code) \(body ?? "", privacy: .public)")
+            throw FastVaultServiceError.registrationFailed(
+                operation: operation,
+                statusCode: code,
+                responseBody: body
+            )
+        } catch {
+            logger.error("FastVault \(operation, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            throw FastVaultServiceError.networkFailure(error)
         }
     }
 }
@@ -384,6 +378,8 @@ enum FastVaultServiceError: Error, LocalizedError {
     case invalidSignURL
     case invalidResponse
     case signFailed(statusCode: Int, responseBody: String?)
+    case registrationFailed(operation: String, statusCode: Int, responseBody: String?)
+    case networkFailure(Error)
 
     var errorDescription: String? {
         switch self {
@@ -392,14 +388,19 @@ enum FastVaultServiceError: Error, LocalizedError {
         case .invalidResponse:
             return "FastVault sign returned an invalid response"
         case .signFailed(let statusCode, let responseBody):
-            let body: String
-            if let responseBody, !responseBody.isEmpty {
-                body = responseBody
-            } else {
-                body = "empty response body"
-            }
-            return "FastVault sign failed with status \(statusCode): \(body)"
+            return "FastVault sign failed with status \(statusCode): \(describeBody(responseBody))"
+        case .registrationFailed(let operation, let statusCode, let responseBody):
+            return "FastVault \(operation) failed with status \(statusCode): \(describeBody(responseBody))"
+        case .networkFailure(let error):
+            return "FastVault network error: \(error.localizedDescription)"
         }
+    }
+
+    private func describeBody(_ body: String?) -> String {
+        guard let body, !body.isEmpty else {
+            return "empty response body"
+        }
+        return body
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
@@ -113,106 +113,118 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
             break
         }
         if let config = fastSignConfig {
-            switch tssType {
-            case .Keygen:
-                Task {
-                    let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
-                    if isTssBatchEnabled {
-                        fastVaultService.batchCreate(
-                            name: vault.name,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            hexChainCode: vault.hexChainCode,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            lib_type: vault.libType == .DKLS ? 1 : 0,
-                            protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
-                        )
-                    } else {
-                        fastVaultService.create(name: vault.name,
-                                                sessionID: sessionID,
-                                                hexEncryptionKey: encryptionKeyHex!,
-                                                hexChainCode: vault.hexChainCode,
-                                                encryptionPassword: config.password,
-                                                email: config.email,
-                                                lib_type: vault.libType == .DKLS ? 1 : 0)
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.registerFastVaultServer(tssType: tssType, config: config)
+                } catch {
+                    self.logger.error("FastVault registration failed: \(error.localizedDescription, privacy: .public)")
+                    await MainActor.run {
+                        self.errorMessage = "fastVaultRegistrationFailed".localized
+                        self.status = .Failure
                     }
                 }
-            case .KeyImport:
-                Task {
-                    let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
-                    if isTssBatchEnabled {
-                        fastVaultService.batchKeyImport(
-                            name: vault.name,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            lib_type: 2,
-                            chains: chains?.map { $0.name } ?? [],
-                            protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
-                        )
-                    } else {
-                        fastVaultService.keyImport(
-                            name: vault.name,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            hexChainCode: vault.hexChainCode,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            lib_type: 2,
-                            chains: chains?.map { $0.name } ?? []
-                        )
-                    }
-                }
-            case .Reshare:
-                let pubKeyECDSA = config.isExist ? vault.pubKeyECDSA : .empty
-                Task {
-                    let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
-                    if isTssBatchEnabled {
-                        fastVaultService.batchReshare(
-                            publicKeyECDSA: pubKeyECDSA,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            oldParties: vault.signers,
-                            protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
-                        )
-                    } else {
-                        fastVaultService.reshare(
-                            name: vault.name,
-                            publicKeyECDSA: pubKeyECDSA,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            hexChainCode: vault.hexChainCode,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            oldParties: vault.signers,
-                            oldResharePrefix: vault.resharePrefix ?? "",
-                            lib_type: vault.libType == .DKLS ? 1 : 0
-                        )
-                    }
-                }
-            case .Migrate:
-                fastVaultService.migrate(
-                    publicKeyECDSA: vault.pubKeyECDSA,
-                    sessionID: sessionID,
-                    hexEncryptionKey: encryptionKeyHex!,
-                    encryptionPassword: config.password,
-                    email: config.email
-                )
-            case .SingleKeygen:
-                fastVaultService.singleKeygen(
-                    publicKeyECDSA: vault.pubKeyECDSA,
-                    sessionID: sessionID,
-                    hexEncryptionKey: encryptionKeyHex!,
-                    encryptionPassword: config.password,
-                    email: config.email
-                )
             }
         }
         self.isLoading = false
+    }
+
+    private func registerFastVaultServer(tssType: TssType, config: FastSignConfig) async throws {
+        guard let encryptionKeyHex else {
+            throw FastVaultServiceError.invalidResponse
+        }
+        let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
+        switch tssType {
+        case .Keygen:
+            if isTssBatchEnabled {
+                try await fastVaultService.batchCreate(
+                    name: vault.name,
+                    sessionID: sessionID,
+                    hexEncryptionKey: encryptionKeyHex,
+                    hexChainCode: vault.hexChainCode,
+                    encryptionPassword: config.password,
+                    email: config.email,
+                    lib_type: vault.libType == .DKLS ? 1 : 0,
+                    protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
+                )
+            } else {
+                try await fastVaultService.create(
+                    name: vault.name,
+                    sessionID: sessionID,
+                    hexEncryptionKey: encryptionKeyHex,
+                    hexChainCode: vault.hexChainCode,
+                    encryptionPassword: config.password,
+                    email: config.email,
+                    lib_type: vault.libType == .DKLS ? 1 : 0
+                )
+            }
+        case .KeyImport:
+            if isTssBatchEnabled {
+                try await fastVaultService.batchKeyImport(
+                    name: vault.name,
+                    sessionID: sessionID,
+                    hexEncryptionKey: encryptionKeyHex,
+                    encryptionPassword: config.password,
+                    email: config.email,
+                    lib_type: 2,
+                    chains: chains?.map { $0.name } ?? [],
+                    protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
+                )
+            } else {
+                try await fastVaultService.keyImport(
+                    name: vault.name,
+                    sessionID: sessionID,
+                    hexEncryptionKey: encryptionKeyHex,
+                    hexChainCode: vault.hexChainCode,
+                    encryptionPassword: config.password,
+                    email: config.email,
+                    lib_type: 2,
+                    chains: chains?.map { $0.name } ?? []
+                )
+            }
+        case .Reshare:
+            let pubKeyECDSA = config.isExist ? vault.pubKeyECDSA : .empty
+            if isTssBatchEnabled {
+                try await fastVaultService.batchReshare(
+                    publicKeyECDSA: pubKeyECDSA,
+                    sessionID: sessionID,
+                    hexEncryptionKey: encryptionKeyHex,
+                    encryptionPassword: config.password,
+                    email: config.email,
+                    oldParties: vault.signers,
+                    protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
+                )
+            } else {
+                try await fastVaultService.reshare(
+                    name: vault.name,
+                    publicKeyECDSA: pubKeyECDSA,
+                    sessionID: sessionID,
+                    hexEncryptionKey: encryptionKeyHex,
+                    hexChainCode: vault.hexChainCode,
+                    encryptionPassword: config.password,
+                    email: config.email,
+                    oldParties: vault.signers,
+                    oldResharePrefix: vault.resharePrefix ?? "",
+                    lib_type: vault.libType == .DKLS ? 1 : 0
+                )
+            }
+        case .Migrate:
+            try await fastVaultService.migrate(
+                publicKeyECDSA: vault.pubKeyECDSA,
+                sessionID: sessionID,
+                hexEncryptionKey: encryptionKeyHex,
+                encryptionPassword: config.password,
+                email: config.email
+            )
+        case .SingleKeygen:
+            try await fastVaultService.singleKeygen(
+                publicKeyECDSA: vault.pubKeyECDSA,
+                sessionID: sessionID,
+                hexEncryptionKey: encryptionKeyHex,
+                encryptionPassword: config.password,
+                email: config.email
+            )
+        }
     }
 
     func setupPeersFoundCancellable(

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
@@ -15,6 +15,15 @@ enum PeerDiscoveryStatus {
     case Failure
 }
 
+struct VaultRegistrationSnapshot {
+    let name: String
+    let pubKeyECDSA: String
+    let hexChainCode: String
+    let signers: [String]
+    let resharePrefix: String
+    let libType: LibType
+}
+
 class KeygenPeerDiscoveryViewModel: ObservableObject {
 
     private let logger = Logger(subsystem: "peers-discory-viewmodel", category: "communication")
@@ -113,10 +122,18 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
             break
         }
         if let config = fastSignConfig {
+            let snapshot = VaultRegistrationSnapshot(
+                name: vault.name,
+                pubKeyECDSA: vault.pubKeyECDSA,
+                hexChainCode: vault.hexChainCode,
+                signers: vault.signers,
+                resharePrefix: vault.resharePrefix ?? "",
+                libType: vault.libType ?? .GG20
+            )
             Task { [weak self] in
                 guard let self else { return }
                 do {
-                    try await self.registerFastVaultServer(tssType: tssType, config: config)
+                    try await self.registerFastVaultServer(tssType: tssType, config: config, vault: snapshot)
                 } catch {
                     self.logger.error("FastVault registration failed: \(error.localizedDescription, privacy: .public)")
                     await MainActor.run {
@@ -126,14 +143,21 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                 }
             }
         }
+        // isLoading reflects peer-discovery state, not registration — registration failure is surfaced via status = .Failure
         self.isLoading = false
     }
 
-    private func registerFastVaultServer(tssType: TssType, config: FastSignConfig) async throws {
+    private func registerFastVaultServer(
+        tssType: TssType,
+        config: FastSignConfig,
+        vault: VaultRegistrationSnapshot
+    ) async throws {
         guard let encryptionKeyHex else {
-            throw FastVaultServiceError.invalidResponse
+            throw FastVaultServiceError.missingEncryptionKey
         }
         let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
+        let chainNames = chains?.map { $0.name } ?? []
+        let libTypeCode = vault.libType == .DKLS ? 1 : 0
         switch tssType {
         case .Keygen:
             if isTssBatchEnabled {
@@ -144,7 +168,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                     hexChainCode: vault.hexChainCode,
                     encryptionPassword: config.password,
                     email: config.email,
-                    lib_type: vault.libType == .DKLS ? 1 : 0,
+                    lib_type: libTypeCode,
                     protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
                 )
             } else {
@@ -155,7 +179,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                     hexChainCode: vault.hexChainCode,
                     encryptionPassword: config.password,
                     email: config.email,
-                    lib_type: vault.libType == .DKLS ? 1 : 0
+                    lib_type: libTypeCode
                 )
             }
         case .KeyImport:
@@ -167,7 +191,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                     encryptionPassword: config.password,
                     email: config.email,
                     lib_type: 2,
-                    chains: chains?.map { $0.name } ?? [],
+                    chains: chainNames,
                     protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
                 )
             } else {
@@ -179,7 +203,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                     encryptionPassword: config.password,
                     email: config.email,
                     lib_type: 2,
-                    chains: chains?.map { $0.name } ?? []
+                    chains: chainNames
                 )
             }
         case .Reshare:
@@ -204,8 +228,8 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                     encryptionPassword: config.password,
                     email: config.email,
                     oldParties: vault.signers,
-                    oldResharePrefix: vault.resharePrefix ?? "",
-                    lib_type: vault.libType == .DKLS ? 1 : 0
+                    oldResharePrefix: vault.resharePrefix,
+                    lib_type: libTypeCode
                 )
             }
         case .Migrate:


### PR DESCRIPTION
## Summary
- Refactor `FastVaultService` to use the `HTTPClient` + `TargetType` pattern (new `FastVaultAPI.swift`) so all Vultiserver calls go through the project's standard networking layer.
- Convert fire-and-forget registration methods (`create`, `batchCreate`, `keyImport`, `batchKeyImport`, `reshare`, `batchReshare`, `migrate`, `singleKeygen`) to `async throws` and map HTTP failures to a typed `FastVaultServiceError`.
- `KeygenPeerDiscoveryViewModel` now awaits registration inside a single `do/catch`; on failure it logs via `OSLog`, sets `status = .Failure`, and surfaces `fastVaultRegistrationFailed` (localized in all 8 locales) instead of letting users wait for a generic ceremony timeout.

Closes #4140

> [!NOTE]
> Stacked on top of #4139 (`roman/parallel-keygen-execution`). Rebase onto `main` after that PR merges.

## Test plan
- [ ] Keygen with valid Vultiserver credentials completes successfully (single + batch paths).
- [ ] Simulate a Vultiserver 5xx/4xx response and confirm the UI shows the localized failure message immediately rather than hanging until timeout.
- [ ] `Reshare` / `Migrate` / `SingleKeygen` flows all surface the same error UX on server rejection.
- [ ] `validateAccess` still differentiates `.valid`, `.invalidPassword`, and `.vaultNotFound` (custom status codes preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)