### PR TITLE
fix(polkadot): use state_getStorage RPC instead of Subscan REST

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
@@ -17,37 +17,48 @@ class PolkadotService: RpcService {
     private var cachePolkadotBalance: ThreadSafeDictionary<String, (data: BigInt, timestamp: Date)> = ThreadSafeDictionary()
     private var cachePolkadotGenesisBlockHash: ThreadSafeDictionary<String, (data: String, timestamp: Date)> = ThreadSafeDictionary()
 
+    // System.Account storage key prefix: twox128("System") ++ twox128("Account")
+    private static let systemAccountPrefix = "26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da9"
+
     private func fetchBalance(address: String) async throws -> BigInt {
         let cacheKey = "polkadot-\(address)-balance"
         if let cachedData: BigInt = Utils.getCachedData(cacheKey: cacheKey, cache: cachePolkadotBalance, timeInSeconds: 60*1) {
             return cachedData
         }
 
-        let body = ["key": address]
-        let maxRetries = 3
-        let retryDelay: UInt64 = 1_000_000_000 // 1 second in nanoseconds
-
-        for attempt in 1...maxRetries {
-            do {
-                let requestBody = try JSONEncoder().encode(body)
-                let responseBodyData = try await Utils.asyncPostRequest(urlString: Endpoint.polkadotServiceBalance, headers: [:], body: requestBody)
-
-                if let balance = Utils.extractResultFromJson(fromData: responseBodyData, path: "data.account.balance") as? String {
-                    let decimalBalance = (Decimal(string: balance) ?? Decimal.zero) * pow(10, 10)
-                    let bigIntResult = decimalBalance.description.toBigInt()
-                    self.cachePolkadotBalance.set(cacheKey, (data: bigIntResult, timestamp: Date()))
-                    return bigIntResult
-                }
-            } catch {
-                print("PolkadotService > fetchBalance > Error encoding JSON: \(error), Attempt: \(attempt) of \(maxRetries)")
-                if attempt < maxRetries {
-                    try await Task.sleep(nanoseconds: retryDelay)
-                } else {
-                    return BigInt.zero
-                }
-            }
+        guard let pubkey = AnyAddress(string: address, coin: .polkadot)?.data() else {
+            return BigInt.zero
         }
-        return BigInt.zero
+        let blake2Hash = Hash.blake2b(data: pubkey, size: 16) // 128-bit
+        let storageKey = "0x" + Self.systemAccountPrefix + blake2Hash.toHexString() + pubkey.toHexString()
+
+        let result: String = try await sendRPCRequest(method: "state_getStorage", params: [storageKey]) { result in
+            guard let hex = result as? String else {
+                return ""
+            }
+            return hex
+        }
+
+        guard !result.isEmpty else {
+            return BigInt.zero
+        }
+
+        // SCALE AccountInfo: nonce(4) + consumers(4) + providers(4) + sufficients(4) + free(16) + ...
+        let hex = result.hasPrefix("0x") ? String(result.dropFirst(2)) : result
+        guard hex.count >= 64 else { return BigInt.zero }
+
+        // free balance at bytes 16-31 (hex chars 32-63), u128 little-endian
+        let freeHex = String(hex[hex.index(hex.startIndex, offsetBy: 32)..<hex.index(hex.startIndex, offsetBy: 64)])
+        var beHex = ""
+        for i in stride(from: freeHex.count - 2, through: 0, by: -2) {
+            let start = freeHex.index(freeHex.startIndex, offsetBy: i)
+            let end = freeHex.index(start, offsetBy: 2)
+            beHex += String(freeHex[start..<end])
+        }
+
+        let balance = BigInt(beHex, radix: 16) ?? BigInt.zero
+        self.cachePolkadotBalance.set(cacheKey, (data: balance, timestamp: Date()))
+        return balance
     }
 
     private func fetchNonce(address: String) async throws -> BigInt {

--- a/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
@@ -43,8 +43,13 @@ class PolkadotService: RpcService {
             return BigInt.zero
         }
 
-        // SCALE AccountInfo: nonce(4) + consumers(4) + providers(4) + sufficients(4) + free(16) + ...
-        let hex = result.hasPrefix("0x") ? String(result.dropFirst(2)) : result
+        // SCALE AccountInfo (frame_system + pallet_balances v47):
+        //   nonce(u32) + consumers(u32) + providers(u32) + sufficients(u32)
+        //   + AccountData { free(u128), reserved(u128), frozen(u128), flags(u128) }
+        // `free` is always at byte offset 16, length 16 (u128 LE) — stable across
+        // the misc_frozen/fee_frozen -> frozen/flags runtime migration since
+        // `free` is always the first AccountData field.
+        let hex = result.stripHexPrefix()
         guard hex.count >= 64 else { return BigInt.zero }
 
         // free balance at bytes 16-31 (hex chars 32-63), u128 little-endian

--- a/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
@@ -26,7 +26,7 @@ class PolkadotService: RpcService {
             return cachedData
         }
 
-        guard let pubkey = AnyAddress(string: address, coin: .polkadot)?.data() else {
+        guard let pubkey = AnyAddress(string: address, coin: .polkadot)?.data else {
             return BigInt.zero
         }
         let blake2Hash = Hash.blake2b(data: pubkey, size: 16) // 128-bit

--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -488,8 +488,6 @@ class Endpoint {
     // TODO: Switch to Vultisig proxy once ready: "https://api.vultisig.com/dot/"
     static let polkadotTransactionStatusRpc = "https://assethub-polkadot.api.subscan.io"
 
-    static let polkadotServiceBalance = "https://assethub-polkadot.api.subscan.io/api/v2/scan/search"
-
     /// Bittensor RPC endpoint for JSON-RPC calls (nonce, blockHash, specVersion, etc.)
     static let bittensorServiceRpc = "https://bittensor-finney.api.onfinality.io/public"
 


### PR DESCRIPTION
## Summary

- Switch DOT balance fetch from Subscan REST to native Substrate `state_getStorage` JSON-RPC against the existing Vultisig proxy (`api.vultisig.com/dot/`)
- Removes the dead `Endpoint.polkadotServiceBalance` Subscan URL
- Mirrors Android's working implementation and the existing iOS `BittensorService`

## Why

Subscan now requires an API key for unauthenticated requests:

```
$ curl -X POST "https://assethub-polkadot.api.subscan.io/api/v2/scan/search" \
       -H "Content-Type: application/json" \
       -d '{"key":"15gTKR..."}'
HTTP/1.1 400
{"code": 403, "message": "Subscan API strictly requires an API key. Unauthenticated access is disabled."}
```

Result: balance fetch silently returned `BigInt.zero` and the UI showed "Failed to load" for Polkadot.

Android already does it the right way — direct Substrate RPC, no third-party indexer. iOS already had the TODO at `Endpoint.swift:486` to switch to the Vultisig proxy. This PR does that.

## What changed

- `PolkadotService.fetchBalance`:
  - Decode pubkey via WalletCore `AnyAddress(string:coin:.polkadot).data()`
  - Compute storage key: `twox128("System") || twox128("Account")` (precomputed prefix) `|| blake2b128(pubkey) || pubkey`
  - Call `state_getStorage` via existing `sendRPCRequest`
  - SCALE-decode `AccountInfo`: skip 16-byte header (4× u32), read u128 LE for `free`
- Drop `Endpoint.polkadotServiceBalance` (no remaining references)

Same pattern as `BittensorService.swift:22-64` (already shipping).

## Test plan

- [ ] Open a vault holding DOT, switch to Polkadot — balance loads correctly
- [ ] Open a vault with no DOT — balance shows 0 (not "Failed to load")
- [ ] Send DOT — gas/nonce/blockhash still resolve (uses same RPC endpoint, no change)

## Verification

End-to-end probe against the live RPC for `15gTKR6XS9osnZKTrKVF3y9MeLJ9YBCb6TgZNigwEHyMjSnA` returns **7.5863829787 DOT**, matching the user's wallet screenshot showing 7.586 DOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Polkadot balance retrieval mechanism to use a more efficient RPC-based approach for fetching account data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->