### PR TITLE
fix(tss): include self.messageID in DKLS setup message headers

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/commondata",
       "state" : {
-        "revision" : "2d125ea915294beb9062eddfefe3aed4177108b6"
+        "revision" : "ea0f4311b24eb99793d4236f4cf93d5f2095ccc0"
       }
     },
     {

--- a/VultisigApp/VultisigApp/Blockchain/Tss/DKLSMessenger.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/DKLSMessenger.swift
@@ -29,9 +29,8 @@ final class DKLSMessenger {
     }
 
     /// Uploads a setup message to the relay server.
-    /// Setup message routing uses only the explicit `additionalHeader` parameter, NOT `self.messageID`.
-    /// This keeps setup message namespace independent of exchange message namespace (matching Android).
-    /// `self.messageID` is used only for TSS round-trip message exchange (send/pull/delete).
+    /// `self.messageID` is applied first; when `additionalHeader` is provided it overrides the header
+    /// so callers can route a setup message into a different namespace than the TSS exchange.
     func uploadSetupMessage(message: String, _ additionalHeader: String?) async throws {
         let urlString = "\(self.mediatorURL)/setup-message/\(self.sessionID)"
         let url = URL(string: urlString)
@@ -41,6 +40,9 @@ final class DKLSMessenger {
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let messageID = self.messageID {
+            req.setValue(messageID, forHTTPHeaderField: "message_id")
+        }
         if let additionalHeader {
             req.setValue(additionalHeader, forHTTPHeaderField: "message_id")
         }
@@ -75,7 +77,8 @@ final class DKLSMessenger {
     }
 
     /// Downloads a setup message from the relay server.
-    /// Setup message routing uses only the explicit `additionalHeader` parameter, NOT `self.messageID`.
+    /// `self.messageID` is applied first; when `additionalHeader` is provided it overrides the header
+    /// so callers can route a setup message into a different namespace than the TSS exchange.
     func downloadSetupMessage(_ additionalHeader: String?) async throws -> String {
         let urlString = "\(self.mediatorURL)/setup-message/\(self.sessionID)"
         let url = URL(string: urlString)
@@ -85,6 +88,9 @@ final class DKLSMessenger {
         var req = URLRequest(url: url)
         req.httpMethod = "GET"
         req.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let messageID = self.messageID {
+            req.setValue(messageID, forHTTPHeaderField: "message_id")
+        }
         if let additionalHeader {
             req.setValue(additionalHeader, forHTTPHeaderField: "message_id")
         }

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -53,7 +53,7 @@ packages:
     from: 1.17.0
   VultisigCommonData:
     url: https://github.com/vultisig/commondata
-    revision: 2d125ea915294beb9062eddfefe3aed4177108b6
+    revision: ea0f4311b24eb99793d4236f4cf93d5f2095ccc0
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
     exactVersion: 4.3.19


### PR DESCRIPTION
## Summary
- `DKLSMessenger.uploadSetupMessage` / `downloadSetupMessage` now set the `message_id` header from `self.messageID` when present. The explicit `additionalHeader` parameter still overrides it, so callers that want a distinct setup-message namespace keep working.
- Updated the doc comments on both methods to reflect the new precedence (self.messageID applied first, additionalHeader wins).
- Bumps the `VultisigCommonData` revision in `project.yml` + `Package.resolved` to `ea0f431`.

## Test plan
- [ ] Run a DKLS keygen end-to-end and confirm setup message upload/download succeed on the relay.
- [ ] Run a DKLS keysign end-to-end and confirm TSS exchange round-trips work.
- [ ] Regenerate the Xcode project (`make generate`) and verify a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal dependency and infrastructure updates

This release contains primarily internal updates with no visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->