### PR TITLE
refactor(keysign): unify keysign-side PairScreen onto one shared PairScreen

### DIFF
--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallPairScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallPairScreen.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct FunctionCallPairScreen: View {
     @Environment(\.router) var router
-    @StateObject var shareSheetViewModel = ShareSheetViewModel()
 
     let vault: Vault
     let tx: SendTransaction
@@ -17,29 +16,13 @@ struct FunctionCallPairScreen: View {
     let fastVaultPassword: String?
 
     var body: some View {
-        Screen {
-            KeysignDiscoveryView(
-                vault: vault,
-                keysignPayload: keysignPayload,
-                customMessagePayload: nil,
-                fastVaultPassword: fastVaultPassword,
-                shareSheetViewModel: shareSheetViewModel,
-                previewType: .Send,
-                contentPadding: 0
-            ) { input in
-                router.navigate(to: FunctionCallRoute.keysign(input: input, tx: tx, retrySignal: SendRetrySignal()))
-            }
-        }
-        .screenTitle("pair".localized)
-        .screenToolbar {
-            CustomToolbarItem(placement: .trailing) {
-                NavigationQRShareButton(
-                    vault: vault,
-                    type: .Keysign,
-                    viewModel: shareSheetViewModel
-                )
-                .showIf(fastVaultPassword == nil)
-            }
+        PairScreen(
+            vault: vault,
+            keysignPayload: keysignPayload,
+            fastVaultPassword: fastVaultPassword,
+            previewType: .Send
+        ) { input in
+            router.navigate(to: FunctionCallRoute.keysign(input: input, tx: tx, retrySignal: SendRetrySignal()))
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/PairScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/PairScreen.swift
@@ -1,0 +1,91 @@
+//
+//  PairScreen.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Shared pairing screen for every keysign-side flow (Send, Swap, FunctionCall,
+/// QBTC claim, custom message). Owns the screen chrome that used to be
+/// duplicated across each per-flow wrapper: the `Screen` container, the title,
+/// the fast-vault chromeless block, and the trailing QR-share toolbar. The
+/// signing engine itself stays in `KeysignDiscoveryView`; callers supply only
+/// the payload, the preview type, and the post-pair navigation closure.
+struct PairScreen: View {
+    @StateObject private var shareSheetViewModel = ShareSheetViewModel()
+
+    let vault: Vault
+    var keysignPayload: KeysignPayload?
+    var customMessagePayload: CustomMessagePayload?
+    var fastVaultPassword: String?
+    var previewType: QRShareSheetType
+    var swapTransaction: SwapTransaction?
+    var presetSession: KeysignSessionInfo?
+
+    /// Overrides the default `"pair"` screen title. Used by the custom-message
+    /// flow, which shows the running keysign state title instead.
+    var title: String?
+
+    /// Overrides the default share-button visibility (`fastVaultPassword == nil`).
+    /// The custom-message flow gates on `!vault.isFastVault` instead.
+    var isShareButtonVisible: Bool?
+
+    let onKeysignInput: (KeysignInput) -> Void
+
+    init(
+        vault: Vault,
+        keysignPayload: KeysignPayload? = nil,
+        customMessagePayload: CustomMessagePayload? = nil,
+        fastVaultPassword: String? = nil,
+        previewType: QRShareSheetType = .Send,
+        swapTransaction: SwapTransaction? = nil,
+        presetSession: KeysignSessionInfo? = nil,
+        title: String? = nil,
+        isShareButtonVisible: Bool? = nil,
+        onKeysignInput: @escaping (KeysignInput) -> Void
+    ) {
+        self.vault = vault
+        self.keysignPayload = keysignPayload
+        self.customMessagePayload = customMessagePayload
+        self.fastVaultPassword = fastVaultPassword
+        self.previewType = previewType
+        self.swapTransaction = swapTransaction
+        self.presetSession = presetSession
+        self.title = title
+        self.isShareButtonVisible = isShareButtonVisible
+        self.onKeysignInput = onKeysignInput
+    }
+
+    var body: some View {
+        Screen {
+            KeysignDiscoveryView(
+                vault: vault,
+                keysignPayload: keysignPayload,
+                customMessagePayload: customMessagePayload,
+                fastVaultPassword: fastVaultPassword,
+                shareSheetViewModel: shareSheetViewModel,
+                previewType: previewType,
+                swapTransaction: swapTransaction,
+                contentPadding: 0,
+                presetSession: presetSession,
+                onKeysignInput: onKeysignInput
+            )
+        }
+        .screenTitle(title ?? "pair".localized)
+        .if(fastVaultPassword != nil) {
+            $0
+                .screenNavigationBarHidden(true)
+                .screenEdgeInsets(.zero)
+        }
+        .screenToolbar {
+            CustomToolbarItem(placement: .trailing) {
+                NavigationQRShareButton(
+                    vault: vault,
+                    type: .Keysign,
+                    viewModel: shareSheetViewModel
+                )
+                .showIf(isShareButtonVisible ?? (fastVaultPassword == nil))
+            }
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Views/QBTCClaimPairScreen.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Views/QBTCClaimPairScreen.swift
@@ -2,18 +2,17 @@
 //  QBTCClaimPairScreen.swift
 //  VultisigApp
 //
-//  SecureVault pairing screen for the QBTC claim flow. Wraps the
-//  standard `KeysignDiscoveryView` with a preset session so the QR
-//  shows the session the orchestrator will run on. When the peer joins
-//  and `KeysignDiscoveryView` produces a `KeysignInput`, the screen
-//  routes to `QBTCClaimRoute.keysign` to drive the BTC ECDSA round.
+//  SecureVault pairing screen for the QBTC claim flow. Wraps the shared
+//  `PairScreen` with a preset session so the QR shows the session the
+//  orchestrator will run on. When the peer joins and `KeysignDiscoveryView`
+//  produces a `KeysignInput`, the screen routes to `QBTCClaimRoute.keysign`
+//  to drive the BTC ECDSA round.
 //
 
 import SwiftUI
 
 struct QBTCClaimPairScreen: View {
     @Environment(\.router) var router
-    @StateObject var shareSheetViewModel = ShareSheetViewModel()
 
     let vault: Vault
     let keysignPayload: KeysignPayload
@@ -22,39 +21,23 @@ struct QBTCClaimPairScreen: View {
     let selectedUtxos: [ClaimableUtxo]
 
     var body: some View {
-        Screen {
-            KeysignDiscoveryView(
-                vault: vault,
-                keysignPayload: keysignPayload,
-                customMessagePayload: nil,
-                fastVaultPassword: nil,
-                shareSheetViewModel: shareSheetViewModel,
-                previewType: .Send,
-                contentPadding: 0,
-                presetSession: session
-            ) { input in
-                router.navigate(
-                    to: QBTCClaimRoute.keysign(
-                        vault: vault,
-                        btcCoin: keysignPayload.coin,
-                        qbtcCoin: qbtcCoin,
-                        selectedUtxos: selectedUtxos,
-                        fastVaultPassword: nil,
-                        session: session,
-                        participants: input.keysignCommittee
-                    )
-                )
-            }
-        }
-        .screenTitle("pair".localized)
-        .screenToolbar {
-            CustomToolbarItem(placement: .trailing) {
-                NavigationQRShareButton(
+        PairScreen(
+            vault: vault,
+            keysignPayload: keysignPayload,
+            previewType: .Send,
+            presetSession: session
+        ) { input in
+            router.navigate(
+                to: QBTCClaimRoute.keysign(
                     vault: vault,
-                    type: .Keysign,
-                    viewModel: shareSheetViewModel
+                    btcCoin: keysignPayload.coin,
+                    qbtcCoin: qbtcCoin,
+                    selectedUtxos: selectedUtxos,
+                    fastVaultPassword: nil,
+                    session: session,
+                    participants: input.keysignCommittee
                 )
-            }
+            )
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendPairScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendPairScreen.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SendPairScreen: View {
     @Environment(\.router) var router
-    @StateObject var shareSheetViewModel = ShareSheetViewModel()
 
     let vault: Vault
     let tx: SendTransaction
@@ -18,34 +17,13 @@ struct SendPairScreen: View {
     let fastVaultPassword: String?
 
     var body: some View {
-        Screen {
-            KeysignDiscoveryView(
-                vault: vault,
-                keysignPayload: keysignPayload,
-                customMessagePayload: nil,
-                fastVaultPassword: fastVaultPassword,
-                shareSheetViewModel: shareSheetViewModel,
-                previewType: .Send,
-                contentPadding: 0
-            ) { input in
-                router.navigate(to: SendRoute.keysign(input: input, tx: tx, retrySignal: retrySignal))
-            }
-        }
-        .screenTitle("pair".localized)
-        .if(fastVaultPassword != nil) {
-            $0
-                .screenNavigationBarHidden(true)
-                .screenEdgeInsets(.zero)
-        }
-        .screenToolbar {
-            CustomToolbarItem(placement: .trailing) {
-                NavigationQRShareButton(
-                    vault: vault,
-                    type: .Keysign,
-                    viewModel: shareSheetViewModel
-                )
-                .showIf(fastVaultPassword == nil)
-            }
+        PairScreen(
+            vault: vault,
+            keysignPayload: keysignPayload,
+            fastVaultPassword: fastVaultPassword,
+            previewType: .Send
+        ) { input in
+            router.navigate(to: SendRoute.keysign(input: input, tx: tx, retrySignal: retrySignal))
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
@@ -12,7 +12,6 @@ struct SettingsCustomMessageView: View {
     @Environment(\.dismiss) var dismiss
 
     @StateObject var viewModel = SettingsCustomMessageViewModel()
-    @StateObject var shareSheetViewModel = ShareSheetViewModel()
 
     @State var keysignView: KeysignView?
     @State var method: String = .empty
@@ -130,12 +129,12 @@ struct SettingsCustomMessageView: View {
     }
 
     var pair: some View {
-        KeysignDiscoveryView(
+        PairScreen(
             vault: vault,
-            keysignPayload: nil,
             customMessagePayload: customMessagePayload,
             fastVaultPassword: fastVaultPassword.nilIfEmpty,
-            shareSheetViewModel: shareSheetViewModel
+            title: viewModel.state.title,
+            isShareButtonVisible: !vault.isFastVault
         ) { input in
             self.keysignView = KeysignView(
                 vault: input.vault,
@@ -151,16 +150,6 @@ struct SettingsCustomMessageView: View {
                 isInitiateDevice: input.isInitiateDevice
             )
             viewModel.moveToNextView()
-        }
-        .crossPlatformToolbar(viewModel.state.title) {
-            CustomToolbarItem(placement: .trailing) {
-                NavigationQRShareButton(
-                    vault: vault,
-                    type: .Keysign,
-                    viewModel: shareSheetViewModel
-                )
-                .showIf(!vault.isFastVault)
-            }
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapPairScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapPairScreen.swift
@@ -7,7 +7,6 @@ import SwiftUI
 
 struct SwapPairScreen: View {
     @Environment(\.router) var router
-    @StateObject var shareSheetViewModel = ShareSheetViewModel()
 
     let vault: Vault
     let transaction: SwapTransaction
@@ -16,35 +15,14 @@ struct SwapPairScreen: View {
     let fastVaultPassword: String?
 
     var body: some View {
-        Screen {
-            KeysignDiscoveryView(
-                vault: vault,
-                keysignPayload: keysignPayload,
-                customMessagePayload: nil,
-                fastVaultPassword: fastVaultPassword,
-                shareSheetViewModel: shareSheetViewModel,
-                previewType: .Swap,
-                swapTransaction: transaction,
-                contentPadding: 0
-            ) { input in
-                router.navigate(to: SwapRoute.keysign(input: input, transaction: transaction, retrySignal: retrySignal))
-            }
-        }
-        .screenTitle("pair".localized)
-        .if(fastVaultPassword != nil) {
-            $0
-                .screenNavigationBarHidden(true)
-                .screenEdgeInsets(.zero)
-        }
-        .screenToolbar {
-            CustomToolbarItem(placement: .trailing) {
-                NavigationQRShareButton(
-                    vault: vault,
-                    type: .Keysign,
-                    viewModel: shareSheetViewModel
-                )
-                .showIf(fastVaultPassword == nil)
-            }
+        PairScreen(
+            vault: vault,
+            keysignPayload: keysignPayload,
+            fastVaultPassword: fastVaultPassword,
+            previewType: .Swap,
+            swapTransaction: transaction
+        ) { input in
+            router.navigate(to: SwapRoute.keysign(input: input, transaction: transaction, retrySignal: retrySignal))
         }
     }
 }


### PR DESCRIPTION
closes #4514

## What

Unify the keysign-side pairing flows onto a single shared **`PairScreen`** over the existing `KeysignDiscoveryView` engine, removing the chrome that was copy-pasted across five sites.

New `Features/Keysign/Views/PairScreen.swift` owns the previously-duplicated chrome:
- `Screen { KeysignDiscoveryView(...) }`
- `.screenTitle("pair".localized)`
- the fast-vault chromeless block (`.screenNavigationBarHidden(true)` + `.screenEdgeInsets(.zero)`)
- the trailing `NavigationQRShareButton` toolbar
- its own `@StateObject ShareSheetViewModel`, and always `contentPadding: 0`

It takes the payload, preview type, and the post-pair navigation closure, plus optional `title` and `isShareButtonVisible` overrides for the custom-message site.

The five call sites now funnel through it:
- `SendPairScreen`, `SwapPairScreen`, `FunctionCallPairScreen`, `QBTCClaimPairScreen` → thin router-binding shims (hold `@Environment(\.router)`, forward to `PairScreen` with their **unchanged** navigation closure).
- `SettingsCustomMessageView.pair` → `PairScreen` with `title:`/`isShareButtonVisible:` overrides, keeping its inline `KeysignView` builder closure verbatim.

## Engine untouched

`KeysignDiscoveryView`, `KeysignDiscoveryViewModel`, `KeysignInput`, and the session/relay/keysign services are **byte-for-byte identical** to `main` (verified: 0 diff lines). This PR is purely view-chrome extraction + relocating the post-pair navigation closure. Every navigation destination was copied verbatim from the view it replaced — the signing path is unchanged.

## Deviations from the original plan (please confirm)

1. **Thin shims retained instead of deleting the 4 wrappers.** The plan's preferred shape was to delete each `*PairScreen` and move its closure into the route *builder*. The route builders (`SendRouteBuilder`, `SwapRouter`, `FunctionCallRouteBuilder`, `QBTCClaimRouteBuilder`) are plain non-`View` structs invoked from `ContentView`'s `.navigationDestination` closures via `VultisigRouter`; they cannot read `@Environment(\.router)` (the `NavigationRouter` used for `.navigate(to:)`) without a broad change to the routing/`VultisigRouter` contract, which is out of scope for a chrome refactor. Per the plan's documented fallback, each flow keeps an ultra-thin wrapper view (≤~12 LoC: `@Environment(\.router)` + `PairScreen(...) { router.navigate(...) }`). All duplicated **chrome** is gone regardless; the wrappers are now trivial router shims. Net effect on file count: 1 file added, 0 deleted.

2. **LoC delta is smaller than the ~−150 estimate** because the wrappers are kept (as shims) rather than deleted. Within the 5 changed files: **+45 / −134** (net −89 of duplicated chrome consolidated), and the new `PairScreen.swift` adds 91 lines that hold that chrome once. Commit total: 6 files, +136 / −134.

## Behavior changes (please confirm)

- **FunctionCall fast-vault chrome (intended normalization).** `FunctionCallPairScreen` previously did **not** apply the fast-vault chromeless block, while Send/Swap did. Routing it through the shared `PairScreen` now applies the same `.screenNavigationBarHidden(true)` + `.screenEdgeInsets(.zero)` on the fast-vault path. This normalizes pre-existing drift; calling it out explicitly.
- **Custom-message pair padding (minor).** The custom-message `pair` was not wrapped in `Screen`; it now is (via `PairScreen`). Horizontal padding is unchanged (16pt either way), but it picks up `Screen`'s default 12pt top/bottom inset. Title (`"pair".localized` in the `.pair` state) and share-button gating (`!vault.isFastVault`) are preserved.

## Checks

- `make generate` (XcodeGen) — clean; new file registered, gitignored `project.pbxproj` not committed.
- `swiftlint lint --config VultisigApp/.swiftlint.yml` on all 6 changed files — **0 violations, 0 serious**.
- `xcodebuild -scheme VultisigApp -destination 'generic/platform=iOS' build` — **BUILD SUCCEEDED**.
- Tests: grep confirms **no** test references `*PairScreen` / `buildPairScreen` / `SettingsCustomMessage`; this is view-chrome only with no test surface, and the engine is unchanged.

> Manual click-through of each pair screen (Send / Swap / FunctionCall / QBTC claim / custom message), secure + fast-vault paths, is recommended before un-drafting, given this sits adjacent to the signing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated pairing screen functionality across multiple features into a shared, reusable component to reduce code duplication and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->