### PR TITLE
refactor(defi): migrate Tron + Circle off LegacySendTransaction

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositView.swift
@@ -42,10 +42,8 @@ struct CircleDepositView: View {
     }
 
     func handleVerify() async {
-        let success = await viewModel.onContinue()
-        guard success else { return }
+        guard let immutableTx = await viewModel.makeTransaction() else { return }
         await MainActor.run {
-            let immutableTx = SendTransaction.fromLegacy(viewModel.tx, vault: viewModel.vault)
             router.navigate(to: SendRoute.verify(tx: immutableTx, retrySignal: SendRetrySignal(), vault: viewModel.vault))
         }
     }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositViewModel.swift
@@ -24,7 +24,6 @@ final class CircleDepositViewModel: ObservableObject, Form {
     private(set) lazy var form: [FormField] = [amountField]
     var formCancellable: AnyCancellable?
 
-    let tx = LegacySendTransaction()
     let sendInteractor: SendInteractor = DefaultSendInteractor.live
 
     var availableAmount: Decimal {
@@ -47,12 +46,8 @@ final class CircleDepositViewModel: ObservableObject, Form {
         guard let usdcCoin else { return }
         await BalanceService.shared.updateBalance(for: usdcCoin)
 
-        tx.reset(coin: usdcCoin)
-
         setupForm()
         amountField.validators.append(AmountBalanceValidator(balance: usdcCoin.balanceDecimal))
-
-        tx.isFastVault = await sendInteractor.loadFastVault(vault: vault)
     }
 
     func fetchUsdcCoin() {
@@ -64,21 +59,20 @@ final class CircleDepositViewModel: ObservableObject, Form {
         usdcCoin = coin
     }
 
-    func onContinue() async -> Bool {
+    func makeTransaction() async -> SendTransaction? {
         guard let coin = usdcCoin,
               let toAddress = vault.circleWalletAddress else {
-            return false
+            return nil
         }
 
         isLoading = true
         defer { isLoading = false }
 
-        tx.coin = coin
-        tx.fromAddress = coin.address
-        tx.toAddress = toAddress
-        tx.amount = amountField.value
-
-        tx.isFastVault = await sendInteractor.loadFastVault(vault: vault)
-        return true
+        let isFast = await sendInteractor.loadFastVault(vault: vault)
+        return SendTransaction.empty(coin: coin, vault: vault).with(
+            toAddress: toAddress,
+            amount: amountField.value,
+            isFastVault: isFast
+        )
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
@@ -24,8 +24,6 @@ struct CircleWithdrawView: View {
     @State var fastPasswordPresented = false
     @State var fastVaultPassword: String = ""
 
-    @StateObject private var sendTransaction = LegacySendTransaction()
-
     init(vault: Vault, model: CircleViewModel) {
         self.vault = vault
         self._model = StateObject(wrappedValue: model)
@@ -288,13 +286,11 @@ struct CircleWithdrawView: View {
             }
 
             await MainActor.run {
-                self.sendTransaction.reset(coin: usdcCoin)
-                self.sendTransaction.amount = amount
-                self.sendTransaction.toAddress = recipientCoin.address
-                self.sendTransaction.isFastVault = isFastVault
-                self.sendTransaction.fastVaultPassword = fastVaultPassword
-
-                let immutableTx = SendTransaction.fromLegacy(sendTransaction, vault: vault)
+                let immutableTx = SendTransaction.empty(coin: usdcCoin, vault: vault).with(
+                    toAddress: recipientCoin.address,
+                    amount: amount,
+                    isFastVault: isFastVault
+                )
                 router.navigate(
                     to: SendRoute.pairing(
                         vault: vault,

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeView.swift
@@ -13,7 +13,6 @@ struct TronFreezeView: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.router) var router
 
-    @StateObject private var tx = LegacySendTransaction()
     @State private var sendInteractor: SendInteractor = DefaultSendInteractor.live
     @State var amount: String = ""
     @State var percentage: Double = 0.0
@@ -184,10 +183,7 @@ struct TronFreezeView: View {
 
         await MainActor.run {
             self.trxCoin = coin
-            tx.reset(coin: coin)
         }
-
-        tx.isFastVault = await sendInteractor.loadFastVault(vault: vault)
     }
 
     func updatePercentage(from amountStr: String) async {
@@ -222,24 +218,19 @@ struct TronFreezeView: View {
 
         await MainActor.run { isLoading = true }
 
-        // Configure LegacySendTransaction for the freeze operation
-        // The memo encodes the freeze operation type for TronHelper
+        // The memo encodes the freeze operation type for TronHelper.
         let memo = "FREEZE:\(selectedResourceType.tronResourceString)"
-
-        await MainActor.run {
-            tx.coin = coin
-            tx.fromAddress = coin.address
-            tx.toAddress = coin.address  // Freeze goes to self
-            tx.amount = amountDec.description
-            tx.memo = memo
-            tx.isStakingOperation = true
-        }
-
-        tx.isFastVault = await sendInteractor.loadFastVault(vault: vault)
+        let isFast = await sendInteractor.loadFastVault(vault: vault)
 
         await MainActor.run {
             isLoading = false
-            let immutableTx = SendTransaction.fromLegacy(tx, vault: vault)
+            let immutableTx = SendTransaction.empty(coin: coin, vault: vault).with(
+                toAddress: coin.address,  // Freeze goes to self
+                amount: amountDec.description,
+                memo: memo,
+                isFastVault: isFast,
+                isStakingOperation: true
+            )
             router.navigate(to: SendRoute.verify(tx: immutableTx, retrySignal: SendRetrySignal(), vault: vault))
         }
     }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeView.swift
@@ -20,7 +20,6 @@ struct TronUnfreezeView: View {
     @State var error: Error?
     @State var selectedResourceType: TronResourceType = .bandwidth
 
-    @StateObject private var sendTransaction = LegacySendTransaction()
     @State private var sendInteractor: SendInteractor = DefaultSendInteractor.live
 
     init(vault: Vault, model: TronViewModel) {
@@ -255,24 +254,19 @@ struct TronUnfreezeView: View {
             error = nil
         }
 
-        // Configure LegacySendTransaction for the unfreeze operation
-        // The memo encodes the unfreeze operation type for TronHelper
+        // The memo encodes the unfreeze operation type for TronHelper.
         let memo = "UNFREEZE:\(selectedResourceType.tronResourceString)"
-
-        await MainActor.run {
-            sendTransaction.coin = trxCoin
-            sendTransaction.fromAddress = trxCoin.address
-            sendTransaction.toAddress = trxCoin.address  // Unfreeze returns to self
-            sendTransaction.amount = amountDecimal.description
-            sendTransaction.memo = memo
-            sendTransaction.isStakingOperation = true
-        }
-
-        sendTransaction.isFastVault = await sendInteractor.loadFastVault(vault: vault)
+        let isFast = await sendInteractor.loadFastVault(vault: vault)
 
         await MainActor.run {
             isLoading = false
-            let immutableTx = SendTransaction.fromLegacy(sendTransaction, vault: vault)
+            let immutableTx = SendTransaction.empty(coin: trxCoin, vault: vault).with(
+                toAddress: trxCoin.address,  // Unfreeze returns to self
+                amount: amountDecimal.description,
+                memo: memo,
+                isFastVault: isFast,
+                isStakingOperation: true
+            )
             router.navigate(to: SendRoute.verify(tx: immutableTx, retrySignal: SendRetrySignal(), vault: vault))
         }
     }

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -113,12 +113,16 @@ extension SendTransaction {
     /// already pinned a custom gas, the pinned value sticks. That's the fix
     /// for the bug where Verify refresh dropped custom gas (decision 3).
     func with(
+        toAddress: String? = nil,
+        amount: String? = nil,
         gas: BigInt? = nil,
         fee: BigInt? = nil,
         feeMode: FeeMode? = nil,
         estimatedGasLimit: BigInt? = nil,
         memo: String? = nil,
         sendMaxAmount: Bool? = nil,
+        isFastVault: Bool? = nil,
+        isStakingOperation: Bool? = nil,
         memoFunctionDictionary: [String: String]? = nil,
         wasmContractPayload: WasmExecuteContractPayload? = nil
     ) -> SendTransaction {
@@ -126,9 +130,9 @@ extension SendTransaction {
             coin: coin,
             vault: vault,
             fromAddress: fromAddress,
-            toAddress: toAddress,
+            toAddress: toAddress ?? self.toAddress,
             toAddressLabel: toAddressLabel,
-            amount: amount,
+            amount: amount ?? self.amount,
             amountInFiat: amountInFiat,
             memo: memo ?? self.memo,
             gas: gas ?? self.gas,
@@ -138,8 +142,8 @@ extension SendTransaction {
             customGasLimit: customGasLimit,
             customByteFee: customByteFee,
             sendMaxAmount: sendMaxAmount ?? self.sendMaxAmount,
-            isFastVault: isFastVault,
-            isStakingOperation: isStakingOperation,
+            isFastVault: isFastVault ?? self.isFastVault,
+            isStakingOperation: isStakingOperation ?? self.isStakingOperation,
             transactionType: transactionType,
             memoFunctionDictionary: memoFunctionDictionary ?? self.memoFunctionDictionary,
             wasmContractPayload: wasmContractPayload ?? self.wasmContractPayload,


### PR DESCRIPTION
## Summary

The Tron freeze/unfreeze and Circle deposit/withdraw views built up a mutable `LegacySendTransaction` field-by-field and then converted via `SendTransaction.fromLegacy(...)` at hand-off. This PR constructs the immutable `SendTransaction` directly at the hand-off point.

- Drop `@StateObject private var (sendTransaction|tx) = LegacySendTransaction()` from `TronFreezeView`, `TronUnfreezeView`, `CircleWithdrawView`, and `CircleDepositViewModel`.
- Construct `SendTransaction.empty(coin:vault:).with(...)` at the navigation point.
- Drop the redundant `tx.fastVaultPassword = fastVaultPassword` assignment in `CircleWithdrawView` — `fromLegacy(_:vault:)` does not carry the password (it has no `fastVaultPassword` field), and the password already flows via the route param to `SendPairScreen`.
- Extend `SendTransaction.with(...)` to accept `toAddress`, `amount`, `isFastVault`, and `isStakingOperation` so callers can build a hand-off transaction from `.empty(coin:vault:)` without falling back to the full struct constructor.

The remaining `LegacySendTransaction` reference in `Features/Defi` is on `DefiChainMainScreen`, which is required by the `HomeRoute.vaultAction(sendTx:)` signature — that route still feeds the FunctionCall flow which holds onto the legacy class.

## Test plan

- [ ] Smoke test: TRX freeze (BANDWIDTH + ENERGY) → Verify → Keysign
- [ ] Smoke test: TRX unfreeze (BANDWIDTH + ENERGY) → Verify → Keysign
- [ ] Smoke test: Circle deposit (USDC) → Verify → Keysign
- [ ] Smoke test: Circle withdraw (USDC, regular vault) → Pair → Keysign
- [ ] Smoke test: Circle withdraw (USDC, fast vault with password) → password sheet → Pair → Keysign