### PR TITLE
refactor(swap): remove unused picker helpers (#4343)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -161,20 +161,6 @@ enum SwapCryptoLogic {
         return coin
     }
 
-    // MARK: - Picker helpers
-
-    static func pickerFromCoins(fromCoins: [Coin], selected: Coin, fromChain: Chain?) -> [Coin] {
-        fromCoins
-            .filter { $0.chain == fromChain }
-            .sorted { Int($0.chain == selected.chain) > Int($1.chain == selected.chain) }
-    }
-
-    static func pickerToCoins(toCoins: [Coin], selected: Coin, toChain: Chain?) -> [Coin] {
-        toCoins
-            .filter { $0.chain == toChain }
-            .sorted { Int($0.chain == selected.chain) > Int($1.chain == selected.chain) }
-    }
-
     // MARK: - Display: amounts
 
     static func fromFiatAmount(fromCoin: Coin, fromAmount: String) -> String {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -145,16 +145,6 @@ final class SwapDetailsViewModel {
         fetchQuotes(vault: vault, referredCode: referredCode)
     }
 
-    // MARK: - Picker helpers
-
-    func pickerFromCoinsForChain() -> [Coin] {
-        SwapCryptoLogic.pickerFromCoins(fromCoins: fromCoins, selected: fromCoin, fromChain: fromChain)
-    }
-
-    func pickerToCoinsForChain() -> [Coin] {
-        SwapCryptoLogic.pickerToCoins(toCoins: toCoins, selected: toCoin, toChain: toChain)
-    }
-
     func handleFromChainUpdate(vault: Vault) {
         guard
             let fromChain,


### PR DESCRIPTION
## Summary

Closes #4343. Deletes 4 functions with zero call sites outside their own definitions and internal wrappers:

- `SwapCryptoLogic.pickerFromCoins` / `pickerToCoins`
- `SwapDetailsViewModel.pickerFromCoinsForChain` / `pickerToCoinsForChain`

CodeRabbit flagged these on PR #4332 as both dead and latently buggy: `.filter { \$0.chain == fromChain }` returns an empty list when `fromChain` is `nil`, and the trailing `sorted` compares chain equality on an already-single-chain list, so the "selected coin first" intent is a no-op.

## Acceptance (per #4343)

- [x] `xcodebuild` builds clean (`BUILD SUCCEEDED`)
- [x] All `VultisigAppTests` continue to pass (**1097 passed, 0 failures**)
- [x] `rg -n 'pickerFromCoins|pickerToCoins' VultisigApp/` → 0 matches

## Test plan

- [x] SwiftLint clean on changed files
- [x] Build green on iPhone 17 Pro Max simulator
- [x] Full suite passes (1097 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal swap logic by removing redundant helper functions, simplifying the coin selection flow in the swap feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->