### PR TITLE
fix(swap): only show quote countdown timer once a valid quote exists

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -129,7 +129,18 @@ final class SwapDetailsViewModel {
         }
     }
 
+    /// The refresh countdown is meaningful only against a live quote. Until the
+    /// user enters an amount and a valid quote comes back, there's nothing to
+    /// refresh, so the counter stays hidden and parked.
+    var showRefreshCounter: Bool {
+        quote != nil
+    }
+
     func updateTimer(vault: Vault, referredCode: String) {
+        guard showRefreshCounter else {
+            timer = 59
+            return
+        }
         timer -= 1
         if timer < 1 {
             restartTimer(vault: vault, referredCode: referredCode)

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -242,8 +242,11 @@ struct SwapDetailsScreen: View {
         }
     }
 
+    @ViewBuilder
     var refreshCounter: some View {
-        SwapRefreshQuoteCounter(timer: detailsViewModel.timer)
+        if detailsViewModel.showRefreshCounter {
+            SwapRefreshQuoteCounter(timer: detailsViewModel.timer)
+        }
     }
 
     var fields: some View {


### PR DESCRIPTION
## Summary
- The swap quote countdown timer was rendered in the toolbar the moment the swap screen opened — before the user entered any amount or a valid quote returned.
- Gated the counter behind a live quote via a new `showRefreshCounter` (`quote != nil`) property on `SwapDetailsViewModel`.
- `updateTimer(...)` now parks the timer at `59` while there's no quote (nothing to refresh) so the countdown starts fresh once a quote arrives.
- `refreshCounter` in `SwapDetailsScreen` is now a `@ViewBuilder` that renders `SwapRefreshQuoteCounter` only when a quote exists.

## Issue
Closes #4452

## Test Plan
- [x] Open the swap screen — no countdown timer shown until an amount is entered and a valid quote returns
- [x] Enter an amount, get a quote — countdown appears and ticks from 0:59
- [ ] Clear the amount — countdown disappears
- [x] SwiftLint passes (0 violations)
- [x] xcodebuild build succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quote refresh countdown to only display when a quote is available, preventing the timer from appearing prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->