### PR TITLE
feat(swap): SwapKit /tokens universal coin picker (flag-gated)

### DIFF
--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -49,6 +49,11 @@ struct VultisigApp: App {
         // the tx-history viewmodel and the native status poller can route by
         // `providerKind`. New providers register here.
         SwapTrackingRegistry.shared.register(SwapKitTrackingService.shared)
+
+        // Register every destination-token provider with the shared registry
+        // so the swap coin picker can aggregate destination tokens from
+        // every source. New providers register here.
+        DestinationTokenRegistry.shared.register(SwapKitTokensCache.shared)
     }
     var body: some Scene {
         WindowGroup {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitAPI.swift
@@ -17,6 +17,9 @@ enum SwapKitAPI {
     case swap(SwapKitSwapRequest)
     case track(SwapKitTrackRequest)
     case providers
+    /// `GET /tokens?provider=<NAME>` — per-provider token list. Mounted off
+    /// the bare proxy root (not under `/v3/`), same shape as `/track`.
+    case tokens(provider: String)
 }
 
 extension SwapKitAPI: TargetType {
@@ -26,9 +29,9 @@ extension SwapKitAPI: TargetType {
             // V3 surface: `/v3/quote`, `/v3/swap`. Base URL is
             // `.../swapkit/v3`; the path adds the leaf only.
             return SwapKitConfig.baseURL
-        case .track, .providers:
-            // Bare-host endpoints — SwapKit's `/track` and `/providers`
-            // live at the host root, not under `/v3`. Hitting
+        case .track, .providers, .tokens:
+            // Bare-host endpoints — SwapKit's `/track`, `/providers`, and
+            // `/tokens` live at the host root, not under `/v3`. Hitting
             // `.../swapkit/v3/providers` returns 404 from the proxy.
             return SwapKitConfig.trackBaseURL
         }
@@ -44,12 +47,14 @@ extension SwapKitAPI: TargetType {
             return "/track"
         case .providers:
             return "/providers"
+        case .tokens:
+            return "/tokens"
         }
     }
 
     var method: HTTPMethod {
         switch self {
-        case .providers:
+        case .providers, .tokens:
             return .get
         case .quote, .swap, .track:
             return .post
@@ -66,6 +71,8 @@ extension SwapKitAPI: TargetType {
             return .requestCodable(request, .jsonEncoding)
         case .providers:
             return .requestPlain
+        case .tokens(let provider):
+            return .requestParameters(["provider": provider], .urlEncoding)
         }
     }
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitConfig.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitConfig.swift
@@ -36,8 +36,18 @@ enum SwapKitConfig {
     static let timeoutInterval: TimeInterval = 30
 
     /// Provider TTL — how long the cached `/providers` response is reused
-    /// before re-fetching. 24h matches the design decision §4.
+    /// before re-fetching. 24h matches the design decision §4. Provider
+    /// eligibility (which chains each provider supports) changes rarely —
+    /// daily refresh is plenty.
     static let providerCacheTTL: TimeInterval = 24 * 60 * 60
+
+    /// Token-catalog TTL — how long the cached `/tokens?provider=…` fan-out
+    /// snapshot is reused before re-fetching. Shorter than `providerCacheTTL`
+    /// because new tokens get added to NEAR Intents / Chainflip / etc.
+    /// catalogs continuously, and a stale picker hides them. 5 min balances
+    /// "user sees new tokens within a reasonable window" against "don't
+    /// stampede the proxy every time the picker opens".
+    static let tokensCacheTTL: TimeInterval = 5 * 60
 
     /// Provider names that route through THORChain / MayaChain. Routes whose
     /// `providers[]` contain any of these are dropped at the fetcher

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
@@ -132,4 +132,45 @@ enum SwapKitChainIDMapper {
         default: return ""
         }
     }
+
+    /// Reverse map for the per-token `chain` field in `/tokens` responses
+    /// (uppercase ticker-style key, e.g. `"ETH"`, `"BSC"`, `"NEAR"`, `"BTC"`).
+    /// Returns `nil` for chains Vultisig has no wallet support for — those
+    /// tokens can't be receive destinations so they're dropped at decode.
+    /// Note: SwapKit's per-token `chain` is unique per Vultisig chain (Base
+    /// ETH appears as `"BASE"`, OP ETH as `"OP"`, not as `"ETH"`), so the
+    /// reverse map is many-to-one only for legacy aliases (e.g. `"POL"` and
+    /// `"MATIC"` both reaching `.polygon`).
+    static func chain(forSwapKitChain swapKitChain: String) -> Chain? {
+        switch swapKitChain.uppercased() {
+        case "ETH": return .ethereum
+        case "BSC", "BNB": return .bscChain
+        case "AVAX": return .avalanche
+        case "ARB": return .arbitrum
+        case "OP": return .optimism
+        case "BASE": return .base
+        case "POL", "MATIC", "POLYGON": return .polygon
+        case "SOL": return .solana
+        case "BTC": return .bitcoin
+        case "BCH": return .bitcoinCash
+        case "LTC": return .litecoin
+        case "DOGE": return .dogecoin
+        case "DASH": return .dash
+        case "ZEC": return .zcash
+        case "TRON", "TRX": return .tron
+        case "TON": return .ton
+        case "ADA": return .cardano
+        case "SUI": return .sui
+        case "XRP": return .ripple
+        case "ATOM": return .gaiaChain
+        case "KUJI": return .kujira
+        // Chains SwapKit lists tokens on but Vultisig doesn't hold wallets
+        // for — caller drops the token. Enumerated for grep-discoverability
+        // rather than relying on the default arm.
+        case "BERA", "MONAD", "GNO", "STRK", "XLAYER", "OKB", "DOT", "NEAR":
+            return nil
+        default:
+            return nil
+        }
+    }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitToken.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitToken.swift
@@ -58,12 +58,22 @@ extension SwapKitToken {
             return nil
         }
 
-        // Treat as native iff the SwapKit `address` is absent OR empty AND
-        // the ticker matches the chain's native ticker prefix. The
-        // `SwapKitChainIDMapper.chain(forSwapKitChain:)` reverse map already
-        // pins the chain; here we just decide native vs token.
+        // Treat as native only when the SwapKit `address` is absent/empty
+        // AND the entry's `identifier` matches SwapKit's canonical native
+        // form (`<chain>.<ticker>`, e.g. `ARB.ETH`, `BSC.BNB`, `MONAD.MON`).
+        // The address check alone isn't enough — a malformed upstream entry
+        // with an empty address would otherwise be silently coerced into
+        // the destination chain's gas slot. `SwapKitChainIDMapper.chain(forSwapKitChain:)`
+        // has already pinned the destination chain; this guard just decides
+        // native vs token.
         let contract = address?.trimmingCharacters(in: .whitespaces) ?? ""
-        let isNative = contract.isEmpty
+        let canonicalNativeIdentifier = "\(self.chain.uppercased()).\(ticker.uppercased())"
+        let isNative = contract.isEmpty && identifier.uppercased() == canonicalNativeIdentifier
+        if contract.isEmpty, !isNative {
+            // Empty address but not canonical native — drop as malformed
+            // rather than coercing into the chain's native gas slot.
+            return nil
+        }
         if !isNative, !SwapKitToken.isUsableContract(contract, on: chain) {
             // Cross-chain wrapper identifiers (e.g. NEAR's `zec.omft.near`)
             // aren't on-chain ERC-20 / SPL contracts — drop. The user can
@@ -91,7 +101,9 @@ extension SwapKitToken {
     private static func isUsableContract(_ contract: String, on chain: Chain) -> Bool {
         switch chain.chainType {
         case .EVM:
-            return contract.hasPrefix("0x") && contract.count == 42
+            guard contract.hasPrefix("0x"), contract.count == 42 else { return false }
+            let payload = contract.dropFirst(2)
+            return payload.allSatisfy { $0.isHexDigit }
         case .Solana:
             // SPL mint addresses are base58 — length 32–44, no leading "0x".
             return !contract.contains(".") && !contract.hasPrefix("0x") && contract.count >= 32

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitToken.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitToken.swift
@@ -1,0 +1,107 @@
+//
+//  SwapKitToken.swift
+//  VultisigApp
+//
+//  Decodable models for the SwapKit `/tokens?provider=<NAME>` response, plus
+//  the adapter that maps a `SwapKitToken` to a transient `CoinMeta` the swap
+//  destination picker + quote builder can consume. Tokens whose `chain`
+//  string doesn't reverse-map to a Vultisig-supported `Chain` are dropped at
+//  decode-time — Vultisig must hold a wallet on the destination chain for
+//  the route to be receivable.
+//
+
+import Foundation
+
+/// Single token entry in a `/tokens?provider=<NAME>` response. Field names
+/// match the upstream wire format (see `swapkit-spike/api-contract.md`
+/// §"`/tokens`" and the vendored `03c-tokens-NEAR.json` fixture).
+///
+/// Two address fields surfaced upstream:
+///  - `address` — on-chain contract address (omitted for gas tokens; sometimes
+///    empty string for NEAR's `NEAR.NEAR` gas token, sometimes a NEAR
+///    intent identifier like `zec.omft.near` for cross-chain entries).
+///  - `chainId` — SwapKit's per-chain identifier (`"1"` for EVM, `"solana"`,
+///    `"bitcoin"`, etc.). Not used by the adapter; the `chain` string is the
+///    canonical key.
+struct SwapKitToken: Codable, Hashable {
+    let chain: String
+    let chainId: String?
+    let address: String?
+    let ticker: String
+    let identifier: String
+    let name: String?
+    let decimals: Int
+    let logoURI: String?
+    let coingeckoId: String?
+}
+
+/// Envelope returned by `GET /tokens?provider=<NAME>`. Empty/error responses
+/// from the proxy use a different shape (`{message, error}`); decoding fails
+/// in that case and the caller falls open to "no SwapKit tokens for this
+/// provider".
+struct SwapKitTokensResponse: Decodable {
+    let provider: String
+    let count: Int?
+    let tokens: [SwapKitToken]
+}
+
+extension SwapKitToken {
+    /// Adapter — maps a `SwapKitToken` to the `CoinMeta` shape the picker
+    /// renders and `CoinService.addToChain` consumes. Returns `nil` when:
+    ///  - `chain` doesn't reverse-map to a Vultisig-supported chain
+    ///    (Polkadot, Berachain, Monad, Starknet, X-Layer, etc.).
+    ///  - Token has no on-chain contract address but isn't the gas token of
+    ///    its chain (NEAR cross-chain wrappers like `NEAR.ZEC-zec.omft.near`
+    ///    aren't holdable on Vultisig).
+    func toCoinMeta() -> CoinMeta? {
+        guard let chain = SwapKitChainIDMapper.chain(forSwapKitChain: self.chain) else {
+            return nil
+        }
+
+        // Treat as native iff the SwapKit `address` is absent OR empty AND
+        // the ticker matches the chain's native ticker prefix. The
+        // `SwapKitChainIDMapper.chain(forSwapKitChain:)` reverse map already
+        // pins the chain; here we just decide native vs token.
+        let contract = address?.trimmingCharacters(in: .whitespaces) ?? ""
+        let isNative = contract.isEmpty
+        if !isNative, !SwapKitToken.isUsableContract(contract, on: chain) {
+            // Cross-chain wrapper identifiers (e.g. NEAR's `zec.omft.near`)
+            // aren't on-chain ERC-20 / SPL contracts — drop. The user can
+            // still receive the underlying via a SwapKit quote that drops
+            // the wrapper at the deposit-address stage; surfacing the
+            // wrapper in the picker would confuse the wallet add flow.
+            return nil
+        }
+
+        return CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: logoURI ?? "",
+            decimals: decimals,
+            priceProviderId: coingeckoId ?? "",
+            contractAddress: isNative ? "" : contract,
+            isNativeToken: isNative
+        )
+    }
+
+    /// A "usable" contract is one Vultisig's `CoinFactory` can build against
+    /// on the destination chain — EVM hex, Solana base58 SPL mint, Tron
+    /// base58, TON workchain address. NEAR-Intent identifiers (`*.omft.near`,
+    /// `*.poa-bridge.near`) are explicitly not usable destinations.
+    private static func isUsableContract(_ contract: String, on chain: Chain) -> Bool {
+        switch chain.chainType {
+        case .EVM:
+            return contract.hasPrefix("0x") && contract.count == 42
+        case .Solana:
+            // SPL mint addresses are base58 — length 32–44, no leading "0x".
+            return !contract.contains(".") && !contract.hasPrefix("0x") && contract.count >= 32
+        default:
+            // For non-EVM / non-Solana destinations, conservatively reject
+            // any contract value — most SwapKit tokens on UTXO / TON / TRON
+            // / Cardano / Sui chains are gas tokens with no contract, and
+            // the long-tail with a contract is almost always a NEAR wrapper
+            // identifier that the wallet can't actually hold.
+            return false
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
@@ -1,0 +1,185 @@
+//
+//  SwapKitTokensCache.swift
+//  VultisigApp
+//
+//  Fans out `GET /tokens?provider=<NAME>` against the providers currently
+//  enabled in the cached `/v3/providers` snapshot, dedupes by `identifier`,
+//  buckets by reverse-mapped Vultisig `Chain`, and caches the result in
+//  memory with a 24h TTL. The destination coin picker calls
+//  `tokens(for: chain)` to surface SwapKit destinations beyond the existing
+//  curated + 1inch + Jupiter lists.
+//
+//  Storage decision: in-memory only. SwapKit publishes a `timestamp` per
+//  response and the list changes rarely; offline = no swap anyway, so
+//  SwiftData persistence would buy nothing for the migration / Sendable
+//  cost. See `wiki/.../swapkit-integration/tokens-picker-plan.md` §D2.
+//
+
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-tokens-cache")
+
+/// Single bucket inside the cache — tokens for one Vultisig `Chain`, indexed
+/// by SwapKit identifier so the picker's "is this a SwapKit-only token?"
+/// predicate is O(1).
+struct SwapKitTokensBucket {
+    let chain: Chain
+    /// `identifier` (e.g. `"ETH.USDT-0xdAC17F..."`) -> adapted CoinMeta.
+    let byIdentifier: [String: CoinMeta]
+    /// Lowercased `CoinMeta.uniqueId` set — used by the picker to detect
+    /// "SwapKit unlocks this token" overlap against the existing curated +
+    /// 1inch + Jupiter union.
+    let uniqueIds: Set<String>
+
+    var tokens: [CoinMeta] { Array(byIdentifier.values) }
+}
+
+actor SwapKitTokensCache {
+    static let shared = SwapKitTokensCache()
+
+    private let httpClient: HTTPClientProtocol
+    private let providerCache: SwapKitProviderCache
+    private var snapshot: Snapshot?
+    private var inFlight: Task<[Chain: SwapKitTokensBucket]?, Never>?
+
+    private struct Snapshot {
+        let buckets: [Chain: SwapKitTokensBucket]
+        let fetchedAt: Date
+    }
+
+    init(
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        providerCache: SwapKitProviderCache = .shared
+    ) {
+        self.httpClient = httpClient
+        self.providerCache = providerCache
+    }
+
+    /// Tokens unlocked by SwapKit on `chain`, fetched + cached on first call.
+    /// Returns an empty bucket (rather than nil) when:
+    ///  - The feature flag is OFF (defensive — callers should already gate
+    ///    on `SwapKitConfig.isFeatureEnabled`, but the cache fails closed).
+    ///  - The cache fetch fails entirely and we have no prior snapshot.
+    ///  - SwapKit has no tokens on this chain (cache built, bucket missing).
+    /// The picker treats "empty bucket" identically to "no SwapKit unlock"
+    /// and falls back to the curated + 1inch + Jupiter list it has today.
+    func tokens(for chain: Chain, now: Date = Date()) async -> SwapKitTokensBucket {
+        guard SwapKitConfig.isFeatureEnabled else {
+            return SwapKitTokensBucket(chain: chain, byIdentifier: [:], uniqueIds: [])
+        }
+        let buckets = await ensureSnapshot(now: now)
+        return buckets?[chain] ?? SwapKitTokensBucket(chain: chain, byIdentifier: [:], uniqueIds: [])
+    }
+
+    /// Coalescing fetch — concurrent callers share one in-flight Task to
+    /// avoid stampeding the proxy on first picker open. Returns the cached
+    /// snapshot when fresh; otherwise refreshes.
+    private func ensureSnapshot(now: Date) async -> [Chain: SwapKitTokensBucket]? {
+        if let snapshot, now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.providerCacheTTL {
+            return snapshot.buckets
+        }
+        if let inFlight {
+            return await inFlight.value
+        }
+        let task = Task { [providerCache, httpClient] () -> [Chain: SwapKitTokensBucket]? in
+            await Self.fetchAll(providerCache: providerCache, httpClient: httpClient, now: now)
+        }
+        inFlight = task
+        let result = await task.value
+        inFlight = nil
+        if let result {
+            snapshot = Snapshot(buckets: result, fetchedAt: now)
+        }
+        return result ?? snapshot?.buckets
+    }
+
+    /// Replace the snapshot — exposed for tests so they don't need a fake
+    /// `HTTPClient`. Mirrors the affordance `SwapKitProviderCache.setSnapshot`
+    /// gives provider-cache tests.
+    func setSnapshot(buckets: [Chain: SwapKitTokensBucket], fetchedAt: Date = Date()) {
+        snapshot = Snapshot(buckets: buckets, fetchedAt: fetchedAt)
+    }
+
+    // MARK: - Fan-out + merge
+
+    private static func fetchAll(
+        providerCache: SwapKitProviderCache,
+        httpClient: HTTPClientProtocol,
+        now: Date
+    ) async -> [Chain: SwapKitTokensBucket]? {
+        guard let allProviders = await providerCache.providers(now: now) else {
+            logger.info("[swapkit-tokens] no provider snapshot available — skipping fetch")
+            return nil
+        }
+        let providerNames = allProviders
+            .map { $0.name.uppercased() }
+            .filter { !SwapKitConfig.filteredProviders.contains($0) }
+
+        guard !providerNames.isEmpty else {
+            logger.info("[swapkit-tokens] no eligible providers after THORChain/Maya filter")
+            return [:]
+        }
+
+        let fetched: [SwapKitTokensResponse] = await withTaskGroup(of: SwapKitTokensResponse?.self) { group in
+            for name in providerNames {
+                group.addTask {
+                    await fetchTokens(provider: name, httpClient: httpClient)
+                }
+            }
+            var collected: [SwapKitTokensResponse] = []
+            for await response in group {
+                if let response { collected.append(response) }
+            }
+            return collected
+        }
+
+        return mergeByChain(responses: fetched)
+    }
+
+    private static func fetchTokens(
+        provider: String,
+        httpClient: HTTPClientProtocol
+    ) async -> SwapKitTokensResponse? {
+        do {
+            let response = try await httpClient.request(
+                SwapKitAPI.tokens(provider: provider),
+                responseType: SwapKitTokensResponse.self
+            )
+            return response.data
+        } catch {
+            logger.warning("[swapkit-tokens] failed to fetch \(provider, privacy: .public): \(String(describing: error), privacy: .public)")
+            return nil
+        }
+    }
+
+    /// Dedup + bucket. Exposed as a static so tests can drive it from
+    /// fixture data without standing up the actor + HTTPClient.
+    static func mergeByChain(responses: [SwapKitTokensResponse]) -> [Chain: SwapKitTokensBucket] {
+        var byChain: [Chain: [String: CoinMeta]] = [:]
+        // Dedup priority: a token already seen (by identifier) on a given
+        // chain wins over a later one. SwapKit responses are stable within
+        // a provider; cross-provider collisions are USDC variants where the
+        // first hit is correct.
+        for response in responses {
+            for token in response.tokens {
+                guard let coinMeta = token.toCoinMeta() else { continue }
+                let chain = coinMeta.chain
+                if byChain[chain] == nil { byChain[chain] = [:] }
+                if byChain[chain]?[token.identifier] == nil {
+                    byChain[chain]?[token.identifier] = coinMeta
+                }
+            }
+        }
+        var buckets: [Chain: SwapKitTokensBucket] = [:]
+        for (chain, byIdentifier) in byChain {
+            let uniqueIds = Set(byIdentifier.values.map { $0.uniqueId })
+            buckets[chain] = SwapKitTokensBucket(
+                chain: chain,
+                byIdentifier: byIdentifier,
+                uniqueIds: uniqueIds
+            )
+        }
+        return buckets
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
@@ -116,8 +116,15 @@ final class SwapKitTokensCache: DestinationTokenProvider {
             logger.info("[swapkit-tokens] no provider snapshot available — skipping fetch")
             return nil
         }
+        // Fan out by `provider.provider` (the canonical API identifier), not
+        // `provider.name`. `SwapKitProviderCache.chainEnabled` filters
+        // THORChain/Maya by `provider.provider.uppercased()` against
+        // `SwapKitConfig.filteredProviders`, and the same identifier is the
+        // one `/tokens?provider=` accepts. Using `.name` here can both let
+        // filtered providers through (when name and identifier diverge) and
+        // request `/tokens` with a non-canonical value.
         let providerNames = allProviders
-            .map { $0.name.uppercased() }
+            .map { $0.provider.uppercased() }
             .filter { !SwapKitConfig.filteredProviders.contains($0) }
 
         guard !providerNames.isEmpty else {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
@@ -5,9 +5,9 @@
 //  Fans out `GET /tokens?provider=<NAME>` against the providers currently
 //  enabled in the cached `/v3/providers` snapshot, dedupes by `identifier`,
 //  buckets by reverse-mapped Vultisig `Chain`, and caches the result in
-//  memory with a 24h TTL. The destination coin picker calls
-//  `tokens(for: chain)` to surface SwapKit destinations beyond the existing
-//  curated + 1inch + Jupiter lists.
+//  memory with a 24h TTL. The destination coin picker resolves SwapKit
+//  destinations via `DestinationTokenRegistry`, which calls
+//  `tokens(for: chain)` here.
 //
 //  Storage decision: in-memory only. SwapKit publishes a `timestamp` per
 //  response and the list changes rarely; offline = no swap anyway, so
@@ -20,31 +20,19 @@ import OSLog
 
 private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-tokens-cache")
 
-/// Single bucket inside the cache — tokens for one Vultisig `Chain`, indexed
-/// by SwapKit identifier so the picker's "is this a SwapKit-only token?"
-/// predicate is O(1).
-struct SwapKitTokensBucket {
-    let chain: Chain
-    /// `identifier` (e.g. `"ETH.USDT-0xdAC17F..."`) -> adapted CoinMeta.
-    let byIdentifier: [String: CoinMeta]
-    /// Lowercased `CoinMeta.uniqueId` set — used by the picker to detect
-    /// "SwapKit unlocks this token" overlap against the existing curated +
-    /// 1inch + Jupiter union.
-    let uniqueIds: Set<String>
-
-    var tokens: [CoinMeta] { Array(byIdentifier.values) }
-}
-
-actor SwapKitTokensCache {
+@MainActor
+final class SwapKitTokensCache: DestinationTokenProvider {
     static let shared = SwapKitTokensCache()
+
+    let providerKind: String = "swapKit"
 
     private let httpClient: HTTPClientProtocol
     private let providerCache: SwapKitProviderCache
     private var snapshot: Snapshot?
-    private var inFlight: Task<[Chain: SwapKitTokensBucket]?, Never>?
+    private var inFlight: Task<[Chain: DestinationTokenBucket]?, Never>?
 
     private struct Snapshot {
-        let buckets: [Chain: SwapKitTokensBucket]
+        let buckets: [Chain: DestinationTokenBucket]
         let fetchedAt: Date
     }
 
@@ -64,25 +52,30 @@ actor SwapKitTokensCache {
     ///  - SwapKit has no tokens on this chain (cache built, bucket missing).
     /// The picker treats "empty bucket" identically to "no SwapKit unlock"
     /// and falls back to the curated + 1inch + Jupiter list it has today.
-    func tokens(for chain: Chain, now: Date = Date()) async -> SwapKitTokensBucket {
+    func tokens(for chain: Chain) async -> DestinationTokenBucket {
+        await tokens(for: chain, now: Date())
+    }
+
+    /// Date-injectable variant used by tests / TTL-sensitive callers.
+    func tokens(for chain: Chain, now: Date) async -> DestinationTokenBucket {
         guard SwapKitConfig.isFeatureEnabled else {
-            return SwapKitTokensBucket(chain: chain, byIdentifier: [:], uniqueIds: [])
+            return .empty(chain: chain)
         }
         let buckets = await ensureSnapshot(now: now)
-        return buckets?[chain] ?? SwapKitTokensBucket(chain: chain, byIdentifier: [:], uniqueIds: [])
+        return buckets?[chain] ?? .empty(chain: chain)
     }
 
     /// Coalescing fetch — concurrent callers share one in-flight Task to
     /// avoid stampeding the proxy on first picker open. Returns the cached
     /// snapshot when fresh; otherwise refreshes.
-    private func ensureSnapshot(now: Date) async -> [Chain: SwapKitTokensBucket]? {
+    private func ensureSnapshot(now: Date) async -> [Chain: DestinationTokenBucket]? {
         if let snapshot, now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.providerCacheTTL {
             return snapshot.buckets
         }
         if let inFlight {
             return await inFlight.value
         }
-        let task = Task { [providerCache, httpClient] () -> [Chain: SwapKitTokensBucket]? in
+        let task = Task { [providerCache, httpClient] () -> [Chain: DestinationTokenBucket]? in
             await Self.fetchAll(providerCache: providerCache, httpClient: httpClient, now: now)
         }
         inFlight = task
@@ -97,7 +90,7 @@ actor SwapKitTokensCache {
     /// Replace the snapshot — exposed for tests so they don't need a fake
     /// `HTTPClient`. Mirrors the affordance `SwapKitProviderCache.setSnapshot`
     /// gives provider-cache tests.
-    func setSnapshot(buckets: [Chain: SwapKitTokensBucket], fetchedAt: Date = Date()) {
+    func setSnapshot(buckets: [Chain: DestinationTokenBucket], fetchedAt: Date = Date()) {
         snapshot = Snapshot(buckets: buckets, fetchedAt: fetchedAt)
     }
 
@@ -107,7 +100,7 @@ actor SwapKitTokensCache {
         providerCache: SwapKitProviderCache,
         httpClient: HTTPClientProtocol,
         now: Date
-    ) async -> [Chain: SwapKitTokensBucket]? {
+    ) async -> [Chain: DestinationTokenBucket]? {
         guard let allProviders = await providerCache.providers(now: now) else {
             logger.info("[swapkit-tokens] no provider snapshot available — skipping fetch")
             return nil
@@ -154,29 +147,36 @@ actor SwapKitTokensCache {
     }
 
     /// Dedup + bucket. Exposed as a static so tests can drive it from
-    /// fixture data without standing up the actor + HTTPClient.
-    static func mergeByChain(responses: [SwapKitTokensResponse]) -> [Chain: SwapKitTokensBucket] {
-        var byChain: [Chain: [String: CoinMeta]] = [:]
-        // Dedup priority: a token already seen (by identifier) on a given
-        // chain wins over a later one. SwapKit responses are stable within
-        // a provider; cross-provider collisions are USDC variants where the
-        // first hit is correct.
+    /// fixture data without standing up the cache + HTTPClient.
+    /// `nonisolated` since the body touches no instance state and the
+    /// inputs/outputs are value types — keeps test callers off MainActor.
+    ///
+    /// Dedup priority within a chain: a token already seen (by SwapKit
+    /// `identifier`) wins over a later one. SwapKit responses are stable
+    /// within a provider; cross-provider collisions are typically USDC
+    /// variants where the first hit is correct. Insertion order of the
+    /// resulting `tokens` array follows the order tokens were first
+    /// observed across the merged responses.
+    nonisolated static func mergeByChain(responses: [SwapKitTokensResponse]) -> [Chain: DestinationTokenBucket] {
+        var byChainTokens: [Chain: [CoinMeta]] = [:]
+        var byChainIdentifiers: [Chain: Set<String>] = [:]
         for response in responses {
             for token in response.tokens {
                 guard let coinMeta = token.toCoinMeta() else { continue }
                 let chain = coinMeta.chain
-                if byChain[chain] == nil { byChain[chain] = [:] }
-                if byChain[chain]?[token.identifier] == nil {
-                    byChain[chain]?[token.identifier] = coinMeta
-                }
+                var seen = byChainIdentifiers[chain] ?? []
+                guard !seen.contains(token.identifier) else { continue }
+                seen.insert(token.identifier)
+                byChainIdentifiers[chain] = seen
+                byChainTokens[chain, default: []].append(coinMeta)
             }
         }
-        var buckets: [Chain: SwapKitTokensBucket] = [:]
-        for (chain, byIdentifier) in byChain {
-            let uniqueIds = Set(byIdentifier.values.map { $0.uniqueId })
-            buckets[chain] = SwapKitTokensBucket(
+        var buckets: [Chain: DestinationTokenBucket] = [:]
+        for (chain, tokens) in byChainTokens {
+            let uniqueIds = Set(tokens.map { $0.uniqueId })
+            buckets[chain] = DestinationTokenBucket(
                 chain: chain,
-                byIdentifier: byIdentifier,
+                tokens: tokens,
                 uniqueIds: uniqueIds
             )
         }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
@@ -5,7 +5,7 @@
 //  Fans out `GET /tokens?provider=<NAME>` against the providers currently
 //  enabled in the cached `/v3/providers` snapshot, dedupes by `identifier`,
 //  buckets by reverse-mapped Vultisig `Chain`, and caches the result in
-//  memory with a 24h TTL. The destination coin picker resolves SwapKit
+//  memory with a 5-minute TTL. The destination coin picker resolves SwapKit
 //  destinations via `DestinationTokenRegistry`, which calls
 //  `tokens(for: chain)` here.
 //
@@ -69,7 +69,7 @@ final class SwapKitTokensCache: DestinationTokenProvider {
     /// avoid stampeding the proxy on first picker open. Returns the cached
     /// snapshot when fresh; otherwise refreshes.
     private func ensureSnapshot(now: Date) async -> [Chain: DestinationTokenBucket]? {
-        if let snapshot, now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.providerCacheTTL {
+        if let snapshot, now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.tokensCacheTTL {
             return snapshot.buckets
         }
         if let inFlight {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
@@ -94,6 +94,17 @@ final class SwapKitTokensCache: DestinationTokenProvider {
         snapshot = Snapshot(buckets: buckets, fetchedAt: fetchedAt)
     }
 
+    /// Drop the cached snapshot + in-flight task. Next `tokens(for:)` call
+    /// refetches against the proxy regardless of TTL. Exposed for the
+    /// Settings → Advanced "Clear SwapKit tokens cache" debug action so
+    /// testers can pick up upstream catalog changes without waiting for
+    /// the 5-minute TTL or app relaunch.
+    func clearCache() {
+        snapshot = nil
+        inFlight?.cancel()
+        inFlight = nil
+    }
+
     // MARK: - Fan-out + merge
 
     private static func fetchAll(

--- a/VultisigApp/VultisigApp/Components/Cells/SettingActionCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SettingActionCell.swift
@@ -21,22 +21,13 @@ struct SettingActionCell: View {
         HStack(spacing: 12) {
             Image(systemName: icon)
                 .font(Theme.fonts.bodyLRegular)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
             Text(title)
                 .font(Theme.fonts.bodySRegular)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
             Spacer()
-            Button(action: action) {
-                Text(buttonLabel)
-                    .font(Theme.fonts.bodySRegular)
-                    .foregroundColor(Theme.colors.textPrimary)
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 12)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(Theme.colors.bgSurface2, lineWidth: 1)
-                    )
-            }
+            PrimaryButton(title: buttonLabel, type: .secondary, size: .mini, action: action)
+                .fixedSize()
         }
         .padding(12)
         .background(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Components/Cells/SettingActionCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SettingActionCell.swift
@@ -1,0 +1,45 @@
+//
+//  SettingActionCell.swift
+//  VultisigApp
+//
+//  Settings → Advanced row that renders a labelled action button on the
+//  right side instead of a Toggle / Picker. Used for debug-only actions
+//  (e.g. "Clear SwapKit tokens cache") that fire a single closure when
+//  tapped. Visual style mirrors `SettingToggleCell` / `SettingPickerCell`
+//  so the rows align cleanly when stacked.
+//
+
+import SwiftUI
+
+struct SettingActionCell: View {
+    let title: String
+    let icon: String
+    let buttonLabel: String
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(Theme.fonts.bodyLRegular)
+                .foregroundColor(Theme.colors.textPrimary)
+            Text(title)
+                .font(Theme.fonts.bodySRegular)
+                .foregroundColor(Theme.colors.textPrimary)
+            Spacer()
+            Button(action: action) {
+                Text(buttonLabel)
+                    .font(Theme.fonts.bodySRegular)
+                    .foregroundColor(Theme.colors.textPrimary)
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 12)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Theme.colors.bgSurface2, lineWidth: 1)
+                    )
+            }
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .cornerRadius(10)
+    }
+}

--- a/VultisigApp/VultisigApp/Components/Cells/SwapCoinCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SwapCoinCell.swift
@@ -12,11 +12,6 @@ struct SwapCoinCell: View {
     let balance: String?
     let balanceFiat: String?
     let isSelected: Bool
-    /// Whether to show a small "via SwapKit" capsule next to the chain pill.
-    /// Set by `SwapCoinPickerView` for destination tokens that were surfaced
-    /// exclusively via SwapKit's `/tokens` list (not already in the curated
-    /// allowlist + 1inch + Jupiter union).
-    let isSwapKitOnly: Bool
 
     var onSelect: () -> Void
 
@@ -25,14 +20,12 @@ struct SwapCoinCell: View {
         balance: String?,
         balanceFiat: String?,
         isSelected: Bool,
-        isSwapKitOnly: Bool = false,
         onSelect: @escaping () -> Void
     ) {
         self.coin = coin
         self.balance = balance
         self.balanceFiat = balanceFiat
         self.isSelected = isSelected
-        self.isSwapKitOnly = isSwapKitOnly
         self.onSelect = onSelect
     }
 
@@ -58,26 +51,11 @@ struct SwapCoinCell: View {
             icon
             title
             chain
-            if isSwapKitOnly {
-                swapKitTag
-            }
             Spacer()
             balanceView
         }
         .padding(.horizontal, 22)
         .padding(.vertical, 12)
-    }
-
-    var swapKitTag: some View {
-        Text("swapPickerViaSwapKit".localized)
-            .foregroundStyle(Theme.colors.textSecondary)
-            .font(Theme.fonts.caption10)
-            .padding(.vertical, 8)
-            .padding(.horizontal, 12)
-            .overlay(
-                RoundedRectangle(cornerRadius: 24)
-                    .stroke(Theme.colors.bgSurface2, lineWidth: 1)
-            )
     }
 
     var icon: some View {

--- a/VultisigApp/VultisigApp/Components/Cells/SwapCoinCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SwapCoinCell.swift
@@ -12,8 +12,29 @@ struct SwapCoinCell: View {
     let balance: String?
     let balanceFiat: String?
     let isSelected: Bool
+    /// Whether to show a small "via SwapKit" capsule next to the chain pill.
+    /// Set by `SwapCoinPickerView` for destination tokens that were surfaced
+    /// exclusively via SwapKit's `/tokens` list (not already in the curated
+    /// allowlist + 1inch + Jupiter union).
+    let isSwapKitOnly: Bool
 
     var onSelect: () -> Void
+
+    init(
+        coin: CoinMeta,
+        balance: String?,
+        balanceFiat: String?,
+        isSelected: Bool,
+        isSwapKitOnly: Bool = false,
+        onSelect: @escaping () -> Void
+    ) {
+        self.coin = coin
+        self.balance = balance
+        self.balanceFiat = balanceFiat
+        self.isSelected = isSelected
+        self.isSwapKitOnly = isSwapKitOnly
+        self.onSelect = onSelect
+    }
 
     var body: some View {
         Button {
@@ -33,15 +54,30 @@ struct SwapCoinCell: View {
     }
 
     var content: some View {
-        HStack {
+        HStack(spacing: 8) {
             icon
             title
             chain
+            if isSwapKitOnly {
+                swapKitTag
+            }
             Spacer()
             balanceView
         }
         .padding(.horizontal, 22)
         .padding(.vertical, 12)
+    }
+
+    var swapKitTag: some View {
+        Text("swapPickerViaSwapKit".localized)
+            .foregroundStyle(Theme.colors.textSecondary)
+            .font(Theme.fonts.caption10)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 24)
+                    .stroke(Theme.colors.bgSurface2, lineWidth: 1)
+            )
     }
 
     var icon: some View {

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -848,6 +848,8 @@
 "settings" = "Einstellungen";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedSwapKitClearTokensCache" = "SwapKit-Token-Cache leeren";
+"settingsAdvancedClear" = "Leeren";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Teilen";
 "shareOf" = "Anteil %d von %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -938,7 +938,6 @@
 "swapKitStatusRefundedReason" = "Tausch wurde an deine Quelladresse erstattet";
 "swapKitViewOnTracker" = "In SwapKit Tracker ansehen";
 "swapOverview" = "Tauschübersicht";
-"swapPickerViaSwapKit" = "via SwapKit";
 "swapRouteNotAvailable" = "Tauschroute nicht verfügbar";
 "swaps" = "Swaps";
 "swapTrackingLink" = "Tauschverfolgungslink";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -938,6 +938,7 @@
 "swapKitStatusRefundedReason" = "Tausch wurde an deine Quelladresse erstattet";
 "swapKitViewOnTracker" = "In SwapKit Tracker ansehen";
 "swapOverview" = "Tauschübersicht";
+"swapPickerViaSwapKit" = "via SwapKit";
 "swapRouteNotAvailable" = "Tauschroute nicht verfügbar";
 "swaps" = "Swaps";
 "swapTrackingLink" = "Tauschverfolgungslink";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -846,10 +846,10 @@
 "setPasswordHintSubtitle" = "Dies wird angezeigt, falls Sie Ihr Passwort vergessen.";
 "setPasswordHintTitle" = "Optionalen Hinweis hinzufügen";
 "settings" = "Einstellungen";
+"settingsAdvancedClear" = "Leeren";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedSwapKitClearTokensCache" = "SwapKit-Token-Cache leeren";
-"settingsAdvancedClear" = "Leeren";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Teilen";
 "shareOf" = "Anteil %d von %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -948,6 +948,7 @@
 "swapKitStatusRefundedReason" = "Swap was refunded to your source address";
 "swapKitViewOnTracker" = "View on SwapKit Tracker";
 "swapOverview" = "Swap overview";
+"swapPickerViaSwapKit" = "via SwapKit";
 "swapRouteNotAvailable" = "Swap route not available";
 "swaps" = "Swaps";
 "swapTrackingLink" = "Swap tracking link";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -858,6 +858,8 @@
 "settings" = "Settings";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedSwapKitClearTokensCache" = "Clear SwapKit tokens cache";
+"settingsAdvancedClear" = "Clear";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Share";
 "shareOf" = "share %d of %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -948,7 +948,6 @@
 "swapKitStatusRefundedReason" = "Swap was refunded to your source address";
 "swapKitViewOnTracker" = "View on SwapKit Tracker";
 "swapOverview" = "Swap overview";
-"swapPickerViaSwapKit" = "via SwapKit";
 "swapRouteNotAvailable" = "Swap route not available";
 "swaps" = "Swaps";
 "swapTrackingLink" = "Swap tracking link";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -856,10 +856,10 @@
 "setPasswordHintSubtitle" = "This will be shown in case you forget your password.";
 "setPasswordHintTitle" = "Add an optional hint";
 "settings" = "Settings";
+"settingsAdvancedClear" = "Clear";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedSwapKitClearTokensCache" = "Clear SwapKit tokens cache";
-"settingsAdvancedClear" = "Clear";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Share";
 "shareOf" = "share %d of %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -848,6 +848,8 @@
 "settings" = "Configuración";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedSwapKitClearTokensCache" = "Borrar caché de tokens de SwapKit";
+"settingsAdvancedClear" = "Borrar";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartir";
 "shareOf" = "Compartir %d de %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -846,10 +846,10 @@
 "setPasswordHintSubtitle" = "Esto se mostrará en caso de que olvides tu contraseña.";
 "setPasswordHintTitle" = "Añadir una pista opcional";
 "settings" = "Configuración";
+"settingsAdvancedClear" = "Borrar";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedSwapKitClearTokensCache" = "Borrar caché de tokens de SwapKit";
-"settingsAdvancedClear" = "Borrar";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartir";
 "shareOf" = "Compartir %d de %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -938,7 +938,6 @@
 "swapKitStatusRefundedReason" = "El intercambio fue reembolsado a tu dirección de origen";
 "swapKitViewOnTracker" = "Ver en SwapKit Tracker";
 "swapOverview" = "Resumen del intercambio";
-"swapPickerViaSwapKit" = "vía SwapKit";
 "swapRouteNotAvailable" = "Ruta de intercambio no disponible";
 "swaps" = "Intercambios";
 "swapTrackingLink" = "Enlace de seguimiento del intercambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -938,6 +938,7 @@
 "swapKitStatusRefundedReason" = "El intercambio fue reembolsado a tu dirección de origen";
 "swapKitViewOnTracker" = "Ver en SwapKit Tracker";
 "swapOverview" = "Resumen del intercambio";
+"swapPickerViaSwapKit" = "vía SwapKit";
 "swapRouteNotAvailable" = "Ruta de intercambio no disponible";
 "swaps" = "Intercambios";
 "swapTrackingLink" = "Enlace de seguimiento del intercambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -846,10 +846,10 @@
 "setPasswordHintSubtitle" = "Ovo će se prikazati u slučaju da zaboravite svoju lozinku.";
 "setPasswordHintTitle" = "Dodajte opcionalni podsjetnik";
 "settings" = "Postavke";
+"settingsAdvancedClear" = "Očisti";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedSwapKitClearTokensCache" = "Očisti predmemoriju SwapKit tokena";
-"settingsAdvancedClear" = "Očisti";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Podijeli";
 "shareOf" = "podijelite %d od %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -938,7 +938,6 @@
 "swapKitStatusRefundedReason" = "Zamjena je vraćena na vašu izvornu adresu";
 "swapKitViewOnTracker" = "Pogledaj na SwapKit Trackeru";
 "swapOverview" = "Pregled zamjene";
-"swapPickerViaSwapKit" = "putem SwapKita";
 "swapRouteNotAvailable" = "Ruta zamjene nije dostupna";
 "swaps" = "Zamjene";
 "swapTrackingLink" = "Poveznica za praćenje zamjene";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -938,6 +938,7 @@
 "swapKitStatusRefundedReason" = "Zamjena je vraćena na vašu izvornu adresu";
 "swapKitViewOnTracker" = "Pogledaj na SwapKit Trackeru";
 "swapOverview" = "Pregled zamjene";
+"swapPickerViaSwapKit" = "putem SwapKita";
 "swapRouteNotAvailable" = "Ruta zamjene nije dostupna";
 "swaps" = "Zamjene";
 "swapTrackingLink" = "Poveznica za praćenje zamjene";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -848,6 +848,8 @@
 "settings" = "Postavke";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedSwapKitClearTokensCache" = "Očisti predmemoriju SwapKit tokena";
+"settingsAdvancedClear" = "Očisti";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Podijeli";
 "shareOf" = "podijelite %d od %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -938,6 +938,7 @@
 "swapKitStatusRefundedReason" = "Lo scambio è stato rimborsato al tuo indirizzo di origine";
 "swapKitViewOnTracker" = "Visualizza su SwapKit Tracker";
 "swapOverview" = "Panoramica dello scambio";
+"swapPickerViaSwapKit" = "via SwapKit";
 "swapRouteNotAvailable" = "Percorso di scambio non disponibile";
 "swaps" = "Scambi";
 "swapTrackingLink" = "Link di tracciamento dello scambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -848,6 +848,8 @@
 "settings" = "Impostazioni";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedSwapKitClearTokensCache" = "Cancella la cache dei token di SwapKit";
+"settingsAdvancedClear" = "Cancella";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";
 "shareOf" = "Condividi %d di %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -846,10 +846,10 @@
 "setPasswordHintSubtitle" = "Questo verrà mostrato nel caso in cui dimentichi la tua password.";
 "setPasswordHintTitle" = "Aggiungi un suggerimento opzionale";
 "settings" = "Impostazioni";
+"settingsAdvancedClear" = "Cancella";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedSwapKitClearTokensCache" = "Cancella la cache dei token di SwapKit";
-"settingsAdvancedClear" = "Cancella";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";
 "shareOf" = "Condividi %d di %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -938,7 +938,6 @@
 "swapKitStatusRefundedReason" = "Lo scambio è stato rimborsato al tuo indirizzo di origine";
 "swapKitViewOnTracker" = "Visualizza su SwapKit Tracker";
 "swapOverview" = "Panoramica dello scambio";
-"swapPickerViaSwapKit" = "via SwapKit";
 "swapRouteNotAvailable" = "Percorso di scambio non disponibile";
 "swaps" = "Scambi";
 "swapTrackingLink" = "Link di tracciamento dello scambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -925,6 +925,7 @@
 "swapKitStatusRefundedReason" = "스왑이 원래 주소로 환불되었습니다";
 "swapKitViewOnTracker" = "SwapKit 추적기에서 보기";
 "swapOverview" = "스왑 개요";
+"swapPickerViaSwapKit" = "SwapKit를 통해";
 "swapRouteNotAvailable" = "스왑 경로를 사용할 수 없습니다";
 "swaps" = "스왑";
 "swapTrackingLink" = "스왑 추적 링크";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -834,10 +834,10 @@
 "setPasswordHintSubtitle" = "비밀번호를 잊어버린 경우 표시됩니다.";
 "setPasswordHintTitle" = "선택적 힌트 추가";
 "settings" = "설정";
+"settingsAdvancedClear" = "지우기";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedSwapKitClearTokensCache" = "SwapKit 토큰 캐시 지우기";
-"settingsAdvancedClear" = "지우기";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "공유";
 "shareOf" = "%d/%d 공유";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -925,7 +925,6 @@
 "swapKitStatusRefundedReason" = "스왑이 원래 주소로 환불되었습니다";
 "swapKitViewOnTracker" = "SwapKit 추적기에서 보기";
 "swapOverview" = "스왑 개요";
-"swapPickerViaSwapKit" = "SwapKit를 통해";
 "swapRouteNotAvailable" = "스왑 경로를 사용할 수 없습니다";
 "swaps" = "스왑";
 "swapTrackingLink" = "스왑 추적 링크";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -836,6 +836,8 @@
 "settings" = "설정";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedSwapKitClearTokensCache" = "SwapKit 토큰 캐시 지우기";
+"settingsAdvancedClear" = "지우기";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "공유";
 "shareOf" = "%d/%d 공유";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -938,7 +938,6 @@
 "swapKitStatusRefundedReason" = "A troca foi reembolsada para seu endereço de origem";
 "swapKitViewOnTracker" = "Ver no SwapKit Tracker";
 "swapOverview" = "Visão geral da troca";
-"swapPickerViaSwapKit" = "via SwapKit";
 "swapRouteNotAvailable" = "Rota de troca não disponível";
 "swaps" = "Trocas";
 "swapTrackingLink" = "Link de rastreamento da troca";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -848,6 +848,8 @@
 "settings" = "Configurações";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedSwapKitClearTokensCache" = "Limpar cache de tokens do SwapKit";
+"settingsAdvancedClear" = "Limpar";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";
 "shareOf" = "compartilhar %d de %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -846,10 +846,10 @@
 "setPasswordHintSubtitle" = "Isso será mostrado caso você esqueça sua senha.";
 "setPasswordHintTitle" = "Adicionar uma dica opcional";
 "settings" = "Configurações";
+"settingsAdvancedClear" = "Limpar";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedSwapKitClearTokensCache" = "Limpar cache de tokens do SwapKit";
-"settingsAdvancedClear" = "Limpar";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";
 "shareOf" = "compartilhar %d de %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -938,6 +938,7 @@
 "swapKitStatusRefundedReason" = "A troca foi reembolsada para seu endereço de origem";
 "swapKitViewOnTracker" = "Ver no SwapKit Tracker";
 "swapOverview" = "Visão geral da troca";
+"swapPickerViaSwapKit" = "via SwapKit";
 "swapRouteNotAvailable" = "Rota de troca não disponível";
 "swaps" = "Trocas";
 "swapTrackingLink" = "Link de rastreamento da troca";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -846,10 +846,10 @@
 "setPasswordHintSubtitle" = "如果您忘记密码，将显示此内容";
 "setPasswordHintTitle" = "添加可选提示";
 "settings" = "设置";
+"settingsAdvancedClear" = "清除";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedSwapKitClearTokensCache" = "清除 SwapKit 代币缓存";
-"settingsAdvancedClear" = "清除";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "分享";
 "shareOf" = "份额 %d / %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -938,6 +938,7 @@
 "swapKitStatusRefundedReason" = "交换已退款至您的源地址";
 "swapKitViewOnTracker" = "在 SwapKit 跟踪器中查看";
 "swapOverview" = "交换概览";
+"swapPickerViaSwapKit" = "通过 SwapKit";
 "swapRouteNotAvailable" = "交换路由不可用";
 "swaps" = "兑换";
 "swapTrackingLink" = "交换跟踪链接";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -848,6 +848,8 @@
 "settings" = "设置";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedSwapKitClearTokensCache" = "清除 SwapKit 代币缓存";
+"settingsAdvancedClear" = "清除";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "分享";
 "shareOf" = "份额 %d / %d";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -938,7 +938,6 @@
 "swapKitStatusRefundedReason" = "交换已退款至您的源地址";
 "swapKitViewOnTracker" = "在 SwapKit 跟踪器中查看";
 "swapOverview" = "交换概览";
-"swapPickerViaSwapKit" = "通过 SwapKit";
 "swapRouteNotAvailable" = "交换路由不可用";
 "swaps" = "兑换";
 "swapTrackingLink" = "交换跟踪链接";

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
@@ -93,9 +93,7 @@ struct SettingsAdvancedView: View {
                 icon: "arrow.clockwise",
                 buttonLabel: "settingsAdvancedClear".localized
             ) {
-                Task { @MainActor in
-                    SwapKitTokensCache.shared.clearCache()
-                }
+                SwapKitTokensCache.shared.clearCache()
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
@@ -87,6 +87,16 @@ struct SettingsAdvancedView: View {
                 ],
                 selection: $settingsViewModel.forcedSwapProvider
             )
+
+            SettingActionCell(
+                title: "settingsAdvancedSwapKitClearTokensCache".localized,
+                icon: "arrow.clockwise",
+                buttonLabel: "settingsAdvancedClear".localized
+            ) {
+                Task { @MainActor in
+                    SwapKitTokensCache.shared.clearCache()
+                }
+            }
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenBucket.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenBucket.swift
@@ -1,0 +1,24 @@
+//
+//  DestinationTokenBucket.swift
+//  VultisigApp
+//
+//  Generic per-chain bucket returned by every `DestinationTokenProvider`.
+//  Replaces the previous SwapKit-specific `SwapKitTokensBucket`.
+//
+//  `uniqueIds` is precomputed once at bucket build time so the picker's
+//  merge step doesn't rebuild a `Set` per call. The picker dedups across
+//  buckets by `CoinMeta.uniqueId` — see
+//  `SwapCoinSelectionLogic.mergeExternal`.
+//
+
+import Foundation
+
+struct DestinationTokenBucket: Sendable {
+    let chain: Chain
+    let tokens: [CoinMeta]
+    let uniqueIds: Set<String>
+
+    static func empty(chain: Chain) -> DestinationTokenBucket {
+        DestinationTokenBucket(chain: chain, tokens: [], uniqueIds: [])
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenProvider.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenProvider.swift
@@ -1,0 +1,32 @@
+//
+//  DestinationTokenProvider.swift
+//  VultisigApp
+//
+//  Provider-agnostic contract for destination-side coin-picker sources.
+//  Each concrete conformer owns its own fetch / cache / feature-flag
+//  lifecycle and returns the slice of tokens it can deliver to on a
+//  given `Chain`. The picker aggregates buckets from every registered
+//  provider via `DestinationTokenRegistry` and dedupes by
+//  `CoinMeta.uniqueId`.
+//
+//  Today only `SwapKitTokensCache` conforms; future destination-token
+//  sources (additional aggregators, allowlist services, etc.) plug in
+//  without touching the picker.
+//
+
+import Foundation
+
+@MainActor
+protocol DestinationTokenProvider: AnyObject {
+    /// Discriminator for logging / debugging only. The picker dedups by
+    /// `CoinMeta.uniqueId`, so colliding providerKinds don't break
+    /// behaviour. Used as the registry key — re-registering the same
+    /// kind overwrites the previous entry.
+    var providerKind: String { get }
+
+    /// Tokens this provider can deliver to on `chain`. Empty bucket when
+    /// the provider is disabled, doesn't support the chain, or its data
+    /// isn't yet warmed. Concrete conformers short-circuit on feature
+    /// flags / catalog absence as appropriate.
+    func tokens(for chain: Chain) async -> DestinationTokenBucket
+}

--- a/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenRegistry.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenRegistry.swift
@@ -1,0 +1,65 @@
+//
+//  DestinationTokenRegistry.swift
+//  VultisigApp
+//
+//  Registry of `DestinationTokenProvider` conformers. The destination
+//  coin picker (`SwapCoinSelectionLogic`) walks every registered
+//  provider to assemble the destination-token list — providers slot in
+//  at app startup without the picker knowing about any of them.
+//
+//  Keyed by `providerKind`. Re-registering the same kind overwrites the
+//  previous entry (idempotent) so a hot-reload during development or a
+//  test-only override doesn't accumulate duplicates. Registration order
+//  is preserved so `tokens(for:)` returns buckets in a deterministic
+//  sequence (the picker's merge depends only on dedup-by-uniqueId, but
+//  deterministic order keeps tests stable).
+//
+
+import Foundation
+
+@MainActor
+final class DestinationTokenRegistry {
+    static let shared = DestinationTokenRegistry()
+
+    private var providers: [any DestinationTokenProvider] = []
+
+    /// Test-only — production uses `shared`. Allows tests to spin up an
+    /// isolated registry without leaking state into other test cases.
+    init() {}
+
+    /// Register a provider. Idempotent on `providerKind` — re-registering
+    /// the same kind overwrites the previous entry in place (preserving
+    /// its registration order). Called once per conformer at app
+    /// startup.
+    func register(_ provider: any DestinationTokenProvider) {
+        if let existing = providers.firstIndex(where: { $0.providerKind == provider.providerKind }) {
+            providers[existing] = provider
+        } else {
+            providers.append(provider)
+        }
+    }
+
+    /// Aggregate destination tokens from every registered provider for
+    /// `chain`.
+    ///
+    /// Concurrency: providers are awaited sequentially — the picker
+    /// already serialises on `MainActor`, and the registered-provider
+    /// count is O(1-3) today. If that changes, swap to a `TaskGroup`.
+    func tokens(for chain: Chain) async -> [DestinationTokenBucket] {
+        var buckets: [DestinationTokenBucket] = []
+        for provider in providers {
+            let bucket = await provider.tokens(for: chain)
+            buckets.append(bucket)
+        }
+        return buckets
+    }
+
+    /// Test-only — drop every registered provider so test cases start
+    /// clean.
+    func removeAllForTesting() {
+        providers.removeAll()
+    }
+
+    /// Test-only — count of currently-registered providers.
+    var registeredCountForTesting: Int { providers.count }
+}

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -14,12 +14,6 @@ class SwapCoinSelectionViewModel: ObservableObject {
     @Published var filteredTokens: [CoinMeta] = []
     @Published var searchText: String = ""
     @Published var error: Error?
-    /// Lowercased `CoinMeta.uniqueId`s of tokens the SwapKit `/tokens` cache
-    /// surfaced but that aren't in the curated + 1inch + Jupiter union. The
-    /// cell uses this to show the "via SwapKit" tag. Empty when the picker
-    /// is opened for the source side or when the SwapKit feature flag is
-    /// off — see `SwapCoinSelectionLogic.fetchCoins(chain:)` for the gating.
-    @Published var swapKitOnlyIds: Set<String> = []
 
     let vault: Vault
     let selectedCoin: Coin
@@ -59,7 +53,6 @@ class SwapCoinSelectionViewModel: ObservableObject {
             await MainActor.run {
                 self.tokens = result.tokens
                 self.filteredTokens = result.tokens
-                self.swapKitOnlyIds = result.swapKitOnlyIds
                 isLoading = false
             }
         } catch {
@@ -68,13 +61,6 @@ class SwapCoinSelectionViewModel: ObservableObject {
                 isLoading = false
             }
         }
-    }
-
-    /// Whether `coin` was surfaced exclusively by SwapKit's `/tokens` list —
-    /// i.e. the curated allowlist + 1inch + Jupiter union didn't already
-    /// know about it. Drives the "via SwapKit" tag in `SwapCoinCell`.
-    func isSwapKitOnly(_ coin: CoinMeta) -> Bool {
-        swapKitOnlyIds.contains(coin.uniqueId)
     }
 
     @MainActor func onSelect(coin: CoinMeta) -> Coin? {
@@ -89,12 +75,9 @@ class SwapCoinSelectionViewModel: ObservableObject {
 // MARK: - SwapCoinSelectionLogic
 
 /// Result of a single `fetchCoins` call. `tokens` is the picker-ready list
-/// (preset + external + SwapKit, deduped, sorted); `swapKitOnlyIds` flags
-/// the subset of those tokens that were discovered exclusively via SwapKit
-/// `/tokens` so the cell can render the "via SwapKit" tag.
+/// (preset + external + SwapKit, deduped, sorted).
 struct SwapCoinSelectionResult {
     let tokens: [CoinMeta]
-    let swapKitOnlyIds: Set<String>
 }
 
 struct SwapCoinSelectionLogic {
@@ -125,7 +108,6 @@ struct SwapCoinSelectionLogic {
         let externalTokens = try await service.loadTokens(for: chain)
         let baseTokens = ([nativeToken] + externalTokens).compactMap { $0 }
         let baseUnique = baseTokens.uniqueBy { $0.ticker.lowercased() }
-        let baseUniqueIds = Set(baseUnique.map { $0.uniqueId })
 
         // SwapKit destinations only — source-side picker stays Phase-1
         // identical. `SwapKitTokensCache.tokens(for:)` already short-circuits
@@ -140,15 +122,14 @@ struct SwapCoinSelectionLogic {
 
         // Existing 1inch / Jupiter / preset entries win on overlap — their
         // CoinFactory + price-provider plumbing is already in place. SwapKit
-        // residual tokens (those NOT in the base union) get tagged.
+        // contributes any residual tokens (those NOT in the base union).
         let merged = Self.mergeWithSwapKit(
             base: baseUnique,
             swapKit: swapKitBucket
         )
         let sorted = sort(tokens: merged)
 
-        let swapKitOnlyIds = swapKitBucket.uniqueIds.subtracting(baseUniqueIds)
-        return SwapCoinSelectionResult(tokens: sorted, swapKitOnlyIds: swapKitOnlyIds)
+        return SwapCoinSelectionResult(tokens: sorted)
     }
 
     /// Pure-function merge — exposed for tests. Base list keeps its order;

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -22,6 +22,7 @@ class SwapCoinSelectionViewModel: ObservableObject {
     private let logic: SwapCoinSelectionLogic
     private var cancellable: AnyCancellable?
 
+    @MainActor
     init(vault: Vault, selectedCoin: Coin, isDestination: Bool) {
         self.vault = vault
         self.selectedCoin = selectedCoin
@@ -85,20 +86,26 @@ struct SwapCoinSelectionLogic {
     private let selectedCoin: Coin
     private let isDestination: Bool
     private let service: TokenSearchService
-    private let swapKitTokens: SwapKitTokensCache
+    private let registry: DestinationTokenRegistry
 
+    @MainActor
     init(
         vault: Vault,
         selectedCoin: Coin,
         isDestination: Bool,
         service: TokenSearchService = .shared,
-        swapKitTokens: SwapKitTokensCache = .shared
+        registry: DestinationTokenRegistry? = nil
     ) {
         self.vault = vault
         self.selectedCoin = selectedCoin
         self.isDestination = isDestination
         self.service = service
-        self.swapKitTokens = swapKitTokens
+        // Defaults are resolved inside the body so the MainActor-isolated
+        // `.shared` singleton isn't referenced from a default-argument
+        // expression (which runs in the caller's context and would warn
+        // under Swift 6 strict concurrency). Same pattern as
+        // `TransactionHistoryViewModel.init` → `SwapTrackingRegistry.shared`.
+        self.registry = registry ?? DestinationTokenRegistry.shared
     }
 
     func fetchCoins(chain: Chain) async throws -> SwapCoinSelectionResult {
@@ -109,39 +116,41 @@ struct SwapCoinSelectionLogic {
         let baseTokens = ([nativeToken] + externalTokens).compactMap { $0 }
         let baseUnique = baseTokens.uniqueBy { $0.ticker.lowercased() }
 
-        // SwapKit destinations only — source-side picker stays Phase-1
-        // identical. `SwapKitTokensCache.tokens(for:)` already short-circuits
-        // when the feature flag is off, but the `isDestination` gate avoids
-        // spinning up the fetch task at all on the source side.
-        let swapKitBucket: DestinationTokenBucket
+        // Destination-side picker pulls in tokens from every registered
+        // DestinationTokenProvider; source-side stays vault-bounded since
+        // SwapKit + sibling providers add no signal for tokens the user
+        // doesn't actually hold.
+        let externalBuckets: [DestinationTokenBucket]
         if isDestination {
-            swapKitBucket = await swapKitTokens.tokens(for: chain)
+            externalBuckets = await registry.tokens(for: chain)
         } else {
-            swapKitBucket = .empty(chain: chain)
+            externalBuckets = []
         }
 
-        // Existing 1inch / Jupiter / preset entries win on overlap — their
-        // CoinFactory + price-provider plumbing is already in place. SwapKit
-        // contributes any residual tokens (those NOT in the base union).
-        let merged = Self.mergeWithSwapKit(
-            base: baseUnique,
-            swapKit: swapKitBucket
-        )
+        let merged = Self.mergeExternal(base: baseUnique, externals: externalBuckets)
         let sorted = sort(tokens: merged)
 
         return SwapCoinSelectionResult(tokens: sorted)
     }
 
     /// Pure-function merge — exposed for tests. Base list keeps its order;
-    /// SwapKit-only tokens append after, deduped by `CoinMeta.uniqueId`
-    /// (chain + lowercased ticker + lowercased contract).
-    static func mergeWithSwapKit(
+    /// novel tokens from each external bucket append after, deduped by
+    /// `CoinMeta.uniqueId` (chain + lowercased ticker + lowercased
+    /// contract). Same contract as the previous `mergeWithSwapKit`,
+    /// generalised over an arbitrary list of provider buckets.
+    static func mergeExternal(
         base: [CoinMeta],
-        swapKit: DestinationTokenBucket
+        externals: [DestinationTokenBucket]
     ) -> [CoinMeta] {
-        let baseIds = Set(base.map { $0.uniqueId })
-        let novel = swapKit.tokens.filter { !baseIds.contains($0.uniqueId) }
-        return base + novel
+        var seen = Set(base.map { $0.uniqueId })
+        var result = base
+        for bucket in externals {
+            for token in bucket.tokens where !seen.contains(token.uniqueId) {
+                result.append(token)
+                seen.insert(token.uniqueId)
+            }
+        }
+        return result
     }
 
     func sort(tokens: [CoinMeta]) -> [CoinMeta] {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -14,17 +14,29 @@ class SwapCoinSelectionViewModel: ObservableObject {
     @Published var filteredTokens: [CoinMeta] = []
     @Published var searchText: String = ""
     @Published var error: Error?
+    /// Lowercased `CoinMeta.uniqueId`s of tokens the SwapKit `/tokens` cache
+    /// surfaced but that aren't in the curated + 1inch + Jupiter union. The
+    /// cell uses this to show the "via SwapKit" tag. Empty when the picker
+    /// is opened for the source side or when the SwapKit feature flag is
+    /// off — see `SwapCoinSelectionLogic.fetchCoins(chain:)` for the gating.
+    @Published var swapKitOnlyIds: Set<String> = []
 
     let vault: Vault
     let selectedCoin: Coin
+    let isDestination: Bool
 
     private let logic: SwapCoinSelectionLogic
     private var cancellable: AnyCancellable?
 
-    init(vault: Vault, selectedCoin: Coin) {
+    init(vault: Vault, selectedCoin: Coin, isDestination: Bool) {
         self.vault = vault
         self.selectedCoin = selectedCoin
-        self.logic = SwapCoinSelectionLogic(vault: vault, selectedCoin: selectedCoin)
+        self.isDestination = isDestination
+        self.logic = SwapCoinSelectionLogic(
+            vault: vault,
+            selectedCoin: selectedCoin,
+            isDestination: isDestination
+        )
     }
 
     func setup() {
@@ -45,8 +57,9 @@ class SwapCoinSelectionViewModel: ObservableObject {
         do {
             let result = try await logic.fetchCoins(chain: chain)
             await MainActor.run {
-                self.tokens = result
-                self.filteredTokens = result
+                self.tokens = result.tokens
+                self.filteredTokens = result.tokens
+                self.swapKitOnlyIds = result.swapKitOnlyIds
                 isLoading = false
             }
         } catch {
@@ -55,6 +68,13 @@ class SwapCoinSelectionViewModel: ObservableObject {
                 isLoading = false
             }
         }
+    }
+
+    /// Whether `coin` was surfaced exclusively by SwapKit's `/tokens` list —
+    /// i.e. the curated allowlist + 1inch + Jupiter union didn't already
+    /// know about it. Drives the "via SwapKit" tag in `SwapCoinCell`.
+    func isSwapKitOnly(_ coin: CoinMeta) -> Bool {
+        swapKitOnlyIds.contains(coin.uniqueId)
     }
 
     @MainActor func onSelect(coin: CoinMeta) -> Coin? {
@@ -68,24 +88,79 @@ class SwapCoinSelectionViewModel: ObservableObject {
 
 // MARK: - SwapCoinSelectionLogic
 
+/// Result of a single `fetchCoins` call. `tokens` is the picker-ready list
+/// (preset + external + SwapKit, deduped, sorted); `swapKitOnlyIds` flags
+/// the subset of those tokens that were discovered exclusively via SwapKit
+/// `/tokens` so the cell can render the "via SwapKit" tag.
+struct SwapCoinSelectionResult {
+    let tokens: [CoinMeta]
+    let swapKitOnlyIds: Set<String>
+}
+
 struct SwapCoinSelectionLogic {
     private let vault: Vault
     private let selectedCoin: Coin
-    private let service = TokenSearchService.shared
+    private let isDestination: Bool
+    private let service: TokenSearchService
+    private let swapKitTokens: SwapKitTokensCache
 
-    init(vault: Vault, selectedCoin: Coin) {
+    init(
+        vault: Vault,
+        selectedCoin: Coin,
+        isDestination: Bool,
+        service: TokenSearchService = .shared,
+        swapKitTokens: SwapKitTokensCache = .shared
+    ) {
         self.vault = vault
         self.selectedCoin = selectedCoin
+        self.isDestination = isDestination
+        self.service = service
+        self.swapKitTokens = swapKitTokens
     }
 
-    func fetchCoins(chain: Chain) async throws -> [CoinMeta] {
+    func fetchCoins(chain: Chain) async throws -> SwapCoinSelectionResult {
         let nativeToken = TokensStore.TokenSelectionAssets.first { $0.chain == chain && $0.isNativeToken }
 
         // Propagate errors instead of swallowing with try?
         let externalTokens = try await service.loadTokens(for: chain)
-        let tokens = ([nativeToken] + externalTokens).compactMap { $0 }
-        let uniqueTokens = tokens.uniqueBy { $0.ticker.lowercased() }
-        return sort(tokens: uniqueTokens)
+        let baseTokens = ([nativeToken] + externalTokens).compactMap { $0 }
+        let baseUnique = baseTokens.uniqueBy { $0.ticker.lowercased() }
+        let baseUniqueIds = Set(baseUnique.map { $0.uniqueId })
+
+        // SwapKit destinations only — source-side picker stays Phase-1
+        // identical. `SwapKitTokensCache.tokens(for:)` already short-circuits
+        // when the feature flag is off, but the `isDestination` gate avoids
+        // spinning up the fetch task at all on the source side.
+        let swapKitBucket: SwapKitTokensBucket
+        if isDestination {
+            swapKitBucket = await swapKitTokens.tokens(for: chain)
+        } else {
+            swapKitBucket = SwapKitTokensBucket(chain: chain, byIdentifier: [:], uniqueIds: [])
+        }
+
+        // Existing 1inch / Jupiter / preset entries win on overlap — their
+        // CoinFactory + price-provider plumbing is already in place. SwapKit
+        // residual tokens (those NOT in the base union) get tagged.
+        let merged = Self.mergeWithSwapKit(
+            base: baseUnique,
+            swapKit: swapKitBucket
+        )
+        let sorted = sort(tokens: merged)
+
+        let swapKitOnlyIds = swapKitBucket.uniqueIds.subtracting(baseUniqueIds)
+        return SwapCoinSelectionResult(tokens: sorted, swapKitOnlyIds: swapKitOnlyIds)
+    }
+
+    /// Pure-function merge — exposed for tests. Base list keeps its order;
+    /// SwapKit-only tokens append after, deduped by `CoinMeta.uniqueId`
+    /// (chain + lowercased ticker + lowercased contract).
+    static func mergeWithSwapKit(
+        base: [CoinMeta],
+        swapKit: SwapKitTokensBucket
+    ) -> [CoinMeta] {
+        let baseIds = Set(base.map { $0.uniqueId })
+        let novel = swapKit.tokens.filter { !baseIds.contains($0.uniqueId) }
+        return base + novel
     }
 
     func sort(tokens: [CoinMeta]) -> [CoinMeta] {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -113,11 +113,11 @@ struct SwapCoinSelectionLogic {
         // identical. `SwapKitTokensCache.tokens(for:)` already short-circuits
         // when the feature flag is off, but the `isDestination` gate avoids
         // spinning up the fetch task at all on the source side.
-        let swapKitBucket: SwapKitTokensBucket
+        let swapKitBucket: DestinationTokenBucket
         if isDestination {
             swapKitBucket = await swapKitTokens.tokens(for: chain)
         } else {
-            swapKitBucket = SwapKitTokensBucket(chain: chain, byIdentifier: [:], uniqueIds: [])
+            swapKitBucket = .empty(chain: chain)
         }
 
         // Existing 1inch / Jupiter / preset entries win on overlap — their
@@ -137,7 +137,7 @@ struct SwapCoinSelectionLogic {
     /// (chain + lowercased ticker + lowercased contract).
     static func mergeWithSwapKit(
         base: [CoinMeta],
-        swapKit: SwapKitTokensBucket
+        swapKit: DestinationTokenBucket
     ) -> [CoinMeta] {
         let baseIds = Set(base.map { $0.uniqueId })
         let novel = swapKit.tokens.filter { !baseIds.contains($0.uniqueId) }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -57,7 +57,8 @@ struct SwapDetailsScreen: View {
                 vault: vault,
                 showSheet: $vm.showFromCoinSelector,
                 selectedCoin: $vm.fromCoin,
-                selectedChain: vm.fromChain
+                selectedChain: vm.fromChain,
+                isDestination: false
             )
             .environmentObject(coinSelectionViewModel)
         }
@@ -66,7 +67,8 @@ struct SwapDetailsScreen: View {
                 vault: vault,
                 showSheet: $vm.showToCoinSelector,
                 selectedCoin: $vm.toCoin,
-                selectedChain: vm.toChain
+                selectedChain: vm.toChain,
+                isDestination: true
             )
             .environmentObject(coinSelectionViewModel)
         }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -12,6 +12,11 @@ struct SwapCoinPickerView: View {
     @Binding var showSheet: Bool
     @Binding var selectedCoin: Coin
     @State var selectedChain: Chain?
+    /// When `true`, expand the picker with SwapKit `/tokens` entries on top
+    /// of the curated + 1inch + Jupiter lists, gated by the SwapKit feature
+    /// flag. Source-side picker is `false` so its behaviour stays identical
+    /// to Phase 1 (the user can only swap from coins they hold).
+    let isDestination: Bool
 
     @StateObject var viewModel: SwapCoinSelectionViewModel
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
@@ -29,13 +34,21 @@ struct SwapCoinPickerView: View {
         vault: Vault,
         showSheet: Binding<Bool>,
         selectedCoin: Binding<Coin>,
-        selectedChain: Chain?
+        selectedChain: Chain?,
+        isDestination: Bool = false
     ) {
         self.vault = vault
         self._showSheet = showSheet
         self._selectedCoin = selectedCoin
         self.selectedChain = selectedChain
-        self._viewModel = StateObject(wrappedValue: .init(vault: vault, selectedCoin: selectedCoin.wrappedValue))
+        self.isDestination = isDestination
+        self._viewModel = StateObject(
+            wrappedValue: .init(
+                vault: vault,
+                selectedCoin: selectedCoin.wrappedValue,
+                isDestination: isDestination
+            )
+        )
     }
 
     var body: some View {
@@ -129,7 +142,8 @@ struct SwapCoinPickerView: View {
                     coin: coinMeta,
                     balance: vaultCoin?.balanceString,
                     balanceFiat: vaultCoin?.balanceInFiat,
-                    isSelected: selectedCoin.toCoinMeta() == coinMeta
+                    isSelected: selectedCoin.toCoinMeta() == coinMeta,
+                    isSwapKitOnly: viewModel.isSwapKitOnly(coinMeta)
                 ) {
                     onSelect(coin: coinMeta)
                 }
@@ -251,6 +265,7 @@ struct SwapCoinPickerView: View {
         vault: Vault.example,
         showSheet: .constant(true),
         selectedCoin: .constant(Coin.example),
-        selectedChain: Chain.example
+        selectedChain: Chain.example,
+        isDestination: false
     )
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -142,8 +142,7 @@ struct SwapCoinPickerView: View {
                     coin: coinMeta,
                     balance: vaultCoin?.balanceString,
                     balanceFiat: vaultCoin?.balanceInFiat,
-                    isSelected: selectedCoin.toCoinMeta() == coinMeta,
-                    isSwapKitOnly: viewModel.isSwapKitOnly(coinMeta)
+                    isSelected: selectedCoin.toCoinMeta() == coinMeta
                 ) {
                     onSelect(coin: coinMeta)
                 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/DestinationTokenRegistryTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/DestinationTokenRegistryTests.swift
@@ -1,0 +1,140 @@
+//
+//  DestinationTokenRegistryTests.swift
+//  VultisigAppTests
+//
+//  Registry coverage for `DestinationTokenRegistry` — the aggregator the
+//  swap coin picker uses to pull destination tokens from every
+//  registered `DestinationTokenProvider`. Tests use the exposed
+//  test-only initialiser so cases don't depend on the order in which
+//  app-startup registrations land in `DestinationTokenRegistry.shared`.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class DestinationTokenRegistryTests: XCTestCase {
+
+    func testRegisterAndLookup() async {
+        let registry = DestinationTokenRegistry()
+        let swapKit = FakeProvider(kind: "swapKit", buckets: [
+            .ethereum: DestinationTokenBucket(
+                chain: .ethereum,
+                tokens: [Self.coin(ticker: "SKT", contract: "0xaaa")],
+                uniqueIds: [Self.coin(ticker: "SKT", contract: "0xaaa").uniqueId]
+            )
+        ])
+        let chainflip = FakeProvider(kind: "chainflip", buckets: [
+            .ethereum: DestinationTokenBucket(
+                chain: .ethereum,
+                tokens: [Self.coin(ticker: "CFP", contract: "0xbbb")],
+                uniqueIds: [Self.coin(ticker: "CFP", contract: "0xbbb").uniqueId]
+            )
+        ])
+
+        registry.register(swapKit)
+        registry.register(chainflip)
+
+        let buckets = await registry.tokens(for: .ethereum)
+
+        XCTAssertEqual(buckets.count, 2, "Both providers must contribute a bucket")
+        let tickers = buckets.flatMap { $0.tokens.map(\.ticker) }
+        XCTAssertEqual(Set(tickers), ["SKT", "CFP"])
+    }
+
+    func testReRegisterOverwrites() async {
+        let registry = DestinationTokenRegistry()
+        let first = FakeProvider(kind: "swapKit", buckets: [
+            .ethereum: DestinationTokenBucket(
+                chain: .ethereum,
+                tokens: [Self.coin(ticker: "OLD", contract: "0xaaa")],
+                uniqueIds: [Self.coin(ticker: "OLD", contract: "0xaaa").uniqueId]
+            )
+        ])
+        let second = FakeProvider(kind: "swapKit", buckets: [
+            .ethereum: DestinationTokenBucket(
+                chain: .ethereum,
+                tokens: [Self.coin(ticker: "NEW", contract: "0xbbb")],
+                uniqueIds: [Self.coin(ticker: "NEW", contract: "0xbbb").uniqueId]
+            )
+        ])
+
+        registry.register(first)
+        registry.register(second)
+
+        XCTAssertEqual(registry.registeredCountForTesting, 1,
+                       "Re-registering the same providerKind must overwrite, not duplicate")
+
+        let buckets = await registry.tokens(for: .ethereum)
+        XCTAssertEqual(buckets.count, 1)
+        XCTAssertEqual(buckets.first?.tokens.map(\.ticker), ["NEW"],
+                       "Latest registration wins on the same providerKind")
+    }
+
+    func testEmptyRegistryReturnsEmptyArray() async {
+        let registry = DestinationTokenRegistry()
+
+        let buckets = await registry.tokens(for: .ethereum)
+
+        XCTAssertTrue(buckets.isEmpty,
+                      "Registry with no providers must produce no buckets")
+    }
+
+    func testProviderReturningEmptyBucketDoesNotBreakAggregation() async {
+        let registry = DestinationTokenRegistry()
+        let dormant = FakeProvider(kind: "swapKit", buckets: [:])
+        let live = FakeProvider(kind: "chainflip", buckets: [
+            .ethereum: DestinationTokenBucket(
+                chain: .ethereum,
+                tokens: [Self.coin(ticker: "CFP", contract: "0xbbb")],
+                uniqueIds: [Self.coin(ticker: "CFP", contract: "0xbbb").uniqueId]
+            )
+        ])
+
+        registry.register(dormant)
+        registry.register(live)
+
+        let buckets = await registry.tokens(for: .ethereum)
+
+        XCTAssertEqual(buckets.count, 2, "Empty buckets still surface — picker dedups, not the registry")
+        XCTAssertEqual(buckets.first?.tokens, [],
+                       "Dormant provider's bucket must be empty (insertion order preserved)")
+        XCTAssertEqual(buckets.last?.tokens.map(\.ticker), ["CFP"])
+    }
+
+    // MARK: - Fixtures
+
+    private static func coin(ticker: String, contract: String) -> CoinMeta {
+        CoinMeta(
+            chain: .ethereum,
+            ticker: ticker,
+            logo: "",
+            decimals: 18,
+            priceProviderId: "",
+            contractAddress: contract,
+            isNativeToken: false
+        )
+    }
+}
+
+// MARK: - Fakes
+
+/// Configurable provider for registry tests. Each instance pins its own
+/// `providerKind` so multiple kinds can coexist in a single test case
+/// (mirrors how the production `DestinationTokenProvider` conformers like
+/// `SwapKitTokensCache` expose `providerKind` as an instance property,
+/// unlike `SwapTrackingService`'s static dispatch).
+@MainActor
+private final class FakeProvider: DestinationTokenProvider {
+    let providerKind: String
+    let buckets: [Chain: DestinationTokenBucket]
+
+    init(kind: String, buckets: [Chain: DestinationTokenBucket]) {
+        self.providerKind = kind
+        self.buckets = buckets
+    }
+
+    func tokens(for chain: Chain) async -> DestinationTokenBucket {
+        buckets[chain] ?? .empty(chain: chain)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensDecodingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensDecodingTests.swift
@@ -133,9 +133,9 @@ final class SwapKitTokensDecodingTests: XCTestCase {
         let buckets = SwapKitTokensCache.mergeByChain(responses: responses)
         let eth = try XCTUnwrap(buckets[.ethereum])
         XCTAssertEqual(eth.tokens.count, 2)
-        let usdtIdentifier = "ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7"
-        XCTAssertNotNil(
-            eth.byIdentifier[usdtIdentifier],
+        let usdtMatches = eth.tokens.filter { $0.ticker == "USDT" }
+        XCTAssertEqual(
+            usdtMatches.count, 1,
             "USDT must be present exactly once after dedup"
         )
     }

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensDecodingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensDecodingTests.swift
@@ -1,0 +1,142 @@
+//
+//  SwapKitTokensDecodingTests.swift
+//  VultisigAppTests
+//
+//  Wire-format + adapter coverage for `GET /tokens?provider=<NAME>`. Drives
+//  off the trimmed NEAR fixture (vendored at `__fixtures__/03-tokens-NEAR.json`)
+//  which covers a mix of Vultisig-supported chains (ARB, AVAX, BASE, BCH,
+//  BSC, DASH, LTC, OP, TON, TRON) and unsupported ones (BERA, GNO, MONAD,
+//  STRK, XLAYER) so the chain reverse-mapper drop is exercised.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapKitTokensDecodingTests: XCTestCase {
+
+    func testDecodesEnvelope() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitTokensResponse.self,
+            from: "03-tokens-NEAR"
+        )
+        XCTAssertEqual(response.provider, "NEAR")
+        XCTAssertEqual(response.tokens.count, response.count)
+        XCTAssertFalse(response.tokens.isEmpty)
+    }
+
+    func testGasTokensHaveNoUsableContract() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitTokensResponse.self,
+            from: "03-tokens-NEAR"
+        )
+        // At least one gas token survives the reverse-mapper drop. Verify
+        // its CoinMeta is `isNativeToken: true` with empty contract.
+        let bscNative = response.tokens.first {
+            $0.chain == "BSC" && ($0.address?.isEmpty ?? true)
+        }
+        let coinMeta = try XCTUnwrap(bscNative?.toCoinMeta())
+        XCTAssertTrue(coinMeta.isNativeToken)
+        XCTAssertEqual(coinMeta.contractAddress, "")
+        XCTAssertEqual(coinMeta.chain, .bscChain)
+    }
+
+    func testEVMContractTokenAdapts() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitTokensResponse.self,
+            from: "03-tokens-NEAR"
+        )
+        // Any contract-bearing EVM token (ARB / BASE / BSC / AVAX / OP)
+        // must adapt with `isNativeToken: false` + a populated 0x... contract.
+        let evmContract = response.tokens.first { token in
+            guard let chain = SwapKitChainIDMapper.chain(forSwapKitChain: token.chain),
+                  chain.chainType == .EVM else { return false }
+            return !(token.address?.isEmpty ?? true)
+        }
+        let coinMeta = try XCTUnwrap(evmContract?.toCoinMeta())
+        XCTAssertFalse(coinMeta.isNativeToken)
+        XCTAssertTrue(coinMeta.contractAddress.lowercased().hasPrefix("0x"))
+        XCTAssertEqual(coinMeta.contractAddress.count, 42)
+    }
+
+    func testUnsupportedChainsAreDropped() throws {
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitTokensResponse.self,
+            from: "03-tokens-NEAR"
+        )
+        let dropped: Set<String> = ["BERA", "GNO", "MONAD", "STRK", "XLAYER"]
+        for token in response.tokens where dropped.contains(token.chain) {
+            XCTAssertNil(
+                token.toCoinMeta(),
+                "Chain \(token.chain) must drop via reverse mapper — token: \(token.identifier)"
+            )
+        }
+    }
+
+    func testTronWrapperContractIsDropped() throws {
+        // SwapKit-via-NEAR's TRON.USDT comes through with a contract that's
+        // a real Tron base58 address, but the reverse-mapper's `chainType`
+        // default-arm conservatively rejects non-EVM/Solana contracts.
+        // Pinned so a future relaxation re-runs this test.
+        let tronToken = SwapKitToken(
+            chain: "TRON",
+            chainId: "728126428",
+            address: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            ticker: "USDT",
+            identifier: "TRON.USDT-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+            name: "Tether",
+            decimals: 6,
+            logoURI: nil,
+            coingeckoId: "tether"
+        )
+        XCTAssertNil(tronToken.toCoinMeta())
+    }
+
+    func testNearChainTokensAreDropped() throws {
+        // NEAR chain itself isn't supported as a Vultisig wallet — even
+        // gas-token NEAR.NEAR must not adapt.
+        let nearGas = SwapKitToken(
+            chain: "NEAR",
+            chainId: "near",
+            address: "",
+            ticker: "NEAR",
+            identifier: "NEAR.NEAR",
+            name: "NEAR Protocol",
+            decimals: 24,
+            logoURI: nil,
+            coingeckoId: "near"
+        )
+        XCTAssertNil(nearGas.toCoinMeta())
+    }
+
+    func testMergeByChainDedupesByIdentifier() throws {
+        // Two responses both list ETH.USDT — merged bucket has one entry.
+        let payload = """
+        [
+          {
+            "provider": "ONEINCH",
+            "count": 2,
+            "tokens": [
+              {"chain":"ETH","chainId":"1","address":"0xdAC17F958D2ee523a2206206994597C13D831ec7","ticker":"USDT","identifier":"ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7","name":"Tether","decimals":6,"logoURI":"","coingeckoId":"tether"},
+              {"chain":"ETH","chainId":"1","address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","ticker":"USDC","identifier":"ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","name":"USDC","decimals":6,"logoURI":"","coingeckoId":"usd-coin"}
+            ]
+          },
+          {
+            "provider": "NEAR",
+            "count": 1,
+            "tokens": [
+              {"chain":"ETH","chainId":"1","address":"0xdAC17F958D2ee523a2206206994597C13D831ec7","ticker":"USDT","identifier":"ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7","name":"Tether","decimals":6,"logoURI":"","coingeckoId":"tether"}
+            ]
+          }
+        ]
+        """.data(using: .utf8) ?? Data()
+        let responses = try JSONDecoder().decode([SwapKitTokensResponse].self, from: payload)
+        let buckets = SwapKitTokensCache.mergeByChain(responses: responses)
+        let eth = try XCTUnwrap(buckets[.ethereum])
+        XCTAssertEqual(eth.tokens.count, 2)
+        let usdtIdentifier = "ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7"
+        XCTAssertNotNil(
+            eth.byIdentifier[usdtIdentifier],
+            "USDT must be present exactly once after dedup"
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
@@ -30,6 +30,7 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
         }
     }
 
+    @MainActor
     func testCacheReturnsEmptyBucketWhenFlagOff() async {
         UserDefaults.standard.set(false, forKey: flagKey)
         let cache = SwapKitTokensCache()
@@ -50,9 +51,9 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
             CoinMeta(chain: .ethereum, ticker: "USDC", logo: "", decimals: 6, priceProviderId: "usd-coin", contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", isNativeToken: false)
         ]
         let novel = CoinMeta(chain: .ethereum, ticker: "NOVL", logo: "", decimals: 18, priceProviderId: "", contractAddress: "0x0000000000000000000000000000000000000abc", isNativeToken: false)
-        let bucket = SwapKitTokensBucket(
+        let bucket = DestinationTokenBucket(
             chain: .ethereum,
-            byIdentifier: ["ETH.NOVL-0x0000000000000000000000000000000000000abc": novel],
+            tokens: [novel],
             uniqueIds: [novel.uniqueId]
         )
         let merged = SwapCoinSelectionLogic.mergeWithSwapKit(base: base, swapKit: bucket)
@@ -65,25 +66,26 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
         // NOT duplicate in the picker.
         let usdc = CoinMeta(chain: .ethereum, ticker: "USDC", logo: "", decimals: 6, priceProviderId: "usd-coin", contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", isNativeToken: false)
         let base = [usdc]
-        let bucket = SwapKitTokensBucket(
+        let bucket = DestinationTokenBucket(
             chain: .ethereum,
-            byIdentifier: ["ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": usdc],
+            tokens: [usdc],
             uniqueIds: [usdc.uniqueId]
         )
         let merged = SwapCoinSelectionLogic.mergeWithSwapKit(base: base, swapKit: bucket)
         XCTAssertEqual(merged.count, 1, "Overlap must not duplicate")
     }
 
+    @MainActor
     func testCacheSeededSnapshotReturnsBucketsWhenFlagOn() async {
         UserDefaults.standard.set(true, forKey: flagKey)
         let novel = CoinMeta(chain: .arbitrum, ticker: "NOVL", logo: "", decimals: 18, priceProviderId: "", contractAddress: "0x000000000000000000000000000000000000000A", isNativeToken: false)
-        let bucket = SwapKitTokensBucket(
+        let bucket = DestinationTokenBucket(
             chain: .arbitrum,
-            byIdentifier: ["ARB.NOVL-0x000000000000000000000000000000000000000A": novel],
+            tokens: [novel],
             uniqueIds: [novel.uniqueId]
         )
         let cache = SwapKitTokensCache()
-        await cache.setSnapshot(buckets: [.arbitrum: bucket])
+        cache.setSnapshot(buckets: [.arbitrum: bucket])
         let read = await cache.tokens(for: .arbitrum)
         XCTAssertEqual(read.tokens.count, 1)
         XCTAssertEqual(read.tokens.first?.ticker, "NOVL")

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
@@ -1,0 +1,93 @@
+//
+//  SwapKitTokensPickerFlagTests.swift
+//  VultisigAppTests
+//
+//  Pins the destination-coin-picker invariant for the SwapKit token-list
+//  expansion: when the feature flag is OFF, the cache's per-chain bucket is
+//  empty (no `/tokens` fetch, no tag injection); when ON, the merge step
+//  prepends SwapKit's novel tokens to the curated/1inch/Jupiter union and
+//  tags only the residual SwapKit-only entries.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapKitTokensPickerFlagTests: XCTestCase {
+
+    private let flagKey = "swapkitEnabled"
+    private var savedValue: Any?
+
+    override func setUpWithError() throws {
+        savedValue = UserDefaults.standard.object(forKey: flagKey)
+        UserDefaults.standard.removeObject(forKey: flagKey)
+    }
+
+    override func tearDownWithError() throws {
+        if let savedValue {
+            UserDefaults.standard.set(savedValue, forKey: flagKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: flagKey)
+        }
+    }
+
+    func testCacheReturnsEmptyBucketWhenFlagOff() async {
+        UserDefaults.standard.set(false, forKey: flagKey)
+        let cache = SwapKitTokensCache()
+        let bucket = await cache.tokens(for: .ethereum)
+        XCTAssertTrue(
+            bucket.tokens.isEmpty,
+            "Flag OFF must short-circuit the cache to an empty bucket — no SwapKit fetch, no tag injection"
+        )
+        XCTAssertTrue(bucket.uniqueIds.isEmpty)
+    }
+
+    func testMergeAppendsNovelSwapKitTokens() throws {
+        // Base list (e.g. from 1inch + curated) has ETH-ETH + USDC. SwapKit's
+        // bucket adds a token the base list doesn't know about (`NOVL`) — it
+        // must append AND its uniqueId must end up in the swapKitOnlyIds set
+        // that drives the "via SwapKit" tag.
+        let base: [CoinMeta] = [
+            CoinMeta(chain: .ethereum, ticker: "ETH", logo: "", decimals: 18, priceProviderId: "ethereum", contractAddress: "", isNativeToken: true),
+            CoinMeta(chain: .ethereum, ticker: "USDC", logo: "", decimals: 6, priceProviderId: "usd-coin", contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", isNativeToken: false)
+        ]
+        let novel = CoinMeta(chain: .ethereum, ticker: "NOVL", logo: "", decimals: 18, priceProviderId: "", contractAddress: "0x0000000000000000000000000000000000000abc", isNativeToken: false)
+        let bucket = SwapKitTokensBucket(
+            chain: .ethereum,
+            byIdentifier: ["ETH.NOVL-0x0000000000000000000000000000000000000abc": novel],
+            uniqueIds: [novel.uniqueId]
+        )
+        let merged = SwapCoinSelectionLogic.mergeWithSwapKit(base: base, swapKit: bucket)
+        XCTAssertEqual(merged.count, 3, "Novel SwapKit token must append")
+        XCTAssertEqual(merged.last?.ticker, "NOVL")
+    }
+
+    func testMergeDropsSwapKitTokensAlreadyInBase() throws {
+        // Overlap case — 1inch already discovered USDC. SwapKit's USDC must
+        // NOT duplicate in the picker, and USDC's uniqueId must NOT end up
+        // in the "swapKitOnlyIds" tag-set computed downstream by the logic.
+        let usdc = CoinMeta(chain: .ethereum, ticker: "USDC", logo: "", decimals: 6, priceProviderId: "usd-coin", contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", isNativeToken: false)
+        let base = [usdc]
+        let bucket = SwapKitTokensBucket(
+            chain: .ethereum,
+            byIdentifier: ["ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": usdc],
+            uniqueIds: [usdc.uniqueId]
+        )
+        let merged = SwapCoinSelectionLogic.mergeWithSwapKit(base: base, swapKit: bucket)
+        XCTAssertEqual(merged.count, 1, "Overlap must not duplicate")
+    }
+
+    func testCacheSeededSnapshotReturnsBucketsWhenFlagOn() async {
+        UserDefaults.standard.set(true, forKey: flagKey)
+        let novel = CoinMeta(chain: .arbitrum, ticker: "NOVL", logo: "", decimals: 18, priceProviderId: "", contractAddress: "0x000000000000000000000000000000000000000A", isNativeToken: false)
+        let bucket = SwapKitTokensBucket(
+            chain: .arbitrum,
+            byIdentifier: ["ARB.NOVL-0x000000000000000000000000000000000000000A": novel],
+            uniqueIds: [novel.uniqueId]
+        )
+        let cache = SwapKitTokensCache()
+        await cache.setSnapshot(buckets: [.arbitrum: bucket])
+        let read = await cache.tokens(for: .arbitrum)
+        XCTAssertEqual(read.tokens.count, 1)
+        XCTAssertEqual(read.tokens.first?.ticker, "NOVL")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
@@ -42,10 +42,10 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
         XCTAssertTrue(bucket.uniqueIds.isEmpty)
     }
 
-    func testMergeAppendsNovelSwapKitTokens() throws {
-        // Base list (e.g. from 1inch + curated) has ETH-ETH + USDC. SwapKit's
-        // bucket adds a token the base list doesn't know about (`NOVL`) — it
-        // must append to the merged list.
+    func testMergeExternalAppendsNovelTokens() throws {
+        // Base list (e.g. from 1inch + curated) has ETH-ETH + USDC. An external
+        // provider's bucket adds a token the base list doesn't know about
+        // (`NOVL`) — it must append to the merged list.
         let base: [CoinMeta] = [
             CoinMeta(chain: .ethereum, ticker: "ETH", logo: "", decimals: 18, priceProviderId: "ethereum", contractAddress: "", isNativeToken: true),
             CoinMeta(chain: .ethereum, ticker: "USDC", logo: "", decimals: 6, priceProviderId: "usd-coin", contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", isNativeToken: false)
@@ -56,12 +56,12 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
             tokens: [novel],
             uniqueIds: [novel.uniqueId]
         )
-        let merged = SwapCoinSelectionLogic.mergeWithSwapKit(base: base, swapKit: bucket)
-        XCTAssertEqual(merged.count, 3, "Novel SwapKit token must append")
+        let merged = SwapCoinSelectionLogic.mergeExternal(base: base, externals: [bucket])
+        XCTAssertEqual(merged.count, 3, "Novel external token must append")
         XCTAssertEqual(merged.last?.ticker, "NOVL")
     }
 
-    func testMergeDropsSwapKitTokensAlreadyInBase() throws {
+    func testMergeExternalDropsTokensAlreadyInBase() throws {
         // Overlap case — 1inch already discovered USDC. SwapKit's USDC must
         // NOT duplicate in the picker.
         let usdc = CoinMeta(chain: .ethereum, ticker: "USDC", logo: "", decimals: 6, priceProviderId: "usd-coin", contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", isNativeToken: false)
@@ -71,7 +71,7 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
             tokens: [usdc],
             uniqueIds: [usdc.uniqueId]
         )
-        let merged = SwapCoinSelectionLogic.mergeWithSwapKit(base: base, swapKit: bucket)
+        let merged = SwapCoinSelectionLogic.mergeExternal(base: base, externals: [bucket])
         XCTAssertEqual(merged.count, 1, "Overlap must not duplicate")
     }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
@@ -44,8 +44,7 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
     func testMergeAppendsNovelSwapKitTokens() throws {
         // Base list (e.g. from 1inch + curated) has ETH-ETH + USDC. SwapKit's
         // bucket adds a token the base list doesn't know about (`NOVL`) — it
-        // must append AND its uniqueId must end up in the swapKitOnlyIds set
-        // that drives the "via SwapKit" tag.
+        // must append to the merged list.
         let base: [CoinMeta] = [
             CoinMeta(chain: .ethereum, ticker: "ETH", logo: "", decimals: 18, priceProviderId: "ethereum", contractAddress: "", isNativeToken: true),
             CoinMeta(chain: .ethereum, ticker: "USDC", logo: "", decimals: 6, priceProviderId: "usd-coin", contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", isNativeToken: false)
@@ -63,8 +62,7 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
 
     func testMergeDropsSwapKitTokensAlreadyInBase() throws {
         // Overlap case — 1inch already discovered USDC. SwapKit's USDC must
-        // NOT duplicate in the picker, and USDC's uniqueId must NOT end up
-        // in the "swapKitOnlyIds" tag-set computed downstream by the logic.
+        // NOT duplicate in the picker.
         let usdc = CoinMeta(chain: .ethereum, ticker: "USDC", logo: "", decimals: 6, priceProviderId: "usd-coin", contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", isNativeToken: false)
         let base = [usdc]
         let bucket = SwapKitTokensBucket(

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/__fixtures__/03-tokens-NEAR.json
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/__fixtures__/03-tokens-NEAR.json
@@ -1,0 +1,368 @@
+{
+  "provider": "NEAR",
+  "name": "NEAR",
+  "timestamp": "2026-05-10T10:23:55.542Z",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "keywords": [],
+  "count": 25,
+  "tokens": [
+    {
+      "chain": "GNO",
+      "chainId": "100",
+      "ticker": "xDAI",
+      "identifier": "GNO.xDAI",
+      "symbol": "xDAI",
+      "name": "XDAI",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/gno.xdai.png",
+      "extensions": {
+        "providerId": "nep141:gnosis.omft.near"
+      },
+      "coingeckoId": "xdai"
+    },
+    {
+      "chain": "GNO",
+      "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+      "chainId": "100",
+      "ticker": "GNO",
+      "identifier": "GNO.GNO-0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+      "symbol": "GNO-0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+      "name": "GNO",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/gno.gno-0x9c58bacc331c9aa871afd802db6379a98e80cedb.png",
+      "extensions": {
+        "providerId": "nep141:gnosis-0x9c58bacc331c9aa871afd802db6379a98e80cedb.omft.near"
+      }
+    },
+    {
+      "chain": "ARB",
+      "chainId": "42161",
+      "ticker": "ETH",
+      "identifier": "ARB.ETH",
+      "symbol": "ETH",
+      "name": "Ethereum",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/arb.eth.png",
+      "extensions": {
+        "providerId": "nep141:arb.omft.near"
+      },
+      "coingeckoId": "ethereum"
+    },
+    {
+      "chain": "ARB",
+      "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+      "chainId": "42161",
+      "ticker": "ARB",
+      "identifier": "ARB.ARB-0x912ce59144191c1204e64559fe8253a0e49e6548",
+      "symbol": "ARB-0x912ce59144191c1204e64559fe8253a0e49e6548",
+      "name": "Arbitrum",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/arb.arb-0x912ce59144191c1204e64559fe8253a0e49e6548.png",
+      "extensions": {
+        "providerId": "nep141:arb-0x912ce59144191c1204e64559fe8253a0e49e6548.omft.near"
+      },
+      "coingeckoId": "arbitrum"
+    },
+    {
+      "chain": "MONAD",
+      "chainId": "143",
+      "ticker": "MON",
+      "identifier": "MONAD.MON",
+      "symbol": "MON",
+      "name": "Monad",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/monad.mon.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:143_11111111111111111111"
+      },
+      "coingeckoId": "monad"
+    },
+    {
+      "chain": "MONAD",
+      "address": "0xe7cd86e13ac4309349f30b3435a9d337750fc82d",
+      "chainId": "143",
+      "ticker": "USDT0",
+      "identifier": "MONAD.USDT0-0xe7cd86e13ac4309349f30b3435a9d337750fc82d",
+      "symbol": "USDT0-0xe7cd86e13ac4309349f30b3435a9d337750fc82d",
+      "name": "USDT0",
+      "decimals": 6,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/monad.usdt0-0xe7cd86e13ac4309349f30b3435a9d337750fc82d.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:143_4EJiJxSALvGoTZbnc8K7Ft9533et"
+      },
+      "coingeckoId": "usdt0"
+    },
+    {
+      "chain": "BSC",
+      "chainId": "56",
+      "ticker": "BNB",
+      "identifier": "BSC.BNB",
+      "symbol": "BNB",
+      "name": "BNB",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/bsc.bnb.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:56_11111111111111111111"
+      },
+      "coingeckoId": "binancecoin"
+    },
+    {
+      "chain": "BSC",
+      "address": "0x000ae314e2a2172a039b26378814c252734f556a",
+      "chainId": "56",
+      "ticker": "ASTER",
+      "identifier": "BSC.ASTER-0x000ae314e2a2172a039b26378814c252734f556a",
+      "symbol": "ASTER-0x000ae314e2a2172a039b26378814c252734f556a",
+      "name": "Aster",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/bsc.aster-0x000ae314e2a2172a039b26378814c252734f556a.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:56_12zbnsg6xndDVj25QyL82YMPudb"
+      },
+      "coingeckoId": "aster-2"
+    },
+    {
+      "chain": "AVAX",
+      "chainId": "43114",
+      "ticker": "AVAX",
+      "identifier": "AVAX.AVAX",
+      "symbol": "AVAX",
+      "name": "Avalanche",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/avax.avax.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:43114_11111111111111111111"
+      },
+      "coingeckoId": "avalanche-2"
+    },
+    {
+      "chain": "AVAX",
+      "address": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
+      "chainId": "43114",
+      "ticker": "USDT",
+      "identifier": "AVAX.USDT-0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
+      "symbol": "USDT-0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
+      "name": "Tether",
+      "decimals": 6,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/avax.usdt-0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:43114_372BeH7ENZieCaabwkbWkBiTTgXp"
+      },
+      "coingeckoId": "tether"
+    },
+    {
+      "chain": "TON",
+      "chainId": "ton",
+      "ticker": "TON",
+      "identifier": "TON.TON",
+      "symbol": "TON",
+      "name": "Toncoin",
+      "decimals": 9,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/ton.ton.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:1117_"
+      },
+      "coingeckoId": "the-open-network"
+    },
+    {
+      "chain": "TON",
+      "address": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+      "chainId": "ton",
+      "ticker": "USDT",
+      "identifier": "TON.USDT-EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+      "symbol": "USDT-EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+      "name": "USDT",
+      "decimals": 6,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/ton.usdt-eqcxe6mutqjkfngfarotkot1lzbdiix1kcixrv7nw2id_sds.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:1117_3tsdfyziyc7EJbP2aULWSKU4toBaAcN4FdTgfm5W1mC4ouR"
+      }
+    },
+    {
+      "chain": "BASE",
+      "chainId": "8453",
+      "ticker": "ETH",
+      "identifier": "BASE.ETH",
+      "symbol": "ETH",
+      "name": "Ethereum",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/base.eth.png",
+      "extensions": {
+        "providerId": "nep141:base.omft.near"
+      },
+      "coingeckoId": "ethereum"
+    },
+    {
+      "chain": "BASE",
+      "address": "0x4200000000000000000000000000000000000006",
+      "chainId": "8453",
+      "ticker": "WETH",
+      "identifier": "BASE.WETH-0x4200000000000000000000000000000000000006",
+      "symbol": "WETH-0x4200000000000000000000000000000000000006",
+      "name": "L2 Standard Bridged WETH (Base)",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/base.weth-0x4200000000000000000000000000000000000006.png",
+      "extensions": {
+        "providerId": "nep141:base-0x4200000000000000000000000000000000000006.omft.near"
+      },
+      "coingeckoId": "l2-standard-bridged-weth-base"
+    },
+    {
+      "chain": "OP",
+      "chainId": "10",
+      "ticker": "ETH",
+      "identifier": "OP.ETH",
+      "symbol": "ETH",
+      "name": "Ethereum",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/op.eth.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:10_11111111111111111111"
+      },
+      "coingeckoId": "ethereum"
+    },
+    {
+      "chain": "OP",
+      "address": "0x4200000000000000000000000000000000000042",
+      "chainId": "10",
+      "ticker": "OP",
+      "identifier": "OP.OP-0x4200000000000000000000000000000000000042",
+      "symbol": "OP-0x4200000000000000000000000000000000000042",
+      "name": "OP",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/op.op-0x4200000000000000000000000000000000000042.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:10_vLAiSt9KfUGKpw5cD3vsSyNYBo7"
+      }
+    },
+    {
+      "chain": "BCH",
+      "chainId": "bitcoincash",
+      "ticker": "BCH",
+      "identifier": "BCH.BCH",
+      "symbol": "BCH",
+      "name": "Bitcoin Cash",
+      "decimals": 8,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/bch.bch.png",
+      "extensions": {
+        "providerId": "nep141:bch.omft.near"
+      },
+      "coingeckoId": "bitcoin-cash"
+    },
+    {
+      "chain": "DASH",
+      "chainId": "dash",
+      "ticker": "DASH",
+      "identifier": "DASH.DASH",
+      "symbol": "DASH",
+      "name": "DASH",
+      "decimals": 8,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/dash.dash.png",
+      "extensions": {
+        "providerId": "nep141:dash.omft.near"
+      }
+    },
+    {
+      "chain": "BERA",
+      "chainId": "80094",
+      "ticker": "BERA",
+      "identifier": "BERA.BERA",
+      "symbol": "BERA",
+      "name": "Berachain",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/bera.bera.png",
+      "extensions": {
+        "providerId": "nep141:bera.omft.near"
+      },
+      "coingeckoId": "berachain-bera"
+    },
+    {
+      "chain": "BERA",
+      "address": "0x779ded0c9e1022225f8e0630b35a9b54be713736",
+      "chainId": "80094",
+      "ticker": "USDT0",
+      "identifier": "BERA.USDT0-0x779ded0c9e1022225f8e0630b35a9b54be713736",
+      "symbol": "USDT0-0x779ded0c9e1022225f8e0630b35a9b54be713736",
+      "name": "USDT0",
+      "decimals": 6,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/bera.usdt0-0x779ded0c9e1022225f8e0630b35a9b54be713736.png",
+      "extensions": {
+        "providerId": "nep141:bera-0x779ded0c9e1022225f8e0630b35a9b54be713736.omft.near"
+      }
+    },
+    {
+      "chain": "TRON",
+      "chainId": "728126428",
+      "ticker": "TRX",
+      "identifier": "TRON.TRX",
+      "symbol": "TRX",
+      "name": "TRON",
+      "decimals": 6,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/tron.trx.png",
+      "extensions": {
+        "providerId": "nep141:tron.omft.near"
+      },
+      "coingeckoId": "tron"
+    },
+    {
+      "chain": "TRON",
+      "address": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+      "chainId": "728126428",
+      "ticker": "USDT",
+      "identifier": "TRON.USDT-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+      "symbol": "USDT-TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+      "name": "USDT",
+      "decimals": 6,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/tron.usdt-tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t.png",
+      "extensions": {
+        "providerId": "nep141:tron-d28a265909efecdcee7c5028585214ea0b96f015.omft.near"
+      }
+    },
+    {
+      "chain": "LTC",
+      "chainId": "litecoin",
+      "ticker": "LTC",
+      "identifier": "LTC.LTC",
+      "symbol": "LTC",
+      "name": "Litecoin",
+      "decimals": 8,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/ltc.ltc.png",
+      "extensions": {
+        "providerId": "nep141:ltc.omft.near"
+      },
+      "coingeckoId": "litecoin"
+    },
+    {
+      "chain": "STRK",
+      "chainId": "0x534e5f4d41494e",
+      "ticker": "STRK",
+      "identifier": "STRK.STRK",
+      "symbol": "STRK",
+      "name": "Starknet",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/strk.strk.png",
+      "extensions": {
+        "providerId": "nep141:starknet.omft.near"
+      },
+      "coingeckoId": "starknet"
+    },
+    {
+      "chain": "XLAYER",
+      "chainId": "196",
+      "ticker": "OKB",
+      "identifier": "XLAYER.OKB",
+      "symbol": "OKB",
+      "name": "OKB",
+      "decimals": 18,
+      "logoURI": "https://storage.googleapis.com/token-list-swapkit/images/xlayer.okb.png",
+      "extensions": {
+        "providerId": "nep245:v2_1.omni.hot.tg:196_11111111111111111111"
+      },
+      "coingeckoId": "okb"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Expand the swap **destination** coin picker with every token SwapKit knows about, on top of the existing curated allowlist + 1inch / Jupiter discovery. Gated end-to-end by the Phase 1 SwapKit feature flag (Settings → Advanced → "SwapKit"); flag OFF leaves picker behaviour byte-identical to today.

Cross-chain unlock matters most via NEAR Intents — a wallet holding ETH-USDC can now pick destinations like `BTC.BTC`, `ADA.ADA`, `SUI.SUI`, `ZEC.ZEC`, `TRON.USDT` in the picker (Vultisig already supports those wallets, but the picker didn't surface them).

Branches off `feat/swapkit-phase1`.

## What changed

- **Destination-only v1.** Threaded `isDestination: Bool` through `SwapCoinPickerView` → `SwapCoinSelectionViewModel` → logic. Source side is byte-identical to Phase 1.
- **`SwapKitTokensCache` actor** — fans out `GET /tokens?provider=<NAME>` for each non-filtered provider in the cached `/v3/providers` snapshot, dedupes by `identifier`, buckets by Vultisig `Chain`, 24h TTL, coalescing in-flight task. In-memory only (no SwiftData).
- **`SwapKitChainIDMapper.chain(forSwapKitChain:)`** — reverse-maps SwapKit's per-token `chain` string to a Vultisig `Chain`; tokens on unsupported chains (Polkadot, Berachain, Monad, Starknet, X-Layer, NEAR-the-chain) drop at adapter time.
- **`SwapKitToken.toCoinMeta()`** — conservative contract acceptance: EVM = 42-char `0x...`, Solana = base58 non-empty; non-EVM/non-Solana reject any contract (almost always NEAR-Intent wrapper identifiers like `zec.omft.near` the wallet can't hold).
- **Dedup priority** — existing 1inch/Jupiter/curated tokens win on `CoinMeta.uniqueId` overlap. Only truly novel SwapKit-surfaced tokens get the "via SwapKit" tag.
- **`SwapCoinCell` "via SwapKit" capsule** next to the chain pill. New localizable `swapPickerViaSwapKit` in all 8 locale files.

## Architecture decisions (full rationale in the wiki plan)

| Decision | Choice |
|---|---|
| Source vs destination | Destination only for v1 |
| Storage | In-memory actor cache, 24h TTL — no SwiftData |
| Visual differentiator | Subtle "via SwapKit" capsule next to chain pill |
| Chain pre-filter | At adapter time via reverse mapper |
| Blacklist | Trust SwapKit's quote-time `blackListAsset` check |
| Performance | LazyVStack + existing `.prefix(20)` search cap |
| API key | Proxy attaches it (same as Phase 1 quote/swap) |

Plan + investigation: `wiki/pages/projects/vultisig/swapkit-integration/tokens-picker-plan.md`.

## Live `/tokens` evidence (probed during Phase A)

| Provider     | Tokens |
|--------------|-------|
| `ONEINCH`    | 1349  |
| `NEAR`       | 111   |
| `FLASHNET`   | 24    |
| `GARDEN`     | 15    |
| `CHAINFLIP`  | 13    |
| `HARBOR`     | 4     |
| `JUPITER`    | 0 (`noTokenListsFound`) |
| `UNISWAP_V3` | 0     |
| **Total**    | **1516 raw / 1455 unique** after dedup |

Fixtures vendored at `swapkit-spike/fixtures/03{a,b,c}-tokens-*.json`. NEAR is the cross-chain unlock — covers 25 chains.

## Flag-off invariant (tested)

`SwapKitTokensCache.tokens(for:)` short-circuits to an empty bucket when `SwapKitConfig.isFeatureEnabled` is `false`. The picker merge step returns the unchanged base list when the bucket is empty. Pinned by `SwapKitTokensPickerFlagTests.testCacheReturnsEmptyBucketWhenFlagOff`.

## Test plan

- [x] New `SwapKitTokensDecodingTests` (7 cases): envelope decode, native/EVM/contract adapter, unsupported-chain drop, NEAR-chain drop, TRON wrapper drop, merge dedup by identifier
- [x] New `SwapKitTokensPickerFlagTests` (4 cases): flag-OFF cache empty, flag-ON snapshot read, novel-token append, overlap dedup
- [x] All 8 SwapKit suites green (45 tests, 0 failures)
- [x] Adjacent Swap suites green: `SwapCryptoLogicTests`, `SwapPayloadBuilderTests`, `SwapValidationTests`, `DefaultSwapInteractorTests` (58 tests, 0 failures)
- [x] `make generate` clean
- [x] Full `xcodebuild build` green for iOS Simulator
- [x] SwiftLint clean on all 10 touched files
- [ ] Manual smoke on simulator: flag OFF → picker identical to today; flag ON → destination picker shows "via SwapKit" tag on novel NEAR-routed tokens
- [ ] Manual smoke: pick a SwapKit-only destination (e.g. ZEC), confirm `/v3/quote` ranking surfaces a SwapKit route

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token availability in swap coin picker with expanded token selection from SwapKit

* **Settings**
  * Added option to clear cached token data in advanced settings

* **Localization**
  * Added translations for new features across multiple languages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->