### PR TITLE
feat(qbtc): hide QBTC claim behind Settings → Advanced flag

### DIFF
--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -57,7 +57,19 @@ struct ContentView: View {
             .navigationDestination(for: CircleRoute.self) { router.circleRouter.build($0) }
             .navigationDestination(for: TronRoute.self) { router.tronRouter.build($0) }
             .navigationDestination(for: TransactionHistoryRoute.self) { router.transactionHistoryRouter.build($0) }
-            .navigationDestination(for: QBTCClaimRoute.self) { router.qbtcClaimRouter.build($0) }
+            .navigationDestination(for: QBTCClaimRoute.self) { route in
+                // Defense-in-depth — `QBTCClaimRoute` subroutes (pair /
+                // keysign / done) are only pushed from `QBTCClaimScreen`
+                // and its children, which themselves require the QBTC
+                // feature flag. Guarding here too prevents any future
+                // code path from rendering a QBTC sub-screen behind the
+                // flag's back.
+                if QBTCConfig.isFeatureEnabled {
+                    router.qbtcClaimRouter.build(route)
+                } else {
+                    EmptyView()
+                }
+            }
         }
         .environment(\.router, router.navigationRouter)
         .colorScheme(.dark)

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -666,6 +666,7 @@
 "qbtcClaimCtaPartial" = "%1$d von %2$d beanspruchen";
 "qbtcClaimDescription" = "QBTC ist eine quantensichere Version von BTC. Ihre vorhandenen BTC-UTXOs können im Verhältnis 1:1 als QBTC beansprucht werden. Wählen Sie unten die zu beanspruchenden UTXOs aus.";
 "qbtcClaimDescriptionEmphasis" = "quantensicher";
+"qbtcClaimDisabledFromAdvanced" = "QBTC Claim ist auf diesem Gerät deaktiviert. Aktiviere es unter Einstellungen → Erweitert und versuche es erneut.";
 "qbtcClaimEligibleHeader" = "Berechtigte UTXOs";
 "qbtcClaimEmptyPassword" = "Bitte gib dein Fast Vault-Passwort ein, um fortzufahren.";
 "qbtcClaimErrorInvalidBtcPublicKey" = "Ungültiger Bitcoin-Public-Key auf der BTC-Coin des Vaults.";
@@ -849,6 +850,7 @@
 "settingsAdvancedClear" = "Leeren";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "SwapKit-Token-Cache leeren";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Teilen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -674,6 +674,7 @@
 "qbtcClaimCtaPartial" = "Claim %1$d of %2$d";
 "qbtcClaimDescription" = "QBTC is a quantum-resistant version of BTC. Your existing BTC UTXOs are eligible to be claimed as QBTC at a 1:1 ratio. Select which UTXOs to claim below.";
 "qbtcClaimDescriptionEmphasis" = "quantum-resistant";
+"qbtcClaimDisabledFromAdvanced" = "QBTC Claim is disabled on this device. Enable it in Settings → Advanced and try again.";
 "qbtcClaimEligibleHeader" = "Eligible UTXOs";
 "qbtcClaimEmptyPassword" = "Please enter your Fast Vault password to continue.";
 "qbtcClaimErrorInvalidBtcPublicKey" = "Invalid Bitcoin public key on the vault's BTC coin.";
@@ -859,6 +860,7 @@
 "settingsAdvancedClear" = "Clear";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Clear SwapKit tokens cache";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Share";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -666,6 +666,7 @@
 "qbtcClaimCtaPartial" = "Reclamar %1$d de %2$d";
 "qbtcClaimDescription" = "QBTC es una versión resistente a la computación cuántica de BTC. Tus UTXOs de BTC existentes pueden reclamarse como QBTC en proporción 1:1. Selecciona abajo qué UTXOs reclamar.";
 "qbtcClaimDescriptionEmphasis" = "resistente a la computación cuántica";
+"qbtcClaimDisabledFromAdvanced" = "QBTC Claim está desactivado en este dispositivo. Actívalo en Ajustes → Avanzado e inténtalo de nuevo.";
 "qbtcClaimEligibleHeader" = "UTXOs elegibles";
 "qbtcClaimEmptyPassword" = "Introduce tu contraseña de Fast Vault para continuar.";
 "qbtcClaimErrorInvalidBtcPublicKey" = "Clave pública de Bitcoin inválida en la moneda BTC del vault.";
