### PR TITLE
ci: speed up Xcode builds (parallel jobs + DerivedData cache) and drop visionOS destination

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -13,6 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Scheme and project are fixed (defined in VultisigApp/project.yml), so there's
+# no need to discover them at runtime via `xcodebuild -list` (which can stall on
+# SPM resolution).
+env:
+  SCHEME: VultisigApp
+  PROJECT: VultisigApp.xcodeproj
+
 jobs:
   # ---------------------------------------------------------------------------
   # macOS: build + static analysis (native arm64 on the Apple-Silicon runner).
@@ -58,32 +65,18 @@ jobs:
             ${{ runner.os }}-dd-macos-${{ hashFiles('**/Package.resolved') }}-
             ${{ runner.os }}-dd-macos-
 
-      - name: Resolve scheme
-        working-directory: VultisigApp
-        run: |
-          scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          # Pick the first non-test shared scheme (xcodebuild -scheme needs a
-          # scheme, not a build target). Fail fast if none is found.
-          default=$(echo $scheme_list | ruby -e "require 'json'; schemes = JSON.parse(STDIN.gets)['project']['schemes'] || []; app = schemes.find { |s| !s.end_with?('Tests') }; abort('No non-test scheme found in project') unless app; puts app")
-          echo $default > default
-          echo "Using default scheme: $default"
-
       - name: Build & analyze for macOS
         working-directory: VultisigApp
         run: |
-          scheme=$(cat default)
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-
           xcodebuild -version
           swift --version
 
-          echo "Building & analyzing for macOS - scheme: $scheme"
+          echo "Building & analyzing for macOS - scheme: $SCHEME"
           # Note: no `clean` — DerivedData is cached/restored for incremental reuse.
           # Native arm64 (ONLY_ACTIVE_ARCH) on the Apple-Silicon runner.
           xcodebuild build analyze \
-            -scheme "$scheme" \
-            -"$filetype_parameter" "$file_to_build" \
+            -scheme "$SCHEME" \
+            -project "$PROJECT" \
             -destination 'platform=macOS' \
             -derivedDataPath DerivedData \
             -skipMacroValidation \
@@ -137,27 +130,13 @@ jobs:
             ${{ runner.os }}-dd-ios-${{ hashFiles('**/Package.resolved') }}-
             ${{ runner.os }}-dd-ios-
 
-      - name: Resolve scheme
-        working-directory: VultisigApp
-        run: |
-          scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          # Pick the first non-test shared scheme (xcodebuild -scheme needs a
-          # scheme, not a build target). Fail fast if none is found.
-          default=$(echo $scheme_list | ruby -e "require 'json'; schemes = JSON.parse(STDIN.gets)['project']['schemes'] || []; app = schemes.find { |s| !s.end_with?('Tests') }; abort('No non-test scheme found in project') unless app; puts app")
-          echo $default > default
-          echo "Using default scheme: $default"
-
       - name: Build, analyze & test for iOS
         working-directory: VultisigApp
         run: |
-          scheme=$(cat default)
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-
-          echo "Building, analyzing & testing for iOS - scheme: $scheme"
+          echo "Building, analyzing & testing for iOS - scheme: $SCHEME"
           xcodebuild build analyze test \
-            -scheme "$scheme" \
-            -"$filetype_parameter" "$file_to_build" \
+            -scheme "$SCHEME" \
+            -project "$PROJECT" \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.5' \
             -derivedDataPath DerivedData \
             -skipMacroValidation \

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -8,11 +8,18 @@ on:
   merge_group:
     branches: [ "main" ]
 
+# Cancel superseded runs on the same ref (e.g. rapid PR pushes) to free runners.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    name: Build, analyse and test default scheme using xcodebuild command
+  # ---------------------------------------------------------------------------
+  # macOS: build + static analysis (native arm64 on the Apple-Silicon runner).
+  # ---------------------------------------------------------------------------
+  build-macos:
+    name: Build & analyze (macOS)
     runs-on: macos-26
-    
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,6 +31,9 @@ jobs:
       - name: Generate Xcode project
         run: make generate
 
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
       - name: Cache SwiftPM
         uses: actions/cache@v4
         with:
