### PR TITLE
fix(thorchain-lp): show specific error when THORChain not enabled

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "enableDKLS" = "DKLS aktivieren";
 "enableNotificationsForVault" = "Benachrichtigungen für diesen Tresor aktivieren";
 "enablePushNotifications" = "Push-Benachrichtigungen aktivieren";
+"enableThorchain" = "THORChain aktivieren";
+"enablingThorchain" = "THORChain wird aktiviert...";
 "EnglishUK" = "Englisch (UK)";
 "enter4Characters" = "Gib 4 Zeichen ein";
 "enter4DigitCode" = "4-stelligen Code eingeben";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -865,6 +865,7 @@
 "thisVaultOnly" = "Nur dieses Gewölbe";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorChainNotEnabledForLP" = "THORChain ist in diesem Vault nicht aktiviert. Bitte aktiviere THORChain, um diese Funktion zu nutzen.";
 "thresholdNotReachedMessage" = "Schwelle nicht erreicht.\nEs fehlen genügend Anfangsgeräte.";
 "timeout" = "Zeitüberschreitung";
 "title" = "Titel";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -867,7 +867,7 @@
 "thisVaultOnly" = "Nur dieses Gewölbe";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
-"thorChainNotEnabledForLP" = "THORChain ist in diesem Vault nicht aktiviert. Bitte aktiviere THORChain, um diese Funktion zu nutzen.";
+"thorChainNotEnabledForLP" = "THORChain ist in diesem Tresor nicht aktiviert. Bitte aktiviere THORChain, um diese Funktion zu nutzen.";
 "thresholdNotReachedMessage" = "Schwelle nicht erreicht.\nEs fehlen genügend Anfangsgeräte.";
 "timeout" = "Zeitüberschreitung";
 "title" = "Titel";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -270,6 +270,8 @@
 "enableDKLS" = "Enable DKLS";
 "enableNotificationsForVault" = "Enable notifications for this vault";
 "enablePushNotifications" = "Enable push notifications";
+"enableThorchain" = "Enable THORChain";
+"enablingThorchain" = "Enabling THORChain...";
 "EnglishUK" = "English (UK)";
 "enter4Characters" = "Enter up to 4 characters";
 "enter4DigitCode" = "Enter 4-character code";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -875,6 +875,7 @@
 "thisVaultOnly" = "This Vault Only";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorChainNotEnabledForLP" = "THORChain is not enabled on this vault. Please enable THORChain to use this feature.";
 "thresholdNotReachedMessage" = "Threshold not reached.\nMissing enough initial devices.";
 "timeout" = "Timeout";
 "title" = "Title";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -867,7 +867,7 @@
 "thisVaultOnly" = "Solo esta bóveda";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
-"thorChainNotEnabledForLP" = "THORChain no está habilitado en este vault. Por favor, habilita THORChain para usar esta función.";
+"thorChainNotEnabledForLP" = "THORChain no está habilitado en esta bóveda. Por favor, habilita THORChain para usar esta función.";
 "thresholdNotReachedMessage" = "Umbral no alcanzado.\nFaltan suficientes dispositivos iniciales.";
 "timeout" = "Tiempo de espera agotado";
 "title" = "Título";
@@ -1025,7 +1025,7 @@
 "vaultSetup4Title" = "Bóveda segura";
 "vaultShareBackupsViewTitle1" = "Crearás nuevas copias de seguridad de la bóveda";
 "vaultShareBackupsViewTitle2" = ", guárdalas como hiciste antes";
-"vaultType" = "Parte del Bóveda";
+"vaultType" = "Parte de la bóveda";
 "vaultTypeDoesnotMatch" = " El tipo de bóveda no coincide";
 "vaultTypeMismatch" = "El tipo de bóveda no coincide, el dispositivo iniciador y el dispositivo emparejado tienen tipos de bóveda diferentes";
 "vaultTypeMismatchDescription" = "El dispositivo iniciador y el dispositivo de emparejamiento tienen diferentes tipos de Vault. Asegúrate de que ambos dispositivos usen el mismo tipo de Vault.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -865,6 +865,7 @@
 "thisVaultOnly" = "Solo esta bóveda";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorChainNotEnabledForLP" = "THORChain no está habilitado en este vault. Por favor, habilita THORChain para usar esta función.";
 "thresholdNotReachedMessage" = "Umbral no alcanzado.\nFaltan suficientes dispositivos iniciales.";
 "timeout" = "Tiempo de espera agotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "enableDKLS" = "Habilitar DKLS";
 "enableNotificationsForVault" = "Activar notificaciones para esta bóveda";
 "enablePushNotifications" = "Activar notificaciones push";
