### PR TITLE
fix(swap): hide Provider/fees block together when quote error is shown

### DIFF
--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -23,35 +23,44 @@ struct SwapDetailsSummary: View {
         !swapViewModel.priceImpactString(tx: tx).isEmpty
     }
 
+    /// Hide the entire Provider + fees block while a quote error is on screen
+    /// (the tooltip already surfaces the error). Keep it visible during loading
+    /// so placeholders still appear, and whenever a valid quote is available.
+    private var isBlockVisible: Bool {
+        swapViewModel.error == nil || swapViewModel.isLoadingQuotes
+    }
+
     var body: some View {
         content
     }
 
     var content: some View {
         VStack(spacing: 16) {
-            if let providerName = tx.quote?.displayName {
-                getSummaryCell(
-                    leadingText: "provider",
-                    trailingText: providerName
-                )
-            }
+            if isBlockVisible {
+                if let providerName = tx.quote?.displayName {
+                    getSummaryCell(
+                        leadingText: "provider",
+                        trailingText: providerName
+                    )
+                }
 
-            if swapViewModel.showTotalFees(tx: tx) {
-                if hasExpandableFees {
-                    ExpandableView(isExpanded: $showFees) {
-                        totalFeesLabel()
-                    } content: {
-                        HStack {
-                            Rectangle()
-                                .frame(width: 1)
-                                .foregroundStyle(Theme.colors.primaryAccent4)
+                if swapViewModel.showTotalFees(tx: tx) {
+                    if hasExpandableFees {
+                        ExpandableView(isExpanded: $showFees) {
+                            totalFeesLabel()
+                        } content: {
+                            HStack {
+                                Rectangle()
+                                    .frame(width: 1)
+                                    .foregroundStyle(Theme.colors.primaryAccent4)
 
-                            expandableFees
+                                expandableFees
+                            }
+                            .padding(.top, 16)
                         }
-                        .padding(.top, 16)
+                    } else {
+                        totalFeesLabel(showChevron: false)
                     }
-                } else {
-                    totalFeesLabel(showChevron: false)
                 }
             }
         }


### PR DESCRIPTION
## Summary

Mirrors Android PR [vultisig/vultisig-android#4353](https://github.com/vultisig/vultisig-android/pull/4353).

When a quote error occurs (e.g. *"Swap amount too small. Recommended amount …"*) the **Provider** row went blank while **Total Fee**, **Network Fee** and **Swap Fee** kept rendering values from the previous successful quote, leaving the UI internally inconsistent.

The Provider row was previously gated on `tx.quote?.displayName` while the fees block was gated on `swapViewModel.showTotalFees(tx:)`. This PR unifies both behind a single `isBlockVisible` predicate so the entire Provider + total/network/swap fees `VStack` hides as one unit while an error is on screen.

```swift
private var isBlockVisible: Bool {
    swapViewModel.error == nil || swapViewModel.isLoadingQuotes
}
```

The error tooltip near the flip button continues to surface the actual quote error, so no information is lost. Loading placeholders are preserved (`isLoadingQuotes` keeps the block visible during quote refresh after a new amount).

## Why hide instead of clear

Showing `$0.00 / 0` would still mislead the user — there is no swap at all, not a free one. Hiding makes the absence of a quote unambiguous.

Closes #4295

## Test plan

- [ ] Open Swap → from `Tron / USDT`, to `Tron / TRX`, enter `6.055066` (below minimum).
- [ ] Wait for the quote error tooltip to appear near the flip button.
- [ ] Verify the Provider / Total Fee / Network Fee / Swap Fee block is no longer rendered while the error is shown.
- [ ] Increase the amount to a valid value → block reappears once a new quote returns.
- [ ] Sanity-check non-error path: normal swap flow renders Provider + fees and the expandable Total Fee dropdown works as before.
- [ ] During the loading window after typing a new amount, placeholders should still appear.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the swap details display to intelligently show or hide provider and fee information based on quote availability and loading state. This provides a cleaner user interface when quotes are unavailable or still being retrieved, with improved handling of error scenarios during the swap process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->