### PR TITLE
fix(keysign): stage timeout + handleHelperError race + DKLS rethrow + instrumentation (#4327)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -387,9 +387,17 @@ final class DKLSKeysign {
                 try await Task.sleep(for: .milliseconds(500))
             }
         } catch {
-            print("Failed to sign message (\(messageToSign)), error: \(error.localizedDescription)")
+            logger.error("Failed to sign message (\(messageToSign, privacy: .public)) on attempt \(attempt, privacy: .public): \(error.localizedDescription, privacy: .public)")
             if attempt < 3 {
                 try await DKLSKeysignOneMessageWithRetry(attempt: attempt+1, messageToSign: messageToSign)
+            } else {
+                // Surface retry-exhaustion as a typed throw rather than silently
+                // returning. Previously the caller only learned about the failure
+                // indirectly via `signatures.isEmpty` further up the stack, which
+                // collapsed every cause into a generic "fail to sign transaction"
+                // message and risked leaving the UI in a half-finished state.
+                // See vultisig-ios#4327.
+                throw HelperError.runtimeError("DKLS sign message exhausted retries: \(error.localizedDescription)")
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -884,11 +884,12 @@ class KeysignViewModel: ObservableObject {
         default:
             errMessage = "Failed to get signed transaction,error:\(err.localizedDescription)"
         }
-        // since it failed to get transaction or failed to broadcast , go to failed page
-        DispatchQueue.main.async {
-            self.status = .KeysignFailed
-            self.keysignError = errMessage
-        }
+        // Class is @MainActor — assign directly. A previous `DispatchQueue.main.async`
+        // wrapper raced with `tssKeysign`'s post-broadcast `status = .KeysignFinished`
+        // guard: the dispatched block ran on the next runloop tick, after the guard
+        // had already overwritten the status. See vultisig-ios#4327.
+        self.status = .KeysignFailed
+        self.keysignError = errMessage
     }
 
     func getCalculatedNetworkFee() -> (feeCrypto: String, feeFiat: String) {

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -50,6 +50,15 @@ class KeysignViewModel: ObservableObject {
     private var broadcastRetryCount = 0
     private static let maxBroadcastRetries = 1
 
+    /// Top-level timeout for a single keysign run (TSS exchange + broadcast).
+    /// Underlying poll loops can stall without producing a terminal status —
+    /// iOS suspending the network session in background, DKLS retry exhaustion,
+    /// a peer that never sent its share — so this is the safety net that flips
+    /// the UI into the retry-requested view. See vultisig-ios#4327.
+    static let keysignStageTimeout: Duration = .seconds(90)
+
+    private struct KeysignStalledError: Error {}
+
     private var tssService: TssServiceImpl? = nil
     private var tssMessenger: TssMessengerImpl? = nil
     private var stateAccess: LocalStateAccessorImpl? = nil
@@ -217,15 +226,68 @@ class KeysignViewModel: ObservableObject {
     }
 
     func startKeysign() async {
-
-        switch vault.libType {
-        case .GG20, .none:
-            await startKeysignGG20()
-        case .DKLS:
-            await startKeysignDKLS(isImport: false)
-        case .KeyImport:
-            await startKeysignDKLS(isImport: true)
+        do {
+            // Race the keysign body against a stage-level timeout. If the body
+            // wins, `group.next()` returns void and `cancelAll()` retires the
+            // sleeper. If the sleeper wins, it throws `KeysignStalledError`
+            // and we flip the UI into the retry-requested state below.
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask { @MainActor [weak self] in
+                    guard let self else { return }
+                    switch self.vault.libType {
+                    case .GG20, .none:
+                        await self.startKeysignGG20()
+                    case .DKLS:
+                        await self.startKeysignDKLS(isImport: false)
+                    case .KeyImport:
+                        await self.startKeysignDKLS(isImport: true)
+                    }
+                }
+                group.addTask {
+                    try await Task.sleep(for: Self.keysignStageTimeout)
+                    throw KeysignStalledError()
+                }
+                try await group.next()
+                group.cancelAll()
+            }
+        } catch is KeysignStalledError {
+            // Body task may still be running; only intervene if it hasn't
+            // already reached a terminal status of its own. The existing
+            // `KeysignFinished` guards in startKeysignDKLS/GG20 already refuse
+            // to overwrite `KeysignRetryRequested`, so this write is sticky
+            // unless the keysign actually completes and sets a txid (in which
+            // case `KeysignView.onChange(of: txid)` will navigate away and the
+            // retry view is torn down — the correct behaviour).
+            let terminal: [KeysignStatus] = [.KeysignFinished, .KeysignFailed, .KeysignVaultMismatch, .KeysignRetryRequested]
+            guard !terminal.contains(status) else { return }
+            logger.warning("keysign exceeded \(Self.keysignStageTimeout, privacy: .public) stage timeout — requesting retry")
+            self.retryReason = .other("KeysignStalled")
+            setStatus(.KeysignRetryRequested)
+        } catch {
+            logger.error("keysign stage race exited unexpectedly: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    /// Wraps `status = newStatus` with a logger marker. The investigation for
+    /// vultisig-ios#4327 needs a TestFlight `os_log` capture to localise which
+    /// poll loop stalls; keeping the transition trail in one place gives every
+    /// status flip an `info`-level entry without scattering log lines across
+    /// the file.
+    private func setStatus(_ newStatus: KeysignStatus, file: String = #fileID, line: Int = #line) {
+        if status != newStatus {
+            logger.info("status: \(String(describing: self.status), privacy: .public) → \(String(describing: newStatus), privacy: .public) at \(file, privacy: .public):\(line, privacy: .public)")
+        }
+        self.status = newStatus
+    }
+
+    /// Wraps `txid = newTxid` with a logger marker. Counterpart to `setStatus`
+    /// for vultisig-ios#4327 instrumentation. The hash itself is logged at
+    /// `info` so it shows up in `os_log` captures the reporter shares back.
+    private func setTxid(_ newTxid: String, file: String = #fileID, line: Int = #line) {
+        if txid != newTxid {
+            logger.info("txid set: \(newTxid, privacy: .public) at \(file, privacy: .public):\(line, privacy: .public)")
+        }
+        self.txid = newTxid
     }
 
     func startKeysignDKLS(isImport: Bool) async {
@@ -315,17 +377,17 @@ class KeysignViewModel: ObservableObject {
             }
             await broadcastTransaction()
             if let customMessagePayload {
-                txid = customMessagePayload.message
+                setTxid(customMessagePayload.message)
             }
             // broadcastTransaction owns its terminal status — don't overwrite a
             // failure (or retry request) set by handleBroadcastError.
             if status != .KeysignFailed && status != .KeysignRetryRequested {
-                status = .KeysignFinished
+                setStatus(.KeysignFinished)
             }
         } catch {
-            logger.error("TSS keysign failed, error: \(error.localizedDescription)")
+            logger.error("TSS keysign failed, error: \(error.localizedDescription, privacy: .public)")
             keysignError = error.localizedDescription
-            status = .KeysignFailed
+            setStatus(.KeysignFailed)
         }
 
     }
@@ -338,9 +400,9 @@ class KeysignViewModel: ObservableObject {
             do {
                 try await keysignOneMessageWithRetry(msg: msg, attempt: 1)
             } catch {
-                logger.error("TSS keysign failed, error: \(error.localizedDescription)")
+                logger.error("TSS keysign failed, error: \(error.localizedDescription, privacy: .public)")
                 keysignError = error.localizedDescription
-                status = .KeysignFailed
+                setStatus(.KeysignFailed)
                 return
             }
         }
@@ -348,10 +410,10 @@ class KeysignViewModel: ObservableObject {
         await broadcastTransaction()
 
         if let customMessagePayload {
-            txid = customMessagePayload.message
+            setTxid(customMessagePayload.message)
         }
         if status != .KeysignFailed && status != .KeysignRetryRequested {
-            status = .KeysignFinished
+            setStatus(.KeysignFinished)
         }
     }
     // Return value bool indicate whether keysign should be retried
@@ -785,7 +847,7 @@ class KeysignViewModel: ObservableObject {
             broadcastRetryCount += 1
             logger.warning("broadcast failed with retryable error (\(retryable.retryReason.userFacingMessage, privacy: .public)); requesting retry")
             self.retryReason = retryable.retryReason
-            self.status = .KeysignRetryRequested
+            setStatus(.KeysignRetryRequested)
             return
         }
 
@@ -799,7 +861,7 @@ class KeysignViewModel: ObservableObject {
                 || message == "replacement transaction underpriced"
                 || message.contains("This transaction has already been processed") {
                 logger.info("the transaction already broadcast, code:\(code)")
-                self.txid = transactionType.transactionHash
+                setTxid(transactionType.transactionHash)
                 self.approveTxid = transactionType.approveTransactionHash
                 return
             }
@@ -808,7 +870,7 @@ class KeysignViewModel: ObservableObject {
             // Check for Cardano "already broadcasted" errors
             if error.localizedDescription.contains("BadInputsUTxO") {
                 logger.info("Cardano transaction already broadcast - using hash from transactionType \(transactionType.transactionHash, privacy: .public)")
-                self.txid = transactionType.transactionHash
+                setTxid(transactionType.transactionHash)
                 self.approveTxid = transactionType.approveTransactionHash
                 return
             }
@@ -823,7 +885,7 @@ class KeysignViewModel: ObservableObject {
         // hash so this works without per-chain string matching.
         if await isAlreadyOnChain(transactionType: transactionType) {
             logger.info("transaction already on-chain via peer broadcast — using hash \(transactionType.transactionHash, privacy: .public)")
-            self.txid = transactionType.transactionHash
+            setTxid(transactionType.transactionHash)
             self.approveTxid = transactionType.approveTransactionHash
             if let coin = keysignPayload?.coin, coin.chainType == .UTXO {
                 await BlockchairService.shared.clearUTXOCache(for: coin)
@@ -833,7 +895,7 @@ class KeysignViewModel: ObservableObject {
 
         logger.error("\(errMessage, privacy: .public)")
         self.keysignError = errMessage
-        self.status = .KeysignFailed
+        setStatus(.KeysignFailed)
     }
 
     /// Best-effort check that the signed tx is already accepted on the chain
@@ -888,8 +950,8 @@ class KeysignViewModel: ObservableObject {
         // wrapper raced with `tssKeysign`'s post-broadcast `status = .KeysignFinished`
         // guard: the dispatched block ran on the next runloop tick, after the guard
         // had already overwritten the status. See vultisig-ios#4327.
-        self.status = .KeysignFailed
         self.keysignError = errMessage
+        setStatus(.KeysignFailed)
     }
 
     func getCalculatedNetworkFee() -> (feeCrypto: String, feeFiat: String) {

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignView.swift
@@ -5,6 +5,8 @@
 import OSLog
 import SwiftUI
 
+private let logger = Logger(subsystem: "com.vultisig.app", category: "keysign-view")
+
 struct KeysignView: View {
     let vault: Vault
     let keysignCommittee: [String]
@@ -31,6 +33,8 @@ struct KeysignView: View {
     @State var showDoneText = false
     @State var showError = false
 
+    @Environment(\.scenePhase) private var scenePhase
+
     @EnvironmentObject var globalStateViewModel: GlobalStateViewModel
 
     var body: some View {
@@ -38,6 +42,16 @@ struct KeysignView: View {
             .sensoryFeedback(.success, trigger: showDoneText)
             .sensoryFeedback(.error, trigger: showError)
             .sensoryFeedback(.impact(weight: .heavy), trigger: viewModel.status)
+            // Observability hook for vultisig-ios#4327: the issue reporter sees
+            // the "Signing" screen unblock after backgrounding + foregrounding,
+            // which fingerprints iOS auto-resuming a suspended network session.
+            // The log line lets us correlate scene transitions with the status
+            // trail in `os_log` captures from a TestFlight repro.
+            .onChange(of: scenePhase) { oldPhase, newPhase in
+                let isSigning: [KeysignStatus] = [.CreatingInstance, .KeysignECDSA, .KeysignEdDSA, .KeysignMLDSA]
+                guard isSigning.contains(viewModel.status) else { return }
+                logger.info("scenePhase: \(String(describing: oldPhase), privacy: .public) → \(String(describing: newPhase), privacy: .public) while status=\(String(describing: viewModel.status), privacy: .public)")
+            }
         #if os(iOS)
             .onAppear {
                 UIApplication.shared.isIdleTimerDisabled = true


### PR DESCRIPTION
## Summary
Bundles all five recommendations from the [#4327 investigation](https://github.com/vultisig/vultisig-ios/issues/4327) into one PR. Together they remove the "stuck on Signing" failure mode and give us the `os_log` trail to localise the remaining background-suspension stall in a TestFlight repro.

## What changed

### 1. `handleHelperError` deferred-dispatch race (`KeysignViewModel`)
Drops the `DispatchQueue.main.async { … }` wrapper around the terminal status write. The class is `@MainActor`; the wrapper deferred `status = .KeysignFailed` to the next runloop tick, which lost the race against `tssKeysign`'s post-broadcast `status = .KeysignFinished` guard and left the screen stuck on the "Signing" animation.

### 2. Overall keysign-stage timeout (`KeysignViewModel.startKeysign`)
Wraps the keysign body in a `withThrowingTaskGroup` race against a 90s sleeper. On timeout — and only when status hasn't already reached a terminal state — sets `retryReason = .other("KeysignStalled")` and flips `status` to `KeysignRetryRequested`. This surfaces the existing "Try again" UI and pops the user back to verify. Removes the failure mode where the screen sits on the "Signing" animation indefinitely.

### 3. DKLS retry-exhaustion rethrow (`DKLSKeysign.DKLSKeysignOneMessageWithRetry`)
Replaces the `attempt >= 3` silent return with `throw HelperError.runtimeError(...)`, preserving the underlying error message. Swaps `print` for `logger.error` per `.claude/rules/logging.md` and `.claude/rules/error-handling.md`. The caller's empty-signatures check previously collapsed every cause into a generic "fail to sign transaction" message; it now propagates the real cause.

### 4. Status / txid instrumentation (`KeysignViewModel.setStatus/setTxid`)
Single-funnel helpers that log every transition at `info` level with `#fileID:#line` context. Wraps the terminal-state writes (`KeysignFinished` / `KeysignFailed` / `KeysignRetryRequested`) and the peer-broadcast-race `txid` recovery sites in `handleBroadcastError`. Gives a TestFlight `os_log` capture enough trail to pin which poll loop stalls.

### 5. ScenePhase observability (`KeysignView`)
Logs scene transitions while status is mid-signing. The reporter's description ("switch away and back unblocks the screen") fingerprints iOS auto-resuming a suspended network session; correlating phase transitions with the status trail in TestFlight logs will localise the offending poll loop.

## Why one PR

The five items address different defects in the same code path; shipping them together gives the reporter a build where:
- the screen no longer stays on "Signing" forever (timeout flips into the retry UI),
- a DKLS retry exhaustion no longer silently swallows the cause,
- the deferred-dispatch race can't put the status into an indeterminate state, and
- if the bug still repros somehow, the `os_log` capture will tell us exactly which signal stalled.

Each item is independently reviewable inside the commit pair (`94e517472` = #1, `91217771b` = #2–#5).

## Scope

- Touches three files in `Features/Keysign/` and `Blockchain/States/Keysign/` — does **not** touch the `Blockchain/Tss/` critical boundary. `DKLSKeysignOneMessageWithRetry` is the Swift retry wrapper around the TSS call, not the TSS binding itself.
- 0 SwiftLint violations on changed files. Pre-existing custom `no_raw_urlsession` rule text-matches comments, so the network-session phrasing avoids the word verbatim.
- No localization changes — the timeout path uses the existing generic `broadcastRetryGeneric` key via `BroadcastRetryReason.other("KeysignStalled")`.

## Test plan
- [ ] Build + run on iOS / macOS.
- [ ] Happy-path keysign: signature flows through, `setStatus(.KeysignFinished)` fires, navigation to Done works. Verify `os_log` shows the status trail.
- [ ] Force a `getSignedTransaction` failure (e.g., inject in chain-specific signing): screen transitions to `KeysignFailed` immediately without flashing through `KeysignFinished` or stalling on "Signing".
- [ ] Force a peer-broadcast race (start a co-signed tx, let the peer win): `handleBroadcastError`'s `isAlreadyOnChain` fallback still sets `txid` and navigates to Done. The new `setTxid` log line marks the recovery.
- [ ] Force a keysign stall (interrupt one device's network mid-DKLS, or kill the relay): after ~90s the screen should flip into the retry view, *not* sit on "Signing" indefinitely.
- [ ] Force a DKLS retry exhaustion (block the relay POST so attempts 1-3 all fail): the screen now surfaces a `HelperError.runtimeError` with the underlying cause rather than the generic "fail to sign transaction".
- [ ] Background the app mid-signing and return: `os_log` shows a `scenePhase: ... → background → active` line correlated with the status trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-stage timeout for key-signing runs that triggers the retry UI when a stage stalls.
  * Scene-phase logging to correlate app background/foreground transitions with ongoing signing.

* **Bug Fixes**
  * More robust error handling to avoid stale or overwritten signing states and to surface retryable vs final failures.

* **Style / Logging**
  * Improved structured logging for signing attempts and failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->