+"enableThorchain" = "Activar THORChain";
+"enablingThorchain" = "Activando THORChain...";
 "EnglishUK" = "Inglés (UK)";
 "enter4Characters" = "Ingresa 4 caracteres";
 "enter4DigitCode" = "Ingresa código de 4 dígitos";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "enableDKLS" = "Omogući DKLS";
 "enableNotificationsForVault" = "Omogući obavijesti za ovaj trezor";
 "enablePushNotifications" = "Omogući push obavijesti";
+"enableThorchain" = "Omogući THORChain";
+"enablingThorchain" = "Omogućavanje THORChain-a...";
 "EnglishUK" = "Engleski (UK)";
 "enter4Characters" = "Unesi 4 znaka";
 "enter4DigitCode" = "Unesite 4-znamenkasti kod";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -865,6 +865,7 @@
 "thisVaultOnly" = "Samo ovaj trezor";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorChainNotEnabledForLP" = "THORChain nije omogućen na ovom vaultu. Molimo omogućite THORChain da biste koristili ovu značajku.";
 "thresholdNotReachedMessage" = "Prag nije dosegnut.\nNedostaje dovoljno početnih uređaja.";
 "timeout" = "Isteklo vrijeme";
 "title" = "Naslov";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "enableDKLS" = "Abilita DKLS";
 "enableNotificationsForVault" = "Attiva notifiche per questo vault";
 "enablePushNotifications" = "Attiva notifiche push";
+"enableThorchain" = "Attiva THORChain";
+"enablingThorchain" = "Attivazione di THORChain...";
 "EnglishUK" = "Inglese (UK)";
 "enter4Characters" = "Inserisci 4 caratteri";
 "enter4DigitCode" = "Inserisci codice a 4 cifre";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -867,7 +867,7 @@
 "thisVaultOnly" = "Solo questo Vault";
 "thorAddressAutoFilled" = "Indirizzo THORChain (compilato automaticamente)";
 "thorAddressNotFound" = "Indirizzo THORChain non trovato nel vault. Assicurati di avere RUNE nel tuo vault.";
-"thorChainNotEnabledForLP" = "THORChain non è abilitato su questo vault. Abilita THORChain per utilizzare questa funzione.";
+"thorChainNotEnabledForLP" = "THORChain non è abilitato su questo caveau. Abilita THORChain per utilizzare questa funzione.";
 "thresholdNotReachedMessage" = "Soglia non raggiunta.\nMancano dispositivi iniziali sufficienti.";
 "timeout" = "Tempo scaduto";
 "title" = "Titolo";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -865,6 +865,7 @@
 "thisVaultOnly" = "Solo questo Vault";
 "thorAddressAutoFilled" = "Indirizzo THORChain (compilato automaticamente)";
 "thorAddressNotFound" = "Indirizzo THORChain non trovato nel vault. Assicurati di avere RUNE nel tuo vault.";
+"thorChainNotEnabledForLP" = "THORChain non è abilitato su questo vault. Abilita THORChain per utilizzare questa funzione.";
 "thresholdNotReachedMessage" = "Soglia non raggiunta.\nMancano dispositivi iniziali sufficienti.";
 "timeout" = "Tempo scaduto";
 "title" = "Titolo";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -270,6 +270,8 @@
 "enableDKLS" = "DKLS 활성화";
 "enableNotificationsForVault" = "이 볼트에 대한 알림 활성화";
 "enablePushNotifications" = "푸시 알림 활성화";
+"enableThorchain" = "THORChain 활성화";
+"enablingThorchain" = "THORChain 활성화 중...";
 "EnglishUK" = "영어 (영국)";
 "enter4Characters" = "최대 4자 입력";
 "enter4DigitCode" = "4자리 코드 입력";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -874,6 +874,7 @@
 "thisVaultOnly" = "이 볼트만";
 "thorAddressAutoFilled" = "THORChain 주소 (자동 채워짐)";
 "thorAddressNotFound" = "볼트에서 THORChain 주소를 찾을 수 없습니다. RUNE이 볼트에 있는지 확인하세요.";
+"thorChainNotEnabledForLP" = "이 볼트에서 THORChain이 활성화되어 있지 않습니다. 이 기능을 사용하려면 THORChain을 활성화하세요.";
 "thresholdNotReachedMessage" = "임계값에 도달하지 않았습니다.\n초기 기기가 충분하지 않습니다.";
 "timeout" = "시간 초과";
 "title" = "제목";
@@ -1090,7 +1091,7 @@
 "youAreEnteringAnewEra" = "새로운 시대로 접어들어 오래된 시드 문구를 뒤로하고 있습니다. 필요한 것:";
 "youAreEnteringAnewEraHighlight" = "오래된 시드 문구를 뒤로하고 있습니다.";
 "youAreInLocalMode" = "로컬 모드입니다";
