### PR TITLE
fix(swap): SwapKit "no routes" → "amount too small" when pair is supported (#4408)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitError.swift
@@ -23,6 +23,14 @@ enum SwapKitError: Error, LocalizedError, Equatable {
     case swapRouteNotFound
     case outputAmountDeviationTooHigh
     case noRoutesFound
+    /// Disambiguated form of `noRoutesFound` thrown when the cached
+    /// `/v3/providers` snapshot shows at least one non-filtered provider
+    /// enables both source and destination chains — meaning the pair is
+    /// structurally supported, so the 404 must be amount-related rather
+    /// than a pair-coverage gap. The view layer normalizes this to
+    /// `SwapCryptoLogic.Errors.swapAmountTooSmall` so users see the same
+    /// "Amount Too Small" tooltip the THORChain path already produces.
+    case amountBelowProviderMinimum
     case blackListAsset
     case invalidSourceAddress
     case invalidDestinationAddress
@@ -100,6 +108,14 @@ enum SwapKitError: Error, LocalizedError, Equatable {
             return "swapKitErrorOutputAmountDeviationTooHigh".localized
         case .noRoutesFound:
             return "swapKitErrorNoRoutesFound".localized
+        case .amountBelowProviderMinimum:
+            // Reuse the existing THORChain "amount too small" copy rather than
+            // introducing a SwapKit-specific key — the user-facing meaning is
+            // identical and the view layer normalizes this case to
+            // `SwapCryptoLogic.Errors.swapAmountTooSmall` anyway. This
+            // `errorDescription` is only the fallback used if a caller logs
+            // the localized message without going through the tooltip view.
+            return "swapErrorAmountTooSmallDescription".localized
         case .blackListAsset:
             return "swapKitErrorBlackListAsset".localized
         case .invalidSourceAddress:

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
@@ -92,6 +92,41 @@ actor SwapKitProviderCache {
         return Self.chainEnabled(chain, in: providers)
     }
 
+    /// Synchronous variant for tests + offline computation. Returns `true`
+    /// iff at least one non-filtered provider entry's `enabledChainIds`
+    /// contains BOTH the source and destination chain ids. The intersection
+    /// requirement on the same provider entry — rather than a union across
+    /// providers — narrows the false-positive surface when re-classifying
+    /// `noRoutesFound` errors as below-minimum amounts: a provider that
+    /// enables both chains is far more likely to actually route between
+    /// them than two providers that each only handle one side.
+    nonisolated static func pairEnabled(
+        fromChain: Chain,
+        toChain: Chain,
+        in providers: [SwapKitProvider]
+    ) -> Bool {
+        let fromId = SwapKitChainIDMapper.swapKitChainId(for: fromChain)
+        let toId = SwapKitChainIDMapper.swapKitChainId(for: toChain)
+        guard !fromId.isEmpty, !toId.isEmpty else { return false }
+        return providers.contains { provider in
+            guard !SwapKitConfig.filteredProviders.contains(provider.provider.uppercased()) else {
+                return false
+            }
+            return provider.enabledChainIds.contains(fromId)
+                && provider.enabledChainIds.contains(toId)
+        }
+    }
+
+    /// Async variant — refreshes the cache and returns whether the (from, to)
+    /// chain pair has at least one non-filtered provider that enables both
+    /// chains. Returns `true` when the providers list can't be loaded
+    /// (fail-open, mirroring `isEnabled(chain:)`) — the caller treats this
+    /// as "could plausibly be supported" when re-classifying error codes.
+    func isPairSupported(fromChain: Chain, toChain: Chain, now: Date = Date()) async -> Bool {
+        guard let providers = await providers(now: now) else { return true }
+        return Self.pairEnabled(fromChain: fromChain, toChain: toChain, in: providers)
+    }
+
     /// Replace the snapshot — exposed for tests so they don't have to stand
     /// up a fake HTTPClient.
     func setSnapshot(_ snapshot: SwapKitProvidersSnapshot) {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -92,6 +92,21 @@ struct SwapKitService {
             return best
         } catch HTTPError.statusCode(_, let data) {
             if let error = SwapKitError.from(httpData: data) {
+                // SwapKit collapses "amount below provider minimum" and
+                // "pair not supported" into a single byte-identical 404
+                // `noRoutesFound` envelope. Cross-check the cached
+                // `/v3/providers` snapshot: if a non-filtered provider
+                // enables both chains, the pair IS structurally supported
+                // and the failure must be amount-related — re-classify so
+                // the view layer can show "Amount Too Small" instead of
+                // the misleading "No routes available for this pair".
+                if case .noRoutesFound = error,
+                   await providerCache.isPairSupported(
+                       fromChain: fromCoin.chain,
+                       toChain: toCoin.chain
+                   ) {
+                    throw SwapKitError.amountBelowProviderMinimum
+                }
                 throw error
             }
             throw SwapKitError.generic(message: "SwapKit /v3/quote request failed")

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapErrorTooltipView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapErrorTooltipView.swift
@@ -56,6 +56,9 @@ struct SwapErrorTooltipView: View {
         if let swapError = error as? SwapCryptoLogic.Errors {
             return swapError.errorTitle
         }
+        if let normalized = normalizedSwapKitError {
+            return normalized.errorTitle
+        }
         return SwapCryptoLogic.Errors.unexpectedError.errorTitle
     }
 
@@ -63,7 +66,25 @@ struct SwapErrorTooltipView: View {
         if let swapError = error as? SwapCryptoLogic.Errors {
             return swapError.errorDescription ?? error.localizedDescription
         }
+        if let normalized = normalizedSwapKitError {
+            return normalized.errorDescription ?? error.localizedDescription
+        }
         return error.localizedDescription
+    }
+
+    /// Map terminal SwapKit error cases onto the swap-flow's user-facing
+    /// error vocabulary so the tooltip shows a domain-appropriate title and
+    /// description instead of the generic "Unexpected Error" fallback. Only
+    /// covers cases that have a clear `SwapCryptoLogic.Errors` equivalent —
+    /// everything else flows through `error.localizedDescription` as before.
+    private var normalizedSwapKitError: SwapCryptoLogic.Errors? {
+        guard let swapKitError = error as? SwapKitError else { return nil }
+        switch swapKitError {
+        case .amountBelowProviderMinimum:
+            return .swapAmountTooSmall
+        default:
+            return nil
+        }
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitErrorTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitErrorTests.swift
@@ -47,6 +47,26 @@ final class SwapKitErrorTests: XCTestCase {
         XCTAssertEqual(mapped, .unableToBuildTransaction)
     }
 
+    // MARK: - Reclassified disambiguation case
+
+    /// `.amountBelowProviderMinimum` is a synthetic case raised by
+    /// `SwapKitService.fetchBestRoute` after consulting the providers cache —
+    /// it must NEVER be produced by decoding the raw envelope. Decoding the
+    /// upstream `noRoutesFound` code must still land on `.noRoutesFound`.
+    func testAmountBelowProviderMinimumIsNotDecodedFromEnvelope() {
+        XCTAssertNotEqual(decode("noRoutesFound"), .amountBelowProviderMinimum)
+        XCTAssertNotEqual(decode("amountBelowProviderMinimum"), .amountBelowProviderMinimum)
+    }
+
+    /// The reclassified case reuses the existing THORChain `Amount Too Small`
+    /// localized string for its `errorDescription` so no new translation
+    /// cycle is required. The view layer normalizes the case to
+    /// `SwapCryptoLogic.Errors.swapAmountTooSmall` for the tooltip title.
+    func testAmountBelowProviderMinimumDescriptionReusesSwapAmountTooSmallString() {
+        let error: SwapKitError = .amountBelowProviderMinimum
+        XCTAssertEqual(error.errorDescription, "swapErrorAmountTooSmallDescription".localized)
+    }
+
     // MARK: - Generic fallback
 
     func testUnknownCodePreservesMessage() {

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitProviderCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitProviderCacheTests.swift
@@ -135,4 +135,149 @@ final class SwapKitProviderCacheTests: XCTestCase {
         XCTAssertTrue(near.enabledChainIds.contains("1"))
         XCTAssertTrue(near.enabledChainIds.contains("42161"))
     }
+
+    // MARK: - Pair predicate (used to disambiguate noRoutesFound)
+
+    /// BCH→ETH is the canonical below-min repro case: NEAR's `enabledChainIds`
+    /// includes both `bitcoincash` and `1` on the same provider entry, so the
+    /// pair is structurally supported. A `/v3/quote` 404 on this pair therefore
+    /// must be amount-driven, which is what the predicate signals.
+    func testIsPairSupported_bothChainsInOneProvider_returnsTrue() {
+        XCTAssertTrue(
+            SwapKitProviderCache.pairEnabled(
+                fromChain: .bitcoinCash,
+                toChain: .ethereum,
+                in: providers
+            )
+        )
+    }
+
+    /// Same provider must enable BOTH chains — union across providers is
+    /// intentionally not enough. Synthesise two narrow providers that each
+    /// cover one side of the pair and assert the predicate refuses to
+    /// classify the pair as supported.
+    func testIsPairSupported_chainsSplitAcrossProviders_returnsFalse() {
+        let split = [
+            SwapKitProvider(
+                name: "PROVIDER_A",
+                provider: "PROVIDER_A",
+                displayName: nil,
+                displayNameLong: nil,
+                count: 1,
+                enabledChainIds: [SwapKitChainIDMapper.swapKitChainId(for: .bitcoinCash)],
+                supportedChainIds: nil,
+                supportedActions: nil
+            ),
+            SwapKitProvider(
+                name: "PROVIDER_B",
+                provider: "PROVIDER_B",
+                displayName: nil,
+                displayNameLong: nil,
+                count: 1,
+                enabledChainIds: [SwapKitChainIDMapper.swapKitChainId(for: .ethereum)],
+                supportedChainIds: nil,
+                supportedActions: nil
+            )
+        ]
+        XCTAssertFalse(
+            SwapKitProviderCache.pairEnabled(
+                fromChain: .bitcoinCash,
+                toChain: .ethereum,
+                in: split
+            )
+        )
+    }
+
+    /// Filtered providers (THORChain / MayaChain) must not contribute to the
+    /// pair decision. Otherwise the disambiguation would mistakenly classify
+    /// pairs only routable through filtered providers as "supported", and
+    /// surface "amount too small" tooltips for pairs that have no SwapKit
+    /// route at any amount.
+    func testIsPairSupported_filteredProviderDoesNotCount() {
+        let synthetic = [
+            SwapKitProvider(
+                name: "MAYACHAIN",
+                provider: "MAYACHAIN",
+                displayName: nil,
+                displayNameLong: nil,
+                count: 1,
+                enabledChainIds: [
+                    SwapKitChainIDMapper.swapKitChainId(for: .bitcoinCash),
+                    SwapKitChainIDMapper.swapKitChainId(for: .ethereum)
+                ],
+                supportedChainIds: nil,
+                supportedActions: nil
+            )
+        ]
+        XCTAssertFalse(
+            SwapKitProviderCache.pairEnabled(
+                fromChain: .bitcoinCash,
+                toChain: .ethereum,
+                in: synthetic
+            )
+        )
+    }
+
+    /// A chain Vultisig has no SwapKit chain-id mapping for must short-circuit
+    /// to `false` — there's no way to verify support, so we don't claim it.
+    func testIsPairSupported_unmappedChainReturnsFalse() {
+        XCTAssertFalse(
+            SwapKitProviderCache.pairEnabled(
+                fromChain: .mantle,
+                toChain: .ethereum,
+                in: providers
+            )
+        )
+    }
+
+    /// Empty snapshot from the async path: the actor's `isPairSupported`
+    /// returns `true` as a fail-open default so error reclassification still
+    /// fires. The static predicate, used here as a stand-in for "the cache
+    /// had no providers to look at", reports `false` for any pair — fail-open
+    /// behaviour belongs to the async wrapper, not the pure predicate.
+    func testIsPairSupported_emptySnapshotStaticReturnsFalse() {
+        XCTAssertFalse(
+            SwapKitProviderCache.pairEnabled(
+                fromChain: .bitcoinCash,
+                toChain: .ethereum,
+                in: []
+            )
+        )
+    }
+
+    /// Async fail-open: when the cache has nothing in its snapshot AND the
+    /// HTTPClient refuses to fetch, the actor reports the pair as "could be
+    /// supported" so the reclassification path still triggers. The trade-off
+    /// is documented in the wiki plan: degrading to "amount too small" is
+    /// strictly better UX than today's "unexpected error" fallback.
+    func testIsPairSupported_emptySnapshotAsyncFailsOpen() async {
+        let cache = SwapKitProviderCache(httpClient: FailingHTTPClient())
+        let supported = await cache.isPairSupported(
+            fromChain: .bitcoinCash,
+            toChain: .ethereum
+        )
+        XCTAssertTrue(supported)
+    }
+}
+
+// MARK: - Test doubles
+
+/// Minimal `HTTPClientProtocol` that always throws — used to prove the cache's
+/// fail-open behaviour when there is neither a fresh snapshot nor a fetchable
+/// providers list.
+private final class FailingHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+    private enum TestError: Error { case unavailable }
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        _ = target
+        await Task.yield()
+        throw TestError.unavailable
+    }
+
+    func request<T: Decodable>(_ target: TargetType, responseType: T.Type) async throws -> HTTPResponse<T> {
+        _ = target
+        _ = responseType
+        await Task.yield()
+        throw TestError.unavailable
+    }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceTests.swift
@@ -104,7 +104,125 @@ final class SwapKitServiceTests: XCTestCase {
         XCTAssertEqual(best.providers, ["NEAR"])
     }
 
+    // MARK: - noRoutesFound disambiguation
+
+    /// SwapKit's `/v3/quote` 404 envelope is byte-identical for "amount below
+    /// the provider's minimum" and "pair not supported". When the cached
+    /// providers snapshot reports the pair as structurally supported, the
+    /// service must re-classify so the view layer can surface "Amount Too
+    /// Small" instead of the misleading "No routes available for this pair".
+    func testFetchBestRoute_noRoutesFoundOnSupportedPair_reclassifiesToAmountBelowMinimum() async throws {
+        let body = #"{"error":"noRoutesFound","message":"No routes found for BCH.BCH -> ETH.ETH","data":{"sellAsset":"BCH.BCH","buyAsset":"ETH.ETH"}}"#
+        let data = try XCTUnwrap(body.data(using: .utf8))
+        let client = NoRoutesHTTPClient(payload: data)
+        let cache = await Self.makeCacheWithSupportedPair(fromChain: .bitcoinCash, toChain: .ethereum)
+        let service = SwapKitService(httpClient: client, providerCache: cache)
+
+        do {
+            _ = try await service.fetchBestRoute(
+                fromCoin: Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8),
+                toCoin: Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18),
+                amount: Decimal(string: "0.0115") ?? .zero,
+                affiliateFeeBps: 50
+            )
+            XCTFail("Expected SwapKitError.amountBelowProviderMinimum")
+        } catch let error as SwapKitError {
+            XCTAssertEqual(error, .amountBelowProviderMinimum)
+        }
+    }
+
+    /// Pair the cache reports as unsupported must keep the literal
+    /// `noRoutesFound` — the heuristic must not degrade the genuinely
+    /// unsupported-pair message.
+    func testFetchBestRoute_noRoutesFoundOnUnsupportedPair_keepsNoRoutesFound() async throws {
+        let body = #"{"error":"noRoutesFound","message":"No routes found","data":{}}"#
+        let data = try XCTUnwrap(body.data(using: .utf8))
+        let client = NoRoutesHTTPClient(payload: data)
+        // Snapshot contains a non-filtered provider that enables ONLY
+        // bitcoincash — never ethereum — so the pair predicate returns false.
+        let cache = SwapKitProviderCache()
+        await cache.setSnapshot(SwapKitProvidersSnapshot(
+            providers: [
+                SwapKitProvider(
+                    name: "NARROW",
+                    provider: "NARROW",
+                    displayName: nil,
+                    displayNameLong: nil,
+                    count: 1,
+                    enabledChainIds: [SwapKitChainIDMapper.swapKitChainId(for: .bitcoinCash)],
+                    supportedChainIds: nil,
+                    supportedActions: nil
+                )
+            ],
+            fetchedAt: Date()
+        ))
+        let service = SwapKitService(httpClient: client, providerCache: cache)
+
+        do {
+            _ = try await service.fetchBestRoute(
+                fromCoin: Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8),
+                toCoin: Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18),
+                amount: Decimal(string: "0.5") ?? .zero,
+                affiliateFeeBps: 50
+            )
+            XCTFail("Expected SwapKitError.noRoutesFound")
+        } catch let error as SwapKitError {
+            XCTAssertEqual(error, .noRoutesFound)
+        }
+    }
+
+    /// Non-`noRoutesFound` SwapKit errors are surfaced verbatim — the
+    /// disambiguation must not accidentally swallow other documented codes.
+    func testFetchBestRoute_otherErrorsPassThroughUnchanged() async throws {
+        let body = #"{"error":"apiKeyInvalid","message":"API key invalid"}"#
+        let data = try XCTUnwrap(body.data(using: .utf8))
+        let client = NoRoutesHTTPClient(payload: data)
+        let cache = await Self.makeCacheWithSupportedPair(fromChain: .bitcoinCash, toChain: .ethereum)
+        let service = SwapKitService(httpClient: client, providerCache: cache)
+
+        do {
+            _ = try await service.fetchBestRoute(
+                fromCoin: Self.makeNativeCoin(.bitcoinCash, ticker: "BCH", decimals: 8),
+                toCoin: Self.makeNativeCoin(.ethereum, ticker: "ETH", decimals: 18),
+                amount: Decimal(string: "0.5") ?? .zero,
+                affiliateFeeBps: 50
+            )
+            XCTFail("Expected SwapKitError.apiKeyInvalid")
+        } catch let error as SwapKitError {
+            XCTAssertEqual(error, .apiKeyInvalid)
+        }
+    }
+
     // MARK: - Fixtures
+
+    private static func makeNativeCoin(_ chain: Chain, ticker: String, decimals: Int) -> Coin {
+        let meta = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: true)
+        return Coin(asset: meta, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+
+    private static func makeCacheWithSupportedPair(fromChain: Chain, toChain: Chain) async -> SwapKitProviderCache {
+        let cache = SwapKitProviderCache()
+        let snapshot = SwapKitProvidersSnapshot(
+            providers: [
+                SwapKitProvider(
+                    name: "NEAR",
+                    provider: "NEAR",
+                    displayName: nil,
+                    displayNameLong: nil,
+                    count: 1,
+                    enabledChainIds: [
+                        SwapKitChainIDMapper.swapKitChainId(for: fromChain),
+                        SwapKitChainIDMapper.swapKitChainId(for: toChain)
+                    ],
+                    supportedChainIds: nil,
+                    supportedActions: nil
+                )
+            ],
+            fetchedAt: Date()
+        )
+        await cache.setSnapshot(snapshot)
+        return cache
+    }
 
     private func makeRoute(
         routeId: String,
@@ -133,5 +251,31 @@ final class SwapKitServiceTests: XCTestCase {
             ),
             expiration: nil
         )
+    }
+}
+
+// MARK: - Test doubles
+
+/// HTTPClient stub that always throws `HTTPError.statusCode(404, payload)` —
+/// simulates SwapKit's `/v3/quote` returning an error envelope. Mirrors the
+/// shape `SwapKitService.fetchBestRoute` catches.
+private final class NoRoutesHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+    private let payload: Data
+
+    init(payload: Data) {
+        self.payload = payload
+    }
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        _ = target
+        await Task.yield()
+        throw HTTPError.statusCode(404, payload)
+    }
+
+    func request<T: Decodable>(_ target: TargetType, responseType: T.Type) async throws -> HTTPResponse<T> {
+        _ = target
+        _ = responseType
+        await Task.yield()
+        throw HTTPError.statusCode(404, payload)
     }
 }


