### PR TITLE
fix(swap): responsive quote fetching — fast start, no phantom gas/stale flash, animated resolve

### DIFF
--- a/VultisigApp/VultisigApp/Components/Swap/SwapFromToField.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapFromToField.swift
@@ -123,9 +123,12 @@ struct SwapFromToField: View {
             .disabled(title=="to")
         }
         .redacted(reason: title == "to" && detailsViewModel.isLoadingQuotes ? .placeholder : [])
-        // Crossfade the to-amount between its loading skeleton and the resolved
-        // value instead of snapping when a quote lands or refreshes.
-        .animation(.easeInOut(duration: 0.25), value: detailsViewModel.isLoadingQuotes)
+        // Show the skeleton instantly when a fetch starts (nil animation on the
+        // entering edge); crossfade to the resolved value only when it lands.
+        .animation(
+            detailsViewModel.isLoadingQuotes ? nil : .easeInOut(duration: 0.25),
+            value: detailsViewModel.isLoadingQuotes
+        )
         .animation(.easeInOut(duration: 0.25), value: amount)
     }
 
@@ -136,7 +139,10 @@ struct SwapFromToField: View {
             .frame(maxWidth: .infinity, alignment: .trailing)
             .opacity(isFiatVisible() ? 1 : 0)
             .redacted(reason: title == "to" && detailsViewModel.isLoadingQuotes ? .placeholder : [])
-            .animation(.easeInOut(duration: 0.25), value: detailsViewModel.isLoadingQuotes)
+            .animation(
+                detailsViewModel.isLoadingQuotes ? nil : .easeInOut(duration: 0.25),
+                value: detailsViewModel.isLoadingQuotes
+            )
             .animation(.easeInOut(duration: 0.25), value: fiatAmount)
     }
 

--- a/VultisigApp/VultisigApp/Components/Swap/SwapFromToField.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapFromToField.swift
@@ -123,6 +123,10 @@ struct SwapFromToField: View {
             .disabled(title=="to")
         }
         .redacted(reason: title == "to" && detailsViewModel.isLoadingQuotes ? .placeholder : [])
