### PR TITLE
fix: correct USDC reward decimals for Staked RUJI

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -79,7 +79,7 @@ private extension THORChainStakingService {
         // 3. Parse rewards
         let rewardsAmount = BigInt(stake.pendingRevenue?.amount ?? "0") ?? .zero
         let rewardsDecimal = Decimal(string: rewardsAmount.description) ?? 0
-        let rewardsFinal = rewardsDecimal / pow(10, 6) // USDC has 6 decimals
+        let rewardsFinal = rewardsDecimal / pow(10, 8) // THORChain normalizes all assets to 8 decimals
 
         // 4. Parse APR — zero out when there are no active rewards
         let aprString = stake.pool?.summary?.apr?.value ?? "0"


### PR DESCRIPTION
Fixes #4277 (USDC rewards showing wrong decimal values in Staked RUJI). THORChain API returns 1e8 for all assets natively, but the previous code hardcoded 1e6 for USDC division, leading to values that are 100x larger than intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the calculation of rewards for THORChain staking to display accurate values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->