### PR TITLE
fix(tron): compute fee_limit from triggerconstantcontract simulation (supersedes #4131)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
@@ -213,7 +213,8 @@ struct TronChainParametersResponse: Codable {
     /// `feeLimit = energyBudget * energyFeePrice`.
     /// See https://developers.tron.network/docs/resource-model#dynamic-energy-model.
     var energyFeePrice: Int64 {
-        chainParameter.first { $0.key == "getEnergyFee" }?.value ?? 420
+        let value = chainParameter.first { $0.key == "getEnergyFee" }?.value ?? 0
+        return value > 0 ? value : 420
     }
 
     var memoFeeEstimate: Int64 {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPI.swift
@@ -208,6 +208,14 @@ struct TronChainParametersResponse: Codable {
         chainParameter.first { $0.key == "getTransactionFee" }?.value ?? 1000
     }
 
+    /// Sun per energy unit (≈420 sun/energy at the time of writing). Used to
+    /// translate an energy budget into a `fee_limit` value via
+    /// `feeLimit = energyBudget * energyFeePrice`.
+    /// See https://developers.tron.network/docs/resource-model#dynamic-energy-model.
+    var energyFeePrice: Int64 {
+        chainParameter.first { $0.key == "getEnergyFee" }?.value ?? 420
+    }
+
     var memoFeeEstimate: Int64 {
         let memoFee = chainParameter.first { $0.key == "getMemoFee" }?.value ?? 0
         return memoFee > 0 ? memoFee : 1_000_000

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPIService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPIService.swift
@@ -69,6 +69,57 @@ struct TronAPIService {
         return String(account.balance ?? 0)
     }
 
+    // MARK: - Contract simulation
+
+    /// Simulates a TRC20 `transfer(address,uint256)` call via TRON's
+    /// `/wallet/triggerconstantcontract` endpoint and returns the decoded
+    /// response (`energy_used` is the field consumed by fee estimation).
+    /// A placeholder `amount` of `1` is used — energy cost of an ERC20-style
+    /// transfer is dominated by storage-slot writes and is effectively
+    /// constant across amounts on typical TRC20 contracts.
+    ///
+    /// See https://developers.tron.network/docs/resource-model#dynamic-energy-model.
+    func simulateTRC20Transfer(
+        ownerAddress: String,
+        contractAddress: String,
+        toAddress: String
+    ) async throws -> TronTriggerConstantResponse {
+        let parameter = try Self.encodeTrc20TransferParameter(toAddress: toAddress, amount: 1)
+        let response = try await httpClient.request(
+            TronAPI.triggerConstantContract(
+                ownerAddress: ownerAddress,
+                contractAddress: contractAddress,
+                functionSelector: "transfer(address,uint256)",
+                parameter: parameter
+            ),
+            responseType: TronTriggerConstantResponse.self
+        )
+        return response.data
+    }
+
+    /// ABI-encodes `(address, uint256)` for `transfer(address,uint256)`.
+    /// Strips the TRON `41` prefix from the decoded base58 address so the
+    /// resulting hex matches the EVM-style 20-byte address that the TVM
+    /// expects in the calldata.
+    private static func encodeTrc20TransferParameter(
+        toAddress: String,
+        amount: BigInt
+    ) throws -> String {
+        guard let toAddressData = Base58.decode(string: toAddress) else {
+            throw TronAPIError.invalidAddress
+        }
+        var addressHex = toAddressData.hexString
+        if addressHex.lowercased().hasPrefix("41") {
+            addressHex = String(addressHex.dropFirst(2))
+        }
+        let paddedAddress = String(repeating: "0", count: max(0, 64 - addressHex.count)) + addressHex
+
+        let amountHex = String(amount, radix: 16)
+        let paddedAmount = String(repeating: "0", count: max(0, 64 - amountHex.count)) + amountHex
+
+        return paddedAddress + paddedAmount
+    }
+
     // MARK: - Token Info
 
     func getTokenInfo(contractAddress: String) async throws -> (name: String, symbol: String, decimals: Int) {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPIService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronAPIService.swift
@@ -112,6 +112,14 @@ struct TronAPIService {
         if addressHex.lowercased().hasPrefix("41") {
             addressHex = String(addressHex.dropFirst(2))
         }
+        // Reject any payload that doesn't yield a canonical 20-byte (40 hex chars)
+        // address after stripping the optional TRON `41` prefix. Without this
+        // guard, a malformed base58 input could produce ABI calldata that the
+        // TVM silently accepts but simulates against the wrong recipient,
+        // returning a misleading `energy_used`.
+        guard addressHex.count == 40 else {
+            throw TronAPIError.invalidAddress
+        }
         let paddedAddress = String(repeating: "0", count: max(0, 64 - addressHex.count)) + addressHex
 
         let amountHex = String(amount, radix: 16)

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -22,6 +22,22 @@ class TronService {
     private static let BYTES_PER_COIN_TX: Int64 = 300
     private static let BYTES_PER_CONTRACT_TX: Int64 = 345
 
+    /// Headroom multiplier applied to the simulated `energy_used` when
+    /// computing the on-chain `fee_limit` cap. 30% covers the contract's
+    /// per-call dynamic `energy_factor` surge during congested windows. See
+    /// https://developers.tron.network/docs/resource-model#dynamic-energy-model.
+    private static let ENERGY_SAFETY_NUMERATOR: Int64 = 13
+    private static let ENERGY_SAFETY_DENOMINATOR: Int64 = 10
+
+    /// Energy budget used as the `fee_limit` cap when contract simulation
+    /// isn't available (network error, native-TRX swap path where we don't
+    /// have the function selector + parameter at fee-calc time, etc.).
+    /// At ~420 sun/energy this works out to ~21 TRX — generous enough for
+    /// any typical TRC20 or swap, while still being a real number derived
+    /// from chain parameters rather than a magic constant. Mirrors
+    /// `vultisig-android` `TronFeeService.DEFAULT_MAX_ENERGY_USED`.
+    private static let DEFAULT_MAX_ENERGY_USED: Int64 = 50_000_000
+
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.apiService = TronAPIService(httpClient: httpClient)
     }
@@ -39,7 +55,12 @@ class TronService {
 
     // MARK: - Block Info
 
-    func getBlockInfo(coin: Coin, to: String? = nil, memo: String? = nil) async throws -> BlockChainSpecific {
+    func getBlockInfo(
+        coin: Coin,
+        to: String? = nil,
+        memo: String? = nil,
+        isSwap: Bool = false
+    ) async throws -> BlockChainSpecific {
         let response = try await apiService.getNowBlock()
 
         let currentTimestampMillis = UInt64(Date().timeIntervalSince1970 * 1000)
@@ -47,9 +68,11 @@ class TronService {
         let oneHourMillis = Int64(60 * 60 * 1000)
         let expiration = nowMillis + oneHourMillis
 
-        let calculatedFee = try await calculateTronFee(coin: coin, to: to, memo: memo)
-
-        // For swaps, if fee calculation returns 0, use default fee
+        let calculatedFee = try await calculateTronFee(coin: coin, to: to, memo: memo, isSwap: isSwap)
+        // For native transfers with a fully bandwidth-discounted fee (calculatedFee == 0),
+        // fall back to the coin's static `feeDefault` so the UI displays a non-zero "Fees"
+        // line. Contract paths (TRC20 / native swap) always return a non-zero feeLimit
+        // from `calculateTronFee` so they bypass this branch.
         let finalFee = calculatedFee == 0 ? coin.feeDefault.toBigInt() : calculatedFee
         let estimation = String(finalFee)
 
@@ -98,53 +121,94 @@ class TronService {
 
     // MARK: - Private Helpers
 
-    private func calculateTronFee(coin: Coin, to: String?, memo: String?) async throws -> BigInt {
-        do {
-            let memoFee = try await getTronFeeMemo(memo: memo)
-            let activationFee = try await getTronInactiveDestinationFee(to: to)
+    /// Returns the value that becomes both `gasFeeEstimation` (displayed in the
+    /// UI as "Fees") and `$0.feeLimit` for the signed transaction on
+    /// contract paths.
+    ///
+    /// **Native TRX transfer** — bandwidth-only fee. Signing path doesn't
+    /// write `$0.feeLimit` for plain `transfer` contracts, so this number
+    /// only drives the UI.
+    ///
+    /// **TRC20 transfer** — simulate the call via
+    /// `triggerConstantContract` to get a per-tx `energy_used`, apply a
+    /// safety multiplier, translate to sun via the on-chain `energyFeePrice`.
+    /// Replaces the prior fixed 1 TRX / 18 TRX / 36 TRX ladder that
+    /// triggered `OUT_OF_ENERGY` whenever the actual energy cost exceeded
+    /// `fee_limit / energy_price` (see issue/PR #4131).
+    ///
+    /// **Native swap** (`triggerSmartContract` from a TRX coin) — we don't
+    /// yet have the function selector + calldata at this layer, so fall
+    /// back to a generous default budget (`DEFAULT_MAX_ENERGY_USED ×
+    /// energyFeePrice`) — same approach `vultisig-android` takes in
+    /// `TronFeeService.calculateDefaultFees`.
+    ///
+    /// See https://developers.tron.network/docs/set-feelimit.
+    private func calculateTronFee(coin: Coin, to: String?, memo: String?, isSwap: Bool) async throws -> BigInt {
+        let memoFee = (try? await getTronFeeMemo(memo: memo)) ?? .zero
+        let activationFee = (try? await getTronInactiveDestinationFee(to: to)) ?? .zero
+        let chainParams = try? await getCachedChainParameters()
+        let energyPrice = chainParams?.energyFeePrice ?? 420
 
-            let transactionFee: BigInt
-            if coin.isNativeToken {
-                let accountResource = try await apiService.getAccountResource(address: coin.address)
-                let availableBandwidth = accountResource.calculateAvailableBandwidth()
-
-                transactionFee = try await getBandwidthFeeDiscount(
-                    isNativeToken: true,
-                    availableBandwidth: availableBandwidth
-                )
+        let transactionFee: BigInt
+        if coin.isNativeToken {
+            if isSwap {
+                transactionFee = BigInt(Self.DEFAULT_MAX_ENERGY_USED * energyPrice)
             } else {
-                let accountResource = try await apiService.getAccountResource(address: coin.address)
-                let availableEnergy = accountResource.EnergyLimit - accountResource.EnergyUsed
-
-                let isDestinationActive = try await checkIfAccountIsActive(address: to)
-                let energyRequired = isDestinationActive ? 65000 : 130000
-
-                if availableEnergy >= energyRequired {
-                    transactionFee = BigInt(1_000_000)
-                } else {
-                    transactionFee = isDestinationActive ? BigInt(18_000_000) : BigInt(36_000_000)
-                }
+                transactionFee = (try? await calculateNativeTrxFee(coin: coin)) ?? .zero
             }
-
-            let totalFee = transactionFee + memoFee + activationFee
-            return totalFee
-
-        } catch {
-            return BigInt(Self.BYTES_PER_CONTRACT_TX * 1000)
+        } else {
+            transactionFee = await calculateTrc20FeeLimit(coin: coin, to: to, energyPrice: energyPrice)
         }
+
+        return transactionFee + memoFee + activationFee
     }
 
-    private func checkIfAccountIsActive(address: String?) async throws -> Bool {
-        guard let address = address, !address.isEmpty else {
-            return true
+    private func calculateNativeTrxFee(coin: Coin) async throws -> BigInt {
+        let accountResource = try await apiService.getAccountResource(address: coin.address)
+        let availableBandwidth = accountResource.calculateAvailableBandwidth()
+        return try await getBandwidthFeeDiscount(
+            isNativeToken: true,
+            availableBandwidth: availableBandwidth
+        )
+    }
+
+    private func calculateTrc20FeeLimit(coin: Coin, to: String?, energyPrice: Int64) async -> BigInt {
+        guard let to, !to.isEmpty, !coin.contractAddress.isEmpty else {
+            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
         }
 
+        let simulation: TronTriggerConstantResponse
         do {
-            let account = try await apiService.getAccount(address: address)
-            return !account.address.isEmpty
+            simulation = try await apiService.simulateTRC20Transfer(
+                ownerAddress: coin.address,
+                contractAddress: coin.contractAddress,
+                toAddress: to
+            )
         } catch {
-            return false
+            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
         }
+
+        guard simulation.result?.result == true,
+              let energyUsed = simulation.energy_used, energyUsed > 0 else {
+            return Self.defaultContractFeeLimit(energyPrice: energyPrice)
+        }
+
+        return Self.contractFeeLimit(energyUsed: Int64(energyUsed), energyPrice: energyPrice)
+    }
+
+    /// Conservative fallback budget for contract-execution paths whenever
+    /// simulation isn't possible or fails. Used so a transient RPC error
+    /// doesn't silently reintroduce `OUT_OF_ENERGY`.
+    static func defaultContractFeeLimit(energyPrice: Int64) -> BigInt {
+        BigInt(DEFAULT_MAX_ENERGY_USED * energyPrice)
+    }
+
+    /// Translates a simulated `energy_used` into a `fee_limit` cap (in sun),
+    /// applying the documented 30% safety multiplier for dynamic-energy
+    /// surges. Pulled out so the math is testable in isolation.
+    static func contractFeeLimit(energyUsed: Int64, energyPrice: Int64) -> BigInt {
+        let maxEnergyUnits = energyUsed * ENERGY_SAFETY_NUMERATOR / ENERGY_SAFETY_DENOMINATOR
+        return BigInt(maxEnergyUnits * energyPrice)
     }
 
     private func getCachedChainParameters() async throws -> TronChainParametersResponse {

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -152,7 +152,7 @@ class TronService {
         let transactionFee: BigInt
         if coin.isNativeToken {
             if isSwap {
-                transactionFee = BigInt(Self.DEFAULT_MAX_ENERGY_USED * energyPrice)
+                transactionFee = Self.defaultContractFeeLimit(energyPrice: energyPrice)
             } else {
                 transactionFee = (try? await calculateNativeTrxFee(coin: coin)) ?? .zero
             }
@@ -198,17 +198,21 @@ class TronService {
 
     /// Conservative fallback budget for contract-execution paths whenever
     /// simulation isn't possible or fails. Used so a transient RPC error
-    /// doesn't silently reintroduce `OUT_OF_ENERGY`.
+    /// doesn't silently reintroduce `OUT_OF_ENERGY`. Operands are widened to
+    /// `BigInt` before multiplying so anomalous chain-parameter values can't
+    /// overflow `Int64`.
     static func defaultContractFeeLimit(energyPrice: Int64) -> BigInt {
-        BigInt(DEFAULT_MAX_ENERGY_USED * energyPrice)
+        BigInt(DEFAULT_MAX_ENERGY_USED) * BigInt(energyPrice)
     }
 
     /// Translates a simulated `energy_used` into a `fee_limit` cap (in sun),
     /// applying the documented 30% safety multiplier for dynamic-energy
-    /// surges. Pulled out so the math is testable in isolation.
+    /// surges. Pulled out so the math is testable in isolation. All
+    /// multiplications are performed in `BigInt` so an unexpectedly large
+    /// `energy_used` or `energyPrice` can't overflow `Int64` mid-calculation.
     static func contractFeeLimit(energyUsed: Int64, energyPrice: Int64) -> BigInt {
-        let maxEnergyUnits = energyUsed * ENERGY_SAFETY_NUMERATOR / ENERGY_SAFETY_DENOMINATOR
-        return BigInt(maxEnergyUnits * energyPrice)
+        let maxEnergyUnits = (BigInt(energyUsed) * BigInt(ENERGY_SAFETY_NUMERATOR)) / BigInt(ENERGY_SAFETY_DENOMINATOR)
+        return maxEnergyUnits * BigInt(energyPrice)
     }
 
     private func getCachedChainParameters() async throws -> TronChainParametersResponse {

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -711,7 +711,7 @@ private extension BlockChainService {
             // 60 is bc of tss to wait till 5min so all devices can sign.
             return .Ripple(sequence: UInt64(sequence), gas: 180000, lastLedgerSequence: UInt64(lastLedgerSequence) + 60)
         case .tron:
-            return try await tron.getBlockInfo(coin: coin, to: toAddress, memo: memo)
+            return try await tron.getBlockInfo(coin: coin, to: toAddress, memo: memo, isSwap: action == .swap)
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -1,0 +1,272 @@
+//
+//  TronServiceFeeLimitTests.swift
+//  VultisigAppTests
+//
+//  Pins the simulation-based `fee_limit` math behind the TRC20 / swap
+//  OUT_OF_ENERGY fix (issue/PR #4131). The bug being addressed:
+//  `Vault.fee_limit` is a strict upper bound on the energy budget the TVM
+//  is willing to use for a contract call (`max_energy = fee_limit /
+//  energy_unit_price`). The pre-fix code returned a 1 TRX / 18 TRX / 36 TRX
+//  ladder, capping a typical USDT transfer at ~2,400 / ~43,000 / ~86,000
+//  energy — below the ~65,000 energy a TRC20 transfer actually consumes,
+//  triggering `OUT_OF_ENERGY` even when the user had staked enough free
+//  energy to cover the call. See:
+//
+//  - https://developers.tron.network/docs/set-feelimit
+//  - https://developers.tron.network/docs/resource-model#dynamic-energy-model
+//
+
+@testable import VultisigApp
+import XCTest
+import BigInt
+
+@MainActor
+final class TronServiceFeeLimitTests: XCTestCase {
+
+    // MARK: - Math helpers (pure)
+
+    /// `contractFeeLimit` applies the 30% safety multiplier and translates
+    /// energy units into a sun-denominated `fee_limit`. 65,000 energy ×
+    /// 1.3 × 420 sun/energy = 35,490,000 sun (~35 TRX).
+    func testContractFeeLimit_appliesSafetyMultiplierToEnergyAtChainPrice() {
+        XCTAssertEqual(
+            TronService.contractFeeLimit(energyUsed: 65_000, energyPrice: 420),
+            BigInt(35_490_000)
+        )
+    }
+
+    /// The 30% safety multiplier survives integer division (e.g. odd
+    /// numerators don't collapse to a smaller value via truncation).
+    func testContractFeeLimit_safetyMultiplierRoundsDownButStaysAboveBare() {
+        let bare = BigInt(65_000 * 420) // 27,300,000 — what the user would pay without safety
+        let withSafety = TronService.contractFeeLimit(energyUsed: 65_000, energyPrice: 420)
+        XCTAssertGreaterThan(withSafety, bare)
+    }
+
+    /// `defaultContractFeeLimit` returns the docs-backed fallback budget
+    /// used when simulation isn't possible. 50,000,000 energy × 420 sun =
+    /// 21,000,000,000 sun (21 TRX). Mirrors the Android
+    /// `TronFeeService.DEFAULT_MAX_ENERGY_USED` reference.
+    func testDefaultContractFeeLimit_returnsTwentyOneTrxAtCurrentEnergyPrice() {
+        XCTAssertEqual(
+            TronService.defaultContractFeeLimit(energyPrice: 420),
+            BigInt(21_000_000_000)
+        )
+    }
+
+    /// `defaultContractFeeLimit` tracks the on-chain `energyFeePrice` —
+    /// if TRON raises the energy unit price via governance proposal, the
+    /// fallback budget scales accordingly without code change.
+    func testDefaultContractFeeLimit_scalesWithEnergyPrice() {
+        XCTAssertEqual(
+            TronService.defaultContractFeeLimit(energyPrice: 100),
+            BigInt(5_000_000_000)
+        )
+        XCTAssertEqual(
+            TronService.defaultContractFeeLimit(energyPrice: 1_000),
+            BigInt(50_000_000_000)
+        )
+    }
+
+    // MARK: - Dispatch (TronService.getBlockInfo)
+
+    /// Happy path: TRC20 transfer to an existing address with a successful
+    /// simulation. `gasFeeEstimation` should be derived from the simulated
+    /// energy_used (not the previous fixed 1 / 18 / 36 TRX ladder).
+    func testGetBlockInfo_trc20Transfer_usesSimulationResult() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 65_000)
+        let service = TronService(httpClient: stub)
+
+        let coin = makeTrc20Coin()
+        let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
+        let gasFee = extractGasFee(result)
+
+        // 65,000 × 1.3 × 420 = 35,490,000 sun. memo and activation are 0
+        // in this scenario (no memo, destination account "exists" per the
+        // stub's getaccount response).
+        XCTAssertEqual(gasFee, 35_490_000)
+    }
+
+    /// Simulation throws (network error / TRON gateway 5xx). Old behavior
+    /// fell through to `BYTES_PER_CONTRACT_TX * 1000` (~0.345 TRX), which
+    /// silently re-introduced OUT_OF_ENERGY. New behavior: fall back to
+    /// the safe default budget (~21 TRX).
+    func testGetBlockInfo_trc20Transfer_fallsBackOnSimulationError() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 65_000)
+        stub.errors[TronAPI.triggerConstantContract(ownerAddress: "", contractAddress: "", functionSelector: "", parameter: "").path] = HTTPError.invalidResponse
+        let service = TronService(httpClient: stub)
+
+        let coin = makeTrc20Coin()
+        let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
+        let gasFee = extractGasFee(result)
+
+        XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+    }
+
+    /// Simulation returns `result.result = false` (e.g. insufficient TRC20
+    /// balance — common when estimating before the user funds the account).
+    /// Same fallback as the error path.
+    func testGetBlockInfo_trc20Transfer_fallsBackWhenSimulationResultFalse() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 65_000)
+        stub.setResponse(path: "/wallet/triggerconstantcontract", json: """
+        {"result":{"result":false,"message":"REVERT"},"energy_used":0}
+        """)
+        let service = TronService(httpClient: stub)
+
+        let coin = makeTrc20Coin()
+        let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil)
+        let gasFee = extractGasFee(result)
+
+        XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+    }
+
+    /// Native TRX swap (`isSwap == true`). We don't yet have the contract
+    /// function selector + parameter at fee-calc time, so use the default
+    /// budget — better than the prior bandwidth-only fee that would
+    /// trigger OUT_OF_ENERGY on the swap's `triggerSmartContract` path.
+    func testGetBlockInfo_nativeSwap_usesDefaultContractBudget() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        let service = TronService(httpClient: stub)
+
+        let coin = makeNativeCoin()
+        let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil, isSwap: true)
+        let gasFee = extractGasFee(result)
+
+        XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+    }
+
+    /// Native TRX transfer with sufficient bandwidth — bandwidth-discounted
+    /// to 0, then the signing path doesn't write `feeLimit` for plain
+    /// `TransferContract` anyway. `gasFeeEstimation` falls through to
+    /// `coin.feeDefault` for the UI binding (already the prior behavior;
+    /// this test pins that we don't regress it).
+    func testGetBlockInfo_nativeTransfer_returnsZeroForUiFallback() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        // Generous bandwidth — discount kicks in.
+        stub.setResponse(path: "/wallet/getaccountresource", json: """
+        {"freeNetUsed":0,"freeNetLimit":600,"NetUsed":0,"NetLimit":10000,"EnergyUsed":0,"EnergyLimit":0}
+        """)
+        let service = TronService(httpClient: stub)
+
+        let coin = makeNativeCoin()
+        let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil, isSwap: false)
+        let gasFee = extractGasFee(result)
+
+        // Not the contract default — should be the coin.feeDefault fallback,
+        // which is much smaller than `DEFAULT_MAX_ENERGY_USED × energyPrice`.
+        XCTAssertLessThan(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+    }
+
+    // MARK: - Helpers
+
+    private func makeTrc20Coin() -> Coin {
+        let asset = CoinMeta.make(
+            chain: .tron,
+            ticker: "USDT",
+            decimals: 6,
+            isNativeToken: false,
+            contractAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        )
+        return Coin(asset: asset, address: "TKt9bGgWeFFu2yRgULxRhmiBADuoEoadq8", hexPublicKey: "")
+    }
+
+    private func makeNativeCoin() -> Coin {
+        let asset = CoinMeta.make(
+            chain: .tron,
+            ticker: "TRX",
+            decimals: 6,
+            isNativeToken: true
+        )
+        return Coin(asset: asset, address: "TKt9bGgWeFFu2yRgULxRhmiBADuoEoadq8", hexPublicKey: "")
+    }
+
+    private func extractGasFee(_ specific: BlockChainSpecific) -> UInt64 {
+        guard case .Tron(_, _, _, _, _, _, _, _, let gasFee) = specific else {
+            XCTFail("expected .Tron, got \(specific)")
+            return 0
+        }
+        return gasFee
+    }
+}
+
+// MARK: - CoinMeta convenience
+
+private extension CoinMeta {
+    static func make(
+        chain: Chain,
+        ticker: String,
+        decimals: Int = 6,
+        isNativeToken: Bool,
+        contractAddress: String = ""
+    ) -> CoinMeta {
+        CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "",
+            decimals: decimals,
+            priceProviderId: "",
+            contractAddress: contractAddress,
+            isNativeToken: isNativeToken
+        )
+    }
+}
+
+// MARK: - Stub HTTPClient
+
+/// Path-keyed JSON stub. Tests register canned responses (or errors) by
+/// URL path; the stub dispatches on `target.path` so test ordering doesn't
+/// matter and chain-parameter caching inside `TronService` works
+/// transparently.
+private final class TronStubHTTPClient: HTTPClientProtocol {
+
+    var responses: [String: Data] = [:]
+    var errors: [String: Error] = [:]
+
+    // Protocol requires `async`; the body is sync. Silence the lint here.
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        let path = target.path
+        if let error = errors[path] { throw error }
+        guard let data = responses[path] else {
+            XCTFail("TronStubHTTPClient has no stub for path '\(path)'")
+            throw HTTPError.invalidResponse
+        }
+        let response = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: data, response: response)
+    }
+
+    func setResponse(path: String, json: String) {
+        responses[path] = Data(json.utf8)
+    }
+
+    /// Wires up a baseline of valid responses for every endpoint the fee
+    /// path touches. Individual tests override specific entries.
+    func stubDefaults(energyUsed: Int) {
+        setResponse(path: "/wallet/getnowblock", json: """
+        {"block_header":{"raw_data":{"timestamp":1700000000,"number":1,"version":0,"txTrieRoot":"00","parentHash":"00","witness_address":"00"}}}
+        """)
+        setResponse(path: "/wallet/getchainparameters", json: """
+        {"chainParameter":[{"key":"getEnergyFee","value":420},{"key":"getTransactionFee","value":1000}]}
+        """)
+        setResponse(path: "/wallet/getaccountresource", json: """
+        {"freeNetUsed":0,"freeNetLimit":0,"NetUsed":0,"NetLimit":0,"EnergyUsed":0,"EnergyLimit":1000000}
+        """)
+        // Destination "exists" => no activation fee charged.
+        setResponse(path: "/wallet/getaccount", json: """
+        {"address":"TGexisting","balance":1}
+        """)
+        setResponse(path: "/wallet/triggerconstantcontract", json: """
+        {"result":{"result":true},"energy_used":\(energyUsed)}
+        """)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -157,9 +157,10 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil, isSwap: false)
         let gasFee = extractGasFee(result)
 
-        // Not the contract default — should be the coin.feeDefault fallback,
-        // which is much smaller than `DEFAULT_MAX_ENERGY_USED × energyPrice`.
-        XCTAssertLessThan(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
+        // Bandwidth-discounted fee is 0, so `getBlockInfo` falls through to
+        // `coin.feeDefault` for the UI binding. For TRX that resolves to
+        // 100_000 sun (0.1 TRX) — see `Coin.feeDefault`.
+        XCTAssertEqual(gasFee, 100_000)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

Closes #4393

Fixes `OUT_OF_ENERGY` failures on TRC20 transfers and TRX swaps by computing `fee_limit` from a per-transaction TRON simulation instead of a fixed ladder of magic numbers. Ports `vultisig-android` `TronFeeService.calculateEnergyFee` to iOS.

**Supersedes #4131** (hardcoded 150 / 400 TRX floors). See [internal plan](https://github.com/vultisig/vultisig-ios/pull/4131#issuecomment-4491122280) for the three issues with that approach.

## Bug

On TRON, `fee_limit` is a **strict upper bound on the energy budget** (`max_energy_for_tx = fee_limit / energy_unit_price` — currently ≈420 sun/energy). The user's staked free energy does **not** extend this cap. The prior fee path returned a fixed 1 TRX / 18 TRX / 36 TRX ladder, capping a USDT transfer at ~2,380 / ~43,000 / ~86,000 energy — below the ~65,000 energy a TRC20 transfer actually consumes, so the TVM reverted with `OUT_OF_ENERGY` even for users with abundant staked energy.

See [TRON docs — set-feelimit](https://developers.tron.network/docs/set-feelimit).

## Fix

For each contract-bound TRON transaction, derive the `fee_limit` cap from a real `/wallet/triggerconstantcontract` simulation:

| Path | Old behavior | New behavior |
|---|---|---|
| TRC20 transfer | Fixed 1 / 18 / 36 TRX based on energy + dest-active flag | Simulate → `energy_used × 1.3 × energyFeePrice` (~35 TRX for typical USDT) |
| Native-TRX swap (`isSwap: true`) | Bandwidth-only (~0.3 TRX) → OOE on `triggerSmartContract` | Default budget `50M energy × energyFeePrice` (~21 TRX) |
| Native-TRX transfer | Bandwidth-only | Unchanged (signing path doesn't use `feeLimit`) |
| Error catch | `BYTES_PER_CONTRACT_TX × 1000` (~0.345 TRX) — silently reintroduces OOE | Same default budget as swap fallback (~21 TRX) |

The 30% safety multiplier covers the dynamic per-contract `energy_factor` surges that TRON applies during congested windows — see [dynamic energy model docs](https://developers.tron.network/docs/resource-model#dynamic-energy-model).

`isSwap` is threaded from `BlockChainService.fetchSpecific(action: .swap)` so the TRON service knows which native-TRX flow it's serving.

## Changes

- `TronAPI.swift`: new `energyFeePrice` accessor on `TronChainParametersResponse` reading the `getEnergyFee` chain parameter (defaults to 420 sun/energy if missing).
- `TronAPIService.swift`: new `simulateTRC20Transfer(ownerAddress:contractAddress:toAddress:)` and `encodeTrc20TransferParameter(toAddress:amount:)`. Uses placeholder amount `1` for the simulation — energy cost of a TRC20 transfer is dominated by storage-slot writes and is effectively constant across amounts.
- `TronService.swift`: rewrites `calculateTronFee` around the simulation. Extracts the math into static helpers (`contractFeeLimit(energyUsed:energyPrice:)`, `defaultContractFeeLimit(energyPrice:)`) for direct unit testing. Removes the now-unused `checkIfAccountIsActive` helper.
- `BlockChainService.swift`: passes `isSwap: action == .swap` to `tron.getBlockInfo`.

## Tests

`VultisigAppTests/Services/TronServiceFeeLimitTests.swift` — 9 tests across two layers:

- **Math (pure)**: 4 tests pinning the safety multiplier, the docs-backed default budget, and `energyFeePrice` scaling.
- **Dispatch (HTTPClient stub)**: 5 tests covering simulation-success, simulation-error fallback, `result.result == false` fallback, native-swap default budget, and native-transfer falling through to `coin.feeDefault`.

Path-keyed `TronStubHTTPClient` so ordering doesn't matter and `TronService` chain-parameter caching works transparently.

## Verification

- [x] `make build-check` → BUILD SUCCEEDED
- [x] `make test` → 764 tests, 0 failures
- [x] `swiftlint` clean on touched files
- [ ] Real USDT transfer on TronScan from a vault with staked energy → confirm 0 TRX burn
- [ ] Real Sun.io swap from native TRX → confirm contract executes (no OOE)

## References

- [vultisig-ios#4131](https://github.com/vultisig/vultisig-ios/pull/4131) — original PR; this replaces it.
- [TRON docs — set-feelimit](https://developers.tron.network/docs/set-feelimit).
- [TRON docs — dynamic energy model](https://developers.tron.network/docs/resource-model#dynamic-energy-model).
- `vultisig-android/data/.../tron/TronFeeService.kt` — reference impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More accurate Tron fee estimation using dynamic energy-budget simulations, with swap-specific handling and safer fallback caps.
  * TRC20 transfer simulation added to derive contract fees from estimated energy usage.

* **Bug Fixes**
  * Improved default energy pricing and fallback behavior to avoid zero or missing fee limits.

* **Tests**
  * Added comprehensive tests covering fee calculation, simulation fallbacks, and swap/native scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
