### PR TITLE
fix(swap): surface vault-resident coins in the picker (#4321)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -81,9 +81,10 @@ struct SwapCoinSelectionLogic {
     func fetchCoins(chain: Chain) async throws -> [CoinMeta] {
         let nativeToken = TokensStore.TokenSelectionAssets.first { $0.chain == chain && $0.isNativeToken }
 
+        let localTokens = vault.coins.filter { $0.chain == chain }.map { $0.toCoinMeta() }
         // Propagate errors instead of swallowing with try?
         let externalTokens = try await service.loadTokens(for: chain)
-        let tokens = ([nativeToken] + externalTokens).compactMap { $0 }
+        let tokens = ([nativeToken] + externalTokens + localTokens).compactMap { $0 }
         let uniqueTokens = tokens.uniqueBy { $0.ticker.lowercased() }
         return sort(tokens: uniqueTokens)
     }


### PR DESCRIPTION
## Summary
- `SwapCoinSelectionLogic.fetchCoins(chain:)` previously built its candidate list from the static `TokensStore` native entry plus the external token service. Coins the user had already added to the vault but that the external service didn't know about — TC Secured Assets being the motivating case — never appeared in the picker, so the user couldn't select them as a swap side.
- This PR merges `vault.coins.filter { \$0.chain == chain }` into the candidate list. `uniqueBy { \$0.ticker.lowercased() }` already runs after the merge, so external entries continue to take precedence on ticker collision (external metadata stays canonical).

## Why this is the right scope for #4321

[Issue #4321](https://github.com/vultisig/vultisig-ios/issues/4321) reports that swap **FROM** TC Secured ETH-USDC works but swap **TO** TC Secured ETH-USDC fails. The full investigation lives in the wiki under `pages/projects/vultisig/secured-asset-swap-4321/investigation.md` and concludes that the swap-to-secured direction is most likely a server-side question (THORChain may not honour a swap memo destined for a secured-asset denom — the canonical inbound path is the `SECURE+:<thoraddr>` mint flow, which iOS already has in `FunctionCallSecuredAsset`).

This PR ships the smallest correct iOS-side change for users who already hold the secured asset: surface it in the picker so they can pick it as a swap side. Server-side direction support is tracked separately.

## Scope

- One file touched: `Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift`.
- Two-line addition; no changes to ranking, ticker collision behaviour, or the underlying `TokenSearchService`.
- Does **not** touch the TSS critical boundary or any chain-specific signing path.

## Test plan
- [ ] Build + run on iOS / macOS.
- [ ] Confirm a vault that holds a TC Secured Asset (e.g., ETH-USDC enabled via the withdraw flow) sees it offered in the swap coin selection for the THORChain chain.
- [ ] Confirm swap **FROM** TC Secured ETH-USDC still works end-to-end.
- [ ] Confirm regular ETH-chain ERC20s the user has imported but that aren't in the external token service now appear in the picker (positive side effect).
- [ ] Confirm ticker collisions resolve in favour of the external metadata (existing behaviour preserved).
- [ ] No SwiftLint regressions on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token selection in Swap now includes all tokens in your vault, providing a more complete list of available trading options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->