@@ -849,6 +850,7 @@
 "settingsAdvancedClear" = "Borrar";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Borrar caché de tokens de SwapKit";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartir";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -666,6 +666,7 @@
 "qbtcClaimCtaPartial" = "Polaži %1$d od %2$d";
 "qbtcClaimDescription" = "QBTC je kvantno-otporna verzija BTC-a. Vaši postojeći BTC UTXO-i mogu se polagati kao QBTC u omjeru 1:1. Odaberite UTXO-e za polaganje ispod.";
 "qbtcClaimDescriptionEmphasis" = "kvantno-otporna";
+"qbtcClaimDisabledFromAdvanced" = "QBTC Claim je onemogućen na ovom uređaju. Omogući ga u Postavke → Napredno i pokušaj ponovno.";
 "qbtcClaimEligibleHeader" = "Prihvatljivi UTXO-i";
 "qbtcClaimEmptyPassword" = "Unesi svoju Fast Vault lozinku za nastavak.";
 "qbtcClaimErrorInvalidBtcPublicKey" = "Nevažeći Bitcoin javni ključ na BTC coinu vaulta.";
@@ -849,6 +850,7 @@
 "settingsAdvancedClear" = "Očisti";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Očisti predmemoriju SwapKit tokena";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Podijeli";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -666,6 +666,7 @@
 "qbtcClaimCtaPartial" = "Reclama %1$d di %2$d";
 "qbtcClaimDescription" = "QBTC è una versione resistente alla computazione quantistica di BTC. I tuoi UTXO di BTC esistenti possono essere reclamati come QBTC in rapporto 1:1. Seleziona quali UTXO reclamare di seguito.";
 "qbtcClaimDescriptionEmphasis" = "resistente alla computazione quantistica";
+"qbtcClaimDisabledFromAdvanced" = "QBTC Claim è disattivato su questo dispositivo. Attivalo in Impostazioni → Avanzate e riprova.";
 "qbtcClaimEligibleHeader" = "UTXO ammissibili";
 "qbtcClaimEmptyPassword" = "Inserisci la password del tuo Fast Vault per continuare.";
 "qbtcClaimErrorInvalidBtcPublicKey" = "Chiave pubblica Bitcoin non valida sulla moneta BTC del vault.";
@@ -849,6 +850,7 @@
 "settingsAdvancedClear" = "Cancella";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Cancella la cache dei token di SwapKit";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -666,6 +666,7 @@
 "pushNotifications" = "푸시 알림";
 "pushNotificationsDescription" = "서명이 필요하거나 기기가 액세스를 요청할 때 알림을 받으세요.";
 "qbtcClaimCancelled" = "청구가 취소됨";
+"qbtcClaimDisabledFromAdvanced" = "이 기기에서는 QBTC Claim이 비활성화되어 있습니다. 설정 → 고급에서 활성화한 후 다시 시도하세요.";
 "qbtcClaimEmptyPassword" = "계속하려면 Fast Vault 비밀번호를 입력하세요.";
 "qbtcClaimErrorInvalidBtcPublicKey" = "vault의 BTC 코인에 잘못된 Bitcoin 공개 키가 있습니다.";
 "qbtcClaimErrorProofHashMismatch" = "프루프 서비스가 로컬 계산과 일치하지 않는 해시를 반환했습니다; 청구를 중단합니다.";
@@ -837,6 +838,7 @@
 "settingsAdvancedClear" = "지우기";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "SwapKit 토큰 캐시 지우기";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "공유";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -666,6 +666,7 @@
 "qbtcClaimCtaPartial" = "Reivindicar %1$d de %2$d";
 "qbtcClaimDescription" = "QBTC é uma versão resistente à computação quântica do BTC. Os seus UTXOs de BTC existentes podem ser reivindicados como QBTC numa proporção 1:1. Selecione abaixo quais UTXOs reivindicar.";
 "qbtcClaimDescriptionEmphasis" = "resistente à computação quântica";
