### PR TITLE
[Architecture 3.h] Migrate TSS relay messaging to HTTPClient + TargetType

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
@@ -61,7 +61,7 @@ final class DKLSKeygen {
     let localPrivateSecret: String?
     let hexChainCode: String
     let DKLS_LIB_OK: godkls.lib_error = .init(0)
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     // Populated by prepareKeyImportSetup. DKLSKeygenWithRetry consumes the stored
     // handle on attempt 0 and falls back to the normal flow on retry.
@@ -75,7 +75,8 @@ final class DKLSKeygen {
          sessionID: String,
          encryptionKeyHex: String,
          isInitiateDevice: Bool,
-         localUI: String?
+         localUI: String?,
+         httpClient: HTTPClientProtocol = HTTPClient()
     ) {
         self.vault = vault
         self.tssType = tssType
@@ -85,7 +86,8 @@ final class DKLSKeygen {
         self.sessionID = sessionID
         self.encryptionKeyHex = encryptionKeyHex
         self.isInitiateDevice = isInitiateDevice
-        self.messenger = DKLSMessenger(mediatorUrl: self.mediatorURL, sessionID: self.sessionID, messageID: nil, encryptionKeyHex: self.encryptionKeyHex)
+        self.httpClient = httpClient
+        self.messenger = DKLSMessenger(mediatorUrl: self.mediatorURL, sessionID: self.sessionID, messageID: nil, encryptionKeyHex: self.encryptionKeyHex, httpClient: httpClient)
         self.localPartyID = vault.localPartyID
         self.publicKeyECDSA = vault.pubKeyECDSA
         self.localPrivateSecret = localUI

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
@@ -41,6 +41,8 @@ struct DKLSKeyshare {
     let chaincode: String
 }
 
+private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dkls-keygen")
+
 final class DKLSKeygen {
     let vault: Vault
     let tssType: TssType
@@ -59,6 +61,7 @@ final class DKLSKeygen {
     let localPrivateSecret: String?
     let hexChainCode: String
     let DKLS_LIB_OK: godkls.lib_error = .init(0)
+    private let httpClient: HTTPClientProtocol = HTTPClient()
 
     // Populated by prepareKeyImportSetup. DKLSKeygenWithRetry consumes the stored
     // handle on attempt 0 and falls back to the normal flow on retry.
@@ -213,39 +216,37 @@ final class DKLSKeygen {
     }
 
     func pullInboundMessages(handle: godkls.Handle) async throws -> Bool {
-        let urlString = "\(mediatorURL)/message/\(sessionID)/\(self.localPartyID)"
-        print("start pulling inbound messages from:\(urlString)")
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
+        logger.debug("start pulling inbound messages for session \(self.sessionID), party \(self.localPartyID)")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let messageID = self.messenger.messageID {
-            request.setValue(messageID, forHTTPHeaderField: "message_id")
-        }
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
-            let (data, resp) = try await URLSession.shared.data(for: request)
-            guard let httpResp = resp as? HTTPURLResponse else {
-                throw HelperError.runtimeError("fail to convert resp to http url response")
+            let response: HTTPResponse<Data>
+            do {
+                response = try await httpClient.request(TssRelayAPI(
+                    baseURL: baseURL,
+                    endpoint: .pollInboundMessages(
+                        sessionID: sessionID,
+                        localPartyID: localPartyID,
+                        messageID: messenger.messageID
+                    )
+                ))
+            } catch let HTTPError.statusCode(code, _) {
+                throw HelperError.runtimeError("invalid status code: \(code)")
             }
-            switch httpResp.statusCode {
-            case 200 ... 299:
-                if !data.isEmpty {
-                    isFinished = try await processInboundMessage(handle: handle, data: data)
-                    if isFinished {
-                        return true
-                    }
-                } else {
-                    try await Task.sleep(for: .milliseconds(100))
+
+            if !response.data.isEmpty {
+                isFinished = try await processInboundMessage(handle: handle, data: response.data)
+                if isFinished {
+                    return true
                 }
-                // success
-            default:
-                throw HelperError.runtimeError("invalid status code: \(httpResp.statusCode)")
+            } else {
+                try await Task.sleep(for: .milliseconds(100))
             }
+
             let currentTime = DispatchTime.now()
             let elapsedTime = currentTime.uptimeNanoseconds - start.uptimeNanoseconds
             let elapsedTimeInSeconds = Double(elapsedTime) / 1_000_000_000
@@ -310,16 +311,18 @@ final class DKLSKeygen {
     }
 
     func deleteMessageFromServer(hash: String) async throws {
-        let urlString = "\(mediatorURL)/message/\(self.sessionID)/\(self.localPartyID)/\(hash)"
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        if let messageID = self.messenger.messageID {
-            request.setValue(messageID, forHTTPHeaderField: "message_id")
-        }
-        let (_, _) = try await URLSession.shared.data(for: request)
+        _ = try await httpClient.request(TssRelayAPI(
+            baseURL: baseURL,
+            endpoint: .deleteMessage(
+                sessionID: sessionID,
+                localPartyID: localPartyID,
+                hash: hash,
+                messageID: messenger.messageID
+            )
+        ))
     }
     /// Phase 1 of batch key import: uploads setup message to the relay (initiator)
     /// or downloads it (follower), and creates the key-import session handle.

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DilithiumKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DilithiumKeygen.swift
@@ -16,6 +16,8 @@ struct DilithiumKeyshare {
     let keyId: String
 }
 
+private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dilithium-keygen")
+
 final class DilithiumKeygen {
     let vault: Vault
     let tssType: TssType
@@ -30,6 +32,7 @@ final class DilithiumKeygen {
     var setupMessage: [UInt8] = []
     var keyshare: DilithiumKeyshare?
     let MLDSA_LIB_OK: vscore.mldsa_error = .init(0)
+    private let httpClient: HTTPClientProtocol = HTTPClient()
 
     init(vault: Vault,
          tssType: TssType,
@@ -130,35 +133,37 @@ final class DilithiumKeygen {
     }
 
     func pullInboundMessages(handle: vscore.Handle) async throws -> Bool {
-        let urlString = "\(mediatorURL)/message/\(sessionID)/\(self.localPartyID)"
-        print("start pulling inbound messages from:\(urlString)")
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
+        logger.debug("start pulling inbound messages for session \(self.sessionID), party \(self.localPartyID)")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
-            let (data, resp) = try await URLSession.shared.data(for: request)
-            guard let httpResp = resp as? HTTPURLResponse else {
-                throw HelperError.runtimeError("fail to convert resp to http url response")
+            let response: HTTPResponse<Data>
+            do {
+                response = try await httpClient.request(TssRelayAPI(
+                    baseURL: baseURL,
+                    endpoint: .pollInboundMessages(
+                        sessionID: sessionID,
+                        localPartyID: localPartyID,
+                        messageID: messenger.messageID
+                    )
+                ))
+            } catch let HTTPError.statusCode(code, _) {
+                throw HelperError.runtimeError("invalid status code: \(code)")
             }
-            switch httpResp.statusCode {
-            case 200 ... 299:
-                if !data.isEmpty {
-                    isFinished = try await processInboundMessage(handle: handle, data: data)
-                    if isFinished {
-                        return true
-                    }
-                } else {
-                    try await Task.sleep(for: .milliseconds(100))
+
+            if !response.data.isEmpty {
+                isFinished = try await processInboundMessage(handle: handle, data: response.data)
+                if isFinished {
+                    return true
                 }
-            default:
-                throw HelperError.runtimeError("invalid status code: \(httpResp.statusCode)")
+            } else {
+                try await Task.sleep(for: .milliseconds(100))
             }
+
             let currentTime = DispatchTime.now()
             let elapsedTime = currentTime.uptimeNanoseconds - start.uptimeNanoseconds
             let elapsedTimeInSeconds = Double(elapsedTime) / 1_000_000_000
@@ -213,13 +218,18 @@ final class DilithiumKeygen {
     }
 
     func deleteMessageFromServer(hash: String) async throws {
-        let urlString = "\(mediatorURL)/message/\(self.sessionID)/\(self.localPartyID)/\(hash)"
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        let (_, _) = try await URLSession.shared.data(for: request)
+        _ = try await httpClient.request(TssRelayAPI(
+            baseURL: baseURL,
+            endpoint: .deleteMessage(
+                sessionID: sessionID,
+                localPartyID: localPartyID,
+                hash: hash,
+                messageID: messenger.messageID
+            )
+        ))
     }
 
     func DilithiumKeygenWithRetry(attempt: UInt8) async throws {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DilithiumKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DilithiumKeygen.swift
@@ -32,7 +32,7 @@ final class DilithiumKeygen {
     var setupMessage: [UInt8] = []
     var keyshare: DilithiumKeyshare?
     let MLDSA_LIB_OK: vscore.mldsa_error = .init(0)
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     init(vault: Vault,
          tssType: TssType,
@@ -41,7 +41,8 @@ final class DilithiumKeygen {
          sessionID: String,
          encryptionKeyHex: String,
          isInitiateDevice: Bool,
-         setupMessage: [UInt8]
+         setupMessage: [UInt8],
+         httpClient: HTTPClientProtocol = HTTPClient()
     ) {
         self.vault = vault
         self.tssType = tssType
@@ -50,7 +51,8 @@ final class DilithiumKeygen {
         self.sessionID = sessionID
         self.encryptionKeyHex = encryptionKeyHex
         self.isInitiateDevice = isInitiateDevice
-        self.messenger = DKLSMessenger(mediatorUrl: self.mediatorURL, sessionID: self.sessionID, messageID: nil, encryptionKeyHex: self.encryptionKeyHex)
+        self.httpClient = httpClient
+        self.messenger = DKLSMessenger(mediatorUrl: self.mediatorURL, sessionID: self.sessionID, messageID: nil, encryptionKeyHex: self.encryptionKeyHex, httpClient: httpClient)
         self.localPartyID = vault.localPartyID
         self.setupMessage = setupMessage
     }

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
@@ -18,6 +18,8 @@ private extension goschnorr.schnorr_lib_error {
     static let schnorrLibOK = goschnorr.schnorr_lib_error(rawValue: 0)
 }
 
+private let logger = Logger(subsystem: "com.vultisig.app", category: "net-schnorr-keygen")
+
 final class SchnorrKeygen {
     let vault: Vault
     let tssType: TssType
@@ -35,6 +37,7 @@ final class SchnorrKeygen {
     let publicKeyEdDSA: String
     let localPrivateSecret: String?
     let hexChainCode: String
+    private let httpClient: HTTPClientProtocol = HTTPClient()
 
     // Populated by prepareKeyImportSetup. SchnorrKeygenWithRetry consumes the stored
     // handle on attempt 0 and falls back to the normal flow on retry.
@@ -172,39 +175,37 @@ final class SchnorrKeygen {
     }
 
     func pullInboundMessages(handle: goschnorr.Handle) async throws -> Bool {
-        let urlString = "\(mediatorURL)/message/\(sessionID)/\(self.localPartyID)"
-        print("start pulling inbound messages from:\(urlString)")
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
+        logger.debug("start pulling inbound messages for session \(self.sessionID), party \(self.localPartyID)")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let messageID = self.messenger.messageID {
-            request.setValue(messageID, forHTTPHeaderField: "message_id")
-        }
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
-            let (data, resp) = try await URLSession.shared.data(for: request)
-            guard let httpResp = resp as? HTTPURLResponse else {
-                throw HelperError.runtimeError("fail to convert resp to http url response")
+            let response: HTTPResponse<Data>
+            do {
+                response = try await httpClient.request(TssRelayAPI(
+                    baseURL: baseURL,
+                    endpoint: .pollInboundMessages(
+                        sessionID: sessionID,
+                        localPartyID: localPartyID,
+                        messageID: messenger.messageID
+                    )
+                ))
+            } catch let HTTPError.statusCode(code, _) {
+                throw HelperError.runtimeError("invalid status code: \(code)")
             }
-            switch httpResp.statusCode {
-            case 200 ... 299:
-                if !data.isEmpty {
-                    isFinished = try await processInboundMessage(handle: handle, data: data)
-                    if isFinished {
-                        return true
-                    }
-                } else {
-                    try await Task.sleep(for: .milliseconds(100))
+
+            if !response.data.isEmpty {
+                isFinished = try await processInboundMessage(handle: handle, data: response.data)
+                if isFinished {
+                    return true
                 }
-                // success
-            default:
-                throw HelperError.runtimeError("invalid status code: \(httpResp.statusCode)")
+            } else {
+                try await Task.sleep(for: .milliseconds(100))
             }
+
             let currentTime = DispatchTime.now()
             let elapsedTime = currentTime.uptimeNanoseconds - start.uptimeNanoseconds
             let elapsedTimeInSeconds = Double(elapsedTime) / 1_000_000_000
@@ -267,16 +268,18 @@ final class SchnorrKeygen {
     }
 
     func deleteMessageFromServer(hash: String) async throws {
-        let urlString = "\(mediatorURL)/message/\(self.sessionID)/\(self.localPartyID)/\(hash)"
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        if let messageID = self.messenger.messageID {
-            request.setValue(messageID, forHTTPHeaderField: "message_id")
-        }
-        let (_, _) = try await URLSession.shared.data(for: request)
+        _ = try await httpClient.request(TssRelayAPI(
+            baseURL: baseURL,
+            endpoint: .deleteMessage(
+                sessionID: sessionID,
+                localPartyID: localPartyID,
+                hash: hash,
+                messageID: messenger.messageID
+            )
+        ))
     }
 
     /// Downloads the shared setup message from the relay server (default namespace).

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
@@ -37,7 +37,7 @@ final class SchnorrKeygen {
     let publicKeyEdDSA: String
     let localPrivateSecret: String?
     let hexChainCode: String
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     // Populated by prepareKeyImportSetup. SchnorrKeygenWithRetry consumes the stored
     // handle on attempt 0 and falls back to the normal flow on retry.
@@ -52,7 +52,8 @@ final class SchnorrKeygen {
          encryptionKeyHex: String,
          isInitiatedDevice: Bool,
          setupMessage: [UInt8],
-         localUI: String?) {
+         localUI: String?,
+         httpClient: HTTPClientProtocol = HTTPClient()) {
         self.vault = vault
         self.tssType = tssType
         self.keygenCommittee = keygenCommittee
@@ -62,10 +63,12 @@ final class SchnorrKeygen {
         self.encryptionKeyHex = encryptionKeyHex
         self.isInitiateDevice = isInitiatedDevice
         self.setupMessage = setupMessage
+        self.httpClient = httpClient
         self.messenger = DKLSMessenger(mediatorUrl: self.mediatorURL,
                                        sessionID: self.sessionID,
                                        messageID: nil,
-                                       encryptionKeyHex: self.encryptionKeyHex)
+                                       encryptionKeyHex: self.encryptionKeyHex,
+                                       httpClient: httpClient)
         self.localPartyID = vault.localPartyID
         self.publicKeyEdDSA = vault.pubKeyEdDSA
         self.localPrivateSecret = localUI

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -11,6 +11,8 @@ import OSLog
 import Mediator
 import Tss
 
+private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dkls-keysign")
+
 final class DKLSKeysign {
     let keysignCommittee: [String]
     let mediatorURL: String
@@ -26,6 +28,7 @@ final class DKLSKeysign {
     var cache = NSCache<NSString, AnyObject>()
     var signatures = [String: TssKeysignResponse]()
     let DKLS_LIB_OK: godkls.lib_error = .init(0)
+    private let httpClient: HTTPClientProtocol = HTTPClient()
 
     init(keysignCommittee: [String],
          mediatorURL: String,
@@ -207,39 +210,39 @@ final class DKLSKeysign {
     }
 
     func pullInboundMessages(handle: godkls.Handle, messageID: String) async throws -> Bool {
-        let urlString = "\(mediatorURL)/message/\(sessionID)/\(self.localPartyID)"
-        print("start pulling inbound messages from:\(urlString)")
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
+        logger.debug("start pulling inbound messages for session \(self.sessionID), party \(self.localPartyID)")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(messageID, forHTTPHeaderField: "message_id")
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
-            let (data, resp) = try await URLSession.shared.data(for: request)
-            guard let httpResp = resp as? HTTPURLResponse else {
-                throw HelperError.runtimeError("fail to convert resp to http url response")
+            let response: HTTPResponse<Data>
+            do {
+                response = try await httpClient.request(TssRelayAPI(
+                    baseURL: baseURL,
+                    endpoint: .pollInboundMessages(
+                        sessionID: sessionID,
+                        localPartyID: localPartyID,
+                        messageID: messageID
+                    )
+                ))
+            } catch let HTTPError.statusCode(code, _) {
+                throw HelperError.runtimeError("invalid status code: \(code)")
             }
-            switch httpResp.statusCode {
-            case 200 ... 299:
-                if !data.isEmpty {
-                    isFinished = try await processInboundMessage(handle: handle,
-                                                                 data: data,
-                                                                 messageID: messageID)
-                    if isFinished {
-                        return true
-                    }
-                } else {
-                    try await Task.sleep(for: .milliseconds(100))
+
+            if !response.data.isEmpty {
+                isFinished = try await processInboundMessage(handle: handle,
+                                                             data: response.data,
+                                                             messageID: messageID)
+                if isFinished {
+                    return true
                 }
-                // success
-            default:
-                throw HelperError.runtimeError("invalid status code: \(httpResp.statusCode)")
+            } else {
+                try await Task.sleep(for: .milliseconds(100))
             }
+
             let currentTime = DispatchTime.now()
             let elapsedTime = currentTime.uptimeNanoseconds - start.uptimeNanoseconds
             let elapsedTimeInSeconds = Double(elapsedTime) / 1_000_000_000
@@ -293,14 +296,18 @@ final class DKLSKeysign {
     }
 
     func deleteMessageFromServer(hash: String, messageID: String) async throws {
-        let urlString = "\(mediatorURL)/message/\(self.sessionID)/\(self.localPartyID)/\(hash)"
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.addValue(messageID, forHTTPHeaderField: "message_id")
-        let (_, _) = try await URLSession.shared.data(for: request)
+        _ = try await httpClient.request(TssRelayAPI(
+            baseURL: baseURL,
+            endpoint: .deleteMessage(
+                sessionID: sessionID,
+                localPartyID: localPartyID,
+                hash: hash,
+                messageID: messageID
+            )
+        ))
     }
 
     func DKLSKeysignOneMessageWithRetry(attempt: UInt8, messageToSign: String) async throws {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -28,7 +28,7 @@ final class DKLSKeysign {
     var cache = NSCache<NSString, AnyObject>()
     var signatures = [String: TssKeysignResponse]()
     let DKLS_LIB_OK: godkls.lib_error = .init(0)
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     init(keysignCommittee: [String],
          mediatorURL: String,
@@ -38,7 +38,8 @@ final class DKLSKeysign {
          encryptionKeyHex: String,
          chainPath: String,
          isInitiateDevice: Bool,
-         publicKeyECDSA: String) {
+         publicKeyECDSA: String,
+         httpClient: HTTPClientProtocol = HTTPClient()) {
         self.keysignCommittee = keysignCommittee
         self.mediatorURL = mediatorURL
         self.sessionID = sessionID
@@ -49,6 +50,7 @@ final class DKLSKeysign {
         self.isInitiateDevice = isInitiateDevice
         self.localPartyID = vault.localPartyID
         self.publicKeyECDSA = publicKeyECDSA
+        self.httpClient = httpClient
     }
 
     func getSignatures() -> [String: TssKeysignResponse] {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
@@ -20,6 +20,8 @@ struct DilithiumKeysignResponse: Codable {
     }
 }
 
+private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dilithium-keysign")
+
 final class DilithiumKeysign {
     let keysignCommittee: [String]
     let mediatorURL: String
@@ -35,6 +37,7 @@ final class DilithiumKeysign {
     var cache = NSCache<NSString, AnyObject>()
     var signatures = [String: DilithiumKeysignResponse]()
     let MLDSA_LIB_OK: vscore.mldsa_error = .init(0)
+    private let httpClient: HTTPClientProtocol = HTTPClient()
 
     init(keysignCommittee: [String],
          mediatorURL: String,
@@ -191,39 +194,39 @@ final class DilithiumKeysign {
     }
 
     func pullInboundMessages(handle: vscore.Handle, messageID: String) async throws -> Bool {
-        let urlString = "\(mediatorURL)/message/\(sessionID)/\(self.localPartyID)"
-        print("start pulling inbound messages from:\(urlString)")
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
+        logger.debug("start pulling inbound messages for session \(self.sessionID), party \(self.localPartyID)")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(messageID, forHTTPHeaderField: "message_id")
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
-            let (data, resp) = try await URLSession.shared.data(for: request)
-            guard let httpResp = resp as? HTTPURLResponse else {
-                throw HelperError.runtimeError("fail to convert resp to http url response")
+            let response: HTTPResponse<Data>
+            do {
+                response = try await httpClient.request(TssRelayAPI(
+                    baseURL: baseURL,
+                    endpoint: .pollInboundMessages(
+                        sessionID: sessionID,
+                        localPartyID: localPartyID,
+                        messageID: messageID
+                    )
+                ))
+            } catch let HTTPError.statusCode(code, _) {
+                throw HelperError.runtimeError("invalid status code: \(code)")
             }
-            switch httpResp.statusCode {
-            case 200 ... 299:
-                if !data.isEmpty {
-                    isFinished = try await processInboundMessage(handle: handle,
-                                                                 data: data,
-                                                                 messageID: messageID)
-                    if isFinished {
-                        return true
-                    }
-                } else {
-                    try await Task.sleep(for: .milliseconds(100))
+
+            if !response.data.isEmpty {
+                isFinished = try await processInboundMessage(handle: handle,
+                                                             data: response.data,
+                                                             messageID: messageID)
+                if isFinished {
+                    return true
                 }
-                // success
-            default:
-                throw HelperError.runtimeError("invalid status code: \(httpResp.statusCode)")
+            } else {
+                try await Task.sleep(for: .milliseconds(100))
             }
+
             let currentTime = DispatchTime.now()
             let elapsedTime = currentTime.uptimeNanoseconds - start.uptimeNanoseconds
             let elapsedTimeInSeconds = Double(elapsedTime) / 1_000_000_000
@@ -277,14 +280,18 @@ final class DilithiumKeysign {
     }
 
     func deleteMessageFromServer(hash: String, messageID: String) async throws {
-        let urlString = "\(mediatorURL)/message/\(self.sessionID)/\(self.localPartyID)/\(hash)"
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.addValue(messageID, forHTTPHeaderField: "message_id")
-        let (_, _) = try await URLSession.shared.data(for: request)
+        _ = try await httpClient.request(TssRelayAPI(
+            baseURL: baseURL,
+            endpoint: .deleteMessage(
+                sessionID: sessionID,
+                localPartyID: localPartyID,
+                hash: hash,
+                messageID: messageID
+            )
+        ))
     }
 
     func DilithiumKeysignOneMessageWithRetry(attempt: UInt8, messageToSign: String) async throws {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
@@ -37,7 +37,7 @@ final class DilithiumKeysign {
     var cache = NSCache<NSString, AnyObject>()
     var signatures = [String: DilithiumKeysignResponse]()
     let MLDSA_LIB_OK: vscore.mldsa_error = .init(0)
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     init(keysignCommittee: [String],
          mediatorURL: String,
@@ -47,7 +47,8 @@ final class DilithiumKeysign {
          encryptionKeyHex: String,
          chainPath: String,
          isInitiateDevice: Bool,
-         publicKey: String) {
+         publicKey: String,
+         httpClient: HTTPClientProtocol = HTTPClient()) {
         self.keysignCommittee = keysignCommittee
         self.mediatorURL = mediatorURL
         self.sessionID = sessionID
@@ -58,6 +59,7 @@ final class DilithiumKeysign {
         self.isInitiateDevice = isInitiateDevice
         self.localPartyID = vault.localPartyID
         self.publicKey = publicKey
+        self.httpClient = httpClient
     }
 
     func getSignatures() -> [String: DilithiumKeysignResponse] {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
@@ -19,6 +19,8 @@ private extension goschnorr.schnorr_lib_error {
     static let schnorrLibOK = goschnorr.schnorr_lib_error(rawValue: 0)
 }
 
+private let logger = Logger(subsystem: "com.vultisig.app", category: "net-schnorr-keysign")
+
 final class SchnorrKeysign {
     let keysignCommittee: [String]
     let mediatorURL: String
@@ -33,6 +35,7 @@ final class SchnorrKeysign {
     var cache = NSCache<NSString, AnyObject>()
     var signatures = [String: TssKeysignResponse]()
     var keyshare: [UInt8] = []
+    private let httpClient: HTTPClientProtocol = HTTPClient()
 
     init(keysignCommittee: [String],
          mediatorURL: String,
@@ -193,39 +196,39 @@ final class SchnorrKeysign {
     }
 
     func pullInboundMessages(handle: goschnorr.Handle, messageID: String) async throws -> Bool {
-        let urlString = "\(mediatorURL)/message/\(sessionID)/\(self.localPartyID)"
-        print("start pulling inbound messages from:\(urlString)")
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
+        logger.debug("start pulling inbound messages for session \(self.sessionID), party \(self.localPartyID)")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(messageID, forHTTPHeaderField: "message_id")
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
-            let (data, resp) = try await URLSession.shared.data(for: request)
-            guard let httpResp = resp as? HTTPURLResponse else {
-                throw HelperError.runtimeError("fail to convert resp to http url response")
+            let response: HTTPResponse<Data>
+            do {
+                response = try await httpClient.request(TssRelayAPI(
+                    baseURL: baseURL,
+                    endpoint: .pollInboundMessages(
+                        sessionID: sessionID,
+                        localPartyID: localPartyID,
+                        messageID: messageID
+                    )
+                ))
+            } catch let HTTPError.statusCode(code, _) {
+                throw HelperError.runtimeError("invalid status code: \(code)")
             }
-            switch httpResp.statusCode {
-            case 200 ... 299:
-                if !data.isEmpty {
-                    isFinished = try await processInboundMessage(handle: handle,
-                                                                 data: data,
-                                                                 messageID: messageID)
-                    if isFinished {
-                        return true
-                    }
-                } else {
-                    try await Task.sleep(for: .milliseconds(100))
+
+            if !response.data.isEmpty {
+                isFinished = try await processInboundMessage(handle: handle,
+                                                             data: response.data,
+                                                             messageID: messageID)
+                if isFinished {
+                    return true
                 }
-                // success
-            default:
-                throw HelperError.runtimeError("invalid status code: \(httpResp.statusCode)")
+            } else {
+                try await Task.sleep(for: .milliseconds(100))
             }
+
             let currentTime = DispatchTime.now()
             let elapsedTime = currentTime.uptimeNanoseconds - start.uptimeNanoseconds
             let elapsedTimeInSeconds = Double(elapsedTime) / 1_000_000_000
@@ -289,14 +292,18 @@ final class SchnorrKeysign {
     }
 
     func deleteMessageFromServer(hash: String, messageID: String) async throws {
-        let urlString = "\(mediatorURL)/message/\(self.sessionID)/\(self.localPartyID)/\(hash)"
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("invalid url string: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.addValue(messageID, forHTTPHeaderField: "message_id")
-        let (_, _) = try await URLSession.shared.data(for: request)
+        _ = try await httpClient.request(TssRelayAPI(
+            baseURL: baseURL,
+            endpoint: .deleteMessage(
+                sessionID: sessionID,
+                localPartyID: localPartyID,
+                hash: hash,
+                messageID: messageID
+            )
+        ))
     }
 
     func KeysignOneMessageWithRetry(attempt: UInt8, messageToSign: String) async throws {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
@@ -35,7 +35,7 @@ final class SchnorrKeysign {
     var cache = NSCache<NSString, AnyObject>()
     var signatures = [String: TssKeysignResponse]()
     var keyshare: [UInt8] = []
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     init(keysignCommittee: [String],
          mediatorURL: String,
@@ -44,7 +44,8 @@ final class SchnorrKeysign {
          vault: Vault,
          encryptionKeyHex: String,
          isInitiateDevice: Bool,
-         publicKeyEdDSA: String) {
+         publicKeyEdDSA: String,
+         httpClient: HTTPClientProtocol = HTTPClient()) {
         self.keysignCommittee = keysignCommittee
         self.mediatorURL = mediatorURL
         self.sessionID = sessionID
@@ -54,6 +55,7 @@ final class SchnorrKeysign {
         self.isInitiateDevice = isInitiateDevice
         self.localPartyID = vault.localPartyID
         self.publicKeyEdDSA = publicKeyEdDSA
+        self.httpClient = httpClient
     }
 
     func getSignatures() -> [String: TssKeysignResponse] {

--- a/VultisigApp/VultisigApp/Blockchain/Tss/DKLSMessenger.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/DKLSMessenger.swift
@@ -10,53 +10,52 @@ import Mediator
 import OSLog
 import CryptoKit
 
-private let logger = Logger(subsystem: "messenger", category: "dkls")
+private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dkls-messenger")
 final class DKLSMessenger {
     let mediatorURL: String
     let sessionID: String
     var messageID: String?
     let encryptionKeyHex: String
     var counter: Int64 = 1
+    private let httpClient: HTTPClientProtocol
 
     init(mediatorUrl: String,
          sessionID: String,
          messageID: String?,
-         encryptionKeyHex: String) {
+         encryptionKeyHex: String,
+         httpClient: HTTPClientProtocol = HTTPClient()) {
         self.mediatorURL = mediatorUrl
         self.sessionID = sessionID
         self.messageID = messageID
         self.encryptionKeyHex = encryptionKeyHex
+        self.httpClient = httpClient
     }
 
     /// Uploads a setup message to the relay server.
     /// `self.messageID` is applied first; when `additionalHeader` is provided it overrides the header
     /// so callers can route a setup message into a different namespace than the TSS exchange.
     func uploadSetupMessage(message: String, _ additionalHeader: String?) async throws {
-        let urlString = "\(self.mediatorURL)/setup-message/\(self.sessionID)"
-        let url = URL(string: urlString)
-        guard let url else {
-            throw HelperError.runtimeError("URL can't be construct from: \(urlString)")
-        }
-        var req = URLRequest(url: url)
-        req.httpMethod = "POST"
-        req.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let messageID = self.messageID {
-            req.setValue(messageID, forHTTPHeaderField: "message_id")
-        }
-        if let additionalHeader {
-            req.setValue(additionalHeader, forHTTPHeaderField: "message_id")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
 
-        let encryptedBody = message.aesEncryptGCM(key: self.encryptionKeyHex)
-        guard let encryptedBody else {
+        guard let encryptedBody = message.aesEncryptGCM(key: self.encryptionKeyHex),
+              let bodyData = encryptedBody.data(using: .utf8) else {
             throw HelperError.runtimeError("fail to encrypt message body")
         }
-        req.httpBody = encryptedBody.data(using: .utf8)
-        let (_, resp) = try await URLSession.shared.data(for: req)
-        if let httpResponse = resp as? HTTPURLResponse {
-            if !(200...299).contains(httpResponse.statusCode) {
-                throw HelperError.runtimeError("fail to setup message to relay server,status:\(httpResponse.statusCode)")
-            }
+
+        do {
+            _ = try await httpClient.request(TssRelayAPI(
+                baseURL: baseURL,
+                endpoint: .uploadSetupMessage(
+                    sessionID: sessionID,
+                    body: bodyData,
+                    messageID: messageID,
+                    additionalHeader: additionalHeader
+                )
+            ))
+        } catch let HTTPError.statusCode(code, _) {
+            throw HelperError.runtimeError("fail to setup message to relay server,status:\(code)")
         }
     }
 
@@ -66,7 +65,7 @@ final class DKLSMessenger {
             do {
                 return try await downloadSetupMessage(additionalHeader)
             } catch {
-                print("fail to download setup message,error \(error), attempt: \(attempt)")
+                logger.error("fail to download setup message, error \(error.localizedDescription), attempt: \(attempt)")
                 // backoff 1s
                 try await Task.sleep(for: .seconds(1))
             }
@@ -80,28 +79,25 @@ final class DKLSMessenger {
     /// `self.messageID` is applied first; when `additionalHeader` is provided it overrides the header
     /// so callers can route a setup message into a different namespace than the TSS exchange.
     func downloadSetupMessage(_ additionalHeader: String?) async throws -> String {
-        let urlString = "\(self.mediatorURL)/setup-message/\(self.sessionID)"
-        let url = URL(string: urlString)
-        guard let url else {
-            throw HelperError.runtimeError("URL can't be construct from: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            throw HelperError.runtimeError("invalid mediator URL: \(mediatorURL)")
         }
-        var req = URLRequest(url: url)
-        req.httpMethod = "GET"
-        req.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let messageID = self.messageID {
-            req.setValue(messageID, forHTTPHeaderField: "message_id")
+
+        let response: HTTPResponse<Data>
+        do {
+            response = try await httpClient.request(TssRelayAPI(
+                baseURL: baseURL,
+                endpoint: .downloadSetupMessage(
+                    sessionID: sessionID,
+                    messageID: messageID,
+                    additionalHeader: additionalHeader
+                )
+            ))
+        } catch let HTTPError.statusCode(code, _) {
+            throw HelperError.runtimeError("fail to download setup message from relay server,status:\(code)")
         }
-        if let additionalHeader {
-            req.setValue(additionalHeader, forHTTPHeaderField: "message_id")
-        }
-        let (data, resp) = try await URLSession.shared.data(for: req)
-        if let httpResponse = resp as? HTTPURLResponse {
-            if !(200...299).contains(httpResponse.statusCode) {
-                throw HelperError.runtimeError("fail to download setup message from relay server,status:\(httpResponse.statusCode)")
-            }
-        }
-        let setupMsg = String(data: data, encoding: .utf8)
-        guard let setupMsg else {
+
+        guard let setupMsg = String(data: response.data, encoding: .utf8) else {
             throw HelperError.runtimeError("fail to convert setup message")
         }
         if let result = setupMsg.aesDecryptGCM(key: self.encryptionKeyHex) {
@@ -123,21 +119,12 @@ final class DKLSMessenger {
             logger.error("body is nil")
             return
         }
-        let urlString = "\(self.mediatorURL)/message/\(self.sessionID)"
-        let url = URL(string: urlString)
-        guard let url else {
-            logger.error("URL can't be construct from: \(urlString)")
+        guard let baseURL = URL(string: mediatorURL) else {
+            logger.error("invalid mediator URL: \(self.mediatorURL)")
             return
         }
-        var req = URLRequest(url: url)
-        req.httpMethod = "POST"
-        req.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let messageID = self.messageID {
-            req.setValue(messageID, forHTTPHeaderField: "message_id")
-        }
 
-        let encryptedBody = body.aesEncryptGCM(key: self.encryptionKeyHex)
-        guard let encryptedBody else {
+        guard let encryptedBody = body.aesEncryptGCM(key: self.encryptionKeyHex) else {
             logger.error("fail to encrypt message body")
             return
         }
@@ -148,27 +135,25 @@ final class DKLSMessenger {
                           hash: Utils.getMessageBodyHash(msg: body),
                           sequenceNo: self.counter)
         self.counter += 1
-        do {
-            let jsonEncode = JSONEncoder()
-            let encodedBody = try jsonEncode.encode(msg)
-            req.httpBody = encodedBody
-        } catch {
-            logger.error("fail to encode body into json string,\(error)")
-            return
-        }
+
         for _ in 0...3 {
             do {
-                let (_, resp) = try await URLSession.shared.data(for: req)
-                if let httpResponse = resp as? HTTPURLResponse {
-                    if !(200...299).contains(httpResponse.statusCode) {
-                        logger.error("fail to send message to relay server,status:\(httpResponse.statusCode)")
-                        continue // retry
-                    }
-                }
+                _ = try await httpClient.request(TssRelayAPI(
+                    baseURL: baseURL,
+                    endpoint: .sendMessage(
+                        sessionID: sessionID,
+                        message: msg,
+                        messageID: messageID,
+                        addLegacyKeygenHeader: false
+                    )
+                ))
                 logger.info("send message (\(msg.hash) to (\(msg.to)) successfully, sequenceNo:\(msg.sequence_no)")
                 return
+            } catch let HTTPError.statusCode(code, _) {
+                logger.error("fail to send message to relay server,status:\(code)")
+                continue
             } catch {
-                logger.error("fail to send message,error:\(error)")
+                logger.error("fail to send message,error:\(error.localizedDescription)")
             }
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/Tss/TssMessenger.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/TssMessenger.swift
@@ -9,7 +9,7 @@ import Mediator
 import OSLog
 import Tss
 
-private let logger = Logger(subsystem: "messenger", category: "tss")
+private let logger = Logger(subsystem: "com.vultisig.app", category: "net-tss-messenger")
 final class TssMessengerImpl: NSObject, TssMessengerProtocol {
     let mediatorUrl: String
     let sessionID: String
@@ -20,6 +20,7 @@ final class TssMessengerImpl: NSObject, TssMessengerProtocol {
     let isKeygen: Bool
     var vaultPubKey = ""
     let encryptGCM: Bool
+    private let httpClient: HTTPClientProtocol
 
     var counter: Int64 = 1
     init(mediatorUrl: String,
@@ -28,7 +29,8 @@ final class TssMessengerImpl: NSObject, TssMessengerProtocol {
          encryptionKeyHex: String,
          vaultPubKey: String,
          isKeygen: Bool,
-         encryptGCM: Bool) {
+         encryptGCM: Bool,
+         httpClient: HTTPClientProtocol = HTTPClient()) {
         self.mediatorUrl = mediatorUrl
         self.sessionID = sessionID
         self.messageID = messageID
@@ -36,6 +38,7 @@ final class TssMessengerImpl: NSObject, TssMessengerProtocol {
         self.vaultPubKey = vaultPubKey
         self.isKeygen = isKeygen
         self.encryptGCM = encryptGCM
+        self.httpClient = httpClient
     }
 
     func send(_ fromParty: String?, to: String?, body: String?) throws {
@@ -51,27 +54,15 @@ final class TssMessengerImpl: NSObject, TssMessengerProtocol {
             logger.error("body is nil")
             return
         }
-        let urlString = "\(self.mediatorUrl)/message/\(self.sessionID)"
-        let url = URL(string: urlString)
-        guard let url else {
-            logger.error("URL can't be construct from: \(urlString)")
+        guard let baseURL = URL(string: mediatorUrl) else {
+            logger.error("URL can't be construct from: \(self.mediatorUrl)")
             return
         }
-        var req = URLRequest(url: url)
-        req.httpMethod = "POST"
-        req.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let messageID = self.messageID {
-            req.setValue(messageID, forHTTPHeaderField: "message_id")
-        }
-        if isKeygen {
-            req.setValue("vultisig", forHTTPHeaderField: "keygen")
-        }
-        var encryptedBody: String? = nil
+
+        let encryptedBody: String?
         if self.encryptGCM {
-            print("decrypt with AES+GCM")
             encryptedBody = body.aesEncryptGCM(key: self.encryptionKeyHex)
         } else {
-            print("decrypt with AES+CBC")
             encryptedBody = body.aesEncrypt(key: self.encryptionKeyHex)
         }
         guard let encryptedBody else {
@@ -85,33 +76,60 @@ final class TssMessengerImpl: NSObject, TssMessengerProtocol {
                           hash: Utils.getMessageBodyHash(msg: body),
                           sequenceNo: self.counter)
         self.counter += 1
-        do {
-            let jsonEncode = JSONEncoder()
-            let encodedBody = try jsonEncode.encode(msg)
-            req.httpBody = encodedBody
-        } catch {
-            logger.error("fail to encode body into json string,\(error)")
-            return
+
+        // The TssMessenger Objective-C protocol is synchronous (Go callback),
+        // so we kick the HTTP work onto a detached Task and let it retry
+        // independently — preserving the original fire-and-forget semantics.
+        let httpClient = self.httpClient
+        let messageID = self.messageID
+        let isKeygen = self.isKeygen
+        let sessionID = self.sessionID
+        Task.detached {
+            await Self.sendWithRetry(
+                httpClient: httpClient,
+                baseURL: baseURL,
+                sessionID: sessionID,
+                msg: msg,
+                messageID: messageID,
+                addLegacyKeygenHeader: isKeygen,
+                retry: 3
+            )
         }
-        let retry = 3
-        self.sendWithRetry(req: req, msg: msg, retry: retry)
     }
 
-    func sendWithRetry(req: URLRequest, msg: Message, retry: Int) {
-        URLSession.shared.dataTask(with: req) { _, resp, err in
-            if let err {
-                logger.error("fail to send message,error:\(err)")
-                if retry == 0 {
-                    return
-                } else {
-                    self.sendWithRetry(req: req, msg: msg, retry: retry - 1)
-                }
-            }
-            guard let resp = resp as? HTTPURLResponse, (200 ... 299).contains(resp.statusCode) else {
-                logger.error("invalid response code")
+    private static func sendWithRetry(
+        httpClient: HTTPClientProtocol,
+        baseURL: URL,
+        sessionID: String,
+        msg: Message,
+        messageID: String?,
+        addLegacyKeygenHeader: Bool,
+        retry: Int
+    ) async {
+        var remaining = retry
+        repeat {
+            do {
+                _ = try await httpClient.request(TssRelayAPI(
+                    baseURL: baseURL,
+                    endpoint: .sendMessage(
+                        sessionID: sessionID,
+                        message: msg,
+                        messageID: messageID,
+                        addLegacyKeygenHeader: addLegacyKeygenHeader
+                    )
+                ))
+                logger.debug("send message (\(msg.hash) to (\(msg.to)) successfully")
                 return
+            } catch let HTTPError.statusCode(code, _) {
+                logger.error("invalid response code: \(code)")
+                return
+            } catch {
+                logger.error("fail to send message,error:\(error.localizedDescription)")
+                if remaining == 0 {
+                    return
+                }
+                remaining -= 1
             }
-            logger.debug("send message (\(msg.hash) to (\(msg.to)) successfully")
-        }.resume()
+        } while remaining >= 0
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Tss/TssRelayAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/TssRelayAPI.swift
@@ -1,0 +1,119 @@
+//
+//  TssRelayAPI.swift
+//  VultisigApp
+//
+
+import Foundation
+import Mediator
+
+/// TargetType for the TSS relay/mediator server. The relay host is per-session
+/// (passed in at runtime as the mediator URL), so this takes a caller-supplied
+/// `baseURL`. Bodies are AES-GCM-encrypted at the call site before being handed
+/// to the transport — the relay sees only opaque ciphertext.
+struct TssRelayAPI: TargetType {
+    let baseURL: URL
+    let endpoint: Endpoint
+
+    enum Endpoint {
+        /// POST /setup-message/{sessionID}. `body` is already-encrypted UTF-8 bytes.
+        /// When `additionalHeader` is non-nil it overrides `messageID` on the
+        /// `message_id` header, letting callers route a setup payload into a
+        /// different namespace than the TSS exchange.
+        case uploadSetupMessage(sessionID: String, body: Data, messageID: String?, additionalHeader: String?)
+        case downloadSetupMessage(sessionID: String, messageID: String?, additionalHeader: String?)
+        /// POST /message/{sessionID}. The encrypted body sits inside `Message.body`.
+        /// `addLegacyKeygenHeader` adds the GG20-only `keygen: vultisig` header.
+        case sendMessage(sessionID: String, message: Message, messageID: String?, addLegacyKeygenHeader: Bool)
+        /// GET /message/{sessionID}/{localPartyID}. Returns `[Message]`; non-2xx is an error.
+        case pollInboundMessages(sessionID: String, localPartyID: String, messageID: String?)
+        case deleteMessage(sessionID: String, localPartyID: String, hash: String, messageID: String?)
+        /// GET /start/{sessionID}. 404 means "not started yet" and is a valid response.
+        case checkKeygenStarted(sessionID: String)
+    }
+
+    var path: String {
+        switch endpoint {
+        case .uploadSetupMessage(let sessionID, _, _, _),
+             .downloadSetupMessage(let sessionID, _, _):
+            return "/setup-message/\(sessionID)"
+        case .sendMessage(let sessionID, _, _, _):
+            return "/message/\(sessionID)"
+        case .pollInboundMessages(let sessionID, let localPartyID, _):
+            return "/message/\(sessionID)/\(localPartyID)"
+        case .deleteMessage(let sessionID, let localPartyID, let hash, _):
+            return "/message/\(sessionID)/\(localPartyID)/\(hash)"
+        case .checkKeygenStarted(let sessionID):
+            return "/start/\(sessionID)"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch endpoint {
+        case .uploadSetupMessage, .sendMessage:
+            return .post
+        case .downloadSetupMessage, .pollInboundMessages, .checkKeygenStarted:
+            return .get
+        case .deleteMessage:
+            return .delete
+        }
+    }
+
+    var task: HTTPTask {
+        switch endpoint {
+        case .uploadSetupMessage(_, let body, _, _):
+            return .requestData(body)
+        case .sendMessage(_, let message, _, _):
+            return .requestCodable(message, .jsonEncoding)
+        case .downloadSetupMessage, .pollInboundMessages, .deleteMessage, .checkKeygenStarted:
+            return .requestPlain
+        }
+    }
+
+    var headers: [String: String]? {
+        var result: [String: String] = ["Content-Type": "application/json"]
+
+        switch endpoint {
+        case .uploadSetupMessage(_, _, let messageID, let additionalHeader),
+             .downloadSetupMessage(_, let messageID, let additionalHeader):
+            // self.messageID is applied first; additionalHeader overrides it when non-nil.
+            if let messageID {
+                result["message_id"] = messageID
+            }
+            if let additionalHeader {
+                result["message_id"] = additionalHeader
+            }
+
+        case .sendMessage(_, _, let messageID, let addLegacyKeygenHeader):
+            if let messageID {
+                result["message_id"] = messageID
+            }
+            if addLegacyKeygenHeader {
+                result["keygen"] = "vultisig"
+            }
+
+        case .pollInboundMessages(_, _, let messageID),
+             .deleteMessage(_, _, _, let messageID):
+            if let messageID {
+                result["message_id"] = messageID
+            }
+
+        case .checkKeygenStarted:
+            break
+        }
+
+        return result
+    }
+
+    var validationType: ValidationType {
+        switch endpoint {
+        case .checkKeygenStarted:
+            // 404 is the relay's "not started yet" signal — surface it as a
+            // status code instead of an error so the caller can branch.
+            return .customCodes([200, 404])
+        case .uploadSetupMessage, .downloadSetupMessage,
+             .sendMessage, .pollInboundMessages,
+             .deleteMessage:
+            return .successCodes
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
@@ -58,6 +58,7 @@ class JoinKeygenViewModel: ObservableObject {
     var encryptionKeyHex: String = ""
     var singleKeygenType: SingleKeygenType = .MLDSA
     var vaults: [Vault] = []
+    private let httpClient: HTTPClientProtocol = HTTPClient()
 
     init() {
         self.vault = Vault(name: "Main Vault")
@@ -142,37 +143,30 @@ class JoinKeygenViewModel: ObservableObject {
     }
     /// Checks if the key generation process has started by querying the server.
     /// - Throws: `HelperError.runtimeError` if required information is missing or the URL is invalid.
-    ///           Any error thrown by `URLSession` or JSON decoding.
+    ///           Any error thrown by the HTTP client or JSON decoding.
     /// - Note: Updates the `keygenCommittee` and `status` on the main thread if the process has started.
     /// - Returns: Nothing. Updates state via side effects.
     private func checkKeygenStarted() async throws {
         guard let serverURL = serverAddress, let sessionID = sessionID else {
             throw HelperError.runtimeError("Required information for checking key generation status is missing.")
         }
-
-        let urlString = "\(serverURL)/start/\(sessionID)"
-        guard let url = URL(string: urlString) else {
-            throw HelperError.runtimeError("Invalid URL: \(urlString)")
+        guard let baseURL = URL(string: serverURL) else {
+            throw HelperError.runtimeError("Invalid URL: \(serverURL)")
         }
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let response = try await httpClient.request(TssRelayAPI(
+            baseURL: baseURL,
+            endpoint: .checkKeygenStarted(sessionID: sessionID)
+        ))
 
-        let (data, resp) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = resp as? HTTPURLResponse else {
-            self.logger.error("Invalid response from server")
-            return
-        }
-        switch httpResponse.statusCode {
+        switch response.response.statusCode {
         case 200 ... 299:
-            if data.isEmpty {
+            if response.data.isEmpty {
                 self.logger.debug("Key generation not started yet (empty body)")
                 return
             }
             do {
-                let decoder = JSONDecoder()
-                let peers = try decoder.decode([String].self, from: data)
+                let peers = try JSONDecoder().decode([String].self, from: response.data)
                 DispatchQueue.main.async {
                     if peers.contains(self.localPartyID) {
                         // Trust the server's authoritative list order.
@@ -181,13 +175,13 @@ class JoinKeygenViewModel: ObservableObject {
                     }
                 }
             } catch {
-                self.logger.error("Failed to decode response to JSON: \(String(data: data, encoding: .utf8) ?? "N/A") , error: \(error.localizedDescription)")
+                self.logger.error("Failed to decode response to JSON: \(String(data: response.data, encoding: .utf8) ?? "N/A") , error: \(error.localizedDescription)")
             }
         case 404:
             // keygen not started yet
             self.logger.debug("Key generation not started yet (404)")
         default:
-            self.logger.error("Server returned status code \(httpResponse.statusCode)")
+            self.logger.error("Server returned status code \(response.response.statusCode)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
@@ -58,9 +58,10 @@ class JoinKeygenViewModel: ObservableObject {
     var encryptionKeyHex: String = ""
     var singleKeygenType: SingleKeygenType = .MLDSA
     var vaults: [Vault] = []
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
-    init() {
+    init(httpClient: HTTPClientProtocol = HTTPClient()) {
+        self.httpClient = httpClient
         self.vault = Vault(name: "Main Vault")
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/MessagePuller.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/MessagePuller.swift
@@ -13,9 +13,11 @@ class MessagePuller: ObservableObject {
     let vaultPubKey: String
     var cache = NSCache<NSString, AnyObject>()
     private var pollingInboundMessages = true
-    private let logger = Logger(subsystem: "message-puller", category: "communication")
+    private let logger = Logger(subsystem: "com.vultisig.app", category: "net-message-puller")
     private var currentTask: Task<Void, Error>? = nil
     let encryptGCM: Bool
+    private let httpClient: HTTPClientProtocol = HTTPClient()
+
     init(encryptionKeyHex: String,
          pubKey: String,
          encryptGCM: Bool) {
@@ -39,90 +41,102 @@ class MessagePuller: ObservableObject {
         currentTask = Task.detached {
             repeat {
                 if Task.isCancelled {
-                    print("stop pulling for messageid:\(messageID ?? "")")
+                    self.logger.debug("stop pulling for messageid:\(messageID ?? "")")
                     return
                 }
-                print("pulling for messageid:\(messageID ?? "")")
-                self.pollInboundMessages(mediatorURL: mediatorURL,
-                                         sessionID: sessionID,
-                                         localPartyKey: localPartyKey,
-                                         tssService: tssService,
-                                         messageID: messageID)
+                self.logger.debug("pulling for messageid:\(messageID ?? "")")
+                await self.pollInboundMessages(mediatorURL: mediatorURL,
+                                               sessionID: sessionID,
+                                               localPartyKey: localPartyKey,
+                                               tssService: tssService,
+                                               messageID: messageID)
                 try await Task.sleep(for: .seconds(1)) // Back off 1s
             } while self.pollingInboundMessages
         }
     }
 
-    func getHeaders(messageID: String?) -> [String: String] {
-        var header = [String: String]()
-        // for keygen message id will be nil
-        // only keysign will pass message id
-        if let messageID {
-            header["message_id"] = messageID
+    private func pollInboundMessages(mediatorURL: String,
+                                     sessionID: String,
+                                     localPartyKey: String,
+                                     tssService: TssServiceImpl,
+                                     messageID: String?) async {
+        guard let baseURL = URL(string: mediatorURL) else {
+            logger.error("Invalid mediator URL: \(mediatorURL)")
+            return
         }
-        return header
-    }
-    private func pollInboundMessages(mediatorURL: String, sessionID: String, localPartyKey: String, tssService: TssServiceImpl, messageID: String?) {
-        let urlString = "\(mediatorURL)/message/\(sessionID)/\(localPartyKey)"
 
-        Utils.getRequest(urlString: urlString, headers: getHeaders(messageID: messageID), completion: { result in
-            switch result {
-            case .success(let data):
-                do {
-                    print("Response: \(String(data: data, encoding: .utf8) ?? "")")
-                    let decoder = JSONDecoder()
-                    let msgs = try decoder.decode([Message].self, from: data)
-                    let sortedMsgs = msgs.sorted(by: { $0.sequence_no < $1.sequence_no })
-                    for msg in sortedMsgs {
-                        var key = "\(sessionID)-\(localPartyKey)-\(msg.hash)" as NSString
-                        if let messageID {
-                            key = "\(sessionID)-\(localPartyKey)-\(messageID)-\(msg.hash)" as NSString
-                        }
-                        if self.cache.object(forKey: key) != nil {
-                            self.logger.info("message with key:\(key) has been applied before")
-                            // message has been applied before
-                            continue
-                        }
-                        self.logger.debug("Got message from: \(msg.from), to: \(msg.to), key:\(key)")
-                        var decryptedBody: String? = nil
-                        if self.encryptGCM {
-                            print("decrypt with AES+GCM")
-                            decryptedBody = msg.body.aesDecryptGCM(key: self.encryptionKeyHex)
-                        } else {
-                            print("decrypt with AES+CBC")
-                            decryptedBody = msg.body.aesDecrypt(key: self.encryptionKeyHex)
-                        }
-                        try tssService.applyData(decryptedBody)
-                        self.cache.setObject(NSObject(), forKey: key)
-                        Task {
-                            // delete it from a task, since we don't really care about the result
-                            self.deleteMessageFromServer(mediatorURL: mediatorURL,
-                                                         sessionID: sessionID,
-                                                         localPartyKey: localPartyKey,
-                                                         hash: msg.hash,
-                                                         headers: self.getHeaders(messageID: messageID))
-                        }
-                    }
-                } catch {
-                    self.logger.error("Failed to decode response to JSON, data: \(data), error: \(error)")
+        let response: HTTPResponse<Data>
+        do {
+            response = try await httpClient.request(TssRelayAPI(
+                baseURL: baseURL,
+                endpoint: .pollInboundMessages(
+                    sessionID: sessionID,
+                    localPartyID: localPartyKey,
+                    messageID: messageID
+                )
+            ))
+        } catch HTTPError.statusCode(404, _) {
+            // session warming up — silent, matches the original 404 short-circuit
+            return
+        } catch {
+            logger.error("fail to get inbound message,error:\(error.localizedDescription)")
+            return
+        }
+
+        do {
+            let msgs = try JSONDecoder().decode([Message].self, from: response.data)
+            let sortedMsgs = msgs.sorted(by: { $0.sequence_no < $1.sequence_no })
+            for msg in sortedMsgs {
+                var key = "\(sessionID)-\(localPartyKey)-\(msg.hash)" as NSString
+                if let messageID {
+                    key = "\(sessionID)-\(localPartyKey)-\(messageID)-\(msg.hash)" as NSString
                 }
-            case .failure(let error):
-                let err = error as NSError
-                if err.code != 404 {
-                    self.logger.error("fail to get inbound message,error:\(error.localizedDescription)")
+                if cache.object(forKey: key) != nil {
+                    logger.info("message with key:\(key) has been applied before")
+                    continue
+                }
+                logger.debug("Got message from: \(msg.from), to: \(msg.to), key:\(key)")
+                let decryptedBody: String?
+                if encryptGCM {
+                    decryptedBody = msg.body.aesDecryptGCM(key: encryptionKeyHex)
+                } else {
+                    decryptedBody = msg.body.aesDecrypt(key: encryptionKeyHex)
+                }
+                try tssService.applyData(decryptedBody)
+                cache.setObject(NSObject(), forKey: key)
+                Task {
+                    // delete from a separate task — we don't care about the result
+                    await deleteMessageFromServer(baseURL: baseURL,
+                                                  sessionID: sessionID,
+                                                  localPartyKey: localPartyKey,
+                                                  hash: msg.hash,
+                                                  messageID: messageID)
                 }
             }
-        })
+        } catch {
+            logger.error("Failed to decode response to JSON, data: \(response.data), error: \(error.localizedDescription)")
+        }
     }
 
     private func deleteMessageFromServer(
-        mediatorURL: String,
+        baseURL: URL,
         sessionID: String,
         localPartyKey: String,
         hash: String,
-        headers: [String: String]
-    ) {
-        let urlString = "\(mediatorURL)/message/\(sessionID)/\(localPartyKey)/\(hash)"
-        Utils.deleteFromServer(urlString: urlString, headers: headers)
+        messageID: String?
+    ) async {
+        do {
+            _ = try await httpClient.request(TssRelayAPI(
+                baseURL: baseURL,
+                endpoint: .deleteMessage(
+                    sessionID: sessionID,
+                    localPartyID: localPartyKey,
+                    hash: hash,
+                    messageID: messageID
+                )
+            ))
+        } catch {
+            logger.error("Failed to delete message from server, error: \(error.localizedDescription)")
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/MessagePuller.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/MessagePuller.swift
@@ -16,14 +16,16 @@ class MessagePuller: ObservableObject {
     private let logger = Logger(subsystem: "com.vultisig.app", category: "net-message-puller")
     private var currentTask: Task<Void, Error>? = nil
     let encryptGCM: Bool
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     init(encryptionKeyHex: String,
          pubKey: String,
-         encryptGCM: Bool) {
+         encryptGCM: Bool,
+         httpClient: HTTPClientProtocol = HTTPClient()) {
         self.encryptionKeyHex = encryptionKeyHex
         self.vaultPubKey = pubKey
         self.encryptGCM = encryptGCM
+        self.httpClient = httpClient
     }
 
     func stop() {


### PR DESCRIPTION
## Summary

Last bucket of [doc 03 — Unify all API calls on HTTPClient + TargetType](docs/refactors/03-unify-httpclient.md). Moves the TSS keygen/keysign relay/mediator client off direct \`URLSession\` onto the typed \`HTTPClient\` + \`TargetType\` pattern. Crypto boundary — behavior preserved exactly.

**~30 \`URLSession\` sites removed across 10 files. +1 new file (\`TssRelayAPI.swift\`).**

## What's in here

- **NEW \`Blockchain/Tss/TssRelayAPI.swift\`** — struct-shaped \`TargetType\` (mediator URL is per-session, so \`baseURL\` is caller-supplied) with one \`Endpoint\` case per relay route:
  - \`POST /setup-message/{sessionID}\` — encrypted body as raw \`Data\`
  - \`GET /setup-message/{sessionID}\`
  - \`POST /message/{sessionID}\` — \`Message\` JSON envelope
  - \`GET /message/{sessionID}/{localPartyID}\` — inbound poll
  - \`DELETE /message/{sessionID}/{localPartyID}/{hash}\`
  - \`GET /start/{sessionID}\` — \`customCodes([200, 404])\` so "not started yet" is a status, not an error.

- **\`Tss/DKLSMessenger.swift\`** (3 sites) — \`uploadSetupMessage\` / \`downloadSetupMessage\` / \`send\`. AES-GCM encryption still happens at the call site; transport just carries opaque ciphertext.

- **\`Tss/TssMessenger.swift\`** (legacy GG20) — kept the sync \`TssMessengerProtocol.send\` signature for the Go callback bridge; dispatched HTTP work onto \`Task.detached\` to preserve fire-and-forget retry semantics. Still adds the \`keygen: vultisig\` header on keygen via \`addLegacyKeygenHeader\`.

- **Keygen state files** (\`{DKLS,Schnorr,Dilithium}Keygen.swift\`, ~12 sites) — \`pullInboundMessages\` + \`deleteMessageFromServer\`. Still throws on non-2xx (\`HTTPError.statusCode\` mapped to \`HelperError.runtimeError\`).

- **Keysign state files** (\`{DKLS,Schnorr,Dilithium}Keysign.swift\`, ~12 sites) — same pattern, \`messageID\` passed in from caller.

- **\`JoinKeygenViewModel.checkKeygenStarted\`** — \`/start/{sessionID}\` GET. 404 still treated as "not started."

- **\`Features/Keygen/Views/MessagePuller.swift\`** — dropped the \`Utils.getRequest\` / \`Utils.deleteFromServer\` callback path; polls + deletes through \`HTTPClient\`. Catches \`HTTPError.statusCode(404, _)\` explicitly to preserve the original silent-on-404 behavior.

Logger categories follow the \`net-<domain>\` convention agreed for doc 03 (\`net-tss-messenger\`, \`net-dkls-messenger\`, \`net-dkls-keygen\`, etc.).

## Preserved exactly

- Retry counts and backoff: 3× send retries, 10×1s download-setup retry, 1s poll loop, 60s pull timeout, 100ms empty-data sleep, 50ms inter-message sleep.
- \`DKLSMessenger.counter\` increments before send (matches original).
- \`MessagePuller\` cache dedupe key shape: \`session-party[-msgID]-hash\`.
- Encryption mode flag (GCM vs CBC) in legacy \`TssMessenger\`.
- 404 semantics:
  - keygen/keysign state files: throw on any non-2xx (post-\`/start\`, never expected)
  - \`MessagePuller\`: silent
  - \`JoinKeygenViewModel\`: first-class status

## Cross-platform parity

Re-checked Android (\`SessionApiImpl\` + \`TssMessenger\` + \`TssMessagePuller\`) and Windows (\`messenger.go\` + \`session.go\` + \`tss.go\`). **No wire-protocol regression vs iOS-on-main** — pre-existing platform drift unchanged:

- Windows mediator client has no \`/setup-message\` endpoints
- Android treats \`/start/{sessionID}\` 404 as error (iOS leniency is iOS-only)
- Windows \`/message/{sessionID}\` POST expects exactly 202; iOS/Android accept 200–299

These are real cross-platform concerns but out of scope for this PR.

## Verification

- \`make build-check\` → \`BUILD SUCCEEDED\`
- SwiftLint clean across all touched directories
- \`grep URLSession\\|URLRequest\` in scoped files → 0 matches
- The SwiftLint warn rule from #4236 (3.a) will drop ~30 warnings once that PR lands

## Test plan

- [ ] Pair-device manual test: create vault (keygen)
- [ ] Pair-device manual test: sign a transaction (keysign)
- [ ] Pair-device manual test: reshare flow
- [ ] FastVault flow still works (uses the same relay)
- [ ] DKLS batch keygen still works
- [ ] Verify keygen doesn't regress with stale \`message_id\` headers (the 3.a fix lives upstream of this PR — should compose cleanly when 3.a merges)

## Follow-ups

After this lands, Issue 6 closes doc 03:
- Flip the SwiftLint \`URLSession\`-outside-\`Core/Networking/\` rule from warn → error (#4236)
- Delete now-dead \`Utils.getRequest\` / \`Utils.deleteFromServer\` / \`Utils.sendRequest\` callback helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Relay communication now uses an injected HTTP client with typed relay endpoints for all keygen/keysign flows and messaging.
  * Polling/delete flows now rely on response payload presence (empty vs non-empty) and unified error handling for HTTP status codes.
  * Mediator URL validation and structured logger.debug/error added across relay and message flows.
* **New Features**
  * Introduced a typed relay API abstraction for consistent request building and headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->