### PR DESCRIPTION
## Summary

iOS issue #4408: when a SwapKit-routed swap is below the route's minimum amount, users see a "No routes available for this pair" tooltip wrapped in an "Unexpected Error" title. The pair clearly has routes — the amount is just too low. SwapKit's `/v3/quote` 404 collapses "amount below provider minimum" and "pair not supported by any provider" into one byte-identical envelope, so iOS has been unable to disambiguate.

This PR closes that gap by cross-checking the `/v3/providers` snapshot we already cache: if a non-filtered provider lists both source and destination chains in its `enabledChainIds`, the pair IS structurally supported and the failure must be amount-related. We re-classify the error and let the existing "Amount Too Small" copy (already used by the THORChain path) render.

Full empirical reasoning, the live SwapKit API probe, and the alternatives considered are in the wiki plan: `wiki/pages/projects/vultisig/swapkit-integration/no-routes-disambiguation-plan.md`. The plan was reviewed and the false-positive risk explicitly accepted ("ok if we have some false positives, this is only to improve the UX in most of the cases").

## What's in this PR

- **`SwapKitProviderCache.pairEnabled` / `isPairSupported`** — pure-logic per-pair predicate over the cached providers snapshot. No new wire calls.
- **`SwapKitError.amountBelowProviderMinimum`** — new synthetic case raised only by `SwapKitService.fetchBestRoute` after the cache cross-check. Never decoded from the envelope. Reuses the existing `swapErrorAmountTooSmallDescription` localized string — no new translation cycle.
- **`SwapKitService.fetchBestRoute` interception** — when `/v3/quote` returns `noRoutesFound`, ask the cache whether the pair is supported. If yes, throw `amountBelowProviderMinimum`. If no, throw `noRoutesFound` verbatim. Other documented error codes flow through unchanged.
- **`SwapErrorTooltipView` normalization** — map `SwapKitError.amountBelowProviderMinimum` to `SwapCryptoLogic.Errors.swapAmountTooSmall` so the tooltip title flips from "Unexpected Error" to "Amount Too Small" and the description from "No routes available for this pair" to "The swap amount is too small. Please increase the amount."
- **11 new tests** covering the pair predicate (intersection / split / filtered-providers / unmapped chains / empty-snapshot fail-open) and the service-level reclassification (supported pair → amountBelowProviderMinimum, unsupported pair → noRoutesFound verbatim, other codes → pass-through).

