### PR TITLE
fix(tabbar): asset list clipped behind legacy tabbar on iOS < 26 (#4341)

### DIFF
--- a/VultisigApp/VultisigApp/Components/TabBar/VultiTabBar.swift
+++ b/VultisigApp/VultisigApp/Components/TabBar/VultiTabBar.swift
@@ -84,11 +84,25 @@ private extension VultiTabBar {
         items.firstIndex(where: { $0.id == selectedItem.id }) ?? 0
     }
 
+    // 40pt bar bottom-padding + 64pt bar pill + 16pt visual breathing room.
+    var legacyTabBarReservedHeight: CGFloat { 120 }
+
     var legacyTabBar: some View {
         ZStack(alignment: .bottom) {
             TabView(selection: $selectedItem) {
                 ForEach(items) { item in
+                    // The custom bar below is rendered as a ZStack overlay
+                    // (not via TabView's toolbar), so SwiftUI never reserves
+                    // safe-area space for it and scrollable page content runs
+                    // behind it. Publishing the phantom bottom inset
+                    // *per-page* (rather than on the TabView) is the reliable
+                    // placement — `safeAreaInset` doesn't propagate cleanly
+                    // through TabView's layout, especially on macOS's grouped
+                    // style. See vultisig-ios#4341.
                     content(item)
+                        .safeAreaInset(edge: .bottom, spacing: 0) {
+                            Color.clear.frame(height: legacyTabBarReservedHeight)
+                        }
                         .tag(item)
                         #if os(iOS)
                         .tabItem { tabBarItem(for: item) }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
@@ -39,7 +39,8 @@ struct DefiMainScreen: View {
             ScrollViewReader { proxy in
                 VaultMainScreenScrollView(
                     showsIndicators: false,
-                    contentInset: contentInset,
+                    topInset: contentInset,
+                    bottomInset: 0,
                     scrollOffset: $scrollOffset
                 ) {
                     LazyVStack(spacing: 20) {

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -47,7 +47,8 @@ struct VaultMainScreen: View {
                 ScrollViewReader { proxy in
                     VaultMainScreenScrollView(
                         showsIndicators: false,
-                        contentInset: contentInset,
+                        topInset: contentInset,
+                        bottomInset: 0,
                         scrollOffset: $scrollOffset
                     ) {
                         LazyVStack(spacing: 20) {

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainScreenScrollView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainScreenScrollView.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct VaultMainScreenScrollView<Content: View>: View {
     var axes: Axis.Set = .vertical
     var showsIndicators = true
-    var contentInset: CGFloat
+    var topInset: CGFloat
+    var bottomInset: CGFloat
     @Binding var scrollOffset: CGFloat
     @ViewBuilder var content: () -> Content
 
@@ -26,13 +27,15 @@ struct VaultMainScreenScrollView<Content: View>: View {
     init(
         axes: Axis.Set = .vertical,
         showsIndicators: Bool = true,
-        contentInset: CGFloat = 0,
+        topInset: CGFloat = 0,
+        bottomInset: CGFloat = 0,
         scrollOffset: Binding<CGFloat>,
         content: @escaping () -> Content
     ) {
         self.axes = axes
         self.showsIndicators = showsIndicators
-        self.contentInset = contentInset
+        self.topInset = topInset
+        self.bottomInset = bottomInset
         self._scrollOffset = scrollOffset
         self.content = content
     }
@@ -40,7 +43,7 @@ struct VaultMainScreenScrollView<Content: View>: View {
     var body: some View {
         ScrollView(axes, showsIndicators: showsIndicators) {
             contentContainer {
-                insetView
+                insetView(length: topInset)
                 content()
                     .background(
                         GeometryReader { proxy in
@@ -50,7 +53,7 @@ struct VaultMainScreenScrollView<Content: View>: View {
                                 }
                         }
                     )
-                insetView
+                insetView(length: bottomInset)
             }
         }
         .coordinateSpace(name: coordinateSpaceName)
@@ -70,11 +73,13 @@ private extension VaultMainScreenScrollView {
             HStack(spacing: 0) { content() }
         }
     }
-    var insetView: some View {
+
+    @ViewBuilder
+    func insetView(length: CGFloat) -> some View {
         if axes == .vertical {
-            Color.clear.frame(height: contentInset)
+            Color.clear.frame(height: length)
         } else {
-            Color.clear.frame(width: contentInset)
+            Color.clear.frame(width: length)
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #4341. On iOS < 26 and macOS, the last item in the wallet asset list (and the Defi chain list) sits underneath the bottom navigator and cannot be scrolled into view or tapped — most visible on small iPhones (SE 3rd gen, 13 mini) and macOS.

**Root cause.** `VultiTabBar.legacyTabBar` renders the custom bar as a `ZStack` overlay with `.ignoresSafeArea(.all)`, so SwiftUI never reserves bottom safe-area space for descendants. The 78pt clear spacer in `VaultMainScreenScrollView` was the only thing keeping content above the bar, but the bar's top edge sits 104pt above the screen bottom (40pt `.padding(.bottom)` + 64pt pill), so the last 26pt of content rendered behind the bar.

**Fix.**

- `VultiTabBar.swift` — attach `.safeAreaInset(edge: .bottom, spacing: 0) { Color.clear.frame(height: 120) }` to each `content(item)` inside the `ForEach` (per-page, not on the TabView). Per-page placement is the reliable propagation — attaching to the TabView didn't reach pages cleanly, especially on macOS's `tabViewStyle(.grouped)`. 120pt = 40pt bottom padding + 64pt pill + 16pt visual breathing room.
- `VaultMainScreenScrollView.swift` — split `contentInset` into `topInset` + `bottomInset` so the bottom spacer can be opted out where the new safe-area inset already covers the bottom.
- `VaultMainScreen.swift` / `DefiMainScreen.swift` — pass `topInset: contentInset, bottomInset: 0`. The 78pt top spacer still drives the `showBalanceInHeader` scroll threshold (unchanged behavior there).

The bar's overlay rendering is unchanged, so its visual position is preserved on every device. iOS 26+ glass path (`glassTabBar` → native `TabView` with `Tab` items) is untouched — the system already publishes the inset.

## Test plan

- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml ...` — 0 violations on touched files
- [x] `xcodebuild -scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 15 (18.4)'` — `** BUILD SUCCEEDED **`
- [ ] Visual repro on **iPhone SE 3rd gen** simulator (or 13 mini) with a long asset list — confirm the last token is fully visible and tappable
- [ ] Regression check on **iPhone 17 / iOS 26+** — native glass tab bar unaffected
- [ ] Regression check on **macOS** — chains list no longer clipped behind the bar
- [ ] Spot-check the Defi tab on small iPhones — same scroll view, same inset path
- [ ] Spot-check `ChainDetailScreenContainer` — also wraps content in `VultiTabBar`, will now publish the same bottom inset to its pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content spacing and layout issues on legacy iOS devices
  * Improved scroll view inset handling for proper content positioning
  * Enhanced tab bar safe-area configuration to ensure consistent display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4346)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->