### PR TITLE
fix(qbtc): update explorer URL to explorer.qbtc.net

### DIFF
--- a/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
@@ -208,7 +208,7 @@ enum ExplorerLinkBuilder {
         case .sei:
             return "https://seiscan.io/tx/\(txid)"
         case .qbtc:
-            return "https://qbtc-explorer.vercel.app/qbtc/tx/\(txid)"
+            return "https://explorer.qbtc.net/tx/\(txid)"
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
@@ -284,7 +284,7 @@ final class ExplorerLinkBuilderTests: XCTestCase {
     func testGetExplorerURLReturnsQbtcExplorerURL() {
         XCTAssertEqual(
             ExplorerLinkBuilder.getExplorerURL(chain: .qbtc, txid: txHash),
-            "https://qbtc-explorer.vercel.app/qbtc/tx/\(txHash)"
+            "https://explorer.qbtc.net/tx/\(txHash)"
         )
     }
 


### PR DESCRIPTION
## Summary
Updates the QBTC block explorer link from the temporary Vercel deployment to the dedicated domain.

- Old: `https://qbtc-explorer.vercel.app/qbtc/tx/<txid>`
- New: `https://explorer.qbtc.net/tx/<txid>`

## Changes
- `ExplorerLinkBuilder.swift` — QBTC transaction explorer URL
- `ExplorerLinkBuilderTests.swift` — updated expected URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated QBTC transaction explorer link endpoint to improve reliability and accessibility when viewing transaction details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->