## Why this design

- The disambiguation runs only on the unhappy path — the providers cache is already loaded before `/v3/quote` can return `noRoutesFound`, so the heuristic is zero-cost in the steady state.
- Intersection on a SINGLE non-filtered provider entry, not a union across providers. A provider that enables both chains is far more likely to actually route between them than two providers each handling one side. This narrows the false-positive surface to the rare "every chain individually supported but no single provider connects them" case.
- The new case lands at the SwapKitError layer (not directly at `SwapCryptoLogic.Errors`) so the SwapKit layer stays unaware of the swap feature's error vocabulary. The view layer is where errors are normalized for display today, mirroring the existing pattern.
- Reuses `swapErrorAmountTooSmallTitle` / `swapErrorAmountTooSmallDescription` — same copy THORChain already produces — so no translation work is required.

## False positive scope

If every provider enables both `fromChain` and `toChain` individually but NO single provider has both in its `enabledChainIds`, this fix would falsely classify a genuinely-unsupported pair as "amount too small." For NEAR-Intents' 24-chain coverage today (every Vultisig-supported UTXO + every EVM L2 + Solana + TON + Cardano + Sui + Ripple + Tron + ZCash), this is essentially impossible to hit. The risk has been explicitly accepted by the user.

If the cache is empty and the provider list can't be fetched, the predicate fails open and the reclassification fires — degrading to "Amount Too Small" rather than today's "Unexpected Error" tooltip is still strictly better UX.

## Test plan

- [x] `swiftlint` clean on every changed file
- [x] `xcodebuild build -scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'` — **BUILD SUCCEEDED**
- [x] New tests pass: `xcodebuild test -only-testing:VultisigAppTests/SwapKitServiceTests -only-testing:VultisigAppTests/SwapKitProviderCacheTests -only-testing:VultisigAppTests/SwapKitErrorTests`
- [x] Full unit suite: 1108 tests pass, 0 failures (baseline 1097 + 11 new)
- [ ] Manual: in a debug build, attempt BCH→ETH at 0.0115 BCH — confirm tooltip title reads "Amount Too Small" with the THORChain-style description, not "Unexpected Error" / "No routes available"
- [ ] Manual: attempt a genuinely unsupported pair (e.g. GAIA.ATOM → DASH.DASH) — confirm the tooltip still reads "No routes available for this pair"

Closes #4408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging when swap amounts fall below provider minimums
  * Enhanced detection to distinguish between unsupported chain pairs and insufficient amounts
  * Clearer error messages for swap amount constraints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->