### PR TITLE
refactor(actions): unify swap-chain gating on Chain.isSwapAvailable (#4423)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/Actions/Coin+ChainAction.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Actions/Coin+ChainAction.swift
@@ -9,13 +9,6 @@ import Foundation
 
 extension CoinAction {
 
-    static var swapChains: [Chain] = [
-        .solana, .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash,
-        .thorChain, .thorChainChainnet, .thorChainStagenet, .mayaChain, .ethereum, .avalanche, .base, .arbitrum, .blast, .mantle, .hyperliquid,
-        .polygon, .polygonV2, .optimism, .bscChain, .gaiaChain, .kujira, .zksync, .zcash, .ripple,
-        .cronosChain, .tron
-    ]
-
     static var memoChains: [Chain] = [
         .thorChain, .thorChainChainnet, .thorChainStagenet, .mayaChain, .ton, .dydx, .kujira, .gaiaChain, .osmosis,
         // THORChain LP supported chains
@@ -35,7 +28,7 @@ extension Chain {
 
         var actions: [CoinAction] = []
 
-        if CoinAction.swapChains.contains(self) {
+        if self.isSwapAvailable {
             actions.append(.swap)
         }
         actions.append(.send) // always include send

--- a/VultisigApp/VultisigApp/Model/Chain.swift
+++ b/VultisigApp/VultisigApp/Model/Chain.swift
@@ -530,10 +530,10 @@ enum Chain: String, Codable, Hashable, CaseIterable {
                 .tron,
                 .cardano,
                 .sui,
-                .ton:
+                .ton,
+                .polygonV2:
             return true
-        case .polygonV2,
-            .polkadot,
+        case .polkadot,
             .dydx,
             .osmosis,
             .terra,

--- a/VultisigApp/VultisigAppTests/Model/ChainDefaultActionsTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/ChainDefaultActionsTests.swift
@@ -5,10 +5,12 @@
 //  Pins the `.swap` action surfacing in `Chain.defaultActions`. After
 //  `Coin+ChainAction.swift` was refactored to derive swap presence from
 //  `Chain.isSwapAvailable` instead of the hand-maintained
-//  `CoinAction.swapChains` array, four chains changed user-visible
-//  behavior: polygonV2 lost `.swap`; cardano / sui / ton gained it. These
-//  explicit asserts guard against a silent regression of that flip, plus
-//  one already-consistent chain on each side as a sanity axis.
+//  `CoinAction.swapChains` array, three chains gained `.swap`:
+//  cardano / sui / ton (they were missing from the stale `swapChains`
+//  list). polygonV2 — also stale in the old list — was kept on by
+//  flipping `Chain.isSwapAvailable` to include it as the canonical truth.
+//  These explicit asserts guard against a silent regression of that flip,
+//  plus one already-consistent chain on each side as a sanity axis.
 //
 //  `defaultActions` runs through `Array<CoinAction>.filtered`, which strips
 //  `.swap` when `SwapFeatureGate.canSwap()` returns false (locale-gated:
@@ -34,10 +36,10 @@ final class ChainDefaultActionsTests: XCTestCase {
 
     // MARK: - Behavior changes pinned by the swapChains -> isSwapAvailable refactor
 
-    func testPolygonV2DoesNotShowSwap() {
-        XCTAssertFalse(
+    func testPolygonV2ShowsSwap() {
+        XCTAssertTrue(
             Chain.polygonV2.defaultActions.contains(.swap),
-            "polygonV2 was stale in the old swapChains list; isSwapAvailable=false is canonical."
+            "polygonV2 was stale in the old swapChains list; isSwapAvailable=true is canonical."
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Model/ChainDefaultActionsTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/ChainDefaultActionsTests.swift
@@ -1,0 +1,78 @@
+//
+//  ChainDefaultActionsTests.swift
+//  VultisigApp
+//
+//  Pins the `.swap` action surfacing in `Chain.defaultActions`. After
+//  `Coin+ChainAction.swift` was refactored to derive swap presence from
+//  `Chain.isSwapAvailable` instead of the hand-maintained
+//  `CoinAction.swapChains` array, four chains changed user-visible
+//  behavior: polygonV2 lost `.swap`; cardano / sui / ton gained it. These
+//  explicit asserts guard against a silent regression of that flip, plus
+//  one already-consistent chain on each side as a sanity axis.
+//
+//  `defaultActions` runs through `Array<CoinAction>.filtered`, which strips
+//  `.swap` when `SwapFeatureGate.canSwap()` returns false (locale-gated:
+//  GB / JP / MY). To keep the test deterministic across CI / dev machines
+//  we `XCTSkipUnless(SwapFeatureGate.canSwap())` — the truth-table coverage
+//  in `ChainSwapAvailabilityTests` still pins `isSwapAvailable` itself in
+//  every locale.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class ChainDefaultActionsTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipUnless(
+            SwapFeatureGate.canSwap(),
+            "SwapFeatureGate gates .swap out of defaultActions in restricted locales (GB / JP / MY); " +
+            "skipping the swap-presence assertions for this run."
+        )
+    }
+
+    // MARK: - Behavior changes pinned by the swapChains -> isSwapAvailable refactor
+
+    func testPolygonV2DoesNotShowSwap() {
+        XCTAssertFalse(
+            Chain.polygonV2.defaultActions.contains(.swap),
+            "polygonV2 was stale in the old swapChains list; isSwapAvailable=false is canonical."
+        )
+    }
+
+    func testCardanoShowsSwap() {
+        XCTAssertTrue(
+            Chain.cardano.defaultActions.contains(.swap),
+            "cardano was missing from the old swapChains list; isSwapAvailable=true is canonical."
+        )
+    }
+
+    func testSuiShowsSwap() {
+        XCTAssertTrue(
+            Chain.sui.defaultActions.contains(.swap),
+            "sui was missing from the old swapChains list; isSwapAvailable=true is canonical."
+        )
+    }
+
+    func testTonShowsSwap() {
+        XCTAssertTrue(
+            Chain.ton.defaultActions.contains(.swap),
+            "ton was missing from the old swapChains list; isSwapAvailable=true is canonical."
+        )
+    }
+
+    // MARK: - Stable chains (sanity axis)
+    //
+    // These were already consistent between the old swapChains list and
+    // isSwapAvailable. They guard against a refactor that accidentally
+    // collapses every chain into one branch.
+
+    func testBitcoinShowsSwap() {
+        XCTAssertTrue(Chain.bitcoin.defaultActions.contains(.swap))
+    }
+
+    func testPolkadotDoesNotShowSwap() {
+        XCTAssertFalse(Chain.polkadot.defaultActions.contains(.swap))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Model/ChainSwapAvailabilityTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/ChainSwapAvailabilityTests.swift
@@ -54,9 +54,9 @@ final class ChainSwapAvailabilityTests: XCTestCase {
         .cardano: true,
         .sui: true,
         .ton: true,
+        .polygonV2: true,
 
         // Swap-disabled
-        .polygonV2: false,
         .polkadot: false,
         .dydx: false,
         .osmosis: false,
@@ -167,8 +167,8 @@ final class ChainSwapAvailabilityTests: XCTestCase {
     // Guards against an accidental broad enable (e.g. a refactor that
     // collapses both groups into the `true` branch).
 
-    func testPolygonV2SwapDisabled() {
-        XCTAssertFalse(Chain.polygonV2.isSwapAvailable)
+    func testPolygonV2SwapEnabled() {
+        XCTAssertTrue(Chain.polygonV2.isSwapAvailable)
     }
 
     func testPolkadotSwapDisabled() {


### PR DESCRIPTION
## Summary

Closes #4423. Deletes the hand-maintained `CoinAction.swapChains` array (`Coin+ChainAction.swift:12-17`) and unifies on `Chain.isSwapAvailable` (`Model/Chain.swift:502-549`) as the single source of truth for whether the `.swap` action surfaces on a chain. `Chain.isSwapAvailable` is pinned by `ChainSwapAvailabilityTests`.

Along the way, also flips `polygonV2` in `Chain.isSwapAvailable` from `false` → `true` so the canonical truth table actually matches what iOS supports. The original `CoinAction.swapChains` had polygonV2 listed (correctly); `Chain.isSwapAvailable` had it as `false` (wrong). Both lists were stale in different directions — unifying picks the correct value per chain.

## Behavior changes (intentional)

After this PR, `Chain.defaultActions` for these chains shifts:

| Chain | Before | After | Reason |
|---|---|---|---|
| polygonV2 | shows `.swap` (via stale `swapChains` list) | **still shows `.swap`** (now via `isSwapAvailable`) | polygonV2 swaps ARE supported — `isSwapAvailable` was wrong, now corrected. |
| cardano | does NOT show `.swap` | **shows `.swap`** | Was missing from the stale `swapChains` list. SwapKit Phase 4 shipped cardano signing. |
| sui | does NOT show `.swap` | **shows `.swap`** | Was missing from the stale `swapChains` list. SwapKit Phase 4 shipped sui signing. |
| ton | does NOT show `.swap` | **shows `.swap`** | Was missing from the stale `swapChains` list. SwapKit Phase 1 shipped ton signing. |

Net change: 3 chains gain `.swap`, 0 lose it. `SwapFeatureGate.canSwap()` continues to globally gate the action (locale-restricted regions: GB / JP / MY).

## What's in this PR

- Delete `CoinAction.swapChains` static array.
- Replace the only call site in `Chain.defaultActions` with `self.isSwapAvailable`.
- Move `.polygonV2` from the `false` branch of `Chain.isSwapAvailable` to the `true` branch.
- Update `ChainSwapAvailabilityTests` truth-table row + dedicated `testPolygonV2SwapEnabled` (renamed from `…SwapDisabled`).
- New `ChainDefaultActionsTests` pinning the 4 behavior changes (polygonV2 / cardano / sui / ton) plus consistent-axis chains (bitcoin / polkadot).
- `XCTSkipUnless(SwapFeatureGate.canSwap())` in setUp — keeps the test deterministic across locale-restricted CI runs without relying on `UserDefaults`.

## Acceptance (per #4423)

- [x] `xcodebuild build` succeeds.
- [x] `xcodebuild test` for `ChainDefaultActionsTests` + `ChainSwapAvailabilityTests` pass.
- [x] `rg -n 'CoinAction\.swapChains|swapChains:' VultisigApp/` returns 0 production matches.
- [x] SwiftLint clean on changed files.

## Test plan

- [x] New tests in `ChainDefaultActionsTests` cover the 4 behavior changes
- [x] Existing `ChainSwapAvailabilityTests` truth table updated for polygonV2
- [x] Full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated swap availability logic so the Swap action now appears only on chains that report swap support; some chains' swap availability changed.

* **Tests**
  * Added tests covering swap availability and presence of the Swap action across chains, including gated/locale-restricted scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->