### PR TITLE
feat(keysign): live ERC-20 metadata fallback for unknown tokens

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenMetadataResolver.swift
@@ -1,0 +1,104 @@
+//
+//  TokenMetadataResolver.swift
+//  VultisigApp
+//
+//  Live ERC-20 metadata fallback for unknown contracts during dApp tx display.
+//  Used by `JoinKeysignViewModel.resolveTokenDisplay(...)` after vault + TokensStore
+//  lookups miss. Caches per (chain, contractAddress) for 24h since ERC-20 symbol /
+//  decimals are immutable on-chain. Single-flights concurrent resolves of the same
+//  pair so the keysign UI never fires duplicate `eth_call`s.
+//
+
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "token-metadata-resolver")
+
+/// Successful metadata lookup. Empty `symbol` is treated as a failure and not cached.
+struct TokenMetadata: Equatable, Sendable {
+    let symbol: String
+    let decimals: Int
+}
+
+/// Closure-based fetcher so tests can inject a deterministic fake without mocking
+/// SwiftData or the HTTP stack. The production default uses `RpcEvmService.getTokenInfo`.
+typealias TokenMetadataFetcher = @Sendable (_ chain: Chain, _ contractAddress: String) async throws -> TokenMetadata
+
+actor TokenMetadataResolver {
+    static let shared = TokenMetadataResolver()
+
+    private struct CachedEntry {
+        let metadata: TokenMetadata
+        let fetchedAt: Date
+    }
+
+    private var cache: [String: CachedEntry] = [:]
+    private var inFlight: [String: Task<TokenMetadata?, Never>] = [:]
+
+    private let ttl: TimeInterval
+    private let fetcher: TokenMetadataFetcher
+    private let now: @Sendable () -> Date
+
+    init(
+        ttl: TimeInterval = 24 * 60 * 60,
+        now: @escaping @Sendable () -> Date = Date.init,
+        fetcher: @escaping TokenMetadataFetcher = TokenMetadataResolver.defaultFetcher
+    ) {
+        self.ttl = ttl
+        self.now = now
+        self.fetcher = fetcher
+    }
+
+    /// Returns cached metadata if fresh, otherwise fetches via the configured fetcher.
+    /// Returns `nil` on any failure (network error, non-ERC-20 contract, empty symbol).
+    /// Concurrent calls for the same key are deduplicated via in-flight task tracking.
+    func resolve(contractAddress: String, on chain: Chain) async -> TokenMetadata? {
+        let key = cacheKey(chain: chain, contractAddress: contractAddress)
+
+        if let cached = cache[key], now().timeIntervalSince(cached.fetchedAt) < ttl {
+            return cached.metadata
+        }
+
+        if let existing = inFlight[key] {
+            return await existing.value
+        }
+
+        let task = Task<TokenMetadata?, Never> { [fetcher, chain, contractAddress] in
+            do {
+                let metadata = try await fetcher(chain, contractAddress)
+                // `RpcEvmService.getTokenInfo` swallows errors and returns empty strings
+                // — treat that as a failed lookup so we don't cache garbage.
+                guard !metadata.symbol.isEmpty else { return nil }
+                return metadata
+            } catch {
+                logger.warning("Token metadata fetch failed for chain=\(chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .private)")
+                return nil
+            }
+        }
+        inFlight[key] = task
+
+        let result = await task.value
+        inFlight.removeValue(forKey: key)
+        if let result {
+            cache[key] = CachedEntry(metadata: result, fetchedAt: now())
+        }
+        return result
+    }
+
+    private func cacheKey(chain: Chain, contractAddress: String) -> String {
+        "\(chain.rawValue)|\(contractAddress.lowercased())"
+    }
+
+    private static let defaultFetcher: TokenMetadataFetcher = { chain, contractAddress in
+        guard let config = EvmServiceConfig.configurations[chain] else {
+            throw TokenMetadataResolverError.unsupportedChain(chain)
+        }
+        let service = RpcEvmService(config.rpcEndpoint)
+        let info = try await service.getTokenInfo(contractAddress: contractAddress)
+        return TokenMetadata(symbol: info.symbol, decimals: info.decimals)
+    }
+}
+
+enum TokenMetadataResolverError: Error, Equatable {
+    case unsupportedChain(Chain)
+}

