### PR TITLE
feat(defi): move sTCY to DeFi as auto-compounded position

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
+++ b/VultisigApp/VultisigApp.xcodeproj/project.pbxproj
@@ -601,7 +601,6 @@
 		46B60BC02BBB20130043EBBA /* RpcEvmService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B60BBF2BBB20130043EBBA /* RpcEvmService.swift */; };
 		46C8CBBD2BA7753900E68E08 /* Blockchair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C8CBBC2BA7753900E68E08 /* Blockchair.swift */; };
 		46C8CBBF2BA777BF00E68E08 /* BlockchairService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C8CBBE2BA777BF00E68E08 /* BlockchairService.swift */; };
-		475347731FCD706FD03E2747 /* DashService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884FB78FE9A167DB8E5779D8 /* DashService.swift */; };
 		46DE08902BD0D03E00AE8BDE /* CosmosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DE088F2BD0D03E00AE8BDE /* CosmosService.swift */; };
 		46DE08952BD0DCA200AE8BDE /* EvmService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DE08942BD0DCA200AE8BDE /* EvmService.swift */; };
 		46E5BC2B48C51362FE1B0CE7 /* TransactionHistoryRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3649DFEAF4C207AD2307E8B7 /* TransactionHistoryRouter.swift */; };
@@ -610,6 +609,7 @@
 		46F47CBB2B870EE900D964EA /* UTXOTransactionMempool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F47CBA2B870EE900D964EA /* UTXOTransactionMempool.swift */; };
 		46F8F7212B99FDB70099454E /* TransactionBroadcastResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F8F7202B99FDB70099454E /* TransactionBroadcastResponse.swift */; };
 		46F8F7282B9A011B0099454E /* ThorchainBroadcastTransactionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F8F7272B9A011B0099454E /* ThorchainBroadcastTransactionService.swift */; };
+		475347731FCD706FD03E2747 /* DashService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884FB78FE9A167DB8E5779D8 /* DashService.swift */; };
 		49CB6ADB7BAE03968F64D688 /* AgentLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A3AF7D4C4F47BA17581C92 /* AgentLogging.swift */; };
 		4A370C3F7F0151F5BC40FC1F /* AgentTransactionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61CDCEFBC18B3F5073DB943 /* AgentTransactionBuilder.swift */; };
 		4D50FC2F5E9F3BF92C034ADF /* AgentStreamManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE724E2B902EF120C1EE5D8F /* AgentStreamManager.swift */; };
@@ -642,13 +642,16 @@
 		784957DA9E44EAC291A4E593 /* CircleSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2082307F2DAAB6FA5911FFDC /* CircleSetupView.swift */; };
 		7B745269DA629654EEA2982B /* AgentPasswordPromptScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CACC29EED869B7D6CD41A0 /* AgentPasswordPromptScreen.swift */; };
 		83686209DD51EC3F558B532F /* SingleKeygenType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA5F6BCDC1260C8E4D57052 /* SingleKeygenType.swift */; };
+		84EA8FA0C63B4F2B11B39C45 /* THORChainStakeInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF72BB51C0FFBC1BB01AA17 /* THORChainStakeInteractorTests.swift */; };
+		8540AB851B242445AADAC815 /* CoinExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31181CF44EA87AC03D9B9497 /* CoinExtensionTests.swift */; };
 		8572B6910CB7E64BD6260D6C /* TransactionStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6548A1DE3664347EBFA4F1B5 /* TransactionStatusService.swift */; };
 		8B4BFACA727A321A94A8CCA0 /* TransactionHistoryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E33EE28C2420BB980A60F3D /* TransactionHistoryScreen.swift */; };
 		8C61F213A6F1A0F4A97024E5 /* AgentChatMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3FB37A5BFE7156A8C034D7B /* AgentChatMessageView.swift */; };
 		8D8CD1A7DF304D8074C03B4E /* SingleKeygenMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1706BAF79A7E992FFEBF71 /* SingleKeygenMessage.swift */; };
 		8F55CD3B2DC382E500B53E85 /* TokensStore+Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F55CD3A2DC382E400B53E85 /* TokensStore+Token.swift */; };
+		904E87A1D4933DEA5572D055 /* ChainDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FADD02CF36DA8DC9A9894F8 /* ChainDetailViewModelTests.swift */; };
 		9176AD98C5FADC4D5D92F04E /* TransactionHistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546B9FEB444B04006FF576BE /* TransactionHistoryItem.swift */; };
-		927BE27A46C4476AA7DA2901 /* Services/SuiTokenPriceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927BE27A46C4476AA7DA2902 /* Services/SuiTokenPriceTests.swift */; };
+		927BE27A46C4476AA7DA2901 /* SuiTokenPriceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927BE27A46C4476AA7DA2902 /* SuiTokenPriceTests.swift */; };
 		9358531DB65C84AF807A7CEB /* TransactionHistoryTypePill.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1119DA71589F5CCF4138189 /* TransactionHistoryTypePill.swift */; };
 		9802909F69AF78B4BCE010CE /* CircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35953B42171F515630BA7E9B /* CircleView.swift */; };
 		9976DC2B005ADF44E38FE464 /* CircleApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29B3EE2059C84ADD4F8C4F16 /* CircleApiService.swift */; };
