### PR TITLE
fix(send): instant percentage / Max amount fill (optimistic-then-refine)

### DIFF
--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTab.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTab.swift
@@ -98,13 +98,10 @@ struct SendDetailsAmountTab: View {
 
     @ViewBuilder
     var percentageButtons: some View {
-        let isDisabled = viewModel.isLoading || viewModel.isCalculatingFee
         PercentageButtonsStack(selectedPercentage: $percentage)
-            .opacity(isDisabled ? 0.5 : 1.0)
-            .disabled(isDisabled)
             .onChange(of: percentage) { _, newValue in
                 guard let newValue else { return }
-                Task { await viewModel.setMaxAmount(percentage: newValue) }
+                viewModel.setMaxAmount(percentage: newValue)
             }
     }
 

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTextField.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTextField.swift
@@ -95,7 +95,7 @@ struct SendDetailsAmountTextField: View {
         SendCryptoAmountTextField(
             amount: $viewModel.amount,
             onChange: { viewModel.convertToFiat(newValue: $0) },
-            onMaxPressed: { Task { await viewModel.setMaxAmount() } }
+            onMaxPressed: { viewModel.setMaxAmount() }
         )
         .focused($focusedField, equals: .amount)
         .onChange(of: viewModel.coin) { _, _ in

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -457,7 +457,11 @@ final class SendDetailsViewModel {
                     feeMode: self.feeMode,
                     fromAddress: self.fromAddress
                 )))
-                guard !Task.isCancelled else { return }
+                // Skip the refine write if the user moved off Max in the
+                // meantime — a manual amount edit flips `sendMaxAmount` via
+                // `convertToFiat` without cancelling this task, so guard on it
+                // too or we'd clobber their input.
+                guard !Task.isCancelled, self.sendMaxAmount else { return }
                 let refined = SendCryptoLogic.computeMaxAmount(coin: self.coin, fee: result.fee)
                 self.amount = refined
                 self.convertToFiat(newValue: refined, setMaxValue: true)

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -101,6 +101,10 @@ final class SendDetailsViewModel {
     // MARK: - Cancellation
     @ObservationIgnored private var addressResolutionTask: Task<Void, Never>?
 
+    /// Background fee refine for the native-coin Max path. Exposed so the UI
+    /// (and tests) can observe / await the optimistic-fill → refine settle.
+    @ObservationIgnored private(set) var feeRefineTask: Task<Void, Never>?
+
     // MARK: - Init
 
     init(
@@ -401,42 +405,79 @@ final class SendDetailsViewModel {
 
     // MARK: - Max amount
 
-    /// Per-chain max-amount calculation. Delegates the on-chain fetch to
-    /// `interactor.fetchGasAndFee`; max-amount math sits in `SendCryptoLogic`.
-    /// Non-native sources see their gas paid in the chain's native sibling,
-    /// so the deductible fee here is `.zero` for ERC20 / SPL / etc.
-    func setMaxAmount(percentage: Double = 100) async {
+    /// Fill the amount from a percentage preset (25 / 50 / 75 / Max).
+    ///
+    /// The displayed amount fills **synchronously** from `coin.balanceDecimal`
+    /// in every case so the field updates instantly like manual entry — no
+    /// blocking `isLoading`, no awaited fetch on the hot path. Only the
+    /// native-coin Max case needs a real fee (you can't drain the wallet and
+    /// still pay gas), so it fills optimistically with the full balance and
+    /// then refines to `balance − fee` in the background (Option B). Partials
+    /// and non-native sends never reserve a fee — the Verify screen owns the
+    /// precise fee validation before signing.
+    func setMaxAmount(percentage: Double = 100) {
+        cancelFeeRefine()
         errorMessage = ""
-        isLoading = true
-        defer { isLoading = false }
-
-        let maxFee: BigInt
-        do {
-            let result = try await interactor.fetchGasAndFee(SendFeeEstimateRequest(chainSpecific: SendChainSpecificRequest(
-                coin: coin,
-                toAddress: toAddress.isEmpty ? coin.address : toAddress,
-                amount: .zero,
-                memo: memo.isEmpty ? nil : memo,
-                sendMaxAmount: percentage == 100,
-                isDeposit: isDeposit,
-                transactionType: transactionType,
-                gasLimit: gasLimit,
-                feeMode: feeMode,
-                fromAddress: fromAddress
-            )))
-            maxFee = coin.isNativeToken ? result.fee : .zero
-        } catch {
-            logger.error("setMaxAmount failed: \(error.localizedDescription, privacy: .public)")
-            errorMessage = error.localizedDescription
-            return
-        }
 
         sendMaxAmount = percentage == 100
-        let maxAmount = SendCryptoLogic.computeMaxAmount(coin: coin, fee: maxFee)
-        amount = percentage == 100
-            ? maxAmount
-            : SendCryptoLogic.applyPercentage(maxAmount: maxAmount, percentage: percentage, coinDecimals: coin.decimals)
+
+        // Optimistic / instant fill: full balance minus zero fee, scaled by %.
+        let fullBalance = SendCryptoLogic.computeMaxAmount(coin: coin, fee: .zero)
+        amount = sendMaxAmount
+            ? fullBalance
+            : SendCryptoLogic.applyPercentage(maxAmount: fullBalance, percentage: percentage, coinDecimals: coin.decimals)
         convertToFiat(newValue: amount, setMaxValue: sendMaxAmount)
+
+        // Only native-coin Max needs the fee subtracted; refine in the
+        // background without blocking the field or the preset buttons.
+        guard coin.isNativeToken, sendMaxAmount else { return }
+        startFeeRefine()
+    }
+
+    /// Background refine for the native-coin Max path. Re-fetches the real
+    /// max-send fee and settles `amount` to `balance − fee`. Guarded so a
+    /// stale refine can't clobber a newer fill (another preset tap, manual
+    /// edit) — the task is cancelled at the top of `setMaxAmount`, and we
+    /// re-check cancellation after the await before writing.
+    private func startFeeRefine() {
+        isCalculatingFee = true
+        feeRefineTask = Task { [weak self] in
+            guard let self else { return }
+            defer { self.isCalculatingFee = false }
+            do {
+                let result = try await self.interactor.fetchGasAndFee(SendFeeEstimateRequest(chainSpecific: SendChainSpecificRequest(
+                    coin: self.coin,
+                    toAddress: self.toAddress.isEmpty ? self.coin.address : self.toAddress,
+                    amount: .zero,
+                    memo: self.memo.isEmpty ? nil : self.memo,
+                    sendMaxAmount: true,
+                    isDeposit: self.isDeposit,
+                    transactionType: self.transactionType,
+                    gasLimit: self.gasLimit,
+                    feeMode: self.feeMode,
+                    fromAddress: self.fromAddress
+                )))
+                guard !Task.isCancelled else { return }
+                let refined = SendCryptoLogic.computeMaxAmount(coin: self.coin, fee: result.fee)
+                self.amount = refined
+                self.convertToFiat(newValue: refined, setMaxValue: true)
+            } catch is CancellationError {
+                return
+            } catch {
+                // Keep the optimistic full-balance value rather than wiping the
+                // field; the Verify screen recomputes and validates the real
+                // fee before signing.
+                guard !Task.isCancelled else { return }
+                self.logger.error("setMaxAmount fee refine failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Cancel any in-flight native-Max fee refine and clear the indicator.
+    private func cancelFeeRefine() {
+        feeRefineTask?.cancel()
+        feeRefineTask = nil
+        isCalculatingFee = false
     }
 
     // MARK: - Fee / gas refresh

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelMaxAmountTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelMaxAmountTests.swift
@@ -3,15 +3,16 @@
 //  VultisigAppTests
 //
 //  Per-chain integration tests for `SendDetailsViewModel.setMaxAmount`.
-//  Each test drives the VM with a stubbed interactor return shape that
-//  matches what the real `DefaultSendInteractor.fetchChainSpecific` would
-//  produce for that chain, then verifies the VM dispatches to the right
-//  `SendCryptoLogic.computeMaxAmount` arguments.
 //
-//  These aren't validating the per-chain *blockchain* logic (that lives in
-//  the chain-specific helpers — UTXOChainsHelper, CardanoHelper, etc.). They
-//  pin the form VM's dispatch surface so a future refactor can't silently
-//  break which fee-shape it pulls from chainSpecific.
+//  `setMaxAmount` fills the displayed amount synchronously from
+//  `coin.balanceDecimal` in every case (instant fill). Only native-coin Max
+//  needs the real fee subtracted, so it fills optimistically with the full
+//  balance and then refines to `balance − fee` in a background task
+//  (`feeRefineTask`) — tests await that task to observe the settled value.
+//
+//  Non-native sends and partial percentages never touch the interactor: they
+//  fill from balance directly, since the Verify screen owns the precise fee
+//  validation before signing.
 //
 
 import BigInt
@@ -22,9 +23,9 @@ import VultisigCommonData
 @MainActor
 final class SendDetailsViewModelMaxAmountTests: XCTestCase {
 
-    // MARK: - EVM native
+    // MARK: - EVM native (optimistic → refine)
 
-    func testMaxAmountForEVMNativeSubtractsFeeFromBalance() async {
+    func testMaxAmountForEVMNativeOptimisticallyFillsBalanceThenRefinesByFee() async {
         let eth = SendFormFixture.makeETH(rawBalance: "1000000000000000000") // 1 ETH
         let interactor = MockSendInteractor()
         interactor.calculateEVMFeeStub = { _ in
@@ -32,46 +33,54 @@ final class SendDetailsViewModelMaxAmountTests: XCTestCase {
                                     gas: BigInt(50_000_000_000))
         }
         let vm = SendFormFixture.make(coin: eth, interactor: interactor)
-        await vm.setMaxAmount(percentage: 100)
 
+        vm.setMaxAmount(percentage: 100)
+
+        // Optimistic fill — full balance, before the refine lands.
         XCTAssertEqual(vm.sendMaxAmount, true)
+        XCTAssertEqual(vm.amount.replacingOccurrences(of: ",", with: ".").toDecimal(), Decimal(string: "1"))
+
+        await vm.feeRefineTask?.value
+
+        // Refined — balance minus the fetched fee.
         XCTAssertEqual(vm.amount.replacingOccurrences(of: ",", with: ".").toDecimal(), Decimal(string: "0.99"))
+        XCTAssertFalse(vm.isCalculatingFee, "refine must clear the calculating-fee indicator")
+        XCTAssertEqual(interactor.calculateEVMFeeCalls.count, 1)
     }
 
-    func testMaxAmountForEVMTokenReturnsFullBalanceIgnoringGas() async {
+    func testMaxAmountForEVMTokenFillsFullBalanceWithoutFetchingFee() async {
         let usdc = SendFormFixture.makeUSDC(rawBalance: "1000000000") // 1000 USDC
         let interactor = MockSendInteractor()
-        interactor.calculateEVMFeeStub = { _ in
-            SendInteractorFeeResult(fee: BigInt(stringLiteral: "50000000000000000"),
-                                    gas: BigInt(50_000_000_000))
-        }
         let vm = SendFormFixture.make(coin: usdc, interactor: interactor)
-        await vm.setMaxAmount(percentage: 100)
+
+        vm.setMaxAmount(percentage: 100)
+        await vm.feeRefineTask?.value
 
         XCTAssertEqual(vm.amount.replacingOccurrences(of: ",", with: ".").toDecimal(), Decimal(string: "1000"),
                        "ERC20 max-send: gas is paid in native ETH, token balance is the whole pool.")
+        XCTAssertNil(vm.feeRefineTask, "non-native must not kick a fee refine")
+        XCTAssertTrue(interactor.fetchChainSpecificCalls.isEmpty, "non-native max must not hit the interactor")
+        XCTAssertTrue(interactor.calculateEVMFeeCalls.isEmpty, "non-native max must not hit the interactor")
     }
 
-    // MARK: - UTXO
+    // MARK: - UTXO native (optimistic → refine)
 
-    func testMaxAmountForUTXOSubtractsPlanFee() async {
+    func testMaxAmountForUTXOOptimisticallyFillsBalanceThenRefinesByPlanFee() async {
         let btc = SendFormFixture.makeBTC(rawBalance: "100000000") // 1 BTC
         let interactor = MockSendInteractor()
         interactor.fetchChainSpecificStub = { _ in
-            .UTXO(byteFee: BigInt(50), sendMaxAmount: true)
-        }
-        // For UTXO max the VM reads chainSpecific.fee — UTXO's fee accessor
-        // returns 0 with just a byteFee. Use a stub that matches reality:
-        // legacy code plans a transfer for the plan fee. For unit-test
-        // simplicity we override chainSpecific to a fee-bearing variant.
-        interactor.fetchChainSpecificStub = { _ in
-            // Most production code paths read `.fee` off the chainSpecific;
-            // for UTXO that's typically the planned-tx fee. Use the THORChain
-            // variant here as a tagged enum that exposes `.fee` directly.
+            // UTXO max reads `.fee` off chainSpecific; the THORChain variant
+            // exposes a fee-bearing tagged enum convenient for unit tests.
             .THORChain(accountNumber: 0, sequence: 0, fee: 5_000, isDeposit: false, transactionType: 0)
         }
         let vm = SendFormFixture.make(coin: btc, interactor: interactor)
-        await vm.setMaxAmount(percentage: 100)
+
+        vm.setMaxAmount(percentage: 100)
+
+        // Optimistic — full 1 BTC before the plan fee is known.
+        XCTAssertEqual(vm.amount.replacingOccurrences(of: ",", with: ".").toDecimal(), Decimal(string: "1"))
+
+        await vm.feeRefineTask?.value
 
         // 1 BTC = 100_000_000 sats; minus 5_000 sats fee = 99_995_000 sats = 0.99995 BTC.
         XCTAssertEqual(vm.amount.replacingOccurrences(of: ",", with: ".").toDecimal(), Decimal(string: "0.99995"))
@@ -83,77 +92,107 @@ final class SendDetailsViewModelMaxAmountTests: XCTestCase {
         let sol = SendFormFixture.makeCoin(.solana, ticker: "SOL", decimals: 9, isNative: true,
                                            rawBalance: "1000000000") // 1 SOL
         let vm = SendFormFixture.make(coin: sol)
-        await vm.setMaxAmount(percentage: 100)
+
+        vm.setMaxAmount(percentage: 100)
+        await vm.feeRefineTask?.value
 
         // String formatting is locale-dependent — assert the structural
-        // behavior rather than the exact numeric value (which has its own
-        // dedicated coverage in `SendMaxAmountTests`).
+        // behavior rather than the exact numeric value.
         XCTAssertFalse(vm.amount.isEmpty, "setMaxAmount must populate vm.amount")
         XCTAssertTrue(vm.sendMaxAmount, "100% setMaxAmount must flag sendMaxAmount = true")
     }
 
-    // MARK: - Cosmos
+    // MARK: - Cosmos native
 
-    func testMaxAmountForCosmosUsesChainSpecificGasFromInteractor() async {
+    func testMaxAmountForCosmosRefinesViaChainSpecificGas() async {
         let atom = SendFormFixture.makeATOM(rawBalance: "10000000") // 10 ATOM
         let interactor = MockSendInteractor()
         interactor.fetchChainSpecificStub = { _ in
             .Cosmos(accountNumber: 0, sequence: 0, gas: 2_000, transactionType: 0, ibcDenomTrace: nil)
         }
         let vm = SendFormFixture.make(coin: atom, interactor: interactor)
-        await vm.setMaxAmount(percentage: 100)
 
-        // Structural: confirms the VM called fetchChainSpecific (the per-chain
-        // dispatch path went through), populated an amount, and flagged max.
+        vm.setMaxAmount(percentage: 100)
+        await vm.feeRefineTask?.value
+
+        // Structural: native Max refines through fetchChainSpecific, populated
+        // an amount, and flagged max.
         XCTAssertEqual(interactor.fetchChainSpecificCalls.count, 1)
         XCTAssertFalse(vm.amount.isEmpty)
         XCTAssertTrue(vm.sendMaxAmount)
     }
 
-    // MARK: - Percentage scaling
+    // MARK: - Percentage scaling (instant, no fetch)
 
-    func testMaxAmountAt50PercentScalesLinearly() async {
-        let eth = SendFormFixture.makeETH(rawBalance: "1000000000000000000")
+    func testMaxAmountAt50PercentFillsHalfBalanceWithoutFetch() {
+        let eth = SendFormFixture.makeETH(rawBalance: "1000000000000000000") // 1 ETH
         let interactor = MockSendInteractor()
-        interactor.calculateEVMFeeStub = { _ in
-            SendInteractorFeeResult(fee: BigInt.zero, gas: BigInt.zero)
-        }
         let vm = SendFormFixture.make(coin: eth, interactor: interactor)
-        await vm.setMaxAmount(percentage: 50)
 
-        // 1 ETH with zero fee → max = 1 ETH → 50% = 0.5 ETH.
+        vm.setMaxAmount(percentage: 50)
+
+        // 1 ETH → 50% of balance = 0.5 ETH (no fee reserved).
         XCTAssertEqual(vm.amount.replacingOccurrences(of: ",", with: ".").toDecimal(), Decimal(string: "0.5"))
         XCTAssertFalse(vm.sendMaxAmount, "Less-than-100% must not set sendMaxAmount flag.")
+        XCTAssertNil(vm.feeRefineTask, "partial % must not kick a fee refine")
+        XCTAssertTrue(interactor.fetchChainSpecificCalls.isEmpty, "partial % must not hit the interactor")
+        XCTAssertTrue(interactor.calculateEVMFeeCalls.isEmpty, "partial % must not hit the interactor")
+    }
+
+    // MARK: - Race / cancellation guard
+
+    func testNewPresetCancelsInFlightRefineAndWins() async {
+        let eth = SendFormFixture.makeETH(rawBalance: "1000000000000000000") // 1 ETH
+        let interactor = MockSendInteractor()
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: BigInt(stringLiteral: "10000000000000000"), gas: BigInt(50_000_000_000))
+        }
+        let vm = SendFormFixture.make(coin: eth, interactor: interactor)
+
+        // Kick the native-Max refine, then immediately switch to 50% before it
+        // settles. The stale refine must not clobber the newer 50% value.
+        vm.setMaxAmount(percentage: 100)
+        let staleRefine = vm.feeRefineTask
+        vm.setMaxAmount(percentage: 50)
+        await staleRefine?.value
+
+        XCTAssertEqual(vm.amount.replacingOccurrences(of: ",", with: ".").toDecimal(), Decimal(string: "0.5"),
+                       "stale native-Max refine must not overwrite the newer 50% fill")
+        XCTAssertFalse(vm.sendMaxAmount)
+        XCTAssertNil(vm.feeRefineTask, "switching to a partial % must clear the refine task")
     }
 
     // MARK: - Error path
 
-    func testMaxAmountErrorPathPreservesPriorState() async {
-        let eth = SendFormFixture.makeETH()
+    func testMaxAmountRefineErrorKeepsOptimisticBalance() async {
+        let eth = SendFormFixture.makeETH(rawBalance: "1000000000000000000") // 1 ETH
         let interactor = MockSendInteractor()
-        interactor.fetchChainSpecificStub = { _ in
+        interactor.calculateEVMFeeStub = { _ in
             throw NSError(domain: "test", code: -1, userInfo: [NSLocalizedDescriptionKey: "boom"])
         }
         let vm = SendFormFixture.make(coin: eth, interactor: interactor)
-        vm.amount = "0.5"
-        let priorAmount = vm.amount
 
-        await vm.setMaxAmount(percentage: 100)
+        vm.setMaxAmount(percentage: 100)
+        await vm.feeRefineTask?.value
 
-        XCTAssertEqual(vm.amount, priorAmount, "Failed max-amount must leave the existing amount untouched.")
-        XCTAssertNotNil(vm.errorMessage)
-        XCTAssertFalse(vm.isLoading, "isLoading must reset to false after the async call.")
+        // On refine failure we keep the optimistic full-balance value rather
+        // than wiping the field; Verify recomputes the real fee.
+        XCTAssertEqual(vm.amount.replacingOccurrences(of: ",", with: ".").toDecimal(), Decimal(string: "1"),
+                       "failed refine must keep the optimistic balance fill")
+        XCTAssertTrue(vm.sendMaxAmount)
+        XCTAssertFalse(vm.isCalculatingFee, "isCalculatingFee must reset after the refine settles")
     }
 
     // MARK: - feeMode threading
 
-    func testSetMaxAmountThreadsFeeMode() async {
+    func testNativeMaxRefineThreadsFeeMode() async {
         let eth = SendFormFixture.makeETH()
         let interactor = MockSendInteractor()
         let vm = SendFormFixture.make(coin: eth, interactor: interactor)
         vm.feeMode = .fast
 
-        await vm.setMaxAmount(percentage: 100)
+        vm.setMaxAmount(percentage: 100)
+        await vm.feeRefineTask?.value
 
         XCTAssertEqual(interactor.fetchChainSpecificCalls.last?.feeMode, .fast)
         XCTAssertEqual(interactor.calculateEVMFeeCalls.last?.feeMode, .fast)


### PR DESCRIPTION
Closes #4447.

Tapping a percentage preset (25 / 50 / 75 / Max) on the Send details screen blocked on a fee fetch before filling the amount; manual entry was instant. This makes the fill instant.

## Root cause
`SendDetailsViewModel.setMaxAmount(percentage:)` set `isLoading = true` and awaited `interactor.fetchGasAndFee(...)` to compute `balance − fee`. The details screen doesn't otherwise compute a fee (the verify screen does), so the fetch existed only to subtract the fee — and it's wasted for non-native coins (fee discarded → max = full balance) and unnecessary for partials.

## Change (Option B — optimistic fill + async refine)
`setMaxAmount(percentage:)` is now **synchronous**:
- Cancels any in-flight refine, sets `sendMaxAmount = (percentage == 100)`, fills instantly from balance (`SendCryptoLogic.computeMaxAmount(coin:, fee: .zero)`, scaled by `applyPercentage` for partials), then `convertToFiat`. No interactor call.
- **Only native-coin Max** falls through to a background `startFeeRefine()`: sets the non-blocking `isCalculatingFee` (not `isLoading`), runs the same `fetchGasAndFee` request (`sendMaxAmount: true`, feeMode threaded), then settles `amount = balance − fee`.
- Race guard mirrors `SwapDetailsViewModel`: `cancelFeeRefine()` at the top of each call + `guard !Task.isCancelled` after the await before writing, so a newer preset tap / manual edit can't be clobbered by a stale refine. `CancellationError` returns silently; other errors keep the optimistic balance and log (no field-wiping error).
- Percentage buttons are no longer disabled during the refine (dropped the `isLoading || isCalculatingFee` gate); both call sites drop the `Task { await … }` wrapper.

## Behavior
Every token and every partial preset fills **instantly**. Native-coin Max fills instantly and refines in the background.

**Expected (Option B):** on native UTXO / Cardano / TON, Max visibly settles down by the fee a moment after the fill (the fee is amount-dependent there); on EVM/account-based it's exact.

## Scope / verification
- `Features/Send` only — no TSS/crypto/signing; verify-screen fee calc unchanged.
- `build-for-testing` (iPhone 16 / iOS 18.4) green; SwiftLint clean on touched files.
- `SendDetailsViewModelMaxAmountTests` rewritten (9/9) — optimistic→refine for EVM + UTXO, **token + partial assert the interactor is never called**, race-guard (Max → 50% → 50% wins), refine-error keeps optimistic balance, `sendMaxAmount == (percentage == 100)`. Other Send suites unchanged and passing.

## Wiki
`projects/vultisig/send-percentage-amount-speed/instant-fill-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Send screen’s Max action now instantly fills amounts and refines fee in the background for native coins, giving faster feedback and smoother UX.
* **Bug Fixes**
  * Refinement failures no longer clear the optimistic amount; cancellation avoids stale overwrite.
* **Tests**
  * Updated test coverage for optimistic fill, background refine, cancellation and error paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->