### PR TITLE
fix(maya): recompute CACAO single-pool unstake maturity live (#4359)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "buyVultBannerTitle" = "$VULT kaufen";
 "cacaoPool" = "Cacao Pool";
 "cacaoUnstakeMaturityMessage" = "%@ bis zur Erreichung der Einzahlungsreife";
+"cacaoUnstakeMaturityUnknownMessage" = "Einzahlungsreife konnte nicht überprüft werden. Bitte später erneut versuchen.";
 "cancel" = "Abbrechen";
 "canLoseFundsPrompt" = "Mir ist bewusst, dass ich Geld verlieren kann";
 "cardanoOutputBelowMinAda" = "Nicht genug ADA, um die Netzwerkgebühr und Cardanos Mindest-UTXO-Anforderung (~1,4 ADA pro Output) zu decken. Sende zuerst mehr ADA in dieses Vault.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -134,6 +134,7 @@
 "buyVultBannerTitle" = "Buy $VULT";
 "cacaoPool" = "Cacao Pool";
 "cacaoUnstakeMaturityMessage" = "%@ until deposit maturity reached";
+"cacaoUnstakeMaturityUnknownMessage" = "Couldn't verify deposit maturity. Try again later.";
 "cancel" = "Cancel";
 "canLoseFundsPrompt" = "I am aware that I can lose funds";
 "cardanoOutputBelowMinAda" = "Not enough ADA to cover the network fee and Cardano's minimum-UTXO requirement (~1.4 ADA per output). Send more ADA into this vault first.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "buyVultBannerTitle" = "Comprar $VULT";
 "cacaoPool" = "Pool de Cacao";
 "cacaoUnstakeMaturityMessage" = "%@ hasta que se alcance la madurez del depósito";
+"cacaoUnstakeMaturityUnknownMessage" = "No se pudo verificar la madurez del depósito. Inténtalo de nuevo más tarde.";
 "cancel" = "Cancelar";
 "canLoseFundsPrompt" = "Soy consciente de que puedo perder fondos.";
 "cardanoOutputBelowMinAda" = "No hay suficiente ADA para cubrir la tarifa de red y el requisito mínimo de UTXO de Cardano (~1,4 ADA por salida). Envía más ADA a este vault primero.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "buyVultBannerTitle" = "Kupi $VULT";
 "cacaoPool" = "Cacao Pool";
 "cacaoUnstakeMaturityMessage" = "%@ do dosezanja zrelosti depozita";
+"cacaoUnstakeMaturityUnknownMessage" = "Nije moguće provjeriti zrelost depozita. Pokušajte ponovno kasnije.";
 "cancel" = "Otkaži";
 "canLoseFundsPrompt" = "Svjestan sam da mogu izgubiti sredstva";
 "cardanoOutputBelowMinAda" = "Nema dovoljno ADA za pokrivanje mrežne naknade i Cardanovog minimalnog UTXO zahtjeva (~1,4 ADA po izlazu). Najprije pošalji više ADA u ovaj vault.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "buyVultBannerTitle" = "Compra $VULT";
 "cacaoPool" = "Pool Cacao";
 "cacaoUnstakeMaturityMessage" = "%@ fino al raggiungimento della maturità del deposito";
+"cacaoUnstakeMaturityUnknownMessage" = "Impossibile verificare la maturità del deposito. Riprova più tardi.";
 "cancel" = "Annulla";
 "canLoseFundsPrompt" = "Sono consapevole che posso perdere fondi";
 "cardanoOutputBelowMinAda" = "ADA insufficienti per coprire la commissione di rete e il requisito minimo UTXO di Cardano (~1,4 ADA per output). Invia prima più ADA a questo vault.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -134,6 +134,7 @@
 "buyVultBannerTitle" = "$VULT 구매";
 "cacaoPool" = "Cacao 풀";
 "cacaoUnstakeMaturityMessage" = "입금 만기까지 %@";
+"cacaoUnstakeMaturityUnknownMessage" = "입금 만기를 확인할 수 없습니다. 나중에 다시 시도하세요.";
 "cancel" = "취소";
 "canLoseFundsPrompt" = "자금을 잃을 수 있음을 인지합니다";
 "cardanoOutputBelowMinAda" = "네트워크 수수료와 Cardano의 최소 UTXO 요구사항(출력당 약 1.4 ADA)을 충당할 ADA가 부족합니다. 먼저 이 볼트에 ADA를 더 보내세요.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "buyVultBannerTitle" = "Comprar $VULT";
 "cacaoPool" = "Pool de Cacao";
 "cacaoUnstakeMaturityMessage" = "%@ até atingir a maturidade do depósito";
+"cacaoUnstakeMaturityUnknownMessage" = "Não foi possível verificar a maturidade do depósito. Tente novamente mais tarde.";
 "cancel" = "Cancelar";
 "canLoseFundsPrompt" = "Estou ciente de que posso perder fundos";
 "cardanoOutputBelowMinAda" = "ADA insuficiente para cobrir a taxa de rede e o requisito mínimo de UTXO da Cardano (~1,4 ADA por saída). Envie mais ADA para este vault primeiro.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "buyVultBannerTitle" = "购买 $VULT";
 "cacaoPool" = "Cacao 池";
 "cacaoUnstakeMaturityMessage" = "距离存款到期还有 %@";
+"cacaoUnstakeMaturityUnknownMessage" = "无法验证存款到期状态，请稍后重试。";
 "cancel" = "取消";
 "canLoseFundsPrompt" = "我知道我可能会失去资金";
 "cardanoOutputBelowMinAda" = "ADA 不足以支付网络费用和 Cardano 的最低 UTXO 要求（每个输出约 1.4 ADA）。请先向此保险库转入更多 ADA。";

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
@@ -27,40 +27,30 @@ struct MayaChainStakeInteractor: StakeInteractor {
             return []
         }
 
-        guard
-            let health = try? await mayaChainAPIService.getHealth(shouldCache: false),
-            let mimir = try? await mayaChainAPIService.getMimir()
-        else {
-            logger.error("Could not fetch health and mimir for Maya chain")
-            return []
-        }
-
+        let position: MayaCacaoPoolPosition
         do {
-            let position = try await mayaChainAPIService.getCacaoPoolPosition(address: cacao.address)
-            let stakedAmount = position.stakedAmount / pow(10, cacao.decimals)
-            let availableToUnstake = position.availableUnits / pow(10, cacao.decimals)
-            let aprData = try? await mayaChainAPIService.getCacaoPoolAPR()
-
-            let unstakeMetadata = calculateUnstakeMetadata(
-                currentHeight: health.lastMayaNode.height,
-                lastDepositHeight: position.lastDepositHeight,
-                maturityBlocks: mimir.cacaoPoolDepositMaturityBlocks
-            )
-
-            return [
-                StakePositionData(
-                    coin: cacao.meta,
-                    type: .stake,
-                    amount: stakedAmount,
-                    availableToUnstake: availableToUnstake,
-                    apr: aprData?.apr ?? 0,
-                    unstakeMetadata: unstakeMetadata
-                )
-            ]
+            position = try await mayaChainAPIService.getCacaoPoolPosition(address: cacao.address)
         } catch {
-            logger.error("Error fetching Maya CACAO staking details: \(error.localizedDescription, privacy: .private)")
+            logger.error("Error fetching Maya CACAO staking position: \(error.localizedDescription, privacy: .private)")
             return []
         }
+
+        let stakedAmount = position.stakedAmount / pow(10, cacao.decimals)
+        let availableToUnstake = position.availableUnits / pow(10, cacao.decimals)
+        let aprData = try? await mayaChainAPIService.getCacaoPoolAPR()
+
+        let unstakeMetadata = await unstakeMetadata(for: position)
+
+        return [
+            StakePositionData(
+                coin: cacao.meta,
+                type: .stake,
+                amount: stakedAmount,
+                availableToUnstake: availableToUnstake,
+                apr: aprData?.apr ?? 0,
+                unstakeMetadata: unstakeMetadata
+            )
+        ]
     }
 }
 
