### PR TITLE
fix(evm): consistent network fee display across signing devices

### DIFF
--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -149,20 +149,15 @@ enum SendCryptoLogic {
 
     // MARK: - Display: fees
 
-    /// Human-readable gas/fee row. EVM shows Gwei. UTXO + Cardano show the
-    /// planned `fee` (a true amount). Everything else shows `gas` (per-unit).
+    /// Human-readable gas/fee row. EVM, UTXO and Cardano show the total `fee`
+    /// (a true amount) in the native coin, matching the joining device's
+    /// `JoinKeysignGasViewModel`. Everything else shows `gas` (per-unit).
     /// Caller resolves `gasNativeCoin` — for native sends it's the same coin;
     /// for ERC20s it's the EVM-native sibling looked up against the vault.
     static func gasInReadable(coin: Coin, gasNativeCoin: Coin, gas: BigInt, fee: BigInt) -> String {
-        if coin.chain.chainType == .EVM {
-            guard let weiPerGWeiDecimal = Decimal(string: EVMHelper.weiPerGWei.description) else {
-                return .empty
-            }
-            return "\(gasDecimal(gas: gas) / weiPerGWeiDecimal) \(coin.chain.feeUnit)"
-        }
-
         let decimals = gasNativeCoin.decimals
-        let feeToDisplay = (coin.chainType == .UTXO || coin.chainType == .Cardano) ? fee : gas
+        let usesTotalFee = coin.chainType == .EVM || coin.chainType == .UTXO || coin.chainType == .Cardano
+        let feeToDisplay = usesTotalFee ? fee : gas
         let feeDecimal = Decimal(feeToDisplay)
 
         return "\((feeDecimal / pow(10, decimals)).formatToDecimal(digits: decimals).description) \(gasNativeCoin.ticker)"


### PR DESCRIPTION
## Summary
- When sending BNB on BSC (any EVM chain), the **initiating device** showed the network fee as a gas *price* in Gwei (e.g. `0.05 Gwei`), while the **joining device** showed the *total* fee in the native coin (e.g. `0.00000105 BNB`).
- Both numbers describe the same transaction (`0.00000105 BNB ÷ 21000 gas = 0.05 Gwei`) but in different units, so the devices looked inconsistent.
- The initiating device was also internally inconsistent: it paired the Gwei *price* (crypto) with the fiat of the *total* fee.

## Root Cause
For EVM, `chainSpecific.gas` = `maxFeePerGasWei` (per-unit price) and `chainSpecific.fee` = `maxFeePerGas * gasLimit` (total). `SendCryptoLogic.gasInReadable` displayed `gas` in Gwei for EVM, whereas `JoinKeysignGasViewModel` displayed the total `fee` in the native coin.

## Fix
- Changed the EVM branch of `SendCryptoLogic.gasInReadable` to display the total `fee` in the native coin, matching `JoinKeysignGasViewModel`. EVM now joins UTXO/Cardano in showing the true total fee.
- This affects the Send verify screen, Send done screen, Referral overview, and FunctionCall verify screen — all of which already pair this value with the total-fee fiat, so they become internally consistent too.
- The **Gwei** unit is unchanged in the gas-editing screen (`SendGasSettingsViewModel`), where editing a gas price in Gwei is the correct unit.

## Test Plan
- [ ] Send BNB on BSC from a multi-device vault; verify the network fee reads the same on both the initiating and joining devices (e.g. `0.00000105 BNB`).
- [ ] Verify EVM ERC-20 sends show the fee in the native sibling coin.
- [ ] Confirm UTXO/Cardano/Cosmos/Solana fee displays are unchanged.
- [ ] Confirm the gas-editing screen still shows Gwei.
- [ ] SwiftLint passes
- [ ] xcodebuild build succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized fee display across EVM, UTXO, and Cardano networks to show total fees in a consistent format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->