### PR TITLE
fix(evm): port SDK coin-finder to fix ERC-20 auto-discovery (#4334)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmCoinFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmCoinFinder.swift
@@ -1,0 +1,150 @@
+//
+//  EvmCoinFinder.swift
+//  VultisigApp
+//
+//  Cross-platform-parity EVM token discovery.
+//
+//  Mirrors `vultisig-sdk/packages/core/chain/coin/find/resolvers/evm/index.ts`
+//  byte-for-byte where it matters:
+//  1. 1inch `/balance/v1.2/{chain}/balances/{address}` for the holdings map.
+//  2. Drop tokens with zero balance + the native-coin sentinel.
+//  3. 1inch `/token/v1.2/{chain}/custom?addresses=...` for metadata.
+//  4. Keep only tokens with `logoURI && providers.contains("CoinGecko")` —
+//     CoinGecko provenance is the legitimacy signal (allowlist), replacing
+//     the old Alchemy-based `isSpamToken` empty-logo blocklist that was
+//     dropping legit small-caps (see vultisig/vultisig-ios#4334).
+//  5. Top up with VULT if the user holds it but 1inch didn't surface it
+//     (Ethereum-only).
+//
+
+import BigInt
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "evm-coin-finder")
+
+enum EvmCoinFinder {
+
+    /// Chains for which 1inch publishes `/balance` + `/token` APIs. EVM chains
+    /// outside this list have no 1inch surface; callers fall back to the
+    /// TokensStore-iteration path.
+    static let oneInchSupportedChains: Set<Chain> = [
+        .ethereum,
+        .base,
+        .arbitrum,
+        .polygon,
+        .polygonV2,
+        .optimism,
+        .bscChain,
+        .avalanche
+    ]
+
+    /// The "native coin" placeholder address that 1inch uses for the chain
+    /// gas token (ETH/BNB/MATIC/etc.). We exclude it from the discovered set
+    /// because the native coin is already represented as the chain's
+    /// `isNativeToken` entry.
+    static let nativeCoinSentinel = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+
+    /// VULT contract on Ethereum. Used for the top-up at the end of discovery
+    /// — `findEvmCoins` in the SDK does the same.
+    private static let vultEthereumContract = "0xb788144df611029c60b859df47e79b7726c4deba"
+
+    static func isSupported(chain: Chain) -> Bool {
+        oneInchSupportedChains.contains(chain)
+    }
+
+    static func find(chain: Chain, address: String) async -> [CoinMeta] {
+        guard isSupported(chain: chain), let chainId = chain.chainID else {
+            return []
+        }
+
+        let balances: [String: String]
+        do {
+            balances = try await OneInchService.shared.fetchBalances(chain: chainId, address: address)
+        } catch {
+            logger.warning("1inch balance fetch failed for \(chain.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+
+        // Step 1: filter to non-zero balances and drop the native-coin sentinel
+        // (it shows up in 1inch's response for the gas token itself).
+        let heldContracts = balances.compactMap { contract, balance -> String? in
+            let normalised = contract.lowercased()
+            guard normalised != nativeCoinSentinel else { return nil }
+            guard let amount = BigInt(balance), amount > 0 else { return nil }
+            return normalised
+        }
+
+        var discovered: [CoinMeta] = []
+
+        if !heldContracts.isEmpty {
+            let tokenInfo: [String: OneInchToken]
+            do {
+                tokenInfo = try await OneInchService.shared.fetchCustomTokens(
+                    chain: chainId,
+                    addresses: heldContracts
+                )
+            } catch {
+                logger.warning("1inch token-info fetch failed for \(chain.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                tokenInfo = [:]
+            }
+
+            for contract in heldContracts {
+                // 1inch's response keys are lowercase; the lookup table here
+                // is the same shape so a direct hit works without
+                // case-folding the key set.
+                guard let token = tokenInfo[contract] else { continue }
+                // Allowlist: legit tokens have a logoURI AND are tagged as
+                // CoinGecko-known. This is the inverse of the old empty-logo
+                // blocklist — keeps small-cap CoinGecko-listed tokens that
+                // Alchemy doesn't curate, drops random airdrop dust that
+                // CoinGecko hasn't listed.
+                guard let logoURI = token.logoURI, !logoURI.isEmpty else { continue }
+                guard token.isCoinGeckoVerified else { continue }
+
+                // Prefer the curated TokensStore entry when we know the
+                // contract: keeps the bundled logo asset + priceProviderId
+                // instead of the 1inch CDN URL. Matches the same lookup we
+                // do for Cardano CNT auto-discovery.
+                if let known = TokensStore.findTokenMeta(chain: chain, contractAddress: contract) {
+                    discovered.append(known)
+                } else {
+                    discovered.append(CoinMeta(
+                        chain: chain,
+                        ticker: token.symbol,
+                        logo: logoURI,
+                        decimals: token.decimals,
+                        priceProviderId: .empty,
+                        contractAddress: contract,
+                        isNativeToken: false
+                    ))
+                }
+            }
+        }
+
+        // Step 2: VULT top-up on Ethereum — if the address holds VULT but
+        // 1inch didn't surface it, check directly via `eth_call`. Mirrors
+        // the SDK's `findEvmCoins` final block.
+        if chain == .ethereum {
+            let hasVult = discovered.contains { $0.contractAddress.lowercased() == vultEthereumContract }
+            if !hasVult, await balanceCheckErc20(chain: chain, contract: vultEthereumContract, holder: address) > 0,
+               let vult = TokensStore.findTokenMeta(chain: .ethereum, contractAddress: vultEthereumContract) {
+                discovered.append(vult)
+            }
+        }
+
+        return discovered
+    }
+
+    /// Direct `eth_call balanceOf(holder)` against the chain's RPC. Returns
+    /// 0 on any error so callers can use it in an `if > 0` filter without a
+    /// dedicated do/catch.
+    private static func balanceCheckErc20(chain: Chain, contract: String, holder: String) async -> BigInt {
+        do {
+            let service = try EvmService.getService(forChain: chain)
+            return try await service.fetchERC20TokenBalance(contractAddress: contract, walletAddress: holder)
+        } catch {
+            return 0
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceConfig.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceConfig.swift
@@ -21,7 +21,15 @@ struct EvmServiceConfig {
         func getTokens(nativeToken: CoinMeta, address: String, rpcService: RpcServiceStruct) async -> [CoinMeta] {
             switch self {
             case .standard:
-                return await EvmServiceStruct.getTokensStandard(
+                // Mirror the SDK + Windows discovery path: 1inch `/balance` +
+                // `/token` for the chains where 1inch publishes data,
+                // TokensStore-iteration fallback for the rest. The old
+                // Alchemy `getTokenBalances` + heuristic spam blocklist was
+                // dropping legit small-caps — see #4334.
+                if EvmCoinFinder.isSupported(chain: nativeToken.chain) {
+                    return await EvmCoinFinder.find(chain: nativeToken.chain, address: address)
+                }
+                return await EvmServiceStruct.getTokensFallback(
                     nativeToken: nativeToken,
                     address: address,
                     rpcService: rpcService

--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceStruct.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceStruct.swift
@@ -347,89 +347,16 @@ struct EvmServiceStruct {
         }
     }
 
-    // MARK: - Static Helper for Standard Token Fetching
+    // MARK: - Static Helper for Token Discovery Fallback
+    //
+    // Used by EVM chains that 1inch doesn't index. `EvmCoinFinder` handles
+    // the 1inch-supported chains (ethereum/base/arbitrum/polygon/optimism/
+    // bsc/avalanche); anything else falls through to this `balanceOf` walk
+    // over the chain's TokensStore entries.
 
-    static func getTokensStandard(nativeToken: CoinMeta, address: String, rpcService: RpcServiceStruct) async -> [CoinMeta] {
-        // Try alchemy_getTokenBalances first (for chains that support it)
-        do {
-            let tokenBalances: [[String: Any]] = try await rpcService.sendRPCRequest(
-                method: "alchemy_getTokenBalances",
-                params: [address]
-            ) { result in
-                guard
-                    let response = result as? [String: Any],
-                    let tokenBalances = response["tokenBalances"] as? [[String: Any]]
-                else {
-                    return []
-                }
-
-                return tokenBalances
-            }
-
-            // Process tokens from Alchemy
-            var tokenMetadata: [CoinMeta] = []
-
-            for tokenBalance in tokenBalances {
-                guard let contractAddress = tokenBalance["contractAddress"] as? String else {
-                    continue
-                }
-
-                // Fetch metadata for each token
-                let meta: CoinMeta? = try await rpcService.sendRPCRequest(
-                    method: "alchemy_getTokenMetadata",
-                    params: [contractAddress]
-                ) { result in
-                    guard
-                        let response = result as? [String: Any],
-                        let symbol = response["symbol"] as? String,
-                        !symbol.isEmpty
-                    else {
-                        return nil
-                    }
-
-                    let decimals: Int
-                    if let decimalsInt = response["decimals"] as? Int {
-                        decimals = decimalsInt
-                    } else if let decimalsInt64 = response["decimals"] as? Int64 {
-                        decimals = Int(decimalsInt64)
-                    } else {
-                        return nil
-                    }
-
-                    let tokenFromTokenStore = TokensStore.TokenSelectionAssets.first(where: { token in
-                        token.chain == nativeToken.chain &&
-                        token.ticker == symbol &&
-                        token.contractAddress.lowercased() == contractAddress.lowercased()
-                    })
-
-                    let logo = tokenFromTokenStore?.logo ?? response["logo"] as? String ?? ""
-
-                    return CoinMeta(
-                        chain: nativeToken.chain,
-                        ticker: symbol,
-                        logo: logo,
-                        decimals: decimals,
-                        priceProviderId: tokenFromTokenStore?.priceProviderId ?? "",
-                        contractAddress: contractAddress,
-                        isNativeToken: false
-                    )
-                }
-
-                if let coinMeta = meta {
-                    tokenMetadata.append(coinMeta)
-                }
-            }
-
-            return tokenMetadata
-
-        } catch {
-            // Fallback: Check known tokens from TokensStore using standard RPC methods
-            return await getTokensFallback(nativeToken: nativeToken, address: address, rpcService: rpcService)
-        }
-    }
-
-    // Fallback method: Check balance of known tokens from TokensStore
-    private static func getTokensFallback(nativeToken: CoinMeta, address: String, rpcService: RpcServiceStruct) async -> [CoinMeta] {
+    /// Check balance of known tokens from TokensStore via `eth_call balanceOf`.
+    /// Returns only the entries with non-zero balance.
+    static func getTokensFallback(nativeToken: CoinMeta, address: String, rpcService: RpcServiceStruct) async -> [CoinMeta] {
         // Get all known tokens for this chain from TokensStore
         let knownTokens = TokensStore.TokenSelectionAssets.filter { token in
             token.chain == nativeToken.chain && !token.isNativeToken && !token.contractAddress.isEmpty

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/OneInch/OneInchAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/OneInch/OneInchAPI.swift
@@ -8,6 +8,17 @@ import Foundation
 enum OneInchAPI: TargetType {
     case swap(chain: String, params: SwapParams)
     case tokens(chain: Int)
+    /// `/balance/v1.2/{chain}/balances/{address}` — returns the address's
+    /// ERC-20 balances as a `Record<contractAddress, decimalString>`. Used by
+    /// the EVM coin-finder to know which tokens the address actually holds
+    /// (1inch is the source of truth here; Alchemy's `getTokenBalances` was
+    /// dropped because it caps at 100 by market cap, so newer tokens fell off
+    /// — see #4334).
+    case balances(chain: Int, address: String)
+    /// `/token/v1.2/{chain}/custom?addresses=...` — bulk metadata lookup keyed
+    /// on contract address. Returns `OneInchToken` per address, including the
+    /// `providers` array we use to filter to CoinGecko-verified tokens only.
+    case customTokens(chain: Int, addresses: [String])
 
     struct SwapParams {
         let source: String
@@ -31,6 +42,10 @@ enum OneInchAPI: TargetType {
             return "/1inch/swap/v6.1/\(chain)/swap"
         case .tokens(let chain):
             return "/1inch/swap/v6.0/\(chain)/tokens"
+        case .balances(let chain, let address):
+            return "/1inch/balance/v1.2/\(chain)/balances/\(address)"
+        case .customTokens(let chain, _):
+            return "/1inch/token/v1.2/\(chain)/custom"
         }
     }
 
@@ -50,7 +65,11 @@ enum OneInchAPI: TargetType {
                 "referrer": params.referrer,
                 "fee": params.fee
             ], .urlEncoding)
-        case .tokens:
+        case .customTokens(_, let addresses):
+            return .requestParameters([
+                "addresses": addresses.joined(separator: ",")
+            ], .urlEncoding)
+        case .tokens, .balances:
             return .requestPlain
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/OneInch/OneInchService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/OneInch/OneInchService.swift
@@ -82,6 +82,31 @@ struct OneInchService {
         return Array(response.data.tokens.values)
     }
 
+    /// Fetch the ERC-20 balance map for an address. Returns a dictionary keyed
+    /// on lowercased contract address; values are decimal strings of base-unit
+    /// balances. Used by the EVM coin-finder to skip the per-token RPC call
+    /// for tokens the address doesn't actually hold.
+    func fetchBalances(chain: Int, address: String) async throws -> [String: String] {
+        let response = try await httpClient.request(
+            OneInchAPI.balances(chain: chain, address: address),
+            responseType: [String: String].self
+        )
+        return response.data
+    }
+
+    /// Bulk metadata lookup for a set of contract addresses. The response is
+    /// keyed on contract address (lowercased). Used by the EVM coin-finder
+    /// after `fetchBalances` to resolve symbol/decimals/logo for the address's
+    /// actual holdings.
+    func fetchCustomTokens(chain: Int, addresses: [String]) async throws -> [String: OneInchToken] {
+        guard !addresses.isEmpty else { return [:] }
+        let response = try await httpClient.request(
+            OneInchAPI.customTokens(chain: chain, addresses: addresses),
+            responseType: [String: OneInchToken].self
+        )
+        return response.data
+    }
+
     func bps(for discount: Int) -> Double {
         let formattedDiscount = Double(discount) / 100.0
         return max(0, Self.referredFee - formattedDiscount)

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/OneInch/OneInchToken.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/OneInch/OneInchToken.swift
@@ -13,9 +13,18 @@ struct OneInchToken: Codable, Hashable {
     let name: String
     let decimals: Int
     let logoURI: String?
+    /// Source-of-truth list from 1inch's `/token/v1.2/{chain}/custom` response.
+    /// The EVM coin-finder requires `providers.contains("CoinGecko")` as a
+    /// legitimacy signal — matches the SDK's `findEvmCoins` filter (see
+    /// vultisig-sdk/packages/core/chain/coin/find/resolvers/evm/index.ts:69).
+    let providers: [String]?
 
     var logoUrl: URL? {
         return logoURI.flatMap { URL(string: $0) }
+    }
+
+    var isCoinGeckoVerified: Bool {
+        providers?.contains("CoinGecko") ?? false
     }
 }
 

--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -6,7 +6,10 @@
 //
 
 import Foundation
+import OSLog
 import SwiftData
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "coin-service")
 
 @MainActor
 struct CoinService {
@@ -285,11 +288,11 @@ struct CoinService {
 
                     _ =  try addToChain(asset: token, to: vault, priceProviderId: token.priceProviderId)
                 } catch {
-                    print("Error adding the token \(token.ticker) service: \(error.localizedDescription)")
+                    logger.warning("Error adding discovered token \(token.ticker, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 }
             }
         } catch {
-            print("Error fetching service: \(error.localizedDescription)")
+            logger.warning("Error fetching discovered tokens for \(nativeToken.chain.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Chains/EvmCoinFinderTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/EvmCoinFinderTests.swift
@@ -1,0 +1,89 @@
+//
+//  EvmCoinFinderTests.swift
+//  VultisigApp
+//
+//  Pins the legitimacy-filter invariants for the 1inch-based EVM token
+//  discovery path that replaced the Alchemy heuristic blocklist (see #4334).
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class EvmCoinFinderTests: XCTestCase {
+
+    // MARK: - Filter primitive
+
+    func testCoinGeckoVerifiedTrueWhenProvidersIncludeCoinGecko() {
+        let token = OneInchToken(
+            address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            symbol: "USDC",
+            name: "USD Coin",
+            decimals: 6,
+            logoURI: "https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png",
+            providers: ["1inch", "CoinGecko", "Uniswap Labs Default"]
+        )
+        XCTAssertTrue(token.isCoinGeckoVerified)
+    }
+
+    func testCoinGeckoVerifiedFalseWhenProvidersOmitCoinGecko() {
+        // Real-world example: a sketchy airdrop token that 1inch knows about
+        // but CoinGecko hasn't curated. Has metadata but no allowlist signal.
+        let token = OneInchToken(
+            address: "0x00000000002514bf58ae82408e1e217f16a1dfa0",
+            symbol: "ANON",
+            name: "Anon",
+            decimals: 18,
+            logoURI: nil,
+            providers: ["1inch"]
+        )
+        XCTAssertFalse(token.isCoinGeckoVerified)
+    }
+
+    func testCoinGeckoVerifiedFalseWhenProvidersNil() {
+        let token = OneInchToken(
+            address: "0xdeadbeef00000000000000000000000000000000",
+            symbol: "X",
+            name: "X",
+            decimals: 18,
+            logoURI: nil,
+            providers: nil
+        )
+        XCTAssertFalse(token.isCoinGeckoVerified)
+    }
+
+    // MARK: - Chain support
+
+    func testEthereumSupportedChainsMatchSdkResolver() {
+        // Mirrors `vultisig-sdk/.../find/resolvers/evm/index.ts:20-28` —
+        // changing this set requires changing the SDK in lockstep.
+        XCTAssertTrue(EvmCoinFinder.isSupported(chain: .ethereum))
+        XCTAssertTrue(EvmCoinFinder.isSupported(chain: .base))
+        XCTAssertTrue(EvmCoinFinder.isSupported(chain: .arbitrum))
+        XCTAssertTrue(EvmCoinFinder.isSupported(chain: .polygon))
+        XCTAssertTrue(EvmCoinFinder.isSupported(chain: .polygonV2))
+        XCTAssertTrue(EvmCoinFinder.isSupported(chain: .optimism))
+        XCTAssertTrue(EvmCoinFinder.isSupported(chain: .bscChain))
+        XCTAssertTrue(EvmCoinFinder.isSupported(chain: .avalanche))
+    }
+
+    func testUnsupportedChainsFallThroughToTokensStore() {
+        // These EVM chains have no 1inch /balance + /token surface, so the
+        // dispatcher in `EvmServiceConfig.TokenProvider.standard` falls back
+        // to `EvmServiceStruct.getTokensFallback` (TokensStore iteration).
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .blast))
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .cronosChain))
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .zksync))
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .mantle))
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .hyperliquid))
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .sei))
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .tron))
+    }
+
+    func testNonEvmChainsNotSupported() {
+        // Sanity: only EVM chains belong on this list — Solana/Cardano/etc.
+        // have their own discovery paths.
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .solana))
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .cardano))
+        XCTAssertFalse(EvmCoinFinder.isSupported(chain: .bitcoin))
+    }
+}