@@ -33,63 +43,114 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
-      - name: Set Default Scheme
+
+      - name: Cache DerivedData (macOS)
+        uses: actions/cache@v4
+        with:
+          path: VultisigApp/DerivedData
+          # New cache per commit; restore the most recent one for the same
+          # resolved dependency set so unchanged modules aren't recompiled.
+          key: ${{ runner.os }}-dd-macos-${{ hashFiles('**/Package.resolved') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-dd-macos-${{ hashFiles('**/Package.resolved') }}-
+            ${{ runner.os }}-dd-macos-
+
+      - name: Resolve scheme
         working-directory: VultisigApp
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.2.app
-          mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"
-          xcrun --find xcodebuild
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
           default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
-          echo $default | cat >default
-          echo Using default scheme: $default
-          
-      - name: Build for macOS
+          echo $default > default
+          echo "Using default scheme: $default"
+
+      - name: Build & analyze for macOS
         working-directory: VultisigApp
-        env:
-          scheme: ${{ 'default' }}
         run: |
-          if [ $scheme = default ]; then scheme=$(cat default); fi
+          scheme=$(cat default)
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          
-          # Print environment info
-          echo "Xcode version:"
+
           xcodebuild -version
-          echo "Swift version:"
           swift --version
-          
-          # Clean, build and analyze for macOS
-          echo "Building and analyzing for macOS - scheme: $scheme"
-          xcodebuild clean build analyze \
+
+          echo "Building & analyzing for macOS - scheme: $scheme"
+          # Note: no `clean` — DerivedData is cached/restored for incremental reuse.
+          # Native arm64 (ONLY_ACTIVE_ARCH) on the Apple-Silicon runner.
+          xcodebuild build analyze \
             -scheme "$scheme" \
             -"$filetype_parameter" "$file_to_build" \
-            -destination 'platform=macOS,arch=x86_64' \
+            -destination 'platform=macOS' \
+            -derivedDataPath DerivedData \
+            -skipMacroValidation \
             -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \
             ONLY_ACTIVE_ARCH=YES \
             DEBUG_INFORMATION_FORMAT=dwarf \
-            SWIFT_COMPILATION_MODE=wholemodule \
-            OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" \
             ASSETCATALOG_COMPILER_SKIP_APP_STORE_DEPLOYMENT=YES \
             | xcpretty -c && exit ${PIPESTATUS[0]}
 
-      - name: Build and Test for iOS
+  # ---------------------------------------------------------------------------
+  # iOS: build + static analysis + unit tests (iOS Simulator). Runs in parallel
+  # with the macOS job.
+  # ---------------------------------------------------------------------------
+  build-and-test-ios:
+    name: Build, analyze & test (iOS)
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew list xcodegen >/dev/null 2>&1 || brew install xcodegen
+
+      - name: Generate Xcode project
+        run: make generate
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            VultisigApp/.build
+            VultisigApp/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Cache DerivedData (iOS)
+        uses: actions/cache@v4
+        with:
+          path: VultisigApp/DerivedData
+          key: ${{ runner.os }}-dd-ios-${{ hashFiles('**/Package.resolved') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-dd-ios-${{ hashFiles('**/Package.resolved') }}-
+            ${{ runner.os }}-dd-ios-
+
+      - name: Resolve scheme
         working-directory: VultisigApp
-        env:
-          scheme: ${{ 'default' }}
         run: |
-          if [ $scheme = default ]; then scheme=$(cat default); fi
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo $default > default
+          echo "Using default scheme: $default"
+
+      - name: Build, analyze & test for iOS
+        working-directory: VultisigApp
+        run: |
+          scheme=$(cat default)
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          
-          # Build and test for iOS in one command
-          echo "Building and testing for iOS - scheme: $scheme"
+
+          echo "Building, analyzing & testing for iOS - scheme: $scheme"
           xcodebuild build analyze test \
             -scheme "$scheme" \
             -"$filetype_parameter" "$file_to_build" \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.5' \
+            -derivedDataPath DerivedData \
+            -skipMacroValidation \
             -skipPackagePluginValidation \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -22,7 +22,10 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # No authenticated git operations in this job — don't persist the token.
+          persist-credentials: false
 
       - name: Install XcodeGen
         # Idempotent: skip `brew install` if xcodegen is already on the runner.
@@ -35,7 +38,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Cache SwiftPM
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             VultisigApp/.build
@@ -45,7 +48,7 @@ jobs:
             ${{ runner.os }}-spm-
 
       - name: Cache DerivedData (macOS)
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: VultisigApp/DerivedData
           # New cache per commit; restore the most recent one for the same
@@ -59,7 +62,9 @@ jobs:
         working-directory: VultisigApp
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          # Pick the first non-test shared scheme (xcodebuild -scheme needs a
+          # scheme, not a build target). Fail fast if none is found.
+          default=$(echo $scheme_list | ruby -e "require 'json'; schemes = JSON.parse(STDIN.gets)['project']['schemes'] || []; app = schemes.find { |s| !s.end_with?('Tests') }; abort('No non-test scheme found in project') unless app; puts app")
           echo $default > default
           echo "Using default scheme: $default"
 
@@ -99,7 +104,10 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # No authenticated git operations in this job — don't persist the token.
+          persist-credentials: false
 
       - name: Install XcodeGen
         run: brew list xcodegen >/dev/null 2>&1 || brew install xcodegen
@@ -111,7 +119,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.2.app
 
       - name: Cache SwiftPM
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             VultisigApp/.build
@@ -121,7 +129,7 @@ jobs:
             ${{ runner.os }}-spm-
 
       - name: Cache DerivedData (iOS)
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: VultisigApp/DerivedData
           key: ${{ runner.os }}-dd-ios-${{ hashFiles('**/Package.resolved') }}-${{ github.sha }}
@@ -133,7 +141,9 @@ jobs:
         working-directory: VultisigApp
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          # Pick the first non-test shared scheme (xcodebuild -scheme needs a
+          # scheme, not a build target). Fail fast if none is found.
+          default=$(echo $scheme_list | ruby -e "require 'json'; schemes = JSON.parse(STDIN.gets)['project']['schemes'] || []; app = schemes.find { |s| !s.end_with?('Tests') }; abort('No non-test scheme found in project') unless app; puts app")
           echo $default > default
           echo "Using default scheme: $default"
 

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,8 @@ VultisigApp.app
 
 # Claude Code - ignore local settings
 .claude/settings.local.json
+# Agent worktree scratch space — never commit (gitlinks here break checkout).
+.claude/worktrees/
 
 # XcodeGen — project is generated from VultisigApp/project.yml.
 # Run `make generate` from the repo root after pulling project.yml changes.

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -108,6 +108,9 @@ targets:
         CODE_SIGN_IDENTITY: "Apple Development"
         "CODE_SIGN_IDENTITY[sdk=macosx*]": "Apple Development"
         TARGETED_DEVICE_FAMILY: "1,2"
+        # We don't support visionOS — hide "Apple Vision (Designed for iPad)"
+        # from Supported Destinations.
+        SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD: NO
         SUPPORTS_MACCATALYST: NO
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: NO
 
@@ -249,6 +252,9 @@ targets:
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/VultisigApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/VultisigApp"
         BUNDLE_LOADER: "$(TEST_HOST)"
         TARGETED_DEVICE_FAMILY: "1,2"
+        # We don't support visionOS — hide "Apple Vision (Designed for iPad)"
+        # from Supported Destinations.
+        SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD: NO
         SUPPORTS_MACCATALYST: NO
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: YES
         DEAD_CODE_STRIPPING: YES
@@ -281,6 +287,9 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
         TEST_TARGET_NAME: VultisigApp
         TARGETED_DEVICE_FAMILY: "1,2"
+        # We don't support visionOS — hide "Apple Vision (Designed for iPad)"
+        # from Supported Destinations.
+        SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD: NO
         DEAD_CODE_STRIPPING: YES
         SWIFT_EMIT_LOC_STRINGS: NO
 


### PR DESCRIPTION
## Summary

Two related housekeeping changes to the build setup:

1. **Faster CI** — rework the Xcode workflow to cut build time.
2. **Drop visionOS** — remove "Apple Vision (Designed for iPad)" as a supported destination, since we don't support it.

## 1. CI build-time improvements

Splits the single serial job into **two parallel jobs** (`build-macos`, `build-and-test-ios`) and applies low-risk build-time quick wins. Static analysis (`analyze`) is **kept** on every PR build.

| Change | Why |
|---|---|
| **Split into parallel jobs** | macOS and iOS builds ran serially on one runner; now concurrent → ~2× faster wall-clock |
| **Cache DerivedData** (`-derivedDataPath` + `actions/cache`) and **drop `clean`** | `clean` forced a cold full compile every run; caching reuses unchanged modules |
| **macOS → native arm64** (dropped `arch=x86_64`) | The `macos-26` runner is Apple Silicon; x86_64 was cross-compiling |
| **Removed `-debug-time-function-bodies`** | Profiling flag — pure CI overhead, no value |
| **Removed `SWIFT_COMPILATION_MODE=wholemodule`** (macOS) | Wholemodule recompiles the whole module on any change, defeating the new incremental cache |
| **Added `-skipMacroValidation`** | Matches the Makefile |
| **Added `concurrency` + `cancel-in-progress`** | Cancels superseded runs on rapid PR pushes |

### Trade-offs
- **Cost:** two runners instead of one (more compute-minutes) for faster wall-clock; the concurrency-cancel offsets some of it.
- **DerivedData cache size** can be large (GitHub's 10 GB/repo budget, LRU eviction). Worth watching cache hit-rate the first week.
- SwiftLint still runs as a build plugin in both jobs. Extracting it to a separate `lint` job is a further win but touches `project.yml` — left out of this PR.

## 2. Drop visionOS destination

Sets `SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO` on every target (app, unit tests, UI tests) in `project.yml`. Set per-target because XcodeGen auto-injects this setting at the target level (a project `settings.base` value gets overridden). After `make generate`, all build configs report `NO` and none remain `YES`, removing "Apple Vision (Designed for iPad)" from each target's Supported Destinations.

> Only `project.yml` is committed — the `.xcodeproj` is gitignored and regenerated in CI via `make generate`.

## Test plan

- [ ] CI green on both `build-macos` and `build-and-test-ios`
- [ ] Confirm DerivedData cache is saved/restored (check Actions cache list after first run)
- [ ] Confirm "Apple Vision" no longer appears under Supported Destinations after regenerating the project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI concurrency to cancel redundant runs for the same ref.
  * Split macOS and iOS build flows into separate jobs for clearer pipelines.
  * Improved build performance by caching Swift package artifacts and derived build data.
  * Stabilized Xcode build configuration to reduce flaky scheme detection.
  * Disabled Apple Vision (Designed for iPad) destination for the app and its tests.
  * Ignored local agent worktree scratch directories and removed a stale submodule pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->