### PR TITLE
fix(solana): decode WalletCore signed tx as base58 and pin base64 on sendTransaction

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
@@ -49,7 +49,12 @@ struct SolanaAPI: TargetType {
         // HTTPClient owns the JSON serialization.
         switch rpcMethod {
         case .sendTransaction(let encodedTransaction):
-            return .requestParameters(rpcEnvelope(method: "sendTransaction", params: [encodedTransaction]), .jsonEncoding)
+            // Pin the encoding: signed transactions are normalized to base64
+            // before broadcast, while the RPC default is base58.
+            return .requestParameters(
+                rpcEnvelope(method: "sendTransaction", params: [encodedTransaction, ["encoding": "base64"]]),
+                .jsonEncoding
+            )
         case .getBalance(let address):
             return .requestParameters(rpcEnvelope(method: "getBalance", params: [address]), .jsonEncoding)
         case .getRecentPrioritizationFees:

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
@@ -245,11 +245,15 @@ enum SolanaHelper {
                                                                              publicKeys: publicKeys)
         let output = try SolanaSigningOutput(serializedBytes: compileWithSignature)
 
-        guard let txData = Data(base64Encoded: output.encoded) else {
+        // WalletCore emits `output.encoded` as base58: the signing input never
+        // sets `txEncoding`, so the proto default (base58) applies. Normalize
+        // `rawTransaction` to base64 to match the encoding pinned on the
+        // sendTransaction RPC call.
+        guard let txData = Base58.decodeNoCheck(string: output.encoded) else {
             throw HelperError.runtimeError("Failed to decode signed Solana transaction")
         }
         let result = SignedTransactionResult(
-            rawTransaction: output.encoded,
+            rawTransaction: txData.base64EncodedString(),
             transactionHash: try getHashFromRawTransaction(txData: txData)
         )
 
@@ -380,6 +384,8 @@ enum SolanaHelper {
         return Base58.encodeNoCheck(data: sigBytes)
     }
 
+    /// Returns WalletCore's base58 output unchanged — base58 is the Blockaid
+    /// security-scanner contract; do not normalize to base64 here.
     static func getZeroSignedTransaction(keysignPayload: KeysignPayload) throws -> String {
         let coinHexPublicKey = keysignPayload.coin.hexPublicKey
         guard let publicKey = PublicKey(data: Data(hex: coinHexPublicKey), type: PublicKeyType.ed25519) else {

--- a/VultisigApp/VultisigAppTests/Chains/SolanaHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/SolanaHelperTests.swift
@@ -1,0 +1,227 @@
+//
+//  SolanaHelperTests.swift
+//  VultisigApp
+//
+//  Pins the Solana signed-transaction encoding contract: WalletCore compiles
+//  with the proto-default base58 output (txEncoding is never set on the
+//  signing input), SignedTransactionResult.rawTransaction is normalized to
+//  base64 for broadcast, and the transaction hash is the base58 of the first
+//  64-byte signature.
+//
+
+@testable import VultisigApp
+import BigInt
+import Tss
+import WalletCore
+import XCTest
+
+final class SolanaHelperTests: XCTestCase {
+
+    // Deterministic test-only ed25519 key (from WalletCore's Solana tests).
+    private let signerPrivateKeyHex = "8778cc93c6596387e751d2dc693bbd93e434bd233bc5b68a826c56131821cb63"
+    // Base58 of 32 zero bytes — a structurally valid recent blockhash.
+    private let recentBlockHash = "11111111111111111111111111111111"
+
+    // MARK: - Fixtures
+
+    private func makeSignerKey() throws -> PrivateKey {
+        let keyData = try XCTUnwrap(Data(hexString: signerPrivateKeyHex))
+        return try XCTUnwrap(PrivateKey(data: keyData))
+    }
+
+    private func makeRecipientAddress() throws -> String {
+        let keyData = Data(repeating: 0x42, count: 32)
+        let recipientKey = try XCTUnwrap(PrivateKey(data: keyData))
+        return AnyAddress(publicKey: recipientKey.getPublicKeyEd25519(), coin: .solana).description
+    }
+
+    private func makeCoin(privateKey: PrivateKey) -> Coin {
+        let publicKey = privateKey.getPublicKeyEd25519()
+        let meta = CoinMeta(
+            chain: .solana,
+            ticker: "SOL",
+            logo: "solana",
+            decimals: 9,
+            priceProviderId: "solana",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(
+            asset: meta,
+            address: AnyAddress(publicKey: publicKey, coin: .solana).description,
+            hexPublicKey: publicKey.data.hexString
+        )
+    }
+
+    private func makeNativeTransferPayload(privateKey: PrivateKey) throws -> KeysignPayload {
+        KeysignPayload(
+            coin: makeCoin(privateKey: privateKey),
+            toAddress: try makeRecipientAddress(),
+            toAmount: 1_000_000,
+            chainSpecific: .Solana(
+                recentBlockHash: recentBlockHash,
+                priorityFee: 1_000_000,
+                priorityLimit: 100_000,
+                fromAddressPubKey: nil,
+                toAddressPubKey: nil,
+                hasProgramId: false
+            ),
+            utxos: [],
+            memo: nil,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            vaultLocalPartyID: "localPartyID",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    /// Builds TSS keysign responses the same way the Schnorr keysign state
+    /// does: r/s stored little-endian so `TssKeysignResponse.getSignature()`
+    /// reverses them back into the 64-byte ed25519 signature.
+    private func makeSignatures(
+        preImageHashes: [String],
+        privateKey: PrivateKey
+    ) throws -> [String: TssKeysignResponse] {
+        var signatures: [String: TssKeysignResponse] = [:]
+        for hash in preImageHashes {
+            let message = try XCTUnwrap(Data(hexString: hash))
+            let signature = try XCTUnwrap(privateKey.sign(digest: message, curve: .ed25519))
+            let response = TssKeysignResponse()
+            response.msg = hash
+            response.r = Data(signature.prefix(32).reversed()).hexString
+            response.s = Data(signature.suffix(32).reversed()).hexString
+            signatures[hash] = response
+        }
+        return signatures
+    }
+
+    // MARK: - Encoding contract
+
+    /// Regression pin: WalletCore's `SolanaSigningOutput.encoded` is base58
+    /// because the signing input never sets `txEncoding`. If a WalletCore bump
+    /// changes that default, this test fails before users hit a broken decode
+    /// after the TSS ceremony.
+    func testZeroSignedTransactionEncodingIsBase58NotBase64() throws {
+        let payload = try makeNativeTransferPayload(privateKey: makeSignerKey())
+
+        let zeroSigned = try SolanaHelper.getZeroSignedTransaction(keysignPayload: payload)
+
+        let base58Decoded = try XCTUnwrap(
+            Base58.decodeNoCheck(string: zeroSigned),
+            "WalletCore no longer emits base58 — the getSignedTransaction decode path must be revisited"
+        )
+        // The decoded bytes must parse as a Solana tx envelope (shortvec sig
+        // count + 64-byte signature slots + message).
+        XCTAssertNoThrow(try SolanaHelper.getHashFromRawTransaction(txData: base58Decoded))
+        // Strict base64 must not silently decode the same string into the
+        // same bytes — interpreting WalletCore's output as base64 either
+        // fails outright or garbles the transaction.
+        if let base64Decoded = Data(base64Encoded: zeroSigned) {
+            XCTAssertNotEqual(base64Decoded, base58Decoded)
+        }
+    }
+
+    // MARK: - Full signing path
+
+    func testGetSignedTransactionReturnsBase64RawTransactionAndBase58Hash() throws {
+        let privateKey = try makeSignerKey()
+        let payload = try makeNativeTransferPayload(privateKey: privateKey)
+        let preImageHashes = try SolanaHelper.getPreSignedImageHash(keysignPayload: payload)
+        let signatures = try makeSignatures(preImageHashes: preImageHashes, privateKey: privateKey)
+
+        let result = try SolanaHelper.getSignedTransaction(keysignPayload: payload, signatures: signatures)
+
+        let txData = try XCTUnwrap(
+            Data(base64Encoded: result.rawTransaction),
+            "rawTransaction must be base64 for the sendTransaction RPC call"
+        )
+        // Single fee-payer signature: [0x01][64-byte sig][message].
+        XCTAssertEqual(txData.first, 0x01)
+        XCTAssertGreaterThan(txData.count, 65)
+        let signatureBytes = txData.subdata(in: 1..<65)
+        XCTAssertEqual(result.transactionHash, Base58.encodeNoCheck(data: signatureBytes))
+        // The spliced signature must be the one our test key produced.
+        let message = txData.subdata(in: 65..<txData.count)
+        XCTAssertTrue(privateKey.getPublicKeyEd25519().verify(signature: signatureBytes, message: message))
+    }
+
+    // MARK: - Transaction hash extraction
+
+    func testGetHashFromRawTransactionReturnsBase58OfFirstSignature() throws {
+        let signature = Data((0..<64).map { UInt8($0) })
+        var transaction = Data([0x01])
+        transaction.append(signature)
+        transaction.append(Data(repeating: 0xAB, count: 32))
+
+        let hash = try SolanaHelper.getHashFromRawTransaction(txData: transaction)
+
+        XCTAssertEqual(hash, Base58.encodeNoCheck(data: signature))
+    }
+
+    func testGetHashFromRawTransactionThrowsOnGarbageBytes() {
+        // Unterminated shortvec (every byte has the continuation bit set).
+        XCTAssertThrowsError(try SolanaHelper.getHashFromRawTransaction(txData: Data([0xFF, 0xFF, 0xFF])))
+        // Declares two signatures but is far too short to contain them.
+        XCTAssertThrowsError(try SolanaHelper.getHashFromRawTransaction(txData: Data([0x02, 0x00])))
+        XCTAssertThrowsError(try SolanaHelper.getHashFromRawTransaction(txData: Data()))
+    }
+
+    // MARK: - Raw (dApp) signing path
+
+    func testSignRawTransactionSplicesSignatureAndKeepsBase64Encoding() throws {
+        let privateKey = try makeSignerKey()
+        let publicKey = privateKey.getPublicKeyEd25519()
+        let message = Data(repeating: 0x07, count: 80)
+        var unsigned = Data([0x01])
+        unsigned.append(Data(repeating: 0x00, count: 64))
+        unsigned.append(message)
+        let base64Transaction = unsigned.base64EncodedString()
+
+        let preImageHashes = try SolanaHelper.getPreSignedImageHashForRaw(base64Transaction: base64Transaction)
+        XCTAssertEqual(preImageHashes, [message.hexString])
+        let signatures = try makeSignatures(preImageHashes: preImageHashes, privateKey: privateKey)
+
+        let result = try SolanaHelper.signRawTransaction(
+            coinHexPubKey: publicKey.data.hexString,
+            base64Transaction: base64Transaction,
+            signatures: signatures
+        )
+
+        let expectedSignature = try XCTUnwrap(privateKey.sign(digest: message, curve: .ed25519))
+        var expectedSigned = Data([0x01])
+        expectedSigned.append(expectedSignature)
+        expectedSigned.append(message)
+        XCTAssertEqual(Data(base64Encoded: result.rawTransaction), expectedSigned)
+        XCTAssertEqual(result.transactionHash, Base58.encodeNoCheck(data: expectedSignature))
+    }
+
+    // MARK: - RPC request shape
+
+    func testSendTransactionRequestPinsBase64Encoding() throws {
+        let encodedTransaction = "dGVzdC10cmFuc2FjdGlvbg=="
+        let api = SolanaAPI(
+            baseURL: SolanaAPI.rpcBaseURL,
+            usesProxyPath: true,
+            rpcMethod: .sendTransaction(encodedTransaction: encodedTransaction)
+        )
+
+        guard case .requestParameters(let body, _) = api.task else {
+            XCTFail("sendTransaction must use .requestParameters")
+            return
+        }
+        XCTAssertEqual(body["method"] as? String, "sendTransaction")
+        let params = try XCTUnwrap(body["params"] as? [Any])
+        XCTAssertEqual(params.count, 2)
+        XCTAssertEqual(params[0] as? String, encodedTransaction)
+        XCTAssertEqual(params[1] as? [String: String], ["encoding": "base64"])
+    }
+}


### PR DESCRIPTION
## Problem

Every Solana send and swap fails after the TSS keysign ceremony with **"Failed to decode signed Solana transaction"** — the signing ceremony completes (and is wasted), then the post-keysign assembly throws before broadcast. The dApp raw path is broken on the other end: `signRawTransaction` returns base64 but `sendTransaction` sent no encoding config, so the RPC decoded it as base58 and rejected the broadcast with `-32602`.

## Root cause

The co-sign raw-tx change switched `SolanaHelper.getSignedTransaction` to decode `SolanaSigningOutput.encoded` with `Data(base64Encoded:)`. But `SolanaSigningInput.txEncoding` is never set anywhere (transfer, token-transfer, create-ATA, and swap `rawMessage` inputs alike), so WalletCore (walletcore-spm 4.3.19) emits **base58** — the proto default. The strict base64 guard therefore throws for every regular send and every swap (Jupiter and THORChain both funnel through the same `getSignedTransaction(coinHexPubKey:inputData:signatures:)` overload).

## Fix (surgical — zero signing-input/MPC changes)

- `Solana.swift` `getSignedTransaction`: decode `output.encoded` with `Base58.decodeNoCheck` and normalize `rawTransaction` to `txData.base64EncodedString()`. `transactionHash` stays base58 of the first 64-byte signature (the correct Solana txid).
- `SolanaAPI.swift` `.sendTransaction`: params are now `[tx, {"encoding": "base64"}]` — pins the wire encoding instead of relying on the RPC's base58 default. Both signing paths (regular + dApp raw) now uniformly hand base64 to a base64-pinned RPC call.
- `getZeroSignedTransaction`: **unchanged** (comment added) — base58 is the Blockaid security-scanner contract (`SecurityScannerTransactionFactory` feeds it straight to Blockaid).
- `signRawTransaction`: no functional change (already base64).

Setting `txEncoding = .base64` on the signing inputs was rejected instead: it would diverge from the sibling platforms' signing inputs (cross-platform pre-image parity is load-bearing for secure-vault co-signing) and would silently flip `getZeroSignedTransaction`'s output, breaking the Blockaid base58 contract.

## Tests

New `VultisigAppTests/Chains/SolanaHelperTests.swift` (6 tests, all passing; `ChainHelperTests` fixture suite still green):

- `testZeroSignedTransactionEncodingIsBase58NotBase64` — pins the WalletCore base58 output contract; fails on any future walletcore bump that changes the default before users hit a broken decode.
- `testGetSignedTransactionReturnsBase64RawTransactionAndBase58Hash` — full path with a synthetic ed25519 keypair (signs the real pre-image so the in-function `publicKey.verify` passes); asserts base64 `rawTransaction`, hash == base58 of the first 64 signature bytes, and that the spliced signature verifies.
- `testGetHashFromRawTransactionReturnsBase58OfFirstSignature` / `testGetHashFromRawTransactionThrowsOnGarbageBytes` — hand-built `[0x01][64-byte sig][message]` fixture + garbage fixtures.
- `testSignRawTransactionSplicesSignatureAndKeepsBase64Encoding` — dApp raw-path round trip: spliced bytes, base64 round trip, base58 hash.
- `testSendTransactionRequestPinsBase64Encoding` — asserts the JSON-RPC params are `[tx, {"encoding": "base64"}]`.

## Verification

- `make generate` (new test file picked up)
- `swiftlint lint` — 0 violations on all 3 changed files
- `xcodebuild test` (iPhone 17 Pro Max sim) — **TEST SUCCEEDED**, 7/7 tests, 0 failures (app target built green as part of the test run)

## Manual validation checklist

- [ ] Native SOL send (default Vultisig proxy RPC)
- [ ] SPL token send — recipient with existing ATA
- [ ] SPL token send — recipient without ATA (create-and-transfer path)
- [ ] Jupiter swap
- [ ] THORChain swap from SOL
- [ ] dApp `signSolana` with `skipBroadcast = false` (app broadcasts)
- [ ] dApp `signSolana` with `skipBroadcast = true` (dApp broadcasts)
- [ ] Two-device secure-vault send (peer dedup / co-sign parity)
- [ ] Custom Solana RPC override (no proxy path)

Closes #4521

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Solana transaction encoding inconsistency by normalizing format during signing to ensure proper compatibility with RPC submission, improving downstream reliability and transaction handling.

* **Tests**
  * Added comprehensive test suite for Solana transaction signing and encoding, validating transaction formatting, signature handling, and RPC request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->