### PR TITLE
fix(custom-message): insert Verify step between form and pair (#4357)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -494,6 +494,7 @@
 "memoLabel" = "Memo";
 "Merge" = "Zusammenführen";
 "messageDeposit" = "%@ Nachrichteneinzahlung";
+"messageToSign" = "Zu signierende Nachricht";
 "messageVote" = "%@ Nachrichtenabstimmung";
 "migrate" = "Migrieren";
 "migratePasswordDescription" = "Gib dein Passwort ein, um deinen Serveranteil zu entsperren und das Upgrade zu starten";
@@ -817,6 +818,7 @@
 "signer" = "Unterzeichner";
 "signFasterThanEverBefore" = "Schneller als je zuvor signieren";
 "signingErrorTryAgain" = "Fehler beim Unterschreiben";
+"signingMethod" = "Signaturmethode";
 "signingTransaction" = "Transaktion wird signiert";
 "signTransaction" = "Transaktion signieren";
 "skip" = "Überspringen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -501,6 +501,7 @@
 "Merge" = "Merge";
 "message" = "Message";
 "messageDeposit" = "%@ message deposit";
+"messageToSign" = "Message to sign";
 "messageVote" = "%@ message vote";
 "migrate" = "Migrate";
 "migratePasswordDescription" = "Enter your password to unlock your Server Share and start the upgrade";
@@ -827,6 +828,7 @@
 "signer" = "Signer";
 "signFasterThanEverBefore" = "Sign faster than ever before";
 "signingErrorTryAgain" = "Signing Error";
+"signingMethod" = "Signing method";
 "signingTransaction" = "Signing transaction";
 "signTransaction" = "Sign transaction";
 "skip" = "Skip";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -494,6 +494,7 @@
 "memoLabel" = "Memo";
 "Merge" = "Fusionar";
 "messageDeposit" = "%@ depósito de mensaje";
+"messageToSign" = "Mensaje a firmar";
 "messageVote" = "%@ voto de mensaje";
 "migrate" = "Migrar";
 "migratePasswordDescription" = "Introduce tu contraseña para desbloquear tu Parte del Servidor y comenzar la actualización";
@@ -817,6 +818,7 @@
 "signer" = "Firmante";
 "signFasterThanEverBefore" = "Firma más rápido que nunca";
 "signingErrorTryAgain" = "Error al Firmar";
+"signingMethod" = "Método de firma";
 "signingTransaction" = "Firmando transacción";
 "signTransaction" = "Firmar transacción";
 "skip" = "Saltar";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -494,6 +494,7 @@
 "memoLabel" = "Memo";
 "Merge" = "Spoji";
 "messageDeposit" = "%@ depozit poruke";
+"messageToSign" = "Poruka za potpisivanje";
 "messageVote" = "%@ glas poruke";
 "migrate" = "Migrirati";
 "migratePasswordDescription" = "Unesite svoju lozinku za otključavanje server dijela i pokretanje nadogradnje";
@@ -817,6 +818,7 @@
 "signer" = "Potpisnik";
 "signFasterThanEverBefore" = "Potpiši brže nego ikad prije";
 "signingErrorTryAgain" = "Greška pri prijavi";
+"signingMethod" = "Metoda potpisa";
 "signingTransaction" = "Potpisivanje transakcije";
 "signTransaction" = "Potpiši transakciju";
 "skip" = "Preskoči";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -494,6 +494,7 @@
 "memoLabel" = "Memo";
 "Merge" = "Unisci";
 "messageDeposit" = "%@ deposito messaggio";
+"messageToSign" = "Messaggio da firmare";
 "messageVote" = "%@ voto messaggio";
 "migrate" = "Migrare";
 "migratePasswordDescription" = "Inserisci la tua password per sbloccare la quota del server e iniziare l'aggiornamento";
@@ -817,6 +818,7 @@
 "signer" = "Firmatario";
 "signFasterThanEverBefore" = "Firma più velocemente che mai";
 "signingErrorTryAgain" = "Errore di Firma";
+"signingMethod" = "Metodo di firma";
 "signingTransaction" = "Firma della transazione";
 "signTransaction" = "Firma la transazione";
 "skip" = "Salta";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -500,6 +500,7 @@
 "Merge" = "병합";
 "message" = "메시지";
 "messageDeposit" = "%@ 메시지 입금";
+"messageToSign" = "서명할 메시지";
 "messageVote" = "%@ 메시지 투표";
 "migrate" = "마이그레이션";
 "migratePasswordDescription" = "비밀번호를 입력하여 서버 공유를 잠금 해제하고 업그레이드를 시작하세요";
@@ -826,6 +827,7 @@
 "signer" = "서명자";
 "signFasterThanEverBefore" = "그 어느 때보다 빠르게 서명하세요";
 "signingErrorTryAgain" = "서명 오류";
+"signingMethod" = "서명 방식";
 "signingTransaction" = "트랜잭션 서명 중";
 "signTransaction" = "트랜잭션 서명";
 "skip" = "건너뛰기";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -494,6 +494,7 @@
 "memoLabel" = "Memo";
 "Merge" = "Fundir";
 "messageDeposit" = "%@ depósito de mensagem";
+"messageToSign" = "Mensagem a assinar";
 "messageVote" = "%@ voto de mensagem";
 "migrate" = "Migrar";
 "migratePasswordDescription" = "Digite sua senha para desbloquear sua Parte do Servidor e iniciar a atualização";
@@ -817,6 +818,7 @@
 "signer" = "Assinante";
 "signFasterThanEverBefore" = "Assine mais rápido do que nunca";
 "signingErrorTryAgain" = "Erro ao Assinar";
+"signingMethod" = "Método de assinatura";
 "signingTransaction" = "Assinando transação";
 "signTransaction" = "Assinar transação";
 "skip" = "Pular";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -494,6 +494,7 @@
 "memoLabel" = "备注";
 "Merge" = "合并";
 "messageDeposit" = "%@ 消息存款";
+"messageToSign" = "要签名的消息";
 "messageVote" = "%@ 消息投票";
 "migrate" = "迁移";
 "migratePasswordDescription" = "输入您的密码以解锁服务器份额并开始升级";
@@ -817,6 +818,7 @@
 "signer" = "签名者";
 "signFasterThanEverBefore" = "比以往任何时候都更快地签名";
 "signingErrorTryAgain" = "签名错误";
+"signingMethod" = "签名方式";
 "signingTransaction" = "正在签署交易";
 "signTransaction" = "签署交易";
 "skip" = "跳过";

--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsCustomMessageViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsCustomMessageViewModel.swift
@@ -12,6 +12,7 @@ class SettingsCustomMessageViewModel: ObservableObject, TransferViewModel {
 
     enum KeysignState: Int, CaseIterable {
         case initial = 1
+        case verify
         case pair
         case keysign
         case done
@@ -20,6 +21,8 @@ class SettingsCustomMessageViewModel: ObservableObject, TransferViewModel {
             switch self {
             case .initial:
                 return "Sign message".localized
+            case .verify:
+                return "verify".localized
             case .pair:
                 return "pair".localized
             case .keysign:
@@ -53,7 +56,7 @@ class SettingsCustomMessageViewModel: ObservableObject, TransferViewModel {
         switch state {
         case .done, .keysign:
             return false
-        case .initial, .pair:
+        case .initial, .verify, .pair:
             return true
         }
     }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView+MacOS.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView+MacOS.swift
@@ -16,6 +16,9 @@ extension SettingsCustomMessageView {
             case .initial:
                 customMessage
                     .crossPlatformToolbar(viewModel.state.title)
+            case .verify:
+                verify
+                    .crossPlatformToolbar(viewModel.state.title)
             case .pair:
                 pair
             case .keysign, .done:

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
@@ -44,6 +44,8 @@ struct SettingsCustomMessageView: View {
             switch viewModel.state {
             case .initial:
                 customMessage
+            case .verify:
+                verify
             case .pair:
                 pair
             case .keysign, .done:
@@ -59,10 +61,50 @@ struct SettingsCustomMessageView: View {
         }
         .safeAreaInset(edge: .bottom) {
             if viewModel.state == .initial {
+                continueButton
+                    .padding(.bottom, isMacOS ? 40 : 0)
+            }
+        }
+    }
+
+    var verify: some View {
+        ScrollView {
+            verifyContent
+                .padding(.horizontal, 16)
+        }
+        .safeAreaInset(edge: .bottom) {
+            if viewModel.state == .verify {
                 signButton
                     .padding(.bottom, isMacOS ? 40 : 0)
             }
         }
+    }
+
+    var verifyContent: some View {
+        VStack(spacing: 16) {
+            verifyRow(title: "signingMethod".localized, value: method)
+            verifyRow(title: "messageToSign".localized, value: message)
+        }
+        .padding(.top, 12)
+    }
+
+    private func verifyRow(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundColor(Theme.colors.textTertiary)
+            Text(value)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundColor(Theme.colors.textPrimary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(16)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Theme.colors.bgSurface2)
+                )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     var keysign: some View {
@@ -145,6 +187,14 @@ struct SettingsCustomMessageView: View {
                                     vaultLocalPartyID: vault.localPartyID,
                                     chain: Chain.ethereum.name,
                                     decodedMessage: nil)
+    }
+
+    var continueButton: some View {
+        PrimaryButton(title: NSLocalizedString("continue", comment: "")) {
+            viewModel.moveToNextView()
+        }
+        .disabled(!signButtonEnabled)
+        .padding(.horizontal, 16)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Sign Custom Message jumped from the form straight to the QR pair screen, skipping any chance to review the method + message before signing. This PR adds a dedicated Verify step that mirrors the existing shape on Windows and Android, so the iOS flow becomes:

`form → verify → pair → keysign → done`

Closes #4357.

## Cross-platform reference

- **Windows** (`core/ui/vault/keysign/custom-message/index.tsx`) uses a two-step `['form', 'verify']` `useStepNavigation`. Form has Continue; Verify renders read-only `method` + `message` rows and the keysign-start prompt.
- **Android** (`app/.../ui/screens/sign/VerifySignMessageScreen.kt`) has a dedicated verify screen with two `SignMessageBox` rows (`signing_method`, `message_to_sign`) and a bottom sign button (plus a fast-sign button when eligible).
- **iOS** was missing this step entirely — the bug.

## Changes

- `SettingsCustomMessageViewModel.KeysignState` gains a `.verify` case between `.initial` and `.pair`. `canGoBack()` allows back-navigation from verify.
- `SettingsCustomMessageView`:
  - New `verify` view with two read-only rows (method, message-to-sign) styled to match the joiner-side `KeysignCustomMessageConfirmView`.
  - The form's primary button becomes **Continue** (advance to verify).
  - The fast-vault long-press button + password sheet now live on verify — that's where the user commits.
- `SettingsCustomMessageView+MacOS` adds the matching `.verify` branch to its `main` state switch.
- Two new localized keys `signingMethod` / `messageToSign` added to all 8 locale files (en, de, es, hr, it, ko, pt, zh-Hans) and sorted via `sort_localizable.py`.

## Scope

- 11 files, +73 / -1.
- No SwiftLint violations.
- No TSS-boundary code touched.
- Build verified: `xcodebuild build … -scheme VultisigApp` → BUILD SUCCEEDED.

## Test plan

- [ ] Settings → Sign Custom Message → fill method + message → tap **Continue** → confirm verify screen shows the values read-only.
- [ ] On verify → tap **Sign Transaction** → confirm the QR / pair screen appears next.
- [ ] On verify → tap back arrow → confirm return to form with values preserved.
- [ ] Fast-vault path: on verify → long-press **Sign Transaction** → confirm password sheet appears, and keysign proceeds after entering password.
- [ ] macOS: same flow via the `SettingsCustomMessageView+MacOS` switch.
- [ ] Localization: verify both new strings appear translated when the device locale is set to es / de / it / pt / zh-Hans / ko / hr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a verification step to the signing workflow that allows users to review and confirm their message and signing method selection
  * New confirmation screen displays the message to sign and selected signing method before completing the operation

* **Localization**
  * Added full support for eight languages: German, Spanish, Croatian, Italian, Korean, Portuguese, English, and Simplified Chinese

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->