### PR TITLE
refactor: rename LegacySendTransaction → FunctionCallForm + migrate FunctionCall verify chain

### DIFF
--- a/VultisigApp/VultisigApp/Components/Cells/UTXOTransactionCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/UTXOTransactionCell.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct UTXOTransactionCell: View {
     let transaction: UTXOTransactionMempool
-    let tx: LegacySendTransaction
+    let tx: FunctionCallForm
     @ObservedObject var utxoTransactionsService: UTXOTransactionsService
 
     let selfText = NSLocalizedString("self", comment: "")

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/GeneralCodeScannerView.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/GeneralCodeScannerView.swift
@@ -15,7 +15,7 @@ struct GeneralCodeScannerView: View {
     @Binding var showSheet: Bool
     @Binding var selectedChain: Chain?
 
-    let sendTX: LegacySendTransaction
+    let sendTX: FunctionCallForm
     var onJoinKeygen: (() -> Void)?
     var onKeysignTransaction: (() -> Void)?
     var onSendCrypto: (() -> Void)?
@@ -63,7 +63,7 @@ struct GeneralCodeScannerView: View {
     GeneralCodeScannerView(
         showSheet: .constant(true),
         selectedChain: .constant(nil),
-        sendTX: LegacySendTransaction(),
+        sendTX: FunctionCallForm(),
         onJoinKeygen: { print("Join Keygen") },
         onKeysignTransaction: { print("Keysign Transaction") },
         onSendCrypto: { print("Send Crypto") }

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacScannerView.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacScannerView.swift
@@ -12,7 +12,7 @@ import AVFoundation
 
 struct MacScannerView: View {
     let type: DeeplinkFlowType
-    let sendTx: LegacySendTransaction
+    let sendTx: FunctionCallForm
     let selectedVault: Vault?
 
     @Query var vaults: [Vault]
@@ -363,7 +363,7 @@ struct MacScannerView: View {
 }
 
 #Preview {
-    MacScannerView(type: .NewVault, sendTx: LegacySendTransaction(), selectedVault: nil)
+    MacScannerView(type: .NewVault, sendTx: FunctionCallForm(), selectedVault: nil)
         .environmentObject(AppViewModel())
         .environmentObject(DeeplinkViewModel())
         .environmentObject(VaultDetailViewModel())

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -151,13 +151,13 @@ final class BlockChainService {
 
     private let TON_WALLET_STATE_UNINITIALIZED = "uninit"
 
-    /// Legacy entry point — converts to the immutable struct and dispatches
-    /// to the unified `fetchSpecific(tx: SendTransaction)`. The conversion
-    /// pulls vault via `tx.txVault` (the legacy `tx.vault ?? AppViewModel.shared.selectedVault`
-    /// fallback). Throws if neither is available. Remove once every caller
-    /// has migrated.
-    func fetchSpecific(tx: LegacySendTransaction) async throws -> BlockChainSpecific {
-        let converted = try SendTransaction.fromLegacy(tx)
+    /// Entry point used by the FunctionCall flow (`FunctionCallForm` is its
+    /// mutable form-state class). Converts to the immutable struct and
+    /// dispatches to the unified `fetchSpecific(tx: SendTransaction)`. The
+    /// conversion resolves vault via `tx.txVault` (`tx.vault ??
+    /// AppViewModel.shared.selectedVault`); throws if neither is available.
+    func fetchSpecific(tx: FunctionCallForm) async throws -> BlockChainSpecific {
+        let converted = try SendTransaction.fromForm(tx)
         return try await fetchSpecific(tx: converted)
     }
 
@@ -174,7 +174,7 @@ final class BlockChainService {
 
     /// Primitive-typed entry point for the new SendInteractor. Wraps the
     /// private full-signature `fetchSpecific(for:action:…)` so the interactor
-    /// doesn't need a `LegacySendTransaction` reference (Phase A4 / Phase B).
+    /// doesn't need a `FunctionCallForm` reference (Phase A4 / Phase B).
     func fetchSendBlockChainSpecific(
         coin: Coin,
         toAddress: String,

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -16,7 +16,7 @@ struct DefiChainMainScreen: View {
     @StateObject var bondViewModel: DefiChainBondViewModel
     @StateObject var lpsViewModel: DefiChainLPsViewModel
     @StateObject var stakeViewModel: DefiChainStakeViewModel
-    @StateObject private var sendTx = LegacySendTransaction()
+    @StateObject private var sendTx = FunctionCallForm()
     @State private var showPositionSelection = false
     @State private var isLoading = false
     @State private var error: HelperError?

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -43,7 +43,7 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     // Domain models
-    var tx: LegacySendTransaction
+    var tx: FunctionCallForm
     private var vault: Vault
     var isThorchainEnabled: Bool {
         vault.coins.contains { $0.chain == .thorChain && $0.isNativeToken }
@@ -61,7 +61,7 @@ class FunctionCallAddThorLP: FunctionCallAddressable, ObservableObject {
     }
 
     // MARK: Init
-    required init(tx: LegacySendTransaction, vault: Vault) {
+    required init(tx: FunctionCallForm, vault: Vault) {
         self.tx = tx
         self.vault = vault
     }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosIBC.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosIBC.swift
@@ -43,7 +43,7 @@ class FunctionCallCosmosIBC: FunctionCallAddressable, ObservableObject {
 
     @Published var selectedChainObject: Chain? = nil
 
-    private var tx: LegacySendTransaction
+    private var tx: FunctionCallForm
     private var vault: Vault
 
     var addressFields: [String: String] {
@@ -60,7 +60,7 @@ class FunctionCallCosmosIBC: FunctionCallAddressable, ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    required init(tx: LegacySendTransaction, vault: Vault) {
+    required init(tx: FunctionCallForm, vault: Vault) {
         self.tx = tx
         self.vault = vault
         self.amount = tx.coin.balanceDecimal

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosMerge.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosMerge.swift
@@ -38,14 +38,14 @@ class FunctionCallCosmosMerge: ObservableObject {
 
     @Published var balanceLabel: String = NSLocalizedString("amountSelectToken", comment: "")
 
-    @ObservedObject var tx: LegacySendTransaction
+    @ObservedObject var tx: FunctionCallForm
 
     private var vault: Vault
 
     private var cancellables = Set<AnyCancellable>()
 
     required init(
-        tx: LegacySendTransaction, vault: Vault
+        tx: FunctionCallForm, vault: Vault
     ) {
         self.tx = tx
         self.vault = vault

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosSwitch.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosSwitch.swift
@@ -37,7 +37,7 @@ class FunctionCallCosmosSwitch: FunctionCallAddressable, ObservableObject {
     @Published var isTheFormValid: Bool = false
     @Published var customErrorMessage: String? = nil
 
-    private var tx: LegacySendTransaction
+    private var tx: FunctionCallForm
     private var vault: Vault
 
     var addressFields: [String: String] {
@@ -57,7 +57,7 @@ class FunctionCallCosmosSwitch: FunctionCallAddressable, ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    required init(tx: LegacySendTransaction, vault: Vault) {
+    required init(tx: FunctionCallForm, vault: Vault) {
         self.tx = tx
         self.vault = vault
         self.amount = tx.coin.balanceDecimal

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosUnmerge.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosUnmerge.swift
@@ -45,14 +45,14 @@ class FunctionCallCosmosUnmerge: ObservableObject {
     @Published var availableBalance: Decimal = 0.0  // Available balance for validation
     @Published var isLoading: Bool = false
 
-    @ObservedObject var tx: LegacySendTransaction
+    @ObservedObject var tx: FunctionCallForm
 
     private var vault: Vault
 
     private var cancellables = Set<AnyCancellable>()
 
     required init(
-        tx: LegacySendTransaction, vault: Vault
+        tx: FunctionCallForm, vault: Vault
     ) {
         self.tx = tx
         self.vault = vault

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCustom.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCustom.swift
@@ -26,7 +26,7 @@ class FunctionCallCustom: FunctionCallAddressable, ObservableObject {
     @Published var amountValid: Bool = false
     @Published var customValid: Bool = false
 
-    @ObservedObject var tx: LegacySendTransaction
+    @ObservedObject var tx: FunctionCallForm
     private var vault: Vault
 
     private var cancellables = Set<AnyCancellable>()
@@ -36,7 +36,7 @@ class FunctionCallCustom: FunctionCallAddressable, ObservableObject {
         set { _ = newValue }
     }
 
-    required init(tx: LegacySendTransaction, vault: Vault) {
+    required init(tx: FunctionCallForm, vault: Vault) {
         self.tx = tx
         self.vault = vault
     }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallForm.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallForm.swift
@@ -7,49 +7,27 @@ import UniformTypeIdentifiers
 import WalletCore
 import BigInt
 
-/// Mutable form-state holder. Originally the form-state class for the entire
-/// Send + FunctionCall + Referral + Defi flow ecosystem.
+/// Mutable form-state holder for the FunctionCall + Referral form layer.
 ///
-/// After the form-VM rewrite (PRs #4347–#4350), the **Send Details flow** has
-/// been migrated to `SendDetailsViewModel` (`@Observable`) + the immutable
-/// `SendTransaction` struct. The post-Continue chain (Verify / Pair / Keysign
-/// / Done) runs on the immutable struct end-to-end via `SendInteractor` +
-/// `SendRetrySignal`.
+/// **Role**: backs the user-facing form for FunctionCall (LP add, stake,
+/// mint, cosmos merge/IBC/switch, secured-asset mint/withdraw, etc.) and
+/// for the Referral flow. SwiftUI binds form fields directly to this class
+/// via `@ObservedObject` / `@StateObject`. The 11 `FunctionCall*` sub-models
+/// share state through it (token selection, amount, memo dict).
 ///
-/// This class **continues** to back the form layer of:
-/// - **FunctionCall** flow (LP add, stake, mint, etc.) — see
-///   `Features/FunctionCall/Models/FunctionCall*` and
-///   `Features/FunctionCall/ViewModels/FunctionCallViewModel.swift`.
-/// - **Referral** flow (`Features/Referral/ViewModels/ReferralViewModel.swift`).
-/// - **TRON freeze / unfreeze** (`Features/Defi/Protocols/Tron/`).
-/// - **Circle deposit / withdraw** (`Features/Defi/Protocols/Circle/`).
+/// **Boundary**: at the navigation point (when the flow constructs a
+/// `KeysignPayload` or navigates to `FunctionCallRoute.verify` /
+/// `SendRoute.verify`), callers convert this mutable form-state into the
+/// immutable `SendTransaction` struct via
+/// `SendTransaction.fromFunctionCallForm(_:vault:)`. Everything downstream
+/// of the boundary runs on the new immutable shape.
 ///
-/// Each of those flows uses this class as a `@StateObject` / `@ObservedObject`
-/// form-state container the same way `SendDetailsViewModel` does now for Send.
-/// Their continued use is **intentional**: the legacy class is a fine
-/// pattern for these self-contained mutable forms, and a full migration to
-/// per-flow `@Observable` form VMs is out of scope for the Send-pilot series.
-///
-/// **At the navigation boundary** (when those flows construct a `KeysignPayload`
-/// or navigate to `SendRoute.verify` / `SendRoute.pairing` / `SendRoute.keysign`),
-/// callers convert this mutable form-state into the immutable `SendTransaction`
-/// struct via `SendTransaction.fromLegacy(_:vault:)`. The conversion is the
-/// architectural seam — everything downstream of the boundary is on the new
-/// immutable shape.
-///
-/// **Future deletion of this class** would require:
-/// - Per-flow form-VM rewrites for FunctionCall (11 form models + verify VM),
-///   Referral (2 view-models), Tron (2 views), Circle (2 view-models). Each
-///   is roughly the size of the SendDetailsScreen migration that #4350 did.
-/// - Refactor of the 19 `TransactionBuilder` subclasses (in
-///   `Features/FunctionTransaction/TransactionBuilder/`) to return a value-type
-///   `SendTransaction` instead of mutating this class.
-///
-/// That work is tracked in the form-VM rewrite plan but **deferred** beyond
-/// the Send-pilot series. The architecture today is internally consistent:
-/// Send uses the new VM/struct; everything else uses this class until further
-/// notice.
-class LegacySendTransaction: ObservableObject, Hashable {
+/// **Why it exists**: the FunctionCall form's complexity (per-coin token
+/// dropdowns that mutate the shared coin, cross-sub-model state sharing)
+/// genuinely benefits from a single mutable reference type. The simpler
+/// Send / TRON / Circle flows construct `SendTransaction` directly at
+/// hand-off and don't need this class.
+class FunctionCallForm: ObservableObject, Hashable {
     @Published var fromAddress: String = ""
     @Published var toAddress: String = .empty
     @Published var toAddressLabel: String? = nil
@@ -184,7 +162,7 @@ class LegacySendTransaction: ObservableObject, Hashable {
         self.reset(coin: coin)
     }
 
-    static func == (lhs: LegacySendTransaction, rhs: LegacySendTransaction) -> Bool {
+    static func == (lhs: FunctionCallForm, rhs: FunctionCallForm) -> Bool {
         lhs.fromAddress == rhs.fromAddress &&
         lhs.toAddress == rhs.toAddress &&
         lhs.amount == rhs.amount &&

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallInstance.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallInstance.swift
@@ -260,7 +260,7 @@ enum FunctionCallInstance {
         }
     }
 
-    static func getDefault(for coin: Coin, tx: LegacySendTransaction, vault: Vault) -> FunctionCallInstance {
+    static func getDefault(for coin: Coin, tx: FunctionCallForm, vault: Vault) -> FunctionCallInstance {
         switch coin.chain {
         case .thorChain:
             if coin.ticker.uppercased() == "TCY" {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallLeave.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallLeave.swift
@@ -29,13 +29,13 @@ class FunctionCallLeave: FunctionCallAddressable, ObservableObject {
     }
 
     private var cancellables = Set<AnyCancellable>()
-    private var tx: LegacySendTransaction?
+    private var tx: FunctionCallForm?
     private var vault: Vault?
 
     required init() {
     }
 
-    init(tx: LegacySendTransaction, vault: Vault) {
+    init(tx: FunctionCallForm, vault: Vault) {
         self.tx = tx
         self.vault = vault
     }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallReBond.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallReBond.swift
@@ -22,7 +22,7 @@ class FunctionCallReBond: FunctionCallAddressable, ObservableObject {
     @Published var isTheFormValid: Bool = false
     @Published var customErrorMessage: String? = nil
 
-    private var tx: LegacySendTransaction
+    private var tx: FunctionCallForm
     private var vault: Vault
 
     var addressFields: [String: String] {
@@ -44,7 +44,7 @@ class FunctionCallReBond: FunctionCallAddressable, ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    required init(tx: LegacySendTransaction, vault: Vault) {
+    required init(tx: FunctionCallForm, vault: Vault) {
         self.tx = tx
         self.vault = vault
     }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
@@ -30,7 +30,7 @@ class FunctionCallSecuredAsset: FunctionCallAddressable, ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     // Domain models - needed for FunctionCallInstance compatibility
-    var tx: LegacySendTransaction
+    var tx: FunctionCallForm
     private var vault: Vault
 
     var addressFields: [String: String] {
@@ -44,7 +44,7 @@ class FunctionCallSecuredAsset: FunctionCallAddressable, ObservableObject {
         }
     }
 
-    required init(tx: LegacySendTransaction, vault: Vault) {
+    required init(tx: FunctionCallForm, vault: Vault) {
         self.tx = tx
         self.vault = vault
     }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallStake.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallStake.swift
@@ -31,12 +31,12 @@ class FunctionCallStake: FunctionCallAddressable, ObservableObject {
     }
 
     private var cancellables = Set<AnyCancellable>()
-    private var tx: LegacySendTransaction?
+    private var tx: FunctionCallForm?
 
     required init() {
     }
 
-    convenience init(tx: LegacySendTransaction) {
+    convenience init(tx: FunctionCallForm) {
         self.init()
         self.tx = tx
         self.amount = tx.coin.balanceDecimal

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
@@ -65,7 +65,7 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
     }
 
     // Domain models
-    var tx: LegacySendTransaction
+    var tx: FunctionCallForm
     private var vault: Vault
 
     var addressFields: [String: String] {
@@ -79,7 +79,7 @@ class FunctionCallWithdrawSecuredAsset: FunctionCallAddressable, ObservableObjec
         }
     }
 
-    required init(tx: LegacySendTransaction, vault: Vault) {
+    required init(tx: FunctionCallForm, vault: Vault) {
         self.tx = tx
         self.vault = vault
 

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallVerifyViewModel.swift
@@ -120,10 +120,8 @@ class FunctionCallVerifyViewModel: ObservableObject {
         }
     }
 
-    func scan(transaction: LegacySendTransaction, vault: Vault) async {
-        // Migration shim: convert legacy → immutable struct at the boundary.
-        let converted = SendTransaction.fromLegacy(transaction, vault: vault)
-        await securityScanViewModel.scan(transaction: converted)
+    func scan(transaction: SendTransaction) async {
+        await securityScanViewModel.scan(transaction: transaction)
     }
 
     func validateSecurityScanner() -> Bool {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
@@ -53,27 +53,20 @@ class FunctionCallViewModel: ObservableObject {
         logger.info("mediator server stopped.")
     }
 
-    func feesInReadable(tx: LegacySendTransaction, vault: Vault) -> String {
+    func feesInReadable(tx: SendTransaction, vault: Vault) -> String {
         guard let nativeCoin = vault.nativeCoin(for: tx.coin) else { return .empty }
         let fee = nativeCoin.decimal(for: tx.gas)
         return RateProvider.shared.fiatBalanceString(value: fee, coin: nativeCoin)
     }
 
-    func memoDictionary(for txDict: ThreadSafeDictionary<String, String>) -> [String: String] {
-        guard !txDict.allKeysInOrder().isEmpty else {
+    func memoDictionary(for txDict: [String: String]) -> [String: String] {
+        guard !txDict.isEmpty else {
             return [String: String]()
         }
 
-        let validKeys = txDict.allKeysInOrder().filter { key in
-            guard let value = txDict.get(key) else { return false }
-            return !value.isEmpty && value != "0" && value != "0.0"
-        }
-
         var dict = [String: String]()
-        validKeys.forEach { key in
-            guard let value = txDict.get(key) else {
-                return
-            }
+        for (key, value) in txDict {
+            guard !value.isEmpty, value != "0", value != "0.0" else { continue }
             dict[key.toFormattedTitleCase()] = value
         }
 

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
@@ -31,7 +31,7 @@ class FunctionCallViewModel: ObservableObject {
 
     let logger = Logger(subsystem: "deposit-input-details", category: "deposity")
 
-    func loadGasInfoForSending(tx: LegacySendTransaction) async {
+    func loadGasInfoForSending(tx: FunctionCallForm) async {
         do {
             let chainSpecific = try await blockchainService.fetchSpecific(tx: tx)
             tx.gas = chainSpecific.gas
@@ -40,11 +40,11 @@ class FunctionCallViewModel: ObservableObject {
         }
     }
 
-    func loadFastVault(tx: LegacySendTransaction, vault: Vault) async {
+    func loadFastVault(tx: FunctionCallForm, vault: Vault) async {
         tx.isFastVault = await fastVaultService.isEligibleForFastSign(vault: vault)
     }
 
-    func validateAddress(tx: LegacySendTransaction, address: String) {
+    func validateAddress(tx: FunctionCallForm, address: String) {
         isValidAddress = AddressService.validateAddress(address: address, chain: tx.coin.chain)
     }
 
@@ -73,13 +73,13 @@ class FunctionCallViewModel: ObservableObject {
         return dict
     }
 
-    func setRujiToken(to tx: LegacySendTransaction, vault: Vault) {
+    func setRujiToken(to tx: FunctionCallForm, vault: Vault) {
         let rujiToken = vault.coins.first(where: { $0.chain == .thorChain && $0.ticker.uppercased() == "RUJI" })
         guard let rujiToken else { return }
         tx.coin = rujiToken
     }
 
-    func setTcyToken(to tx: LegacySendTransaction, vault: Vault) {
+    func setTcyToken(to tx: FunctionCallForm, vault: Vault) {
         let tcyToken = vault.coins.first(where: { $0.chain == .thorChain && $0.ticker.uppercased() == "TCY" })
         guard let tcyToken else { return }
         tx.coin = tcyToken

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct FunctionCallDetailsScreen: View {
     @Environment(\.router) var router
-    @ObservedObject var tx: LegacySendTransaction
+    @ObservedObject var tx: FunctionCallForm
     @StateObject var functionCallViewModel = FunctionCallViewModel()
     @ObservedObject var vault: Vault
 
@@ -18,7 +18,7 @@ struct FunctionCallDetailsScreen: View {
 
     init(
         vault: Vault,
-        tx: LegacySendTransaction,
+        tx: FunctionCallForm,
         defaultCoin: Coin?
     ) {
         self.vault = vault
@@ -235,7 +235,7 @@ struct FunctionCallDetailsScreen: View {
                         tx.toAddress = toAddress
                     }
 
-                    let immutableTx = SendTransaction.fromLegacy(tx, vault: vault)
+                    let immutableTx = SendTransaction.fromForm(tx, vault: vault)
                     router.navigate(to: FunctionCallRoute.verify(tx: immutableTx, vault: vault))
 
                 } else {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
@@ -235,7 +235,8 @@ struct FunctionCallDetailsScreen: View {
                         tx.toAddress = toAddress
                     }
 
-                    router.navigate(to: FunctionCallRoute.verify(tx: tx, vault: vault))
+                    let immutableTx = SendTransaction.fromLegacy(tx, vault: vault)
+                    router.navigate(to: FunctionCallRoute.verify(tx: immutableTx, vault: vault))
 
                 } else {
                     showInvalidFormAlert = true

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallPairScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallPairScreen.swift
@@ -12,7 +12,7 @@ struct FunctionCallPairScreen: View {
     @StateObject var shareSheetViewModel = ShareSheetViewModel()
 
     let vault: Vault
-    let tx: LegacySendTransaction
+    let tx: SendTransaction
     let keysignPayload: KeysignPayload
     let fastVaultPassword: String?
 
@@ -27,9 +27,7 @@ struct FunctionCallPairScreen: View {
                 previewType: .Send,
                 contentPadding: 0
             ) { input in
-                // Convert legacy → new at the route construction boundary.
-                let immutableTx = SendTransaction.fromLegacy(tx, vault: vault)
-                router.navigate(to: FunctionCallRoute.keysign(input: input, tx: immutableTx, retrySignal: SendRetrySignal()))
+                router.navigate(to: FunctionCallRoute.keysign(input: input, tx: tx, retrySignal: SendRetrySignal()))
             }
         }
         .screenTitle("pair".localized)

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRoute.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRoute.swift
@@ -6,7 +6,7 @@
 //
 
 enum FunctionCallRoute: Hashable {
-    case details(defaultCoin: Coin?, sendTx: LegacySendTransaction, vault: Vault)
+    case details(defaultCoin: Coin?, sendTx: FunctionCallForm, vault: Vault)
     case verify(tx: SendTransaction, vault: Vault)
     case pair(vault: Vault, tx: SendTransaction, keysignPayload: KeysignPayload, fastVaultPassword: String?)
     case keysign(input: KeysignInput, tx: SendTransaction, retrySignal: SendRetrySignal)

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRoute.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRoute.swift
@@ -7,8 +7,8 @@
 
 enum FunctionCallRoute: Hashable {
     case details(defaultCoin: Coin?, sendTx: LegacySendTransaction, vault: Vault)
-    case verify(tx: LegacySendTransaction, vault: Vault)
-    case pair(vault: Vault, tx: LegacySendTransaction, keysignPayload: KeysignPayload, fastVaultPassword: String?)
+    case verify(tx: SendTransaction, vault: Vault)
+    case pair(vault: Vault, tx: SendTransaction, keysignPayload: KeysignPayload, fastVaultPassword: String?)
     case keysign(input: KeysignInput, tx: SendTransaction, retrySignal: SendRetrySignal)
     case functionTransaction(vault: Vault, transactionType: FunctionTransactionType)
 }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRouteBuilder.swift
@@ -12,7 +12,7 @@ struct FunctionCallRouteBuilder {
     @ViewBuilder
     func buildDetailsScreen(
         defaultCoin: Coin?,
-        sendTx: LegacySendTransaction,
+        sendTx: FunctionCallForm,
         vault: Vault
     ) -> some View {
         FunctionCallDetailsScreen(

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRouteBuilder.swift
@@ -23,14 +23,14 @@ struct FunctionCallRouteBuilder {
     }
 
     @ViewBuilder
-    func buildVerifyScreen(tx: LegacySendTransaction, vault: Vault) -> some View {
-        FunctionCallVerifyScreen(tx: tx, vault: vault)
+    func buildVerifyScreen(tx: SendTransaction, vault: Vault) -> some View {
+        FunctionCallVerifyScreen(transaction: tx, vault: vault)
     }
 
     @ViewBuilder
     func buildPairScreen(
         vault: Vault,
-        tx: LegacySendTransaction,
+        tx: SendTransaction,
         keysignPayload: KeysignPayload,
         fastVaultPassword: String?
     ) -> some View {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallVerifyScreen.swift
@@ -12,10 +12,11 @@ struct FunctionCallVerifyScreen: View {
     @Environment(\.router) var router
     @StateObject var depositViewModel = FunctionCallViewModel()
     @StateObject var depositVerifyViewModel = FunctionCallVerifyViewModel()
-    @ObservedObject var tx: LegacySendTransaction
+    let transaction: SendTransaction
     let vault: Vault
 
     @State var fastPasswordPresented = false
+    @State var fastVaultPassword: String = ""
     @State var isForReferral = false
     @State private var error: HelperError?
 
@@ -23,7 +24,7 @@ struct FunctionCallVerifyScreen: View {
         Screen {
             VStack(spacing: 0) {
                 if isForReferral {
-                    ReferralSendOverviewView(sendTx: tx)
+                    ReferralSendOverviewView(transaction: transaction)
                 } else {
                     summary
                 }
@@ -38,8 +39,8 @@ struct FunctionCallVerifyScreen: View {
         .onDisappear {
             depositVerifyViewModel.isLoading = false
             // Clear password if navigating back (not forward to keysign)
-            if tx.isFastVault {
-                tx.fastVaultPassword =  .empty
+            if transaction.isFastVault {
+                fastVaultPassword = .empty
             }
         }
         .alert(item: $error) { error in
@@ -52,7 +53,7 @@ struct FunctionCallVerifyScreen: View {
         .onLoad {
             depositVerifyViewModel.onLoad()
             Task {
-                await depositVerifyViewModel.scan(transaction: tx, vault: vault)
+                await depositVerifyViewModel.scan(transaction: transaction)
             }
         }
         .bottomSheet(isPresented: $depositVerifyViewModel.showSecurityScannerSheet) {
@@ -69,17 +70,17 @@ struct FunctionCallVerifyScreen: View {
         SendCryptoVerifySummaryView(
             input: SendCryptoVerifySummary(
                 fromName: vault.name,
-                fromAddress: tx.fromAddress,
-                toAddress: tx.toAddress,
-                network: tx.coin.chain.name,
-                networkImage: tx.coin.chain.logo,
+                fromAddress: transaction.fromAddress,
+                toAddress: transaction.toAddress,
+                network: transaction.coin.chain.name,
+                networkImage: transaction.coin.chain.logo,
                 memo: "",
-                memoFunctionDictionary: depositViewModel.memoDictionary(for: tx.memoFunctionDictionary),
-                feeCrypto: tx.gasInReadable,
-                feeFiat: depositViewModel.feesInReadable(tx: tx, vault: vault),
-                coinImage: tx.coin.logo,
+                memoFunctionDictionary: depositViewModel.memoDictionary(for: transaction.memoFunctionDictionary),
+                feeCrypto: transaction.gasInReadable,
+                feeFiat: depositViewModel.feesInReadable(tx: transaction, vault: vault),
+                coinImage: transaction.coin.logo,
                 amount: getAmount(),
-                coinTicker: tx.coin.ticker
+                coinTicker: transaction.coin.ticker
             ),
             securityScannerState: $depositVerifyViewModel.securityScannerState
         )
@@ -87,7 +88,7 @@ struct FunctionCallVerifyScreen: View {
 
     var pairedSignButton: some View {
         VStack {
-            if tx.isFastVault {
+            if transaction.isFastVault {
                 Text(NSLocalizedString("holdForPairedSign", comment: ""))
                     .foregroundColor(Theme.colors.textTertiary)
                     .font(Theme.fonts.bodySMedium)
@@ -97,12 +98,12 @@ struct FunctionCallVerifyScreen: View {
                         fastPasswordPresented = true
                     } longPressAction: {
                         // Clear password for paired sign (long press)
-                        tx.fastVaultPassword = .empty
+                        fastVaultPassword = .empty
                         onSignPress()
                     }
                     .crossPlatformSheet(isPresented: $fastPasswordPresented) {
                         FastVaultEnterPasswordView(
-                            password: $tx.fastVaultPassword,
+                            password: $fastVaultPassword,
                             vault: vault,
                             onSubmit: { onSignPress() }
                         )
@@ -117,20 +118,15 @@ struct FunctionCallVerifyScreen: View {
 
     private func getAmount() -> String {
         // Check if this is a THORChain LP operation
-        if let pool = tx.memoFunctionDictionary.get("pool"), !pool.isEmpty {
+        if let pool = transaction.memoFunctionDictionary["pool"], !pool.isEmpty {
             // For LP operations, show context about which pool
             let cleanPoolName = ThorchainService.cleanPoolName(pool)
-            if tx.coin.chain == .thorChain {
-                // Adding RUNE to a specific pool
-                return tx.amountDecimal.formatForDisplay() + " " + tx.coin.ticker + " → " + cleanPoolName + " LP"
-            } else {
-                // Adding L1 asset to its pool
-                return tx.amountDecimal.formatForDisplay() + " " + tx.coin.ticker + " → " + cleanPoolName + " LP"
-            }
+            // Adding source asset to its pool (THORChain RUNE or any L1 asset).
+            return transaction.amountDecimal.formatForDisplay() + " " + transaction.coin.ticker + " → " + cleanPoolName + " LP"
         }
 
         // Default display for non-LP operations
-        return tx.amountDecimal.formatForDisplay()
+        return transaction.amountDecimal.formatForDisplay()
     }
 
     private func onSignPress() {
@@ -143,14 +139,13 @@ struct FunctionCallVerifyScreen: View {
     func signAndMoveToNextView() {
         Task {
             do {
-                let converted = SendTransaction.fromLegacy(tx, vault: vault)
-                let result = try await depositVerifyViewModel.createKeysignPayload(tx: converted)
+                let result = try await depositVerifyViewModel.createKeysignPayload(tx: transaction)
                 await MainActor.run {
                     router.navigate(to: FunctionCallRoute.pair(
                         vault: vault,
-                        tx: tx,
+                        tx: transaction,
                         keysignPayload: result,
-                        fastVaultPassword: tx.fastVaultPassword.nilIfEmpty
+                        fastVaultPassword: fastVaultPassword.nilIfEmpty
                     ))
                 }
             } catch {
@@ -164,7 +159,7 @@ struct FunctionCallVerifyScreen: View {
 
 #Preview {
     FunctionCallVerifyScreen(
-        tx: LegacySendTransaction(),
+        transaction: .empty(coin: .example, vault: .example),
         vault: Vault.example
     )
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -13,7 +13,7 @@ struct FunctionTransactionScreen: View {
     let transactionType: FunctionTransactionType
 
     @StateObject private var functionCallViewModel = FunctionCallViewModel()
-    @State private var sendTx: LegacySendTransaction?
+    @State private var sendTx: FunctionCallForm?
     @State var isLoading: Bool = false
 
     @Environment(\.dismiss) var dismiss
@@ -154,7 +154,7 @@ struct FunctionTransactionScreen: View {
 
             sendTx = tx
             isLoading = false
-            let immutableTx = SendTransaction.fromLegacy(tx, vault: vault)
+            let immutableTx = SendTransaction.fromForm(tx, vault: vault)
             router.navigate(to: FunctionCallRoute.verify(tx: immutableTx, vault: vault))
         }
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -154,7 +154,8 @@ struct FunctionTransactionScreen: View {
 
             sendTx = tx
             isLoading = false
-            router.navigate(to: FunctionCallRoute.verify(tx: tx, vault: vault))
+            let immutableTx = SendTransaction.fromLegacy(tx, vault: vault)
+            router.navigate(to: FunctionCallRoute.verify(tx: immutableTx, vault: vault))
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
@@ -23,8 +23,8 @@ extension TransactionBuilder {
     // continue mutating fields downstream (e.g. `tx.gas`, `tx.fastVaultPassword`).
     // Once the FunctionCall flow migrates to a per-flow form VM this method
     // goes away in favor of `buildSendTransaction(vault:)`.
-    func buildTransaction() -> LegacySendTransaction {
-        let sendTx = LegacySendTransaction()
+    func buildTransaction() -> FunctionCallForm {
+        let sendTx = FunctionCallForm()
         sendTx.fromAddress = coin.address
         sendTx.coin = coin
         sendTx.amount = amount

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -23,7 +23,7 @@ struct HomeScreen: View {
 
     @State var showScanner: Bool = false
     @State var showBackupNow = false
-    @StateObject private var sendTx = LegacySendTransaction()
+    @StateObject private var sendTx = FunctionCallForm()
     @State var selectedChain: Chain? = nil
 
     @State var walletShowPortfolioHeader: Bool = false

--- a/VultisigApp/VultisigApp/Features/Home/Navigation/HomeRoute.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Navigation/HomeRoute.swift
@@ -7,5 +7,5 @@
 
 enum HomeRoute: Hashable {
     case home(showingVaultSelector: Bool)
-    case vaultAction(action: VaultAction, sendTx: LegacySendTransaction, vault: Vault)
+    case vaultAction(action: VaultAction, sendTx: FunctionCallForm, vault: Vault)
 }

--- a/VultisigApp/VultisigApp/Features/Home/Navigation/HomeRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Navigation/HomeRouteBuilder.swift
@@ -16,7 +16,7 @@ struct HomeRouteBuilder {
 
     @MainActor
     @ViewBuilder
-    func buildActionRoute(action: VaultAction, sendTx: LegacySendTransaction, vault: Vault) -> some View {
+    func buildActionRoute(action: VaultAction, sendTx: FunctionCallForm, vault: Vault) -> some View {
         switch action {
         case .send(let coin, let hasPreselectedCoin):
             SendRouteBuilder().buildDetailsScreen(

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/Navigation/KeygenRoute.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/Navigation/KeygenRoute.swift
@@ -27,9 +27,9 @@ enum KeygenRoute: Hashable {
         singleKeygenType: SingleKeygenType?
     )
     case joinKeysign(vault: Vault)
-    case macScanner(type: DeeplinkFlowType, sendTx: LegacySendTransaction, selectedVault: Vault?)
+    case macScanner(type: DeeplinkFlowType, sendTx: FunctionCallForm, selectedVault: Vault?)
     case macAddressScanner(selectedVault: Vault?, resultId: UUID)
-    case generalQRImport(type: DeeplinkFlowType, selectedVault: Vault?, sendTx: LegacySendTransaction?)
+    case generalQRImport(type: DeeplinkFlowType, selectedVault: Vault?, sendTx: FunctionCallForm?)
     case reviewYourVaults(
         vault: Vault,
         tssType: TssType,

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/Navigation/KeygenRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/Navigation/KeygenRouteBuilder.swift
@@ -85,7 +85,7 @@ struct KeygenRouteBuilder {
     @ViewBuilder
     func buildMacScannerScreen(
         type: DeeplinkFlowType,
-        sendTx: LegacySendTransaction,
+        sendTx: FunctionCallForm,
         selectedVault: Vault?
     ) -> some View {
         #if os(macOS)
@@ -118,7 +118,7 @@ struct KeygenRouteBuilder {
     func buildGeneralQRImportScreen(
         type: DeeplinkFlowType,
         selectedVault: Vault?,
-        sendTx: LegacySendTransaction?
+        sendTx: FunctionCallForm?
     ) -> some View {
         GeneralQRImportMacView(
             type: type,

--- a/VultisigApp/VultisigApp/Features/Onboarding/Views/CreateVaultView.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/Views/CreateVaultView.swift
@@ -47,7 +47,7 @@ struct CreateVaultView: View {
             guard shouldNavigate else { return }
             router.navigate(to: KeygenRoute.macScanner(
                 type: .NewVault,
-                sendTx: LegacySendTransaction(),
+                sendTx: FunctionCallForm(),
                 selectedVault: selectedVault
             ))
             navigateToScanQR = false
@@ -211,7 +211,7 @@ extension CreateVaultView {
                 GeneralCodeScannerView(
                     showSheet: $showSheet,
                     selectedChain: .constant(nil),
-                    sendTX: LegacySendTransaction(),
+                    sendTX: FunctionCallForm(),
                     onJoinKeygen: {
                         shouldJoinKeygen = true
                     }

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/EditReferralViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/EditReferralViewModel.swift
@@ -79,7 +79,7 @@ class EditReferralViewModel: ObservableObject {
         }
     }
 
-    func verifyReferralEntries(tx: LegacySendTransaction) async -> Bool {
+    func verifyReferralEntries(tx: FunctionCallForm) async -> Bool {
         guard enoughGas(tx: tx) else {
             await showError(message: "insufficientBalance")
             return false
@@ -98,7 +98,7 @@ private extension EditReferralViewModel {
         }
     }
 
-    func enoughGas(tx: LegacySendTransaction) -> Bool {
+    func enoughGas(tx: FunctionCallForm) -> Bool {
         let decimals = tx.coin.decimals
         let gas = Decimal(tx.gas) / pow(10, decimals)
         let amount = totalFeeAmount + gas
@@ -108,7 +108,7 @@ private extension EditReferralViewModel {
     }
 
     @MainActor
-    func createTransaction(tx: LegacySendTransaction, preferredAsset: THORChainAsset?) {
+    func createTransaction(tx: FunctionCallForm, preferredAsset: THORChainAsset?) {
         var preferredAssetCoin: Coin?
         if let preferredAsset {
             preferredAssetCoin = try? CoinService.addIfNeeded(asset: preferredAsset.asset, to: vault, priceProviderId: preferredAsset.asset.priceProviderId)

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/ReferralViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/ReferralViewModel.swift
@@ -137,7 +137,7 @@ class ReferralViewModel: ObservableObject {
         expireInCount -= 1
     }
 
-    func verifyReferralEntries(tx: LegacySendTransaction) async -> Bool {
+    func verifyReferralEntries(tx: FunctionCallForm) async -> Bool {
         await verifyReferralCode()
 
         guard isReferralCodeVerified else {
@@ -180,7 +180,7 @@ class ReferralViewModel: ObservableObject {
         return fiatAmount.formatToFiat(includeCurrencySymbol: true)
     }
 
-    func getNativeCoin(tx: LegacySendTransaction) {
+    func getNativeCoin(tx: FunctionCallForm) {
         nativeCoin = tx.vault?.coins.first(where: { $0.chain == .thorChain && $0.isNativeToken })
 
         if let nativeCoin {
@@ -188,7 +188,7 @@ class ReferralViewModel: ObservableObject {
         }
     }
 
-    func loadGasInfoForSending(tx: LegacySendTransaction) async {
+    func loadGasInfoForSending(tx: FunctionCallForm) async {
         do {
             let chainSpecific = try await blockchainService.fetchSpecific(tx: tx)
             tx.gas = chainSpecific.gas
@@ -213,7 +213,7 @@ class ReferralViewModel: ObservableObject {
         isFeesLoading = false
     }
 
-    private func setupTransaction(tx: LegacySendTransaction) {
+    private func setupTransaction(tx: FunctionCallForm) {
         tx.amount = totalFee.formatDecimalToLocale()
 
         guard let currentVault else {
@@ -318,7 +318,7 @@ class ReferralViewModel: ObservableObject {
         return text.rangeOfCharacter(from: .whitespacesAndNewlines) != nil
     }
 
-    private func enoughGas(tx: LegacySendTransaction) -> Bool {
+    private func enoughGas(tx: FunctionCallForm) -> Bool {
         let decimals = tx.coin.decimals
         let gas = Decimal(tx.gas) / pow(10, decimals)
         let amount = totalFee + gas
@@ -380,7 +380,7 @@ class ReferralViewModel: ObservableObject {
         return "\(collectedAssetAmount.formatForDisplay()) \(assetTicker)"
     }
 
-    func setup(tx: LegacySendTransaction, defaultVault: Vault?) {
+    func setup(tx: FunctionCallForm, defaultVault: Vault?) {
         self.currentVault = currentVault ?? defaultVault
         let newValueFiat = tx.amountDecimal * Decimal(tx.coin.price)
         let truncatedValueFiat = newValueFiat.truncated(toPlaces: 2) // Assuming 2 decimal places for fiat

--- a/VultisigApp/VultisigApp/Features/Referral/Views/CreateReferralDetailsView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/CreateReferralDetailsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CreateReferralDetailsView: View {
-    @ObservedObject var sendTx: LegacySendTransaction
+    @ObservedObject var sendTx: FunctionCallForm
     @ObservedObject var referralViewModel: ReferralViewModel
     var onNext: () -> Void
 
@@ -218,7 +218,7 @@ struct CreateReferralDetailsView: View {
 
 #Preview {
     CreateReferralDetailsView(
-        sendTx: LegacySendTransaction(),
+        sendTx: FunctionCallForm(),
         referralViewModel: ReferralViewModel(),
         onNext: {}
     )

--- a/VultisigApp/VultisigApp/Features/Referral/Views/EditReferralDetailsView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/EditReferralDetailsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct EditReferralDetailsView: View {
     @StateObject var viewModel: EditReferralViewModel
-    @ObservedObject var sendTx: LegacySendTransaction
+    @ObservedObject var sendTx: FunctionCallForm
     var onNext: () -> Void
 
     @EnvironmentObject var homeViewModel: HomeViewModel
@@ -18,7 +18,7 @@ struct EditReferralDetailsView: View {
 
     init(
         viewModel: EditReferralViewModel,
-        sendTx: LegacySendTransaction,
+        sendTx: FunctionCallForm,
         onNext: @escaping () -> Void
     ) {
         self._viewModel = StateObject(wrappedValue: viewModel)
@@ -224,7 +224,7 @@ struct EditReferralDetailsView: View {
             thornameDetails: .example,
             currentBlockHeight: 0
         ),
-        sendTx: LegacySendTransaction(),
+        sendTx: FunctionCallForm(),
         onNext: {}
     )
 }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferralSendOverviewView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferralSendOverviewView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ReferralSendOverviewView: View {
-    @ObservedObject var sendTx: LegacySendTransaction
+    let transaction: SendTransaction
 
     var body: some View {
         VStack(spacing: 16) {
@@ -44,7 +44,7 @@ struct ReferralSendOverviewView: View {
                 .frame(width: 24, height: 24)
                 .cornerRadius(32)
 
-            Text("\(sendTx.amount)")
+            Text("\(transaction.amount)")
                 .foregroundColor(Theme.colors.textPrimary)
 
             Text("RUNE")
@@ -65,7 +65,7 @@ struct ReferralSendOverviewView: View {
 
             getCell(
                 title: "from",
-                description: sendTx.vault?.name ?? "",
+                description: transaction.vault.name,
                 bracketValue: getVaultAddress()
             )
 
@@ -81,14 +81,14 @@ struct ReferralSendOverviewView: View {
 
             getCell(
                 title: "gas",
-                description: "\(sendTx.gasInReadable)"
+                description: "\(transaction.gasInReadable)"
             )
 
             separator
 
             getCell(
                 title: "memo",
-                description: sendTx.memo,
+                description: transaction.memo,
                 isForMemo: true
             )
         }
@@ -126,7 +126,7 @@ struct ReferralSendOverviewView: View {
     }
 
     private func getVaultAddress() -> String? {
-        guard let nativeCoin = sendTx.vault?.coins.first(where: { $0.chain == .thorChain && $0.isNativeToken }) else {
+        guard let nativeCoin = transaction.vault.coins.first(where: { $0.chain == .thorChain && $0.isNativeToken }) else {
             return nil
         }
 
@@ -136,7 +136,7 @@ struct ReferralSendOverviewView: View {
 
 #Preview {
     ReferralSendOverviewView(
-        sendTx: LegacySendTransaction(),
+        transaction: .empty(coin: .example, vault: .example)
     )
     .environmentObject(HomeViewModel())
 }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferralTransactionDetailsView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferralTransactionDetailsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ReferralTransactionDetailsView: View {
     let hash: String
-    let sendTx: LegacySendTransaction
+    let sendTx: FunctionCallForm
     @ObservedObject var referralViewModel: ReferralViewModel
 
     @Environment(\.openURL) var openURL
@@ -178,6 +178,6 @@ struct ReferralTransactionDetailsView: View {
 }
 
 #Preview {
-    ReferralTransactionDetailsView(hash: "", sendTx: LegacySendTransaction(), referralViewModel: ReferralViewModel())
+    ReferralTransactionDetailsView(hash: "", sendTx: FunctionCallForm(), referralViewModel: ReferralViewModel())
         .environmentObject(AppViewModel())
 }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferralTransactionFlowScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferralTransactionFlowScreen.swift
@@ -80,7 +80,8 @@ struct ReferralTransactionFlowScreen: View {
 
     func moveToNext() {
         guard let vault else { return }
-        router.navigate(to: FunctionCallRoute.verify(tx: sendTx, vault: vault))
+        let immutableTx = SendTransaction.fromLegacy(sendTx, vault: vault)
+        router.navigate(to: FunctionCallRoute.verify(tx: immutableTx, vault: vault))
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferralTransactionFlowScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferralTransactionFlowScreen.swift
@@ -11,7 +11,7 @@ struct ReferralTransactionFlowScreen: View {
     @StateObject var referralViewModel: ReferralViewModel
     @ObservedObject var vaultSelectionViewModel: VaultSelectedViewModel
 
-    @StateObject private var sendTx = LegacySendTransaction()
+    @StateObject private var sendTx = FunctionCallForm()
     @StateObject var shareSheetViewModel = ShareSheetViewModel()
     @StateObject var functionCallViewModel = FunctionCallViewModel()
     @StateObject var functionCallVerifyViewModel = FunctionCallVerifyViewModel()
@@ -80,7 +80,7 @@ struct ReferralTransactionFlowScreen: View {
 
     func moveToNext() {
         guard let vault else { return }
-        let immutableTx = SendTransaction.fromLegacy(sendTx, vault: vault)
+        let immutableTx = SendTransaction.fromForm(sendTx, vault: vault)
         router.navigate(to: FunctionCallRoute.verify(tx: immutableTx, vault: vault))
     }
 }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferralTransactionOverviewView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferralTransactionOverviewView.swift
@@ -10,7 +10,7 @@ import RiveRuntime
 
 struct ReferralTransactionOverviewView: View {
     let hash: String
-    let sendTx: LegacySendTransaction
+    let sendTx: FunctionCallForm
     let isEdit: Bool
     @ObservedObject var referralViewModel: ReferralViewModel
 
@@ -50,7 +50,7 @@ struct ReferralTransactionOverviewView: View {
 #Preview {
     ReferralTransactionOverviewView(
         hash: "",
-        sendTx: LegacySendTransaction(),
+        sendTx: FunctionCallForm(),
         isEdit: false,
         referralViewModel: ReferralViewModel()
     )

--- a/VultisigApp/VultisigApp/Features/Reshare/Views/ReshareView+macOS.swift
+++ b/VultisigApp/VultisigApp/Features/Reshare/Views/ReshareView+macOS.swift
@@ -31,7 +31,7 @@ extension ReshareView {
         PrimaryButton(title: "joinReshare", type: .secondary) {
             router.navigate(to: KeygenRoute.macScanner(
                 type: .NewVault,
-                sendTx: LegacySendTransaction(),
+                sendTx: FunctionCallForm(),
                 selectedVault: nil
             ))
         }

--- a/VultisigApp/VultisigApp/Features/Reshare/Views/ReshareView.swift
+++ b/VultisigApp/VultisigApp/Features/Reshare/Views/ReshareView.swift
@@ -59,7 +59,7 @@ struct ReshareView: View {
             GeneralCodeScannerView(
                 showSheet: $showJoinReshare,
                 selectedChain: .constant(nil),
-                sendTX: LegacySendTransaction(),
+                sendTX: FunctionCallForm(),
                 onJoinKeygen: {
                     shouldJoinKeygen = true
                 }

--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -4,7 +4,7 @@
 //
 //  Pure helpers for the send flow. Every function takes only the primitives
 //  it actually reads — no shared draft/store type. The form ViewModel
-//  (mutable) and `LegacySendTransaction` (immutable hand-off, lands in Phase B)
+//  (mutable) and `FunctionCallForm` (immutable hand-off, lands in Phase B)
 //  feed their own fields in via convenience computed properties.
 //
 //  Mirrors the shape of `SwapCryptoLogic`.

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendRetrySignal.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendRetrySignal.swift
@@ -3,7 +3,7 @@
 //  VultisigApp
 //
 //  Single-purpose flow signal between Keysign (writer) and Verify (reader).
-//  Replaces the legacy `LegacySendTransaction.pendingRetryReason` side-channel
+//  Replaces the legacy `FunctionCallForm.pendingRetryReason` side-channel
 //  — that field stops surviving the form-state rewrite (Phase B step 5), so
 //  the retry intent gets its own tiny @Observable holder that threads through
 //  the `verify → pair → keysign` route value sequence.

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -7,7 +7,7 @@
 //  passes; consumers (Verify / Pair / Keysign / Done) read it but never
 //  mutate it. Form-time mutation lives on the details VM.
 //
-//  Replaces the legacy `class LegacySendTransaction: ObservableObject` —
+//  Replaces the legacy `class FunctionCallForm: ObservableObject` —
 //  see [[projects/vultisig/transaction-model-refactor/send-pilot-plan]] for
 //  the three kickoff decisions baked in:
 //    1. `memoFunctionDictionary` is a plain `[String: String]` (the immutable
@@ -152,39 +152,36 @@ extension SendTransaction {
     }
 }
 
-// MARK: - Legacy converter (migration-period only)
+// MARK: - FunctionCallForm boundary converter
 
 extension SendTransaction {
-    enum LegacyConversionError: Error, LocalizedError {
+    enum FormConversionError: Error, LocalizedError {
         case missingVault
 
         var errorDescription: String? {
             switch self {
             case .missingVault:
-                return "Cannot convert LegacySendTransaction: vault unavailable. Either set tx.vault before converting, or pass a vault explicitly via fromLegacy(_:vault:)."
+                return "Cannot convert FunctionCallForm: vault unavailable. Either set tx.vault before converting, or pass a vault explicitly via fromForm(_:vault:)."
             }
         }
     }
 
-    /// Converts a `LegacySendTransaction` (the old `@Published` ObservableObject)
-    /// into the new immutable struct. Resolves the vault via the legacy
-    /// `txVault` fallback (`tx.vault ?? AppViewModel.shared.selectedVault`).
-    /// Throws if neither is available — non-optional vault is decision 2 of
-    /// the Send pilot.
-    ///
-    /// **Migration-period only.** Delete this extension along with
-    /// `LegacySendTransaction` once every call site has migrated.
-    static func fromLegacy(_ tx: LegacySendTransaction) throws -> SendTransaction {
+    /// Converts a `FunctionCallForm` (the FunctionCall/Referral mutable
+    /// form-state class) into the immutable `SendTransaction` struct at the
+    /// navigation boundary. Resolves the vault via `tx.vault ??
+    /// AppViewModel.shared.selectedVault`. Throws if neither is available —
+    /// non-optional vault is decision 2 of the Send pilot.
+    static func fromForm(_ tx: FunctionCallForm) throws -> SendTransaction {
         guard let vault = tx.txVault else {
-            throw LegacyConversionError.missingVault
+            throw FormConversionError.missingVault
         }
-        return fromLegacy(tx, vault: vault)
+        return fromForm(tx, vault: vault)
     }
 
-    /// Same as `fromLegacy(_:)` but with the vault supplied explicitly — use
+    /// Same as `fromForm(_:)` but with the vault supplied explicitly — use
     /// this from contexts where the vault is already in hand (e.g., screens
     /// that received it as a route param).
-    static func fromLegacy(_ tx: LegacySendTransaction, vault: Vault) -> SendTransaction {
+    static func fromForm(_ tx: FunctionCallForm, vault: Vault) -> SendTransaction {
         SendTransaction(
             coin: tx.coin,
             vault: vault,

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -3,7 +3,7 @@
 //  VultisigApp
 //
 //  Form-state-on-VM rewrite of the Send Details screen. Owns every form
-//  field directly (replacing the legacy `LegacySendTransaction`'s
+//  field directly (replacing the legacy `FunctionCallForm`'s
 //  `@Published` fields) and produces an immutable `SendTransaction` only
 //  on Continue via `makeTransaction()`. Async work goes through
 //  `SendInteractor` so tests can inject a mock.
@@ -69,7 +69,7 @@ final class SendDetailsViewModel {
     var customGasLimit: BigInt? = nil
     var customByteFee: BigInt? = nil
 
-    // MARK: - VM state (replaces `LegacySendTransaction.isCalculatingFee` etc.)
+    // MARK: - VM state (replaces `FunctionCallForm.isCalculatingFee` etc.)
     var isLoading: Bool = false
     var isValidatingForm: Bool = false
     var isCalculatingFee: Bool = false

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRoute.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRoute.swift
@@ -6,7 +6,7 @@
 //
 
 enum SendRoute: Hashable {
-    case details(coin: Coin?, hasPreselectedCoin: Bool, tx: LegacySendTransaction, vault: Vault)
+    case details(coin: Coin?, hasPreselectedCoin: Bool, tx: FunctionCallForm, vault: Vault)
     case verify(tx: SendTransaction, retrySignal: SendRetrySignal, vault: Vault)
     case pairing(vault: Vault, tx: SendTransaction, retrySignal: SendRetrySignal, keysignPayload: KeysignPayload, fastVaultPassword: String?)
     case keysign(input: KeysignInput, tx: SendTransaction, retrySignal: SendRetrySignal)

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouteBuilder.swift
@@ -14,7 +14,7 @@ struct SendRouteBuilder {
     func buildDetailsScreen(
         coin: Coin?,
         hasPreselectedCoin: Bool,
-        tx: LegacySendTransaction,
+        tx: FunctionCallForm,
         vault: Vault
     ) -> some View {
         SendDetailsScreen(

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -23,7 +23,7 @@ struct ChainDetailScreen: View {
     @State var showReceiveSheet: Bool = false
     @State var scrollProxy: ScrollViewProxy?
 
-    @StateObject private var sendTx = LegacySendTransaction()
+    @StateObject private var sendTx = FunctionCallForm()
 
     private let scrollReferenceId = "chainDetailScreenBottomContentId"
 

--- a/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CoinDetailScreen: View {
     let coin: Coin
     let vault: Vault
-    @ObservedObject var sendTx: LegacySendTransaction
+    @ObservedObject var sendTx: FunctionCallForm
     @Binding var isPresented: Bool
     var onCoinAction: (VaultAction) -> Void
 
@@ -25,7 +25,7 @@ struct CoinDetailScreen: View {
     init(
         coin: Coin,
         vault: Vault,
-        sendTx: LegacySendTransaction,
+        sendTx: FunctionCallForm,
         isPresented: Binding<Bool>,
         onCoinAction: @escaping (VaultAction) -> Void
     ) {


### PR DESCRIPTION
## Summary

Two changes in one PR:

### 1. FunctionCall verify chain on `SendTransaction`

The post-Continue handoff chain now carries the immutable struct end-to-end. The form layer (`FunctionCallDetailsScreen` + the 11 `FunctionCall*` sub-models) keeps the mutable form-state class for SwiftUI binding and converts at the navigation boundary.

- `FunctionCallRoute.{verify,pair}` cases carry `SendTransaction`.
- `FunctionCallVerifyScreen` rewritten with `let transaction: SendTransaction` and `@State private var fastVaultPassword: String` for the password sheet binding (the legacy `tx.fastVaultPassword` mutation path is gone; the password already flows via the route param to keysign).
- `FunctionCallPairScreen.tx` is `SendTransaction` — no `fromLegacy` shim needed at the route construction boundary anymore.
- `FunctionCallVerifyViewModel.{createKeysignPayload,scan}` take `SendTransaction`. `scan` no longer needs the legacy converter.
- `FunctionCallViewModel.{feesInReadable,memoDictionary}` take `SendTransaction` / `[String: String]` directly.
- `ReferralSendOverviewView` rebound to `let transaction: SendTransaction`.
- Conversion at the boundary: `FunctionCallDetailsScreen.button.onTap`, `ReferralTransactionFlowScreen.moveToNext`, and `FunctionTransactionScreen.onVerify` build the immutable struct via `fromForm(_:vault:)` right before navigating.

### 2. Rename `LegacySendTransaction` → `FunctionCallForm`

The "Legacy" prefix was a migration artifact from the Send pilot that implied the class would die. After the Send / TRON / Circle migrations, the class only backs FunctionCall + Referral, where the form complexity (per-coin token dropdowns that mutate shared coin, sub-model state sharing across 11 `FunctionCall*` models) genuinely benefits from a single mutable reference type.

- File moved: `Features/Send/ViewModels/LegacySendTransaction.swift` → `Features/FunctionCall/Models/FunctionCallForm.swift`. Class renamed. Doc comment rewritten to describe its role positively rather than apologetically.
- Mass rename across ~50 files: FunctionCall flow, Referral flow, entry-point carriers (Home, Wallet, Onboarding, Reshare, Keygen, scanners, TransactionBuilder, BlockChainService).
- `SendTransaction.fromLegacy(_:)` / `fromLegacy(_:vault:)` → `fromForm(_:)` / `fromForm(_:vault:)`. `LegacyConversionError` → `FormConversionError`.
- `BlockChainService.fetchSpecific(tx: FunctionCallForm)` shim doc updated.
- Regenerate `project.pbxproj` for the moved file.

## Verification

- 108 Send tests + full `VultisigAppTests` suite green
- Build succeeds (iPhone 17 simulator)
- SwiftLint clean on all touched files
- `grep -r "LegacySendTransaction\|fromLegacy\|LegacyConversionError" VultisigApp` → 0 hits

## Test plan

- [ ] Smoke test FunctionCall verify → keysign for: LP add (THORChain), LP add (Mayachain), RUJI stake, SECURE+ mint, cosmos merge/unmerge/IBC switch, custom memo (RUNE)
- [ ] Smoke test Referral: register + edit
- [ ] Smoke test Send (regression): UTXO BTC, EVM with custom gas, ERC20
- [ ] Smoke test TRON freeze/unfreeze + Circle deposit/withdraw (no regressions from #4355)