### PR TITLE
feat(defi): disable Circle deposits, keep withdrawals

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapQuote.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/KyberSwap/KyberSwapQuote.swift
@@ -41,7 +41,7 @@ struct KyberSwapQuote: Codable, Hashable {
 
     /// Fallback gas price (1 gwei) applied only when the aggregator's
     /// `routeSummary.gasPrice` is missing or unparseable.
-    static let fallbackGasPriceWei = BigInt("1000000000") ?? BigInt(0)
+    static let fallbackGasPriceWei = BigInt(1_000_000_000)
 
     /// Parses a KyberSwap-returned `gasPrice` string into wei. The fallback
     /// applies only when the input is unparseable; valid sub-gwei responses

--- a/VultisigApp/VultisigApp/Components/ImageView/CachedAsyncImage.swift
+++ b/VultisigApp/VultisigApp/Components/ImageView/CachedAsyncImage.swift
@@ -10,9 +10,12 @@
 // swiftlint:disable no_raw_urlrequest no_raw_urlsession
 import SwiftUI
 
-//
-// This view uses a custom default
-/// <doc://com.apple.documentation/documentation/Foundation/URLSession>
+// Forked from Apple's `AsyncImage`; `URLRequest` is part of the public API
+// for cache keys, custom headers, and `URLSession` integration. Does not
+// belong behind `HTTPClient`/`TargetType` (which are typed-JSON-API helpers).
+
+///
+/// This view uses a custom default
 /// instance to load an image from the specified URL, and then display it.
 /// For example, you can display an icon that's stored on a server:
 ///
@@ -67,10 +70,6 @@ import SwiftUI
 ///         }
 ///     }
 ///
-
-// Forked from Apple's `AsyncImage`; `URLRequest` is part of the public API
-// for cache keys, custom headers, and `URLSession` integration. Does not
-// belong behind `HTTPClient`/`TargetType` (which are typed-JSON-API helpers).
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct CachedAsyncImage<Content>: View where Content: View {
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChainSelection/ViewModel/DefiSelectChainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChainSelection/ViewModel/DefiSelectChainViewModel.swift
@@ -17,10 +17,10 @@ class DefiSelectChainViewModel: ObservableObject {
     /// Indicates if Ethereum is available in the vault (required for Circle)
     private var hasEthereum: Bool = false
 
-    /// Snapshot of the vault's persisted Circle state when the sheet loaded.
-    /// Circle can no longer be enabled from this list: it only remains visible
-    /// for vaults that already had it enabled, so they can turn it off.
-    private var circleAlreadyEnabled: Bool = false
+    /// Whether the vault already has a Circle account. Circle can no longer be
+    /// enabled from this list, so it only appears for vaults that already
+    /// created an account, letting them hide it from their DeFi portfolio.
+    private var hasCircleAccount: Bool = false
 
     @Published var chains: [Chain] = []
 
@@ -41,8 +41,8 @@ class DefiSelectChainViewModel: ObservableObject {
     /// Returns true if Circle should be visible (vault has Ethereum and matches search filter)
     var shouldShowCircle: Bool {
         // Circle can no longer be newly enabled; only show it for vaults that
-        // already had it enabled so they can still turn it off.
-        guard circleAlreadyEnabled else { return false }
+        // already created a Circle account so they can still hide it.
+        guard hasCircleAccount else { return false }
 
         // Circle requires Ethereum chain in the vault
         guard hasEthereum else { return false }
@@ -62,7 +62,6 @@ class DefiSelectChainViewModel: ObservableObject {
         // Filter Defi enabled chains for selection
         selection = Set(vault.defiChains)
         isCircleEnabled = vault.isCircleEnabled
-        circleAlreadyEnabled = vault.isCircleEnabled
     }
 
     private func setupChains(for vault: Vault) {
@@ -71,6 +70,9 @@ class DefiSelectChainViewModel: ObservableObject {
 
         // Check if vault has Ethereum (required for Circle)
         hasEthereum = vault.chains.contains(.ethereum)
+
+        // Circle only remains available to vaults with an existing account
+        hasCircleAccount = vault.circleWalletAddress?.isEmpty == false
     }
 
     func isSelected(asset: CoinMeta) -> Bool {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChainSelection/ViewModel/DefiSelectChainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChainSelection/ViewModel/DefiSelectChainViewModel.swift
@@ -17,6 +17,11 @@ class DefiSelectChainViewModel: ObservableObject {
     /// Indicates if Ethereum is available in the vault (required for Circle)
     private var hasEthereum: Bool = false
 
+    /// Snapshot of the vault's persisted Circle state when the sheet loaded.
+    /// Circle can no longer be enabled from this list: it only remains visible
+    /// for vaults that already had it enabled, so they can turn it off.
+    private var circleAlreadyEnabled: Bool = false
+
     @Published var chains: [Chain] = []
 
     var filteredChains: [Chain] {
@@ -35,6 +40,10 @@ class DefiSelectChainViewModel: ObservableObject {
 
     /// Returns true if Circle should be visible (vault has Ethereum and matches search filter)
     var shouldShowCircle: Bool {
+        // Circle can no longer be newly enabled; only show it for vaults that
+        // already had it enabled so they can still turn it off.
+        guard circleAlreadyEnabled else { return false }
+
         // Circle requires Ethereum chain in the vault
         guard hasEthereum else { return false }
 
@@ -53,6 +62,7 @@ class DefiSelectChainViewModel: ObservableObject {
         // Filter Defi enabled chains for selection
         selection = Set(vault.defiChains)
         isCircleEnabled = vault.isCircleEnabled
+        circleAlreadyEnabled = vault.isCircleEnabled
     }
 
     private func setupChains(for vault: Vault) {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/ViewModel/DefiMainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/ViewModel/DefiMainViewModel.swift
@@ -50,7 +50,12 @@ final class DefiMainViewModel: ObservableObject {
             value: { vault.coins(for: $0).totalDefiBalanceInFiatDecimal }
         )
 
-        showsCircle = vault.isCircleEnabled && vault.chains.contains(.ethereum)
+        // Circle is no longer offered to new users: only show it for vaults
+        // that already created a Circle account, so they can still withdraw.
+        let hasCircleAccount = vault.circleWalletAddress?.isEmpty == false
+        showsCircle = vault.isCircleEnabled
+            && vault.chains.contains(.ethereum)
+            && hasCircleAccount
     }
 
     private var circleName: String { "Circle" }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleConstants.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleConstants.swift
@@ -12,6 +12,10 @@ struct CircleConstants {
     static let usdcMainnet = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     static let usdcSepolia = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
 
+    /// Circle deposits and new account onboarding are currently disabled.
+    /// Existing account holders can still view their balance and withdraw funds.
+    static let depositsEnabled = false
+
     struct Design {
         static let horizontalPadding: CGFloat = 20
         static let cardPadding: CGFloat = 16

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleSetupView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleSetupView.swift
@@ -239,6 +239,7 @@ struct CircleSetupView: View {
                     isSystemIcon: true,
                     action: { router.navigate(to: CircleRoute.deposit(vault: vault)) }
                 )
+                .disabled(!CircleConstants.depositsEnabled)
             }
         }
         .padding(CircleConstants.Design.cardPadding)
@@ -348,7 +349,7 @@ struct CircleSetupView: View {
             ) {
                 Task { await createWallet() }
             }
-            .disabled(model.isLoading)
+            .disabled(model.isLoading || !CircleConstants.depositsEnabled)
         }
         .padding(CircleConstants.Design.cardPadding)
         .background(cardBackground)

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -459,7 +459,6 @@ extension SendTransaction {
     }
 }
 
-
 // MARK: - Convenience computed (delegates to SendCryptoLogic)
 
 extension SendTransaction {


### PR DESCRIPTION
## Summary

Winds down Circle in the DeFi tab. Circle is now only available to vaults that **already created a Circle account** — those users can still view their balance and **withdraw**, but no new deposits or onboarding are possible, and Circle is hidden everywhere for everyone else.

### Behavior

| Vault state | DeFi portfolio row | Select-chains sheet | Deposit | Withdraw |
|---|---|---|---|---|
| No Circle account | Hidden | Hidden | — | — |
| Has Circle account, enabled | Shown | Shown (can toggle off) | **Disabled** | Works |
| Has Circle account, toggled off | Hidden | Shown (can toggle back on) | Disabled | Works |

"Has Circle account" = `vault.circleWalletAddress` is set.

## Implementation

- `CircleConstants.depositsEnabled = false` — single, self-documenting toggle.
- `CircleSetupView`: Deposit `DefiButton` and Open Account `PrimaryButton` disabled when deposits are off; Withdraw untouched.
- `DefiMainViewModel.showsCircle`: now `isCircleEnabled && chains.contains(.ethereum) && hasCircleAccount` (account = `circleWalletAddress` non-empty). The `isCircleEnabled` flag remains so account holders can still hide the row via the select-chains toggle.
- `DefiSelectChainViewModel.shouldShowCircle`: gated on `hasCircleAccount` (replacing the earlier `isCircleEnabled` snapshot), so the Circle toggle only appears for account holders. Account existence can't change within the sheet, so there's no mid-session disappearance.

## Incidental warning fixes (separate commit)

- `KyberSwapQuote`: fallback gas price uses non-failable `BigInt(1_000_000_000)` (the local `BigInt("...")` edit would have made it optional and broken `parseGasPriceWei`'s return type).
- `CachedAsyncImage`: resolved `orphaned_doc_comment` by moving the forked-from-Apple note above the doc comment.
- `SendTransaction`: removed stray blank line.

## Test plan

- [ ] Vault that never used Circle → no Circle row in DeFi tab, and Circle absent from the select-chains sheet.
- [ ] Vault with a Circle account + balance → row shown, Deposit disabled, Withdraw works.
- [ ] Vault with a Circle account → Circle appears in select-chains sheet; toggling off hides the portfolio row, toggling back on restores it.
- [ ] Vault with Circle account but no funds → Open Account path unreachable; Withdraw disabled only by zero balance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Circle deposits are disabled; existing account holders can still view balances and withdraw funds.
  * Deposit and onboarding actions are disabled when deposits are disabled to prevent deposit attempts.
  * Circle is hidden from chain selection unless the vault already has an existing Circle account.

* **Documentation**
  * Clarified notes around image loading and Circle integration (no user-facing API changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->