### PR TITLE
feat(staking): LUNA/LUNC delegate flow — screen + viewmodel + validator picker (PR2/5)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Models/Staking/CosmosStakingPayload.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Models/Staking/CosmosStakingPayload.swift
@@ -1,0 +1,91 @@
+//
+//  CosmosStakingPayload.swift
+//  VultisigApp
+//
+//  Carries the staking-operation intent from the per-flow `TransactionBuilder`
+//  through `SendTransaction` into the Verify → KeysignPayload bridge. At
+//  build-keysign time the `CosmosStakingSignDataResolver` consumes this
+//  payload, encodes the matching `Any`-wrapped Cosmos-SDK message via
+//  `CosmosStakingHelper`, builds the SignDoc bytes, and writes
+//  `KeysignPayload.signData = .signDirect(...)`.
+//
+//  Discriminated by `opType`. Field set per op:
+//    .delegate            → validatorAddress, denom, amount
+//    .undelegate          → validatorAddress, denom, amount
+//    .redelegate          → validatorSrcAddress, validatorDstAddress, denom, amount
+//    .withdrawRewards     → validators (1..N), denom
+//
+//  Local to iOS only — the proto-mappable bridge to `KeysignMessage` does NOT
+//  round-trip this field. Same posture as `qbtcClaimPayload`; the SignDoc
+//  bytes produced from it are what the peer device sees, and those bytes are
+//  the contract.
+//
+
+import Foundation
+
+enum CosmosStakingOpType: String, Codable, Hashable {
+    case delegate
+    case undelegate
+    case redelegate
+    case withdrawRewards
+}
+
+struct CosmosStakingPayload: Codable, Hashable {
+    let opType: CosmosStakingOpType
+    let validatorAddress: String?
+    let validatorSrcAddress: String?
+    let validatorDstAddress: String?
+    let validators: [String]?
+    let denom: String
+    /// Base-unit string (e.g. `"1000000"` for 1 LUNA). `nil` for
+    /// `.withdrawRewards` — `MsgWithdrawDelegatorReward` carries no Coin.
+    let amount: String?
+
+    static func delegate(validator: String, denom: String, amount: String) -> CosmosStakingPayload {
+        CosmosStakingPayload(
+            opType: .delegate,
+            validatorAddress: validator,
+            validatorSrcAddress: nil,
+            validatorDstAddress: nil,
+            validators: nil,
+            denom: denom,
+            amount: amount
+        )
+    }
+
+    static func undelegate(validator: String, denom: String, amount: String) -> CosmosStakingPayload {
+        CosmosStakingPayload(
+            opType: .undelegate,
+            validatorAddress: validator,
+            validatorSrcAddress: nil,
+            validatorDstAddress: nil,
+            validators: nil,
+            denom: denom,
+            amount: amount
+        )
+    }
+
+    static func redelegate(src: String, dst: String, denom: String, amount: String) -> CosmosStakingPayload {
+        CosmosStakingPayload(
+            opType: .redelegate,
+            validatorAddress: nil,
+            validatorSrcAddress: src,
+            validatorDstAddress: dst,
+            validators: nil,
+            denom: denom,
+            amount: amount
+        )
+    }
+
+    static func withdrawRewards(validators: [String], denom: String) -> CosmosStakingPayload {
+        CosmosStakingPayload(
+            opType: .withdrawRewards,
+            validatorAddress: nil,
+            validatorSrcAddress: nil,
+            validatorDstAddress: nil,
+            validators: validators,
+            denom: denom,
+            amount: nil
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingSignDataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingSignDataResolver.swift
@@ -1,0 +1,227 @@
+//
+//  CosmosStakingSignDataResolver.swift
+//  VultisigApp
+//
+//  Builds the SignDoc artefacts (bodyBytes, authInfoBytes, chainId,
+//  accountNumber) for a Cosmos-SDK staking operation. Consumed by the
+//  Verify → KeysignPayload bridge whenever
+//  `SendTransaction.cosmosStakingPayload != nil`.
+//
+//  Each `opType` dispatches to the matching `CosmosStakingHelper.encode*`
+//  call, packs the resulting `Any`-wrapped message(s) into a TxBody, and
+//  pairs them with an AuthInfo derived from the chain's
+//  `CosmosStakingConfig` entry. Gas + fee are scaled linearly with the
+//  message count for the batched-claim path; single-msg flows use the
+//  per-chain base values.
+//
+//  Validator-address preflight gating (bech32 / HRP / payload length) is
+//  enforced HERE — before any SignDoc bytes are produced — so an invalid
+//  validator throws at build time, never burning an MPC ceremony on a
+//  chain-rejected tx (Spec Risk 5 + Decision 1B mitigation).
+//
+
+import Foundation
+import OSLog
+
+enum CosmosStakingSignDataResolver {
+    enum Errors: Error, LocalizedError {
+        case missingChainSpecific
+        case invalidPublicKey
+        case missingPayloadField(String)
+        case validatorPreflightFailed(String)
+        case noValidatorsToClaim
+
+        var errorDescription: String? {
+            switch self {
+            case .missingChainSpecific:
+                return "Missing Cosmos chain-specific account/sequence info for staking"
+            case .invalidPublicKey:
+                return "Invalid compressed secp256k1 public key for staking"
+            case .missingPayloadField(let field):
+                return "Cosmos staking payload missing required field: \(field)"
+            case .validatorPreflightFailed(let reason):
+                return "Validator address rejected by bech32 preflight: \(reason)"
+            case .noValidatorsToClaim:
+                return "Withdraw rewards requires at least one validator"
+            }
+        }
+    }
+
+    private static let logger = Logger(
+        subsystem: "com.vultisig.app",
+        category: "cosmos-staking-sign-resolver"
+    )
+
+    /// Resolves the SignDoc artefacts for a staking payload. Caller passes
+    /// the immutable `SendTransaction` and the Cosmos chain-specific
+    /// (already populated upstream by `BlockChainService.fetchSpecific(...)`).
+    static func resolve(
+        sendTransaction: SendTransaction,
+        chainSpecific: BlockChainSpecific
+    ) throws -> SignDirect {
+        guard let payload = sendTransaction.cosmosStakingPayload else {
+            throw Errors.missingPayloadField("cosmosStakingPayload")
+        }
+        guard case .Cosmos(let accountNumber, let sequence, _, _, _) = chainSpecific else {
+            throw Errors.missingChainSpecific
+        }
+        guard let pubKey = Data(hexString: sendTransaction.coin.hexPublicKey) else {
+            throw Errors.invalidPublicKey
+        }
+        let chain = sendTransaction.coin.chain
+        let entry = try CosmosStakingConfig.entry(for: chain)
+        let delegator = sendTransaction.coin.address
+
+        let msgsAny = try encodeMessages(
+            payload: payload,
+            chain: chain,
+            delegator: delegator,
+            denom: entry.bondDenom
+        )
+
+        // Linear gas + fee scaling for batched-claim — single-msg flows use
+        // N=1 which collapses to the base config values.
+        let multiplier = UInt64(max(msgsAny.count, 1))
+        let gasLimit = entry.gasLimit * multiplier
+        let feeAmount = entry.feeAmount * multiplier
+
+        let bodyBytes = CosmosStakingHelper.buildTxBodyMulti(msgsAny: msgsAny, memo: "")
+        let authInfoBytes = CosmosStakingHelper.buildAuthInfo(
+            pubKey: pubKey,
+            sequence: sequence,
+            gasLimit: gasLimit,
+            feeDenom: entry.feeDenom,
+            feeAmount: feeAmount
+        )
+
+        logger.info(
+            """
+            Built Cosmos staking SignDoc: op=\(payload.opType.rawValue, privacy: .public) \
+            chain=\(chain.rawValue, privacy: .public) msgs=\(msgsAny.count) \
+            gas=\(gasLimit) fee=\(feeAmount)\(entry.feeDenom, privacy: .public)
+            """
+        )
+
+        return SignDirect(
+            bodyBytes: bodyBytes.base64EncodedString(),
+            authInfoBytes: authInfoBytes.base64EncodedString(),
+            chainID: entry.chainId,
+            accountNumber: String(accountNumber)
+        )
+    }
+
+    // MARK: - Per-op encoders
+
+    private static func encodeMessages(
+        payload: CosmosStakingPayload,
+        chain: Chain,
+        delegator: String,
+        denom: String
+    ) throws -> [Data] {
+        switch payload.opType {
+        case .delegate:
+            return [try encodeDelegate(payload: payload, chain: chain, delegator: delegator, denom: denom)]
+        case .undelegate:
+            return [try encodeUndelegate(payload: payload, chain: chain, delegator: delegator, denom: denom)]
+        case .redelegate:
+            return [try encodeRedelegate(payload: payload, chain: chain, delegator: delegator, denom: denom)]
+        case .withdrawRewards:
+            return try encodeWithdrawRewards(payload: payload, chain: chain, delegator: delegator)
+        }
+    }
+
+    private static func encodeDelegate(
+        payload: CosmosStakingPayload,
+        chain: Chain,
+        delegator: String,
+        denom: String
+    ) throws -> Data {
+        guard let validator = payload.validatorAddress, !validator.isEmpty else {
+            throw Errors.missingPayloadField("validatorAddress")
+        }
+        guard let amount = payload.amount, !amount.isEmpty else {
+            throw Errors.missingPayloadField("amount")
+        }
+        try preflight(validator: validator, chain: chain)
+        return CosmosStakingHelper.encodeDelegate(
+            delegator: delegator,
+            validator: validator,
+            amount: amount,
+            denom: denom
+        )
+    }
+
+    private static func encodeUndelegate(
+        payload: CosmosStakingPayload,
+        chain: Chain,
+        delegator: String,
+        denom: String
+    ) throws -> Data {
+        guard let validator = payload.validatorAddress, !validator.isEmpty else {
+            throw Errors.missingPayloadField("validatorAddress")
+        }
+        guard let amount = payload.amount, !amount.isEmpty else {
+            throw Errors.missingPayloadField("amount")
+        }
+        try preflight(validator: validator, chain: chain)
+        return CosmosStakingHelper.encodeUndelegate(
+            delegator: delegator,
+            validator: validator,
+            amount: amount,
+            denom: denom
+        )
+    }
+
+    private static func encodeRedelegate(
+        payload: CosmosStakingPayload,
+        chain: Chain,
+        delegator: String,
+        denom: String
+    ) throws -> Data {
+        guard let src = payload.validatorSrcAddress, !src.isEmpty else {
+            throw Errors.missingPayloadField("validatorSrcAddress")
+        }
+        guard let dst = payload.validatorDstAddress, !dst.isEmpty else {
+            throw Errors.missingPayloadField("validatorDstAddress")
+        }
+        guard let amount = payload.amount, !amount.isEmpty else {
+            throw Errors.missingPayloadField("amount")
+        }
+        try preflight(validator: src, chain: chain)
+        try preflight(validator: dst, chain: chain)
+        return CosmosStakingHelper.encodeBeginRedelegate(
+            delegator: delegator,
+            validatorSrc: src,
+            validatorDst: dst,
+            amount: amount,
+            denom: denom
+        )
+    }
+
+    private static func encodeWithdrawRewards(
+        payload: CosmosStakingPayload,
+        chain: Chain,
+        delegator: String
+    ) throws -> [Data] {
+        guard let validators = payload.validators, !validators.isEmpty else {
+            throw Errors.noValidatorsToClaim
+        }
+        return try validators.map { validator in
+            try preflight(validator: validator, chain: chain)
+            return CosmosStakingHelper.encodeWithdrawDelegatorReward(
+                delegator: delegator,
+                validator: validator
+            )
+        }
+    }
+
+    // MARK: - Validator preflight
+
+    private static func preflight(validator: String, chain: Chain) throws {
+        do {
+            try ValidatorBech32Preflight.validate(validator, for: chain)
+        } catch {
+            throw Errors.validatorPreflightFailed(error.localizedDescription)
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -209,6 +209,11 @@
 "continueThresholdOfTotal" = "Weiter (%d-von-%d)";
 "copyAddress" = "Adresse kopieren";
 "correctAmountCheck" = "Die Menge ist korrekt";
+"cosmosStakingDelegateStubSubtitle" = "Verdiene Staking-Belohnungen, indem du an einen Validator delegierst. Die Entbindung dauert 21 Tage.";
+"cosmosStakingDelegateTitle" = "%@ staken";
+"cosmosStakingNoValidatorsFound" = "Keine Validatoren gefunden";
+"cosmosStakingSelectValidator" = "Validator auswählen";
+"cosmosStakingValidatorPicker" = "Validator";
 "costs" = "Kosten";
 "createFolder" = "Ordner erstellen";
 "createQR" = "QR erstellen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -211,6 +211,11 @@
 "continueThresholdOfTotal" = "Continue (%d-of-%d)";
 "copyAddress" = "Copy address";
 "correctAmountCheck" = "The amount is correct";
+"cosmosStakingDelegateStubSubtitle" = "Earn staking rewards by delegating to a validator. Unbonding takes 21 days.";
+"cosmosStakingDelegateTitle" = "Stake %@";
+"cosmosStakingNoValidatorsFound" = "No validators found";
+"cosmosStakingSelectValidator" = "Select Validator";
+"cosmosStakingValidatorPicker" = "Validator";
 "costs" = "Costs";
 "createFolder" = "Create Folder";
 "createQR" = "Create QR";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -209,6 +209,11 @@
 "continueThresholdOfTotal" = "Continuar (%d-de-%d)";
 "copyAddress" = "Copiar dirección";
 "correctAmountCheck" = "La cantidad es correcta";
+"cosmosStakingDelegateStubSubtitle" = "Gana recompensas de staking delegando a un validador. El desbloqueo toma 21 días.";
+"cosmosStakingDelegateTitle" = "Stake %@";
+"cosmosStakingNoValidatorsFound" = "No se encontraron validadores";
+"cosmosStakingSelectValidator" = "Seleccionar validador";
+"cosmosStakingValidatorPicker" = "Validador";
 "costs" = "Costos";
 "createFolder" = "Crear carpeta";
 "createQR" = "Crear QR";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -209,6 +209,11 @@
 "continueThresholdOfTotal" = "Nastavi (%d-od-%d)";
 "copyAddress" = "Kopiraj adresu";
 "correctAmountCheck" = "Iznos je točan";
+"cosmosStakingDelegateStubSubtitle" = "Zaradite nagrade za staking delegiranjem validatoru. Odjava traje 21 dan.";
+"cosmosStakingDelegateTitle" = "Stake %@";
+"cosmosStakingNoValidatorsFound" = "Nije pronađen nijedan validator";
+"cosmosStakingSelectValidator" = "Odaberite validatora";
+"cosmosStakingValidatorPicker" = "Validator";
 "costs" = "Troškovi";
 "createFolder" = "Kreiraj mapu";
 "createQR" = "Stvori QR";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -209,6 +209,11 @@
 "continueThresholdOfTotal" = "Continua (%d-di-%d)";
 "copyAddress" = "Copia indirizzo";
 "correctAmountCheck" = "La quantità è corretta";
+"cosmosStakingDelegateStubSubtitle" = "Guadagna ricompense di staking delegando a un validatore. Lo sblocco richiede 21 giorni.";
+"cosmosStakingDelegateTitle" = "Stake %@";
+"cosmosStakingNoValidatorsFound" = "Nessun validatore trovato";
+"cosmosStakingSelectValidator" = "Seleziona validatore";
+"cosmosStakingValidatorPicker" = "Validatore";
 "costs" = "Costi";
 "createFolder" = "Crea cartella";
 "createQR" = "Crea QR";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -211,6 +211,11 @@
 "continueThresholdOfTotal" = "계속 (%d/%d)";
 "copyAddress" = "주소 복사";
 "correctAmountCheck" = "금액이 올바릅니다";
+"cosmosStakingDelegateStubSubtitle" = "검증인에게 위임하여 스테이킹 보상을 받으세요. 언본딩에는 21일이 소요됩니다.";
+"cosmosStakingDelegateTitle" = "%@ 스테이킹";
+"cosmosStakingNoValidatorsFound" = "검증인을 찾을 수 없습니다";
+"cosmosStakingSelectValidator" = "검증인 선택";
+"cosmosStakingValidatorPicker" = "검증인";
 "costs" = "비용";
 "createFolder" = "폴더 생성";
 "createQR" = "QR 생성";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -209,6 +209,11 @@
 "continueThresholdOfTotal" = "Continuar (%d-de-%d)";
 "copyAddress" = "Copiar endereço";
 "correctAmountCheck" = "A quantidade está correta";
+"cosmosStakingDelegateStubSubtitle" = "Ganhe recompensas de staking delegando a um validador. O desbloqueio leva 21 dias.";
+"cosmosStakingDelegateTitle" = "Stake %@";
+"cosmosStakingNoValidatorsFound" = "Nenhum validador encontrado";
+"cosmosStakingSelectValidator" = "Selecionar validador";
+"cosmosStakingValidatorPicker" = "Validador";
 "costs" = "Custos";
 "createFolder" = "Criar pasta";
 "createQR" = "Criar QR";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -209,6 +209,11 @@
 "continueThresholdOfTotal" = "继续 (%d/%d)";
 "copyAddress" = "复制地址";
 "correctAmountCheck" = "金额正确";
+"cosmosStakingDelegateStubSubtitle" = "通过委托给验证人赚取质押奖励。解绑需要 21 天。";
+"cosmosStakingDelegateTitle" = "质押 %@";
+"cosmosStakingNoValidatorsFound" = "未找到验证人";
+"cosmosStakingSelectValidator" = "选择验证人";
+"cosmosStakingValidatorPicker" = "验证人";
 "costs" = "成本";
 "createFolder" = "创建文件夹";
 "createQR" = "创建二维码";

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -126,23 +126,27 @@ struct DefiChainMainScreen: View {
                     )
                 }
             case .stake:
-                DefiChainStakedView(
-                    viewModel: stakeViewModel,
-                    onStake: { onStake(position: $0) },
-                    onUnstake: { onUnstake(position: $0) },
-                    onWithdraw: { position in
-                        guard let rewards = position.rewards, let rewardsCoin = position.rewardCoin else {
-                            return
-                        }
-                        onTransactionToPresent(.withdrawRewards(
-                            coin: position.coin,
-                            rewards: rewards,
-                            rewardsCoin: rewardsCoin
-                        ))
-                    },
-                    onTransfer: { onTransfer(position: $0) },
-                    emptyStateView: { emptyStateView }
-                )
+                if chain == .terra || chain == .terraClassic, let nativeCoin {
+                    cosmosDelegateStubView(coin: nativeCoin)
+                } else {
+                    DefiChainStakedView(
+                        viewModel: stakeViewModel,
+                        onStake: { onStake(position: $0) },
+                        onUnstake: { onUnstake(position: $0) },
+                        onWithdraw: { position in
+                            guard let rewards = position.rewards, let rewardsCoin = position.rewardCoin else {
+                                return
+                            }
+                            onTransactionToPresent(.withdrawRewards(
+                                coin: position.coin,
+                                rewards: rewards,
+                                rewardsCoin: rewardsCoin
+                            ))
+                        },
+                        onTransfer: { onTransfer(position: $0) },
+                        emptyStateView: { emptyStateView }
+                    )
+                }
             case .liquidityPool:
                 DefiChainLPsView(
                     vault: vault,
@@ -168,6 +172,21 @@ struct DefiChainMainScreen: View {
             subtitle: "noPositionsSelectedSubtitle".localized,
             buttonTitle: "managePositions".localized,
             action: { showPositionSelection.toggle() }
+        )
+    }
+
+    /// Stub entry-point for LUNA / LUNC delegate flow. PR5 replaces this
+    /// with the full `DefiChainStakedView` once `CosmosStakeInteractor` is
+    /// wired into `DefiInteractorResolver`. Today the user only sees the
+    /// "Stake LUNA / LUNC" CTA that routes into `CosmosDelegateTransactionScreen`.
+    private func cosmosDelegateStubView(coin: Coin) -> some View {
+        ActionBannerView(
+            title: String(format: "cosmosStakingDelegateTitle".localized, coin.ticker),
+            subtitle: "cosmosStakingDelegateStubSubtitle".localized,
+            buttonTitle: String(format: "cosmosStakingDelegateTitle".localized, coin.ticker),
+            action: {
+                onTransactionToPresent(.cosmosDelegate(coin: coin.toCoinMeta()))
+            }
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
@@ -87,6 +87,13 @@ final class DefiChainMainViewModel: ObservableObject {
             [.bond, .stake, .liquidityPool]
         case .mayaChain:
             [.bond, .stake, .liquidityPool]
+        case .terra, .terraClassic:
+            // Stake-only segment for Cosmos-SDK staking on LUNA / LUNC.
+            // The polished position-card UI (Figma 75718:98399 populated /
+            // 75718:98358 empty) lands in a follow-up PR; today the stake
+            // segment renders a delegate-CTA stub via `DefiChainStakedView`'s
+            // empty-state fallback.
+            [.stake]
         default:
             []
         }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Model/FunctionTransactionType.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Model/FunctionTransactionType.swift
@@ -17,6 +17,7 @@ enum FunctionTransactionType: Hashable {
     case redeem(coin: CoinMeta, yCoin: CoinMeta)
     case addLP(position: LPPosition)
     case removeLP(position: LPPosition)
+    case cosmosDelegate(coin: CoinMeta)
 
     var coins: [CoinMeta] {
         switch self {
@@ -38,6 +39,8 @@ enum FunctionTransactionType: Hashable {
             return [position.coin1, position.coin2]
         case .removeLP(let position):
             return [position.coin1, position.coin2]
+        case .cosmosDelegate(let coin):
+            return [coin]
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/Delegate/CosmosDelegateTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/Delegate/CosmosDelegateTransactionScreen.swift
@@ -1,0 +1,159 @@
+//
+//  CosmosDelegateTransactionScreen.swift
+//  VultisigApp
+//
+//  Delegate input form for LUNA / LUNC. Two sections — validator picker
+//  (opens the `ValidatorSelectionScreen` sheet) and amount (uses the
+//  existing `AmountTextField`). Mirrors `BondTransactionScreen` shape.
+//
+
+import SwiftUI
+
+struct CosmosDelegateTransactionScreen: View {
+    enum FocusedField {
+        case validator, amount
+    }
+
+    @StateObject var viewModel: CosmosDelegateTransactionViewModel
+    var onVerify: (TransactionBuilder) -> Void
+
+    @State private var focusedFieldBinding: FocusedField? = .none
+    @FocusState private var focusedField: FocusedField?
+    @State private var percentageSelected: Double?
+    @State private var showValidatorPicker: Bool = false
+
+    var body: some View {
+        FormScreen(
+            title: String(format: "cosmosStakingDelegateTitle".localized, viewModel.coin.ticker),
+            validForm: $viewModel.validForm,
+            onContinue: onContinue
+        ) {
+            FormExpandableSection(
+                title: "cosmosStakingValidatorPicker".localized,
+                isValid: viewModel.selectedValidator != nil,
+                value: viewModel.selectedValidator?.moniker ?? "",
+                showValue: viewModel.selectedValidator != nil,
+                focusedField: $focusedFieldBinding,
+                focusedFieldEquals: .validator
+            ) {
+                focusedFieldBinding = $0 ? .validator : .amount
+                if $0 {
+                    showValidatorPicker = true
+                }
+            } content: {
+                validatorButton
+            }
+
+            FormExpandableSection(
+                title: viewModel.amountField.label ?? .empty,
+                isValid: viewModel.amountField.valid,
+                value: .empty,
+                showValue: false,
+                focusedField: $focusedFieldBinding,
+                focusedFieldEquals: .amount
+            ) {
+                focusedFieldBinding = $0 ? .amount : .validator
+            } content: {
+                VStack(spacing: 12) {
+                    AmountTextField(
+                        amount: $viewModel.amountField.value,
+                        error: $viewModel.amountField.error,
+                        ticker: viewModel.coin.ticker,
+                        type: .button,
+                        availableAmount: viewModel.stakeableBalance,
+                        decimals: viewModel.coin.decimals,
+                        percentage: $percentageSelected
+                    )
+                    .focused($focusedField, equals: .amount)
+
+                    gasReservationInfo
+                }
+            }
+        }
+        .crossPlatformSheet(isPresented: $showValidatorPicker) {
+            ValidatorSelectionScreen(
+                isPresented: $showValidatorPicker,
+                selectedValidator: $viewModel.selectedValidator,
+                chain: viewModel.coin.chain,
+                chainTicker: viewModel.coin.ticker
+            )
+        }
+        .onLoad { viewModel.onLoad() }
+        .onChange(of: percentageSelected) { _, newValue in
+            guard let newValue else { return }
+            viewModel.onPercentage(newValue)
+        }
+        .onChange(of: viewModel.selectedValidator) { _, _ in
+            focusedFieldBinding = .amount
+        }
+        .onChange(of: focusedFieldBinding) { _, newValue in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                focusedField = newValue
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var validatorButton: some View {
+        Button {
+            showValidatorPicker = true
+        } label: {
+            HStack(spacing: 8) {
+                if let validator = viewModel.selectedValidator {
+                    Text(validator.moniker.isEmpty
+                         ? truncated(validator.operatorAddress)
+                         : validator.moniker)
+                        .font(Theme.fonts.bodyMMedium)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                } else {
+                    Text("cosmosStakingSelectValidator".localized)
+                        .font(Theme.fonts.bodyMMedium)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                }
+                Spacer()
+                Icon(named: "chevron-right", color: Theme.colors.textTertiary, size: 16)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(Theme.colors.bgSurface1)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var gasReservationInfo: some View {
+        if let message = viewModel.gasReservationMessage {
+            HStack(spacing: 8) {
+                Icon(named: "info", color: Theme.colors.textTertiary, size: 14)
+                Text(message)
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                Spacer()
+            }
+            .padding(12)
+            .background(Theme.colors.bgSurface1)
+            .cornerRadius(8)
+        }
+    }
+
+    private func onContinue() {
+        switch focusedFieldBinding {
+        case .validator:
+            showValidatorPicker = true
+        case .amount, .none:
+            guard viewModel.selectedValidator != nil else {
+                focusedFieldBinding = .validator
+                showValidatorPicker = true
+                return
+            }
+            guard let transactionBuilder = viewModel.transactionBuilder else { return }
+            onVerify(transactionBuilder)
+        }
+    }
+
+    private func truncated(_ address: String) -> String {
+        guard address.count > 14 else { return address }
+        return address.prefix(8) + "…" + address.suffix(4)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/Delegate/CosmosDelegateTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/Delegate/CosmosDelegateTransactionViewModel.swift
@@ -1,0 +1,91 @@
+//
+//  CosmosDelegateTransactionViewModel.swift
+//  VultisigApp
+//
+//  Form view-model for the LUNA / LUNC delegate flow. Same `Form` +
+//  `[FormField]` + `transactionBuilder` shape as `BondTransactionViewModel`
+//  and `StakeTransactionViewModel` — view holds only `@FocusState` and
+//  cosmetic state, every business field lives here.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class CosmosDelegateTransactionViewModel: ObservableObject, Form {
+    let coin: Coin
+    let vault: Vault
+
+    @Published var validForm: Bool = false
+    @Published var selectedValidator: CosmosValidator?
+
+    @Published var amountField = FormField(
+        label: "amount".localized,
+        placeholder: "0",
+        validators: [
+            RequiredValidator(errorMessage: "emptyAmountField".localized)
+        ]
+    )
+
+    private(set) var isMaxAmount: Bool = false
+    private(set) lazy var form: [FormField] = [amountField]
+
+    var formCancellable: AnyCancellable?
+    var cancellables = Set<AnyCancellable>()
+
+    init(coin: Coin, vault: Vault) {
+        self.coin = coin
+        self.vault = vault
+    }
+
+    func onLoad() {
+        setupForm()
+        amountField.validators.append(AmountBalanceValidator(balance: stakeableBalance))
+    }
+
+    /// Headroom-aware stakeable balance — the cosmos fee for a single
+    /// `MsgDelegate` lives in the same denom as the bond, so we must reserve
+    /// it before letting the user delegate up to "max".
+    var stakeableBalance: Decimal {
+        let total = coin.balanceDecimal
+        let reserved = feeReservation
+        let remaining = total - reserved
+        return remaining > 0 ? remaining : 0
+    }
+
+    /// Gas-reservation message shown inline under the amount field — mirrors
+    /// the `StakeTransactionViewModel.gasReservationMessage` pattern for
+    /// CACAO.
+    var gasReservationMessage: String? {
+        guard feeReservation > 0 else { return nil }
+        return String(
+            format: "reservesForGas".localized,
+            feeReservation.formatted(),
+            coin.ticker
+        )
+    }
+
+    private var feeReservation: Decimal {
+        guard let entry = try? CosmosStakingConfig.entry(for: coin.chain) else {
+            return 0
+        }
+        let divisor = pow(Decimal(10), coin.decimals)
+        return Decimal(entry.feeAmount) / divisor
+    }
+
+    var transactionBuilder: TransactionBuilder? {
+        validateErrors()
+        guard validForm, let validator = selectedValidator else { return nil }
+        guard !validator.jailed else { return nil }
+        return CosmosDelegateTransactionBuilder(
+            coin: coin,
+            amount: amountField.value.formatToDecimal(digits: coin.decimals),
+            sendMaxAmount: isMaxAmount,
+            validatorAddress: validator.operatorAddress
+        )
+    }
+
+    func onPercentage(_ percentage: Double) {
+        isMaxAmount = percentage == 100
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/ValidatorSelection/ValidatorCard.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/ValidatorSelection/ValidatorCard.swift
@@ -1,0 +1,120 @@
+//
+//  ValidatorCard.swift
+//  VultisigApp
+//
+//  Per-validator row in the cosmos validator-picker sheet. Matches Figma
+//  node `75918:75443` — 36pt monogram avatar (first letter of the moniker
+//  on a gradient circle, per Figma `75963:74534`), moniker, voting power as
+//  the subline, commission % on the right, optional check on selection.
+//
+
+import SwiftUI
+
+struct ValidatorCard: View {
+    let validator: CosmosValidator
+    let chainTicker: String
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 12) {
+                avatar
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(validator.moniker.isEmpty ? validator.operatorAddress.truncated() : validator.moniker)
+                        .font(Theme.fonts.bodySMedium)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                        .lineLimit(1)
+                    Text(votingPowerText)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 8)
+                Text(commissionText)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .lineLimit(1)
+                if isSelected {
+                    Icon(named: "check", color: Theme.colors.alertSuccess, size: 16)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(background)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var avatar: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.colors.primaryAccent3, Theme.colors.primaryAccent4],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            Text(monogram)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+        }
+        .frame(width: 36, height: 36)
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        if isSelected {
+            Theme.colors.bgSurface1
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Theme.colors.alertSuccess.opacity(0.5), lineWidth: 1)
+                )
+        } else {
+            Theme.colors.bgSurface1
+        }
+    }
+
+    private var monogram: String {
+        let source = validator.moniker.isEmpty ? validator.operatorAddress : validator.moniker
+        return String(source.prefix(1)).uppercased()
+    }
+
+    private var votingPowerText: String {
+        let display = formatVotingPower(validator.votingPower, decimals: 6)
+        return "\(display) \(chainTicker)"
+    }
+
+    private var commissionText: String {
+        let percentage = validator.commission * 100
+        let nsNumber = NSDecimalNumber(decimal: percentage)
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        return "\(formatter.string(from: nsNumber) ?? "0")%"
+    }
+
+    /// Voting power arrives as base-units `Decimal` (uluna). For display we
+    /// scale down by the chain's native decimals and round to thousands so
+    /// values like "200,392 LUNA" match the Figma reference.
+    private func formatVotingPower(_ value: Decimal, decimals: Int) -> String {
+        let divisor = pow(Decimal(10), decimals)
+        let scaled = value / divisor
+        let nsNumber = NSDecimalNumber(decimal: scaled)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: nsNumber) ?? "0"
+    }
+}
+
+private extension String {
+    /// Compact `terravaloper1abc…xyz` truncation for fallback display.
+    func truncated() -> String {
+        guard count > 14 else { return self }
+        return prefix(8) + "…" + suffix(4)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/ValidatorSelection/ValidatorSelectionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/ValidatorSelection/ValidatorSelectionScreen.swift
@@ -1,0 +1,101 @@
+//
+//  ValidatorSelectionScreen.swift
+//  VultisigApp
+//
+//  Validator-picker sheet for the LUNA / LUNC delegate / redelegate flows.
+//  Matches Figma `75918:74747` — `SearchTextField` + scrollable `LazyVStack`
+//  of `ValidatorCard`s with the selected-state stroke variant.
+//
+//  Sheet-presented; on tap the screen sets the parent's `selectedValidator`
+//  binding and dismisses itself via `isPresented`.
+//
+
+import SwiftUI
+
+struct ValidatorSelectionScreen: View {
+    @Binding var isPresented: Bool
+    @Binding var selectedValidator: CosmosValidator?
+    let chainTicker: String
+    @StateObject var viewModel: ValidatorSelectionViewModel
+
+    init(
+        isPresented: Binding<Bool>,
+        selectedValidator: Binding<CosmosValidator?>,
+        chain: Chain,
+        chainTicker: String,
+        excludedValidators: Set<String> = []
+    ) {
+        self._isPresented = isPresented
+        self._selectedValidator = selectedValidator
+        self.chainTicker = chainTicker
+        self._viewModel = .init(wrappedValue: ValidatorSelectionViewModel(
+            chain: chain,
+            excludedValidators: excludedValidators
+        ))
+    }
+
+    var body: some View {
+        Screen {
+            VStack(spacing: 8) {
+                SearchTextField(value: $viewModel.searchText)
+                ScrollView {
+                    if viewModel.isLoading {
+                        loadingView
+                    } else if let error = viewModel.error {
+                        ErrorMessage(text: error)
+                            .padding(.top, 48)
+                    } else if !viewModel.filteredValidators.isEmpty {
+                        list
+                    } else {
+                        ErrorMessage(text: "cosmosStakingNoValidatorsFound")
+                            .padding(.top, 48)
+                    }
+                }
+                .cornerRadius(12)
+            }
+        }
+        .screenTitle("cosmosStakingSelectValidator".localized)
+        .screenBackButtonHidden()
+        .screenToolbar {
+            CustomToolbarItem(placement: .leading) {
+                ToolbarButton(image: "x") {
+                    isPresented.toggle()
+                }
+            }
+        }
+        .applySheetSize()
+        .sheetStyle()
+        .onDisappear { viewModel.searchText = "" }
+        .onLoad {
+            Task { await viewModel.load() }
+        }
+    }
+
+    private var list: some View {
+        LazyVStack(spacing: 8) {
+            ForEach(viewModel.filteredValidators, id: \.operatorAddress) { validator in
+                ValidatorCard(
+                    validator: validator,
+                    chainTicker: chainTicker,
+                    isSelected: selectedValidator?.operatorAddress == validator.operatorAddress
+                ) {
+                    selectedValidator = validator
+                    isPresented = false
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            SpinningLineLoader()
+                .scaleEffect(1.2)
+            Text(NSLocalizedString("loading", comment: ""))
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textTertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, 48)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/ValidatorSelection/ValidatorSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/ValidatorSelection/ValidatorSelectionViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  ValidatorSelectionViewModel.swift
+//  VultisigApp
+//
+//  Backs the cosmos validator-picker sheet. Loads the bonded validator set
+//  from `CosmosStakingService`, sorts by voting power descending, filters
+//  jailed validators out, and surfaces search + selection state.
+//
+//  Cache is per-sheet (the spec D-5 calls for no SwiftData persistence).
+//
+
+import Foundation
+import OSLog
+
+@MainActor
+final class ValidatorSelectionViewModel: ObservableObject {
+    @Published var searchText: String = ""
+    @Published private(set) var validators: [CosmosValidator] = []
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var error: String?
+
+    let chain: Chain
+    private let service: CosmosStakingServiceProtocol
+    private let logger = Logger(
+        subsystem: "com.vultisig.app",
+        category: "validator-selection"
+    )
+
+    /// Validators excluded from the visible list — e.g. the source validator
+    /// when redelegating (you can't redelegate to yourself). Defaults to
+    /// empty for the delegate flow.
+    let excludedValidators: Set<String>
+
+    init(
+        chain: Chain,
+        service: CosmosStakingServiceProtocol = CosmosStakingService(),
+        excludedValidators: Set<String> = []
+    ) {
+        self.chain = chain
+        self.service = service
+        self.excludedValidators = excludedValidators
+    }
+
+    var filteredValidators: [CosmosValidator] {
+        let pool = validators.filter { !excludedValidators.contains($0.operatorAddress) }
+        guard searchText.isNotEmpty else { return pool }
+        let needle = searchText.lowercased()
+        return pool.filter { validator in
+            validator.moniker.lowercased().contains(needle)
+                || validator.operatorAddress.lowercased().contains(needle)
+        }
+    }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            let raw = try await service.fetchValidators(chain: chain)
+            validators = Self.sortAndFilter(raw)
+        } catch {
+            logger.error("Validator fetch failed: \(error.localizedDescription, privacy: .public)")
+            self.error = error.localizedDescription
+        }
+    }
+
+    /// Keeps bonded + un-jailed validators, sorted by descending voting power.
+    /// Surfaced as a static helper so tests can pin the sort/filter contract
+    /// independent of the network layer.
+    static func sortAndFilter(_ raw: [CosmosValidator]) -> [CosmosValidator] {
+        raw
+            .filter { !$0.jailed && $0.status == .bonded }
+            .sorted { $0.votingPower > $1.votingPower }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -139,6 +139,13 @@ struct FunctionTransactionScreen: View {
                         onVerify: onVerify
                     )
                 }
+            case .cosmosDelegate(let coin):
+                resolvingCoin(coinMeta: coin) { coin in
+                    CosmosDelegateTransactionScreen(
+                        viewModel: CosmosDelegateTransactionViewModel(coin: coin, vault: vault),
+                        onVerify: onVerify
+                    )
+                }
             }
         }
         .withLoading(isLoading: $isLoading)
@@ -146,6 +153,19 @@ struct FunctionTransactionScreen: View {
 
     func onVerify(_ transactionBuilder: TransactionBuilder) {
         Task { @MainActor in
+            // Cosmos staking flows bypass the legacy `FunctionCallForm`
+            // round-trip — the SignDoc payload travels via
+            // `SendTransaction.cosmosStakingPayload`, which `fromForm(_:)`
+            // would drop. Skip directly to the immutable struct so the
+            // Verify → KeysignPayload resolver sees the staking intent.
+            if transactionBuilder.cosmosStakingPayload != nil {
+                isLoading = true
+                let immutableTx = transactionBuilder.buildSendTransaction(vault: vault)
+                isLoading = false
+                router.navigate(to: FunctionCallRoute.verify(tx: immutableTx, vault: vault))
+                return
+            }
+
             isLoading = true
             let tx = transactionBuilder.buildTransaction()
 

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Cosmos/CosmosDelegateTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Cosmos/CosmosDelegateTransactionBuilder.swift
@@ -1,0 +1,66 @@
+//
+//  CosmosDelegateTransactionBuilder.swift
+//  VultisigApp
+//
+//  Per-flow builder for LUNA / LUNC `MsgDelegate`. The builder is a pure
+//  value-type carrier; SignDoc bytes are produced lazily by
+//  `CosmosStakingSignDataResolver.resolve(...)` at Verify → KeysignPayload
+//  bridge time so the chain-specific account/sequence are always fresh.
+//
+//  Mirrors the shape of `BondMayaTransactionBuilder` — `memo = ""` (cosmos
+//  staking msgs carry no memo), `transactionType = .unspecified`, real
+//  payload travels via the `cosmosStakingPayload` accessor.
+//
+
+import BigInt
+import Foundation
+import VultisigCommonData
+
+struct CosmosDelegateTransactionBuilder: TransactionBuilder {
+    let coin: Coin
+    let amount: String
+    let sendMaxAmount: Bool
+    let validatorAddress: String
+
+    var memo: String { "" }
+
+    var memoFunctionDictionary: ThreadSafeDictionary<String, String> {
+        ThreadSafeDictionary<String, String>()
+    }
+
+    var transactionType: VSTransactionType { .unspecified }
+    var wasmContractPayload: WasmExecuteContractPayload? { nil }
+    /// `toAddress` doubles as the verify-screen "destination" — for delegate
+    /// flows the operator (`terravaloper1…`) is what the user is sending
+    /// stake to.
+    var toAddress: String { validatorAddress }
+
+    var cosmosStakingPayload: CosmosStakingPayload? {
+        let denom = (try? CosmosStakingConfig.bondDenom(for: coin.chain)) ?? ""
+        let baseAmount = baseUnitsString(amount: amount, decimals: coin.decimals)
+        return CosmosStakingPayload.delegate(
+            validator: validatorAddress,
+            denom: denom,
+            amount: baseAmount
+        )
+    }
+
+    /// Converts a human-decimal amount string (e.g. `"1.5"`) to the
+    /// chain's base-unit string (e.g. `"1500000"` for LUNA 6-decimals).
+    /// Decimal-based to avoid floating-point drift across the boundary.
+    private func baseUnitsString(amount: String, decimals: Int) -> String {
+        let normalized = amount.replacingOccurrences(of: ",", with: ".")
+        guard let parsed = Decimal(string: normalized) else { return "0" }
+        let multiplier = pow(Decimal(10), decimals)
+        let raw = parsed * multiplier
+        let handler = NSDecimalNumberHandler(
+            roundingMode: .down,
+            scale: 0,
+            raiseOnExactness: false,
+            raiseOnOverflow: false,
+            raiseOnUnderflow: false,
+            raiseOnDivideByZero: false
+        )
+        return NSDecimalNumber(decimal: raw).rounding(accordingToBehavior: handler).stringValue
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
@@ -16,9 +16,18 @@ protocol TransactionBuilder {
     var transactionType: VSTransactionType { get }
     var wasmContractPayload: WasmExecuteContractPayload? { get }
     var toAddress: String { get }
+    /// Cosmos-SDK staking / distribution operation intent. Populated only by
+    /// the per-flow Cosmos staking builders (delegate, undelegate, redelegate,
+    /// withdrawRewards); every other builder uses the default `nil`.
+    var cosmosStakingPayload: CosmosStakingPayload? { get }
 }
 
 extension TransactionBuilder {
+    /// Default — only Cosmos staking builders override this. Keeping the
+    /// requirement defaulted means every existing `TransactionBuilder`
+    /// conformer compiles unchanged.
+    var cosmosStakingPayload: CosmosStakingPayload? { nil }
+
     // Builds the legacy mutable form-state class. Used by call sites that
     // continue mutating fields downstream (e.g. `tx.gas`, `tx.fastVaultPassword`).
     // Once the FunctionCall flow migrates to a per-flow form VM this method
@@ -58,11 +67,12 @@ extension TransactionBuilder {
             customGasLimit: nil,
             customByteFee: nil,
             sendMaxAmount: sendMaxAmount,
-            isStakingOperation: false,
+            isStakingOperation: cosmosStakingPayload != nil,
             transactionType: transactionType,
             memoFunctionDictionary: memoFunctionDictionary.allItems(),
             wasmContractPayload: wasmContractPayload,
-            feeCoin: SendTransaction.resolveFeeCoin(coin: coin, vault: vault)
+            feeCoin: SendTransaction.resolveFeeCoin(coin: coin, vault: vault),
+            cosmosStakingPayload: cosmosStakingPayload
         )
     }
 }

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -228,6 +228,14 @@ struct SendTransaction: Hashable {
     /// full coin list at read time.
     let feeCoin: Coin
     let feeCoinSnapshot: SendCoinSnapshot
+
+    /// Cosmos-SDK x/staking + x/distribution operation intent. Non-nil only
+    /// for LUNA / LUNC delegate / undelegate / redelegate / claim flows;
+    /// populated by the per-flow `TransactionBuilder` and consumed by the
+    /// Verify → KeysignPayload bridge to produce the SignDoc bytes.
+    /// Local-only on iOS — does not round-trip through the proto-mappable
+    /// `KeysignMessage` bridge (same posture as `qbtcClaimPayload`).
+    let cosmosStakingPayload: CosmosStakingPayload?
 }
 
 extension SendTransaction {
@@ -251,7 +259,8 @@ extension SendTransaction {
             lhs.transactionType == rhs.transactionType &&
             lhs.memoFunctionDictionary == rhs.memoFunctionDictionary &&
             lhs.wasmContractPayload == rhs.wasmContractPayload &&
-            lhs.feeCoinSnapshot == rhs.feeCoinSnapshot
+            lhs.feeCoinSnapshot == rhs.feeCoinSnapshot &&
+            lhs.cosmosStakingPayload == rhs.cosmosStakingPayload
     }
 
     func hash(into hasher: inout Hasher) {
@@ -275,6 +284,7 @@ extension SendTransaction {
         hasher.combine(memoFunctionDictionary)
         hasher.combine(wasmContractPayload)
         hasher.combine(feeCoinSnapshot)
+        hasher.combine(cosmosStakingPayload)
     }
 }
 
@@ -299,7 +309,8 @@ extension SendTransaction {
         transactionType: VSTransactionType,
         memoFunctionDictionary: [String: String],
         wasmContractPayload: WasmExecuteContractPayload?,
-        feeCoin: Coin
+        feeCoin: Coin,
+        cosmosStakingPayload: CosmosStakingPayload? = nil
     ) {
         self.coin = coin
         self.vault = vault
@@ -324,6 +335,7 @@ extension SendTransaction {
         self.wasmContractPayload = wasmContractPayload
         self.feeCoin = feeCoin
         self.feeCoinSnapshot = SendCoinSnapshot(coin: feeCoin)
+        self.cosmosStakingPayload = cosmosStakingPayload
     }
 }
 
@@ -390,7 +402,8 @@ extension SendTransaction {
         transactionType: VSTransactionType? = nil,
         memoFunctionDictionary: [String: String]? = nil,
         wasmContractPayload: SendTransactionUpdate<WasmExecuteContractPayload?>? = nil,
-        feeCoin: Coin? = nil
+        feeCoin: Coin? = nil,
+        cosmosStakingPayload: SendTransactionUpdate<CosmosStakingPayload?>? = nil
     ) -> SendTransaction {
         let resolvedVault = vault ?? self.vault
         let resolvedCoin = coin ?? self.coin
@@ -414,6 +427,10 @@ extension SendTransaction {
             guard let wasmContractPayload else { return self.wasmContractPayload }
             return wasmContractPayload.value
         }()
+        let resolvedCosmosStakingPayload: CosmosStakingPayload? = {
+            guard let cosmosStakingPayload else { return self.cosmosStakingPayload }
+            return cosmosStakingPayload.value
+        }()
         return SendTransaction(
             coin: resolvedCoin,
             vault: resolvedVault,
@@ -434,7 +451,8 @@ extension SendTransaction {
             transactionType: transactionType ?? self.transactionType,
             memoFunctionDictionary: memoFunctionDictionary ?? self.memoFunctionDictionary,
             wasmContractPayload: resolvedWasmContractPayload,
-            feeCoin: feeCoin ?? self.feeCoin
+            feeCoin: feeCoin ?? self.feeCoin,
+            cosmosStakingPayload: resolvedCosmosStakingPayload
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -134,7 +134,7 @@ struct SendCryptoVerifyLogic {
         do {
             let chainSpecific = try await interactor.fetchChainSpecific(tx: tx)
 
-            return try await interactor.buildKeysignPayload(
+            let basePayload = try await interactor.buildKeysignPayload(
                 coin: tx.coin,
                 toAddress: tx.toAddress,
                 amount: tx.amountInRaw,
@@ -143,6 +143,44 @@ struct SendCryptoVerifyLogic {
                 wasmExecuteContractPayload: tx.wasmContractPayload,
                 vault: vault
             )
+
+            // Cosmos staking branch — when the per-flow builder produced a
+            // `cosmosStakingPayload`, swap the base payload's `signData` for
+            // a freshly-resolved `.signDirect(...)` carrying the proto-encoded
+            // MsgDelegate / MsgUndelegate / MsgBeginRedelegate /
+            // MsgWithdrawDelegatorReward bytes. The SignDoc is the contract
+            // the peer device sees; everything else on `KeysignPayload`
+            // becomes descriptive (verify-summary) only.
+            if tx.cosmosStakingPayload != nil {
+                let signDirect = try CosmosStakingSignDataResolver.resolve(
+                    sendTransaction: tx,
+                    chainSpecific: chainSpecific
+                )
+                return KeysignPayload(
+                    coin: basePayload.coin,
+                    toAddress: basePayload.toAddress,
+                    toAmount: basePayload.toAmount,
+                    chainSpecific: basePayload.chainSpecific,
+                    utxos: basePayload.utxos,
+                    memo: basePayload.memo,
+                    swapPayload: basePayload.swapPayload,
+                    approvePayload: basePayload.approvePayload,
+                    vaultPubKeyECDSA: basePayload.vaultPubKeyECDSA,
+                    vaultLocalPartyID: basePayload.vaultLocalPartyID,
+                    libType: basePayload.libType,
+                    wasmExecuteContractPayload: basePayload.wasmExecuteContractPayload,
+                    tronTransferContractPayload: basePayload.tronTransferContractPayload,
+                    tronTriggerSmartContractPayload: basePayload.tronTriggerSmartContractPayload,
+                    tronTransferAssetContractPayload: basePayload.tronTransferAssetContractPayload,
+                    qbtcClaimPayload: basePayload.qbtcClaimPayload,
+                    isQbtcClaim: basePayload.isQbtcClaim,
+                    skipBroadcast: basePayload.skipBroadcast,
+                    signData: .signDirect(signDirect),
+                    dappMetadata: basePayload.dappMetadata
+                )
+            }
+
+            return basePayload
 
         } catch {
             // Handle UTXO-specific errors with more user-friendly messages

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/Bech32TestUtils.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/Bech32TestUtils.swift
@@ -1,0 +1,79 @@
+//
+//  Bech32TestUtils.swift
+//  VultisigAppTests
+//
+//  Shared bech32 encoder helpers extracted out of `ValidatorBech32PreflightTests`
+//  so suites that need a valid `terravaloper1…` address — e.g. the staking
+//  resolver tests — don't have to inline the encoder. Kept fileprivate-free
+//  here so `Bech32TestUtils.makeValoperAddress(...)` reads cleanly at the
+//  call site.
+//
+
+import Foundation
+
+enum Bech32TestUtils {
+    /// Builds a checksum-valid bech32 address for the given hrp by
+    /// hashing a deterministic 20-byte payload (`[0, 1, 2, ..., 19]`).
+    static func makeValoperAddress(hrp: String = "terravaloper", payloadLength: Int = 20) -> String {
+        let payload = (0..<payloadLength).map { UInt8($0 & 0xff) }
+        return encodeBech32(hrp: hrp, payload: payload)
+    }
+
+    /// Public bech32 encoder — the same code that lives in
+    /// `ValidatorBech32PreflightTests` was extracted here verbatim so any
+    /// suite can construct valid addresses without duplicating the
+    /// polymod table.
+    static func encodeBech32(hrp: String, payload: [UInt8]) -> String {
+        let charset = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+        let data5Bit = convertBits(payload, from: 8, to: 5, pad: true)
+        let checksum = createChecksum(hrp: hrp, data: data5Bit)
+        let combined = data5Bit + checksum
+        return hrp + "1" + String(combined.map { charset[Int($0)] })
+    }
+
+    private static func convertBits(_ data: [UInt8], from fromBits: Int, to toBits: Int, pad: Bool) -> [UInt8] {
+        var acc = 0
+        var bits = 0
+        var result: [UInt8] = []
+        let maxv = (1 << toBits) - 1
+        for value in data {
+            acc = (acc << fromBits) | Int(value)
+            bits += fromBits
+            while bits >= toBits {
+                bits -= toBits
+                result.append(UInt8((acc >> bits) & maxv))
+            }
+        }
+        if pad && bits > 0 {
+            result.append(UInt8((acc << (toBits - bits)) & maxv))
+        }
+        return result
+    }
+
+    private static func createChecksum(hrp: String, data: [UInt8]) -> [UInt8] {
+        let values = hrpExpand(hrp) + data + Array(repeating: UInt8(0), count: 6)
+        let mod = polymod(values) ^ 1
+        return (0..<6).map { UInt8((mod >> (5 * (5 - $0))) & 0x1f) }
+    }
+
+    private static func hrpExpand(_ hrp: String) -> [UInt8] {
+        let bytes = Array(hrp.utf8)
+        var out: [UInt8] = bytes.map { $0 >> 5 }
+        out.append(0)
+        out.append(contentsOf: bytes.map { $0 & 0x1f })
+        return out
+    }
+
+    private static func polymod(_ values: [UInt8]) -> UInt32 {
+        let generator: [UInt32] = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+        var chk: UInt32 = 1
+        for value in values {
+            let top = chk >> 25
+            chk = ((chk & 0x1ffffff) << 5) ^ UInt32(value)
+            for index in 0..<5 where ((top >> index) & 1) == 1 {
+                chk ^= generator[index]
+            }
+        }
+        return chk
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosDelegateTransactionBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosDelegateTransactionBuilderTests.swift
@@ -1,0 +1,99 @@
+//
+//  CosmosDelegateTransactionBuilderTests.swift
+//  VultisigAppTests
+//
+//  Pins the `CosmosDelegateTransactionBuilder` → `SendTransaction` →
+//  `cosmosStakingPayload` contract. The PR1 helper byte tests cover wire
+//  format; this suite covers the builder's responsibility — base-unit
+//  conversion + payload-field discriminator + `TransactionBuilder` defaults.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class CosmosDelegateTransactionBuilderTests: XCTestCase {
+
+    private static func makeLunaCoin() -> Coin {
+        let meta = CoinMeta(
+            chain: .terra,
+            ticker: "LUNA",
+            logo: "LunaLogo",
+            decimals: 6,
+            priceProviderId: "terra-luna-2",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(
+            asset: meta,
+            address: "terra1delegator0000000000000000000000000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+
+    func testBuilderProducesDelegatePayloadWithCanonicalBondDenom() {
+        let builder = CosmosDelegateTransactionBuilder(
+            coin: Self.makeLunaCoin(),
+            amount: "1.5",
+            sendMaxAmount: false,
+            validatorAddress: "terravaloper1abc"
+        )
+        let payload = builder.cosmosStakingPayload
+        XCTAssertNotNil(payload)
+        XCTAssertEqual(payload?.opType, .delegate)
+        XCTAssertEqual(payload?.validatorAddress, "terravaloper1abc")
+        XCTAssertEqual(payload?.denom, "uluna")
+    }
+
+    func testBuilderConvertsHumanDecimalToBaseUnits() {
+        let builder = CosmosDelegateTransactionBuilder(
+            coin: Self.makeLunaCoin(),
+            amount: "1.5",
+            sendMaxAmount: false,
+            validatorAddress: "terravaloper1abc"
+        )
+        XCTAssertEqual(builder.cosmosStakingPayload?.amount, "1500000")
+    }
+
+    func testBuilderHandlesCommaAsDecimalSeparator() {
+        let builder = CosmosDelegateTransactionBuilder(
+            coin: Self.makeLunaCoin(),
+            amount: "0,5",
+            sendMaxAmount: false,
+            validatorAddress: "terravaloper1abc"
+        )
+        XCTAssertEqual(builder.cosmosStakingPayload?.amount, "500000")
+    }
+
+    func testBuilderEmitsEmptyMemoForCosmosStaking() {
+        let builder = CosmosDelegateTransactionBuilder(
+            coin: Self.makeLunaCoin(),
+            amount: "1",
+            sendMaxAmount: false,
+            validatorAddress: "terravaloper1abc"
+        )
+        XCTAssertEqual(builder.memo, "")
+    }
+
+    func testToAddressDefaultsToValidatorForVerifyScreenDisplay() {
+        let builder = CosmosDelegateTransactionBuilder(
+            coin: Self.makeLunaCoin(),
+            amount: "1",
+            sendMaxAmount: false,
+            validatorAddress: "terravaloper1abc"
+        )
+        XCTAssertEqual(builder.toAddress, "terravaloper1abc")
+    }
+
+    func testBuildSendTransactionPropagatesStakingPayload() {
+        let builder = CosmosDelegateTransactionBuilder(
+            coin: Self.makeLunaCoin(),
+            amount: "1",
+            sendMaxAmount: false,
+            validatorAddress: "terravaloper1abc"
+        )
+        let tx = builder.buildSendTransaction(vault: .example)
+        XCTAssertNotNil(tx.cosmosStakingPayload)
+        XCTAssertEqual(tx.cosmosStakingPayload?.opType, .delegate)
+        XCTAssertTrue(tx.isStakingOperation)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingPayloadTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingPayloadTests.swift
@@ -1,0 +1,79 @@
+//
+//  CosmosStakingPayloadTests.swift
+//  VultisigAppTests
+//
+//  Locks the `CosmosStakingPayload` factory contract so the per-flow
+//  builders can rely on the field-discrimination invariants without
+//  re-validating per call site.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class CosmosStakingPayloadTests: XCTestCase {
+
+    func testDelegateFactoryPopulatesOnlyValidatorAndAmount() {
+        let payload = CosmosStakingPayload.delegate(
+            validator: "terravaloper1abc",
+            denom: "uluna",
+            amount: "1000000"
+        )
+        XCTAssertEqual(payload.opType, .delegate)
+        XCTAssertEqual(payload.validatorAddress, "terravaloper1abc")
+        XCTAssertEqual(payload.amount, "1000000")
+        XCTAssertEqual(payload.denom, "uluna")
+        XCTAssertNil(payload.validatorSrcAddress)
+        XCTAssertNil(payload.validatorDstAddress)
+        XCTAssertNil(payload.validators)
+    }
+
+    func testUndelegateFactoryReusesValidatorField() {
+        let payload = CosmosStakingPayload.undelegate(
+            validator: "terravaloper1abc",
+            denom: "uluna",
+            amount: "500000"
+        )
+        XCTAssertEqual(payload.opType, .undelegate)
+        XCTAssertEqual(payload.validatorAddress, "terravaloper1abc")
+        XCTAssertEqual(payload.amount, "500000")
+        XCTAssertNil(payload.validatorSrcAddress)
+        XCTAssertNil(payload.validatorDstAddress)
+    }
+
+    func testRedelegateFactoryPopulatesSrcAndDstNotValidator() {
+        let payload = CosmosStakingPayload.redelegate(
+            src: "terravaloper1src",
+            dst: "terravaloper1dst",
+            denom: "uluna",
+            amount: "250000"
+        )
+        XCTAssertEqual(payload.opType, .redelegate)
+        XCTAssertEqual(payload.validatorSrcAddress, "terravaloper1src")
+        XCTAssertEqual(payload.validatorDstAddress, "terravaloper1dst")
+        XCTAssertEqual(payload.amount, "250000")
+        XCTAssertNil(payload.validatorAddress)
+    }
+
+    func testWithdrawRewardsFactoryCarriesValidatorListNoAmount() {
+        let payload = CosmosStakingPayload.withdrawRewards(
+            validators: ["terravaloper1abc", "terravaloper1def"],
+            denom: "uluna"
+        )
+        XCTAssertEqual(payload.opType, .withdrawRewards)
+        XCTAssertEqual(payload.validators, ["terravaloper1abc", "terravaloper1def"])
+        XCTAssertNil(payload.amount)
+        XCTAssertNil(payload.validatorAddress)
+    }
+
+    func testCodableRoundTripPreservesAllFields() throws {
+        let payload = CosmosStakingPayload.redelegate(
+            src: "terravaloper1src",
+            dst: "terravaloper1dst",
+            denom: "uluna",
+            amount: "250000"
+        )
+        let encoded = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(CosmosStakingPayload.self, from: encoded)
+        XCTAssertEqual(decoded, payload)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingSignDataResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingSignDataResolverTests.swift
@@ -1,0 +1,261 @@
+//
+//  CosmosStakingSignDataResolverTests.swift
+//  VultisigAppTests
+//
+//  Pins the Verify → KeysignPayload bridge for the Cosmos staking flow.
+//
+//  Two contracts under test:
+//    1. Byte-equality — the resolver's `bodyBytes` for a single MsgDelegate
+//       match the helper's `buildTxBodyMulti([encodeDelegate(...)], memo: "")`
+//       output verbatim. This is the "memo-pin" guard against silent SDK
+//       drift: if the helper changes its wire shape on a future bump, this
+//       test fails loud.
+//    2. Preflight gating — invalid validator addresses are rejected BEFORE
+//       any SignDoc bytes get produced. The MPC ceremony never sees them.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class CosmosStakingSignDataResolverTests: XCTestCase {
+
+    // MARK: - Test fixtures
+
+    /// Real checksum-valid `terravaloper1…` address — built once via the
+    /// bech32 encoder so the preflight gate doesn't reject it.
+    private static let validValidator = Bech32TestUtils.makeValoperAddress()
+
+    private static func makeChainSpecific(accountNumber: UInt64 = 100, sequence: UInt64 = 42) -> BlockChainSpecific {
+        .Cosmos(
+            accountNumber: accountNumber,
+            sequence: sequence,
+            gas: 7_500,
+            transactionType: 0,
+            ibcDenomTrace: nil
+        )
+    }
+
+    private static func makeTerraCoin() -> Coin {
+        let meta = CoinMeta(
+            chain: .terra,
+            ticker: "LUNA",
+            logo: "LunaLogo",
+            decimals: 6,
+            priceProviderId: "terra-luna-2",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        // 33-byte compressed secp256k1 pubkey (all 0x02) keeps the AuthInfo
+        // bytes deterministic across runs.
+        let pubKeyHex = "02" + String(repeating: "00", count: 32)
+        return Coin(
+            asset: meta,
+            address: "terra1delegator0000000000000000000000000000000",
+            hexPublicKey: pubKeyHex
+        )
+    }
+
+    private static func makeSendTransaction(
+        payload: CosmosStakingPayload,
+        coin: Coin? = nil
+    ) -> SendTransaction {
+        let coin = coin ?? makeTerraCoin()
+        return SendTransaction(
+            coin: coin,
+            vault: .example,
+            fromAddress: coin.address,
+            toAddress: payload.validatorAddress ?? "",
+            toAddressLabel: nil,
+            amount: "0",
+            amountInFiat: "",
+            memo: "",
+            gas: .zero,
+            fee: .zero,
+            feeMode: .default,
+            estimatedGasLimit: nil,
+            customGasLimit: nil,
+            customByteFee: nil,
+            sendMaxAmount: false,
+            isStakingOperation: true,
+            transactionType: .unspecified,
+            memoFunctionDictionary: [:],
+            wasmContractPayload: nil,
+            feeCoin: coin,
+            cosmosStakingPayload: payload
+        )
+    }
+
+    // MARK: - Byte-pin
+
+    func testDelegateBodyBytesMatchHelperEncoderOutput() throws {
+        let coin = Self.makeTerraCoin()
+        let payload = CosmosStakingPayload.delegate(
+            validator: Self.validValidator,
+            denom: "uluna",
+            amount: "1000000"
+        )
+        let tx = Self.makeSendTransaction(payload: payload, coin: coin)
+
+        let signDirect = try CosmosStakingSignDataResolver.resolve(
+            sendTransaction: tx,
+            chainSpecific: Self.makeChainSpecific()
+        )
+
+        let expectedAny = CosmosStakingHelper.encodeDelegate(
+            delegator: coin.address,
+            validator: Self.validValidator,
+            amount: "1000000",
+            denom: "uluna"
+        )
+        let expectedBody = CosmosStakingHelper.buildTxBodyMulti(msgsAny: [expectedAny], memo: "")
+        XCTAssertEqual(
+            signDirect.bodyBytes,
+            expectedBody.base64EncodedString(),
+            "Resolver body bytes must equal the helper encoder output for the same inputs"
+        )
+    }
+
+    func testDelegateChainIdComesFromConfigEntry() throws {
+        let payload = CosmosStakingPayload.delegate(
+            validator: Self.validValidator,
+            denom: "uluna",
+            amount: "1000000"
+        )
+        let tx = Self.makeSendTransaction(payload: payload)
+
+        let signDirect = try CosmosStakingSignDataResolver.resolve(
+            sendTransaction: tx,
+            chainSpecific: Self.makeChainSpecific()
+        )
+        XCTAssertEqual(signDirect.chainID, "phoenix-1")
+    }
+
+    func testAccountNumberFlowsFromChainSpecific() throws {
+        let payload = CosmosStakingPayload.delegate(
+            validator: Self.validValidator,
+            denom: "uluna",
+            amount: "1000000"
+        )
+        let tx = Self.makeSendTransaction(payload: payload)
+
+        let signDirect = try CosmosStakingSignDataResolver.resolve(
+            sendTransaction: tx,
+            chainSpecific: Self.makeChainSpecific(accountNumber: 9_999, sequence: 11)
+        )
+        XCTAssertEqual(signDirect.accountNumber, "9999")
+    }
+
+    // MARK: - Multi-msg gas scaling (claim path)
+
+    func testBatchClaimGasAndFeeScaleLinearlyWithValidatorCount() throws {
+        let payload = CosmosStakingPayload.withdrawRewards(
+            validators: [Self.validValidator, Self.validValidator, Self.validValidator],
+            denom: "uluna"
+        )
+        let tx = Self.makeSendTransaction(payload: payload)
+
+        let signDirect = try CosmosStakingSignDataResolver.resolve(
+            sendTransaction: tx,
+            chainSpecific: Self.makeChainSpecific()
+        )
+        // Recompute the expected AuthInfo with N=3 multiplier — the resolver
+        // must produce the same bytes.
+        let entry = try CosmosStakingConfig.entry(for: .terra)
+        let pubKey = Data(hexString: tx.coin.hexPublicKey) ?? Data()
+        let expectedAuthInfo = CosmosStakingHelper.buildAuthInfo(
+            pubKey: pubKey,
+            sequence: 42,
+            gasLimit: entry.gasLimit * 3,
+            feeDenom: entry.feeDenom,
+            feeAmount: entry.feeAmount * 3
+        )
+        XCTAssertEqual(signDirect.authInfoBytes, expectedAuthInfo.base64EncodedString())
+    }
+
+    // MARK: - Preflight gating
+
+    func testInvalidValidatorAddressIsRejectedBeforeSigning() {
+        let payload = CosmosStakingPayload.delegate(
+            validator: "terra1NOT_A_VALOPER",
+            denom: "uluna",
+            amount: "1000000"
+        )
+        let tx = Self.makeSendTransaction(payload: payload)
+
+        XCTAssertThrowsError(
+            try CosmosStakingSignDataResolver.resolve(
+                sendTransaction: tx,
+                chainSpecific: Self.makeChainSpecific()
+            )
+        ) { error in
+            guard case CosmosStakingSignDataResolver.Errors.validatorPreflightFailed = error else {
+                XCTFail("Expected validatorPreflightFailed, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testEmptyAmountIsRejectedForDelegate() {
+        let payload = CosmosStakingPayload(
+            opType: .delegate,
+            validatorAddress: Self.validValidator,
+            validatorSrcAddress: nil,
+            validatorDstAddress: nil,
+            validators: nil,
+            denom: "uluna",
+            amount: nil
+        )
+        let tx = Self.makeSendTransaction(payload: payload)
+
+        XCTAssertThrowsError(
+            try CosmosStakingSignDataResolver.resolve(
+                sendTransaction: tx,
+                chainSpecific: Self.makeChainSpecific()
+            )
+        ) { error in
+            guard case CosmosStakingSignDataResolver.Errors.missingPayloadField(let field) = error else {
+                XCTFail("Expected missingPayloadField, got \(error)")
+                return
+            }
+            XCTAssertEqual(field, "amount")
+        }
+    }
+
+    func testEmptyValidatorsListIsRejectedForWithdrawRewards() {
+        let payload = CosmosStakingPayload.withdrawRewards(validators: [], denom: "uluna")
+        let tx = Self.makeSendTransaction(payload: payload)
+
+        XCTAssertThrowsError(
+            try CosmosStakingSignDataResolver.resolve(
+                sendTransaction: tx,
+                chainSpecific: Self.makeChainSpecific()
+            )
+        ) { error in
+            guard case CosmosStakingSignDataResolver.Errors.noValidatorsToClaim = error else {
+                XCTFail("Expected noValidatorsToClaim, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testNonCosmosChainSpecificIsRejected() {
+        let payload = CosmosStakingPayload.delegate(
+            validator: Self.validValidator,
+            denom: "uluna",
+            amount: "1000000"
+        )
+        let tx = Self.makeSendTransaction(payload: payload)
+
+        XCTAssertThrowsError(
+            try CosmosStakingSignDataResolver.resolve(
+                sendTransaction: tx,
+                chainSpecific: .Ethereum(maxFeePerGasWei: 0, priorityFeeWei: 0, nonce: 0, gasLimit: 0)
+            )
+        ) { error in
+            guard case CosmosStakingSignDataResolver.Errors.missingChainSpecific = error else {
+                XCTFail("Expected missingChainSpecific, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/ValidatorSelectionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Staking/ValidatorSelectionViewModelTests.swift
@@ -1,0 +1,174 @@
+//
+//  ValidatorSelectionViewModelTests.swift
+//  VultisigAppTests
+//
+//  Locks the validator-picker contract — sort-by-voting-power-desc, filter
+//  jailed + non-bonded validators out, case-insensitive search across
+//  moniker and operator address, and exclusion list (used by the
+//  redelegate flow to keep the user from redelegating to themselves).
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class ValidatorSelectionViewModelTests: XCTestCase {
+
+    func testSortAndFilterDropsJailedAndNonBondedAndSortsByVotingPowerDesc() {
+        let raw = [
+            CosmosValidator(
+                operatorAddress: "terravaloper1c",
+                moniker: "Charlie",
+                commission: 0.05,
+                jailed: false,
+                status: .bonded,
+                votingPower: 100
+            ),
+            CosmosValidator(
+                operatorAddress: "terravaloper1a",
+                moniker: "Alice",
+                commission: 0.03,
+                jailed: false,
+                status: .bonded,
+                votingPower: 1_000
+            ),
+            CosmosValidator(
+                operatorAddress: "terravaloper1jailed",
+                moniker: "Jailed",
+                commission: 0.20,
+                jailed: true,
+                status: .bonded,
+                votingPower: 500
+            ),
+            CosmosValidator(
+                operatorAddress: "terravaloper1unbonded",
+                moniker: "Unbonded",
+                commission: 0.10,
+                jailed: false,
+                status: .unbonded,
+                votingPower: 200
+            ),
+            CosmosValidator(
+                operatorAddress: "terravaloper1b",
+                moniker: "Bob",
+                commission: 0.04,
+                jailed: false,
+                status: .bonded,
+                votingPower: 250
+            )
+        ]
+        let filtered = ValidatorSelectionViewModel.sortAndFilter(raw)
+        XCTAssertEqual(filtered.map(\.moniker), ["Alice", "Bob", "Charlie"])
+    }
+
+    func testFilteredValidatorsAppliesCaseInsensitiveSearch() {
+        let vm = ValidatorSelectionViewModel(
+            chain: .terra,
+            service: StubService(validators: Self.sampleValidators)
+        )
+        // Seed the cache via load(); we bypass the network by injecting a
+        // stub that resolves synchronously.
+        let exp = expectation(description: "load")
+        Task {
+            await vm.load()
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+
+        vm.searchText = "all"
+        XCTAssertEqual(vm.filteredValidators.map(\.moniker), ["Allnodes"])
+    }
+
+    func testFilteredValidatorsMatchesOperatorAddressSubstring() {
+        let vm = ValidatorSelectionViewModel(
+            chain: .terra,
+            service: StubService(validators: Self.sampleValidators)
+        )
+        let exp = expectation(description: "load")
+        Task {
+            await vm.load()
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+
+        vm.searchText = "VALOPER1A"
+        XCTAssertEqual(vm.filteredValidators.map(\.operatorAddress), ["terravaloper1aaa"])
+    }
+
+    func testExclusionListHidesSourceValidator() {
+        let vm = ValidatorSelectionViewModel(
+            chain: .terra,
+            service: StubService(validators: Self.sampleValidators),
+            excludedValidators: ["terravaloper1aaa"]
+        )
+        let exp = expectation(description: "load")
+        Task {
+            await vm.load()
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertFalse(vm.filteredValidators.contains { $0.operatorAddress == "terravaloper1aaa" })
+    }
+
+    func testFetchFailureSurfacesErrorAndKeepsEmptyList() {
+        let vm = ValidatorSelectionViewModel(
+            chain: .terra,
+            service: ThrowingService()
+        )
+        let exp = expectation(description: "load")
+        Task {
+            await vm.load()
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+
+        XCTAssertNotNil(vm.error)
+        XCTAssertTrue(vm.filteredValidators.isEmpty)
+    }
+
+    // MARK: - Fixtures
+
+    private static let sampleValidators: [CosmosValidator] = [
+        CosmosValidator(
+            operatorAddress: "terravaloper1aaa",
+            moniker: "Allnodes",
+            commission: 0.05,
+            jailed: false,
+            status: .bonded,
+            votingPower: 200_392_000_000
+        ),
+        CosmosValidator(
+            operatorAddress: "terravaloper1bbb",
+            moniker: "Stakefish",
+            commission: 0.10,
+            jailed: false,
+            status: .bonded,
+            votingPower: 150_000_000_000
+        )
+    ]
+}
+
+// MARK: - Stubs
+
+private struct StubService: CosmosStakingServiceProtocol {
+    let validators: [CosmosValidator]
+
+    func fetchDelegations(chain: Chain, address: String) async throws -> [CosmosDelegation] { [] }
+    func fetchUnbondingDelegations(chain: Chain, address: String) async throws -> [CosmosUnbondingDelegation] { [] }
+    func fetchDelegatorRewards(chain: Chain, address: String) async throws -> CosmosDelegatorRewards {
+        CosmosDelegatorRewards(rewards: [], total: [])
+    }
+    func fetchValidators(chain: Chain) async throws -> [CosmosValidator] { validators }
+    func fetchRedelegations(chain: Chain, address: String) async throws -> [CosmosRedelegationEntry] { [] }
+}
+
+private struct ThrowingService: CosmosStakingServiceProtocol {
+    struct StubError: Error {}
+
+    func fetchDelegations(chain: Chain, address: String) async throws -> [CosmosDelegation] { throw StubError() }
+    func fetchUnbondingDelegations(chain: Chain, address: String) async throws -> [CosmosUnbondingDelegation] { throw StubError() }
+    func fetchDelegatorRewards(chain: Chain, address: String) async throws -> CosmosDelegatorRewards { throw StubError() }
+    func fetchValidators(chain: Chain) async throws -> [CosmosValidator] { throw StubError() }
+    func fetchRedelegations(chain: Chain, address: String) async throws -> [CosmosRedelegationEntry] { throw StubError() }
+}


### PR DESCRIPTION
## Summary

PR2 of the LUNA/LUNC Cosmos-SDK staking workstream. Builds the first user-visible flow on top of [#4425](https://github.com/vultisig/vultisig-ios/pull/4425)'s service / helper / config foundation:

- `CosmosDelegateTransactionScreen` + `CosmosDelegateTransactionViewModel` — `Form` + `FormField` shape mirroring `BondTransactionViewModel`. Stakeable balance reserves gas headroom from `CosmosStakingConfig`.
- `ValidatorSelectionScreen` + `ValidatorSelectionViewModel` — sheet-presented picker. Sorts by voting power desc, filters jailed + non-bonded, case-insensitive search across moniker + operator address. Accepts an `excludedValidators` set for the PR3 redelegate flow.
- `ValidatorCard` — per-row component matching Figma `75918:75443` (36pt monogram avatar, moniker, voting power subline, commission %, selected-state stroke).
- `CosmosDelegateTransactionBuilder` — value-type carrier that emits a `CosmosStakingPayload.delegate(...)` via the new `TransactionBuilder.cosmosStakingPayload` accessor.
- `CosmosStakingSignDataResolver` — encodes the Any-wrapped `MsgDelegate` / `MsgUndelegate` / `MsgBeginRedelegate` / `MsgWithdrawDelegatorReward` via the PR1 `CosmosStakingHelper`, builds AuthInfo + SignDoc, gates every validator address through `ValidatorBech32Preflight` BEFORE producing bytes (fail-closed per Risk-5 in the spec). Linear gas/fee scaling for the multi-msg claim path; single-msg flows collapse to N=1.
- DeFi-tab stub entry-point — surfaces a "Stake LUNA" / "Stake LUNC" `ActionBannerView` CTA on the `.stake` segment for `.terra` / `.terraClassic`. PR5 replaces the stub with the full `DefiChainStakedView` once `CosmosStakeInteractor` is wired.

Part of #4363, depends on #4425.

## SendTransaction cascade

The `SendTransaction` struct now carries a `cosmosStakingPayload: CosmosStakingPayload?`. The field defaults to `nil` on the memberwise init, so **zero existing call sites needed patching** — the PR1 hand-off estimated ~17 production + ~9 test sites but the defaulted-parameter approach keeps the diff confined to:

- `Features/Send/Models/SendTransaction.swift` — new field + `Hashable` + `copy(...)` builder
- `Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift` — protocol accessor (default `nil`) + `buildSendTransaction(vault:)` passthrough
- `Features/Send/ViewModels/SendCryptoVerifyLogic.swift` — splice the resolver when `tx.cosmosStakingPayload != nil`
- `Features/FunctionTransaction/FunctionTransactionScreen.swift` — bypass the legacy `FunctionCallForm.fromForm(_:)` round-trip for staking builders

The existing Cosmos `signDirect` plumbing in `CosmosSignDataBuilder.getMessages` + `TerraHelperStruct.getPreSignedInputData` wraps the resolver's bytes as-is via `WalletCore.CosmosMessage.signDirectMessage` — zero changes to the signing pipeline.

## Test plan

- [x] `make generate` clean
- [x] `xcodebuild build -scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'` → BUILD SUCCEEDED
- [x] SwiftLint clean on all 15 changed files
- [x] PR2 tests pass (24/24 — `CosmosStakingPayloadTests`, `CosmosDelegateTransactionBuilderTests`, `CosmosStakingSignDataResolverTests`, `ValidatorSelectionViewModelTests`)
- [x] PR1 tests still pass (47/47 — `CosmosStakingHelperTests`, `CosmosStakingConfigTests`, `CosmosStakingServiceTests`, `ValidatorBech32PreflightTests`)
- [x] Localization keys added to all 8 locale files; `sort_localizable.py` clean
- [ ] Manual smoke test on a real LUNA vault (deferred to PR5 once the interactor wires the DeFi tab)

The byte-pin test (`testDelegateBodyBytesMatchHelperEncoderOutput`) asserts that the resolver's `bodyBytes` equal `CosmosStakingHelper.buildTxBodyMulti([encodeDelegate(...)], memo: "")` verbatim — this is the regression guard against silent SDK drift. The matching SDK golden bytes are pinned in PR1's `CosmosStakingHelperTests` against the cosmos-staking SDK fixtures, so the chain composes: resolver bytes == helper bytes == SDK bytes.

## Per-screen Figma re-pull

Re-pulled at implementation time:
- `75918:75443` — Validator card (Default / selected variants) → `ValidatorCard.swift`

Skipped re-pull due to MCP response-size cap (>93k chars truncated):
- `75918:74747` — Validator picker sheet → built from the structural shape captured in the May pull + the existing iOS `AssetSelectionListScreen` pattern.
- `75718:98523` — Stake LUNA (input) → mirrored the `BondTransactionScreen` shape captured in the May pull.
- `75718:98537` — Stake overview (verify) → reuses the existing send-verify shell; nothing PR2-specific.

## What's NOT in this PR

- Undelegate + redelegate flows → PR3
- Claim rewards (single + batch) → PR4
- Polished DeFi-tab position cards + `CosmosStakeInteractor` wiring + APY column + unbonding-lock microcopy → PR5
- Localized strings for the deferred flows → PR5

## Next PR

PR3 — Undelegate + redelegate flows (mirrors this PR's shape; adds `CosmosRedelegationCooldownGate` for the 21-day cooldown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>