### PR TITLE
fix(keysign): hash-verify fallback when peer wins broadcast race

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -834,6 +834,10 @@ class KeysignViewModel: ObservableObject {
         if await isAlreadyOnChain(transactionType: transactionType) {
             logger.info("transaction already on-chain via peer broadcast — using hash \(transactionType.transactionHash, privacy: .public)")
             self.txid = transactionType.transactionHash
+            self.approveTxid = transactionType.approveTransactionHash
+            if let coin = keysignPayload?.coin, coin.chainType == .UTXO {
+                await BlockchairService.shared.clearUTXOCache(for: coin)
+            }
             return
         }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -662,7 +662,7 @@ class KeysignViewModel: ObservableObject {
                                 await BlockchairService.shared.clearUTXOCache(for: keysignPayload.coin)
                             }
                         case .failure(let error):
-                            self.handleBroadcastError(error: error, transactionType: transactionType)
+                            Task { await self.handleBroadcastError(error: error, transactionType: transactionType) }
                         }
                     }
                 case .bitcoinCash, .litecoin, .dogecoin, .dash, .zcash:
@@ -676,14 +676,14 @@ class KeysignViewModel: ObservableObject {
                                 await BlockchairService.shared.clearUTXOCache(for: keysignPayload.coin)
                             }
                         case .failure(let error):
-                            self.handleBroadcastError(error: error, transactionType: transactionType)
+                            Task { await self.handleBroadcastError(error: error, transactionType: transactionType) }
                         }
                     }
                 case .cardano:
                     do {
                         self.txid = try await CardanoService.shared.broadcastTransaction(signedTransaction: tx.rawTransaction)
                     } catch {
-                        self.handleBroadcastError(error: error, transactionType: transactionType)
+                        await self.handleBroadcastError(error: error, transactionType: transactionType)
                     }
                 case .gaiaChain, .kujira, .osmosis, .dydx, .terra, .terraClassic, .noble, .akash, .qbtc:
                     let service = try CosmosService.getService(forChain: keysignPayload.coin.chain)
@@ -745,7 +745,7 @@ class KeysignViewModel: ObservableObject {
                 self.txid = regularTxHash
             }
         } catch {
-            handleBroadcastError(error: error, transactionType: transactionType)
+            await handleBroadcastError(error: error, transactionType: transactionType)
         }
 
         if txid == "Transaction already broadcasted." {
@@ -789,7 +789,7 @@ class KeysignViewModel: ObservableObject {
         }
     }
 
