### PR TITLE
fix(circle): iOS USDC withdraw signs a no-op — route through native-coin path (#4484)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleViewLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleViewLogic.swift
@@ -139,10 +139,6 @@ struct CircleViewLogic {
             data: dataHex
         )
 
-        guard let coin = vault.coins.first(where: { $0.chain == chain && $0.ticker == "USDC" }) else {
-            throw CircleServiceError.keysignError("Missing USDC Coin")
-        }
-
         let chainSpecific = BlockChainSpecific.Ethereum(
             maxFeePerGasWei: boostedGasPrice,
             priorityFeeWei: boostedPriorityFee,
@@ -150,13 +146,42 @@ struct CircleViewLogic {
             gasLimit: gasLimit
         )
 
-        let payloadWithData = KeysignPayload(
+        return try makeWithdrawalKeysignPayload(
+            vault: vault,
+            chain: chain,
+            to: to,
+            value: value,
+            memoHex: dataHex,
+            chainSpecific: chainSpecific
+        )
+    }
+
+    /// Assembles the keysign payload for a Circle MSCA withdrawal.
+    ///
+    /// A withdrawal is a contract call to the MSCA — `execute(USDC, 0, transfer(vault, amount))`
+    /// — whose calldata travels in `memo`. The EVM signer only forwards `memo` as `tx.data` on
+    /// the native-coin path; an ERC-20 coin instead builds a plain `transfer(toAddress, toAmount)`
+    /// and drops the memo, which with `toAmount == 0` signs a no-op. The payload coin must
+    /// therefore be the chain's native coin, not the USDC token.
+    func makeWithdrawalKeysignPayload(
+        vault: Vault,
+        chain: Chain,
+        to: String,
+        value: BigInt,
+        memoHex: String,
+        chainSpecific: BlockChainSpecific
+    ) throws -> KeysignPayload {
+        guard let coin = vault.coins.first(where: { $0.chain == chain && $0.isNativeToken }) else {
+            throw CircleServiceError.keysignError("Missing native coin for \(chain.name)")
+        }
+
+        return KeysignPayload(
             coin: coin,
             toAddress: to,
             toAmount: value,
             chainSpecific: chainSpecific,
             utxos: [],
-            memo: dataHex, // Pass contract data as hex memo
+            memo: memoHex, // execute(...) calldata; only forwarded as tx.data on the native-coin path
             swapPayload: nil, // No swap payload = shows as Send
             approvePayload: nil,
             vaultPubKeyECDSA: vault.pubKeyECDSA,
@@ -171,8 +196,6 @@ struct CircleViewLogic {
             skipBroadcast: false,
             signData: nil
         )
-
-        return payloadWithData
     }
 
     static func getChainDetails() -> (chain: Chain, usdcContract: String) {

--- a/VultisigApp/VultisigAppTests/Defi/CircleWithdrawTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/CircleWithdrawTests.swift
@@ -1,0 +1,178 @@
+//
+//  CircleWithdrawTests.swift
+//  VultisigAppTests
+//
+//  Covers the Circle USDC-yield withdraw signing path. The regression guard is
+//  `makeWithdrawalKeysignPayload`: a withdraw is a contract call to the MSCA —
+//  `execute(USDC, 0, transfer(vault, amount))` carried in `memo` — and the EVM
+//  signer only forwards `memo` as `tx.data` on the NATIVE-coin path. If the
+//  payload coin is the USDC ERC-20 token, the signer instead builds
+//  `transfer(MSCA, 0)` and drops the memo — a no-op that confirms but moves 0
+//  USDC. `getWithdrawalValues` is the pure ABI encoder for that calldata.
+//
+
+import BigInt
+import WalletCore
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class CircleWithdrawTests: XCTestCase {
+
+    private let usdcContract = CircleConstants.usdcMainnet
+    private let mscaAddress = "0x2222222222222222222222222222222222222222"
+    private let recipient = "0x1111111111111111111111111111111111111111"
+
+    // execute(address,uint256,bytes)
+    private let executeSelector = "b61d27f6"
+    // ERC-20 transfer(address,uint256)
+    private let transferSelector = "a9059cbb"
+
+    // MARK: - getWithdrawalValues — ERC-20 (USDC) path
+
+    func testWithdrawalValuesEncodesExecuteWrappingTransferForUsdc() throws {
+        let vault = makeVault(mscaAddress: mscaAddress)
+        let amount = BigInt(1_000_000) // 1 USDC (6 decimals) = 0xF4240
+
+        let (to, value, data) = try CircleService.shared.getWithdrawalValues(
+            vault: vault,
+            recipientAddress: recipient,
+            amount: amount,
+            info: .init(usdcContract: usdcContract),
+            isNative: false
+        )
+
+        // Call targets the MSCA and sends 0 ETH value — the USDC moves via the inner transfer.
+        XCTAssertEqual(to, mscaAddress)
+        XCTAssertEqual(value, BigInt(0))
+
+        let hex = data.hexString.lowercased()
+        XCTAssertTrue(hex.hasPrefix(executeSelector), "outer call must be execute(address,uint256,bytes)")
+        XCTAssertTrue(hex.contains(transferSelector), "inner calldata must be ERC-20 transfer(address,uint256)")
+        XCTAssertTrue(hex.contains(noPrefix(usdcContract)), "execute target should be the USDC contract")
+        XCTAssertTrue(hex.contains(noPrefix(recipient)), "inner transfer recipient should be the vault address")
+        XCTAssertTrue(hex.contains("f4240"), "inner transfer amount (1_000_000 = 0xF4240) should be encoded")
+    }
+
+    // MARK: - getWithdrawalValues — native ETH path
+
+    func testWithdrawalValuesEncodesPlainExecuteForNative() throws {
+        let vault = makeVault(mscaAddress: mscaAddress)
+        let amount = BigInt(1_000_000)
+
+        let (to, value, data) = try CircleService.shared.getWithdrawalValues(
+            vault: vault,
+            recipientAddress: recipient,
+            amount: amount,
+            info: .init(usdcContract: usdcContract),
+            isNative: true
+        )
+
+        XCTAssertEqual(to, mscaAddress)
+        XCTAssertEqual(value, amount, "native withdraw forwards the ETH value to the execute call")
+
+        let hex = data.hexString.lowercased()
+        XCTAssertTrue(hex.hasPrefix(executeSelector))
+        XCTAssertFalse(hex.contains(transferSelector), "native withdraw has empty inner data — no ERC-20 transfer")
+        XCTAssertTrue(hex.contains(noPrefix(recipient)), "execute target is the recipient for a native withdraw")
+    }
+
+    func testWithdrawalValuesThrowsForInvalidRecipient() {
+        let vault = makeVault(mscaAddress: mscaAddress)
+        XCTAssertThrowsError(try CircleService.shared.getWithdrawalValues(
+            vault: vault,
+            recipientAddress: "not-an-address",
+            amount: BigInt(1),
+            info: .init(usdcContract: usdcContract),
+            isNative: false
+        ))
+    }
+
+    func testWithdrawalValuesThrowsWhenWalletAddressMissing() {
+        let vault = makeVault(mscaAddress: nil)
+        XCTAssertThrowsError(try CircleService.shared.getWithdrawalValues(
+            vault: vault,
+            recipientAddress: recipient,
+            amount: BigInt(1),
+            info: .init(usdcContract: usdcContract),
+            isNative: false
+        ))
+    }
+
+    // MARK: - makeWithdrawalKeysignPayload — the #4484 regression guard
+
+    func testWithdrawalPayloadUsesNativeCoinNotUsdc() throws {
+        let vault = makeVault(mscaAddress: mscaAddress)
+        vault.coins = [
+            makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        ]
+        let memo = "0xb61d27f6deadbeef"
+
+        let payload = try CircleViewLogic().makeWithdrawalKeysignPayload(
+            vault: vault,
+            chain: .ethereum,
+            to: mscaAddress,
+            value: BigInt(0),
+            memoHex: memo,
+            chainSpecific: ethChainSpecific()
+        )
+
+        // Crux of #4484: an ERC-20 coin makes the EVM signer drop the memo and sign
+        // transfer(MSCA, 0) — a no-op. The payload must carry the NATIVE coin so the
+        // signer routes the execute() calldata through `memo → tx.data`.
+        XCTAssertTrue(payload.coin.isNativeToken, "withdraw payload must use the native coin")
+        XCTAssertEqual(payload.coin.ticker, "ETH")
+        XCTAssertNotEqual(payload.coin.ticker, "USDC")
+
+        // The execute() calldata must survive verbatim, targeting the MSCA with 0 value.
+        XCTAssertEqual(payload.toAddress, mscaAddress)
+        XCTAssertEqual(payload.toAmount, BigInt(0))
+        XCTAssertEqual(payload.memo, memo)
+    }
+
+    func testWithdrawalPayloadThrowsWhenNoNativeCoin() {
+        let vault = makeVault(mscaAddress: mscaAddress)
+        vault.coins = [makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)]
+
+        XCTAssertThrowsError(try CircleViewLogic().makeWithdrawalKeysignPayload(
+            vault: vault,
+            chain: .ethereum,
+            to: mscaAddress,
+            value: BigInt(0),
+            memoHex: "0x",
+            chainSpecific: ethChainSpecific()
+        ))
+    }
+
+    // MARK: - Helpers
+
+    private func noPrefix(_ address: String) -> String {
+        String(address.dropFirst(2)).lowercased()
+    }
+
+    private func makeVault(mscaAddress: String?) -> Vault {
+        let vault = Vault(
+            name: "Test Vault",
+            signers: [],
+            pubKeyECDSA: "test-pub-ecdsa",
+            pubKeyEdDSA: "test-pub-eddsa",
+            keyshares: [],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        vault.circleWalletAddress = mscaAddress
+        return vault
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {
+        let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: isNative)
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+
+    private func ethChainSpecific() -> BlockChainSpecific {
+        .Ethereum(maxFeePerGasWei: BigInt(1), priorityFeeWei: BigInt(1), nonce: 0, gasLimit: BigInt(21_000))
+    }
+}


### PR DESCRIPTION
Fixes #4484.

## Problem
iOS Circle USDC-yield **withdrawals** silently move **0 USDC** — the tx confirms (`status 0x1`) but nothing transfers. `CircleViewLogic.getWithdrawalPayload` set the keysign `coin` to the **USDC ERC-20 token**, so the EVM signer took the `ERC20Helper` path: it builds `USDC.transfer(toAddress, toAmount)` and **ignores `memo`**. With `toAmount = 0` and `toAddress = MSCA`, the signed tx becomes `transfer(MSCA, 0)` — a no-op. The MSCA `execute(USDC, 0, transfer(vault, amount))` calldata sits in `memo`, which is only forwarded as `tx.data` on the **native-coin** path.

On-chain proof from the issue (`0xb43cff…46ca`): `to` = USDC contract, calldata `transfer(0x1125…abc2, 0)` → 0 USDC moved.

## Fix
Select the chain's **native coin** for the withdraw payload, so the generic contract-call path runs and `memo → tx.data` carries the `execute()` calldata. The resulting tx is `to=MSCA, value=0, data=execute(USDC, 0, transfer(vault, amount))`, and the inner transfer actually executes.

This matches the other platforms (iOS was the only one wrong):
- **Android** — `srcToken = nativeCoin` (`WithdrawUsdcCircleStrategy.kt`)
- **SDK / extension** — `chainFeeCoin[Ethereum]` (`vultisig-sdk .../circleWithdraw/build.ts`)

The coin selection + `KeysignPayload` assembly is extracted into a pure `makeWithdrawalKeysignPayload(...)` so the regression is unit-testable (the bug lived inside a networked `async` function). The execute()-calldata encoder (`CircleService.getWithdrawalValues`) was already correct and is unchanged.

## Tests — `VultisigAppTests/Defi/CircleWithdrawTests.swift` (6 cases, all green)
- `getWithdrawalValues` encodes `execute(address,uint256,bytes)` wrapping the inner ERC-20 `transfer(address,uint256)` for USDC — asserts both selectors (`0xb61d27f6` / `0xa9059cbb`), MSCA target, value 0, USDC contract + recipient + amount; plain `execute` with empty inner data for the native path; invalid-recipient and missing-MSCA throw.
- `makeWithdrawalKeysignPayload` picks the **native** coin (not USDC) and preserves the calldata in `memo`, `to=MSCA`, `value=0` — the #4484 no-op guard.

SwiftLint clean; `make generate` clean; full app+test build green; `CircleWithdrawTests` 6/6.

## ⚠️ Known caveat (acceptance criterion #4: verify screen)
With a native-coin payload the Send/verify hero reads from the payload, so it will show **"0 ETH → MSCA"** instead of the USDC amount (the real amount/recipient live inside the `execute()` calldata). Blockaid simulation *may* decode and render a proper "transfer N USDC" hero, but that's **unverified pending an on-device run**. This is a UX-display follow-up, not a correctness blocker — surfacing the decoded USDC amount on verify can be a separate change.

## Out of scope
- The separate "Circle wallet not deployed" (undeployed SCA) issue.
- Dead code `CircleService.getKeysignPayload` (the unused native-coin builder, i.e. the *correct* pattern) is left intact to keep this PR focused — candidate for a follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Circle USDC withdrawal payload construction to ensure correct processing of withdrawal requests.

* **Tests**
  * Added comprehensive test coverage for Circle withdrawal functionality, including validation for ERC-20 and native token paths, error handling, and regression checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->