### PR TITLE
fix(keysign): use total fee for EVM network fee display on Join Keysign screen (#4180)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignGasViewModel.swift
@@ -31,20 +31,14 @@ struct JoinKeysignGasViewModel {
         }
 
         if payload.coin.chainType == .EVM {
-            let gas = payload.chainSpecific.gas
+            let totalFeeWei = payload.chainSpecific.fee
+            let gasAmount = Decimal(totalFeeWei) / pow(10, nativeToken.decimals)
+            let gasInReadable = gasAmount.formatToDecimal(digits: nativeToken.decimals)
 
-            guard let weiPerGWeiDecimal = Decimal(string: EVMHelper.weiPerGWei.description),
-                  let gasDecimal = Decimal(string: gas.description) else {
-                return (.empty, .empty)
-            }
-
-            let gasGwei = gasDecimal / weiPerGWeiDecimal
-            let gasInReadable = gasGwei.formatToDecimal(digits: nativeToken.decimals)
-
-            var feeInReadable = feesInReadable(coin: payload.coin, fee: payload.chainSpecific.fee)
+            var feeInReadable = feesInReadable(coin: payload.coin, fee: totalFeeWei)
             feeInReadable = feeInReadable.nilIfEmpty.map { $0 } ?? ""
 
-            return ("\(gasInReadable) \(payload.coin.chain.feeUnit)", feeInReadable)
+            return ("\(gasInReadable) \(nativeToken.ticker)", feeInReadable)
         }
 
         // For UTXO and Cardano chains, calculate total fee using WalletCore (like first device)


### PR DESCRIPTION
## Problem
On the Join Keysign overview screen for EVM transactions, the "Est. network fee" shows inflated values (e.g. `1.796834992 Gwei` paired with `$215,569,312.67`). The crypto display shows the gas **price** while the fiat conversion uses the **total fee** — two different quantities.

## Root Cause
In `JoinKeysignGasViewModel.getCalculatedNetworkFee`, the EVM branch used:
- `payload.chainSpecific.gas` (`maxFeePerGasWei`, the gas price) for the crypto display, converted to Gwei
- `payload.chainSpecific.fee` (`maxFeePerGas × gasLimit`, total fee in wei) for the fiat conversion

These are different quantities, producing an incoherent pair.

## Fix
Use `payload.chainSpecific.fee` (total fee in wei) for **both** sides:
- Convert wei → native token units via `nativeToken.decimals` for the crypto display
- Pass the same wei value to `feesInReadable` for fiat conversion
- Display with `nativeToken.ticker` (e.g. `ETH`) instead of `Gwei`

This matches how the dApp cosmos fee branch and the non-EVM branch already work.

## Changes
- `JoinKeysignGasViewModel.swift`: 5 insertions, 11 deletions in the EVM branch only

Closes #4180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected EVM network fee (gas) calculation and display in the keysign transaction flow to accurately reflect the total transaction fee using the native token denomination.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4338)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->