### PR TITLE
feat(settings): enable QBTC claim, MLDSA, SwapKit & Custom RPC by default; remove advanced toggles

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitConfig.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitConfig.swift
@@ -61,19 +61,12 @@ enum SwapKitConfig {
         "MAYACHAIN_STREAMING"
     ]
 
-    /// Advanced-settings flag (Settings → Advanced → "SwapKit"). When
-    /// `false`, SwapKit is dropped from every coin's `swapProviders` list
-    /// and `SwapKitService.fetchBestRoute` short-circuits to `nil`. The key
-    /// is the same `@AppStorage` value `SettingsViewModel.swapkitEnabled`
-    /// writes to, so the toggle and this read share one source of truth.
-    /// Default `true` — users can opt out via Settings → Advanced.
+    /// Gates SwapKit across the app — `swapProviders` list inclusion and
+    /// `SwapKitService.fetchBestRoute`. SwapKit has shipped and is always
+    /// enabled; the former Settings → Advanced opt-out toggle has been
+    /// removed. The property is kept as a single source of truth so the
+    /// call sites retain one gate if we ever need to dark-launch a change.
     static var isFeatureEnabled: Bool {
-        // `bool(forKey:)` returns false when the key is absent, so we check
-        // for the object directly to distinguish "never set" (default on)
-        // from "explicitly set to false".
-        guard let stored = UserDefaults.standard.object(forKey: "swapkitEnabled") as? Bool else {
-            return true
-        }
-        return stored
+        true
     }
 }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -921,12 +921,10 @@
 "settings" = "Einstellungen";
 "settingsAdvancedClear" = "Leeren";
 "settingsAdvancedCustomRPC" = "Eigene RPC-Endpunkte";
-"settingsAdvancedCustomRPCToggle" = "Eigenes RPC";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Verwalten";
 "settingsAdvancedSwapKitClearTokensCache" = "SwapKit-Token-Cache leeren";
-"settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Teilen";
 "shareOf" = "Anteil %d von %d";
 "shareQRType" = "Typ";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -925,7 +925,6 @@
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Verwalten";
-"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "SwapKit-Token-Cache leeren";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Teilen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -929,12 +929,10 @@
 "settings" = "Settings";
 "settingsAdvancedClear" = "Clear";
 "settingsAdvancedCustomRPC" = "Custom RPC Endpoints";
-"settingsAdvancedCustomRPCToggle" = "Custom RPC";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Manage";
 "settingsAdvancedSwapKitClearTokensCache" = "Clear SwapKit tokens cache";
-"settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Share";
 "shareOf" = "share %d of %d";
 "shareQRType" = "Type";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -933,7 +933,6 @@
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Manage";
-"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Clear SwapKit tokens cache";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Share";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -921,12 +921,10 @@
 "settings" = "Configuración";
 "settingsAdvancedClear" = "Borrar";
 "settingsAdvancedCustomRPC" = "Endpoints RPC personalizados";
-"settingsAdvancedCustomRPCToggle" = "RPC personalizado";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Gestionar";
 "settingsAdvancedSwapKitClearTokensCache" = "Borrar caché de tokens de SwapKit";
-"settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartir";
 "shareOf" = "Compartir %d de %d";
 "shareQRType" = "Tipo";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -925,7 +925,6 @@
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Gestionar";
-"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Borrar caché de tokens de SwapKit";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartir";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -925,7 +925,6 @@
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Upravljaj";
-"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Očisti predmemoriju SwapKit tokena";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Podijeli";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -921,12 +921,10 @@
 "settings" = "Postavke";
 "settingsAdvancedClear" = "Očisti";
 "settingsAdvancedCustomRPC" = "Prilagođeni RPC endpointi";
-"settingsAdvancedCustomRPCToggle" = "Prilagođeni RPC";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Upravljaj";
 "settingsAdvancedSwapKitClearTokensCache" = "Očisti predmemoriju SwapKit tokena";
-"settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Podijeli";
 "shareOf" = "podijelite %d od %d";
 "shareQRType" = "Vrsta";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -925,7 +925,6 @@
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Gestisci";
-"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Cancella la cache dei token di SwapKit";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -921,12 +921,10 @@
 "settings" = "Impostazioni";
 "settingsAdvancedClear" = "Cancella";
 "settingsAdvancedCustomRPC" = "Endpoint RPC personalizzati";
