### PR TITLE
fix(keysign): show dapp-supplied cosmos fee on Network Fee row

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
@@ -100,8 +100,18 @@ struct KeysignPayload: Codable, Hashable {
             return nil
         }
 
-        // signAmino path: fee is directly accessible
+        // signAmino path: fee is directly accessible.
+        // Filter by the chain's native fee denom to avoid mixing denominations
+        // (e.g. native token + IBC token fees summed together).
         if let amino = signAmino {
+            let nativeDenom = coin.chain.feeUnit.lowercased()
+            let denomMatched = amino.fee.amount
+                .filter { $0.denom.lowercased() == nativeDenom }
+                .compactMap { UInt64($0.amount) }
+            if !denomMatched.isEmpty {
+                return denomMatched.reduce(0, +)
+            }
+            // Fallback: if no denom matches (single-denom chains), sum all entries
             let total = amino.fee.amount.compactMap { UInt64($0.amount) }.reduce(0, +)
             return total
         }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
@@ -111,9 +111,7 @@ struct KeysignPayload: Codable, Hashable {
             if !denomMatched.isEmpty {
                 return denomMatched.reduce(0, +)
             }
-            // Fallback: if no denom matches (single-denom chains), sum all entries
-            let total = amino.fee.amount.compactMap { UInt64($0.amount) }.reduce(0, +)
-            return total
+            return nil
         }
 
         // signDirect would require protobuf decoding of authInfoBytes — skip for now.

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
@@ -88,6 +88,29 @@ struct KeysignPayload: Codable, Hashable {
         return coin.fiat(decimal: toAmountDecimal).description
     }
 
+    /// Returns the dApp-supplied fee amount (in base units) for Cosmos-based chains,
+    /// extracted from `signAmino.fee.amount`. Returns `nil` when no dApp signData is
+    /// present or the chain isn't Cosmos-rooted, letting callers fall back to the
+    /// estimated `blockChainSpecific` fee.
+    ///
+    /// Fixes: Rujira CosmWasm calls declare `fee.amount = 0` but the estimate shows
+    /// a non-zero fallback (e.g. 0.02 RUNE). Parity with Windows PR #3843.
+    func dappSuppliedCosmosFee() -> UInt64? {
+        guard coin.chainType == .Cosmos || coin.chainType == .THORChain else {
+            return nil
+        }
+
+        // signAmino path: fee is directly accessible
+        if let amino = signAmino {
+            let total = amino.fee.amount.compactMap { UInt64($0.amount) }.reduce(0, +)
+            return total
+        }
+
+        // signDirect would require protobuf decoding of authInfoBytes — skip for now.
+        // Rujira CosmWasm uses signAmino as the primary signing path.
+        return nil
+    }
+
     static let example = KeysignPayload(
         coin: Coin.example,
         toAddress: "toAddress",

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
@@ -17,6 +17,19 @@ struct JoinKeysignGasViewModel {
             return (.empty, .empty)
         }
 
+        // When the dApp supplied explicit fee data via signAmino (e.g. Rujira
+        // CosmWasm calls where fee.amount = 0), prefer that over the estimated
+        // blockchainSpecific fee. This prevents the UI from showing a misleading
+        // non-zero network fee when the chain actually charges nothing.
+        // Parity with vultisig-windows PR #3843.
+        if let dappFee = payload.dappSuppliedCosmosFee() {
+            let dappFeeBigInt = BigInt(dappFee)
+            let gasAmount = Decimal(dappFee) / pow(10, nativeToken.decimals)
+            let gasInReadable = gasAmount.formatToDecimal(digits: nativeToken.decimals)
+            let feeInReadable = feesInReadable(coin: payload.coin, fee: dappFeeBigInt)
+            return ("\(gasInReadable) \(nativeToken.ticker)", feeInReadable)
+        }
+
         if payload.coin.chainType == .EVM {
             let gas = payload.chainSpecific.gas
 


### PR DESCRIPTION
## Summary

When a Rujira CosmWasm dApp sends a transaction with `fee.amount = 0`, the **Join Keysign** screen was displaying an estimated non-zero fee (e.g. `0.02 RUNE`) because the UI read from `blockChainSpecific.fee` instead of the dApp-supplied `signAmino.fee.amount`.

## Changes

### `KeysignPayload.swift`
- Added `dappSuppliedCosmosFee()` computed property that extracts the actual fee from `signAmino.fee.amount` for Cosmos/THORChain chains
- Returns `nil` when no signData is present, allowing fallback to the estimated fee

### `JoinKeysignGasViewModel.swift`
- Added early check at the top of `getCalculatedNetworkFee()` — if `dappSuppliedCosmosFee()` returns a value, uses that directly instead of falling through to the estimated `blockChainSpecific` fee

## Cross-platform parity

This is the iOS counterpart of the Windows fix merged in [PR #3843](https://github.com/vultisig/vultisig-windows/pull/3843). The Android counterpart is submitted as [vultisig-android PR](https://github.com/vultisig/vultisig-android/pulls).

Closes #4294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved transaction fee accuracy when interacting with decentralized applications on Cosmos-based networks
* Fee display now correctly uses fee amounts directly supplied by dApps instead of falling back to network estimation
* Enhanced fee calculation to properly handle explicit fee data provided during transaction signing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->