### PR TITLE
feat(swap): carry swap-fee coin context on OneInchTransaction and render it on the co-signer

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/commondata",
       "state" : {
-        "revision" : "dc4b8edc5e30946bd59efdb76ab1f41d0b7c3e6b"
+        "revision" : "5a72a86cb061dade165d42ad426ba3639fb9a877"
       }
     },
     {

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -243,6 +243,10 @@ extension SwapPayload {
                 isAffiliate: value.isAffiliate
             ))
         case .oneinchSwapPayload(let value):
+            // `has*` guards distinguish "legacy sender, context unknown"
+            // (field absent → nil) from a populated value. Empty strings are
+            // normalized to nil so consumers have a single "unknown" shape.
+            let swapFeeTokenId = value.quote.tx.hasSwapFeeTokenID ? value.quote.tx.swapFeeTokenID.nilIfEmpty : nil
             self = .generic(GenericSwapPayload(
                 fromCoin: try ProtoCoinResolver.resolve(coin: value.fromCoin),
                 toCoin: try ProtoCoinResolver.resolve(coin: value.toCoin),
@@ -258,10 +262,13 @@ extension SwapPayload {
                         gasPrice: value.quote.tx.gasPrice,
                         gas: value.quote.tx.gas,
                         swapFee: value.quote.tx.swapFee,
-                        swapFeeTokenContract: ""
+                        swapFeeTokenContract: swapFeeTokenId ?? ""
                     )
                 ),
-                provider: SwapProviderId.from(rawValue: value.provider)
+                provider: SwapProviderId.from(rawValue: value.provider),
+                swapFeeChain: value.quote.tx.hasSwapFeeChain ? value.quote.tx.swapFeeChain.nilIfEmpty : nil,
+                swapFeeTokenId: swapFeeTokenId,
+                swapFeeDecimals: value.quote.tx.hasSwapFeeDecimals ? Int(value.quote.tx.swapFeeDecimals) : nil
             ))
         case .kyberswapSwapPayload(let value):
             self = .generic(GenericSwapPayload(
@@ -350,6 +357,20 @@ extension SwapPayload {
                         $0.gas = payload.quote.tx.gas
                         if payload.quote.tx.swapFee != "0" {
                             $0.swapFee = payload.quote.tx.swapFee
+                            // Explicit presence matters: receivers treat
+                            // absent fields as "legacy sender → render no
+                            // fee", while a present-but-empty token id breaks
+                            // their coin-key lookup. Never set from nils so
+                            // re-encoded legacy payloads stay byte-stable.
+                            if let swapFeeChain = payload.swapFeeChain, !swapFeeChain.isEmpty {
+                                $0.swapFeeChain = swapFeeChain
+                            }
+                            if let swapFeeTokenId = payload.swapFeeTokenId, !swapFeeTokenId.isEmpty {
+                                $0.swapFeeTokenID = swapFeeTokenId
+                            }
+                            if let swapFeeDecimals = payload.swapFeeDecimals {
+                                $0.swapFeeDecimals = Int32(swapFeeDecimals)
+                            }
                         }
                     }
                 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/GenericSwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/GenericSwapPayload.swift
@@ -15,4 +15,13 @@ struct GenericSwapPayload: Codable, Hashable {
     let toAmountDecimal: Decimal
     let quote: EVMQuote
     let provider: SwapProviderId
+
+    /// Coin context for `quote.tx.swapFee`. The amount alone is ambiguous
+    /// because providers denominate the affiliate fee in different coins
+    /// (KyberSwap charges it in the destination token; LiFi declares the
+    /// fee token on the quote). nil means unknown (legacy sender) — the
+    /// co-signer renders no fee row rather than guessing a coin.
+    var swapFeeChain: String? = nil
+    var swapFeeTokenId: String? = nil
+    var swapFeeDecimals: Int? = nil
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignSwapFeeViewModel.swift
@@ -1,0 +1,95 @@
+//
+//  JoinKeysignSwapFeeViewModel.swift
+//  VultisigApp
+//
+
+import Foundation
+import BigInt
+
+/// Resolves the swap-fee row shown on the co-signer's swap confirm screen.
+/// The co-signer holds only the serialized keysign payload (no live quote),
+/// so the fee coin is reconstructed from the payload's coin context. The
+/// resolver never guesses: whenever the fee cannot be attributed to a coin
+/// with certainty it returns nil and the UI renders no row — a missing row
+/// beats a fiat value that's wrong by orders of magnitude.
+struct JoinKeysignSwapFeeViewModel {
+
+    struct ResolvedSwapFee {
+        /// Fee in human units. Scaled by the wire decimals (not the resolved
+        /// coin's) — the sender serialized the raw amount in those units.
+        let amount: Decimal
+        /// Display coin: supplies ticker and rate identity.
+        let coin: CoinMeta
+    }
+
+    /// Formatted (crypto, fiat) strings for the swap-fee row, or nil for no
+    /// row. Fiat is empty when no rate is available, consistent with the
+    /// network-fee row.
+    func getSwapFee(swapPayload: SwapPayload?, vault: Vault?) -> (feeCrypto: String, feeFiat: String)? {
+        guard let resolved = resolveSwapFee(swapPayload: swapPayload, vault: vault) else {
+            return nil
+        }
+        let cryptoString = "\(resolved.amount.formatForDisplay()) \(resolved.coin.ticker)"
+        let fiatString: String
+        if let rate = RateProvider.shared.rate(for: resolved.coin) {
+            let fiatValue = RateProvider.shared.fiatBalance(value: resolved.amount, rate: rate)
+            fiatString = fiatValue.formatToFiatForFee(includeCurrencySymbol: true)
+        } else {
+            fiatString = .empty
+        }
+        return (cryptoString, fiatString)
+    }
+
+    func resolveSwapFee(swapPayload: SwapPayload?, vault: Vault?) -> ResolvedSwapFee? {
+        // Only general (1inch-shaped) swaps carry a bare swap-fee amount;
+        // other payload variants encode fees elsewhere.
+        guard case let .generic(payload) = swapPayload else { return nil }
+        guard let fee = BigInt(payload.quote.tx.swapFee), fee > 0 else { return nil }
+
+        // Pre-context senders omit chain/decimals — render no row rather
+        // than guessing a coin (a 6-decimal destination-token fee read as an
+        // 18-decimal native amount is wrong by ~10^12).
+        guard
+            let chainName = payload.swapFeeChain,
+            let chain = Chain(name: chainName),
+            let wireDecimals = payload.swapFeeDecimals
+        else { return nil }
+
+        guard let coin = resolveDisplayCoin(
+            chain: chain,
+            tokenId: payload.swapFeeTokenId,
+            fromCoin: payload.fromCoin,
+            toCoin: payload.toCoin,
+            vault: vault
+        ) else { return nil }
+
+        let rawAmount = Decimal(string: String(fee)) ?? .zero
+        let amount = rawAmount / pow(10, wireDecimals)
+        return ResolvedSwapFee(amount: amount, coin: coin)
+    }
+
+    /// Token fees must match one side of the swap (those coins travelled
+    /// with the payload, complete with price-provider identity). Native fees
+    /// resolve via the vault's own coin for that chain — live rate — with a
+    /// TokensStore fallback when the vault doesn't hold it. An unknown token
+    /// id resolves to nothing: never guess.
+    private func resolveDisplayCoin(
+        chain: Chain,
+        tokenId: String?,
+        fromCoin: Coin,
+        toCoin: Coin,
+        vault: Vault?
+    ) -> CoinMeta? {
+        guard let tokenId = tokenId?.nilIfEmpty else {
+            if let vaultNative = vault?.nativeCoin(for: chain) {
+                return vaultNative.toCoinMeta()
+            }
+            return TokensStore.TokenSelectionAssets.first(where: {
+                $0.isNativeToken && $0.chain == chain
+            })
+        }
+        return [fromCoin, toCoin].first(where: {
+            $0.chain == chain && $0.contractAddress.caseInsensitiveCompare(tokenId) == .orderedSame
+        })?.toCoinMeta()
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -90,6 +90,7 @@ class JoinKeysignViewModel: ObservableObject {
     }
 
     private let gasViewModel = JoinKeysignGasViewModel()
+    private let swapFeeViewModel = JoinKeysignSwapFeeViewModel()
 
     init() {
         self.vault = Vault(name: "Main Vault")
@@ -711,6 +712,12 @@ class JoinKeysignViewModel: ObservableObject {
     func getCalculatedNetworkFee() -> (feeCrypto: String, feeFiat: String) {
         guard let keysignPayload else { return (.empty, .empty) }
         return gasViewModel.getCalculatedNetworkFee(payload: keysignPayload)
+    }
+
+    /// Swap-fee row for the swap confirm screen, nil when the payload
+    /// carries no fee or no trustworthy coin context (legacy sender).
+    func getSwapFee() -> (feeCrypto: String, feeFiat: String)? {
+        swapFeeViewModel.getSwapFee(swapPayload: keysignPayload?.swapPayload, vault: vault)
     }
 
     func getFromFiatAmount() -> String {

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -38,6 +38,11 @@ struct KeysignSwapConfirmView: View {
                 showIcon: true
             )
 
+            if let swapFee = viewModel.getSwapFee() {
+                separator
+                getFeeCell(title: "swapFee", fees: swapFee)
+            }
+
             separator
             getNetworkFeeCell()
         }
@@ -156,9 +161,12 @@ struct KeysignSwapConfirmView: View {
     }
 
     private func getNetworkFeeCell() -> some View {
-        let fees = viewModel.getCalculatedNetworkFee()
-        return HStack(spacing: 4) {
-            Text(NSLocalizedString("networkFee", comment: ""))
+        getFeeCell(title: "networkFee", fees: viewModel.getCalculatedNetworkFee())
+    }
+
+    private func getFeeCell(title: String, fees: (feeCrypto: String, feeFiat: String)) -> some View {
+        HStack(spacing: 4) {
+            Text(NSLocalizedString(title, comment: ""))
                 .foregroundColor(Theme.colors.textTertiary)
                 .font(Theme.fonts.bodySMedium)
 

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -212,13 +212,34 @@ extension SwapCryptoLogic {
             )
 
         case let .oneinch(evmQuote, _), let .lifi(evmQuote, _, _), let .kyberswap(evmQuote, _):
+            // Attribute the affiliate fee to its coin so peers holding only
+            // the serialized payload (the co-signer has no live quote) don't
+            // guess. `swapFeeCoin` is what the initiator's own fiat display
+            // uses, so both devices agree by construction.
+            var swapFeeChain: String?
+            var swapFeeTokenId: String?
+            var swapFeeDecimals: Int?
+            if transaction.quote.evmSwapFeeBigInt != nil {
+                let resolvedFeeCoin = swapFeeCoin(
+                    quote: transaction.quote,
+                    fromCoin: fromCoin,
+                    toCoin: toCoin,
+                    feeCoin: transaction.feeCoin
+                )
+                swapFeeChain = resolvedFeeCoin.chain.name
+                swapFeeTokenId = resolvedFeeCoin.contractAddress.nilIfEmpty
+                swapFeeDecimals = resolvedFeeCoin.decimals
+            }
             let payload = GenericSwapPayload(
                 fromCoin: fromCoin,
                 toCoin: toCoin,
                 fromAmount: amountInCoin,
                 toAmountDecimal: toDecimal,
                 quote: evmQuote,
-                provider: transaction.quote.swapProviderId ?? .oneInch
+                provider: transaction.quote.swapProviderId ?? .oneInch,
+                swapFeeChain: swapFeeChain,
+                swapFeeTokenId: swapFeeTokenId,
+                swapFeeDecimals: swapFeeDecimals
             )
             return try await keysignFactory.buildTransfer(
                 coin: fromCoin,

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -522,7 +522,11 @@ enum SwapCryptoLogic {
         return fiatValue
     }
 
-    private static func swapFeeCoin(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin) -> Coin {
+    /// Resolves the coin the quote's swap fee is denominated in. Also the
+    /// source of truth for the coin context serialized onto the keysign
+    /// payload — serializing this output guarantees the initiator's fiat
+    /// display and the co-signer's agree by construction.
+    static func swapFeeCoin(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin) -> Coin {
         guard let contract = quote?.swapFeeTokenContract else {
             return feeCoin
         }

--- a/VultisigApp/VultisigAppTests/Chains/KeysignPayloadCodable.swift
+++ b/VultisigApp/VultisigAppTests/Chains/KeysignPayloadCodable.swift
@@ -673,6 +673,9 @@ extension VSOneInchTransaction: @retroactive Codable {
         case gasPrice = "gas_price"
         case gas
         case swapFee = "swap_fee"
+        case swapFeeChain = "swap_fee_chain"
+        case swapFeeTokenID = "swap_fee_token_id"
+        case swapFeeDecimals = "swap_fee_decimals"
     }
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -683,6 +686,17 @@ extension VSOneInchTransaction: @retroactive Codable {
         try container.encode(gasPrice, forKey: .gasPrice)
         try container.encode(gas, forKey: .gas)
         try container.encode(swapFee, forKey: .swapFee)
+        // Optional proto fields with explicit presence: encode only when set
+        // so fixtures distinguish absent from present-but-empty.
+        if hasSwapFeeChain {
+            try container.encode(swapFeeChain, forKey: .swapFeeChain)
+        }
+        if hasSwapFeeTokenID {
+            try container.encode(swapFeeTokenID, forKey: .swapFeeTokenID)
+        }
+        if hasSwapFeeDecimals {
+            try container.encode(swapFeeDecimals, forKey: .swapFeeDecimals)
+        }
     }
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -694,6 +708,15 @@ extension VSOneInchTransaction: @retroactive Codable {
         gasPrice = try container.decodeIfPresent(String.self, forKey: .gasPrice) ?? String()
         gas = try container.decode(Int64.self, forKey: .gas)
         swapFee = try container.decodeIfPresent(String.self, forKey: .swapFee) ?? String()
+        if let chain = try container.decodeIfPresent(String.self, forKey: .swapFeeChain) {
+            swapFeeChain = chain
+        }
+        if let tokenID = try container.decodeIfPresent(String.self, forKey: .swapFeeTokenID) {
+            swapFeeTokenID = tokenID
+        }
+        if let decimals = try container.decodeIfPresent(Int32.self, forKey: .swapFeeDecimals) {
+            swapFeeDecimals = decimals
+        }
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Keysign/SwapFeeProtoMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SwapFeeProtoMappingTests.swift
@@ -1,0 +1,354 @@
+//
+//  SwapFeeProtoMappingTests.swift
+//  VultisigAppTests
+//
+//  Coverage for the swap-fee coin context on `OneInchTransaction`
+//  (swap_fee_chain / swap_fee_token_id / swap_fee_decimals): proto
+//  round-trips with explicit presence, raw pre-context wire bytes,
+//  the co-signer display resolver's never-guess semantics, and
+//  persisted-JSON back-compat for `GenericSwapPayload`.
+//
+
+import BigInt
+import XCTest
+import VultisigCommonData
+@testable import VultisigApp
+
+@MainActor
+final class SwapFeeProtoMappingTests: XCTestCase {
+
+    // MARK: - Proto round-trip
+
+    func testProtoRoundTripCarriesSwapFeeCoinContext() throws {
+        let payload = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 6
+        )
+
+        let proto = SwapPayload.generic(payload).mapToProtobuff()
+        guard case let .oneinchSwapPayload(value) = proto else {
+            XCTFail("Expected .oneinchSwapPayload"); return
+        }
+        XCTAssertTrue(value.quote.tx.hasSwapFeeChain)
+        XCTAssertTrue(value.quote.tx.hasSwapFeeTokenID)
+        XCTAssertTrue(value.quote.tx.hasSwapFeeDecimals)
+        XCTAssertEqual(value.quote.tx.swapFeeChain, "Ethereum")
+        XCTAssertEqual(value.quote.tx.swapFeeTokenID, usdcContract)
+        XCTAssertEqual(value.quote.tx.swapFeeDecimals, 6)
+
+        let decoded = try SwapPayload(proto: proto)
+        guard case let .generic(decodedPayload) = decoded else {
+            XCTFail("Expected .generic"); return
+        }
+        XCTAssertEqual(decodedPayload.swapFeeChain, "Ethereum")
+        XCTAssertEqual(decodedPayload.swapFeeTokenId, usdcContract)
+        XCTAssertEqual(decodedPayload.swapFeeDecimals, 6)
+        XCTAssertEqual(decodedPayload.quote.tx.swapFee, "5000000")
+        XCTAssertEqual(
+            decodedPayload.quote.tx.swapFeeTokenContract, usdcContract,
+            "Decoded quote should be self-consistent with the wire token id"
+        )
+    }
+
+    func testProtoRoundTripWithoutContextLeavesFieldsAbsent() throws {
+        let payload = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: nil,
+            swapFeeTokenId: nil,
+            swapFeeDecimals: nil
+        )
+
+        let proto = SwapPayload.generic(payload).mapToProtobuff()
+        guard case let .oneinchSwapPayload(value) = proto else {
+            XCTFail("Expected .oneinchSwapPayload"); return
+        }
+        XCTAssertFalse(value.quote.tx.hasSwapFeeChain, "nil context must be absent, not present-empty")
+        XCTAssertFalse(value.quote.tx.hasSwapFeeTokenID)
+        XCTAssertFalse(value.quote.tx.hasSwapFeeDecimals)
+
+        let decoded = try SwapPayload(proto: proto)
+        guard case let .generic(decodedPayload) = decoded else {
+            XCTFail("Expected .generic"); return
+        }
+        XCTAssertNil(decodedPayload.swapFeeChain)
+        XCTAssertNil(decodedPayload.swapFeeTokenId)
+        XCTAssertNil(decodedPayload.swapFeeDecimals)
+    }
+
+    func testZeroSwapFeeSetsNeitherFeeNorContextOnProto() {
+        let payload = makeGenericPayload(
+            swapFee: "0",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 6
+        )
+
+        let proto = SwapPayload.generic(payload).mapToProtobuff()
+        guard case let .oneinchSwapPayload(value) = proto else {
+            XCTFail("Expected .oneinchSwapPayload"); return
+        }
+        XCTAssertEqual(value.quote.tx.swapFee, "", "Zero fee stays off the wire")
+        XCTAssertFalse(value.quote.tx.hasSwapFeeChain)
+        XCTAssertFalse(value.quote.tx.hasSwapFeeTokenID)
+        XCTAssertFalse(value.quote.tx.hasSwapFeeDecimals)
+    }
+
+    // MARK: - Pre-context wire bytes
+
+    func testPreContextWireBytesDecodeWithNilContextAndNoFeeRow() throws {
+        // A sender that predates the schema extension serializes only
+        // fields 1-7 on the transaction.
+        var legacyProto = VSOneInchSwapPayload()
+        legacyProto.fromCoin = ProtoCoinResolver.proto(from: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true))
+        legacyProto.toCoin = ProtoCoinResolver.proto(from: makeUSDC())
+        legacyProto.fromAmount = "1000000000000000000"
+        legacyProto.toAmountDecimal = "3000"
+        legacyProto.quote = .with {
+            $0.dstAmount = "3000000000"
+            $0.tx = .with {
+                $0.from = "0xFrom"
+                $0.to = "0xRouter"
+                $0.data = "0x"
+                $0.value = "0"
+                $0.gasPrice = "1"
+                $0.gas = 100_000
+                $0.swapFee = "5000000"
+            }
+        }
+        legacyProto.provider = "1inch"
+
+        let bytes = try legacyProto.serializedData()
+        let reparsed = try VSOneInchSwapPayload(serializedBytes: bytes)
+        let decoded = try SwapPayload(proto: .oneinchSwapPayload(reparsed))
+
+        guard case let .generic(payload) = decoded else {
+            XCTFail("Expected .generic"); return
+        }
+        XCTAssertEqual(payload.quote.tx.swapFee, "5000000")
+        XCTAssertNil(payload.swapFeeChain)
+        XCTAssertNil(payload.swapFeeTokenId)
+        XCTAssertNil(payload.swapFeeDecimals)
+
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: decoded, vault: nil)
+        XCTAssertNil(resolved, "Pre-context sender → never guess a coin, render no row")
+    }
+
+    // MARK: - Display resolver
+
+    func testResolverMatchesToCoinAndAppliesWireDecimals() {
+        // 5_000_000 raw @ 6 decimals is 5.0 USDC — not 5e-12 (the failure
+        // mode of reading a destination-token fee with native 18 decimals).
+        let payload = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract.uppercased(),
+            swapFeeDecimals: 6
+        )
+
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .generic(payload), vault: nil)
+
+        XCTAssertEqual(resolved?.amount, 5)
+        XCTAssertEqual(resolved?.coin.ticker, "USDC", "Token id matches toCoin case-insensitively")
+    }
+
+    func testResolverWireDecimalsWinOverResolvedCoinDecimals() {
+        // toCoin says 6 decimals but the wire declares 18 — the sender
+        // serialized the raw amount in wire units, so wire wins.
+        let payload = makeGenericPayload(
+            swapFee: "1000000000000000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 18
+        )
+
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .generic(payload), vault: nil)
+
+        XCTAssertEqual(resolved?.amount, 1)
+    }
+
+    func testResolverNilTokenIdFallsBackToVaultNativeCoin() {
+        let vault = Vault(name: "Test Vault")
+        vault.coins.append(makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true))
+        let payload = makeGenericPayload(
+            swapFee: "10000000000000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: nil,
+            swapFeeDecimals: 18
+        )
+
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .generic(payload), vault: vault)
+
+        XCTAssertEqual(resolved?.amount, Decimal(string: "0.01"))
+        XCTAssertEqual(resolved?.coin.ticker, "ETH")
+        XCTAssertTrue(resolved?.coin.isNativeToken ?? false)
+    }
+
+    func testResolverNilTokenIdWithoutVaultUsesTokensStoreNative() {
+        let payload = makeGenericPayload(
+            swapFee: "10000000000000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: nil,
+            swapFeeDecimals: 18
+        )
+
+        let resolved = JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .generic(payload), vault: nil)
+
+        XCTAssertEqual(resolved?.coin.ticker, "ETH")
+        XCTAssertTrue(resolved?.coin.isNativeToken ?? false)
+    }
+
+    func testResolverUnknownChainYieldsNoRow() {
+        let payload = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: "NotARealChain",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 6
+        )
+
+        XCTAssertNil(JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .generic(payload), vault: nil))
+    }
+
+    func testResolverUnknownTokenIdYieldsNoRow() {
+        let payload = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            swapFeeDecimals: 6
+        )
+
+        XCTAssertNil(JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .generic(payload), vault: nil))
+    }
+
+    func testResolverMissingDecimalsYieldsNoRow() {
+        let payload = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: nil
+        )
+
+        XCTAssertNil(JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .generic(payload), vault: nil))
+    }
+
+    func testResolverZeroFeeYieldsNoRow() {
+        let payload = makeGenericPayload(
+            swapFee: "0",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 6
+        )
+
+        XCTAssertNil(JoinKeysignSwapFeeViewModel().resolveSwapFee(swapPayload: .generic(payload), vault: nil))
+    }
+
+    func testGetSwapFeeWithRateProducesFiatValue() {
+        let payload = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 6
+        )
+        let cryptoId = RateProvider.cryptoId(for: makeUSDC().toCoinMeta()).id
+        // In-memory rates update before the storage write, so a storage
+        // failure in the test harness doesn't invalidate the assertion.
+        try? RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: cryptoId, value: 1.0)
+        ])
+
+        let fees = JoinKeysignSwapFeeViewModel().getSwapFee(swapPayload: .generic(payload), vault: nil)
+
+        XCTAssertNotNil(fees)
+        XCTAssertTrue(fees?.feeCrypto.contains("USDC") ?? false)
+        XCTAssertFalse(fees?.feeFiat.isEmpty ?? true, "Seeded rate should produce a fiat string")
+    }
+
+    // MARK: - Persisted-JSON back-compat
+
+    func testGenericSwapPayloadJSONWithoutContextKeysDecodes() throws {
+        // A payload persisted before the context fields existed encodes the
+        // same JSON as one with nil context today (optionals are omitted).
+        let legacy = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: nil,
+            swapFeeTokenId: nil,
+            swapFeeDecimals: nil
+        )
+        let data = try JSONEncoder().encode(legacy)
+        let json = try XCTUnwrap(String(bytes: data, encoding: .utf8))
+        XCTAssertFalse(json.contains("swapFeeChain"), "nil optionals must be omitted from persisted JSON")
+
+        let decoded = try JSONDecoder().decode(GenericSwapPayload.self, from: data)
+        XCTAssertNil(decoded.swapFeeChain)
+        XCTAssertNil(decoded.swapFeeTokenId)
+        XCTAssertNil(decoded.swapFeeDecimals)
+        XCTAssertEqual(decoded.quote.tx.swapFee, "5000000")
+    }
+
+    func testGenericSwapPayloadJSONRoundTripsContext() throws {
+        let payload = makeGenericPayload(
+            swapFee: "5000000",
+            swapFeeChain: "Ethereum",
+            swapFeeTokenId: usdcContract,
+            swapFeeDecimals: 6
+        )
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(GenericSwapPayload.self, from: data)
+        XCTAssertEqual(decoded.swapFeeChain, "Ethereum")
+        XCTAssertEqual(decoded.swapFeeTokenId, usdcContract)
+        XCTAssertEqual(decoded.swapFeeDecimals, 6)
+    }
+
+    // MARK: - Fixtures
+
+    private let usdcContract = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, contract: String = "") -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals,
+            priceProviderId: ticker.lowercased(),
+            contractAddress: contract,
+            isNativeToken: isNative
+        )
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+
+    private func makeUSDC() -> Coin {
+        makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: usdcContract)
+    }
+
+    private func makeGenericPayload(
+        swapFee: String,
+        swapFeeChain: String?,
+        swapFeeTokenId: String?,
+        swapFeeDecimals: Int?
+    ) -> GenericSwapPayload {
+        GenericSwapPayload(
+            fromCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            toCoin: makeUSDC(),
+            fromAmount: BigInt("1000000000000000000"),
+            toAmountDecimal: 3000,
+            quote: EVMQuote(
+                dstAmount: "3000000000",
+                tx: EVMQuote.Transaction(
+                    from: "0xFrom",
+                    to: "0xRouter",
+                    data: "0x",
+                    value: "0",
+                    gasPrice: "1",
+                    gas: 100_000,
+                    swapFee: swapFee,
+                    swapFeeTokenContract: swapFeeTokenId ?? ""
+                )
+            ),
+            provider: .oneInch,
+            swapFeeChain: swapFeeChain,
+            swapFeeTokenId: swapFeeTokenId,
+            swapFeeDecimals: swapFeeDecimals
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapCryptoLogicTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapCryptoLogicTests.swift
@@ -193,6 +193,51 @@ final class SwapCryptoLogicTests: XCTestCase {
         XCTAssertTrue(SwapCryptoLogic.isAffiliate)
     }
 
+    // MARK: - swapFeeCoin
+
+    func testSwapFeeCoinMatchesFromCoinContractCaseInsensitively() {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let quote = SwapQuote.lifi(
+            makeEVMQuote(swapFee: "1", swapFeeTokenContract: "usdc-CONTRACT"),
+            fee: nil,
+            integratorFee: nil
+        )
+        let result = SwapCryptoLogic.swapFeeCoin(quote: quote, fromCoin: usdc, toCoin: eth, feeCoin: eth)
+        XCTAssertEqual(result.ticker, "USDC")
+    }
+
+    func testSwapFeeCoinMatchesToCoinContract() {
+        // KyberSwap shape: fee denominated in the destination token.
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let quote = SwapQuote.kyberswap(
+            makeEVMQuote(swapFee: "1", swapFeeTokenContract: "USDC-contract"),
+            fee: nil
+        )
+        let result = SwapCryptoLogic.swapFeeCoin(quote: quote, fromCoin: eth, toCoin: usdc, feeCoin: eth)
+        XCTAssertEqual(result.ticker, "USDC")
+    }
+
+    func testSwapFeeCoinFallsBackToFeeCoinWithoutContract() {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let quote = SwapQuote.oneinch(makeEVMQuote(swapFee: "1"), fee: nil)
+        let result = SwapCryptoLogic.swapFeeCoin(quote: quote, fromCoin: usdc, toCoin: usdc, feeCoin: eth)
+        XCTAssertEqual(result.ticker, "ETH")
+    }
+
+    func testSwapFeeCoinFallsBackToFeeCoinForUnknownContract() {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let quote = SwapQuote.kyberswap(
+            makeEVMQuote(swapFee: "1", swapFeeTokenContract: "0xdeadbeef"),
+            fee: nil
+        )
+        let result = SwapCryptoLogic.swapFeeCoin(quote: quote, fromCoin: usdc, toCoin: usdc, feeCoin: eth)
+        XCTAssertEqual(result.ticker, "ETH")
+    }
+
     // MARK: - Fixtures
 
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {
@@ -274,7 +319,9 @@ final class SwapCryptoLogicTests: XCTestCase {
 
     private func makeEVMQuote(
         dstAmount: String = "0",
-        toAddress: String = "0xTo"
+        toAddress: String = "0xTo",
+        swapFee: String = "0",
+        swapFeeTokenContract: String = ""
     ) -> EVMQuote {
         EVMQuote(
             dstAmount: dstAmount,
@@ -284,7 +331,9 @@ final class SwapCryptoLogicTests: XCTestCase {
                 data: "0x",
                 value: "0",
                 gasPrice: "0",
-                gas: 0
+                gas: 0,
+                swapFee: swapFee,
+                swapFeeTokenContract: swapFeeTokenContract
             )
         )
     }

--- a/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
@@ -151,6 +151,127 @@ final class SwapPayloadBuilderTests: XCTestCase {
         XCTAssertEqual(generic.provider, .lifi)
     }
 
+    // MARK: - Swap-fee coin context
+
+    func testKyberSwapPayloadCarriesDestinationTokenFeeContext() async throws {
+        // KyberSwap denominates the affiliate fee in the destination token
+        // (chargeFeeBy: "currency_out") — the serialized context must point
+        // at toCoin so the co-signer doesn't misread a 6-decimal token
+        // amount as an 18-decimal native one.
+        let vault = makeVault()
+        let transaction = makeNativeToTokenTransaction(
+            quote: .kyberswap(
+                makeEVMQuote(
+                    toAddress: "0xKyber",
+                    swapFee: "5000000",
+                    swapFeeTokenContract: usdcContract
+                ),
+                fee: BigInt(1_000)
+            )
+        )
+
+        let payload = try await SwapCryptoLogic.buildSwapKeysignPayload(
+            transaction: transaction,
+            chainSpecific: ethereumChainSpecific(),
+            vault: vault,
+            now: fixedNow
+        )
+
+        guard case let .generic(generic) = payload.swapPayload else {
+            XCTFail("Expected .generic swapPayload"); return
+        }
+        XCTAssertEqual(generic.swapFeeChain, "Ethereum")
+        XCTAssertEqual(generic.swapFeeTokenId, usdcContract)
+        XCTAssertEqual(generic.swapFeeDecimals, 6)
+    }
+
+    func testLifiPayloadCarriesQuoteDeclaredTokenFeeContext() async throws {
+        // LiFi declares the fee token on the quote; here it matches the
+        // source token.
+        let vault = makeVault()
+        let transaction = makeTokenToNativeTransaction(
+            quote: .lifi(
+                makeEVMQuote(
+                    toAddress: "0xLifi",
+                    swapFee: "250000",
+                    swapFeeTokenContract: usdcContract
+                ),
+                fee: BigInt(1_000),
+                integratorFee: nil
+            )
+        )
+
+        let payload = try await SwapCryptoLogic.buildSwapKeysignPayload(
+            transaction: transaction,
+            chainSpecific: ethereumChainSpecific(),
+            vault: vault,
+            now: fixedNow
+        )
+
+        guard case let .generic(generic) = payload.swapPayload else {
+            XCTFail("Expected .generic swapPayload"); return
+        }
+        XCTAssertEqual(generic.swapFeeChain, "Ethereum")
+        XCTAssertEqual(generic.swapFeeTokenId, usdcContract)
+        XCTAssertEqual(generic.swapFeeDecimals, 6)
+    }
+
+    func testLifiPayloadNativeFeeContextHasNilTokenId() async throws {
+        // No fee-token contract on the quote → fee falls to the chain's
+        // native fee coin: empty contract serializes as nil token id with
+        // the native coin's decimals.
+        let vault = makeVault()
+        let transaction = makeTokenToNativeTransaction(
+            quote: .lifi(
+                makeEVMQuote(
+                    toAddress: "0xLifi",
+                    swapFee: "10000000000000000",
+                    swapFeeTokenContract: ""
+                ),
+                fee: BigInt(1_000),
+                integratorFee: nil
+            )
+        )
+
+        let payload = try await SwapCryptoLogic.buildSwapKeysignPayload(
+            transaction: transaction,
+            chainSpecific: ethereumChainSpecific(),
+            vault: vault,
+            now: fixedNow
+        )
+
+        guard case let .generic(generic) = payload.swapPayload else {
+            XCTFail("Expected .generic swapPayload"); return
+        }
+        XCTAssertEqual(generic.swapFeeChain, "Ethereum")
+        XCTAssertNil(generic.swapFeeTokenId)
+        XCTAssertEqual(generic.swapFeeDecimals, 18)
+    }
+
+    func testOneInchZeroSwapFeeLeavesFeeContextNil() async throws {
+        let vault = makeVault()
+        let transaction = makeNativeToTokenTransaction(
+            quote: .oneinch(
+                makeEVMQuote(toAddress: "0x1inch", swapFee: "0", swapFeeTokenContract: ""),
+                fee: BigInt(1_000)
+            )
+        )
+
+        let payload = try await SwapCryptoLogic.buildSwapKeysignPayload(
+            transaction: transaction,
+            chainSpecific: ethereumChainSpecific(),
+            vault: vault,
+            now: fixedNow
+        )
+
+        guard case let .generic(generic) = payload.swapPayload else {
+            XCTFail("Expected .generic swapPayload"); return
+        }
+        XCTAssertNil(generic.swapFeeChain)
+        XCTAssertNil(generic.swapFeeTokenId)
+        XCTAssertNil(generic.swapFeeDecimals)
+    }
+
     // MARK: - Approve gating
 
     func testApprovePayloadNilForNativeSource() async throws {
@@ -243,6 +364,58 @@ final class SwapPayloadBuilderTests: XCTestCase {
         return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
     }
 
+    /// Real-shaped contract address so swap-fee context tests exercise the
+    /// case-insensitive token-id match against an actual hex string.
+    private let usdcContract = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+    /// Coin with an explicit contract address (empty for natives) — the
+    /// swap-fee context serializes `contractAddress.nilIfEmpty`, so these
+    /// fixtures must not carry the placeholder "<TICKER>-contract".
+    private func makeContractCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, contract: String) -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals,
+            priceProviderId: ticker.lowercased(),
+            contractAddress: contract,
+            isNativeToken: isNative
+        )
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+
+    private func makeNativeToTokenTransaction(quote: SwapQuote) -> SwapTransaction {
+        let eth = makeContractCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true, contract: "")
+        let usdc = makeContractCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: usdcContract)
+        return SwapTransaction(
+            fromCoin: eth,
+            toCoin: usdc,
+            fromAmount: 1.0,
+            quote: quote,
+            gas: 0,
+            thorchainFee: 0,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: eth
+        )
+    }
+
+    private func makeTokenToNativeTransaction(quote: SwapQuote) -> SwapTransaction {
+        let eth = makeContractCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true, contract: "")
+        let usdc = makeContractCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: usdcContract)
+        return SwapTransaction(
+            fromCoin: usdc,
+            toCoin: eth,
+            fromAmount: 100,
+            quote: quote,
+            gas: 0,
+            thorchainFee: 0,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: eth
+        )
+    }
+
     private func makeThorQuote(
         inboundAddress: String?,
         router: String?
@@ -268,7 +441,11 @@ final class SwapPayloadBuilderTests: XCTestCase {
         )
     }
 