-"settingsAdvancedCustomRPCToggle" = "RPC personalizzato";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Gestisci";
 "settingsAdvancedSwapKitClearTokensCache" = "Cancella la cache dei token di SwapKit";
-"settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";
 "shareOf" = "Condividi %d di %d";
 "shareQRType" = "Tipo";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -902,7 +902,6 @@
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "관리";
-"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "SwapKit 토큰 캐시 지우기";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "공유";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -898,12 +898,10 @@
 "settings" = "설정";
 "settingsAdvancedClear" = "지우기";
 "settingsAdvancedCustomRPC" = "사용자 지정 RPC 엔드포인트";
-"settingsAdvancedCustomRPCToggle" = "사용자 지정 RPC";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "관리";
 "settingsAdvancedSwapKitClearTokensCache" = "SwapKit 토큰 캐시 지우기";
-"settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "공유";
 "shareOf" = "%d/%d 공유";
 "shareQRType" = "유형";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -921,12 +921,10 @@
 "settings" = "Configurações";
 "settingsAdvancedClear" = "Limpar";
 "settingsAdvancedCustomRPC" = "Endpoints RPC personalizados";
-"settingsAdvancedCustomRPCToggle" = "RPC personalizado";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Gerir";
 "settingsAdvancedSwapKitClearTokensCache" = "Limpar cache de tokens do SwapKit";
-"settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";
 "shareOf" = "compartilhar %d de %d";
 "shareQRType" = "Tipo";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -925,7 +925,6 @@
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "Gerir";
-"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "Limpar cache de tokens do SwapKit";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "Compartilhar";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -921,12 +921,10 @@
 "settings" = "设置";
 "settingsAdvancedClear" = "清除";
 "settingsAdvancedCustomRPC" = "自定义 RPC 端点";
-"settingsAdvancedCustomRPCToggle" = "自定义 RPC";
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "管理";
 "settingsAdvancedSwapKitClearTokensCache" = "清除 SwapKit 代币缓存";
-"settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "分享";
 "shareOf" = "份额 %d / %d";
 "shareQRType" = "类型";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -925,7 +925,6 @@
 "settingsAdvancedForcedSwapProvider" = "Force swap provider";
 "settingsAdvancedForcedSwapProviderAll" = "All providers";
 "settingsAdvancedManage" = "管理";
-"settingsAdvancedQBTCClaimToggle" = "QBTC Claim";
 "settingsAdvancedSwapKitClearTokensCache" = "清除 SwapKit 代币缓存";
 "settingsAdvancedSwapKitToggle" = "SwapKit";
 "share" = "分享";

--- a/VultisigApp/VultisigApp/Features/CustomRPC/CustomRPCConfig.swift
+++ b/VultisigApp/VultisigApp/Features/CustomRPC/CustomRPCConfig.swift
@@ -10,13 +10,12 @@
 import Foundation
 
 enum CustomRPCConfig {
-    /// Advanced-settings opt-in flag (Settings → Advanced → "Custom RPC").
-    /// When `false`, the Custom RPC row is filtered out of the General
-    /// settings section. The key is the same `@AppStorage` value
-    /// `SettingsViewModel.customRPCEnabled` writes to, so the toggle and this
-    /// read share one source of truth. Default `false` — opt-in while we
-    /// develop + smoke-test.
+    /// Gates the Custom RPC row in the General settings section. Custom RPC
+    /// has shipped and is always enabled; the former Settings → Advanced
+    /// opt-in toggle has been removed. The property is kept as a single
+    /// source of truth so the call site retains one gate if we ever need to
+    /// dark-launch a change.
     static var isFeatureEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "customRPCEnabled")
+        true
     }
 }

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/QBTCConfig.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/QBTCConfig.swift
@@ -7,9 +7,8 @@
 //  quantum-security onboarding hop, join-keysign QBTC fork — gates against
 //  this single source of truth.
 //
-//  The flag is independent of `isMLDSAEnabled`. MLDSA gates *keygen*; this
-//  flag gates QBTC *claim UI*. Both need to be true for an end-to-end
-//  claim, but the toggles are orthogonal.
+//  This gate is orthogonal to MLDSA keygen: MLDSA gates *keygen* (driven
+//  by the QBTC claim flow), this gates QBTC *claim UI*.
 //
 //  QBTC claim is enabled for everyone — the former Settings → Advanced
 //  opt-in toggle has been removed now that the workstream has shipped.

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/QBTCConfig.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/QBTCConfig.swift
@@ -2,41 +2,28 @@
 //  QBTCConfig.swift
 //  VultisigApp
 //