@@ -78,20 +68,24 @@ private extension MayaChainStakeInteractor {
         vault.defiPositions.first { $0.chain == .mayaChain }?.staking ?? []
     }
 
-    func calculateUnstakeMetadata(
-        currentHeight: Int64,
-        lastDepositHeight: Int64,
-        maturityBlocks: Int64
-    ) -> UnstakeMetadata? {
-        let differenceBlocks = currentHeight - lastDepositHeight
-        guard differenceBlocks < maturityBlocks else { return nil }
+    /// Builds maturity metadata from raw block inputs read live from health (current height) and
+    /// mimir (maturity window). On a verification failure the position is surfaced as `.unknown`
+    /// rather than dropped — so the unstake CTA is gated with an explanation instead of silently
+    /// keeping a stale (possibly still-locked) row.
+    func unstakeMetadata(for position: MayaCacaoPoolPosition) async -> UnstakeMetadata {
+        guard
+            let health = try? await mayaChainAPIService.getHealth(shouldCache: false),
+            let mimir = try? await mayaChainAPIService.getMimir()
+        else {
+            logger.error("Could not verify Maya CACAO maturity (health/mimir unavailable)")
+            return .unknown
+        }
 
-        let blocksPerDay: Double = 14400
-        let blocksRemaining = maturityBlocks - differenceBlocks
-        let daysRemaining = Double(blocksRemaining) / blocksPerDay
-        let secondsRemaining = daysRemaining * 24 * 60 * 60
-        let unstakeAvailableDate = Date().addingTimeInterval(secondsRemaining)
-
-        return UnstakeMetadata(unstakeAvailableDate: unstakeAvailableDate.timeIntervalSince1970)
+        return UnstakeMetadata(
+            lastDepositHeight: position.lastDepositHeight,
+            maturityBlocks: mimir.cacaoPoolDepositMaturityBlocks,
+            snapshotHeight: health.lastMayaNode.height,
+            snapshotTimestamp: Date().timeIntervalSince1970
+        )
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
@@ -25,7 +25,7 @@ final class StakePosition {
 
     var canUnstake: Bool {
         let unstakeAmount = availableToUnstake ?? amount
-        return !unstakeAmount.isZero && (unstakeMetadata?.canUnstake ?? true)
+        return !unstakeAmount.isZero && (unstakeMetadata?.canUnstake() ?? true)
     }
 
     var unstakeMessage: String? {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/UnstakeMetadata.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/UnstakeMetadata.swift
@@ -7,37 +7,151 @@
 
 import Foundation
 
+/// Maturity gate for an unstake CTA.
+///
+/// Persisted inside `StakePosition` (a `@Model`) as an encoded `Codable` value. Rather than baking
+/// an absolute unlock `Date` at fetch time — which freezes maturity into a stale snapshot and never
+/// re-derives on later view appearances — this holds the RAW block inputs and the height/timestamp
+/// the read was taken at, then recomputes maturity live on every gate evaluation. This mirrors the
+/// Android `computeMaturityStatus` contract (`remaining = lastDepositHeight + maturityBlocks -
+/// currentHeight`) and its `UNKNOWN` state for reads that could not be verified.
 struct UnstakeMetadata: Hashable, Codable {
-    let unstakeAvailableDate: TimeInterval
+    /// On-chain height of the member's last deposit.
+    let lastDepositHeight: Int64
+    /// Maturity window in blocks (read live from mimir).
+    let maturityBlocks: Int64
+    /// Chain height observed when this snapshot was taken.
+    let snapshotHeight: Int64
+    /// Wall-clock time (seconds since 1970) when this snapshot was taken; used to project the
+    /// height forward so the gate re-derives between refreshes instead of staying frozen.
+    let snapshotTimestamp: TimeInterval
+    /// `true` when the maturity/height read could not be verified (RPC failure). The CTA stays
+    /// disabled but the UI explains why instead of leaving an unexplained grey button.
+    let isUnknown: Bool
 
-    var canUnstake: Bool {
-        let now = Date().timeIntervalSince1970
-        return now >= unstakeAvailableDate
+    /// Seconds per Maya block; matches Android `MAYA_BLOCK_TIME_SECONDS`.
+    private static let blockTimeSeconds: Double = 6
+
+    init(
+        lastDepositHeight: Int64,
+        maturityBlocks: Int64,
+        snapshotHeight: Int64,
+        snapshotTimestamp: TimeInterval,
+        isUnknown: Bool = false
+    ) {
+        self.lastDepositHeight = lastDepositHeight
+        self.maturityBlocks = maturityBlocks
+        self.snapshotHeight = snapshotHeight
+        self.snapshotTimestamp = snapshotTimestamp
+        self.isUnknown = isUnknown
     }
 
-    func unstakeMessage(for coin: CoinMeta) -> String? {
-        switch coin {
-        case TokensStore.cacao:
-            let now = Date().timeIntervalSince1970
-            let secondsRemaining = unstakeAvailableDate - now
+    /// Represents a read that failed verification: maturity is unknown, CTA stays gated.
+    static let unknown = UnstakeMetadata(
+        lastDepositHeight: 0,
+        maturityBlocks: 0,
+        snapshotHeight: 0,
+        snapshotTimestamp: 0,
+        isUnknown: true
+    )
 
-            // If can already unstake, return nil (no message needed)
-            guard secondsRemaining > 0 else {
-                return nil
-            }
+    /// Projects the snapshot height forward by the wall-clock elapsed since the snapshot, so the
+    /// gate keeps advancing between successful refreshes rather than comparing a frozen value.
+    private func projectedHeight(at referenceDate: Date) -> Int64 {
+        guard snapshotTimestamp > 0 else { return snapshotHeight }
+        let elapsed = referenceDate.timeIntervalSince1970 - snapshotTimestamp
+        guard elapsed > 0 else { return snapshotHeight }
+        let elapsedBlocks = Int64(elapsed / Self.blockTimeSeconds)
+        return snapshotHeight + elapsedBlocks
+    }
 
-            let formatter = DateComponentsFormatter()
-            formatter.allowedUnits = [.day, .hour, .minute]
-            formatter.unitsStyle = .short
-            formatter.maximumUnitCount = 2
+    /// Blocks remaining until maturity, derived live from the projected height. `0` when mature.
+    func remainingBlocks(at referenceDate: Date = Date()) -> Int64 {
+        guard !isUnknown else { return maturityBlocks }
+        let remaining = lastDepositHeight + maturityBlocks - projectedHeight(at: referenceDate)
+        return max(0, remaining)
+    }
 
-            guard let timeString = formatter.string(from: secondsRemaining) else {
-                return nil
-            }
+    /// Seconds remaining until maturity, derived live. `0` when mature.
+    func remainingSeconds(at referenceDate: Date = Date()) -> TimeInterval {
+        Double(remainingBlocks(at: referenceDate)) * Self.blockTimeSeconds
+    }
 
-            return String(format: "cacaoUnstakeMaturityMessage".localized, timeString)
-        default:
+    /// Mature (and verified) ⇒ unstake allowed. Unknown ⇒ gated.
+    func canUnstake(at referenceDate: Date = Date()) -> Bool {
+        guard !isUnknown else { return false }
+        return remainingBlocks(at: referenceDate) == 0
+    }
+
+    func unstakeMessage(for coin: CoinMeta, at referenceDate: Date = Date()) -> String? {
+        guard coin == TokensStore.cacao else { return nil }
+
+        if isUnknown {
+            return "cacaoUnstakeMaturityUnknownMessage".localized
+        }
+
+        let secondsRemaining = remainingSeconds(at: referenceDate)
+        guard secondsRemaining > 0 else { return nil }
+
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.unitsStyle = .short
+        formatter.maximumUnitCount = 2
+
+        guard let timeString = formatter.string(from: secondsRemaining) else {
             return nil
         }
+
+        return String(format: "cacaoUnstakeMaturityMessage".localized, timeString)
+    }
+}
+
+// MARK: - Migration-safe decoding
+
+extension UnstakeMetadata {
+    private enum CodingKeys: String, CodingKey {
+        case lastDepositHeight
+        case maturityBlocks
+        case snapshotHeight
+        case snapshotTimestamp
+        case isUnknown
+        // Legacy shape: an absolute unlock date persisted by older builds.
+        case unstakeAvailableDate
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let lastDepositHeight = try container.decodeIfPresent(Int64.self, forKey: .lastDepositHeight) {
+            self.lastDepositHeight = lastDepositHeight
+            self.maturityBlocks = try container.decodeIfPresent(Int64.self, forKey: .maturityBlocks) ?? 0
+            self.snapshotHeight = try container.decodeIfPresent(Int64.self, forKey: .snapshotHeight) ?? 0
+            self.snapshotTimestamp = try container.decodeIfPresent(TimeInterval.self, forKey: .snapshotTimestamp) ?? 0
+            self.isUnknown = try container.decodeIfPresent(Bool.self, forKey: .isUnknown) ?? false
+            return
+        }
+
+        // Legacy persisted row: rebuild raw inputs from the frozen unlock date so the row keeps
+        // gating sanely until the next successful refresh overwrites it. The blocks-remaining
+        // anchor is derived from the legacy date relative to its own snapshot timestamp.
+        let legacyUnlock = try container.decodeIfPresent(TimeInterval.self, forKey: .unstakeAvailableDate) ?? 0
+        let now = Date().timeIntervalSince1970
+        let secondsRemaining = max(0, legacyUnlock - now)
+        let blocksRemaining = Int64(secondsRemaining / Self.blockTimeSeconds)
+
+        self.lastDepositHeight = 0
+        self.maturityBlocks = blocksRemaining
+        self.snapshotHeight = 0
+        self.snapshotTimestamp = now
+        self.isUnknown = false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(lastDepositHeight, forKey: .lastDepositHeight)
+        try container.encode(maturityBlocks, forKey: .maturityBlocks)
+        try container.encode(snapshotHeight, forKey: .snapshotHeight)
+        try container.encode(snapshotTimestamp, forKey: .snapshotTimestamp)
+        try container.encode(isUnknown, forKey: .isUnknown)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/UnstakeMetadata.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/UnstakeMetadata.swift
@@ -137,7 +137,8 @@ extension UnstakeMetadata {
         let legacyUnlock = try container.decodeIfPresent(TimeInterval.self, forKey: .unstakeAvailableDate) ?? 0
         let now = Date().timeIntervalSince1970
         let secondsRemaining = max(0, legacyUnlock - now)
-        let blocksRemaining = Int64(secondsRemaining / Self.blockTimeSeconds)
+        // Round up: flooring could let a migrated row unlock up to one block (~6s) early.
+        let blocksRemaining = Int64(ceil(secondsRemaining / Self.blockTimeSeconds))
 
         self.lastDepositHeight = 0
         self.maturityBlocks = blocksRemaining

--- a/VultisigApp/VultisigAppTests/Defi/MayaCacaoUnstakeMetadataTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/MayaCacaoUnstakeMetadataTests.swift
@@ -1,0 +1,158 @@
+//
+//  MayaCacaoUnstakeMetadataTests.swift
+//  VultisigAppTests
+//
+//  Maturity gating for the MayaChain CACAO single-pool unstake CTA.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class MayaCacaoUnstakeMetadataTests: XCTestCase {
+
+    private let blockTime: TimeInterval = 6
+    /// 21-day maturity window (live mimir value at time of writing): 302400 blocks.
+    private let maturityBlocks: Int64 = 302_400
+
+    // MARK: - Matured position enables unstake
+
+    func test_maturedPosition_enablesUnstake() {
+        // last_deposit_height + maturity is already behind the snapshot height ⇒ remaining 0.
+        let meta = UnstakeMetadata(
+            lastDepositHeight: 1_000,
+            maturityBlocks: maturityBlocks,
+            snapshotHeight: 1_000 + maturityBlocks + 10,
+            snapshotTimestamp: Date().timeIntervalSince1970
+        )
+
+        XCTAssertTrue(meta.canUnstake())
+        XCTAssertEqual(meta.remainingBlocks(), 0)
+        XCTAssertEqual(meta.remainingSeconds(), 0)
+        XCTAssertNil(meta.unstakeMessage(for: TokensStore.cacao), "Mature ⇒ no maturity hint.")
+    }
+
+    // MARK: - Not-yet-matured position is gated with correct remaining
+
+    func test_notYetMatured_isGatedWithCorrectRemaining() {
+        let reference = Date(timeIntervalSince1970: 1_000_000)
+        let remainingBlocks: Int64 = 14_400 // exactly one day of 6s blocks
+
+        let meta = UnstakeMetadata(
+            lastDepositHeight: 1_000,
+            maturityBlocks: maturityBlocks,
+            // snapshot height leaves exactly `remainingBlocks` to go.
+            snapshotHeight: 1_000 + maturityBlocks - remainingBlocks,
+            snapshotTimestamp: reference.timeIntervalSince1970
+        )
+
+        XCTAssertFalse(meta.canUnstake(at: reference))
+        XCTAssertEqual(meta.remainingBlocks(at: reference), remainingBlocks)
+        XCTAssertEqual(meta.remainingSeconds(at: reference), Double(remainingBlocks) * blockTime)
+        XCTAssertNotNil(meta.unstakeMessage(for: TokensStore.cacao, at: reference))
+    }
+
+    // MARK: - Recompute is live (not frozen)
+
+    /// The same raw inputs evaluated at a later wall-clock time must advance toward maturity and
+    /// eventually flip to enabled — proving the gate re-derives instead of comparing a frozen date.
+    func test_recomputeIsLive_flipsToEnabledAsTimePasses() {
+        let snapshot = Date(timeIntervalSince1970: 1_000_000)
+        let remainingBlocks: Int64 = 14_400 // one day to go at snapshot time
+
+        let meta = UnstakeMetadata(
+            lastDepositHeight: 1_000,
+            maturityBlocks: maturityBlocks,
+            snapshotHeight: 1_000 + maturityBlocks - remainingBlocks,
+            snapshotTimestamp: snapshot.timeIntervalSince1970
+        )
+
+        // At snapshot time: still locked.
+        XCTAssertFalse(meta.canUnstake(at: snapshot))
+
+        // Halfway through the remaining window: still locked, but less remaining.
+        let halfway = snapshot.addingTimeInterval(Double(remainingBlocks) * blockTime / 2)
+        XCTAssertFalse(meta.canUnstake(at: halfway))
+        XCTAssertLessThan(meta.remainingBlocks(at: halfway), remainingBlocks)
+
+        // Past the full window: now mature without any refresh.
+        let afterMaturity = snapshot.addingTimeInterval(Double(remainingBlocks) * blockTime + 60)
+        XCTAssertTrue(meta.canUnstake(at: afterMaturity))
+        XCTAssertEqual(meta.remainingBlocks(at: afterMaturity), 0)
+    }
+
+    func test_remainingNeverGoesNegative() {
+        let meta = UnstakeMetadata(
+            lastDepositHeight: 1_000,
+            maturityBlocks: maturityBlocks,
+            snapshotHeight: 1_000 + maturityBlocks + 50_000,
+            snapshotTimestamp: Date().timeIntervalSince1970
+        )
+        XCTAssertEqual(meta.remainingBlocks(), 0)
+        XCTAssertGreaterThanOrEqual(meta.remainingSeconds(), 0)
+    }
+
+    // MARK: - Unknown / unverified state
+
+    func test_unknownState_gatesAndExplains() {
+        let meta = UnstakeMetadata.unknown
+
+        XCTAssertTrue(meta.isUnknown)
+        XCTAssertFalse(meta.canUnstake(), "Couldn't-verify ⇒ CTA must stay gated.")
+        XCTAssertEqual(
+            meta.unstakeMessage(for: TokensStore.cacao),
+            "cacaoUnstakeMaturityUnknownMessage".localized,
+            "Unknown ⇒ explicit explanation, not a silent grey button."
+        )
+    }
+
+    // MARK: - Non-cacao coins get no hint
+
+    func test_unstakeMessage_nilForNonCacaoCoin() {
+        let meta = UnstakeMetadata(
+            lastDepositHeight: 1_000,
+            maturityBlocks: maturityBlocks,
+            snapshotHeight: 1_000,
+            snapshotTimestamp: Date().timeIntervalSince1970
+        )
+        XCTAssertNil(meta.unstakeMessage(for: .example))
+    }
+
+    // MARK: - Migration-safe decoding of the legacy persisted shape
+
+    /// Older builds persisted an absolute `unstakeAvailableDate`. Decoding must not crash and must
+    /// keep gating sanely: a future legacy unlock ⇒ still locked; a past unlock ⇒ mature.
+    func test_legacyDecoding_futureUnlock_staysLocked() throws {
+        let future = Date().addingTimeInterval(24 * 60 * 60).timeIntervalSince1970
+        let json = "{\"unstakeAvailableDate\": \(future)}".data(using: .utf8)!
+
+        let meta = try JSONDecoder().decode(UnstakeMetadata.self, from: json)
+
+        XCTAssertFalse(meta.isUnknown)
+        XCTAssertFalse(meta.canUnstake(), "Legacy future unlock ⇒ still gated.")
+        XCTAssertGreaterThan(meta.remainingBlocks(), 0)
+    }
+
+    func test_legacyDecoding_pastUnlock_isMature() throws {
+        let past = Date().addingTimeInterval(-60).timeIntervalSince1970
+        let json = "{\"unstakeAvailableDate\": \(past)}".data(using: .utf8)!
+
+        let meta = try JSONDecoder().decode(UnstakeMetadata.self, from: json)
+
+        XCTAssertFalse(meta.isUnknown)
+        XCTAssertTrue(meta.canUnstake(), "Legacy past unlock ⇒ mature.")
+        XCTAssertEqual(meta.remainingBlocks(), 0)
+    }
+
+    /// A round-trip through the new encoder preserves the raw inputs.
+    func test_codableRoundTrip_preservesRawInputs() throws {
+        let original = UnstakeMetadata(
+            lastDepositHeight: 12_345,
+            maturityBlocks: maturityBlocks,
+            snapshotHeight: 50_000,
+            snapshotTimestamp: 1_700_000_000
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(UnstakeMetadata.self, from: data)
+        XCTAssertEqual(original, decoded)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [#4359](https://github.com/vultisig/vultisig-ios/issues/4359) — the MayaChain **CACAO single-pool** (Cacao Pool, memo `POOL-:<bps>`) **Unstake** CTA stays greyed past the unbond window.

The maturity window was already read live from mimir (`CACAOPOOLDEPOSITMATURITYBLOCKS` = 302400 / 21 days) — there was **no hardcoded-7-day bug**. The defect was UI state-staleness: `MayaChainStakeInteractor` baked maturity into an **absolute `unstakeAvailableDate`** that was persisted and compared against the live clock, so the gate only re-derived on a successful `refresh()` (onLoad / pull-to-refresh), and any transient RPC failure left a stale locked row with no explanation.

## Fix

- **`UnstakeMetadata`** — replace the persisted absolute `unstakeAvailableDate` with **raw block inputs** (`lastDepositHeight`, `maturityBlocks`, `snapshotHeight`, `snapshotTimestamp`) + an `isUnknown` flag. `canUnstake(at:)` / `remaining*(at:)` now **recompute live** (`remaining = lastDepositHeight + maturityBlocks - projectedHeight`, projecting the snapshot height forward by wall-clock elapsed at 6s/block), so the gate self-advances between refreshes instead of reading a frozen date.
- **`MayaChainStakeInteractor`** — on a health/mimir verification failure, return an explicit `.unknown` metadata (CTA gated **with a hint**) instead of silently keeping/dropping a stale row.
- **`StakePosition.canUnstake`** — evaluates the live recompute; nil metadata still defaults to enabled (unchanged).
- Added `cacaoUnstakeMaturityUnknownMessage` to all 8 locales (sorted) for the "couldn't verify" state.

Mirrors the Android contract (`GetMayaCacaoMaturityStatusUseCaseImpl` + `MayaCacaoMaturityStatus.UNKNOWN`, android#4498 / PR #4074): recompute per read, distinguish "still locked" from "couldn't verify", never persist an absolute unlock timestamp.

## SwiftData migration

`UnstakeMetadata` is a `Codable` value encoded inside the `StakePosition` `@Model` (not a `@Model` itself), so the schema is unchanged. A custom `init(from:)` decodes legacy `unstakeAvailableDate`-only payloads (future unlock → still gated; past → mature) with defaults on every new key — existing persisted rows decode without crashing and gate sanely until the next refresh overwrites them.

## Tests

New `MayaCacaoUnstakeMetadataTests` (9 cases): matured enables; not-yet-matured gated with correct remaining; **live recompute flips locked→enabled with no refresh**; remaining never negative; unknown-state gates + emits the explanation; non-cacao coin gets no hint; legacy decode; Codable round-trip. **28/28 passed** alongside `DefiChainStakeViewModelTests` + `DefiPositionsStorageServiceTests`. Build green, SwiftLint clean (no new warnings).

## Notes

- Behavior scope is the **unstake gate only** — stake/deposit flow untouched.
- QA caveat: the original report couldn't be reproduced against a specific position. If a known-matured maya address stays greyed **after** a successful pull-to-refresh, escalate to check that address's `cacao_provider` `last_deposit_height` for upstream indexer lag.

Wiki: `projects/vultisig/maya-cacao-unstake-4359/investigation.md`. Cross-platform: vultisig-android#4498 (primary), vultisig-windows#3924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unstake maturity verification and messaging when maturity cannot be determined.
  * Unstake gating now updates live (no frozen timestamps) and reliably prevents unstaking when maturity is unknown.

* **Localization**
  * Added a new user-facing "unstake maturity unknown" message in English, German, Spanish, Croatian, Italian, Korean, Portuguese and Simplified Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->