+"qbtcClaimDisabledFromAdvanced" = "QBTC Claim está desativado neste dispositivo. Ative em Definições → Avançado e tente novamente.";
 "qbtcClaimEligibleHeader" = "UTXOs elegíveis";
 "qbtcClaimEmptyPassword" = "Insira a senha do seu Fast Vault para continuar.";
 "qbtcClaimErrorInvalidBtcPublicKey" = "Chave pública Bitcoin inválida na moeda BTC do vault.";
@@ -849,6 +850,7 @@
 "settingsAdvancedClear" = "Limpar";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Limpar cache de tokens do SwapKit";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -667,6 +667,7 @@
 "qbtcClaimCtaPartial" = "领取 %2$d 个中的 %1$d 个";
 "qbtcClaimDescription" = "QBTC 是 BTC 的抗量子版本。您现有的 BTC UTXO 可以按 1:1 的比例领取为 QBTC。请在下方选择要领取的 UTXO。";
 "qbtcClaimDescriptionEmphasis" = "抗量子";
+"qbtcClaimDisabledFromAdvanced" = "本设备已停用 QBTC Claim。请在“设置 → 高级”中启用后重试。";
 "qbtcClaimEligibleHeader" = "符合条件的 UTXO";
 "qbtcClaimEmptyPassword" = "请输入您的 Fast Vault 密码以继续。";
 "qbtcClaimErrorInvalidBtcPublicKey" = "保险库 BTC 币上的 Bitcoin 公钥无效。";
@@ -849,6 +850,7 @@
 "settingsAdvancedClear" = "清除";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
+"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "清除 SwapKit 代币缓存";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "分享";

--- a/VultisigApp/VultisigApp/Features/Home/Navigation/HomeRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Navigation/HomeRouteBuilder.swift
@@ -47,7 +47,15 @@ struct HomeRouteBuilder {
                 coinType: coinType
             )
         case .qbtcClaim(let vault):