-//  Configuration for the QBTC claim workstream. Mirrors `SwapKitConfig`'s
-//  `isFeatureEnabled` shape so every QBTC user-facing surface — promo
-//  banner, Claim button, chain-picker entry, claim flow, quantum-security
-//  onboarding hop, join-keysign QBTC fork — gates against a single source
-//  of truth.
+//  Configuration for the QBTC claim workstream. Every QBTC user-facing
+//  surface — promo banner, Claim button, chain-picker entry, claim flow,
+//  quantum-security onboarding hop, join-keysign QBTC fork — gates against
+//  this single source of truth.
 //
 //  The flag is independent of `isMLDSAEnabled`. MLDSA gates *keygen*; this
 //  flag gates QBTC *claim UI*. Both need to be true for an end-to-end
 //  claim, but the toggles are orthogonal.
 //
-//  Behaviour:
-//  - New / existing installs default OFF — `UserDefaults.standard.bool(...)`
-//    returns `false` for any unset key.
-//  - Toggle in Settings → Advanced → "QBTC Claim".
-//  - In-flight claim at flag-flip: the running keysign screen completes
-//    naturally (we don't proactively pop a mid-session screen). New entry
-//    points are blocked. Same precedent as SwapKit.
-//  - Existing vault state preserved: if a user adds the QBTC chain with
-//    the flag on and then flips it off, the QBTC `Coin` row stays on the
-//    vault and any past QBTC claim tx in history remains visible. The
-//    flag controls visibility of new entry points, not data lifecycle.
+//  QBTC claim is enabled for everyone — the former Settings → Advanced
+//  opt-in toggle has been removed now that the workstream has shipped.
 //
 
 import Foundation
 
 enum QBTCConfig {
-    /// Advanced-settings opt-in flag (Settings → Advanced → "QBTC Claim").
-    /// When `false`, every QBTC claim UI surface is hidden — promo banner,
-    /// Claim button, chain-picker entry, claim flow, onboarding hop, join-
-    /// keysign QBTC fork. Existing vault state (QBTC coin row, past claim
-    /// tx history) is preserved — the flag controls UI visibility only.
-    /// The key is the same `@AppStorage` value `SettingsViewModel.qbtcEnabled`
-    /// writes to, so the toggle and this read share one source of truth.
-    /// Default `false` — opt-in while we develop + smoke-test.
+    /// Gates every QBTC claim UI surface — promo banner, Claim button,
+    /// chain-picker entry, claim flow, onboarding hop, join-keysign QBTC
+    /// fork. Now that QBTC claim has shipped it is always enabled; the
+    /// kill-switch is kept so the call sites retain a single source of
+    /// truth if we ever need to dark-launch a follow-up change.
     static var isFeatureEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "qbtcEnabled")
+        true
     }
 }

