### PR TITLE
fix(swap): show SwapKit UTXO/Cardano network fee from the transaction plan

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -67,7 +67,7 @@ extension SwapTransaction {
     private var fromAmountString: String { fromAmount.description }
 
     var fee: BigInt {
-        SwapCryptoLogic.fee(quote: quote, thorchainFee: thorchainFee)
+        SwapCryptoLogic.fee(quote: quote, fromCoin: fromCoin, thorchainFee: thorchainFee)
     }
 
     var amountInCoinDecimal: BigInt {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -68,14 +68,26 @@ enum SwapCryptoLogic {
 
     // MARK: - Quote-derived
 
-    static func fee(quote: SwapQuote?, thorchainFee: BigInt) -> BigInt {
+    static func fee(quote: SwapQuote?, fromCoin: Coin, thorchainFee: BigInt) -> BigInt {
         switch quote {
         case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
             return thorchainFee
         case let .oneinch(_, fee), let .kyberswap(_, fee), let .lifi(_, fee, _):
             return fee ?? 0
         case let .swapkit(_, fee, _):
-            return fee ?? 0
+            // SwapKit's wire `inbound` fee for UTXO/Cardano sources doesn't
+            // reflect the realized on-chain miner fee — it renders as a
+            // misleadingly small amount on the Network Fee row (e.g. a BTC swap
+            // showing 0.0000008 BTC). For these chains compute the fee the same
+            // way Send does: from the WalletCore transaction plan, carried in
+            // `thorchainFee` (populated in `SwapDetailsViewModel.updateFees`).
+            // EVM/other SwapKit sources keep the wire-reported inbound fee.
+            switch fromCoin.chain.chainType {
+            case .UTXO, .Cardano:
+                return thorchainFee
+            default:
+                return fee ?? 0
+            }
         case nil:
             return .zero
         }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -332,7 +332,7 @@ extension SwapDetailsViewModel {
     }
 
     var fee: BigInt {
-        SwapCryptoLogic.fee(quote: quote, thorchainFee: thorchainFee)
+        SwapCryptoLogic.fee(quote: quote, fromCoin: fromCoin, thorchainFee: thorchainFee)
     }
 
     var fromAmountDecimal: Decimal {

--- a/VultisigApp/VultisigAppTests/Swap/SwapCryptoLogicTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapCryptoLogicTests.swift
@@ -31,37 +31,74 @@ final class SwapCryptoLogicTests: XCTestCase {
     // MARK: - fee
 
     func testFeeForThorchainQuoteUsesThorchainFee() {
-        let result = SwapCryptoLogic.fee(quote: .thorchain(makeThorQuote()), thorchainFee: BigInt(7_777))
+        let result = SwapCryptoLogic.fee(quote: .thorchain(makeThorQuote()), fromCoin: makeBTC(), thorchainFee: BigInt(7_777))
         XCTAssertEqual(result, BigInt(7_777))
     }
 
     func testFeeForMayachainQuoteUsesThorchainFee() {
-        let result = SwapCryptoLogic.fee(quote: .mayachain(makeThorQuote()), thorchainFee: BigInt(99))
+        let result = SwapCryptoLogic.fee(quote: .mayachain(makeThorQuote()), fromCoin: makeBTC(), thorchainFee: BigInt(99))
         XCTAssertEqual(result, BigInt(99))
     }
 
     func testFeeForOneInchQuoteUsesQuoteFee() {
-        let result = SwapCryptoLogic.fee(quote: .oneinch(makeEVMQuote(), fee: BigInt(42)), thorchainFee: BigInt(123))
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let result = SwapCryptoLogic.fee(quote: .oneinch(makeEVMQuote(), fee: BigInt(42)), fromCoin: eth, thorchainFee: BigInt(123))
         XCTAssertEqual(result, BigInt(42))
     }
 
     func testFeeForKyberSwapQuoteUsesQuoteFee() {
-        let result = SwapCryptoLogic.fee(quote: .kyberswap(makeEVMQuote(), fee: BigInt(11)), thorchainFee: .zero)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let result = SwapCryptoLogic.fee(quote: .kyberswap(makeEVMQuote(), fee: BigInt(11)), fromCoin: eth, thorchainFee: .zero)
         XCTAssertEqual(result, BigInt(11))
     }
 
     func testFeeForLifiQuoteUsesQuoteFee() {
-        let result = SwapCryptoLogic.fee(quote: .lifi(makeEVMQuote(), fee: BigInt(5), integratorFee: nil), thorchainFee: .zero)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let result = SwapCryptoLogic.fee(quote: .lifi(makeEVMQuote(), fee: BigInt(5), integratorFee: nil), fromCoin: eth, thorchainFee: .zero)
         XCTAssertEqual(result, BigInt(5))
     }
 
     func testFeeForEVMQuoteWithNilFeeReturnsZero() {
-        let result = SwapCryptoLogic.fee(quote: .oneinch(makeEVMQuote(), fee: nil), thorchainFee: .zero)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let result = SwapCryptoLogic.fee(quote: .oneinch(makeEVMQuote(), fee: nil), fromCoin: eth, thorchainFee: .zero)
         XCTAssertEqual(result, .zero)
     }
 
     func testFeeForNilQuoteReturnsZero() {
-        XCTAssertEqual(SwapCryptoLogic.fee(quote: nil, thorchainFee: .zero), .zero)
+        XCTAssertEqual(SwapCryptoLogic.fee(quote: nil, fromCoin: makeBTC(), thorchainFee: .zero), .zero)
+    }
+
+    // SwapKit UTXO sources surface a misleading wire `inbound` fee; the Network
+    // Fee row must instead show the transaction-plan fee (carried in
+    // `thorchainFee`), matching the Send flow.
+    func testFeeForSwapKitUTXOSourceUsesPlanFee() {
+        let result = SwapCryptoLogic.fee(
+            quote: makeSwapKitQuote(fee: BigInt(80)),
+            fromCoin: makeBTC(),
+            thorchainFee: BigInt(12_345)
+        )
+        XCTAssertEqual(result, BigInt(12_345))
+    }
+
+    func testFeeForSwapKitCardanoSourceUsesPlanFee() {
+        let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true)
+        let result = SwapCryptoLogic.fee(
+            quote: makeSwapKitQuote(fee: BigInt(7)),
+            fromCoin: ada,
+            thorchainFee: BigInt(170_000)
+        )
+        XCTAssertEqual(result, BigInt(170_000))
+    }
+
+    // EVM (and other non-plan) SwapKit sources keep the wire-reported inbound fee.
+    func testFeeForSwapKitEVMSourceUsesQuoteFee() {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let result = SwapCryptoLogic.fee(
+            quote: makeSwapKitQuote(fee: BigInt(42)),
+            fromCoin: eth,
+            thorchainFee: BigInt(999)
+        )
+        XCTAssertEqual(result, BigInt(42))
     }
 
     // MARK: - inboundFeeDecimal
@@ -161,6 +198,44 @@ final class SwapCryptoLogicTests: XCTestCase {
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {
         let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: isNative)
         return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+
+    private func makeBTC() -> Coin {
+        makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
+    }
+
+    /// SwapKit quote fixture. The `fee` function only branches on the quote case
+    /// and the source chain, so the response body shape (EVM here) is irrelevant.
+    private func makeSwapKitQuote(fee: BigInt?) -> SwapQuote {
+        let json = """
+        {
+          "swapId": "swap-1",
+          "routeId": "route-1",
+          "providers": ["Chainflip"],
+          "sellAsset": "BTC.BTC",
+          "buyAsset": "ETH.ETH",
+          "sellAmount": "0.01",
+          "expectedBuyAmount": "0.1",
+          "expectedBuyAmountMaxSlippage": "0.1",
+          "sourceAddress": "bc1from",
+          "destinationAddress": "0xto",
+          "targetAddress": "0xtarget",
+          "meta": { "txType": "EVM" },
+          "tx": {
+            "from": "0xfrom",
+            "to": "0xto",
+            "value": "0",
+            "data": "0x",
+            "gas": "200000",
+            "gasPrice": "20000000000"
+          },
+          "fees": []
+        }
+        """
+        // Test fixture: a decode failure here is a test bug, so force-try is acceptable.
+        // swiftlint:disable:next force_try
+        let response = try! JSONDecoder().decode(SwapKitSwapResponse.self, from: Data(json.utf8))
+        return .swapkit(response, fee: fee, subProvider: "Chainflip")
     }
 
     private func makeThorQuote(


### PR DESCRIPTION
## Problem

On the Swap screen, swapping **BTC → ETH via SwapKit** showed the Network Fee as `0.0000008 BTC`. That value is SwapKit's wire `inbound` fee, which doesn't reflect the realized on-chain miner fee — it renders as a misleadingly tiny amount.

By contrast, the **Send** flow computes the BTC fee from a WalletCore transaction plan and displays the real total fee in BTC.

## Fix

Route SwapKit swaps from a UTXO (BTC/LTC/DOGE/BCH/DASH/ZEC) or Cardano source through the **same transaction-plan fee the Send flow uses**, rather than the inbound fee.

That plan fee is already computed into `thorchainFee` (`SwapCryptoLogic.thorchainFee` → `getBitcoinTransactionPlan(...).fee` for `.UTXO` / `CardanoHelper.calculateDynamicFee` for `.Cardano`), populated in both fee-recompute paths:
- `SwapDetailsViewModel.updateFees`
- `SwapVerifyViewModel` refresh

`SwapCryptoLogic.fee` now takes `fromCoin` so it can branch on the source chain type:
- **SwapKit + UTXO/Cardano** → transaction-plan fee (`thorchainFee`)
- **SwapKit + EVM/other** → unchanged (wire-reported inbound fee)
- THORChain/Maya/1inch/Kyber/LI.FI → unchanged

This also makes the gas-token balance check more accurate for these swaps, since it reads the same `fee`.

## Affected display

The corrected fee flows through `swapGasString` → the Network Fee row on both the swap details summary and the Verify screen.

## Tests

- Updated existing `SwapCryptoLogicTests.fee` cases for the new `fromCoin` parameter.
- Added coverage for the new branches: SwapKit UTXO source and Cardano source use the plan fee; SwapKit EVM source keeps the inbound fee.
- `xcodebuild build-for-testing` succeeds; `SwapCryptoLogicTests` (28 tests) pass; SwiftLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap fee calculation to account for the origin blockchain. UTXO and Cardano-based swaps now route through network fee sources, while other blockchain types use their respective fee mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->