### PR TITLE
fix(wallet): show Buy VULT banner until vault reaches Silver tier

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
@@ -17,9 +17,9 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
 
     var isAppBanner: Bool {
         switch self {
-        case .upgradeVault, .backupVault:
+        case .upgradeVault, .backupVault, .buyVult:
             return false
-        case .buyVult, .followVultisig:
+        case .followVultisig:
             return true
         }
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -160,6 +160,11 @@ struct VaultMainScreen: View {
                 onBanner: onBannerPressed,
                 onClose: onBannerClosed
             )
+            // Rebuild the carousel per vault so a banner dismissed on one vault
+            // (without being persisted, e.g. `.buyVult` below Silver tier) shows
+            // again when switching to another vault, instead of staying hidden by
+            // the carousel's cached internal banner state.
+            .id(vault.id)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -92,6 +92,14 @@ class VaultDetailViewModel: ObservableObject {
             return
         }
 
+        // `.buyVult` is only dismissed permanently once the vault holds at least
+        // the Silver-tier VULT amount. Below that, skip persistence so the banner
+        // returns the next time the user opens the vault screen (the carousel has
+        // already hidden it for the current visit).
+        if banner == .buyVult, !hasReachedSilverTier(vault: vault) {
+            return
+        }
+
         vault.closedBanners = Array(Set(vault.closedBanners + [banner.rawValue]))
         do {
             try Storage.shared.save()
@@ -104,6 +112,11 @@ class VaultDetailViewModel: ObservableObject {
     func canShowChainSelection(vault: Vault) -> Bool {
         // Vault cannot change chains for KeyImport for now
         vault.libType != .KeyImport
+    }
+
+    private func hasReachedSilverTier(vault: Vault) -> Bool {
+        let vultBalance = VultTierService().getVultToken(for: vault)?.balanceDecimal ?? 0
+        return vultBalance >= VultDiscountTier.silver.balanceToUnlock
     }
 }
 


### PR DESCRIPTION
## Summary
- `.buyVult` was an app-level banner — closing it appended to the persisted `appClosedBanners`, so it never returned. Not intended.
- `.buyVult` is now a **per-vault** banner (`isAppBanner` → `false`), so its dismissal/visibility flow through `vault.closedBanners`.
- In `removeBanner`, dismissing `.buyVult` is only persisted to `vault.closedBanners` when the vault holds at least the Silver-tier amount (≥ 3000 VULT). Below that, persistence is skipped, so the banner returns the next time the user opens the vault screen.
- Reuses existing `VultTierService.getVultToken` and `VultDiscountTier.silver.balanceToUnlock` — no new thresholds, no display-time gate.

## Behavior
- **< 3000 VULT:** close hides it for the current visit (carousel handles that); it returns on the next entry to the vault screen.
- **≥ 3000 VULT (Silver+):** dismissal persists and sticks permanently.
- Existing users who previously dismissed it (stale `"buyVult"` in `appClosedBanners`) will see it again, since `.buyVult` now checks `vault.closedBanners`.

## Test Plan
- [ ] Vault with < 3000 VULT: close banner → gone for visit → returns after tab/vault switch; `vault.closedBanners` does not gain `"buyVult"`.
- [ ] Vault with ≥ 3000 VULT: close banner → persists to `vault.closedBanners`, does not return.
- [ ] Migration: user who previously dismissed it sees it again (with < 3000 VULT).
- [x] SwiftLint passes (0 violations on changed files)
- [x] xcodebuild build succeeds (`make build-check`)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Promotional banner behavior tightened: the buy-promotion banner can no longer be permanently dismissed unless your vault reaches the required tier; if below the threshold, dismissed banners will reappear on your next visit.
* **UI Improvements**
  * Banner carousel now reliably refreshes when switching between vaults so each vault shows the correct set of banners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->