### PR TITLE
refactor(keygen): mirror Windows auto-kickoff predicate + tests (#4374)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
@@ -278,7 +278,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
                 $0.forEach { peer in
                     self.autoSelectPeer(peer)
                 }
-                self.startFastVaultKeygenIfNeeded(state: state)
+                self.startKeygenIfNeeded(state: state)
             }
     }
 
@@ -309,7 +309,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         return status == .WaitingForDevices && selections.count < 2
     }
 
-    func startFastVaultKeygenIfNeeded(state: SetupVaultState) {
+    func startKeygenIfNeeded(state: SetupVaultState) {
         guard isValidPeers(state: state), !state.hasOtherDevices else { return }
         startKeygen()
     }

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
@@ -322,6 +322,19 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         return isValid
     }
 
+    /// Decides whether peer-discovery has reached the auto-kickoff threshold.
+    /// Fixed-device flows (2/2 and 3/3) skip the manual Continue button once
+    /// every peer is connected; 4+ device flows require an explicit tap so the
+    /// initiating device can choose which peers to commit. Reshare never
+    /// auto-starts. Mirrors the Windows `AutoStartKeygen` component
+    /// (`core/ui/mpc/keygen/peers/AutoStartKeygen.tsx`). See vultisig-ios#4374.
+    func shouldAutoStartKeygen(totalDeviceCount: Int) -> Bool {
+        guard tssType != .Reshare else { return false }
+        guard totalDeviceCount <= 3 else { return false }
+        guard status == .WaitingForDevices else { return false }
+        return selections.count >= totalDeviceCount
+    }
+
     func startDiscovery() {
         self.mediator.start(name: self.serviceName)
         self.logger.info("mediator server started")

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
@@ -442,11 +442,7 @@ struct PeerDiscoveryScreen: View {
     }
 
     func autoStartKeygenIfReady() {
-        guard isFixedDeviceMode,
-              viewModel.selections.count >= totalDeviceCount,
-              viewModel.status == .WaitingForDevices else {
-            return
-        }
+        guard viewModel.shouldAutoStartKeygen(totalDeviceCount: totalDeviceCount) else { return }
         viewModel.startKeygen()
     }
 

--- a/VultisigApp/VultisigAppTests/Keygen/KeygenPeerDiscoveryViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Keygen/KeygenPeerDiscoveryViewModelTests.swift
@@ -1,0 +1,110 @@
+//
+//  KeygenPeerDiscoveryViewModelTests.swift
+//  VultisigAppTests
+//
+//  Locks in the auto-kickoff behavior for fixed-device secure-vault flows
+//  (2/2, 3/3) and the manual-Continue requirement for 4+ device flows.
+//  Mirrors the Windows `AutoStartKeygen` component reference cited in
+//  vultisig-ios#4374.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class KeygenPeerDiscoveryViewModelTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeVM(
+        tssType: TssType = .Keygen,
+        status: PeerDiscoveryStatus = .WaitingForDevices,
+        selectionCount: Int = 1
+    ) -> KeygenPeerDiscoveryViewModel {
+        let vm = KeygenPeerDiscoveryViewModel()
+        vm.tssType = tssType
+        vm.status = status
+        vm.localPartyID = "iPhone-Local"
+        vm.selections = []
+        vm.selections.insert(vm.localPartyID)
+        for index in 1..<selectionCount {
+            vm.selections.insert("Peer-\(index)")
+        }
+        return vm
+    }
+
+    // MARK: - Fixed-device auto-start (2/2 and 3/3)
+
+    func testShouldAutoStartTwoOfTwoWhenPartnerConnected() {
+        let vm = makeVM(selectionCount: 2)
+        XCTAssertTrue(vm.shouldAutoStartKeygen(totalDeviceCount: 2))
+    }
+
+    func testShouldNotAutoStartTwoOfTwoWhilePartnerStillConnecting() {
+        let vm = makeVM(selectionCount: 1)
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 2))
+    }
+
+    func testShouldAutoStartThreeOfThreeWhenAllPeersConnected() {
+        let vm = makeVM(selectionCount: 3)
+        XCTAssertTrue(vm.shouldAutoStartKeygen(totalDeviceCount: 3))
+    }
+
+    func testShouldNotAutoStartThreeOfThreeWithOnlyOnePeer() {
+        let vm = makeVM(selectionCount: 2)
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 3))
+    }
+
+    // MARK: - 4+ device flows always require manual Continue
+
+    func testShouldNotAutoStartFourDeviceVaultEvenAtThreshold() {
+        let vm = makeVM(selectionCount: 4)
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 4))
+    }
+
+    func testShouldNotAutoStartFiveDeviceVaultEvenAtThreshold() {
+        let vm = makeVM(selectionCount: 5)
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 5))
+    }
+
+    // MARK: - Reshare never auto-starts
+
+    func testShouldNotAutoStartReshareEvenWhenAtFixedDeviceThreshold() {
+        let vm = makeVM(tssType: .Reshare, selectionCount: 2)
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 2))
+    }
+
+    func testShouldNotAutoStartReshareThreeOfThree() {
+        let vm = makeVM(tssType: .Reshare, selectionCount: 3)
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 3))
+    }
+
+    // MARK: - Status guard
+
+    func testShouldNotAutoStartWhenKeygenAlreadyInProgress() {
+        let vm = makeVM(status: .Keygen, selectionCount: 2)
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 2))
+    }
+
+    func testShouldNotAutoStartAfterFailure() {
+        let vm = makeVM(status: .Failure, selectionCount: 2)
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 2))
+    }
+
+    // MARK: - Edge cases
+
+    func testShouldAutoStartWhenMorePeersJoinedThanRequired() {
+        // 2/2 vault but somehow three peers are in the selection set. The
+        // threshold is "met or exceeded" — auto-start fires regardless.
+        let vm = makeVM(selectionCount: 3)
+        XCTAssertTrue(vm.shouldAutoStartKeygen(totalDeviceCount: 2))
+    }
+
+    func testShouldNotAutoStartWithZeroSelections() {
+        // Edge case: localPartyID is normally inserted into `selections` at
+        // init. If something clears the set, auto-start must not fire.
+        let vm = makeVM(selectionCount: 1)
+        vm.selections.removeAll()
+        XCTAssertFalse(vm.shouldAutoStartKeygen(totalDeviceCount: 2))
+    }
+}


