### PR TITLE
docs(tron): fix stale receipt.result comment

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/TronTransactionStatusResponse.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/TronTransactionStatusResponse.swift
@@ -17,7 +17,12 @@ struct TronTransactionStatusResponse: Codable {
     let resMessage: String?  // Error message (present on failure)
 
     struct TronReceipt: Codable {
-        let result: String?  // Only present on failure: "FAILED", "OUT_OF_ENERGY", etc.
+        // Present on both success and failure per Tron protocol.
+        // Values: "SUCCESS" (committed), "FAILED", "REVERT", "OUT_OF_ENERGY",
+        // "OUT_OF_TIME", "BANDWIDTH_ERROR", "ACCOUNT_FREEZED" (failure modes).
+        // Empty string also possible when a contract executes without explicit code.
+        // See sdk#545 + https://developers.tron.network/reference/gettransactioninfobyid
+        let result: String?
         let net_fee: Int?
         let energy_fee: Int?
         let energy_usage_total: Int64?


### PR DESCRIPTION
Closes vultisig/vultiagent-app#853

## what

fixes stale comment on `TronReceipt.result` that said "only present on failure" - it's actually present on both success (`"SUCCESS"`) and failure (`"FAILED"`, `"REVERT"`, `"OUT_OF_ENERGY"`, etc.) per Tron protocol.

## how

`VultisigApp/Core/Services/TransactionStatus/Models/TronTransactionStatusResponse.swift:20` - replaced the one-liner stale comment with a proper multi-line doc comment listing all known values + canonical docs link + sdk#545 ref.

## risk

trivial - doc only, no runtime behavior changed.

🤖 Agent-generated

## receipts

Docs-only change verified — single file, zero runtime behavior change:

```diff
-        let result: String?  // Only present on failure: "FAILED", "OUT_OF_ENERGY", etc.
+        // Present on both success and failure per Tron protocol.
+        // Values: "SUCCESS" (committed), "FAILED", "REVERT", "OUT_OF_ENERGY",
+        // "OUT_OF_TIME", "BANDWIDTH_ERROR", "ACCOUNT_FREEZED" (failure modes).
+        // Empty string also possible when a contract executes without explicit code.
+        // See sdk#545 + https://developers.tron.network/reference/gettransactioninfobyid
+        let result: String?
```

1-file diff, comment-only — no tests to run, no UI surface changed.

— captured 2026-05-25 sweep