### PR TITLE
fix(keyimport): restrict swap chains and CoinService writes to imported chains

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "close" = "Schließen";
 "coinAddressCopied" = "Münzadresse kopiert";
 "coinPool" = "%@-Pool";
+"coinServiceChainNotEnabledForKeyImport" = "Chain %@ ist für diesen importierten Vault nicht aktiviert";
 "collectedRewards" = "Gesammelte Belohnungen";
 "compoundedCoin" = "%@ aufgezinst";
 "congratsExclamation" = "Glückwunsch!";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -194,6 +194,7 @@
 "close" = "Close";
 "coinAddressCopied" = "%@ address copied";
 "coinPool" = "%@ Pool";
+"coinServiceChainNotEnabledForKeyImport" = "Chain %@ is not enabled for this imported vault";
 "collectedRewards" = "Collected rewards";
 "compoundedCoin" = "Compounded %@";
 "congratsExclamation" = "Congrats!";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "close" = "Cerrar";
 "coinAddressCopied" = "Dirección de moneda copiada";
 "coinPool" = "Pool de %@";
+"coinServiceChainNotEnabledForKeyImport" = "La cadena %@ no está habilitada para esta bóveda importada";
 "collectedRewards" = "Recompensas recolectadas";
 "compoundedCoin" = "%@ Compuesto";
 "congratsExclamation" = "¡Felicidades!";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "close" = "Zatvori";
 "coinAddressCopied" = "Adresa kopirana";
 "coinPool" = "%@ Pool";
+"coinServiceChainNotEnabledForKeyImport" = "Lanac %@ nije omogućen za ovaj uvezeni vault";
 "collectedRewards" = "Prikupljene nagrade";
 "compoundedCoin" = "%@ Složeno";
 "congratsExclamation" = "Čestitamo!";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "close" = "Chiudi";
 "coinAddressCopied" = "Indirizzo %@ copiato";
 "coinPool" = "Pool %@";
+"coinServiceChainNotEnabledForKeyImport" = "La chain %@ non è abilitata per questo vault importato";
 "collectedRewards" = "Premi raccolti";
 "compoundedCoin" = "%@ Composto";
 "congratsExclamation" = "Congratulazioni!";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -194,6 +194,7 @@
 "close" = "닫기";
 "coinAddressCopied" = "%@ 주소 복사됨";
 "coinPool" = "%@ 풀";
+"coinServiceChainNotEnabledForKeyImport" = "이 가져온 볼트에서 %@ 체인이 활성화되어 있지 않습니다";
 "collectedRewards" = "수집된 보상";
 "compoundedCoin" = "복리 %@";
 "congratsExclamation" = "축하합니다!";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "close" = "Fechar";
 "coinAddressCopied" = "Endereço %@ copiado";
 "coinPool" = "Pool de %@";
+"coinServiceChainNotEnabledForKeyImport" = "A chain %@ não está habilitada para este vault importado";
 "collectedRewards" = "Recompensas coletadas";
 "compoundedCoin" = "%@ Composto";
 "congratsExclamation" = "Parabéns!";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "close" = "关闭";
 "coinAddressCopied" = "%@ 地址已复制";
 "coinPool" = "%@ 池";
+"coinServiceChainNotEnabledForKeyImport" = "此导入的保险库未启用 %@ 链";
 "collectedRewards" = "已收集的奖励";
 "compoundedCoin" = "已复利 %@";
 "congratsExclamation" = "恭喜！";

--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -14,7 +14,7 @@ enum CoinServiceError: LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .chainNotEnabledForKeyImport(let chain):
-            return "Chain \(chain.name) is not enabled for this imported vault"
+            return String(format: "coinServiceChainNotEnabledForKeyImport".localized, chain.name)
         }
     }
 }
