### PR TITLE
Surface upstream trading-halt as a distinct swap error (#4491)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapError.swift
@@ -10,6 +10,7 @@ import Foundation
 enum SwapError: Error, LocalizedError {
     case routeUnavailable
     case noLiquidityPool
+    case tradingHalted
     case swapAmountTooSmall
     case lessThenMinSwapAmount(amount: String)
     case serverError(message: String)
@@ -20,6 +21,8 @@ enum SwapError: Error, LocalizedError {
             return "swapRouteNotAvailable".localized
         case .noLiquidityPool:
             return "noLiquidityPool".localized
+        case .tradingHalted:
+            return "swapTradingHalted".localized
         case .swapAmountTooSmall:
             return "swapAmountTooSmall".localized
         case .lessThenMinSwapAmount(let amount):

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -356,24 +356,11 @@ private extension SwapService {
                 return .thorchain(quote)
             }
         } catch let error as ThorchainSwapError {
-            print("❌ [COSMOS DEBUG] THORChain error: code=\(error.code), message=\(error.message)")
-            if error.code == 3 {
-                if error.message.contains("not enough asset to pay for fees") {
-                    throw SwapError.swapAmountTooSmall
-                } else if error.message.localizedCaseInsensitiveContains("invalid symbol") ||
-                    error.message.localizedCaseInsensitiveContains("bad to asset") ||
-                    error.message.localizedCaseInsensitiveContains("bad from asset") ||
-                    error.message.localizedCaseInsensitiveContains("pool does not exist") {
-                    // This typically means no liquidity pool exists for this token pair
-                    throw SwapError.noLiquidityPool
-                } else {
-                    throw SwapError.serverError(message: error.message)
-                }
-            } else {
-                throw SwapError.routeUnavailable
-            }
+            logger.error("THORChain swap error: code=\(error.code, privacy: .public), message=\(error.message, privacy: .public)")
+            throw Self.mapThorchainSwapError(error)
         } catch let error as MayachainSwapError {
-            throw SwapError.serverError(message: error.error)
+            logger.error("MAYAChain swap error: code=\(error.code ?? -1, privacy: .public), message=\(error.error, privacy: .public)")
+            throw Self.mapMayachainSwapError(error)
         } catch let error as SwapError {
             throw error
         } catch {
@@ -482,6 +469,56 @@ private extension SwapService {
             fee: service.inboundFee(from: response, fromCoin: fromCoin),
             subProvider: response.subProvider
         )
+    }
+}
+
+// MARK: - Upstream error mapping
+
+extension SwapService {
+    /// Substrings THORChain/MAYAChain emit when a chain or asset is paused
+    /// upstream (e.g. a protocol-wide trading halt after an incident). This is
+    /// a *temporary* condition the user can retry, distinct from a permanently
+    /// unsupported pair, so it gets its own user-facing message rather than the
+    /// generic "route not available" or a leaked raw upstream string.
+    private static let tradingHaltedMarkers = ["trading is halted", "trading halted"]
+
+    private static func isTradingHalted(_ message: String) -> Bool {
+        tradingHaltedMarkers.contains { message.localizedCaseInsensitiveContains($0) }
+    }
+
+    /// Translate a decoded THORChain quote error into the user-facing `SwapError`.
+    /// A trading halt is detected on any code so a paused chain surfaces as a
+    /// retryable message instead of `routeUnavailable`; otherwise the existing
+    /// code-3 classification (fees / unsupported pair / raw server message) and
+    /// the non-code-3 `routeUnavailable` fallback are preserved.
+    static func mapThorchainSwapError(_ error: ThorchainSwapError) -> SwapError {
+        if isTradingHalted(error.message) {
+            return .tradingHalted
+        }
+        if error.code == 3 {
+            if error.message.contains("not enough asset to pay for fees") {
+                return .swapAmountTooSmall
+            } else if error.message.localizedCaseInsensitiveContains("invalid symbol") ||
+                error.message.localizedCaseInsensitiveContains("bad to asset") ||
+                error.message.localizedCaseInsensitiveContains("bad from asset") ||
+                error.message.localizedCaseInsensitiveContains("pool does not exist") {
+                // This typically means no liquidity pool exists for this token pair
+                return .noLiquidityPool
+            } else {
+                return .serverError(message: error.message)
+            }
+        }
+        return .routeUnavailable
+    }
+
+    /// Translate a decoded MAYAChain quote error into the user-facing `SwapError`.
+    /// A trading halt surfaces as the retryable message; any other error keeps
+    /// the previous behaviour of relaying the raw upstream string.
+    static func mapMayachainSwapError(_ error: MayachainSwapError) -> SwapError {
+        if isTradingHalted(error.error) {
+            return .tradingHalted
+        }
+        return .serverError(message: error.error)
     }
 }
 

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1024,6 +1024,7 @@
 "swapRouteNotAvailable" = "Tauschroute nicht verfügbar";
 "swaps" = "Swaps";
 "swapTrackingLink" = "Tauschverfolgungslink";
+"swapTradingHalted" = "Der Handel für diesen Vermögenswert ist vorübergehend ausgesetzt. Bitte versuche es später erneut.";
 "swapTXHash" = "Tausch-Tx-Hash";
 "swapVerifyCheckbox1Description" = "Der Tauschbetrag ist korrekt";
 "swapVerifyCheckbox2Description" = "Ich stimme dem Mindestbetrag zu, den ich erhalten werde";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1032,6 +1032,7 @@
 "swapRouteNotAvailable" = "Swap route not available";
 "swaps" = "Swaps";
 "swapTrackingLink" = "Swap tracking link";
+"swapTradingHalted" = "Trading for this asset is temporarily halted. Please try again later.";
 "swapTXHash" = "Swap Tx Hash";
 "swapVerifyCheckbox1Description" = "The swap amount is correct";
 "swapVerifyCheckbox2Description" = "I agree with the min. amount I'll receive";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1024,6 +1024,7 @@
 "swapRouteNotAvailable" = "Ruta de intercambio no disponible";
 "swaps" = "Intercambios";
 "swapTrackingLink" = "Enlace de seguimiento del intercambio";
+"swapTradingHalted" = "La negociación de este activo está suspendida temporalmente. Inténtalo de nuevo más tarde.";
 "swapTXHash" = "Hash de la transacción de intercambio";
 "swapVerifyCheckbox1Description" = "La cantidad del intercambio es correcta";
 "swapVerifyCheckbox2Description" = "Acepto el monto mínimo que recibiré";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1024,6 +1024,7 @@
 "swapRouteNotAvailable" = "Ruta zamjene nije dostupna";
 "swaps" = "Zamjene";
 "swapTrackingLink" = "Poveznica za praćenje zamjene";
+"swapTradingHalted" = "Trgovanje ovom imovinom privremeno je zaustavljeno. Pokušajte ponovno kasnije.";
 "swapTXHash" = "Zamjenski Tx hash";
 "swapVerifyCheckbox1Description" = "Iznos zamjene je točan";
 "swapVerifyCheckbox2Description" = "Slažem se s minimalnim iznosom koji ću primiti";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1024,6 +1024,7 @@
 "swapRouteNotAvailable" = "Percorso di scambio non disponibile";
 "swaps" = "Scambi";
 "swapTrackingLink" = "Link di tracciamento dello scambio";
+"swapTradingHalted" = "La negoziazione di questo asset è temporaneamente sospesa. Riprova più tardi.";
 "swapTXHash" = "Hash Tx dello scambio";
 "swapVerifyCheckbox1Description" = "L'importo dello scambio è corretto";
 "swapVerifyCheckbox2Description" = "Accetto l'importo minimo che riceverò";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -999,6 +999,7 @@
 "swapProvidersSheetTitle" = "공급자 선택";
 "swapRouteNotAvailable" = "스왑 경로를 사용할 수 없습니다";
 "swaps" = "스왑";
+"swapTradingHalted" = "이 자산의 거래가 일시적으로 중단되었습니다. 나중에 다시 시도해 주세요.";
 "swapTrackingLink" = "스왑 추적 링크";
 "swapTXHash" = "스왑 Tx 해시";
 "swapVerifyCheckbox1Description" = "스왑 금액이 올바릅니다";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1024,6 +1024,7 @@
 "swapRouteNotAvailable" = "Rota de troca não disponível";
 "swaps" = "Trocas";
 "swapTrackingLink" = "Link de rastreamento da troca";
+"swapTradingHalted" = "A negociação deste ativo está temporariamente suspensa. Tente novamente mais tarde.";
 "swapTXHash" = "Hash da Tx da troca";
 "swapVerifyCheckbox1Description" = "O valor da troca está correto";
 "swapVerifyCheckbox2Description" = "Concordo com o valor mínimo que receberei";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1024,6 +1024,7 @@
 "swapRouteNotAvailable" = "交换路由不可用";
 "swaps" = "兑换";
 "swapTrackingLink" = "交换跟踪链接";
+"swapTradingHalted" = "该资产的交易已暂时停止，请稍后再试。";
 "swapTXHash" = "交换交易哈希";
 "swapVerifyCheckbox1Description" = "交换金额正确";
 "swapVerifyCheckbox2Description" = "我同意我将收到的最小金额";

--- a/VultisigApp/VultisigAppTests/Swap/SwapServiceTradingHaltedTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapServiceTradingHaltedTests.swift
@@ -1,0 +1,114 @@
+//
+//  SwapServiceTradingHaltedTests.swift
+//  VultisigAppTests
+//
+//  Locks the upstream trading-halt detection in SwapService's error mapping.
+//  When THORChain or MAYAChain pauses trading for an asset upstream (e.g. a
+//  protocol-wide halt after an incident), the quote endpoint returns
+//  "trading is halted, can't process swap". That is a temporary, retryable
+//  condition — distinct from a permanently unsupported pair — so it must map
+//  to the dedicated `.tradingHalted` case (a clean "try again later" message)
+//  instead of the generic `.routeUnavailable` (THORChain) or a leaked raw
+//  upstream string via `.serverError` (MAYAChain).
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapServiceTradingHaltedTests: XCTestCase {
+
+    private let haltMessage = "trading is halted, can't process swap"
+
+    // MARK: - Trading halt → .tradingHalted (both providers)
+
+    func testThorchainTradingHaltedMapsToTradingHalted() {
+        // THORChain has historically returned the halt on a non-3 code, which
+        // previously collapsed to `.routeUnavailable`.
+        let error = ThorchainSwapError(code: 0, message: haltMessage)
+        let mapped = SwapService.mapThorchainSwapError(error)
+        assertTradingHalted(mapped)
+    }
+
+    func testThorchainTradingHaltedOnCode3MapsToTradingHalted() {
+        // Defensive: if THORChain ever returns the halt under code 3, it must
+        // still surface as `.tradingHalted`, not a raw `.serverError`.
+        let error = ThorchainSwapError(code: 3, message: haltMessage)
+        let mapped = SwapService.mapThorchainSwapError(error)
+        assertTradingHalted(mapped)
+    }
+
+    func testMayachainTradingHaltedMapsToTradingHalted() {
+        // MAYAChain previously leaked this raw string via `.serverError`.
+        let error = MayachainSwapError(code: nil, error: haltMessage)
+        let mapped = SwapService.mapMayachainSwapError(error)
+        assertTradingHalted(mapped)
+    }
+
+    func testTradingHaltedDetectionIsCaseInsensitive() {
+        let upper = ThorchainSwapError(code: 0, message: "TRADING IS HALTED")
+        assertTradingHalted(SwapService.mapThorchainSwapError(upper))
+
+        let alt = MayachainSwapError(code: 1, error: "Trading halted for this asset")
+        assertTradingHalted(SwapService.mapMayachainSwapError(alt))
+    }
+
+    // MARK: - Regression guards (non-halt errors map as before)
+
+    func testThorchainCode3FeesStillMapsToAmountTooSmall() {
+        let error = ThorchainSwapError(code: 3, message: "not enough asset to pay for fees")
+        XCTAssertEqual(
+            SwapService.mapThorchainSwapError(error).errorDescription,
+            "swapAmountTooSmall".localized
+        )
+    }
+
+    func testThorchainCode3PoolMissingStillMapsToNoLiquidityPool() {
+        let error = ThorchainSwapError(code: 3, message: "pool does not exist")
+        XCTAssertEqual(
+            SwapService.mapThorchainSwapError(error).errorDescription,
+            "noLiquidityPool".localized
+        )
+    }
+
+    func testThorchainNonCode3StillMapsToRouteUnavailable() {
+        let error = ThorchainSwapError(code: 5, message: "some other upstream failure")
+        XCTAssertEqual(
+            SwapService.mapThorchainSwapError(error).errorDescription,
+            "swapRouteNotAvailable".localized
+        )
+    }
+
+    func testThorchainCode3UnknownStillRelaysServerMessage() {
+        let error = ThorchainSwapError(code: 3, message: "totally novel server complaint")
+        XCTAssertEqual(
+            SwapService.mapThorchainSwapError(error).errorDescription,
+            "totally novel server complaint"
+        )
+    }
+
+    func testMayachainNonHaltStillRelaysRawServerMessage() {
+        let error = MayachainSwapError(code: 2, error: "maya specific upstream detail")
+        XCTAssertEqual(
+            SwapService.mapMayachainSwapError(error).errorDescription,
+            "maya specific upstream detail"
+        )
+    }
+
+    // MARK: - Helper
+
+    private func assertTradingHalted(
+        _ error: SwapError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            error.errorDescription,
+            "swapTradingHalted".localized,
+            "expected .tradingHalted message",
+            file: file,
+            line: line
+        )
+        // Guard against the localized lookup silently returning the raw key.
+        XCTAssertNotEqual(error.errorDescription, "swapTradingHalted", file: file, line: line)
+    }
+}


