### PR TITLE
refactor(send): extract SendInteractor.fetchGasAndFee + remove duplicated dispatch

### DIFF
--- a/VultisigApp/VultisigApp/Features/Send/Interactor/SendInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Interactor/SendInteractor.swift
@@ -87,4 +87,50 @@ extension SendInteractor {
             fromAddress: tx.fromAddress
         )
     }
+
+    /// Unified gas + fee fetch used by the Send Details form (both refresh
+    /// and max-amount paths). EVM goes through `calculateEVMFee` to honor the
+    /// dynamic fee mode; UTXO + Cardano read `fee` off the chain-specific
+    /// (the byte-fee × planned size); other chains use `gas` as a flat fee.
+    ///
+    /// Callers that need the "fee that's actually deducted from THIS coin's
+    /// balance" (e.g. computing max-amount) post-process the result: gas is
+    /// paid in the native sibling for ERC20 / SPL etc., so non-native sources
+    /// see `.zero` for the deductible fee even though the real gas/fee here
+    /// is non-zero. That distinction stays at the call site — this method
+    /// always returns the true on-chain values.
+    func fetchGasAndFee(
+        coin: Coin,
+        toAddress: String,
+        amount: BigInt,
+        memo: String?,
+        sendMaxAmount: Bool,
+        isDeposit: Bool,
+        transactionType: VSTransactionType,
+        gasLimit: BigInt?,
+        feeMode: FeeMode,
+        fromAddress: String
+    ) async throws -> SendInteractorFeeResult {
+        let chainSpecific = try await fetchChainSpecific(
+            coin: coin,
+            toAddress: toAddress,
+            amount: amount,
+            memo: memo,
+            sendMaxAmount: sendMaxAmount,
+            isDeposit: isDeposit,
+            transactionType: transactionType,
+            gasLimit: gasLimit,
+            feeMode: feeMode,
+            fromAddress: fromAddress
+        )
+
+        switch coin.chainType {
+        case .EVM:
+            return try await calculateEVMFee(coin: coin, fromAddress: fromAddress, feeMode: feeMode)
+        case .UTXO, .Cardano:
+            return SendInteractorFeeResult(fee: chainSpecific.fee, gas: chainSpecific.gas)
+        default:
+            return SendInteractorFeeResult(fee: chainSpecific.gas, gas: chainSpecific.gas)
+        }
+    }
 }

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -299,9 +299,10 @@ final class SendDetailsViewModel {
 
     // MARK: - Max amount
 
-    /// Per-chain max-amount calculation. Async because each chain fetches its
-    /// own gas/fee shape via the interactor; the pure math then sits in
-    /// `SendCryptoLogic.computeMaxAmount`.
+    /// Per-chain max-amount calculation. Delegates the on-chain fetch to
+    /// `interactor.fetchGasAndFee`; max-amount math sits in `SendCryptoLogic`.
+    /// Non-native sources see their gas paid in the chain's native sibling,
+    /// so the deductible fee here is `.zero` for ERC20 / SPL / etc.
     func setMaxAmount(percentage: Double = 100) async {
         errorMessage = ""
         isLoading = true
@@ -309,10 +310,10 @@ final class SendDetailsViewModel {
 
         let maxFee: BigInt
         do {
-            let chainSpecific = try await interactor.fetchChainSpecific(
+            let result = try await interactor.fetchGasAndFee(
                 coin: coin,
                 toAddress: toAddress.isEmpty ? coin.address : toAddress,
-                amount: BigInt.zero,
+                amount: .zero,
                 memo: memo.isEmpty ? nil : memo,
                 sendMaxAmount: percentage == 100,
                 isDeposit: isDeposit,
@@ -321,18 +322,7 @@ final class SendDetailsViewModel {
                 feeMode: feeMode,
                 fromAddress: fromAddress
             )
-
-            switch coin.chainType {
-            case .UTXO, .Cardano:
-                maxFee = chainSpecific.fee
-            case .EVM:
-                let fees = try await interactor.calculateEVMFee(coin: coin, fromAddress: fromAddress, feeMode: feeMode)
-                maxFee = coin.isNativeToken ? fees.fee : .zero
-            case .Solana:
-                maxFee = coin.isNativeToken ? BigInt(SolanaHelper.defaultFeeInLamports) : .zero
-            default:
-                maxFee = chainSpecific.gas
-            }
+            maxFee = coin.isNativeToken ? result.fee : .zero
         } catch {
             logger.error("setMaxAmount failed: \(error.localizedDescription, privacy: .public)")
             errorMessage = error.localizedDescription
@@ -349,8 +339,8 @@ final class SendDetailsViewModel {
 
     // MARK: - Fee / gas refresh
 
-    /// Re-fetches chain-specific + EVM fee, **threading `feeMode` end-to-end**
-    /// (this is the regression-test target for the feeMode bug fix). Preserves
+    /// Re-fetches gas + fee for the current form state, **threading `feeMode`
+    /// end-to-end** (regression target for the feeMode bug fix). Preserves
     /// `customGasLimit` / `customByteFee` so user-pinned values survive refresh.
     func loadGasInfo() async {
         // Phase D lesson — zero-amount state reset.
@@ -366,7 +356,7 @@ final class SendDetailsViewModel {
         defer { isCalculatingFee = false }
 
         do {
-            let chainSpecific = try await interactor.fetchChainSpecific(
+            let result = try await interactor.fetchGasAndFee(
                 coin: coin,
                 toAddress: toAddress,
                 amount: amountInRaw,
@@ -378,19 +368,8 @@ final class SendDetailsViewModel {
                 feeMode: feeMode,
                 fromAddress: fromAddress
             )
-
-            switch coin.chainType {
-            case .EVM:
-                let evm = try await interactor.calculateEVMFee(coin: coin, fromAddress: fromAddress, feeMode: feeMode)
-                fee = evm.fee
-                gas = evm.gas
-            case .UTXO, .Cardano:
-                fee = chainSpecific.fee
-                gas = chainSpecific.gas
-            default:
-                fee = chainSpecific.gas
-                gas = chainSpecific.gas
-            }
+            gas = result.gas
+            fee = result.fee
         } catch {
             logger.error("loadGasInfo failed: \(error.localizedDescription, privacy: .public)")
             errorMessage = error.localizedDescription

--- a/VultisigApp/VultisigAppTests/Send/SendInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendInteractorTests.swift
@@ -45,6 +45,84 @@ final class SendInteractorTests: XCTestCase {
         XCTAssertEqual(a, b)
         XCTAssertNotEqual(a, c)
     }
+
+    // MARK: - fetchGasAndFee dispatch
+
+    func testFetchGasAndFeeForEVMUsesCalculateEVMFee() async throws {
+        let mock = MockSendInteractor()
+        mock.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: BigInt(stringLiteral: "630000000000000"),
+                                    gas: BigInt(stringLiteral: "30000000000"))
+        }
+        let eth = SendFormFixture.makeETH()
+
+        let result = try await mock.fetchGasAndFee(
+            coin: eth, toAddress: "to", amount: .zero, memo: nil,
+            sendMaxAmount: false, isDeposit: false,
+            transactionType: .unspecified, gasLimit: nil,
+            feeMode: .fast, fromAddress: eth.address
+        )
+
+        XCTAssertEqual(mock.calculateEVMFeeCalls.count, 1, "EVM path must dispatch to calculateEVMFee")
+        XCTAssertEqual(mock.calculateEVMFeeCalls.first?.feeMode, .fast, "feeMode threaded")
+        XCTAssertEqual(result.fee, BigInt(stringLiteral: "630000000000000"))
+        XCTAssertEqual(result.gas, BigInt(stringLiteral: "30000000000"))
+    }
+
+    func testFetchGasAndFeeForUTXOUsesChainSpecificFee() async throws {
+        let mock = MockSendInteractor()
+        mock.fetchChainSpecificStub = { _ in
+            .UTXO(byteFee: BigInt(50), sendMaxAmount: false)
+        }
+        let btc = SendFormFixture.makeBTC()
+
+        let result = try await mock.fetchGasAndFee(
+            coin: btc, toAddress: "bc1q...", amount: BigInt(1_000), memo: nil,
+            sendMaxAmount: false, isDeposit: false,
+            transactionType: .unspecified, gasLimit: nil,
+            feeMode: .default, fromAddress: btc.address
+        )
+
+        XCTAssertTrue(mock.calculateEVMFeeCalls.isEmpty, "UTXO must not hit EVM fee path")
+        // For UTXO, BlockChainSpecific.fee falls through to gas (= byteFee).
+        XCTAssertEqual(result.fee, BigInt(50))
+        XCTAssertEqual(result.gas, BigInt(50))
+    }
+
+    func testFetchGasAndFeeForCosmosUsesChainSpecificGas() async throws {
+        let mock = MockSendInteractor()
+        mock.fetchChainSpecificStub = { _ in
+            .Cosmos(accountNumber: 0, sequence: 0, gas: UInt64(7_500),
+                    transactionType: 0, ibcDenomTrace: nil)
+        }
+        let atom = SendFormFixture.makeATOM()
+
+        let result = try await mock.fetchGasAndFee(
+            coin: atom, toAddress: "cosmos1...", amount: BigInt(1_000), memo: nil,
+            sendMaxAmount: false, isDeposit: false,
+            transactionType: .unspecified, gasLimit: nil,
+            feeMode: .default, fromAddress: atom.address
+        )
+
+        XCTAssertTrue(mock.calculateEVMFeeCalls.isEmpty)
+        XCTAssertEqual(result.fee, BigInt(7_500))
+        XCTAssertEqual(result.gas, BigInt(7_500))
+    }
+
+    func testFetchGasAndFeeThreadsFeeModeToChainSpecificFetch() async throws {
+        let mock = MockSendInteractor()
+        let atom = SendFormFixture.makeATOM()
+
+        _ = try await mock.fetchGasAndFee(
+            coin: atom, toAddress: "cosmos1...", amount: BigInt(1_000), memo: nil,
+            sendMaxAmount: false, isDeposit: false,
+            transactionType: .unspecified, gasLimit: nil,
+            feeMode: .fast, fromAddress: atom.address
+        )
+
+        XCTAssertEqual(mock.fetchChainSpecificCalls.first?.feeMode, .fast,
+                       "feeMode must thread through to fetchChainSpecific for non-EVM chains too")
+    }
 }
 
 /// Minimal stub recording the `feeMode` it last received. Lets us assert the


### PR DESCRIPTION
## Summary

\`SendDetailsViewModel.setMaxAmount\` and \`loadGasInfo\` carried near-identical 12-LOC per-chain switches: fetch chain-specific, dispatch to EVM / UTXO+Cardano / default for gas+fee resolution. Extract to a single \`SendInteractor.fetchGasAndFee(...)\` default-extension method.

- Both VM methods drop the switch and call the helper.
- The "non-native pays gas in the native sibling, so deductible fee is \`.zero\`" logic stays at the \`setMaxAmount\` call site (max-amount concern, not gas-fetch concern). One line: \`maxFee = coin.isNativeToken ? result.fee : .zero\`.
- VM net change: -26 LOC.

The helper composes the existing \`fetchChainSpecific\` + \`calculateEVMFee\` protocol methods, so no new conformance burden on mocks.

## Tests

\`SendInteractorTests\` grows 3 → 7. Four new tests pin the dispatch:

| New test | What it pins |
|----------|--------------|
| \`testFetchGasAndFeeForEVMUsesCalculateEVMFee\` | EVM hits the EVM fee path, \`feeMode\` threaded |
| \`testFetchGasAndFeeForUTXOUsesChainSpecificFee\` | UTXO uses \`chainSpecific\`, not EVM |
| \`testFetchGasAndFeeForCosmosUsesChainSpecificGas\` | Cosmos default path |
| \`testFetchGasAndFeeThreadsFeeModeToChainSpecificFetch\` | \`feeMode\` forwarded to \`fetchChainSpecific\` too |

All Send tests still pass (60 in the four affected suites + 7 interactor tests). SwiftLint clean on touched files.

## Test plan

- [x] \`xcodebuild test\` — 67/67 in touched suites
- [x] SwiftLint clean on touched files
- [ ] Manual: max-amount on UTXO BTC, EVM native, ERC20 (non-native), Cosmos ATOM