### PR TITLE
fix(keygen): show nav bar on PeerDiscoveryScreen for secure vault

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
@@ -171,7 +171,20 @@ struct PeerDiscoveryScreen: View {
             Screen {
                 states
             }
-            .screenNavigationBarHidden()
+            .screenTitle("pair".localized)
+            .screenNavigationBarHidden(!selectedTab.hasOtherDevices)
+            .screenBackButtonHidden(hideBackButton)
+            .screenToolbar {
+                CustomToolbarItem(placement: .trailing) {
+                    if isShareButtonVisible {
+                        NavigationQRShareButton(
+                            vault: vault,
+                            type: .Keygen,
+                            viewModel: shareSheetViewModel
+                        )
+                    }
+                }
+            }
             .screenEdgeInsets(ScreenEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
             .screenBackground(.gradient)
             .onAppear {
@@ -188,20 +201,6 @@ struct PeerDiscoveryScreen: View {
             }
 #endif
         }
-        .if(viewModel.status == .WaitingForDevices && selectedTab.hasOtherDevices) {
-            $0.crossPlatformToolbar("", showsBackButton: !hideBackButton) {
-                CustomToolbarItem(placement: .trailing) {
-                    if isShareButtonVisible {
-                        NavigationQRShareButton(
-                            vault: vault,
-                            type: .Keygen,
-                            viewModel: shareSheetViewModel
-                        )
-                    }
-                }
-            }
-        }
-        .navigationBarBackButtonHidden(hideBackButton)
 #if os(iOS)
         .detectOrientation($orientation)
         .onChange(of: orientation) { _, _ in


### PR DESCRIPTION
Closes #4505

Make `PeerDiscoveryScreen` route its title, conditional nav-bar hide, back-button state, and QR-share button through `Screen` (the `SendPairScreen` pattern) so the secure-vault pairing step renders a proper navigation bar instead of none.

Also fixes **iPad** and **Reshare-secure**, which hit the same screen, and **preserves the fast-path chromeless behavior** (the bar stays hidden when `!selectedTab.hasOtherDevices`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved peer discovery screen UI organization by consolidating title, navigation button, and toolbar management into a unified configuration approach, enhancing maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->