### PR DESCRIPTION
Closes #4334.

## Summary

Replaces the Alchemy-based EVM token discovery with a Swift port of the SDK's [`findEvmCoins`](https://github.com/vultisig/vultisig-sdk/blob/main/packages/core/chain/coin/find/resolvers/evm/index.ts). Same data source as Windows + SDK, so cross-platform parity is restored.

See the [investigation comment](https://github.com/vultisig/vultisig-ios/issues/4334#issuecomment-4423787451) on #4334 for the full reproduction + empirical proxy probes.

## Three stacked bugs the old path had

| # | Bug | Impact |
|---|---|---|
| 1 | `alchemy_getTokenBalances` capped at 100 tokens; iOS never paginated. | Users with >100 token interactions silently lost newly-received tokens. |
| 2 | `isSpamToken` rejected any token with empty `logo`. Alchemy doesn't curate logos for most tokens outside its top set. | Legit small-cap CoinGecko-listed tokens were getting filtered as spam. |
| 3 | iOS used Alchemy; Windows/SDK use 1inch + CoinGecko allowlist. | Cross-platform inconsistency for the same vault. |

## Changes

**New `EvmCoinFinder.swift`** — Swift mirror of the SDK resolver:
- 1inch `/balance/v1.2/{chain}/balances/{address}` for holdings (no 100-token cap; saw 1298 entries on a high-activity address vs Alchemy's 100).
- Non-zero balance + native-coin sentinel filter.
- 1inch `/token/v1.2/{chain}/custom?addresses=...` for bulk metadata.
- Filter: `logoURI && providers.contains(\"CoinGecko\")` — CoinGecko verification is the legitimacy signal, replacing the heuristic empty-logo blocklist.
- VULT top-up on Ethereum (matches SDK).
- Prefers curated `TokensStore` entries when the contract matches — gets the bundled logo asset + working `priceProviderId` instead of the 1inch CDN URL.

**Supported chains** — match the SDK exactly: Ethereum, Base, Arbitrum, Polygon, polygonV2, Optimism, BSC, Avalanche. EVM chains outside the 1inch surface (Blast, Cronos, zkSync, Mantle, Hyperliquid, Sei, Tron) fall through to the existing TokensStore-iteration path via `EvmServiceStruct.getTokensFallback` (now public; was private).

**OneInch surface additions**:
- `OneInchAPI.balances(chain:address:)`.
- `OneInchAPI.customTokens(chain:addresses:)`.
- `OneInchToken.providers: [String]?` + `isCoinGeckoVerified` helper.

**Removed**: `EvmServiceStruct.getTokensStandard` (Alchemy + heuristic spam blocklist). All consumers route through the new finder or the TokensStore fallback.

**Adjacent**: `CoinService.addDiscoveredTokens` replaces two `print(...)` calls with `Logger` (`.claude/rules/logging.md`). `@MainActor` was already correct (struct-level annotation).

## Test plan

- [x] `xcodebuild build` green.
- [x] New `EvmCoinFinderTests` (6 cases) covering the CoinGecko-verified filter primitive + supported-chain set parity with the SDK.
- [x] Empirical validation against the Vultisig proxy:
  - `/balance/v1.2/1/balances/0xd8da...6045` → 1298 entries, 103 non-zero (vs Alchemy's 100-entry cap).
  - `/token/v1.2/1/custom?addresses=...` returns `providers` array including `CoinGecko` for legit tokens (USDC, USDT, PEPE, ARB, GRT, ALPHA) and excluding it for spam (WALLY2.0, ANON, iPhone15).
- [ ] **Mainnet manual smoke**: pick a vault on ETH mainnet that has a small-cap ERC-20 the old path dropped, open the chain detail, confirm it now auto-surfaces.
- [ ] **Regression check**: re-discover a vault already holding USDC/USDT/PEPE/SHIB — confirm same tokens still appear, no dupes.
- [ ] **Non-1inch chain**: open chain detail for Cronos / zkSync / Mantle — confirm TokensStore-fallback path still produces the same set as before.

## Cross-platform

- vultisig-android — likely has the same Alchemy-based approach. Suggest filing a parity ticket and porting the same SDK resolver.
- vultisig-windows — already uses the SDK resolver. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced EVM token discovery using indexed balance and bulk metadata lookups with CoinGecko verification and native-chain support checks.
  * Added Ethereum-specific VULT detection via direct balance probe.
  * Fallback balance-walk for unsupported chains to preserve token discovery.

* **Chores**
  * Replaced ad-hoc prints with structured logging for discovery workflows.

* **Tests**
  * Added tests covering token verification flags and supported-chain behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4339)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->