### PR TITLE
feat(cosmos): LUNA/LUNC staking PR1 — config, helper, service, bech32 preflight

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Models/Staking/CosmosStakingConfig.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Models/Staking/CosmosStakingConfig.swift
@@ -1,0 +1,120 @@
+//
+//  CosmosStakingConfig.swift
+//  VultisigApp
+//
+//  Per-chain configuration for Cosmos-SDK x/staking + x/distribution flows.
+//  The table is the sole gas / fee / valoper-prefix source for the delegate,
+//  undelegate, redelegate and withdraw-reward msg encoders — every consumer
+//  goes through `entry(for:)` so we never hand-roll gas budgets at call sites.
+//
+//  Values mirror the agent app's `COSMOS_CHAIN_CONFIG` table at
+//  `vultiagent-app/src/services/cosmosTx.ts` and the SDK's
+//  `BuildCosmosStakingOptions` consumer contract. Adding a chain here also
+//  promotes it into the staking-allowlist semantics (`isStakingSupported`).
+//
+
+import Foundation
+
+enum CosmosStakingConfig {
+    /// Per-chain staking parameters. `bondDenom` and `feeDenom` are identical
+    /// for both Terra chains today; the distinction is kept because Cosmos
+    /// chains exist where they differ (chains that pay fees in a non-bond
+    /// denom — e.g. dYdX where the bond denom is uadydx but fees pay in
+    /// USDC). Future chain additions will exercise that asymmetry.
+    struct Entry: Equatable {
+        let chainId: String
+        let bondDenom: String
+        let feeDenom: String
+        let valoperHrp: String
+        /// Gas units to budget for a single-msg tx on this chain.
+        /// Multi-msg batched txs scale linearly (see `cosmosTx.ts:858-867`).
+        let gasLimit: UInt64
+        /// Fee amount in `feeDenom` base units for a single-msg tx.
+        let feeAmount: UInt64
+        /// Cosmos-SDK unbonding period — 21 days canonical default; both
+        /// Terra chains keep it. Surfaced via "21-day unbonding lock" UX
+        /// microcopy on the active-delegation card.
+        let unbondingDays: Int
+    }
+
+    /// The allowlist + gas / fee / valoper-prefix table. Keying staking
+    /// support purely off `table.keys` means there's no second list to
+    /// maintain — `isStakingSupported(.thorChain)` returns false even
+    /// though THORChain is a Cosmos-SDK chain, because THOR uses its own
+    /// bond model rather than x/staking.
+    ///
+    /// LUNC gas (1.5M units / 100M uluna) is the empirically-verified
+    /// floor — agent-app txs `534BFEF22F…` (delegate) and `200345EA31…`
+    /// (withdraw-rewards) used 1.07M gas with 28% headroom; smaller
+    /// budgets OoG on `columbus-5`.
+    static let table: [Chain: Entry] = [
+        .terra: Entry(
+            chainId: "phoenix-1",
+            bondDenom: "uluna",
+            feeDenom: "uluna",
+            valoperHrp: "terravaloper",
+            gasLimit: 300_000,
+            feeAmount: 7_500,
+            unbondingDays: 21
+        ),
+        .terraClassic: Entry(
+            chainId: "columbus-5",
+            bondDenom: "uluna",
+            feeDenom: "uluna",
+            valoperHrp: "terravaloper",
+            gasLimit: 1_500_000,
+            feeAmount: 100_000_000,
+            unbondingDays: 21
+        )
+    ]
+
+    static func entry(for chain: Chain) throws -> Entry {
+        guard let entry = table[chain] else {
+            throw CosmosStakingConfigError.unsupportedChain(chain)
+        }
+        return entry
+    }
+
+    static func isStakingSupported(_ chain: Chain) -> Bool {
+        table[chain] != nil
+    }
+
+    static func chainId(for chain: Chain) throws -> String {
+        try entry(for: chain).chainId
+    }
+
+    static func bondDenom(for chain: Chain) throws -> String {
+        try entry(for: chain).bondDenom
+    }
+
+    static func feeDenom(for chain: Chain) throws -> String {
+        try entry(for: chain).feeDenom
+    }
+
+    static func valoperHrp(for chain: Chain) throws -> String {
+        try entry(for: chain).valoperHrp
+    }
+
+    static func gasLimit(for chain: Chain) throws -> UInt64 {
+        try entry(for: chain).gasLimit
+    }
+
+    static func feeAmount(for chain: Chain) throws -> UInt64 {
+        try entry(for: chain).feeAmount
+    }
+
+    static func unbondingDays(for chain: Chain) throws -> Int {
+        try entry(for: chain).unbondingDays
+    }
+}
+
+enum CosmosStakingConfigError: Error, LocalizedError, Equatable {
+    case unsupportedChain(Chain)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedChain(let chain):
+            return "Cosmos staking not supported for \(chain.name)"
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Models/Staking/CosmosStakingDTOs.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Models/Staking/CosmosStakingDTOs.swift
@@ -1,0 +1,369 @@
+//
+//  CosmosStakingDTOs.swift
+//  VultisigApp
+//
+//  Read-side DTOs for Cosmos-SDK x/staking + x/distribution LCD endpoints.
+//  Shape mirrors the SDK's `lcdQueries.ts` types in
+//  `vultisig-sdk/packages/core/chain/chains/cosmos/staking/lcdQueries.ts` —
+//  same field names (snake_case on the wire, mapped to camelCase here via
+//  `CodingKeys`), same optionality, same fallback behaviour for fresh
+//  delegators that don't yet have a rewards entry.
+//
+
+import Foundation
+
+// MARK: - Wire-level coin
+
+struct CosmosStakingCoin: Codable, Equatable {
+    let denom: String
+    let amount: String
+}
+
+// MARK: - Delegations
+
+struct CosmosDelegation: Equatable {
+    let validatorAddress: String
+    let balance: CosmosStakingCoin
+    /// `shares` is a `cosmos.Dec` (18-decimal fixed-point) string on the
+    /// wire. We expose it as the raw string — UI consumers convert via
+    /// `Decimal(string:)` when needed.
+    let shares: String
+}
+
+struct CosmosDelegationResponse: Decodable {
+    let delegationResponses: [DelegationResponseEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case delegationResponses = "delegation_responses"
+    }
+
+    struct DelegationResponseEntry: Decodable {
+        let delegation: DelegationInner
+        let balance: CosmosStakingCoin
+
+        struct DelegationInner: Decodable {
+            let delegatorAddress: String
+            let validatorAddress: String
+            let shares: String
+
+            enum CodingKeys: String, CodingKey {
+                case delegatorAddress = "delegator_address"
+                case validatorAddress = "validator_address"
+                case shares
+            }
+        }
+    }
+
+    func toDelegations() -> [CosmosDelegation] {
+        delegationResponses.map { entry in
+            CosmosDelegation(
+                validatorAddress: entry.delegation.validatorAddress,
+                balance: entry.balance,
+                shares: entry.delegation.shares
+            )
+        }
+    }
+}
+
+// MARK: - Unbonding delegations
+
+struct CosmosUnbondingDelegation: Equatable {
+    let validatorAddress: String
+    let entries: [CosmosUnbondingEntry]
+}
+
+struct CosmosUnbondingEntry: Equatable, Codable {
+    let creationHeight: Int64
+    let completionTime: Date
+    let initialBalance: Decimal
+    let balance: Decimal
+}
+
+struct CosmosUnbondingDelegationResponse: Decodable {
+    let unbondingResponses: [UnbondingDelegationEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case unbondingResponses = "unbonding_responses"
+    }
+
+    struct UnbondingDelegationEntry: Decodable {
+        let validatorAddress: String
+        let entries: [WireEntry]
+
+        enum CodingKeys: String, CodingKey {
+            case validatorAddress = "validator_address"
+            case entries
+        }
+
+        struct WireEntry: Decodable {
+            let creationHeight: String
+            let completionTime: String
+            let initialBalance: String
+            let balance: String
+
+            enum CodingKeys: String, CodingKey {
+                case creationHeight = "creation_height"
+                case completionTime = "completion_time"
+                case initialBalance = "initial_balance"
+                case balance
+            }
+        }
+    }
+
+    func toUnbondingDelegations() -> [CosmosUnbondingDelegation] {
+        unbondingResponses.map { wire in
+            CosmosUnbondingDelegation(
+                validatorAddress: wire.validatorAddress,
+                entries: wire.entries.compactMap(Self.makeEntry)
+            )
+        }
+    }
+
+    private static func makeEntry(_ wire: UnbondingDelegationEntry.WireEntry) -> CosmosUnbondingEntry? {
+        guard let creationHeight = Int64(wire.creationHeight),
+              let completion = CosmosStakingDateParser.parse(wire.completionTime),
+              let initialBalance = Decimal(string: wire.initialBalance),
+              let balance = Decimal(string: wire.balance) else {
+            return nil
+        }
+        return CosmosUnbondingEntry(
+            creationHeight: creationHeight,
+            completionTime: completion,
+            initialBalance: initialBalance,
+            balance: balance
+        )
+    }
+}
+
+// MARK: - Rewards
+
+struct CosmosDelegatorReward: Equatable {
+    let validatorAddress: String
+    /// Multi-asset rewards are technically possible (e.g. a chain that
+    /// rewards in multiple denoms). v1 aggregates by denom downstream and
+    /// surfaces only the bond denom total; the full array is preserved
+    /// here so v1.1 can expand the per-validator row without a DTO change.
+    let reward: [CosmosStakingCoin]
+}
+
+struct CosmosDelegatorRewards: Equatable {
+    let rewards: [CosmosDelegatorReward]
+    let total: [CosmosStakingCoin]
+}
+
+struct CosmosDelegatorRewardsResponse: Decodable {
+    /// Both `rewards` and `total` arrive as `null` on some LCD firmwares
+    /// when the delegator has never accrued any rewards. The SDK falls
+    /// back to `[]` at `lcdQueries.ts:198-202`; iOS does the same.
+    let rewards: [WireReward]?
+    let total: [WireCoin]?
+
+    struct WireReward: Decodable {
+        let validatorAddress: String
+        let reward: [WireCoin]?
+
+        enum CodingKeys: String, CodingKey {
+            case validatorAddress = "validator_address"
+            case reward
+        }
+    }
+
+    struct WireCoin: Decodable {
+        let denom: String
+        /// LCD returns reward amounts as `cosmos.Dec` strings — they
+        /// frequently include a fractional component because rewards
+        /// accrue per-block. We keep them as the raw string at the DTO
+        /// boundary and let the position-aggregation layer convert.
+        let amount: String
+    }
+
+    func toRewards() -> CosmosDelegatorRewards {
+        let rewards = (self.rewards ?? []).map { wire in
+            CosmosDelegatorReward(
+                validatorAddress: wire.validatorAddress,
+                reward: (wire.reward ?? []).map { CosmosStakingCoin(denom: $0.denom, amount: $0.amount) }
+            )
+        }
+        let total = (self.total ?? []).map { CosmosStakingCoin(denom: $0.denom, amount: $0.amount) }
+        return CosmosDelegatorRewards(rewards: rewards, total: total)
+    }
+}
+
+// MARK: - Validators
+
+struct CosmosValidator: Equatable {
+    let operatorAddress: String
+    let moniker: String
+    /// Commission rate as a fixed-point `cosmos.Dec` (1.0 = 100%). Display
+    /// layer multiplies by 100 to render "5%". Keep as `Decimal` to avoid
+    /// floating-point drift in sort comparisons.
+    let commission: Decimal
+    let jailed: Bool
+    let status: Status
+    /// Voting power proxied via `tokens` (uint string of bond-denom base
+    /// units). Sufficient for sort-by-power without pulling
+    /// staking-pool totals. Future "% of pool" UX needs the pool fetch.
+    let votingPower: Decimal
+
+    enum Status: String, Equatable, Codable {
+        case bonded
+        case unbonded
+        case unbonding
+        case unspecified
+    }
+}
+
+struct CosmosValidatorListResponse: Decodable {
+    let validators: [WireValidator]
+
+    struct WireValidator: Decodable {
+        let operatorAddress: String
+        let jailed: Bool?
+        let status: String
+        let tokens: String
+        let description: WireDescription
+        let commission: WireCommission
+
+        enum CodingKeys: String, CodingKey {
+            case operatorAddress = "operator_address"
+            case jailed
+            case status
+            case tokens
+            case description
+            case commission
+        }
+
+        struct WireDescription: Decodable {
+            let moniker: String
+        }
+
+        struct WireCommission: Decodable {
+            let commissionRates: WireRates
+
+            enum CodingKeys: String, CodingKey {
+                case commissionRates = "commission_rates"
+            }
+
+            struct WireRates: Decodable {
+                let rate: String
+            }
+        }
+    }
+
+    func toValidators() -> [CosmosValidator] {
+        validators.map { wire in
+            CosmosValidator(
+                operatorAddress: wire.operatorAddress,
+                moniker: wire.description.moniker,
+                commission: Decimal(string: wire.commission.commissionRates.rate) ?? 0,
+                jailed: wire.jailed ?? false,
+                status: mapStatus(wire.status),
+                votingPower: Decimal(string: wire.tokens) ?? 0
+            )
+        }
+    }
+
+    private func mapStatus(_ raw: String) -> CosmosValidator.Status {
+        switch raw {
+        case "BOND_STATUS_BONDED": return .bonded
+        case "BOND_STATUS_UNBONDED": return .unbonded
+        case "BOND_STATUS_UNBONDING": return .unbonding
+        default: return .unspecified
+        }
+    }
+}
+
+// MARK: - Redelegations (used by the cooldown gate)
+
+struct CosmosRedelegationEntry: Equatable {
+    let srcValidator: String
+    let dstValidator: String
+    let completionTime: Date
+}
+
+struct CosmosRedelegationResponse: Decodable {
+    let redelegationResponses: [Entry]
+
+    enum CodingKeys: String, CodingKey {
+        case redelegationResponses = "redelegation_responses"
+    }
+
+    struct Entry: Decodable {
+        let redelegation: Redelegation
+        let entries: [WireEntry]
+
+        struct Redelegation: Decodable {
+            let validatorSrcAddress: String
+            let validatorDstAddress: String
+
+            enum CodingKeys: String, CodingKey {
+                case validatorSrcAddress = "validator_src_address"
+                case validatorDstAddress = "validator_dst_address"
+            }
+        }
+
+        struct WireEntry: Decodable {
+            let redelegationEntry: RedelegationEntry
+
+            enum CodingKeys: String, CodingKey {
+                case redelegationEntry = "redelegation_entry"
+            }
+
+            struct RedelegationEntry: Decodable {
+                let completionTime: String
+
+                enum CodingKeys: String, CodingKey {
+                    case completionTime = "completion_time"
+                }
+            }
+        }
+    }
+
+    func toRedelegations() -> [CosmosRedelegationEntry] {
+        var out: [CosmosRedelegationEntry] = []
+        for entry in redelegationResponses {
+            for wire in entry.entries {
+                guard let date = CosmosStakingDateParser.parse(wire.redelegationEntry.completionTime) else {
+                    continue
+                }
+                out.append(
+                    CosmosRedelegationEntry(
+                        srcValidator: entry.redelegation.validatorSrcAddress,
+                        dstValidator: entry.redelegation.validatorDstAddress,
+                        completionTime: date
+                    )
+                )
+            }
+        }
+        return out
+    }
+}
+
+// MARK: - Shared date parser
+
+/// LCD wire dates arrive in two shapes — RFC3339 with fractional seconds
+/// (`2026-06-02T13:00:00.123456789Z`, from per-block payouts that don't
+/// align to whole seconds) and without (`2026-06-10T10:00:00Z`, from
+/// gov-proposal or genesis-anchored entries). One `ISO8601DateFormatter`
+/// only accepts one of those — we try the fractional form first because
+/// it's the more common shape, then fall back to the plain form.
+enum CosmosStakingDateParser {
+    private static let withFraction: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let withoutFraction: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static func parse(_ value: String) -> Date? {
+        if let date = withFraction.date(from: value) {
+            return date
+        }
+        return withoutFraction.date(from: value)
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingAPI.swift
@@ -1,0 +1,70 @@
+//
+//  CosmosStakingAPI.swift
+//  VultisigApp
+//
+//  Read-side TargetType for Cosmos-SDK x/staking + x/distribution LCD
+//  endpoints. The path layout mirrors the SDK consumer at
+//  `vultisig-sdk/packages/core/chain/chains/cosmos/staking/lcdQueries.ts`.
+//
+//  Base URL is supplied by the caller via `CosmosServiceConfig.baseURL`
+//  (already wired for Terra phoenix-1 and TerraClassic columbus-5). Keeping
+//  the chain off this struct lets the same TargetType serve both chains —
+//  only the host differs.
+//
+
+import Foundation
+
+struct CosmosStakingAPI: TargetType {
+    let baseURL: URL
+    let endpoint: Endpoint
+
+    enum Endpoint {
+        case delegations(address: String)
+        case unbondingDelegations(address: String)
+        case delegatorRewards(address: String)
+        /// Validator list. We hardcode `status=BOND_STATUS_BONDED` and
+        /// `pagination.limit=300` — the agent app uses the same caps. Terra
+        /// has roughly 130 active validators today; 300 keeps headroom
+        /// without paging. If a chain ever exceeds 300, the resolver layer
+        /// will need to page — surfaced via a follow-up.
+        case bondedValidators
+        case redelegations(address: String)
+    }
+
+    var path: String {
+        switch endpoint {
+        case .delegations(let address):
+            return "/cosmos/staking/v1beta1/delegations/\(address)"
+        case .unbondingDelegations(let address):
+            return "/cosmos/staking/v1beta1/delegators/\(address)/unbonding_delegations"
+        case .delegatorRewards(let address):
+            return "/cosmos/distribution/v1beta1/delegators/\(address)/rewards"
+        case .bondedValidators:
+            return "/cosmos/staking/v1beta1/validators"
+        case .redelegations(let address):
+            return "/cosmos/staking/v1beta1/delegators/\(address)/redelegations"
+        }
+    }
+
+    var method: HTTPMethod { .get }
+
+    var task: HTTPTask {
+        switch endpoint {
+        case .bondedValidators:
+            return .requestParameters(
+                [
+                    "status": "BOND_STATUS_BONDED",
+                    "pagination.limit": 300
+                ],
+                .urlEncoding
+            )
+        default:
+            return .requestPlain
+        }
+    }
+
+    /// LCD GETs occasionally take longer than the default 60s when the
+    /// validator list is freshly cold-cached. Bumping per-request is
+    /// cheaper than retrying — and the user can pull-to-refresh.
+    var timeoutInterval: TimeInterval { 30 }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingService.swift
@@ -1,0 +1,96 @@
+//
+//  CosmosStakingService.swift
+//  VultisigApp
+//
+//  Read-side service for Cosmos-SDK x/staking + x/distribution LCD
+//  endpoints. Goes through the shared `HTTPClient` per the networking
+//  rule — view-models call only the service.
+//
+//  Mirrors the SDK consumer at
+//  `vultisig-sdk/packages/core/chain/chains/cosmos/staking/lcdQueries.ts`.
+//
+
+import Foundation
+import OSLog
+
+protocol CosmosStakingServiceProtocol {
+    func fetchDelegations(chain: Chain, address: String) async throws -> [CosmosDelegation]
+    func fetchUnbondingDelegations(chain: Chain, address: String) async throws -> [CosmosUnbondingDelegation]
+    func fetchDelegatorRewards(chain: Chain, address: String) async throws -> CosmosDelegatorRewards
+    func fetchValidators(chain: Chain) async throws -> [CosmosValidator]
+    func fetchRedelegations(chain: Chain, address: String) async throws -> [CosmosRedelegationEntry]
+}
+
+struct CosmosStakingService: CosmosStakingServiceProtocol {
+
+    private let httpClient: HTTPClientProtocol
+    private let logger: Logger
+
+    init(
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "cosmos-staking-service")
+    ) {
+        self.httpClient = httpClient
+        self.logger = logger
+    }
+
+    func fetchDelegations(chain: Chain, address: String) async throws -> [CosmosDelegation] {
+        let baseURL = try Self.baseURL(for: chain)
+        let response = try await httpClient.request(
+            CosmosStakingAPI(baseURL: baseURL, endpoint: .delegations(address: address)),
+            responseType: CosmosDelegationResponse.self
+        )
+        return response.data.toDelegations()
+    }
+
+    func fetchUnbondingDelegations(chain: Chain, address: String) async throws -> [CosmosUnbondingDelegation] {
+        let baseURL = try Self.baseURL(for: chain)
+        let response = try await httpClient.request(
+            CosmosStakingAPI(baseURL: baseURL, endpoint: .unbondingDelegations(address: address)),
+            responseType: CosmosUnbondingDelegationResponse.self
+        )
+        return response.data.toUnbondingDelegations()
+    }
+
+    func fetchDelegatorRewards(chain: Chain, address: String) async throws -> CosmosDelegatorRewards {
+        let baseURL = try Self.baseURL(for: chain)
+        let response = try await httpClient.request(
+            CosmosStakingAPI(baseURL: baseURL, endpoint: .delegatorRewards(address: address)),
+            responseType: CosmosDelegatorRewardsResponse.self
+        )
+        return response.data.toRewards()
+    }
+
+    func fetchValidators(chain: Chain) async throws -> [CosmosValidator] {
+        let baseURL = try Self.baseURL(for: chain)
+        let response = try await httpClient.request(
+            CosmosStakingAPI(baseURL: baseURL, endpoint: .bondedValidators),
+            responseType: CosmosValidatorListResponse.self
+        )
+        return response.data.toValidators()
+    }
+
+    func fetchRedelegations(chain: Chain, address: String) async throws -> [CosmosRedelegationEntry] {
+        let baseURL = try Self.baseURL(for: chain)
+        let response = try await httpClient.request(
+            CosmosStakingAPI(baseURL: baseURL, endpoint: .redelegations(address: address)),
+            responseType: CosmosRedelegationResponse.self
+        )
+        return response.data.toRedelegations()
+    }
+
+    // MARK: - Per-chain base URL
+
+    /// Resolves the LCD host for the chain by going through
+    /// `CosmosServiceConfig` — that's the single source of truth for every
+    /// Cosmos REST root in the app (Terra and TerraClassic are wired direct
+    /// to publicnode there). Keeping the lookup centralized means swapping
+    /// to the api.vultisig.com proxy later is a one-line edit.
+    private static func baseURL(for chain: Chain) throws -> URL {
+        let config = try CosmosServiceConfig.getConfig(forChain: chain)
+        guard let url = config.baseURL else {
+            throw CosmosStakingConfigError.unsupportedChain(chain)
+        }
+        return url
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/ValidatorBech32Preflight.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/ValidatorBech32Preflight.swift
@@ -1,0 +1,190 @@
+//
+//  ValidatorBech32Preflight.swift
+//  VultisigApp
+//
+//  Sanity-checks a Cosmos validator operator address (`terravaloper1…`)
+//  before the MPC ceremony spends a signing round on a tx the chain will
+//  reject post-broadcast. Mirrors the agent-app `requireValoper(...)` guard
+//  at `vultiagent-app/src/services/cosmosTx.ts:1110-1140`.
+//
+//  Three checks, in order:
+//    1. Bech32 decode succeeds (charset + checksum).
+//    2. HRP matches the per-chain expected operator prefix (e.g.
+//       `terravaloper` for both Terra phoenix-1 and TerraClassic
+//       columbus-5).
+//    3. The decoded data payload is exactly 20 bytes (the operator's
+//       AccAddress equivalent; consensus pub keys are 32 bytes and would
+//       slip past prefix-only validation).
+//
+//  Implements BIP-173 bech32 decode (32-symbol charset + polymod checksum)
+//  inline rather than pulling a generic bech32 dependency. Future Cosmos
+//  chains that adopt bech32m for valoper addresses would need the variant
+//  flag — Terra uses classic bech32 today.
+//
+
+import Foundation
+
+enum ValidatorBech32Preflight {
+
+    enum ValidatorBech32Error: Error, LocalizedError, Equatable {
+        case empty
+        case badEncoding
+        case wrongPrefix(actual: String, expected: String)
+        case wrongPayloadLength(actual: Int, expected: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .empty:
+                return "Validator address is empty"
+            case .badEncoding:
+                return "Validator address is not valid bech32"
+            case .wrongPrefix(let actual, let expected):
+                return "Validator address prefix '\(actual)' does not match expected '\(expected)'"
+            case .wrongPayloadLength(let actual, let expected):
+                return "Validator address payload is \(actual) bytes, expected \(expected)"
+            }
+        }
+    }
+
+    /// Expected operator address payload length. Cosmos AccAddress + valoper
+    /// share the same 20-byte (ripemd160(sha256(pubkey))) shape; consensus
+    /// pubkeys (`*valconspub1…`) are 32 bytes and would otherwise pass a
+    /// prefix-only check.
+    private static let expectedPayloadLength = 20
+
+    static func validate(_ address: String, for chain: Chain) throws {
+        guard !address.isEmpty else { throw ValidatorBech32Error.empty }
+
+        let expectedHrp = try CosmosStakingConfig.valoperHrp(for: chain)
+        let decoded = try decode(address)
+
+        guard decoded.hrp == expectedHrp else {
+            throw ValidatorBech32Error.wrongPrefix(actual: decoded.hrp, expected: expectedHrp)
+        }
+        guard decoded.payload.count == expectedPayloadLength else {
+            throw ValidatorBech32Error.wrongPayloadLength(
+                actual: decoded.payload.count,
+                expected: expectedPayloadLength
+            )
+        }
+    }
+
+    // MARK: - BIP-173 bech32 decode
+
+    struct Decoded: Equatable {
+        let hrp: String
+        let payload: [UInt8]
+    }
+
+    /// BIP-173 charset.
+    private static let charset = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+
+    /// Decodes a bech32 string (`<hrp>1<data><checksum>`) and returns the
+    /// HRP plus the converted 8-bit payload. Throws `.badEncoding` on any
+    /// charset / checksum / structure violation.
+    static func decode(_ address: String) throws -> Decoded {
+        let lowered = address.lowercased()
+        // Mixed case is forbidden per BIP-173; if upper- and lower-case
+        // characters both appear, the address is invalid.
+        if lowered != address && address.uppercased() != address {
+            throw ValidatorBech32Error.badEncoding
+        }
+        // Bech32 spec caps the full string at 90 chars; we keep that guard
+        // but allow the agent-app's empirically observed valoper widths.
+        guard lowered.count >= 8 && lowered.count <= 90 else {
+            throw ValidatorBech32Error.badEncoding
+        }
+        guard let separatorIndex = lowered.lastIndex(of: "1") else {
+            throw ValidatorBech32Error.badEncoding
+        }
+        let hrp = String(lowered[..<separatorIndex])
+        let dataPart = String(lowered[lowered.index(after: separatorIndex)...])
+        guard !hrp.isEmpty, dataPart.count >= 6 else {
+            throw ValidatorBech32Error.badEncoding
+        }
+        for char in hrp where !(char >= "!" && char <= "~") {
+            throw ValidatorBech32Error.badEncoding
+        }
+
+        // Map data chars → 5-bit values via the charset lookup.
+        var values: [UInt8] = []
+        values.reserveCapacity(dataPart.count)
+        for char in dataPart {
+            guard let index = charset.firstIndex(of: char) else {
+                throw ValidatorBech32Error.badEncoding
+            }
+            values.append(UInt8(index))
+        }
+
+        guard verifyChecksum(hrp: hrp, data: values) else {
+            throw ValidatorBech32Error.badEncoding
+        }
+
+        // Drop the 6-byte checksum and convert the remaining 5-bit groups
+        // back to 8-bit bytes.
+        let payload5Bit = Array(values.dropLast(6))
+        guard let payload8Bit = convertBits(payload5Bit, from: 5, to: 8, pad: false) else {
+            throw ValidatorBech32Error.badEncoding
+        }
+        return Decoded(hrp: hrp, payload: payload8Bit)
+    }
+
+    // MARK: - Polymod checksum (BIP-173)
+
+    private static func polymod(_ values: [UInt8]) -> UInt32 {
+        let generator: [UInt32] = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+        var chk: UInt32 = 1
+        for value in values {
+            let top = chk >> 25
+            chk = ((chk & 0x1ffffff) << 5) ^ UInt32(value)
+            for index in 0..<5 where ((top >> index) & 1) == 1 {
+                chk ^= generator[index]
+            }
+        }
+        return chk
+    }
+
+    /// Expands the HRP into the prefix the polymod step consumes:
+    /// high-bits || 0 || low-bits.
+    private static func hrpExpand(_ hrp: String) -> [UInt8] {
+        let bytes = Array(hrp.utf8)
+        var result: [UInt8] = bytes.map { $0 >> 5 }
+        result.append(0)
+        result.append(contentsOf: bytes.map { $0 & 0x1f })
+        return result
+    }
+
+    private static func verifyChecksum(hrp: String, data: [UInt8]) -> Bool {
+        polymod(hrpExpand(hrp) + data) == 1
+    }
+
+    /// Converts a contiguous bit-stream between bit widths. Used here to
+    /// drop the 5→8 bit packing the data part uses. Returns nil when the
+    /// input cannot be cleanly converted (input bits don't divide into the
+    /// output width and `pad` is false).
+    private static func convertBits(_ data: [UInt8], from fromBits: Int, to toBits: Int, pad: Bool) -> [UInt8]? {
+        var acc: Int = 0
+        var bits: Int = 0
+        var result: [UInt8] = []
+        let maxv = (1 << toBits) - 1
+        let maxAcc = (1 << (fromBits + toBits - 1)) - 1
+
+        for value in data {
+            if Int(value) >> fromBits != 0 { return nil }
+            acc = ((acc << fromBits) | Int(value)) & maxAcc
+            bits += fromBits
+            while bits >= toBits {
+                bits -= toBits
+                result.append(UInt8((acc >> bits) & maxv))
+            }
+        }
+        if pad {
+            if bits > 0 {
+                result.append(UInt8((acc << (toBits - bits)) & maxv))
+            }
+        } else if bits >= fromBits || ((acc << (toBits - bits)) & maxv) != 0 {
+            return nil
+        }
+        return result
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosStakingHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosStakingHelper.swift
@@ -1,0 +1,226 @@
+//
+//  CosmosStakingHelper.swift
+//  VultisigApp
+//
+//  Pure stateless byte-builder for Cosmos-SDK x/staking + x/distribution
+//  messages. Ports the agent-app `buildCosmosStakingTx` + SDK
+//  `buildCosmosStakingTx` byte-for-byte so the iOS encoder stays byte-equal
+//  with the SDK reference encoder under the SignDoc / TxBody contract.
+//
+//  Each `encode*` method returns the `Any`-wrapped message bytes
+//  (`{ type_url, value }`) ready to drop into a TxBody. `buildTxBodyMulti`
+//  packs N `Any`-wrapped messages into a single TxBody — used both by the
+//  single-msg flows (delegate / undelegate / redelegate) and by the
+//  multi-msg batched-claim flow (one TxBody covering claims from N
+//  validators, signed in a single MPC ceremony).
+//
+//  Reuses the proto encoders from QBTCHelper (`Data.appendProto*`
+//  extensions) — proto3 default-skip semantics match the SDK and the wire
+//  format is identical.
+//
+
+import CryptoSwift
+import Foundation
+
+enum CosmosStakingHelper {
+    // MARK: - Type URLs
+
+    static let msgDelegateTypeURL = "/cosmos.staking.v1beta1.MsgDelegate"
+    static let msgUndelegateTypeURL = "/cosmos.staking.v1beta1.MsgUndelegate"
+    static let msgBeginRedelegateTypeURL = "/cosmos.staking.v1beta1.MsgBeginRedelegate"
+    static let msgWithdrawDelegatorRewardTypeURL = "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
+    static let pubKeyTypeURL = "/cosmos.crypto.secp256k1.PubKey"
+
+    /// Proto SignMode value for SIGN_MODE_DIRECT — the only mode the iOS
+    /// staking path uses. Amino sign-mode is reserved for legacy hardware
+    /// paths and not exercised here.
+    private static let signModeDirect: UInt64 = 1
+
+    struct SignDocArtifacts: Equatable {
+        let bytes: Data
+        let hashHex: String
+    }
+
+    // MARK: - Msg encoders (each returns Any-wrapped bytes)
+
+    /// Encodes a `MsgDelegate` into `Any { type_url, value }`.
+    /// Wire shape of `value`: `{ delegator_address(1), validator_address(2),
+    /// Coin { denom(1), amount(2) }(3) }`.
+    static func encodeDelegate(
+        delegator: String,
+        validator: String,
+        amount: String,
+        denom: String
+    ) -> Data {
+        let coin = encodeCoin(denom: denom, amount: amount)
+        var msg = Data()
+        msg.appendProtoString(fieldNumber: 1, value: delegator)
+        msg.appendProtoString(fieldNumber: 2, value: validator)
+        msg.appendProtoBytes(fieldNumber: 3, data: coin)
+        return wrapAny(typeURL: msgDelegateTypeURL, value: msg)
+    }
+
+    /// Encodes a `MsgUndelegate` — identical wire shape to `MsgDelegate`,
+    /// distinguished only by the `Any` typeUrl.
+    static func encodeUndelegate(
+        delegator: String,
+        validator: String,
+        amount: String,
+        denom: String
+    ) -> Data {
+        let coin = encodeCoin(denom: denom, amount: amount)
+        var msg = Data()
+        msg.appendProtoString(fieldNumber: 1, value: delegator)
+        msg.appendProtoString(fieldNumber: 2, value: validator)
+        msg.appendProtoBytes(fieldNumber: 3, data: coin)
+        return wrapAny(typeURL: msgUndelegateTypeURL, value: msg)
+    }
+
+    /// Encodes a `MsgBeginRedelegate`.
+    /// Wire shape of `value`: `{ delegator_address(1),
+    /// validator_src_address(2), validator_dst_address(3),
+    /// Coin { denom(1), amount(2) }(4) }`.
+    ///
+    /// Note the 2/3 order — field 2 is the SOURCE validator, field 3 is the
+    /// DESTINATION. Swapping them silently produces a tx that redelegates
+    /// the wrong way; the SDK test suite calls this out as a regression
+    /// guard at `cosmos-staking.test.ts:153-162`.
+    static func encodeBeginRedelegate(
+        delegator: String,
+        validatorSrc: String,
+        validatorDst: String,
+        amount: String,
+        denom: String
+    ) -> Data {
+        let coin = encodeCoin(denom: denom, amount: amount)
+        var msg = Data()
+        msg.appendProtoString(fieldNumber: 1, value: delegator)
+        msg.appendProtoString(fieldNumber: 2, value: validatorSrc)
+        msg.appendProtoString(fieldNumber: 3, value: validatorDst)
+        msg.appendProtoBytes(fieldNumber: 4, data: coin)
+        return wrapAny(typeURL: msgBeginRedelegateTypeURL, value: msg)
+    }
+
+    /// Encodes a `MsgWithdrawDelegatorReward`.
+    /// Wire shape: `{ delegator_address(1), validator_address(2) }` — no
+    /// Coin field. The distribution-module typeUrl carries the discriminator.
+    static func encodeWithdrawDelegatorReward(
+        delegator: String,
+        validator: String
+    ) -> Data {
+        var msg = Data()
+        msg.appendProtoString(fieldNumber: 1, value: delegator)
+        msg.appendProtoString(fieldNumber: 2, value: validator)
+        return wrapAny(typeURL: msgWithdrawDelegatorRewardTypeURL, value: msg)
+    }
+
+    // MARK: - TxBody + AuthInfo + SignDoc
+
+    /// Packs N `Any`-wrapped messages into a single TxBody, preserving order.
+    /// Single-msg flows pass a one-element array; batched claim passes one
+    /// `Any`-wrapped `MsgWithdrawDelegatorReward` per validator.
+    ///
+    /// Wire shape: `{ messages(1, repeated Any), memo(2, optional) }`.
+    /// `timeout_height` (field 3) and extension options (4/5) are intentionally
+    /// omitted — they default to 0 / unset, matching the SDK encoder.
+    static func buildTxBodyMulti(msgsAny: [Data], memo: String = "") -> Data {
+        var txBody = Data()
+        for anyMsg in msgsAny {
+            txBody.appendProtoBytes(fieldNumber: 1, data: anyMsg)
+        }
+        if !memo.isEmpty {
+            txBody.appendProtoString(fieldNumber: 2, value: memo)
+        }
+        return txBody
+    }
+
+    /// Builds the `AuthInfo` for a single-signer secp256k1 tx in SIGN_MODE_DIRECT.
+    ///
+    /// AuthInfo wire shape: `{ signer_infos(1, repeated), fee(2) }`.
+    /// SignerInfo: `{ public_key(1, Any), mode_info(2), sequence(3) }`.
+    /// ModeInfo: `{ single(1) }` → Single: `{ mode(1) }`.
+    /// Fee: `{ amount(1, repeated Coin), gas_limit(2) }`.
+    static func buildAuthInfo(
+        pubKey: Data,
+        sequence: UInt64,
+        gasLimit: UInt64,
+        feeDenom: String,
+        feeAmount: UInt64
+    ) -> Data {
+        // Inner secp256k1.PubKey: { key(1, bytes) }
+        var pubKeyInner = Data()
+        pubKeyInner.appendProtoBytes(fieldNumber: 1, data: pubKey)
+
+        // Any-wrapped pub key: { type_url(1), value(2) }
+        var pubKeyAny = Data()
+        pubKeyAny.appendProtoString(fieldNumber: 1, value: pubKeyTypeURL)
+        pubKeyAny.appendProtoBytes(fieldNumber: 2, data: pubKeyInner)
+
+        // ModeInfo.Single: { mode(1, varint) }
+        var single = Data()
+        single.appendProtoVarint(fieldNumber: 1, value: signModeDirect)
+        // ModeInfo: { single(1) }
+        var modeInfo = Data()
+        modeInfo.appendProtoBytes(fieldNumber: 1, data: single)
+
+        // SignerInfo: { public_key(1, Any), mode_info(2), sequence(3) }
+        var signerInfo = Data()
+        signerInfo.appendProtoBytes(fieldNumber: 1, data: pubKeyAny)
+        signerInfo.appendProtoBytes(fieldNumber: 2, data: modeInfo)
+        signerInfo.appendProtoVarint(fieldNumber: 3, value: sequence)
+
+        // Fee.amount Coin: { denom(1), amount(2) }
+        let feeCoin = encodeCoin(denom: feeDenom, amount: String(feeAmount))
+
+        // Fee: { amount(1, repeated Coin), gas_limit(2) }
+        var fee = Data()
+        fee.appendProtoBytes(fieldNumber: 1, data: feeCoin)
+        fee.appendProtoVarint(fieldNumber: 2, value: gasLimit)
+
+        // AuthInfo: { signer_infos(1, repeated), fee(2) }
+        var authInfo = Data()
+        authInfo.appendProtoBytes(fieldNumber: 1, data: signerInfo)
+        authInfo.appendProtoBytes(fieldNumber: 2, data: fee)
+        return authInfo
+    }
+
+    /// Builds the SignDoc bytes and returns them alongside their SHA-256
+    /// hex digest — the digest is the pre-image hash that the MPC layer
+    /// signs.
+    ///
+    /// SignDoc wire shape:
+    /// `{ body_bytes(1), auth_info_bytes(2), chain_id(3), account_number(4) }`.
+    static func buildSignDoc(
+        bodyBytes: Data,
+        authInfoBytes: Data,
+        chainId: String,
+        accountNumber: UInt64
+    ) -> SignDocArtifacts {
+        var signDoc = Data()
+        signDoc.appendProtoBytes(fieldNumber: 1, data: bodyBytes)
+        signDoc.appendProtoBytes(fieldNumber: 2, data: authInfoBytes)
+        signDoc.appendProtoString(fieldNumber: 3, value: chainId)
+        signDoc.appendProtoVarint(fieldNumber: 4, value: accountNumber)
+        return SignDocArtifacts(bytes: signDoc, hashHex: signDoc.sha256().toHexString())
+    }
+
+    // MARK: - Helpers
+
+    /// `Coin` wire shape: `{ denom(1), amount(2) }`. Used in MsgDelegate,
+    /// MsgUndelegate, MsgBeginRedelegate, and Fee.amount.
+    private static func encodeCoin(denom: String, amount: String) -> Data {
+        var coin = Data()
+        coin.appendProtoString(fieldNumber: 1, value: denom)
+        coin.appendProtoString(fieldNumber: 2, value: amount)
+        return coin
+    }
+
+    /// Wraps an inner message body in `google.protobuf.Any`: `{ type_url(1),
+    /// value(2) }`. Cosmos-SDK msgs are always Any-wrapped inside TxBody.
+    private static func wrapAny(typeURL: String, value: Data) -> Data {
+        var anyMsg = Data()
+        anyMsg.appendProtoString(fieldNumber: 1, value: typeURL)
+        anyMsg.appendProtoBytes(fieldNumber: 2, data: value)
+        return anyMsg
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingConfigTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingConfigTests.swift
@@ -1,0 +1,102 @@
+//
+//  CosmosStakingConfigTests.swift
+//  VultisigAppTests
+//
+//  Pins the per-chain Cosmos staking config table against the cross-platform
+//  contract documented in the LUNA / LUNC staking design doc — same chain
+//  IDs, gas budgets, fee amounts, valoper prefixes, and unbonding periods
+//  the Android + Windows siblings will ship against.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class CosmosStakingConfigTests: XCTestCase {
+
+    // MARK: - Allowlist
+
+    func testIsStakingSupportedTrueForTerraAndTerraClassic() {
+        XCTAssertTrue(CosmosStakingConfig.isStakingSupported(.terra))
+        XCTAssertTrue(CosmosStakingConfig.isStakingSupported(.terraClassic))
+    }
+
+    func testIsStakingSupportedFalseForThorchainAndMaya() {
+        // THORChain + Maya are Cosmos-SDK chains but use vault-bond models,
+        // not x/staking. The allowlist must exclude them so generic staking
+        // calls don't accidentally fire at vault bond nodes.
+        XCTAssertFalse(CosmosStakingConfig.isStakingSupported(.thorChain))
+        XCTAssertFalse(CosmosStakingConfig.isStakingSupported(.mayaChain))
+    }
+
+    func testIsStakingSupportedFalseForOtherCosmosChains() {
+        // Gaia, Osmosis, etc. could support generic x/staking but we haven't
+        // landed the per-chain entries yet. The allowlist must default to
+        // "not supported" until each chain gets verified gas / fee values.
+        XCTAssertFalse(CosmosStakingConfig.isStakingSupported(.gaiaChain))
+        XCTAssertFalse(CosmosStakingConfig.isStakingSupported(.osmosis))
+        XCTAssertFalse(CosmosStakingConfig.isStakingSupported(.dydx))
+        XCTAssertFalse(CosmosStakingConfig.isStakingSupported(.kujira))
+        XCTAssertFalse(CosmosStakingConfig.isStakingSupported(.noble))
+    }
+
+    func testEntryThrowsForUnsupportedChain() {
+        XCTAssertThrowsError(try CosmosStakingConfig.entry(for: .thorChain)) { error in
+            guard case CosmosStakingConfigError.unsupportedChain(let chain) = error else {
+                XCTFail("Expected unsupportedChain error, got \(error)")
+                return
+            }
+            XCTAssertEqual(chain, .thorChain)
+        }
+    }
+
+    // MARK: - Terra (phoenix-1) contract
+
+    func testTerraEntryMatchesContract() throws {
+        let entry = try CosmosStakingConfig.entry(for: .terra)
+        XCTAssertEqual(entry.chainId, "phoenix-1")
+        XCTAssertEqual(entry.bondDenom, "uluna")
+        XCTAssertEqual(entry.feeDenom, "uluna")
+        XCTAssertEqual(entry.valoperHrp, "terravaloper")
+        XCTAssertEqual(entry.gasLimit, 300_000)
+        XCTAssertEqual(entry.feeAmount, 7_500)
+        XCTAssertEqual(entry.unbondingDays, 21)
+    }
+
+    // MARK: - TerraClassic (columbus-5) contract
+
+    func testTerraClassicEntryMatchesContract() throws {
+        let entry = try CosmosStakingConfig.entry(for: .terraClassic)
+        XCTAssertEqual(entry.chainId, "columbus-5")
+        XCTAssertEqual(entry.bondDenom, "uluna")
+        XCTAssertEqual(entry.feeDenom, "uluna")
+        XCTAssertEqual(entry.valoperHrp, "terravaloper")
+        XCTAssertEqual(entry.gasLimit, 1_500_000)
+        XCTAssertEqual(entry.feeAmount, 100_000_000)
+        XCTAssertEqual(entry.unbondingDays, 21)
+    }
+
+    func testTerraClassicGasIsFiveTimesPhoenix() throws {
+        // Empirical fact pinned by agent-app on-chain measurements — the
+        // columbus-5 stability-tax / value-per-byte module bills extra gas
+        // and the 5x multiplier is the smallest budget that lands txs.
+        // Smaller budgets OoG.
+        let phoenix = try CosmosStakingConfig.gasLimit(for: .terra)
+        let classic = try CosmosStakingConfig.gasLimit(for: .terraClassic)
+        XCTAssertEqual(classic, phoenix * 5)
+    }
+
+    // MARK: - Per-field accessor parity
+
+    func testFieldAccessorsAgreeWithEntry() throws {
+        for chain: Chain in [.terra, .terraClassic] {
+            let entry = try CosmosStakingConfig.entry(for: chain)
+            XCTAssertEqual(try CosmosStakingConfig.chainId(for: chain), entry.chainId)
+            XCTAssertEqual(try CosmosStakingConfig.bondDenom(for: chain), entry.bondDenom)
+            XCTAssertEqual(try CosmosStakingConfig.feeDenom(for: chain), entry.feeDenom)
+            XCTAssertEqual(try CosmosStakingConfig.valoperHrp(for: chain), entry.valoperHrp)
+            XCTAssertEqual(try CosmosStakingConfig.gasLimit(for: chain), entry.gasLimit)
+            XCTAssertEqual(try CosmosStakingConfig.feeAmount(for: chain), entry.feeAmount)
+            XCTAssertEqual(try CosmosStakingConfig.unbondingDays(for: chain), entry.unbondingDays)
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/delegations.json
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/delegations.json
@@ -1,0 +1,27 @@
+{
+  "delegation_responses": [
+    {
+      "delegation": {
+        "delegator_address": "terra1delegator00000000000000000000000000ab",
+        "validator_address": "terravaloper1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "shares": "1000000.000000000000000000"
+      },
+      "balance": {
+        "denom": "uluna",
+        "amount": "1000000"
+      }
+    },
+    {
+      "delegation": {
+        "delegator_address": "terra1delegator00000000000000000000000000ab",
+        "validator_address": "terravaloper1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "shares": "500000.000000000000000000"
+      },
+      "balance": {
+        "denom": "uluna",
+        "amount": "500000"
+      }
+    }
+  ],
+  "pagination": { "next_key": null, "total": "2" }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/redelegations.json
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/redelegations.json
@@ -1,0 +1,19 @@
+{
+  "redelegation_responses": [
+    {
+      "redelegation": {
+        "delegator_address": "terra1delegator00000000000000000000000000ab",
+        "validator_src_address": "terravaloper1srcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcs",
+        "validator_dst_address": "terravaloper1dstdstdstdstdstdstdstdstdstdstdstdsts"
+      },
+      "entries": [
+        {
+          "redelegation_entry": {
+            "completion_time": "2026-06-14T08:30:00Z"
+          },
+          "balance": "100000"
+        }
+      ]
+    }
+  ]
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/rewards-empty.json
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/rewards-empty.json
@@ -1,0 +1,4 @@
+{
+  "rewards": null,
+  "total": null
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/rewards.json
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/rewards.json
@@ -1,0 +1,19 @@
+{
+  "rewards": [
+    {
+      "validator_address": "terravaloper1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "reward": [
+        { "denom": "uluna", "amount": "123456.789000000000000000" }
+      ]
+    },
+    {
+      "validator_address": "terravaloper1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "reward": [
+        { "denom": "uluna", "amount": "55000.000000000000000000" }
+      ]
+    }
+  ],
+  "total": [
+    { "denom": "uluna", "amount": "178456.789000000000000000" }
+  ]
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/unbonding-delegations.json
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/unbonding-delegations.json
@@ -1,0 +1,22 @@
+{
+  "unbonding_responses": [
+    {
+      "delegator_address": "terra1delegator00000000000000000000000000ab",
+      "validator_address": "terravaloper1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "entries": [
+        {
+          "creation_height": "12345678",
+          "completion_time": "2026-06-02T13:00:00.123456789Z",
+          "initial_balance": "100000",
+          "balance": "100000"
+        },
+        {
+          "creation_height": "12345700",
+          "completion_time": "2026-06-10T10:00:00Z",
+          "initial_balance": "200000",
+          "balance": "200000"
+        }
+      ]
+    }
+  ]
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/validators.json
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/validators.json
@@ -1,0 +1,27 @@
+{
+  "validators": [
+    {
+      "operator_address": "terravaloper1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "jailed": false,
+      "status": "BOND_STATUS_BONDED",
+      "tokens": "50000000000000",
+      "description": { "moniker": "Validator A" },
+      "commission": { "commission_rates": { "rate": "0.050000000000000000" } }
+    },
+    {
+      "operator_address": "terravaloper1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "jailed": true,
+      "status": "BOND_STATUS_BONDED",
+      "tokens": "10000000000000",
+      "description": { "moniker": "Validator B (Jailed)" },
+      "commission": { "commission_rates": { "rate": "0.100000000000000000" } }
+    },
+    {
+      "operator_address": "terravaloper1ccccccccccccccccccccccccccccccccccc",
+      "status": "BOND_STATUS_UNBONDED",
+      "tokens": "0",
+      "description": { "moniker": "Validator C (Unbonded)" },
+      "commission": { "commission_rates": { "rate": "0.020000000000000000" } }
+    }
+  ]
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingHelperTests.swift
@@ -1,0 +1,486 @@
+//
+//  CosmosStakingHelperTests.swift
+//  VultisigAppTests
+//
+//  Locks down the wire-format invariants for the Cosmos x/staking +
+//  x/distribution proto encoders. Mirrors the SDK round-trip test pattern
+//  at `vultisig-sdk/packages/sdk/tests/unit/platforms/react-native/
+//  cosmos-staking.test.ts` — same test names where applicable, same fixture
+//  shapes (cosmoshub-4 inputs verbatim) — but uses pure Swift parsing of the
+//  produced bytes rather than a cosmjs-types bridge.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class CosmosStakingHelperTests: XCTestCase {
+
+    // MARK: - Fixtures (mirror SDK FX)
+
+    private enum FX {
+        static let chainId = "cosmoshub-4"
+        static let delegator = "cosmos1abcdefghijklmnopqrstuvwxyz0123456789ab"
+        static let validator = "cosmosvaloper1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzaaa"
+        static let validatorSrc = "cosmosvaloper1srcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcs"
+        static let validatorDst = "cosmosvaloper1dstdstdstdstdstdstdstdstdstdstdstdsts"
+        static let amount = "1000000"
+        static let denom = "uatom"
+        static let feeAmount: UInt64 = 7_500
+        static let gasLimit: UInt64 = 250_000
+        static let sequence: UInt64 = 42
+        static let accountNumber: UInt64 = 100
+        // 33-byte compressed secp256k1 pubkey, all 0x02 — matches the SDK
+        // fixture verbatim.
+        static let pubKey = Data(repeating: 0x02, count: 33)
+    }
+
+    // MARK: - MsgDelegate
+
+    func testMsgDelegateUsesCanonicalTypeURL() {
+        let anyMsg = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator,
+            validator: FX.validator,
+            amount: FX.amount,
+            denom: FX.denom
+        )
+        let unwrapped = try? Self.decodeAny(anyMsg)
+        XCTAssertEqual(unwrapped?.typeURL, "/cosmos.staking.v1beta1.MsgDelegate")
+    }
+
+    func testMsgDelegateEncodesAllFieldsInOrder() throws {
+        let anyMsg = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator,
+            validator: FX.validator,
+            amount: FX.amount,
+            denom: FX.denom
+        )
+        let unwrapped = try Self.decodeAny(anyMsg)
+        let fields = try Self.parseFields(unwrapped.value)
+        XCTAssertEqual(try Self.string(field: 1, in: fields), FX.delegator)
+        XCTAssertEqual(try Self.string(field: 2, in: fields), FX.validator)
+
+        let coinBytes = try Self.bytes(field: 3, in: fields)
+        let coinFields = try Self.parseFields(coinBytes)
+        XCTAssertEqual(try Self.string(field: 1, in: coinFields), FX.denom)
+        XCTAssertEqual(try Self.string(field: 2, in: coinFields), FX.amount)
+    }
+
+    func testMsgDelegateIsDeterministicForIdenticalInputs() {
+        let a = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        let b = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        XCTAssertEqual(a, b)
+    }
+
+    func testMsgDelegateBytesChangeWhenValidatorChanges() {
+        let a = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        let b = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator,
+            validator: "cosmosvaloper1otherotherotherotherotherotherother",
+            amount: FX.amount,
+            denom: FX.denom
+        )
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: - MsgUndelegate
+
+    func testMsgUndelegateUsesUndelegateTypeURL() throws {
+        let anyMsg = CosmosStakingHelper.encodeUndelegate(
+            delegator: FX.delegator,
+            validator: FX.validator,
+            amount: FX.amount,
+            denom: FX.denom
+        )
+        let unwrapped = try Self.decodeAny(anyMsg)
+        XCTAssertEqual(unwrapped.typeURL, "/cosmos.staking.v1beta1.MsgUndelegate")
+    }
+
+    func testMsgUndelegateHasIdenticalWireShapeToDelegate() throws {
+        // Same fields in same positions; only typeUrl differs. Pulling the
+        // inner bytes through the same parser must produce the same field
+        // structure.
+        let delegate = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        let undelegate = CosmosStakingHelper.encodeUndelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        let delegateValue = try Self.decodeAny(delegate).value
+        let undelegateValue = try Self.decodeAny(undelegate).value
+        XCTAssertEqual(delegateValue, undelegateValue)
+    }
+
+    // MARK: - MsgBeginRedelegate
+
+    func testMsgBeginRedelegateUsesCanonicalTypeURL() throws {
+        let anyMsg = CosmosStakingHelper.encodeBeginRedelegate(
+            delegator: FX.delegator,
+            validatorSrc: FX.validatorSrc,
+            validatorDst: FX.validatorDst,
+            amount: FX.amount,
+            denom: FX.denom
+        )
+        let unwrapped = try Self.decodeAny(anyMsg)
+        XCTAssertEqual(unwrapped.typeURL, "/cosmos.staking.v1beta1.MsgBeginRedelegate")
+    }
+
+    func testMsgBeginRedelegateEncodesSrcAtFieldTwoAndDstAtFieldThree() throws {
+        // The whole point of this test is the regression guard SDK calls
+        // out at cosmos-staking.test.ts:153-162 — a src/dst swap would
+        // produce a tx that drains the wrong validator.
+        let anyMsg = CosmosStakingHelper.encodeBeginRedelegate(
+            delegator: FX.delegator,
+            validatorSrc: FX.validatorSrc,
+            validatorDst: FX.validatorDst,
+            amount: FX.amount,
+            denom: FX.denom
+        )
+        let fields = try Self.parseFields(try Self.decodeAny(anyMsg).value)
+        XCTAssertEqual(try Self.string(field: 1, in: fields), FX.delegator)
+        XCTAssertEqual(try Self.string(field: 2, in: fields), FX.validatorSrc)
+        XCTAssertEqual(try Self.string(field: 3, in: fields), FX.validatorDst)
+        let coin = try Self.parseFields(try Self.bytes(field: 4, in: fields))
+        XCTAssertEqual(try Self.string(field: 1, in: coin), FX.denom)
+        XCTAssertEqual(try Self.string(field: 2, in: coin), FX.amount)
+    }
+
+    func testMsgBeginRedelegateSrcAndDstAreNotInterchangeable() throws {
+        let normal = CosmosStakingHelper.encodeBeginRedelegate(
+            delegator: FX.delegator,
+            validatorSrc: FX.validatorSrc,
+            validatorDst: FX.validatorDst,
+            amount: FX.amount,
+            denom: FX.denom
+        )
+        let swapped = CosmosStakingHelper.encodeBeginRedelegate(
+            delegator: FX.delegator,
+            validatorSrc: FX.validatorDst,
+            validatorDst: FX.validatorSrc,
+            amount: FX.amount,
+            denom: FX.denom
+        )
+        XCTAssertNotEqual(normal, swapped)
+    }
+
+    // MARK: - MsgWithdrawDelegatorReward
+
+    func testMsgWithdrawRewardUsesDistributionTypeURL() throws {
+        let anyMsg = CosmosStakingHelper.encodeWithdrawDelegatorReward(
+            delegator: FX.delegator,
+            validator: FX.validator
+        )
+        let unwrapped = try Self.decodeAny(anyMsg)
+        XCTAssertEqual(unwrapped.typeURL, "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward")
+    }
+
+    func testMsgWithdrawRewardHasNoCoinField() throws {
+        let anyMsg = CosmosStakingHelper.encodeWithdrawDelegatorReward(
+            delegator: FX.delegator,
+            validator: FX.validator
+        )
+        let fields = try Self.parseFields(try Self.decodeAny(anyMsg).value)
+        XCTAssertEqual(try Self.string(field: 1, in: fields), FX.delegator)
+        XCTAssertEqual(try Self.string(field: 2, in: fields), FX.validator)
+        XCTAssertEqual(fields.count, 2, "MsgWithdrawDelegatorReward must have exactly 2 fields")
+    }
+
+    // MARK: - buildTxBodyMulti
+
+    func testTxBodySinglePacksMessageAtFieldOne() throws {
+        let anyMsg = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        let txBody = CosmosStakingHelper.buildTxBodyMulti(msgsAny: [anyMsg])
+        let fields = try Self.parseFields(txBody)
+        XCTAssertEqual(fields.filter { $0.tag == 1 }.count, 1)
+        XCTAssertEqual(try Self.bytes(field: 1, in: fields), anyMsg)
+    }
+
+    func testTxBodyMultiPacksAllMessagesPreservingOrder() throws {
+        let validators = [
+            "cosmosvaloper1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "cosmosvaloper1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "cosmosvaloper1ccccccccccccccccccccccccccccccccccc"
+        ]
+        let msgs = validators.map {
+            CosmosStakingHelper.encodeWithdrawDelegatorReward(
+                delegator: FX.delegator,
+                validator: $0
+            )
+        }
+        let txBody = CosmosStakingHelper.buildTxBodyMulti(msgsAny: msgs)
+        let fields = try Self.parseFields(txBody)
+        let messageEntries = fields.filter { $0.tag == 1 }
+        XCTAssertEqual(messageEntries.count, validators.count)
+        for (index, entry) in messageEntries.enumerated() {
+            XCTAssertEqual(entry.value, msgs[index], "TxBody message at index \(index) must round-trip")
+        }
+    }
+
+    func testTxBodyMultiHandlesEightMessagesForBatchedClaimSoftCap() throws {
+        // The batched-claim UI soft cap is 8 validators per tx. The encoder
+        // imposes no cap of its own — exercising N=8 here pins linear
+        // packing all the way up to the UI ceiling.
+        let validators = (1...8).map { index in
+            "cosmosvaloper1batch00000000000000000000000000000\(index)"
+        }
+        let msgs = validators.map {
+            CosmosStakingHelper.encodeWithdrawDelegatorReward(
+                delegator: FX.delegator,
+                validator: $0
+            )
+        }
+        let txBody = CosmosStakingHelper.buildTxBodyMulti(msgsAny: msgs)
+        let fields = try Self.parseFields(txBody)
+        XCTAssertEqual(fields.filter { $0.tag == 1 }.count, 8)
+    }
+
+    func testTxBodyEmbedsMemoAtFieldTwoWhenProvided() throws {
+        let anyMsg = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        let txBody = CosmosStakingHelper.buildTxBodyMulti(
+            msgsAny: [anyMsg],
+            memo: "claim airdrop via vultiagent"
+        )
+        let fields = try Self.parseFields(txBody)
+        XCTAssertEqual(try Self.string(field: 2, in: fields), "claim airdrop via vultiagent")
+    }
+
+    func testTxBodyOmitsMemoFieldWhenEmpty() throws {
+        let anyMsg = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        let txBody = CosmosStakingHelper.buildTxBodyMulti(msgsAny: [anyMsg], memo: "")
+        let fields = try Self.parseFields(txBody)
+        // proto3 default-skip: an empty memo is not emitted at all. Pinning
+        // this guards against the encoder accidentally writing a zero-byte
+        // memo field that would change the SignDoc hash.
+        XCTAssertEqual(fields.filter { $0.tag == 2 }.count, 0)
+    }
+
+    func testTxBodyMixesMsgTypesPreservingTypeURLOrder() throws {
+        let delegate = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator, amount: FX.amount, denom: FX.denom
+        )
+        let withdraw = CosmosStakingHelper.encodeWithdrawDelegatorReward(
+            delegator: FX.delegator,
+            validator: FX.validator
+        )
+        let txBody = CosmosStakingHelper.buildTxBodyMulti(msgsAny: [delegate, withdraw])
+        let messages = try Self.parseFields(txBody).filter { $0.tag == 1 }
+        XCTAssertEqual(messages.count, 2)
+        let firstType = try Self.decodeAny(messages[0].value).typeURL
+        let secondType = try Self.decodeAny(messages[1].value).typeURL
+        XCTAssertEqual(firstType, "/cosmos.staking.v1beta1.MsgDelegate")
+        XCTAssertEqual(secondType, "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward")
+    }
+
+    // MARK: - AuthInfo
+
+    func testAuthInfoEmbedsPubKeyAnyAndFee() throws {
+        let authInfo = CosmosStakingHelper.buildAuthInfo(
+            pubKey: FX.pubKey,
+            sequence: FX.sequence,
+            gasLimit: FX.gasLimit,
+            feeDenom: FX.denom,
+            feeAmount: FX.feeAmount
+        )
+        let fields = try Self.parseFields(authInfo)
+
+        // signer_infos at field 1 (single entry)
+        let signerInfoEntries = fields.filter { $0.tag == 1 }
+        XCTAssertEqual(signerInfoEntries.count, 1)
+        let signerInfo = try Self.parseFields(signerInfoEntries[0].value)
+
+        // Inner field 1 = pubkey Any
+        let pubKeyAny = try Self.bytes(field: 1, in: signerInfo)
+        let pubKeyAnyFields = try Self.parseFields(pubKeyAny)
+        XCTAssertEqual(try Self.string(field: 1, in: pubKeyAnyFields), "/cosmos.crypto.secp256k1.PubKey")
+
+        // Inner field 3 = sequence
+        let sequence = try Self.varint(field: 3, in: signerInfo)
+        XCTAssertEqual(sequence, FX.sequence)
+
+        // Fee at field 2
+        let fee = try Self.parseFields(try Self.bytes(field: 2, in: fields))
+        let coin = try Self.parseFields(try Self.bytes(field: 1, in: fee))
+        XCTAssertEqual(try Self.string(field: 1, in: coin), FX.denom)
+        XCTAssertEqual(try Self.string(field: 2, in: coin), String(FX.feeAmount))
+        XCTAssertEqual(try Self.varint(field: 2, in: fee), FX.gasLimit)
+    }
+
+    // MARK: - SignDoc
+
+    func testSignDocBytesChangeWhenAccountNumberChanges() {
+        let body = CosmosStakingHelper.buildTxBodyMulti(
+            msgsAny: [
+                CosmosStakingHelper.encodeDelegate(
+                    delegator: FX.delegator, validator: FX.validator,
+                    amount: FX.amount, denom: FX.denom
+                )
+            ]
+        )
+        let authInfo = CosmosStakingHelper.buildAuthInfo(
+            pubKey: FX.pubKey, sequence: FX.sequence,
+            gasLimit: FX.gasLimit, feeDenom: FX.denom, feeAmount: FX.feeAmount
+        )
+        let docA = CosmosStakingHelper.buildSignDoc(
+            bodyBytes: body, authInfoBytes: authInfo,
+            chainId: FX.chainId, accountNumber: FX.accountNumber
+        )
+        let docB = CosmosStakingHelper.buildSignDoc(
+            bodyBytes: body, authInfoBytes: authInfo,
+            chainId: FX.chainId, accountNumber: FX.accountNumber + 1
+        )
+        XCTAssertNotEqual(docA.bytes, docB.bytes)
+        XCTAssertNotEqual(docA.hashHex, docB.hashHex)
+    }
+
+    func testSignDocHashIsSha256OfBytes() {
+        let body = CosmosStakingHelper.buildTxBodyMulti(
+            msgsAny: [
+                CosmosStakingHelper.encodeDelegate(
+                    delegator: FX.delegator, validator: FX.validator,
+                    amount: FX.amount, denom: FX.denom
+                )
+            ]
+        )
+        let authInfo = CosmosStakingHelper.buildAuthInfo(
+            pubKey: FX.pubKey, sequence: FX.sequence,
+            gasLimit: FX.gasLimit, feeDenom: FX.denom, feeAmount: FX.feeAmount
+        )
+        let doc = CosmosStakingHelper.buildSignDoc(
+            bodyBytes: body, authInfoBytes: authInfo,
+            chainId: FX.chainId, accountNumber: FX.accountNumber
+        )
+        XCTAssertEqual(doc.hashHex.count, 64)
+        XCTAssertEqual(doc.hashHex, doc.hashHex.lowercased())
+    }
+
+    func testSignDocIsDeterministic() {
+        let msg = CosmosStakingHelper.encodeDelegate(
+            delegator: FX.delegator, validator: FX.validator,
+            amount: FX.amount, denom: FX.denom
+        )
+        let body = CosmosStakingHelper.buildTxBodyMulti(msgsAny: [msg])
+        let authInfo = CosmosStakingHelper.buildAuthInfo(
+            pubKey: FX.pubKey, sequence: FX.sequence,
+            gasLimit: FX.gasLimit, feeDenom: FX.denom, feeAmount: FX.feeAmount
+        )
+        let a = CosmosStakingHelper.buildSignDoc(
+            bodyBytes: body, authInfoBytes: authInfo,
+            chainId: FX.chainId, accountNumber: FX.accountNumber
+        )
+        let b = CosmosStakingHelper.buildSignDoc(
+            bodyBytes: body, authInfoBytes: authInfo,
+            chainId: FX.chainId, accountNumber: FX.accountNumber
+        )
+        XCTAssertEqual(a, b)
+    }
+}
+
+// MARK: - Proto wire-format parser (test-only)
+
+/// Tiny proto wire-format walker used by the helper tests to parse the
+/// bytes the encoder produces. NOT used in production — kept inside the
+/// test file so the production encoder remains the single proto authority.
+private extension CosmosStakingHelperTests {
+
+    struct ProtoField: Equatable {
+        let tag: Int
+        let wireType: Int
+        let value: Data
+        let varint: UInt64?
+    }
+
+    enum ProtoParseError: Error {
+        case truncated
+        case missingField(Int)
+        case wrongType
+    }
+
+    static func decodeAny(_ data: Data) throws -> (typeURL: String, value: Data) {
+        let fields = try parseFields(data)
+        return (try string(field: 1, in: fields), try bytes(field: 2, in: fields))
+    }
+
+    static func parseFields(_ data: Data) throws -> [ProtoField] {
+        var fields: [ProtoField] = []
+        var offset = data.startIndex
+        while offset < data.endIndex {
+            guard let (tagRaw, afterTag) = readVarint(data, at: offset) else {
+                throw ProtoParseError.truncated
+            }
+            let tag = Int(tagRaw >> 3)
+            let wireType = Int(tagRaw & 0x7)
+            offset = afterTag
+            switch wireType {
+            case 0: // varint
+                guard let (value, afterValue) = readVarint(data, at: offset) else {
+                    throw ProtoParseError.truncated
+                }
+                fields.append(ProtoField(tag: tag, wireType: wireType, value: Data(), varint: value))
+                offset = afterValue
+            case 2: // length-delimited
+                guard let (length, afterLength) = readVarint(data, at: offset) else {
+                    throw ProtoParseError.truncated
+                }
+                let end = afterLength + Int(length)
+                guard end <= data.endIndex else { throw ProtoParseError.truncated }
+                let payload = data.subdata(in: afterLength..<end)
+                fields.append(ProtoField(tag: tag, wireType: wireType, value: payload, varint: nil))
+                offset = end
+            default:
+                throw ProtoParseError.wrongType
+            }
+        }
+        return fields
+    }
+
+    static func string(field: Int, in fields: [ProtoField]) throws -> String {
+        let bytes = try bytes(field: field, in: fields)
+        guard let value = String(bytes: bytes, encoding: .utf8) else {
+            throw ProtoParseError.wrongType
+        }
+        return value
+    }
+
+    static func bytes(field: Int, in fields: [ProtoField]) throws -> Data {
+        guard let entry = fields.first(where: { $0.tag == field && $0.wireType == 2 }) else {
+            throw ProtoParseError.missingField(field)
+        }
+        return entry.value
+    }
+
+    static func varint(field: Int, in fields: [ProtoField]) throws -> UInt64 {
+        guard let entry = fields.first(where: { $0.tag == field && $0.wireType == 0 }),
+              let value = entry.varint else {
+            throw ProtoParseError.missingField(field)
+        }
+        return value
+    }
+
+    static func readVarint(_ data: Data, at offset: Data.Index) -> (UInt64, Data.Index)? {
+        var result: UInt64 = 0
+        var shift: UInt64 = 0
+        var cursor = offset
+        while cursor < data.endIndex {
+            let byte = data[cursor]
+            result |= UInt64(byte & 0x7f) << shift
+            cursor = data.index(after: cursor)
+            if (byte & 0x80) == 0 {
+                return (result, cursor)
+            }
+            shift += 7
+            if shift > 63 { return nil }
+        }
+        return nil
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingServiceTests.swift
@@ -1,0 +1,138 @@
+//
+//  CosmosStakingServiceTests.swift
+//  VultisigAppTests
+//
+//  DTO parse coverage for the Cosmos x/staking + x/distribution LCD
+//  reader. Each test exercises a single endpoint via a fixture JSON copy
+//  of the on-the-wire shape; the SDK / agent app produce the same shapes
+//  so the parsing tests double as a wire-format contract.
+//
+//  Fixtures live in `VultisigAppTests/Blockchain/Cosmos/Staking/
+//  CosmosStakingFixtures/` (a folder reference so the JSONs land under
+//  `CosmosStakingFixtures/*.json` in the bundle rather than flattening
+//  to the root — the root is reserved for `ChainHelperTests`).
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class CosmosStakingServiceTests: XCTestCase {
+
+    // MARK: - Delegations
+
+    func testDelegationsResponseParsesAllEntriesAndPreservesOrder() throws {
+        let response: CosmosDelegationResponse = try loadFixture("delegations")
+        let delegations = response.toDelegations()
+        XCTAssertEqual(delegations.count, 2)
+        XCTAssertEqual(delegations[0].validatorAddress, "terravaloper1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        XCTAssertEqual(delegations[0].balance, CosmosStakingCoin(denom: "uluna", amount: "1000000"))
+        XCTAssertEqual(delegations[0].shares, "1000000.000000000000000000")
+        XCTAssertEqual(delegations[1].validatorAddress, "terravaloper1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        XCTAssertEqual(delegations[1].balance.amount, "500000")
+    }
+
+    // MARK: - Unbonding delegations
+
+    func testUnbondingDelegationsParseAllEntriesAndDecodeDates() throws {
+        let response: CosmosUnbondingDelegationResponse = try loadFixture("unbonding-delegations")
+        let unbonding = response.toUnbondingDelegations()
+        XCTAssertEqual(unbonding.count, 1)
+        let entries = unbonding[0].entries
+        XCTAssertEqual(entries.count, 2)
+
+        // First entry: RFC3339 with fractional seconds — the SDK ships
+        // this shape from on-chain payouts that aren't aligned to whole-
+        // second boundaries.
+        XCTAssertEqual(entries[0].creationHeight, 12_345_678)
+        XCTAssertEqual(entries[0].initialBalance, Decimal(string: "100000"))
+        XCTAssertEqual(entries[0].balance, Decimal(string: "100000"))
+        XCTAssertNotNil(entries[0].completionTime)
+
+        // Second entry: whole-second completion time — both formats must
+        // parse without the fractional component making it mandatory.
+        XCTAssertEqual(entries[1].creationHeight, 12_345_700)
+        XCTAssertNotNil(entries[1].completionTime)
+        XCTAssertGreaterThan(entries[1].completionTime, entries[0].completionTime)
+    }
+
+    // MARK: - Rewards
+
+    func testDelegatorRewardsParsesMultiValidatorRewardsAndTotal() throws {
+        let response: CosmosDelegatorRewardsResponse = try loadFixture("rewards")
+        let rewards = response.toRewards()
+        XCTAssertEqual(rewards.rewards.count, 2)
+        XCTAssertEqual(rewards.total.count, 1)
+        XCTAssertEqual(rewards.total[0], CosmosStakingCoin(denom: "uluna", amount: "178456.789000000000000000"))
+    }
+
+    func testDelegatorRewardsFallsBackToEmptyOnNullPayload() throws {
+        // `rewards: null` and `total: null` arrive from some LCD firmwares
+        // when the delegator has never accrued. The SDK falls back to []
+        // at lcdQueries.ts:198-202 — iOS must do the same.
+        let response: CosmosDelegatorRewardsResponse = try loadFixture("rewards-empty")
+        let rewards = response.toRewards()
+        XCTAssertTrue(rewards.rewards.isEmpty)
+        XCTAssertTrue(rewards.total.isEmpty)
+    }
+
+    // MARK: - Validators
+
+    func testValidatorListMapsStatusFlags() throws {
+        let response: CosmosValidatorListResponse = try loadFixture("validators")
+        let validators = response.toValidators()
+        XCTAssertEqual(validators.count, 3)
+
+        XCTAssertEqual(validators[0].moniker, "Validator A")
+        XCTAssertEqual(validators[0].status, .bonded)
+        XCTAssertFalse(validators[0].jailed)
+        XCTAssertEqual(validators[0].commission, Decimal(string: "0.050000000000000000"))
+        XCTAssertEqual(validators[0].votingPower, Decimal(string: "50000000000000"))
+
+        XCTAssertEqual(validators[1].moniker, "Validator B (Jailed)")
+        XCTAssertTrue(validators[1].jailed)
+        XCTAssertEqual(validators[1].status, .bonded)
+
+        XCTAssertEqual(validators[2].status, .unbonded)
+    }
+
+    func testValidatorJailedDefaultsFalseWhenMissing() throws {
+        // The `jailed` field is missing from the unbonded validator entry
+        // (`Validator C`). Cosmos LCDs sometimes omit `false` booleans;
+        // the wire DTO must default to `false` rather than failing decode.
+        let response: CosmosValidatorListResponse = try loadFixture("validators")
+        let unbonded = response.toValidators().first { $0.moniker.contains("Unbonded") }
+        XCTAssertFalse(unbonded?.jailed ?? true)
+    }
+
+    // MARK: - Redelegations
+
+    func testRedelegationsResponseFlattensAllEntriesAndDecodesDates() throws {
+        let response: CosmosRedelegationResponse = try loadFixture("redelegations")
+        let entries = response.toRedelegations()
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].srcValidator, "terravaloper1srcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcs")
+        XCTAssertEqual(entries[0].dstValidator, "terravaloper1dstdstdstdstdstdstdstdstdstdstdstdsts")
+        // Whole-second completion time decodes via the same fractional-
+        // seconds-tolerant ISO8601 formatter.
+        XCTAssertNotNil(entries[0].completionTime)
+    }
+
+    // MARK: - Bundle loader
+
+    private func loadFixture<T: Decodable>(_ name: String) throws -> T {
+        let bundle = Bundle(for: type(of: self))
+        guard let url = bundle.url(
+            forResource: name,
+            withExtension: "json",
+            subdirectory: "CosmosStakingFixtures"
+        ) else {
+            throw NSError(
+                domain: "CosmosStakingServiceTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Missing fixture CosmosStakingFixtures/\(name).json"]
+            )
+        }
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/ValidatorBech32PreflightTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/ValidatorBech32PreflightTests.swift
@@ -1,0 +1,209 @@
+//
+//  ValidatorBech32PreflightTests.swift
+//  VultisigAppTests
+//
+//  Mirrors the agent-app `requireValoper(...)` guard at
+//  `vultiagent-app/src/services/cosmosTx.ts:1110-1140`. Every test case
+//  exists to fail loud before the MPC ceremony spends a signing round on
+//  a tx the chain will reject.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class ValidatorBech32PreflightTests: XCTestCase {
+
+    // MARK: - Empty / structural
+
+    func testEmptyAddressIsRejected() {
+        XCTAssertThrowsError(try ValidatorBech32Preflight.validate("", for: .terra)) { error in
+            XCTAssertEqual(error as? ValidatorBech32Preflight.ValidatorBech32Error, .empty)
+        }
+    }
+
+    func testGarbageStringIsRejected() {
+        XCTAssertThrowsError(try ValidatorBech32Preflight.validate("not bech32 at all!!", for: .terra)) { error in
+            XCTAssertEqual(error as? ValidatorBech32Preflight.ValidatorBech32Error, .badEncoding)
+        }
+    }
+
+    func testStringWithoutSeparatorIsRejected() {
+        XCTAssertThrowsError(try ValidatorBech32Preflight.validate("terravaloperabcdefghij", for: .terra))
+    }
+
+    func testMixedCaseAddressIsRejected() {
+        // BIP-173 forbids mixed case. A Terra address pasted from a
+        // misformatted email signature must not slip through.
+        let mixed = makeValidValoperAddress().uppercasedFirstHalf()
+        XCTAssertThrowsError(try ValidatorBech32Preflight.validate(mixed, for: .terra))
+    }
+
+    // MARK: - Prefix
+
+    func testWrongPrefixIsRejectedForTerra() {
+        // `terra1…` is a delegator account address; `terravaloper1…` is the
+        // operator address. The valoper form is what x/staking expects;
+        // accidentally using the account form would burn an MPC ceremony.
+        let address = makeAddress(hrp: "terra", payloadLength: 20)
+        XCTAssertThrowsError(try ValidatorBech32Preflight.validate(address, for: .terra)) { error in
+            guard case .wrongPrefix(let actual, let expected) =
+                    error as? ValidatorBech32Preflight.ValidatorBech32Error else {
+                XCTFail("Expected wrongPrefix, got \(error)")
+                return
+            }
+            XCTAssertEqual(actual, "terra")
+            XCTAssertEqual(expected, "terravaloper")
+        }
+    }
+
+    func testCosmoshubValoperRejectedOnTerraChain() {
+        // Cosmoshub valoper would pass a generic "cosmos" prefix check —
+        // the per-chain HRP guard is the only thing that catches it.
+        let address = makeAddress(hrp: "cosmosvaloper", payloadLength: 20)
+        XCTAssertThrowsError(try ValidatorBech32Preflight.validate(address, for: .terra)) { error in
+            guard case .wrongPrefix(let actual, let expected) =
+                    error as? ValidatorBech32Preflight.ValidatorBech32Error else {
+                XCTFail("Expected wrongPrefix, got \(error)")
+                return
+            }
+            XCTAssertEqual(actual, "cosmosvaloper")
+            XCTAssertEqual(expected, "terravaloper")
+        }
+    }
+
+    // MARK: - Payload length
+
+    func testThirtyTwoByteConsensusPayloadIsRejected() {
+        // *valconspub1… consensus pubkeys are 32 bytes wrapped in the same
+        // bech32 envelope. The HRP differs in production, but a malicious
+        // submitter could spoof the valoper HRP — the payload-length guard
+        // catches that.
+        let address = makeAddress(hrp: "terravaloper", payloadLength: 32)
+        XCTAssertThrowsError(try ValidatorBech32Preflight.validate(address, for: .terra)) { error in
+            guard case .wrongPayloadLength(let actual, let expected) =
+                    error as? ValidatorBech32Preflight.ValidatorBech32Error else {
+                XCTFail("Expected wrongPayloadLength, got \(error)")
+                return
+            }
+            XCTAssertEqual(actual, 32)
+            XCTAssertEqual(expected, 20)
+        }
+    }
+
+    // MARK: - Happy path
+
+    func testValid20ByteTerraValoperPasses() throws {
+        let address = makeAddress(hrp: "terravaloper", payloadLength: 20)
+        XCTAssertNoThrow(try ValidatorBech32Preflight.validate(address, for: .terra))
+    }
+
+    func testValid20ByteTerraValoperAlsoPassesOnTerraClassic() throws {
+        // LUNC shares the `terravaloper` HRP with LUNA — both chains pass
+        // the same address.
+        let address = makeAddress(hrp: "terravaloper", payloadLength: 20)
+        XCTAssertNoThrow(try ValidatorBech32Preflight.validate(address, for: .terraClassic))
+    }
+
+    // MARK: - Decode primitive (covers the bech32 routine itself)
+
+    func testRoundTripDecodeProducesOriginalHrpAndPayload() throws {
+        let payload = Data((0..<20).map { _ in UInt8.random(in: 0...255) })
+        let address = encodeBech32(hrp: "terravaloper", payload: Array(payload))
+        let decoded = try ValidatorBech32Preflight.decode(address)
+        XCTAssertEqual(decoded.hrp, "terravaloper")
+        XCTAssertEqual(decoded.payload, Array(payload))
+    }
+
+    func testFlippedChecksumByteIsRejected() {
+        // The last char of a valid bech32 address is part of the checksum.
+        // Flipping it must be rejected.
+        var address = makeAddress(hrp: "terravaloper", payloadLength: 20)
+        let charBefore = address.removeLast()
+        // Pick the next charset symbol — guaranteed to change the checksum.
+        let charset = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+        let oldIndex = charset.firstIndex(of: charBefore) ?? 0
+        let nextIndex = (oldIndex + 1) % charset.count
+        address.append(charset[nextIndex])
+        XCTAssertThrowsError(try ValidatorBech32Preflight.validate(address, for: .terra))
+    }
+
+    // MARK: - Helpers
+
+    private func makeValidValoperAddress() -> String {
+        makeAddress(hrp: "terravaloper", payloadLength: 20)
+    }
+
+    private func makeAddress(hrp: String, payloadLength: Int) -> String {
+        // Deterministic payload so tests are reproducible.
+        let payload = (0..<payloadLength).map { UInt8($0 & 0xff) }
+        return encodeBech32(hrp: hrp, payload: payload)
+    }
+
+    /// Test-only bech32 encoder used to assemble inputs. The production
+    /// code only ever decodes, so this round-trip helper lives in the test
+    /// target — keeps the prod surface narrower.
+    private func encodeBech32(hrp: String, payload: [UInt8]) -> String {
+        let charset = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+        let data5Bit = convertBits(payload, from: 8, to: 5, pad: true)
+        let checksum = createChecksum(hrp: hrp, data: data5Bit)
+        let combined = data5Bit + checksum
+        return hrp + "1" + String(combined.map { charset[Int($0)] })
+    }
+
+    private func convertBits(_ data: [UInt8], from fromBits: Int, to toBits: Int, pad: Bool) -> [UInt8] {
+        var acc = 0
+        var bits = 0
+        var result: [UInt8] = []
+        let maxv = (1 << toBits) - 1
+        for value in data {
+            acc = (acc << fromBits) | Int(value)
+            bits += fromBits
+            while bits >= toBits {
+                bits -= toBits
+                result.append(UInt8((acc >> bits) & maxv))
+            }
+        }
+        if pad && bits > 0 {
+            result.append(UInt8((acc << (toBits - bits)) & maxv))
+        }
+        return result
+    }
+
+    private func createChecksum(hrp: String, data: [UInt8]) -> [UInt8] {
+        let values = hrpExpand(hrp) + data + Array(repeating: UInt8(0), count: 6)
+        let mod = polymod(values) ^ 1
+        return (0..<6).map { UInt8((mod >> (5 * (5 - $0))) & 0x1f) }
+    }
+
+    private func hrpExpand(_ hrp: String) -> [UInt8] {
+        let bytes = Array(hrp.utf8)
+        var out: [UInt8] = bytes.map { $0 >> 5 }
+        out.append(0)
+        out.append(contentsOf: bytes.map { $0 & 0x1f })
+        return out
+    }
+
+    private func polymod(_ values: [UInt8]) -> UInt32 {
+        let generator: [UInt32] = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+        var chk: UInt32 = 1
+        for value in values {
+            let top = chk >> 25
+            chk = ((chk & 0x1ffffff) << 5) ^ UInt32(value)
+            for index in 0..<5 where ((top >> index) & 1) == 1 {
+                chk ^= generator[index]
+            }
+        }
+        return chk
+    }
+}
+
+// MARK: - String mixed-case helper
+
+private extension String {
+    /// Uppercases roughly the first half of the string — used to assemble
+    /// a mixed-case bech32 input for the BIP-173 mixed-case rejection test.
+    func uppercasedFirstHalf() -> String {
+        let mid = index(startIndex, offsetBy: count / 2)
+        return self[startIndex..<mid].uppercased() + self[mid...]
+    }
+}

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -227,6 +227,7 @@ targets:
           # resource and collides with `ChainHelperTests.testChainHelpers`,
           # which enumerates every top-level JSON in the bundle root.
           - "Swap/SwapKit/__fixtures__/**"
+          - "Blockchain/Cosmos/Staking/CosmosStakingFixtures/**"
       # Static fixture JSONs bundled with the test target as a *folder
       # reference* (blue folder in Xcode) so they land at
       # `__fixtures__/*.json` inside the bundle instead of flattening into
@@ -234,6 +235,9 @@ targets:
       # `ChainHelperTests.testChainHelpers`, which enumerates every top-level
       # JSON and decodes it as `[ChainHelperTestCase]`.
       - path: VultisigAppTests/Swap/SwapKit/__fixtures__
+        type: folder
+        buildPhase: resources
+      - path: VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures
         type: folder
         buildPhase: resources
 


### PR DESCRIPTION
## Summary

PR 1 of 5 for LUNA / LUNC Cosmos-SDK staking on iOS. Lays down the model + service + signing layers — no UI in this PR; the new screens land in PRs 2-5.

- **`CosmosStakingConfig`** — per-chain gas / fee / valoper-HRP / unbonding-days table keyed by `Chain`, with allowlist semantics from `table.keys`. Numbers verbatim from the agent app's `COSMOS_CHAIN_CONFIG`. LUNC gas (1.5M / 100M uluna) is the empirically-verified floor.
- **`CosmosStakingHelper`** — pure stateless proto encoders for `MsgDelegate` / `MsgUndelegate` / `MsgBeginRedelegate` / `MsgWithdrawDelegatorReward`, plus `buildTxBodyMulti` / `buildAuthInfo` / `buildSignDoc`. Reuses the `Data.appendProto*` extensions QBTCHelper introduced — proto3 default-skip semantics already match the SDK reference encoder.
- **`ValidatorBech32Preflight`** — bech32 decode + HRP guard + 20-byte payload guard, refusing malformed valoper addresses before the MPC ceremony fires. Inline BIP-173 decoder.
- **`CosmosStakingService`** — `HTTPClient`-backed reader for delegations, unbonding delegations, delegator rewards (with null-fallback for fresh delegators), bonded validators, and redelegations.
- **DTOs** — snake_case → camelCase wire DTOs mirroring the SDK's `lcdQueries.ts` shapes. Date parser tolerates both fractional and whole-second RFC3339.

47 new tests, 0 failures, ~13s. SwiftLint clean. `BUILD SUCCEEDED`.

## Cross-platform contract

Per [the design doc](https://github.com/vultisig/vultisig-knowledge), this PR pins the contract Android + Windows siblings will ship against:

| | LUNA | LUNC |
|---|---|---|
| Chain ID | `phoenix-1` | `columbus-5` |
| Bond / fee denom | `uluna` | `uluna` |
| Validator HRP | `terravaloper` | `terravaloper` |
| Gas | 300_000 | 1_500_000 |
| Fee | 7_500 uluna | 100_000_000 uluna |
| Unbonding | 21d | 21d |

## Files added

- `VultisigApp/VultisigApp/Blockchain/Cosmos/Models/Staking/CosmosStakingConfig.swift`
- `VultisigApp/VultisigApp/Blockchain/Cosmos/Models/Staking/CosmosStakingDTOs.swift`
- `VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosStakingHelper.swift`
- `VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingAPI.swift`
- `VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingService.swift`
- `VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/ValidatorBech32Preflight.swift`
- `VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/*.swift` (4 test files)
- `VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures/*.json` (6 fixtures)

`project.yml` carries the new fixture folder reference; the rest auto-discovers via XcodeGen path scans.

## Reference sources

- Byte-equality contract: `vultisig-sdk/packages/sdk/tests/unit/platforms/react-native/cosmos-staking.test.ts`
- Per-chain gas table: `vultiagent-app/src/services/cosmosTx.ts` (`COSMOS_CHAIN_CONFIG`)
- Bech32 preflight semantics: `vultiagent-app/src/services/cosmosTx.ts:1110-1140` (`requireValoper`)
- LCD shapes: `vultisig-sdk/packages/core/chain/chains/cosmos/staking/lcdQueries.ts`
- QBTC encoder reuse: `Blockchain/Cosmos/Signing/QBTCHelper.swift` (`Data.appendProto*` extensions)

## Out of scope (later PRs)

- PR2: `LUNAStakeScreen` + `LUNAStakeViewModel` + `CosmosDelegateTransactionBuilder` + validator picker
- PR3: Undelegate + redelegate (with 21-day cooldown gate)
- PR4: Claim rewards (single + batched up to 8 validators)
- PR5: DeFi-tab wiring + localised strings + Figma polish

## Test plan

- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` clean on new files
- [x] `make generate` succeeds
- [x] `xcodebuild build -scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'` → BUILD SUCCEEDED
- [x] `xcodebuild test` on the 4 new test classes → 47 / 47 passing
- [ ] CodeRabbit review

Part of #4363.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added Cosmos staking support: delegate, undelegate, and redelegate tokens across supported chains
- Added validator address validation and rewards management for Cosmos networks

## Tests
- Added comprehensive test coverage for staking operations and validator address validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->