### PR TITLE
fix(qbtc): chain detail screen — explorer account link + hide unsupported Buy

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/Actions/Coin+ChainAction.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Actions/Coin+ChainAction.swift
@@ -36,7 +36,9 @@ extension Chain {
         }
         actions.append(.send) // always include send
 
-        actions.append(.buy)
+        if self.isBuyAvailable {
+            actions.append(.buy)
+        }
         let enableSell = UserDefaults.standard.bool(forKey: "SellEnabled")
         if enableSell {
             actions.append(.sell)

--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -658,7 +658,7 @@ class Endpoint {
         case .sei:
             return "https://seiscan.io/address/\(address)"
         case .qbtc:
-            return nil
+            return "https://explorer.qbtc.net/qbtc/address/\(address)"
         case .bittensor:
             return "https://taostats.io/account/\(address)"
         case .none:

--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -658,7 +658,7 @@ class Endpoint {
         case .sei:
             return "https://seiscan.io/address/\(address)"
         case .qbtc:
-            return "https://explorer.qbtc.net/qbtc/address/\(address)"
+            return "https://explorer.qbtc.net/qbtc/account/\(address)"
         case .bittensor:
             return "https://taostats.io/account/\(address)"
         case .none:

--- a/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
@@ -297,7 +297,7 @@ enum ExplorerLinkBuilder {
         case .bittensor:
             return "https://taostats.io/account/\(address)"
         case .qbtc:
-            return "https://explorer.qbtc.net/qbtc/address/\(address)"
+            return "https://explorer.qbtc.net/qbtc/account/\(address)"
         }
     }
 

--- a/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
@@ -297,7 +297,7 @@ enum ExplorerLinkBuilder {
         case .bittensor:
             return "https://taostats.io/account/\(address)"
         case .qbtc:
-            return nil
+            return "https://explorer.qbtc.net/qbtc/address/\(address)"
         }
     }
 

--- a/VultisigApp/VultisigApp/Model/Chain.swift
+++ b/VultisigApp/VultisigApp/Model/Chain.swift
@@ -548,6 +548,13 @@ enum Chain: String, Codable, Hashable, CaseIterable {
         }
     }
 
+    /// Whether the fiat on-ramp (Buy) flow is offered for this chain. QBTC has
+    /// no on-ramp provider, so Buy is hidden; every other chain keeps the
+    /// existing behaviour.
+    var isBuyAvailable: Bool {
+        self != .qbtc
+    }
+
     /// Cosmos-SDK native staking via delegate / undelegate / redelegate /
     /// claim-rewards. Only the LUNA / LUNC chains today; other Cosmos
     /// chains (gaia / kujira / osmosis / etc.) are out of scope for the

--- a/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
@@ -290,7 +290,7 @@ final class ExplorerLinkBuilderTests: XCTestCase {
 
     func testGetExplorerByAddressURLProducesNonEmptyURLForEveryChain() {
         let address = "test-address"
-        for chain in Chain.allCases where chain != .qbtc {
+        for chain in Chain.allCases {
             let url = ExplorerLinkBuilder.getExplorerByAddressURL(chain: chain, address: address)
             XCTAssertNotNil(url, "Chain \(chain.rawValue) returned nil for address URL")
             XCTAssertFalse(
@@ -300,7 +300,10 @@ final class ExplorerLinkBuilderTests: XCTestCase {
         }
     }
 
-    func testGetExplorerByAddressURLReturnsNilForQbtc() {
-        XCTAssertNil(ExplorerLinkBuilder.getExplorerByAddressURL(chain: .qbtc, address: "addr"))
+    func testGetExplorerByAddressURLReturnsQbtcExplorerURL() {
+        XCTAssertEqual(
+            ExplorerLinkBuilder.getExplorerByAddressURL(chain: .qbtc, address: "addr"),
+            "https://explorer.qbtc.net/qbtc/address/addr"
+        )
     }
 }

--- a/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
@@ -303,7 +303,7 @@ final class ExplorerLinkBuilderTests: XCTestCase {
     func testGetExplorerByAddressURLReturnsQbtcExplorerURL() {
         XCTAssertEqual(
             ExplorerLinkBuilder.getExplorerByAddressURL(chain: .qbtc, address: "addr"),
-            "https://explorer.qbtc.net/qbtc/address/addr"
+            "https://explorer.qbtc.net/qbtc/account/addr"
         )
     }
 }


### PR DESCRIPTION
## What & why

Two fixes for the QBTC chain detail screen.

### 1. Explorer (cube) button did nothing

`ChainDetailScreenContainer.onExplorer()` builds the URL via `Endpoint.getExplorerByAddressURLByGroup(chain:address:)` and `guard`s on a non-nil result. For `.qbtc` that function returned `nil`, so the guard failed and the tap silently did nothing. The parallel builder `ExplorerLinkBuilder.getExplorerByAddressURL` (used by the UTXO transaction cells) returned `nil` for `.qbtc` too.

**Fix:** both address-URL builders now return `https://explorer.qbtc.net/qbtc/account/<address>`, matching the `/qbtc/` path scheme already used for tx links (`https://explorer.qbtc.net/qbtc/tx/<txid>`, added in #4513).

### 2. Buy button shown though QBTC has no on-ramp

`Chain.defaultActions` appended `.buy` unconditionally for every chain, so the QBTC chain detail screen offered a Buy button even though there is no fiat on-ramp provider for QBTC.

**Fix:** gate the `.buy` action behind a new `Chain.isBuyAvailable` flag (true for all chains except QBTC). `CoinActionResolver` already derives from `defaultActions`, so Buy is removed everywhere consistently for QBTC.

## Changes

- `Endpoint.getExplorerByAddressURLByGroup` — return the QBTC account URL (was `nil`).
- `ExplorerLinkBuilder.getExplorerByAddressURL` — return the QBTC account URL (was `nil`).
- `Chain.isBuyAvailable` — new flag; `Coin+ChainAction.defaultActions` gates `.buy` on it.
- Tests — `testGetExplorerByAddressURLProducesNonEmptyURLForEveryChain` no longer excludes `.qbtc`; replaced the nil assertion with a positive one.

## Validation

- `swiftlint` — 0 violations on changed files.
- `xcodebuild -scheme VultisigApp -destination 'generic/platform=iOS' build` — **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added blockchain explorer support for QBTC — users can open QBTC account pages to view address details and transactions.

* **Behavior Changes**
  * The Buy (fiat on‑ramp) option is now hidden for QBTC; Buy remains available for other chains.

* **Tests**
  * Updated tests to verify QBTC explorer URL generation and that every supported chain produces a valid address URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->