### PR TITLE
test(pricing): verify MAYA.MAYA pool-based pricing

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/CryptoPriceService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CryptoPriceService.swift
@@ -159,6 +159,31 @@ public class CryptoPriceService: ObservableObject {
         return target?.id
     }
 }
+
+extension CryptoPriceService {
+    /// Pure computation for the MAYAChain pool-derived USD price of a non-CACAO Maya asset.
+    /// Internal access so unit tests can validate the math without exercising the live mayanode endpoint.
+    func calculateMayaPoolPrice(pool: MAYAChainPoolResponse, cacaoPriceUSD: Double, coins: [CoinMeta], assetName: String) -> Double {
+        guard let balanceCacao = Double(pool.balanceCacao),
+              let balanceAsset = Double(pool.balanceAsset),
+              balanceAsset > 0 else {
+            return 0.0
+        }
+
+        let ticker = assetName.components(separatedBy: ".").last ?? ""
+        let assetDecimals = coins.first(where: {
+            $0.chain == .mayaChain && $0.ticker.uppercased() == ticker
+        })?.decimals ?? 4
+
+        let cacaoDecimals: Double = 10
+        let cacaoNormalized = balanceCacao / pow(10, cacaoDecimals)
+        let assetNormalized = balanceAsset / pow(10, Double(assetDecimals))
+        let priceInCacao = cacaoNormalized / assetNormalized
+
+        return priceInCacao * cacaoPriceUSD
+    }
+}
+
 private extension CryptoPriceService {
 
     @MainActor func refresh(vault: Vault) {
@@ -379,26 +404,6 @@ private extension CryptoPriceService {
             logger.warning("Failed to fetch MAYAChain pool price for \(assetName): \(error.localizedDescription)")
             return nil
         }
-    }
-
-    func calculateMayaPoolPrice(pool: MAYAChainPoolResponse, cacaoPriceUSD: Double, coins: [CoinMeta], assetName: String) -> Double {
-        guard let balanceCacao = Double(pool.balanceCacao),
-              let balanceAsset = Double(pool.balanceAsset),
-              balanceAsset > 0 else {
-            return 0.0
-        }
-
-        let ticker = assetName.components(separatedBy: ".").last ?? ""
-        let assetDecimals = coins.first(where: {
-            $0.chain == .mayaChain && $0.ticker.uppercased() == ticker
-        })?.decimals ?? 4
-
-        let cacaoDecimals: Double = 10
-        let cacaoNormalized = balanceCacao / pow(10, cacaoDecimals)
-        let assetNormalized = balanceAsset / pow(10, Double(assetDecimals))
-        let priceInCacao = cacaoNormalized / assetNormalized
-
-        return priceInCacao * cacaoPriceUSD
     }
 
     private func coinGeckoPlatform(chain: Chain) -> String {

--- a/VultisigApp/VultisigAppTests/Services/MayaPoolPriceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/MayaPoolPriceTests.swift
@@ -1,0 +1,183 @@
+//
+//  MayaPoolPriceTests.swift
+//  VultisigAppTests
+//
+//  Verifies the MAYA.MAYA pool-derived pricing pipeline added in PR #4104
+//  (issue #4280). Targets the pure `calculateMayaPoolPrice` computation so
+//  the math is checked without hitting the live mayanode endpoint.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class MayaPoolPriceTests: XCTestCase {
+
+    private let mayaCoin = CoinMeta(
+        chain: .mayaChain,
+        ticker: "MAYA",
+        logo: "maya",
+        decimals: 4,
+        priceProviderId: "",
+        contractAddress: "maya",
+        isNativeToken: false
+    )
+
+    // MARK: - calculateMayaPoolPrice
+
+    func test_calculateMayaPoolPrice_equalDepth_returnsCacaoPriceUSD() {
+        // 100 CACAO (10 decimals) vs 100 MAYA (4 decimals) → 1 CACAO per MAYA.
+        let pool = MAYAChainPoolResponse(
+            balanceCacao: "1000000000000",
+            balanceAsset: "1000000"
+        )
+
+        let price = CryptoPriceService.shared.calculateMayaPoolPrice(
+            pool: pool,
+            cacaoPriceUSD: 0.5,
+            coins: [mayaCoin],
+            assetName: "MAYA.MAYA"
+        )
+
+        XCTAssertEqual(price, 0.5, accuracy: 1e-9)
+    }
+
+    func test_calculateMayaPoolPrice_scarceAsset_doublesPrice() {
+        // 200 CACAO vs 100 MAYA → 2 CACAO per MAYA.
+        let pool = MAYAChainPoolResponse(
+            balanceCacao: "2000000000000",
+            balanceAsset: "1000000"
+        )
+
+        let price = CryptoPriceService.shared.calculateMayaPoolPrice(
+            pool: pool,
+            cacaoPriceUSD: 0.5,
+            coins: [mayaCoin],
+            assetName: "MAYA.MAYA"
+        )
+
+        XCTAssertEqual(price, 1.0, accuracy: 1e-9)
+    }
+
+    func test_calculateMayaPoolPrice_abundantAsset_lowersPrice() {
+        // 100 CACAO vs 1000 MAYA → 0.1 CACAO per MAYA.
+        let pool = MAYAChainPoolResponse(
+            balanceCacao: "1000000000000",
+            balanceAsset: "10000000"
+        )
+
+        let price = CryptoPriceService.shared.calculateMayaPoolPrice(
+            pool: pool,
+            cacaoPriceUSD: 0.5,
+            coins: [mayaCoin],
+            assetName: "MAYA.MAYA"
+        )
+
+        XCTAssertEqual(price, 0.05, accuracy: 1e-9)
+    }
+
+    func test_calculateMayaPoolPrice_zeroAssetBalance_returnsZero() {
+        let pool = MAYAChainPoolResponse(
+            balanceCacao: "1000000000000",
+            balanceAsset: "0"
+        )
+
+        let price = CryptoPriceService.shared.calculateMayaPoolPrice(
+            pool: pool,
+            cacaoPriceUSD: 0.5,
+            coins: [mayaCoin],
+            assetName: "MAYA.MAYA"
+        )
+
+        XCTAssertEqual(price, 0.0)
+    }
+
+    func test_calculateMayaPoolPrice_nonNumericBalances_returnsZero() {
+        let pool = MAYAChainPoolResponse(
+            balanceCacao: "not-a-number",
+            balanceAsset: "1000000"
+        )
+
+        let price = CryptoPriceService.shared.calculateMayaPoolPrice(
+            pool: pool,
+            cacaoPriceUSD: 0.5,
+            coins: [mayaCoin],
+            assetName: "MAYA.MAYA"
+        )
+
+        XCTAssertEqual(price, 0.0)
+    }
+
+    func test_calculateMayaPoolPrice_unknownTicker_fallsBackToFourDecimals() {
+        // Asset not present in `coins` — calculator must fall back to 4 decimals
+        // (matches all current Maya pool assets in TokensStore).
+        let pool = MAYAChainPoolResponse(
+            balanceCacao: "1000000000000",
+            balanceAsset: "1000000"
+        )
+
+        let price = CryptoPriceService.shared.calculateMayaPoolPrice(
+            pool: pool,
+            cacaoPriceUSD: 1.0,
+            coins: [],
+            assetName: "MAYA.AZTEC"
+        )
+
+        // 100 CACAO vs 100 AZTEC at 4-decimal fallback → 1 CACAO each.
+        XCTAssertEqual(price, 1.0, accuracy: 1e-9)
+    }
+
+    func test_calculateMayaPoolPrice_decodesFromMayanodeJSONShape() throws {
+        // Defends against accidental rename of the `balance_cacao` / `balance_asset`
+        // JSON keys returned by https://mayanode.mayachain.info/mayachain/pool/MAYA.MAYA
+        let json = #"""
+        {
+            "balance_cacao": "1000000000000",
+            "balance_asset": "1000000"
+        }
+        """#.data(using: .utf8)!
+
+        let pool = try JSONDecoder().decode(MAYAChainPoolResponse.self, from: json)
+
+        XCTAssertEqual(pool.balanceCacao, "1000000000000")
+        XCTAssertEqual(pool.balanceAsset, "1000000")
+
+        let price = CryptoPriceService.shared.calculateMayaPoolPrice(
+            pool: pool,
+            cacaoPriceUSD: 0.5,
+            coins: [mayaCoin],
+            assetName: "MAYA.MAYA"
+        )
+        XCTAssertEqual(price, 0.5, accuracy: 1e-9)
+    }
+
+    // MARK: - Routing — guards against regressions in the rate-lookup identifier
+
+    func test_rateProvider_routesMayaTokenToContractIdentifier() {
+        // The pricing pipeline saves Rate(crypto: "maya"); RateProvider must
+        // resolve the same identifier when the UI looks up the rate.
+        let cryptoId = RateProvider.cryptoId(for: mayaCoin)
+
+        switch cryptoId {
+        case .contract(let id):
+            XCTAssertEqual(id, "maya", "MAYA token must lookup by contract \"maya\" so saved rates round-trip")
+        case .priceProvider:
+            XCTFail("MAYA token must not route through priceProvider — its providerId is empty")
+        }
+    }
+
+    func test_tokensStore_mayaCoinMetadataMatchesPipelineExpectations() throws {
+        // Locks the TokensStore values that the pricing pipeline depends on:
+        // contractAddress "maya" (used as Rate.crypto and asset lookup),
+        // chain .mayaChain (routes to fetchMayaChainPoolPrices), 4 decimals
+        // (used by calculateMayaPoolPrice), and an empty priceProviderId
+        // (forces the .contract branch in RateProvider.cryptoId).
+        let maya = try XCTUnwrap(TokensStore.TokenSelectionAssets.first(where: {
+            $0.chain == .mayaChain && $0.ticker == "MAYA"
+        }))
+
+        XCTAssertEqual(maya.contractAddress, "maya")
+        XCTAssertEqual(maya.decimals, 4)
+        XCTAssertEqual(maya.priceProviderId, "")
+        XCTAssertFalse(maya.isNativeToken)
+    }
+}


### PR DESCRIPTION
## Summary

Verifies the pipeline that was added in PR #4104 is functional; added 9 unit tests for `CryptoPriceService.calculateMayaPoolPrice` and the rate-lookup routing. **No production code changes needed** beyond moving `calculateMayaPoolPrice` from a `private` extension to an internal one so `@testable` tests can reach it. Behaviour and call sites are unchanged.

Walked through the pipeline end-to-end:

- `CryptoPriceService.fetchPrices(contracts:chain:coins:)` routes `chain == .mayaChain` to `fetchMayaChainPoolPrices`.
- `fetchMayaChainPoolPrices` builds `MAYA.<ticker>` (so the MAYA token's `contractAddress: "maya"` becomes `MAYA.MAYA`), fetches the mayanode pool, computes the price, and saves `Rate(fiat: "usd", crypto: "maya", value: price)`.
- `RateProvider.cryptoId(for:)` resolves the MAYA `CoinMeta` (chainType `.THORChain`, non-native, empty `priceProviderId`) to `.contract("maya")` — same identifier the rate is stored under, so Portfolio / Token Details lookups round-trip correctly.
- The CACAO precondition is guarded: pricing returns `[]` if the CACAO USD rate hasn't been resolved.

The pipeline was already correct; this PR locks in the contract with tests.

## What is covered

`MayaPoolPriceTests` (9 tests):

- Pure-function math for equal pool depth, scarce asset, abundant asset, zero balance, and unparseable input.
- The 4-decimal fallback branch when the asset metadata is missing from `coins`.
- JSON-shape decoding from the mayanode response (`balance_cacao` / `balance_asset` snake_case keys).
- `RateProvider.cryptoId(for:)` returns `.contract("maya")` for the MAYA token — the load-bearing tie between save and lookup.
- `TokensStore.MAYA` metadata snapshot (`contractAddress: "maya"`, decimals 4, empty `priceProviderId`, non-native) so future edits to `TokensStore` can't silently break the pricing path.

An integration-style test that exercises `fetchPrices(contracts:chain:coins:)` end-to-end is intentionally omitted: the `HTTPClient` injection on `CryptoPriceService.shared` isn't reachable for the singleton instance, and stubbing requires more invasive plumbing. The pure-function tests plus the routing assertions are sufficient to prove the pipeline.

Closes #4280.

## Test plan

- [x] `make generate`
- [x] `make build-check` succeeds
- [x] `xcodebuild -only-testing:VultisigAppTests/MayaPoolPriceTests` — 9/9 pass in <10ms
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — zero new warnings on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for MAYA pool price calculation across multiple scenarios, including edge cases and data validation.

* **Refactor**
  * Reorganized internal pricing service method for improved code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->