### PR TITLE
feat(fast-vault): cache eligibility on Vault + drop loadFastVault indirection

### DIFF
--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -159,6 +159,7 @@ extension VultisigApp {
                 switch scenePhase {
                 case .active:
                     continueLogin()
+                    appViewModel.refreshFastVaultEligibilityIfNeeded()
                 case .background:
                     resetLogin()
                 default:

--- a/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultEligibilityRefresher.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultEligibilityRefresher.swift
@@ -1,0 +1,72 @@
+//
+//  FastVaultEligibilityRefresher.swift
+//  VultisigApp
+//
+//  Refreshes the cached `fastVaultEligibility` field on the `Vault` model.
+//  Reads are sync (`vault.fastVaultEligibility`); refreshes happen only at
+//  planned trigger points (app foreground, vault switch). Replaces the
+//  pattern where every Send / FunctionCall / Referral / QBTC screen called
+//  `FastVaultService.isEligibleForFastSign(vault:)` on mount.
+//
+
+import Foundation
+import OSLog
+
+@MainActor
+final class FastVaultEligibilityRefresher {
+
+    static let shared = FastVaultEligibilityRefresher()
+
+    private let logger = Logger(subsystem: "com.vultisig.app", category: "fast-vault-cache")
+    private let checkEligibility: @MainActor (Vault) async -> Bool
+    private let saveStorage: @MainActor () -> Void
+    private let now: @MainActor () -> Date
+    private let stalenessThreshold: TimeInterval
+
+    nonisolated static let defaultStalenessThreshold: TimeInterval = 24 * 60 * 60  // 24h
+
+    init(
+        checkEligibility: @MainActor @escaping (Vault) async -> Bool = { await FastVaultService.shared.isEligibleForFastSign(vault: $0) },
+        saveStorage: @MainActor @escaping () -> Void = FastVaultEligibilityRefresher.defaultSaveStorage,
+        now: @MainActor @escaping () -> Date = { Date() },
+        stalenessThreshold: TimeInterval = FastVaultEligibilityRefresher.defaultStalenessThreshold
+    ) {
+        self.checkEligibility = checkEligibility
+        self.saveStorage = saveStorage
+        self.now = now
+        self.stalenessThreshold = stalenessThreshold
+    }
+
+    /// Refreshes the cached eligibility for the vault unconditionally. The
+    /// underlying `FastVaultService.isEligibleForFastSign(vault:)` short-circuits
+    /// to `false` locally if `vault.isFastVault` is false, so non-FastVaults
+    /// don't pay the network round-trip.
+    func refresh(_ vault: Vault) async {
+        let isEligible = await checkEligibility(vault)
+        vault.fastVaultEligibility = isEligible
+        vault.fastVaultEligibilityCheckedAt = now()
+        saveStorage()
+        logger.debug("refreshed eligibility for vault=\(vault.pubKeyECDSA, privacy: .public): \(isEligible)")
+    }
+
+    /// Refreshes only if the cache is empty or older than `stalenessThreshold`.
+    /// Use this on app foreground + vault switch — cheap when fresh, network
+    /// hit on staleness.
+    func refreshIfStale(_ vault: Vault) async {
+        if let checkedAt = vault.fastVaultEligibilityCheckedAt,
+           now().timeIntervalSince(checkedAt) < stalenessThreshold {
+            return
+        }
+        await refresh(vault)
+    }
+
+    @MainActor
+    private static func defaultSaveStorage() {
+        do {
+            try Storage.shared.save()
+        } catch {
+            // Logger inside instance; can't easily call from static. Fail silently —
+            // the cache is best-effort; next refresh will overwrite.
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultService.swift
@@ -122,7 +122,10 @@ final class FastVaultService {
     /// - Returns: `true` if the vault exists in the backend, is not a local backup, and is configured as a fast vault
     func isEligibleForFastSign(vault: Vault) async -> Bool {
         let isExist = await exist(pubKeyECDSA: vault.pubKeyECDSA)
-        return isExist && vault.isFastVault
+        // Use the structural helper, NOT `vault.isFastVault`. The latter reads
+        // the cache that this method's result feeds — reading it here would
+        // permanently lock eligibility at the first cached value.
+        return isExist && vault.hasServerSigner
     }
 
     func create(

--- a/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
@@ -45,6 +45,18 @@ class AppViewModel: ObservableObject {
 
         self.showingVaultSelector = showingVaultSelector
         self.restartNavigation = restartNavigation
+
+        if let vault = selectedVault {
+            Task { await FastVaultEligibilityRefresher.shared.refreshIfStale(vault) }
+        }
+    }
+
+    /// Triggers a fast-vault eligibility refresh for the currently selected vault
+    /// if its cache is stale. Called by the app's scenePhase `.active` hook so
+    /// the cache stays fresh after the app moves to the foreground.
+    func refreshFastVaultEligibilityIfNeeded() {
+        guard let vault = selectedVault else { return }
+        Task { await FastVaultEligibilityRefresher.shared.refreshIfStale(vault) }
     }
 
     func loadSelectedVault(for vaults: [Vault]) {

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositView.swift
@@ -42,7 +42,7 @@ struct CircleDepositView: View {
     }
 
     func handleVerify() async {
-        guard let immutableTx = await viewModel.makeTransaction() else { return }
+        guard let immutableTx = viewModel.makeTransaction() else { return }
         await MainActor.run {
             router.navigate(to: SendRoute.verify(tx: immutableTx, retrySignal: SendRetrySignal(), vault: viewModel.vault))
         }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositViewModel.swift
@@ -68,7 +68,7 @@ final class CircleDepositViewModel: ObservableObject, Form {
         isLoading = true
         defer { isLoading = false }
 
-        let isFast = await sendInteractor.loadFastVault(vault: vault)
+        let isFast = vault.fastVaultEligibility
         return SendTransaction.empty(coin: coin, vault: vault).with(
             toAddress: toAddress,
             amount: amountField.value,

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleDepositViewModel.swift
@@ -59,7 +59,7 @@ final class CircleDepositViewModel: ObservableObject, Form {
         usdcCoin = coin
     }
 
-    func makeTransaction() async -> SendTransaction? {
+    func makeTransaction() -> SendTransaction? {
         guard let coin = usdcCoin,
               let toAddress = vault.circleWalletAddress else {
             return nil
@@ -68,11 +68,9 @@ final class CircleDepositViewModel: ObservableObject, Form {
         isLoading = true
         defer { isLoading = false }
 
-        let isFast = vault.fastVaultEligibility
         return SendTransaction.empty(coin: coin, vault: vault).with(
             toAddress: toAddress,
-            amount: amountField.value,
-            isFastVault: isFast
+            amount: amountField.value
         )
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
@@ -20,7 +20,6 @@ struct CircleWithdrawView: View {
     @State var percentage: Double = 0.0
     @State var isLoading = false
     @State var error: Error?
-    @State var isFastVault = false
     @State var fastPasswordPresented = false
     @State var fastVaultPassword: String = ""
 
@@ -42,9 +41,6 @@ struct CircleWithdrawView: View {
         }
         .screenTitle("circleWithdrawTitle".localized)
         .withLoading(isLoading: $isLoading)
-        .task {
-            await loadFastVaultStatus()
-        }
         .crossPlatformSheet(isPresented: $fastPasswordPresented) {
             FastVaultEnterPasswordView(
                 password: $fastVaultPassword,
@@ -163,7 +159,7 @@ struct CircleWithdrawView: View {
 
     @ViewBuilder
     var withdrawButton: some View {
-        if isFastVault {
+        if vault.isFastVault {
             VStack {
                 Text("holdForPairedSign".localized)
                     .foregroundColor(Theme.colors.textTertiary)
@@ -192,12 +188,6 @@ struct CircleWithdrawView: View {
 
     var isButtonDisabled: Bool {
         amount.isEmpty || (Decimal(string: amount) ?? 0) <= 0 || (Decimal(string: amount) ?? 0) > model.balance || vaultEthBalance <= 0 || isLoading
-    }
-
-    func loadFastVaultStatus() async {
-        // Cached value populated by `FastVaultEligibilityRefresher` on app
-        // foreground + vault switch. Sync read; no network call.
-        isFastVault = vault.fastVaultEligibility
     }
 
     func updatePercentage(from amountStr: String) async {
@@ -285,8 +275,7 @@ struct CircleWithdrawView: View {
             await MainActor.run {
                 let immutableTx = SendTransaction.empty(coin: usdcCoin, vault: vault).with(
                     toAddress: recipientCoin.address,
-                    amount: amount,
-                    isFastVault: isFastVault
+                    amount: amount
                 )
                 router.navigate(
                     to: SendRoute.pairing(

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
@@ -195,12 +195,9 @@ struct CircleWithdrawView: View {
     }
 
     func loadFastVaultStatus() async {
-        let isExist = await FastVaultService.shared.exist(pubKeyECDSA: vault.pubKeyECDSA)
-        let isLocalBackup = vault.localPartyID.lowercased().contains("server-")
-
-        await MainActor.run {
-            isFastVault = isExist && !isLocalBackup
-        }
+        // Cached value populated by `FastVaultEligibilityRefresher` on app
+        // foreground + vault switch. Sync read; no network call.
+        isFastVault = vault.fastVaultEligibility
     }
 
     func updatePercentage(from amountStr: String) async {

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeView.swift
@@ -220,7 +220,6 @@ struct TronFreezeView: View {
 
         // The memo encodes the freeze operation type for TronHelper.
         let memo = "FREEZE:\(selectedResourceType.tronResourceString)"
-        let isFast = vault.fastVaultEligibility
 
         await MainActor.run {
             isLoading = false
@@ -228,7 +227,6 @@ struct TronFreezeView: View {
                 toAddress: coin.address,  // Freeze goes to self
                 amount: amountDec.description,
                 memo: memo,
-                isFastVault: isFast,
                 isStakingOperation: true
             )
             router.navigate(to: SendRoute.verify(tx: immutableTx, retrySignal: SendRetrySignal(), vault: vault))

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeView.swift
@@ -220,7 +220,7 @@ struct TronFreezeView: View {
 
         // The memo encodes the freeze operation type for TronHelper.
         let memo = "FREEZE:\(selectedResourceType.tronResourceString)"
-        let isFast = await sendInteractor.loadFastVault(vault: vault)
+        let isFast = vault.fastVaultEligibility
 
         await MainActor.run {
             isLoading = false

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeView.swift
@@ -256,7 +256,7 @@ struct TronUnfreezeView: View {
 
         // The memo encodes the unfreeze operation type for TronHelper.
         let memo = "UNFREEZE:\(selectedResourceType.tronResourceString)"
-        let isFast = await sendInteractor.loadFastVault(vault: vault)
+        let isFast = vault.fastVaultEligibility
 
         await MainActor.run {
             isLoading = false

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeView.swift
@@ -256,7 +256,6 @@ struct TronUnfreezeView: View {
 
         // The memo encodes the unfreeze operation type for TronHelper.
         let memo = "UNFREEZE:\(selectedResourceType.tronResourceString)"
-        let isFast = vault.fastVaultEligibility
 
         await MainActor.run {
             isLoading = false
@@ -264,7 +263,6 @@ struct TronUnfreezeView: View {
                 toAddress: trxCoin.address,  // Unfreeze returns to self
                 amount: amountDecimal.description,
                 memo: memo,
-                isFastVault: isFast,
                 isStakingOperation: true
             )
             router.navigate(to: SendRoute.verify(tx: immutableTx, retrySignal: SendRetrySignal(), vault: vault))

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallForm.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallForm.swift
@@ -44,7 +44,9 @@ class FunctionCallForm: ObservableObject, Hashable {
     @Published var isCalculatingFee: Bool = false
     @Published var feeMode: FeeMode = .default
     @Published var sendMaxAmount: Bool = false
-    @Published var isFastVault: Bool = false
+    /// FastVault eligibility — sourced from the `Vault` cache populated by
+    /// `FastVaultEligibilityRefresher`. Returns `false` if no vault is set yet.
+    var isFastVault: Bool { vault?.fastVaultEligibility ?? false }
     @Published var fastVaultPassword: String = .empty
     @Published var isStakingOperation: Bool = false
     @Published var memoFunctionDictionary: ThreadSafeDictionary<String, String> = ThreadSafeDictionary()

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallForm.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallForm.swift
@@ -44,9 +44,6 @@ class FunctionCallForm: ObservableObject, Hashable {
     @Published var isCalculatingFee: Bool = false
     @Published var feeMode: FeeMode = .default
     @Published var sendMaxAmount: Bool = false
-    /// FastVault eligibility — sourced from the `Vault` cache populated by
-    /// `FastVaultEligibilityRefresher`. Returns `false` if no vault is set yet.
-    var isFastVault: Bool { vault?.fastVaultEligibility ?? false }
     @Published var fastVaultPassword: String = .empty
     @Published var isStakingOperation: Bool = false
     @Published var memoFunctionDictionary: ThreadSafeDictionary<String, String> = ThreadSafeDictionary()

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
@@ -40,8 +40,13 @@ class FunctionCallViewModel: ObservableObject {
         }
     }
 
+    // swiftlint:disable:next async_without_await
     func loadFastVault(tx: FunctionCallForm, vault: Vault) async {
-        tx.isFastVault = await fastVaultService.isEligibleForFastSign(vault: vault)
+        // Cached value populated by `FastVaultEligibilityRefresher` on app
+        // foreground + vault switch. Sync read; no network call on the hot path.
+        // The `async` is preserved for callsite-API stability across the
+        // FunctionCall flow (callers `await` this in a Task).
+        tx.isFastVault = vault.fastVaultEligibility
     }
 
     func validateAddress(tx: FunctionCallForm, address: String) {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
@@ -40,15 +40,6 @@ class FunctionCallViewModel: ObservableObject {
         }
     }
 
-    // swiftlint:disable:next async_without_await
-    func loadFastVault(tx: FunctionCallForm, vault: Vault) async {
-        // Cached value populated by `FastVaultEligibilityRefresher` on app
-        // foreground + vault switch. Sync read; no network call on the hot path.
-        // The `async` is preserved for callsite-API stability across the
-        // FunctionCall flow (callers `await` this in a Task).
-        tx.isFastVault = vault.fastVaultEligibility
-    }
-
     func validateAddress(tx: FunctionCallForm, address: String) {
         isValidAddress = AddressService.validateAddress(address: address, chain: tx.coin.chain)
     }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
@@ -297,6 +297,5 @@ private extension FunctionCallDetailsScreen {
 
     func loadGasInfo() async {
         await functionCallViewModel.loadGasInfoForSending(tx: tx)
-        await functionCallViewModel.loadFastVault(tx: tx, vault: vault)
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallVerifyScreen.swift
@@ -39,7 +39,7 @@ struct FunctionCallVerifyScreen: View {
         .onDisappear {
             depositVerifyViewModel.isLoading = false
             // Clear password if navigating back (not forward to keysign)
-            if transaction.isFastVault {
+            if vault.isFastVault {
                 fastVaultPassword = .empty
             }
         }
@@ -88,7 +88,7 @@ struct FunctionCallVerifyScreen: View {
 
     var pairedSignButton: some View {
         VStack {
-            if transaction.isFastVault {
+            if vault.isFastVault {
                 Text(NSLocalizedString("holdForPairedSign", comment: ""))
                     .foregroundColor(Theme.colors.textTertiary)
                     .font(Theme.fonts.bodySMedium)

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -150,7 +150,6 @@ struct FunctionTransactionScreen: View {
             let tx = transactionBuilder.buildTransaction()
 
             await functionCallViewModel.loadGasInfoForSending(tx: tx)
-            await functionCallViewModel.loadFastVault(tx: tx, vault: vault)
 
             sendTx = tx
             isLoading = false

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
@@ -58,7 +58,6 @@ extension TransactionBuilder {
             customGasLimit: nil,
             customByteFee: nil,
             sendMaxAmount: sendMaxAmount,
-            isFastVault: false,
             isStakingOperation: false,
             transactionType: transactionType,
             memoFunctionDictionary: memoFunctionDictionary.allItems(),

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/EditReferralDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/EditReferralDetailsViewModel.swift
@@ -48,9 +48,6 @@ final class EditReferralDetailsViewModel {
 
     // MARK: - Send-transaction props
     var gas: BigInt = .zero
-    /// FastVault eligibility — sourced from the `Vault` cache populated by
-    /// `FastVaultEligibilityRefresher` (app foreground + vault switch).
-    var isFastVault: Bool { vault.fastVaultEligibility }
 
     // MARK: - Init
 
@@ -173,7 +170,6 @@ final class EditReferralDetailsViewModel {
             amount: totalFeeAmount.formatDecimalToLocale(),
             memo: memo,
             gas: gas,
-            isFastVault: isFastVault,
             transactionType: .unspecified,
             memoFunctionDictionary: ["memo": ""]
         )

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/EditReferralDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/EditReferralDetailsViewModel.swift
@@ -48,7 +48,9 @@ final class EditReferralDetailsViewModel {
 
     // MARK: - Send-transaction props
     var gas: BigInt = .zero
-    var isFastVault: Bool = false
+    /// FastVault eligibility — sourced from the `Vault` cache populated by
+    /// `FastVaultEligibilityRefresher` (app foreground + vault switch).
+    var isFastVault: Bool { vault.fastVaultEligibility }
 
     // MARK: - Init
 
@@ -136,12 +138,6 @@ final class EditReferralDetailsViewModel {
         } catch {
             logger.error("loadGasInfo failed: \(error.localizedDescription)")
         }
-    }
-
-    // MARK: - Network — fast vault
-
-    func loadFastVault() async {
-        isFastVault = await interactor.loadFastVault(vault: vault)
     }
 
     // MARK: - Verify + boundary

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/ReferralDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/ReferralDetailsViewModel.swift
@@ -78,11 +78,8 @@ final class ReferralDetailsViewModel {
     // MARK: - Async state
     var isLoading: Bool = false
 
-    // MARK: - Send-transaction props (replaces tx.gas / tx.isFastVault)
+    // MARK: - Send-transaction props (replaces tx.gas)
     var gas: BigInt = .zero
-    /// FastVault eligibility — sourced from the `Vault` cache populated by
-    /// `FastVaultEligibilityRefresher` (app foreground + vault switch).
-    var isFastVault: Bool { vault.fastVaultEligibility }
 
     // MARK: - Alert
     var showReferralAlert: Bool = false
@@ -351,7 +348,6 @@ final class ReferralDetailsViewModel {
             amount: totalFee.formatDecimalToLocale(),
             memo: memo,
             gas: gas,
-            isFastVault: isFastVault,
             transactionType: .unspecified,
             memoFunctionDictionary: ["memo": ""]
         )

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/ReferralDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/ReferralDetailsViewModel.swift
@@ -80,7 +80,9 @@ final class ReferralDetailsViewModel {
 
     // MARK: - Send-transaction props (replaces tx.gas / tx.isFastVault)
     var gas: BigInt = .zero
-    var isFastVault: Bool = false
+    /// FastVault eligibility — sourced from the `Vault` cache populated by
+    /// `FastVaultEligibilityRefresher` (app foreground + vault switch).
+    var isFastVault: Bool { vault.fastVaultEligibility }
 
     // MARK: - Alert
     var showReferralAlert: Bool = false
@@ -248,12 +250,6 @@ final class ReferralDetailsViewModel {
         } catch {
             logger.error("loadGasInfo failed: \(error.localizedDescription)")
         }
-    }
-
-    // MARK: - Network — fast vault
-
-    func loadFastVault() async {
-        isFastVault = await interactor.loadFastVault(vault: vault)
     }
 
     // MARK: - Network — referral data

--- a/VultisigApp/VultisigApp/Features/Send/Interactor/DefaultSendInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Interactor/DefaultSendInteractor.swift
@@ -28,10 +28,12 @@ struct DefaultSendInteractor: SendInteractor {
         )
     }
 
+    // swiftlint:disable:next async_without_await
     func loadFastVault(vault: Vault) async -> Bool {
-        let exists = await fastVault.exist(pubKeyECDSA: vault.pubKeyECDSA)
-        let isLocalBackup = vault.localPartyID.lowercased().hasPrefix("server-")
-        return exists && !isLocalBackup
+        // Cached value populated by `FastVaultEligibilityRefresher` on app
+        // foreground + vault switch. Sync read; no network call on the hot path.
+        // The `async` is required by `SendInteractor` protocol conformance.
+        vault.fastVaultEligibility
     }
 
     func fetchChainSpecific(_ request: SendChainSpecificRequest) async throws -> BlockChainSpecific {

--- a/VultisigApp/VultisigApp/Features/Send/Interactor/DefaultSendInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Interactor/DefaultSendInteractor.swift
@@ -28,14 +28,6 @@ struct DefaultSendInteractor: SendInteractor {
         )
     }
 
-    // swiftlint:disable:next async_without_await
-    func loadFastVault(vault: Vault) async -> Bool {
-        // Cached value populated by `FastVaultEligibilityRefresher` on app
-        // foreground + vault switch. Sync read; no network call on the hot path.
-        // The `async` is required by `SendInteractor` protocol conformance.
-        vault.fastVaultEligibility
-    }
-
     func fetchChainSpecific(_ request: SendChainSpecificRequest) async throws -> BlockChainSpecific {
         try await blockchain.fetchSendBlockChainSpecific(
             coin: request.coin,

--- a/VultisigApp/VultisigApp/Features/Send/Interactor/SendInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Interactor/SendInteractor.swift
@@ -87,10 +87,6 @@ struct SendFeeEstimateRequest: Equatable {
 }
 
 protocol SendInteractor {
-    /// Fast Vault eligibility for a given vault — exists on the server AND
-    /// wasn't a local-only backup.
-    func loadFastVault(vault: Vault) async -> Bool
-
     /// Chain-specific fee / nonce / blockhash data needed to assemble the
     /// keysign payload. `feeMode` controls EVM priority and UTXO byte-fee
     /// tier — never hardcode `.default` at the call site.

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -41,7 +41,6 @@ struct SendDetailsSeed: Hashable {
     let customGasLimit: BigInt?
     let customByteFee: BigInt?
     let sendMaxAmount: Bool
-    let isFastVault: Bool
     let isStakingOperation: Bool
     let transactionType: VSTransactionType
     let memoFunctionDictionary: [String: String]
@@ -66,7 +65,6 @@ struct SendDetailsSeed: Hashable {
             customGasLimit: nil,
             customByteFee: nil,
             sendMaxAmount: false,
-            isFastVault: false,
             isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:],
@@ -99,7 +97,6 @@ struct SendDetailsSeed: Hashable {
             customGasLimit: tx.customGasLimit,
             customByteFee: tx.customByteFee,
             sendMaxAmount: tx.sendMaxAmount,
-            isFastVault: tx.isFastVault,
             isStakingOperation: tx.isStakingOperation,
             transactionType: tx.transactionType,
             memoFunctionDictionary: tx.memoFunctionDictionary.allItems(),
@@ -180,7 +177,6 @@ struct SendTransaction: Hashable {
 
     // Mode flags
     let sendMaxAmount: Bool
-    let isFastVault: Bool
     let isStakingOperation: Bool
     let transactionType: VSTransactionType
 
@@ -214,7 +210,6 @@ extension SendTransaction {
             lhs.customGasLimit == rhs.customGasLimit &&
             lhs.customByteFee == rhs.customByteFee &&
             lhs.sendMaxAmount == rhs.sendMaxAmount &&
-            lhs.isFastVault == rhs.isFastVault &&
             lhs.isStakingOperation == rhs.isStakingOperation &&
             lhs.transactionType == rhs.transactionType &&
             lhs.memoFunctionDictionary == rhs.memoFunctionDictionary &&
@@ -238,7 +233,6 @@ extension SendTransaction {
         hasher.combine(customGasLimit)
         hasher.combine(customByteFee)
         hasher.combine(sendMaxAmount)
-        hasher.combine(isFastVault)
         hasher.combine(isStakingOperation)
         hasher.combine(transactionType)
         hasher.combine(memoFunctionDictionary)
@@ -264,7 +258,6 @@ extension SendTransaction {
         customGasLimit: BigInt?,
         customByteFee: BigInt?,
         sendMaxAmount: Bool,
-        isFastVault: Bool,
         isStakingOperation: Bool,
         transactionType: VSTransactionType,
         memoFunctionDictionary: [String: String],
@@ -288,7 +281,6 @@ extension SendTransaction {
         self.customGasLimit = customGasLimit
         self.customByteFee = customByteFee
         self.sendMaxAmount = sendMaxAmount
-        self.isFastVault = isFastVault
         self.isStakingOperation = isStakingOperation
         self.transactionType = transactionType
         self.memoFunctionDictionary = memoFunctionDictionary
@@ -329,7 +321,6 @@ extension SendTransaction {
             customGasLimit: nil,
             customByteFee: nil,
             sendMaxAmount: false,
-            isFastVault: false,
             isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:],
@@ -358,7 +349,6 @@ extension SendTransaction {
         customGasLimit: SendTransactionUpdate<BigInt?>? = nil,
         customByteFee: SendTransactionUpdate<BigInt?>? = nil,
         sendMaxAmount: Bool? = nil,
-        isFastVault: Bool? = nil,
         isStakingOperation: Bool? = nil,
         transactionType: VSTransactionType? = nil,
         memoFunctionDictionary: [String: String]? = nil,
@@ -403,7 +393,6 @@ extension SendTransaction {
             customGasLimit: resolvedCustomGasLimit,
             customByteFee: resolvedCustomByteFee,
             sendMaxAmount: sendMaxAmount ?? self.sendMaxAmount,
-            isFastVault: isFastVault ?? self.isFastVault,
             isStakingOperation: isStakingOperation ?? self.isStakingOperation,
             transactionType: transactionType ?? self.transactionType,
             memoFunctionDictionary: memoFunctionDictionary ?? self.memoFunctionDictionary,
@@ -428,7 +417,6 @@ extension SendTransaction {
         estimatedGasLimit: BigInt? = nil,
         memo: String? = nil,
         sendMaxAmount: Bool? = nil,
-        isFastVault: Bool? = nil,
         isStakingOperation: Bool? = nil,
         memoFunctionDictionary: [String: String]? = nil,
         wasmContractPayload: WasmExecuteContractPayload? = nil
@@ -442,7 +430,6 @@ extension SendTransaction {
             feeMode: feeMode,
             estimatedGasLimit: estimatedGasLimit.map { .set($0) },
             sendMaxAmount: sendMaxAmount,
-            isFastVault: isFastVault,
             isStakingOperation: isStakingOperation,
             memoFunctionDictionary: memoFunctionDictionary,
             wasmContractPayload: wasmContractPayload.map { .set($0) }
@@ -496,7 +483,6 @@ extension SendTransaction {
             customGasLimit: tx.customGasLimit,
             customByteFee: tx.customByteFee,
             sendMaxAmount: tx.sendMaxAmount,
-            isFastVault: tx.isFastVault,
             isStakingOperation: tx.isStakingOperation,
             transactionType: tx.transactionType,
             memoFunctionDictionary: tx.memoFunctionDictionary.allItems(),

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -58,10 +58,6 @@ final class SendDetailsViewModel {
     var memo: String = ""
     var feeMode: FeeMode = .default
     var sendMaxAmount: Bool = false
-    /// FastVault eligibility — sourced from the `Vault` cache populated by
-    /// `FastVaultEligibilityRefresher` (app foreground + vault switch). No
-    /// per-screen network call needed.
-    var isFastVault: Bool { vault.fastVaultEligibility }
     var isStakingOperation: Bool = false
     var transactionType: VSTransactionType = .unspecified
     var memoFunctionDictionary: [String: String] = [:]
@@ -132,8 +128,6 @@ final class SendDetailsViewModel {
         memo = seed.memo
         feeMode = seed.feeMode
         sendMaxAmount = seed.sendMaxAmount
-        // `isFastVault` is computed from `vault.fastVaultEligibility` — no
-        // hydration needed; the cache is the source of truth.
         isStakingOperation = seed.isStakingOperation
         transactionType = seed.transactionType
         memoFunctionDictionary = seed.memoFunctionDictionary
@@ -658,7 +652,6 @@ final class SendDetailsViewModel {
             customGasLimit: customGasLimit,
             customByteFee: customByteFee,
             sendMaxAmount: sendMaxAmount,
-            isFastVault: isFastVault,
             isStakingOperation: isStakingOperation,
             transactionType: transactionType,
             memoFunctionDictionary: memoFunctionDictionary,

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -58,7 +58,10 @@ final class SendDetailsViewModel {
     var memo: String = ""
     var feeMode: FeeMode = .default
     var sendMaxAmount: Bool = false
-    var isFastVault: Bool = false
+    /// FastVault eligibility — sourced from the `Vault` cache populated by
+    /// `FastVaultEligibilityRefresher` (app foreground + vault switch). No
+    /// per-screen network call needed.
+    var isFastVault: Bool { vault.fastVaultEligibility }
     var isStakingOperation: Bool = false
     var transactionType: VSTransactionType = .unspecified
     var memoFunctionDictionary: [String: String] = [:]
@@ -129,7 +132,8 @@ final class SendDetailsViewModel {
         memo = seed.memo
         feeMode = seed.feeMode
         sendMaxAmount = seed.sendMaxAmount
-        isFastVault = seed.isFastVault
+        // `isFastVault` is computed from `vault.fastVaultEligibility` — no
+        // hydration needed; the cache is the source of truth.
         isStakingOperation = seed.isStakingOperation
         transactionType = seed.transactionType
         memoFunctionDictionary = seed.memoFunctionDictionary
@@ -320,15 +324,6 @@ final class SendDetailsViewModel {
     private func stopCountdownTask() {
         countdownTask?.cancel()
         countdownTask = nil
-    }
-
-    // MARK: - Fast vault
-
-    /// Decision 2 win: vault is non-optional, so no singleton lookup.
-    /// Decision: use `hasPrefix("server-")` for local-party check (Phase D
-    /// lesson) — the interactor's `loadFastVault(vault:)` already does this.
-    func loadFastVault() async {
-        isFastVault = await interactor.loadFastVault(vault: vault)
     }
 
     // MARK: - Address resolution

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
@@ -351,8 +351,6 @@ extension SendDetailsScreen {
                 }
             }
         }
-
-        await viewModel.loadFastVault()
     }
 
 }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
@@ -163,7 +163,7 @@ struct SendVerifyScreen: View {
 
     var pairedSignButton: some View {
         VStack {
-            if tx.isFastVault {
+            if vault.isFastVault {
                 Text(NSLocalizedString("holdForPairedSign", comment: ""))
                     .foregroundColor(Theme.colors.textTertiary)
                     .font(Theme.fonts.bodySMedium)

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
@@ -20,7 +20,6 @@ struct SettingsCustomMessageView: View {
 
     @State var fastVaultPassword: String = .empty
     @State var fastPasswordPresented = false
-    @State var isFastVault = false
 
     let vault: Vault
     private let fastVaultService = FastVaultService.shared
@@ -30,7 +29,6 @@ struct SettingsCustomMessageView: View {
             Background()
             main
         }
-        .onLoad(perform: onLoad)
     }
 
     var view: some View {
@@ -119,7 +117,7 @@ struct SettingsCustomMessageView: View {
                     type: .Keysign,
                     viewModel: shareSheetViewModel
                 )
-                .showIf(!isFastVault)
+                .showIf(!vault.isFastVault)
             }
         }
     }
@@ -150,7 +148,7 @@ struct SettingsCustomMessageView: View {
     @ViewBuilder
     var signButton: some View {
         VStack(spacing: 16) {
-            if isFastVault {
+            if vault.isFastVault {
                 Text(NSLocalizedString("holdForPairedSign", comment: ""))
                     .foregroundColor(Theme.colors.textTertiary)
                     .font(Theme.fonts.bodySMedium)
@@ -176,12 +174,6 @@ struct SettingsCustomMessageView: View {
             }
         }
         .padding(.horizontal, 16)
-    }
-
-    func onLoad() {
-        // Cached value populated by `FastVaultEligibilityRefresher` on app
-        // foreground + vault switch. No network call here.
-        isFastVault = vault.fastVaultEligibility
     }
 
     func onSignPress() {

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
@@ -179,9 +179,9 @@ struct SettingsCustomMessageView: View {
     }
 
     func onLoad() {
-        Task { @MainActor in
-            isFastVault = await fastVaultService.isEligibleForFastSign(vault: vault)
-        }
+        // Cached value populated by `FastVaultEligibilityRefresher` on app
+        // foreground + vault switch. No network call here.
+        isFastVault = vault.fastVaultEligibility
     }
 
     func onSignPress() {

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
@@ -24,10 +24,12 @@ struct DefaultSwapInteractor: SwapInteractor {
         )
     }
 
+    // swiftlint:disable:next async_without_await
     func loadFastVault(vault: Vault) async -> Bool {
-        let exists = await fastVault.exist(pubKeyECDSA: vault.pubKeyECDSA)
-        let isLocalBackup = vault.localPartyID.lowercased().hasPrefix("server-")
-        return exists && !isLocalBackup
+        // Cached value populated by `FastVaultEligibilityRefresher` on app
+        // foreground + vault switch. Sync read; no network call on the hot path.
+        // The `async` is required by `SwapInteractor` protocol conformance.
+        vault.fastVaultEligibility
     }
 
     func fetchQuote(

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
@@ -24,14 +24,6 @@ struct DefaultSwapInteractor: SwapInteractor {
         )
     }
 
-    // swiftlint:disable:next async_without_await
-    func loadFastVault(vault: Vault) async -> Bool {
-        // Cached value populated by `FastVaultEligibilityRefresher` on app
-        // foreground + vault switch. Sync read; no network call on the hot path.
-        // The `async` is required by `SwapInteractor` protocol conformance.
-        vault.fastVaultEligibility
-    }
-
     func fetchQuote(
         amount: Decimal,
         fromCoin: Coin,

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/SwapInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/SwapInteractor.swift
@@ -11,10 +11,6 @@ import BigInt
 import Foundation
 
 protocol SwapInteractor {
-    /// Fast Vault eligibility for a given vault — exists on the server AND wasn't a
-    /// local-only backup.
-    func loadFastVault(vault: Vault) async -> Bool
-
     /// Aggregator quote fetch + discount-tier resolution. Returns nil when there's no
     /// amount to quote; throws `SwapCryptoLogic.Errors.sameAsset` when from/to coins match.
     func fetchQuote(

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -26,7 +26,6 @@ struct SwapTransaction: Hashable {
     let thorchainFee: BigInt
     let vultDiscountBps: Int
     let referralDiscountBps: Int
-    let isFastVault: Bool
 
     /// Native coin that pays for gas — `fromCoin` for native sources, the EVM-native
     /// sibling (e.g. ETH for an USDC source) otherwise. Precomputed at construction
@@ -54,7 +53,6 @@ extension SwapTransaction {
             thorchainFee: thorchainFee ?? self.thorchainFee,
             vultDiscountBps: vultDiscountBps ?? self.vultDiscountBps,
             referralDiscountBps: referralDiscountBps ?? self.referralDiscountBps,
-            isFastVault: isFastVault,
             feeCoin: feeCoin
         )
     }
@@ -223,7 +221,6 @@ extension SwapTransaction {
             thorchainFee: 0,
             vultDiscountBps: 0,
             referralDiscountBps: 0,
-            isFastVault: false,
             feeCoin: .example
         )
     }()

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -33,7 +33,6 @@ final class SwapDetailsViewModel {
     var gas: BigInt = .zero
     var vultDiscountBps: Int = 0
     var referralDiscountBps: Int = 0
-    var isFastVault: Bool = false
 
     // MARK: - UI state (details-screen-only)
 
@@ -78,13 +77,6 @@ final class SwapDetailsViewModel {
         fromCoins = resolvedFromCoins
         toCoins = resolvedToCoins
         dataLoaded = true
-    }
-
-    /// Snapshots the FastVault eligibility from the vault's cache (populated by
-    /// `FastVaultEligibilityRefresher`). Captured at form time so a later cache
-    /// refresh doesn't flip the routing decision mid-flow.
-    func captureFastVaultEligibility(from vault: Vault) {
-        isFastVault = vault.fastVaultEligibility
     }
 
     func updateCoinLists() {
@@ -212,7 +204,6 @@ final class SwapDetailsViewModel {
             thorchainFee: thorchainFee,
             vultDiscountBps: vultDiscountBps,
             referralDiscountBps: referralDiscountBps,
-            isFastVault: isFastVault,
             feeCoin: feeCoin
         )
     }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -80,8 +80,11 @@ final class SwapDetailsViewModel {
         dataLoaded = true
     }
 
-    func loadFastVault(vault: Vault) async {
-        isFastVault = await interactor.loadFastVault(vault: vault)
+    /// Snapshots the FastVault eligibility from the vault's cache (populated by
+    /// `FastVaultEligibilityRefresher`). Captured at form time so a later cache
+    /// refresh doesn't flip the routing decision mid-flow.
+    func captureFastVaultEligibility(from vault: Vault) {
+        isFastVault = vault.fastVaultEligibility
     }
 
     func updateCoinLists() {

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -77,7 +77,6 @@ struct SwapDetailsScreen: View {
             // `load(...)` seeds `detailsViewModel.fromCoin/toCoin`; no manual
             // re-assignment afterwards or `onChange` would re-fire the quote fetch.
             detailsViewModel.load(initialFromCoin: fromCoin, initialToCoin: toCoin, vault: vault)
-            detailsViewModel.captureFastVaultEligibility(from: vault)
             setData()
         }
         .onDisappear {

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -77,10 +77,8 @@ struct SwapDetailsScreen: View {
             // `load(...)` seeds `detailsViewModel.fromCoin/toCoin`; no manual
             // re-assignment afterwards or `onChange` would re-fire the quote fetch.
             detailsViewModel.load(initialFromCoin: fromCoin, initialToCoin: toCoin, vault: vault)
+            detailsViewModel.captureFastVaultEligibility(from: vault)
             setData()
-        }
-        .task {
-            await detailsViewModel.loadFastVault(vault: vault)
         }
         .onDisappear {
             #if os(iOS)

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -216,7 +216,7 @@ struct SwapVerifyScreen: View {
 
     @ViewBuilder
     var signButton: some View {
-        if currentTransaction.isFastVault {
+        if vault.isFastVault {
             Text(NSLocalizedString("holdForPairedSign", comment: ""))
                 .foregroundColor(Theme.colors.textTertiary)
                 .font(Theme.fonts.bodySMedium)

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -29,6 +29,12 @@ final class Vault: ObservableObject, Codable {
     var defiChains: [Chain] = []
     var isCircleEnabled: Bool = true  // Controls Circle visibility in DeFi section
 
+    // FastVault eligibility cache — populated by FastVaultEligibilityRefresher on
+    // app foreground + vault switch. Reads are sync; refresh happens at planned
+    // trigger points rather than per-screen-mount. Not encoded (local-only state).
+    var fastVaultEligibility: Bool = false
+    var fastVaultEligibilityCheckedAt: Date? = nil
+
     @Relationship(deleteRule: .cascade) var coins = [Coin]()
     @Relationship(deleteRule: .cascade) var hiddenTokens = [HiddenToken]()
     @Relationship(deleteRule: .cascade) var referralCode: ReferralCode?

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -176,7 +176,33 @@ final class Vault: ObservableObject, Codable {
         return coins.first(where: { $0.chain == chain && $0.isNativeToken })
     }
 
+    /// Whether this vault can be signed via the FastVault path. Single
+    /// source of truth — readers everywhere route on this. The value is
+    /// cached on the model (`fastVaultEligibility` + `fastVaultEligibilityCheckedAt`,
+    /// populated by `FastVaultEligibilityRefresher` on vault open + scenePhase
+    /// active) and falls back to the structural `hasServerSigner` check when
+    /// the cache hasn't been populated yet — best-effort optimistic value
+    /// until the refresher fires.
+    ///
+    /// Never true for the server-side party itself; only the user-side
+    /// devices ever route to FastVault signing.
     var isFastVault: Bool {
+        guard !localPartyID.lowercased().starts(with: "server-") else { return false }
+
+        if fastVaultEligibilityCheckedAt != nil {
+            return fastVaultEligibility
+        }
+
+        return hasServerSigner
+    }
+
+    /// Structural-only check: is there a `server-` party in this vault's
+    /// signer list (and we're not the server ourselves)? Internal helper —
+    /// used by `FastVaultService.isEligibleForFastSign` to compute the
+    /// canonical eligibility (`isExist && hasServerSigner`) before writing
+    /// the result to the cache. Reading `isFastVault` here would create a
+    /// circular dependency on the cached value the refresher is computing.
+    var hasServerSigner: Bool {
         if localPartyID.lowercased().starts(with: "server-") {
             return false
         }

--- a/VultisigApp/VultisigAppTests/Referral/ReferralDetailsViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Referral/ReferralDetailsViewModelTests.swift
@@ -29,7 +29,7 @@ final class ReferralDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.registrationFee, 0)
         XCTAssertEqual(vm.feePerBlock, 0)
         XCTAssertEqual(vm.gas, .zero)
-        XCTAssertFalse(vm.isFastVault)
+        XCTAssertFalse(vm.vault.isFastVault)
     }
 
     func testNativeCoinResolvesFromVaultRuneCoin() {

--- a/VultisigApp/VultisigAppTests/Send/Mocks/MockSendInteractor.swift
+++ b/VultisigApp/VultisigAppTests/Send/Mocks/MockSendInteractor.swift
@@ -60,7 +60,6 @@ final class MockSendInteractor: SendInteractor {
         let vault: Vault
     }
 
-    private(set) var loadFastVaultCalls: [Vault] = []
     private(set) var fetchChainSpecificCalls: [FetchChainSpecificCall] = []
     private(set) var calculateEVMFeeCalls: [CalculateEVMFeeCall] = []
     private(set) var buildKeysignPayloadCalls: [BuildKeysignPayloadCall] = []
@@ -70,7 +69,6 @@ final class MockSendInteractor: SendInteractor {
 
     // MARK: - Stubs
 
-    var loadFastVaultResult: Bool = false
     var fetchChainSpecificStub: ((FetchChainSpecificCall) throws -> BlockChainSpecific) = { _ in
         // Sensible default: a Cosmos-shaped chain specific with zero fees.
         .Cosmos(accountNumber: 0, sequence: 0, gas: .zero, transactionType: 0, ibcDenomTrace: nil)
@@ -85,11 +83,6 @@ final class MockSendInteractor: SendInteractor {
     var buildKeysignPayloadStub: ((BuildKeysignPayloadCall) throws -> KeysignPayload)?
 
     // MARK: - Conformance
-
-    func loadFastVault(vault: Vault) async -> Bool {
-        loadFastVaultCalls.append(vault)
-        return loadFastVaultResult
-    }
 
     func fetchChainSpecific(_ request: SendChainSpecificRequest) async throws -> BlockChainSpecific {
         let call = FetchChainSpecificCall(request: request)

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -138,7 +138,7 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
             gas: tx.gas, fee: tx.fee, feeMode: .default,
             estimatedGasLimit: nil, customGasLimit: nil, customByteFee: nil,
             sendMaxAmount: true,
-            isFastVault: false, isStakingOperation: false,
+            isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:], wasmContractPayload: nil,
             feeCoin: eth
@@ -191,7 +191,7 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
             customGasLimit: BigInt(50_000),
             customByteFee: nil,
             sendMaxAmount: false,
-            isFastVault: false, isStakingOperation: false,
+            isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:], wasmContractPayload: nil,
             feeCoin: eth
@@ -324,7 +324,7 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
             amount: "1", amountInFiat: "", memo: "",
             gas: .zero, fee: .zero, feeMode: .default,
             estimatedGasLimit: nil, customGasLimit: nil, customByteFee: nil,
-            sendMaxAmount: false, isFastVault: false, isStakingOperation: false,
+            sendMaxAmount: false, isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:], wasmContractPayload: nil,
             feeCoin: eth
@@ -358,7 +358,7 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
             gas: .zero, fee: .zero, feeMode: .default,
             estimatedGasLimit: nil, customGasLimit: nil, customByteFee: nil,
             sendMaxAmount: true,  // <-- the path under test
-            isFastVault: false, isStakingOperation: false,
+            isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:], wasmContractPayload: nil,
             feeCoin: eth
@@ -389,7 +389,7 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
             estimatedGasLimit: BigInt(21_000),
             customGasLimit: BigInt(50_000),
             customByteFee: nil,
-            sendMaxAmount: false, isFastVault: false, isStakingOperation: false,
+            sendMaxAmount: false, isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:], wasmContractPayload: nil,
             feeCoin: eth
@@ -517,7 +517,6 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
             customGasLimit: customGasLimit,
             customByteFee: nil,
             sendMaxAmount: false,
-            isFastVault: false,
             isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:],

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelMakeTransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelMakeTransactionTests.swift
@@ -30,7 +30,7 @@ final class SendDetailsViewModelMakeTransactionTests: XCTestCase {
         vm.feeMode = .fast
         vm.estimatedGasLimit = BigInt(21_000)
         vm.sendMaxAmount = false
-        vm.isFastVault = true
+        vm.vault.fastVaultEligibility = true  // computed `vm.isFastVault` reads this
         vm.isStakingOperation = false
         vm.transactionType = .unspecified
 

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelMakeTransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelMakeTransactionTests.swift
@@ -30,7 +30,6 @@ final class SendDetailsViewModelMakeTransactionTests: XCTestCase {
         vm.feeMode = .fast
         vm.estimatedGasLimit = BigInt(21_000)
         vm.sendMaxAmount = false
-        vm.vault.fastVaultEligibility = true  // computed `vm.isFastVault` reads this
         vm.isStakingOperation = false
         vm.transactionType = .unspecified
 
@@ -49,7 +48,6 @@ final class SendDetailsViewModelMakeTransactionTests: XCTestCase {
         XCTAssertEqual(tx.feeMode, .fast)
         XCTAssertEqual(tx.estimatedGasLimit, BigInt(21_000))
         XCTAssertFalse(tx.sendMaxAmount)
-        XCTAssertTrue(tx.isFastVault)
         XCTAssertFalse(tx.isStakingOperation)
         XCTAssertEqual(tx.transactionType, .unspecified)
     }

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelTests.swift
@@ -24,7 +24,7 @@ final class SendDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.memo, "")
         XCTAssertEqual(vm.feeMode, .default)
         XCTAssertFalse(vm.sendMaxAmount)
-        XCTAssertFalse(vm.isFastVault)
+        XCTAssertFalse(vm.vault.isFastVault)
         XCTAssertNil(vm.customGasLimit)
         XCTAssertNil(vm.customByteFee)
         XCTAssertTrue(vm.memoFunctionDictionary.isEmpty)
@@ -329,21 +329,33 @@ final class SendDetailsViewModelTests: XCTestCase {
     }
 
     // MARK: - Fast vault
-    // `isFastVault` is now a computed property reading `vault.fastVaultEligibility`.
-    // The cache is populated by `FastVaultEligibilityRefresher` (see its tests).
+    // `vault.isFastVault` is the unified read — cache-first with structural
+    // fallback. The cache is populated by `FastVaultEligibilityRefresher`
+    // (see its tests for the populate path).
 
-    func testIsFastVaultReflectsVaultCacheTrue() {
+    func testVaultIsFastVaultReflectsCachedTrue() {
         let vault = SendFormFixture.makeVault()
         vault.fastVaultEligibility = true
+        vault.fastVaultEligibilityCheckedAt = Date()
         let vm = SendFormFixture.make(vault: vault)
-        XCTAssertTrue(vm.isFastVault)
+        XCTAssertTrue(vm.vault.isFastVault)
     }
 
-    func testIsFastVaultReflectsVaultCacheFalse() {
+    func testVaultIsFastVaultReflectsCachedFalse() {
         let vault = SendFormFixture.makeVault()
         vault.fastVaultEligibility = false
+        vault.fastVaultEligibilityCheckedAt = Date()
         let vm = SendFormFixture.make(vault: vault)
-        XCTAssertFalse(vm.isFastVault)
+        XCTAssertFalse(vm.vault.isFastVault)
+    }
+
+    func testVaultIsFastVaultFallsBackToStructuralWhenCacheEmpty() {
+        // No cache yet (checkedAt == nil). With a `server-` signer in the
+        // list, the structural fallback returns true.
+        let vault = SendFormFixture.makeVault()
+        vault.signers = ["iPhone-test", "server-abc"]
+        let vm = SendFormFixture.make(vault: vault)
+        XCTAssertTrue(vm.vault.isFastVault)
     }
 
     // MARK: - Amount sync validation (Phase 2b)

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelTests.swift
@@ -329,25 +329,20 @@ final class SendDetailsViewModelTests: XCTestCase {
     }
 
     // MARK: - Fast vault
+    // `isFastVault` is now a computed property reading `vault.fastVaultEligibility`.
+    // The cache is populated by `FastVaultEligibilityRefresher` (see its tests).
 
-    func testLoadFastVaultEligibleSetsFlag() async {
-        let interactor = MockSendInteractor()
-        interactor.loadFastVaultResult = true
-        let vm = SendFormFixture.make(interactor: interactor)
-
-        await vm.loadFastVault()
-
+    func testIsFastVaultReflectsVaultCacheTrue() {
+        let vault = SendFormFixture.makeVault()
+        vault.fastVaultEligibility = true
+        let vm = SendFormFixture.make(vault: vault)
         XCTAssertTrue(vm.isFastVault)
-        XCTAssertEqual(interactor.loadFastVaultCalls.count, 1)
     }
 
-    func testLoadFastVaultIneligibleLeavesFlagFalse() async {
-        let interactor = MockSendInteractor()
-        interactor.loadFastVaultResult = false
-        let vm = SendFormFixture.make(interactor: interactor)
-
-        await vm.loadFastVault()
-
+    func testIsFastVaultReflectsVaultCacheFalse() {
+        let vault = SendFormFixture.makeVault()
+        vault.fastVaultEligibility = false
+        let vm = SendFormFixture.make(vault: vault)
         XCTAssertFalse(vm.isFastVault)
     }
 

--- a/VultisigApp/VultisigAppTests/Send/SendInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendInteractorTests.swift
@@ -160,8 +160,6 @@ private final class StubSendInteractor: SendInteractor {
     var lastFeeMode: FeeMode?
     var lastGasLimit: BigInt?
 
-    func loadFastVault(vault: Vault) async -> Bool { false }
-
     func fetchChainSpecific(_ request: SendChainSpecificRequest) async throws -> BlockChainSpecific {
         lastGasLimit = request.gasLimit
         lastFeeMode = request.feeMode

--- a/VultisigApp/VultisigAppTests/Send/SendPhaseDRegressionTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendPhaseDRegressionTests.swift
@@ -191,7 +191,6 @@ final class SendPhaseDRegressionTests: XCTestCase {
             customGasLimit: nil,
             customByteFee: nil,
             sendMaxAmount: false,
-            isFastVault: false,
             isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:],

--- a/VultisigApp/VultisigAppTests/Send/SendTransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendTransactionTests.swift
@@ -28,7 +28,6 @@ final class SendTransactionTests: XCTestCase {
         XCTAssertEqual(tx.fee, .zero)
         XCTAssertEqual(tx.feeMode, .default)
         XCTAssertFalse(tx.sendMaxAmount)
-        XCTAssertFalse(tx.isFastVault)
         XCTAssertNil(tx.customGasLimit)
         XCTAssertNil(tx.customByteFee)
         XCTAssertTrue(tx.memoFunctionDictionary.isEmpty)
@@ -113,7 +112,6 @@ final class SendTransactionTests: XCTestCase {
             customGasLimit: BigInt(50_000), // user pinned
             customByteFee: nil,
             sendMaxAmount: false,
-            isFastVault: false,
             isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:],
@@ -154,7 +152,6 @@ final class SendTransactionTests: XCTestCase {
             customGasLimit: nil,
             customByteFee: BigInt(80),
             sendMaxAmount: false,
-            isFastVault: false,
             isStakingOperation: false,
             transactionType: .unspecified,
             memoFunctionDictionary: [:],
@@ -250,12 +247,6 @@ final class SendTransactionTests: XCTestCase {
         XCTAssertTrue(updated.sendMaxAmount)
     }
 
-    func testWithUpdatesIsFastVault() throws {
-        let tx = try seed(isFastVault: false)
-        let updated = tx.with(isFastVault: true)
-        XCTAssertTrue(updated.isFastVault)
-    }
-
     func testWithUpdatesIsStakingOperation() throws {
         let tx = try seed(isStakingOperation: false)
         let updated = tx.with(isStakingOperation: true)
@@ -292,7 +283,7 @@ final class SendTransactionTests: XCTestCase {
         let updated = tx.with(
             toAddress: "x", amount: "y", gas: BigInt(1), fee: BigInt(2),
             feeMode: .fast, estimatedGasLimit: BigInt(3), memo: "z",
-            sendMaxAmount: true, isFastVault: true, isStakingOperation: true,
+            sendMaxAmount: true, isStakingOperation: true,
             memoFunctionDictionary: ["k": "v"], wasmContractPayload: nil
         )
         XCTAssertEqual(updated.coin, tx.coin)
@@ -314,7 +305,6 @@ final class SendTransactionTests: XCTestCase {
         memo: String = "",
         feeMode: FeeMode = .default,
         sendMaxAmount: Bool = false,
-        isFastVault: Bool = false,
         isStakingOperation: Bool = false
     ) throws -> SendTransaction {
         let vault = try TestStore.makeVault()
@@ -327,7 +317,7 @@ final class SendTransactionTests: XCTestCase {
             feeMode: feeMode,
             estimatedGasLimit: nil, customGasLimit: nil, customByteFee: nil,
             sendMaxAmount: sendMaxAmount,
-            isFastVault: isFastVault, isStakingOperation: isStakingOperation,
+            isStakingOperation: isStakingOperation,
             transactionType: .unspecified,
             memoFunctionDictionary: [:], wasmContractPayload: nil,
             feeCoin: eth

--- a/VultisigApp/VultisigAppTests/Services/FastVaultEligibilityRefresherTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/FastVaultEligibilityRefresherTests.swift
@@ -1,0 +1,155 @@
+//
+//  FastVaultEligibilityRefresherTests.swift
+//  VultisigAppTests
+//
+//  Unit tests for the fast-vault eligibility cache refresher. Closure-injected
+//  dependencies (`checkEligibility`, `saveStorage`, `now`) keep tests fully
+//  offline.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class FastVaultEligibilityRefresherTests: XCTestCase {
+
+    // MARK: - refresh
+
+    func testRefreshUpdatesCacheAndTimestamp() async {
+        let vault = SendFormFixture.makeVault()
+        XCTAssertFalse(vault.fastVaultEligibility)
+        XCTAssertNil(vault.fastVaultEligibilityCheckedAt)
+
+        let fixedDate = Date(timeIntervalSince1970: 1_000_000)
+        var saveCalls = 0
+        let refresher = FastVaultEligibilityRefresher(
+            checkEligibility: { _ in true },
+            saveStorage: { saveCalls += 1 },
+            now: { fixedDate }
+        )
+
+        await refresher.refresh(vault)
+
+        XCTAssertTrue(vault.fastVaultEligibility)
+        XCTAssertEqual(vault.fastVaultEligibilityCheckedAt, fixedDate)
+        XCTAssertEqual(saveCalls, 1)
+    }
+
+    func testRefreshCanFlipFromTrueToFalse() async {
+        let vault = SendFormFixture.makeVault()
+        vault.fastVaultEligibility = true
+        vault.fastVaultEligibilityCheckedAt = Date(timeIntervalSince1970: 0)
+
+        let refresher = FastVaultEligibilityRefresher(
+            checkEligibility: { _ in false },
+            saveStorage: { },
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+
+        await refresher.refresh(vault)
+
+        XCTAssertFalse(vault.fastVaultEligibility)
+        XCTAssertEqual(vault.fastVaultEligibilityCheckedAt, Date(timeIntervalSince1970: 100))
+    }
+
+    func testRefreshPassesVaultToCheckClosure() async {
+        let vault = SendFormFixture.makeVault()
+        vault.pubKeyECDSA = "specific-pubkey"
+
+        var receivedVault: Vault?
+        let refresher = FastVaultEligibilityRefresher(
+            checkEligibility: { v in
+                receivedVault = v
+                return true
+            },
+            saveStorage: { },
+            now: { Date() }
+        )
+
+        await refresher.refresh(vault)
+
+        XCTAssertIdentical(receivedVault, vault)
+    }
+
+    // MARK: - refreshIfStale
+
+    func testRefreshIfStaleRunsWhenNeverChecked() async {
+        let vault = SendFormFixture.makeVault()
+        XCTAssertNil(vault.fastVaultEligibilityCheckedAt)
+
+        var checkCalls = 0
+        let refresher = FastVaultEligibilityRefresher(
+            checkEligibility: { _ in checkCalls += 1; return true },
+            saveStorage: { },
+            now: { Date() }
+        )
+
+        await refresher.refreshIfStale(vault)
+        XCTAssertEqual(checkCalls, 1)
+        XCTAssertTrue(vault.fastVaultEligibility)
+    }
+
+    func testRefreshIfStaleSkipsWhenWithinThreshold() async {
+        let vault = SendFormFixture.makeVault()
+        let lastCheck = Date(timeIntervalSince1970: 1_000_000)
+        vault.fastVaultEligibility = true
+        vault.fastVaultEligibilityCheckedAt = lastCheck
+
+        var checkCalls = 0
+        // Threshold = 24h; now = lastCheck + 1h → within threshold
+        let refresher = FastVaultEligibilityRefresher(
+            checkEligibility: { _ in checkCalls += 1; return false },
+            saveStorage: { },
+            now: { lastCheck.addingTimeInterval(60 * 60) },
+            stalenessThreshold: 24 * 60 * 60
+        )
+
+        await refresher.refreshIfStale(vault)
+
+        XCTAssertEqual(checkCalls, 0)
+        XCTAssertTrue(vault.fastVaultEligibility, "cached value preserved")
+        XCTAssertEqual(vault.fastVaultEligibilityCheckedAt, lastCheck, "timestamp untouched")
+    }
+
+    func testRefreshIfStaleRunsWhenExpired() async {
+        let vault = SendFormFixture.makeVault()
+        let lastCheck = Date(timeIntervalSince1970: 1_000_000)
+        vault.fastVaultEligibility = false
+        vault.fastVaultEligibilityCheckedAt = lastCheck
+
+        var checkCalls = 0
+        // Threshold = 24h; now = lastCheck + 25h → expired
+        let now = lastCheck.addingTimeInterval(25 * 60 * 60)
+        let refresher = FastVaultEligibilityRefresher(
+            checkEligibility: { _ in checkCalls += 1; return true },
+            saveStorage: { },
+            now: { now },
+            stalenessThreshold: 24 * 60 * 60
+        )
+
+        await refresher.refreshIfStale(vault)
+
+        XCTAssertEqual(checkCalls, 1)
+        XCTAssertTrue(vault.fastVaultEligibility)
+        XCTAssertEqual(vault.fastVaultEligibilityCheckedAt, now)
+    }
+
+    func testRefreshIfStaleRunsAtExactThresholdBoundary() async {
+        // At exactly `stalenessThreshold` elapsed, treat as stale (>=).
+        let vault = SendFormFixture.makeVault()
+        let lastCheck = Date(timeIntervalSince1970: 1_000_000)
+        vault.fastVaultEligibilityCheckedAt = lastCheck
+
+        var checkCalls = 0
+        let refresher = FastVaultEligibilityRefresher(
+            checkEligibility: { _ in checkCalls += 1; return true },
+            saveStorage: { },
+            now: { lastCheck.addingTimeInterval(24 * 60 * 60) },  // exactly at threshold
+            stalenessThreshold: 24 * 60 * 60
+        )
+
+        await refresher.refreshIfStale(vault)
+
+        XCTAssertEqual(checkCalls, 1)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/DefaultSwapInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/DefaultSwapInteractorTests.swift
@@ -10,42 +10,10 @@ import XCTest
 @MainActor
 final class DefaultSwapInteractorTests: XCTestCase {
 
-    // MARK: - loadFastVault
-
-    func testLoadFastVaultReturnsTrueWhenServerExistsAndPartyIsRemote() async {
-        let fastVault = MockFastVaultService()
-        fastVault.stubbedExist = true
-        let interactor = makeInteractor(fastVault: fastVault)
-
-        let vault = makeVault(localPartyID: "iPhone-12345")
-        let result = await interactor.loadFastVault(vault: vault)
-
-        XCTAssertTrue(result)
-        XCTAssertEqual(fastVault.existCallCount, 1)
-        XCTAssertEqual(fastVault.lastQueriedPubKey, vault.pubKeyECDSA)
-    }
-
-    func testLoadFastVaultReturnsFalseForServerPrefixLocalParty() async {
-        let fastVault = MockFastVaultService()
-        fastVault.stubbedExist = true
-        let interactor = makeInteractor(fastVault: fastVault)
-
-        let vault = makeVault(localPartyID: "Server-12345")
-        let result = await interactor.loadFastVault(vault: vault)
-
-        XCTAssertFalse(result)
-    }
-
-    func testLoadFastVaultReturnsFalseWhenServerDoesNotExist() async {
-        let fastVault = MockFastVaultService()
-        fastVault.stubbedExist = false
-        let interactor = makeInteractor(fastVault: fastVault)
-
-        let result = await interactor.loadFastVault(vault: makeVault())
-        XCTAssertFalse(result)
-    }
-
     // MARK: - fetchQuote guards
+    // Note: FastVault eligibility moved off the interactor — now lives on
+    // `Vault.fastVaultEligibility` populated by `FastVaultEligibilityRefresher`.
+    // See `FastVaultEligibilityRefresherTests` for the eligibility logic tests.
 
     func testFetchQuoteReturnsNilForZeroAmount() async throws {
         let quoteService = MockQuoteService(stubbedResult: .failure(StubError.shouldNotBeCalled))

--- a/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
@@ -202,7 +202,6 @@ final class SwapPayloadBuilderTests: XCTestCase {
             thorchainFee: BigInt(2_000),
             vultDiscountBps: 0,
             referralDiscountBps: 0,
-            isFastVault: false,
             feeCoin: rune
         )
     }
@@ -219,7 +218,6 @@ final class SwapPayloadBuilderTests: XCTestCase {
             thorchainFee: BigInt(2_000),
             vultDiscountBps: 0,
             referralDiscountBps: 0,
-            isFastVault: false,
             feeCoin: cacao
         )
     }
@@ -236,7 +234,6 @@ final class SwapPayloadBuilderTests: XCTestCase {
             thorchainFee: 0,
             vultDiscountBps: 0,
             referralDiscountBps: 0,
-            isFastVault: false,
             feeCoin: eth
         )
     }


### PR DESCRIPTION
## Summary

Fast-vault eligibility (`FastVaultService.isEligibleForFastSign(vault:)`) was hit per screen mount in Send, Swap, FunctionCall, Referral, and Settings flows — a network round-trip every time. This PR caches the result on the `Vault` SwiftData model and refreshes it only at two trigger points:

1. **App foreground** (`scenePhase` becomes `.active`) — refreshes the currently selected vault if its cache is stale (>24h or never checked).
2. **Vault switch** (`AppViewModel.set(selectedVault:)`) — same.

All consumer reads become synchronous (`vault.fastVaultEligibility`); no hot-path network calls remain.

## Changes

- **New**: `Core/Services/FastVault/FastVaultEligibilityRefresher.swift` — `@MainActor` service, closure-injected (`checkEligibility`, `saveStorage`, `now`), 24h staleness threshold. Two entry points: `refresh(_:)` (force) and `refreshIfStale(_:)` (skip if fresh).
- **`Vault` SwiftData `@Model`** — adds `fastVaultEligibility: Bool` + `fastVaultEligibilityCheckedAt: Date?`. Not in `CodingKeys` (local-only state; doesn't roundtrip with vault import/export). Lightweight SwiftData migration.
- **`AppViewModel.set(selectedVault:)`** — fires async background refresh for the new vault.
- **`AppViewModel.refreshFastVaultEligibilityIfNeeded()`** — called from `VultisigApp.swift` on `scenePhase .active`.
- **`DefaultSendInteractor.loadFastVault`** / **`DefaultSwapInteractor.loadFastVault`** / **`FunctionCallViewModel.loadFastVault`** — return `vault.fastVaultEligibility` (sync wrapped in async to preserve protocol contracts; `async_without_await` suppressed per-line).
- **`SettingsCustomMessageView.onLoad`** — reads `vault.fastVaultEligibility` directly (no more `await fastVaultService.isEligibleForFastSign`).

## Test plan

- [x] 7 new `FastVaultEligibilityRefresherTests`: refresh updates cache + timestamp; can flip true→false; passes vault to check closure; refreshIfStale skips when fresh; runs when expired / never-checked; threshold boundary (>=).
- [x] Full Send + SendPhaseD + Referral regression suite (75 tests total) green.
- [x] SwiftLint clean on all 9 changed files.
- [ ] **Manual smoke required** (the cache's behavior changes user-visible state on first-run / stale-cache edge cases):
  - [ ] Cold start with selected Fast Vault → Send screen loads, `isFastVault` becomes true within seconds (cache populates async).
  - [ ] Cold start with selected Secure Vault → Send screen loads, `isFastVault` stays false.
  - [ ] Background → 24h → foreground → cache refreshes and reflects current server state.
  - [ ] Switch from Fast → Secure vault → next Send screen shows correct fast-vault routing.
  - [ ] First-ever launch with newly imported Fast Vault → first Send screen mount may show `isFastVault = false` until refresh completes (acceptable race; UI re-renders via SwiftData observation when cache flips).

## Known limitations

- `FastVaultService.isEligibleForFastSign(vault:)` swallows network errors and returns `false`. Transient network failures during refresh will cache a `false` value until the next trigger (24h or vault switch). Future work could refactor `exist(pubKeyECDSA:)` to throw on transient errors so the refresher can keep the previous cached value — out of scope here.
- The cache lives on the Vault `@Model`, so SwiftData persists it. Cross-device vault import (via `.vult` file or re-encoded backup) starts with `fastVaultEligibility: false` and re-populates on next refresh trigger — that's by design (the field is local-only state, not a vault property).

## Stack

- This PR branches off **`refactor/referral-form-vm` (PR-A, #4369)**. Inherits PR-A's clean Referral surface so `ReferralDetailsViewModel.loadFastVault` is migrated as part of this PR's `interactor.loadFastVault` change.
- Once PR-A and PR-B (#4370) land, this rebases onto whichever is base at the time.
- Tracked in workstream [[fast-vault-cache/overview]] (wiki).

🤖 Generated with [Claude Code](https://claude.com/claude-code)