### PR TITLE
fix(function-call): preflight THORChain inbound state for LP Add + SECURE+ Mint

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "importVaultShareSubtitle" = "Verwenden Sie einen Tresoranteil, um Ihren Tresor wiederherzustellen.";
 "importVaultShareTitle" = "Tresoranteil importieren";
 "importYourVaultShare" = "Importiere deinen Vault-Anteil";
+"inboundAddressNotFound" = "%@ wird derzeit von THORChain nicht unterstützt.";
 "inboundPaused" = "Inbound actions are paused for %@. Try again later.";
 "incorrectCodeTryAgain" = "Falscher Code. Versuche es erneut.";
 "incorrectPassword" = "Falsches Passwort";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -457,6 +457,7 @@
 "importVaultShareSubtitle" = "Use a vault share to recover your vault.";
 "importVaultShareTitle" = "Import vault share";
 "importYourVaultShare" = "Import your vault share";
+"inboundAddressNotFound" = "%@ is not currently supported by THORChain.";
 "inboundPaused" = "Inbound actions are paused for %@. Try again later.";
 "incorrectCodeTryAgain" = "Incorrect code. Try again.";
 "incorrectPassword" = "Incorrect Password";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "importVaultShareSubtitle" = "Usa una parte de bóveda para recuperar tu bóveda.";
 "importVaultShareTitle" = "Importar parte de bóveda";
 "importYourVaultShare" = "Importa tu parte del vault";
+"inboundAddressNotFound" = "%@ no es compatible actualmente con THORChain.";
 "inboundPaused" = "Inbound actions are paused for %@. Try again later.";
 "incorrectCodeTryAgain" = "Código incorrecto. Inténtalo de nuevo.";
 "incorrectPassword" = "Contraseña incorrecta";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "importVaultShareSubtitle" = "Koristite dijeljenje trezora da oporavite svoj trezor.";
 "importVaultShareTitle" = "Uvezi dijeljenje trezora";
 "importYourVaultShare" = "Uvezi svoj dio trezora";
+"inboundAddressNotFound" = "%@ trenutačno nije podržan na THORChainu.";
 "inboundPaused" = "Inbound actions are paused for %@. Try again later.";
 "incorrectCodeTryAgain" = "Netočan kod. Pokušajte ponovo.";
 "incorrectPassword" = "Netočna lozinka";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "importVaultShareSubtitle" = "Usa una condivisione vault per recuperare il tuo vault.";
 "importVaultShareTitle" = "Importa condivisione vault";
 "importYourVaultShare" = "Importa la tua quota di vault";
+"inboundAddressNotFound" = "%@ non è attualmente supportato da THORChain.";
 "inboundPaused" = "Le azioni in entrata sono in pausa per %@. Riprova più tardi.";
 "incorrectCodeTryAgain" = "Codice errato. Riprova.";
 "incorrectPassword" = "Password errata";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "importVaultShareSubtitle" = "Use um compartilhamento de cofre para recuperar seu cofre.";
 "importVaultShareTitle" = "Importar compartilhamento de cofre";
 "importYourVaultShare" = "Importe sua parte do cofre";
+"inboundAddressNotFound" = "%@ não é atualmente suportado pela THORChain.";
 "inboundPaused" = "Inbound actions are paused for %@. Try again later.";
 "incorrectCodeTryAgain" = "Código incorreto. Tente novamente.";
 "incorrectPassword" = "Senha incorreta";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -451,6 +451,7 @@
 "importVaultShareSubtitle" = "使用保险库共享来恢复您的保险库。";
 "importVaultShareTitle" = "导入保险库共享";
 "importYourVaultShare" = "导入您的保险库份额";
