### PR TITLE
fix: cancel delayed macOS UI updates

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/commondata",
       "state" : {
-        "revision" : "798af1557c0f2217ede66576b67b2afd22011dba"
+        "revision" : "c26bb9f9839429967a47fc44bd0440958e755709"
       }
     },
     {

--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/commondata",
       "state" : {
-        "revision" : "c26bb9f9839429967a47fc44bd0440958e755709"
+        "revision" : "798af1557c0f2217ede66576b67b2afd22011dba"
       }
     },
     {

--- a/VultisigApp/VultisigApp/Components/NotificationBanner/NotificationBannerView.swift
+++ b/VultisigApp/VultisigApp/Components/NotificationBanner/NotificationBannerView.swift
@@ -32,6 +32,7 @@ struct NotificationBannerView: View {
     @State private var progress: Double = 0.0
     @Binding var isVisible: Bool
     @State var isVisibleInternal: Bool = false
+    @State private var dismissalTask: Task<Void, Never>?
 
     let animation: Animation = .interpolatingSpring(mass: 1, stiffness: 100, damping: 15)
     private let duration: Double = 1.3
@@ -80,24 +81,35 @@ struct NotificationBannerView: View {
             .opacity(isVisibleInternal ? 1.0 : 0.0)
             .animation(.interpolatingSpring(mass: 1, stiffness: 100, damping: 15), value: isVisibleInternal)
             .onAppear {
+                withAnimation(.interpolatingSpring(mass: 1, stiffness: 100, damping: 15)) {
+                    isVisibleInternal = true
+                }
                 progress = 1.0
-
-                DispatchQueue.main.asyncAfter(deadline: .now() + duration + progressDelay) {
+                dismissalTask?.cancel()
+                dismissalTask = Task { @MainActor in
+                    let hideDelay = Int((duration + Double(progressDelay)) * 1000)
+                    do {
+                        try await Task.sleep(for: .milliseconds(hideDelay))
+                    } catch {
+                        return
+                    }
+                    guard !Task.isCancelled else { return }
                     withAnimation(animation) {
                         isVisibleInternal = false
                     }
-
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                        isVisible = false
+                    do {
+                        try await Task.sleep(for: .milliseconds(200))
+                    } catch {
+                        return
                     }
+                    guard !Task.isCancelled else { return }
+                    isVisible = false
                 }
             }
         }
         .padding(.horizontal, 12)
-        .onAppear {
-            withAnimation(.interpolatingSpring(mass: 1, stiffness: 100, damping: 15)) {
-                isVisibleInternal = true
-            }
+        .onDisappear {
+            dismissalTask?.cancel()
         }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Utils/DelayedTask.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/DelayedTask.swift
@@ -1,0 +1,26 @@
+//
+//  DelayedTask.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Schedules `action` to run on the main actor after `delay`. The returned
+/// task can be cancelled to abort the pending action — including the post-
+/// sleep main-thread hop, which is what prevents a stale closure from
+/// running after the owning view has been torn down.
+@MainActor
+func delayedTask(
+    after delay: Duration,
+    action: @MainActor @escaping () -> Void
+) -> Task<Void, Never> {
+    Task { @MainActor in
+        do {
+            try await Task.sleep(for: delay)
+        } catch {
+            return
+        }
+        guard !Task.isCancelled else { return }
+        action()
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
@@ -27,6 +27,8 @@ struct DefiMainScreen: View {
     @State var focusSearch: Bool = false
     @State var scrollOffset: CGFloat = 0
     @State var showChainSelection: Bool = false
+    @State private var searchScrollTask: Task<Void, Never>?
+    @State private var clearSearchTask: Task<Void, Never>?
 
     private let scrollReferenceId = "DefiMainScreenBottomContentId"
     private let contentInset: CGFloat = 78
@@ -60,11 +62,14 @@ struct DefiMainScreen: View {
             .onChange(of: showSearchHeader) { _, showSearchHeader in
                 if showSearchHeader {
                     focusSearch = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+                    searchScrollTask?.cancel()
+                    searchScrollTask = delayedTask(after: .milliseconds(700)) {
                         withAnimation {
                             scrollProxy?.scrollTo(scrollReferenceId, anchor: .center)
                         }
                     }
+                } else {
+                    searchScrollTask?.cancel()
                 }
             }
             .crossPlatformSheet(isPresented: $showChainSelection) {
@@ -84,6 +89,10 @@ struct DefiMainScreen: View {
         .throttledOnAppear(interval: 15.0, action: refresh)
         .onChange(of: vault) { _, _ in
             refresh()
+        }
+        .onDisappear {
+            searchScrollTask?.cancel()
+            clearSearchTask?.cancel()
         }
     }
 
@@ -171,7 +180,8 @@ struct DefiMainScreen: View {
     func onCustomizeChains() {
         showChainSelection = true
         // Clear search after sheet gets presented
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        clearSearchTask?.cancel()
+        clearSearchTask = delayedTask(after: .seconds(1)) {
             clearSearch()
         }
     }
@@ -180,6 +190,20 @@ struct DefiMainScreen: View {
         let showBalanceInHeader: Bool = offset < contentInset
         guard showBalanceInHeader != self.showBalanceInHeader else { return }
         self.showBalanceInHeader = showBalanceInHeader
+    }
+}
+
+private extension DefiMainScreen {
+    func delayedTask(after delay: Duration, action: @MainActor @escaping () -> Void) -> Task<Void, Never> {
+        Task { @MainActor in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            action()
+        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
@@ -193,20 +193,6 @@ struct DefiMainScreen: View {
     }
 }
 
-private extension DefiMainScreen {
-    func delayedTask(after delay: Duration, action: @MainActor @escaping () -> Void) -> Task<Void, Never> {
-        Task { @MainActor in
-            do {
-                try await Task.sleep(for: delay)
-            } catch {
-                return
-            }
-            guard !Task.isCancelled else { return }
-            action()
-        }
-    }
-}
-
 #Preview {
     DefiMainScreen(
         vault: .example,

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -32,6 +32,15 @@ struct HomeScreen: View {
     @State private var deeplinkError: Error?
 
     @State private var capturedGeometryHeight: CGFloat = 600
+    @State private var processDeeplinkTask: Task<Void, Never>?
+    @State private var selectVaultTask: Task<Void, Never>?
+    @State private var joinKeysignTask: Task<Void, Never>?
+    @State private var joinKeygenTask: Task<Void, Never>?
+    @State private var initialDeeplinkTask: Task<Void, Never>?
+    @State private var retrySendDeeplinkTask: Task<Void, Never>?
+    @State private var sendRouteTask: Task<Void, Never>?
+    @State private var addressOnlyRouteTask: Task<Void, Never>?
+    @State private var scannerCloseTask: Task<Void, Never>?
 
     @EnvironmentObject var vaultDetailViewModel: VaultDetailViewModel
     @EnvironmentObject var deeplinkViewModel: DeeplinkViewModel
@@ -72,7 +81,8 @@ struct HomeScreen: View {
 
             if showScanner {
                 showScanner = false
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                processDeeplinkTask?.cancel()
+                processDeeplinkTask = delayedTask(after: .milliseconds(300)) {
                     presetValuesForDeeplink()
                 }
             } else {
@@ -116,6 +126,9 @@ struct HomeScreen: View {
             Button(NSLocalizedString("dismiss", comment: ""), role: .cancel) {}
         } message: {
             Text(phoneCheckUpdateViewModel.latestVersionString)
+        }
+        .onDisappear {
+            cancelDelayedTasks()
         }
     }
 
@@ -176,7 +189,7 @@ struct HomeScreen: View {
     private func applyModifiers<V: View>(to view: V, selectedVault: Vault, geo: GeometryProxy)
     -> some View {
         let withBasicModifiers =
-        view
+            view
             .onAppear {
                 capturedGeometryHeight = geo.size.height
             }
@@ -302,8 +315,8 @@ struct HomeScreen: View {
                     showVaultSelector.toggle()
                     if deeplinkViewModel.pendingSendDeeplink {
                         let isAddressOnly =
-                        deeplinkViewModel.address != nil && deeplinkViewModel.assetChain == nil
-                        && deeplinkViewModel.assetTicker == nil
+                            deeplinkViewModel.address != nil && deeplinkViewModel.assetChain == nil
+                            && deeplinkViewModel.assetTicker == nil
 
                         if isAddressOnly, let address = deeplinkViewModel.address {
                             processAddressOnlyDeeplink(address: address, vault: vault)
@@ -311,7 +324,8 @@ struct HomeScreen: View {
                             handleSendDeeplinkAfterVaultSelection(vault: vault)
                         }
                     } else {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        selectVaultTask?.cancel()
+                        selectVaultTask = delayedTask(after: .milliseconds(300)) {
                             appViewModel.set(selectedVault: vault, restartNavigation: false)
                         }
                     }
@@ -359,7 +373,8 @@ extension HomeScreen {
 
         appViewModel.set(selectedVault: vault, restartNavigation: false)
         showVaultSelector = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        joinKeysignTask?.cancel()
+        joinKeysignTask = delayedTask(after: .milliseconds(100)) {
             navigateToJoinKeysign()
         }
     }
@@ -371,7 +386,8 @@ extension HomeScreen {
     fileprivate func moveToCreateVaultView() {
         guard let selectedVault = appViewModel.selectedVault else { return }
         showVaultSelector = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        joinKeygenTask?.cancel()
+        joinKeygenTask = delayedTask(after: .milliseconds(100)) {
             navigateToJoinKeygen(selectedVault: selectedVault)
         }
     }
@@ -384,14 +400,14 @@ extension HomeScreen {
         var fetchVaultDescriptor = FetchDescriptor<Vault>()
         fetchVaultDescriptor.relationshipKeyPathsForPrefetching = [
             \.coins,
-             \.hiddenTokens,
-             \.referralCode,
-             \.referredCode,
-             \.defiPositions,
-             \.bondPositions,
-             \.stakePositions,
-             \.lpPositions,
-             \.closedBanners
+            \.hiddenTokens,
+            \.referralCode,
+            \.referredCode,
+            \.defiPositions,
+            \.bondPositions,
+            \.stakePositions,
+            \.lpPositions,
+            \.closedBanners
         ]
         do {
             vaults = try modelContext.fetch(fetchVaultDescriptor)
@@ -410,7 +426,8 @@ extension HomeScreen {
         } else if !vaults.isEmpty {
             presetValuesForDeeplink()
         } else if deeplinkViewModel.type != nil {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            initialDeeplinkTask?.cancel()
+            initialDeeplinkTask = delayedTask(after: .milliseconds(800)) {
                 if !vaults.isEmpty && deeplinkViewModel.type != nil {
                     presetValuesForDeeplink()
                 } else if deeplinkViewModel.type != nil {
@@ -456,7 +473,8 @@ extension HomeScreen {
         }
 
         guard !vaults.isEmpty else {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            retrySendDeeplinkTask?.cancel()
+            retrySendDeeplinkTask = delayedTask(after: .seconds(1)) {
                 if !vaults.isEmpty {
                     handleSendDeeplink()
                 }
@@ -511,7 +529,8 @@ extension HomeScreen {
 
         let coinToUse: Coin? = coin ?? vault.coins.first
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        sendRouteTask?.cancel()
+        sendRouteTask = delayedTask(after: .milliseconds(300)) {
             vaultRoute = .mainAction(.send(
                 coin: coinToUse,
                 hasPreselectedCoin: coinToUse != nil,
@@ -589,7 +608,8 @@ extension HomeScreen {
 
         deeplinkViewModel.address = address
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        addressOnlyRouteTask?.cancel()
+        addressOnlyRouteTask = delayedTask(after: .milliseconds(300)) {
             self.vaultRoute = .mainAction(
                 .send(
                     coin: coinToUse,
@@ -602,7 +622,8 @@ extension HomeScreen {
     private func closeScannerIfNeeded(completion: @escaping () -> Void) {
         if showScanner {
             showScanner = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            scannerCloseTask?.cancel()
+            scannerCloseTask = delayedTask(after: .milliseconds(300)) {
                 completion()
             }
         } else {
@@ -637,6 +658,32 @@ extension HomeScreen {
 
     fileprivate func navigateToImportBackup() {
         router.navigate(to: OnboardingRoute.importVaultShare)
+    }
+}
+
+private extension HomeScreen {
+    func delayedTask(after delay: Duration, action: @MainActor @escaping () -> Void) -> Task<Void, Never> {
+        Task { @MainActor in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            action()
+        }
+    }
+
+    func cancelDelayedTasks() {
+        processDeeplinkTask?.cancel()
+        selectVaultTask?.cancel()
+        joinKeysignTask?.cancel()
+        joinKeygenTask?.cancel()
+        initialDeeplinkTask?.cancel()
+        retrySendDeeplinkTask?.cancel()
+        sendRouteTask?.cancel()
+        addressOnlyRouteTask?.cancel()
+        scannerCloseTask?.cancel()
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -32,15 +32,26 @@ struct HomeScreen: View {
     @State private var deeplinkError: Error?
 
     @State private var capturedGeometryHeight: CGFloat = 600
-    @State private var processDeeplinkTask: Task<Void, Never>?
-    @State private var selectVaultTask: Task<Void, Never>?
-    @State private var joinKeysignTask: Task<Void, Never>?
-    @State private var joinKeygenTask: Task<Void, Never>?
-    @State private var initialDeeplinkTask: Task<Void, Never>?
-    @State private var retrySendDeeplinkTask: Task<Void, Never>?
-    @State private var sendRouteTask: Task<Void, Never>?
-    @State private var addressOnlyRouteTask: Task<Void, Never>?
-    @State private var scannerCloseTask: Task<Void, Never>?
+    /// Cancellable delayed-UI-mutation tasks keyed by trigger. The dictionary
+    /// preserves per-call-site replace semantics (firing the same trigger
+    /// twice cancels the prior in-flight task before scheduling the new one)
+    /// while `cancelDelayedTasks()` on `.onDisappear` clears every pending
+    /// task in one shot. See [[fix-macos-cancellable-ui-delays]].
+    @State private var delayedTasks: [DelayedTaskID: Task<Void, Never>] = [:]
+
+    /// Identifiers for the deferred UI mutations on this screen. One case
+    /// per trigger; names mirror the prior `<name>Task` `@State` vars.
+    private enum DelayedTaskID: Hashable {
+        case processDeeplink
+        case selectVault
+        case joinKeysign
+        case joinKeygen
+        case initialDeeplink
+        case retrySendDeeplink
+        case sendRoute
+        case addressOnlyRoute
+        case scannerClose
+    }
 
     @EnvironmentObject var vaultDetailViewModel: VaultDetailViewModel
     @EnvironmentObject var deeplinkViewModel: DeeplinkViewModel
@@ -81,8 +92,7 @@ struct HomeScreen: View {
 
             if showScanner {
                 showScanner = false
-                processDeeplinkTask?.cancel()
-                processDeeplinkTask = delayedTask(after: .milliseconds(300)) {
+                scheduleDelayedTask(.processDeeplink, after: .milliseconds(300)) {
                     presetValuesForDeeplink()
                 }
             } else {
@@ -324,8 +334,7 @@ struct HomeScreen: View {
                             handleSendDeeplinkAfterVaultSelection(vault: vault)
                         }
                     } else {
-                        selectVaultTask?.cancel()
-                        selectVaultTask = delayedTask(after: .milliseconds(300)) {
+                        scheduleDelayedTask(.selectVault, after: .milliseconds(300)) {
                             appViewModel.set(selectedVault: vault, restartNavigation: false)
                         }
                     }
@@ -373,8 +382,7 @@ extension HomeScreen {
 
         appViewModel.set(selectedVault: vault, restartNavigation: false)
         showVaultSelector = false
-        joinKeysignTask?.cancel()
-        joinKeysignTask = delayedTask(after: .milliseconds(100)) {
+        scheduleDelayedTask(.joinKeysign, after: .milliseconds(100)) {
             navigateToJoinKeysign()
         }
     }
@@ -386,8 +394,7 @@ extension HomeScreen {
     fileprivate func moveToCreateVaultView() {
         guard let selectedVault = appViewModel.selectedVault else { return }
         showVaultSelector = false
-        joinKeygenTask?.cancel()
-        joinKeygenTask = delayedTask(after: .milliseconds(100)) {
+        scheduleDelayedTask(.joinKeygen, after: .milliseconds(100)) {
             navigateToJoinKeygen(selectedVault: selectedVault)
         }
     }
@@ -426,8 +433,7 @@ extension HomeScreen {
         } else if !vaults.isEmpty {
             presetValuesForDeeplink()
         } else if deeplinkViewModel.type != nil {
-            initialDeeplinkTask?.cancel()
-            initialDeeplinkTask = delayedTask(after: .milliseconds(800)) {
+            scheduleDelayedTask(.initialDeeplink, after: .milliseconds(800)) {
                 if !vaults.isEmpty && deeplinkViewModel.type != nil {
                     presetValuesForDeeplink()
                 } else if deeplinkViewModel.type != nil {
@@ -473,8 +479,7 @@ extension HomeScreen {
         }
 
         guard !vaults.isEmpty else {
-            retrySendDeeplinkTask?.cancel()
-            retrySendDeeplinkTask = delayedTask(after: .seconds(1)) {
+            scheduleDelayedTask(.retrySendDeeplink, after: .seconds(1)) {
                 if !vaults.isEmpty {
                     handleSendDeeplink()
                 }
@@ -529,8 +534,7 @@ extension HomeScreen {
 
         let coinToUse: Coin? = coin ?? vault.coins.first
 
-        sendRouteTask?.cancel()
-        sendRouteTask = delayedTask(after: .milliseconds(300)) {
+        scheduleDelayedTask(.sendRoute, after: .milliseconds(300)) {
             vaultRoute = .mainAction(.send(
                 coin: coinToUse,
                 hasPreselectedCoin: coinToUse != nil,
@@ -608,8 +612,7 @@ extension HomeScreen {
 
         deeplinkViewModel.address = address
 
-        addressOnlyRouteTask?.cancel()
-        addressOnlyRouteTask = delayedTask(after: .milliseconds(300)) {
+        scheduleDelayedTask(.addressOnlyRoute, after: .milliseconds(300)) {
             self.vaultRoute = .mainAction(
                 .send(
                     coin: coinToUse,
@@ -622,8 +625,7 @@ extension HomeScreen {
     private func closeScannerIfNeeded(completion: @escaping () -> Void) {
         if showScanner {
             showScanner = false
-            scannerCloseTask?.cancel()
-            scannerCloseTask = delayedTask(after: .milliseconds(300)) {
+            scheduleDelayedTask(.scannerClose, after: .milliseconds(300)) {
                 completion()
             }
         } else {
@@ -662,28 +664,21 @@ extension HomeScreen {
 }
 
 private extension HomeScreen {
-    func delayedTask(after delay: Duration, action: @MainActor @escaping () -> Void) -> Task<Void, Never> {
-        Task { @MainActor in
-            do {
-                try await Task.sleep(for: delay)
-            } catch {
-                return
-            }
-            guard !Task.isCancelled else { return }
-            action()
-        }
+    /// Cancels any in-flight task with the same `id` before scheduling the
+    /// new one — preserves the prior named-state contract that firing the
+    /// same trigger twice doesn't leave two delayed actions racing.
+    private func scheduleDelayedTask(
+        _ id: DelayedTaskID,
+        after delay: Duration,
+        action: @MainActor @escaping () -> Void
+    ) {
+        delayedTasks[id]?.cancel()
+        delayedTasks[id] = delayedTask(after: delay, action: action)
     }
 
     func cancelDelayedTasks() {
-        processDeeplinkTask?.cancel()
-        selectVaultTask?.cancel()
-        joinKeysignTask?.cancel()
-        joinKeygenTask?.cancel()
-        initialDeeplinkTask?.cancel()
-        retrySendDeeplinkTask?.cancel()
-        sendRouteTask?.cancel()
-        addressOnlyRouteTask?.cancel()
-        scannerCloseTask?.cancel()
+        delayedTasks.values.forEach { $0.cancel() }
+        delayedTasks.removeAll()
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -30,6 +30,8 @@ struct ChainDetailScreen: View {
     /// key — pickup happens once `qbtcQuantumKeygenCompleted` fires so the
     /// user lands back here with QBTC already added to the vault.
     @State private var pendingQbtcAddAfterKeygen: Bool = false
+    @State private var addressCopyTask: Task<Void, Never>?
+    @State private var coinDetailTask: Task<Void, Never>?
 
     private let scrollReferenceId = "chainDetailScreenBottomContentId"
 
@@ -161,7 +163,8 @@ struct ChainDetailScreen: View {
                 onShare: { showReceiveSheet = false },
                 onCopy: { coin in
                     showReceiveSheet = false
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                    addressCopyTask?.cancel()
+                    addressCopyTask = delayedTask(after: .milliseconds(350)) {
                         onAddressCopy?(coin)
                     }
                 }
@@ -196,13 +199,15 @@ struct ChainDetailScreen: View {
             if newValue != nil {
                 #if os(macOS)
                 // Add a small delay on macOS to prevent state conflicts
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                coinDetailTask?.cancel()
+                coinDetailTask = delayedTask(after: .milliseconds(50)) {
                     showCoinDetail = true
                 }
                 #else
                 showCoinDetail = true
                 #endif
             } else {
+                coinDetailTask?.cancel()
                 showCoinDetail = false
             }
         }
@@ -216,6 +221,10 @@ struct ChainDetailScreen: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .qbtcQuantumKeygenCompleted)) { note in
             handleQuantumKeygenCompleted(note: note)
+        }
+        .onDisappear {
+            addressCopyTask?.cancel()
+            coinDetailTask?.cancel()
         }
     }
 
@@ -303,6 +312,20 @@ struct ChainDetailScreen: View {
             }
             .buttonStyle(.plain)
             .transition(.opacity)
+        }
+    }
+}
+
+private extension ChainDetailScreen {
+    func delayedTask(after delay: Duration, action: @MainActor @escaping () -> Void) -> Task<Void, Never> {
+        Task { @MainActor in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            action()
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -317,20 +317,6 @@ struct ChainDetailScreen: View {
 }
 
 private extension ChainDetailScreen {
-    func delayedTask(after delay: Duration, action: @MainActor @escaping () -> Void) -> Task<Void, Never> {
-        Task { @MainActor in
-            do {
-                try await Task.sleep(for: delay)
-            } catch {
-                return
-            }
-            guard !Task.isCancelled else { return }
-            action()
-        }
-    }
-}
-
-private extension ChainDetailScreen {
     func onRefreshButton() {
         refresh()
     }


### PR DESCRIPTION
## Summary
- Replace selected delayed SwiftUI/AppKit UI mutations with cancellable main-actor tasks
- Cancel pending delayed tasks when the relevant views disappear or state changes
- Scope the change to macOS crash-adjacent Home, ChainDetail, DefiMain, and notification banner flows

## Issue
Fixes #3984

## Test Plan
- swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/VultisigApp/Components/NotificationBanner/NotificationBannerView.swift VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift VultisigApp/VultisigApp/Features/Home/HomeScreen.swift VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
- git diff --check
- xcodebuild build -project VultisigApp/VultisigApp.xcodeproj -scheme VultisigApp -destination 'platform=macOS'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced legacy delayed callbacks with cancellable async tasks for more reliable UI timing.
  * Notification banners now dismiss cleanly and respect cancellation.
  * Search/header interactions reliably scroll when shown and avoid duplicate actions.
  * Navigation and deeplink flows trigger at consistent, configurable delays.
  * Chain/coin detail presentation and address-copy actions are debounced and cancelled on view disappearance for improved responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->