### PR TITLE
fix(thorchain): restore sRUJI to its on-chain denom

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/THORChainTokenMetadataFactory.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/THORChainTokenMetadataFactory.swift
@@ -33,7 +33,7 @@ enum THORChainTokenMetadataFactory {
             } else if asset == "x/ruji" {
                 symbol = "RUJI"
                 ticker = "ruji"
-            } else if asset == "x/staking-ruji" {
+            } else if asset == TokensStore.sruji.contractAddress {
                 symbol = "sRUJI"
                 ticker = "sruji"
             } else if asset == "x/staking-tcy" {

--- a/VultisigApp/VultisigApp/Core/Extensions/THORBalanceExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/THORBalanceExtension.swift
@@ -21,19 +21,10 @@ extension [CosmosBalance] {
         for balance in self {
             if coin.isNativeToken && balance.denom.lowercased() == denom {
                 return balance.amount
-            } else if !coin.isNativeToken && balance.denom.lowercased() == apiDenom(for: coin) {
+            } else if !coin.isNativeToken && balance.denom.lowercased() == coin.contractAddress.lowercased() {
                 return balance.amount
             }
         }
         return .zero
-    }
-
-    private func apiDenom(for coin: CoinMeta) -> String {
-        switch coin {
-        case TokensStore.sruji:
-            return "x/staking-x/ruji"
-        default:
-            return coin.contractAddress.lowercased()
-        }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -243,13 +243,21 @@ struct CoinService {
         return tokens
     }
 
-    /// Migrate coins and hidden tokens that reference old contract addresses from PR #3837.
-    /// Old addresses (e.g. "x/staking-x/tcy") are updated to new ones (e.g. "x/staking-tcy").
-    /// If both old and new coins exist, the old duplicate is removed.
+    /// Migrate coins and hidden tokens that reference stale contract addresses.
+    /// Each entry is `(stale, correct)`: any coin/hidden-token holding the
+    /// `stale` value is rewritten to `correct`; if both already coexist the
+    /// stale duplicate is deleted.
+    ///   - sTCY: the on-chain denom moved `x/staking-x/tcy → x/staking-tcy`
+    ///           in PR #3837. Migrate forward.
+    ///   - sRUJI: PR #3837 also renamed sRUJI's contract locally, but the
+    ///            chain never moved — the denom is still `x/staking-x/ruji`.
+    ///            Issue #4318 fixes this by reverting `TokensStore.sruji`'s
+    ///            contract; migrate any vault that picked up the stale value
+    ///            back to the on-chain denom.
     static func migrateOldContractAddresses(vault: Vault) {
         let migrations: [(oldAddress: String, newAddress: String)] = [
             ("x/staking-x/tcy", "x/staking-tcy"),
-            ("x/staking-x/ruji", "x/staking-ruji")
+            ("x/staking-ruji", TokensStore.sruji.contractAddress)
         ]
 
         for migration in migrations {

--- a/VultisigApp/VultisigApp/Core/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/TokensStore.swift
@@ -2091,7 +2091,11 @@ class TokensStore {
         logo: "xruji", // Use same logo as RUJI
         decimals: 8,
         priceProviderId: "rujira",
-        contractAddress: "x/staking-ruji",
+        // The on-chain denom for sRUJI is `x/staking-x/ruji` — PR #3837 renamed
+        // this locally to `x/staking-ruji` (mirroring the sTCY rename) but the
+        // chain never actually moved sRUJI, so the renamed contract didn't
+        // match any balance. Restored to the real denom (see issue #4318).
+        contractAddress: "x/staking-x/ruji",
         isNativeToken: false
     )
 

--- a/VultisigApp/VultisigApp/Features/Wallet/Models/HiddenToken.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Models/HiddenToken.swift
@@ -41,11 +41,16 @@ class HiddenToken {
         contractAddress.lowercased()
     }
 
-    /// Known old contract addresses that were migrated in PR #3837
-    /// Maps old address -> new address for THORChain staking tokens
+    /// Maps a stale contract address recorded on existing hidden tokens to the
+    /// current `TokensStore` value, so toggling the same asset off then on
+    /// continues to match even when its contractAddress was rewritten.
+    ///   - sTCY: chain moved `x/staking-x/tcy → x/staking-tcy` (PR #3837).
+    ///   - sRUJI: PR #3837 also renamed sRUJI locally, but issue #4318 reverts
+    ///            that — vaults that stored the renamed value need to match
+    ///            the on-chain denom now used by `TokensStore.sruji`.
     private static let migratedContractAddresses: [String: String] = [
         "x/staking-x/tcy": "x/staking-tcy",
-        "x/staking-x/ruji": "x/staking-ruji"
+        "x/staking-ruji": TokensStore.sruji.contractAddress
     ]
 
     /// Check if this hidden token matches a CoinMeta

--- a/VultisigApp/VultisigAppTests/Services/ThorchainSRujiTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ThorchainSRujiTests.swift
@@ -1,0 +1,104 @@
+//
+//  ThorchainSRujiTests.swift
+//  VultisigAppTests
+//
+//  Regression cover for issue #4318. sRUJI's on-chain denom is
+//  `x/staking-x/ruji` — PR #3837 had renamed it locally to
+//  `x/staking-ruji` (mirroring sTCY, which actually moved on the
+//  chain). Vaults that picked up the stale contract address can no
+//  longer match the API response and end up with duplicate or
+//  zero-balance rows. These tests pin the pieces that, together,
+//  prevent the regression from recurring:
+//    1. `TokensStore.sruji.contractAddress` matches the on-chain denom.
+//    2. `[CosmosBalance].balance(denom:coin:)` returns the balance
+//       emitted under the on-chain denom for `TokensStore.sruji`.
+//    3. `THORChainTokenMetadataFactory.create(asset:)` maps the
+//       on-chain denom to `sRUJI` / `sruji`.
+//    4. `HiddenToken.matches(_:)` accepts a hidden entry that was
+//       persisted with the stale contract address — so toggling sRUJI
+//       off-then-on on an existing vault doesn't reappear as a stale
+//       duplicate.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class ThorchainSRujiTests: XCTestCase {
+
+    private let onChainDenom = "x/staking-x/ruji"
+    private let staleDenom = "x/staking-ruji"
+
+    // MARK: - 1. Source-of-truth pin
+
+    func test_tokensStore_sruji_usesOnChainDenom() {
+        XCTAssertEqual(TokensStore.sruji.contractAddress, onChainDenom)
+        XCTAssertEqual(TokensStore.sruji.ticker, "sRUJI")
+        XCTAssertEqual(TokensStore.sruji.chain, .thorChain)
+    }
+
+    // MARK: - 2. Balance lookup against on-chain denom
+
+    func test_cosmosBalances_balance_findsSRujiByOnChainDenom() {
+        let balances: [CosmosBalance] = [
+            CosmosBalance(denom: "rune", amount: "1000"),
+            CosmosBalance(denom: onChainDenom, amount: "8833889972")
+        ]
+
+        // `balance(denom:coin:)` is called with the chain's native ticker;
+        // the non-native branch keys on the coin's contractAddress.
+        let amount = balances.balance(denom: "rune", coin: TokensStore.sruji)
+
+        XCTAssertEqual(amount, "8833889972")
+    }
+
+    func test_cosmosBalances_balance_returnsZeroForMissingDenom() {
+        let balances: [CosmosBalance] = [
+            CosmosBalance(denom: "rune", amount: "1000")
+        ]
+
+        let amount = balances.balance(denom: "rune", coin: TokensStore.sruji)
+
+        XCTAssertEqual(amount, .zero)
+    }
+
+    func test_cosmosBalances_balance_ignoresStaleDenom() {
+        // The pre-fix code would resolve sRUJI by the renamed denom; assert
+        // the lookup now requires the actual on-chain denom and won't
+        // accidentally pick up a stale entry.
+        let balances: [CosmosBalance] = [
+            CosmosBalance(denom: staleDenom, amount: "123456")
+        ]
+
+        let amount = balances.balance(denom: "rune", coin: TokensStore.sruji)
+
+        XCTAssertEqual(amount, .zero)
+    }
+
+    // MARK: - 3. Denom → metadata mapping
+
+    func test_metadataFactory_mapsOnChainDenomToSRuji() {
+        let meta = THORChainTokenMetadataFactory.create(asset: onChainDenom)
+
+        XCTAssertEqual(meta.symbol, "sRUJI")
+        XCTAssertEqual(meta.ticker, "sruji")
+        XCTAssertEqual(meta.chain, "THOR")
+        XCTAssertEqual(meta.decimals, 8)
+    }
+
+    // MARK: - 4. Hidden-token matching across the rename
+
+    func test_hiddenToken_matches_staleContractAgainstCurrentSRuji() {
+        // A user who had sRUJI hidden before this fix would have it stored
+        // with the renamed contract — toggling sRUJI on must still find that
+        // hidden entry and unhide it, not produce a duplicate row.
+        let stale = HiddenToken(chain: .thorChain, ticker: "sRUJI", contractAddress: staleDenom)
+
+        XCTAssertTrue(stale.matches(TokensStore.sruji))
+    }
+
+    func test_hiddenToken_matches_currentContractAgainstCurrentSRuji() {
+        let current = HiddenToken(chain: .thorChain, ticker: "sRUJI", contractAddress: onChainDenom)
+
+        XCTAssertTrue(current.matches(TokensStore.sruji))
+    }
+}


### PR DESCRIPTION
## Summary
- Reverts `TokensStore.sruji.contractAddress` to `x/staking-x/ruji` (the actual on-chain denom — sRUJI never moved, despite PR #3837 renaming it locally to mirror sTCY).
- Drops the `apiDenom(for:)` redirect in `THORBalanceExtension` (introduced by PR #4154 as a symptom-level patch) — contract address now equals denom again, no special-case needed.
- Flips the RUJI entry in `CoinService.migrateOldContractAddresses` + `HiddenToken.migratedContractAddresses` so vaults that already absorbed the stale rename rewrite back to the on-chain denom on next launch. sTCY entries untouched (that one is a real chain-side move).
- Updates the `THORChainTokenMetadataFactory.create(asset:)` dead branch to key on the real denom, so a freshly-discovered sRUJI balance maps to `sRUJI` / `sruji` instead of falling through to the raw denom string.
- All non-source-of-truth references go through `TokensStore.sruji.contractAddress` — the literal `"x/staking-x/ruji"` exists in exactly one place now.

## Why the previous fix wasn't enough
The `apiDenom` redirect made the user-toggled `TokensStore.sruji` row resolve its balance, but auto-discovery (`ThorchainService.fetchTokens` → `CoinService.addDiscoveredTokens`) builds a fresh `CoinMeta(contractAddress: "x/staking-x/ruji")` on every refresh. `Vault.coin(for:)` keys on contract address, so the discovered CoinMeta didn't match the user's row → `addToChain` inserted a second sRUJI Coin → the balance row visibly clobbers itself on each refresh (issue #4318's "appears briefly, disappears within 1-2 seconds").

## Verification against the chain
- `gateway.liquify.com/chain/thorchain_api/cosmos/bank/v1beta1/denoms_metadata` returns `base: "x/staking-x/ruji", symbol: "sRUJI"`.
- `thor1n7q4ztkmqd7u89g0mxs68eg2uvasa76459kphz` (88.33 sRUJI) reports the balance under the same denom — useful test address.

## Test plan
- [x] `ThorchainSRujiTests` — 7 unit cases (TokensStore pin, balance lookup including a stale-denom negative case, metadata factory mapping, hidden-token matches against both current and stale contracts).
- [ ] Manual: toggle sRUJI off then on from THORChain detail's "Manage tokens" — single row, balance persists across pull-to-refresh.
- [ ] Manual: vault that previously had sRUJI added under the stale contract launches once → vault.coins shows the row rewritten to `x/staking-x/ruji` (no duplicate, balance restored).
- [ ] Manual regression: sTCY still shows balance correctly; sTCY migration unchanged.

Fixes #4318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sRUJI token balance recognition and contract address resolution on THORChain, addressing a previous denom rename issue.
  * Improved non-native token balance matching with direct contract address comparison.

* **Tests**
  * Added comprehensive test coverage for sRUJI token handling across balance queries, metadata resolution, and hidden token matching.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4342)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->