### PR TITLE
chore(settings): make transaction history public

### DIFF
--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -34,7 +34,6 @@ class SettingsViewModel: ObservableObject {
     @AppStorage("thorchainChainnet") var enableThorchainChainnet: Bool = false
     @AppStorage("SellEnabled") var sellEnabled: Bool = false
     @AppStorage("isMLDSAEnabled") var isMLDSAEnabled: Bool = false
-    @AppStorage("txHistoryEnabled") var txHistoryEnabled: Bool = false
     @AppStorage("tssBatchEnabled") var tssBatchEnabled: Bool = false
 
     init() {

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
@@ -62,12 +62,6 @@ struct SettingsAdvancedView: View {
             )
 
             SettingToggleCell(
-                title: "transactionHistory",
-                icon: "clock.arrow.circlepath",
-                isEnabled: $settingsViewModel.txHistoryEnabled
-            )
-
-            SettingToggleCell(
                 title: "TSS Batching",
                 icon: "bolt.horizontal",
                 isEnabled: $settingsViewModel.tssBatchEnabled

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreenContainer.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreenContainer.swift
@@ -55,7 +55,6 @@ struct ChainDetailScreenContainer: View {
                             ToolbarButton(image: "clock.arrow.circlepath", action: onHistory) { _ in
                                 Icon(named: "clock.arrow.circlepath", color: Theme.colors.textPrimary, size: 20, isSystem: true)
                             }
-                            .showIf(SettingsViewModel.shared.txHistoryEnabled)
                         }
                         CustomToolbarItem(placement: .trailing) {
                             ToolbarButton(image: "square-3d", action: onExplorer)
@@ -89,7 +88,6 @@ struct ChainDetailScreenContainer: View {
                 ToolbarButton(image: "clock.arrow.circlepath", action: onHistory) { _ in
                     Icon(named: "clock.arrow.circlepath", color: Theme.colors.textPrimary, size: 20, isSystem: true)
                 }
-                .showIf(SettingsViewModel.shared.txHistoryEnabled)
             }
             CustomToolbarItem(placement: .trailing) {
                 ToolbarButton(image: "square-3d", action: onExplorer)

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift
@@ -84,7 +84,6 @@ struct HomeMainHeaderView: View {
                 Icon(named: "clock.arrow.circlepath", color: Theme.colors.textPrimary, size: 20, isSystem: true)
             }
             .accessibilityIdentifier(AccessibilityID.Home.historyButton)
-            .showIf(SettingsViewModel.shared.txHistoryEnabled)
             ToolbarButton(image: "settings", action: settingsAction)
                 .accessibilityIdentifier(AccessibilityID.Home.settingsButton)
         }


### PR DESCRIPTION
## Summary
- Remove the `txHistoryEnabled` feature flag and its row from **Settings → Advanced**
- Transaction history button is now always visible on the home header and chain detail screen (both iOS and macOS)
- `"transactionHistory"` localization key is kept — it's still used as the `TransactionHistoryScreen` title

## Test plan
- [ ] Launch app → open a vault → confirm the history button (clock icon) is visible next to Settings on the home header
- [ ] Tap history button → confirm it navigates to the Transaction History screen
- [ ] Open a chain detail screen (iOS + macOS) → confirm history button appears in the toolbar
- [ ] Settings → Advanced → confirm the "Transaction History" toggle is gone
- [ ] No new SwiftLint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed transaction history setting from advanced options; the feature is now permanently enabled and always visible throughout the app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->