-"youArePermanentlyDeletingVault" = "이 앱에서 볼트 부분을 영구적으로 삭제하고 있습니다";
+"youArePermanentlyDeletingVault" = "이 앱에서 볼트 공유를 영구적으로 삭제하고 있습니다";
 "youreSending" = "전송 중입니다";
 "youreSwapping" = "스왑 중입니다";
 "yourFriendsReferralCode" = "친구 추천 코드";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -867,7 +867,7 @@
 "thisVaultOnly" = "Apenas este cofre";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
-"thorChainNotEnabledForLP" = "THORChain não está habilitado neste vault. Por favor, habilite THORChain para usar este recurso.";
+"thorChainNotEnabledForLP" = "THORChain não está habilitado neste cofre. Por favor, habilite THORChain para usar este recurso.";
 "thresholdNotReachedMessage" = "Limite não alcançado.\nFaltam dispositivos iniciais suficientes.";
 "timeout" = "Tempo esgotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -865,6 +865,7 @@
 "thisVaultOnly" = "Apenas este cofre";
 "thorAddressAutoFilled" = "THORChain Address (auto-filled)";
 "thorAddressNotFound" = "THORChain address not found in vault. Please ensure you have RUNE in your vault.";
+"thorChainNotEnabledForLP" = "THORChain não está habilitado neste vault. Por favor, habilite THORChain para usar este recurso.";
 "thresholdNotReachedMessage" = "Limite não alcançado.\nFaltam dispositivos iniciais suficientes.";
 "timeout" = "Tempo esgotado";
 "title" = "Título";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "enableDKLS" = "Ativar DKLS";
 "enableNotificationsForVault" = "Ativar notificações para este cofre";
 "enablePushNotifications" = "Ativar notificações push";
+"enableThorchain" = "Ativar THORChain";
+"enablingThorchain" = "Ativando THORChain...";
 "EnglishUK" = "Inglês (UK)";
 "enter4Characters" = "Digite 4 caracteres";
 "enter4DigitCode" = "Insira código de 4 dígitos";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -264,6 +264,8 @@
 "enableDKLS" = "启用 DKLS";
 "enableNotificationsForVault" = "为此保险库启用通知";
 "enablePushNotifications" = "启用推送通知";
+"enableThorchain" = "启用 THORChain";
+"enablingThorchain" = "正在启用 THORChain...";
 "EnglishUK" = "英语（英国）";
 "enter4Characters" = "输入最多 4 个字符";
 "enter4DigitCode" = "输入4位代码";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -865,6 +865,7 @@
 "thisVaultOnly" = "仅此保险库";
 "thorAddressAutoFilled" = "THORChain 地址 (自动填充)";
 "thorAddressNotFound" = "保险库中未找到 THORChain 地址。请确保您的保险库中有 RUNE。";
+"thorChainNotEnabledForLP" = "此保险库未启用 THORChain。请启用 THORChain 以使用此功能。";
 "thresholdNotReachedMessage" = "未达到阈值。\n缺少足够的初始设备";
 "timeout" = "超时";
 "title" = "标题";

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -6,6 +6,9 @@
 import SwiftUI
 import Foundation
 import Combine
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-add-thor-lp")
 
 // MARK: - Main ViewModel
 
@@ -42,7 +45,8 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     // Domain models
     var tx: SendTransaction
     private var vault: Vault
