### PR TITLE
test(vault): pin Vault.isFastVault contract for #4348

### DIFF
--- a/VultisigApp/VultisigAppTests/Model/VaultIsFastVaultTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/VaultIsFastVaultTests.swift
@@ -1,0 +1,75 @@
+//
+//  VaultIsFastVaultTests.swift
+//  VultisigAppTests
+//
+//  Pins the current contract of `Vault.isFastVault` so the fix for
+//  vultisig-ios#4348 can't silently change behavior without updating the
+//  tests too.
+//
+//  Background — #4348: today `isFastVault` is purely structural. Any signer
+//  in `vault.signers` whose name starts with `server-` flips the property to
+//  `true`, and the rest of the app uses that one bool as the migrate-routing
+//  key (UpgradeVaultViewModifier, VaultSettingsScreen, VaultRouteBuilder,
+//  VaultShareBackupsView). There's no way for iOS to know whether the
+//  server share is still online-managed or has been imported into another
+//  peer device (e.g. a Windows install holds the share locally). The fix
+//  must replace or supplement this check — Option A/C in the issue both
+//  require additional state or a user prompt.
+//
+//  When that fix lands, the assertion in
+//  `testIsFastVaultIsPurelyStructural_serverSignerWins` is the canary —
+//  it should fail or have to flip, surfacing the contract change in code
+//  review.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class VaultIsFastVaultTests: XCTestCase {
+
+    // MARK: - Pin: structural-only contract (the bug behind #4348)
+
+    /// Pre-#4348: any `server-*` signer flips `isFastVault` to `true`,
+    /// regardless of whether the server share is still online-managed.
+    /// This is the property the migrate flow keys off — and exactly the
+    /// gap reported in the issue. When the fix lands this test must
+    /// change.
+    func testIsFastVaultIsPurelyStructural_serverSignerWins() {
+        let vault = Vault(name: "test")
+        vault.localPartyID = "iPhone-12345"
+        vault.signers = ["iPhone-12345", "server-abc"]
+
+        XCTAssertTrue(
+            vault.isFastVault,
+            """
+            Pre-#4348 contract: any `server-*` signer => `isFastVault == true`.
+            If you're here because this assertion failed, you're either fixing
+            or regressing #4348. Update the test alongside the fix — don't loosen
+            it silently.
+            """
+        )
+    }
+
+    // MARK: - Companion invariants (these stay true after #4348 is fixed)
+
+    /// A device that IS itself the server-side party (its `localPartyID`
+    /// starts with `server-`) must never read as a fast vault — only the
+    /// user-side devices ever route to the FastVault flow.
+    func testIsFastVault_serverLocalParty_returnsFalse() {
+        let vault = Vault(name: "test")
+        vault.localPartyID = "server-12345"
+        vault.signers = ["iPhone-1", "server-12345"]
+
+        XCTAssertFalse(vault.isFastVault)
+    }
+
+    /// No `server-*` signer in the list => peer flow, always.
+    func testIsFastVault_noServerSigner_returnsFalse() {
+        let vault = Vault(name: "test")
+        vault.localPartyID = "iPhone-1"
+        vault.signers = ["iPhone-1", "iPhone-2"]
+
+        XCTAssertFalse(vault.isFastVault)
+    }
+}


### PR DESCRIPTION
## Summary

Adds three pure-Swift contract tests on `Vault.isFastVault` so the fix for #4348 ("Vault upgrade silently calls online VultiServer instead of peer-discovery when server share is self-hosted on another device") can't silently change behavior without updating the tests too.

**Tests-only PR. No source changes. Draft until #4348 has a fix direction so the canary's review-time signal is loaded.**

### Background — what #4348 actually breaks

Today `Vault.isFastVault` is the migrate-routing key in four places (`UpgradeVaultViewModifier`, `VaultSettingsScreen`, `VaultRouteBuilder`, `VaultShareBackupsView`). The property is purely structural — scans `vault.signers` for any `server-*` prefix and returns true if found. There is no way to know whether that server share is still online-managed or has been imported into another peer device. The result is that iOS unconditionally routes to `FastVaultService.migrate(…)` whenever any `server-*` signer is in the list, even when the user has moved the share to a local Windows install.

Full investigation: [issue thread](https://github.com/vultisig/vultisig-ios/issues/4348).

### The three pins

| Test | Purpose |
|---|---|
| `testIsFastVaultIsPurelyStructural_serverSignerWins` | **Canary.** Pre-#4348 contract: any `server-*` signer => `isFastVault == true`. When the fix lands this assertion must flip — that's the point. The test docstring tells the next author exactly what to do. |
| `testIsFastVault_serverLocalParty_returnsFalse` | Invariant that holds before *and* after a fix: a device whose `localPartyID` is itself `server-*` never reads as a fast vault. |
| `testIsFastVault_noServerSigner_returnsFalse` | Same: a vault with no `server-*` signer is always peer flow. |

### Companion test that already exists

`SendPhaseDRegressionTests.testFastVaultLocalPartyServerPrefixCases` pins the `lowercased().hasPrefix("server-")` expression itself (8 cases). That covers the *spelling*; this PR covers the *property's behavioral contract*.

### Test plan

- [x] `make test` — all 3 new tests pass, full suite green (758 tests).
- [x] No `swiftlint` warnings introduced.
- [ ] Re-flip the canary assertion when #4348 lands its real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite to verify vault fast-vault behavior across different signer configurations and scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->