### PR DESCRIPTION
## Summary

When a swap fails because the destination chain is **halted upstream** (a THORChain/MAYAChain trading pause), the quote endpoint returns `"trading is halted, can't process swap"`. The iOS error mapping previously:

- **THORChain** — collapsed non-code-3 errors to `.routeUnavailable` → user saw a generic *"Swap route not available"*.
- **MAYAChain** — relayed the raw upstream string verbatim via `.serverError` → user saw a leaked internal message.

Neither let the user distinguish a **temporary halt** (retry later) from a **permanently unsupported pair**. Repro: ETH → ZEC (Maya has ZEC trading paused).

## What changed (iOS-only)

- **`SwapError.tradingHalted`** — new case with a clean, localized *"Trading for this asset is temporarily halted. Please try again later."* message (`swapTradingHalted`). It reaches the UI via the existing `LocalizedError.errorDescription` path (the Swap view models surface `error.localizedDescription`), so no view changes are needed.
- **`SwapService` error mapping** — extracted the THORChain/MAYAChain error→`SwapError` translation out of the inline `do/catch` in `fetchCrossChainQuote` into testable static helpers `mapThorchainSwapError` / `mapMayachainSwapError`. Both now detect `"trading is halted"` / `"trading halted"` (case-insensitive) → `.tradingHalted`. THORChain detection runs **before** the code check, so a halt returned under code 3 is still classified correctly. Every other THORChain (code-3 fees / unsupported pair / unknown server message; non-code-3 `routeUnavailable`) and MAYAChain (`serverError`) classification is unchanged.
- **Logging** — replaced the leftover `print("❌ [COSMOS DEBUG] …")` in the THORChain catch with `Logger.error` (OSLog), and added equivalent structured logging for the MAYAChain branch, per `.claude/rules/logging.md`.
- **Localization** — added `swapTradingHalted` to all 7 canonical locales (en/de/es/hr/it/pt/zh-Hans) **plus the existing `ko`** so Korean users don't fall back to the raw key, and ran `sort_localizable.py`.

