### PR TITLE
fix(defi): allow unbond from any non-Active node state (#4345)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/BondNode.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/BondNode.swift
@@ -22,14 +22,12 @@ enum BondNodeState: String, CaseIterable, Codable {
     case disabled
     case unknown
 
-    /// Whether the node can be unbonded
+    /// Whether the node can be unbonded. Mirrors the rule used by Maya's API
+    /// helper (`MayaChainAPIService+Bonds.swift`): any non-`Active` state is
+    /// fair game. `Unknown` is allowed by default so a stale/missing status
+    /// doesn't strand the user — the chain rejects bad txs at submit anyway.
     var canUnbond: Bool {
-        switch self {
-        case .standby, .disabled, .whitelisted:
-            return true
-        case .ready, .active, .unknown:
-            return false
-        }
+        self != .active
     }
 
     /// Whether a user can bond to this node

--- a/VultisigApp/VultisigAppTests/Defi/BondNodeStateTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/BondNodeStateTests.swift
@@ -1,0 +1,90 @@
+//
+//  BondNodeStateTests.swift
+//  VultisigAppTests
+//
+//  Lock in the unbond/bond gating rules for Maya and THORChain bond nodes.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class BondNodeStateTests: XCTestCase {
+
+    // MARK: - canUnbond — any non-Active state
+
+    func testCanUnbondActiveIsFalse() {
+        XCTAssertFalse(BondNodeState.active.canUnbond)
+    }
+
+    func testCanUnbondStandbyIsTrue() {
+        XCTAssertTrue(BondNodeState.standby.canUnbond)
+    }
+
+    func testCanUnbondReadyIsTrue() {
+        // The reported bug: Ready nodes were wrongly disabled. Maya itself
+        // accepts unbond txs from Ready nodes (status != "Active").
+        XCTAssertTrue(BondNodeState.ready.canUnbond)
+    }
+
+    func testCanUnbondDisabledIsTrue() {
+        XCTAssertTrue(BondNodeState.disabled.canUnbond)
+    }
+
+    func testCanUnbondWhitelistedIsTrue() {
+        XCTAssertTrue(BondNodeState.whitelisted.canUnbond)
+    }
+
+    func testCanUnbondUnknownIsTrue() {
+        // Stale or missing status shouldn't strand users behind a greyed-out
+        // button — let them try; THORNode rejects bad txs at submit.
+        XCTAssertTrue(BondNodeState.unknown.canUnbond)
+    }
+
+    func testCanUnbondOnlyActiveBlocked() {
+        // Sweep all cases to lock in the single-state exclusion shape so a
+        // future enum addition doesn't silently re-enable the gating bug.
+        for state in BondNodeState.allCases {
+            XCTAssertEqual(state.canUnbond, state != .active, "canUnbond mismatch for \(state)")
+        }
+    }
+
+    // MARK: - canBond — guard against regressions in the sibling rule
+
+    func testCanBondAllowsWhitelistedStandbyReadyActive() {
+        XCTAssertTrue(BondNodeState.whitelisted.canBond)
+        XCTAssertTrue(BondNodeState.standby.canBond)
+        XCTAssertTrue(BondNodeState.ready.canBond)
+        XCTAssertTrue(BondNodeState.active.canBond)
+    }
+
+    func testCanBondBlocksDisabledAndUnknown() {
+        XCTAssertFalse(BondNodeState.disabled.canBond)
+        XCTAssertFalse(BondNodeState.unknown.canBond)
+    }
+
+    // MARK: - isEarningRewards
+
+    func testIsEarningRewardsOnlyTrueForActive() {
+        for state in BondNodeState.allCases {
+            XCTAssertEqual(state.isEarningRewards, state == .active, "isEarningRewards mismatch for \(state)")
+        }
+    }
+
+    // MARK: - init(fromAPIStatus:)
+
+    func testInitFromAPIStatusKnownStrings() {
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "Active"), .active)
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "active"), .active)
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "ACTIVE"), .active)
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "Standby"), .standby)
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "Ready"), .ready)
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "Whitelisted"), .whitelisted)
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "Disabled"), .disabled)
+    }
+
+    func testInitFromAPIStatusUnknownFallsBackToUnknown() {
+        XCTAssertEqual(BondNodeState(fromAPIStatus: ""), .unknown)
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "Banned"), .unknown)
+        XCTAssertEqual(BondNodeState(fromAPIStatus: "garbage"), .unknown)
+    }
+}


### PR DESCRIPTION
## Summary

`BondNodeState.canUnbond` gated the Unbond button off `.standby`, `.disabled`, `.whitelisted` only — `.ready` and `.unknown` were wrongly disabled even though Maya itself accepts the tx. The canonical rule lives in our own API helper [`MayaChainAPIService+Bonds.swift:219`](https://github.com/vultisig/vultisig-ios/blob/main/VultisigApp/VultisigApp/Blockchain/Maya/API/MayaChainAPIService%2BBonds.swift#L219):

```swift
let canUnbond = nodeDetails.status != "Active"  // Can only unbond when node is churned out
```

This PR brings the iOS model in line — any non-Active state allows unbond:

```swift
var canUnbond: Bool { self != .active }
```

`.unknown` is now allowed too. The reasoning: a stale or missing status shouldn't strand the user behind a greyed-out button; Maya/THORNode rejects bad txs at submit. Matches the parallel [Android #4479](https://github.com/vultisig/vultisig-android/issues/4479) and [Windows #3917](https://github.com/vultisig/vultisig-windows/issues/3917) fixes so behaviour is unified across clients.

Closes #4345.

## Tests

New `VultisigAppTests/Defi/BondNodeStateTests.swift` — 12 cases:

- `canUnbond`: explicit assertion per state (Active false; Standby / Ready / Disabled / Whitelisted / Unknown true) + a sweep-style test using `BondNodeState.allCases` so a future enum addition can't silently re-introduce the gating bug.
- `canBond`: regression coverage on the sibling rule (Whitelisted / Standby / Ready / Active allowed; Disabled / Unknown blocked).
- `isEarningRewards`: only `.active` returns true.
- `init(fromAPIStatus:)`: case-insensitive mapping for known statuses + fallback to `.unknown` for empty / unrecognised strings.

`xcodebuild test … -only-testing:VultisigAppTests/BondNodeStateTests` → 12/12, ~0.02s. SwiftLint clean.

## Acceptance criteria check

- [x] Ready → Unbond enabled.
- [x] Active → Unbond disabled (with existing "Wait for churn" subtext from `DefiChainActiveNodeView`).
- [x] Disabled / Whitelisted → Unbond enabled (already worked; regression-covered).
- [x] Unknown → Unbond enabled (chain rejects bad txs).
- [x] Same behaviour for THORChain bonded nodes — `BondNodeState` is shared.
- [ ] Manual smoke: confirm `BondNodeStateView` chip shows the correct state name so users see *why* Unbond is disabled when on an Active node.

## Follow-up (separate ticket, scoped out of this PR)

Per the issue body: the "Wait for churn out" subtext doesn't surface *when* the next churn-out window opens for the user's specific node. `nextChurn` is the next chain churn, but for an `Active` user-bonded node the unbond window is the *first* churn that rotates them out. Worth surfacing "available after ≈ X days" using the nodes-list schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unbond eligibility logic to allow unbonding for all node states except active, fixing behavior for states not previously handled by explicit conditions.

* **Tests**
  * Added comprehensive test suite for bond node state validation, including unbond and bond eligibility checks across all states, reward eligibility verification, and API status mapping with case-insensitive handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->