### PR TITLE
fix(evm): ERC20 sends on Hyperliquid/Sei sign with correct chainID

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Common/erc20.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Common/erc20.swift
@@ -21,10 +21,9 @@ class ERC20Helper {
     }
 
     func getChainId(chain: Chain) -> String {
-        if chain == Chain.ethereumSepolia {
-            return "11155111"
-        }
-        return self.coinType.chainId
+        // Delegate to EVMHelper so EVM chainID special-cases (e.g. Hyperliquid, Sei)
+        // stay in a single source of truth and ERC20 sends sign with the correct EIP-155 chainID.
+        return EVMHelper(coinType: coinType).getChainId(chain: chain)
     }
 
     private func configureGasForChain(


### PR DESCRIPTION
## Summary
- `ERC20Helper.getChainId` only special-cased Sepolia and otherwise returned `coinType.chainId`. Since Hyperliquid and Sei both map to `CoinType.ethereum`, every ERC20 token send on those chains was signed with **chainID 1 (Ethereum mainnet)** and rejected on broadcast (EIP-155 mismatch) — also a latent cross-chain replay surface.
- `EVMHelper.getChainId` already special-cases these chains (Hyperliquid → 999, Sei → 1329, Sepolia → 11155111), but the cases were never mirrored into `ERC20Helper`.
- Fix: `ERC20Helper.getChainId` now delegates to `EVMHelper.getChainId`, making it the single source of truth so the two paths can't drift again.

## Issue
Closes #4526

## Test Plan
- [x] Send a Hyperliquid ERC20 (e.g. USDT0) and confirm the signed tx carries chainID 999 and broadcasts successfully
- [ ] Send a Sei ERC20 and confirm chainID 1329
- [x] Regression: native EVM + standard ERC20 (Ethereum, BSC) sends still sign/broadcast correctly
- [x] SwiftLint passes
- [x] xcodebuild build succeeds

https://liquidscan.io/tx/0xe91a679bf22b08c2ef334bdc2d8388d6a1e3d19f7b177ec58ecce7fdaef4a2ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved EVM chain ID resolution logic to enhance consistency and reliability across different blockchain networks, particularly for chains with specialized chainID requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->