### PR TITLE
refactor(swap): localize hardcoded swap fee label strings

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -864,6 +864,7 @@
 "swapErrorUnexpectedDescription" = "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.";
 "swapErrorUnexpectedTitle" = "Unerwarteter Fehler";
 "swapFee" = "Tauschgebühr";
+"swapFeePercentage" = "Tauschgebühr (%.2f%%)";
 "swapOverview" = "Tauschübersicht";
 "swapRouteNotAvailable" = "Tauschroute nicht verfügbar";
 "swaps" = "Swaps";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -874,6 +874,7 @@
 "swapErrorUnexpectedDescription" = "An unexpected error occurred. Please try again.";
 "swapErrorUnexpectedTitle" = "Unexpected Error";
 "swapFee" = "Swap Fee";
+"swapFeePercentage" = "Swap Fee (%.2f%%)";
 "swapOverview" = "Swap overview";
 "swapRouteNotAvailable" = "Swap route not available";
 "swaps" = "Swaps";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -864,6 +864,7 @@
 "swapErrorUnexpectedDescription" = "Ocurrió un error inesperado. Por favor, inténtalo de nuevo.";
 "swapErrorUnexpectedTitle" = "Error Inesperado";
 "swapFee" = "Tarifa de intercambio";
+"swapFeePercentage" = "Tarifa de intercambio (%.2f%%)";
 "swapOverview" = "Resumen del intercambio";
 "swapRouteNotAvailable" = "Ruta de intercambio no disponible";
 "swaps" = "Intercambios";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -864,6 +864,7 @@
 "swapErrorUnexpectedDescription" = "Došlo je do neočekivane greške. Molimo pokušajte ponovo.";
 "swapErrorUnexpectedTitle" = "Neočekivana Greška";
 "swapFee" = "Naknada za zamjenu";
+"swapFeePercentage" = "Naknada za zamjenu (%.2f%%)";
 "swapOverview" = "Pregled zamjene";
 "swapRouteNotAvailable" = "Ruta zamjene nije dostupna";
 "swaps" = "Zamjene";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -864,6 +864,7 @@
 "swapErrorUnexpectedDescription" = "Si è verificato un errore imprevisto. Per favore riprova.";
 "swapErrorUnexpectedTitle" = "Errore Imprevisto";
 "swapFee" = "Commissione di scambio";
+"swapFeePercentage" = "Commissione di scambio (%.2f%%)";
 "swapOverview" = "Panoramica dello scambio";
 "swapRouteNotAvailable" = "Percorso di scambio non disponibile";
 "swaps" = "Scambi";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -864,6 +864,7 @@
 "swapErrorUnexpectedDescription" = "Ocorreu um erro inesperado. Por favor, tente novamente.";
 "swapErrorUnexpectedTitle" = "Erro Inesperado";
 "swapFee" = "Taxa de troca";
+"swapFeePercentage" = "Taxa de troca (%.2f%%)";
 "swapOverview" = "Visão geral da troca";
 "swapRouteNotAvailable" = "Rota de troca não disponível";
 "swaps" = "Trocas";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -864,6 +864,7 @@
 "swapErrorUnexpectedDescription" = "发生意外错误。请重试。";
 "swapErrorUnexpectedTitle" = "意外错误";
 "swapFee" = "交换费用";
+"swapFeePercentage" = "交换费用 (%.2f%%)";
 "swapOverview" = "交换概览";
 "swapRouteNotAvailable" = "交换路由不可用";
 "swaps" = "兑换";

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -252,11 +252,11 @@ struct SwapCryptoLogic {
         // Struct: `slippageBps`.
         // If not present, we can calculate: (AffiliateFeeFiat / InputFiat) * 10000
 
-        guard let quote = tx.quote else { return "Swap Fee" }
+        guard let quote = tx.quote else { return "swapFee".localized }
 
         // Get affiliate fee fiat value
         let affiliateFeeString = baseAffiliateFee(tx: tx)
-        guard !affiliateFeeString.isEmpty else { return "Swap Fee (0.00%)" }
+        guard !affiliateFeeString.isEmpty else { return String(format: "swapFeePercentage".localized, 0.0) }
 
         // We need raw numbers for math, reusing logic for efficiency
         var feeAmt: Decimal = 0
@@ -278,12 +278,12 @@ struct SwapCryptoLogic {
 
         let inputFiat = tx.fromCoin.fiat(decimal: tx.fromAmountDecimal)
 
-        guard inputFiat > 0 else { return "Swap Fee" }
+        guard inputFiat > 0 else { return "swapFee".localized }
 
         let rate = (feeFiat / inputFiat)
         let percentage = rate * 100
 
-        return "Swap Fee (\(String(format: "%.2f", NSDecimalNumber(decimal: percentage).doubleValue))%)"
+        return String(format: "swapFeePercentage".localized, NSDecimalNumber(decimal: percentage).doubleValue)
     }
 
     func outboundFeeString(tx: SwapTransaction) -> String {


### PR DESCRIPTION
## Summary
- Replace three hardcoded English strings in `swapFeeLabel(tx:)` with localized keys
- Reuse existing `swapFee` for the plain fallback; add `swapFeePercentage` format key for zero-fee and computed percentage cases
- Add translations across all 7 locales (en, de, es, hr, it, pt, zh-Hans)

## Test Plan
- [x] SwiftLint passes (`swiftlint lint --config VultisigApp/.swiftlint.yml`)
- [ ] Manual: verify Swap UI fee label renders correctly with and without affiliate fee
- [ ] Manual: verify localized rendering on non-English locales

## Related
- Closes #4144
- Follow-up to #4143

Co-Authored-By: Claude <noreply@anthropic.com>