+        // Crossfade the to-amount between its loading skeleton and the resolved
+        // value instead of snapping when a quote lands or refreshes.
+        .animation(.easeInOut(duration: 0.25), value: detailsViewModel.isLoadingQuotes)
+        .animation(.easeInOut(duration: 0.25), value: amount)
     }
 
     var fiatBalance: some View {
@@ -132,6 +136,8 @@ struct SwapFromToField: View {
             .frame(maxWidth: .infinity, alignment: .trailing)
             .opacity(isFiatVisible() ? 1 : 0)
             .redacted(reason: title == "to" && detailsViewModel.isLoadingQuotes ? .placeholder : [])
+            .animation(.easeInOut(duration: 0.25), value: detailsViewModel.isLoadingQuotes)
+            .animation(.easeInOut(duration: 0.25), value: fiatAmount)
     }
 
     private func isFiatVisible() -> Bool {

--- a/VultisigApp/VultisigApp/Components/TextFields/SwapCryptoAmountTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/SwapCryptoAmountTextField.swift
@@ -33,13 +33,12 @@ struct SwapCryptoAmountTextField: View {
     var field: some View {
         let customBiding = Binding<String>(
             get: { amount },
-            set: {
-                // Don't validate or convert here - just save what the user typed
-                amount = $0
-
-                DebounceHelper.shared.debounce(delay: 3) {
-                    Task { await onChange(amount) }
-                }
+            set: { newValue in
+                // Don't validate or convert here - just save what the user typed.
+                // Report every keystroke immediately; the quote-fetch path owns
+                // debounce timing, so the field stays a dumb input.
+                amount = newValue
+                Task { await onChange(newValue) }
             }
         )
 

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -411,7 +411,11 @@ private extension SwapDetailsViewModel {
                 throw balanceError
             }
         } catch {
-            guard (error as? URLError)?.code != .cancelled else { return }
+            // Ignore cancellation from a superseding amount edit — surfacing it
+            // would overwrite the next fetch's state with a stale error.
+            if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                return
+            }
             self.error = error
         }
     }
@@ -438,6 +442,13 @@ private extension SwapDetailsViewModel {
                 vault: vault
             )
         } catch {
+            // A superseding amount edit cancels the in-flight task; cancellation
+            // must not surface as a fee error — it was previously mapped to the
+            // misleading `insufficientGas`, which is what users saw while typing.
+            if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                return
+            }
+
             logger.warning("Update fees error: \(error.localizedDescription)")
 
             switch error {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -355,22 +355,21 @@ private extension SwapDetailsViewModel {
             return
         }
 
-        // Leading-edge feedback: show the skeleton immediately on keystroke,
-        // before the debounce sleep, so input is acknowledged at once. A
-        // superseding keystroke cancels this task before its `defer` is armed
-        // (the cancel guard returns first), so the flags stay true for the new
-        // task and aren't stranded; the winning task's `defer` clears them.
+        // Leading-edge feedback: clear the previous quote's outputs and show the
+        // skeleton immediately on keystroke, before the debounce sleep, so a
+        // stale to-amount / fee can't show through while the new quote loads.
+        // The loading flags are cleared only by the winning (non-cancelled) task.
+        quote = nil
+        gas = .zero
+        thorchainFee = .zero
+        vultDiscountBps = 0
+        referralDiscountBps = 0
         isLoadingQuotes = true
         isLoadingFees = true
 
         updateQuoteTask = Task { [weak self] in
             try? await Task.sleep(for: Self.quoteDebounce)
-            guard !Task.isCancelled else { return }
-
-            defer {
-                self?.isLoadingQuotes = false
-                self?.isLoadingFees = false
-            }
+            guard !Task.isCancelled, let self else { return }
 
             // Sequential, not parallel: `updateFees` reads `self.quote`, so
             // running them concurrently raced — fees could see the `quote = nil`
@@ -379,9 +378,18 @@ private extension SwapDetailsViewModel {
             // Skip `updateFees` if `updateQuotes` already failed: with `quote`
             // still nil, `updateFees` would throw and overwrite the real error
             // (`swapAmountTooSmall`, `sameAsset`, etc.) with `insufficientGas`.
-            await self?.updateQuotes(vault: vault, referredCode: referredCode)
-            guard let self, self.error == nil, self.quote != nil else { return }
-            await self.updateFees(vault: vault)
+            await self.updateQuotes(vault: vault, referredCode: referredCode)
+            if self.error == nil, self.quote != nil {
+                await self.updateFees(vault: vault)
+            }
+
+            // Only the winning task clears the loading state. A superseded task
+            // that resumed after being cancelled must leave the skeleton up for
+            // its successor — otherwise clearing the flag unmasks the in-between
+            // reset values and the previous quote flashes through.
+            guard !Task.isCancelled else { return }
+            self.isLoadingQuotes = false
+            self.isLoadingFees = false
         }
     }
 
@@ -401,6 +409,9 @@ private extension SwapDetailsViewModel {
                 vault: vault,
                 referredCode: referredCode
             )
+            // A superseding edit cancelled this fetch — don't write its stale
+            // quote over the state the new fetch is about to populate.
+            guard !Task.isCancelled else { return }
             if let result {
                 quote = result.quote
                 vultDiscountBps = result.vultDiscountBps
@@ -434,13 +445,17 @@ private extension SwapDetailsViewModel {
                 fromAmount: amountDecimal,
                 quote: quote
             )
-            gas = chainSpecific.gas
-            thorchainFee = try await interactor.computeThorchainFee(
+            guard !Task.isCancelled else { return }
+            let computedFee = try await interactor.computeThorchainFee(
                 chainSpecific: chainSpecific,
                 fromCoin: fromCoin,
                 fromAmount: amountDecimal,
                 vault: vault
             )
+            // A superseding edit cancelled this fetch — don't write stale fees.
+            guard !Task.isCancelled else { return }
+            gas = chainSpecific.gas
+            thorchainFee = computedFee
         } catch {
             // A superseding amount edit cancels the in-flight task; cancellation
             // must not surface as a fee error — it was previously mapped to the

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -364,6 +364,7 @@ private extension SwapDetailsViewModel {
         thorchainFee = .zero
         vultDiscountBps = 0
         referralDiscountBps = 0
+        error = nil
         isLoadingQuotes = true
         isLoadingFees = true
 

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -333,6 +333,10 @@ extension SwapDetailsViewModel {
 
 private extension SwapDetailsViewModel {
 
+    // Single source of truth for the quote-fetch debounce. The amount field
+    // reports keystrokes immediately, so all debounce timing lives here.
+    static let quoteDebounce: Duration = .milliseconds(300)
+
     func fetchQuotes(vault: Vault, referredCode: String) {
         updateQuoteTask?.cancel()
 
@@ -351,12 +355,18 @@ private extension SwapDetailsViewModel {
             return
         }
 
+        // Leading-edge feedback: show the skeleton immediately on keystroke,
+        // before the debounce sleep, so input is acknowledged at once. A
+        // superseding keystroke cancels this task before its `defer` is armed
+        // (the cancel guard returns first), so the flags stay true for the new
+        // task and aren't stranded; the winning task's `defer` clears them.
+        isLoadingQuotes = true
+        isLoadingFees = true
+
         updateQuoteTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 200_000_000)
+            try? await Task.sleep(for: Self.quoteDebounce)
             guard !Task.isCancelled else { return }
 
-            self?.isLoadingQuotes = true
-            self?.isLoadingFees = true
             defer {
                 self?.isLoadingQuotes = false
                 self?.isLoadingFees = false

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -205,6 +205,10 @@ struct SwapDetailsScreen: View {
     var summary: some View {
         SwapDetailsSummary(detailsViewModel: detailsViewModel)
             .redacted(reason: detailsViewModel.isLoadingQuotes ? .placeholder : [])
+            // Crossfade the fees between their loading skeleton and the resolved
+            // values instead of snapping when a quote lands or refreshes.
+            .animation(.easeInOut(duration: 0.25), value: detailsViewModel.isLoadingQuotes)
+            .animation(.easeInOut(duration: 0.25), value: detailsViewModel.totalFeeString)
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -205,9 +205,12 @@ struct SwapDetailsScreen: View {
     var summary: some View {
         SwapDetailsSummary(detailsViewModel: detailsViewModel)
             .redacted(reason: detailsViewModel.isLoadingQuotes ? .placeholder : [])
-            // Crossfade the fees between their loading skeleton and the resolved
-            // values instead of snapping when a quote lands or refreshes.
-            .animation(.easeInOut(duration: 0.25), value: detailsViewModel.isLoadingQuotes)
+            // Show the skeleton instantly when a fetch starts (nil animation on
+            // the entering edge); crossfade to the resolved values when they land.
+            .animation(
+                detailsViewModel.isLoadingQuotes ? nil : .easeInOut(duration: 0.25),
+                value: detailsViewModel.isLoadingQuotes
+            )
             .animation(.easeInOut(duration: 0.25), value: detailsViewModel.totalFeeString)
     }
 


### PR DESCRIPTION
Closes #4445.

Makes the swap amount → quote flow responsive and correct while typing. Five focused commits:

## 1. Collapse the stacked debounce (`3d1bcc1d8`)
`SwapCryptoAmountTextField` debounced keystrokes by **3 seconds** (`DebounceHelper.shared.debounce(delay: 3)`), and `fetchQuotes` added another 200 ms — ~3.2 s before a fetch started. Removed the text-field debounce (the field now reports keystrokes immediately) and made `fetchQuotes` the single source of truth at **300 ms** (named constant). Loading flags are set synchronously on the leading edge so feedback is immediate.

## 2. Stop cancelled fetches surfacing as "insufficient gas" (`8fd0d24fd`)
Each keystroke cancels the in-flight `updateQuoteTask`. `updateFees`'s catch-all mapped *any* error — including the cancellation — to `Errors.insufficientGas`. Both `updateQuotes` and `updateFees` now ignore cancellation (`CancellationError` / `URLError.cancelled`) and return without writing an error. Genuine shortfalls still surface via the real fee-vs-balance check (unchanged).

## 3. Stop a cancelled quote writing stale to-amount/fees (`39ed49bed`)
A superseded task resumed after its `await` and wrote the old quote/gas/fee, then its `defer` cleared the skeleton — flashing the previous quote. Now: guard `!Task.isCancelled` after each `await` before writing; only the winning task clears the loading flags; the previous quote's outputs are reset on the leading edge.

## 4. Animate to-amount and fees as they resolve (`15f8e8834`)
Crossfade the values in when a quote lands/refreshes instead of snapping.

## 5. Show the skeleton instantly, animate only the resolve (`55d5339ad`)
Directional animation (`isLoadingQuotes ? nil : .easeInOut`) so the skeleton appears instantly when a fetch starts and only the resolved value/fees crossfade in.

## Net behavior
Type an amount → **instant skeleton** → ~300 ms → values **fade in cleanly**, with no phantom gas error and no stale flash.

## Scope / verification
- Touches `Features/Swap` only — no TSS/crypto/signing.
- `build-for-testing` (iPhone 16 / iOS 18.4) green; SwiftLint clean on all touched files.
- No `SwapDetailsViewModel` test exists and the debounce/cancel timing isn't cleanly testable without an injectable scheduler, so no flaky wall-clock test was added.

## Out of scope / follow-ups
- Quote *fetch duration* (multi-provider fan-out latency).
- `DebounceHelper.shared` per-instance cleanup for the Send / FunctionCall fields (it remains a single shared work-item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading-state animations for swaps so placeholders crossfade to values only after quotes finish loading.
  * Made swap amount inputs more responsive by applying user edits immediately and invoking change handlers per keystroke.
  * Fixed race conditions in quote and fee fetching: centralized debounce timing, clear stale state early, and ignore cancelled intermediate requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->