-            QBTCClaimScreen(vault: vault)
+            // Defense-in-depth: every upstream entry to `.qbtcClaim` is
+            // already gated by `QBTCConfig.isFeatureEnabled`. Guarding here
+            // too means any future caller that wires a new entry point
+            // without remembering the flag still can't surface the flow.
+            if QBTCConfig.isFeatureEnabled {
+                QBTCClaimScreen(vault: vault)
+            } else {
+                EmptyView()
+            }
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -227,6 +227,11 @@ class JoinKeysignViewModel: ObservableObject {
         // message hash itself. Skip the standard factory so it doesn't
         // fail trying to build sighashes from a body that isn't there.
         if keysignPayload.isQbtcClaim {
+            guard QBTCConfig.isFeatureEnabled else {
+                self.errorMsg = "qbtcClaimDisabledFromAdvanced".localized
+                self.status = .FailedToStart
+                return
+            }
             return
         }
         do {
@@ -313,6 +318,11 @@ class JoinKeysignViewModel: ObservableObject {
             // round-suffixed derivation of a base session. The peer
             // derives the claimer's QBTC address from its own vault.
             if let payload = self.keysignPayload, payload.isQbtcClaim {
+                guard QBTCConfig.isFeatureEnabled else {
+                    self.errorMsg = "qbtcClaimDisabledFromAdvanced".localized
+                    self.status = .FailedToStart
+                    return
+                }
                 let session = KeysignSessionInfo(
                     sessionId: keysignMsg.sessionID,
                     encryptionKeyHex: keysignMsg.encryptionKeyHex,

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/QBTCConfig.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/QBTCConfig.swift
@@ -1,0 +1,42 @@
+//
+//  QBTCConfig.swift
+//  VultisigApp
+//
+//  Configuration for the QBTC claim workstream. Mirrors `SwapKitConfig`'s
+//  `isFeatureEnabled` shape so every QBTC user-facing surface — promo
+//  banner, Claim button, chain-picker entry, claim flow, quantum-security
+//  onboarding hop, join-keysign QBTC fork — gates against a single source
+//  of truth.
+//
+//  The flag is independent of `isMLDSAEnabled`. MLDSA gates *keygen*; this
+//  flag gates QBTC *claim UI*. Both need to be true for an end-to-end
+//  claim, but the toggles are orthogonal.
+//
+//  Behaviour:
+//  - New / existing installs default OFF — `UserDefaults.standard.bool(...)`
+//    returns `false` for any unset key.
+//  - Toggle in Settings → Advanced → "QBTC Claim".
+//  - In-flight claim at flag-flip: the running keysign screen completes
+//    naturally (we don't proactively pop a mid-session screen). New entry
+//    points are blocked. Same precedent as SwapKit.
+//  - Existing vault state preserved: if a user adds the QBTC chain with
+//    the flag on and then flips it off, the QBTC `Coin` row stays on the
+//    vault and any past QBTC claim tx in history remains visible. The
+//    flag controls visibility of new entry points, not data lifecycle.
+//
+
+import Foundation
+
+enum QBTCConfig {
+    /// Advanced-settings opt-in flag (Settings → Advanced → "QBTC Claim").
+    /// When `false`, every QBTC claim UI surface is hidden — promo banner,
+    /// Claim button, chain-picker entry, claim flow, onboarding hop, join-
+    /// keysign QBTC fork. Existing vault state (QBTC coin row, past claim
+    /// tx history) is preserved — the flag controls UI visibility only.
+    /// The key is the same `@AppStorage` value `SettingsViewModel.qbtcEnabled`
+    /// writes to, so the toggle and this read share one source of truth.
+    /// Default `false` — opt-in while we develop + smoke-test.
+    static var isFeatureEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "qbtcEnabled")
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -36,6 +36,7 @@ class SettingsViewModel: ObservableObject {
     @AppStorage("isMLDSAEnabled") var isMLDSAEnabled: Bool = false
     @AppStorage("tssBatchEnabled") var tssBatchEnabled: Bool = false
     @AppStorage("swapkitEnabled") var swapkitEnabled: Bool = false
+    @AppStorage("qbtcEnabled") var qbtcEnabled: Bool = false
     /// Debug-only: force every swap quote through a single provider so a
     /// tester can verify a specific signing path in isolation. Empty string
     /// = no force (production ranking across all providers). Otherwise one

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
@@ -73,6 +73,12 @@ struct SettingsAdvancedView: View {
                 isEnabled: $settingsViewModel.swapkitEnabled
             )
 
+            SettingToggleCell(
+                title: "settingsAdvancedQBTCClaimToggle".localized,
+                icon: "lock.shield",
+                isEnabled: $settingsViewModel.qbtcEnabled
+            )
+
             SettingPickerCell(
                 title: "settingsAdvancedForcedSwapProvider".localized,
                 icon: "arrow.triangle.branch",

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -54,16 +54,22 @@ struct ChainDetailScreen: View {
     /// QBTC promo banner is visible on the BTC chain detail screen when
     /// the vault's BTC address has at least one claimable UTXO. This is
     /// now independent of whether the QBTC chain is already enabled on
-    /// the vault — the eligibility checker drives both branches.
+    /// the vault — the eligibility checker drives both branches. Hidden
+    /// entirely when `QBTCConfig.isFeatureEnabled` is `false`.
     private var showsQbtcBanner: Bool {
-        nativeCoin.chain == .bitcoin && qbtcEligibility.hasClaimableUtxos
+        QBTCConfig.isFeatureEnabled
+            && nativeCoin.chain == .bitcoin
+            && qbtcEligibility.hasClaimableUtxos
     }
 
     /// QBTC chain detail's Claim button mirrors the same predicate: only
     /// show it when there's actually something to claim. Hides the
     /// 96pt reserved padding too so the list flows full-bleed otherwise.
+    /// Hidden entirely when `QBTCConfig.isFeatureEnabled` is `false`.
     private var showsQbtcClaimButton: Bool {
-        nativeCoin.chain == .qbtc && qbtcEligibility.hasClaimableUtxos
+        QBTCConfig.isFeatureEnabled
+            && nativeCoin.chain == .qbtc
+            && qbtcEligibility.hasClaimableUtxos
     }
 
     /// Bottom clearance for the Claim button. macOS / iPadOS / iOS<26
@@ -338,8 +344,12 @@ private extension ChainDetailScreen {
 
     /// Kicks the QBTC eligibility check on entry / pull-to-refresh for
     /// both `.bitcoin` and `.qbtc` chain detail screens. No-ops on other
-    /// chains so we don't fire network calls speculatively.
+    /// chains so we don't fire network calls speculatively. Also no-ops
+    /// when the QBTC feature flag is off — flag-off users shouldn't burn
+    /// network budget on the eligibility check since the banner / button
+    /// it drives are hidden anyway.
     func refreshQbtcEligibility() {
+        guard QBTCConfig.isFeatureEnabled else { return }
         guard nativeCoin.chain == .bitcoin || nativeCoin.chain == .qbtc else { return }
         let btcCoin: Coin?
         if nativeCoin.chain == .bitcoin {
@@ -433,6 +443,7 @@ private extension ChainDetailScreen {
     }
 
     func handleQuantumKeygenCompleted(note: Notification) {
+        guard QBTCConfig.isFeatureEnabled else { return }
         guard pendingQbtcAddAfterKeygen else { return }
         let completedPubKey = note.userInfo?[QuantumKeygenNotification.vaultPubKeyECDSAKey] as? String
         guard completedPubKey == vault.pubKeyECDSA else { return }

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -339,6 +339,11 @@ struct VaultMainScreen: View {
     }
 
     func handleQuantumKeygenCompleted(note: Notification) {
+        // Defense-in-depth: with the chain picker gated upstream, the
+        // pending quantum-chain asset cannot be set with the flag off.
+        // Guarding here too means any future code path that posts the
+        // `qbtcQuantumKeygenCompleted` notification still respects the flag.
+        guard QBTCConfig.isFeatureEnabled else { return }
         guard let pendingAsset = pendingQuantumChainAsset else { return }
         let completedPubKey = note.userInfo?[QuantumKeygenNotification.vaultPubKeyECDSAKey] as? String
         guard completedPubKey == vault.pubKeyECDSA else { return }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/CoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/CoinSelectionViewModel.swift
@@ -58,6 +58,11 @@ class CoinSelectionViewModel: ObservableObject {
 
     func requiresQuantumKeygen(for asset: CoinMeta, vault: Vault) -> Bool {
         guard asset.chain.signingKeyType == .MLDSA else { return false }
+        // Defense-in-depth: with QBTC gated out of `filteredChains`, MLDSA
+        // assets cannot reach this code path with the flag off. Guarding
+        // here too means a future code path that hands an MLDSA asset
+        // straight to the keygen prompt still respects the feature flag.
+        guard QBTCConfig.isFeatureEnabled else { return false }
         return vault.publicKeyMLDSA44 == nil || vault.publicKeyMLDSA44?.isEmpty == true
     }
 
@@ -84,6 +89,11 @@ class CoinSelectionViewModel: ObservableObject {
                 return enableThorchainChainnet
             }
             if asset.chain.signingKeyType == .MLDSA {
+                // QBTC is the only MLDSA chain today. The feature flag gates
+                // visibility in addition to MLDSA-key presence so flag-off
+                // users never see QBTC in the picker. When MLDSA is later
+                // used for non-QBTC chains, narrow this guard to `.qbtc`.
+                guard QBTCConfig.isFeatureEnabled else { return false }
                 return hasMLDSAKey || showMldsaChainsWithoutKey
             }
             return true

--- a/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimFeatureFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimFeatureFlagTests.swift
@@ -1,0 +1,183 @@
+//
+//  QBTCClaimFeatureFlagTests.swift
+//  VultisigAppTests
+//
+//  Locks the opt-in behaviour for QBTC claim: the workstream is off by
+//  default; flipping the `qbtcEnabled` UserDefaults key (the same key
+//  `SettingsViewModel.qbtcEnabled` writes to via `@AppStorage`) lights
+//  it up. Surface-level gates (chain-picker visibility, navigation
+//  arms) are also locked in here so a regression doesn't quietly
+//  expose the flow.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class QBTCClaimFeatureFlagTests: XCTestCase {
+
+    private let flagKey = "qbtcEnabled"
+    private var savedFlag: Any?
+
+    override func setUpWithError() throws {
+        savedFlag = UserDefaults.standard.object(forKey: flagKey)
+        UserDefaults.standard.removeObject(forKey: flagKey)
+    }
+
+    override func tearDownWithError() throws {
+        if let savedFlag {
+            UserDefaults.standard.set(savedFlag, forKey: flagKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: flagKey)
+        }
+    }
+
+    // MARK: - isFeatureEnabled
+
+    func testFeatureFlagDefaultsToOff() {
+        UserDefaults.standard.removeObject(forKey: flagKey)
+        XCTAssertFalse(
+            QBTCConfig.isFeatureEnabled,
+            "QBTC must be opt-in — default off while the workstream is in active development"
+        )
+    }
+
+    func testFeatureFlagOnReadsTrue() {
+        UserDefaults.standard.set(true, forKey: flagKey)
+        XCTAssertTrue(QBTCConfig.isFeatureEnabled)
+    }
+
+    func testFeatureFlagOffReadsFalse() {
+        UserDefaults.standard.set(false, forKey: flagKey)
+        XCTAssertFalse(QBTCConfig.isFeatureEnabled)
+    }
+
+    // MARK: - CoinSelectionViewModel chain picker gating
+
+    func testChainPickerHidesQbtcWhenFlagOff() {
+        UserDefaults.standard.set(false, forKey: flagKey)
+        let vault = makeVaultWithMLDSAKey()
+        let viewModel = CoinSelectionViewModel()
+        viewModel.showMldsaChainsWithoutKey = true
+        viewModel.setData(for: vault, checkForSelected: false)
+        XCTAssertFalse(
+            viewModel.filteredChains.contains(.qbtc),
+            "QBTC must not appear in the chain picker with the feature flag off"
+        )
+    }
+
+    func testChainPickerShowsQbtcWhenFlagOnAndMldsaKeyPresent() {
+        UserDefaults.standard.set(true, forKey: flagKey)
+        let vault = makeVaultWithMLDSAKey()
+        let viewModel = CoinSelectionViewModel()
+        viewModel.showMldsaChainsWithoutKey = false
+        viewModel.setData(for: vault, checkForSelected: false)
+        XCTAssertTrue(
+            viewModel.filteredChains.contains(.qbtc),
+            "QBTC must appear when the feature flag is on and the vault has an MLDSA key"
+        )
+    }
+
+    func testChainPickerShowsQbtcWhenFlagOnAndShowWithoutKey() {
+        // Mirrors the production path where the chain picker is invoked
+        // with `showMldsaChainsWithoutKey = true` so the user can request
+        // the quantum keygen by tapping QBTC even if the vault has no
+        // MLDSA key yet.
+        UserDefaults.standard.set(true, forKey: flagKey)
+        let vault = makeVaultWithoutMLDSAKey()
+        let viewModel = CoinSelectionViewModel()
+        viewModel.showMldsaChainsWithoutKey = true
+        viewModel.setData(for: vault, checkForSelected: false)
+        XCTAssertTrue(
+            viewModel.filteredChains.contains(.qbtc),
+            "QBTC must appear when the flag is on and the picker is in keygen-prompting mode"
+        )
+    }
+
+    func testRequiresQuantumKeygenReturnsFalseWhenFlagOff() {
+        UserDefaults.standard.set(false, forKey: flagKey)
+        let vault = makeVaultWithoutMLDSAKey()
+        let viewModel = CoinSelectionViewModel()
+        let qbtcAsset = makeQbtcMeta()
+        XCTAssertFalse(
+            viewModel.requiresQuantumKeygen(for: qbtcAsset, vault: vault),
+            "With the flag off, `requiresQuantumKeygen` must return false so the keygen prompt never fires"
+        )
+    }
+
+    func testRequiresQuantumKeygenReturnsTrueWhenFlagOnAndNoMldsaKey() {
+        UserDefaults.standard.set(true, forKey: flagKey)
+        let vault = makeVaultWithoutMLDSAKey()
+        let viewModel = CoinSelectionViewModel()
+        let qbtcAsset = makeQbtcMeta()
+        XCTAssertTrue(
+            viewModel.requiresQuantumKeygen(for: qbtcAsset, vault: vault),
+            "Flag-on + no MLDSA key: the picker must surface the keygen prompt"
+        )
+    }
+
+    func testRequiresQuantumKeygenReturnsFalseForNonMldsaAssetRegardlessOfFlag() {
+        UserDefaults.standard.set(true, forKey: flagKey)
+        let vault = makeVaultWithoutMLDSAKey()
+        let viewModel = CoinSelectionViewModel()
+        let btcAsset = CoinMeta(
+            chain: .bitcoin,
+            ticker: "BTC",
+            logo: "",
+            decimals: 8,
+            priceProviderId: "",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        XCTAssertFalse(viewModel.requiresQuantumKeygen(for: btcAsset, vault: vault))
+    }
+
+    // MARK: - Helpers
+
+    private func makeQbtcMeta() -> CoinMeta {
+        guard let meta = TokensStore.TokenSelectionAssets.first(where: {
+            $0.chain == .qbtc && $0.isNativeToken
+        }) else {
+            return CoinMeta(
+                chain: .qbtc,
+                ticker: "QBTC",
+                logo: "qbtc",
+                decimals: 8,
+                priceProviderId: "",
+                contractAddress: "",
+                isNativeToken: true
+            )
+        }
+        return meta
+    }
+
+    private func makeVaultWithMLDSAKey() -> Vault {
+        let vault = Vault(
+            name: "QBTC Test Vault",
+            signers: [],
+            pubKeyECDSA: "ECDSAKey",
+            pubKeyEdDSA: "EdDSAKey",
+            keyshares: [],
+            localPartyID: "partyID",
+            hexChainCode: "hexCode",
+            resharePrefix: nil,
+            libType: .GG20
+        )
+        vault.publicKeyMLDSA44 = "mldsa44-pubkey"
+        return vault
+    }
+
+    private func makeVaultWithoutMLDSAKey() -> Vault {
+        Vault(
+            name: "QBTC Test Vault",
+            signers: [],
+            pubKeyECDSA: "ECDSAKey",
+            pubKeyEdDSA: "EdDSAKey",
+            keyshares: [],
+            localPartyID: "partyID",
+            hexChainCode: "hexCode",
+            resharePrefix: nil,
+            libType: .GG20
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `QBTCConfig.isFeatureEnabled` (UserDefaults-backed, default **off**) and a Settings → Advanced → **QBTC Claim** toggle, mirroring the existing SwapKit FF pattern.
- Gates every QBTC claim UI surface on the flag so flag-off users can't reach the flow:
  - `ContentView` navigation destination for `QBTCClaimRoute`
  - `HomeRouteBuilder.qbtcClaim` route
  - `ChainDetailScreen` QBTC promo banner, Claim button, eligibility refresh, quantum-keygen handler
  - `VaultMainScreen` quantum-keygen completion path
  - `CoinSelectionViewModel` chain-picker MLDSA filter + `requiresQuantumKeygen`
  - `JoinKeysignViewModel` two QBTC-claim fork points (preflight + start)
- Localizes both new strings (`settingsAdvancedQBTCClaimToggle`, `qbtcClaimDisabledFromAdvanced`) across all 8 locales (en, de, es, hr, it, ko, pt, zh-Hans).
- Adds `QBTCClaimFeatureFlagTests` (9 tests) pinning default-off, on/off reads, chain-picker visibility, and `requiresQuantumKeygen` gating.

## Behaviour

- **Default**: off. Fresh installs and existing installs both read `false` until the user opts in.
- **Toggle on**: every gated surface lights up immediately — the existing eligibility / MLDSA-key checks then decide visibility.
- **Toggle off mid-session**: a running keysign completes naturally (we don't proactively pop a screen), but new entry points are blocked. Same precedent as SwapKit.
- **Existing vault state preserved**: if a user adds the QBTC chain with the flag on and flips it off, the QBTC coin row and any historical claim tx remain on the vault. The flag controls UI entry, not data lifecycle.
- **Independent of `isMLDSAEnabled`**: that flag gates *keygen*; this one gates QBTC *claim UI*. Both must be true end-to-end, but the toggles are orthogonal.

## Test plan

- [x] `xcodebuild test -only-testing:VultisigAppTests/QBTCClaimFeatureFlagTests` — 9/9 passing
- [ ] Manual: fresh install → QBTC entry points are absent (chain picker, BTC chain-detail banner, navigation routes)
- [ ] Manual: flip flag on → QBTC reappears in chain picker; eligible BTC vault shows the promo banner
- [ ] Manual: flip flag off mid-session → no new QBTC route can be pushed; existing QBTC coin row stays put
- [ ] Manual: verify all 8 locales render `settingsAdvancedQBTCClaimToggle` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added QBTC Claim toggle in Advanced Settings; feature disabled by default.
  * QBTC Claim UI elements now respect the feature toggle setting across the app.

* **Documentation**
  * Added localized text for QBTC Claim controls and status messages across 8 supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->