### PR TITLE
fix: keysign discovery success banner shows error icon (#4286)

### DIFF
--- a/VultisigApp/VultisigApp/Components/NotificationBanner/BannerViewModifier.swift
+++ b/VultisigApp/VultisigApp/Components/NotificationBanner/BannerViewModifier.swift
@@ -33,7 +33,7 @@ private struct BannerViewModifier: ViewModifier {
 }
 
 extension View {
-    func withBanner(text: Binding<String?>, style: NotificationBannerStyle = .error) -> some View {
+    func withBanner(text: Binding<String?>, style: NotificationBannerStyle = .success) -> some View {
         modifier(BannerViewModifier(text: text, style: style))
     }
 }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
@@ -32,7 +32,7 @@ struct SendVerifyScreen: View {
             }
         }
         .screenTitle("verify".localized)
-        .withBanner(text: $retryBannerText)
+        .withBanner(text: $retryBannerText, style: .error)
         .alert(item: $error) { error in
             Alert(
                 title: Text(NSLocalizedString("error", comment: "")),

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapVerifyView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapVerifyView.swift
@@ -28,7 +28,7 @@ struct SwapVerifyView: View {
             Background()
             view
         }
-        .withBanner(text: $retryBannerText)
+        .withBanner(text: $retryBannerText, style: .error)
         .onReceive(timer) { _ in
             swapViewModel.updateTimer(tx: tx, vault: vault, referredCode: referredViewModel.savedReferredCode)
         }


### PR DESCRIPTION
## Summary
- Closes #4286
- Flip `withBanner(text:style:)` default from `.error` to `.success`, since the only call sites that omit `style:` (now just `KeysignDiscoveryView`) emit success messages
- Pass `style: .error` explicitly at `SwapVerifyView` and `SendVerifyScreen`, which surface `RetryableBroadcastError.userFacingMessage` and were relying on the old `.error` default — without this, both retry banners would render success/green chrome on a real error

## Test plan
- [ ] Trigger a keysign on a non-fast-vault and confirm the *"Notification was successfully sent!"* banner renders with green/check chrome (not red/X)
- [ ] Force a swap broadcast retry path (e.g. submit a swap that hits a transient retryable error) and confirm `SwapVerifyView` still shows the retry message in red/error chrome
- [ ] Force a send broadcast retry path and confirm `SendVerifyScreen` retry banner still renders red/error chrome
- [ ] No regression on `DefiChainMainScreen` (passes `style: .error` explicitly — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected notification banner styling to ensure error notifications consistently display with appropriate visual treatment across send and swap verification screens, improving user experience and feedback clarity.

* **Style**
  * Updated the default notification banner appearance to use success styling instead of the previous error styling, providing better visual consistency throughout the application when banner style is not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->