## Tests

New `SwapServiceTradingHaltedTests` (9 cases, all passing):
- `"trading is halted, can't process swap"` → `.tradingHalted` for **both** THORChain and MAYAChain branches.
- Halt returned under THORChain **code 3** still → `.tradingHalted`.
- Case-insensitive detection (`TRADING IS HALTED`, `Trading halted …`).
- Regression guards: code-3 fees → `.swapAmountTooSmall`, `pool does not exist` → `.noLiquidityPool`, non-code-3 → `.routeUnavailable`, unknown code-3 still relays the server message, MAYAChain non-halt still relays the raw string.

## Verification

- `swiftlint --config VultisigApp/.swiftlint.yml` on changed files: **0 violations**.
- `xcodebuild build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**.
- `xcodebuild test -only-testing:VultisigAppTests/SwapServiceTradingHaltedTests`: **9/9 passed**.
- `make generate` run (new test file added).

## Notes

- iOS-only change. Android and Windows companions exist and own their error copy separately.
- Edge case: THORChain has historically returned the halt on a non-3 code (which is why it previously hit the `routeUnavailable` fallback); the mapping now matches the halt substring regardless of code, and a test pins the code-3 case too.

Closes #4491

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and user-facing messaging for temporarily halted trading on supported blockchain networks.

* **Improvements**
  * Standardized error handling for upstream provider failures with improved error classification and clarity.

* **Localization**
  * Added trading halt notification messages in 8 languages (English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->