+"inboundAddressNotFound" = "THORChain 目前不支持 %@。";
 "inboundPaused" = "%@ 的入站操作已暂停。请稍后再试。";
 "incorrectCodeTryAgain" = "验证码错误。请重试。";
 "incorrectPassword" = "密码错误";

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -120,7 +120,10 @@ final class FunctionCallAddThorLP {
 
         // RUNE-side LP adds deposit to the THORChain network itself
         // (MsgDeposit), so there is no source-chain inbound to resolve.
+        // Clear any destination a prior source-coin may have resolved so a
+        // stale non-RUNE inbound/router is never reused.
         if coin.chain == .thorChain {
+            toAddress = ""
             isApprovalRequired = false
             approvePayload = nil
             customErrorMessage = nil
@@ -218,10 +221,17 @@ final class FunctionCallAddThorLP {
 
             // RUNE-pin when source coin is non-RUNE and not in the
             // selected pool — same intent as legacy initialize().
+            // This swaps the source chain to THORChain, so any inbound that
+            // the concurrent fetch resolved for the original coin is now
+            // stale; clear it so it can't leak into the transaction.
             if coin.ticker.uppercased() != "RUNE" && !isInThePool,
                let runeCoin = vault.runeCoin {
                 coin = runeCoin
                 coinSelectionHandler?(runeCoin)
+                toAddress = ""
+                isApprovalRequired = false
+                approvePayload = nil
+                customErrorMessage = nil
             }
 
             self.poolNameMap = nameMap

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -118,30 +118,46 @@ final class FunctionCallAddThorLP {
     private func fetchInboundAddressAndSetupApproval() async {
         let addresses = await ThorchainService.shared.fetchThorchainInboundAddress()
 
+        // RUNE-side LP adds deposit to the THORChain network itself
+        // (MsgDeposit), so there is no source-chain inbound to resolve.
         if coin.chain == .thorChain {
             isApprovalRequired = false
             approvePayload = nil
+            customErrorMessage = nil
             return
         }
 
         let chainName = ThorchainService.getInboundChainName(for: coin.chain)
         guard let inbound = addresses.first(where: { $0.chain.uppercased() == chainName.uppercased() }) else {
+            customErrorMessage = String(format: "inboundAddressNotFound".localized, chainName)
             return
         }
 
+        // When THORChain has halted/paused the source chain it returns no
+        // usable inbound vault. Surface a localized reason and leave
+        // `toAddress` empty so `isTheFormValid` blocks submission — otherwise
+        // signing proceeds with an empty destination and wallet-core rejects
+        // it with the raw `Error_invalid_address` enum.
         if inbound.halted || inbound.global_trading_paused || inbound.chain_trading_paused || inbound.chain_lp_actions_paused {
+            customErrorMessage = String(format: "inboundPaused".localized, inbound.chain)
             return
         }
 
         let destinationAddress: String
         if coin.shouldApprove {
-            destinationAddress = inbound.router ?? inbound.address
+            guard let router = inbound.router, !router.isEmpty else {
+                customErrorMessage = String(format: "routerNotAvailable".localized, inbound.chain)
+                isApprovalRequired = false
+                return
+            }
+            destinationAddress = router
         } else {
             destinationAddress = inbound.address
         }
 
         toAddress = destinationAddress
         isApprovalRequired = coin.shouldApprove
+        customErrorMessage = nil
         if isApprovalRequired {
             approvePayload = toAddress.isEmpty ? nil : ERC20ApprovePayload(
                 amount: amountInRaw,
@@ -316,7 +332,10 @@ final class FunctionCallAddThorLP {
         let currentBalance = coin.balanceDecimal
         let amountValid = amount > 0 && amount <= currentBalance
         let poolValid = !selectedPool.value.isEmpty
-        return amountValid && poolValid
+        // Non-RUNE LP adds are an on-chain transfer to the THORChain inbound
+        // vault; block until that destination resolves and isn't halted.
+        let inboundValid = coin.chain == .thorChain || (!toAddress.isEmpty && customErrorMessage == nil)
+        return amountValid && poolValid && inboundValid
     }
 
     private var fullPoolName: String {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
@@ -37,6 +37,12 @@ final class FunctionCallSecuredAsset {
     /// without dipping into screen-owned state.
     var coin: Coin
 
+    /// Inbound-state error for non-RUNE source chains (halted/paused/missing
+    /// inbound, or unavailable approval router). Tracked separately from the
+    /// amount/address validation so the two never clobber each other; both
+    /// are folded into `customErrorMessage` by `updateErrorMessage()`.
+    @ObservationIgnored private var inboundStateError: String?
+
     @ObservationIgnored private let vault: Vault
     @ObservationIgnored private var loadingTasks: [Task<Void, Never>] = []
 
@@ -76,24 +82,33 @@ final class FunctionCallSecuredAsset {
             toAddress = coin.address
             isApprovalRequired = false
             approvePayload = nil
+            inboundStateError = nil
+            updateErrorMessage()
             return
         }
 
         let chainName = ThorchainService.getInboundChainName(for: coin.chain)
         guard let inbound = addresses.first(where: { $0.chain.uppercased() == chainName.uppercased() }) else {
+            inboundStateError = String(format: "inboundAddressNotFound".localized, chainName)
+            updateErrorMessage()
             return
         }
 
+        // A halted/paused source chain has no usable inbound vault; leave
+        // `toAddress` empty so the form blocks submission instead of signing
+        // with an empty destination (raw `Error_invalid_address` at sign time).
         if inbound.halted || inbound.global_trading_paused || inbound.chain_trading_paused || inbound.chain_lp_actions_paused {
-            customErrorMessage = String(format: "inboundPaused".localized, inbound.chain)
+            inboundStateError = String(format: "inboundPaused".localized, inbound.chain)
+            updateErrorMessage()
             return
         }
 
         let destinationAddress: String
         if coin.shouldApprove {
             guard let router = inbound.router, !router.isEmpty else {
-                customErrorMessage = String(format: "routerNotAvailable".localized, inbound.chain)
+                inboundStateError = String(format: "routerNotAvailable".localized, inbound.chain)
                 isApprovalRequired = false
+                updateErrorMessage()
                 return
             }
             destinationAddress = router
@@ -103,12 +118,14 @@ final class FunctionCallSecuredAsset {
 
         toAddress = destinationAddress
         isApprovalRequired = coin.shouldApprove
+        inboundStateError = nil
         if isApprovalRequired {
             approvePayload = toAddress.isEmpty ? nil : ERC20ApprovePayload(
                 amount: amountInRaw,
                 spender: toAddress
             )
         }
+        updateErrorMessage()
     }
 
     func isAmountValid(against coin: Coin) -> Bool {
@@ -122,13 +139,19 @@ final class FunctionCallSecuredAsset {
     var isTheFormValid: Bool {
         let amountValid = isAmountValid(against: coin)
         let thorValid = !thorAddress.isEmpty
-        return amountValid && thorValid
+        // For non-RUNE sources the mint is an on-chain transfer to the
+        // THORChain inbound vault; require a resolved, non-paused inbound.
+        let inboundValid = coin.chain == .thorChain || (!toAddress.isEmpty && inboundStateError == nil)
+        return amountValid && thorValid && inboundValid
     }
 
     private func updateErrorMessage(against coin: Coin? = nil) {
         var errors: [String] = []
         let targetCoin = coin ?? self.coin
 
+        if let inboundStateError {
+            errors.append(inboundStateError)
+        }
         if thorAddress.isEmpty {
             errors.append("thorAddressNotFound".localized)
         }


### PR DESCRIPTION
## Summary

THORChain **LP Add** (and **SECURE+ Mint**) on a chain whose THORChain inbound is halted/paused let the user sail past **Continue → Verify → Sign** with an empty destination address. wallet-core then rejected the empty UTXO destination at sign time with its raw, untranslated enum string **`Error_invalid_address`** — the exact symptom in the issue.

Root cause: `FunctionCallAddThorLP.fetchInboundAddressAndSetupApproval()` silently `return`ed on a halted inbound, leaving `toAddress` empty, while `isTheFormValid` never checked it. `FunctionCallSecuredAsset` had the same hole — its paused message was set but clobbered by amount validation and never blocked Continue.

### Changes
- **`FunctionCallAddThorLP`** — on halted/paused / missing-inbound / missing approval router, set a localized `customErrorMessage` instead of returning silently. `isTheFormValid` now requires a resolved, non-paused inbound for non-RUNE source chains, so **Continue is blocked at the Details screen** and surfaces the localized reason via the existing invalid-form alert. RUNE-side adds (MsgDeposit, no source inbound) are unaffected. Also tightened ERC20 approval to error out when the router is unavailable rather than silently falling back to the vault address.
- **`FunctionCallSecuredAsset`** — track `inboundStateError` separately from amount/address validation (no clobbering), set it on missing inbound, and gate `isTheFormValid` the same way.
- **Localization** — added `inboundAddressNotFound` ("%@ is not currently supported by THORChain.") to all 7 mandatory locales; ran `sort_localizable.py`. (`inboundPaused` / `routerNotAvailable` already existed.)

### Out of scope / deferred
- Generic localization of the raw wallet-core `Error_invalid_address` across **all** signing paths — it's a wallet-core enum surfaced via the keysign/TSS-adjacent display path (review-gated, HIGH security tier). The preflight prevents it from ever being reached in the reported LP/Mint flows.
- `Est. network fee: 0 LTC` and the misleading "Notification sent" toast — separate issues flagged in the report.
- Blocking halted chains in the picker (defense-in-depth) — broader UI change.

## Issue
Closes #4372

## Test Plan
- [x] With LTC.LTC inbound halted on THORChain: Functions → Add Liquidity → LTC.LTC → enter amount → **Continue** now shows the localized paused message and does **not** reach Verify/Sign.
- [x] Same for SECURE+ Mint on a halted chain.
- [ ] Non-halted chain LP Add / Mint still proceeds normally; RUNE-side LP Add unaffected.
- [x] SwiftLint passes
- [x] xcodebuild build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevents approval prompts for THORChain LP adds and clears stale approval/address state when switching to RUNE.

* **Bug Fixes**
  * Forms now block submission if inbound address resolution fails, is paused, or unavailable; error messages surface consistently.

* **Localization**
  * Added "address not supported" notifications in English, German, Spanish, Croatian, Italian, Portuguese, and Simplified Chinese.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vultisig/vultisig-ios/pull/4449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->