### PR TITLE
fix(storage): remove silent db wipe on modelcontainer init failure

### DIFF
--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -104,33 +104,12 @@ struct VultisigApp: App {
 
             return modelContainer
         } catch {
-            // Schema-breaking change in the swap-tracking refactor. Existing
-            // tx-history rows from earlier builds of this branch carry the
-            // old 10-column `swapKit*` shape and won't load against the new
-            // relationship-based schema. Wipe the on-disk store and retry —
-            // testers reinstall anyway, this is the belt-and-suspenders path
-            // so the app at least launches cleanly on first relaunch after
-            // upgrade rather than crashing on a schema-mismatch error.
-            if let storeURL = modelConfiguration.url as URL? {
-                try? FileManager.default.removeItem(at: storeURL)
-                // SwiftData writes -shm / -wal companions alongside the
-                // SQLite store; drop them too so the retry sees a clean slate.
-                let shm = storeURL.appendingPathExtension("shm")
-                let wal = storeURL.appendingPathExtension("wal")
-                try? FileManager.default.removeItem(at: shm)
-                try? FileManager.default.removeItem(at: wal)
-            }
-            do {
-                let modelContainer = try ModelContainer(
-                    for: schema,
-                    migrationPlan: MigrationPlan.self,
-                    configurations: [modelConfiguration]
-                )
-                Storage.shared.modelContext = modelContainer.mainContext
-                return modelContainer
-            } catch {
-                fatalError("Could not create ModelContainer: \(error)")
-            }
+            // NEVER wipe the store on migration failure — that destroys user
+            // vaults. SwiftData's lightweight migration handles all additive
+            // changes (new models, new optional relationships) automatically.
+            // If we ever need a destructive schema change, add an explicit
+            // SchemaMigrationPlan stage rather than silently nuking the DB.
+            fatalError("Could not create ModelContainer: \(error)")
         }
     }()
 


### PR DESCRIPTION
## what was broken

PR #4394 (SwapKit Phase 1, shipped in v1.37.56) replaced the original `fatalError` in `sharedModelContainer` with a silent SQLite store wipe + retry:

```swift
// before:
fatalError("Could not create ModelContainer: \(error)")

// after (v1.37.56):
try? FileManager.default.removeItem(at: storeURL)   // nukes all vaults
try? FileManager.default.removeItem(at: shm)
try? FileManager.default.removeItem(at: wal)
// ... retry
```

The code comment said *"testers reinstall anyway"* — that scaffolding shipped to production. If `ModelContainer` init fails for any reason, every vault the user ever created is silently deleted with no warning.

SamYap reported auto-migrated wallets disappearing after updating to v1.37.57 (Discord 2026-05-26 03:05 UTC). This wipe is the only code path in the app that can cause ALL vaults to vanish without user action.

## fix

Remove the wipe block entirely. Restore `fatalError` as the last-resort handler — a visible crash communicates a real problem; a silent full-vault wipe does not. The catch block is annotated to prevent this pattern from being re-introduced.

SwiftData's lightweight migration handles the `SwapTrackingMetadata` model addition and the optional `swapTracking` relationship on `TransactionHistoryItem` automatically (new empty table + nil-defaulted column). These changes never required a wipe — the old `swapKit*` columns they were protecting against existed only in development-branch builds, not in any App Store or TestFlight release before v1.37.56.

## risk

Low. This reverts a dangerous catch block back to the original pre-#4394 behavior. No schema changes, no data transforms. Existing vaults unaffected.

## rollout

Hotfix candidate. Patch on top of v1.37.57. No App Store re-submission gate — TestFlight build sufficient to validate.

🤖 Agent-generated