### PR TITLE
fix(send): hide memo field for Cardano (temporary, #4377)

### DIFF
--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
@@ -14,9 +14,19 @@ struct SendDetailsAdditionalSection: View {
 
     @EnvironmentObject var appViewModel: AppViewModel
 
+    /// Temporary mitigation for #4326 — Cardano memos silently drop on-chain
+    /// because WalletCore doesn't expose CIP-20 auxiliary data yet. Hide the
+    /// memo input entirely until proper metadata support lands; tracked in
+    /// #4377. Re-enable by removing this guard when #4326 closes.
+    private var supportsMemo: Bool {
+        viewModel.coin.chain != .cardano
+    }
+
     var body: some View {
         VStack(spacing: 14) {
-            addMemoField
+            if supportsMemo {
+                addMemoField
+            }
         }
         .onAppear {
             if !viewModel.memo.isEmpty {

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
@@ -14,17 +14,12 @@ struct SendDetailsAdditionalSection: View {
 
     @EnvironmentObject var appViewModel: AppViewModel
 
-    /// Temporary mitigation for #4326 — Cardano memos silently drop on-chain
-    /// because WalletCore doesn't expose CIP-20 auxiliary data yet. Hide the
-    /// memo input entirely until proper metadata support lands; tracked in
-    /// #4377. Re-enable by removing this guard when #4326 closes.
-    private var supportsMemo: Bool {
-        viewModel.coin.chain != .cardano
-    }
-
     var body: some View {
         VStack(spacing: 14) {
-            if supportsMemo {
+            // Memo input is gated by `Chain.supportsMemo` so per-chain
+            // capability lives in the model, not scattered across UI.
+            // Cardano currently returns false (see #4326 / #4377).
+            if viewModel.coin.chain.supportsMemo {
                 addMemoField
             }
         }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
@@ -57,11 +57,11 @@ struct SendDetailsScreen: View {
                 viewModel.initializePendingTransactionState(for: newValue.chain)
                 PendingTransactionManager.shared.stopPollingForChain(oldValue.chain)
                 viewModel.refreshPendingTransactionState()
-                // Temporary mitigation for #4326: Cardano memos silently drop
-                // on-chain. The memo input is hidden for Cardano in
-                // `SendDetailsAdditionalSection`; clear any previously-typed
-                // value so it doesn't ride along invisibly. Tracked in #4377.
-                if newValue.chain == .cardano {
+                // Per-chain capability lives on `Chain.supportsMemo`. Clear
+                // any previously-typed memo when switching into a chain that
+                // doesn't support memos so it doesn't ride along invisibly.
+                // (See #4326 / #4377 for the Cardano case.)
+                if !newValue.chain.supportsMemo {
                     viewModel.memo = ""
                 }
             }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
@@ -57,6 +57,13 @@ struct SendDetailsScreen: View {
                 viewModel.initializePendingTransactionState(for: newValue.chain)
                 PendingTransactionManager.shared.stopPollingForChain(oldValue.chain)
                 viewModel.refreshPendingTransactionState()
+                // Temporary mitigation for #4326: Cardano memos silently drop
+                // on-chain. The memo input is hidden for Cardano in
+                // `SendDetailsAdditionalSection`; clear any previously-typed
+                // value so it doesn't ride along invisibly. Tracked in #4377.
+                if newValue.chain == .cardano {
+                    viewModel.memo = ""
+                }
             }
             .onChange(of: viewModel.toAddress) { _, _ in
                 viewModel.cancelAddressResolution()

--- a/VultisigApp/VultisigApp/Model/Chain.swift
+++ b/VultisigApp/VultisigApp/Model/Chain.swift
@@ -598,6 +598,22 @@ extension Chain {
         }
     }
 
+    /// Whether the Send flow's memo input should be exposed for this chain.
+    /// Currently every chain supports a memo at the protocol level except
+    /// Cardano — WalletCore doesn't yet expose CIP-20 auxiliary data fields,
+    /// so iOS Cardano signing silently drops anything the user types. Hiding
+    /// the input avoids the silent-drop bug until proper metadata support
+    /// lands. See #4326 (root) and #4377 (this mitigation); remove the
+    /// `.cardano` case here when #4326 closes.
+    var supportsMemo: Bool {
+        switch self {
+        case .cardano:
+            return false
+        default:
+            return true
+        }
+    }
+
     static var keyImportEnabledChains: [Chain] {
         allCases.filter {
             switch $0 {


### PR DESCRIPTION
## Summary

Temporary mitigation for #4326 — Cardano sends silently drop user-typed memos because WalletCore doesn't expose CIP-20 auxiliary data fields yet. Eliminate the bug by hiding the memo input entirely for Cardano until the real fix lands.

Fixes #4377. Related: #4326.

## Changes

- **`SendDetailsAdditionalSection`** — gates the `addMemoField` render on `viewModel.coin.chain != .cardano`. Memo input is not shown for Cardano source coins.
- **`SendDetailsScreen.onChange(of: viewModel.coin)`** — clears `viewModel.memo` when the user switches the source coin to Cardano. Prevents a memo typed on another chain from riding invisibly through Continue.

Both spots carry inline `#4326`/`#4377` references + "remove when #4326 closes" notes for the implementer of the proper fix.

## Test plan

- [x] `xcodebuild build` green (iPhone 17 simulator).
- [x] `swiftlint` clean on changed files.
- [x] `SendDetailsViewModelTests` + `SendPhaseDRegressionTests` regression suites pass — no behavioral change for non-Cardano sends.
- [ ] Manual smoke (simulator):
  - [ ] Cardano (ADA) selected → memo field is not visible on the Send Details screen.
  - [ ] Type a memo on ETH → switch source coin to ADA → memo input disappears AND `viewModel.memo` is cleared (verify by switching back to ETH; memo should be empty).
  - [ ] Type a memo on THORChain (RUNE) → Continue → Verify shows the memo. No regression.

## When to remove

Remove both gates (the `supportsMemo` guard in `SendDetailsAdditionalSection` and the chain-switch clear in `SendDetailsScreen`) when #4326 closes — i.e., when iOS Cardano signing includes CIP-20 metadata before preimage signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The memo input field now only appears for chains that support memos, preventing users from entering unsupported data.
  * Memo text is automatically cleared when switching to a chain that doesn't support memos, preventing data from persisting incorrectly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->