-    private func makeEVMQuote(toAddress: String) -> EVMQuote {
+    private func makeEVMQuote(
+        toAddress: String,
+        swapFee: String = "0",
+        swapFeeTokenContract: String = ""
+    ) -> EVMQuote {
         EVMQuote(
             dstAmount: "1000000000000000000",
             tx: EVMQuote.Transaction(
@@ -277,7 +454,9 @@ final class SwapPayloadBuilderTests: XCTestCase {
                 data: "0x",
                 value: "0",
                 gasPrice: "0",
-                gas: 0
+                gas: 0,
+                swapFee: swapFee,
+                swapFeeTokenContract: swapFeeTokenContract
             )
         )
     }

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -57,12 +57,15 @@ packages:
     from: 1.17.0
   VultisigCommonData:
     url: https://github.com/vultisig/commondata
-    # Pinned to the main revision that merged the SwapKitSwapPayload proto
-    # (commondata #86, merged 2026-05-23). `SwapKitSwapPayload` is `oneof`
-    # entry 26 on `KeysignPayload` — carries pre-built tx bytes for non-EVM
-    # SwapKit routes (BTC PSBT, TON, ADA CBOR, TRON, SUI PTB, DOGE/BCH/DASH
-    # PSBT legacy P2PKH, ZEC Sapling).
-    revision: dc4b8edc5e30946bd59efdb76ab1f41d0b7c3e6b
+    # Pinned to the main revision that added coin context for `swap_fee` on
+    # `OneInchTransaction` (commondata #87, merged 2026-06-03): optional
+    # `swap_fee_chain = 8`, `swap_fee_token_id = 9`, `swap_fee_decimals = 10`
+    # with explicit presence, so receivers can attribute the affiliate fee
+    # to the right coin (KyberSwap denominates it in the destination token).
+    # Deliberately NOT head: the next schema change adds a `sign_sui` case
+    # to the `KeysignPayload.sign_data` oneof, which our exhaustive
+    # `OneOf_SignData` switches would be forced to handle.
+    revision: 5a72a86cb061dade165d42ad426ba3639fb9a877
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
     exactVersion: 4.3.19


### PR DESCRIPTION
## Problem

`OneInchTransaction.swap_fee` is a bare amount with no coin context, and aggregators denominate the affiliate fee in different coins:

| Provider | Fee coin |
|----------|----------|
| LI.FI / 1inch / SwapKit | source chain's native fee coin (e.g. ETH, 18 decimals) |
| **KyberSwap** | **destination token (e.g. USDC, 6 decimals)** — `chargeFeeBy: "currency_out"` |

The co-signer in a Secure Vault join flow holds only the serialized `KeysignPayload` (no live quote), so it cannot attribute the fee to a coin — iOS currently renders **no swap-fee row at all** on the co-signer, and any guess would misread a 6-decimal token amount as an 18-decimal native one (off by ~10¹²).

## Solution

Adopt commondata #87's optional coin-context fields on `OneInchTransaction` (`swap_fee_chain = 8`, `swap_fee_token_id = 9`, `swap_fee_decimals = 10`, explicit presence):

- **Populate (initiator)**: `SwapPayloadBuilder` serializes the output of `SwapCryptoLogic.swapFeeCoin` — the same resolution the initiator's own fiat display uses — so initiator and co-signer agree by construction. Native fee coins serialize with the token id absent (not empty); fields are only written when the fee is non-zero, so re-encoded legacy payloads stay byte-stable.
- **Read (co-signer)**: `init(from:)` threads the fields through with `has*` presence guards; absent ≠ empty. The decoded quote's `swapFeeTokenContract` is also populated from the wire token id for self-consistency. The legacy read-only `kyberswapSwapPayload` case is untouched.
- **Render**: `KeysignSwapConfirmView` gains a Swap Fee row beneath the provider row (existing `"swapFee"` localization key, no new strings), resolved by a new `JoinKeysignSwapFeeViewModel` mirroring vultisig-windows' `getSwapFeeFromPayload` never-guess semantics: unknown chain, missing decimals, or a token id matching neither side of the swap → no row; empty token id → vault native coin (TokensStore fallback); wire decimals win over the resolved coin's; fiat via RateProvider with empty fiat when no rate.

### Pin-bump scoping

`commondata` is pinned to **exactly `5a72a86`** (the #87 merge commit), deliberately not head: the next schema change (#89) adds a `sign_sui` case to the `KeysignPayload.sign_data` oneof, and iOS's `OneOf_SignData` switches are exhaustive — pinning to head would force unplanned SignSui semantics into this PR.

## Tests

- **New `SwapFeeProtoMappingTests` (15)**: proto round-trip with populated context (`has*` true), nil context → fields absent (not present-empty), zero fee → neither fee nor context on the wire, raw pre-#87 bytes (fields 1–7 only) decode with nil context and no fee row, display-resolver matrix (toCoin match @ 6 decimals ⇒ 5.0 units — pins the decimal-misread bug class; wire decimals win; empty token id → native via vault and via TokensStore; unknown chain / unknown token id / missing decimals / zero fee → no row; fiat with seeded rate), persisted-JSON back-compat (missing keys decode to nil; nil optionals omitted on encode).
- **`SwapPayloadBuilderTests` (+4)**: KyberSwap destination-token context, LiFi quote-declared token context, LiFi native fee → nil token id + native decimals, 1inch zero fee → nil context.
- **`SwapCryptoLogicTests` (+4)**: `swapFeeCoin` from/to case-insensitive contract match + fee-coin fallbacks.
- Fixture `VSOneInchTransaction` Codable extended with the three snake_case keys (encode only when `has*`, `decodeIfPresent` on read); fixture-consuming suites (`ChainHelperTests`, `BitcoinPsbtSignerTests`, `EvmCoinFinderTests`) re-run green.

## Manual validation checklist

- [ ] KyberSwap swap (fee in destination token, e.g. USDC 6 decimals): co-signer fiat swap-fee matches initiator on a two-device Secure Vault sign
- [ ] LI.FI swap (token fee and native fee variants): co-signer fiat matches initiator
- [ ] 1inch / SwapKit swap (swap_fee "0" in practice): no swap-fee row on either device (absence parity)
- [ ] Mixed versions, old initiator → new co-signer: payload decodes, no fee row, signing unaffected
- [ ] Mixed versions, new initiator → old co-signer: old device ignores the new optional fields, signing unaffected
- [ ] iOS → Windows cross-platform fiat match (pending Windows consuming an SDK build with the regenerated protos)

Closes #4520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added swap fee display row to keysign swap confirmation screen for improved transaction transparency.

* **Improvements**
  * Enhanced swap fee metadata handling across supported swap providers for more accurate fee information in confirmations.

* **Dependencies**
  * Updated common data dependency to support enhanced swap fee context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->