### PR TITLE
fix(wallet): re-seed chains synchronously on vault switch

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -16,6 +16,13 @@ class VaultDetailViewModel: ObservableObject {
 
     private let logic = VaultDetailLogic()
     private var updateBalanceTask: Task<Void, Never>?
+    // Identity tracker for the vault `chains` was last sorted against. Used to
+    // re-seed `chains` synchronously when `updateBalance(vault:)` is called
+    // against a different vault than the cached list belongs to — the
+    // vault-switch case. Without this, the `chains.isEmpty` guard below skips
+    // the synchronous seed and the user sees the previous vault's chain list
+    // until the async refresh lands (~250ms debounce + network round trip).
+    private var chainsVaultPubKeyECDSA: String?
 
     @AppStorage("appClosedBanners") private var appClosedBanners: [String] = []
 
@@ -28,12 +35,17 @@ class VaultDetailViewModel: ObservableObject {
     }
 
     func updateBalance(vault: Vault) {
-        // Seed `chains` synchronously on first call so the list isn't blank
-        // through the debounce + fetch window. Subsequent refreshes leave the
-        // existing order in place until the async sort below replaces it —
-        // avoids the visible "stale-then-fresh" double reorder (#4337).
-        if chains.isEmpty {
+        // Seed `chains` synchronously when the cached list is empty (first
+        // call) OR when the cached list was sorted against a different vault
+        // than the one we're now refreshing — the vault-switch case. The
+        // same-vault refresh path (post-swap, balance cascade) still skips
+        // the seed, leaving the existing order in place until the async sort
+        // below replaces it. That preserves the fix for the "stale-then-fresh"
+        // double reorder while ensuring the list flips instantly on a vault
+        // identity flip instead of waiting on the debounce + fetch window.
+        if chains.isEmpty || chainsVaultPubKeyECDSA != vault.pubKeyECDSA {
             chains = logic.sortedChains(vault: vault)
+            chainsVaultPubKeyECDSA = vault.pubKeyECDSA
         }
 
         updateBalanceTask?.cancel()
@@ -43,13 +55,14 @@ class VaultDetailViewModel: ObservableObject {
             // throttledOnAppear, pull-to-refresh). Post-swap they can stack
             // 2–3 deep within a second; without this sleep each call kicks
             // off a full price + per-coin balance refresh and the resulting
-            // reorders are visible as flicker (#4337).
+            // reorders are visible as flicker.
             try? await Task.sleep(for: .milliseconds(250))
             guard !Task.isCancelled, let self else { return }
             let updated = await self.logic.updateBalance(vault: vault)
             if !Task.isCancelled {
                 await MainActor.run {
                     self.chains = updated
+                    self.chainsVaultPubKeyECDSA = vault.pubKeyECDSA
                 }
             }
         }
@@ -57,6 +70,7 @@ class VaultDetailViewModel: ObservableObject {
 
     func groupChains(vault: Vault) {
         chains = logic.sortedChains(vault: vault)
+        chainsVaultPubKeyECDSA = vault.pubKeyECDSA
     }
 
     func getGroupAsync(_ viewModel: CoinSelectionViewModel) {

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -1,0 +1,127 @@
+//
+//  VaultDetailViewModelTests.swift
+//  VultisigAppTests
+//
+//  Regression tests for the `chains.isEmpty || chainsVaultPubKeyECDSA !=
+//  vault.pubKeyECDSA` seed guard in `VaultDetailViewModel.updateBalance(vault:)`.
+//
+//  The earlier `chains.isEmpty` guard was vault-blind: after switching vaults
+//  the cached list still belonged to the previous vault, so the synchronous
+//  seed was skipped and the wallet tab kept rendering stale chains until the
+//  async refresh landed (~250ms debounce + network round trip). These tests
+//  pin the fix and the invariants it must preserve:
+//
+//    1. First call on an empty model seeds synchronously.
+//    2. Switching to a different vault re-seeds synchronously, even with a
+//       non-empty `chains` array.
+//    3. Same-vault calls do *not* re-seed — preserves the prior fix for the
+//       visible "stale-then-fresh" double reorder on post-swap refreshes.
+//    4. `groupChains(vault:)` keeps the identity tracker in sync so a
+//       subsequent same-vault `updateBalance` call still skips the seed.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class VaultDetailViewModelTests: XCTestCase {
+
+    func testUpdateBalance_firstCall_seedsChainsSynchronously() {
+        let vault = makeVault(pubKey: "vault-a", chains: [.bitcoin, .ethereum])
+        let vm = VaultDetailViewModel()
+
+        vm.updateBalance(vault: vault)
+
+        XCTAssertEqual(Set(vm.chains), Set(vault.chainsWithCoins))
+    }
+
+    /// The bug: switching vaults with a non-empty `chains` array used to skip
+    /// the synchronous seed entirely. After this fix the seed fires when the
+    /// vault identity flips, so the list reflects the new vault before the
+    /// debounced async refresh runs.
+    func testUpdateBalance_vaultSwitch_reSeedsChainsSynchronously() {
+        let vaultA = makeVault(pubKey: "vault-a", chains: [.bitcoin, .ethereum])
+        let vaultB = makeVault(pubKey: "vault-b", chains: [.solana, .gaiaChain])
+        let vm = VaultDetailViewModel()
+
+        vm.updateBalance(vault: vaultA)
+        XCTAssertEqual(Set(vm.chains), Set(vaultA.chainsWithCoins))
+
+        // Different vault, same VM — `chains` is non-empty but belongs to
+        // vault A. The synchronous seed must still fire.
+        vm.updateBalance(vault: vaultB)
+        XCTAssertEqual(Set(vm.chains), Set(vaultB.chainsWithCoins))
+        XCTAssertFalse(vm.chains.contains(where: { vaultA.chainsWithCoins.contains($0) && !vaultB.chainsWithCoins.contains($0) }),
+                       "Stale chains from vault A must not survive the switch to vault B")
+    }
+
+    /// Calling `updateBalance` repeatedly against the same vault must not
+    /// re-seed `chains`. The "stale-then-fresh" double reorder this gate was
+    /// originally added to prevent depends on this invariant — the seed only
+    /// fires on identity change, not on every refresh.
+    func testUpdateBalance_sameVaultRefresh_doesNotReSeedChains() {
+        let vault = makeVault(pubKey: "vault-a", chains: [.bitcoin, .ethereum])
+        let vm = VaultDetailViewModel()
+
+        vm.updateBalance(vault: vault)
+        // Mutate the array in a way that the seed would clobber. If the
+        // second call re-seeds, this sentinel disappears.
+        let sentinel: [Chain] = [.dydx]
+        vm.chains = sentinel
+
+        vm.updateBalance(vault: vault)
+
+        XCTAssertEqual(vm.chains, sentinel,
+                       "Same-vault updateBalance must not synchronously re-seed chains")
+    }
+
+    /// `groupChains(vault:)` is another seed site. It must update the identity
+    /// tracker so a subsequent `updateBalance(vault:)` call against the same
+    /// vault hits the skip branch (no double seed).
+    func testGroupChains_updatesIdentityTracker_soSameVaultUpdateDoesNotReSeed() {
+        let vault = makeVault(pubKey: "vault-a", chains: [.bitcoin, .ethereum])
+        let vm = VaultDetailViewModel()
+
+        vm.groupChains(vault: vault)
+        let sentinel: [Chain] = [.dydx]
+        vm.chains = sentinel
+
+        vm.updateBalance(vault: vault)
+
+        XCTAssertEqual(vm.chains, sentinel,
+                       "updateBalance after groupChains for the same vault must not re-seed")
+    }
+
+    // MARK: - Helpers
+
+    /// Build a Vault populated with native coins for the requested chains.
+    /// `chainsWithCoins` is what `VaultDetailLogic.sortedChains(vault:)` reads
+    /// to seed the list, so populating `coins` is enough to drive the tests
+    /// without touching the network or a SwiftData container.
+    private func makeVault(pubKey: String, chains: [Chain]) -> Vault {
+        let vault = Vault(
+            name: "Vault-\(pubKey)",
+            signers: [],
+            pubKeyECDSA: pubKey,
+            pubKeyEdDSA: "ed-\(pubKey)",
+            keyshares: [],
+            localPartyID: "party-\(pubKey)",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        vault.coins = chains.map { chain in
+            let meta = CoinMeta(
+                chain: chain,
+                ticker: chain.ticker,
+                logo: "",
+                decimals: 8,
+                priceProviderId: "",
+                contractAddress: "",
+                isNativeToken: true
+            )
+            return Coin(asset: meta, address: "addr-\(pubKey)-\(chain.name)", hexPublicKey: "")
+        }
+        return vault
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a regression where switching vaults on the home screen left the chains list showing the previous vault's data for ~250ms+ until the async balance refresh landed. Pull-to-refresh masked the bug because by then the original refresh had already completed.

## Root cause

Introduced by #4337 (post-swap flicker fix). The `chains.isEmpty` guard in `VaultDetailViewModel.updateBalance(vault:)` was vault-blind: after a vault switch, `chains` holds the previous vault's data → synchronous seed is skipped → stale list rendered while the 250ms async tail does its work.

## Fix

Adds a `chainsVaultPubKeyECDSA` identity tracker. Guard expanded from `chains.isEmpty` to `chains.isEmpty || chainsVaultPubKeyECDSA != vault.pubKeyECDSA` — re-seeds synchronously when the vault identity flips, leaves same-vault refreshes on the skip branch (preserves #4337's flicker fix).

## Verification

1. Vault A funded with BTC + ETH; vault B funded with SOL + ATOM
2. Open home screen on vault A — see BTC + ETH
3. Switch to vault B via vault picker
4. **Before this PR**: home shows BTC + ETH for ~250ms+ before updating to SOL + ATOM
5. **After this PR**: home shows SOL + ATOM immediately

## Test plan

- [x] Unit test: `VaultDetailViewModel.chains` flips synchronously when `updateBalance(vault:)` is called with a different vault
- [x] `xcodebuild clean test` green on iPhone 17 Pro Max
- [ ] Manual repro/verify per the steps above

## Plan
[[projects/vultisig/ios-bugs/vault-switch-chain-refresh-plan]]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where switching between vaults would display outdated chain ordering until the background refresh completed. The chain list now updates immediately when switching vaults.

* **Tests**
  * Added regression tests to verify correct chain list behavior when switching vaults and updating balances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->