### PR TITLE
fix(tss-relay): send message_id for setup messages only on non-keygen IDs

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tss/TssRelayAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/TssRelayAPI.swift
@@ -73,8 +73,11 @@ struct TssRelayAPI: TargetType {
         var result: [String: String] = ["Content-Type": "application/json"]
 
         switch endpoint {
-        case .uploadSetupMessage(_, _, _, let additionalHeader),
-             .downloadSetupMessage(_, _, let additionalHeader):
+        case .uploadSetupMessage(_, _, let messageID, let additionalHeader),
+             .downloadSetupMessage(_, let messageID, let additionalHeader):
+            if let messageID, messageID != KeygenMessageId.rootECDSA && messageID != KeygenMessageId.rootEdDSA {
+                result["message_id"] = messageID
+            }
             if let additionalHeader {
                 result["message_id"] = additionalHeader
             }

--- a/VultisigApp/VultisigAppTests/Tss/TssRelayAPITests.swift
+++ b/VultisigApp/VultisigAppTests/Tss/TssRelayAPITests.swift
@@ -16,14 +16,18 @@ final class TssRelayAPITests: XCTestCase {
 
     // MARK: - uploadSetupMessage
 
-    func testUploadSetupMessage_additionalHeaderSet_usesAdditionalHeader() {
-        let sut = api(.uploadSetupMessage(sessionID: "s", body: Data(), messageID: "ignored", additionalHeader: "extra"))
-        XCTAssertEqual(sut.headers?["message_id"], "extra")
+    func testUploadSetupMessage_nonKeygenMessageID_setsMessageIDHeader() {
+        let sut = api(.uploadSetupMessage(sessionID: "s", body: Data(), messageID: "msg-123", additionalHeader: nil))
+        XCTAssertEqual(sut.headers?["message_id"], "msg-123")
     }
 
-    func testUploadSetupMessage_onlyMessageIDSet_noMessageIDHeader() {
-        // messageID is intentionally ignored for uploadSetupMessage; only additionalHeader counts.
-        let sut = api(.uploadSetupMessage(sessionID: "s", body: Data(), messageID: "msg-123", additionalHeader: nil))
+    func testUploadSetupMessage_keygenECDSAMessageID_noMessageIDHeader() {
+        let sut = api(.uploadSetupMessage(sessionID: "s", body: Data(), messageID: KeygenMessageId.rootECDSA, additionalHeader: nil))
+        XCTAssertNil(sut.headers?["message_id"])
+    }
+
+    func testUploadSetupMessage_keygenEdDSAMessageID_noMessageIDHeader() {
+        let sut = api(.uploadSetupMessage(sessionID: "s", body: Data(), messageID: KeygenMessageId.rootEdDSA, additionalHeader: nil))
         XCTAssertNil(sut.headers?["message_id"])
     }
 
@@ -32,21 +36,35 @@ final class TssRelayAPITests: XCTestCase {
         XCTAssertNil(sut.headers?["message_id"])
     }
 
+    func testUploadSetupMessage_additionalHeaderSet_usesAdditionalHeader() {
+        let sut = api(.uploadSetupMessage(sessionID: "s", body: Data(), messageID: nil, additionalHeader: "extra"))
+        XCTAssertEqual(sut.headers?["message_id"], "extra")
+    }
+
     func testUploadSetupMessage_bothSet_additionalHeaderWins() {
         let sut = api(.uploadSetupMessage(sessionID: "s", body: Data(), messageID: "msg-123", additionalHeader: "extra"))
         XCTAssertEqual(sut.headers?["message_id"], "extra")
     }
 
-    // MARK: - downloadSetupMessage
-
-    func testDownloadSetupMessage_additionalHeaderSet_usesAdditionalHeader() {
-        let sut = api(.downloadSetupMessage(sessionID: "s", messageID: "ignored", additionalHeader: "extra"))
+    func testUploadSetupMessage_keygenMessageIDWithAdditionalHeader_additionalHeaderWins() {
+        let sut = api(.uploadSetupMessage(sessionID: "s", body: Data(), messageID: KeygenMessageId.rootECDSA, additionalHeader: "extra"))
         XCTAssertEqual(sut.headers?["message_id"], "extra")
     }
 
-    func testDownloadSetupMessage_onlyMessageIDSet_noMessageIDHeader() {
-        // messageID is intentionally ignored for downloadSetupMessage; only additionalHeader counts.
+    // MARK: - downloadSetupMessage
+
+    func testDownloadSetupMessage_nonKeygenMessageID_setsMessageIDHeader() {
         let sut = api(.downloadSetupMessage(sessionID: "s", messageID: "msg-123", additionalHeader: nil))
+        XCTAssertEqual(sut.headers?["message_id"], "msg-123")
+    }
+
+    func testDownloadSetupMessage_keygenECDSAMessageID_noMessageIDHeader() {
+        let sut = api(.downloadSetupMessage(sessionID: "s", messageID: KeygenMessageId.rootECDSA, additionalHeader: nil))
+        XCTAssertNil(sut.headers?["message_id"])
+    }
+
+    func testDownloadSetupMessage_keygenEdDSAMessageID_noMessageIDHeader() {
+        let sut = api(.downloadSetupMessage(sessionID: "s", messageID: KeygenMessageId.rootEdDSA, additionalHeader: nil))
         XCTAssertNil(sut.headers?["message_id"])
     }
 
@@ -55,8 +73,18 @@ final class TssRelayAPITests: XCTestCase {
         XCTAssertNil(sut.headers?["message_id"])
     }
 
+    func testDownloadSetupMessage_additionalHeaderSet_usesAdditionalHeader() {
+        let sut = api(.downloadSetupMessage(sessionID: "s", messageID: nil, additionalHeader: "extra"))
+        XCTAssertEqual(sut.headers?["message_id"], "extra")
+    }
+
     func testDownloadSetupMessage_bothSet_additionalHeaderWins() {
         let sut = api(.downloadSetupMessage(sessionID: "s", messageID: "msg-123", additionalHeader: "extra"))
+        XCTAssertEqual(sut.headers?["message_id"], "extra")
+    }
+
+    func testDownloadSetupMessage_keygenMessageIDWithAdditionalHeader_additionalHeaderWins() {
+        let sut = api(.downloadSetupMessage(sessionID: "s", messageID: KeygenMessageId.rootECDSA, additionalHeader: "extra"))
         XCTAssertEqual(sut.headers?["message_id"], "extra")
     }
 


### PR DESCRIPTION
## Summary

- For `uploadSetupMessage` and `downloadSetupMessage`, the `message_id` header is now populated from `messageID` when it is **not** a keygen root ID (`p-ecdsa` / `p-eddsa`)
- Keysign setup messages therefore carry the correct routing header automatically, without relying on the `additionalHeader` override
- `additionalHeader` still wins when both are set, preserving backward compatibility

## Test plan

- [ ] `testUploadSetupMessage_nonKeygenMessageID_setsMessageIDHeader` — non-keygen `messageID` → header is set
- [ ] `testUploadSetupMessage_keygenECDSAMessageID_noMessageIDHeader` — `p-ecdsa` → no header
- [ ] `testUploadSetupMessage_keygenEdDSAMessageID_noMessageIDHeader` — `p-eddsa` → no header
- [ ] `testUploadSetupMessage_bothSet_additionalHeaderWins` — `additionalHeader` overrides `messageID`
- [ ] `testUploadSetupMessage_keygenMessageIDWithAdditionalHeader_additionalHeaderWins` — `additionalHeader` overrides even keygen ID
- [ ] Mirror of all above for `downloadSetupMessage`
- [ ] Existing `sendMessage`, `pollInboundMessages`, `checkKeygenStarted` regression guards unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected message ID header construction for setup message endpoints to properly respect optional message IDs while correctly handling special keygen identifier cases
  * Enhanced header override logic to ensure additional headers take precedence over message ID headers when provided

* **Tests**
  * Expanded test coverage for message ID header handling across setup message endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->