### PR TITLE
fix(swap): show LI.FI/OneInch/Kyber network fee in native ETH (#4322)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -150,20 +150,25 @@ struct SwapCryptoLogic {
 
     func swapGasString(tx: SwapTransaction) -> String {
         let coin = feeCoin(tx: tx)
-        let decimals = coin.decimals
 
-        // Use tx.fee for swap quotes (which includes corrected gas price calculations)
-        // Fall back to tx.gas for other transaction types
-        let gasValue = tx.quote != nil ? tx.fee : tx.gas
+        // Quote-driven swaps: `tx.fee` is the total network fee in the chain's
+        // smallest unit (gasPrice × gasLimit for EVM). Format as a native amount
+        // so the row reads "0.000861 ETH (~$2.00)" rather than a raw Gwei figure.
+        if tx.quote != nil {
+            let amount = coin.decimal(for: tx.fee)
+            return "\(amount.formatToDecimal(digits: coin.decimals).description) \(coin.ticker)"
+        }
 
+        // No quote: `tx.gas` is a gas price in wei for EVM chains, so display Gwei.
         if coin.chain.chainType == .EVM {
             guard let weiPerGWeiDecimal = Decimal(string: EVMHelper.weiPerGWei.description) else {
                 return .empty
             }
-            return "\((Decimal(gasValue) / weiPerGWeiDecimal).formatToDecimal(digits: 0).description) \(coin.chain.feeUnit)"
-        } else {
-            return "\((Decimal(gasValue) / pow(10, decimals)).formatToDecimal(digits: decimals).description) \(coin.ticker)"
+            return "\((Decimal(tx.gas) / weiPerGWeiDecimal).formatToDecimal(digits: 0).description) \(coin.chain.feeUnit)"
         }
+
+        let amount = coin.decimal(for: tx.gas)
+        return "\(amount.formatToDecimal(digits: coin.decimals).description) \(coin.ticker)"
     }
 
     func approveFeeString(tx: SwapTransaction) -> String {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -154,7 +154,11 @@ struct SwapCryptoLogic {
         // Quote-driven swaps: `tx.fee` is the total network fee in the chain's
         // smallest unit (gasPrice × gasLimit for EVM). Format as a native amount
         // so the row reads "0.000861 ETH (~$2.00)" rather than a raw Gwei figure.
+        // `feeCoin(tx:)` falls back to `tx.fromCoin` when the chain's native
+        // asset isn't in `tx.fromCoins` — guard against that to avoid formatting
+        // a wei-denominated fee with an ERC20's decimals/ticker.
         if tx.quote != nil {
+            guard coin.isNativeToken else { return .empty }
             let amount = coin.decimal(for: tx.fee)
             return "\(amount.formatToDecimal(digits: coin.decimals).description) \(coin.ticker)"
         }

--- a/VultisigApp/VultisigAppTests/Services/SwapNetworkFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapNetworkFeeTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+import BigInt
+@testable import VultisigApp
+
+// `formatToDecimal` uses `Locale.current`, so hardcoded `.`-separated
+// expected strings fail on simulators in comma-decimal locales.
+private extension String {
+    var localeDecimal: String {
+        let sep = Locale.current.decimalSeparator ?? "."
+        return replacingOccurrences(of: ".", with: sep)
+    }
+}
+
+/// Pins the format produced by `SwapCryptoLogic.swapGasString(tx:)` for
+/// quote-driven EVM swaps (LI.FI / OneInch / KyberSwap). The bug being
+/// guarded against: when a quote was attached, the function divided
+/// `tx.fee` (already wei) by 1e9 and labelled the result `Gwei`, so the
+/// verify screen displayed numbers like `121,094 Gwei` — visually
+/// indistinguishable from a gas-limit. Expected behaviour is to format
+/// the wei value as a native amount (`0.000861 ETH`) the same way the
+/// non-EVM branch does.
+final class SwapNetworkFeeTests: XCTestCase {
+
+    private func makeEthCoin() -> Coin {
+        let meta = CoinMeta(
+            chain: .ethereum,
+            ticker: "ETH",
+            logo: "eth",
+            decimals: 18,
+            priceProviderId: "ethereum",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(asset: meta, address: "test", hexPublicKey: "test")
+    }
+
+    private func makeEvmQuote() -> EVMQuote {
+        EVMQuote(
+            dstAmount: "0",
+            tx: EVMQuote.Transaction(
+                from: "0x0",
+                to: "0x0",
+                data: "0x",
+                value: "0",
+                gasPrice: "0",
+                gas: 0
+            )
+        )
+    }
+
+    func testSwapGasStringForLiFiEvmQuoteFormatsAsNativeEth() {
+        let logic = SwapCryptoLogic()
+        let tx = SwapTransaction()
+        let eth = makeEthCoin()
+        tx.fromCoin = eth
+        // 0.00086087 ETH expressed in wei (gasPrice × gasLimit pre-aggregated by LiFi).
+        tx.quote = .lifi(makeEvmQuote(), fee: BigInt("860870000000000"), integratorFee: nil)
+
+        let result = logic.swapGasString(tx: tx)
+
+        XCTAssertEqual(result, "0.00086087 ETH".localeDecimal)
+        XCTAssertFalse(result.contains("Gwei"), "EVM swap quote network fee must not be labelled Gwei")
+    }
+
+    func testSwapGasStringForOneInchEvmQuoteFormatsAsNativeEth() {
+        let logic = SwapCryptoLogic()
+        let tx = SwapTransaction()
+        let eth = makeEthCoin()
+        tx.fromCoin = eth
+        tx.quote = .oneinch(makeEvmQuote(), fee: BigInt("860870000000000"))
+
+        let result = logic.swapGasString(tx: tx)
+
+        XCTAssertEqual(result, "0.00086087 ETH".localeDecimal)
+    }
+
+    func testSwapGasStringForKyberSwapEvmQuoteFormatsAsNativeEth() {
+        let logic = SwapCryptoLogic()
+        let tx = SwapTransaction()
+        let eth = makeEthCoin()
+        tx.fromCoin = eth
+        tx.quote = .kyberswap(makeEvmQuote(), fee: BigInt("860870000000000"))
+
+        let result = logic.swapGasString(tx: tx)
+
+        XCTAssertEqual(result, "0.00086087 ETH".localeDecimal)
+    }
+
+    func testSwapGasStringWithoutQuoteStillRendersGweiOnEvm() {
+        // Without a quote `tx.gas` represents a gas price in wei and the
+        // legacy "Gwei" label is correct in the user-editing flow.
+        let logic = SwapCryptoLogic()
+        let tx = SwapTransaction()
+        let eth = makeEthCoin()
+        tx.fromCoin = eth
+        tx.quote = nil
+        tx.gas = BigInt("25000000000") // 25 gwei
+
+        let result = logic.swapGasString(tx: tx)
+
+        XCTAssertTrue(result.contains("Gwei"), "Without a quote the EVM gas-price label should remain Gwei")
+        XCTAssertTrue(result.hasPrefix("25"), "25 gwei should render as 25 Gwei, got \(result)")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/SwapNetworkFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapNetworkFeeTests.swift
@@ -34,6 +34,19 @@ final class SwapNetworkFeeTests: XCTestCase {
         return Coin(asset: meta, address: "test", hexPublicKey: "test")
     }
 
+    private func makeUsdcCoin() -> Coin {
+        let meta = CoinMeta(
+            chain: .ethereum,
+            ticker: "USDC",
+            logo: "usdc",
+            decimals: 6,
+            priceProviderId: "usd-coin",
+            contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            isNativeToken: false
+        )
+        return Coin(asset: meta, address: "test", hexPublicKey: "test")
+    }
+
     private func makeEvmQuote() -> EVMQuote {
         EVMQuote(
             dstAmount: "0",
@@ -80,6 +93,37 @@ final class SwapNetworkFeeTests: XCTestCase {
         let eth = makeEthCoin()
         tx.fromCoin = eth
         tx.quote = .kyberswap(makeEvmQuote(), fee: BigInt("860870000000000"))
+
+        let result = logic.swapGasString(tx: tx)
+
+        XCTAssertEqual(result, "0.00086087 ETH".localeDecimal)
+    }
+
+    func testSwapGasStringFromNonNativeCoinWithoutNativeInListReturnsEmpty() {
+        // Regression: when `tx.fromCoin` is a non-native ERC20 and `tx.fromCoins`
+        // doesn't contain the chain's native asset, `feeCoin(tx:)` falls back to
+        // `tx.fromCoin`. Without the guard we'd format a wei-denominated fee with
+        // USDC's 6 decimals + "USDC" ticker, producing an absurd number labelled
+        // with the wrong asset. The display should suppress the row instead.
+        let logic = SwapCryptoLogic()
+        let tx = SwapTransaction()
+        tx.fromCoin = makeUsdcCoin()
+        tx.fromCoins = [makeUsdcCoin()] // no native ETH in list
+        tx.quote = .lifi(makeEvmQuote(), fee: BigInt("860870000000000"), integratorFee: nil)
+
+        let result = logic.swapGasString(tx: tx)
+
+        XCTAssertEqual(result, "", "Should return empty when no native asset is available to denominate the fee")
+    }
+
+    func testSwapGasStringFromNonNativeCoinWithNativeInListUsesNativeForDisplay() {
+        // When `tx.fromCoin` is USDC but the user's wallet has ETH on the same
+        // chain, `feeCoin(tx:)` resolves to ETH and the fee renders correctly.
+        let logic = SwapCryptoLogic()
+        let tx = SwapTransaction()
+        tx.fromCoin = makeUsdcCoin()
+        tx.fromCoins = [makeUsdcCoin(), makeEthCoin()]
+        tx.quote = .lifi(makeEvmQuote(), fee: BigInt("860870000000000"), integratorFee: nil)
 
         let result = logic.swapGasString(tx: tx)
 


### PR DESCRIPTION
## Summary

- The Swap verify screen was rendering the LI.FI/OneInch/KyberSwap EVM **Network Fee** as a raw Gwei figure (e.g. `121,094 Gwei`), which reads like a gas-limit. Android shows it correctly as `0.00086087 ETH (~$2.00)`.
- Root cause in `SwapCryptoLogic.swapGasString(tx:)`: when a quote was attached, `tx.fee` is already the *total* network fee in wei (gasPrice × gasLimit), but the EVM branch divided by 1e9 and labelled the result `Gwei`.
- Fix: when `tx.quote != nil`, format `tx.fee` as a native amount (using the existing `coin.decimal(for:)` helper) so the verify row reads `0.000861 ETH (~$2.00)`. The no-quote branch is unchanged — there `tx.gas` is a gas price in wei and the `Gwei` label is correct.
- Added `SwapNetworkFeeTests` to pin the new behaviour for LI.FI, OneInch, and KyberSwap, plus a guard test that the no-quote path still renders Gwei.

## Test plan

- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — no new warnings
- [x] `make build-check` — BUILD SUCCEEDED
- [x] `xcodebuild test ... -only-testing:VultisigAppTests/SwapNetworkFeeTests` — 4/4 pass
- [ ] Manual on-device verification (LI.FI Ethereum→Base swap) — out of scope for this PR; the fix is unit-tested and the verify view already pairs the crypto string with a fiat string so no UI changes are needed.

Closes #4322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap network fee display to show accurate native token amounts when a swap quote is present (e.g., shows ETH amount instead of Gwei).
  * Preserved legacy Gwei display for EVM flows when no quote is available.
  * Fixed fee display for non-native source assets to avoid showing incorrect fee text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->