### PR TITLE
feat(swap): banded provider preference on top of best-net selection

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -82,10 +82,23 @@ struct SwapService {
         throw firstError ?? SwapError.routeUnavailable
     }
 
-    /// Pick the quote with the highest net output in `toCoin` units. Every provider in a
-    /// candidate set swaps to the same `toCoin`, so the destination amount is directly
-    /// comparable. Falls back to the first quote (priority order from `resolveAllProviders`)
-    /// when no quote produces a comparable amount.
+    /// Width of the priority band, as a fraction of the best net output. Quotes whose net
+    /// output lands within this band of the best are treated as effectively tied on rate, so
+    /// the higher-priority provider is preferred over a marginally larger raw output. 1%.
+    static let providerPreferenceBand: Decimal = 0.01
+
+    /// Pick the best quote across providers. The ranking metric is net output in `toCoin`
+    /// units (every provider in a candidate set swaps to the same `toCoin`, so the
+    /// destination amount is directly comparable). On top of that metric a banded
+    /// provider-preference layer applies: among quotes within `providerPreferenceBand` (1%)
+    /// of the best net output, the highest-priority provider wins instead of the raw maximum.
+    /// This keeps near-tie routes on the more trusted/integrated provider without ever
+    /// trading away a materially better rate (anything outside the band loses on output).
+    /// Falls back to the first quote (priority order from `resolveAllProviders`) when no
+    /// quote produces a comparable amount.
+    ///
+    /// iOS is the cross-platform anchor for this rule; the canonical spec lives in
+    /// `vultisig-sdk` and other platforms mirror this implementation.
     static func selectBestQuote(
         quotes: [SwapQuote],
         toCoin: Coin
@@ -97,17 +110,51 @@ struct SwapService {
             return (quote, value)
         }
 
-        if let best = ranked.max(by: { $0.1 < $1.1 }) {
-            let summary = ranked
-                .map { "\($0.0.displayName ?? "?")=\($0.1)" }
-                .joined(separator: ", ")
-            let pickedName = best.0.displayName ?? "?"
-            logger.info("[swap-rank] candidates=\(quotes.count, privacy: .public) [\(summary, privacy: .public)] → \(pickedName, privacy: .public)")
-            return best.0
+        guard let best = ranked.max(by: { $0.1 < $1.1 }) else {
+            logger.warning("[swap-rank] no quote was rankable, returning first by priority")
+            return quotes.first
         }
 
-        logger.warning("[swap-rank] no quote was rankable, returning first by priority")
-        return quotes.first
+        // Quotes within the band of the best net output are treated as tied on rate; among
+        // those, prefer the higher-priority (lower index) provider. Tie-break inside the same
+        // priority by higher net output (defensive — a provider rarely appears twice).
+        let floor = best.1 * (1 - providerPreferenceBand)
+        let inBand = ranked.filter { $0.1 >= floor }
+        let picked = inBand.min { lhs, rhs in
+            let lhsPriority = priority(of: lhs.0)
+            let rhsPriority = priority(of: rhs.0)
+            if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
+            return lhs.1 > rhs.1
+        } ?? best
+
+        let summary = ranked
+            .map { "\($0.0.displayName ?? "?")=\($0.1)" }
+            .joined(separator: ", ")
+        let inBandSummary = inBand
+            .map { "\($0.0.displayName ?? "?")=\($0.1)(p\(priority(of: $0.0)))" }
+            .joined(separator: ", ")
+        logger.info("[swap-rank] candidates=\(quotes.count, privacy: .public) [\(summary, privacy: .public)] best=\(best.0.displayName ?? "?", privacy: .public)=\(best.1, privacy: .public) floor=\(floor, privacy: .public) inBand=[\(inBandSummary, privacy: .public)] → \(picked.0.displayName ?? "?", privacy: .public)")
+        return picked.0
+    }
+
+    /// Provider preference order for the banded selection. Lower index = preferred. Keyed off
+    /// the enum case (not `displayName`, which can carry SwapKit sub-provider text). THORChain
+    /// (all networks) is most preferred, then Maya, SwapKit, KyberSwap, 1inch, LI.FI.
+    private static func priority(of quote: SwapQuote) -> Int {
+        switch quote {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet:
+            return 0
+        case .mayachain:
+            return 1
+        case .swapkit:
+            return 2
+        case .kyberswap:
+            return 3
+        case .oneinch:
+            return 4
+        case .lifi:
+            return 5
+        }
     }
 
     private func fetchQuoteForProvider(

--- a/VultisigApp/VultisigAppTests/Services/SwapQuoteRankingTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapQuoteRankingTests.swift
@@ -129,6 +129,56 @@ final class SwapQuoteRankingTests: XCTestCase {
         XCTAssertEqual(pick?.displayName, "LI.FI")
     }
 
+    // MARK: - Banded provider preference
+
+    func test_selectBestQuote_nearTieWithinBand_priorityWins_swapKitOverLifi() {
+        // SwapKit (priority 2) and LI.FI (priority 5) within 1% of each other on net output:
+        // LI.FI's raw output is slightly higher but still inside the band, so the
+        // higher-priority SwapKit quote wins instead of the raw maximum.
+        // SwapKit reports expectedBuyAmount in human units; LI.FI 0.03 ETH dstAmount in wei.
+        let swapKit: SwapQuote = .swapkit(makeSwapKitResponse(expectedBuyAmount: "0.0299"), fee: nil, subProvider: "Chainflip")
+        let lifi: SwapQuote = .lifi(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil, integratorFee: nil) // 0.03
+
+        // best = LI.FI 0.03, floor = 0.0297, SwapKit 0.0299 is in band → SwapKit wins on priority.
+        let pick = SwapService.selectBestQuote(quotes: [lifi, swapKit], toCoin: ethCoin())
+
+        XCTAssertEqual(pick?.displayName, "SwapKit (Chainflip)")
+    }
+
+    func test_selectBestQuote_priorityOrderingWithinBand_thorchainOverOneInch() {
+        // THORChain (priority 0) vs 1inch (priority 4) within 1%: 1inch's raw output is
+        // marginally higher but in band, so THORChain wins on priority.
+        let thor: SwapQuote = .thorchain(makeThorQuote(expectedAmountOut: "2990000")) // 0.0299 ETH
+        let oneInch: SwapQuote = .oneinch(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil) // 0.03 ETH
+
+        // best = 1inch 0.03, floor = 0.0297, THORChain 0.0299 in band → THORChain wins.
+        let pick = SwapService.selectBestQuote(quotes: [oneInch, thor], toCoin: ethCoin())
+
+        XCTAssertEqual(pick?.displayName, "THORChain")
+    }
+
+    func test_selectBestQuote_exactBandBoundaryIsInclusive() {
+        // A quote exactly at best * 0.99 is included (>= floor) and, being higher priority,
+        // wins. best = 1inch 0.03 → floor = 0.0297. THORChain at exactly 0.0297 is in band.
+        let thor: SwapQuote = .thorchain(makeThorQuote(expectedAmountOut: "2970000")) // 0.0297 ETH
+        let oneInch: SwapQuote = .oneinch(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil) // 0.03 ETH
+
+        let pick = SwapService.selectBestQuote(quotes: [oneInch, thor], toCoin: ethCoin())
+
+        XCTAssertEqual(pick?.displayName, "THORChain")
+    }
+
+    func test_selectBestQuote_justOutsideBand_betterRateWins() {
+        // THORChain just below the floor (best 0.03 → floor 0.0297; THORChain 0.0296) must
+        // NOT win on priority — only 1inch is in band, so the better rate wins.
+        let thor: SwapQuote = .thorchain(makeThorQuote(expectedAmountOut: "2960000")) // 0.0296 ETH
+        let oneInch: SwapQuote = .oneinch(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil) // 0.03 ETH
+
+        let pick = SwapService.selectBestQuote(quotes: [oneInch, thor], toCoin: ethCoin())
+
+        XCTAssertEqual(pick?.displayName, "1Inch")
+    }
+
     // MARK: - Same-chain ERC20→ETH regression
 
     func test_sameChainErc20ToEth_aggregatorWinsOverThorchain() {
@@ -207,6 +257,40 @@ final class SwapQuoteRankingTests: XCTestCase {
             router: nil,
             maxStreamingQuantity: nil
         )
+    }
+
+    /// SwapKit responses are `Decodable`-only (custom `init(from:)`, no memberwise init), so
+    /// build the fixture from a minimal EVM-txType JSON payload. `expectedBuyAmount` is the
+    /// field `expectedNetToAmount` reads, in human units.
+    private func makeSwapKitResponse(expectedBuyAmount: String) -> SwapKitSwapResponse {
+        let json = """
+        {
+          "swapId": "swap-1",
+          "routeId": "route-1",
+          "providers": ["Chainflip"],
+          "sellAsset": "ETH.USDC",
+          "buyAsset": "ETH.ETH",
+          "sellAmount": "10",
+          "expectedBuyAmount": "\(expectedBuyAmount)",
+          "expectedBuyAmountMaxSlippage": "\(expectedBuyAmount)",
+          "sourceAddress": "0xfrom",
+          "destinationAddress": "0xto",
+          "targetAddress": "0xtarget",
+          "meta": { "txType": "EVM" },
+          "tx": {
+            "from": "0xfrom",
+            "to": "0xto",
+            "value": "0",
+            "data": "0x",
+            "gas": "200000",
+            "gasPrice": "20000000000"
+          },
+          "fees": []
+        }
+        """
+        // Test fixture: a decode failure here is a test bug, so force-unwrap is acceptable.
+        // swiftlint:disable:next force_try
+        return try! JSONDecoder().decode(SwapKitSwapResponse.self, from: Data(json.utf8))
     }
 
     private func makeEVMQuote(dstAmount: String, gas: Int64 = 200_000, gasPrice: String = "20000000000") -> EVMQuote {


### PR DESCRIPTION
## What

Adds a banded provider-preference layer on top of `SwapService.selectBestQuote(quotes:toCoin:)`. Previously the selector was a pure max-by-net-output. Now:

1. `best` = max net output (unchanged metric).
2. **1% band:** `floor = best.netOutput * (1 - 0.01)` (computed in `Decimal`, no `Double`). Among quotes with `netOutput >= floor`, the **highest-priority** provider wins. Tie-break within the same priority by higher net output.
3. Unrankable fallback (`quotes.first` by priority) unchanged.

### Priority order (lower = preferred)

Keyed off the **enum case** (not `displayName`, which can carry SwapKit sub-provider text):

| Provider | Priority |
|---|---|
| `.thorchain` / `.thorchainChainnet` / `.thorchainStagenet` | 0 |
| `.mayachain` | 1 |
| `.swapkit` | 2 |
| `.kyberswap` | 3 |
| `.oneinch` | 4 |
| `.lifi` | 5 |

### The metric is unchanged

The ranking metric is still net output in `toCoin` units. The band only resolves **near-ties**: anything outside 1% of the best still loses on rate, so a materially better quote always wins. `Coin+Swaps.swapProviders` is untouched (metadata/fallback only).

The `[swap-rank]` log now records `best` (name+value), the band floor, the in-band candidate set with priorities, and the priority-picked winner — all `privacy: .public`, consistent with the existing line.

iOS is the cross-platform **anchor** for this rule. Canonical spec: vultisig/vultisig-sdk#605. Other platforms should mirror this implementation.

## Regression safety

`test_sameChainErc20ToEth_aggregatorWinsOverThorchain` stays green and unmodified: 1inch=0.0030, kyber=0.00296, lifi=0.00295, thor=0.0029 → best=0.0030, floor=0.0030×0.99=0.00297 → only 1inch is in band → 1inch wins. The band does not weaken this case.

## Tests (all green — 19/19 in `SwapQuoteRankingTests`)

New:
- `nearTieWithinBand_priorityWins_swapKitOverLifi` — SwapKit (p2) beats LI.FI (p5) when within 1% (LI.FI raw slightly higher).
- `priorityOrderingWithinBand_thorchainOverOneInch` — THORChain (p0) beats 1inch (p4) within band.
- `exactBandBoundaryIsInclusive` — quote exactly at `best × 0.99` is included and wins on priority.
- `justOutsideBand_betterRateWins` — quote just below the floor does NOT win on priority.

Existing `picksMaxNetOutput`, `thorchainWinsWhenItHasHighestOutput`, the unrankable-fallback tests, and the regression all still pass.

The near-tie test uses the real **SwapKit** pair (built via a minimal EVM-txType JSON fixture, since `SwapKitSwapResponse` is `Decodable`-only with a custom `init(from:)`).

## Build + lint

- `xcodebuild build-for-testing` on iPhone 17 Pro sim: **TEST BUILD SUCCEEDED**
- `test-without-building -only-testing:VultisigAppTests/SwapQuoteRankingTests`: **19 tests, 0 failures**
- SwiftLint on both touched files: **0 violations**

## Follow-up

The user-facing provider picker (#4459, Silver tier) should later reflect THIS banded winner as "Best", so the displayed recommendation matches what routing actually selects.

closes #4450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced swap quote selection to intelligently choose the best provider by balancing price competitiveness within a tolerance band, then using provider priority for tie-breaking when options are similarly priced.
* **Tests**
  * Added comprehensive test coverage for the updated quote selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->