### PR TITLE
fix(btc): map Blockchair UTXO transaction_hash via CodingKeys

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Models/Blockchair/Blockchair.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Models/Blockchair/Blockchair.swift
@@ -34,5 +34,15 @@ struct Blockchair: Codable {
         let transactionHash: String?
         let index: Int?
         let value: Int?
-	}
+
+        // Blockchair returns `transaction_hash` (snake_case) over the wire. The default
+        // `JSONDecoder` we use through `HTTPClient` doesn't apply
+        // `.convertFromSnakeCase`, so map the field explicitly here. `index` and `value`
+        // are already a single word and need no remap.
+        enum CodingKeys: String, CodingKey {
+            case transactionHash = "transaction_hash"
+            case index
+            case value
+        }
+    }
 }

--- a/VultisigApp/VultisigAppTests/Chains/BlockchairResponseTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/BlockchairResponseTests.swift
@@ -1,0 +1,68 @@
+//
+//  BlockchairResponseTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+/// Regression coverage for the v1.36.51+ BTC send failure (issue #4306).
+///
+/// `BlockchairUtxo.transactionHash` decodes from the wire field
+/// `transaction_hash`. Before the HTTPClient migration the service used a
+/// custom `JSONDecoder` with `.convertFromSnakeCase`, which masked the
+/// missing `CodingKeys`. The migrated `HTTPClient` uses a vanilla
+/// `JSONDecoder`, so without explicit keys every UTXO decoded with a `nil`
+/// `transactionHash` and was dropped by `KeysignPayloadFactory.selectUTXOs`,
+/// preventing BTC sends.
+final class BlockchairResponseTests: XCTestCase {
+
+    /// Real Blockchair-shaped payload so the test pins the wire contract,
+    /// not just the field renaming.
+    private let payload: Data = {
+        let json = """
+        {
+            "data": {
+                "bc1qexampleaddress0000000000000000000000": {
+                    "address": {
+                        "type": null,
+                        "script_hex": "",
+                        "balance": 250000
+                    },
+                    "utxo": [
+                        {
+                            "block_id": 800000,
+                            "transaction_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                            "index": 0,
+                            "value": 100000
+                        },
+                        {
+                            "block_id": 800001,
+                            "transaction_hash": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+                            "index": 1,
+                            "value": 150000
+                        }
+                    ]
+                }
+            }
+        }
+        """
+        return Data(json.utf8)
+    }()
+
+    func test_blockchairUtxoDecodes_transactionHash_fromSnakeCase() throws {
+        // Mirrors the decoder configuration `HTTPClient` uses by default —
+        // no key strategy, no special handling. The fix lives in the model.
+        let response = try JSONDecoder().decode(BlockchairResponse.self, from: payload)
+
+        let entry = try XCTUnwrap(response.data["bc1qexampleaddress0000000000000000000000"])
+        let utxos = try XCTUnwrap(entry.utxo)
+
+        XCTAssertEqual(utxos.count, 2)
+        XCTAssertEqual(utxos[0].transactionHash, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+        XCTAssertEqual(utxos[0].index, 0)
+        XCTAssertEqual(utxos[0].value, 100000)
+        XCTAssertEqual(utxos[1].transactionHash, "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")
+        XCTAssertEqual(entry.address?.balance, 250000)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the BTC send regression introduced in v1.36.51. After Architecture 3.b (#4237) migrated `BlockchairService` to `HTTPClient`, the new decoder no longer applies `.convertFromSnakeCase`, so `BlockchairUtxo.transactionHash` (wire field `transaction_hash`) silently decoded to `nil` for every UTXO. `KeysignPayloadFactory.selectUTXOs` then dropped them all and threw `notEnoughUTXOError`, blocking BTC, BCH, LTC, DOGE, and ZEC sends.

Closes #4306.

## Diagnosis

- **Symptom** — Send BTC fails on both Secured and Fast vaults in v1.36.51+. Error surfaces before any TSS round; `KeysignPayloadFactory.selectUTXOs` throws because every UTXO from Blockchair has `transactionHash == nil`.
- **What sibling implementations do**
  - **vultisig-sdk** (`packages/core/chain/chains/utxo/tx/getUtxos.ts`) reads `transaction_hash` directly from the wire payload.
  - **vultisig-android** (`data/.../api/models/Blockchair.kt`) annotates `BlockChairUtxoInfo.transactionHash` with `@SerialName("transaction_hash")`.
  - **vultisig-windows** routes UTXO logic through the SDK (same as above).
- **Where iOS diverges** — `VultisigApp/Blockchain/UTXO/Models/Blockchair/Blockchair.swift:33-37` had no `CodingKeys`, relying on the `.convertFromSnakeCase` strategy that the pre-3.b BlockchairService applied to its hand-built `JSONDecoder`. Architecture 3.b removed that strategy when it switched to `HTTPClient`'s default decoder.
- **Fix** — Add explicit `CodingKeys` to `BlockchairUtxo` so the wire mapping is self-documenting and works under `HTTPClient`'s default decoder. Same shape as the cherry-pick already living on `feat/qbtc-claim` (commit `b497acb0a`). `scriptHex` on `BlockchairAddress` is also unmapped post-migration but is dead code (no callers), so it stays as-is — no drive-by.

## Test plan

- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/...` — 0 violations on changed files.
- [x] `make generate` — Xcode project regenerated cleanly.
- [x] `make test` — full unit-test suite passes (248 tests, 0 failures).
- [x] `BlockchairResponseTests.test_blockchairUtxoDecodes_transactionHash_fromSnakeCase` — pinned regression: real-shape Blockchair payload decoded through a vanilla `JSONDecoder` (mirroring `HTTPClient`) now populates `transactionHash`.
- [ ] **QA** — Send BTC from a Secured Vault.
- [ ] **QA** — Send BTC from a Fast Vault.
- [ ] **QA** — Spot-check BCH, LTC, DOGE, ZEC sends to confirm they all share the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blockchain transaction data mapping to ensure correct field translation from API responses.

* **Tests**
  * Added regression test to validate blockchain response data parsing and field population.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->