### PR TITLE
chore(zcash): update consensus branch ID to 30f33754

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitZcashSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitZcashSigner.swift
@@ -13,7 +13,7 @@
 //  Sighash: WalletCore's ZEC signer implements ZIP-243 (the Sapling
 //  signature digest with the personalised Blake2b-256). It reads the branch
 //  ID from `BitcoinTransactionPlan.branchID` — the existing native ZEC
-//  send (`UTXOChainsHelper.swift:138-139`) uses `f04dec4d`, and we match
+//  send (`UTXOChainsHelper.swift:138-139`) uses `30f33754`, and we match
 //  that here so the digest output is identical to a manually-sent ZEC
 //  transaction. (Deviating to the Sapling-v4 spec ID `0x76b809bb` would
 //  produce a different digest that the chain rejects.)
@@ -58,7 +58,7 @@ private let nu5VersionGroupID: UInt32 = 0x26A7270A
 /// (`UTXOChainsHelper.swift:138-139`). WalletCore reads it as the branch
 /// identifier for ZIP-243's personalised Blake2b. Diverging to the
 /// Sapling-v4-spec `0x76b809bb` would produce a digest the network rejects.
-private let zcashBranchID: Data = Data(hexString: "f04dec4d")!
+private let zcashBranchID: Data = Data(hexString: "30f33754")!
 
 enum SwapKitZcashSigner {
 

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
@@ -135,7 +135,7 @@ class UTXOChainsHelper {
         var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
 
         if coin == .zcash {
-            plan.branchID = Data(hexString: "f04dec4d")! // Correct hex string
+            plan.branchID = Data(hexString: "30f33754")!
         }
 
         input.plan = plan
@@ -208,7 +208,7 @@ class UTXOChainsHelper {
         }
 
         if coin == .zcash {
-            plan.branchID = Data(hexString: "f04dec4d")! // Correct hex string
+            plan.branchID = Data(hexString: "30f33754")!
         }
 
         input.plan = plan
@@ -220,7 +220,7 @@ class UTXOChainsHelper {
         var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
 
         if coin == .zcash {
-            plan.branchID = Data(hexString: "f04dec4d")! // Correct hex string
+            plan.branchID = Data(hexString: "30f33754")!
         }
 
         return plan
@@ -276,7 +276,7 @@ class UTXOChainsHelper {
         var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
 
         if coin == .zcash {
-            plan.branchID = Data(hexString: "f04dec4d")!
+            plan.branchID = Data(hexString: "30f33754")!
         }
 
         // Build raw transaction manually using plan data

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitZcashTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitZcashTests.swift
@@ -138,7 +138,7 @@ final class SwapKitZcashTests: XCTestCase {
         // BranchID matches the existing native ZEC send path
         // (`UTXOChainsHelper.swift:138-139`). Diverging would produce a
         // digest the network rejects.
-        XCTAssertEqual(input.plan.branchID.hexString, "f04dec4d")
+        XCTAssertEqual(input.plan.branchID.hexString, "30f33754")
     }
 
     func testZcashSignerDerivesToAddressFromPSBTOutputScriptNotTargetAddress() throws {


### PR DESCRIPTION
## Summary

Updates Zcash's consensus branch ID from `f04dec4d` to `30f33754`.

The branch ID is injected onto the frozen `BitcoinTransactionPlan` and read by WalletCore as the ZIP-243 personalised Blake2b branch identifier. Changing it affects the signature digest, so the new value must match the network's active consensus epoch.

https://blockchair.com/zcash/transaction/73f57200dfbf01f8847380f4cc803ef6356370659879ef0ce6559a5fdb699174

## Changes

- `UTXOChainsHelper.swift` — all four native ZEC signing/plan paths (`getBitcoinSigningInputData`, `getBitcoinPreSigningInputData`, `getBitcoinTransactionPlan`, `getUnsignedTransactionHex`).
- `SwapKitZcashSigner.swift` — `zcashBranchID` constant + stale comment reference.
- `SwapKitZcashTests.swift` — updated branch ID assertion.

## Notes

The value is stored as the literal hex string `30f33754` (matching the existing `Data(hexString:)` convention in this file), as requested.

⚠️ HIGH security tier — signing-critical change, requires maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Zcash transaction signing to use the correct branch ID value, ensuring all Zcash transactions are now properly validated and compatible with the ZEC network according to current protocol specifications.

## Tests
* Updated test cases to validate the corrected Zcash branch ID implementation across transaction signing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->