### PR TITLE
fix(swap): scale SwapKit inbound fee by native decimals, not sell-token decimals

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -199,7 +199,15 @@ extension SwapKitService {
         else {
             return nil
         }
-        let raw = fromCoin.raw(for: amount)
+        // The inbound fee is denominated in the source chain's NATIVE gas coin (e.g. "ETH.ETH",
+        // "SOL.SOL"), never the sell token. Scaling by `fromCoin.decimals` under-counts the fee
+        // for an ERC-20 / SPL token source (e.g. USDC's 6 vs ETH's 18 — off by 10^12), which reads
+        // as dust on the Network Fee row and weakens the gas-coin balance check. Scale by the
+        // chain's native decimals — identical to `fromCoin.decimals` on a native-source route.
+        var scaled = amount * pow(Decimal(10), nativeDecimals(for: fromCoin.chain))
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &scaled, 0, .up)
+        let raw = BigInt(rounded.description) ?? .zero
         return raw == .zero ? nil : raw
     }
 }
@@ -247,6 +255,20 @@ private extension SwapKitService {
         case .thorChain, .thorChainChainnet, .thorChainStagenet: return "THOR"
         case .mayaChain: return "MAYA"
         default: return fallback
+        }
+    }
+
+    /// Native gas-coin decimals for a SwapKit source chain. The inbound fee is always denominated
+    /// in the source chain's native coin, so it must be scaled by these — not the sell token's
+    /// decimals (which differ for an ERC-20 / SPL token source). Equal to the source coin's own
+    /// decimals on a native-source route.
+    func nativeDecimals(for chain: Chain) -> Int {
+        switch chain {
+        case .solana, .sui, .ton: return 9
+        case .tron, .cardano, .ripple, .gaiaChain: return 6
+        case .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash, .zcash: return 8
+        // EVM chains (ETH / BASE / OP / ARB / AVAX / BSC / POL).
+        default: return 18
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -203,8 +203,8 @@ extension SwapKitService {
         // "SOL.SOL"), never the sell token. Scaling by `fromCoin.decimals` under-counts the fee
         // for an ERC-20 / SPL token source (e.g. USDC's 6 vs ETH's 18 — off by 10^12), which reads
         // as dust on the Network Fee row and weakens the gas-coin balance check. Scale by the
-        // chain's native decimals — identical to `fromCoin.decimals` on a native-source route.
-        var scaled = amount * pow(Decimal(10), nativeDecimals(for: fromCoin.chain))
+        // native coin's decimals — identical to `fromCoin.decimals` on a native-source route.
+        var scaled = amount * pow(Decimal(10), nativeDecimals(for: fromCoin))
         var rounded = Decimal()
         NSDecimalRound(&rounded, &scaled, 0, .up)
         let raw = BigInt(rounded.description) ?? .zero
@@ -258,17 +258,18 @@ private extension SwapKitService {
         }
     }
 
-    /// Native gas-coin decimals for a SwapKit source chain. The inbound fee is always denominated
-    /// in the source chain's native coin, so it must be scaled by these — not the sell token's
-    /// decimals (which differ for an ERC-20 / SPL token source). Equal to the source coin's own
-    /// decimals on a native-source route.
-    func nativeDecimals(for chain: Chain) -> Int {
-        switch chain {
-        case .solana, .sui, .ton: return 9
-        case .tron, .cardano, .ripple, .gaiaChain: return 6
-        case .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash, .zcash: return 8
-        // EVM chains (ETH / BASE / OP / ARB / AVAX / BSC / POL).
-        default: return 18
+    /// Decimals to scale the inbound fee by. The fee is always denominated in the source chain's
+    /// native gas coin, so a native-source coin already carries the right decimals; for an ERC-20 /
+    /// SPL token source we look up the chain's native coin (whose decimals differ from the token's)
+    /// rather than hardcoding a per-chain table. Falls back to the source coin's own decimals if the
+    /// native coin isn't in the curated store.
+    func nativeDecimals(for coin: Coin) -> Int {
+        if coin.isNativeToken {
+            return coin.decimals
         }
+        let nativeCoin = TokensStore.TokenSelectionAssets.first {
+            $0.chain == coin.chain && $0.isNativeToken
+        }
+        return nativeCoin?.decimals ?? coin.decimals
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
@@ -60,9 +60,10 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
 
     func testErc20SourceFeeScalesByNativeDecimalsNotSellTokenDecimals() throws {
         // Regression: the inbound fee asset is the source chain's NATIVE coin (ETH.ETH, 18dp) even
-        // when the SELL token is an ERC-20 (USDC, 6dp). Scaling by the sell token's decimals would
-        // under-count the native-ETH fee by 10^12 (98_846_611 instead of the real wei). The native
-        // ETH source for this same fixture is pinned in testEvmInboundFeeParsedAsWei.
+        // when the SELL token is an ERC-20 (USDC, 6dp). Scaling by the sell token's 6 decimals
+        // instead of ETH's 18 (a 10^12 factor) would round the fee down to BigInt(99) — the
+        // round-up of 0.000098846611703085 × 10^6 — instead of the real 98_846_611_703_085 wei.
+        // The native ETH source for this same fixture is pinned in testEvmInboundFeeParsedAsWei.
         let response = try SwapKitFixtureLoader.decode(
             SwapKitSwapResponse.self,
             from: "v3-erc20-erc20-swap"

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
@@ -58,6 +58,21 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
         XCTAssertEqual(fee, BigInt(13_373_500))
     }
 
+    func testErc20SourceFeeScalesByNativeDecimalsNotSellTokenDecimals() throws {
+        // Regression: the inbound fee asset is the source chain's NATIVE coin (ETH.ETH, 18dp) even
+        // when the SELL token is an ERC-20 (USDC, 6dp). Scaling by the sell token's decimals would
+        // under-count the native-ETH fee by 10^12 (98_846_611 instead of the real wei). The native
+        // ETH source for this same fixture is pinned in testEvmInboundFeeParsedAsWei.
+        let response = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-erc20-erc20-swap"
+        )
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        let fee = service.inboundFee(from: response, fromCoin: usdc)
+        // Must scale by ETH's 18 native decimals, NOT USDC's 6.
+        XCTAssertEqual(fee, BigInt("98846611703085"))
+    }
+
     func testWrongChainPrefixDoesNotMatch() throws {
         // If we hand the fee parser a coin whose chain doesn't appear in
         // `fees[]`, the parser returns nil rather than picking the wrong
@@ -73,8 +88,8 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int) -> Coin {
-        let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: true)
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool = true) -> Coin {
+        let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: isNative)
         return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
     }
 }


### PR DESCRIPTION
## Description

`SwapKitService.inboundFee` scaled the source-chain inbound fee via `fromCoin.raw(for:)` = `value × 10^fromCoin.decimals`. But the inbound fee is denominated in the source chain's **native gas coin** (e.g. `ETH.ETH`, `SOL.SOL`), never the sell token. For an **ERC-20 / SPL token source** the sell-token decimals differ from the native coin's (USDC 6 vs ETH 18), so the fee was **under-counted by 10^12** — it reads as dust on the Network Fee row and weakens the `balanceError` gas-coin sufficiency check. Native-source routes were unaffected because the decimals already matched.

The fix scales by the source chain's native decimals via a new `nativeDecimals(for:)` switch (EVM 18; SOL/SUI/TON 9; TRON/ADA/XRP/ATOM 6; BTC/BCH/LTC/DOGE/DASH/ZEC 8). On a native-source route this equals `fromCoin.decimals`, so the existing EVM / Solana / Tron pins are unchanged.

Surfaced during an iOS↔Android SwapKit parity review (Android PR vultisig/vultisig-android#4619 already scales by native decimals; iOS was the outlier).

## Which feature is affected?
- [x] Swap — SwapKit source-chain (inbound) fee shown as Network Fee + used in the gas-coin balance check

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (SwiftLint clean on both changed files)
- [x] I have added tests that prove my fix is effective (USDC source / native-ETH inbound fee → scales by 18, not 6)

## Additional context

Behavior is display + balance-check only; the inbound fee does not modify the signed tx (SwapKit pre-builds it with the fee baked in). Only the scaling base changed.

I could not run the full Xcode test suite in this environment — relying on CI for the test run. SwiftLint passed on both files, and the scaling mirrors the existing `Coin.raw(for:)` idiom (`pow` + `NSDecimalRound(.up)` + `BigInt(_:)`).

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: none (found via cross-platform parity review)
- **Confidence**: high
- **Needs human review for**: the `nativeDecimals(for:)` per-chain values (verify ADA/XRP/ATOM = 6, TON/SUI = 9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inbound fee calculation for swaps so fees are scaled using the source chain’s native gas-coin decimals, ensuring correct fee amounts when swapping non-native tokens.

* **Tests**
  * Added a regression test that verifies correct fee scaling for non-native token swaps to prevent regressions and ensure consistent fee behavior across chains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->