### PR TITLE
feat(keysign): implement Bitcoin PSBT (SignBitcoin) co-signing

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosSignDataBuilder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosSignDataBuilder.swift
@@ -51,7 +51,7 @@ enum CosmosSignDataBuilder {
                     }
                 }
             }
-        case .signSolana, .signTon:
+        case .signSolana, .signTon, .signBitcoin:
             return nil
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Models/SignBitcoin.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Models/SignBitcoin.swift
@@ -1,0 +1,176 @@
+//
+//  SignBitcoin.swift
+//  VultisigApp
+//
+//  Structured PSBT representation for Bitcoin dApp co-signing.
+//  Mirrors the `SignBitcoin` proto from commondata so co-signing devices can
+//  display verifiable transaction details and recompute exact BIP-143 sighashes
+//  without trusting an opaque base64 PSBT blob.
+//
+
+import Foundation
+import VultisigCommonData
+
+struct BitcoinInput: Codable, Hashable {
+    /// Previous txid (hex, big-endian display order)
+    let hash: String
+    /// Previous output index (vout)
+    let index: UInt32
+    /// Satoshis (from witness UTXO)
+    let amount: Int64
+    /// Hex scriptPubKey of the UTXO being spent
+    let scriptPubKey: String
+    /// "p2wpkh", "p2pkh", "p2tr", "p2sh-p2wpkh"
+    let scriptType: String
+    /// BIP-143/341 sighash flag; 0 means SIGHASH_ALL (1) by convention
+    let sighashType: UInt32
+    /// Whether this device signs this input
+    let isOurs: Bool
+    /// For P2SH-P2WPKH: hex redeem script
+    let redeemScript: String?
+    /// nSequence
+    let sequence: UInt32
+
+    init(
+        hash: String,
+        index: UInt32,
+        amount: Int64,
+        scriptPubKey: String,
+        scriptType: String,
+        sighashType: UInt32,
+        isOurs: Bool,
+        redeemScript: String?,
+        sequence: UInt32
+    ) {
+        self.hash = hash
+        self.index = index
+        self.amount = amount
+        self.scriptPubKey = scriptPubKey
+        self.scriptType = scriptType
+        self.sighashType = sighashType
+        self.isOurs = isOurs
+        self.redeemScript = redeemScript
+        self.sequence = sequence
+    }
+
+    init(proto: VSBitcoinInput) {
+        self.hash = proto.hash
+        self.index = proto.index
+        self.amount = proto.amount
+        self.scriptPubKey = proto.scriptPubKey
+        self.scriptType = proto.scriptType
+        self.sighashType = proto.hasSighashType ? proto.sighashType : 0
+        self.isOurs = proto.isOurs
+        self.redeemScript = proto.hasRedeemScript ? proto.redeemScript : nil
+        self.sequence = proto.hasSequence ? proto.sequence : 0xFFFFFFFF
+    }
+
+    func mapToProtobuff() -> VSBitcoinInput {
+        .with {
+            $0.hash = self.hash
+            $0.index = self.index
+            $0.amount = self.amount
+            $0.scriptPubKey = self.scriptPubKey
+            $0.scriptType = self.scriptType
+            if self.sighashType != 0 {
+                $0.sighashType = self.sighashType
+            }
+            $0.isOurs = self.isOurs
+            if let redeemScript = self.redeemScript {
+                $0.redeemScript = redeemScript
+            }
+            $0.sequence = self.sequence
+        }
+    }
+
+    /// Effective sighash flag (treats 0 as SIGHASH_ALL per proto convention).
+    var effectiveSighashType: UInt32 {
+        sighashType == 0 ? 1 : sighashType
+    }
+}
+
+struct BitcoinOutput: Codable, Hashable {
+    /// Satoshis
+    let amount: Int64
+    /// Decoded address (empty for OP_RETURN)
+    let address: String
+    /// Hex data if OP_RETURN
+    let opReturnData: String?
+    /// Hex output scriptPubKey
+    let scriptPubKey: String
+    /// Whether output is change back to sender
+    let isChange: Bool
+
+    init(
+        amount: Int64,
+        address: String,
+        opReturnData: String?,
+        scriptPubKey: String,
+        isChange: Bool
+    ) {
+        self.amount = amount
+        self.address = address
+        self.opReturnData = opReturnData
+        self.scriptPubKey = scriptPubKey
+        self.isChange = isChange
+    }
+
+    init(proto: VSBitcoinOutput) {
+        self.amount = proto.amount
+        self.address = proto.address
+        self.opReturnData = proto.hasOpReturnData ? proto.opReturnData : nil
+        self.scriptPubKey = proto.scriptPubKey
+        self.isChange = proto.isChange
+    }
+
+    func mapToProtobuff() -> VSBitcoinOutput {
+        .with {
+            $0.amount = self.amount
+            $0.address = self.address
+            if let opReturnData = self.opReturnData {
+                $0.opReturnData = opReturnData
+            }
+            $0.scriptPubKey = self.scriptPubKey
+            $0.isChange = self.isChange
+        }
+    }
+}
+
+struct SignBitcoin: Codable, Hashable {
+    /// Transaction version (typically 1 or 2)
+    let version: UInt32
+    /// Transaction locktime
+    let locktime: UInt32
+    /// All inputs in exact PSBT order
+    let inputs: [BitcoinInput]
+    /// All outputs in exact PSBT order
+    let outputs: [BitcoinOutput]
+
+    init(
+        version: UInt32,
+        locktime: UInt32,
+        inputs: [BitcoinInput],
+        outputs: [BitcoinOutput]
+    ) {
+        self.version = version
+        self.locktime = locktime
+        self.inputs = inputs
+        self.outputs = outputs
+    }
+
+    init(proto: VSSignBitcoin) {
+        self.version = proto.version
+        self.locktime = proto.locktime
+        self.inputs = proto.inputs.map { BitcoinInput(proto: $0) }
+        self.outputs = proto.outputs.map { BitcoinOutput(proto: $0) }
+    }
+
+    func mapToProtobuff() -> VSSignBitcoin {
+        .with {
+            $0.version = self.version
+            $0.locktime = self.locktime
+            $0.inputs = self.inputs.map { $0.mapToProtobuff() }
+            $0.outputs = self.outputs.map { $0.mapToProtobuff() }
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/BitcoinPsbtSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/BitcoinPsbtSigner.swift
@@ -27,6 +27,7 @@ enum BitcoinPsbtSignerError: Error, LocalizedError {
     case invalidRedeemScript(inputIndex: Int)
     case unsupportedSighashType(UInt32)
     case invalidScriptPubKey(inputIndex: Int)
+    case invalidOutputScriptPubKey(outputIndex: Int)
     case negativeAmount(inputIndex: Int, amount: Int64)
     case missingSignature(sighashHex: String)
     case invalidPublicKey(String)
@@ -47,6 +48,8 @@ enum BitcoinPsbtSignerError: Error, LocalizedError {
             return "Unsupported sighash type: 0x\(String(flag, radix: 16)). Only SIGHASH_ALL is supported."
         case .invalidScriptPubKey(let i):
             return "Input #\(i): invalid scriptPubKey hex"
+        case .invalidOutputScriptPubKey(let i):
+            return "Output #\(i): invalid scriptPubKey hex"
         case .negativeAmount(let i, let amount):
             return "Input #\(i): amount must be non-negative, got \(amount)"
         case .missingSignature(let hex):
@@ -75,10 +78,13 @@ enum BitcoinPsbtSigner {
         return hash256(data)
     }
 
-    static func _hashOutputs(_ signBitcoin: SignBitcoin) -> Data {
-        let data = signBitcoin.outputs.reduce(Data()) { acc, output in
-            let scriptBytes = Data(hexString: output.scriptPubKey) ?? Data()
-            return acc + serializeOutput(amount: output.amount, scriptPubKey: scriptBytes)
+    static func _hashOutputs(_ signBitcoin: SignBitcoin) throws -> Data {
+        var data = Data()
+        for (index, output) in signBitcoin.outputs.enumerated() {
+            guard let scriptBytes = Data(hexString: output.scriptPubKey) else {
+                throw BitcoinPsbtSignerError.invalidOutputScriptPubKey(outputIndex: index)
+            }
+            data += serializeOutput(amount: output.amount, scriptPubKey: scriptBytes)
         }
         return hash256(data)
     }
@@ -96,7 +102,7 @@ enum BitcoinPsbtSigner {
 
         let hashPrevouts = _hashPrevouts(signBitcoin)
         let hashSequence = _hashSequence(signBitcoin)
-        let hashOutputs = _hashOutputs(signBitcoin)
+        let hashOutputs = try _hashOutputs(signBitcoin)
 
         var sighashes: [Data] = []
         for (i, input) in signBitcoin.inputs.enumerated() where input.isOurs {

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/BitcoinPsbtSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/BitcoinPsbtSigner.swift
@@ -1,0 +1,338 @@
+//
+//  BitcoinPsbtSigner.swift
+//  VultisigApp
+//
+//  BIP-143 sighash + signed-tx assembly for the structured `SignBitcoin`
+//  PSBT keysign payload. Mirrors the SDK port at
+//  vultisig-sdk/packages/core/mpc/keysign/signingInputs/resolvers/bitcoin/sighash.ts
+//  and vultisig-sdk/packages/core/mpc/tx/compile/compileSignBitcoinTx.ts.
+//
+//  Currently supports P2WPKH and P2SH-P2WPKH inputs (SIGHASH_ALL only).
+//  P2TR (BIP-341) is intentionally deferred — both the SDK and this port
+//  surface a typed error if a `is_ours` input uses an unsupported script.
+//
+
+import Foundation
+import OSLog
+import Tss
+import WalletCore
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "btc-psbt-signer")
+
+enum BitcoinPsbtSignerError: Error, LocalizedError {
+    case noInputs
+    case noSignableInputs
+    case unsupportedScriptType(String)
+    case missingRedeemScript(inputIndex: Int)
+    case invalidRedeemScript(inputIndex: Int)
+    case unsupportedSighashType(UInt32)
+    case invalidScriptPubKey(inputIndex: Int)
+    case negativeAmount(inputIndex: Int, amount: Int64)
+    case missingSignature(sighashHex: String)
+    case invalidPublicKey(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noInputs:
+            return "SignBitcoin has no inputs"
+        case .noSignableInputs:
+            return "No signable inputs (all isOurs == false)"
+        case .unsupportedScriptType(let type):
+            return "Unsupported script type for BIP-143 sighash: \(type)"
+        case .missingRedeemScript(let i):
+            return "Input #\(i): P2SH-P2WPKH inputs require a redeem script"
+        case .invalidRedeemScript(let i):
+            return "Input #\(i): unsupported redeem script for P2SH-P2WPKH"
+        case .unsupportedSighashType(let flag):
+            return "Unsupported sighash type: 0x\(String(flag, radix: 16)). Only SIGHASH_ALL is supported."
+        case .invalidScriptPubKey(let i):
+            return "Input #\(i): invalid scriptPubKey hex"
+        case .negativeAmount(let i, let amount):
+            return "Input #\(i): amount must be non-negative, got \(amount)"
+        case .missingSignature(let hex):
+            return "Missing signature for sighash \(hex.prefix(16))..."
+        case .invalidPublicKey(let key):
+            return "Invalid public key: \(key)"
+        }
+    }
+}
+
+enum BitcoinPsbtSigner {
+
+    // MARK: - Internal helpers (exposed for unit testing of BIP-143 intermediate values).
+
+    static func _hashPrevouts(_ signBitcoin: SignBitcoin) -> Data {
+        let data = signBitcoin.inputs.reduce(Data()) { acc, input in
+            acc + serializeOutpoint(hash: input.hash, index: input.index)
+        }
+        return hash256(data)
+    }
+
+    static func _hashSequence(_ signBitcoin: SignBitcoin) -> Data {
+        let data = signBitcoin.inputs.reduce(Data()) { acc, input in
+            acc + writeUInt32LE(input.sequence)
+        }
+        return hash256(data)
+    }
+
+    static func _hashOutputs(_ signBitcoin: SignBitcoin) -> Data {
+        let data = signBitcoin.outputs.reduce(Data()) { acc, output in
+            let scriptBytes = Data(hexString: output.scriptPubKey) ?? Data()
+            return acc + serializeOutput(amount: output.amount, scriptPubKey: scriptBytes)
+        }
+        return hash256(data)
+    }
+
+    // MARK: - Public API
+
+    /// Compute one BIP-143 sighash per `is_ours` input, in input order.
+    static func preSigningHashes(_ signBitcoin: SignBitcoin) throws -> [Data] {
+        guard !signBitcoin.inputs.isEmpty else {
+            throw BitcoinPsbtSignerError.noInputs
+        }
+        guard signBitcoin.inputs.contains(where: { $0.isOurs }) else {
+            throw BitcoinPsbtSignerError.noSignableInputs
+        }
+
+        let hashPrevouts = _hashPrevouts(signBitcoin)
+        let hashSequence = _hashSequence(signBitcoin)
+        let hashOutputs = _hashOutputs(signBitcoin)
+
+        var sighashes: [Data] = []
+        for (i, input) in signBitcoin.inputs.enumerated() where input.isOurs {
+            let scriptCode = try scriptCode(for: input, inputIndex: i)
+            let sighashFlag = input.effectiveSighashType
+            let baseType = sighashFlag & 0x1F
+            let anyoneCanPay = (sighashFlag & 0x80) != 0
+            guard baseType == 0x01, !anyoneCanPay else {
+                throw BitcoinPsbtSignerError.unsupportedSighashType(sighashFlag)
+            }
+            guard input.amount >= 0 else {
+                throw BitcoinPsbtSignerError.negativeAmount(inputIndex: i, amount: input.amount)
+            }
+
+            // BIP-143 preimage:
+            // version || hashPrevouts || hashSequence || outpoint || scriptCode
+            //   || value || sequence || hashOutputs || locktime || sighashType
+            var preimage = Data()
+            preimage.append(writeUInt32LE(signBitcoin.version))
+            preimage.append(hashPrevouts)
+            preimage.append(hashSequence)
+            preimage.append(serializeOutpoint(hash: input.hash, index: input.index))
+            preimage.append(scriptCode)
+            preimage.append(writeUInt64LE(UInt64(input.amount)))
+            preimage.append(writeUInt32LE(input.sequence))
+            preimage.append(hashOutputs)
+            preimage.append(writeUInt32LE(signBitcoin.locktime))
+            preimage.append(writeUInt32LE(sighashFlag))
+
+            sighashes.append(hash256(preimage))
+        }
+        return sighashes
+    }
+
+    /// Assemble a raw signed segwit transaction from `SignBitcoin` + MPC signatures.
+    /// Witness layout for P2WPKH and P2SH-P2WPKH: `[der_sig||sighash_flag, pubKey]`.
+    static func compileSignedTransaction(
+        signBitcoin: SignBitcoin,
+        signatures: [String: TssKeysignResponse],
+        pubKeyHex: String
+    ) throws -> SignedTransactionResult {
+        guard let pubKeyData = Data(hexString: pubKeyHex),
+              PublicKey(data: pubKeyData, type: .secp256k1) != nil else {
+            throw BitcoinPsbtSignerError.invalidPublicKey(pubKeyHex)
+        }
+
+        let sighashes = try preSigningHashes(signBitcoin)
+        let provider = SignatureProvider(signatures: signatures)
+
+        // Assemble witnesses for `is_ours` inputs first (one signature per
+        // sighash, in is_ours order). Non-ours inputs get an empty witness
+        // stack — the resulting tx is invalid on-chain if any non-ours inputs
+        // exist (matches SDK behavior: multi-party PSBT preservation is a
+        // follow-up).
+        var witnesses: [[Data]] = Array(repeating: [], count: signBitcoin.inputs.count)
+        var sighashIndex = 0
+        for (i, input) in signBitcoin.inputs.enumerated() where input.isOurs {
+            let sighash = sighashes[sighashIndex]
+            sighashIndex += 1
+
+            let derSig = provider.getDerSignature(preHash: sighash)
+            guard !derSig.isEmpty else {
+                throw BitcoinPsbtSignerError.missingSignature(sighashHex: sighash.hexString)
+            }
+            var sigPlusFlag = derSig
+            sigPlusFlag.append(UInt8(input.effectiveSighashType & 0xFF))
+            witnesses[i] = [sigPlusFlag, pubKeyData]
+        }
+
+        let rawTx = serializeSegwitTransaction(signBitcoin: signBitcoin, witnesses: witnesses)
+        return SignedTransactionResult(
+            rawTransaction: rawTx.hexString,
+            transactionHash: txid(signBitcoin)
+        )
+    }
+
+    // MARK: - Sighash helpers
+
+    private static func scriptCode(for input: BitcoinInput, inputIndex: Int) throws -> Data {
+        switch input.scriptType.lowercased() {
+        case "p2wpkh":
+            guard let scriptPubKey = Data(hexString: input.scriptPubKey) else {
+                throw BitcoinPsbtSignerError.invalidScriptPubKey(inputIndex: inputIndex)
+            }
+            return try p2wpkhScriptCode(witnessProgram: scriptPubKey, inputIndex: inputIndex)
+        case "p2sh-p2wpkh":
+            guard let redeemHex = input.redeemScript else {
+                throw BitcoinPsbtSignerError.missingRedeemScript(inputIndex: inputIndex)
+            }
+            guard let redeemScript = Data(hexString: redeemHex) else {
+                throw BitcoinPsbtSignerError.invalidRedeemScript(inputIndex: inputIndex)
+            }
+            return try p2wpkhScriptCode(witnessProgram: redeemScript, inputIndex: inputIndex)
+        default:
+            throw BitcoinPsbtSignerError.unsupportedScriptType(input.scriptType)
+        }
+    }
+
+    /// Derive the BIP-143 scriptCode from a P2WPKH witness program
+    /// (`0x00 0x14 <20-byte-hash>`). The leading `0x19` is the script length
+    /// per BIP-143, included in the scriptCode itself.
+    private static func p2wpkhScriptCode(witnessProgram: Data, inputIndex: Int) throws -> Data {
+        guard witnessProgram.count == 22,
+              witnessProgram[0] == 0x00,
+              witnessProgram[1] == 0x14 else {
+            throw BitcoinPsbtSignerError.invalidRedeemScript(inputIndex: inputIndex)
+        }
+        let pubkeyHash = witnessProgram.subdata(in: 2..<22)
+        var scriptCode = Data([0x19, 0x76, 0xa9, 0x14])
+        scriptCode.append(pubkeyHash)
+        scriptCode.append(contentsOf: [0x88, 0xac])
+        return scriptCode
+    }
+
+    // MARK: - Tx serialization
+
+    /// Build a segwit transaction (BIP-141 marker+flag, witness stacks).
+    /// P2SH-P2WPKH inputs include a scriptSig that pushes the redeem script.
+    private static func serializeSegwitTransaction(
+        signBitcoin: SignBitcoin,
+        witnesses: [[Data]]
+    ) -> Data {
+        var tx = Data()
+        tx.append(writeUInt32LE(signBitcoin.version))
+        tx.append(0x00) // marker
+        tx.append(0x01) // flag
+        tx.append(serializeInputsAndOutputs(signBitcoin))
+        for stack in witnesses {
+            tx.append(writeVarInt(UInt64(stack.count)))
+            for item in stack {
+                tx.append(writeVarInt(UInt64(item.count)))
+                tx.append(item)
+            }
+        }
+        tx.append(writeUInt32LE(signBitcoin.locktime))
+        return tx
+    }
+
+    /// Shared input/output serialization (varint counts + per-input scriptSig
+    /// + per-output value/script). Excludes version/locktime/witness data so
+    /// the same bytes can be reused for both the segwit tx body and the
+    /// non-witness txid preimage.
+    private static func serializeInputsAndOutputs(_ signBitcoin: SignBitcoin) -> Data {
+        var data = Data()
+        data.append(writeVarInt(UInt64(signBitcoin.inputs.count)))
+        for input in signBitcoin.inputs {
+            data.append(serializeOutpoint(hash: input.hash, index: input.index))
+            let scriptSig = scriptSig(for: input)
+            data.append(writeVarInt(UInt64(scriptSig.count)))
+            data.append(scriptSig)
+            data.append(writeUInt32LE(input.sequence))
+        }
+        data.append(writeVarInt(UInt64(signBitcoin.outputs.count)))
+        for output in signBitcoin.outputs {
+            data.append(writeUInt64LE(UInt64(output.amount)))
+            let script = Data(hexString: output.scriptPubKey) ?? Data()
+            data.append(writeVarInt(UInt64(script.count)))
+            data.append(script)
+        }
+        return data
+    }
+
+    /// scriptSig is empty for native segwit and `<push redeem_script>` for P2SH-P2WPKH.
+    private static func scriptSig(for input: BitcoinInput) -> Data {
+        guard input.scriptType.lowercased() == "p2sh-p2wpkh",
+              let redeemHex = input.redeemScript,
+              let redeem = Data(hexString: redeemHex) else {
+            return Data()
+        }
+        var scriptSig = Data()
+        scriptSig.append(UInt8(redeem.count & 0xFF))
+        scriptSig.append(redeem)
+        return scriptSig
+    }
+
+    /// txid is double-sha256 of the *non-witness* serialization, displayed in
+    /// reverse byte order (Bitcoin convention).
+    private static func txid(_ signBitcoin: SignBitcoin) -> String {
+        var tx = Data()
+        tx.append(writeUInt32LE(signBitcoin.version))
+        tx.append(serializeInputsAndOutputs(signBitcoin))
+        tx.append(writeUInt32LE(signBitcoin.locktime))
+        return Data(hash256(tx).reversed()).hexString
+    }
+}
+
+// MARK: - Byte helpers
+
+/// Little-endian 4-byte uint.
+private func writeUInt32LE(_ value: UInt32) -> Data {
+    withUnsafeBytes(of: value.littleEndian) { Data($0) }
+}
+
+/// Little-endian 8-byte uint (Bitcoin amounts are unsigned).
+private func writeUInt64LE(_ value: UInt64) -> Data {
+    withUnsafeBytes(of: value.littleEndian) { Data($0) }
+}
+
+/// Bitcoin CompactSize varint encoding.
+private func writeVarInt(_ value: UInt64) -> Data {
+    if value < 0xFD {
+        return Data([UInt8(value)])
+    }
+    if value <= 0xFFFF {
+        var buf = Data([0xFD])
+        buf.append(writeUInt32LE(UInt32(value)).prefix(2))
+        return buf
+    }
+    if value <= 0xFFFFFFFF {
+        var buf = Data([0xFE])
+        buf.append(writeUInt32LE(UInt32(value)))
+        return buf
+    }
+    var buf = Data([0xFF])
+    buf.append(writeUInt64LE(value))
+    return buf
+}
+
+/// Outpoint: txid bytes (display order reversed to internal LE) + 4-byte vout LE.
+private func serializeOutpoint(hash: String, index: UInt32) -> Data {
+    let txid = Data(hexString: hash) ?? Data()
+    var out = Data(txid.reversed())
+    out.append(writeUInt32LE(index))
+    return out
+}
+
+/// Tx output: 8-byte value LE + varint script length + scriptPubKey bytes.
+private func serializeOutput(amount: Int64, scriptPubKey: Data) -> Data {
+    var out = Data()
+    out.append(writeUInt64LE(UInt64(bitPattern: amount)))
+    out.append(writeVarInt(UInt64(scriptPubKey.count)))
+    out.append(scriptPubKey)
+    return out
+}
+
+/// double-SHA256 (Bitcoin's hash256).
+private func hash256(_ data: Data) -> Data {
+    Hash.sha256SHA256(data: data)
+}

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
@@ -34,6 +34,15 @@ class UTXOChainsHelper {
 
     // before keysign , we need to get the preSignedImageHash , so it can be signed with TSS
     func getPreSignedImageHash(keysignPayload: KeysignPayload) throws -> [String] {
+        // Structured PSBT path: bypass WalletCore's planner and compute
+        // BIP-143 sighashes directly from the dApp-supplied SignBitcoin
+        // fields. Mirrors the SDK port; preserves exact input ordering so
+        // `compileSignedTransaction` can match signatures back to inputs.
+        if let signBitcoin = keysignPayload.signBitcoin {
+            return try BitcoinPsbtSigner.preSigningHashes(signBitcoin)
+                .map { $0.hexString }
+                .sorted()
+        }
         let inputData = try getBitcoinPreSigningInputData(keysignPayload: keysignPayload)
         let preHashes = TransactionCompiler.preImageHashes(coinType: coin, txInputData: inputData)
         let preSignOutputs = try BitcoinPreSigningOutput(serializedBytes: preHashes)
@@ -214,6 +223,16 @@ class UTXOChainsHelper {
     }
 
     func getSignedTransaction(keysignPayload: KeysignPayload, signatures: [String: TssKeysignResponse]) throws -> SignedTransactionResult {
+        // Structured PSBT path: assemble the signed segwit tx from the
+        // SignBitcoin fields + MPC signatures directly (skips WalletCore's
+        // tx planner which can't represent dApp-supplied input/output sets).
+        if let signBitcoin = keysignPayload.signBitcoin {
+            return try BitcoinPsbtSigner.compileSignedTransaction(
+                signBitcoin: signBitcoin,
+                signatures: signatures,
+                pubKeyHex: keysignPayload.coin.hexPublicKey
+            )
+        }
         let inputData = try getBitcoinPreSigningInputData(keysignPayload: keysignPayload)
         return try getSignedTransaction(coinHexPublicKey: keysignPayload.coin.hexPublicKey, inputData: inputData, signatures: signatures)
     }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -637,6 +637,13 @@
 "proposalID" = "Proposal ID";
 "provider" = "Anbieter";
 "providerLabel" = "Anbieter (optional)";
+"psbtChangeMarker" = "Wechselgeld";
+"psbtInputs" = "Eingänge";
+"psbtNetworkFee" = "Netzwerkgebühr";
+"psbtOpReturn" = "OP_RETURN";
+"psbtOutputs" = "Ausgänge";
+"psbtSignedByThisDevice" = "Auf diesem Gerät signiert";
+"psbtTransactionDetails" = "Transaktionsdetails (PSBT)";
 "pushNotifications" = "Push-Benachrichtigungen";
 "pushNotificationsDescription" = "Erhalte eine Benachrichtigung, wenn deine Signatur erforderlich ist oder ein Gerät Zugang anfordert.";
 "rawPayload" = "Rohdaten";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -641,6 +641,7 @@
 "psbtInputs" = "Eingänge";
 "psbtNetworkFee" = "Netzwerkgebühr";
 "psbtOpReturn" = "OP_RETURN";
+"psbtOpReturnFormat" = "OP_RETURN: %@";
 "psbtOutputs" = "Ausgänge";
 "psbtSignedByThisDevice" = "Auf diesem Gerät signiert";
 "psbtTransactionDetails" = "Transaktionsdetails (PSBT)";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -645,6 +645,13 @@
 "proposalID" = "Proposal ID";
 "provider" = "Provider";
 "providerLabel" = "Provider (optional)";
+"psbtChangeMarker" = "Change";
+"psbtInputs" = "Inputs";
+"psbtNetworkFee" = "Network Fee";
+"psbtOpReturn" = "OP_RETURN";
+"psbtOutputs" = "Outputs";
+"psbtSignedByThisDevice" = "Signed by this device";
+"psbtTransactionDetails" = "Transaction Details (PSBT)";
 "pushNotifications" = "Push notifications";
 "pushNotificationsDescription" = "Get notified when your signature is required or a device requests access.";
 "rawPayload" = "Raw Payload";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -649,6 +649,7 @@
 "psbtInputs" = "Inputs";
 "psbtNetworkFee" = "Network Fee";
 "psbtOpReturn" = "OP_RETURN";
+"psbtOpReturnFormat" = "OP_RETURN: %@";
 "psbtOutputs" = "Outputs";
 "psbtSignedByThisDevice" = "Signed by this device";
 "psbtTransactionDetails" = "Transaction Details (PSBT)";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -641,6 +641,7 @@
 "psbtInputs" = "Entradas";
 "psbtNetworkFee" = "Comisión de red";
 "psbtOpReturn" = "OP_RETURN";
+"psbtOpReturnFormat" = "OP_RETURN: %@";
 "psbtOutputs" = "Salidas";
 "psbtSignedByThisDevice" = "Firmado por este dispositivo";
 "psbtTransactionDetails" = "Detalles de la transacción (PSBT)";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -637,6 +637,13 @@
 "proposalID" = "Proposal ID";
 "provider" = "Proveedor";
 "providerLabel" = "Proveedor (opcional)";
+"psbtChangeMarker" = "Cambio";
+"psbtInputs" = "Entradas";
+"psbtNetworkFee" = "Comisión de red";
+"psbtOpReturn" = "OP_RETURN";
+"psbtOutputs" = "Salidas";
+"psbtSignedByThisDevice" = "Firmado por este dispositivo";
+"psbtTransactionDetails" = "Detalles de la transacción (PSBT)";
 "pushNotifications" = "Notificaciones push";
 "pushNotificationsDescription" = "Recibe notificaciones cuando se requiera tu firma o un dispositivo solicite acceso.";
 "rawPayload" = "Datos sin procesar";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -637,6 +637,13 @@
 "proposalID" = "Proposal ID";
 "provider" = "Davatelj usluga";
 "providerLabel" = "Pružatelj (opcionalno)";
+"psbtChangeMarker" = "Povrat";
+"psbtInputs" = "Ulazi";
+"psbtNetworkFee" = "Mrežna naknada";
+"psbtOpReturn" = "OP_RETURN";
+"psbtOutputs" = "Izlazi";
+"psbtSignedByThisDevice" = "Potpisano s ovog uređaja";
+"psbtTransactionDetails" = "Detalji transakcije (PSBT)";
 "pushNotifications" = "Push obavijesti";
 "pushNotificationsDescription" = "Primajte obavijesti kada je potreban vaš potpis ili kada uređaj zahtijeva pristup.";
 "rawPayload" = "Sirovi podaci";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -641,6 +641,7 @@
 "psbtInputs" = "Ulazi";
 "psbtNetworkFee" = "Mrežna naknada";
 "psbtOpReturn" = "OP_RETURN";
+"psbtOpReturnFormat" = "OP_RETURN: %@";
 "psbtOutputs" = "Izlazi";
 "psbtSignedByThisDevice" = "Potpisano s ovog uređaja";
 "psbtTransactionDetails" = "Detalji transakcije (PSBT)";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -641,6 +641,7 @@
 "psbtInputs" = "Ingressi";
 "psbtNetworkFee" = "Commissione di rete";
 "psbtOpReturn" = "OP_RETURN";
+"psbtOpReturnFormat" = "OP_RETURN: %@";
 "psbtOutputs" = "Uscite";
 "psbtSignedByThisDevice" = "Firmato da questo dispositivo";
 "psbtTransactionDetails" = "Dettagli transazione (PSBT)";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -637,6 +637,13 @@
 "proposalID" = "ID Proposta";
 "provider" = "Fornitore";
 "providerLabel" = "Fornitore (opzionale)";
+"psbtChangeMarker" = "Resto";
+"psbtInputs" = "Ingressi";
+"psbtNetworkFee" = "Commissione di rete";
+"psbtOpReturn" = "OP_RETURN";
+"psbtOutputs" = "Uscite";
+"psbtSignedByThisDevice" = "Firmato da questo dispositivo";
+"psbtTransactionDetails" = "Dettagli transazione (PSBT)";
 "pushNotifications" = "Notifiche push";
 "pushNotificationsDescription" = "Ricevi una notifica quando è richiesta la tua firma o un dispositivo richiede l'accesso.";
 "rawPayload" = "Dati grezzi";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -645,6 +645,13 @@
 "proposalID" = "제안 ID";
 "provider" = "공급자";
 "providerLabel" = "공급자 (선택 사항)";
+"psbtChangeMarker" = "잔돈";
+"psbtInputs" = "입력";
+"psbtNetworkFee" = "네트워크 수수료";
+"psbtOpReturn" = "OP_RETURN";
+"psbtOutputs" = "출력";
+"psbtSignedByThisDevice" = "이 기기에서 서명됨";
+"psbtTransactionDetails" = "트랜잭션 세부 정보 (PSBT)";
 "pushNotifications" = "푸시 알림";
 "pushNotificationsDescription" = "서명이 필요하거나 기기가 액세스를 요청할 때 알림을 받으세요.";
 "rawPayload" = "원시 페이로드";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -649,6 +649,7 @@
 "psbtInputs" = "입력";
 "psbtNetworkFee" = "네트워크 수수료";
 "psbtOpReturn" = "OP_RETURN";
+"psbtOpReturnFormat" = "OP_RETURN: %@";
 "psbtOutputs" = "출력";
 "psbtSignedByThisDevice" = "이 기기에서 서명됨";
 "psbtTransactionDetails" = "트랜잭션 세부 정보 (PSBT)";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -641,6 +641,7 @@
 "psbtInputs" = "Entradas";
 "psbtNetworkFee" = "Taxa de rede";
 "psbtOpReturn" = "OP_RETURN";
+"psbtOpReturnFormat" = "OP_RETURN: %@";
 "psbtOutputs" = "Saídas";
 "psbtSignedByThisDevice" = "Assinado por este dispositivo";
 "psbtTransactionDetails" = "Detalhes da transação (PSBT)";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -637,6 +637,13 @@
 "proposalID" = "Proposal ID";
 "provider" = "Provedor";
 "providerLabel" = "Provedor (opcional)";
+"psbtChangeMarker" = "Troco";
+"psbtInputs" = "Entradas";
+"psbtNetworkFee" = "Taxa de rede";
+"psbtOpReturn" = "OP_RETURN";
+"psbtOutputs" = "Saídas";
+"psbtSignedByThisDevice" = "Assinado por este dispositivo";
+"psbtTransactionDetails" = "Detalhes da transação (PSBT)";
 "pushNotifications" = "Notificações push";
 "pushNotificationsDescription" = "Receba notificações quando sua assinatura for necessária ou um dispositivo solicitar acesso.";
 "rawPayload" = "Dados brutos";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -638,6 +638,13 @@
 "proposalID" = "提案 ID";
 "provider" = "提供商";
 "providerLabel" = "提供商（可选）";
+"psbtChangeMarker" = "找零";
+"psbtInputs" = "输入";
+"psbtNetworkFee" = "网络费用";
+"psbtOpReturn" = "OP_RETURN";
+"psbtOutputs" = "输出";
+"psbtSignedByThisDevice" = "由此设备签名";
+"psbtTransactionDetails" = "交易详情 (PSBT)";
 "pushNotifications" = "推送通知";
 "pushNotificationsDescription" = "当需要您的签名或设备请求访问时收到通知。";
 "rawPayload" = "原始数据";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -642,6 +642,7 @@
 "psbtInputs" = "输入";
 "psbtNetworkFee" = "网络费用";
 "psbtOpReturn" = "OP_RETURN";
+"psbtOpReturnFormat" = "OP_RETURN: %@";
 "psbtOutputs" = "输出";
 "psbtSignedByThisDevice" = "由此设备签名";
 "psbtTransactionDetails" = "交易详情 (PSBT)";

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Cosmos+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Cosmos+ProtoMappable.swift
@@ -12,6 +12,7 @@ enum SignData: Codable, Hashable {
     case signDirect(SignDirect)
     case signSolana(SignSolana)
     case signTon(SignTon)
+    case signBitcoin(SignBitcoin)
 
     init?(proto: VSKeysignPayload.OneOf_SignData) {
         switch proto {
@@ -23,11 +24,8 @@ enum SignData: Codable, Hashable {
             self = .signSolana(SignSolana(proto: vSSignSolana))
         case .signTon(let vSSignTon):
             self = .signTon(SignTon(proto: vSSignTon))
-        case .signBitcoin:
-            // Bitcoin PSBT signing arrived in commondata after iOS shipped
-            // its initial sign-data wrappers. Surface as nil until iOS adds
-            // a corresponding domain type.
-            return nil
+        case .signBitcoin(let vSSignBitcoin):
+            self = .signBitcoin(SignBitcoin(proto: vSSignBitcoin))
         }
     }
 
@@ -41,6 +39,8 @@ enum SignData: Codable, Hashable {
             return .signSolana(vSSignSolana.mapToProtobuff())
         case .signTon(let vSSignTon):
             return .signTon(vSSignTon.mapToProtobuff())
+        case .signBitcoin(let vSSignBitcoin):
+            return .signBitcoin(vSSignBitcoin.mapToProtobuff())
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
@@ -97,6 +97,13 @@ struct KeysignPayload: Codable, Hashable {
         return ton
     }
 
+    var signBitcoin: SignBitcoin? {
+        guard case let .signBitcoin(bitcoin) = signData else {
+            return nil
+        }
+        return bitcoin
+    }
+
     var fromAmountString: String {
         let decimalAmount = Decimal(string: swapPayload?.fromAmount.description ?? "") ?? Decimal.zero
         let power = Decimal(sign: .plus, exponent: -(swapPayload?.fromCoin.decimals ?? 1), significand: 1)

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignBitcoinDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignBitcoinDisplayView.swift
@@ -17,7 +17,10 @@ struct SignBitcoinDisplayView: View {
 
     private var totalIn: Int64 { signBitcoin.inputs.reduce(0) { $0 + $1.amount } }
     private var totalOut: Int64 { signBitcoin.outputs.reduce(0) { $0 + $1.amount } }
-    private var fee: Int64 { max(0, totalIn - totalOut) }
+    // Show the raw delta — clamping to zero would mask malformed PSBTs from
+    // a co-signer. Negative values are surfaced visually below.
+    private var fee: Int64 { totalIn - totalOut }
+    private var hasInvalidFee: Bool { fee < 0 }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -77,7 +80,7 @@ struct SignBitcoinDisplayView: View {
                 .frame(minWidth: 52, alignment: .leading)
             Spacer()
             Text(formatBtc(satoshis: fee))
-                .foregroundStyle(Theme.colors.textPrimary)
+                .foregroundStyle(hasInvalidFee ? Theme.colors.alertWarning : Theme.colors.textPrimary)
                 .font(Theme.fonts.priceBodyS)
         }
         .font(Theme.fonts.bodySMedium)

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignBitcoinDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignBitcoinDisplayView.swift
@@ -162,7 +162,7 @@ struct SignBitcoinDisplayView: View {
 
     private func displayLabel(for output: BitcoinOutput) -> String {
         if output.opReturnData != nil {
-            return "OP_RETURN"
+            return "psbtOpReturn".localized
         }
         if !output.address.isEmpty {
             return output.address
@@ -172,7 +172,7 @@ struct SignBitcoinDisplayView: View {
 
     private func badgeText(for output: BitcoinOutput) -> String? {
         if let data = output.opReturnData {
-            return "psbtOpReturn".localized + ": " + data
+            return String(format: "psbtOpReturnFormat".localized, data)
         }
         if output.isChange {
             return "psbtChangeMarker".localized

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignBitcoinDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignBitcoinDisplayView.swift
@@ -1,0 +1,197 @@
+//
+//  SignBitcoinDisplayView.swift
+//  VultisigApp
+//
+//  Renders the structured PSBT (`SignBitcoin`) keysign payload so co-signers
+//  can verify every input/output and the computed fee before approving.
+//  Mirrors the Windows/extension PSBT confirmation panel; the structured
+//  proto exists precisely so devices don't have to trust an opaque blob.
+//
+
+import SwiftUI
+
+struct SignBitcoinDisplayView: View {
+    let signBitcoin: SignBitcoin
+
+    @State private var isExpanded: Bool = true
+
+    private var totalIn: Int64 { signBitcoin.inputs.reduce(0) { $0 + $1.amount } }
+    private var totalOut: Int64 { signBitcoin.outputs.reduce(0) { $0 + $1.amount } }
+    private var fee: Int64 { max(0, totalIn - totalOut) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Button {
+                withAnimation {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(alignment: .center) {
+                    Text("psbtTransactionDetails".localized)
+                        .font(Theme.fonts.bodySMedium)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                    Spacer()
+                    Icon(named: "chevron-down", color: Theme.colors.textTertiary, size: 16)
+                        .rotationEffect(.degrees(isExpanded ? 180 : 0))
+                }
+            }
+            .buttonStyle(.borderless)
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 16) {
+                    inputsSection
+                    outputsSection
+                    feeRow
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var inputsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("psbtInputs", count: signBitcoin.inputs.count)
+            ForEach(Array(signBitcoin.inputs.enumerated()), id: \.offset) { index, input in
+                inputRow(index: index, input: input)
+            }
+        }
+    }
+
+    private var outputsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader("psbtOutputs", count: signBitcoin.outputs.count)
+            ForEach(Array(signBitcoin.outputs.enumerated()), id: \.offset) { index, output in
+                outputRow(index: index, output: output)
+            }
+        }
+    }
+
+    private var feeRow: some View {
+        HStack(spacing: 4) {
+            Text("psbtNetworkFee".localized)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .frame(minWidth: 52, alignment: .leading)
+            Spacer()
+            Text(formatBtc(satoshis: fee))
+                .foregroundStyle(Theme.colors.textPrimary)
+                .font(Theme.fonts.priceBodyS)
+        }
+        .font(Theme.fonts.bodySMedium)
+    }
+
+    // MARK: - Rows
+
+    private func sectionHeader(_ key: String, count: Int) -> some View {
+        Text("\(key.localized) (\(count))")
+            .font(Theme.fonts.bodySMedium)
+            .foregroundStyle(Theme.colors.textPrimary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func inputRow(index: Int, input: BitcoinInput) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text("#\(index)")
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                Text(formatOutpoint(hash: input.hash, index: input.index))
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+                Text(formatBtc(satoshis: input.amount))
+                    .font(Theme.fonts.priceBodyS)
+                    .foregroundStyle(Theme.colors.textPrimary)
+            }
+            HStack(spacing: 8) {
+                Text(input.scriptType.uppercased())
+                    .font(Theme.fonts.caption10)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                if input.isOurs {
+                    Text("psbtSignedByThisDevice".localized)
+                        .font(Theme.fonts.caption10)
+                        .foregroundStyle(Theme.colors.alertSuccess)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Theme.colors.bgPrimary))
+    }
+
+    private func outputRow(index: Int, output: BitcoinOutput) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text("#\(index)")
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                Text(displayLabel(for: output))
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+                Text(formatBtc(satoshis: output.amount))
+                    .font(Theme.fonts.priceBodyS)
+                    .foregroundStyle(Theme.colors.textPrimary)
+            }
+            if let badge = badgeText(for: output) {
+                HStack {
+                    Text(badge)
+                        .font(Theme.fonts.caption10)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Theme.colors.bgPrimary))
+    }
+
+    // MARK: - Formatting
+
+    private func displayLabel(for output: BitcoinOutput) -> String {
+        if output.opReturnData != nil {
+            return "OP_RETURN"
+        }
+        if !output.address.isEmpty {
+            return output.address
+        }
+        return output.scriptPubKey
+    }
+
+    private func badgeText(for output: BitcoinOutput) -> String? {
+        if let data = output.opReturnData {
+            return "psbtOpReturn".localized + ": " + data
+        }
+        if output.isChange {
+            return "psbtChangeMarker".localized
+        }
+        return nil
+    }
+
+    private func formatOutpoint(hash: String, index: UInt32) -> String {
+        // Bitcoin txids are conventionally truncated to first 8 / last 8 chars
+        // when displayed in compact UIs; we render the full txid:vout but rely
+        // on lineLimit + truncationMode for clipping.
+        return "\(hash):\(index)"
+    }
+
+    /// Format satoshis as a BTC-denominated string with up to 8 decimals.
+    private func formatBtc(satoshis: Int64) -> String {
+        let value = Decimal(satoshis) / Decimal(100_000_000)
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 8
+        formatter.numberStyle = .decimal
+        let formatted = formatter.string(from: value as NSDecimalNumber) ?? "\(satoshis)"
+        return "\(formatted) BTC"
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -130,6 +130,9 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
                         vault: vault,
                         fromAddress: coin.address
                     )
+                } else if let signBitcoin = input.keysignPayload?.signBitcoin {
+                    Separator()
+                    SignBitcoinDisplayView(signBitcoin: signBitcoin)
                 }
             }
         }

--- a/VultisigApp/VultisigAppTests/Chains/BitcoinPsbtSignerTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/BitcoinPsbtSignerTests.swift
@@ -152,9 +152,39 @@ final class BitcoinPsbtSignerTests: XCTestCase {
             "52b0a642eea2fb7ae638c36f6252b6750293dbe574a806984b8e4d8548339a3b"
         )
         XCTAssertEqual(
-            BitcoinPsbtSigner._hashOutputs(signBitcoin).hexString,
+            try BitcoinPsbtSigner._hashOutputs(signBitcoin).hexString,
             "863ef3e1a92afbfdb97f31ad0fc7683ee943e9abcf2501590ff8f6551f47e5e5"
         )
+    }
+
+    func testInvalidOutputScriptPubKeyThrows() {
+        let input = BitcoinInput(
+            hash: "00".padding(toLength: 64, withPad: "0", startingAt: 0),
+            index: 0,
+            amount: 100_000,
+            scriptPubKey: "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1",
+            scriptType: "p2wpkh",
+            sighashType: 1,
+            isOurs: true,
+            redeemScript: nil,
+            sequence: 0xFFFFFFFF
+        )
+        let badOutput = BitcoinOutput(
+            amount: 50_000,
+            address: "",
+            opReturnData: nil,
+            scriptPubKey: "not-a-hex-string",
+            isChange: false
+        )
+        let payload = SignBitcoin(version: 2, locktime: 0, inputs: [input], outputs: [badOutput])
+
+        XCTAssertThrowsError(try BitcoinPsbtSigner.preSigningHashes(payload)) { err in
+            guard case BitcoinPsbtSignerError.invalidOutputScriptPubKey(let i) = err else {
+                XCTFail("Expected invalidOutputScriptPubKey, got \(err)")
+                return
+            }
+            XCTAssertEqual(i, 0)
+        }
     }
 
     func testNoOursInputsThrows() {

--- a/VultisigApp/VultisigAppTests/Chains/BitcoinPsbtSignerTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/BitcoinPsbtSignerTests.swift
@@ -1,0 +1,240 @@
+//
+//  BitcoinPsbtSignerTests.swift
+//  VultisigAppTests
+//
+//  Validates the BIP-143 sighash implementation against the reference
+//  test vector from https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
+//  ("Native P2WPKH" example), and exercises codec round-trip via SignData.
+//
+
+@testable import VultisigApp
+import VultisigCommonData
+import WalletCore
+import XCTest
+
+final class BitcoinPsbtSignerTests: XCTestCase {
+
+    // BIP-143 reference vector: native P2WPKH input #1.
+    //
+    // See https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#native-p2wpkh
+    // Input 0 (non-segwit, isOurs = false here so we don't sighash it),
+    // input 1 (P2WPKH, value 6 BTC, scriptPubKey 0x001419 0x... -- but the
+    // BIP-143 vector specifies the witness program as a 22-byte 0x00 0x14
+    // pushdata over a 20-byte hash).
+    //
+    // The BIP says:
+    //   hashPrevouts = double_sha256(...) =
+    //     96b827c8483d4e9b96712b6713a7b68d6e8003a781feba36c31143470b4efd37
+    //   hashSequence = double_sha256(...) =
+    //     52b0a642eea2fb7ae638c36f6252b6750293dbe574a806984b8e4d8548339a3b
+    //   hashOutputs = double_sha256(...) =
+    //     863ef3e1a92afbfdb97f31ad0fc7683ee943e9abcf2501590ff8f6551f47e5e5
+    //
+    // The full signature hash for input 1 is:
+    //   c37af31116d1b27caf68aae9e3ac82f1477929014d5b917657d0eb49478cb670
+    func testBip143NativeP2WPKHReferenceSighash() throws {
+        let inputAmount: Int64 = 600_000_000 // 6 BTC in satoshis
+        let scriptPubKeyHex = "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1"
+        // Coinbase-style first input (not signed, isOurs=false)
+        // Input #0 sequence is 0xFFFFFFEE in the BIP-143 spec ("eeffffff" LE in the raw tx).
+        // BIP-143 commits to every input's sequence in `hashSequence`, so this matters for the sighash.
+        let nonOurs = BitcoinInput(
+            hash: "9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff",
+            index: 0,
+            amount: 625_000_000,
+            scriptPubKey: "2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac",
+            scriptType: "p2pk",
+            sighashType: 1,
+            isOurs: false,
+            redeemScript: nil,
+            sequence: 0xFFFFFFEE
+        )
+        let ours = BitcoinInput(
+            hash: "8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef",
+            index: 1,
+            amount: inputAmount,
+            scriptPubKey: scriptPubKeyHex,
+            scriptType: "p2wpkh",
+            sighashType: 1,
+            isOurs: true,
+            redeemScript: nil,
+            sequence: 0xFFFFFFFF
+        )
+        let out0 = BitcoinOutput(
+            amount: 112_340_000,
+            address: "",
+            opReturnData: nil,
+            scriptPubKey: "76a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac",
+            isChange: false
+        )
+        let out1 = BitcoinOutput(
+            amount: 223_450_000,
+            address: "",
+            opReturnData: nil,
+            scriptPubKey: "76a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac",
+            isChange: false
+        )
+        let signBitcoin = SignBitcoin(
+            version: 1,
+            locktime: 17,
+            inputs: [nonOurs, ours],
+            outputs: [out0, out1]
+        )
+
+        let hashes = try BitcoinPsbtSigner.preSigningHashes(signBitcoin)
+        XCTAssertEqual(hashes.count, 1, "Only the is_ours input should produce a sighash")
+        XCTAssertEqual(
+            hashes[0].hexString,
+            "c37af31116d1b27caf68aae9e3ac82f1477929014d5b917657d0eb49478cb670",
+            "BIP-143 native P2WPKH reference sighash mismatch"
+        )
+    }
+
+    /// Quick sanity check: WalletCore's `Hash.sha256SHA256` should be the
+    /// Bitcoin double-SHA256. Empty input maps to a known constant.
+    func testHashSha256d() {
+        let h = Hash.sha256SHA256(data: Data()).hexString
+        XCTAssertEqual(h, "5df6e0e2761359d30a8275058e299fcc0381534545f55cf43e41983f5d4c9456")
+    }
+
+    /// Verify each BIP-143 intermediate value (hashPrevouts/hashSequence/hashOutputs)
+    /// against the spec's reference values for the native P2WPKH vector.
+    func testBip143NativeP2WPKHIntermediateHashes() {
+        let nonOurs = BitcoinInput(
+            hash: "9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff",
+            index: 0,
+            amount: 625_000_000,
+            scriptPubKey: "2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac",
+            scriptType: "p2pk",
+            sighashType: 1,
+            isOurs: false,
+            redeemScript: nil,
+            sequence: 0xFFFFFFEE
+        )
+        let ours = BitcoinInput(
+            hash: "8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef",
+            index: 1,
+            amount: 600_000_000,
+            scriptPubKey: "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1",
+            scriptType: "p2wpkh",
+            sighashType: 1,
+            isOurs: true,
+            redeemScript: nil,
+            sequence: 0xFFFFFFFF
+        )
+        let out0 = BitcoinOutput(
+            amount: 112_340_000,
+            address: "",
+            opReturnData: nil,
+            scriptPubKey: "76a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac",
+            isChange: false
+        )
+        let out1 = BitcoinOutput(
+            amount: 223_450_000,
+            address: "",
+            opReturnData: nil,
+            scriptPubKey: "76a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac",
+            isChange: false
+        )
+        let signBitcoin = SignBitcoin(
+            version: 1,
+            locktime: 17,
+            inputs: [nonOurs, ours],
+            outputs: [out0, out1]
+        )
+
+        XCTAssertEqual(
+            BitcoinPsbtSigner._hashPrevouts(signBitcoin).hexString,
+            "96b827c8483d4e9b96712b6713a7b68d6e8003a781feba36c31143470b4efd37"
+        )
+        XCTAssertEqual(
+            BitcoinPsbtSigner._hashSequence(signBitcoin).hexString,
+            "52b0a642eea2fb7ae638c36f6252b6750293dbe574a806984b8e4d8548339a3b"
+        )
+        XCTAssertEqual(
+            BitcoinPsbtSigner._hashOutputs(signBitcoin).hexString,
+            "863ef3e1a92afbfdb97f31ad0fc7683ee943e9abcf2501590ff8f6551f47e5e5"
+        )
+    }
+
+    func testNoOursInputsThrows() {
+        let input = BitcoinInput(
+            hash: "00".padding(toLength: 64, withPad: "0", startingAt: 0),
+            index: 0,
+            amount: 1000,
+            scriptPubKey: "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1",
+            scriptType: "p2wpkh",
+            sighashType: 1,
+            isOurs: false,
+            redeemScript: nil,
+            sequence: 0xFFFFFFFF
+        )
+        let payload = SignBitcoin(version: 2, locktime: 0, inputs: [input], outputs: [])
+        XCTAssertThrowsError(try BitcoinPsbtSigner.preSigningHashes(payload)) { err in
+            guard case BitcoinPsbtSignerError.noSignableInputs = err else {
+                return XCTFail("Expected noSignableInputs, got \(err)")
+            }
+        }
+    }
+
+    func testUnsupportedScriptTypeThrows() {
+        let input = BitcoinInput(
+            hash: "00".padding(toLength: 64, withPad: "0", startingAt: 0),
+            index: 0,
+            amount: 1000,
+            scriptPubKey: "5120" + String(repeating: "00", count: 32),
+            scriptType: "p2tr",
+            sighashType: 1,
+            isOurs: true,
+            redeemScript: nil,
+            sequence: 0xFFFFFFFF
+        )
+        let payload = SignBitcoin(version: 2, locktime: 0, inputs: [input], outputs: [])
+        XCTAssertThrowsError(try BitcoinPsbtSigner.preSigningHashes(payload)) { err in
+            guard case BitcoinPsbtSignerError.unsupportedScriptType("p2tr") = err else {
+                return XCTFail("Expected unsupportedScriptType(p2tr), got \(err)")
+            }
+        }
+    }
+
+    /// Round-trip a `SignData.signBitcoin` payload through the proto+JSON
+    /// codable surface used by integration tests. The previous behaviour was
+    /// a hard-throw on encode (see issue #4317); this confirms the new path
+    /// is symmetric.
+    func testSignDataSignBitcoinCodableRoundTrip() throws {
+        let input = BitcoinInput(
+            hash: "8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef",
+            index: 1,
+            amount: 600_000_000,
+            scriptPubKey: "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1",
+            scriptType: "p2wpkh",
+            sighashType: 1,
+            isOurs: true,
+            redeemScript: nil,
+            sequence: 0xFFFFFFFF
+        )
+        let output = BitcoinOutput(
+            amount: 590_000_000,
+            address: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+            opReturnData: nil,
+            scriptPubKey: "0020c7a1f1a4d6b4c1802a59631966a18359de779e8a6a65973735a3ccdfdabc407d",
+            isChange: false
+        )
+        let original = SignData.signBitcoin(SignBitcoin(
+            version: 2,
+            locktime: 0,
+            inputs: [input],
+            outputs: [output]
+        ))
+
+        // Encode and decode through the proto-backed Codable surface (same
+        // path the relay uses for keysign payload transport in tests).
+        let proto = original.mapToProtobuff()
+        let encoded = try JSONEncoder().encode(proto)
+        let decodedProto = try JSONDecoder().decode(VSKeysignPayload.OneOf_SignData.self, from: encoded)
+        guard let decoded = SignData(proto: decodedProto) else {
+            return XCTFail("Failed to decode signBitcoin SignData")
+        }
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Chains/KeysignPayloadCodable.swift
+++ b/VultisigApp/VultisigAppTests/Chains/KeysignPayloadCodable.swift
@@ -890,6 +890,7 @@ extension VSKeysignPayload.OneOf_SignData: @retroactive Codable {
         case signAmino = "sign_amino"
         case signSolana = "sign_solana"
         case signTon = "sign_ton"
+        case signBitcoin = "sign_bitcoin"
     }
 
     public init(from decoder: any Decoder) throws {
@@ -908,6 +909,9 @@ extension VSKeysignPayload.OneOf_SignData: @retroactive Codable {
         } else if container.contains(.signTon) {
             let signTon = try container.decode(VSSignTon.self, forKey: .signTon)
             self = .signTon(signTon)
+        } else if container.contains(.signBitcoin) {
+            let signBitcoin = try container.decode(VSSignBitcoin.self, forKey: .signBitcoin)
+            self = .signBitcoin(signBitcoin)
         } else {
             throw DecodingError.dataCorrupted(
                 DecodingError.Context(
@@ -929,17 +933,8 @@ extension VSKeysignPayload.OneOf_SignData: @retroactive Codable {
             try container.encode(vSSignSolana, forKey: .signSolana)
         case .signTon(let vSSignTon):
             try container.encode(vSSignTon, forKey: .signTon)
-        case .signBitcoin:
-            // Bitcoin PSBT signing is not yet exposed through the iOS Codable
-            // surface used by these tests. Fail loudly rather than emit an
-            // empty `sign_data` object that the decoder above would reject.
-            throw EncodingError.invalidValue(
-                self,
-                EncodingError.Context(
-                    codingPath: encoder.codingPath,
-                    debugDescription: "VSKeysignPayload.OneOf_SignData.signBitcoin is not encodable through the test Codable surface."
-                )
-            )
+        case .signBitcoin(let vSSignBitcoin):
+            try container.encode(vSSignBitcoin, forKey: .signBitcoin)
         }
     }
 }
@@ -1237,6 +1232,118 @@ extension VSSignTon: @retroactive Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init()
         tonMessages = try container.decode([VSTonMessage].self, forKey: .tonMessages)
+    }
+}
+
+extension VSBitcoinInput: @retroactive Codable {
+    enum CodingKeys: String, CodingKey {
+        case hash
+        case index
+        case amount
+        case scriptPubKey = "script_pub_key"
+        case scriptType = "script_type"
+        case sighashType = "sighash_type"
+        case isOurs = "is_ours"
+        case redeemScript = "redeem_script"
+        case sequence
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(hash, forKey: .hash)
+        try container.encode(index, forKey: .index)
+        try container.encode(amount, forKey: .amount)
+        try container.encode(scriptPubKey, forKey: .scriptPubKey)
+        try container.encode(scriptType, forKey: .scriptType)
+        if hasSighashType {
+            try container.encode(sighashType, forKey: .sighashType)
+        }
+        try container.encode(isOurs, forKey: .isOurs)
+        if hasRedeemScript {
+            try container.encode(redeemScript, forKey: .redeemScript)
+        }
+        if hasSequence {
+            try container.encode(sequence, forKey: .sequence)
+        }
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        hash = try container.decode(String.self, forKey: .hash)
+        index = try container.decode(UInt32.self, forKey: .index)
+        amount = try container.decode(Int64.self, forKey: .amount)
+        scriptPubKey = try container.decode(String.self, forKey: .scriptPubKey)
+        scriptType = try container.decode(String.self, forKey: .scriptType)
+        if let v = try container.decodeIfPresent(UInt32.self, forKey: .sighashType) {
+            sighashType = v
+        }
+        isOurs = try container.decode(Bool.self, forKey: .isOurs)
+        if let v = try container.decodeIfPresent(String.self, forKey: .redeemScript) {
+            redeemScript = v
+        }
+        if let v = try container.decodeIfPresent(UInt32.self, forKey: .sequence) {
+            sequence = v
+        }
+    }
+}
+
+extension VSBitcoinOutput: @retroactive Codable {
+    enum CodingKeys: String, CodingKey {
+        case amount
+        case address
+        case opReturnData = "op_return_data"
+        case scriptPubKey = "script_pub_key"
+        case isChange = "is_change"
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(amount, forKey: .amount)
+        try container.encode(address, forKey: .address)
+        if hasOpReturnData {
+            try container.encode(opReturnData, forKey: .opReturnData)
+        }
+        try container.encode(scriptPubKey, forKey: .scriptPubKey)
+        try container.encode(isChange, forKey: .isChange)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        amount = try container.decode(Int64.self, forKey: .amount)
+        address = try container.decode(String.self, forKey: .address)
+        if let v = try container.decodeIfPresent(String.self, forKey: .opReturnData) {
+            opReturnData = v
+        }
+        scriptPubKey = try container.decode(String.self, forKey: .scriptPubKey)
+        isChange = try container.decode(Bool.self, forKey: .isChange)
+    }
+}
+
+extension VSSignBitcoin: @retroactive Codable {
+    enum CodingKeys: String, CodingKey {
+        case version
+        case locktime
+        case inputs
+        case outputs
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(version, forKey: .version)
+        try container.encode(locktime, forKey: .locktime)
+        try container.encode(inputs, forKey: .inputs)
+        try container.encode(outputs, forKey: .outputs)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init()
+        version = try container.decode(UInt32.self, forKey: .version)
+        locktime = try container.decode(UInt32.self, forKey: .locktime)
+        inputs = try container.decode([VSBitcoinInput].self, forKey: .inputs)
+        outputs = try container.decode([VSBitcoinOutput].self, forKey: .outputs)
     }
 }
 


### PR DESCRIPTION
Closes #4317

## Summary

Brings iOS to parity with the SDK (vultisig/vultisig-sdk#174) and Windows extension (vultisig/vultisig-windows#3672) for dApp PSBT co-signing. The structured `SignBitcoin` proto from commondata#77 previously hit a `return nil` stub in `SignData(proto:)`, so any iOS device receiving a PSBT keysign over the relay was unable to participate (Ordinals / Runes / CoinJoin / bridges all blocked for vaults that include an iOS device).

### What's in this PR

- **Domain type & wiring** — adds `SignBitcoin` / `BitcoinInput` / `BitcoinOutput` Swift types mirroring the proto, wires the `signBitcoin` arm into the `SignData` enum's `init?(proto:)` / `mapToProtobuff()`, and exposes a `KeysignPayload.signBitcoin` computed accessor alongside `signAmino` / `signDirect` / `signSolana` / `signTon`.
- **BIP-143 sighash + signed-tx assembly** — new `BitcoinPsbtSigner` ports `sighash.ts` and `compileSignBitcoinTx.ts` from the SDK. Supports **P2WPKH** and **P2SH-P2WPKH**, SIGHASH_ALL only. **P2TR is deferred** (matches SDK scope) — throws a typed `BitcoinPsbtSignerError.unsupportedScriptType("p2tr")` if a `is_ours` input uses an unsupported script. Uses TrustWalletCore's `Hash.sha256SHA256` for double-SHA256.
- **UTXO branch** — `UTXOChainsHelper.getPreSignedImageHash` and `getSignedTransaction` short-circuit to `BitcoinPsbtSigner` when the payload carries a `SignBitcoin`, bypassing WalletCore's tx planner. The existing `utxo_specific` + `utxo_info` path is unchanged for normal BTC sends.
- **Codable round-trip** — replaces the explicit `EncodingError.invalidValue` throw in `KeysignPayloadCodable` for the `signBitcoin` arm with real Codable conformances on `VSSignBitcoin` / `VSBitcoinInput` / `VSBitcoinOutput`. Added a round-trip test.
- **Confirmation UI** — new `SignBitcoinDisplayView` rendering inputs (txid:vout, amount, script type, "Signed by this device" badge), outputs (address / OP_RETURN / change marker), and computed fee = sum(inputs) − sum(outputs). Wired into `SendCryptoVerifySummaryView`. All amounts use `Theme.fonts.priceBodyS`. 7 new keys (`psbtInputs`, `psbtOutputs`, `psbtNetworkFee`, `psbtChangeMarker`, `psbtOpReturn`, `psbtSignedByThisDevice`, `psbtTransactionDetails`) added to all 8 locale files.

### Tests

- `BitcoinPsbtSignerTests`:
  - `testBip143NativeP2WPKHReferenceSighash` — full sighash matches BIP-143 reference vector (`c37af3...8cb670`)
  - `testBip143NativeP2WPKHIntermediateHashes` — hashPrevouts/hashSequence/hashOutputs each match spec values
  - `testHashSha256d` — sanity-checks the WalletCore double-SHA256 primitive
  - `testNoOursInputsThrows`, `testUnsupportedScriptTypeThrows` — error paths
  - `testSignDataSignBitcoinCodableRoundTrip` — proto round-trip works through the Codable surface
- Existing `UTXOChainsHelperTest` and `ChainHelperTests` confirmed still passing — the legacy UTXO send path is untouched.

### Out of scope (follow-ups)

- **Manual e2e** — Windows-extension-initiated dApp PSBT co-signed by an iOS device, broadcast tx structurally identical to the dApp's expected shape, plus regression check that normal BTC sends still work. **Not performed in this PR.**
- **P2TR (BIP-341)** — deferred, matches SDK scope.
- **Multi-party PSBT preservation** — non-`is_ours` inputs currently get an empty witness stack, so the signed tx is invalid on-chain if any non-ours inputs exist. The SDK has the same limitation today.
- **File rename** — the `SignData` enum still lives in `Cosmos+ProtoMappable.swift`. The issue suggests renaming; left to a follow-up to keep this diff focused.

## Test plan

- [ ] Co-sign a dApp PSBT initiated from the Windows extension (fast vault, then a secure 2-of-3 vault including an iOS device); confirm broadcast tx matches the dApp's expected structure
- [ ] Verify normal BTC sends still work via the existing `utxo_specific` + `utxo_info` path
- [ ] Verify the keysign confirmation screen renders inputs/outputs/fee correctly for PSBT payloads (incl. OP_RETURN and change markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PSBT co-signing support with an expandable transaction preview showing inputs, outputs, fees, OP_RETURN badges, and change markers.

* **Bug Fixes**
  * Fixed Bitcoin fee handling for a previously misrouted signing mode so fees are computed consistently.

* **Localization**
  * Added PSBT UI strings in English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.

* **Tests**
  * Added unit tests for PSBT sighash computation and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="200" alt="Simulator Screenshot - iPhone 17e - 2026-05-08 at 11 29 15" src="https://github.com/user-attachments/assets/9f5125ed-f1f4-47b1-a0df-97f5d2380582" />
