### PR TITLE
fix(swap): surface route-unavailable (not "too small") + native default coin for TRX→SUI

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -290,7 +290,12 @@ private extension SwapService {
         } catch let error as SwapError {
             throw error
         } catch {
-            throw SwapError.swapAmountTooSmall
+            // Amount-too-small conditions are caught explicitly above
+            // (empty/zero quote, below recommended minimum, "not enough asset
+            // to pay for fees"). Any remaining unmapped failure here is a
+            // transport/decoding/coverage issue, so surface it as
+            // route-unavailable rather than masquerading as "Amount Too Small".
+            throw SwapError.routeUnavailable
         }
     }
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -92,21 +92,15 @@ struct SwapKitService {
             return best
         } catch HTTPError.statusCode(_, let data) {
             if let error = SwapKitError.from(httpData: data) {
-                // SwapKit collapses "amount below provider minimum" and
-                // "pair not supported" into a single byte-identical 404
-                // `noRoutesFound` envelope. Cross-check the cached
-                // `/v3/providers` snapshot: if a non-filtered provider
-                // enables both chains, the pair IS structurally supported
-                // and the failure must be amount-related — re-classify so
-                // the view layer can show "Amount Too Small" instead of
-                // the misleading "No routes available for this pair".
-                if case .noRoutesFound = error,
-                   await providerCache.isPairSupported(
-                       fromChain: fromCoin.chain,
-                       toChain: toCoin.chain
-                   ) {
-                    throw SwapKitError.amountBelowProviderMinimum
-                }
+                // SwapKit returns a 404 `noRoutesFound` envelope both when the
+                // amount is below a provider's minimum AND when the pair simply
+                // can't be routed. The envelope carries no minimum/amount
+                // metadata to tell the two apart, so we surface `noRoutesFound`
+                // ("No routes available for this pair") rather than guessing
+                // "Amount Too Small" from a coarse provider-coverage heuristic —
+                // that heuristic mislabelled genuinely unroutable pairs (e.g.
+                // TRX→SUI) as too-small for every amount, and failed open when
+                // the provider cache couldn't load.
                 throw error
             }
             throw SwapKitError.generic(message: "SwapKit /v3/quote request failed")

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -973,6 +973,7 @@
 "swapErrorInsufficientFundsTitle" = "Unzureichendes Guthaben";
 "swapErrorInsufficientGasDescription" = "Nicht genügend Gas-Token, um die Netzwerkgebühr zu decken. Bitte fügen Sie Gas zu Ihrem Wallet hinzu.";
 "swapErrorInsufficientGasTitle" = "Unzureichendes Gas";
+"swapErrorRouteUnavailableTitle" = "Keine Route verfügbar";
 "swapErrorSameAssetDescription" = "Es ist nicht möglich, dasselbe Asset zu tauschen. Bitte wählen Sie ein anderes Asset.";
 "swapErrorSameAssetTitle" = "Gleiches Asset";
 "swapErrorUnexpectedDescription" = "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -981,6 +981,7 @@
 "swapErrorInsufficientFundsTitle" = "Insufficient Funds";
 "swapErrorInsufficientGasDescription" = "Not enough gas token to cover the network fee. Please add gas to your wallet.";
 "swapErrorInsufficientGasTitle" = "Insufficient Gas";
+"swapErrorRouteUnavailableTitle" = "No Route Available";
 "swapErrorSameAssetDescription" = "Can't swap to the same asset. Please select a different asset.";
 "swapErrorSameAssetTitle" = "Same Asset";
 "swapErrorUnexpectedDescription" = "An unexpected error occurred. Please try again.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -973,6 +973,7 @@
 "swapErrorInsufficientFundsTitle" = "Fondos Insuficientes";
 "swapErrorInsufficientGasDescription" = "Token de gas insuficiente para cubrir la tarifa de red. Por favor, agrega gas a tu billetera.";
 "swapErrorInsufficientGasTitle" = "Gas Insuficiente";
+"swapErrorRouteUnavailableTitle" = "Sin Ruta Disponible";
 "swapErrorSameAssetDescription" = "No se puede intercambiar por el mismo activo. Por favor, selecciona un activo diferente.";
 "swapErrorSameAssetTitle" = "Mismo Activo";
 "swapErrorUnexpectedDescription" = "Ocurrió un error inesperado. Por favor, inténtalo de nuevo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -973,6 +973,7 @@
 "swapErrorInsufficientFundsTitle" = "Nedovoljna Sredstva";
 "swapErrorInsufficientGasDescription" = "Nedovoljno gas tokena za pokrivanje mrežne naknade. Molimo dodajte gas u svoj novčanik.";
 "swapErrorInsufficientGasTitle" = "Nedovoljan Gas";
+"swapErrorRouteUnavailableTitle" = "Ruta Nije Dostupna";
 "swapErrorSameAssetDescription" = "Ne možete zamijeniti isti asset. Molimo odaberite drugi asset.";
 "swapErrorSameAssetTitle" = "Isti Asset";
 "swapErrorUnexpectedDescription" = "Došlo je do neočekivane greške. Molimo pokušajte ponovo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -973,6 +973,7 @@
 "swapErrorInsufficientFundsTitle" = "Fondi Insufficienti";
 "swapErrorInsufficientGasDescription" = "Token gas insufficiente per coprire la commissione di rete. Per favore aggiungi gas al tuo portafoglio.";
 "swapErrorInsufficientGasTitle" = "Gas Insufficiente";
+"swapErrorRouteUnavailableTitle" = "Nessuna Rotta Disponibile";
 "swapErrorSameAssetDescription" = "Non è possibile scambiare lo stesso asset. Per favore seleziona un asset diverso.";
 "swapErrorSameAssetTitle" = "Stesso Asset";
 "swapErrorUnexpectedDescription" = "Si è verificato un errore imprevisto. Per favore riprova.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -946,6 +946,7 @@
 "swapErrorAmountTooSmallTitle" = "금액이 너무 작음";
 "swapErrorInboundAddressDescription" = "인바운드 주소가 유효하지 않습니다. 다시 시도하세요.";
 "swapErrorInboundAddressTitle" = "유효하지 않은 주소";
+"swapErrorRouteUnavailableTitle" = "사용 가능한 경로 없음";
 "swapErrorInsufficientFundsDescription" = "스왑을 실행하기에 자금이 부족합니다. 지갑에 자금을 추가하세요.";
 "swapErrorInsufficientFundsTitle" = "자금 부족";
 "swapErrorInsufficientGasDescription" = "네트워크 수수료를 충당할 가스 토큰이 부족합니다. 지갑에 가스를 추가하세요.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -973,6 +973,7 @@
 "swapErrorInsufficientFundsTitle" = "Fundos Insuficientes";
 "swapErrorInsufficientGasDescription" = "Token de gas insuficiente para cobrir a taxa de rede. Por favor, adicione gas à sua carteira.";
 "swapErrorInsufficientGasTitle" = "Gas Insuficiente";
+"swapErrorRouteUnavailableTitle" = "Nenhuma Rota Disponível";
 "swapErrorSameAssetDescription" = "Não é possível trocar pelo mesmo ativo. Por favor, selecione um ativo diferente.";
 "swapErrorSameAssetTitle" = "Mesmo Ativo";
 "swapErrorUnexpectedDescription" = "Ocorreu um erro inesperado. Por favor, tente novamente.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -973,6 +973,7 @@
 "swapErrorInsufficientFundsTitle" = "余额不足";
 "swapErrorInsufficientGasDescription" = "Gas 代币不足以支付网络费用。请向钱包添加 Gas。";
 "swapErrorInsufficientGasTitle" = "Gas 不足";
+"swapErrorRouteUnavailableTitle" = "无可用路由";
 "swapErrorSameAssetDescription" = "无法兑换相同的资产。请选择不同的资产。";
 "swapErrorSameAssetTitle" = "相同资产";
 "swapErrorUnexpectedDescription" = "发生意外错误。请重试。";

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -140,10 +140,14 @@ enum SwapCryptoLogic {
             return firstVaultCoin
         }
 
-        let coinMeta = TokensStore.TokenSelectionAssets
-            .filter { $0.chain == chain }
-            .sorted { $0.isNativeToken && !$1.isNativeToken }
-            .first
+        // Prefer the chain's native coin. The previous `.sorted` comparator
+        // (`$0.isNativeToken && !$1.isNativeToken`) is not a strict weak
+        // ordering and didn't reliably promote the native coin, so for chains
+        // whose curated list places a bridged token first (e.g. ETH-on-Sui
+        // before native SUI) `.first` returned the wrong default. Pick the
+        // native coin explicitly, falling back to the first coin of the chain.
+        let chainAssets = TokensStore.TokenSelectionAssets.filter { $0.chain == chain }
+        let coinMeta = chainAssets.first(where: { $0.isNativeToken }) ?? chainAssets.first
         let pubKey = vault.chainPublicKeys.first { $0.chain == chain }?.publicKeyHex
         let isDerived = pubKey != nil
         guard let coinMeta,

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapErrorTooltipView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapErrorTooltipView.swift
@@ -56,6 +56,9 @@ struct SwapErrorTooltipView: View {
         if let swapError = error as? SwapCryptoLogic.Errors {
             return swapError.errorTitle
         }
+        if let swapError = error as? SwapError {
+            return title(for: swapError)
+        }
         if let normalized = normalizedSwapKitError {
             return normalized.errorTitle
         }
@@ -70,6 +73,21 @@ struct SwapErrorTooltipView: View {
             return normalized.errorDescription ?? error.localizedDescription
         }
         return error.localizedDescription
+    }
+
+    /// Domain-appropriate title for the swap-flow's `SwapError` cases. Without
+    /// this branch a `SwapError` (e.g. `.routeUnavailable` raised when SwapKit
+    /// reports no route for the pair) would fall through to the generic
+    /// "Unexpected Error" title even though its `errorDescription` is specific.
+    private func title(for swapError: SwapError) -> String {
+        switch swapError {
+        case .routeUnavailable, .noLiquidityPool:
+            return "swapErrorRouteUnavailableTitle".localized
+        case .swapAmountTooSmall, .lessThenMinSwapAmount:
+            return SwapCryptoLogic.Errors.swapAmountTooSmall.errorTitle
+        case .serverError:
+            return SwapCryptoLogic.Errors.unexpectedError.errorTitle
+        }
     }
 
     /// Map terminal SwapKit error cases onto the swap-flow's user-facing

--- a/VultisigApp/VultisigAppTests/Swap/SwapCryptoLogicTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapCryptoLogicTests.swift
@@ -156,6 +156,45 @@ final class SwapCryptoLogicTests: XCTestCase {
         XCTAssertTrue(SwapCryptoLogic.isAffiliate)
     }
 
+    // MARK: - getDefaultCoin (TokensStore fallback)
+
+    /// When the vault holds the Sui chain but not the native SUI coin,
+    /// `getDefaultCoin` falls back to `TokensStore.TokenSelectionAssets`. That
+    /// curated list places a bridged ETH-on-Sui token BEFORE native SUI, so the
+    /// old non-strict-weak `.sorted` comparator returned ETH. The fix must pick
+    /// native SUI deterministically.
+    func testGetDefaultCoinForSuiReturnsNativeSuiNotBridgedEth() throws {
+        let vault = makeVaultWithValidKeys()
+        let coin = try XCTUnwrap(SwapCryptoLogic.getDefaultCoin(for: .sui, vault: vault))
+        XCTAssertEqual(coin.chain, .sui)
+        XCTAssertEqual(coin.ticker, "SUI")
+        XCTAssertTrue(coin.isNativeToken)
+        XCTAssertNotEqual(coin.ticker, "ETH")
+    }
+
+    /// Sanity: the vault path still takes precedence — a vault that already
+    /// holds the native coin returns that exact coin, not a TokensStore lookup.
+    func testGetDefaultCoinPrefersNativeCoinFromVault() throws {
+        let sui = makeCoin(.sui, ticker: "SUI", decimals: 9, isNative: true)
+        let vault = makeVaultWithValidKeys(coins: [sui])
+        let coin = try XCTUnwrap(SwapCryptoLogic.getDefaultCoin(for: .sui, vault: vault))
+        XCTAssertTrue(coin.isNativeToken)
+        XCTAssertEqual(coin.ticker, "SUI")
+    }
+
+    private func makeVaultWithValidKeys(coins: [Coin] = []) -> Vault {
+        // A real 64-char hex key so CoinFactory can derive the Sui address in
+        // the TokensStore-fallback branch (placeholder keys would throw).
+        let pubKey = "feedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00dfeedf00d"
+        let vault = Vault(name: "test-vault")
+        vault.localPartyID = "test-device-123"
+        vault.pubKeyECDSA = pubKey
+        vault.pubKeyEdDSA = pubKey
+        vault.hexChainCode = String(repeating: "0", count: 64)
+        vault.coins = coins
+        return vault
+    }
+
     // MARK: - Fixtures
 
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceTests.swift
@@ -104,14 +104,15 @@ final class SwapKitServiceTests: XCTestCase {
         XCTAssertEqual(best.providers, ["NEAR"])
     }
 
-    // MARK: - noRoutesFound disambiguation
+    // MARK: - noRoutesFound surfacing
 
-    /// SwapKit's `/v3/quote` 404 envelope is byte-identical for "amount below
-    /// the provider's minimum" and "pair not supported". When the cached
-    /// providers snapshot reports the pair as structurally supported, the
-    /// service must re-classify so the view layer can surface "Amount Too
-    /// Small" instead of the misleading "No routes available for this pair".
-    func testFetchBestRoute_noRoutesFoundOnSupportedPair_reclassifiesToAmountBelowMinimum() async throws {
+    /// SwapKit's `/v3/quote` 404 `noRoutesFound` envelope carries no
+    /// minimum/amount metadata, so it must surface as `noRoutesFound`
+    /// ("No routes available for this pair") even when the cached providers
+    /// snapshot reports the pair as structurally supported. The previous
+    /// behaviour re-classified this to `amountBelowProviderMinimum` and showed
+    /// "Amount Too Small" for genuinely unroutable pairs (e.g. TRX→SUI).
+    func testFetchBestRoute_noRoutesFoundOnSupportedPair_keepsNoRoutesFound() async throws {
         let body = #"{"error":"noRoutesFound","message":"No routes found for BCH.BCH -> ETH.ETH","data":{"sellAsset":"BCH.BCH","buyAsset":"ETH.ETH"}}"#
         let data = try XCTUnwrap(body.data(using: .utf8))
         let client = NoRoutesHTTPClient(payload: data)
@@ -125,15 +126,14 @@ final class SwapKitServiceTests: XCTestCase {
                 amount: Decimal(string: "0.0115") ?? .zero,
                 affiliateFeeBps: 50
             )
-            XCTFail("Expected SwapKitError.amountBelowProviderMinimum")
+            XCTFail("Expected SwapKitError.noRoutesFound")
         } catch let error as SwapKitError {
-            XCTAssertEqual(error, .amountBelowProviderMinimum)
+            XCTAssertEqual(error, .noRoutesFound)
+            XCTAssertNotEqual(error, .amountBelowProviderMinimum)
         }
     }
 
-    /// Pair the cache reports as unsupported must keep the literal
-    /// `noRoutesFound` — the heuristic must not degrade the genuinely
-    /// unsupported-pair message.
+    /// Pair the cache reports as unsupported must also surface `noRoutesFound`.
     func testFetchBestRoute_noRoutesFoundOnUnsupportedPair_keepsNoRoutesFound() async throws {
         let body = #"{"error":"noRoutesFound","message":"No routes found","data":{}}"#
         let data = try XCTUnwrap(body.data(using: .utf8))
@@ -171,8 +171,35 @@ final class SwapKitServiceTests: XCTestCase {
         }
     }
 
-    /// Non-`noRoutesFound` SwapKit errors are surfaced verbatim — the
-    /// disambiguation must not accidentally swallow other documented codes.
+    /// Fail-open path: when the provider cache can't load (empty snapshot via
+    /// the actor's `nil` providers fallback), `noRoutesFound` must NOT degrade
+    /// into "Amount Too Small". An unroutable pair on an unavailable cache
+    /// surfaces `noRoutesFound`.
+    func testFetchBestRoute_noRoutesFoundWithUnavailableCache_keepsNoRoutesFound() async throws {
+        let body = #"{"error":"noRoutesFound","message":"No routes found"}"#
+        let data = try XCTUnwrap(body.data(using: .utf8))
+        let client = NoRoutesHTTPClient(payload: data)
+        // No snapshot set and the HTTP client always 404s, so the cache's
+        // `providers()` returns nil → `isPairSupported` would fail open to
+        // `true`. The service must not consult that heuristic any more.
+        let cache = SwapKitProviderCache(httpClient: client)
+        let service = SwapKitService(httpClient: client, providerCache: cache)
+
+        do {
+            _ = try await service.fetchBestRoute(
+                fromCoin: Self.makeNativeCoin(.tron, ticker: "TRX", decimals: 6),
+                toCoin: Self.makeNativeCoin(.sui, ticker: "SUI", decimals: 9),
+                amount: Decimal(string: "1") ?? .zero,
+                affiliateFeeBps: 50
+            )
+            XCTFail("Expected SwapKitError.noRoutesFound")
+        } catch let error as SwapKitError {
+            XCTAssertEqual(error, .noRoutesFound)
+            XCTAssertNotEqual(error, .amountBelowProviderMinimum)
+        }
+    }
+
+    /// Non-`noRoutesFound` SwapKit errors are surfaced verbatim.
     func testFetchBestRoute_otherErrorsPassThroughUnchanged() async throws {
         let body = #"{"error":"apiKeyInvalid","message":"API key invalid"}"#
         let data = try XCTUnwrap(body.data(using: .utf8))


### PR DESCRIPTION
## Summary

Fixes two independent defects on the TRX→SUI swap path (#4456).

### Symptom 1 (PRIMARY) — "Amount Too Small" shown for any amount on an unroutable pair
**Root cause:** TRX→SUI's only common SwapKit provider is filtered, so `/v3/quote` returns a 404 `noRoutesFound`. `SwapKitService.fetchBestRoute` re-mapped that to `amountBelowProviderMinimum` (rendered as **"Amount Too Small"**) whenever a coarse provider-coverage heuristic (`SwapKitProviderCache.isPairSupported`) judged the pair "structurally supported". That heuristic is too coarse **and fails open** (`return true`) when its `/v3/providers` cache can't load — so a genuinely unroutable pair shows "Amount Too Small" for *every* amount. The 404 envelope (`SwapKitErrorEnvelope`) only carries `error`/`message` — no minimum/amount metadata that would justify the "too small" claim.

**Fix:**
- `SwapKitService.fetchBestRoute` — removed the `isPairSupported`-driven re-classification. `noRoutesFound` now flows through unchanged, surfacing **"No routes available for this pair"** instead of "Amount Too Small". The fail-open path can no longer drive a "too small" message.
- `SwapErrorTooltipView` — added a `SwapError` branch to `errorTitle` (the view previously only special-cased `SwapCryptoLogic.Errors` and `SwapKitError`, so a `SwapError.routeUnavailable` would show the generic **"Unexpected Error"** title even though it has a specific description). `routeUnavailable`/`noLiquidityPool` now render a real title; `swapAmountTooSmall`/`lessThenMinSwapAmount` map to the existing too-small title; `serverError` to the generic title. New key `swapErrorRouteUnavailableTitle` added to all locale files + sorted with `sort_localizable.py`.
- `SwapService` THORChain/Maya catch-all (optional item, **DONE**) — the unmapped-error fallthrough threw `SwapError.swapAmountTooSmall`. Amount-too-small conditions are already detected explicitly above it (empty/zero quote, below recommended minimum, "not enough asset to pay for fees"), so any remaining unmapped failure is transport/decoding/coverage and now throws `SwapError.routeUnavailable`. Low-risk; existing THORChain mapping tests unaffected.

### Symptom 2 (SECONDARY) — destination showed bridged ETH under the "Sui" chain
**Root cause:** `SwapCryptoLogic.getDefaultCoin`'s TokensStore fallback used an invalid sort comparator `{ $0.isNativeToken && !$1.isNativeToken }` — not a strict weak ordering, so `.first` returned whatever the curated list placed first. `TokensStore.TokenSelectionAssets` lists a bridged ETH-on-Sui token **before** native SUI, so the fallback returned ETH. The vault path (filter `chain == chain && isNativeToken`) was already correct; the bug was only the fallback when the vault has the Sui chain but not the native SUI coin.

**Fix:** replaced the broken `.sorted{...}.first` with an explicit native-first pick: `chainAssets.first(where: \.isNativeToken) ?? chainAssets.first`. Vault path still takes precedence. `SwapDetailsViewModel.handleToChainUpdate` delegates straight to `getDefaultCoin`, so no VM change was needed.

## Optional items
- **THORChain/Maya catch-all** — DONE (changed to `routeUnavailable`, see above). Safe because amount-too-small is detected explicitly upstream.
- **TokensStore Sui reorder** — SKIPPED. The comparator fix is the real fix and is deterministic; reordering the curated `TokenSelectionAssets` list risks disturbing other ordering assumptions for no added benefit.

## Tests
- `SwapKitServiceTests`: updated the former "reclassify to amountBelowProviderMinimum" tests to assert `noRoutesFound` is preserved on a supported pair, an unsupported pair, **and** under an unavailable cache (fail-open path). Other SwapKit error codes still pass through verbatim.
- `SwapCryptoLogicTests`: added `testGetDefaultCoinForSuiReturnsNativeSuiNotBridgedEth` (native SUI selected, not ETH, in the TokensStore-fallback scenario) and `testGetDefaultCoinPrefersNativeCoinFromVault` (vault path precedence).

## Quality gates
- **SwiftLint**: clean on all touched `.swift` files — `Found 0 violations, 0 serious in 6 files`.
- **Build**: `** BUILD SUCCEEDED **` (iPhone 17 Pro simulator, Debug; ran `make generate` first as the worktree's `.xcodeproj` lacked `project.pbxproj`).
- **Tests**: 48 tests across `SwapCryptoLogicTests` + `SwapKitServiceTests` + `SwapKitErrorTests` — `** TEST SUCCEEDED **`, 0 failures.

## Verification status
Runtime / visual verification is **PENDING** — I did not run a live TRX→SUI swap on device/simulator. Changes are covered by unit tests + a clean build; the live tooltip copy ("No Route Available" title) was not visually confirmed.

## MERGE-ORDER NOTE
Symptom-2 touches `SwapCryptoLogic.swift` (and the tooltip/`SwapDetailsViewModel` area), which **overlaps with open PR #4463**. Whichever of these two PRs merges second will need a rebase.

closes #4456

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap route error detection to distinguish between unavailable routes and other connection issues.
  * Fixed default coin selection in swap flows to correctly prioritize native tokens.

* **Localization**
  * Added "No Route Available" error message translations across eight languages (English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->