-    private let isThorchainEnabled: Bool
+    @Published private(set) var isThorchainEnabled: Bool
+    @Published var isEnablingThorchain: Bool = false
 
     // MARK: Addressable conformance helpers
     var addressFields: [String: String] {
@@ -62,9 +66,33 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     }
 
     func initialize() {
+        cancellables.removeAll()
         prefillPairedAddress()
         setupValidation()
         loadInitialState()
+    }
+
+    @MainActor
+    func enableThorchain() async {
+        guard !isEnablingThorchain, !isThorchainEnabled else { return }
+        guard let runeMeta = TokensStore.TokenSelectionAssets.first(where: {
+            $0.chain == .thorChain && $0.isNativeToken
+        }) else { return }
+
+        isEnablingThorchain = true
+        defer { isEnablingThorchain = false }
+
+        do {
+            try await CoinService.addToChain(assets: [runeMeta], to: vault)
+        } catch {
+            logger.error("Failed to enable THORChain for LP: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        isThorchainEnabled = vault.coins.contains { $0.chain == .thorChain && $0.isNativeToken }
+        if isThorchainEnabled {
+            initialize()
+        }
     }
 
     private func loadInitialState() {
@@ -313,6 +341,8 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
             return
         }
 
+        customErrorMessage = nil
+
         // Recompute amount validity when amount or selectedPool changes
         Publishers.CombineLatest($amount, $selectedPool)
             .receive(on: DispatchQueue.main)
@@ -388,6 +418,17 @@ struct FunctionCallAddThorLPView: View {
     @ObservedObject var model: FunctionCallAddThorLP
 
     var body: some View {
+        Group {
+            if model.isThorchainEnabled {
+                formView
+            } else {
+                EnableThorchainCTASection(model: model)
+            }
+        }
+        .withLoading(text: "enablingThorchain".localized, isLoading: $model.isEnablingThorchain)
+    }
+
+    private var formView: some View {
         VStack {
             PoolSelectorSection(model: model)
 
@@ -415,6 +456,32 @@ struct FunctionCallAddThorLPView: View {
                 isValid: Binding(get: { model.amountValid }, set: { model.amountValid = $0 })
             )
         }
+    }
+}
+
+struct EnableThorchainCTASection: View {
+    @ObservedObject var model: FunctionCallAddThorLP
+
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "exclamationmark.triangle")
+                    .font(Theme.fonts.bodyMRegular)
+                    .foregroundStyle(Theme.colors.alertWarning)
+
+                Text("thorChainNotEnabledForLP".localized)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            PrimaryButton(title: "enableThorchain", isLoading: model.isEnablingThorchain) {
+                Task { await model.enableThorchain() }
+            }
+        }
+        .padding(16)
+        .background(Theme.colors.bgSurface1)
+        .cornerRadius(12)
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -45,7 +45,9 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     // Domain models
     var tx: SendTransaction
     private var vault: Vault
-    @Published private(set) var isThorchainEnabled: Bool
+    private(set) var isThorchainEnabled: Bool {
+        vault.coins.contains { $0.chain == .thorChain && $0.isNativeToken }
+    }
     @Published var isEnablingThorchain: Bool = false
 
     // MARK: Addressable conformance helpers
@@ -62,7 +64,6 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     required init(tx: SendTransaction, vault: Vault) {
         self.tx = tx
         self.vault = vault
-        self.isThorchainEnabled = vault.coins.contains { $0.chain == .thorChain && $0.isNativeToken }
     }
 
     func initialize() {
@@ -85,11 +86,10 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
         do {
             try await CoinService.addToChain(assets: [runeMeta], to: vault)
         } catch {
-            logger.error("Failed to enable THORChain for LP: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to enable THORChain for LP: \(error.localizedDescription, privacy: .private)")
             return
         }
 
-        isThorchainEnabled = vault.coins.contains { $0.chain == .thorChain && $0.isNativeToken }
         if isThorchainEnabled {
             initialize()
         }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -42,6 +42,7 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     // Domain models
     var tx: SendTransaction
     private var vault: Vault
+    private let isThorchainEnabled: Bool
 
     // MARK: Addressable conformance helpers
     var addressFields: [String: String] {
@@ -57,6 +58,7 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     required init(tx: SendTransaction, vault: Vault) {
         self.tx = tx
         self.vault = vault
+        self.isThorchainEnabled = vault.coins.contains { $0.chain == .thorChain && $0.isNativeToken }
     }
 
     func initialize() {
@@ -305,6 +307,12 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     }
 
     private func setupValidation() {
+        guard isThorchainEnabled else {
+            customErrorMessage = "thorChainNotEnabledForLP".localized
+            isTheFormValid = false
+            return
+        }
+
         // Recompute amount validity when amount or selectedPool changes
         Publishers.CombineLatest($amount, $selectedPool)
             .receive(on: DispatchQueue.main)

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -45,7 +45,7 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     // Domain models
     var tx: SendTransaction
     private var vault: Vault
-    private(set) var isThorchainEnabled: Bool {
+    var isThorchainEnabled: Bool {
         vault.coins.contains { $0.chain == .thorChain && $0.isNativeToken }
     }
     @Published var isEnablingThorchain: Bool = false


### PR DESCRIPTION
## Summary
- Add THORChain LP form now detects when THORChain is not enabled on the vault and surfaces a specific localized error instead of the generic "Form Invalid / red star" popup.
- Continue stays disabled until THORChain is enabled; once enabled, the error clears automatically.

Closes #4179

## Test Plan
- [ ] SwiftLint passes
- [ ] With THORChain disabled: ETH -> Functions -> Add THORChain LP -> ETH.USDT -> enter amount -> Continue -> expect specific error mentioning THORChain enablement.
- [ ] Enable THORChain on the vault, return to the screen, tap Continue -> flow proceeds normally.
- [ ] No regression when THORChain is already enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app CTA to enable THORChain with an enabling/loading state and automatic refresh once enabled.

* **Bug Fixes**
  * Block LP actions when THORChain isn’t enabled and show a clear, localized gating/error message.

* **Localization**
  * Added THORChain enable/enabling/error messages across multiple languages; updated Korean vault-deletion wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->