### PR TITLE
Swap Paired/Fast Sign CTA order to match Figma

### DIFF
--- a/VultisigApp/VultisigApp/Components/Buttons/SigningCTAButtons.swift
+++ b/VultisigApp/VultisigApp/Components/Buttons/SigningCTAButtons.swift
@@ -7,11 +7,11 @@ import SwiftUI
 
 /// Bottom call-to-action row for fast/paired signing confirmation screens.
 ///
-/// Fast Vaults render two side-by-side buttons: a primary, flexible-width
-/// "Fast Sign" (server co-sign via the FastVault password sheet) and a
-/// fixed-width secondary "Paired" button (paired-device signing). Secure
-/// (N-of-M) vaults render a single full-width button that triggers the
-/// paired path.
+/// Fast Vaults render two side-by-side buttons: a fixed-width secondary
+/// "Paired" button (paired-device signing) on the left and a primary,
+/// flexible-width "Fast Sign" (server co-sign via the FastVault password
+/// sheet) on the right. Secure (N-of-M) vaults render a single full-width
+/// button that triggers the paired path.
 struct SigningCTAButtons: View {
     let isFastVault: Bool
     let isLoading: Bool
@@ -51,15 +51,6 @@ struct SigningCTAButtons: View {
     private var fastVaultButtons: some View {
         HStack(spacing: 12) {
             PrimaryButton(
-                title: "fastSign".localized,
-                isLoading: isLoading,
-                type: .primary,
-                size: .medium,
-                action: onFastSign
-            )
-            .frame(maxWidth: .infinity)
-
-            PrimaryButton(
                 title: "paired".localized,
                 leadingView: {
                     Icon(named: "devices", color: pairedIconColor, size: 20)
@@ -69,6 +60,15 @@ struct SigningCTAButtons: View {
                 action: onPairedSign
             )
             .fixedSize(horizontal: true, vertical: false)
+
+            PrimaryButton(
+                title: "fastSign".localized,
+                isLoading: isLoading,
+                type: .primary,
+                size: .medium,
+                action: onFastSign
+            )
+            .frame(maxWidth: .infinity)
         }
     }
 


### PR DESCRIPTION
Closes #4501

Swap the Fast Vault signing CTA order so **Paired** (fixed-width secondary, left) and **Fast Sign** (flexible-width primary, right) match the Figma layout. iOS counterpart of Android vultisig/vultisig-android#4765.

This is a pure layout swap in the shared `SigningCTAButtons` component, so it fixes all 5 verify screens at once (Send / Swap / FunctionCall / Circle / CustomMessage). Each button keeps its existing props and width modifier (`fixedSize` vs `maxWidth: .infinity`) — only the order is reversed — and the file's doc comment was updated to describe the new left/right arrangement.

### Deferred: Fast-Sign-only disabled state
The Figma secondary note ("disabled view greys only Fast Sign, leaving Paired enabled") was intentionally **not** applied. `SigningCTAButtons.body` gates the whole group via `.disabled(isDisabled)`, and every call site binds `isDisabled` to transaction-readiness flags (`signButtonDisabled` / `isButtonDisabled` / `!signButtonEnabled`). That gate means "the transaction isn't ready to sign" and must block **both** signing paths — wiring a Fast-Sign-only disabled state to this shared readiness gate would let paired-signing start on an unconfirmed/invalid transaction. Greying only Fast Sign would need a separate Fast-Sign-specific signal plus design confirmation, consistent with the issue's own "confirm with design" caveat. Left `.disabled(isDisabled)` untouched.

### Figma
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=67186-146845 (Paired left/narrow, Fast Sign right/wide)

### Verification
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/VultisigApp/Components/Buttons/SigningCTAButtons.swift` — 0 violations.
- `xcodebuild build -project VultisigApp/VultisigApp.xcodeproj -scheme VultisigApp -destination 'platform=iOS Simulator,id=<iPhone Air>'` — **BUILD SUCCEEDED**.

No new strings (`fastSign` / `paired` already localized), no new files. Pure layout change; the in-file `#Preview` already exercises the fast/loading/disabled/secure variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code documentation for clarity.

* **Style**
  * Code formatting and layout improvements with no behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->