### PR TITLE
fix(kyberswap): remove iOS-only fee overlays (#4404)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapQuote.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapQuote.swift
@@ -39,6 +39,18 @@ struct KyberSwapQuote: Codable, Hashable {
         return Int64(data.gas) ?? Int64(EVMHelper.defaultETHSwapGasUnit)
     }
 
+    /// Fallback gas price (1 gwei) applied only when the aggregator's
+    /// `routeSummary.gasPrice` is missing or unparseable.
+    static let fallbackGasPriceWei = BigInt("1000000000") ?? BigInt(0)
+
+    /// Parses a KyberSwap-returned `gasPrice` string into wei. The fallback
+    /// applies only when the input is unparseable; valid sub-gwei responses
+    /// flow through unchanged.
+    static func parseGasPriceWei(_ raw: String?) -> BigInt {
+        guard let raw, let parsed = BigInt(raw) else { return fallbackGasPriceWei }
+        return parsed
+    }
+
     var tx: Transaction {
 
         return Transaction(

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapQuote.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapQuote.swift
@@ -31,18 +31,12 @@ struct KyberSwapQuote: Codable, Hashable {
         return data.amountOut
     }
 
-    func gasForChain(_ chain: Chain) -> Int64 {
-        let baseGas = Int64(data.gas) ?? 600000
-        let gasMultiplierTimes10: Int64
-
-        switch chain {
-        case .ethereum, .arbitrum, .optimism, .base, .polygon, .avalanche, .bscChain:
-            gasMultiplierTimes10 = 20
-        default:
-            gasMultiplierTimes10 = 16
-        }
-
-        return (baseGas * gasMultiplierTimes10) / 10
+    /// Returns the gas-limit estimate from KyberSwap's `routeSummary.gas`.
+    /// KyberSwap pre-buffers this value to absorb pool-state shifts; no
+    /// additional client-side multiplier is applied. Matches the SDK /
+    /// Windows extension and Android KyberSwap mappings.
+    var gas: Int64 {
+        return Int64(data.gas) ?? Int64(EVMHelper.defaultETHSwapGasUnit)
     }
 
     var tx: Transaction {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapService.swift
@@ -162,9 +162,10 @@ struct KyberSwapService {
             finalGas = BigInt(kyberGas)
         }
         buildResponse.data.gas = finalGas.description
-        let gasPriceValue = BigInt(gasPrice) ?? BigInt("20000000000")
-        let minGasPrice = BigInt("1000000000")
-        let finalGasPrice = gasPriceValue < minGasPrice ? minGasPrice : gasPriceValue
+        // KyberSwap's routeSummary.gasPrice is the network's effective gas
+        // price as the aggregator sees it; use it verbatim. The fallback
+        // (1 gwei) only fires when the API returns an unparseable value.
+        let finalGasPrice = KyberSwapQuote.parseGasPriceWei(gasPrice)
 
         let fee = finalGas * finalGasPrice
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapService.swift
@@ -154,16 +154,12 @@ struct KyberSwapService {
         // Update gasPrice from route response
         buildResponse.data.gasPrice = gasPrice
 
-        guard let chainEnum = Chain.allCases.first(where: { (try? getChainName(for: $0)) == chain }) else {
-            throw KyberSwapError.apiError(code: -1, message: "Unknown chain: \(chain)", details: nil)
-        }
-        let calculatedGas = buildResponse.gasForChain(chainEnum)
-
+        let kyberGas = buildResponse.gas
         let finalGas: BigInt
-        if calculatedGas == 0 {
+        if kyberGas == 0 {
             finalGas = BigInt(EVMHelper.defaultETHSwapGasUnit)
         } else {
-            finalGas = BigInt(calculatedGas)
+            finalGas = BigInt(kyberGas)
         }
         buildResponse.data.gas = finalGas.description
         let gasPriceValue = BigInt(gasPrice) ?? BigInt("20000000000")

--- a/VultisigApp/VultisigAppTests/Swap/KyberSwapQuoteTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/KyberSwapQuoteTests.swift
@@ -1,0 +1,110 @@
+//
+//  KyberSwapQuoteTests.swift
+//  VultisigAppTests
+//
+//  Pins the fee-overlay-free behavior on iOS: `routeSummary.gas` flows
+//  through verbatim and `routeSummary.gasPrice` is used un-floored. Two
+//  iOS-only overlays (a 2.0x gas multiplier and a 1 gwei gas-price floor)
+//  used to compound to ~13x over the extension's displayed fee for the
+//  same KyberSwap route. Both have been removed; these tests guard
+//  against regression.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+final class KyberSwapQuoteTests: XCTestCase {
+
+    // MARK: - gas (formerly gasForChain)
+
+    func testGasReturnsApiValueUnmultiplied() {
+        // Real KyberSwap response on Ethereum at 2026-05-26: routeSummary.gas = 1_892_998.
+        // Before the fix iOS multiplied by 2.0 on Ethereum and returned 3_785_996.
+        let quote = makeQuote(gas: "1892998")
+        XCTAssertEqual(quote.gas, 1_892_998)
+    }
+
+    func testGasOnLowMultiplierChainStillReturnsApiValue() {
+        // Before the fix non-mainnet EVM chains used a 1.6x multiplier
+        // (e.g. zkSync, Linea). Now every chain uses the API value as-is.
+        let quote = makeQuote(gas: "500000")
+        XCTAssertEqual(quote.gas, 500_000)
+    }
+
+    func testGasFallsBackToDefaultWhenUnparseable() {
+        // Defensive: a malformed `gas` field falls back to the EVM swap default,
+        // never to a hardcoded 600_000 or any chain-specific value.
+        let quote = makeQuote(gas: "not-a-number")
+        XCTAssertEqual(quote.gas, Int64(EVMHelper.defaultETHSwapGasUnit))
+    }
+
+    // MARK: - parseGasPriceWei
+
+    func testParseGasPriceWeiPassesSubGweiValueThrough() {
+        // KyberSwap returned 0.1286 gwei (= 128_575_467 wei) at the time of
+        // the bug report. Before the fix iOS floored this to 1 gwei
+        // (1_000_000_000 wei), a 7.78x inflation. The fix removes the floor.
+        let result = KyberSwapQuote.parseGasPriceWei("128575467")
+        XCTAssertEqual(result, BigInt("128575467"))
+    }
+
+    func testParseGasPriceWeiFallsBackToOneGweiWhenNil() {
+        // The defensive fallback (1 gwei) still fires when the aggregator
+        // returns no value at all.
+        let result = KyberSwapQuote.parseGasPriceWei(nil)
+        XCTAssertEqual(result, BigInt("1000000000"))
+    }
+
+    func testParseGasPriceWeiFallsBackToOneGweiWhenUnparseable() {
+        // Same fallback when the value is non-numeric.
+        let result = KyberSwapQuote.parseGasPriceWei("nonsense")
+        XCTAssertEqual(result, BigInt("1000000000"))
+    }
+
+    func testParseGasPriceWeiHonoursMultiGweiResponse() {
+        // Sanity: high-congestion responses pass through unchanged.
+        let result = KyberSwapQuote.parseGasPriceWei("25000000000") // 25 gwei
+        XCTAssertEqual(result, BigInt("25000000000"))
+    }
+
+    // MARK: - Compound fee shape pinning
+
+    func testFeeShapeMatchesApiValuesAtCurrentNetworkState() {
+        // Recreates the bug-report swap (USDT -> USDC on Ethereum) at the
+        // network state observed during the wiki investigation. Asserts the
+        // recovered `gas * gasPrice` equals the API's own quote, NOT the
+        // pre-fix iOS overlay output.
+        let gas = makeQuote(gas: "1892998").gas
+        let gasPriceWei = KyberSwapQuote.parseGasPriceWei("128575467")
+        let fee = BigInt(gas) * gasPriceWei
+
+        // 1_892_998 * 128_575_467 = 243_393_101_880_066 wei (~0.000243 ETH).
+        // The pre-fix iOS path produced 3_785_996 * 1_000_000_000 =
+        // 3_785_996_000_000_000 wei (~0.003786 ETH), ~15.6x over.
+        XCTAssertEqual(fee, BigInt("243393101880066"))
+        XCTAssertLessThan(fee, BigInt("500000000000000")) // < 0.0005 ETH
+    }
+
+    // MARK: - Fixture
+
+    private func makeQuote(gas: String, gasPrice: String? = "128575467") -> KyberSwapQuote {
+        return KyberSwapQuote(
+            code: 0,
+            message: "",
+            data: KyberSwapQuote.Data(
+                amountIn: "14272184",
+                amountInUsd: "14.256",
+                amountOut: "14689000",
+                amountOutUsd: "14.684",
+                gas: gas,
+                gasUsd: "0.413",
+                data: "0x",
+                routerAddress: "0x0000000000000000000000000000000000000000",
+                transactionValue: "0",
+                gasPrice: gasPrice
+            ),
+            requestId: "test-fixture"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4404 — KyberSwap network fee on iOS displays at ~13x the value the Windows / extension shows for the same route. Same provider, same KyberSwap quote — pure iOS math discrepancy.

Two iOS-only overlays in the KyberSwap initiator-display path compound to the bug:

1. **A hardcoded 2.0x gas multiplier** in `KyberSwapQuote.gasForChain(_:)`. KyberSwap's `routeSummary.gas` is already pre-buffered (~2-3x actual on-chain consumption); doubling it gives iOS ~5x the gas the swap really needs.
2. **A 1 gwei minimum gas-price floor** in `KyberSwapService.buildTransaction()`. At today's Ethereum base fee (~0.13 gwei), the floor inflates the gas price ~7.8x over the network truth.

Combined: 2.0 x 7.8 = ~15.6x over KyberSwap's own `routeSummary.gasUsd: 0.41` truth. Matches the observed 13x within timing drift.

Neither overlay exists in the SDK / Windows extension or in Android's KyberSwap mapping. The wiki investigation linked below walked through every alternative; deleting both iOS overlays is the simplest fix that lands iOS on the same numbers as the other two platforms.

References:
- Investigation: `wiki/pages/projects/vultisig/swap-fee-display-parity/cross-platform-evm-divergence.md`
- Related but separate: #74 (initiator-vs-cosigner display asymmetry on the SAME device pair, out of scope here)

## What's in this PR

- Replace `KyberSwapQuote.gasForChain(_:)` with a `gas` computed property that returns `routeSummary.gas` verbatim. Fallback when unparseable is `EVMHelper.defaultETHSwapGasUnit` (matching the OneInch / LiFi paths) instead of a magic-number 600_000.
- Replace the `max(gasPrice, 1 gwei)` floor in `KyberSwapService.buildTransaction()` with `KyberSwapQuote.parseGasPriceWei(_:)`, which only applies the 1 gwei fallback when the API value is missing or unparseable — never when KyberSwap returns a valid sub-gwei reading.
- Drop the dead chain-enum lookup at the gas-limit call site (it only existed to feed the now-removed per-chain dispatch).
- Add 8 unit tests in `VultisigAppTests/Swap/KyberSwapQuoteTests.swift` pinning the new behavior, including a compound-fee shape test that recovers the API-derived ~0.000243 ETH expected fee for the USDT->USDC fixture used in the wiki investigation.

## Verification

**KyberSwap API ground truth** (USDT 14.27 -> USDC on Ethereum, 2026-05-26):
- `routeSummary.gas = 1_892_998`
- `routeSummary.gasPrice = 128_575_467` (0.1286 gwei)
- `routeSummary.gasUsd = 0.413` (KyberSwap's own truth)

**Before this PR (iOS displayed)**:
- `finalGas = 1_892_998 * 2.0 = 3_785_996`
- `finalGasPrice = max(128_575_467, 1_000_000_000) = 1_000_000_000` (1 gwei, floor fires)
- `fee = 3_785_996_000_000_000 wei` (~0.003786 ETH, ~$8.37 -> **~20x over the API truth**)

**After this PR (iOS displayed)**:
- `finalGas = 1_892_998` (API value verbatim)
- `finalGasPrice = 128_575_467` (sub-gwei value flows through)
- `fee = 243_393_101_880_066 wei` (~0.000243 ETH, ~$0.51 -> **within 1.3x of the API's $0.41 truth**)

Pinned in `KyberSwapQuoteTests.testFeeShapeMatchesApiValuesAtCurrentNetworkState`.

## Risks

- **Network congestion**: KyberSwap's `routeSummary.gas` already includes a simulation buffer that absorbs pool-state shifts. The SDK / Windows extension and Android both rely on it alone for KyberSwap routes and don't appear to have hit congestion-related failures. If iOS sees out-of-gas reverts in production, the right next step is bumping the simulation buffer in `EthereumFeeService.inflatedGasLimit (* 1.5)` for the cosigner path — not re-adding a blanket 2x at quote time.
- **Sub-gwei gas-price safety**: the 1 gwei floor was guarding against zero / missing RPC gas-price responses. The `parseGasPriceWei` helper preserves that fallback for `nil` / unparseable inputs; it just stops clamping valid sub-gwei readings. Verified via `testParseGasPriceWeiFallsBackToOneGweiWhenNil` and `testParseGasPriceWeiFallsBackToOneGweiWhenUnparseable`.
- **Cosigner-side display drift**: iOS's cosigner already shows a slightly different KyberSwap fee than the initiator because they compute via different paths (`EthereumFeeService.calculateFees` vs `KyberSwapService.buildTransaction`). After this fix the cosigner will continue to show ~0.001 ETH while the initiator shows ~0.000243 ETH — a ~3x asymmetry on the same device pair. That's the structural issue tracked in #74 and is explicitly out of scope here; this PR only closes the cross-platform divergence.

## What's NOT in this PR

These were identified during the wiki investigation but are explicitly scoped out:
- **Android `DEFAULT_SWAP_LIMIT = 600_000` cleanup** — Android over-estimates by ~3x on KyberSwap-style routes, but lands at 6.7x truth (vs iOS's 20x). Different platform, different bug.
- **Extension RPC-estimate guard** — the SDK's `bigIntMax(estimatedGasLimit, thirdPartyGasLimitEstimation, minimumGasLimit)` picks the largest of three, which means KyberSwap's already-buffered estimate always wins. Tightening would touch the simulation-vs-buffer trade-off and needs its own design review.
- **iOS initiator-vs-cosigner asymmetry (#74)** — same provider, same device, two different fee paths. Worked on separately.
- **`EthereumFeeService` 1 gwei priority-fee floor** — same pathology as the KyberSwap floor but on a different code path (Send + Swap-cosigner + FunctionCall). Affects every iOS EVM tx; worth a follow-up but not on the critical path for #4404.

## Test plan

- [x] Lint clean on changed files
- [x] `xcodebuild build -scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'` -> `BUILD SUCCEEDED`
- [x] `xcodebuild test -only-testing:VultisigAppTests/KyberSwapQuoteTests` -> 8/8 pass
- [x] Full `VultisigAppTests` suite -> 1105 tests, 0 failures
- [ ] Manual: open the iOS Swap screen, USDT -> USDC on Ethereum via KyberSwap, confirm the network-fee row shows a sub-cent value (was ~$8 before)
- [ ] Manual: same swap on Arbitrum (also had 2.0x), confirm fee row matches L2 expectations
- [ ] Manual: KyberSwap-supported swap on a non-mainnet chain (e.g. Linea / zkSync, previously 1.6x), confirm fee row is reasonable
- [ ] Manual: confirm an actual KyberSwap signing flow still succeeds end-to-end on testnet (sub-gwei gas price no longer over-budgeted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced KyberSwap swap fee calculation accuracy by refining how gas limits are estimated—now using API-provided values directly instead of chain-specific multipliers.
  * Improved gas price parsing with more robust fallback handling to ensure consistent fee calculations across all supported blockchain networks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->