@@ -1792,12 +1795,14 @@
 		1CF1829BAF85766FCAA71794 /* ZipImportDuplicateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ZipImportDuplicateTests.swift; sourceTree = "<group>"; };
 		1DC3C4A790D620AB105DF39D /* EVMTransactionStatusProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EVMTransactionStatusProvider.swift; sourceTree = "<group>"; };
 		1E33EE28C2420BB980A60F3D /* TransactionHistoryScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionHistoryScreen.swift; sourceTree = "<group>"; };
+		1FF72BB51C0FFBC1BB01AA17 /* THORChainStakeInteractorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = THORChainStakeInteractorTests.swift; sourceTree = "<group>"; };
 		2082307F2DAAB6FA5911FFDC /* CircleSetupView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CircleSetupView.swift; sourceTree = "<group>"; };
 		25397BD8D2AFBC8FB7C3DDBB /* CircleDashboardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CircleDashboardView.swift; sourceTree = "<group>"; };
 		27C4FDA6EBC0D15510EDB236 /* ScannerMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScannerMode.swift; sourceTree = "<group>"; };
 		2803BC564BA64B97AB6C428D /* ChainDetailActionButtons+macOS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ChainDetailActionButtons+macOS.swift"; sourceTree = "<group>"; };
 		2987AFF9D2BF542D8A798F9E /* VaultNotificationSetupSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultNotificationSetupSheet.swift; sourceTree = "<group>"; };
 		29B3EE2059C84ADD4F8C4F16 /* CircleApiService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CircleApiService.swift; sourceTree = "<group>"; };
+		31181CF44EA87AC03D9B9497 /* CoinExtensionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoinExtensionTests.swift; sourceTree = "<group>"; };
 		35953B42171F515630BA7E9B /* CircleView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CircleView.swift; sourceTree = "<group>"; };
 		35B621377F63B9A5B4DEE2D1 /* AgentAuthService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentAuthService.swift; sourceTree = "<group>"; };
 		3649DFEAF4C207AD2307E8B7 /* TransactionHistoryRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionHistoryRouter.swift; sourceTree = "<group>"; };
@@ -1834,7 +1839,6 @@
 		46B60BBF2BBB20130043EBBA /* RpcEvmService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RpcEvmService.swift; sourceTree = "<group>"; };
 		46C8CBBC2BA7753900E68E08 /* Blockchair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Blockchair.swift; sourceTree = "<group>"; };
 		46C8CBBE2BA777BF00E68E08 /* BlockchairService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockchairService.swift; sourceTree = "<group>"; };
-		884FB78FE9A167DB8E5779D8 /* DashService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashService.swift; sourceTree = "<group>"; };
 		46DE088F2BD0D03E00AE8BDE /* CosmosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CosmosService.swift; sourceTree = "<group>"; };
 		46DE08942BD0DCA200AE8BDE /* EvmService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EvmService.swift; sourceTree = "<group>"; };
 		46E98FFB2BAE407300C53D97 /* DecodingErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingErrorExtension.swift; sourceTree = "<group>"; };
@@ -1872,15 +1876,17 @@
 		7C77BD6311232B1382C49417 /* TransactionHistoryAssetFilterView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionHistoryAssetFilterView.swift; sourceTree = "<group>"; };
 		7CD3665CC777D1BD45B08AC8 /* CosmosTransactionStatusAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CosmosTransactionStatusAPI.swift; sourceTree = "<group>"; };
 		7E4C8B2D53A1F06E8D2B49FA /* TronResourcesLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TronResourcesLoader.swift; sourceTree = "<group>"; };
+		7FADD02CF36DA8DC9A9894F8 /* ChainDetailViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChainDetailViewModelTests.swift; sourceTree = "<group>"; };
 		80CACC29EED869B7D6CD41A0 /* AgentPasswordPromptScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentPasswordPromptScreen.swift; sourceTree = "<group>"; };
 		834B4865644FA4A2EACF956E /* TransactionHistoryData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TransactionHistoryData.swift; sourceTree = "<group>"; };
 		84EDDEF72A877329900F12D6 /* CreateMldsaRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMldsaRequest.swift; sourceTree = "<group>"; };
 		85ED8A4004502BBCBEAF924E /* CircleDepositViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleDepositViewModel.swift; sourceTree = "<group>"; };
+		884FB78FE9A167DB8E5779D8 /* DashService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashService.swift; sourceTree = "<group>"; };
 		8922E2B9288FCFE9626B80C1 /* AgentChatViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentChatViewModel.swift; sourceTree = "<group>"; };
 		8BE8825D6F0DBD6E8F28CB49 /* DefiCircleRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefiCircleRow.swift; sourceTree = "<group>"; };
 		8E6A38BCCA67E47B84787AA0 /* ForegroundNotificationParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForegroundNotificationParser.swift; sourceTree = "<group>"; };
 		8F55CD3A2DC382E400B53E85 /* TokensStore+Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TokensStore+Token.swift"; sourceTree = "<group>"; };
-		927BE27A46C4476AA7DA2902 /* Services/SuiTokenPriceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/SuiTokenPriceTests.swift; sourceTree = "<group>"; };
+		927BE27A46C4476AA7DA2902 /* SuiTokenPriceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Services/SuiTokenPriceTests.swift; sourceTree = "<group>"; };
 		9329F94E8B6ADC49CF18B0B5 /* HomePage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HomePage.swift; sourceTree = "<group>"; };
 		93EF791E371FD688E09C0829 /* NotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		95F9E808DB3DFACA1E3B84E4 /* ReferralCodeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralCodeSheet.swift; sourceTree = "<group>"; };
@@ -2472,7 +2478,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		DE2EDA742E324604004713ED /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		DE2EDA742E324604004713ED /* Exceptions for "TestData" folder in "VultisigAppTests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				arb.json,
@@ -2503,7 +2509,18 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		DE2EDA722E3245A4004713ED /* TestData */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (DE2EDA742E324604004713ED /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TestData; sourceTree = "<group>"; };
+		DE2EDA722E3245A4004713ED /* TestData */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				DE2EDA742E324604004713ED /* Exceptions for "TestData" folder in "VultisigAppTests" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = TestData;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -5703,6 +5720,16 @@
 			path = SheetPresentedCounterManager;
 			sourceTree = "<group>";
 		};
+		A5C08F3A166C055B203B1ADF /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				1FF72BB51C0FFBC1BB01AA17 /* THORChainStakeInteractorTests.swift */,
+				7FADD02CF36DA8DC9A9894F8 /* ChainDetailViewModelTests.swift */,
+			);
+			name = Services;
+			path = Services;
+			sourceTree = "<group>";
+		};
 		A62758F32B97CE7E00ADE3A6 /* Styles */ = {
 			isa = PBXGroup;
 			children = (
@@ -5986,6 +6013,7 @@
 			isa = PBXGroup;
 			children = (
 				B5293CDA2DBC00B800C6C66A /* StringExtensionTests.swift */,
+				31181CF44EA87AC03D9B9497 /* CoinExtensionTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -6457,8 +6485,9 @@
 				DE8AD7482BC7A84100339775 /* Utils */,
 				DEF2E2CE2B9DA41A000737B8 /* Chains */,
 				DE49A17A2B65F6DB000F3AFB /* VultisigAppTests.swift */,
-				927BE27A46C4476AA7DA2902 /* Services/SuiTokenPriceTests.swift */,
+				927BE27A46C4476AA7DA2902 /* SuiTokenPriceTests.swift */,
 				FDC8064E13E4758250781597 /* Snapshots */,
+				A5C08F3A166C055B203B1ADF /* Services */,
 			);
 			path = VultisigAppTests;
 			sourceTree = "<group>";
@@ -6921,7 +6950,7 @@
 			);
 			mainGroup = DE49A15A2B65F6D9000F3AFB;
 			packageReferences = (
-				D9A22EB52B667C41007281BF /* XCLocalSwiftPackageReference "../Mediator" */,
+				D9A22EB52B667C41007281BF /* XCLocalSwiftPackageReference "Mediator" */,
 				DE49A1B32B6A1088000F3AFB /* XCRemoteSwiftPackageReference "CodeScanner" */,
 				DEEDAEE62B8B50A4005170E8 /* XCRemoteSwiftPackageReference "BigInt" */,
 				DEFF59022BD23A12005DFDF9 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
@@ -8169,10 +8198,13 @@
 				DEF4295B2CA66D57004B6D0B /* ERC20Test.swift in Sources */,
 				DE49A17B2B65F6DB000F3AFB /* VultisigAppTests.swift in Sources */,
 				DE214FF62E308EEE00CEEA71 /* ChainHelperTests.swift in Sources */,
-				927BE27A46C4476AA7DA2901 /* Services/SuiTokenPriceTests.swift in Sources */,
+				927BE27A46C4476AA7DA2901 /* SuiTokenPriceTests.swift in Sources */,
 				D2FE6763BED8CC3044A39FBA /* ZipImportDuplicateTests.swift in Sources */,
 				CFF1B0DCBE47EAF6A1C28914 /* CreateVaultSnapshotTests.swift in Sources */,
 				AA15C50444DA9182DE80C9ED /* SnapshotDeviceConfigs.swift in Sources */,
+				8540AB851B242445AADAC815 /* CoinExtensionTests.swift in Sources */,
+				84EA8FA0C63B4F2B11B39C45 /* THORChainStakeInteractorTests.swift in Sources */,
+				904E87A1D4933DEA5572D055 /* ChainDetailViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8198,7 +8230,7 @@
 /* Begin PBXTargetDependency section */
 		B227A2B22F203CF800A32DBE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = B227A2B12F203CF800A32DBE /* SwiftLintBuildToolPlugin */;
+			productRef = B227A2B12F203CF800A32DBE /* plugin:SwiftLintBuildToolPlugin */;
 		};
 		DE49A1782B65F6DB000F3AFB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -8622,7 +8654,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		D9A22EB52B667C41007281BF /* XCLocalSwiftPackageReference "../Mediator" */ = {
+		D9A22EB52B667C41007281BF /* XCLocalSwiftPackageReference "Mediator" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../Mediator;
 		};
@@ -8719,7 +8751,7 @@
 			package = A6D44A592D51950600C66726 /* XCRemoteSwiftPackageReference "rive-ios" */;
 			productName = RiveRuntime;
 		};
-		B227A2B12F203CF800A32DBE /* SwiftLintBuildToolPlugin */ = {
+		B227A2B12F203CF800A32DBE /* plugin:SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B227A2B02F203C8000A32DBE /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";

--- a/VultisigApp/VultisigApp/Core/Extensions/CoinExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/CoinExtension.swift
@@ -14,12 +14,17 @@ extension Coin {
         return chain.coinType
     }
 
+    static let defiOnlyTickers: Set<String> = ["STCY"]
+
+    var isDefiOnly: Bool {
+        Coin.defiOnlyTickers.contains(ticker.uppercased())
+    }
 }
 
 extension Array where Element: Coin {
 
     var totalBalanceInFiatDecimal: Decimal {
-        return reduce(Decimal(0), { $0 + $1.balanceInFiatDecimal })
+        return reduce(Decimal(0)) { $0 + ($1.isDefiOnly ? 0 : $1.balanceInFiatDecimal) }
     }
 
     var totalBalanceInFiatString: String {

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "assets" = "Vermögenswerte";
 "atLeastOneDevice" = "Mindestens ein Gerät";
 "atLeastOneDeviceSubtitle" = "Jedes Gerät, auf dem Vultisig ausgeführt werden kann, funktioniert.";
+"autocompounderInfo" = "Auto-Compounder-Info";
+"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Verfügbar";
 "availableLPUnits" = "Verfügbare LP-Einheiten";
 "availableNodes" = "Verfügbare Knoten";
@@ -285,7 +287,6 @@
 "emptyLPsField" = "Leeres LPs-Feld";
 "enable" = "Aktivieren";
 "enableAll" = "Alle aktivieren";
-"enableAutoCompounding" = "Auto-Compounding aktivieren";
 "enableBiometricsFastSigning" = "Aktivieren Sie die Biometrie schnelles Signieren";
 "enableDKLS" = "DKLS aktivieren";
 "enableNotificationsForVault" = "Benachrichtigungen für diesen Tresor aktivieren";
@@ -901,6 +902,7 @@
 "transactionID" = "Transaktions-ID";
 "transactionSuccessful" = "Transaktion erfolgreich";
 "transactionTrackingLink" = "Transaktionsverfolgungslink";
+"transfer" = "Übertragen";
 "tronBandwidth" = "Bandbreite";
 "tronBandwidthDescription" = "Bandbreitenpunkte werden für jede Transaktion auf TRON benötigt, einschließlich Standard-Token-Sendungen und Smart-Contract-Interaktionen. Jeder TRON-Benutzer erhält täglich 600 kostenlose Bandbreitenpunkte, die ungefähr zwei grundlegende Sendungen abdecken können. Darüber hinaus können Sie durch das Staking von TRX zusätzliche Bandbreitenpunkte verdienen und so Ihr tägliches Kontingent erhöhen, um mehr Transaktionen zu unterstützen. Wenn Sie genügend Bandbreitenpunkte haben, können Sie Token senden, TRX staken oder mit Smart Contracts interagieren, ohne TRX als Gasgebühren zu zahlen.";
 "tronEnergy" = "Energie";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -88,7 +88,6 @@
 "atLeastOneDevice" = "Mindestens ein Gerät";
 "atLeastOneDeviceSubtitle" = "Jedes Gerät, auf dem Vultisig ausgeführt werden kann, funktioniert.";
 "autocompounderInfo" = "Auto-Compounder-Info";
-"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Verfügbar";
 "availableLPUnits" = "Verfügbare LP-Einheiten";
 "availableNodes" = "Verfügbare Knoten";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -96,7 +96,6 @@
 "atLeastOneDevice" = "At least one device";
 "atLeastOneDeviceSubtitle" = "Any device that can run Vultisig will work.";
 "autocompounderInfo" = "Auto-Compounder Info";
-"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Available";
 "availableLPUnits" = "Available LP Units";
 "availableNodes" = "Available Nodes";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -95,6 +95,8 @@
 "asymmetricDepositInfo" = "You can deposit just CACAO or just the asset. Maya will automatically balance your position.";
 "atLeastOneDevice" = "At least one device";
 "atLeastOneDeviceSubtitle" = "Any device that can run Vultisig will work.";
+"autocompounderInfo" = "Auto-Compounder Info";
+"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Available";
 "availableLPUnits" = "Available LP Units";
 "availableNodes" = "Available Nodes";
@@ -291,7 +293,6 @@
 "emptyLPsField" = "Empty LPs field";
 "enable" = "Enable";
 "enableAll" = "Enable all";
-"enableAutoCompounding" = "Enable Auto-Compound";
 "enableBiometricsFastSigning" = "Enable Biometrics Fast Signing";
 "enableDKLS" = "Enable DKLS";
 "enableNotificationsForVault" = "Enable notifications for this vault";
@@ -915,6 +916,7 @@
 "transactionSuccessful" = "Transaction successful";
 "transactionSuccessfulHighlight" = "successful";
 "transactionTrackingLink" = "Transaction tracking link";
+"transfer" = "Transfer";
 "tronBandwidth" = "Bandwidth";
 "tronBandwidthDescription" = "Bandwidth Points are required for every transaction on TRON, including both standard token sends and smart contract interactions. Every TRON user receives 600 free Bandwidth Points per day, which can cover approximately two basic sends. Additionally, you can earn extra Bandwidth Points by staking TRX, increasing your daily balance to support more transactions. If you have enough Bandwidth Points, you can send tokens, stake TRX, or interact with smart contracts without paying TRX in gas fees.";
 "tronEnergy" = "Energy";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -88,7 +88,6 @@
 "atLeastOneDevice" = "Al menos un dispositivo";
 "atLeastOneDeviceSubtitle" = "Cualquier dispositivo que pueda ejecutar Vultisig funcionará.";
 "autocompounderInfo" = "Información del Auto-Compounder";
-"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Disponible";
 "availableLPUnits" = "Unidades LP Disponibles";
 "availableNodes" = "Nodos Disponibles";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "assets" = "Activos";
 "atLeastOneDevice" = "Al menos un dispositivo";
 "atLeastOneDeviceSubtitle" = "Cualquier dispositivo que pueda ejecutar Vultisig funcionará.";
+"autocompounderInfo" = "Información del Auto-Compounder";
+"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Disponible";
 "availableLPUnits" = "Unidades LP Disponibles";
 "availableNodes" = "Nodos Disponibles";
@@ -285,7 +287,6 @@
 "emptyLPsField" = "Campo de LPs vacío";
 "enable" = "Permitir";
 "enableAll" = "Activar todas";
-"enableAutoCompounding" = "Habilitar Auto-Compounding";
 "enableBiometricsFastSigning" = "Habilitar la firma rápida de biometría";
 "enableDKLS" = "Habilitar DKLS";
 "enableNotificationsForVault" = "Activar notificaciones para esta bóveda";
@@ -901,6 +902,7 @@
 "transactionID" = "ID de Transacción";
 "transactionSuccessful" = "Transacción exitosa";
 "transactionTrackingLink" = "Enlace de seguimiento de transacción";
+"transfer" = "Transferir";
 "tronBandwidth" = "Ancho de Banda";
 "tronBandwidthDescription" = "Los Puntos de Ancho de Banda son necesarios para cada transacción en TRON, incluyendo envíos estándar de tokens e interacciones con contratos inteligentes. Cada usuario de TRON recibe 600 Puntos de Ancho de Banda gratuitos por día, que pueden cubrir aproximadamente dos envíos básicos. Además, puedes ganar Puntos de Ancho de Banda adicionales haciendo staking de TRX, aumentando tu cuota diaria para soportar más transacciones. Si tienes suficientes Puntos de Ancho de Banda, puedes enviar tokens, hacer staking de TRX o interactuar con contratos inteligentes sin pagar TRX en tarifas de gas.";
 "tronEnergy" = "Energía";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "assets" = "Imovine";
 "atLeastOneDevice" = "Barem jedan uređaj";
 "atLeastOneDeviceSubtitle" = "Bilo koji uređaj koji može pokrenuti Vultisig će raditi.";
+"autocompounderInfo" = "Auto-Compounder informacije";
+"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Dostupno";
 "availableLPUnits" = "Dostupne LP Jedinice";
 "availableNodes" = "Dostupni Čvorovi";
@@ -285,7 +287,6 @@
 "emptyLPsField" = "Prazno polje LPs";
 "enable" = "Omogućiti";
 "enableAll" = "Omogući sve";
-"enableAutoCompounding" = "Omogući Auto-Compounding";
 "enableBiometricsFastSigning" = "Omogući biometriju brzo potpisivanje";
 "enableDKLS" = "Omogući DKLS";
 "enableNotificationsForVault" = "Omogući obavijesti za ovaj trezor";
@@ -901,6 +902,7 @@
 "transactionID" = "ID transakcije";
 "transactionSuccessful" = "Transakcija uspješna";
 "transactionTrackingLink" = "Poveznica za praćenje transakcije";
+"transfer" = "Prijenos";
 "tronBandwidth" = "Propusnost";
 "tronBandwidthDescription" = "Bodovi propusnosti potrebni su za svaku transakciju na TRON-u, uključujući standardna slanja tokena i interakcije s pametnim ugovorima. Svaki TRON korisnik dnevno dobiva 600 besplatnih bodova propusnosti, koji mogu pokriti otprilike dva osnovna slanja. Dodatno, možete zaraditi dodatne bodove propusnosti stakingom TRX-a, povećavajući svoju dnevnu kvotu za podršku većem broju transakcija. Ako imate dovoljno bodova propusnosti, možete slati tokene, stakati TRX ili komunicirati s pametnim ugovorima bez plaćanja TRX-a za gas naknade.";
 "tronEnergy" = "Energija";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -88,7 +88,6 @@
 "atLeastOneDevice" = "Barem jedan uređaj";
 "atLeastOneDeviceSubtitle" = "Bilo koji uređaj koji može pokrenuti Vultisig će raditi.";
 "autocompounderInfo" = "Auto-Compounder informacije";
-"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Dostupno";
 "availableLPUnits" = "Dostupne LP Jedinice";
 "availableNodes" = "Dostupni Čvorovi";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "assets" = "Asset";
 "atLeastOneDevice" = "Almeno un dispositivo";
 "atLeastOneDeviceSubtitle" = "Qualsiasi dispositivo in grado di eseguire Vultisig funzionerà.";
+"autocompounderInfo" = "Informazioni Auto-Compounder";
+"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Disponibile";
 "availableLPUnits" = "Unità LP Disponibili";
 "availableNodes" = "Nodi Disponibili";
@@ -285,7 +287,6 @@
 "emptyLPsField" = "Campo LPs vuoto";
 "enable" = "Abilitare";
 "enableAll" = "Attiva tutte";
-"enableAutoCompounding" = "Abilita Auto-Compounding";
 "enableBiometricsFastSigning" = "Abilita Biometrics Firma rapida";
 "enableDKLS" = "Abilita DKLS";
 "enableNotificationsForVault" = "Attiva notifiche per questo vault";
@@ -901,6 +902,7 @@
 "transactionID" = "ID Transazione";
 "transactionSuccessful" = "Transazione riuscita";
 "transactionTrackingLink" = "Link di tracciamento transazione";
+"transfer" = "Trasferisci";
 "tronBandwidth" = "Larghezza di Banda";
 "tronBandwidthDescription" = "I Punti di Larghezza di Banda sono necessari per ogni transazione su TRON, inclusi invii standard di token e interazioni con smart contract. Ogni utente TRON riceve 600 Punti di Larghezza di Banda gratuiti al giorno, che possono coprire circa due invii base. Inoltre, puoi guadagnare Punti di Larghezza di Banda aggiuntivi facendo staking di TRX, aumentando la tua quota giornaliera per supportare più transazioni. Se hai abbastanza Punti di Larghezza di Banda, puoi inviare token, fare staking di TRX o interagire con smart contract senza pagare TRX in commissioni gas.";
 "tronEnergy" = "Energia";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -88,7 +88,6 @@
 "atLeastOneDevice" = "Almeno un dispositivo";
 "atLeastOneDeviceSubtitle" = "Qualsiasi dispositivo in grado di eseguire Vultisig funzionerà.";
 "autocompounderInfo" = "Informazioni Auto-Compounder";
-"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Disponibile";
 "availableLPUnits" = "Unità LP Disponibili";
 "availableNodes" = "Nodi Disponibili";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -96,7 +96,6 @@
 "atLeastOneDevice" = "기기 최소 1개";
 "atLeastOneDeviceSubtitle" = "Vultisig를 실행할 수 있는 기기라면 모두 가능합니다.";
 "autocompounderInfo" = "자동 복리 정보";
-"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "사용 가능";
 "availableLPUnits" = "사용 가능한 LP 단위";
 "availableNodes" = "사용 가능한 노드";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -95,6 +95,8 @@
 "asymmetricDepositInfo" = "CACAO 또는 자산만 입금할 수 있습니다. Maya가 자동으로 포지션을 조정합니다.";
 "atLeastOneDevice" = "기기 최소 1개";
 "atLeastOneDeviceSubtitle" = "Vultisig를 실행할 수 있는 기기라면 모두 가능합니다.";
+"autocompounderInfo" = "자동 복리 정보";
+"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "사용 가능";
 "availableLPUnits" = "사용 가능한 LP 단위";
 "availableNodes" = "사용 가능한 노드";
@@ -291,7 +293,6 @@
 "emptyLPsField" = "LP 필드가 비어 있습니다";
 "enable" = "활성화";
 "enableAll" = "모두 활성화";
-"enableAutoCompounding" = "자동 복리 활성화";
 "enableBiometricsFastSigning" = "생체인식 빠른 서명 활성화";
 "enableDKLS" = "DKLS 활성화";
 "enableNotificationsForVault" = "이 볼트에 대한 알림 활성화";
@@ -915,6 +916,7 @@
 "transactionSuccessful" = "트랜잭션 성공";
 "transactionSuccessfulHighlight" = "성공";
 "transactionTrackingLink" = "트랜잭션 추적 링크";
+"transfer" = "전송";
 "tronBandwidth" = "대역폭";
 "tronBandwidthDescription" = "대역폭 포인트는 표준 토큰 전송 및 스마트 계약 상호작용을 포함한 TRON의 모든 트랜잭션에 필요합니다. 모든 TRON 사용자는 하루 600개의 무료 대역폭 포인트를 받습니다. 또한 TRX를 스테이킹하여 추가 대역폭 포인트를 얻어 더 많은 트랜잭션을 지원할 수 있습니다.";
 "tronEnergy" = "에너지";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "assets" = "Ativos";
 "atLeastOneDevice" = "Pelo menos um dispositivo";
 "atLeastOneDeviceSubtitle" = "Qualquer dispositivo que possa executar o Vultisig funcionará.";
+"autocompounderInfo" = "Informações do Auto-Compounder";
+"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Disponível";
 "availableLPUnits" = "Unidades LP Disponíveis";
 "availableNodes" = "Nós Disponíveis";
@@ -285,7 +287,6 @@
 "emptyLPsField" = "Campo de LPs vazio";
 "enable" = "Habilitar";
 "enableAll" = "Ativar todas";
-"enableAutoCompounding" = "Habilitar Auto-Compounding";
 "enableBiometricsFastSigning" = "Ativar biometria assinatura rápida";
 "enableDKLS" = "Ativar DKLS";
 "enableNotificationsForVault" = "Ativar notificações para este cofre";
@@ -901,6 +902,7 @@
 "transactionID" = "ID de Transação";
 "transactionSuccessful" = "Transação bem-sucedida";
 "transactionTrackingLink" = "Link de rastreamento de transação";
+"transfer" = "Transferir";
 "tronBandwidth" = "Largura de Banda";
 "tronBandwidthDescription" = "Pontos de Largura de Banda são necessários para cada transação na TRON, incluindo envios padrão de tokens e interações com contratos inteligentes. Cada usuário TRON recebe 600 Pontos de Largura de Banda gratuitos por dia, que podem cobrir aproximadamente dois envios básicos. Além disso, você pode ganhar Pontos de Largura de Banda extras fazendo staking de TRX, aumentando seu saldo diário para suportar mais transações. Se você tiver Pontos de Largura de Banda suficientes, pode enviar tokens, fazer staking de TRX ou interagir com contratos inteligentes sem pagar TRX em taxas de gas.";
 "tronEnergy" = "Energia";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -88,7 +88,6 @@
 "atLeastOneDevice" = "Pelo menos um dispositivo";
 "atLeastOneDeviceSubtitle" = "Qualquer dispositivo que possa executar o Vultisig funcionará.";
 "autocompounderInfo" = "Informações do Auto-Compounder";
-"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "Disponível";
 "availableLPUnits" = "Unidades LP Disponíveis";
 "availableNodes" = "Nós Disponíveis";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -88,7 +88,6 @@
 "atLeastOneDevice" = "至少一台 Vultisig 设备";
 "atLeastOneDeviceSubtitle" = "任何可以运行 Vultisig 的设备都可以使用。";
 "autocompounderInfo" = "自动复利信息";
-"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "可用";
 "availableLPUnits" = "可用 LP 单位";
 "availableNodes" = "可用节点";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "assets" = "资产";
 "atLeastOneDevice" = "至少一台 Vultisig 设备";
 "atLeastOneDeviceSubtitle" = "任何可以运行 Vultisig 的设备都可以使用。";
+"autocompounderInfo" = "自动复利信息";
+"autocompounderInfoURL" = "https://docs.rujira.network/ecosystem-products/tcy-autocompounder";
 "available" = "可用";
 "availableLPUnits" = "可用 LP 单位";
 "availableNodes" = "可用节点";
@@ -285,7 +287,6 @@
 "emptyLPsField" = "LPs 字段为空";
 "enable" = "启用";
 "enableAll" = "全部启用";
-"enableAutoCompounding" = "启用自动复利";
 "enableBiometricsFastSigning" = "启用生物识别快速签名";
 "enableDKLS" = "启用 DKLS";
 "enableNotificationsForVault" = "为此保险库启用通知";
@@ -901,6 +902,7 @@
 "transactionID" = "交易 ID";
 "transactionSuccessful" = "交易成功";
 "transactionTrackingLink" = "交易跟踪链接";
+"transfer" = "转账";
 "tronBandwidth" = "带宽";
 "tronBandwidthDescription" = "带宽点数是 TRON 上每笔交易所必需的，包括标准代币发送和智能合约交互。每个 TRON 用户每天获得 600 个免费带宽点数，大约可以覆盖两次基本发送。此外，您可以通过质押 TRX 获得额外的带宽点数，增加每日配额以支持更多交易。如果您有足够的带宽点数，您可以发送代币、质押 TRX 或与智能合约交互，而无需支付 TRX 作为 Gas 费用。";
 "tronEnergy" = "能量";

--- a/VultisigApp/VultisigApp/Core/Utils/URL.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/URL.swift
@@ -24,4 +24,8 @@ class StaticURL {
         }
         return url
     }()
+
+    enum Defi {
+        static let tcyAutoCompounderInfo = URL(string: "https://docs.rujira.network/ecosystem-products/tcy-autocompounder")!
+    }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
@@ -28,6 +28,7 @@ struct DefiPositionsService {
         case .thorChain:
             [
                 TokensStore.tcy,
+                TokensStore.stcy,
                 TokensStore.ruji,
                 TokensStore.yrune,
                 TokensStore.ytcy

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -16,6 +16,7 @@ struct DefiChainMainScreen: View {
     @StateObject var bondViewModel: DefiChainBondViewModel
     @StateObject var lpsViewModel: DefiChainLPsViewModel
     @StateObject var stakeViewModel: DefiChainStakeViewModel
+    @StateObject var sendTx = SendTransaction()
     @State private var showPositionSelection = false
     @State private var isLoading = false
     @State private var error: HelperError?
@@ -109,6 +110,7 @@ struct DefiChainMainScreen: View {
                             rewardsCoin: rewardsCoin
                         ))
                     },
+                    onTransfer: { onTransfer(position: $0) },
                     emptyStateView: { emptyStateView }
                 )
             case .liquidityPool:
@@ -141,8 +143,10 @@ struct DefiChainMainScreen: View {
 
     func onStake(position: StakePosition) {
         switch position.type {
-        case .stake, .compound:
-            onTransactionToPresent(.stake(coin: position.coin, defaultAutocompound: false))
+        case .stake:
+            onTransactionToPresent(.stake(coin: position.coin, isAutocompound: false))
+        case .compound:
+            onTransactionToPresent(.stake(coin: stakeCoin(for: position.coin), isAutocompound: true))
         case .index:
             onTransactionToPresent(.mint(coin: coin(for: position.coin), yCoin: position.coin))
         }
@@ -150,16 +154,45 @@ struct DefiChainMainScreen: View {
 
     func onUnstake(position: StakePosition) {
         switch position.type {
-        case .stake, .compound:
+        case .stake:
             onTransactionToPresent(
                 .unstake(
                     coin: position.coin,
-                    defaultAutocompound: false,
+                    isAutocompound: false,
                     availableToUnstake: position.availableToUnstake
+                )
+            )
+        case .compound:
+            onTransactionToPresent(
+                .unstake(
+                    coin: stakeCoin(for: position.coin),
+                    isAutocompound: true,
+                    availableToUnstake: position.amount
                 )
             )
         case .index:
             onTransactionToPresent(.redeem(coin: coin(for: position.coin), yCoin: position.coin))
+        }
+    }
+
+    func onTransfer(position: StakePosition) {
+        guard let coin = vault.coins.first(where: { $0.toCoinMeta() == position.coin }) else {
+            return
+        }
+        sendTx.reset(coin: coin)
+        router.navigate(to: HomeRoute.vaultAction(
+            action: .send(coin: coin, hasPreselectedCoin: true),
+            sendTx: sendTx,
+            vault: vault
+        ))
+    }
+
+    func stakeCoin(for compoundCoin: CoinMeta) -> CoinMeta {
+        switch compoundCoin.ticker.uppercased() {
+        case "STCY":
+            return TokensStore.tcy
+        default:
+            return compoundCoin
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
@@ -13,6 +13,10 @@ struct THORChainStakeInteractor: StakeInteractor {
     private let thorchainAPIService = THORChainAPIService()
     private let stakingService = THORChainStakingService.shared
 
+    static func scaledAmount(rawAmount: Decimal, decimals: Int) -> Decimal {
+        rawAmount / pow(10, decimals)
+    }
+
     func fetchStakePositions(vault: Vault) async -> [StakePosition] {
         guard let runeCoin = vault.runeCoin else { return [] }
         let vaultStakePositions = vault.defiPositions.first { $0.chain == .thorChain }?.staking ?? []
@@ -74,7 +78,7 @@ private extension THORChainStakeInteractor {
 
         case "STCY":
             let rawAmount = await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)
-            let amount = rawAmount / pow(10, coinMeta.decimals)
+            let amount = THORChainStakeInteractor.scaledAmount(rawAmount: rawAmount, decimals: coinMeta.decimals)
             return StakePosition(
                 coin: coinMeta,
                 type: .compound,

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
@@ -5,6 +5,10 @@
 //  Created by Gaston Mazzeo on 21/11/2025.
 //
 
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-stake-interactor")
+
 struct THORChainStakeInteractor: StakeInteractor {
     private let thorchainAPIService = THORChainAPIService()
     private let stakingService = THORChainStakingService.shared
@@ -54,8 +58,7 @@ private extension THORChainStakeInteractor {
                     vault: vault
                 )
             } catch {
-                print("Error fetching \(ticker) staking details: \(error.localizedDescription)")
-                // Fallback to using local staked balance
+                logger.error("Error fetching \(ticker) staking details: \(error.localizedDescription)")
                 return StakePosition(
                     coin: coinMeta,
                     type: .stake,
@@ -68,6 +71,20 @@ private extension THORChainStakeInteractor {
                     vault: vault
                 )
             }
+
+        case "STCY":
+            let amount = await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)
+            return StakePosition(
+                coin: coinMeta,
+                type: .compound,
+                amount: amount,
+                apr: nil,
+                estimatedReward: nil,
+                nextPayout: nil,
+                rewards: nil,
+                rewardCoin: nil,
+                vault: vault
+            )
 
         case "YRUNE", "YTCY":
             return StakePosition(
@@ -102,7 +119,7 @@ private extension THORChainStakeInteractor {
         do {
             try DefiPositionsStorageService().upsert(positions)
         } catch {
-            print("An error occured while saving staked positions: \(error)")
+            logger.error("An error occured while saving staked positions: \(error.localizedDescription)")
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
@@ -73,7 +73,8 @@ private extension THORChainStakeInteractor {
             }
 
         case "STCY":
-            let amount = await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)
+            let rawAmount = await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)
+            let amount = rawAmount / pow(10, coinMeta.decimals)
             return StakePosition(
                 coin: coinMeta,
                 type: .compound,

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
@@ -111,8 +111,7 @@ struct DefiChainStakedPositionView: View {
     }
 
     func openAutocompounderInfo() {
-        guard let url = URL(string: "autocompounderInfoURL".localized) else { return }
-        openURL(url)
+        openURL(StaticURL.Defi.tcyAutoCompounderInfo)
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
@@ -195,6 +195,7 @@ struct DefiChainStakedPositionView: View {
             VStack(alignment: .leading, spacing: 16) {
                 PrimaryButton(title: withdrawTitle, action: onWithdraw)
                     .showIf(canWithdraw)
+                PrimaryButton(title: "transfer".localized, action: onTransfer)
                 compoundButtonsView
 
                 if let unstakeMessage = position.unstakeMessage {
@@ -210,9 +211,6 @@ struct DefiChainStakedPositionView: View {
 
     var compoundButtonsView: some View {
         HStack(alignment: .top, spacing: 16) {
-            DefiButton(title: "transfer".localized, icon: "send", type: .secondary) {
-                onTransfer()
-            }
             DefiButton(title: removeButonTitle, icon: "minus-circle", type: .secondary) {
                 onUnstake()
             }.disabled(unstakeDisabled)

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionView.swift
@@ -8,11 +8,14 @@
 import SwiftUI
 
 struct DefiChainStakedPositionView: View {
+    @Environment(\.openURL) private var openURL
+
     let position: StakePosition
     let fiatAmount: String
     var onStake: () -> Void
     var onUnstake: () -> Void
     var onWithdraw: () -> Void
+    var onTransfer: () -> Void
 
     var stakedAmount: String {
         AmountFormatter.formatCryptoAmount(value: position.amount, coin: position.coin)
@@ -49,6 +52,8 @@ struct DefiChainStakedPositionView: View {
     var hasEstimatedReward: Bool { position.estimatedReward != nil }
     var hasNextPayout: Bool { position.nextPayout != nil }
 
+    var isCompound: Bool { position.type == .compound }
+
     var body: some View {
         ContainerView {
             VStack(spacing: 16) {
@@ -75,9 +80,19 @@ struct DefiChainStakedPositionView: View {
             )
 
             VStack(alignment: .leading, spacing: .zero) {
-                Text(title)
-                    .font(Theme.fonts.bodySMedium)
-                    .foregroundStyle(Theme.colors.textTertiary)
+                HStack(spacing: 6) {
+                    Text(title)
+                        .font(Theme.fonts.bodySMedium)
+                        .foregroundStyle(Theme.colors.textTertiary)
+
+                    if isCompound {
+                        Button(action: openAutocompounderInfo) {
+                            Icon(named: "circle-info", color: Theme.colors.textTertiary, size: 14)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("autocompounderInfo".localized)
+                    }
+                }
 
                 HiddenBalanceText(stakedAmount)
                     .font(Theme.fonts.priceTitle1)
@@ -93,6 +108,11 @@ struct DefiChainStakedPositionView: View {
             }
             Spacer()
         }
+    }
+
+    func openAutocompounderInfo() {
+        guard let url = URL(string: "autocompounderInfoURL".localized) else { return }
+        openURL(url)
     }
 
     @ViewBuilder
@@ -160,7 +180,7 @@ struct DefiChainStakedPositionView: View {
     @ViewBuilder
     var stakeButtonsView: some View {
         switch position.type {
-        case .stake, .compound:
+        case .stake:
             VStack(alignment: .leading, spacing: 16) {
                 PrimaryButton(title: withdrawTitle, action: onWithdraw)
                     .showIf(canWithdraw)
@@ -172,8 +192,34 @@ struct DefiChainStakedPositionView: View {
                         .foregroundStyle(Theme.colors.textSecondary)
                 }
             }
+        case .compound:
+            VStack(alignment: .leading, spacing: 16) {
+                PrimaryButton(title: withdrawTitle, action: onWithdraw)
+                    .showIf(canWithdraw)
+                compoundButtonsView
+
+                if let unstakeMessage = position.unstakeMessage {
+                    Text(unstakeMessage)
+                        .font(Theme.fonts.caption10)
+                        .foregroundStyle(Theme.colors.textSecondary)
+                }
+            }
         case .index:
             indexButtonsView
+        }
+    }
+
+    var compoundButtonsView: some View {
+        HStack(alignment: .top, spacing: 16) {
+            DefiButton(title: "transfer".localized, icon: "send", type: .secondary) {
+                onTransfer()
+            }
+            DefiButton(title: removeButonTitle, icon: "minus-circle", type: .secondary) {
+                onUnstake()
+            }.disabled(unstakeDisabled)
+            DefiButton(title: addButonTitle, icon: "plus-circle") {
+                onStake()
+            }
         }
     }
 
@@ -244,7 +290,8 @@ struct DefiChainStakedPositionView: View {
             fiatAmount: "",
             onStake: {},
             onUnstake: {},
-            onWithdraw: {}
+            onWithdraw: {},
+            onTransfer: {}
         )
 
         DefiChainStakedPositionView(
@@ -262,7 +309,8 @@ struct DefiChainStakedPositionView: View {
             fiatAmount: "",
             onStake: {},
             onUnstake: {},
-            onWithdraw: {}
+            onWithdraw: {},
+            onTransfer: {}
         )
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
@@ -12,6 +12,7 @@ struct DefiChainStakedView<EmptyStateView: View>: View {
     var onStake: (StakePosition) -> Void
     var onUnstake: (StakePosition) -> Void
     var onWithdraw: (StakePosition) -> Void
+    var onTransfer: (StakePosition) -> Void
     var emptyStateView: () -> EmptyStateView
 
     var showLoading: Bool {
@@ -44,7 +45,8 @@ struct DefiChainStakedView<EmptyStateView: View>: View {
                         fiatAmount: fiatAmount,
                         onStake: { onStake(position) },
                         onUnstake: { onUnstake(position) },
-                        onWithdraw: { onWithdraw(position) }
+                        onWithdraw: { onWithdraw(position) },
+                        onTransfer: { onTransfer(position) }
                     )
                 }
             } else {
@@ -60,6 +62,7 @@ struct DefiChainStakedView<EmptyStateView: View>: View {
         onStake: { _ in },
         onUnstake: { _ in },
         onWithdraw: { _ in },
+        onTransfer: { _ in },
         emptyStateView: { EmptyView() }
     )
     .environmentObject(HomeViewModel())

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Model/FunctionTransactionType.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Model/FunctionTransactionType.swift
@@ -10,8 +10,8 @@ import Foundation
 enum FunctionTransactionType: Hashable {
     case bond(coin: CoinMeta, node: String?)
     case unbond(node: BondNode)
-    case stake(coin: CoinMeta, defaultAutocompound: Bool)
-    case unstake(coin: CoinMeta, defaultAutocompound: Bool, availableToUnstake: Decimal? = nil)
+    case stake(coin: CoinMeta, isAutocompound: Bool)
+    case unstake(coin: CoinMeta, isAutocompound: Bool, availableToUnstake: Decimal? = nil)
     case withdrawRewards(coin: CoinMeta, rewards: Decimal, rewardsCoin: CoinMeta)
     case mint(coin: CoinMeta, yCoin: CoinMeta)
     case redeem(coin: CoinMeta, yCoin: CoinMeta)

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -67,20 +67,20 @@ struct FunctionTransactionScreen: View {
                         )
                     }
                 }
-            case .stake(let coin, let defaultAutocompound):
+            case .stake(let coin, let isAutocompound):
                 resolvingCoin(coinMeta: coin) {
                     StakeTransactionScreen(
-                        viewModel: StakeTransactionViewModel(coin: $0, vault: vault, defaultAutocompound: defaultAutocompound),
+                        viewModel: StakeTransactionViewModel(coin: $0, vault: vault, isAutocompound: isAutocompound),
                         onVerify: onVerify
                     )
                 }
-            case .unstake(let coin, let defaultAutocompound, let availableToUnstake):
+            case .unstake(let coin, let isAutocompound, let availableToUnstake):
                 resolvingCoin(coinMeta: coin) {
                     UnstakeTransactionScreen(
                         viewModel: UnstakeTransactionViewModel(
                             coin: $0,
                             vault: vault,
-                            defaultAutocompound: defaultAutocompound,
+                            isAutocompound: isAutocompound,
                             availableToUnstake: availableToUnstake
                         ),
                         onVerify: onVerify

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Stake/StakeTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Stake/StakeTransactionScreen.swift
@@ -26,10 +26,7 @@ struct StakeTransactionScreen: View {
             guard let transactionBuilder = viewModel.transactionBuilder else { return }
             onVerify(transactionBuilder)
         } customView: {
-            VStack(spacing: 12) {
-                autocompoundToggle
-                gasReservationInfo
-            }
+            gasReservationInfo
         }
         .onLoad { viewModel.onLoad() }
         .onChange(of: percentageSelected) { _, newValue in
@@ -39,22 +36,15 @@ struct StakeTransactionScreen: View {
     }
 
     @ViewBuilder
-    var autocompoundToggle: some View {
-        if viewModel.supportsAutocompound {
-            AutocompoundToggle(isEnabled: $viewModel.isAutocompound)
-        }
-    }
-
-    @ViewBuilder
     var gasReservationInfo: some View {
         if let message = viewModel.gasReservationMessage {
             HStack(spacing: 8) {
                 Image(systemName: "info.circle")
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                     .font(Theme.fonts.caption12)
                 Text(message)
                     .font(Theme.fonts.caption12)
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                 Spacer()
             }
             .padding(12)
@@ -69,7 +59,7 @@ struct StakeTransactionScreen: View {
         viewModel: StakeTransactionViewModel(
             coin: .example,
             vault: .example,
-            defaultAutocompound: false
+            isAutocompound: false
         )
     ) { _ in }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Stake/StakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Stake/StakeTransactionViewModel.swift
@@ -11,13 +11,8 @@ import Combine
 final class StakeTransactionViewModel: ObservableObject, Form {
     let coin: Coin
     let vault: Vault
-    let defaultAutocompound: Bool
+    let isAutocompound: Bool
 
-    var supportsAutocompound: Bool {
-        coin.supportsAutocompound
-    }
-
-    @Published var isAutocompound: Bool = false
     @Published var validForm: Bool = false
     @Published private(set) var stakedAmount: Decimal = 0
     @Published var amountField = FormField(
@@ -55,16 +50,15 @@ final class StakeTransactionViewModel: ObservableObject, Form {
         return nil
     }
 
-    init(coin: Coin, vault: Vault, defaultAutocompound: Bool) {
+    init(coin: Coin, vault: Vault, isAutocompound: Bool) {
         self.coin = coin
         self.vault = vault
-        self.defaultAutocompound = defaultAutocompound
+        self.isAutocompound = isAutocompound
     }
 
     func onLoad() {
         setupForm()
         amountField.validators.append(AmountBalanceValidator(balance: coin.balanceDecimal))
-        isAutocompound = defaultAutocompound
     }
 
     var transactionBuilder: TransactionBuilder? {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionScreen.swift
@@ -24,32 +24,12 @@ struct UnstakeTransactionScreen: View {
             guard let transactionBuilder = viewModel.transactionBuilder else { return }
             onVerify(transactionBuilder)
         } customView: {
-            autocompoundToggle
+            EmptyView()
         }
         .onLoad { viewModel.onLoad() }
         .onChange(of: viewModel.percentageSelected) { _, newValue in
             guard let newValue else { return }
             viewModel.onPercentage(newValue)
-        }
-    }
-
-    @ViewBuilder
-    var autocompoundToggle: some View {
-        if viewModel.supportsAutocompound {
-            AutocompoundToggle(isEnabled: $viewModel.isAutocompound)
-        }
-    }
-}
-
-struct AutocompoundToggle: View {
-    @Binding var isEnabled: Bool
-    var body: some View {
-        HStack {
-            Text("enableAutoCompounding".localized)
-                .font(Theme.fonts.bodySMedium)
-                .foregroundStyle(Theme.colors.textPrimary)
-            Spacer()
-            VultiToggle(isOn: $isEnabled)
         }
     }
 }
@@ -59,7 +39,7 @@ struct AutocompoundToggle: View {
         viewModel: UnstakeTransactionViewModel(
             coin: .example,
             vault: .example,
-            defaultAutocompound: false
+            isAutocompound: false
         )
     ) { _ in }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -11,17 +11,12 @@ import Combine
 final class UnstakeTransactionViewModel: ObservableObject, Form {
     let coin: Coin
     let vault: Vault
-    let defaultAutocompound: Bool
+    let isAutocompound: Bool
     let availableToUnstake: Decimal?
-
-    var supportsAutocompound: Bool {
-        coin.supportsAutocompound
-    }
 
     @Published var percentageSelected: Double? = 100
     @Published var availableAmount: Decimal = 0
     var autocompoundBalance: Decimal = 0
-    @Published var isAutocompound: Bool = false
     @Published var validForm: Bool = false
     @Published var amountField = FormField(label: "amount".localized)
 
@@ -33,26 +28,25 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     var formCancellable: AnyCancellable?
     var cancellables = Set<AnyCancellable>()
 
-    init(coin: Coin, vault: Vault, defaultAutocompound: Bool, availableToUnstake: Decimal? = nil) {
+    init(coin: Coin, vault: Vault, isAutocompound: Bool, availableToUnstake: Decimal? = nil) {
         self.coin = coin
         self.vault = vault
-        self.defaultAutocompound = defaultAutocompound
+        self.isAutocompound = isAutocompound
         self.availableToUnstake = availableToUnstake
     }
 
     func onLoad() {
         setupForm()
-        // Use availableToUnstake if provided, otherwise fall back to stakedBalanceDecimal
         availableAmount = availableToUnstake ?? coin.stakedBalanceDecimal
         setupAmountField()
 
-        $isAutocompound
-            .receive(on: DispatchQueue.main)
-            .sink(weak: self) { viewModel, _ in
-                viewModel.updateAvailableBalance()
+        if isAutocompound {
+            Task { @MainActor in
+                await fetchAutocompoundBalance()
+                self.availableAmount = autocompoundBalance
+                self.setupAmountField()
             }
-            .store(in: &cancellables)
-        isAutocompound = defaultAutocompound
+        }
     }
 
     var transactionBuilder: TransactionBuilder? {
@@ -93,19 +87,6 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
 
     func onPercentage(_ percentage: Double) {
         isMaxAmount = percentage == 100
-    }
-
-    func updateAvailableBalance() {
-        Task { @MainActor in
-            if autocompoundBalance == .zero {
-                await fetchAutocompoundBalance()
-            }
-
-            // Use availableToUnstake if provided, otherwise fall back to stakedBalanceDecimal
-            let defaultBalance = availableToUnstake ?? coin.stakedBalanceDecimal
-            self.availableAmount = isAutocompound ? autocompoundBalance : defaultBalance
-            self.setupAmountField()
-        }
     }
 
     func setupAmountField() {

--- a/VultisigApp/VultisigApp/Features/Home/Service/VaultDefiChainsService.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Service/VaultDefiChainsService.swift
@@ -23,18 +23,6 @@ struct VaultDefiChainsService {
 
         let allDefiChains = (vault.chains + vault.defiChains).filter { CoinAction.defiChains.contains($0) }
         vault.defiChains = Array(Set(allDefiChains))
-        vault.defiPositions = vault.defiPositions.map {
-            if $0.chain == .thorChain {
-                return DefiPositions(
-                    chain: .thorChain,
-                    bonds: $0.bonds,
-                    staking: $0.staking.filter { $0.ticker.lowercased() != "stcy" },
-                    lps: $0.lps
-                )
-            } else {
-                return $0
-            }
-        }
         vault.stakePositions = []
         do {
             try await Storage.shared.save()

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
@@ -48,6 +48,7 @@ final class ChainDetailViewModel: ObservableObject {
 
     var tokens: [Coin] {
         return vault.coins.filter { $0.chain == nativeCoin.chain }
+            .filter { !Self.defiOnlyTickers.contains($0.ticker.uppercased()) }
             .uniqueBy { $0.uniqueId }
             .sorted {
                 if $0.isNativeToken != $1.isNativeToken {
@@ -56,6 +57,8 @@ final class ChainDetailViewModel: ObservableObject {
                 return ($0.balanceInFiatDecimal) > ($1.balanceInFiatDecimal)
             }
     }
+
+    private static let defiOnlyTickers: Set<String> = ["STCY"]
 
     var filteredTokens: [Coin] {
         if searchText.isEmpty {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
@@ -48,7 +48,7 @@ final class ChainDetailViewModel: ObservableObject {
 
     var tokens: [Coin] {
         return vault.coins.filter { $0.chain == nativeCoin.chain }
-            .filter { !Self.defiOnlyTickers.contains($0.ticker.uppercased()) }
+            .filter { !$0.isDefiOnly }
             .uniqueBy { $0.uniqueId }
             .sorted {
                 if $0.isNativeToken != $1.isNativeToken {
@@ -57,8 +57,6 @@ final class ChainDetailViewModel: ObservableObject {
                 return ($0.balanceInFiatDecimal) > ($1.balanceInFiatDecimal)
             }
     }
-
-    private static let defiOnlyTickers: Set<String> = ["STCY"]
 
     var filteredTokens: [Coin] {
         if searchText.isEmpty {

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -343,15 +343,6 @@ class Coin: ObservableObject, Codable, Hashable {
     func toCoinMeta() -> CoinMeta {
         return CoinMeta(chain: chain, ticker: ticker, logo: logo, decimals: decimals, priceProviderId: priceProviderId, contractAddress: contractAddress, isNativeToken: isNativeToken)
     }
-
-    var supportsAutocompound: Bool {
-        switch ticker.uppercased() {
-        case "TCY":
-            return true
-        default:
-            return false
-        }
-    }
 }
 
 extension Coin: Comparable {

--- a/VultisigApp/VultisigAppTests/Extensions/CoinExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/CoinExtensionTests.swift
@@ -1,0 +1,86 @@
+//
+//  CoinExtensionTests.swift
+//  VultisigAppTests
+//
+//  Created by Gaston Mazzeo on 20/04/2026.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class CoinExtensionTests: XCTestCase {
+
+    func test_isDefiOnly_trueForSTCY() {
+        let coin = makeCoin(ticker: "STCY", chain: .thorChain, isNative: false)
+        XCTAssertTrue(coin.isDefiOnly)
+    }
+
+    func test_isDefiOnly_caseInsensitive() {
+        for ticker in ["stcy", "Stcy", "StCy", "STCY"] {
+            let coin = makeCoin(ticker: ticker, chain: .thorChain, isNative: false)
+            XCTAssertTrue(coin.isDefiOnly, "Expected \(ticker) to be DeFi-only")
+        }
+    }
+
+    func test_isDefiOnly_falseForCommonTickers() {
+        for ticker in ["BTC", "ETH", "RUNE", "TCY", "YRUNE", "YTCY", "USDC"] {
+            let coin = makeCoin(ticker: ticker, chain: .thorChain, isNative: false)
+            XCTAssertFalse(coin.isDefiOnly, "Expected \(ticker) not to be DeFi-only")
+        }
+    }
+
+    func test_defiOnlyTickers_containsSTCY() {
+        XCTAssertTrue(Coin.defiOnlyTickers.contains("STCY"))
+    }
+
+    func test_totalBalanceInFiatDecimal_emptyArrayReturnsZero() {
+        let coins: [Coin] = []
+        XCTAssertEqual(coins.totalBalanceInFiatDecimal, 0)
+    }
+
+    func test_totalBalanceInFiatDecimal_allDefiOnlyReturnsZero() {
+        let coins = [
+            makeCoin(ticker: "STCY", chain: .thorChain, isNative: false),
+            makeCoin(ticker: "stcy", chain: .thorChain, isNative: false)
+        ]
+        XCTAssertEqual(coins.totalBalanceInFiatDecimal, 0)
+    }
+
+    func test_totalBalanceInFiatDecimal_skipsDefiOnlyBeforeFiatLookup() {
+        let stcy = makeCoin(ticker: "STCY", chain: .thorChain, isNative: false)
+        stcy.rawBalance = "999999999999999999"
+        let coins = [stcy]
+        XCTAssertEqual(
+            coins.totalBalanceInFiatDecimal, 0,
+            "DeFi-only coins must be filtered before any fiat conversion"
+        )
+    }
+
+    func test_totalBalanceInFiatDecimal_filterRemovesOnlyDefiOnly() {
+        let btc = makeCoin(ticker: "BTC", chain: .bitcoin, isNative: true)
+        let rune = makeCoin(ticker: "RUNE", chain: .thorChain, isNative: true)
+        let stcy = makeCoin(ticker: "STCY", chain: .thorChain, isNative: false)
+
+        let filtered = [btc, rune, stcy].filter { !$0.isDefiOnly }
+        XCTAssertEqual(filtered.count, 2)
+        XCTAssertTrue(filtered.contains(where: { $0.ticker == "BTC" }))
+        XCTAssertTrue(filtered.contains(where: { $0.ticker == "RUNE" }))
+        XCTAssertFalse(filtered.contains(where: { $0.ticker == "STCY" }))
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoin(ticker: String, chain: Chain, isNative: Bool) -> Coin {
+        let meta = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "",
+            decimals: 8,
+            priceProviderId: "",
+            contractAddress: "",
+            isNativeToken: isNative
+        )
+        return Coin(asset: meta, address: "test", hexPublicKey: "test")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/ChainDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ChainDetailViewModelTests.swift
@@ -1,0 +1,111 @@
+//
+//  ChainDetailViewModelTests.swift
+//  VultisigAppTests
+//
+//  Created by Gaston Mazzeo on 20/04/2026.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class ChainDetailViewModelTests: XCTestCase {
+
+    func test_tokens_excludesDefiOnly() {
+        let native = makeCoin(ticker: "RUNE", chain: .thorChain, isNative: true)
+        let tcy = makeCoin(ticker: "TCY", chain: .thorChain, isNative: false)
+        let stcy = makeCoin(ticker: "STCY", chain: .thorChain, isNative: false)
+
+        let vault = Vault(name: "test")
+        vault.coins = [native, tcy, stcy]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: native)
+
+        let tickers = viewModel.tokens.map { $0.ticker }
+        XCTAssertEqual(tickers.count, 2)
+        XCTAssertTrue(tickers.contains("RUNE"))
+        XCTAssertTrue(tickers.contains("TCY"))
+        XCTAssertFalse(tickers.contains("STCY"))
+    }
+
+    func test_tokens_filtersByChain() {
+        let rune = makeCoin(ticker: "RUNE", chain: .thorChain, isNative: true)
+        let btc = makeCoin(ticker: "BTC", chain: .bitcoin, isNative: true)
+        let eth = makeCoin(ticker: "ETH", chain: .ethereum, isNative: true)
+
+        let vault = Vault(name: "test")
+        vault.coins = [rune, btc, eth]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: rune)
+
+        XCTAssertEqual(viewModel.tokens.count, 1)
+        XCTAssertEqual(viewModel.tokens.first?.ticker, "RUNE")
+    }
+
+    func test_tokens_nativeFirst() {
+        let native = makeCoin(ticker: "RUNE", chain: .thorChain, isNative: true)
+        let tcy = makeCoin(ticker: "TCY", chain: .thorChain, isNative: false)
+
+        let vault = Vault(name: "test")
+        vault.coins = [tcy, native]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: native)
+
+        XCTAssertEqual(viewModel.tokens.first?.ticker, "RUNE")
+    }
+
+    func test_filteredTokens_emptySearchReturnsAllTokens() {
+        let native = makeCoin(ticker: "RUNE", chain: .thorChain, isNative: true)
+        let tcy = makeCoin(ticker: "TCY", chain: .thorChain, isNative: false)
+
+        let vault = Vault(name: "test")
+        vault.coins = [native, tcy]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: native)
+        viewModel.searchText = ""
+
+        XCTAssertEqual(viewModel.filteredTokens.count, 2)
+    }
+
+    func test_filteredTokens_searchIsCaseInsensitive() {
+        let native = makeCoin(ticker: "RUNE", chain: .thorChain, isNative: true)
+        let tcy = makeCoin(ticker: "TCY", chain: .thorChain, isNative: false)
+
+        let vault = Vault(name: "test")
+        vault.coins = [native, tcy]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: native)
+        viewModel.searchText = "tcy"
+
+        XCTAssertEqual(viewModel.filteredTokens.count, 1)
+        XCTAssertEqual(viewModel.filteredTokens.first?.ticker, "TCY")
+    }
+
+    func test_filteredTokens_excludesDefiOnlyEvenWhenMatchingSearch() {
+        let native = makeCoin(ticker: "RUNE", chain: .thorChain, isNative: true)
+        let stcy = makeCoin(ticker: "STCY", chain: .thorChain, isNative: false)
+
+        let vault = Vault(name: "test")
+        vault.coins = [native, stcy]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: native)
+        viewModel.searchText = "stcy"
+
+        XCTAssertTrue(viewModel.filteredTokens.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoin(ticker: String, chain: Chain, isNative: Bool) -> Coin {
+        let meta = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "",
+            decimals: 8,
+            priceProviderId: "",
+            contractAddress: "",
+            isNativeToken: isNative
+        )
+        return Coin(asset: meta, address: "test", hexPublicKey: "test")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
@@ -1,0 +1,43 @@
+//
+//  THORChainStakeInteractorTests.swift
+//  VultisigAppTests
+//
+//  Created by Gaston Mazzeo on 20/04/2026.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class THORChainStakeInteractorTests: XCTestCase {
+
+    func test_scaledAmount_stcyWithEightDecimals() {
+        let result = THORChainStakeInteractor.scaledAmount(rawAmount: 344_000_000, decimals: 8)
+        XCTAssertEqual(result, Decimal(string: "3.44"))
+    }
+
+    func test_scaledAmount_zeroRawAmount() {
+        let result = THORChainStakeInteractor.scaledAmount(rawAmount: 0, decimals: 8)
+        XCTAssertEqual(result, 0)
+    }
+
+    func test_scaledAmount_zeroDecimalsReturnsRawUnchanged() {
+        let result = THORChainStakeInteractor.scaledAmount(rawAmount: 42, decimals: 0)
+        XCTAssertEqual(result, 42)
+    }
+
+    func test_scaledAmount_largeRawAmount() {
+        let result = THORChainStakeInteractor.scaledAmount(rawAmount: 100_000_000_000, decimals: 8)
+        XCTAssertEqual(result, 1_000)
+    }
+
+    func test_scaledAmount_eighteenDecimals() {
+        let rawAmount = Decimal(string: "1000000000000000000")!
+        let result = THORChainStakeInteractor.scaledAmount(rawAmount: rawAmount, decimals: 18)
+        XCTAssertEqual(result, 1)
+    }
+
+    func test_scaledAmount_preservesSmallFractions() {
+        let result = THORChainStakeInteractor.scaledAmount(rawAmount: 1, decimals: 8)
+        XCTAssertEqual(result, Decimal(string: "0.00000001"))
+    }
+}


### PR DESCRIPTION
## Summary

Moves sTCY from the Wallet tab to the DeFi tab as a first-class auto-compounded staking position, and removes the manual auto-compound toggle in favour of coin-derived behaviour.

- **Wallet**: sTCY is filtered out of the chain detail token list (DeFi-only token).
- **DeFi**: sTCY now surfaces as a staked position on THORChain with Transfer, Unstake and Stake actions, plus an info icon linking to the [Rujira TCY auto-compounder docs](https://docs.rujira.network/ecosystem-products/tcy-autocompounder).
- **Stake/Unstake screens**: the auto-compound toggle is removed entirely. Auto-compound behaviour is inferred from the entry coin — TCY ⇒ `isAutocompound=false`, sTCY ⇒ `isAutocompound=true`.
- **Transfer**: sends sTCY to another address via the standard send flow.
- Localized new keys (`autocompounderInfo`, `autocompounderInfoURL`, `transfer`) across all 8 locale files.

Figma reference: [node-id=50787-145843](https://www.figma.com/design/).

## Test Plan

- [x] SwiftLint clean (no new warnings)
- [x] `xcodebuild` succeeds on iOS simulator
- [ ] Wallet ▸ THORChain no longer shows sTCY in the token list
- [ ] DeFi ▸ THORChain ▸ Stake shows sTCY position with info icon
- [ ] Info icon opens the Rujira auto-compounder docs in browser
- [ ] `Transfer` on sTCY position navigates to send with sTCY preselected
- [ ] `Stake auto-compounded` routes with `isAutocompound=true`
- [ ] `Unstake auto-compounded` routes with `isAutocompound=true`
- [ ] TCY stake/unstake no longer displays the auto-compound toggle
- [ ] TCY path still routes with `isAutocompound=false`

## Related

- Closes #3970

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added transfer action for compound staking positions, enabling users to send compounded rewards to other addresses
  * Introduced Auto-Compounder information display with integrated documentation links
  * Expanded language support with translations for new transfer and auto-compounder features across eight languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->