### PR TITLE
fix(zcash): enable ZIP-317 fee calculation for sends

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
@@ -97,6 +97,10 @@ class UTXOChainsHelper {
         input.byteFee = Int64(byteFee)
         input.hashType = BitcoinScript.hashTypeForCoin(coinType: coin)
         input.useMaxAmount = sendMaxAmount
+        // Zcash enforces ZIP-317: the fee must cover the tx's logical actions,
+        // not just its byte size. Enable it so the planner below computes a
+        // conforming fee and the node doesn't reject the swap broadcast.
+        input.zip0317 = coin == .zcash
         for inputUtxo in keysignPayload.utxos {
             let lockScript = BitcoinScript.lockScriptForAddress(address: keysignPayload.coin.address, coin: coin)
 

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
@@ -154,6 +154,11 @@ class UTXOChainsHelper {
             $0.toAddress = keysignPayload.toAddress
             $0.changeAddress = keysignPayload.coin.address
             $0.byteFee = Int64(byteFee)
+            // Zcash enforces ZIP-317 fees: the fee must cover the tx's logical
+            // actions, not just its byte size. Enabling this lets WalletCore's
+            // planner compute a conforming fee and avoids node rejection
+            // ("tx unpaid action limit exceeds limit of 0").
+            $0.zip0317 = coin == .zcash
             $0.coinType = coin.rawValue
             if let memoData = keysignPayload.memo?.data(using: .utf8) {
                 $0.outputOpReturn = memoData


### PR DESCRIPTION
## Problem

Sending a Zcash transaction fails with:

> Error: 66: tx unpaid action limit exceeds limit of 0

This is a **ZIP-317** enforcement rejection. Since NU5, Zcash grades transactions by *logical actions* (≈ `max(transparent_inputs, transparent_outputs)`) and requires the fee to cover them. The relay default `-txunpaidactionlimit` is `0`, so any tx whose fee falls below the conventional minimum (`5000 zat × max(2, logical_actions)`, i.e. ≥ 0.0001 ZEC) is rejected.

The signing paths built `BitcoinSigningInput` with only a flat `byteFee × size` fee, which could land below the ZIP-317 conventional fee and get rejected.

## Fix

Set `BitcoinSigningInput.zip0317 = true` for Zcash so WalletCore's planner computes a ZIP-317-conforming fee. Applied to both fee-planning paths:

- **Regular send** — `getBitcoinSigningInput`
- **Swap (THORChain/Maya)** — `getSigningInputData`, where `AnySigner.plan` runs

The SwapKit Zcash path (`SwapKitZcashSigner`) is unaffected — it signs a provider-supplied PSBT with a frozen plan/fee and never runs WalletCore's fee planner.

https://blockchair.com/zcash/transaction/f03de22ceda874dfbf8718d997699d4f2c272cb102d1c9d4ee6674a752c18eed

## Test plan

- [ ] Send a transparent ZEC transaction and confirm it broadcasts without the "unpaid action limit" error.
- [ ] Perform a ZEC → asset swap via THORChain/Maya and confirm the broadcast succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)