### PR TITLE
fix(ripple): derive XRP fee from server load instead of hardcoded 180k drops

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -8,6 +8,32 @@ import WalletCore
 import BigInt
 import OSLog
 
+enum RippleFee {
+    /// XRPL reference (base) fee under no load.
+    static let referenceFeeDrops = 10
+    /// Margin applied to the open-ledger cost to survive escalation while the
+    /// TSS devices sign.
+    static let safetyMultiplier = BigInt(2)
+    /// Upper bound; comfortably covers fee escalation under load while keeping
+    /// the cost negligible (0.002 XRP).
+    static let maxFeeDrops = 2000
+
+    /// Derives a fee (in drops) from the server's reported load.
+    ///
+    /// The open-ledger cost is `base_fee * load_factor / load_base`. We apply a
+    /// safety multiplier so the transaction survives further escalation during
+    /// the TSS signing window, then clamp to `[referenceFeeDrops, maxFeeDrops]`.
+    static func recommendedFee(baseFee: Int?, loadFactor: Int?, loadBase: Int?) -> BigInt {
+        let base = BigInt(baseFee ?? referenceFeeDrops)
+        let factor = BigInt(loadFactor ?? 1)
+        let divisor = BigInt(max(loadBase ?? 1, 1))
+
+        let openLedgerFee = max(base, base * factor / divisor)
+        let recommended = openLedgerFee * safetyMultiplier
+        return min(max(recommended, BigInt(referenceFeeDrops)), BigInt(maxFeeDrops))
+    }
+}
+
 class RippleService {
 
     static let shared = RippleService()
@@ -77,6 +103,28 @@ class RippleService {
         let availableBalance = max(totalBalance - reservedBalance, BigInt(0))
 
         return availableBalance.description
+    }
+
+    /// Resolves the fee (in drops) for an XRPL Payment.
+    ///
+    /// The XRPL reference fee is 10 drops; servers escalate it under load via
+    /// `load_factor / load_base`. We compute the current open-ledger cost and
+    /// apply a safety multiplier so the transaction survives fee escalation
+    /// during the (up to 5 min) TSS signing window, then clamp to a sane
+    /// ceiling. Any failure falls back to that ceiling so a send is never
+    /// blocked on the fee lookup.
+    func fetchFee() async -> BigInt {
+        do {
+            let state = try await fetchServerState()?.result?.state
+            return RippleFee.recommendedFee(
+                baseFee: state?.validatedLedger?.baseFee,
+                loadFactor: state?.loadFactor,
+                loadBase: state?.loadBase
+            )
+        } catch {
+            logger.error("fetchFee: falling back to ceiling: \(error.localizedDescription)")
+            return BigInt(RippleFee.maxFeeDrops)
+        }
     }
 
     func fetchServerState() async throws -> RippleServerStateResponse? {
@@ -198,18 +246,24 @@ struct RippleServerStateResponse: Codable {
     }
 
     struct State: Codable {
+        let loadBase: Int?
+        let loadFactor: Int?
         let validatedLedger: ValidatedLedger?
 
         enum CodingKeys: String, CodingKey {
+            case loadBase = "load_base"
+            case loadFactor = "load_factor"
             case validatedLedger = "validated_ledger"
         }
     }
 
     struct ValidatedLedger: Codable {
+        let baseFee: Int?
         let reserveBase: Int?
         let reserveInc: Int?
 
         enum CodingKeys: String, CodingKey {
+            case baseFee = "base_fee"
             case reserveBase = "reserve_base"
             case reserveInc = "reserve_inc"
         }

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -692,14 +692,16 @@ private extension BlockChainService {
             return .Ton(sequenceNumber: seqno, expireAt: expireAt, bounceable: isBounceable, sendMaxAmount: sendMaxAmount, jettonAddress: senderJettonWallet, isActiveDestination: !isBounceable)
         case .ripple:
 
-            let account = try await ripple.fetchAccountsInfo(for: coin.address)
+            async let accountTask = ripple.fetchAccountsInfo(for: coin.address)
+            async let feeTask = ripple.fetchFee()
+            let (account, fee) = try await (accountTask, feeTask)
 
             let sequence = account?.result?.accountData?.sequence ?? 0
 
             let lastLedgerSequence = account?.result?.ledgerCurrentIndex ?? 0
 
             // 60 is bc of tss to wait till 5min so all devices can sign.
-            return .Ripple(sequence: UInt64(sequence), gas: 180000, lastLedgerSequence: UInt64(lastLedgerSequence) + 60)
+            return .Ripple(sequence: UInt64(sequence), gas: UInt64(fee), lastLedgerSequence: UInt64(lastLedgerSequence) + 60)
         case .tron:
             return try await tron.getBlockInfo(coin: coin, to: toAddress, memo: memo, isSwap: action == .swap)
         }

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -226,7 +226,7 @@ class Coin: ObservableObject, Codable, Hashable {
         case .ton:
             return TonHelper.defaultFee.description
         case .ripple:
-            return "180000"
+            return RippleFee.maxFeeDrops.description
         case .akash:
             return "3000" // 0.003 AKT Cosmos station uses something like that
         case .qbtc:

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleFeeTests.swift
@@ -1,0 +1,59 @@
+//
+//  RippleFeeTests.swift
+//  VultisigAppTests
+//
+//  Pins the dynamic XRP fee math behind the 180,000-drop overpayment fix
+//  (issue #4535). The pre-fix code hardcoded a 180,000-drop (0.18 XRP) fee on
+//  every send — ~15,000× the XRPL reference fee of 10 drops. `recommendedFee`
+//  now derives the fee from the server's reported load
+//  (`base_fee * load_factor / load_base`), applies a safety multiplier for the
+//  TSS signing window, and clamps to `[referenceFeeDrops, maxFeeDrops]`.
+//
+//  - https://xrpl.org/docs/concepts/transactions/transaction-cost
+//
+
+@testable import VultisigApp
+import XCTest
+import BigInt
+
+final class RippleFeeTests: XCTestCase {
+
+    func testNoLoadUsesReferenceFeeWithSafetyMultiplier() {
+        // Under no load load_factor == load_base, so open-ledger == base_fee.
+        let fee = RippleFee.recommendedFee(baseFee: 10, loadFactor: 256, loadBase: 256)
+        XCTAssertEqual(fee, BigInt(20)) // 10 * (256/256) * 2
+    }
+
+    func testModerateLoadScalesFee() {
+        // 4× load: 10 * (1024/256) * 2 = 80 drops.
+        let fee = RippleFee.recommendedFee(baseFee: 10, loadFactor: 1024, loadBase: 256)
+        XCTAssertEqual(fee, BigInt(80))
+    }
+
+    func testExtremeLoadIsClampedToCeiling() {
+        let fee = RippleFee.recommendedFee(baseFee: 10, loadFactor: 1_000_000, loadBase: 256)
+        XCTAssertEqual(fee, BigInt(RippleFee.maxFeeDrops))
+    }
+
+    func testNeverFallsBelowReferenceFee() {
+        let fee = RippleFee.recommendedFee(baseFee: 0, loadFactor: 0, loadBase: 256)
+        XCTAssertEqual(fee, BigInt(RippleFee.referenceFeeDrops))
+    }
+
+    func testMissingFieldsFallBackToReferenceFee() {
+        // Nil server values default to base 10, factor 1, divisor 1 → 10 * 2.
+        let fee = RippleFee.recommendedFee(baseFee: nil, loadFactor: nil, loadBase: nil)
+        XCTAssertEqual(fee, BigInt(20))
+    }
+
+    func testZeroLoadBaseDoesNotCrash() {
+        // load_base of 0 would divide-by-zero; it must be coerced to 1.
+        let fee = RippleFee.recommendedFee(baseFee: 10, loadFactor: 256, loadBase: 0)
+        XCTAssertEqual(fee, BigInt(RippleFee.maxFeeDrops)) // 10 * 256 * 2 clamped
+    }
+
+    func testFeeStaysWellBelowLegacyHardcodedValue() {
+        let fee = RippleFee.recommendedFee(baseFee: 10, loadFactor: 256, loadBase: 256)
+        XCTAssertLessThan(fee, BigInt(180_000))
+    }
+}


### PR DESCRIPTION
## Summary
- Every XRP send paid a hardcoded **180,000-drop fee (0.18 XRP)** — roughly **15,000×** the XRPL reference fee of 10 drops, subtracted from max-send on every transaction.
- Replaced the constant in `BlockChainService` with a fee derived from the server's reported load: `base_fee * load_factor / load_base` (from the existing `server_state` RPC).
- Apply a **2× safety multiplier** so the tx survives fee escalation during the up-to-5-minute TSS signing window, then clamp to `[10, 2000]` drops.
- Falls back to the 2,000-drop ceiling on any lookup error, so a send is never blocked on the fee query.
- Account info and the fee are fetched concurrently (`async let`) to avoid adding latency.
- Updated the stale `Coin.feeDefault` Ripple fallback (`180000` → `RippleFee.maxFeeDrops`) so nothing else inherits the bad value.

Under normal load XRP sends now pay **20 drops** (~\$0.00004) instead of 180,000 drops.

## Issue
Closes #4535

## Test Plan
- [x] New `RippleFeeTests` (7 cases): no-load, moderate load, ceiling clamp, sub-reference floor, nil fields, divide-by-zero guard — all pass
- [x] SwiftLint passes (0 violations)
- [x] Test target builds and runs clean (`xcodebuild test`)
- [ ] Manual: send XRP and confirm the displayed "Fees" is a few drops, not 0.18 XRP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic fee recommendation for XRP payments using real-time network state.

* **Improvements**
  * Replaced hardcoded Ripple transaction fee with a computed fee that considers network load, includes a safety multiplier, clamps to min/max, and falls back to a safe default on errors.
  * Fetching account info and fee now occurs concurrently for faster responses.

* **Tests**
  * Added tests covering fee calculations, load scenarios, edge cases, and fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->