### PR TITLE
fix(qbtc): include /qbtc path segment in tx explorer URL

### DIFF
--- a/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
@@ -208,7 +208,7 @@ enum ExplorerLinkBuilder {
         case .sei:
             return "https://seiscan.io/tx/\(txid)"
         case .qbtc:
-            return "https://explorer.qbtc.net/tx/\(txid)"
+            return "https://explorer.qbtc.net/qbtc/tx/\(txid)"
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
@@ -284,7 +284,7 @@ final class ExplorerLinkBuilderTests: XCTestCase {
     func testGetExplorerURLReturnsQbtcExplorerURL() {
         XCTAssertEqual(
             ExplorerLinkBuilder.getExplorerURL(chain: .qbtc, txid: txHash),
-            "https://explorer.qbtc.net/tx/\(txHash)"
+            "https://explorer.qbtc.net/qbtc/tx/\(txHash)"
         )
     }
 


### PR DESCRIPTION
## Summary
- The QBTC transaction explorer expects the chain prefix in the URL path. Transaction links from the tx history view now point to `https://explorer.qbtc.net/qbtc/tx/<txid>` instead of `https://explorer.qbtc.net/tx/<txid>`.
- Updated `ExplorerLinkBuilder.getExplorerURL` for `.qbtc` and the matching unit test.

## Test Plan
- [x] SwiftLint passes
- [ ] Open a QBTC transaction from tx history and confirm the explorer link resolves correctly

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Qbtc transaction explorer link path to ensure users are directed to the correct blockchain explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->