--- a/VultisigApp/VultisigApp/Core/Services/TokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenMetadataResolver.swift
@@ -67,8 +67,15 @@ actor TokenMetadataResolver {
             do {
                 let metadata = try await fetcher(chain, contractAddress)
                 // `RpcEvmService.getTokenInfo` swallows errors and returns empty strings
-                // — treat that as a failed lookup so we don't cache garbage.
-                guard !metadata.symbol.isEmpty else { return nil }
+                // — treat that as a failed lookup so we don't cache garbage. Also bound
+                // `decimals` to a sane range: the contract is untrusted, and downstream
+                // formatting computes `BigInt(10).power(decimals)`. A malicious or
+                // misbehaving contract returning e.g. 65535 would chew CPU during render.
+                // 36 is well above any legitimate token (18 is the de-facto ceiling).
+                guard !metadata.symbol.isEmpty,
+                      (0...36).contains(metadata.decimals) else {
+                    return nil
+                }
                 return metadata
             } catch {
                 logger.warning("Token metadata fetch failed for chain=\(chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .private)")

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -406,7 +406,7 @@ class JoinKeysignViewModel: ObservableObject {
         let functionName = parsedParams.flatMap {
             ContractCallExtractor.evmFunctionName(from: $0.functionSignature)
         }.map(capitalizeFirstCharacter)
-        let resolvedTokenDisplay = resolveTokenDisplay(parsedParams: parsedParams)
+        let resolvedTokenDisplay = await resolveTokenDisplay(parsedParams: parsedParams)
 
         DispatchQueue.main.async {
             // Default to showing the extension decoded string as the Memo
@@ -448,7 +448,7 @@ class JoinKeysignViewModel: ObservableObject {
 
     private func resolveTokenDisplay(
         parsedParams: ParsedMemoParams?
-    ) -> ContractCallHeroDisplay? {
+    ) async -> ContractCallHeroDisplay? {
         guard let params = parsedParams else { return nil }
         guard let pair = ContractCallExtractor.extract(
             signature: params.functionSignature,
@@ -459,7 +459,8 @@ class JoinKeysignViewModel: ObservableObject {
         guard let chain = resolvedContractCallChain() else { return nil }
         let addressLower = pair.tokenAddress.lowercased()
 
-        // Check vault first (user has added it), then built-in tokens registry.
+        // Check vault first (user has added it), then built-in tokens registry, then a
+        // live `eth_call` against the contract for unknown tokens.
         let ticker: String
         let decimals: Int
         let logo: String
@@ -476,6 +477,13 @@ class JoinKeysignViewModel: ObservableObject {
             ticker = builtIn.ticker
             decimals = builtIn.decimals
             logo = builtIn.logo
+        } else if let resolved = await TokenMetadataResolver.shared.resolve(
+            contractAddress: pair.tokenAddress,
+            on: chain
+        ) {
+            ticker = resolved.symbol
+            decimals = resolved.decimals
+            logo = "" // No logo asset for resolved-only tokens; the user can add to vault to attach one.
         } else {
             return nil
         }

--- a/VultisigApp/VultisigAppTests/Services/TokenMetadataResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TokenMetadataResolverTests.swift
@@ -69,6 +69,24 @@ final class TokenMetadataResolverTests: XCTestCase {
         XCTAssertNil(result, "Empty symbol must be treated as a failed lookup.")
     }
 
+    func testResolveReturnsNilOnUnreasonableDecimals() async {
+        // A malicious / misbehaving contract could return any uint16+ value. Downstream
+        // we compute `BigInt(10).power(decimals)`, which would chew CPU for huge values.
+        let resolver = TokenMetadataResolver(fetcher: { _, _ in
+            TokenMetadata(symbol: "EVIL", decimals: 65535)
+        })
+        let result = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        XCTAssertNil(result, "Decimals outside the sane range must be treated as a failed lookup.")
+    }
+
+    func testResolveAcceptsBoundaryDecimals() async {
+        let resolver = TokenMetadataResolver(fetcher: { _, _ in
+            TokenMetadata(symbol: "EDGE", decimals: 36)
+        })
+        let result = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        XCTAssertEqual(result, TokenMetadata(symbol: "EDGE", decimals: 36))
+    }
+
     func testResolveDoesNotCacheFailures() async {
         let counter = CallCounter()
         let shouldFail = AtomicBool(true)

--- a/VultisigApp/VultisigAppTests/Services/TokenMetadataResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TokenMetadataResolverTests.swift
@@ -1,0 +1,168 @@
+//
+//  TokenMetadataResolverTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class TokenMetadataResolverTests: XCTestCase {
+    private let usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+    func testResolveCachesSuccessfulFetch() async {
+        let counter = CallCounter()
+        let resolver = TokenMetadataResolver(fetcher: { _, _ in
+            await counter.increment()
+            return TokenMetadata(symbol: "USDC", decimals: 6)
+        })
+
+        let first = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        let second = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+
+        XCTAssertEqual(first, TokenMetadata(symbol: "USDC", decimals: 6))
+        XCTAssertEqual(second, first)
+        let calls = await counter.value
+        XCTAssertEqual(calls, 1, "Second call must hit the cache; fetcher invoked exactly once.")
+    }
+
+    func testResolveDifferentChainsCacheIndependently() async {
+        let counter = CallCounter()
+        let resolver = TokenMetadataResolver(fetcher: { chain, _ in
+            await counter.increment()
+            return TokenMetadata(symbol: chain == .ethereum ? "USDC" : "USDC.e", decimals: 6)
+        })
+
+        _ = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        _ = await resolver.resolve(contractAddress: usdcAddress, on: .arbitrum)
+        let calls = await counter.value
+        XCTAssertEqual(calls, 2, "Same address on different chains is a different cache key.")
+    }
+
+    func testResolveAddressIsCaseInsensitive() async {
+        let counter = CallCounter()
+        let resolver = TokenMetadataResolver(fetcher: { _, _ in
+            await counter.increment()
+            return TokenMetadata(symbol: "USDC", decimals: 6)
+        })
+
+        _ = await resolver.resolve(contractAddress: usdcAddress.lowercased(), on: .ethereum)
+        _ = await resolver.resolve(contractAddress: usdcAddress.uppercased(), on: .ethereum)
+        let calls = await counter.value
+        XCTAssertEqual(calls, 1, "Different casings of the same address share a cache slot.")
+    }
+
+    func testResolveReturnsNilOnFetcherThrow() async {
+        let resolver = TokenMetadataResolver(fetcher: { _, _ in
+            throw TestError.boom
+        })
+        let result = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        XCTAssertNil(result)
+    }
+
+    func testResolveReturnsNilOnEmptySymbol() async {
+        // `RpcEvmService.getTokenInfo` returns ("", "", 0) on its own internal failures.
+        // The resolver must not cache that as a successful lookup.
+        let resolver = TokenMetadataResolver(fetcher: { _, _ in
+            TokenMetadata(symbol: "", decimals: 0)
+        })
+        let result = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        XCTAssertNil(result, "Empty symbol must be treated as a failed lookup.")
+    }
+
+    func testResolveDoesNotCacheFailures() async {
+        let counter = CallCounter()
+        let shouldFail = AtomicBool(true)
+        let resolver = TokenMetadataResolver(fetcher: { _, _ in
+            await counter.increment()
+            if await shouldFail.value {
+                throw TestError.boom
+            }
+            return TokenMetadata(symbol: "USDC", decimals: 6)
+        })
+
+        let firstFailed = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        XCTAssertNil(firstFailed)
+
+        await shouldFail.set(false)
+        let secondSucceeded = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        XCTAssertEqual(secondSucceeded, TokenMetadata(symbol: "USDC", decimals: 6))
+
+        let calls = await counter.value
+        XCTAssertEqual(calls, 2, "Failures must not poison the cache; the second call must retry.")
+    }
+
+    func testResolveSingleFlightsConcurrentCalls() async {
+        let counter = CallCounter()
+        let resolver = TokenMetadataResolver(fetcher: { _, _ in
+            await counter.increment()
+            // Simulate slow RPC so the second caller arrives mid-flight.
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            return TokenMetadata(symbol: "USDC", decimals: 6)
+        })
+
+        async let first = resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        async let second = resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        async let third = resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+
+        let results = await [first, second, third]
+        XCTAssertEqual(results.compactMap { $0 }.count, 3)
+        let calls = await counter.value
+        XCTAssertEqual(calls, 1, "Concurrent resolves of the same key must dedupe to one fetch.")
+    }
+
+    func testResolveRefetchesAfterTTL() async {
+        let counter = CallCounter()
+        let clock = MutableClock(start: Date(timeIntervalSince1970: 0))
+        let resolver = TokenMetadataResolver(
+            ttl: 100,
+            now: { clock.now },
+            fetcher: { _, _ in
+                await counter.increment()
+                return TokenMetadata(symbol: "USDC", decimals: 6)
+            }
+        )
+
+        _ = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        clock.advance(by: 99)
+        _ = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        let beforeExpiry = await counter.value
+        XCTAssertEqual(beforeExpiry, 1)
+
+        clock.advance(by: 2) // cross 101s — past TTL
+        _ = await resolver.resolve(contractAddress: usdcAddress, on: .ethereum)
+        let afterExpiry = await counter.value
+        XCTAssertEqual(afterExpiry, 2)
+    }
+}
+
+// MARK: - Test helpers
+
+private actor CallCounter {
+    private(set) var value: Int = 0
+    func increment() { value += 1 }
+}
+
+private actor AtomicBool {
+    private var stored: Bool
+    init(_ initial: Bool) { stored = initial }
+    var value: Bool { stored }
+    func set(_ next: Bool) { stored = next }
+}
+
+/// `Date()`-backed clocks aren't time-travel-friendly. This is a `Sendable` clock the
+/// resolver uses through its `now` injection.
+private final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: Date
+    init(start: Date) { current = start }
+    var now: Date {
+        lock.lock(); defer { lock.unlock() }
+        return current
+    }
+    func advance(by seconds: TimeInterval) {
+        lock.lock(); defer { lock.unlock() }
+        current = current.addingTimeInterval(seconds)
+    }
+}
+
+private enum TestError: Error { case boom }


### PR DESCRIPTION
Closes #4149 (Phase 2 token-metadata RPC piece).

## Summary

Adds `TokenMetadataResolver`, an actor that fetches `symbol()` + `decimals()` from an unknown ERC-20 contract via `eth_call` and caches the result for 24h. Plumbs it into `JoinKeysignViewModel.resolveTokenDisplay(...)` as the third fallback after vault coins and `TokensStore`.

Before this change, dApp transactions involving tokens not in the user's vault and not in `TokensStore` showed the function name with no token context. After this change, the verify/done screens render the resolved symbol + decimals so the user sees ``Approve 100 NEW_TOKEN`` instead of the raw call.

Reuses existing `RpcEvmService.getTokenInfo(...)` plumbing — no new ABI decoder.

## Behavior

* Cache key is ``(chain.rawValue, contractAddress.lowercased())`` so the same address on different chains is a separate slot and casing differences collapse.
* Single-flight: concurrent resolves of the same key dedupe to one in-flight Task. Three parallel callers ⇒ one `eth_call` round trip.
* Failures are NOT cached. Next caller retries.
* TTL defaults to 24h. Token metadata is immutable on-chain so expiry only matters for new deployments.

## DI seam

The resolver takes an injectable ``TokenMetadataFetcher`` closure so tests don't need to mock SwiftData or the HTTP stack. The production default uses ``EvmServiceConfig.configurations[chain]`` to pick the right RPC endpoint per chain.

## Tests

8 new tests in `VultisigAppTests/Services/TokenMetadataResolverTests.swift`:

| Test | Asserts |
|---|---|
| ``testResolveCachesSuccessfulFetch`` | second call hits cache (1 fetch invocation) |
| ``testResolveDifferentChainsCacheIndependently`` | same address, different chains ⇒ separate cache slots |
| ``testResolveAddressIsCaseInsensitive`` | upper/lower casing of the same address share a slot |
| ``testResolveReturnsNilOnFetcherThrow`` | RPC error ⇒ nil, no crash |
| ``testResolveReturnsNilOnEmptySymbol`` | ``RpcEvmService.getTokenInfo`` failure mode (empty tuple) ⇒ nil, not cached |
| ``testResolveDoesNotCacheFailures`` | failed lookup doesn't poison the cache; subsequent success retries |
| ``testResolveSingleFlightsConcurrentCalls`` | 3 parallel resolves of the same key ⇒ 1 fetch |
| ``testResolveRefetchesAfterTTL`` | injected mutable clock; expiry triggers refetch |

## Out of scope (deferred to follow-ups)

- Known-contracts label registry (``"Uniswap V2 Router"``, etc.) — Blockaid already labels suspicious contracts.
- Generic swap-intent inference beyond the existing KyberSwap path — Blockaid surfaces ``"you're swapping X for Y"`` from token-transfer events.

Both noted in the audit at the [internal wiki](file:///Users/gaston/workspace/wiki/pages/projects/vultisig/dapp-signing-decode/overview.md) (not in-repo).

## Test plan

- [x] ``swiftlint`` — 0 violations on the 3 changed files.
- [x] ``xcodebuild test -only-testing VultisigAppTests/TokenMetadataResolverTests`` — 8 tests, 0 failures.
- [ ] Smoke: trigger a dApp transaction (e.g. via WalletConnect with a fresh deployer token), confirm the verify screen shows the resolved symbol + amount instead of the raw function name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token metadata cached with a 24‑hour TTL to improve performance
  * Live fallback resolution for unknown contract tokens to fetch symbols and decimals
  * Chain-aware and case‑insensitive token resolution so identical contracts on different networks are handled separately
  * Concurrent lookups deduplicated to avoid duplicate network requests; invalid or failing fetches are ignored (not cached)

* **Tests**
  * Added comprehensive tests for caching, TTL expiry, single‑flight deduplication, retries, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->