### PR TITLE
fix(keysign): show LP fields and amount title on joiner verify screen

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignMessageConfirmView.swift
@@ -14,6 +14,7 @@ struct KeysignMessageConfirmView: View {
         ZStack {
             VStack(spacing: 24) {
                 let fees = viewModel.getCalculatedNetworkFee()
+                let lpDictionary = lpMemoDictionary(for: viewModel.keysignPayload)
                 SendCryptoVerifySummaryView(
                     input: SendCryptoVerifySummary(
                         fromName: viewModel.vault.name,
@@ -24,10 +25,11 @@ struct KeysignMessageConfirmView: View {
                         memo: viewModel.memo ?? .empty,
                         decodedFunctionSignature: viewModel.decodedFunctionSignature,
                         decodedFunctionArguments: viewModel.decodedFunctionArguments,
+                        memoFunctionDictionary: lpDictionary,
                         feeCrypto: fees.feeCrypto,
                         feeFiat: fees.feeFiat,
                         coinImage: viewModel.keysignPayload?.coin.logo ?? .empty,
-                        amount: viewModel.keysignPayload?.toAmountString ?? .empty,
+                        amount: lpAmountTitle(for: viewModel.keysignPayload, lpDictionary: lpDictionary),
                         coinTicker: viewModel.keysignPayload?.coin.ticker ?? .empty,
                         keysignPayload: viewModel.keysignPayload,
                         hero: viewModel.heroContent,
@@ -55,6 +57,48 @@ struct KeysignMessageConfirmView: View {
         Text(NSLocalizedString("verify", comment: ""))
             .frame(maxWidth: .infinity, alignment: .center)
             .font(Theme.fonts.bodyLMedium)
+    }
+
+    /// Reconstructs the LP `memoFunctionDictionary` from a THORChain LP add/remove memo so the
+    /// joiner verify screen mirrors the Pool / Paired Address / Memo rows shown to the initiator.
+    /// Returns `nil` for non-LP memos so unrelated transactions are unaffected.
+    private func lpMemoDictionary(for payload: KeysignPayload?) -> [String: String]? {
+        guard let memo = payload?.memo, !memo.isEmpty else { return nil }
+        let parts = memo.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        guard let prefix = parts.first else { return nil }
+
+        switch prefix {
+        case "+":
+            guard parts.count >= 2, !parts[1].isEmpty else { return nil }
+            var dict: [String: String] = ["pool": parts[1]]
+            if parts.count >= 3, !parts[2].isEmpty {
+                dict["pairedAddress"] = parts[2]
+            }
+            dict["memo"] = memo
+            return dict
+        case "-":
+            guard parts.count >= 3, !parts[1].isEmpty, !parts[2].isEmpty else { return nil }
+            var dict: [String: String] = ["pool": parts[1]]
+            if let basisPoints = Int(parts[2]) {
+                let percentage = Double(basisPoints) / 100.0
+                dict["withdrawPercentage"] = "\(percentage)%"
+            }
+            dict["memo"] = memo
+            return dict
+        default:
+            return nil
+        }
+    }
+
+    /// Mirrors `FunctionCallVerifyScreen.getAmount()` so the joiner shows the same
+    /// `<amount> <ticker> → <pool> LP` title as the initiator for LP operations.
+    private func lpAmountTitle(for payload: KeysignPayload?, lpDictionary: [String: String]?) -> String {
+        let defaultAmount = payload?.toAmountString ?? .empty
+        guard let payload, let pool = lpDictionary?["pool"], !pool.isEmpty else {
+            return defaultAmount
+        }
+        let cleanPoolName = ThorchainService.cleanPoolName(pool)
+        return defaultAmount + " " + payload.coin.ticker + " → " + cleanPoolName + " LP"
     }
 }
 


### PR DESCRIPTION
## Summary
- Joining device's keysign confirmation screen now parses THORChain LP memos (`+:POOL[:PAIRED]` / `-:POOL:BPS`) and reconstructs the `memoFunctionDictionary` so Pool, Paired Address, and Memo rows render — matching the initiator.
- Joiner's amount title now uses the same LP-aware formula as the initiator (`1 USDC → ETH.USDC LP`).
- iOS-only change. No `KeysignPayload` wire-format changes; pairing compatibility with Android/Windows is preserved.

Closes #4189

## Test Plan
- [ ] SwiftLint passes
- [ ] On initiator: Function Call → Add LP to THORChain pool (e.g., ETH.USDC). On joiner: scan pairing QR → both verify screens show the same amount title and the Pool / Paired Address rows.
- [ ] Repeat for an LP Remove operation: joiner shows Pool row (no Paired Address) and the Memo row.
- [ ] Non-LP transactions on the joiner are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved confirmation view for liquidity pool transactions with enhanced details. Transaction confirmations now display destination pool names alongside transaction amounts with refined formatting, giving users clearer context when confirming THORChain liquidity pool operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->