### PR TITLE
fix(keysign): show DAppRequestBanner on custom-message confirm (#4375)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignCustomMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignCustomMessageConfirmView.swift
@@ -65,6 +65,9 @@ struct KeysignCustomMessageConfirmView: View {
 
     @ViewBuilder
     var heroSection: some View {
+        if let metadata = viewModel.dappMetadata, !metadata.isEmpty {
+            DAppRequestBanner(metadata: metadata)
+        }
         if let title = viewModel.decodedFunctionName {
             Text(title)
                 .font(Theme.fonts.bodyLMedium)
@@ -74,7 +77,10 @@ struct KeysignCustomMessageConfirmView: View {
     }
 
     var hasHeroSection: Bool {
-        viewModel.decodedFunctionName != nil
+        if let metadata = viewModel.dappMetadata, !metadata.isEmpty {
+            return true
+        }
+        return viewModel.decodedFunctionName != nil
     }
 
     var hasTransactionDetails: Bool {


### PR DESCRIPTION
## Summary

`KeysignCustomMessageConfirmView` is the joiner-side verification screen for dApp-initiated custom-message signatures (SIWE login, Cosmos `signArbitrary`, etc.). Its `heroSection` only rendered the EVM function name (e.g. \"personal_sign\") and never showed the `DAppRequestBanner` that other join/verify/done screens already use to surface the dApp's self-declared name + URL + icon.

This PR wires the banner above the existing function-name hero when `viewModel.dappMetadata` is present and non-empty, mirroring the pattern already used in:
- `KeysignMessageConfirmView.swift:39` (regular keysign join verify)
- `JoinKeysignDoneSummary.swift:116` (join keysign done)
- `JoinSwapDoneSummary.swift:48-49` (join swap done)

Closes #4375.

## Implementation

```swift
@ViewBuilder
var heroSection: some View {
    if let metadata = viewModel.dappMetadata, !metadata.isEmpty {
        DAppRequestBanner(metadata: metadata)
    }
    if let title = viewModel.decodedFunctionName {
        Text(title)
            .font(Theme.fonts.bodyLMedium)
            .foregroundColor(Theme.colors.textPrimary)
            .frame(maxWidth: .infinity, alignment: .center)
    }
}

var hasHeroSection: Bool {
    if let metadata = viewModel.dappMetadata, !metadata.isEmpty {
        return true
    }
    return viewModel.decodedFunctionName != nil
}
```

`hasHeroSection` now also flips true when only metadata is present, so the surrounding separator renders correctly on screens that don't decode an EVM function name (Cosmos `signArbitrary`).

## Acceptance criteria

- [x] Joiner Custom Message Confirm screen shows `DAppRequestBanner` (name + URL + icon) when payload carries `dAppMetadata`.
- [x] Falls back to existing function-name hero when no dApp metadata (Settings → Custom Message entry path).
- [ ] Manual smoke: trigger a `personal_sign` from a dApp (e.g. Polymarket SIWE), join from second iOS device — confirm the banner appears above the method/message rows.
- [ ] Manual smoke: trigger a Cosmos `signArbitrary` from Rujira, join from second iOS device — confirm banner appears (and function-name hero is absent — no EVM decode applies).
- [ ] Manual smoke: enter from Settings → Custom Message → trigger keysign — confirm no banner, function-name hero only.

## Scope

- One file. No SwiftLint violations. No localization changes (`DAppRequestBanner` brings its own \"dappRequestFrom\" key).
- Does not touch the TSS critical boundary.
- No unit tests added — this is a SwiftUI conditional render with no testable predicate. The Acceptance section above is the manual smoke matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the keysign confirmation screen to properly display DApp request information when signing custom messages from decentralized applications, ensuring users have full visibility of request details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->