@@ -203,8 +203,12 @@ struct CoinService {
     /// Without this, features like the swap-quote-driven VULT tier check
     /// would silently inject ETH (and discover ERC20s) into a key-import
     /// vault that derived TSS shares only for THORChain.
+    ///
+    /// Legacy JSON backups predate `chainPublicKeys` persistence; skip the
+    /// guard when the list is empty to avoid soft-bricking restored vaults.
     static func assertChainAllowed(asset: CoinMeta, vault: Vault) throws {
         guard vault.libType == .KeyImport else { return }
+        guard !vault.chainPublicKeys.isEmpty else { return }
         guard !vault.chainPublicKeys.contains(where: { $0.chain == asset.chain }) else { return }
         throw CoinServiceError.chainNotEnabledForKeyImport(asset.chain)
     }

--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -8,6 +8,17 @@
 import Foundation
 import SwiftData
 
+enum CoinServiceError: LocalizedError, Equatable {
+    case chainNotEnabledForKeyImport(Chain)
+
+    var errorDescription: String? {
+        switch self {
+        case .chainNotEnabledForKeyImport(let chain):
+            return "Chain \(chain.name) is not enabled for this imported vault"
+        }
+    }
+}
+
 @MainActor
 struct CoinService {
 
@@ -139,6 +150,8 @@ struct CoinService {
     }
 
     static func addToChain(asset: CoinMeta, to vault: Vault, priceProviderId: String?) throws -> Coin? {
+        try assertChainAllowed(asset: asset, vault: vault)
+
         let pubKey = vault.chainPublicKeys.first { $0.chain == asset.chain }?.publicKeyHex
         let isDerived = pubKey != nil
         let newCoin = try CoinFactory.create(
@@ -184,6 +197,16 @@ struct CoinService {
         }
 
         return try addToChain(asset: asset, to: vault, priceProviderId: priceProviderId)
+    }
+
+    /// Rejects writes to chains the user did not enable at import time.
+    /// Without this, features like the swap-quote-driven VULT tier check
+    /// would silently inject ETH (and discover ERC20s) into a key-import
+    /// vault that derived TSS shares only for THORChain.
+    static func assertChainAllowed(asset: CoinMeta, vault: Vault) throws {
+        guard vault.libType == .KeyImport else { return }
+        guard !vault.chainPublicKeys.contains(where: { $0.chain == asset.chain }) else { return }
+        throw CoinServiceError.chainNotEnabledForKeyImport(asset.chain)
     }
 
     static func fetchDiscoveredTokens(nativeCoin: CoinMeta, address: String) async throws -> [CoinMeta] {

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -222,6 +222,7 @@ struct SwapCoinPickerView: View {
         return coinSelectionViewModel.chains
             .filter(\.isSwapAvailable)
             .filter { vault.chains.contains($0) }
+            .filter { vault.availableChains.contains($0) }
     }
 
     private func reloadCoins() {

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/CoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/CoinSelectionViewModel.swift
@@ -118,6 +118,7 @@ class CoinSelectionViewModel: ObservableObject {
             return filteredChains
                 .filter(\.isSwapAvailable)
                 .filter { vault.chains.contains($0) }
+                .filter { vault.availableChains.contains($0) }
         case .send:
             return filteredChains
                 .filter { vault.chains.contains($0) }

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -199,8 +199,10 @@ final class Vault: ObservableObject, Codable {
             // KeyImport vaults can only operate on chains whose per-chain TSS
             // keyshares were derived during import. `coins` may temporarily
             // drift if a feature inserts an unauthorized native token, so use
-            // `chainPublicKeys` as the authoritative source.
-            chainPublicKeys.map(\.chain)
+            // `chainPublicKeys` as the authoritative source. Legacy JSON
+            // backups predate `chainPublicKeys` persistence — fall back to the
+            // coin-derived list so a restored vault stays usable.
+            chainPublicKeys.isEmpty ? chains : chainPublicKeys.map(\.chain)
         }
     }
 

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -196,7 +196,11 @@ final class Vault: ObservableObject, Codable {
         case .GG20, .DKLS, nil:
             Chain.allCases
         case .KeyImport:
-            chains
+            // KeyImport vaults can only operate on chains whose per-chain TSS
+            // keyshares were derived during import. `coins` may temporarily
+            // drift if a feature inserts an unauthorized native token, so use
+            // `chainPublicKeys` as the authoritative source.
+            chainPublicKeys.map(\.chain)
         }
     }
 

--- a/VultisigApp/VultisigAppTests/KeyImport/KeyImportChainRestrictionTests.swift
+++ b/VultisigApp/VultisigAppTests/KeyImport/KeyImportChainRestrictionTests.swift
@@ -38,6 +38,26 @@ final class KeyImportChainRestrictionTests: XCTestCase {
         XCTAssertEqual(vault.availableChains.count, Chain.allCases.count)
     }
 
+    func testAvailableChains_keyImportLegacyVault_fallsBackToCoinDerivedChains() {
+        // Legacy JSON backups predate `chainPublicKeys` persistence. A vault
+        // restored from that format has libType=KeyImport but an empty
+        // chainPublicKeys list. We must not soft-brick the restored vault:
+        // fall back to coin-derived chains so it keeps working.
+        let vault = Vault(name: "LegacyKeyImport", libType: .KeyImport)
+        vault.chainPublicKeys = []
+        vault.coins.append(makeNativeCoin(chain: .thorChain))
+
+        XCTAssertEqual(vault.availableChains, [.thorChain])
+    }
+
+    func testAssertChainAllowed_keyImportLegacyVault_doesNotBlockWrites() {
+        let vault = Vault(name: "LegacyKeyImport", libType: .KeyImport)
+        vault.chainPublicKeys = []
+        let ethMeta = makeMeta(chain: .ethereum, ticker: "ETH", isNative: true)
+
+        XCTAssertNoThrow(try CoinService.assertChainAllowed(asset: ethMeta, vault: vault))
+    }
+
     // MARK: - CoinService.assertChainAllowed
 
     func testAssertChainAllowed_keyImportVault_throwsForUnauthorizedChain() {

--- a/VultisigApp/VultisigAppTests/KeyImport/KeyImportChainRestrictionTests.swift
+++ b/VultisigApp/VultisigAppTests/KeyImport/KeyImportChainRestrictionTests.swift
@@ -1,0 +1,154 @@
+//
+//  KeyImportChainRestrictionTests.swift
+//  VultisigAppTests
+//
+//  Covers the rule that key-import vaults can only operate on chains whose
+//  per-chain TSS shares were derived during import:
+//    - `Vault.availableChains` returns `chainPublicKeys` for KeyImport vaults.
+//    - `CoinService.assertChainAllowed` rejects writes to other chains.
+//    - `CoinSelectionViewModel.filterChains(.swap, vault:)` restricts the
+//      swap chain picker accordingly.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class KeyImportChainRestrictionTests: XCTestCase {
+
+    // MARK: - Vault.availableChains
+
+    func testAvailableChains_keyImportVault_returnsChainPublicKeys() {
+        let vault = makeKeyImportVault(chains: [.thorChain])
+        XCTAssertEqual(vault.availableChains, [.thorChain])
+    }
+
+    func testAvailableChains_keyImportVault_ignoresCoinsNotInChainPublicKeys() {
+        // Simulate the bug we're fixing: a stray ETH coin sneaks in even though
+        // the user only enabled THORChain at import. `availableChains` must
+        // still reflect the user's selection, not the drifted coin set.
+        let vault = makeKeyImportVault(chains: [.thorChain])
+        vault.coins.append(makeNativeCoin(chain: .ethereum))
+
+        XCTAssertEqual(vault.availableChains, [.thorChain])
+    }
+
+    func testAvailableChains_dklsVault_returnsAllChains() {
+        let vault = Vault(name: "DKLS", libType: .DKLS)
+        XCTAssertEqual(vault.availableChains.count, Chain.allCases.count)
+    }
+
+    // MARK: - CoinService.assertChainAllowed
+
+    func testAssertChainAllowed_keyImportVault_throwsForUnauthorizedChain() {
+        let vault = makeKeyImportVault(chains: [.thorChain])
+        let ethMeta = makeMeta(chain: .ethereum, ticker: "ETH", isNative: true)
+
+        XCTAssertThrowsError(try CoinService.assertChainAllowed(asset: ethMeta, vault: vault)) { error in
+            guard let coinError = error as? CoinServiceError else {
+                return XCTFail("Expected CoinServiceError, got \(error)")
+            }
+            XCTAssertEqual(coinError, .chainNotEnabledForKeyImport(.ethereum))
+        }
+    }
+
+    func testAssertChainAllowed_keyImportVault_allowsEnabledChain() throws {
+        let vault = makeKeyImportVault(chains: [.thorChain])
+        let runeMeta = makeMeta(chain: .thorChain, ticker: "RUNE", isNative: true)
+
+        XCTAssertNoThrow(try CoinService.assertChainAllowed(asset: runeMeta, vault: vault))
+    }
+
+    func testAssertChainAllowed_dklsVault_allowsAnyChain() throws {
+        let vault = Vault(name: "DKLS", libType: .DKLS)
+        let ethMeta = makeMeta(chain: .ethereum, ticker: "ETH", isNative: true)
+
+        XCTAssertNoThrow(try CoinService.assertChainAllowed(asset: ethMeta, vault: vault))
+    }
+
+    // MARK: - CoinService.addToChain (full path)
+
+    func testAddToChain_keyImportVault_throwsForUnauthorizedChain() {
+        let vault = makeKeyImportVault(chains: [.thorChain])
+        let ethMeta = makeMeta(chain: .ethereum, ticker: "ETH", isNative: true)
+        let initialCoinCount = vault.coins.count
+
+        XCTAssertThrowsError(try CoinService.addToChain(asset: ethMeta, to: vault, priceProviderId: nil)) { error in
+            XCTAssertEqual(error as? CoinServiceError, .chainNotEnabledForKeyImport(.ethereum))
+        }
+        XCTAssertEqual(vault.coins.count, initialCoinCount, "Vault coins must not grow when a chain is rejected")
+    }
+
+    // MARK: - CoinSelectionViewModel.filterChains
+
+    func testFilterChains_swap_keyImportVault_restrictsToChainPublicKeys() {
+        let vault = makeKeyImportVault(chains: [.thorChain])
+        // Stage the bug: an ETH native coin already exists on the vault.
+        // The swap picker must still hide it because ETH was not enabled at import.
+        vault.coins.append(makeNativeCoin(chain: .ethereum))
+        vault.coins.append(makeNativeCoin(chain: .thorChain))
+
+        let viewModel = CoinSelectionViewModel()
+        viewModel.setData(for: vault, checkForSelected: false)
+
+        let chains = viewModel.filterChains(type: .swap, vault: vault)
+
+        XCTAssertTrue(chains.contains(.thorChain), "THORChain (enabled at import) must be selectable")
+        XCTAssertFalse(chains.contains(.ethereum), "Ethereum (not enabled at import) must be filtered out")
+    }
+
+    func testFilterChains_swap_dklsVault_unaffectedByKeyImportFilter() {
+        let vault = Vault(name: "DKLS", libType: .DKLS)
+        vault.coins.append(makeNativeCoin(chain: .ethereum))
+        vault.coins.append(makeNativeCoin(chain: .thorChain))
+
+        let viewModel = CoinSelectionViewModel()
+        viewModel.setData(for: vault, checkForSelected: false)
+
+        let chains = viewModel.filterChains(type: .swap, vault: vault)
+
+        // DKLS vault: the existing `vault.chains` filter still requires native
+        // coins, but the new `availableChains` filter is a no-op (allCases).
+        XCTAssertTrue(chains.contains(.thorChain))
+        XCTAssertTrue(chains.contains(.ethereum))
+    }
+
+    // MARK: - Helpers
+
+    private func makeKeyImportVault(chains: [Chain]) -> Vault {
+        let vault = Vault(name: "KeyImport", libType: .KeyImport)
+        vault.pubKeyECDSA = "ecdsa-root"
+        vault.pubKeyEdDSA = "eddsa-root"
+        vault.hexChainCode = "00"
+        vault.chainPublicKeys = chains.map { chain in
+            ChainPublicKey(
+                chain: chain,
+                publicKeyHex: "pub-\(chain.name)",
+                isEddsa: chain.signingKeyType == .EdDSA
+            )
+        }
+        // Mirror what `setDefaultCoinsOnce` would produce post-import: each
+        // enabled chain gets its native coin.
+        for chain in chains {
+            vault.coins.append(makeNativeCoin(chain: chain))
+        }
+        return vault
+    }
+
+    private func makeMeta(chain: Chain, ticker: String, isNative: Bool) -> CoinMeta {
+        CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "",
+            decimals: 18,
+            priceProviderId: "",
+            contractAddress: "",
+            isNativeToken: isNative
+        )
+    }
+
+    private func makeNativeCoin(chain: Chain) -> Coin {
+        let meta = makeMeta(chain: chain, ticker: chain.ticker, isNative: true)
+        return Coin(asset: meta, address: "addr-\(chain.name)", hexPublicKey: "pub-\(chain.name)")
+    }
+}


### PR DESCRIPTION
Closes #4316

## Summary

A user importing a seed phrase with only THORChain selected would silently get Ethereum (and a swarm of discovered ERC20s) injected into the vault as soon as any swap quote ran. `VultTierService.fetchDiscountTier` (called from `DefaultSwapInteractor.fetchQuote` on every quote) reaches `addEthChainIfNeeded` → `CoinService.addToChain([ethNativeToken])`, which had no awareness of `vault.chainPublicKeys` — so the import-time gate was bypassed and a coin got added whose chain never had a per-chain TSS keyshare derived. The Ethereum native-token add then triggers `addDiscoveredTokens`, fanning out to every non-spam ERC20 the address holds.

This PR closes the gap with two layered defenses and broadens the `availableChains` semantic so the same fix applies to other surfaces.

## What changed

- **`CoinService.addToChain`** — now calls a new `assertChainAllowed(asset:vault:)` first. For `libType == .KeyImport` vaults, it throws `CoinServiceError.chainNotEnabledForKeyImport(chain)` if the chain isn't in `vault.chainPublicKeys`. Callers using `try?` (VultTierService, swap coin selection, etc.) silently no-op; explicit `try` callers surface the error.
- **Swap chain pickers** — both `CoinSelectionViewModel.filterChains(type: .swap, vault:)` and `SwapCoinPickerView.availableChains` add a `.filter { vault.availableChains.contains($0) }` step. Applies to **both** the from- and to-coin chain selectors.
- **`Vault.availableChains`** — for KeyImport vaults, switched from `chains` (derived from `coins`) to `chainPublicKeys.map(\.chain)`. The `chainPublicKeys` array is the authoritative record of what the user enabled at import time and doesn't drift if a stray coin sneaks in. For DKLS/GG20 vaults the behavior is unchanged (`Chain.allCases`).

## Why two layers

The `addToChain` guard is the structural fix — it catches every silent-injection path (VultTier, swap selection, DeFi, function calls, referrals). The swap UI filter is defense-in-depth: even if a coin ever slips into the vault by some other route (e.g. a future SwiftData migration, or this guard regresses), the swap UI still won't surface chains the user didn't enable at import.

## Test plan

`KeyImportChainRestrictionTests` covers (9 tests, all passing):
- [x] `Vault.availableChains` returns `chainPublicKeys` for KeyImport vaults
- [x] `Vault.availableChains` ignores stray coins not in `chainPublicKeys` (drift case)
- [x] `Vault.availableChains` returns all chains for DKLS vaults
- [x] `assertChainAllowed` throws for unauthorized chain on KeyImport vault
- [x] `assertChainAllowed` allows the imported chain
- [x] `assertChainAllowed` is a no-op for DKLS vaults
- [x] `addToChain` throws + leaves `vault.coins` unchanged on rejection
- [x] `filterChains(.swap)` hides Ethereum on a THORChain-only KeyImport vault even when a stray ETH coin is present
- [x] `filterChains(.swap)` is unaffected for DKLS vaults

Manual checks to do before merge:
- [ ] Import a fresh seed with only THORChain selected → confirm `vault.chainPublicKeys` and `vault.coins` only contain THORChain
- [ ] Open swap, type an amount → no ETH injected; quote still works
- [ ] Open `/buy VULT` banner → behaves gracefully (VULT tier just unavailable)
- [ ] DKLS vault unaffected: full chain list still appears in swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented adding/deriving coins for chains that weren’t enabled when a vault was imported via key-import.

* **Improvements**
  * Swap coin selection now only shows chains that are enabled for the current vault, reducing unsupported swap options.

* **Localization**
  * Added a user-facing message (multiple locales) explaining when a selected chain is not enabled for an imported vault.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4333)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->