### PR TITLE
fix(keysign): center glow arc on signing screen

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignAnimationView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignAnimationView.swift
@@ -23,6 +23,9 @@ struct KeysignAnimationView: View {
             animationVM?.view()
         }
         .ignoresSafeArea()
+        .readSize { size in
+            animationVMInstance?.numberProperty(fromPath: "posXcircles")?.value = Float(size.width / 2)
+        }
         .onChange(of: connected) { _, newValue in
             animationVMInstance?.booleanProperty(fromPath: "Connected")?.value = newValue
         }


### PR DESCRIPTION
## Summary
- `keysign.riv` has a `posXcircles` number property that controls the horizontal center of the bottom glow/arc animation
- Without setting it, it defaults to `0` and the arc renders flush against the left edge — visibly broken on macOS
- `KeygenAnimationView` already uses the same `readSize` + `posXcircles` pattern; this mirrors it in `KeysignAnimationView`

## Issue
Closes #4358

## Test Plan
- [ ] Start a keysign flow and reach the Signing screen on macOS — glow arc should be centered behind the "Signing" label
- [ ] Verify the same screen on iOS still looks correct (was already working)
- [ ] SwiftLint passes (no new violations)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keysign animation display to properly adjust animation positioning based on screen size, ensuring optimal visual alignment across all device sizes and orientations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->