### PR TITLE
fix(defi): enable Maya "Bond to Node" CTA

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/MayaChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/MayaChainBondInteractor.swift
@@ -87,40 +87,12 @@ struct MayaChainBondInteractor: BondInteractor {
         true
     }
 
-    func canAddBond(vault: Vault) async -> Bool {
-        guard let cacaoCoin = vault.coins.first(where: { $0.chain == .mayaChain && $0.isNativeToken }) else {
-            return false
-        }
-
-        do {
-            // Fetch bondable pools, user's LP positions, and all bonded units in parallel
-            async let bondablePoolsTask = mayaChainAPIService.getPools()
-            async let memberDetailsTask = mayaChainAPIService.getMemberDetails(address: cacaoCoin.address)
-            async let allBondedUnitsTask = mayaChainAPIService.getAllBondedLPUnitsByPool(address: cacaoCoin.address)
-
-            let bondablePools = try await bondablePoolsTask
-            let memberDetails = try await memberDetailsTask
-            let allBondedUnits = try await allBondedUnitsTask
-
-            // Get set of bondable pool names
-            let bondablePoolNames = Set(bondablePools.filter { $0.bondable }.map { $0.asset })
-
-            // Check if any bondable pool has available units > 0
-            for pool in memberDetails.pools {
-                let totalUnits = UInt64(pool.liquidityUnits) ?? 0
-                let bondedUnits = allBondedUnits[pool.pool] ?? 0
-                let availableUnits = totalUnits > bondedUnits ? totalUnits - bondedUnits : 0
-
-                if availableUnits > 0 && bondablePoolNames.contains(pool.pool) {
-                    return true
-                }
-            }
-
-            return false
-        } catch {
-            print("Error checking Maya bond eligibility: \(error)")
-            return false
-        }
+    // swiftlint:disable:next async_without_await
+    func canAddBond(vault _: Vault) async -> Bool {
+        // Matches THORChain and Android: the bond form itself enumerates bondable LP
+        // pools and validates submission. Pre-gating the CTA on LP availability stranded
+        // users with CACAO but no LPs and made discovering the flow impossible.
+        return true
     }
 }
 


### PR DESCRIPTION
## Summary

The "Bond to Node" CTA on **MayaChain → DeFi → Bonded** was permanently disabled for any vault that didn't already hold unbonded LP units in a bondable pool. This stranded users who held CACAO but no LPs and made it impossible to ever reach the bond flow.

`MayaChainBondInteractor.canAddBond` now always returns `true`, matching:

- **THORChain** (`THORChainBondInteractor.canAddBond`) — also always `true`
- **Android** (`DepositFormViewModel.loadMayaBondableAssets`) — bond form is reachable unconditionally; empty asset list when no LPs

The downstream `BondMayaTransactionScreen` already enumerates bondable assets via `MayaUserLPAssetsDataSource` and enforces LP-units / whitelist validation at submit time, so submission is still safely gated — only the CTA is no longer pre-gated.

## Test Plan

- [ ] SwiftLint passes
- [ ] Build succeeds
- [ ] Manual: open a Maya vault with CACAO funded but no LPs → DeFi → Bonded tab → "Bond to Node" is enabled and tappable
- [ ] Manual: tapping opens `BondMayaTransactionScreen`; node-address field works; asset picker reflects user's available LP positions (empty if none)
- [ ] Manual: with LP positions, the bond flow proceeds end-to-end through keysign

## Related

Closes #4185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified bond eligibility verification by removing unnecessary network calls and streamlining the validation process, enabling faster and more reliable access to bonding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->