### PR TITLE
fix(defi): simpler position pipeline + RUJI APR formatting

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -65,9 +65,19 @@ private extension THORChainStakingService {
         let response = try await httpClient.request(target, responseType: AccountRootData.self)
         let decoded = response.data
 
-        guard let stake = decoded.data.node?.stakingV2?.first(where: {
+        // Distinguish "address has no RUJI stake" (genuine empty) from "response is missing /
+        // partial" (don't trust it). Returning `.empty` for the latter caused persisted RUJI
+        // positions to be silently overwritten with zero on stale GraphQL responses.
+        guard let node = decoded.data.node else {
+            throw StakingError.invalidResponse
+        }
+        guard let stakingV2 = node.stakingV2 else {
+            throw StakingError.invalidResponse
+        }
+        guard let stake = stakingV2.first(where: {
             $0.bonded.asset.metadata?.symbol.uppercased() == "RUJI"
         }) else {
+            // The address has staking entries but none for RUJI — genuine zero stake.
             return .empty
         }
 
@@ -81,10 +91,9 @@ private extension THORChainStakingService {
         let rewardsDecimal = Decimal(string: rewardsAmount.description) ?? 0
         let rewardsFinal = rewardsDecimal / pow(10, 8) // THORChain normalizes all assets to 8 decimals
 
-        // 4. Parse APR — zero out when there are no active rewards
-        let aprString = stake.pool?.summary?.apr?.value ?? "0"
-        let rawApr = Double(aprString) ?? 0.0
-        let apr: Double? = rewardsAmount > .zero ? rawApr : 0.0
+        // 4. Parse APR. The fractional-rate conversion (12-decimal Bigint → e.g. 0.0116 for
+        // 1.16%) lives on the model itself; see `AccountRootData...APR.fractionalRate`.
+        let apr: Double? = stake.pool?.summary?.apr?.fractionalRate
 
         // 5. Create USDC coin meta for rewards
         let usdcCoin = CoinMeta(

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/TargetType/THORChainStakingAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/TargetType/THORChainStakingAPI.swift
@@ -111,6 +111,7 @@ enum THORChainStakingAPI: TargetType {
                   summary {
                     apr {
                       value
+                      status
                     }
                   }
                 }

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+TCYStake.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+TCYStake.swift
@@ -63,28 +63,30 @@ extension ThorchainService {
         }
     }
 
-    func fetchTcyAutoCompoundAmount(address: String) async -> Decimal {
-        // Use THORNode endpoint to get all balances and find x/staking-tcy.
-        // Decoded via JSONSerialization rather than a Codable so unknown balance
-        // shapes don't break the lookup.
-        do {
-            let raw = try await httpClient.request(ThorchainMainnetAPI.balances(address: address))
-            if let json = try JSONSerialization.jsonObject(with: raw.data) as? [String: Any],
-               let balances = json["balances"] as? [[String: Any]] {
-
-                for balance in balances {
-                    if let denom = balance["denom"] as? String,
-                       denom == "x/staking-tcy",
-                       let amountString = balance["amount"] as? String,
-                       let amount = UInt64(amountString) {
-                        return Decimal(amount)
-                    }
-                }
-            }
-        } catch {
-            print("Error fetching auto-compound balance: \(error.localizedDescription)")
+    /// Fetches the user's `x/staking-tcy` (auto-compound STCY) balance from THORNode.
+    ///
+    /// Throws on transport / decoding failure — callers MUST distinguish this from a
+    /// successful zero. Silently swallowing the error and returning `.zero` (the previous
+    /// behavior) caused persisted STCY positions to be overwritten with zero on every
+    /// transient hiccup.
+    ///
+    /// Returns `.zero` only when the endpoint responds successfully but the user has no
+    /// `x/staking-tcy` balance in the response (genuine zero stake).
+    func fetchTcyAutoCompoundAmount(address: String) async throws -> Decimal {
+        let raw = try await httpClient.request(ThorchainMainnetAPI.balances(address: address))
+        guard let json = try JSONSerialization.jsonObject(with: raw.data) as? [String: Any],
+              let balances = json["balances"] as? [[String: Any]] else {
+            throw HelperError.runtimeError("Malformed THORNode balances response")
         }
 
+        for balance in balances {
+            if let denom = balance["denom"] as? String,
+               denom == "x/staking-tcy",
+               let amountString = balance["amount"] as? String,
+               let amount = UInt64(amountString) {
+                return Decimal(amount)
+            }
+        }
         return .zero
     }
 

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainServiceFactory.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainServiceFactory.swift
@@ -18,7 +18,7 @@ protocol ThorchainServiceProtocol {
     func ensureTHORChainChainID() -> String
     func broadcastTransaction(jsonString: String) async -> Result<String, Error>
     func fetchTcyStakedAmount(address: String) async -> Decimal
-    func fetchTcyAutoCompoundAmount(address: String) async -> Decimal
+    func fetchTcyAutoCompoundAmount(address: String) async throws -> Decimal
     func fetchMergeAccounts(address: String) async -> [MergeAccountResponse.ResponseData.Node.AccountMerge.MergeAccount]
     func resolveTNS(name: String, chain: Chain) async throws -> String
     func fetchYieldTokenPrice(for contract: String) async -> Double?

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenet2Service.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenet2Service.swift
@@ -536,7 +536,7 @@ extension ThorchainStagenetService {
         return 0
     }
     // swiftlint:disable:next unused_parameter async_without_await
-    func fetchTcyAutoCompoundAmount(address: String) async -> Decimal {
+    func fetchTcyAutoCompoundAmount(address: String) async throws -> Decimal {
         return 0
     }
     // swiftlint:disable:next unused_parameter async_without_await

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetService.swift
@@ -527,7 +527,7 @@ extension ThorchainChainnetService {
         return 0
     }
     // swiftlint:disable:next unused_parameter async_without_await
-    func fetchTcyAutoCompoundAmount(address: String) async -> Decimal {
+    func fetchTcyAutoCompoundAmount(address: String) async throws -> Decimal {
         // Stagenet doesn't support TCY auto-compound
         return 0
     }

--- a/VultisigApp/VultisigApp/Core/Models/AccountRootData.swift
+++ b/VultisigApp/VultisigApp/Core/Models/AccountRootData.swift
@@ -5,6 +5,8 @@
 //  Created on 2025/01/03.
 //
 
+import Foundation
+
 struct AccountRootData: Decodable {
     let data: ResponseData
 
@@ -53,7 +55,21 @@ struct AccountRootData: Decodable {
             }
 
             struct APR: Decodable {
+                /// Bigint scalar from the Rujira GraphQL schema. Decimal values (rates, prices) are
+                /// scaled to 12 decimal places — divide by 10^12 to get the fractional rate (e.g.
+                /// `11623890337` → `0.011624` → `1.16%`).
                 let value: String
+                /// `AVAILABLE` | `NOT_APPLICABLE` | `SOON`. Treat anything but `AVAILABLE` as no APR.
+                let status: String?
+
+                /// Fractional rate (e.g. `0.0116` for 1.16% APR), or `nil` when the pool isn't
+                /// `AVAILABLE` or the value can't be parsed.
+                var fractionalRate: Double? {
+                    if let status, status != "AVAILABLE" { return nil }
+                    guard let raw = Decimal(string: value) else { return nil }
+                    let scaled = raw / pow(10, 12)
+                    return NSDecimalNumber(decimal: scaled).doubleValue
+                }
             }
 
             struct Bonded: Decodable {

--- a/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
@@ -346,7 +346,9 @@ private extension BalanceService {
                 let tcyStakedBalance = await service.fetchTcyStakedAmount(address: identifier.address)
 
                 if enableAutoCompoundStakedBalance {
-                    let tcyAutoCompoundBalance = await service.fetchTcyAutoCompoundAmount(address: identifier.address)
+                    // Auto-compound contributes to the displayed balance; on transient failure
+                    // fall back to the staked-only amount rather than blanking the whole row.
+                    let tcyAutoCompoundBalance = (try? await service.fetchTcyAutoCompoundAmount(address: identifier.address)) ?? .zero
                     let totalStakedBalance = tcyStakedBalance + tcyAutoCompoundBalance
                     return totalStakedBalance.description
                 }

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsStorageService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsStorageService.swift
@@ -28,43 +28,19 @@ struct DefiPositionsStorageService {
     @discardableResult
     @MainActor
     func upsert(lp positions: [LPPositionData], for vault: Vault) throws -> [LPPosition] {
-        let vaultPubKey = vault.pubKeyECDSA
-        let descriptor = FetchDescriptor<LPPosition>(
-            predicate: #Predicate<LPPosition> { position in
-                position.id.contains(vaultPubKey)
-            }
-        )
         let existingByCoin2 = Dictionary(
-            try Storage.shared.modelContext.fetch(descriptor).map { ($0.coin2, $0) },
+            vault.lpPositions.map { ($0.coin2, $0) },
             uniquingKeysWith: { _, latest in latest }
         )
 
-        var materialized: [LPPosition] = []
-        materialized.reserveCapacity(positions.count)
-        for dto in positions {
+        let materialized = positions.map { dto -> LPPosition in
             if let existing = existingByCoin2[dto.coin2] {
-                existing.coin1 = dto.coin1
-                existing.coin1Amount = dto.coin1Amount
-                existing.coin2Amount = dto.coin2Amount
-                existing.poolName = dto.poolName
-                existing.poolUnits = dto.poolUnits
-                existing.apr = dto.apr
-                existing.lastUpdated = .now
-                materialized.append(existing)
-            } else {
-                let model = LPPosition(
-                    coin1: dto.coin1,
-                    coin1Amount: dto.coin1Amount,
-                    coin2: dto.coin2,
-                    coin2Amount: dto.coin2Amount,
-                    poolName: dto.poolName,
-                    poolUnits: dto.poolUnits,
-                    apr: dto.apr,
-                    vault: vault
-                )
-                Storage.shared.modelContext.insert(model)
-                materialized.append(model)
+                existing.apply(dto)
+                return existing
             }
+            let model = LPPosition(dto, vault: vault)
+            Storage.shared.modelContext.insert(model)
+            return model
         }
 
         try saveAndNotify()
@@ -73,38 +49,26 @@ struct DefiPositionsStorageService {
 
     // MARK: - Bond positions
 
-    /// Upserts bond positions - updates existing ones or inserts new ones based on their unique ID
-    /// Also removes stale positions that are no longer present in the new positions array
+    /// Upserts the given bond positions and removes any persisted row not in the input.
+    ///
+    /// Empty input deletes everything for the vault — callers MUST distinguish a genuine "user
+    /// has no bonds" from a refresh failure before passing `[]`. Bond uses a single-shot API so
+    /// delete-stale is safe; stake/LP can't (per-row enable/disable).
     @MainActor
     func upsert(_ positions: [BondPosition], for vault: Vault) throws {
-        let vaultPubKey = vault.pubKeyECDSA
+        let newIDs = Set(positions.map(\.id))
 
-        let allVaultPositionsDescriptor = FetchDescriptor<BondPosition>(
-            predicate: #Predicate<BondPosition> { position in
-                position.id.contains(vaultPubKey)
-            }
+        for stale in vault.bondPositions where !newIDs.contains(stale.id) {
+            Storage.shared.modelContext.delete(stale)
+        }
+
+        let existingByID = Dictionary(
+            vault.bondPositions.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
         )
-        let allExistingPositions = try Storage.shared.modelContext.fetch(allVaultPositionsDescriptor)
-
-        // Callers MUST distinguish failure from a genuine empty result before passing []:
-        // an empty array here will delete all persisted positions for the vault.
-        if positions.isEmpty {
-            for existingPosition in allExistingPositions {
-                Storage.shared.modelContext.delete(existingPosition)
-            }
-            try saveAndNotify()
-            return
-        }
-
-        let existingPositionsByID = Dictionary(allExistingPositions.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
-        let newPositionIDs = Set(positions.map { $0.id })
-
-        for existingPosition in allExistingPositions where !newPositionIDs.contains(existingPosition.id) {
-            Storage.shared.modelContext.delete(existingPosition)
-        }
 
         for position in positions {
-            if let existing = existingPositionsByID[position.id] {
+            if let existing = existingByID[position.id] {
                 existing.amount = position.amount
                 existing.apy = position.apy
                 existing.nextReward = position.nextReward
@@ -124,50 +88,19 @@ struct DefiPositionsStorageService {
     @discardableResult
     @MainActor
     func upsert(stake positions: [StakePositionData], for vault: Vault) throws -> [StakePosition] {
-        let ids = positions.map { $0.id(for: vault) }
-        let descriptor = FetchDescriptor<StakePosition>(
-            predicate: #Predicate<StakePosition> { position in
-                ids.contains(position.id)
-            }
-        )
-        let existingByID = Dictionary(
-            try Storage.shared.modelContext.fetch(descriptor).map { ($0.id, $0) },
+        let existingByCoin = Dictionary(
+            vault.stakePositions.map { ($0.coin, $0) },
             uniquingKeysWith: { _, latest in latest }
         )
 
-        var materialized: [StakePosition] = []
-        materialized.reserveCapacity(positions.count)
-        for dto in positions {
-            let id = dto.id(for: vault)
-            if let existing = existingByID[id] {
-                existing.coin = dto.coin
-                existing.type = dto.type
-                existing.amount = dto.amount
-                existing.availableToUnstake = dto.availableToUnstake
-                existing.apr = dto.apr
-                existing.estimatedReward = dto.estimatedReward
-                existing.nextPayout = dto.nextPayout
-                existing.rewards = dto.rewards
-                existing.rewardCoin = dto.rewardCoin
-                existing.unstakeMetadata = dto.unstakeMetadata
-                materialized.append(existing)
-            } else {
-                let model = StakePosition(
-                    coin: dto.coin,
-                    type: dto.type,
-                    amount: dto.amount,
-                    availableToUnstake: dto.availableToUnstake,
-                    apr: dto.apr,
-                    estimatedReward: dto.estimatedReward,
-                    nextPayout: dto.nextPayout,
-                    rewards: dto.rewards,
-                    rewardCoin: dto.rewardCoin,
-                    unstakeMetadata: dto.unstakeMetadata,
-                    vault: vault
-                )
-                Storage.shared.modelContext.insert(model)
-                materialized.append(model)
+        let materialized = positions.map { dto -> StakePosition in
+            if let existing = existingByCoin[dto.coin] {
+                existing.apply(dto)
+                return existing
             }
+            let model = StakePosition(dto, vault: vault)
+            Storage.shared.modelContext.insert(model)
+            return model
         }
 
         try saveAndNotify()
@@ -177,18 +110,10 @@ struct DefiPositionsStorageService {
     // MARK: - Enable / disable position
 
     /// Inserts a zero-amount stake row when the user enables a stake position, so the row is
-    /// visible immediately (with its CTAs) before the first refresh completes. Idempotent: a
-    /// no-op if a row for the coin already exists.
+    /// visible immediately (with its CTAs) before the first refresh completes. Idempotent.
     @MainActor
     func addZero(stakeCoin coin: CoinMeta, to vault: Vault) throws {
-        let id = "\(coin.chain.ticker)_\(coin.contractAddress)_\(vault.pubKeyECDSA)"
-        let descriptor = FetchDescriptor<StakePosition>(
-            predicate: #Predicate<StakePosition> { position in
-                position.id == id
-            }
-        )
-        guard try Storage.shared.modelContext.fetch(descriptor).isEmpty else { return }
-
+        guard !vault.stakePositions.contains(where: { $0.coin == coin }) else { return }
         let model = StakePosition(
             coin: coin,
             type: StakePositionType.defaultType(for: coin),
@@ -202,13 +127,7 @@ struct DefiPositionsStorageService {
     /// Removes the persisted stake row when the user disables a stake position.
     @MainActor
     func removeStake(coin: CoinMeta, from vault: Vault) throws {
-        let id = "\(coin.chain.ticker)_\(coin.contractAddress)_\(vault.pubKeyECDSA)"
-        let descriptor = FetchDescriptor<StakePosition>(
-            predicate: #Predicate<StakePosition> { position in
-                position.id == id
-            }
-        )
-        for stale in try Storage.shared.modelContext.fetch(descriptor) {
+        for stale in vault.stakePositions where stale.coin == coin {
             Storage.shared.modelContext.delete(stale)
         }
         try saveAndNotify()
@@ -217,15 +136,7 @@ struct DefiPositionsStorageService {
     /// Inserts a zero-amount LP row paired against the chain's native coin. Idempotent.
     @MainActor
     func addZero(lpCoin2 coin2: CoinMeta, nativeCoin: CoinMeta, to vault: Vault) throws {
-        let vaultPubKey = vault.pubKeyECDSA
-        let descriptor = FetchDescriptor<LPPosition>(
-            predicate: #Predicate<LPPosition> { position in
-                position.id.contains(vaultPubKey)
-            }
-        )
-        let existing = try Storage.shared.modelContext.fetch(descriptor)
-        guard !existing.contains(where: { $0.coin2 == coin2 }) else { return }
-
+        guard !vault.lpPositions.contains(where: { $0.coin2 == coin2 }) else { return }
         let model = LPPosition(
             coin1: nativeCoin,
             coin1Amount: 0,
@@ -243,13 +154,7 @@ struct DefiPositionsStorageService {
     /// Removes the persisted LP row when the user disables an LP position.
     @MainActor
     func removeLP(coin2: CoinMeta, from vault: Vault) throws {
-        let vaultPubKey = vault.pubKeyECDSA
-        let descriptor = FetchDescriptor<LPPosition>(
-            predicate: #Predicate<LPPosition> { position in
-                position.id.contains(vaultPubKey)
-            }
-        )
-        for stale in try Storage.shared.modelContext.fetch(descriptor) where stale.coin2 == coin2 {
+        for stale in vault.lpPositions where stale.coin2 == coin2 {
             Storage.shared.modelContext.delete(stale)
         }
         try saveAndNotify()

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsStorageService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsStorageService.swift
@@ -20,40 +20,33 @@ struct DefiPositionsStorageService {
 
     // MARK: - LP positions
 
-    /// Upserts LP positions for a vault. Materializes value-type DTOs into `@Model` instances inside
-    /// the model context so the interactor never has to construct `LPPosition(... vault:)` itself
-    /// (which would mutate `vault.lpPositions` via the inverse relationship as a side effect).
-    /// Returns the persisted `@Model` array so callers can update `@Published` state from a single
-    /// stable source.
+    /// Upserts the given DTOs. No delete-stale: rows persist until the user disables the
+    /// position (see `removeLP(coin2:from:)`) or the row's amount is updated by a later upsert.
+    /// Lookup is keyed by `coin2` so a placeholder row inserted by `addZero(lpCoin2:...)` (with
+    /// a synthesized poolName) merges with the API response that carries the canonical poolName
+    /// (e.g. `ETH.USDC-0x...`).
     @discardableResult
     @MainActor
     func upsert(lp positions: [LPPositionData], for vault: Vault) throws -> [LPPosition] {
-        // Vault-scoped delete-stale: rows on this vault whose IDs are not in the input are
-        // removed. Safe for LP because the LP API call is single-shot — the interactor either
-        // throws (VM skips upsert entirely) or returns the user's full LP set, so an absent
-        // ID genuinely means the user no longer holds that pool.
         let vaultPubKey = vault.pubKeyECDSA
-        let allVaultLPsDescriptor = FetchDescriptor<LPPosition>(
+        let descriptor = FetchDescriptor<LPPosition>(
             predicate: #Predicate<LPPosition> { position in
                 position.id.contains(vaultPubKey)
             }
         )
-        let allExisting = try Storage.shared.modelContext.fetch(allVaultLPsDescriptor)
-        let existingByID = Dictionary(allExisting.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
-        let newIDs = Set(positions.map { $0.id(for: vault) })
-
-        for stale in allExisting where !newIDs.contains(stale.id) {
-            Storage.shared.modelContext.delete(stale)
-        }
+        let existingByCoin2 = Dictionary(
+            try Storage.shared.modelContext.fetch(descriptor).map { ($0.coin2, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
 
         var materialized: [LPPosition] = []
         materialized.reserveCapacity(positions.count)
-
         for dto in positions {
-            let id = dto.id(for: vault)
-            if let existing = existingByID[id] {
+            if let existing = existingByCoin2[dto.coin2] {
+                existing.coin1 = dto.coin1
                 existing.coin1Amount = dto.coin1Amount
                 existing.coin2Amount = dto.coin2Amount
+                existing.poolName = dto.poolName
                 existing.poolUnits = dto.poolUnits
                 existing.apr = dto.apr
                 existing.lastUpdated = .now
@@ -74,8 +67,7 @@ struct DefiPositionsStorageService {
             }
         }
 
-        try Storage.shared.save()
-        NotificationCenter.default.post(name: .defiPositionsDidChange, object: nil)
+        try saveAndNotify()
         return materialized
     }
 
@@ -87,7 +79,6 @@ struct DefiPositionsStorageService {
     func upsert(_ positions: [BondPosition], for vault: Vault) throws {
         let vaultPubKey = vault.pubKeyECDSA
 
-        // Fetch all existing bond positions for this vault
         let allVaultPositionsDescriptor = FetchDescriptor<BondPosition>(
             predicate: #Predicate<BondPosition> { position in
                 position.id.contains(vaultPubKey)
@@ -101,65 +92,51 @@ struct DefiPositionsStorageService {
             for existingPosition in allExistingPositions {
                 Storage.shared.modelContext.delete(existingPosition)
             }
-            try Storage.shared.save()
-            NotificationCenter.default.post(name: .defiPositionsDidChange, object: nil)
+            try saveAndNotify()
             return
         }
 
-        // Create lookup for existing positions
         let existingPositionsByID = Dictionary(allExistingPositions.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
         let newPositionIDs = Set(positions.map { $0.id })
 
-        // Delete positions that are no longer present
         for existingPosition in allExistingPositions where !newPositionIDs.contains(existingPosition.id) {
             Storage.shared.modelContext.delete(existingPosition)
         }
 
-        // Update or insert new positions
         for position in positions {
             if let existing = existingPositionsByID[position.id] {
-                // Update existing position
                 existing.amount = position.amount
                 existing.apy = position.apy
                 existing.nextReward = position.nextReward
                 existing.nextChurn = position.nextChurn
             } else {
-                // Insert new position
                 Storage.shared.modelContext.insert(position)
             }
         }
 
-        try Storage.shared.save()
-        NotificationCenter.default.post(name: .defiPositionsDidChange, object: nil)
+        try saveAndNotify()
     }
 
     // MARK: - Stake positions
 
-    /// Upserts stake positions for a vault. See `upsert(lp:for:)` for the rationale around
-    /// DTO-based materialization.
-    ///
-    /// **No delete-stale.** The stake interactor fetches per-coin and silently omits any
-    /// coin whose individual fetch failed (per-coin partial-failure protection — see
-    /// `THORChainStakeInteractor.fetchStakePositions`). If we deleted persisted rows for IDs
-    /// missing from the input, a transient failure on one coin would wipe its row from the
-    /// UI until the next successful refresh restored it. Stale rows for fully-exited
-    /// positions are filtered out at display time by the VM (`vaultStakePositions.contains`).
-    /// Bond and LP use single-shot APIs and can safely delete-stale.
+    /// Upserts the given DTOs. No delete-stale (see `upsert(lp:for:)`); rows are removed only via
+    /// `removeStake(coin:from:)` when the user disables a position.
     @discardableResult
     @MainActor
     func upsert(stake positions: [StakePositionData], for vault: Vault) throws -> [StakePosition] {
         let ids = positions.map { $0.id(for: vault) }
-        let fetchDescriptor = FetchDescriptor<StakePosition>(
+        let descriptor = FetchDescriptor<StakePosition>(
             predicate: #Predicate<StakePosition> { position in
                 ids.contains(position.id)
             }
         )
-        let existing = try Storage.shared.modelContext.fetch(fetchDescriptor)
-        let existingByID = Dictionary(existing.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
+        let existingByID = Dictionary(
+            try Storage.shared.modelContext.fetch(descriptor).map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
 
         var materialized: [StakePosition] = []
         materialized.reserveCapacity(positions.count)
-
         for dto in positions {
             let id = dto.id(for: vault)
             if let existing = existingByID[id] {
@@ -193,8 +170,96 @@ struct DefiPositionsStorageService {
             }
         }
 
+        try saveAndNotify()
+        return materialized
+    }
+
+    // MARK: - Enable / disable position
+
+    /// Inserts a zero-amount stake row when the user enables a stake position, so the row is
+    /// visible immediately (with its CTAs) before the first refresh completes. Idempotent: a
+    /// no-op if a row for the coin already exists.
+    @MainActor
+    func addZero(stakeCoin coin: CoinMeta, to vault: Vault) throws {
+        let id = "\(coin.chain.ticker)_\(coin.contractAddress)_\(vault.pubKeyECDSA)"
+        let descriptor = FetchDescriptor<StakePosition>(
+            predicate: #Predicate<StakePosition> { position in
+                position.id == id
+            }
+        )
+        guard try Storage.shared.modelContext.fetch(descriptor).isEmpty else { return }
+
+        let model = StakePosition(
+            coin: coin,
+            type: StakePositionType.defaultType(for: coin),
+            amount: 0,
+            vault: vault
+        )
+        Storage.shared.modelContext.insert(model)
+        try saveAndNotify()
+    }
+
+    /// Removes the persisted stake row when the user disables a stake position.
+    @MainActor
+    func removeStake(coin: CoinMeta, from vault: Vault) throws {
+        let id = "\(coin.chain.ticker)_\(coin.contractAddress)_\(vault.pubKeyECDSA)"
+        let descriptor = FetchDescriptor<StakePosition>(
+            predicate: #Predicate<StakePosition> { position in
+                position.id == id
+            }
+        )
+        for stale in try Storage.shared.modelContext.fetch(descriptor) {
+            Storage.shared.modelContext.delete(stale)
+        }
+        try saveAndNotify()
+    }
+
+    /// Inserts a zero-amount LP row paired against the chain's native coin. Idempotent.
+    @MainActor
+    func addZero(lpCoin2 coin2: CoinMeta, nativeCoin: CoinMeta, to vault: Vault) throws {
+        let vaultPubKey = vault.pubKeyECDSA
+        let descriptor = FetchDescriptor<LPPosition>(
+            predicate: #Predicate<LPPosition> { position in
+                position.id.contains(vaultPubKey)
+            }
+        )
+        let existing = try Storage.shared.modelContext.fetch(descriptor)
+        guard !existing.contains(where: { $0.coin2 == coin2 }) else { return }
+
+        let model = LPPosition(
+            coin1: nativeCoin,
+            coin1Amount: 0,
+            coin2: coin2,
+            coin2Amount: 0,
+            poolName: "\(coin2.chain.swapAsset).\(coin2.ticker)",
+            poolUnits: "0",
+            apr: 0,
+            vault: vault
+        )
+        Storage.shared.modelContext.insert(model)
+        try saveAndNotify()
+    }
+
+    /// Removes the persisted LP row when the user disables an LP position.
+    @MainActor
+    func removeLP(coin2: CoinMeta, from vault: Vault) throws {
+        let vaultPubKey = vault.pubKeyECDSA
+        let descriptor = FetchDescriptor<LPPosition>(
+            predicate: #Predicate<LPPosition> { position in
+                position.id.contains(vaultPubKey)
+            }
+        )
+        for stale in try Storage.shared.modelContext.fetch(descriptor) where stale.coin2 == coin2 {
+            Storage.shared.modelContext.delete(stale)
+        }
+        try saveAndNotify()
+    }
+}
+
+private extension DefiPositionsStorageService {
+    @MainActor
+    func saveAndNotify() throws {
         try Storage.shared.save()
         NotificationCenter.default.post(name: .defiPositionsDidChange, object: nil)
-        return materialized
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -35,14 +35,10 @@ struct DefiChainMainScreen: View {
         vault.nativeCoin(for: chain)
     }
 
-    /// Surfaced via the `.withBanner(...)` toast modifier; the active segment's VM owns the
-    /// underlying error state.
+    /// Surfaced via the `.withBanner(...)` toast modifier. Only Bond surfaces a refresh error
+    /// today — Stake and LP refreshes silently keep persisted rows on failure (see ViewModels).
     private var refreshError: String? {
-        switch viewModel.selectedPosition {
-        case .bond: return bondViewModel.refreshError
-        case .stake: return stakeViewModel.refreshError
-        case .liquidityPool: return lpsViewModel.refreshError
-        }
+        bondViewModel.refreshError
     }
 
     var body: some View {
@@ -61,7 +57,13 @@ struct DefiChainMainScreen: View {
             viewModel.onLoad()
             Task { await refresh() }
         }
-        .refreshable { await refresh() }
+        .refreshable {
+            // SwiftUI binds the `.refreshable` task to the refresh-control's spinner.
+            // When the user lets go, the spinner dismisses and the task is cancelled —
+            // which propagates to every in-flight network call inside `refresh()` and
+            // surfaces as `CancellationError`. Detach so cancellation stops here.
+            await Task { @MainActor in await refresh() }.value
+        }
         .onChange(of: vault) { _, vault in
             update(vault: vault)
         }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/LPsInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/LPsInteractor.swift
@@ -6,5 +6,8 @@
 //
 
 protocol LPsInteractor {
-    func fetchLPPositions(vault: Vault) async throws -> [LPPositionData]
+    /// Returns one DTO per pool the API successfully returned. Top-level failures return an
+    /// empty array — storage upserts only what's returned, so persisted rows keep their last
+    /// good value.
+    func fetchLPPositions(vault: Vault) async -> [LPPositionData]
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/MayaChainLPsInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/MayaChainLPsInteractor.swift
@@ -17,19 +17,22 @@ struct MayaChainLPsInteractor: LPsInteractor {
         SettingsAPRPeriod.current.rawValue
     }
 
-    func fetchLPPositions(vault: Vault) async throws -> [LPPositionData] {
-        // Snapshot CACAO's address + decimals on `MainActor` before the async network call.
+    func fetchLPPositions(vault: Vault) async -> [LPPositionData] {
         guard let cacao = await cacaoSnapshot(in: vault) else { return [] }
-        let vaultLPPositions = await readVaultLPPositions(in: vault)
+        let enabled = await readVaultLPPositions(in: vault)
+        guard !enabled.isEmpty else { return [] }
 
-        let apiPositions = try await mayaAPIService.getLPPositions(
-            address: cacao.address,
-            userLPs: vaultLPPositions,
-            period: aprPeriod
-        )
-
-        // Persistence is the ViewModel's responsibility — see THORChainLPsInteractor.
-        return convertToLPPositions(apiPositions, cacaoDecimals: cacao.decimals)
+        do {
+            let apiPositions = try await mayaAPIService.getLPPositions(
+                address: cacao.address,
+                userLPs: enabled,
+                period: aprPeriod
+            )
+            return convert(apiPositions, cacaoDecimals: cacao.decimals)
+        } catch {
+            logger.error("Failed to fetch Maya LP positions: \(error.localizedDescription, privacy: .private)")
+            return []
+        }
     }
 }
 
@@ -50,12 +53,11 @@ private extension MayaChainLPsInteractor {
         vault.defiPositions.first { $0.chain == .mayaChain }?.lps ?? []
     }
 
-    func convertToLPPositions(_ apiPositions: [THORChainLPPosition], cacaoDecimals: Int) -> [LPPositionData] {
+    func convert(_ apiPositions: [THORChainLPPosition], cacaoDecimals: Int) -> [LPPositionData] {
         var result: [LPPositionData] = []
         let cacaoCoin = TokensStore.cacao
 
         for apiPosition in apiPositions {
-            // Parse the pool asset (e.g., "BTC.BTC", "ETH.ETH")
             let components = apiPosition.asset.split(separator: ".")
             guard components.count == 2 else { continue }
 
@@ -88,7 +90,6 @@ private extension MayaChainLPsInteractor {
                 )
             )
         }
-
         return result
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/THORChainLPsInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/THORChainLPsInteractor.swift
@@ -13,31 +13,26 @@ private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-
 struct THORChainLPsInteractor: LPsInteractor {
     private let thorchainAPIService = THORChainAPIService()
 
-    /// Period for LUVI-based APR calculation. Options: "1h", "24h", "7d", "14d", "30d", "90d", "100d", "180d", "365d", "all"
-    /// - "7d": Weekly performance, higher volatility
-    /// - "30d": Monthly average, balanced view (DEFAULT, matches thorchain.org)
-    /// - "100d": Longer-term average, more stable
-    /// Default is 30d to match thorchain.org and the API default
     var aprPeriod: String {
         SettingsAPRPeriod.current.rawValue
     }
 
-    func fetchLPPositions(vault: Vault) async throws -> [LPPositionData] {
-        // Snapshot the RUNE coin's address on `MainActor` before the async network call.
-        // Reading `Coin` properties off the main actor would violate the SwiftData rule.
+    func fetchLPPositions(vault: Vault) async -> [LPPositionData] {
         guard let runeAddress = await runeAddress(in: vault) else { return [] }
-        let vaultLPPositions = await readVaultLPPositions(in: vault)
+        let enabled = await readVaultLPPositions(in: vault)
+        guard !enabled.isEmpty else { return [] }
 
-        let apiPositions = try await thorchainAPIService.getLPPositions(
-            address: runeAddress,
-            userLPs: vaultLPPositions,
-            period: aprPeriod
-        )
-
-        // Persistence is the ViewModel's responsibility — it calls
-        // `DefiPositionsStorageService.upsert(lp:for:)` on the returned DTOs. Persisting here
-        // too would double-write and double-fire `.defiPositionsDidChange`.
-        return convertToLPPositions(apiPositions)
+        do {
+            let apiPositions = try await thorchainAPIService.getLPPositions(
+                address: runeAddress,
+                userLPs: enabled,
+                period: aprPeriod
+            )
+            return convert(apiPositions)
+        } catch {
+            logger.error("Failed to fetch THORChain LP positions: \(error.localizedDescription, privacy: .private)")
+            return []
+        }
     }
 }
 
@@ -52,11 +47,9 @@ private extension THORChainLPsInteractor {
         vault.defiPositions.first { $0.chain == .thorChain }?.lps ?? []
     }
 
-    func convertToLPPositions(_ apiPositions: [THORChainLPPosition]) -> [LPPositionData] {
+    func convert(_ apiPositions: [THORChainLPPosition]) -> [LPPositionData] {
         var result: [LPPositionData] = []
-
         for apiPosition in apiPositions {
-            // Parse the pool asset (e.g., "BTC.BTC", "ETH.ETH")
             let components = apiPosition.asset.split(separator: ".")
             guard components.count == 2 else { continue }
 
@@ -81,8 +74,7 @@ private extension THORChainLPsInteractor {
                 continue
             }
 
-            // Convert amounts from base units to decimal
-            // Note: THORChain uses 8 decimals for RUNE
+            // THORChain uses 8 decimals for RUNE
             let runeAmount = apiPosition.currentRuneAmount / pow(10, runeCoin.decimals)
             let assetAmount = apiPosition.currentAssetAmount / pow(10, runeCoin.decimals)
 
@@ -94,11 +86,10 @@ private extension THORChainLPsInteractor {
                     coin2Amount: assetAmount,
                     poolName: apiPosition.asset,
                     poolUnits: apiPosition.poolStats.units,
-                    apr: apiPosition.apr // Already in decimal format (e.g., 0.0067 for 0.67%)
+                    apr: apiPosition.apr
                 )
             )
         }
-
         return result
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
@@ -20,12 +20,10 @@ struct MayaChainStakeInteractor: StakeInteractor {
     private let mayaChainAPIService = MayaChainAPIService()
 
     func fetchStakePositions(vault: Vault) async -> [StakePositionData] {
-        // Snapshot the value-type fields off the `@Model` Coin while we're on `MainActor`,
-        // then operate exclusively on value types in the async branch.
         guard let cacao = await cacaoSnapshot(in: vault) else { return [] }
 
-        let vaultStakePositions = await vaultStakePositions(in: vault)
-        guard vaultStakePositions.contains(where: { $0.ticker == cacao.meta.ticker }) else {
+        let enabled = await vaultStakePositions(in: vault)
+        guard enabled.contains(where: { $0.ticker == cacao.meta.ticker }) else {
             return []
         }
 
@@ -39,12 +37,8 @@ struct MayaChainStakeInteractor: StakeInteractor {
 
         do {
             let position = try await mayaChainAPIService.getCacaoPoolPosition(address: cacao.address)
-
-            // Use value for display amount (includes earnings)
             let stakedAmount = position.stakedAmount / pow(10, cacao.decimals)
-            // Use units for unstake amount (what can actually be withdrawn)
             let availableToUnstake = position.availableUnits / pow(10, cacao.decimals)
-
             let aprData = try? await mayaChainAPIService.getCacaoPoolAPR()
 
             let unstakeMetadata = calculateUnstakeMetadata(
@@ -64,9 +58,6 @@ struct MayaChainStakeInteractor: StakeInteractor {
                 )
             ]
         } catch {
-            // On API failure, omit the position. The previously persisted CACAO @Model
-            // remains untouched in `vault.stakePositions`, so the user keeps seeing
-            // stale data until the next refresh — see THORChainStakeInteractor.
             logger.error("Error fetching Maya CACAO staking details: \(error.localizedDescription, privacy: .private)")
             return []
         }
@@ -93,11 +84,7 @@ private extension MayaChainStakeInteractor {
         maturityBlocks: Int64
     ) -> UnstakeMetadata? {
         let differenceBlocks = currentHeight - lastDepositHeight
-
-        // If maturity has been reached, no metadata needed
-        guard differenceBlocks < maturityBlocks else {
-            return nil
-        }
+        guard differenceBlocks < maturityBlocks else { return nil }
 
         let blocksPerDay: Double = 14400
         let blocksRemaining = maturityBlocks - differenceBlocks

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/StakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/StakeInteractor.swift
@@ -6,5 +6,8 @@
 //
 
 protocol StakeInteractor {
+    /// Returns one DTO per coin that was successfully fetched. Per-coin failures are silently
+    /// omitted — storage upserts only what's returned, so the persisted row keeps its last good
+    /// value until the next refresh.
     func fetchStakePositions(vault: Vault) async -> [StakePositionData]
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
@@ -18,25 +18,17 @@ struct THORChainStakeInteractor: StakeInteractor {
 
     func fetchStakePositions(vault: Vault) async -> [StakePositionData] {
         // Snapshot every `@Model` value the async branch will need on `MainActor`, then operate
-        // exclusively on value types. Reading `Coin` properties off the main actor would violate
-        // the SwiftData rule (`/.claude/rules/swiftdata.md`) and break under Swift 6 strict
-        // concurrency.
-        guard
-            let runeMeta = await runeMeta(in: vault),
-            let stakeSnapshots = await coinSnapshots(in: vault)
-        else { return [] }
+        // exclusively on value types.
+        guard let runeMeta = await runeMeta(in: vault) else { return [] }
+        let snapshots = await coinSnapshots(in: vault)
 
-        var positions: [StakePositionData] = []
-        for snapshot in stakeSnapshots {
-            if let position = await createStakePosition(snapshot: snapshot, runeMeta: runeMeta) {
-                positions.append(position)
+        var dtos: [StakePositionData] = []
+        for snapshot in snapshots {
+            if let dto = await dto(for: snapshot, runeMeta: runeMeta) {
+                dtos.append(dto)
             }
-            // On per-coin fetch failures we omit the position. The previously persisted
-            // `StakePosition` for that coin remains untouched in `vault.stakePositions`,
-            // so the user keeps seeing stale-but-non-empty data until the next refresh.
         }
-
-        return positions.sorted { $0.amount > $1.amount }
+        return dtos
     }
 }
 
@@ -53,13 +45,10 @@ private extension THORChainStakeInteractor {
         vault.runeCoin?.toCoinMeta()
     }
 
-    /// Reads the user's enabled stake coins (`vault.defiPositions[.thorChain].staking`),
-    /// resolves each to the matching `vault.coins` row, and snapshots the value-type fields
-    /// into `CoinSnapshot`. Returns `nil` if the vault has no THORChain defiPositions entry.
     @MainActor
-    func coinSnapshots(in vault: Vault) -> [CoinSnapshot]? {
+    func coinSnapshots(in vault: Vault) -> [CoinSnapshot] {
         let enabled = vault.defiPositions.first { $0.chain == .thorChain }?.staking ?? []
-        return enabled.compactMap { meta -> CoinSnapshot? in
+        return enabled.compactMap { meta in
             guard let coin = vault.coins.first(where: { $0.ticker == meta.ticker && $0.chain == meta.chain }) else {
                 return nil
             }
@@ -72,8 +61,10 @@ private extension THORChainStakeInteractor {
         }
     }
 
-    func createStakePosition(snapshot: CoinSnapshot, runeMeta: CoinMeta) async -> StakePositionData? {
+    func dto(for snapshot: CoinSnapshot, runeMeta: CoinMeta) async -> StakePositionData? {
         let ticker = snapshot.meta.ticker.uppercased()
+        let type = StakePositionType.defaultType(for: snapshot.meta)
+
         switch ticker {
         case "TCY", "RUJI":
             do {
@@ -84,7 +75,7 @@ private extension THORChainStakeInteractor {
                 )
                 return StakePositionData(
                     coin: snapshot.meta,
-                    type: .stake,
+                    type: type,
                     amount: details.stakedAmount,
                     apr: details.apr,
                     estimatedReward: details.estimatedReward,
@@ -98,27 +89,27 @@ private extension THORChainStakeInteractor {
             }
 
         case "STCY":
-            let rawAmount = await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: snapshot.address)
-            let amount = THORChainStakeInteractor.scaledAmount(rawAmount: rawAmount, decimals: snapshot.meta.decimals)
-            return StakePositionData(
-                coin: snapshot.meta,
-                type: .compound,
-                amount: amount
-            )
+            do {
+                let rawAmount = try await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: snapshot.address)
+                let amount = THORChainStakeInteractor.scaledAmount(rawAmount: rawAmount, decimals: snapshot.meta.decimals)
+                return StakePositionData(coin: snapshot.meta, type: type, amount: amount)
+            } catch {
+                logger.error("Error fetching STCY auto-compound amount: \(error.localizedDescription, privacy: .private)")
+                return nil
+            }
 
         case "YRUNE", "YTCY":
-            return StakePositionData(
-                coin: snapshot.meta,
-                type: .index,
-                amount: snapshot.balance
-            )
+            // Reads `coin.balanceDecimal` (kept up-to-date by `BalanceService`). Only update the
+            // persisted row when balance is non-zero — `BalanceService` may briefly observe zero
+            // mid-refresh, which would otherwise clobber a previously good amount.
+            guard snapshot.balance > 0 else { return nil }
+            return StakePositionData(coin: snapshot.meta, type: type, amount: snapshot.balance)
 
         default:
-            return StakePositionData(
-                coin: snapshot.meta,
-                type: .stake,
-                amount: snapshot.stakedBalance
-            )
+            // Same rationale as YRUNE/YTCY — `coin.stakedBalanceDecimal` mirrors a chain read
+            // that can transiently report zero.
+            guard snapshot.stakedBalance > 0 else { return nil }
+            return StakePositionData(coin: snapshot.meta, type: type, amount: snapshot.stakedBalance)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/LPPosition.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/LPPosition.swift
@@ -44,4 +44,28 @@ final class LPPosition {
         self.vault = vault
         self.id = "\(coin1.chain.ticker)_\(coin1.contractAddress)_\(poolName)_\(vault.pubKeyECDSA)"
     }
+
+    convenience init(_ dto: LPPositionData, vault: Vault) {
+        self.init(
+            coin1: dto.coin1,
+            coin1Amount: dto.coin1Amount,
+            coin2: dto.coin2,
+            coin2Amount: dto.coin2Amount,
+            poolName: dto.poolName,
+            poolUnits: dto.poolUnits,
+            apr: dto.apr,
+            vault: vault
+        )
+    }
+
+    /// Updates everything except the lookup key (`coin2`) and the persistent `id`.
+    func apply(_ dto: LPPositionData) {
+        coin1 = dto.coin1
+        coin1Amount = dto.coin1Amount
+        coin2Amount = dto.coin2Amount
+        poolName = dto.poolName
+        poolUnits = dto.poolUnits
+        apr = dto.apr
+        lastUpdated = .now
+    }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/LPPositionData.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/LPPositionData.swift
@@ -16,8 +16,4 @@ struct LPPositionData: Sendable, Equatable {
     let poolName: String
     let poolUnits: String
     let apr: Double
-
-    func id(for vault: Vault) -> String {
-        "\(coin1.chain.ticker)_\(coin1.contractAddress)_\(poolName)_\(vault.pubKeyECDSA)"
-    }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
@@ -60,6 +60,35 @@ final class StakePosition {
         self.vault = vault
         self.id = "\(coin.chain.ticker)_\(coin.contractAddress)_\(vault.pubKeyECDSA)"
     }
+
+    convenience init(_ dto: StakePositionData, vault: Vault) {
+        self.init(
+            coin: dto.coin,
+            type: dto.type,
+            amount: dto.amount,
+            availableToUnstake: dto.availableToUnstake,
+            apr: dto.apr,
+            estimatedReward: dto.estimatedReward,
+            nextPayout: dto.nextPayout,
+            rewards: dto.rewards,
+            rewardCoin: dto.rewardCoin,
+            unstakeMetadata: dto.unstakeMetadata,
+            vault: vault
+        )
+    }
+
+    /// Updates everything except the lookup key (`coin`) and the persistent `id`.
+    func apply(_ dto: StakePositionData) {
+        type = dto.type
+        amount = dto.amount
+        availableToUnstake = dto.availableToUnstake
+        apr = dto.apr
+        estimatedReward = dto.estimatedReward
+        nextPayout = dto.nextPayout
+        rewards = dto.rewards
+        rewardCoin = dto.rewardCoin
+        unstakeMetadata = dto.unstakeMetadata
+    }
 }
 
 enum StakePositionType: String, Codable, Equatable {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
@@ -66,4 +66,15 @@ enum StakePositionType: String, Codable, Equatable {
     case stake
     case compound
     case index
+
+    static func defaultType(for coin: CoinMeta) -> StakePositionType {
+        switch coin.ticker.uppercased() {
+        case "STCY":
+            return .compound
+        case "YRUNE", "YTCY":
+            return .index
+        default:
+            return .stake
+        }
+    }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePositionData.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePositionData.swift
@@ -46,8 +46,4 @@ struct StakePositionData: Sendable, Equatable {
         self.rewardCoin = rewardCoin
         self.unstakeMetadata = unstakeMetadata
     }
-
-    func id(for vault: Vault) -> String {
-        "\(coin.chain.ticker)_\(coin.contractAddress)_\(vault.pubKeyECDSA)"
-    }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePositionData.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePositionData.swift
@@ -22,10 +22,6 @@ struct StakePositionData: Sendable, Equatable {
     let rewards: Decimal?
     let rewardCoin: CoinMeta?
     let unstakeMetadata: UnstakeMetadata?
-    /// `true` when the position came from a successful network fetch and should be persisted.
-    /// `false` for fallback values built from cached metadata after an API failure — those
-    /// must not overwrite the persisted record with stale data.
-    let shouldPersist: Bool
 
     init(
         coin: CoinMeta,
@@ -37,8 +33,7 @@ struct StakePositionData: Sendable, Equatable {
         nextPayout: TimeInterval? = nil,
         rewards: Decimal? = nil,
         rewardCoin: CoinMeta? = nil,
-        unstakeMetadata: UnstakeMetadata? = nil,
-        shouldPersist: Bool = true
+        unstakeMetadata: UnstakeMetadata? = nil
     ) {
         self.coin = coin
         self.type = type
@@ -50,7 +45,6 @@ struct StakePositionData: Sendable, Equatable {
         self.rewards = rewards
         self.rewardCoin = rewardCoin
         self.unstakeMetadata = unstakeMetadata
-        self.shouldPersist = shouldPersist
     }
 
     func id(for vault: Vault) -> String {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/LPs/DefiChainLPsView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/LPs/DefiChainLPsView.swift
@@ -19,16 +19,16 @@ struct DefiChainLPsView<EmptyStateView: View>: View {
     }
 
     var formattedLPs: [(position: LPPosition, fiatAmount: String)] {
-        viewModel.lpPositions.compactMap { position -> (position: LPPosition, fiatAmount: Decimal)? in
-            guard let coin = vault.coins.first(where: { $0.toCoinMeta() == position.coin1 }) else {
-                return nil
+        viewModel.lpPositions
+            .map { position -> (position: LPPosition, fiatAmount: Decimal) in
+                // Use `position.coin1` (CoinMeta) for the rate lookup rather than requiring a
+                // matching `Coin` row in `vault.coins`. Otherwise zero-amount placeholders for
+                // freshly-enabled pools disappear here even after the VM has them.
+                let fiatAmount = RateProvider.shared.fiatBalance(value: position.coin1Amount, coin: position.coin1)
+                return (position, fiatAmount)
             }
-
-            let fiatAmount = coin.fiat(decimal: position.coin1Amount)
-            return (position, fiatAmount)
-        }
-        .sorted { $0.fiatAmount > $1.fiatAmount }
-        .map { ($0.position, $0.fiatAmount.formatToFiat(includeCurrencySymbol: true))}
+            .sorted { $0.fiatAmount > $1.fiatAmount }
+            .map { ($0.position, $0.fiatAmount.formatToFiat(includeCurrencySymbol: true))}
     }
 
     var body: some View {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
@@ -92,17 +92,44 @@ struct DefiChainSelectPositionsScreen: View {
 
     @MainActor
     func updateVaultDefiPositions() {
-        viewModel.vault.defiPositions.removeAll(where: { $0.chain == viewModel.chain })
-        viewModel.vault.defiPositions.append(
+        let chain = viewModel.chain
+        let vault = viewModel.vault
+
+        let previous = vault.defiPositions.first { $0.chain == chain }
+        let previousStaking = Set(previous?.staking ?? [])
+        let previousLps = Set(previous?.lps ?? [])
+        let newStaking = Set(selection[safe: 1] ?? [])
+        let newLps = Set(selection[safe: 2] ?? [])
+
+        vault.defiPositions.removeAll { $0.chain == chain }
+        vault.defiPositions.append(
             DefiPositions(
-                chain: viewModel.chain,
+                chain: chain,
                 bonds: Array(Set(selection[safe: 0] ?? [])),
-                staking: Array(Set(selection[safe: 1] ?? [])),
-                lps: Array(Set(selection[safe: 2] ?? []))
+                staking: Array(newStaking),
+                lps: Array(newLps)
             )
         )
 
         try? Storage.shared.save()
+
+        // Mirror the enable/disable into persisted position rows so the user sees a row with its
+        // CTA immediately (zero amount) — the next refresh updates the amount.
+        let storage = DefiPositionsStorageService()
+        for added in newStaking.subtracting(previousStaking) {
+            try? storage.addZero(stakeCoin: added, to: vault)
+        }
+        for removed in previousStaking.subtracting(newStaking) {
+            try? storage.removeStake(coin: removed, from: vault)
+        }
+        if let nativeCoin = vault.nativeCoin(for: chain)?.toCoinMeta() {
+            for added in newLps.subtracting(previousLps) {
+                try? storage.addZero(lpCoin2: added, nativeCoin: nativeCoin, to: vault)
+            }
+        }
+        for removed in previousLps.subtracting(newLps) {
+            try? storage.removeLP(coin2: removed, from: vault)
+        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
@@ -5,7 +5,10 @@
 //  Created by Gaston Mazzeo on 23/10/2025.
 //
 
+import OSLog
 import SwiftUI
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-chain-select-positions")
 
 struct DefiChainSelectPositionsScreen: View {
     @ObservedObject var viewModel: DefiChainMainViewModel
@@ -111,24 +114,44 @@ struct DefiChainSelectPositionsScreen: View {
             )
         )
 
-        try? Storage.shared.save()
+        do {
+            try Storage.shared.save()
+        } catch {
+            logger.error("Failed to save vault defi positions: \(error.localizedDescription, privacy: .private)")
+        }
 
         // Mirror the enable/disable into persisted position rows so the user sees a row with its
         // CTA immediately (zero amount) — the next refresh updates the amount.
         let storage = DefiPositionsStorageService()
         for added in newStaking.subtracting(previousStaking) {
-            try? storage.addZero(stakeCoin: added, to: vault)
+            do {
+                try storage.addZero(stakeCoin: added, to: vault)
+            } catch {
+                logger.error("Failed to add zero stake row for \(added.ticker, privacy: .public): \(error.localizedDescription, privacy: .private)")
+            }
         }
         for removed in previousStaking.subtracting(newStaking) {
-            try? storage.removeStake(coin: removed, from: vault)
+            do {
+                try storage.removeStake(coin: removed, from: vault)
+            } catch {
+                logger.error("Failed to remove stake row for \(removed.ticker, privacy: .public): \(error.localizedDescription, privacy: .private)")
+            }
         }
         if let nativeCoin = vault.nativeCoin(for: chain)?.toCoinMeta() {
             for added in newLps.subtracting(previousLps) {
-                try? storage.addZero(lpCoin2: added, nativeCoin: nativeCoin, to: vault)
+                do {
+                    try storage.addZero(lpCoin2: added, nativeCoin: nativeCoin, to: vault)
+                } catch {
+                    logger.error("Failed to add zero LP row for \(added.ticker, privacy: .public): \(error.localizedDescription, privacy: .private)")
+                }
             }
         }
         for removed in previousLps.subtracting(newLps) {
-            try? storage.removeLP(coin2: removed, from: vault)
+            do {
+                try storage.removeLP(coin2: removed, from: vault)
+            } catch {
+                logger.error("Failed to remove LP row for \(removed.ticker, privacy: .public): \(error.localizedDescription, privacy: .private)")
+            }
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedView.swift
@@ -20,16 +20,18 @@ struct DefiChainStakedView<EmptyStateView: View>: View {
     }
 
     var formattedStakePositions: [(position: StakePosition, fiatAmount: String)] {
-        viewModel.stakePositions.compactMap { position -> (position: StakePosition, fiatAmount: Decimal)? in
-            guard let coin = viewModel.vault.coins.first(where: { $0.toCoinMeta() == position.coin }) else {
-                return nil
+        viewModel.stakePositions
+            .map { position -> (position: StakePosition, fiatAmount: Decimal) in
+                // Use the position's `CoinMeta` for the rate lookup so zero-amount placeholders
+                // (and any position whose `Coin` row isn't yet in `vault.coins` — e.g. when the
+                // background `CoinService.addToChain` call hasn't completed or silently failed)
+                // still render. Filtering by `vault.coins.first(...)` here was the reason
+                // freshly-enabled positions disappeared after a refresh.
+                let fiatAmount = RateProvider.shared.fiatBalance(value: position.amount, coin: position.coin)
+                return (position, fiatAmount)
             }
-
-            let fiatAmount = coin.fiat(decimal: position.amount)
-            return (position, fiatAmount)
-        }
-        .sorted { $0.fiatAmount > $1.fiatAmount }
-        .map { ($0.position, $0.fiatAmount.formatToFiat(includeCurrencySymbol: true))}
+            .sorted { $0.fiatAmount > $1.fiatAmount }
+            .map { ($0.position, $0.fiatAmount.formatToFiat(includeCurrencySymbol: true))}
     }
 
     var body: some View {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainLPsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainLPsViewModel.swift
@@ -24,7 +24,7 @@ final class DefiChainLPsViewModel: ObservableObject {
         vault.lpPositions.filter { vaultLPPositions.contains($0.coin2) }
     }
 
-    var hasLPPositions: Bool { !vaultLPPositions.isEmpty }
+    var hasLPPositions: Bool { !lpPositions.isEmpty }
 
     var vaultLPPositions: [CoinMeta] {
         vault.defiPositions.first { $0.chain == chain }?.lps ?? []
@@ -40,7 +40,8 @@ final class DefiChainLPsViewModel: ObservableObject {
         self.chain = chain
         self.interactor = interactor ?? DefiInteractorResolver.lpsInteractor(for: chain)
         self.storage = storage
-        self.initialLoadingDone = !vault.lpPositions.isEmpty
+        let enabledLPs = vault.defiPositions.first { $0.chain == chain }?.lps ?? []
+        self.initialLoadingDone = vault.lpPositions.contains { enabledLPs.contains($0.coin2) }
     }
 
     func update(vault: Vault) {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainLPsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainLPsViewModel.swift
@@ -7,28 +7,28 @@
 
 import Foundation
 import OSLog
-import SwiftData
 
 private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-chain-lps-view-model")
 
 @MainActor
 final class DefiChainLPsViewModel: ObservableObject {
     @Published private(set) var vault: Vault
-    @Published private(set) var lpPositions: [LPPosition] = []
-    @Published private(set) var initialLoadingDone: Bool = false
-    @Published private(set) var refreshError: String?
+    @Published private(set) var initialLoadingDone: Bool
 
-    var hasLPPositions: Bool {
-        !vaultLPPositions.isEmpty
+    private let chain: Chain
+    private let interactor: LPsInteractor?
+    private let storage: DefiPositionsStorageService
+
+    /// See `DefiChainStakeViewModel.stakePositions` for why this is computed and not cached.
+    var lpPositions: [LPPosition] {
+        vault.lpPositions.filter { vaultLPPositions.contains($0.coin2) }
     }
+
+    var hasLPPositions: Bool { !vaultLPPositions.isEmpty }
 
     var vaultLPPositions: [CoinMeta] {
         vault.defiPositions.first { $0.chain == chain }?.lps ?? []
     }
-
-    private let interactor: LPsInteractor?
-    private let storage: DefiPositionsStorageService
-    private let chain: Chain
 
     init(
         vault: Vault,
@@ -40,43 +40,25 @@ final class DefiChainLPsViewModel: ObservableObject {
         self.chain = chain
         self.interactor = interactor ?? DefiInteractorResolver.lpsInteractor(for: chain)
         self.storage = storage
-        self.lpPositions = persistedPositions()
-        self.initialLoadingDone = !lpPositions.isEmpty
+        self.initialLoadingDone = !vault.lpPositions.isEmpty
     }
 
     func update(vault: Vault) {
         self.vault = vault
-        self.lpPositions = persistedPositions()
     }
 
     func refresh() async {
-        refreshError = nil
-        guard hasLPPositions else {
-            // No LP coins enabled — preserve any prior in-memory state and just mark loaded.
+        guard let interactor else {
             initialLoadingDone = true
             return
         }
 
-        guard let interactor = interactor else {
-            initialLoadingDone = true
-            return
-        }
-
+        let dtos = await interactor.fetchLPPositions(vault: vault)
         do {
-            let dtos = try await interactor.fetchLPPositions(vault: vault)
             try storage.upsert(lp: dtos, for: vault)
-            lpPositions = persistedPositions()
         } catch {
-            // Preserve last-known UI state and surface error for the screen banner.
-            logger.error("Failed to refresh LP positions for chain \(self.chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .private)")
-            refreshError = "defiRefreshFailed".localized
+            logger.error("Failed to persist LP positions for chain \(self.chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .private)")
         }
         initialLoadingDone = true
-    }
-}
-
-private extension DefiChainLPsViewModel {
-    func persistedPositions() -> [LPPosition] {
-        vault.lpPositions.filter { vaultLPPositions.contains($0.coin2) }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
@@ -13,20 +13,28 @@ private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-chain
 @MainActor
 final class DefiChainStakeViewModel: ObservableObject {
     @Published private(set) var vault: Vault
-    private let chain: Chain
-    @Published private(set) var stakePositions: [StakePosition] = []
-    @Published private(set) var initialLoadingDone: Bool = false
-    @Published private(set) var refreshError: String?
+    @Published private(set) var initialLoadingDone: Bool
 
-    var hasStakePositions: Bool {
-        !stakePositions.isEmpty
+    private let chain: Chain
+    private let interactor: StakeInteractor?
+    private let storage: DefiPositionsStorageService
+
+    /// Computed against the live `vault.stakePositions` relationship rather than a cached
+    /// snapshot. Caching here would let the view dereference a `StakePosition` after storage
+    /// deletes it (e.g. when the user disables a position) and crash on attribute fault. The
+    /// host screen's `@ObservedObject vault` re-renders whenever the relationship changes, so
+    /// this property re-evaluates with a fresh array.
+    var stakePositions: [StakePosition] {
+        vault.stakePositions
+            .filter { vaultStakePositions.contains($0.coin) }
+            .sorted { $0.amount > $1.amount }
     }
+
+    var hasStakePositions: Bool { !stakePositions.isEmpty }
 
     var vaultStakePositions: [CoinMeta] {
         vault.defiPositions.first { $0.chain == chain }?.staking ?? []
     }
-    private let interactor: StakeInteractor?
-    private let storage: DefiPositionsStorageService
 
     init(
         vault: Vault,
@@ -38,18 +46,15 @@ final class DefiChainStakeViewModel: ObservableObject {
         self.chain = chain
         self.interactor = interactor ?? DefiInteractorResolver.stakeInteractor(for: chain)
         self.storage = storage
-        self.stakePositions = persistedPositions()
-        self.initialLoadingDone = !stakePositions.isEmpty
+        self.initialLoadingDone = !vault.stakePositions.isEmpty
     }
 
     func update(vault: Vault) {
         self.vault = vault
-        self.stakePositions = persistedPositions()
     }
 
     func refresh() async {
-        refreshError = nil
-        guard let interactor = interactor else {
+        guard let interactor else {
             initialLoadingDone = true
             return
         }
@@ -57,24 +62,9 @@ final class DefiChainStakeViewModel: ObservableObject {
         let dtos = await interactor.fetchStakePositions(vault: vault)
         do {
             try storage.upsert(stake: dtos, for: vault)
-            stakePositions = persistedPositions()
         } catch {
             logger.error("Failed to persist stake positions for chain \(self.chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .private)")
-            refreshError = "defiRefreshFailed".localized
         }
         initialLoadingDone = true
-    }
-}
-
-private extension DefiChainStakeViewModel {
-    /// Reads current persisted positions filtered by the user's enabled stake coins.
-    /// Safe to call after `upsert` because interactors no longer construct `@Model`
-    /// instances (which would have polluted `vault.stakePositions` via the inverse
-    /// relationship before save). DTOs flow through the storage materialization
-    /// boundary and are the only path to mutating `vault.stakePositions`.
-    func persistedPositions() -> [StakePosition] {
-        vault.stakePositions
-            .filter { vaultStakePositions.contains($0.coin) }
-            .sorted { $0.amount > $1.amount }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
@@ -46,7 +46,8 @@ final class DefiChainStakeViewModel: ObservableObject {
         self.chain = chain
         self.interactor = interactor ?? DefiInteractorResolver.stakeInteractor(for: chain)
         self.storage = storage
-        self.initialLoadingDone = !vault.stakePositions.isEmpty
+        let enabledStakes = vault.defiPositions.first { $0.chain == chain }?.staking ?? []
+        self.initialLoadingDone = vault.stakePositions.contains { enabledStakes.contains($0.coin) }
     }
 
     func update(vault: Vault) {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 import Combine
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "unstake-transaction-view-model")
 
 final class UnstakeTransactionViewModel: ObservableObject, Form {
     let coin: Coin
@@ -100,7 +103,13 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     func fetchAutocompoundBalance() async {
         switch coin.ticker.uppercased() {
         case "TCY":
-            let amount = (try? await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)) ?? .zero
+            let amount: Decimal
+            do {
+                amount = try await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)
+            } catch {
+                logger.error("Failed to fetch TCY autocompound balance: \(error.localizedDescription, privacy: .private)")
+                amount = .zero
+            }
             self.autocompoundBalance = coin.valueWithDecimals(value: amount)
         default:
             break

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -100,7 +100,7 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
     func fetchAutocompoundBalance() async {
         switch coin.ticker.uppercased() {
         case "TCY":
-            let amount = await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)
+            let amount = (try? await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: coin.address)) ?? .zero
             self.autocompoundBalance = coin.valueWithDecimals(value: amount)
         default:
             break

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainBalanceView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainBalanceView.swift
@@ -38,6 +38,7 @@ struct VaultMainBalanceView: View {
             .foregroundStyle(Theme.colors.textPrimary)
             .contentTransition(.numericText())
             .animation(.interpolatingSpring, value: balanceToShow)
+            .animation(.interpolatingSpring, value: homeViewModel.hideVaultBalance)
     }
 
     var toggleBalanceVisibilityButton: some View {

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainLPsViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainLPsViewModelTests.swift
@@ -33,7 +33,7 @@ final class DefiChainLPsViewModelTests: XCTestCase {
 
     // MARK: - Init
 
-    func testInitWithNoPersistedPositionsMarksInitialLoadingPending() {
+    func testInitWithNoPersistedPositionsLeavesArrayEmpty() {
         let vm = makeViewModel()
         XCTAssertTrue(vm.lpPositions.isEmpty)
         XCTAssertFalse(vm.initialLoadingDone)
@@ -41,7 +41,7 @@ final class DefiChainLPsViewModelTests: XCTestCase {
 
     // MARK: - Refresh
 
-    func testRefreshSuccessReplacesPersistedArray() async throws {
+    func testRefreshSuccessPersistsAndPublishes() async throws {
         let rune = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
         let btc = CoinMeta.make(chain: .bitcoin, ticker: "BTC")
         interactor.stub = [
@@ -53,40 +53,11 @@ final class DefiChainLPsViewModelTests: XCTestCase {
 
         XCTAssertEqual(vm.lpPositions.count, 1)
         XCTAssertEqual(vm.lpPositions.first?.apr, 0.05)
-        XCTAssertNil(vm.refreshError)
         XCTAssertTrue(vm.initialLoadingDone)
     }
 
-    /// Regression: an LP fetch that throws must NOT clear the persisted list, and must surface refreshError.
-    func testRefreshFailurePreservesStateAndSetsError() async throws {
-        let storage = DefiPositionsStorageService()
-        let rune = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
-        let btc = CoinMeta.make(chain: .bitcoin, ticker: "BTC")
-        try storage.upsert(lp: [
-            LPPositionData(coin1: rune, coin1Amount: 100, coin2: btc, coin2Amount: 1, poolName: "BTC.BTC", poolUnits: "10", apr: 0.05)
-        ], for: vault)
-
-        interactor.error = MockInteractorError.generic
-
-        let vm = makeViewModel()
-        await vm.refresh()
-
-        XCTAssertEqual(vm.lpPositions.count, 1, "Throw must not clear persisted positions.")
-        XCTAssertNotNil(vm.refreshError, "Throw must set refreshError for the screen banner.")
-    }
-
-    func testRefreshNoLpsEnabledMarksLoadingDoneWithoutCallingInteractor() async {
-        // Disable LP coins
-        vault.defiPositions = [DefiPositions(chain: .thorChain, bonds: [], staking: [], lps: [])]
-
-        let vm = makeViewModel()
-        await vm.refresh()
-
-        XCTAssertEqual(interactor.callCount, 0, "Refresh must short-circuit when no LP coins are enabled.")
-        XCTAssertTrue(vm.initialLoadingDone)
-    }
-
-    func testRefreshEmptySuccessClearsStalePositions() async throws {
+    /// Empty interactor result (top-level API failure) must not wipe persisted rows.
+    func testRefreshEmptyPreservesPersistedState() async throws {
         let storage = DefiPositionsStorageService()
         let rune = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
         let btc = CoinMeta.make(chain: .bitcoin, ticker: "BTC")
@@ -94,16 +65,14 @@ final class DefiChainLPsViewModelTests: XCTestCase {
             LPPositionData(coin1: rune, coin1Amount: 50, coin2: btc, coin2Amount: 0.5, poolName: "BTC.BTC", poolUnits: "5", apr: 0.04)
         ], for: vault)
 
-        interactor.stub = [] // empty success — LP API is single-shot, [] means user has no LPs.
-
         let vm = makeViewModel()
         XCTAssertEqual(vm.lpPositions.count, 1)
+
+        interactor.stub = []
         await vm.refresh()
 
-        // Storage's LP upsert applies vault-scoped delete-stale, so empty success clears the
-        // list. Failures throw (preserved by `testRefreshFailurePreservesStateAndSetsError`).
-        XCTAssertEqual(vm.lpPositions.count, 0, "Empty LP success clears persisted rows for the vault.")
-        XCTAssertNil(vm.refreshError)
+        XCTAssertEqual(vm.lpPositions.count, 1)
+        XCTAssertEqual(vm.lpPositions.first?.coin1Amount, 50)
     }
 
     // MARK: - Helpers

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainStakeViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainStakeViewModelTests.swift
@@ -19,7 +19,6 @@ final class DefiChainStakeViewModelTests: XCTestCase {
         vault = DefiTestStore.makeVault()
         interactor = MockStakeInteractor()
 
-        // Enable TCY in defi positions so vaultStakePositions resolves correctly.
         let tcyMeta = CoinMeta.make(chain: .thorChain, ticker: "TCY")
         vault.defiPositions = [DefiPositions(chain: .thorChain, bonds: [], staking: [tcyMeta], lps: [])]
     }
@@ -34,10 +33,10 @@ final class DefiChainStakeViewModelTests: XCTestCase {
 
     // MARK: - Init
 
-    func testInitWithEmptyPersistedPositionsMarksInitialLoadingPending() {
+    func testInitWithoutPersistedPositionsLeavesArrayEmpty() {
         let vm = makeViewModel()
         XCTAssertTrue(vm.stakePositions.isEmpty)
-        XCTAssertFalse(vm.initialLoadingDone)
+        XCTAssertFalse(vm.initialLoadingDone, "No persisted rows ⇒ skeleton must show until first refresh.")
     }
 
     func testInitWithPersistedPositionsMarksInitialLoadingDone() throws {
@@ -54,7 +53,7 @@ final class DefiChainStakeViewModelTests: XCTestCase {
 
     // MARK: - Refresh
 
-    func testRefreshSuccessReplacesPublishedArray() async throws {
+    func testRefreshSuccessPersistsAndPublishes() async throws {
         let vm = makeViewModel()
         let tcyMeta = CoinMeta.make(chain: .thorChain, ticker: "TCY")
         interactor.stub = [
@@ -67,10 +66,10 @@ final class DefiChainStakeViewModelTests: XCTestCase {
         XCTAssertEqual(vm.stakePositions.first?.amount, 42)
         XCTAssertEqual(vm.stakePositions.first?.apr, 0.05)
         XCTAssertTrue(vm.initialLoadingDone)
-        XCTAssertNil(vm.refreshError)
     }
 
-    /// Regression test for Bug 2: refresh that returns no DTOs must not flicker the list to empty.
+    /// Refresh that returns no DTOs (e.g. all per-coin fetches failed) must not flicker the list
+    /// to empty — persisted rows stay visible.
     func testRefreshEmptyPreservesPersistedState() async throws {
         let storage = DefiPositionsStorageService()
         let tcyMeta = CoinMeta.make(chain: .thorChain, ticker: "TCY")
@@ -81,29 +80,26 @@ final class DefiChainStakeViewModelTests: XCTestCase {
         let vm = makeViewModel()
         XCTAssertEqual(vm.stakePositions.count, 1)
 
-        interactor.stub = [] // no DTOs returned (e.g. all per-coin fetches failed)
+        interactor.stub = []
         await vm.refresh()
 
-        XCTAssertEqual(vm.stakePositions.count, 1, "Empty interactor result must NOT clear the list — persisted positions stay visible.")
+        XCTAssertEqual(vm.stakePositions.count, 1)
         XCTAssertEqual(vm.stakePositions.first?.amount, 100)
-        XCTAssertEqual(vm.stakePositions.first?.apr, 0.1)
     }
 
-    func testRefreshPartialSuccessOnlyUpdatesReturnedCoins() async throws {
+    /// Per-coin partial success: TCY refresh succeeds, RUJI's per-coin fetch failed (interactor
+    /// omits it). RUJI's persisted row must stay untouched.
+    func testRefreshPartialSuccessPreservesOmittedCoinsRow() async throws {
         let storage = DefiPositionsStorageService()
         let tcyMeta = CoinMeta.make(chain: .thorChain, ticker: "TCY")
         let rujiMeta = CoinMeta.make(chain: .thorChain, ticker: "RUJI")
 
-        // Enable both
         vault.defiPositions = [DefiPositions(chain: .thorChain, bonds: [], staking: [tcyMeta, rujiMeta], lps: [])]
-
-        // Seed with prior data for both
         try storage.upsert(stake: [
             StakePositionData(coin: tcyMeta, type: .stake, amount: 100, apr: 0.1),
             StakePositionData(coin: rujiMeta, type: .stake, amount: 200, apr: 0.2)
         ], for: vault)
 
-        // Only TCY succeeds in this refresh — RUJI per-coin fetch failed and was omitted.
         interactor.stub = [
             StakePositionData(coin: tcyMeta, type: .stake, amount: 150, apr: 0.15)
         ]
@@ -111,30 +107,10 @@ final class DefiChainStakeViewModelTests: XCTestCase {
         let vm = makeViewModel()
         await vm.refresh()
 
-        // TCY updates to 150; RUJI keeps its prior 200.
         let tcy = vm.stakePositions.first { $0.coin.ticker == "TCY" }
         let ruji = vm.stakePositions.first { $0.coin.ticker == "RUJI" }
         XCTAssertEqual(tcy?.amount, 150)
-        XCTAssertEqual(ruji?.amount, 200, "Persisted RUJI must remain — partial-failure refresh preserves untouched coins.")
-    }
-
-    func testUpdateVaultReSnapshotsCache() throws {
-        let vm = makeViewModel()
-        XCTAssertTrue(vm.stakePositions.isEmpty)
-
-        // Build a second vault with persisted positions, swap.
-        let storage = DefiPositionsStorageService()
-        let other = DefiTestStore.makeVault(pubKey: "other-vault")
-        let tcyMeta = CoinMeta.make(chain: .thorChain, ticker: "TCY")
-        other.defiPositions = [DefiPositions(chain: .thorChain, bonds: [], staking: [tcyMeta], lps: [])]
-        try storage.upsert(stake: [
-            StakePositionData(coin: tcyMeta, type: .stake, amount: 999, apr: 0.3)
-        ], for: other)
-
-        vm.update(vault: other)
-
-        XCTAssertEqual(vm.stakePositions.count, 1)
-        XCTAssertEqual(vm.stakePositions.first?.amount, 999)
+        XCTAssertEqual(ruji?.amount, 200, "RUJI must keep its persisted amount when omitted from refresh.")
     }
 
     // MARK: - Helpers

--- a/VultisigApp/VultisigAppTests/Defi/DefiPositionsStorageServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiPositionsStorageServiceTests.swift
@@ -37,7 +37,7 @@ final class DefiPositionsStorageServiceTests: XCTestCase {
 
         XCTAssertEqual(materialized.count, 1)
         XCTAssertEqual(materialized.first?.amount, 10)
-        XCTAssertEqual(vault.stakePositions.count, 1, "Inverse relationship should attach the materialized model.")
+        XCTAssertEqual(vault.stakePositions.count, 1)
     }
 
     func testUpsertStakeUpdatesExistingInPlace() throws {
@@ -57,16 +57,24 @@ final class DefiPositionsStorageServiceTests: XCTestCase {
         XCTAssertEqual(materialized.first?.apr, 0.12)
     }
 
-    func testUpsertStakeReturnsModelsInDtoOrder() throws {
+    func testUpsertStakeOmittedDtoLeavesPersistedRowUntouched() throws {
         let runeMeta = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
         let tcyMeta = CoinMeta.make(chain: .thorChain, ticker: "TCY")
 
-        let materialized = try service.upsert(stake: [
-            StakePositionData(coin: runeMeta, type: .stake, amount: 1),
-            StakePositionData(coin: tcyMeta, type: .stake, amount: 2)
+        _ = try service.upsert(stake: [
+            StakePositionData(coin: runeMeta, type: .stake, amount: 10),
+            StakePositionData(coin: tcyMeta, type: .stake, amount: 20)
         ], for: vault)
 
-        XCTAssertEqual(materialized.map(\.coin.ticker), ["RUNE", "TCY"])
+        // Refresh succeeds for RUNE only — TCY's per-coin fetch failed and was omitted.
+        // The persisted TCY row must stay untouched.
+        _ = try service.upsert(stake: [
+            StakePositionData(coin: runeMeta, type: .stake, amount: 15)
+        ], for: vault)
+
+        XCTAssertEqual(vault.stakePositions.count, 2)
+        XCTAssertEqual(vault.stakePositions.first(where: { $0.coin.ticker == "RUNE" })?.amount, 15)
+        XCTAssertEqual(vault.stakePositions.first(where: { $0.coin.ticker == "TCY" })?.amount, 20)
     }
 
     // MARK: - LP upsert
@@ -81,7 +89,6 @@ final class DefiPositionsStorageServiceTests: XCTestCase {
 
         XCTAssertEqual(materialized.count, 1)
         XCTAssertEqual(vault.lpPositions.count, 1)
-        XCTAssertEqual(materialized.first?.coin2.ticker, "BTC")
     }
 
     func testUpsertLpUpdatesExistingInPlace() throws {
@@ -98,8 +105,107 @@ final class DefiPositionsStorageServiceTests: XCTestCase {
 
         XCTAssertEqual(vault.lpPositions.count, 1)
         XCTAssertEqual(materialized.first?.coin1Amount, 200)
-        XCTAssertEqual(materialized.first?.coin2Amount, 2)
         XCTAssertEqual(materialized.first?.apr, 0.08)
+    }
+
+    func testUpsertLpOmittedDtoLeavesPersistedRowUntouched() throws {
+        let rune = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
+        let btc = CoinMeta.make(chain: .bitcoin, ticker: "BTC")
+        let eth = CoinMeta.make(chain: .ethereum, ticker: "ETH")
+
+        _ = try service.upsert(lp: [
+            LPPositionData(coin1: rune, coin1Amount: 1, coin2: btc, coin2Amount: 1, poolName: "BTC.BTC", poolUnits: "1", apr: 0.04),
+            LPPositionData(coin1: rune, coin1Amount: 2, coin2: eth, coin2Amount: 2, poolName: "ETH.ETH", poolUnits: "2", apr: 0.05)
+        ], for: vault)
+
+        // Partial refresh — BTC missing from input. Persisted BTC row stays.
+        _ = try service.upsert(lp: [
+            LPPositionData(coin1: rune, coin1Amount: 3, coin2: eth, coin2Amount: 3, poolName: "ETH.ETH", poolUnits: "3", apr: 0.06)
+        ], for: vault)
+
+        XCTAssertEqual(vault.lpPositions.count, 2)
+        XCTAssertEqual(Set(vault.lpPositions.map { $0.coin2.ticker }), ["BTC", "ETH"])
+    }
+
+    // MARK: - Enable / disable
+
+    func testAddZeroStakeInsertsZeroRow() throws {
+        let runeMeta = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
+
+        try service.addZero(stakeCoin: runeMeta, to: vault)
+
+        XCTAssertEqual(vault.stakePositions.count, 1)
+        XCTAssertEqual(vault.stakePositions.first?.amount, 0)
+        XCTAssertEqual(vault.stakePositions.first?.coin.ticker, "RUNE")
+    }
+
+    func testAddZeroStakeIsIdempotent() throws {
+        let runeMeta = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
+        _ = try service.upsert(stake: [
+            StakePositionData(coin: runeMeta, type: .stake, amount: 42)
+        ], for: vault)
+
+        try service.addZero(stakeCoin: runeMeta, to: vault)
+
+        XCTAssertEqual(vault.stakePositions.count, 1)
+        XCTAssertEqual(vault.stakePositions.first?.amount, 42, "Existing row must not be clobbered.")
+    }
+
+    func testRemoveStakeDeletesRow() throws {
+        let runeMeta = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
+        try service.addZero(stakeCoin: runeMeta, to: vault)
+        XCTAssertEqual(vault.stakePositions.count, 1)
+
+        try service.removeStake(coin: runeMeta, from: vault)
+
+        XCTAssertEqual(vault.stakePositions.count, 0)
+    }
+
+    func testAddZeroLpInsertsZeroRow() throws {
+        let runeMeta = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
+        let btcMeta = CoinMeta.make(chain: .bitcoin, ticker: "BTC")
+
+        try service.addZero(lpCoin2: btcMeta, nativeCoin: runeMeta, to: vault)
+
+        XCTAssertEqual(vault.lpPositions.count, 1)
+        XCTAssertEqual(vault.lpPositions.first?.coin1Amount, 0)
+        XCTAssertEqual(vault.lpPositions.first?.coin2.ticker, "BTC")
+    }
+
+    func testRemoveLpDeletesRow() throws {
+        let runeMeta = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
+        let btcMeta = CoinMeta.make(chain: .bitcoin, ticker: "BTC")
+        try service.addZero(lpCoin2: btcMeta, nativeCoin: runeMeta, to: vault)
+        XCTAssertEqual(vault.lpPositions.count, 1)
+
+        try service.removeLP(coin2: btcMeta, from: vault)
+
+        XCTAssertEqual(vault.lpPositions.count, 0)
+    }
+
+    func testLpZeroPlaceholderMergesWithApiPoolName() throws {
+        let runeMeta = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
+        let usdcMeta = CoinMeta.make(chain: .ethereum, ticker: "USDC")
+
+        // Enable: zero placeholder with synthesized poolName.
+        try service.addZero(lpCoin2: usdcMeta, nativeCoin: runeMeta, to: vault)
+
+        // Refresh: API returns canonical poolName with contract suffix. Same coin2 ⇒ merge.
+        _ = try service.upsert(lp: [
+            LPPositionData(
+                coin1: runeMeta,
+                coin1Amount: 100,
+                coin2: usdcMeta,
+                coin2Amount: 50,
+                poolName: "ETH.USDC-0xabc",
+                poolUnits: "10",
+                apr: 0.07
+            )
+        ], for: vault)
+
+        XCTAssertEqual(vault.lpPositions.count, 1, "Placeholder must merge with API row, not duplicate.")
+        XCTAssertEqual(vault.lpPositions.first?.coin1Amount, 100)
+        XCTAssertEqual(vault.lpPositions.first?.poolName, "ETH.USDC-0xabc")
     }
 
     // MARK: - Notifications
@@ -130,55 +236,5 @@ final class DefiPositionsStorageServiceTests: XCTestCase {
         ], for: vault)
 
         await fulfillment(of: [expectation], timeout: 1.0)
-    }
-
-    // MARK: - Empty input
-
-    func testUpsertStakeEmptyArrayDoesNotModifyStorage() throws {
-        let runeMeta = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
-        _ = try service.upsert(stake: [
-            StakePositionData(coin: runeMeta, type: .stake, amount: 1)
-        ], for: vault)
-
-        XCTAssertEqual(vault.stakePositions.count, 1)
-
-        // Confirm Stake upsert does NOT delete-stale (asymmetric with Bond — documented).
-        _ = try service.upsert(stake: [], for: vault)
-        XCTAssertEqual(vault.stakePositions.count, 1, "Stake upsert with [] must NOT delete persisted positions; only Bond does delete-stale.")
-    }
-
-    func testUpsertLpEmptyArrayDeletesStalePositions() throws {
-        let rune = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
-        let btc = CoinMeta.make(chain: .bitcoin, ticker: "BTC")
-        _ = try service.upsert(lp: [
-            LPPositionData(coin1: rune, coin1Amount: 1, coin2: btc, coin2Amount: 1, poolName: "BTC.BTC", poolUnits: "1", apr: 0.04)
-        ], for: vault)
-
-        XCTAssertEqual(vault.lpPositions.count, 1)
-
-        // LP API is single-shot: an empty success means the user has no LPs left for this vault.
-        // Delete-stale is correct here (matches Bond's contract).
-        _ = try service.upsert(lp: [], for: vault)
-        XCTAssertEqual(vault.lpPositions.count, 0, "LP upsert with [] deletes all persisted rows for the vault.")
-    }
-
-    func testUpsertLpDeletesPositionsMissingFromInput() throws {
-        let rune = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
-        let btc = CoinMeta.make(chain: .bitcoin, ticker: "BTC")
-        let eth = CoinMeta.make(chain: .ethereum, ticker: "ETH")
-        _ = try service.upsert(lp: [
-            LPPositionData(coin1: rune, coin1Amount: 1, coin2: btc, coin2Amount: 1, poolName: "BTC.BTC", poolUnits: "1", apr: 0.04),
-            LPPositionData(coin1: rune, coin1Amount: 2, coin2: eth, coin2Amount: 2, poolName: "ETH.ETH", poolUnits: "2", apr: 0.05)
-        ], for: vault)
-
-        XCTAssertEqual(vault.lpPositions.count, 2)
-
-        // Refresh returns only ETH — the user fully exited BTC. BTC must be removed.
-        _ = try service.upsert(lp: [
-            LPPositionData(coin1: rune, coin1Amount: 2, coin2: eth, coin2Amount: 2, poolName: "ETH.ETH", poolUnits: "2", apr: 0.05)
-        ], for: vault)
-
-        XCTAssertEqual(vault.lpPositions.count, 1)
-        XCTAssertEqual(vault.lpPositions.first?.coin2.ticker, "ETH")
     }
 }

--- a/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
@@ -15,7 +15,6 @@ import Foundation
 
 final class MockStakeInteractor: StakeInteractor, @unchecked Sendable {
     var stub: [StakePositionData] = []
-    var error: Error?
     private(set) var callCount = 0
 
     func fetchStakePositions(vault: Vault) async -> [StakePositionData] {
@@ -26,12 +25,10 @@ final class MockStakeInteractor: StakeInteractor, @unchecked Sendable {
 
 final class MockLPsInteractor: LPsInteractor, @unchecked Sendable {
     var stub: [LPPositionData] = []
-    var error: Error?
     private(set) var callCount = 0
 
-    func fetchLPPositions(vault: Vault) async throws -> [LPPositionData] {
+    func fetchLPPositions(vault: Vault) async -> [LPPositionData] {
         callCount += 1
-        if let error { throw error }
         return stub
     }
 }

--- a/VultisigApp/VultisigAppTests/Defi/THORChainLPsInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/THORChainLPsInteractorTests.swift
@@ -21,7 +21,7 @@ final class THORChainLPsInteractorTests: XCTestCase {
         defer { DefiTestStore.restore(token) }
         let vault = DefiTestStore.makeVault()
         // No RUNE coin → early-return guard returns [] without an API call.
-        let result = try await THORChainLPsInteractor().fetchLPPositions(vault: vault)
+        let result = await THORChainLPsInteractor().fetchLPPositions(vault: vault)
         XCTAssertTrue(result.isEmpty)
-            }
+    }
 }

--- a/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
@@ -45,6 +45,47 @@ final class THORChainStakeInteractorTests: XCTestCase {
         XCTAssertEqual(result, Decimal(string: "0.00000001"))
     }
 
+    // MARK: - APR fractionalRate
+
+    /// Per the Rujira GraphQL schema, `Bigint` decimal scalars are scaled to 12 decimal places.
+    /// `11623890337` should resolve to `0.011624` (≈ 1.16% when rendered as a percentage).
+    func test_aprFractionalRate_scales12Decimals() throws {
+        let apr = try decodeAPR(value: "11623890337", status: "AVAILABLE")
+        let result = try XCTUnwrap(apr.fractionalRate)
+        XCTAssertEqual(result, 0.011623890337, accuracy: 1e-12)
+    }
+
+    func test_aprFractionalRate_treatsMissingStatusAsAvailable() throws {
+        // Backwards-compat: if the API ever omits `status`, fall back to using the value.
+        let apr = try decodeAPR(value: "1000000000000", status: nil)
+        let result = try XCTUnwrap(apr.fractionalRate)
+        XCTAssertEqual(result, 1.0, accuracy: 1e-12)
+    }
+
+    func test_aprFractionalRate_returnsNilForNotApplicable() throws {
+        let apr = try decodeAPR(value: "0", status: "NOT_APPLICABLE")
+        XCTAssertNil(apr.fractionalRate)
+    }
+
+    func test_aprFractionalRate_returnsNilForSoon() throws {
+        let apr = try decodeAPR(value: "0", status: "SOON")
+        XCTAssertNil(apr.fractionalRate)
+    }
+
+    func test_aprFractionalRate_returnsNilForUnparseableValue() throws {
+        let apr = try decodeAPR(value: "garbage", status: "AVAILABLE")
+        XCTAssertNil(apr.fractionalRate)
+    }
+
+    // MARK: - Helpers
+
+    private func decodeAPR(value: String, status: String?) throws -> AccountRootData.ResponseData.AccountNode.APR {
+        var json = "{\"value\":\"\(value)\""
+        if let status { json += ",\"status\":\"\(status)\"" }
+        json += "}"
+        return try JSONDecoder().decode(AccountRootData.ResponseData.AccountNode.APR.self, from: Data(json.utf8))
+    }
+
     // MARK: - fetchStakePositions early-return paths
     //
     // Branching tests for TCY/RUJI/STCY/YRUNE/default require injecting
@@ -59,5 +100,5 @@ final class THORChainStakeInteractorTests: XCTestCase {
         // No RUNE coin in vault → guard short-circuits.
         let result = await THORChainStakeInteractor().fetchStakePositions(vault: vault)
         XCTAssertTrue(result.isEmpty)
-            }
+    }
 }


### PR DESCRIPTION
## Summary

Simplify the DeFi position pipeline so the user-visible bugs ("position randomly hits 0", crash when disabling a position, malformed RUJI APR) go away by construction rather than by accumulating special cases. Net effect across the branch: ~5 distinct mechanisms collapse into one, ~95 lines removed from storage, ~130 lines of view-model machinery dropped. RUJI APR display fixed using the documented Rujira `Bigint` 12-decimal scaling. 42 unit tests, all green.

## The pipeline (after)

**Refresh** (`DefiChain*ViewModel.refresh()`):
1. Show persisted positions (read live from `vault.stakePositions` / `vault.lpPositions`)
2. Fetch from network — interactor returns only successfully fetched positions
3. `storage.upsert(...)` writes whatever came back
4. View re-renders with the updated relationship array

**Enable position** (`DefiChainSelectPositionsScreen.updateVaultDefiPositions`):
1. `storage.addZero(stakeCoin:to:)` / `addZero(lpCoin2:nativeCoin:to:)` — zero placeholder row, idempotent
2. `vault.defiPositions` change triggers refresh via existing `.onChange`

**Disable position**:
1. `storage.removeStake(coin:from:)` / `removeLP(coin2:from:)` — explicit deletion

That's the whole flow. No `enabled` parameter on upsert, no fancy "preserve vs reset" classification, no error-class taxonomy. Per-coin failures inside the interactor are silently omitted from the result; storage upserts what it gets; persisted rows survive transient API hiccups.

## Concrete fixes

### 1. Crash on disable (`StakePosition.coin` attribute fault)

VMs no longer cache `[StakePosition]` / `[LPPosition]` in `@Published` arrays. After ` removeStake` deletes a model, the cache held a stale reference; SwiftUI re-rendered before any cache-invalidation, accessed `position.coin`, faulted. Fix: expose as a computed property over the live relationship — host screen's `@ObservedObject vault: Vault` (Vault is both `@Model` and `ObservableObject`) re-renders on relationship mutations.

```swift
var stakePositions: [StakePosition] {
    vault.stakePositions
        .filter { vaultStakePositions.contains($0.coin) }
        .sorted { $0.amount > $1.amount }
}
```

### 2. RUJI APR showing nonsense (e.g. `1,162,389,033,700%`)

Rujira's GraphQL `Bigint` scalar self-documents (introspected from `https://api.rujira.network/api/graphql`):

> Decimal values (e.g., prices) are scaled to 12 decimal places. Example: \$1.12 → 1120000000000

So a raw `apr.value = 11623890337` is `0.011624` (≈ 1.16% APR — same fractional convention as the LP code). Conversion now lives on `AccountRootData...APR.fractionalRate` (the model owns its own interpretation). Also queries `apr.status` and treats `NOT_APPLICABLE` / `SOON` as `nil` rather than 0. Dropped the `rewardsAmount > 0 ? apr : 0` gate — pool APR is independent of whether a particular user has accrued rewards.

### 3. Per-coin transient zeros clobbering good amounts (YRUNE/YTCY/default)

For tokens whose "amount" is read from `coin.balanceDecimal` (no separate API), the interactor only includes the DTO when the value is non-zero. A mid-`BalanceService` snapshot of 0 doesn't overwrite a previously persisted real amount.

### 4. THORNode endpoint hardening

- `THORChainStakingService.fetchRujiStakingDetails`: distinguish "address has no RUJI stake" (genuine empty) from "response missing/partial" — the latter throws so the persisted row stays untouched.
- `ThorchainService.fetchTcyAutoCompoundAmount`: now `throws` on transport / decoding failure instead of silently returning `.zero` (which used to clobber persisted STCY rows on every transient hiccup). `BalanceService` and `UnstakeTransactionViewModel` use `try?` to fall back without overwriting.

### 5. Pull-to-refresh cancellation

`.refreshable` binds its task to the spinner; releasing dismisses the spinner and cancels the task, propagating `CancellationError` to in-flight network calls. Detached the inner task so cancellation stops at the boundary.

## Architecture changes

### Interactors
- `StakeInteractor.fetchStakePositions(vault:)` returns `[StakePositionData]` — only valid (successfully fetched) positions. Per-coin failures silently omit. Never throws.
- `LPsInteractor.fetchLPPositions(vault:)` same: returns `[LPPositionData]`, top-level failure returns `[]`.

### Storage (`DefiPositionsStorageService`)
- `upsert(stake: [StakePositionData], for: Vault)` / `upsert(lp: [LPPositionData], for: Vault)` — plain insert-or-update, no delete-stale
- `addZero(stakeCoin:to:)` / `addZero(lpCoin2:nativeCoin:to:)` — idempotent zero-row insertion (called from the toggle screen on enable)
- `removeStake(coin:from:)` / `removeLP(coin2:from:)` — explicit deletion (called on disable)
- `upsert(_:for:)` for `BondPosition` unchanged in shape (single-shot API, delete-stales)

In a follow-up commit on this branch, the storage service was further simplified: 265 → 170 lines.
- FetchDescriptors replaced with direct relationship reads (`vault.stakePositions` etc.)
- Stake upsert keys by `coin` instead of a synthesized `id`
- Per-field assignments moved onto `@Model` types as `apply(_ dto:)` and `convenience init(_ dto:, vault:)`
- Bond's empty-input special case folded into the main delete-stale loop

### View models
- Drop `@Published` cached arrays; expose computed properties over the live relationship
- Drop `refreshError` / banner machinery — silent preservation on failure is the contract now
- `update(vault:)` just reassigns the vault reference; computed properties handle the rest

### Toggle screen (`DefiChainSelectPositionsScreen`)
On save, diff old vs new `defiPositions[chain]` and call storage `addZero` / `removeStake` / `removeLP` for added/removed coins. Existing `.onChange(of: vault.defiPositions)` handles the refresh kick.

## Removed (deliberately)

- `Error+DefiPositionPreservation.swift` — error classification (preserve-class vs reset-class)
- `StakeFetchOutcome` / `LPFetchOutcome` enums
- `shouldPersist` flag on `StakePositionData`
- `ensurePlaceholders(...)` methods on storage
- Refresh-error banner wiring on Stake/LP (Bond keeps its banner)

These were intermediate designs from earlier iterations; the simpler model makes them unnecessary.

## Test plan

- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — no new violations
- [x] `xcodebuild build` (iOS Simulator) — clean
- [x] `xcodebuild test` for Defi suite — 42 / 42 pass, including:
  - 14 storage tests (insert, update, omit, addZero idempotency, remove, placeholder→canonical poolName merge, notification posting)
  - VM tests (init with/without persisted, refresh success, refresh empty preserves persisted, partial refresh keeps omitted-coin rows)
  - 6 RUJI APR tests (12-decimal scaling, missing-status fallback, `NOT_APPLICABLE` / `SOON` → nil, unparseable input)
- [ ] Manual: enable a stake position → zero row appears → refresh updates it
- [ ] Manual: disable a stake position → no crash, row gone
- [ ] Manual: airplane-mode mid-refresh → persisted positions stay visible (no flicker to empty)
- [ ] Manual: confirm RUJI APR renders as a sane percentage (~1–2% range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable/disable staking and LP positions via zero-amount placeholders; improved fiat value display using direct rate lookups.

* **Bug Fixes**
  * Preserve persisted positions when partial/empty refreshes occur; more robust APR handling (status-aware, scaled values).
  * TCY auto‑compound fetch now fails safely with UI fallback to zero.

* **Refactor**
  * Streamlined DeFi refresh/persistence and view models to derive live positions.

* **Tests**
  * Added coverage for partial upserts and APR decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->