### PR TITLE
fix(swap): lower THORChain streaming slippage threshold 3%→1% (#4367)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -9,6 +9,7 @@ paths:
 - Write readable code — prefer clear naming over comments
 - No dead code: remove unused functions, variables, imports
 - No commented-out code blocks
+- No GitHub issue / PR mentions in code comments (`#1234`, `vultisig-ios#1234`, `See PR #...`). Issue context belongs in the commit message and PR description; comments must explain *why* the code is the way it is. Issue numbers rot when issues get closed, renumbered, or moved across repos.
 - No force unwraps (`!`) except in tests or when provably safe
 - Prefer `guard` for early returns over nested `if let`
 - Keep functions focused — one responsibility per function

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -14,8 +14,13 @@ struct SwapService {
     static let shared = SwapService()
 
     /// Fall back from rapid to streaming THORChain swap when rapid slippage
-    /// (`fees.total` share of output) exceeds this threshold. 300 bps = 3%.
-    static let streamingSlippageThresholdBps = 300
+    /// (`fees.total` share of output) exceeds this threshold. 100 bps = 1%.
+    /// Streaming typically drops slippage from ~41 bps to ~9 bps on trades
+    /// it covers; a 1% cutoff captures mid-size cross-chain swaps that
+    /// otherwise route via rapid despite being good streaming candidates.
+    /// Mirrored in `vultisig-sdk` (`THORCHAIN_STREAMING_SLIPPAGE_THRESHOLD_BPS`)
+    /// and `vultisig-android` (`STREAMING_SLIPPAGE_THRESHOLD_BPS`).
+    static let streamingSlippageThresholdBps = 100
 
     func fetchQuote(
         amount: Decimal,

--- a/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
@@ -44,6 +44,44 @@ final class ThorchainAntiRektTests: XCTestCase {
         XCTAssertLessThan(bps ?? Int.max, SwapService.streamingSlippageThresholdBps)
     }
 
+    // MARK: - 1% threshold boundary
+
+    func test_rapidSlippageBps_justBelowOnePercent_doesNotTriggerStreaming() async {
+        // 99 bps slippage — just under the 1% (100 bps) cutoff.
+        // 99 / 10000 = 0.99% via authoritative totalBps field.
+        let rapid = makeQuote(expectedAmountOut: "10000", feesTotal: "0", totalBps: 99)
+        XCTAssertEqual(SwapService.rapidSlippageBps(fromQuote: rapid), 99)
+        XCTAssertLessThan(SwapService.rapidSlippageBps(fromQuote: rapid) ?? .max, SwapService.streamingSlippageThresholdBps)
+
+        let mock = MockSwapProvider(response: .success(makeQuote(expectedAmountOut: "999999", feesTotal: "0")))
+        let result = await SwapService.shared.maybeUpgradeToStreaming(
+            rapid: rapid, service: mock, provider: .thorchain,
+            address: "addr", fromAsset: "BTC.BTC", toAsset: "TRX.TRX",
+            amount: "100000000", referredCode: "", vultTierDiscount: 0
+        )
+
+        XCTAssertEqual(result.expectedAmountOut, rapid.expectedAmountOut)
+        XCTAssertEqual(mock.callCount, 0, "Streaming must not be fetched at 99 bps with a 1% threshold")
+    }
+
+    func test_rapidSlippageBps_justAboveOnePercent_triggersStreamingFetch() async {
+        // 101 bps slippage — just over the 1% (100 bps) cutoff.
+        let rapid = makeQuote(expectedAmountOut: "10000", feesTotal: "0", totalBps: 101, maxStreamingQuantity: 10)
+        XCTAssertEqual(SwapService.rapidSlippageBps(fromQuote: rapid), 101)
+        XCTAssertGreaterThan(SwapService.rapidSlippageBps(fromQuote: rapid) ?? 0, SwapService.streamingSlippageThresholdBps)
+
+        let streaming = makeQuote(expectedAmountOut: "20000", feesTotal: "0")
+        let mock = MockSwapProvider(response: .success(streaming))
+        let result = await SwapService.shared.maybeUpgradeToStreaming(
+            rapid: rapid, service: mock, provider: .thorchain,
+            address: "addr", fromAsset: "BTC.BTC", toAsset: "TRX.TRX",
+            amount: "100000000", referredCode: "", vultTierDiscount: 0
+        )
+
+        XCTAssertEqual(result.expectedAmountOut, streaming.expectedAmountOut)
+        XCTAssertEqual(mock.callCount, 1, "Streaming must be fetched at 101 bps with a 1% threshold")
+    }
+
     func test_rapidSlippageBps_zeroFees_returnsZero() {
         let quote = makeQuote(expectedAmountOut: "100000", feesTotal: "0", totalBps: nil)
 


### PR DESCRIPTION
## Summary
- `SwapService.streamingSlippageThresholdBps` controls when the rapid-quote path falls back to a streaming quote and picks the better via `selectBetterQuote`. Drop the cutoff from 300 bps (3%) to 100 bps (1%) so mid-size cross-chain swaps actually trigger the comparison.
- Per THORChain docs, streaming typically drops slippage from ~41 bps to ~9 bps on trades it covers. Free quote improvement for the user — no revenue impact, no protocol cost.
- Mirror changes land in parallel on Android (`STREAMING_SLIPPAGE_THRESHOLD_BPS`) and the SDK (`THORCHAIN_STREAMING_SLIPPAGE_THRESHOLD_BPS`) so behavior stays consistent across clients.

Closes #4367.

## Tests

- All 14 existing `ThorchainAntiRektTests` keep passing — they read the threshold from `SwapService.streamingSlippageThresholdBps` rather than hardcoding 300, and the slippage values they use (50, 1832, 6433) sit comfortably either side of both the old and new cutoffs.
- Two new boundary tests pin the 1% cutoff explicitly:
  - `test_rapidSlippageBps_justBelowOnePercent_doesNotTriggerStreaming` — a 99-bps quote must not fetch streaming.
  - `test_rapidSlippageBps_justAboveOnePercent_triggersStreamingFetch` — a 101-bps quote must fetch streaming.

`xcodebuild test … -only-testing:VultisigAppTests/ThorchainAntiRektTests` → 16/16, ~0.04s.

## Also in this PR

A `.claude/rules/code-quality.md` line forbidding GitHub issue / PR mentions in source-file comments — issue numbers rot when issues get closed, renumbered, or moved across repos. The context belongs in commit messages and PR descriptions where reviewers expect it.

## Scope

- Three files. No SwiftLint violations. No localization changes.
- Does not touch the TSS critical boundary.
- Tradeoff (per issue): streaming swaps take longer (5-30 min vs 5-10 min for rapid). Today the app switches silently; a follow-up UX issue can add a "Streaming swap (~N min, better price)" indicator on the swap preview.

## Test plan
- [x] All 16 ThorchainAntiRektTests pass locally.
- [ ] Manual smoke: large enough BTC→TRX (or similar mid-size cross-chain) swap that crosses 1% slippage on rapid — confirm streaming quote is fetched and chosen if better.
- [ ] Manual smoke: tiny swap with ≤1% slippage — confirm rapid path is still used (no extra latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the slippage threshold for THORChain swaps from 3% to 1%, improving the automatic fallback to streaming quotes for enhanced transaction protection.

* **Chores**
  * Added code quality guidelines to restrict GitHub issue and PR references from source code comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->