### PR TITLE
fix(utxo): drop accidental 2.5x double-multiply on UTXO fee (6.25x → 2.5x, match Android)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -16,10 +16,6 @@ struct BlockSpecificCacheItem {
 }
 final class BlockChainService {
 
-    static func normalizeUTXOFee(_ value: BigInt) -> BigInt {
-        return value * 2 + value / 2 // x2.5 fee
-    }
-
     static func normalizeEVMFee(_ value: BigInt) -> BigInt {
         let normalized = value + value / 2 // x1.5 fee
         return max(normalized, 1) // To avoid 0 miner tips
@@ -259,9 +255,9 @@ final class BlockChainService {
             // Use a much lower value that WalletCore can work with: divide by 10
             result = sats / 10 // 500k / 10 = 50k sats/byte (still high but workable)
         } else {
-            // For other chains, use normal normalization and multipliers
-            let normalized = Self.normalizeUTXOFee(sats)
-            let prioritized = Float(normalized) * feeMode.utxoMultiplier
+            // The API rate is already a next-block suggestion; apply only the fee-mode
+            // tier (fast 2.5x / normal 1x / low 0.75x) to match Android's 2.5x default.
+            let prioritized = Float(sats) * feeMode.utxoMultiplier
             result = BigInt(prioritized)
         }
 


### PR DESCRIPTION
## What

Fixes the UTXO fee being **6.25× the suggested next-block rate** by default. Closes the iOS half of #4529.

`normalizeUTXOFee` applied a hardcoded ×2.5, and `fetchUTXOFee` then multiplied the result **again** by `feeMode.utxoMultiplier` (`.fast` = 2.5). Default sends and all swaps (which hardcode `.fast`) therefore paid 2.5 × 2.5 = **6.25×**.

## Change

Remove the redundant `normalizeUTXOFee` step; apply only the fee-mode tier to the API rate (which is already a next-block suggestion):

| Mode | Before | After |
|------|--------|-------|
| Low | 1.875× | 0.75× |
| Normal | 2.5× | 1× |
| **Fast (default)** | **6.25×** | **2.5×** |

2.5× for the default matches Android's `UtxoFeeService` (`gas × 5 / 2`). DOGE keeps its separate `/10` path (unchanged).

Cross-device safe: the computed `byteFee` is baked into `BlockChainSpecific.UTXO` and shared via the keysign payload, so both devices sign the same plan — this only changes how the initiator derives the rate.

## receipts

- **Scope:** one function removed (single caller, no other refs repo-wide — `grep -rn normalizeUTXOFee` confirms), one expression simplified.
- **Math verified by hand:** `.fast` default 2.5 × 2.5 = 6.25 → 2.5; matches Android `UtxoFeeService.kt` non-DOGE `gas.multiply(5).divide(2)`.
- **Not compiled locally** (no iOS build env on this machine) — relying on CI to build. Change is a 3-line arithmetic simplification with no new symbols or API changes.

Heads up — AI-assisted change; reviewer please confirm the CI build + a real UTXO send fee looks right before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTXO fee calculation logic for more accurate transaction prioritization across supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->