--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -30,10 +30,7 @@ class SettingsViewModel: ObservableObject {
     @AppStorage("sepolia") var enableSepolia: Bool = false
     @AppStorage("thorchainChainnet") var enableThorchainChainnet: Bool = false
     @AppStorage("SellEnabled") var sellEnabled: Bool = false
-    @AppStorage("isMLDSAEnabled") var isMLDSAEnabled: Bool = false
     @AppStorage("tssBatchEnabled") var tssBatchEnabled: Bool = false
-    @AppStorage("swapkitEnabled") var swapkitEnabled: Bool = true
-    @AppStorage("customRPCEnabled") var customRPCEnabled: Bool = false
     /// Debug-only: force every swap quote through a single provider so a
     /// tester can verify a specific signing path in isolation. Empty string
     /// = no force (production ranking across all providers). Otherwise one

--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -33,7 +33,6 @@ class SettingsViewModel: ObservableObject {
     @AppStorage("isMLDSAEnabled") var isMLDSAEnabled: Bool = false
     @AppStorage("tssBatchEnabled") var tssBatchEnabled: Bool = false
     @AppStorage("swapkitEnabled") var swapkitEnabled: Bool = true
-    @AppStorage("qbtcEnabled") var qbtcEnabled: Bool = false
     @AppStorage("customRPCEnabled") var customRPCEnabled: Bool = false
     /// Debug-only: force every swap quote through a single provider so a
     /// tester can verify a specific signing path in isolation. Empty string

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
@@ -38,27 +38,9 @@ struct SettingsAdvancedView: View {
             )
 
             SettingToggleCell(
-                title: "MLDSA",
-                icon: "lock.shield",
-                isEnabled: $settingsViewModel.isMLDSAEnabled
-            )
-
-            SettingToggleCell(
                 title: "TSS Batching",
                 icon: "bolt.horizontal",
                 isEnabled: $settingsViewModel.tssBatchEnabled
-            )
-
-            SettingToggleCell(
-                title: "settingsAdvancedSwapKitToggle".localized,
-                icon: "arrow.triangle.swap",
-                isEnabled: $settingsViewModel.swapkitEnabled
-            )
-
-            SettingToggleCell(
-                title: "settingsAdvancedCustomRPCToggle".localized,
-                icon: "network",
-                isEnabled: $settingsViewModel.customRPCEnabled
             )
 
             SettingPickerCell(

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
@@ -56,12 +56,6 @@ struct SettingsAdvancedView: View {
             )
 
             SettingToggleCell(
-                title: "settingsAdvancedQBTCClaimToggle".localized,
-                icon: "lock.shield",
-                isEnabled: $settingsViewModel.qbtcEnabled
-            )
-
-            SettingToggleCell(
                 title: "settingsAdvancedCustomRPCToggle".localized,
                 icon: "network",
                 isEnabled: $settingsViewModel.customRPCEnabled

--- a/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimFeatureFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimFeatureFlagTests.swift
@@ -2,12 +2,11 @@
 //  QBTCClaimFeatureFlagTests.swift
 //  VultisigAppTests
 //
-//  Locks the opt-in behaviour for QBTC claim: the workstream is off by
-//  default; flipping the `qbtcEnabled` UserDefaults key (the same key
-//  `SettingsViewModel.qbtcEnabled` writes to via `@AppStorage`) lights
-//  it up. Surface-level gates (chain-picker visibility, navigation
-//  arms) are also locked in here so a regression doesn't quietly
-//  expose the flow.
+//  Locks the shipped behaviour for QBTC claim: the workstream is enabled
+//  for everyone now that the former Settings → Advanced opt-in toggle has
+//  been removed. Surface-level gates (chain-picker visibility, navigation
+//  arms) are also locked in here so a regression doesn't quietly hide the
+//  flow.
 //
 
 import XCTest
@@ -16,108 +15,54 @@ import XCTest
 @MainActor
 final class QBTCClaimFeatureFlagTests: XCTestCase {
 
-    private let flagKey = "qbtcEnabled"
-    private var savedFlag: Any?
-
-    override func setUpWithError() throws {
-        savedFlag = UserDefaults.standard.object(forKey: flagKey)
-        UserDefaults.standard.removeObject(forKey: flagKey)
-    }
-
-    override func tearDownWithError() throws {
-        if let savedFlag {
-            UserDefaults.standard.set(savedFlag, forKey: flagKey)
-        } else {
-            UserDefaults.standard.removeObject(forKey: flagKey)
-        }
-    }
-
     // MARK: - isFeatureEnabled
 
-    func testFeatureFlagDefaultsToOff() {
-        UserDefaults.standard.removeObject(forKey: flagKey)
-        XCTAssertFalse(
+    func testFeatureFlagIsAlwaysEnabled() {
+        XCTAssertTrue(
             QBTCConfig.isFeatureEnabled,
-            "QBTC must be opt-in — default off while the workstream is in active development"
+            "QBTC claim has shipped — the feature is always enabled"
         )
-    }
-
-    func testFeatureFlagOnReadsTrue() {
-        UserDefaults.standard.set(true, forKey: flagKey)
-        XCTAssertTrue(QBTCConfig.isFeatureEnabled)
-    }
-
-    func testFeatureFlagOffReadsFalse() {
-        UserDefaults.standard.set(false, forKey: flagKey)
-        XCTAssertFalse(QBTCConfig.isFeatureEnabled)
     }
 
     // MARK: - CoinSelectionViewModel chain picker gating
 
-    func testChainPickerHidesQbtcWhenFlagOff() {
-        UserDefaults.standard.set(false, forKey: flagKey)
-        let vault = makeVaultWithMLDSAKey()
-        let viewModel = CoinSelectionViewModel()
-        viewModel.showMldsaChainsWithoutKey = true
-        viewModel.setData(for: vault, checkForSelected: false)
-        XCTAssertFalse(
-            viewModel.filteredChains.contains(.qbtc),
-            "QBTC must not appear in the chain picker with the feature flag off"
-        )
-    }
-
-    func testChainPickerShowsQbtcWhenFlagOnAndMldsaKeyPresent() {
-        UserDefaults.standard.set(true, forKey: flagKey)
+    func testChainPickerShowsQbtcWhenMldsaKeyPresent() {
         let vault = makeVaultWithMLDSAKey()
         let viewModel = CoinSelectionViewModel()
         viewModel.showMldsaChainsWithoutKey = false
         viewModel.setData(for: vault, checkForSelected: false)
         XCTAssertTrue(
             viewModel.filteredChains.contains(.qbtc),
-            "QBTC must appear when the feature flag is on and the vault has an MLDSA key"
+            "QBTC must appear when the vault has an MLDSA key"
         )
     }
 
-    func testChainPickerShowsQbtcWhenFlagOnAndShowWithoutKey() {
+    func testChainPickerShowsQbtcWhenShowWithoutKey() {
         // Mirrors the production path where the chain picker is invoked
         // with `showMldsaChainsWithoutKey = true` so the user can request
         // the quantum keygen by tapping QBTC even if the vault has no
         // MLDSA key yet.
-        UserDefaults.standard.set(true, forKey: flagKey)
         let vault = makeVaultWithoutMLDSAKey()
         let viewModel = CoinSelectionViewModel()
         viewModel.showMldsaChainsWithoutKey = true
         viewModel.setData(for: vault, checkForSelected: false)
         XCTAssertTrue(
             viewModel.filteredChains.contains(.qbtc),
-            "QBTC must appear when the flag is on and the picker is in keygen-prompting mode"
+            "QBTC must appear when the picker is in keygen-prompting mode"
         )
     }
 
-    func testRequiresQuantumKeygenReturnsFalseWhenFlagOff() {
-        UserDefaults.standard.set(false, forKey: flagKey)
-        let vault = makeVaultWithoutMLDSAKey()
-        let viewModel = CoinSelectionViewModel()
-        let qbtcAsset = makeQbtcMeta()
-        XCTAssertFalse(
-            viewModel.requiresQuantumKeygen(for: qbtcAsset, vault: vault),
-            "With the flag off, `requiresQuantumKeygen` must return false so the keygen prompt never fires"
-        )
-    }
-
-    func testRequiresQuantumKeygenReturnsTrueWhenFlagOnAndNoMldsaKey() {
-        UserDefaults.standard.set(true, forKey: flagKey)
+    func testRequiresQuantumKeygenReturnsTrueWhenNoMldsaKey() {
         let vault = makeVaultWithoutMLDSAKey()
         let viewModel = CoinSelectionViewModel()
         let qbtcAsset = makeQbtcMeta()
         XCTAssertTrue(
             viewModel.requiresQuantumKeygen(for: qbtcAsset, vault: vault),
-            "Flag-on + no MLDSA key: the picker must surface the keygen prompt"
+            "No MLDSA key: the picker must surface the keygen prompt"
         )
     }
 
-    func testRequiresQuantumKeygenReturnsFalseForNonMldsaAssetRegardlessOfFlag() {
-        UserDefaults.standard.set(true, forKey: flagKey)
+    func testRequiresQuantumKeygenReturnsFalseForNonMldsaAsset() {
         let vault = makeVaultWithoutMLDSAKey()
         let viewModel = CoinSelectionViewModel()
         let btcAsset = CoinMeta(

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitFeatureFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitFeatureFlagTests.swift
@@ -2,10 +2,10 @@
 //  SwapKitFeatureFlagTests.swift
 //  VultisigAppTests
 //
-//  Locks the opt-out behaviour for SwapKit: the integration is on by
-//  default; the `swapkitEnabled` UserDefaults key (the same key
-//  `SettingsViewModel.swapkitEnabled` writes to via `@AppStorage`) can
-//  turn it off. `Coin+Swaps.swapProviders` is the single point of gating.
+//  Locks the shipped behaviour for SwapKit: the integration is enabled for
+//  everyone now that the former Settings → Advanced opt-out toggle has been
+//  removed. `Coin+Swaps.swapProviders` is the single point of gating, and
+//  the `forcedSwapProvider` debug picker still narrows the provider list.
 //
 
 import XCTest
@@ -13,24 +13,15 @@ import XCTest
 
 final class SwapKitFeatureFlagTests: XCTestCase {
 
-    private let flagKey = "swapkitEnabled"
     private let forcedKey = "forcedSwapProvider"
-    private var savedFlag: Any?
     private var savedForced: Any?
 
     override func setUpWithError() throws {
-        savedFlag = UserDefaults.standard.object(forKey: flagKey)
         savedForced = UserDefaults.standard.object(forKey: forcedKey)
-        UserDefaults.standard.removeObject(forKey: flagKey)
         UserDefaults.standard.removeObject(forKey: forcedKey)
     }
 
     override func tearDownWithError() throws {
-        if let savedFlag {
-            UserDefaults.standard.set(savedFlag, forKey: flagKey)
-        } else {
-            UserDefaults.standard.removeObject(forKey: flagKey)
-        }
         if let savedForced {
             UserDefaults.standard.set(savedForced, forKey: forcedKey)
         } else {
@@ -40,72 +31,36 @@ final class SwapKitFeatureFlagTests: XCTestCase {
 
     // MARK: - isFeatureEnabled
 
-    func testFeatureFlagDefaultsToOn() {
-        UserDefaults.standard.removeObject(forKey: flagKey)
+    func testFeatureFlagIsAlwaysEnabled() {
         XCTAssertTrue(
             SwapKitConfig.isFeatureEnabled,
-            "SwapKit must be on by default — users can opt out via Settings → Advanced"
+            "SwapKit has shipped — the feature is always enabled"
         )
-    }
-
-    func testFeatureFlagOnReadsTrue() {
-        UserDefaults.standard.set(true, forKey: flagKey)
-        XCTAssertTrue(SwapKitConfig.isFeatureEnabled)
-    }
-
-    func testFeatureFlagOffReadsFalse() {
-        UserDefaults.standard.set(false, forKey: flagKey)
-        XCTAssertFalse(SwapKitConfig.isFeatureEnabled)
     }
 
     // MARK: - Coin+Swaps gating
 
-    func testSwapkitDroppedFromEthereumProvidersWhenFlagOff() {
-        UserDefaults.standard.set(false, forKey: flagKey)
+    func testSwapkitPresentInEthereumProviders() {
         let providers = makeCoin(chain: .ethereum, ticker: "ETH").swapProviders
-        XCTAssertFalse(
+        XCTAssertTrue(
             providers.contains(.swapkit),
-            "When the flag is off, `.swapkit` must not appear in Ethereum's provider list"
+            "Ethereum's provider list must include `.swapkit`"
         )
-        // Existing providers must still be intact — the flag only affects SwapKit.
         XCTAssertTrue(providers.contains(.lifi))
         XCTAssertTrue(providers.contains(.kyberswap(.ethereum)))
         XCTAssertTrue(providers.contains(.oneinch(.ethereum)))
     }
 
-    func testSwapkitPresentInEthereumProvidersWhenFlagOn() {
-        UserDefaults.standard.set(true, forKey: flagKey)
-        let providers = makeCoin(chain: .ethereum, ticker: "ETH").swapProviders
-        XCTAssertTrue(
-            providers.contains(.swapkit),
-            "When the flag is on, Ethereum's provider list must include `.swapkit`"
-        )
-    }
-
-    func testSwapkitDroppedFromSolanaProvidersWhenFlagOff() {
-        UserDefaults.standard.set(false, forKey: flagKey)
+    func testSwapkitPresentInSolanaProviders() {
         let providers = makeCoin(chain: .solana, ticker: "SOL").swapProviders
-        XCTAssertFalse(providers.contains(.swapkit))
+        XCTAssertTrue(providers.contains(.swapkit))
         XCTAssertTrue(providers.contains(.lifi))
         XCTAssertTrue(providers.contains(.thorchain))
-    }
-
-    func testFlagOffDoesNotAffectNonSwapKitChains() {
-        // THORChain has no `.swapkit` arm in the switch (the SwapKit
-        // integration explicitly filters THORChain/Maya routes upstream).
-        // Toggling the flag must not change its provider list — pinned so a
-        // future refactor doesn't drop it into the filter path.
-        UserDefaults.standard.set(false, forKey: flagKey)
-        let off = makeCoin(chain: .thorChain, ticker: "RUNE").swapProviders
-        UserDefaults.standard.set(true, forKey: flagKey)
-        let on = makeCoin(chain: .thorChain, ticker: "RUNE").swapProviders
-        XCTAssertEqual(off, on)
     }
 
     // MARK: - Forced swap provider (debug picker)
 
     func testForcedProviderDefaultPreservesAllProviders() {
-        UserDefaults.standard.set(true, forKey: flagKey)
         UserDefaults.standard.removeObject(forKey: forcedKey)
         let providers = makeCoin(chain: .ethereum, ticker: "ETH").swapProviders
         // Default (empty string) → no force. Production ranking sees the
@@ -117,28 +72,24 @@ final class SwapKitFeatureFlagTests: XCTestCase {
     }
 
     func testForcedSwapKitFiltersOutOthers() {
-        UserDefaults.standard.set(true, forKey: flagKey)
         UserDefaults.standard.set("swapkit", forKey: forcedKey)
         let providers = makeCoin(chain: .ethereum, ticker: "ETH").swapProviders
         XCTAssertEqual(providers, [.swapkit])
     }
 
     func testForcedOneInchFiltersOutOthers() {
-        UserDefaults.standard.set(true, forKey: flagKey)
         UserDefaults.standard.set("oneInch", forKey: forcedKey)
         let providers = makeCoin(chain: .ethereum, ticker: "ETH").swapProviders
         XCTAssertEqual(providers, [.oneinch(.ethereum)])
     }
 
     func testForcedKyberFiltersOutOthers() {
-        UserDefaults.standard.set(true, forKey: flagKey)
         UserDefaults.standard.set("kyberSwap", forKey: forcedKey)
         let providers = makeCoin(chain: .ethereum, ticker: "ETH").swapProviders
         XCTAssertEqual(providers, [.kyberswap(.ethereum)])
     }
 
     func testForcedLiFiFiltersOutOthers() {
-        UserDefaults.standard.set(true, forKey: flagKey)
         UserDefaults.standard.set("lifi", forKey: forcedKey)
         let providers = makeCoin(chain: .solana, ticker: "SOL").swapProviders
         XCTAssertEqual(providers, [.lifi])
@@ -149,28 +100,15 @@ final class SwapKitFeatureFlagTests: XCTestCase {
         // variants (.thorchain / .thorchainChainnet / .thorchainStagenet)
         // so a tester debugging THORChain doesn't have to know which
         // network variant Vultisig is configured for.
-        UserDefaults.standard.set(true, forKey: flagKey)
         UserDefaults.standard.set("thorchain", forKey: forcedKey)
         let btc = makeCoin(chain: .bitcoin, ticker: "BTC").swapProviders
         XCTAssertEqual(btc, [.thorchain])
-    }
-
-    func testForcedSwapKitWithFeatureFlagOffReturnsEmpty() {
-        // The SwapKit flag still takes precedence — if SwapKit is off
-        // globally, forcing it produces an empty array (no fallback to
-        // any other provider). The tester sees "no providers" in the UI
-        // instead of silently routing through a different provider.
-        UserDefaults.standard.set(false, forKey: flagKey)
-        UserDefaults.standard.set("swapkit", forKey: forcedKey)
-        let providers = makeCoin(chain: .ethereum, ticker: "ETH").swapProviders
-        XCTAssertTrue(providers.isEmpty)
     }
 
     func testForcedProviderNotEligibleForChainReturnsEmpty() {
         // Ripple has only [.thorchain] naturally. Forcing 1inch produces
         // an empty list — Vultisig won't route through a provider that
         // doesn't support the chain at all.
-        UserDefaults.standard.set(true, forKey: flagKey)
         UserDefaults.standard.set("oneInch", forKey: forcedKey)
         let providers = makeCoin(chain: .ripple, ticker: "XRP").swapProviders
         XCTAssertTrue(providers.isEmpty)

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
@@ -3,44 +3,15 @@
 //  VultisigAppTests
 //
 //  Pins the destination-coin-picker invariant for the SwapKit token-list
-//  expansion: when the feature flag is OFF, the cache's per-chain bucket is
-//  empty (no `/tokens` fetch, no tag injection); when ON, the merge step
-//  prepends SwapKit's novel tokens to the curated/1inch/Jupiter union and
-//  tags only the residual SwapKit-only entries.
+//  expansion: the merge step prepends SwapKit's novel tokens to the
+//  curated/1inch/Jupiter union and tags only the residual SwapKit-only
+//  entries.
 //
 
 import XCTest
 @testable import VultisigApp
 
 final class SwapKitTokensPickerFlagTests: XCTestCase {
-
-    private let flagKey = "swapkitEnabled"
-    private var savedValue: Any?
-
-    override func setUpWithError() throws {
-        savedValue = UserDefaults.standard.object(forKey: flagKey)
-        UserDefaults.standard.removeObject(forKey: flagKey)
-    }
-
-    override func tearDownWithError() throws {
-        if let savedValue {
-            UserDefaults.standard.set(savedValue, forKey: flagKey)
-        } else {
-            UserDefaults.standard.removeObject(forKey: flagKey)
-        }
-    }
-
-    @MainActor
-    func testCacheReturnsEmptyBucketWhenFlagOff() async {
-        UserDefaults.standard.set(false, forKey: flagKey)
-        let cache = SwapKitTokensCache()
-        let bucket = await cache.tokens(for: .ethereum)
-        XCTAssertTrue(
-            bucket.tokens.isEmpty,
-            "Flag OFF must short-circuit the cache to an empty bucket — no SwapKit fetch, no tag injection"
-        )
-        XCTAssertTrue(bucket.uniqueIds.isEmpty)
-    }
 
     func testMergeExternalAppendsNovelTokens() throws {
         // Base list (e.g. from 1inch + curated) has ETH-ETH + USDC. An external
@@ -76,8 +47,7 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
     }
 
     @MainActor
-    func testCacheSeededSnapshotReturnsBucketsWhenFlagOn() async {
-        UserDefaults.standard.set(true, forKey: flagKey)
+    func testCacheSeededSnapshotReturnsBuckets() async {
         let novel = CoinMeta(chain: .arbitrum, ticker: "NOVL", logo: "", decimals: 18, priceProviderId: "", contractAddress: "0x000000000000000000000000000000000000000A", isNativeToken: false)
         let bucket = DestinationTokenBucket(
             chain: .arbitrum,


### PR DESCRIPTION
## Summary

These features have all shipped, so they no longer need their opt-in/opt-out gates in **Settings → Advanced**. This removes the toggles and makes each feature always-on.

## Changes

### QBTC claim
- `QBTCConfig.isFeatureEnabled` now always returns `true`.
- Removed the `qbtcEnabled` `@AppStorage` flag and the "QBTC Claim" toggle.
- Removed `settingsAdvancedQBTCClaimToggle` localization key from all locales.

### SwapKit
- `SwapKitConfig.isFeatureEnabled` now always returns `true` (was defaulting on via UserDefaults).
- Removed the `swapkitEnabled` `@AppStorage` flag and the "SwapKit" toggle.
- Removed `settingsAdvancedSwapKitToggle` localization key from all locales.
- Trimmed the flag-off scenarios from `SwapKitFeatureFlagTests` / `SwapKitTokensPickerFlagTests`. The `forcedSwapProvider` debug picker and the SwapKit token-cache clear action remain.

### Custom RPC
- `CustomRPCConfig.isFeatureEnabled` now always returns `true` (was defaulting off via UserDefaults).
- Removed the `customRPCEnabled` `@AppStorage` flag and the "Custom RPC" toggle.
- Removed `settingsAdvancedCustomRPCToggle` localization key from all locales.

### MLDSA
- The `isMLDSAEnabled` flag was **orphaned** — nothing consumed it (MLDSA keygen runs through the QBTC claim path). The dead toggle and `@AppStorage` property are simply removed.
- Updated the stale `QBTCConfig` comment that referenced it.

## Notes

The `*Config.isFeatureEnabled` properties are kept (returning `true`) as a single source of truth so the existing call-site gates stay wired up and a future change could still dark-launch behind them.

## Testing

- `swiftlint lint` — 0 violations on all changed files.
- `sort_localizable.py` — all 8 locale files sorted.
- Feature-flag unit tests updated to lock the always-on behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized labels for forced swap provider selection and management across supported languages.

* **Chores**
  * Removed several Advanced Settings toggles (QBTC Claim, SwapKit, Custom RPC, MLDSA); those features are now always enabled.
  * Updated settings UI to reflect removed toggles and surface the forced swap provider picker.
  * Test suites updated to match the always-enabled feature behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->