### PR TITLE
fix(keygen): resolve tss-batch feature flag once per flow

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
@@ -53,6 +53,7 @@ class JoinKeygenViewModel: ObservableObject {
     @Published var error: JoinKeygenError? = nil
     @Published var serverAddress: String? = nil
     @Published var oldResharePrefix: String = ""
+    @Published var isTssBatchEnabled: Bool = false
 
     var encryptionKeyHex: String = ""
     var singleKeygenType: SingleKeygenType = .MLDSA
@@ -84,6 +85,10 @@ class JoinKeygenViewModel: ObservableObject {
 
         if let isAllowed = self.isCameraPermissionGranted, !isAllowed {
             status = .NoCameraAccess
+        }
+
+        Task { @MainActor in
+            self.isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
@@ -40,6 +40,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         }
     }
     @Published var isLoading: Bool = false
+    @Published var isTssBatchEnabled: Bool = false
 
     private var peersFoundCancellable: AnyCancellable?
     private let mediator = Mediator.shared
@@ -112,87 +113,81 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         case .secure:
             break
         }
-        if let config = fastSignConfig {
+        Task { @MainActor in
+            let resolvedFlag = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
+            self.isTssBatchEnabled = resolvedFlag
+            guard let config = fastSignConfig else { return }
             switch tssType {
             case .Keygen:
-                Task {
-                    let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
-                    if isTssBatchEnabled {
-                        fastVaultService.batchCreate(
-                            name: vault.name,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            hexChainCode: vault.hexChainCode,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            lib_type: vault.libType == .DKLS ? 1 : 0,
-                            protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
-                        )
-                    } else {
-                        fastVaultService.create(name: vault.name,
-                                                sessionID: sessionID,
-                                                hexEncryptionKey: encryptionKeyHex!,
-                                                hexChainCode: vault.hexChainCode,
-                                                encryptionPassword: config.password,
-                                                email: config.email,
-                                                lib_type: vault.libType == .DKLS ? 1 : 0)
-                    }
+                if resolvedFlag {
+                    fastVaultService.batchCreate(
+                        name: vault.name,
+                        sessionID: sessionID,
+                        hexEncryptionKey: encryptionKeyHex!,
+                        hexChainCode: vault.hexChainCode,
+                        encryptionPassword: config.password,
+                        email: config.email,
+                        lib_type: vault.libType == .DKLS ? 1 : 0,
+                        protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
+                    )
+                } else {
+                    fastVaultService.create(name: vault.name,
+                                            sessionID: sessionID,
+                                            hexEncryptionKey: encryptionKeyHex!,
+                                            hexChainCode: vault.hexChainCode,
+                                            encryptionPassword: config.password,
+                                            email: config.email,
+                                            lib_type: vault.libType == .DKLS ? 1 : 0)
                 }
             case .KeyImport:
-                Task {
-                    let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
-                    if isTssBatchEnabled {
-                        fastVaultService.batchKeyImport(
-                            name: vault.name,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            lib_type: 2,
-                            chains: chains?.map { $0.name } ?? [],
-                            protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
-                        )
-                    } else {
-                        fastVaultService.keyImport(
-                            name: vault.name,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            hexChainCode: vault.hexChainCode,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            lib_type: 2,
-                            chains: chains?.map { $0.name } ?? []
-                        )
-                    }
+                if resolvedFlag {
+                    fastVaultService.batchKeyImport(
+                        name: vault.name,
+                        sessionID: sessionID,
+                        hexEncryptionKey: encryptionKeyHex!,
+                        encryptionPassword: config.password,
+                        email: config.email,
+                        lib_type: 2,
+                        chains: chains?.map { $0.name } ?? [],
+                        protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
+                    )
+                } else {
+                    fastVaultService.keyImport(
+                        name: vault.name,
+                        sessionID: sessionID,
+                        hexEncryptionKey: encryptionKeyHex!,
+                        hexChainCode: vault.hexChainCode,
+                        encryptionPassword: config.password,
+                        email: config.email,
+                        lib_type: 2,
+                        chains: chains?.map { $0.name } ?? []
+                    )
                 }
             case .Reshare:
                 let pubKeyECDSA = config.isExist ? vault.pubKeyECDSA : .empty
-                Task {
-                    let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
-                    if isTssBatchEnabled {
-                        fastVaultService.batchReshare(
-                            publicKeyECDSA: pubKeyECDSA,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            oldParties: vault.signers,
-                            protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
-                        )
-                    } else {
-                        fastVaultService.reshare(
-                            name: vault.name,
-                            publicKeyECDSA: pubKeyECDSA,
-                            sessionID: sessionID,
-                            hexEncryptionKey: encryptionKeyHex!,
-                            hexChainCode: vault.hexChainCode,
-                            encryptionPassword: config.password,
-                            email: config.email,
-                            oldParties: vault.signers,
-                            oldResharePrefix: vault.resharePrefix ?? "",
-                            lib_type: vault.libType == .DKLS ? 1 : 0
-                        )
-                    }
+                if resolvedFlag {
+                    fastVaultService.batchReshare(
+                        publicKeyECDSA: pubKeyECDSA,
+                        sessionID: sessionID,
+                        hexEncryptionKey: encryptionKeyHex!,
+                        encryptionPassword: config.password,
+                        email: config.email,
+                        oldParties: vault.signers,
+                        protocols: [BatchKeygenRequest.protocolECDSA, BatchKeygenRequest.protocolEdDSA]
+                    )
+                } else {
+                    fastVaultService.reshare(
+                        name: vault.name,
+                        publicKeyECDSA: pubKeyECDSA,
+                        sessionID: sessionID,
+                        hexEncryptionKey: encryptionKeyHex!,
+                        hexChainCode: vault.hexChainCode,
+                        encryptionPassword: config.password,
+                        email: config.email,
+                        oldParties: vault.signers,
+                        oldResharePrefix: vault.resharePrefix ?? "",
+                        lib_type: vault.libType == .DKLS ? 1 : 0
+                    )
                 }
             case .Migrate:
                 fastVaultService.migrate(

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
@@ -80,6 +80,7 @@ class KeygenViewModel: ObservableObject {
     var isInitiateDevice: Bool
     var keyImportInput: KeyImportInput?
     var singleKeygenType: SingleKeygenType?
+    var isTssBatchEnabled: Bool = false
 
     @Published var isLinkActive = false
     @Published var keygenError: String = ""
@@ -119,6 +120,7 @@ class KeygenViewModel: ObservableObject {
                  encryptionKeyHex: String,
                  oldResharePrefix: String,
                  initiateDevice: Bool,
+                 isTssBatchEnabled: Bool,
                  keyImportInput: KeyImportInput? = nil,
                  singleKeygenType: SingleKeygenType? = nil
     ) async {
@@ -131,6 +133,7 @@ class KeygenViewModel: ObservableObject {
         self.encryptionKeyHex = encryptionKeyHex
         self.oldResharePrefix = oldResharePrefix
         self.isInitiateDevice = initiateDevice
+        self.isTssBatchEnabled = isTssBatchEnabled
         self.keyImportInput = keyImportInput
         self.singleKeygenType = singleKeygenType
         let isEncryptGCM = await FeatureFlagService().isFeatureEnabled(feature: .EncryptGCM)
@@ -303,9 +306,8 @@ class KeygenViewModel: ObservableObject {
     }
 
     func startKeyImportKeygen(modelContext: ModelContext) async throws {
-        let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
-        let useParallelPath = isTssBatchEnabled
-        self.logger.info("KeyImport flow starting: execution=\(useParallelPath ? "parallel" : "sequential"), tssBatchEnabled=\(isTssBatchEnabled)")
+        let useParallelPath = self.isTssBatchEnabled
+        self.logger.info("KeyImport flow starting: execution=\(useParallelPath ? "parallel" : "sequential"), tssBatchEnabled=\(self.isTssBatchEnabled)")
 
         var wallet: HDWallet?
 
@@ -614,9 +616,8 @@ class KeygenViewModel: ObservableObject {
     func startKeygenDKLS(context: ModelContext, localUIEcdsa: String? = nil, localUIEddsa: String? = nil) async {
         await updateProgress(50)
         do {
-            let isTssBatchEnabled = await FeatureFlagService().isFeatureEnabled(feature: .TssBatch)
-            let useParallelPath = isTssBatchEnabled && (self.tssType == .Keygen || self.tssType == .Migrate || self.tssType == .Reshare)
-            self.logger.info("\(self.tssType.rawValue) flow starting: execution=\(useParallelPath ? "parallel" : "sequential"), tssBatchEnabled=\(isTssBatchEnabled)")
+            let useParallelPath = self.isTssBatchEnabled && (self.tssType == .Keygen || self.tssType == .Migrate || self.tssType == .Reshare)
+            self.logger.info("\(self.tssType.rawValue) flow starting: execution=\(useParallelPath ? "parallel" : "sequential"), tssBatchEnabled=\(self.isTssBatchEnabled)")
 
             let dklsKeygen = DKLSKeygen(vault: self.vault,
                                         tssType: self.tssType,

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
@@ -104,6 +104,7 @@ struct JoinKeygenView: View {
             keyImportInput: viewModel.keyImportInput,
             singleKeygenType: viewModel.singleKeygenType,
             isInitiateDevice: false,
+            isTssBatchEnabled: viewModel.isTssBatchEnabled,
             hideBackButton: $hideBackButton
         )
     }

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/KeygenView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/KeygenView.swift
@@ -25,6 +25,7 @@ struct KeygenView: View {
     let keyImportInput: KeyImportInput?
     let singleKeygenType: SingleKeygenType?
     let isInitiateDevice: Bool
+    let isTssBatchEnabled: Bool
     @Binding var hideBackButton: Bool
 
     @StateObject var viewModel = KeygenViewModel()
@@ -312,6 +313,7 @@ struct KeygenView: View {
             encryptionKeyHex: encryptionKeyHex,
             oldResharePrefix: oldResharePrefix,
             initiateDevice: isInitiateDevice,
+            isTssBatchEnabled: isTssBatchEnabled,
             keyImportInput: keyImportInput,
             singleKeygenType: singleKeygenType
         )
@@ -348,6 +350,7 @@ struct KeygenView: View {
         keyImportInput: nil,
         singleKeygenType: nil,
         isInitiateDevice: false,
+        isTssBatchEnabled: false,
         hideBackButton: .constant(false)
     )
     .frame(maxWidth: 600, maxHeight: isMacOS ? 600 : .infinity)

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
@@ -479,6 +479,7 @@ struct PeerDiscoveryScreen: View {
             keyImportInput: keyImportInput,
             singleKeygenType: singleKeygenType,
             isInitiateDevice: true,
+            isTssBatchEnabled: viewModel.isTssBatchEnabled,
             hideBackButton: $hideBackButton
         )
     }


### PR DESCRIPTION
## Summary

Fixes #4141.

The `tss-batch` feature flag was being fetched independently by `KeygenPeerDiscoveryViewModel` / `JoinKeygenViewModel` (which decides whether to hit the batch or non-batch FastVault registration endpoint) and by `KeygenViewModel` (which decides whether to run ECDSA/EdDSA in parallel or sequentially). The two fetches could diverge and leave the client in a split state — registered with one endpoint variant but executing the other.

- Resolve the flag once on `KeygenPeerDiscoveryViewModel` / `JoinKeygenViewModel` and expose it as `@Published var isTssBatchEnabled`
- Thread the resolved boolean through `KeygenView` into `KeygenViewModel.setData(...)`
- `KeygenViewModel.startKeygenDKLS` and `startKeyImportKeygen` now read `self.isTssBatchEnabled` instead of fetching again
- Peer-discovery's consolidated task also drives the `batchCreate` / `batchKeyImport` / `batchReshare` vs non-batch FastVault calls from the same resolved value

## Test plan

- [ ] Keygen (fast vault) — verify server registration and TSS execution agree
- [ ] Reshare (fast vault) — same
- [ ] KeyImport (fast vault) — same
- [ ] Regular (non-fast) Keygen still works
- [ ] Joining device (`JoinKeygenView`) picks up the resolved flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)