### PR TITLE
fix(keysign): retry hash-verify on peer-broadcast race propagation lag

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -827,26 +827,42 @@ class KeysignViewModel: ObservableObject {
     }
 
     /// Best-effort check that the signed tx is already accepted on the chain
-    /// (mempool or block). Returns true only on positive evidence — any
-    /// transient lookup failure or `notFound` falls through so the caller
-    /// surfaces the original broadcast error.
+    /// (mempool or block). Returns true only on positive evidence (`.confirmed`
+    /// or `.pending`); `.failed` is conclusive and fails fast. `.notFound` and
+    /// transient lookup errors are retried with backoff because a peer-broadcast
+    /// tx often takes a few seconds to propagate to our RPC node / indexer
+    /// (Cosmos LCD index lag is the worst offender), and a single early miss
+    /// would otherwise show the user a "failed" screen for a tx that's already
+    /// landing.
     private func isAlreadyOnChain(transactionType: SignedTransactionType) async -> Bool {
         guard let chain = keysignPayload?.coin.chain else { return false }
         let hash = transactionType.transactionHash
         guard !hash.isEmpty else { return false }
 
-        do {
-            let result = try await TransactionStatusService.shared.checkTransactionStatus(txHash: hash, chain: chain)
-            switch result.status {
-            case .confirmed, .pending:
-                return true
-            case .notFound, .failed:
-                return false
+        let maxAttempts = 3
+        let backoff: Duration = .seconds(2)
+
+        for attempt in 1...maxAttempts {
+            do {
+                let result = try await TransactionStatusService.shared.checkTransactionStatus(txHash: hash, chain: chain)
+                switch result.status {
+                case .confirmed, .pending:
+                    return true
+                case .failed:
+                    return false
+                case .notFound:
+                    break
+                }
+            } catch {
+                logger.warning("hash-verify lookup failed (attempt \(attempt)/\(maxAttempts)) for \(hash, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
-        } catch {
-            logger.warning("hash-verify lookup failed for \(hash, privacy: .public): \(error.localizedDescription, privacy: .public)")
-            return false
+
+            if attempt < maxAttempts {
+                try? await Task.sleep(for: backoff)
+            }
         }
+
+        return false
     }
 
     func handleHelperError(err: Error) {


### PR DESCRIPTION
## Summary

When the user co-signs a transaction across devices (e.g. macOS as initiator, Android as co-signer), each device broadcasts the signed tx independently. When a peer wins the RPC race, our broadcast call fails with a duplicate / sequence / mempool error, and `KeysignViewModel.handleBroadcastError` falls through to a hash-verify lookup added in #4252.

That lookup ran exactly once. If the peer's tx hadn't yet propagated to the RPC node or indexer — which is common on Cosmos LCDs (indexer lag), and possible on every chain at the second the broadcast race lands — the lookup returned `.notFound`, the keysign UI flipped to `.KeysignFailed`, and the user saw "Sending failed" on macOS while Android showed the same tx as confirmed. Reported as #4250.

This patch keeps the hash-verify behaviour but retries up to 3 times with a 2-second backoff between attempts. `.confirmed` / `.pending` short-circuit to success on the first observation. `.failed` is conclusive (chain-level revert) and fails fast — no retry. Only `.notFound` and transient lookup errors retry, since those are exactly the propagation-lag signals.

Worst-case extra delay on a genuinely failed broadcast is ~4 seconds (2 backoffs), which is well within UX expectations for the failure path and far better than the current behaviour of permanently mislabelling a successful tx.

## Test Plan

- [x] `swiftlint lint` — 0 violations
- [x] `make build-check` — `BUILD SUCCEEDED`
- [ ] Manual: co-sign a Cosmos / THORChain tx between macOS (initiator) + a peer device, observe macOS reports success rather than failure when the peer wins the broadcast race.

## Related

- Closes #4250
- Builds on #4252 (chain-agnostic hash-verify fallback for the same broadcast-race scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction confirmation detection with exponential backoff retry logic. The system now retries transaction status lookups instead of immediately reporting them as unconfirmed, providing better reliability during temporary service disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->