### PR TITLE
fix(macos): prevent reentrant state mutation during render commit (banners carousel + sheet blur)

### DIFF
--- a/VultisigApp/VultisigApp/Components/Sheet/SheetPresentedCounterManager/SheetPresentedViewModifier.swift
+++ b/VultisigApp/VultisigApp/Components/Sheet/SheetPresentedCounterManager/SheetPresentedViewModifier.swift
@@ -25,7 +25,17 @@ private struct SheetPresentedViewModifier: ViewModifier {
             .blur(radius: blurContent ? 6 : 0)
             .animation(.easeInOut(duration: 0.1), value: blurContent)
             .onReceive(sheetPresentedCounterManager.$counter) { newValue in
-                blurContent = newValue > 0
+                // Guard the write so an unchanged value never emits a graph
+                // mutation. The publisher lands on the runloop and can fire
+                // during a sheet's own animated transition commit; a no-op
+                // assignment mid-commit re-invalidates the laying-out root and
+                // triggers a reentrant AppKit constraint update that crashes on
+                // macOS. The counter changes more often than the boolean (every
+                // increment/decrement), so this guard collapses most ticks to
+                // no-ops.
+                let shouldBlur = newValue > 0
+                guard blurContent != shouldBlur else { return }
+                blurContent = shouldBlur
             }
             #if os(iOS)
             // Remove blur when enter background as the iOS dismisses sheet

--- a/VultisigApp/VultisigApp/Features/Common/Views/Banners/BannersCarousel.swift
+++ b/VultisigApp/VultisigApp/Features/Common/Views/Banners/BannersCarousel.swift
@@ -6,6 +6,9 @@
 //
 
 import SwiftUI
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "banners-carousel")
 
 struct BannersCarousel<Banner: CarouselBannerType>: View {
     @Binding var banners: [Banner]
@@ -20,6 +23,7 @@ struct BannersCarousel<Banner: CarouselBannerType>: View {
     @State var bannersCount: Int = 0
     @State var bannersToRemove: Set<AnyHashable> = []
     @State private var timer: Timer?
+    @State private var removalTask: Task<Void, Never>?
     @State var showCarousel: Bool = false
 
     @State var internalBanners: [Banner] = []
@@ -105,22 +109,32 @@ struct BannersCarousel<Banner: CarouselBannerType>: View {
         }
         .onDisappear {
             stopTimer()
+            removalTask?.cancel()
+            removalTask = nil
         }
         .onChange(of: currentIndex) {
+            guard currentIndex >= 0 && currentIndex < internalBanners.count else { return }
+            // Sync the scroll position to the active index only when it actually
+            // differs. A no-op write still emits a graph mutation, which — if it
+            // lands mid render-commit — can reenter AppKit's constraint cycle and
+            // crash on macOS. Guarding it keeps reciprocal index/scroll syncs from
+            // ping-ponging.
+            guard scrollPosition != currentIndex else { return }
             withAnimation {
-                guard currentIndex >= 0 && currentIndex < internalBanners.count else { return }
                 scrollPosition = currentIndex
             }
         }
         .onChange(of: scrollPosition) {
-            guard let newScrollPosition = scrollPosition else {
-                return
-            }
-
-            withAnimation {
-                currentIndex = newScrollPosition
-                startTimer()
-            }
+            guard let newScrollPosition = scrollPosition else { return }
+            // Only adopt a user-driven scroll change when it moves us to a new
+            // index; otherwise this would write back the value the index handler
+            // just set and re-trigger the cycle.
+            guard currentIndex != newScrollPosition else { return }
+            currentIndex = newScrollPosition
+            // Restart the auto-advance timer outside any animation block: nesting
+            // a timer (re)start inside withAnimation runs an NSAnimationContext at
+            // the same time a publisher/runloop tick is committing layout.
+            startTimer()
         }
     }
 
@@ -132,57 +146,45 @@ struct BannersCarousel<Banner: CarouselBannerType>: View {
         }
 
         guard let indexToRemove = internalBanners.firstIndex(where: { $0.id == banner.id }) else {
-            print("Banner not found")
+            logger.warning("Banner not found for removal")
             return
         }
 
         // Calculate the new current index before removal
-        let newCurrentIndex: Int
-        if internalBanners.count <= 1 {
-            newCurrentIndex = 0
-        } else if indexToRemove < currentIndex {
-            // If we're removing a banner before current position
-            newCurrentIndex = currentIndex - 1
-        } else if indexToRemove == currentIndex {
-            // If we're removing the current banner
-            if indexToRemove == internalBanners.count - 1 {
-                // If it's the last banner, go to previous
-                newCurrentIndex = max(0, currentIndex - 1)
-            } else {
-                // Otherwise stay at same index (next banner will slide into position)
-                newCurrentIndex = currentIndex
-            }
-        } else {
-            // If we're removing a banner after current position
-            newCurrentIndex = currentIndex
-        }
+        let newCurrentIndex = BannersCarouselIndex.afterRemoval(
+            removedIndex: indexToRemove,
+            currentIndex: currentIndex,
+            countBeforeRemoval: internalBanners.count
+        )
 
         // Start the removal animation
-        _ = withAnimation(.easeInOut(duration: 0.4)) {
+        withAnimation(.easeInOut(duration: 0.4)) {
             bannersToRemove.insert(AnyHashable(banner.id))
         }
 
-        // Wait for removal animation to complete, then update the data
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+        // Wait for removal animation to complete, then update the data. A
+        // cancellable task (cancelled in stopTimer/onDisappear) prevents a stale
+        // closure from mutating state after the view is torn down.
+        removalTask?.cancel()
+        removalTask = delayedTask(after: .milliseconds(400)) {
             // Remove the banner from the array
             internalBanners.removeAll { $0.id == banner.id }
             bannersToRemove.remove(AnyHashable(banner.id))
 
-            // Update indices without animation to prevent conflicts
-            if !internalBanners.isEmpty {
-                let safeIndex = min(max(0, newCurrentIndex), internalBanners.count - 1)
-                currentIndex = safeIndex
-                scrollPosition = safeIndex
-            } else {
-                currentIndex = 0
-                scrollPosition = 0
+            // Update indices without animation to prevent conflicts. Guard each
+            // write so an unchanged value never emits a graph mutation.
+            let targetIndex = internalBanners.isEmpty
+                ? 0
+                : min(max(0, newCurrentIndex), internalBanners.count - 1)
+            if currentIndex != targetIndex {
+                currentIndex = targetIndex
+            }
+            if scrollPosition != targetIndex {
+                scrollPosition = targetIndex
             }
 
-            // Restart timer after a brief delay
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                if !internalBanners.isEmpty {
-                    startTimer()
-                }
+            if !internalBanners.isEmpty {
+                startTimer()
             }
 
             // Notify parent that banner was removed
@@ -193,12 +195,13 @@ struct BannersCarousel<Banner: CarouselBannerType>: View {
     private func startTimer() {
         stopTimer()
         timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
+            let nextIndex = BannersCarouselIndex.next(after: currentIndex, count: bannersCount)
+            // Guard the auto-advance write: if there's nothing to advance to
+            // (e.g. a single banner) the value is unchanged, so skip the mutation
+            // entirely rather than emit a no-op graph update from a runloop tick.
+            guard nextIndex != currentIndex else { return }
             withAnimation(.easeInOut(duration: 0.5)) {
-                if currentIndex < bannersCount - 1 {
-                    currentIndex += 1
-                } else {
-                    currentIndex = 0
-                }
+                currentIndex = nextIndex
             }
         }
     }
@@ -214,6 +217,38 @@ struct BannersCarousel<Banner: CarouselBannerType>: View {
             showCarousel = shouldShow
             bannersCount = count
         }
+    }
+}
+
+/// Pure index math for the carousel, extracted so the wrap-around and
+/// post-removal logic can be unit-tested without a view host.
+enum BannersCarouselIndex {
+    /// Index the auto-advance timer should move to next, wrapping back to the
+    /// start after the last banner. Returns `current` unchanged when there is
+    /// nothing to advance to (zero or one banner) so callers can no-op the write.
+    static func next(after current: Int, count: Int) -> Int {
+        guard count > 1 else { return current }
+        return current < count - 1 ? current + 1 : 0
+    }
+
+    /// Index that should become current after the banner at `removedIndex` is
+    /// removed, given the count *before* removal.
+    static func afterRemoval(removedIndex: Int, currentIndex: Int, countBeforeRemoval: Int) -> Int {
+        guard countBeforeRemoval > 1 else { return 0 }
+
+        if removedIndex < currentIndex {
+            // Removing a banner before the current one shifts us back by one.
+            return currentIndex - 1
+        }
+
+        if removedIndex == currentIndex {
+            // Removing the current banner: if it was last, step back; otherwise
+            // the next banner slides into this slot, so the index is unchanged.
+            return removedIndex == countBeforeRemoval - 1 ? max(0, currentIndex - 1) : currentIndex
+        }
+
+        // Removing a banner after the current one leaves the index unchanged.
+        return currentIndex
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Views/BannersCarouselIndexTests.swift
+++ b/VultisigApp/VultisigAppTests/Views/BannersCarouselIndexTests.swift
@@ -1,0 +1,84 @@
+//
+//  BannersCarouselIndexTests.swift
+//  VultisigAppTests
+//
+//  Unit tests for `BannersCarouselIndex`, the pure index math extracted from
+//  `BannersCarousel`. Covers the auto-advance wrap-around and the post-removal
+//  index recalculation — the logic that drives the carousel's state writes.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class BannersCarouselIndexTests: XCTestCase {
+
+    // MARK: - next(after:count:) — auto-advance wrap-around
+
+    func testNextAdvancesWithinBounds() {
+        XCTAssertEqual(BannersCarouselIndex.next(after: 0, count: 3), 1)
+        XCTAssertEqual(BannersCarouselIndex.next(after: 1, count: 3), 2)
+    }
+
+    func testNextWrapsFromLastToFirst() {
+        XCTAssertEqual(BannersCarouselIndex.next(after: 2, count: 3), 0)
+    }
+
+    func testNextIsNoOpForSingleBanner() {
+        // With a single banner there is nothing to advance to: returning the
+        // same index lets the caller guard the write and avoid a no-op mutation.
+        XCTAssertEqual(BannersCarouselIndex.next(after: 0, count: 1), 0)
+    }
+
+    func testNextIsNoOpForEmptyCount() {
+        XCTAssertEqual(BannersCarouselIndex.next(after: 0, count: 0), 0)
+    }
+
+    // MARK: - afterRemoval(removedIndex:currentIndex:countBeforeRemoval:)
+
+    func testRemovalOfBannerBeforeCurrentShiftsIndexBack() {
+        // current = 2, remove index 0 -> the active banner is now at index 1.
+        XCTAssertEqual(
+            BannersCarouselIndex.afterRemoval(removedIndex: 0, currentIndex: 2, countBeforeRemoval: 3),
+            1
+        )
+    }
+
+    func testRemovalOfBannerAfterCurrentKeepsIndex() {
+        // current = 0, remove index 2 -> still on index 0.
+        XCTAssertEqual(
+            BannersCarouselIndex.afterRemoval(removedIndex: 2, currentIndex: 0, countBeforeRemoval: 3),
+            0
+        )
+    }
+
+    func testRemovalOfCurrentNonLastKeepsIndex() {
+        // current = 1 (middle), remove it -> next banner slides into slot 1.
+        XCTAssertEqual(
+            BannersCarouselIndex.afterRemoval(removedIndex: 1, currentIndex: 1, countBeforeRemoval: 3),
+            1
+        )
+    }
+
+    func testRemovalOfCurrentLastStepsBack() {
+        // current = 2 (last), remove it -> step back to index 1.
+        XCTAssertEqual(
+            BannersCarouselIndex.afterRemoval(removedIndex: 2, currentIndex: 2, countBeforeRemoval: 3),
+            1
+        )
+    }
+
+    func testRemovalOfOnlyBannerResetsToZero() {
+        XCTAssertEqual(
+            BannersCarouselIndex.afterRemoval(removedIndex: 0, currentIndex: 0, countBeforeRemoval: 1),
+            0
+        )
+    }
+
+    func testRemovalOfCurrentFirstWhenItIsLastRemainingStepsBackToZero() {
+        // Two banners, current = 1 (last), remove it -> back to 0.
+        XCTAssertEqual(
+            BannersCarouselIndex.afterRemoval(removedIndex: 1, currentIndex: 1, countBeforeRemoval: 2),
+            0
+        )
+    }
+}


### PR DESCRIPTION
## The crash class

macOS-only hard crash: `EXC_BREAKPOINT (SIGTRAP)` from an `NSException` thrown inside AppKit's constraint cycle (`-[NSWindow _postWindowNeedsUpdateConstraints]`) **while SwiftUI is committing a render transaction inside `NSHostingView.layout`**.

Root cause: a view mutates observable `@State`/`@Published` state **synchronously during an animated layout/commit** that is driven by a timer/publisher (runloop) tick — not a user gesture. That mid-cycle write re-invalidates the SwiftUI graph, which reenters AppKit's constraint update and throws a fatal `NSException`. On iOS the same situation is only the purple "Modifying state during view update" warning; on macOS it is a hard crash. The crashed thread runs through a runloop observer / display-link commit (`CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER` -> `CATransaction NS_setFlushesWithDisplayLink`), confirming a timer/publisher-driven animated mutation.

This is the **same class as #4125** (which swept three `asyncAfter` sites and documented this exact signature), here at two sites that PR did not cover. The fix shape deliberately follows the durable pattern from that work — **idempotent guarded writes + breaking the animated feedback loop + cancellable `Task`**, not the `asyncAfter`/`Task {}` "deferral" anti-pattern that #4124/#4125 were removing.

## Sites fixed

### 1. `BannersCarousel` (`Features/Common/Views/Banners/BannersCarousel.swift`)
Sits on the idle Home tab (`VaultMainScreen`), matching the "several minutes in, not at launch" repro. It had a **mutually-recursive animated loop**: a 3s repeating `Timer` did `withAnimation { currentIndex += 1 }`; `onChange(currentIndex)` did `withAnimation { scrollPosition = … }`; and `onChange(scrollPosition)` did `withAnimation { currentIndex = …; startTimer() }`. `scrollPosition` drives `.scrollPosition(id:)` (layout). Timer (runloop) + nested `withAnimation` (NSAnimationContext) + reciprocal writes = the crash signature.

- **Broke the reciprocal loop with no-op guards on every write.** `currentIndex -> scrollPosition` only writes when the values differ; `scrollPosition -> currentIndex` only writes when they differ. A no-op write still emits a graph mutation, so a sync that lands mid-commit with an unchanged value previously re-invalidated the graph; the guards make it a true no-op and stop the handlers ping-ponging.
- **Pulled `startTimer()` out of `withAnimation`** (both in the `scrollPosition` handler and inside the timer tick) so a timer (re)start never runs an `NSAnimationContext` concurrently with a runloop tick committing layout.
- **Guarded the auto-advance write** (skip when the next index equals the current).
- **Replaced both `DispatchQueue.main.asyncAfter` calls** in `removeBanner` with a single cancellable `delayedTask` (the existing #4125-style helper backed by `Task { @MainActor }` + `Task.sleep`), stored in `@State` and **cancelled in `onDisappear`** so a stale closure can't mutate state on a torn-down view. The auto-advance timer is also already invalidated in `onDisappear`.
- **Extracted the wrap-around + post-removal index math** into a pure `BannersCarouselIndex` enum and unit-tested it.
- **Replaced `print()` with OSLog `Logger`.**

Behavior preserved: still auto-advances every 3s, still wraps around, still tracks manual swipe, indicators still follow the page. Only the reentrancy/loop is removed.

### 2. `SheetPresentedViewModifier` (`Components/Sheet/SheetPresentedCounterManager/SheetPresentedViewModifier.swift`)
`onReceive(counterManager.$counter)` (Combine, lands on the runloop) set `blurContent` (`@State`) under `.animation(.easeInOut, value: blurContent)`, animating a `.blur` over the entire NavigationStack (mounted once at `ContentView`). If the publisher fired during a sheet's own animated transition commit, it re-invalidated the laying-out root.

- **No-op guard:** compute `let shouldBlur = newValue > 0` and only assign when `blurContent != shouldBlur`. The counter changes on every increment/decrement (more often than the boolean flips), so the guard collapses most ticks to no-ops and keeps the write out of the commit.
- **Why guard, not a derived/computed blur:** the manager is read via a plain `@Environment(\.sheetPresentedCounterManager)` value (the env key's `static let` default instance), **not** `@EnvironmentObject`. Plain environment values do not re-render on `@Published` changes, so `.blur(radius: counter > 0 ? … : 0)` would not update reactively — only `onReceive` observes the publisher. Keeping `onReceive` + guarding the write is the option that both removes the in-commit mutation and preserves behavior. No `asyncAfter` introduced.

Behavior preserved: content still blurs when a sheet is presented and unblurs on dismiss, same easeInOut feel.

## Tests
Added `BannersCarouselIndexTests` (10 cases) covering `BannersCarouselIndex.next(after:count:)` (wrap-around, single/empty no-ops) and `afterRemoval(removedIndex:currentIndex:countBeforeRemoval:)` (remove before/after/at current, last-item step-back, single-banner reset). The reciprocal-loop and guard logic that lives in the view body is not directly unit-testable without a view host; no fake tests were added for it — it relies on the build + the reasoning above. All 10 new tests pass.

## Build results (both required, both green)
- **macOS** (`platform=macOS,arch=arm64`, the crashing platform): **BUILD SUCCEEDED**
- **iOS Simulator** (iPhone 17, regression check): **BUILD SUCCEEDED**
- SwiftLint clean on all touched files (0 violations).
- New unit tests: 10 passed, 0 failed (run on iPhone 17 sim; the unit-test target is iOS-only).

## Scope and honest caveats
- **Runtime macOS crash repro is NOT verified** — no macOS exception-breakpoint repro was available here. The two sites were root-caused from the crash signature and the #4125 precedent; the exact crashing view is not runtime-confirmed.
- The crash class can fire from multiple sites. The other ranked suspects from the investigation — **CrossPlatformSheet**, **KeysignDiscoveryView**, **StepsAnimationView** — are intentionally **out of scope** for this PR (lower confidence) and remain follow-ups that need a runtime exception-breakpoint session to confirm.
- Because of the above, this uses **`Addresses #4470` without an auto-close keyword** rather than `closes`.

Addresses #4470

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sheet transition performance by preventing unnecessary blur state updates.
  * Fixed banner carousel navigation to prevent redundant state changes and improved state synchronization.
  * Enhanced banner removal timing with better task cancellation handling.

* **Tests**
  * Added comprehensive unit tests for banner carousel navigation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->