### PR TITLE
fix(security): show Blockaid Solana scan reasons for risky txs

### DIFF
--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidExtensions.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidExtensions.swift
@@ -44,10 +44,8 @@ extension BlockaidTransactionScanResponseJson {
         let riskLevel = result.validation.toSolanaValidationRiskLevel()
         let isSecure = riskLevel == .noRisk || riskLevel == .low
 
-        var description: String?
-        if isSecure {
-            description = result.validation.features.prefix(3).joined(separator: "\n")
-        }
+        let summary = result.validation.features.prefix(3).joined(separator: "\n")
+        let description: String? = isSecure || summary.isEmpty ? nil : summary
 
         let warnings = result.validation.extendedFeatures.map { extendedFeature in
             SecurityWarning(
@@ -122,9 +120,8 @@ extension BlockaidTransactionScanResponseJson.BlockaidSolanaResultJson.BlockaidS
         let riskLevel = toSolanaValidationRiskLevel()
         let isSecure = riskLevel == .noRisk || riskLevel == .low
 
-        let description: String? = isSecure
-            ? features.prefix(3).joined(separator: "\n")
-            : nil
+        let summary = features.prefix(3).joined(separator: "\n")
+        let description: String? = isSecure || summary.isEmpty ? nil : summary
 
         let warnings = extendedFeatures.map { feature in
             SecurityWarning(

--- a/VultisigApp/VultisigAppTests/Services/BlockaidExtensionsTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BlockaidExtensionsTests.swift
@@ -1,0 +1,135 @@
+//
+//  BlockaidExtensionsTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+/// Covers the Solana Blockaid scan → `SecurityScannerResult` mapping. The
+/// warning sheet only renders when `!isSecure`, so the human-readable risk
+/// summary (top-3 `features`) must be attached on the non-secure branch, and
+/// an empty `features` array must yield `nil` (not `""`) so the sheet keeps its
+/// default copy.
+final class BlockaidExtensionsTests: XCTestCase {
+
+    // MARK: - toSolanaSecurityScannerResult
+
+    /// Non-secure scan with features: description is the top-3 features joined
+    /// by newline so the warning sheet can surface the actual reasons.
+    func test_toSolanaSecurityScannerResult_nonSecureWithFeatures_setsTopThreeDescription() throws {
+        let response = try decodeScanResponse(
+            resultType: "Malicious",
+            features: ["Reason A", "Reason B", "Reason C", "Reason D"]
+        )
+
+        let result = try response.toSolanaSecurityScannerResult(provider: "blockaid")
+
+        XCTAssertFalse(result.isSecure)
+        XCTAssertEqual(result.description, "Reason A\nReason B\nReason C")
+    }
+
+    /// Secure scan with no features: description stays nil (the sheet doesn't
+    /// render for secure results anyway).
+    func test_toSolanaSecurityScannerResult_secureWithoutFeatures_descriptionNil() throws {
+        let response = try decodeScanResponse(resultType: "Benign", features: [])
+
+        let result = try response.toSolanaSecurityScannerResult(provider: "blockaid")
+
+        XCTAssertTrue(result.isSecure)
+        XCTAssertNil(result.description)
+    }
+
+    /// Empty-guard: a non-secure scan with no features must produce a nil
+    /// description, not "", so the sheet falls back to its default copy.
+    func test_toSolanaSecurityScannerResult_nonSecureWithoutFeatures_descriptionNil() throws {
+        let response = try decodeScanResponse(resultType: "Malicious", features: [])
+
+        let result = try response.toSolanaSecurityScannerResult(provider: "blockaid")
+
+        XCTAssertFalse(result.isSecure)
+        XCTAssertNil(result.description)
+    }
+
+    // MARK: - BlockaidSolanaValidationJson.toKeysignScannerResult
+
+    func test_solanaKeysignScannerResult_nonSecureWithFeatures_setsTopThreeDescription() throws {
+        let validation = try decodeSolanaValidation(
+            resultType: "Malicious",
+            features: ["Reason A", "Reason B", "Reason C", "Reason D"]
+        )
+
+        let result = validation.toKeysignScannerResult(provider: "blockaid")
+
+        XCTAssertFalse(result.isSecure)
+        XCTAssertEqual(result.description, "Reason A\nReason B\nReason C")
+    }
+
+    func test_solanaKeysignScannerResult_secureWithoutFeatures_descriptionNil() throws {
+        let validation = try decodeSolanaValidation(resultType: "Benign", features: [])
+
+        let result = validation.toKeysignScannerResult(provider: "blockaid")
+
+        XCTAssertTrue(result.isSecure)
+        XCTAssertNil(result.description)
+    }
+
+    func test_solanaKeysignScannerResult_nonSecureWithoutFeatures_descriptionNil() throws {
+        let validation = try decodeSolanaValidation(resultType: "Malicious", features: [])
+
+        let result = validation.toKeysignScannerResult(provider: "blockaid")
+
+        XCTAssertFalse(result.isSecure)
+        XCTAssertNil(result.description)
+    }
+}
+
+// MARK: - Fixture helpers
+
+private extension BlockaidExtensionsTests {
+    /// Builds a Solana validation JSON body. `features` is the array of
+    /// human-readable risk strings Blockaid returns for the Solana shape.
+    func validationJSON(resultType: String, features: [String]) -> String {
+        let featuresJSON = features
+            .map { "\"\($0)\"" }
+            .joined(separator: ", ")
+        return """
+        {
+          "result_type": "\(resultType)",
+          "reason": "",
+          "features": [\(featuresJSON)],
+          "extended_features": []
+        }
+        """
+    }
+
+    func decodeScanResponse(
+        resultType: String,
+        features: [String]
+    ) throws -> BlockaidTransactionScanResponseJson {
+        let json = """
+        {
+          "status": "Success",
+          "result": {
+            "validation": \(validationJSON(resultType: resultType, features: features))
+          },
+          "error": null,
+          "request_id": "r"
+        }
+        """
+        return try JSONDecoder().decode(
+            BlockaidTransactionScanResponseJson.self,
+            from: Data(json.utf8)
+        )
+    }
+
+    func decodeSolanaValidation(
+        resultType: String,
+        features: [String]
+    ) throws -> BlockaidTransactionScanResponseJson.BlockaidSolanaResultJson.BlockaidSolanaValidationJson {
+        try JSONDecoder().decode(
+            BlockaidTransactionScanResponseJson.BlockaidSolanaResultJson.BlockaidSolanaValidationJson.self,
+            from: Data(validationJSON(resultType: resultType, features: features).utf8)
+        )
+    }
+}


### PR DESCRIPTION
closes #4511

## Problem

Blockaid's Solana scan reasons were never shown for risky transactions — the warning sheet always displayed the generic default copy instead of the actual flagged reasons.

## Root cause (inverted branch)

In `BlockaidExtensions.swift`, `toSolanaSecurityScannerResult` built the scan `description` (the top-3 risk `features`, which are the human-readable reasons rendered in the warning sheet) **only on the `isSecure` branch**:

```swift
var description: String?
if isSecure {
    description = result.validation.features.prefix(3).joined(separator: "\n")
}
```

But the warning sheet renders **only when NOT secure** — `SecurityScannerState.shouldShowWarning` is `!result.isSecure`. So for exactly the risky transactions where the sheet appears, `description` was `nil`, and `SecurityScannerBottomSheet` fell back to the generic `"securityScannerDefaultDescription"` copy. The reasons were only ever computed for secure transactions, where the sheet never shows.

## Fix

Attach the summary on the **non-secure** branch instead:

```swift
let summary = result.validation.features.prefix(3).joined(separator: "\n")
let description: String? = isSecure || summary.isEmpty ? nil : summary
```

### Why the empty-guard is required

`SecurityScannerBottomSheet` resolves copy as `self.description ?? "securityScannerDefaultDescription".localized`. That fallback only fires when `description` is `nil`. An empty `features` array joins to `""`, which is non-nil and would render as a **blank** description, suppressing the default copy. The `summary.isEmpty ? nil` guard ensures an empty features array yields `nil` so the sheet keeps its default message. This mirrors the Android implementation (non-secure branch + empty-guard).

## Second edit (consistency / future-proofing — latent UI effect)

The same inverted ternary existed in the Solana keysign mapping `BlockaidSolanaValidationJson.toKeysignScannerResult(provider:)`, and is corrected identically.

**NOTE:** this second edit's UI effect is currently **latent**. The keysign confirm screen only renders the "Scanned by Blockaid" header (`SecurityScannerHeaderView`) — no warning sheet is wired into the keysign confirm flow yet, so nothing consumes `description` there today. The edit is for consistency and to avoid re-introducing the bug when that sheet is eventually added.

## Not touched

`toSecurityScannerResult` (EVM/BTC/SUI) and the EVM keysign `toKeysignScannerResult` read `validation.description` directly and were already correct.

## Tests

Added `VultisigAppTests/Services/BlockaidExtensionsTests.swift` (JSON-fixture decoding, mirrors `BlockaidSolanaSimulationParserTests`). 6 cases — 3 per mapping:
- non-secure + features → `description` == top-3 joined by `\n`
- secure + empty features → `description` nil
- non-secure + empty features → `description` nil (empty-guard)

## Verification

- `make generate` (new test file picked up)
- `swiftlint lint` — 0 violations on both changed files
- `xcodebuild build` (generic/platform=iOS) — **BUILD SUCCEEDED**
- All Blockaid tests pass: 46/46 (6 new + 40 existing), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security scan descriptions to display top validation details for risk assessment
  * Fixed handling of empty or secure validation results to avoid unnecessary descriptions

* **Tests**
  * Added comprehensive test suite for security scan result mapping and validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->