-    func handleBroadcastError(error: Error, transactionType: SignedTransactionType) {
+    func handleBroadcastError(error: Error, transactionType: SignedTransactionType) async {
         if let retryable = error as? RetryableBroadcastError,
            broadcastRetryCount < Self.maxBroadcastRetries {
             broadcastRetryCount += 1
@@ -825,10 +825,45 @@ class KeysignViewModel: ObservableObject {
 
             errMessage = "Failed to broadcast transaction,error:\(error.localizedDescription)"
         }
+
+        // Chain-agnostic fallback: when a co-signing peer wins the broadcast
+        // race, our broadcast call fails (mempool / sequence / duplicate
+        // errors) but the signed tx is already on-chain. Look it up by hash
+        // before declaring failure — every chain has the same deterministic
+        // hash so this works without per-chain string matching.
+        if await isAlreadyOnChain(transactionType: transactionType) {
+            logger.info("transaction already on-chain via peer broadcast — using hash \(transactionType.transactionHash, privacy: .public)")
+            self.txid = transactionType.transactionHash
+            return
+        }
+
         logger.error("\(errMessage, privacy: .public)")
         DispatchQueue.main.async {
             self.keysignError = errMessage
             self.status = .KeysignFailed
+        }
+    }
+
+    /// Best-effort check that the signed tx is already accepted on the chain
+    /// (mempool or block). Returns true only on positive evidence — any
+    /// transient lookup failure or `notFound` falls through so the caller
+    /// surfaces the original broadcast error.
+    private func isAlreadyOnChain(transactionType: SignedTransactionType) async -> Bool {
+        guard let chain = keysignPayload?.coin.chain else { return false }
+        let hash = transactionType.transactionHash
+        guard !hash.isEmpty else { return false }
+
+        do {
+            let result = try await TransactionStatusService.shared.checkTransactionStatus(txHash: hash, chain: chain)
+            switch result.status {
+            case .confirmed, .pending:
+                return true
+            case .notFound, .failed:
+                return false
+            }
+        } catch {
+            logger.warning("hash-verify lookup failed for \(hash, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return false
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -327,7 +327,11 @@ class KeysignViewModel: ObservableObject {
             if let customMessagePayload {
                 txid = customMessagePayload.message
             }
-            status = .KeysignFinished
+            // broadcastTransaction owns its terminal status — don't overwrite a
+            // failure (or retry request) set by handleBroadcastError.
+            if status != .KeysignFailed && status != .KeysignRetryRequested {
+                status = .KeysignFinished
+            }
         } catch {
             logger.error("TSS keysign failed, error: \(error.localizedDescription)")
             keysignError = error.localizedDescription
@@ -356,7 +360,9 @@ class KeysignViewModel: ObservableObject {
         if let customMessagePayload {
             txid = customMessagePayload.message
         }
-        status = .KeysignFinished
+        if status != .KeysignFailed && status != .KeysignRetryRequested {
+            status = .KeysignFinished
+        }
     }
     // Return value bool indicate whether keysign should be retried
     func keysignOneMessageWithRetry(msg: String, attempt: UInt8) async throws {
@@ -794,10 +800,8 @@ class KeysignViewModel: ObservableObject {
            broadcastRetryCount < Self.maxBroadcastRetries {
             broadcastRetryCount += 1
             logger.warning("broadcast failed with retryable error (\(retryable.retryReason.userFacingMessage, privacy: .public)); requesting retry")
-            DispatchQueue.main.async {
-                self.retryReason = retryable.retryReason
-                self.status = .KeysignRetryRequested
-            }
+            self.retryReason = retryable.retryReason
+            self.status = .KeysignRetryRequested
             return
         }
 
@@ -812,14 +816,16 @@ class KeysignViewModel: ObservableObject {
                 || message.contains("This transaction has already been processed") {
                 logger.info("the transaction already broadcast, code:\(code)")
                 self.txid = transactionType.transactionHash
+                self.approveTxid = transactionType.approveTransactionHash
                 return
             }
         default:
 
             // Check for Cardano "already broadcasted" errors
-            if error.localizedDescription.contains("BadInputsUTxO") || error.localizedDescription.contains("timed out") {
+            if error.localizedDescription.contains("BadInputsUTxO") {
                 logger.info("Cardano transaction already broadcast - using hash from transactionType \(transactionType.transactionHash, privacy: .public)")
                 self.txid = transactionType.transactionHash
+                self.approveTxid = transactionType.approveTransactionHash
                 return
             }
 
@@ -842,10 +848,8 @@ class KeysignViewModel: ObservableObject {
         }
 
         logger.error("\(errMessage, privacy: .public)")
-        DispatchQueue.main.async {
-            self.keysignError = errMessage
-            self.status = .KeysignFailed
-        }
+        self.keysignError = errMessage
+        self.status = .KeysignFailed
     }
 
     /// Best-effort check that the signed tx is already accepted on the chain


### PR DESCRIPTION
## Summary

When co-signing a transaction across devices, every device broadcasts independently. When a peer wins the RPC race, iOS would see "tx already in mempool / sequence mismatch / already known" errors and flip the signing screen to **failed** — even though the tx is on-chain and funds moved.

Pre-fix, this was pattern-matched only for **EVM** (`already known`, `replacement transaction underpriced`, `This transaction has already been processed`) and **Cardano** (`BadInputsUTxO`, `timed out`). Every other chain (Cosmos, THORChain, Mayachain, UTXO, Solana, Sui, Tron, Ripple, Polkadot, Bittensor, Ton) fell through to the failure branch.

## Fix — chain-agnostic hash verification

`handleBroadcastError` now runs a hash lookup before falling through to `.KeysignFailed`:

```swift
if await isAlreadyOnChain(transactionType: transactionType) {
    self.txid = transactionType.transactionHash
    return  // treat as success
}
```

`isAlreadyOnChain` calls `TransactionStatusService.shared.checkTransactionStatus(txHash:chain:)` which already has per-chain providers (EVM, UTXO, Cosmos, Solana, THORChain, Cardano, Polkadot, Bittensor, Sui, Ton, Ripple, Tron). Only short-circuits to success on **positive evidence** (`.confirmed` or `.pending`). `.notFound`, `.failed`, or thrown errors fall through so we never claim success on uncertainty.

`handleBroadcastError` becomes `async`; inline `catch` sites add `await`, the two callback-based UTXO sites wrap the call in `Task { ... }`.

The existing EVM/Cardano string short-circuits stay alongside hash-verify per the issue's staged plan — a follow-up can remove them once the hash-verify path has soaked.

## Test plan

- [ ] `make build-check` clean
- [ ] SwiftLint passes on `KeysignViewModel.swift`
- [ ] Two-device keysign on a Cosmos chain (e.g. THORChain): force the second device to lose the race and confirm the signing screen shows success with the correct txid
- [ ] Same scenario on a UTXO chain (Bitcoin or Litecoin)
- [ ] Same scenario on Solana
- [ ] Single-device keysign on every supported chain still succeeds (regression — the new path only fires on broadcast failure)
- [ ] Broadcast a deliberately invalid tx (insufficient funds) and confirm the failure path still shows the error (the hash lookup must return `.notFound` and fall through)

## Files

- `VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift` — new `isAlreadyOnChain(transactionType:)` helper, async `handleBroadcastError`, callers updated

## Related

Closes #4170. Sibling issues will be filed against `vultisig-sdk` (Windows) and `vultisig-android`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction broadcast reliability with an automatic on-chain status fallback: confirmed or pending results are treated as successful and clear UTXO cache where applicable, reducing false failure alerts.
  * More consistent broadcast status handling and retry behavior to avoid race conditions that could overwrite failure or retry states.
  * Better population of approval transaction IDs for previously handled/bad-input cases for clearer tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->