### PR TITLE
chore(deps): bump VultisigCommonData to main (post-#83 merge)

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/commondata",
       "state" : {
-        "revision" : "c26bb9f9839429967a47fc44bd0440958e755709"
+        "revision" : "9d2ee6358a9895cb408e792f4e48af03ec6b31cf"
       }
     },
     {

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -53,11 +53,7 @@ packages:
     from: 1.17.0
   VultisigCommonData:
     url: https://github.com/vultisig/commondata
-    # Temporary: pinned to the head of vultisig/commondata#83
-    # (`TRANSACTION_TYPE_QBTC_CLAIM_WITH_PROOF` + `QbtcClaimContext` replaced
-    # by `is_qbtc_claim` bool, merged with main for Cardano tokens + DAppMetadata).
-    # Flip to a `revision: <merge-sha>` once that PR merges.
-    revision: c26bb9f9839429967a47fc44bd0440958e755709
+    revision: 9d2ee6358a9895cb408e792f4e48af03ec6b31cf
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
     exactVersion: 4.3.19


### PR DESCRIPTION
## Summary
- Flips the temporary PR-head pin to the merge commit on `vultisig/commondata` main now that PR #83 (QBTC claim transaction type + SecureVault context) has landed.
- Old revision: `c26bb9f9839429967a47fc44bd0440958e755709` (head of vultisig/commondata#83 before merge).
- New revision: `9d2ee6358a9895cb408e792f4e48af03ec6b31cf` (merge commit on `main`).
- Diff between old and new: **1 commit, 0 file changes** — purely merge-commit metadata. No protobuf or generated-Swift drift.
- Drops the multi-line "Temporary: pinned to the head of …" comment from `project.yml` since the pin is no longer temporary.

## Test plan
- [x] `make generate` regenerates the xcodeproj cleanly.
- [x] `xcodebuild -resolvePackageDependencies` updates `Package.resolved` to the new revision.
- [x] `xcodebuild build … generic/platform=iOS Simulator` → **BUILD SUCCEEDED**.
- [ ] Spot-check QBTC claim + SecureVault flows in simulator (no schema change expected from this bump alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency pins to latest revisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->