### PR DESCRIPTION
## Summary

The 2/2 + 3/3 auto-kickoff behavior is **already implemented on iOS** — the issue body looked at `KeygenPeerDiscoveryViewModel.swift` and missed the screen-level wiring in `PeerDiscoveryScreen.swift`:

- [`isFixedDeviceMode` (`PeerDiscoveryScreen.swift:97-100`)](https://github.com/vultisig/vultisig-ios/blob/main/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift#L97-L100) returns `true` for `totalDeviceCount <= 3` (Reshare excluded).
- [`bottomButton` (`PeerDiscoveryScreen.swift:410-426`)](https://github.com/vultisig/vultisig-ios/blob/main/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift#L410-L426) wraps the `PrimaryButton` in `if !isFixedDeviceMode { … }`, so the Continue button is hidden for 2/2 and 3/3.
- [`autoStartKeygenIfReady()` (`PeerDiscoveryScreen.swift:444-451`)](https://github.com/vultisig/vultisig-ios/blob/main/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift#L444-L451) is already wired to `.onChange(of: viewModel.selections)` and kicks `startKeygen()` as soon as the threshold is met.

This PR **adjusts the iOS implementation to match the Windows reference architecture** and **adds the missing tests**, with no user-visible behavior change.

## What changed

- **Matching the Windows shape**: Windows keeps the decision predicate in a small, isolated component ([`AutoStartKeygen.tsx`](https://github.com/vultisig/vultisig-windows/blob/main/core/ui/mpc/keygen/peers/AutoStartKeygen.tsx) — `useEffect` over `selectedPeers.length` + `targetDeviceCount`, with a `targetDeviceCount > 3` guard). On iOS the decision lived inline in `PeerDiscoveryScreen.autoStartKeygenIfReady()`. Extracted it to `KeygenPeerDiscoveryViewModel.shouldAutoStartKeygen(totalDeviceCount:)` as a pure predicate so the iOS shape mirrors Windows: pure function of `(tssType, status, selections, totalDeviceCount)`, sole side effect (`startKeygen()`) sits in the screen.
- **Tests**: 12 XCTest cases in `VultisigAppTests/Keygen/KeygenPeerDiscoveryViewModelTests.swift` lock in:
  - 2/2 and 3/3 auto-start when the threshold is met,
  - 2/2 and 3/3 *not* auto-starting while still connecting,
  - 4-device and 5-device flows always requiring manual Continue,
  - Reshare exclusion at every fixed-device count,
  - status guards (`Keygen` / `Failure`),
  - extra peers in the selection set, and a cleared selection.

## Scope

- Three files. No SwiftLint violations. No localization changes.
- Does not touch the TSS critical boundary.
- Tests pass locally: `xcodebuild test … -only-testing:VultisigAppTests/KeygenPeerDiscoveryViewModelTests` → 12/12, ~0.04s.

## Test plan
- [x] All 12 new tests pass locally.
- [ ] Manual smoke: setup a new vault → Secure → 2-device or 3-device → confirm the Continue button is absent and keygen starts automatically once the partner connects.
- [ ] Manual smoke: setup a new vault → Secure → 4-device or 5-device → confirm the Continue button is visible and required.
- [ ] Manual smoke: Reshare from a 2-device or 3-device vault → confirm the Continue button is still visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined automatic key generation triggering during peer discovery. Keygen now intelligently initiates only for non-Reshare flows with three or fewer devices, once all required peers are discovered and connected. This improvement provides more predictable behavior throughout the vault setup process, reducing manual intervention and streamlining the experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->