### PR TITLE
fix(defi): add macOS refresh button on chain DeFi tab

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -307,6 +307,11 @@ private extension DefiChainMainScreen {
         guard !isRefreshing else { return }
 
         isRefreshing = true
+        // `defer` runs even on Task cancellation (e.g. view disappears
+        // mid-refresh). Without it, the flag stays `true` forever and the
+        // guard above silently drops every subsequent refresh call.
+        defer { isRefreshing = false }
+
         // Refresh all three position categories in parallel so the aggregate balance shown
         // in `DefiChainBalanceView` reflects every position type — not just the currently
         // selected segment. The native-coin balance refresh runs independently.
@@ -315,7 +320,6 @@ private extension DefiChainMainScreen {
         async let stakeRefresh: Void = stakeViewModel.refresh()
         async let lpsRefresh: Void = lpsViewModel.refresh()
         _ = await (mainRefresh, bondRefresh, stakeRefresh, lpsRefresh)
-        isRefreshing = false
     }
 
     func update(vault: Vault) {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -21,6 +21,7 @@ struct DefiChainMainScreen: View {
     @State private var isLoading = false
     @State private var error: HelperError?
     @State private var refreshErrorToast: String?
+    @State private var isRefreshing = false
 
     init(vault: Vault, chain: Chain) {
         self.vault = vault
@@ -83,7 +84,13 @@ struct DefiChainMainScreen: View {
                 isPresented: $showPositionSelection
             )
         }
-        .crossPlatformToolbar(ignoresTopEdge: true) {}
+        .crossPlatformToolbar(ignoresTopEdge: true) {
+            #if os(macOS)
+            CustomToolbarItem(placement: .trailing) {
+                RefreshToolbarButton(onRefresh: { Task { await refresh() } })
+            }
+            #endif
+        }
         .withLoading(isLoading: $isLoading)
         .withBanner(text: $refreshErrorToast, style: .error)
         .alert(item: $error) { error in
@@ -103,11 +110,6 @@ struct DefiChainMainScreen: View {
             CircularAccessoryIconButton(icon: "crypto-wallet-pen", type: .secondary) {
                 showPositionSelection.toggle()
             }
-            #if os(macOS)
-            CircularAccessoryIconButton(icon: "refresh", type: .secondary) {
-                Task { await refresh() }
-            }
-            #endif
         }
     }
 
@@ -302,6 +304,9 @@ private extension DefiChainMainScreen {
 
 private extension DefiChainMainScreen {
     func refresh() async {
+        guard !isRefreshing else { return }
+
+        isRefreshing = true
         // Refresh all three position categories in parallel so the aggregate balance shown
         // in `DefiChainBalanceView` reflects every position type — not just the currently
         // selected segment. The native-coin balance refresh runs independently.
@@ -310,6 +315,7 @@ private extension DefiChainMainScreen {
         async let stakeRefresh: Void = stakeViewModel.refresh()
         async let lpsRefresh: Void = lpsViewModel.refresh()
         _ = await (mainRefresh, bondRefresh, stakeRefresh, lpsRefresh)
+        isRefreshing = false
     }
 
     func update(vault: Vault) {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -101,6 +101,11 @@ struct DefiChainMainScreen: View {
             CircularAccessoryIconButton(icon: "crypto-wallet-pen", type: .secondary) {
                 showPositionSelection.toggle()
             }
+            #if os(macOS)
+            CircularAccessoryIconButton(icon: "refresh", type: .secondary) {
+                Task { await refresh() }
+            }
+            #endif
         }
     }
 


### PR DESCRIPTION
## Summary
- On macOS the chain detail DeFi tab (`DefiChainMainScreen`) had no manual refresh affordance — `.refreshable` is iOS pull-to-refresh only, and the `crossPlatformToolbar` is empty here.
- Adds a `CircularAccessoryIconButton` with the existing `refresh` asset next to the position-edit button, gated by `#if os(macOS)`. On tap it runs the existing `refresh()` function, which already refreshes balance + bonds + stake + LPs in parallel.
- No new state, no spinner, no localized strings; iOS `.refreshable` modifier untouched.

Closes #4283

## Test plan
- [x] `make build-check` — succeeds.
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift` — 0 violations.
- [ ] Manual macOS smoke: open a chain DeFi tab, tap the new refresh icon, confirm balance and positions reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS-only refresh button added to the DeFi positions view to manually refresh positions and portfolio data.

* **Bug Fixes**
  * Refresh now prevents overlapping runs, improving stability and avoiding duplicate refresh activity when a refresh is already in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->