### PR TITLE
fix(circle): route USDC withdraw through verify for correct display (#4490)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -192,7 +192,7 @@
 "circleSetupOpenAccount" = "Open Account";
 "circleTitle" = "Circle";
 "circleUSDCDeposited" = "USDC deposited";
-"circleWithdrawAmount" = "Amount";
+"circleWithdrawAmountLabel" = "Amount";
 "circleWithdrawConfirm" = "Continue";
 "circleWithdrawTitle" = "Withdraw USDC";
 "claim" = "Claim";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -192,7 +192,7 @@
 "circleSetupOpenAccount" = "계정 개설";
 "circleTitle" = "Circle";
 "circleUSDCDeposited" = "USDC 입금됨";
-"circleWithdrawAmount" = "금액";
+"circleWithdrawAmountLabel" = "금액";
 "circleWithdrawConfirm" = "계속";
 "circleWithdrawTitle" = "USDC 출금";
 "claim" = "수령";

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
@@ -20,8 +20,6 @@ struct CircleWithdrawView: View {
     @State var percentage: Double = 0.0
     @State var isLoading = false
     @State var error: Error?
-    @State var fastPasswordPresented = false
-    @State var fastVaultPassword: String = ""
 
     init(vault: Vault, model: CircleViewModel) {
         self.vault = vault
@@ -41,13 +39,6 @@ struct CircleWithdrawView: View {
         }
         .screenTitle("circleWithdrawTitle".localized)
         .withLoading(isLoading: $isLoading)
-        .crossPlatformSheet(isPresented: $fastPasswordPresented) {
-            FastVaultEnterPasswordView(
-                password: $fastVaultPassword,
-                vault: vault,
-                onSubmit: { Task { await handleWithdraw() } }
-            )
-        }
     }
 
     var footerView: some View {
@@ -158,16 +149,13 @@ struct CircleWithdrawView: View {
     }
 
     var withdrawButton: some View {
-        SigningCTAButtons(
-            isFastVault: vault.isFastVault,
-            isDisabled: isButtonDisabled,
-            singleSignTitle: "circleWithdrawConfirm",
-            onFastSign: { fastPasswordPresented = true },
-            onPairedSign: {
-                fastVaultPassword = ""
-                Task { await handleWithdraw() }
-            }
-        )
+        // Builds the native-ETH MSCA payload, then routes to the shared verify
+        // screen, where the user confirms amount/recipient and chooses the
+        // fast/paired signing path.
+        PrimaryButton(title: "circleWithdrawConfirm".localized) {
+            Task { await handleWithdraw() }
+        }
+        .disabled(isButtonDisabled)
     }
 
     var vaultEthBalance: Decimal {
@@ -228,7 +216,7 @@ struct CircleWithdrawView: View {
                 throw NSError(domain: "CircleWithdraw", code: 404, userInfo: [NSLocalizedDescriptionKey: "ETH address not found"])
             }
 
-            // Use USDC coin for display purposes on success screen
+            // USDC coin drives the verify/done screens' amount + recipient display.
             guard let usdcCoin = vault.coins.first(where: { $0.chain == chain && $0.ticker == "USDC" }) else {
                 throw NSError(domain: "CircleWithdraw", code: 404, userInfo: [NSLocalizedDescriptionKey: "USDC coin not found"])
             }
@@ -262,17 +250,21 @@ struct CircleWithdrawView: View {
             }
 
             await MainActor.run {
+                // The USDC `tx` is for display only — it drives the verify
+                // summary's amount + recipient. The signed transaction is the
+                // pre-built native-ETH MSCA `execute(...)` payload, passed
+                // through verify verbatim so the withdraw is not re-derived as
+                // a USDC `transfer(MSCA, 0)` no-op.
                 let immutableTx = SendTransaction.empty(coin: usdcCoin, vault: vault).with(
                     toAddress: recipientCoin.address,
                     amount: amount
                 )
                 router.navigate(
-                    to: SendRoute.pairing(
-                        vault: vault,
+                    to: SendRoute.verify(
                         tx: immutableTx,
                         retrySignal: SendRetrySignal(),
-                        keysignPayload: payload,
-                        fastVaultPassword: fastVaultPassword.nilIfEmpty
+                        vault: vault,
+                        prebuiltKeysignPayload: payload
                     )
                 )
 

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleWithdrawView.swift
@@ -5,10 +5,13 @@
 //  Created by Enrique Souza on 2025-12-13.
 //
 
+import OSLog
 import SwiftUI
 import BigInt
 import WalletCore
 import VultisigCommonData
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "circle-withdraw")
 
 struct CircleWithdrawView: View {
     let vault: Vault
@@ -67,7 +70,7 @@ struct CircleWithdrawView: View {
         VStack(spacing: CircleConstants.Design.verticalSpacing) {
             VStack(spacing: 0) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("circleWithdrawAmount".localized)
+                    Text("circleWithdrawAmountLabel".localized)
                         .font(CircleConstants.Fonts.subtitle)
                         .foregroundStyle(Theme.colors.textSecondary)
 
@@ -239,7 +242,7 @@ struct CircleWithdrawView: View {
                             ethAddress: recipientCoin.address
                         )
                     } catch {
-                        print("Circle create wallet error: \(error.localizedDescription)")
+                        logger.error("Circle create wallet error: \(error.localizedDescription)")
                     }
                     payload = try await attemptPayload()
                 } else {

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
@@ -18,6 +18,34 @@ struct KeysignInput: Hashable {
     let isInitiateDevice: Bool
 }
 
+/// Opt-in override for the `.Send` QR-preview hero (amount + recipient + coin
+/// logo). The pairing preview otherwise reads these from `keysignPayload`, but
+/// some flows sign a payload whose surface differs from what the user should
+/// see: a Circle USDC withdraw signs a native-ETH MSCA `execute(...)` call
+/// (so the payload reads "0 ETH → MSCA"), while the user is really moving
+/// "N USDC → vault". Supplying this surfaces the display values without
+/// touching the signed payload. `nil` (the default) keeps the payload-derived
+/// preview for every other send.
+struct SendPreviewOverride: Hashable {
+    let amount: String
+    let toAddress: String
+    let coinLogo: String
+
+    /// Builds an override only when the signed payload's coin differs from the
+    /// display `tx` coin — i.e. the signed surface ("0 ETH → MSCA") would
+    /// mislead and the display values ("N USDC → vault") should be shown
+    /// instead. Returns `nil` when the coins match, so every regular send keeps
+    /// the payload-derived preview untouched.
+    static func makeIfNeeded(displayTx: SendTransaction, signedPayload: KeysignPayload) -> SendPreviewOverride? {
+        guard displayTx.coin != signedPayload.coin else { return nil }
+        return SendPreviewOverride(
+            amount: "\(displayTx.amount) \(displayTx.coin.ticker)",
+            toAddress: displayTx.toAddress,
+            coinLogo: displayTx.coin.logo
+        )
+    }
+}
+
 struct KeysignDiscoveryView: View {
     let vault: Vault
     let keysignPayload: KeysignPayload?
@@ -25,6 +53,7 @@ struct KeysignDiscoveryView: View {
     let fastVaultPassword: String?
     @ObservedObject var shareSheetViewModel: ShareSheetViewModel
     @State var previewType: QRShareSheetType = .Send
+    var sendPreviewOverride: SendPreviewOverride?
     var swapTransaction: SwapTransaction?
     var contentPadding: CGFloat?
     var presetSession: KeysignSessionInfo? = nil
@@ -262,9 +291,9 @@ struct KeysignDiscoveryView: View {
             displayScale: displayScale,
             type: previewType,
             vaultName: vault.name,
-            amount: previewType == .Send ? keysignPayload?.toAmountWithTickerString ?? "" : "",
-            toAddress: previewType == .Send ? keysignPayload?.toAddress ?? "" : "",
-            coinLogo: previewType == .Send ? keysignPayload?.coin.logo ?? "" : "",
+            amount: previewType == .Send ? (sendPreviewOverride?.amount ?? keysignPayload?.toAmountWithTickerString ?? "") : "",
+            toAddress: previewType == .Send ? (sendPreviewOverride?.toAddress ?? keysignPayload?.toAddress ?? "") : "",
+            coinLogo: previewType == .Send ? (sendPreviewOverride?.coinLogo ?? keysignPayload?.coin.logo ?? "") : "",
             fromAmount: previewType == .Swap ? getSwapFromAmount() : "",
             toAmount: previewType == .Swap ? getSwapToAmount() : ""
         )

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
@@ -37,7 +37,7 @@ struct SendPreviewOverride: Hashable {
     /// instead. Returns `nil` when the coins match, so every regular send keeps
     /// the payload-derived preview untouched.
     static func makeIfNeeded(displayTx: SendTransaction, signedPayload: KeysignPayload) -> SendPreviewOverride? {
-        guard displayTx.coin != signedPayload.coin else { return nil }
+        guard displayTx.coin.id != signedPayload.coin.id else { return nil }
         return SendPreviewOverride(
             amount: "\(displayTx.amount) \(displayTx.coin.ticker)",
             toAddress: displayTx.toAddress,

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/PairScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/PairScreen.swift
@@ -19,6 +19,7 @@ struct PairScreen: View {
     var customMessagePayload: CustomMessagePayload?
     var fastVaultPassword: String?
     var previewType: QRShareSheetType
+    var sendPreviewOverride: SendPreviewOverride?
     var swapTransaction: SwapTransaction?
     var presetSession: KeysignSessionInfo?
 
@@ -38,6 +39,7 @@ struct PairScreen: View {
         customMessagePayload: CustomMessagePayload? = nil,
         fastVaultPassword: String? = nil,
         previewType: QRShareSheetType = .Send,
+        sendPreviewOverride: SendPreviewOverride? = nil,
         swapTransaction: SwapTransaction? = nil,
         presetSession: KeysignSessionInfo? = nil,
         title: String? = nil,
@@ -49,6 +51,7 @@ struct PairScreen: View {
         self.customMessagePayload = customMessagePayload
         self.fastVaultPassword = fastVaultPassword
         self.previewType = previewType
+        self.sendPreviewOverride = sendPreviewOverride
         self.swapTransaction = swapTransaction
         self.presetSession = presetSession
         self.title = title
@@ -65,6 +68,7 @@ struct PairScreen: View {
                 fastVaultPassword: fastVaultPassword,
                 shareSheetViewModel: shareSheetViewModel,
                 previewType: previewType,
+                sendPreviewOverride: sendPreviewOverride,
                 swapTransaction: swapTransaction,
                 contentPadding: 0,
                 presetSession: presetSession,

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -37,10 +37,24 @@ class SendCryptoVerifyViewModel: ObservableObject {
     private let interactor: SendInteractor
     private let logic: SendCryptoVerifyLogic
 
-    init(transaction: SendTransaction, interactor: SendInteractor = DefaultSendInteractor.live) {
+    /// A keysign payload built by the calling flow that must be signed verbatim,
+    /// instead of being re-derived from `transaction` on confirm. Circle USDC
+    /// withdrawals rely on this: the signed tx is a native-ETH MSCA
+    /// `execute(USDC, 0, transfer(vault, amount))` call whose calldata lives in
+    /// `memo`, while `transaction` carries the USDC coin purely so the verify
+    /// summary shows the real amount and recipient. Re-deriving from the USDC
+    /// `transaction` would instead sign `transfer(MSCA, 0)` — a no-op.
+    private let prebuiltKeysignPayload: KeysignPayload?
+
+    init(
+        transaction: SendTransaction,
+        interactor: SendInteractor = DefaultSendInteractor.live,
+        prebuiltKeysignPayload: KeysignPayload? = nil
+    ) {
         self.transaction = transaction
         self.interactor = interactor
         self.logic = SendCryptoVerifyLogic(interactor: interactor)
+        self.prebuiltKeysignPayload = prebuiltKeysignPayload
     }
 
     func onLoad() {
@@ -125,6 +139,13 @@ class SendCryptoVerifyViewModel: ObservableObject {
 
         if !isValidForm {
             throw HelperError.runtimeError("mustAgreeTermsError")
+        }
+
+        // A flow that pre-built its keysign payload (e.g. Circle withdraw) must
+        // sign it verbatim. Re-deriving from `transaction` here would change the
+        // signed tx, so confirm against the pre-built payload directly.
+        if let prebuiltKeysignPayload {
+            return prebuiltKeysignPayload
         }
 
         try await logic.validateUtxosIfNeeded(tx: transaction)

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -116,6 +116,14 @@ class SendCryptoVerifyViewModel: ObservableObject {
     }
 
     func validateBalanceWithFee() {
+        // A flow that pre-built its keysign payload (e.g. Circle withdraw)
+        // validates the user's amount against the real source balance upstream
+        // (the MSCA's USDC balance), and `transaction` here carries a display-only
+        // USDC coin whose `rawBalance` is the vault EOA (~0). Running the standard
+        // balance check would wrongly trip `walletBalanceExceededError` and disable
+        // signing, so skip it — mirrors the Tron-staking skip in the logic.
+        guard prebuiltKeysignPayload == nil else { return }
+
         let result = logic.validateBalanceWithFee(tx: transaction)
         if !result.isValid {
             errorMessage = result.errorMessage ?? ""

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRoute.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRoute.swift
@@ -7,7 +7,7 @@
 
 enum SendRoute: Hashable {
     case details(seed: SendDetailsSeed)
-    case verify(tx: SendTransaction, retrySignal: SendRetrySignal, vault: Vault)
+    case verify(tx: SendTransaction, retrySignal: SendRetrySignal, vault: Vault, prebuiltKeysignPayload: KeysignPayload? = nil)
     case pairing(vault: Vault, tx: SendTransaction, retrySignal: SendRetrySignal, keysignPayload: KeysignPayload, fastVaultPassword: String?)
     case keysign(input: KeysignInput, tx: SendTransaction, retrySignal: SendRetrySignal)
     case done(vault: Vault, hash: String, chain: Chain, tx: SendTransaction?, keysignPayload: KeysignPayload?)

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouteBuilder.swift
@@ -22,8 +22,18 @@ struct SendRouteBuilder {
     }
 
     @ViewBuilder
-    func buildVerifyScreen(tx: SendTransaction, retrySignal: SendRetrySignal, vault: Vault) -> some View {
-        SendVerifyScreen(transaction: tx, retrySignal: retrySignal, vault: vault)
+    func buildVerifyScreen(
+        tx: SendTransaction,
+        retrySignal: SendRetrySignal,
+        vault: Vault,
+        prebuiltKeysignPayload: KeysignPayload? = nil
+    ) -> some View {
+        SendVerifyScreen(
+            transaction: tx,
+            retrySignal: retrySignal,
+            vault: vault,
+            prebuiltKeysignPayload: prebuiltKeysignPayload
+        )
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouter.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouter.swift
@@ -16,8 +16,13 @@ struct SendRouter {
         switch route {
         case .details(let seed):
             viewBuilder.buildDetailsScreen(seed: seed)
-        case .verify(let tx, let retrySignal, let vault):
-            viewBuilder.buildVerifyScreen(tx: tx, retrySignal: retrySignal, vault: vault)
+        case .verify(let tx, let retrySignal, let vault, let prebuiltKeysignPayload):
+            viewBuilder.buildVerifyScreen(
+                tx: tx,
+                retrySignal: retrySignal,
+                vault: vault,
+                prebuiltKeysignPayload: prebuiltKeysignPayload
+            )
         case .pairing(let vault, let tx, let retrySignal, let keysignPayload, let fastVaultPassword):
             viewBuilder.buildPairScreen(
                 vault: vault,

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendPairScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendPairScreen.swift
@@ -21,9 +21,20 @@ struct SendPairScreen: View {
             vault: vault,
             keysignPayload: keysignPayload,
             fastVaultPassword: fastVaultPassword,
-            previewType: .Send
+            previewType: .Send,
+            sendPreviewOverride: sendPreviewOverride
         ) { input in
             router.navigate(to: SendRoute.keysign(input: input, tx: tx, retrySignal: retrySignal))
         }
+    }
+
+    /// When the signed payload's coin differs from the display `tx` coin, the
+    /// payload-derived pairing/QR preview ("0 ETH → MSCA" for a Circle USDC
+    /// withdraw) would mislead. In that case surface the display `tx`'s amount
+    /// + recipient instead, leaving the signed payload untouched. For every
+    /// regular send the coins match, so this stays `nil` and the preview keeps
+    /// reading from the payload.
+    private var sendPreviewOverride: SendPreviewOverride? {
+        SendPreviewOverride.makeIfNeeded(displayTx: tx, signedPayload: keysignPayload)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
@@ -24,8 +24,13 @@ struct SendVerifyScreen: View {
     @State private var error: HelperError?
     @State private var retryBannerText: String?
 
-    init(transaction: SendTransaction, retrySignal: SendRetrySignal, vault: Vault) {
-        _sendCryptoVerifyViewModel = StateObject(wrappedValue: SendCryptoVerifyViewModel(transaction: transaction))
+    init(transaction: SendTransaction, retrySignal: SendRetrySignal, vault: Vault, prebuiltKeysignPayload: KeysignPayload? = nil) {
+        _sendCryptoVerifyViewModel = StateObject(
+            wrappedValue: SendCryptoVerifyViewModel(
+                transaction: transaction,
+                prebuiltKeysignPayload: prebuiltKeysignPayload
+            )
+        )
         self.retrySignal = retrySignal
         self.vault = vault
     }

--- a/VultisigApp/VultisigAppTests/Keysign/SendPreviewOverrideTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SendPreviewOverrideTests.swift
@@ -1,0 +1,99 @@
+//
+//  SendPreviewOverrideTests.swift
+//  VultisigAppTests
+//
+//  Covers `SendPreviewOverride.makeIfNeeded` — the opt-in pairing/QR-preview
+//  override. A Circle USDC withdraw signs a native-ETH MSCA `execute(...)` call
+//  (the keysign payload reads "0 ETH → MSCA"), while the user is moving
+//  "N USDC → vault". The override surfaces the display values in the pairing
+//  hero WITHOUT touching the signed payload. For a regular send the display tx
+//  coin and the signed payload coin match, so the override is `nil` and the
+//  preview keeps reading from the payload.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class SendPreviewOverrideTests: XCTestCase {
+
+    func testOverrideSurfacesDisplayUsdcWhenSignedCoinDiffers() throws {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        let vaultRecipient = "0x1111111111111111111111111111111111111111"
+        let displayTx = try makeTransaction(coin: usdc, toAddress: vaultRecipient, amount: "5")
+
+        // Signed payload is the native-ETH MSCA execute() call — "0 ETH → MSCA".
+        let signed = makePayload(
+            coin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            toAddress: "0x2222222222222222222222222222222222222222",
+            toAmount: BigInt(0)
+        )
+
+        let override = SendPreviewOverride.makeIfNeeded(displayTx: displayTx, signedPayload: signed)
+
+        let unwrapped = try XCTUnwrap(override, "differing coins must produce a display override")
+        XCTAssertEqual(unwrapped.amount, "5 USDC", "preview must show the USDC amount, not 0 ETH")
+        XCTAssertEqual(unwrapped.toAddress, vaultRecipient, "preview must show the vault recipient, not the MSCA")
+        XCTAssertEqual(unwrapped.coinLogo, usdc.logo)
+    }
+
+    func testOverrideIsNilForRegularSendWhereCoinsMatch() throws {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        let displayTx = try makeTransaction(coin: usdc, toAddress: "0x1111111111111111111111111111111111111111", amount: "5")
+
+        // A normal ERC-20 send signs the very same coin it displays.
+        let signed = makePayload(coin: usdc, toAddress: displayTx.toAddress, toAmount: BigInt(5_000_000))
+
+        XCTAssertNil(
+            SendPreviewOverride.makeIfNeeded(displayTx: displayTx, signedPayload: signed),
+            "matching coins must keep the payload-derived preview untouched"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {
+        let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: isNative)
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+
+    private func makeTransaction(coin: Coin, toAddress: String, amount: String) throws -> SendTransaction {
+        let vault = try TestStore.makeVault()
+        return SendTransaction(
+            coin: coin, vault: vault, fromAddress: coin.address,
+            toAddress: toAddress, toAddressLabel: nil,
+            amount: amount, amountInFiat: "", memo: "",
+            gas: .zero, fee: .zero, feeMode: .default,
+            estimatedGasLimit: nil, customGasLimit: nil, customByteFee: nil,
+            sendMaxAmount: false, isStakingOperation: false,
+            transactionType: .unspecified,
+            memoFunctionDictionary: [:], wasmContractPayload: nil,
+            feeCoin: coin
+        )
+    }
+
+    private func makePayload(coin: Coin, toAddress: String, toAmount: BigInt) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: toAddress,
+            toAmount: toAmount,
+            chainSpecific: .Ethereum(maxFeePerGasWei: BigInt(1), priorityFeeWei: BigInt(1), nonce: 0, gasLimit: BigInt(21_000)),
+            utxos: [],
+            memo: "0xb61d27f6",
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -151,6 +151,61 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         XCTAssertEqual(vm.errorMessage, "walletBalanceExceededError")
     }
 
+    /// Circle USDC withdraw regression: the display `transaction` carries the USDC
+    /// token whose `rawBalance` is the vault EOA (~0), NOT the MSCA balance the amount
+    /// was actually validated against upstream. With a pre-built payload present the
+    /// standard balance check must be skipped — otherwise a normal withdraw trips
+    /// `walletBalanceExceededError`, sets `hasBalanceError`, and disables signing.
+    func testValidateBalanceWithFeeSkippedWhenPrebuiltPayloadPresent() throws {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false,
+                            rawBalance: "0") // vault EOA USDC is ~0; real balance lives on the MSCA
+        let tx = try makeTransaction(coin: usdc, amount: "5") // 5 USDC > 0 EOA balance
+        let nativeEth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                                 rawBalance: "1000000000000000000")
+        let prebuilt = KeysignPayload(
+            coin: nativeEth,
+            toAddress: "0x2222222222222222222222222222222222222222",
+            toAmount: BigInt(0),
+            chainSpecific: .Ethereum(maxFeePerGasWei: BigInt(1), priorityFeeWei: BigInt(1), nonce: 0, gasLimit: BigInt(21_000)),
+            utxos: [],
+            memo: "0xb61d27f6",
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+        let vm = SendCryptoVerifyViewModel(transaction: tx, prebuiltKeysignPayload: prebuilt)
+
+        vm.validateBalanceWithFee()
+
+        XCTAssertFalse(vm.hasBalanceError, "pre-built payload flow must not trip the EOA balance check")
+        XCTAssertFalse(vm.showAlert)
+        XCTAssertEqual(vm.errorMessage, "")
+    }
+
+    /// Without a pre-built payload, the same insufficient-balance USDC tx must still
+    /// flag the error — the skip is strictly opt-in to the pre-built-payload flow.
+    func testValidateBalanceWithFeeStillRunsWithoutPrebuiltPayload() throws {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false,
+                            rawBalance: "0")
+        let tx = try makeTransaction(coin: usdc, amount: "5")
+        let vm = SendCryptoVerifyViewModel(transaction: tx)
+
+        vm.validateBalanceWithFee()
+
+        XCTAssertTrue(vm.hasBalanceError, "regular sends keep the balance check")
+        XCTAssertEqual(vm.errorMessage, "walletBalanceExceededError")
+    }
+
     // MARK: - validateSecurityScanner
 
     func testValidateSecurityScannerReturnsTrueWhenStateIdle() throws {

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -482,6 +482,107 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         XCTAssertEqual(interactor.validateUtxosIfNeededCalls.first?.ticker, "BTC")
     }
 
+    // MARK: - validateForm — pre-built keysign payload pass-through
+
+    /// Circle USDC withdraw signs a native-ETH MSCA `execute(USDC, 0, transfer(vault, amount))`
+    /// call whose calldata lives in `memo`, while the `transaction` carries the USDC token
+    /// purely so the verify summary shows the real amount + recipient. When a pre-built
+    /// payload is supplied, `validateForm()` must return it verbatim and must NOT re-derive
+    /// from the USDC `transaction` — re-deriving would route the USDC ERC-20 coin through the
+    /// transfer path and sign `transfer(MSCA, 0)`, the #4484 no-op.
+    func testValidateFormReturnsPrebuiltPayloadVerbatimWithoutRederiving() async throws {
+        let interactor = MockSendInteractor()
+
+        // The signed payload: native ETH, MSCA target, value 0, execute() calldata in memo.
+        let mscaAddress = "0x2222222222222222222222222222222222222222"
+        let executeMemo = "0xb61d27f6deadbeef"
+        let nativeEth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                                 rawBalance: "1000000000000000000")
+        let prebuilt = KeysignPayload(
+            coin: nativeEth,
+            toAddress: mscaAddress,
+            toAmount: BigInt(0),
+            chainSpecific: .Ethereum(maxFeePerGasWei: BigInt(1), priorityFeeWei: BigInt(1), nonce: 0, gasLimit: BigInt(21_000)),
+            utxos: [],
+            memo: executeMemo,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pub",
+            vaultLocalPartyID: "party",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+
+        // The display `transaction` carries the USDC token — the no-op trap if re-derived.
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, rawBalance: "1000000")
+        let tx = try makeTransaction(coin: usdc, amount: "1")
+        let vm = SendCryptoVerifyViewModel(
+            transaction: tx,
+            interactor: interactor,
+            prebuiltKeysignPayload: prebuilt
+        )
+        vm.isAddressCorrect = true
+        vm.isAmountCorrect = true
+
+        let payload = try await vm.validateForm()
+
+        // Returned verbatim — the #4489 native-ETH execute() payload, unchanged.
+        XCTAssertEqual(payload, prebuilt)
+        XCTAssertTrue(payload.coin.isNativeToken, "signed coin must stay native ETH, not USDC")
+        XCTAssertEqual(payload.coin.ticker, "ETH")
+        XCTAssertEqual(payload.toAddress, mscaAddress)
+        XCTAssertEqual(payload.toAmount, BigInt(0))
+        XCTAssertEqual(payload.memo, executeMemo, "execute() calldata must survive in memo")
+
+        // No re-derivation: the USDC transaction must never reach the payload builder.
+        XCTAssertTrue(interactor.buildKeysignPayloadCalls.isEmpty,
+                      "pre-built payload must bypass buildKeysignPayload — no USDC transfer(MSCA, 0)")
+        XCTAssertTrue(interactor.fetchChainSpecificCalls.isEmpty)
+        XCTAssertTrue(interactor.validateUtxosIfNeededCalls.isEmpty)
+    }
+
+    /// The confirmation checkboxes still gate signing even with a pre-built payload — the
+    /// withdraw must not bypass the verify confirmation it was re-routed through to restore.
+    func testValidateFormWithPrebuiltPayloadStillEnforcesCheckboxes() async throws {
+        let interactor = MockSendInteractor()
+        let nativeEth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                                 rawBalance: "1000000000000000000")
+        let prebuilt = try await interactor.buildKeysignPayload(
+            coin: nativeEth,
+            toAddress: "0x2222222222222222222222222222222222222222",
+            amount: BigInt(0),
+            memo: "0xb61d27f6",
+            chainSpecific: .Ethereum(maxFeePerGasWei: BigInt(1), priorityFeeWei: BigInt(1), nonce: 0, gasLimit: BigInt(21_000)),
+            wasmExecuteContractPayload: nil,
+            vault: try TestStore.makeVault()
+        )
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, rawBalance: "1000000")
+        let vm = SendCryptoVerifyViewModel(
+            transaction: try makeTransaction(coin: usdc, amount: "1"),
+            interactor: interactor,
+            prebuiltKeysignPayload: prebuilt
+        )
+        vm.isAddressCorrect = false
+        vm.isAmountCorrect = false
+
+        do {
+            _ = try await vm.validateForm()
+            XCTFail("validateForm must throw when the confirmation checkboxes are unchecked")
+        } catch let error as HelperError {
+            guard case .runtimeError(let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "mustAgreeTermsError")
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, rawBalance: String = "0") -> Coin {


### PR DESCRIPTION
## Summary

Re-routes the Circle USDC **withdraw** through the shared verify/confirmation screen (mirroring `CircleDepositView`) so it shows the real **amount + recipient** and restores the confirmation checkboxes — **without changing the signed transaction from #4489**.

`Closes #4490`

## Background

After #4489 (the #4484 no-op fix), the withdraw keysign payload is the **native ETH** coin (amount `0`; the real `transfer(vault, amount)` lives inside the MSCA `execute(...)` calldata carried in `memo`). Two problems remained:

1. **Withdraw skipped verify entirely** — it navigated straight to `SendRoute.pairing`, so there was no amount/address confirmation step.
2. **Display was off** — the keysign hero (`KeysignViewModel.heroContent`) is Blockaid-only; on a Blockaid miss it falls back to the payload → **"0 ETH"**.

## The critical risk (and why a naive re-route would regress #4489)

`SendVerifyScreen` normally re-derives the payload on confirm via `validateForm()` → `buildKeysignPayload(tx:)`. The withdraw's display `tx` carries the **USDC** coin, so re-deriving would route through `ERC20Helper` and rebuild **`USDC.transfer(MSCA, 0)`** — exactly the #4484 no-op. So simply swapping `pairing` → `verify(tx:)` would **re-break #4489**.

## The fix (Option A, made safe — pass-through pre-built payload)

- `SendRoute.verify` gains an **optional `prebuiltKeysignPayload: KeysignPayload?`** (defaults to `nil`, so all existing callers — Send, Deposit, Tron freeze/unfreeze — are unchanged and keep re-deriving).
- When a pre-built payload is present, `SendCryptoVerifyViewModel.validateForm()` returns it **verbatim** and skips `buildKeysignPayload` — no re-derivation.
- `CircleWithdrawView` navigates to `SendRoute.verify(tx: <USDC display tx>, …, prebuiltKeysignPayload: <native-ETH execute() payload>)`. The verify summary renders amount + recipient from the USDC `tx` (no Blockaid dependency); the bytes signed are the **native-ETH `execute(...)` payload** built exactly as in #4489.
- The withdraw screen's fast/paired CTA + fast-vault password sheet are removed; the fast-vault password is now entered on the verify screen (consistent with Deposit/Tron/Send).

### Why the signed tx is unchanged from #4489
The payload object passed to keysign is the **same** `KeysignPayload` `CircleViewLogic.getWithdrawalPayload` already produced (native ETH coin, `to = MSCA`, `value = 0`, `memo = execute(USDC, 0, transfer(vault, amount))`). The USDC `tx` is **display-only** and never reaches the keysign builder.

## Verify-screen re-derivation finding
Confirmed by code: `SendVerifyScreen.signAndMoveToNextView()` uses the **return value** of `validateForm()` as the `keysignPayload`, and `validateForm()` → `SendCryptoVerifyLogic.buildKeysignPayload(tx:vault:)` builds from `tx.coin`. For a USDC `tx` that is the no-op path. The pass-through bypasses this; a unit test pins that `buildKeysignPayload` is **never called** when a pre-built payload is supplied.

## Tests
- ✅ **#4489 `CircleWithdrawTests` (6) stay green** — incl. `testWithdrawalPayloadUsesNativeCoinNotUsdc` and the `execute()`-wrapping encoder tests → no #4484 regression.
- ✅ **New `SendCryptoVerifyViewModelTests`:**
  - `testValidateFormReturnsPrebuiltPayloadVerbatimWithoutRederiving` — pre-built **native-ETH** payload returned verbatim (coin = ETH, `to = MSCA`, `toAmount = 0`, `memo` intact) **and** `buildKeysignPayload`/`fetchChainSpecific`/`validateUtxos` never called (USDC `tx` never re-derived).
  - `testValidateFormWithPrebuiltPayloadStillEnforcesCheckboxes` — confirmation checkboxes still gate signing.
- `Executed 35 tests, 0 failures` (CircleWithdrawTests + SendCryptoVerifyViewModelTests).

## Checks
- SwiftLint: **0 violations** in changed files.
- Build: **BUILD SUCCEEDED** (iOS Simulator, app scheme).

## Needs on-device check
End-to-end Ethereum withdraw to confirm the verify screen now shows **"N USDC → recipient"** (not "0 ETH"), the checkboxes appear, and the broadcast tx remains the native-ETH `execute(...)` (status success, moves N USDC from the MSCA) as in the #4489 e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional send-preview override so pairing/QR previews can show a display-only USDC amount/address when the signed payload differs.

* **Improvements**
  * Streamlined Circle withdrawal UI: single confirmation button and removed fast-vault password step.
  * Verification flow accepts prebuilt transaction payloads so the USDC display remains read-only while carrying the signing payload through verify.

* **Tests**
  * Added tests for prebuilt-payload verification, balance-check behavior, checkbox gating, and send-preview override.

* **Localization**
  * Renamed withdrawal amount label key (no change to displayed text)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->