### PR TITLE
fix(ui): capitalize VULT discount tier names

### DIFF
--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/Model/VultDiscountTier.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/Model/VultDiscountTier.swift
@@ -17,7 +17,7 @@ enum VultDiscountTier: String, Identifiable, CaseIterable {
     case ultimate
 
     var id: String { rawValue }
-    var name: String { rawValue }
+    var name: String { rawValue.capitalized }
     var icon: String { "vult-\(rawValue)" }
 
     var bpsDiscount: Int {


### PR DESCRIPTION
## Summary

- Tier names ("bronze", "silver", "gold", "platinum", "diamond", "ultimate") rendered lowercase on the **\$VULT Discount Tiers** screen. Capitalize them at the source so every consumer renders consistently.
- One-line change in `VultDiscountTier.name`: `rawValue` → `rawValue.capitalized`.

## Why at `name` and not at the call site

`tier.name` is consumed in five places (row label, scroll-anchor id, sheet heading, formatted "unlock X tier" string, two log lines). Capitalizing at the property means every consumer is fixed at once and future call sites can't reintroduce the bug.

## Why this is safe

- `tier.icon` builds from `rawValue` directly (`"vult-\(rawValue)"`) — image assets `vult-bronze`, `vult-silver`, etc. are untouched.
- No `.strings` files have a `bronze` / `silver` / … key, so `tier.name.localized` already falls through to identity output. Capitalization changes user-facing copy only; nothing breaks.
- `.id(tier.name)` and `scrollTo(tier.name, anchor: .bottom)` both use the same source — internally consistent before and after.
- The only external consumer of `VultDiscountTier` (`Components/Swap/SwapDetailsSummary.swift:153`) uses `tier.icon`, not `tier.name`.

## Test plan

- [ ] Open Settings → \$VULT Discount Tiers and confirm the six tier rows render `Bronze / Silver / Gold / Platinum / Diamond / Ultimate`.
- [ ] Open any tier's bottom sheet — confirm the heading and the "Unlock X tier" copy are capitalized.
- [ ] Confirm scroll-to-active-tier still works (anchor id is `tier.name`; both write/read use the same property).
- [ ] Verify the swap details summary still shows the correct `vult-<tier>` icon.

## Out of scope

The pre-existing `import BigInt` SourceKit diagnostic in this file isn't related to this change — it's the indexer not having resolved SPM packages in this checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated discount tier names to display with proper capitalization, enhancing the visual presentation of tier information throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->