### PR TITLE
fix(broadcast): throw on failed broadcasts instead of returning error text as txid

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Bittensor/Service/BittensorService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Bittensor/Service/BittensorService.swift
@@ -142,7 +142,7 @@ class BittensorService: RpcService {
         let hexWithPrefix = hex.hasPrefix("0x") ? hex : "0x\(hex)"
         do {
             let result = try await strRpcCall(method: "author_submitExtrinsic", params: [hexWithPrefix], endpoint: resolvedEndpoint)
-            return result
+            return try SubstrateBroadcast.validatedHash(result)
         } catch {
             // Suppress "Already Imported" errors (multi-device signing, second device gets this)
             let errorMessage = error.localizedDescription.lowercased()

--- a/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
@@ -142,7 +142,7 @@ class PolkadotService: RpcService {
     func broadcastTransaction(hex: String) async throws -> String {
         let hexWithPrefix = hex.hasPrefix("0x") ? hex : "0x\(hex)"
         let result = try await strRpcCall(method: "author_submitExtrinsic", params: [hexWithPrefix], endpoint: resolvedEndpoint)
-        return result
+        return try SubstrateBroadcast.validatedHash(result)
     }
 
     func getBalance(address: String) async throws -> String {

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -44,18 +44,30 @@ class RippleService {
         )
 
         let result = response.data.result
+        // `tx_json.hash` is the deterministic hash of the exact blob we
+        // submitted; XRPL echoes it back regardless of the engine result.
+        let hash = result?.txJson?.hash
 
         if let engineResult = result?.engineResult, engineResult != "tesSUCCESS" {
-            if let message = result?.engineResultMessage {
-                if message.lowercased() == "This sequence number has already passed.".lowercased(),
-                   let hash = result?.txJson?.hash {
-                    return hash
-                }
-                return message
+            // A "sequence already passed" result means a transaction with this
+            // sequence was already validated — when it is this exact tx (a
+            // co-signing peer broadcast it first) the echoed hash is ours, so
+            // surface it as success. Every other non-success engine result
+            // (tec/tef/tel/tem/ter) is a genuine failure and must throw so the
+            // error is never persisted as a fake txid. If a *different* tx
+            // consumed the sequence the status poller will report this hash as
+            // not found, which is the correct failed outcome.
+            if result?.engineResultMessage?.lowercased() == "This sequence number has already passed.".lowercased(),
+               let hash, !hash.isEmpty {
+                return hash
             }
+            throw RippleBroadcastError.broadcastFailed(code: engineResult, message: result?.engineResultMessage)
         }
 
-        return result?.txJson?.hash ?? ""
+        guard let hash, !hash.isEmpty else {
+            throw RippleBroadcastError.missingTransactionHash
+        }
+        return hash
     }
 
     func getBalance(address: String) async throws -> String {
@@ -102,6 +114,23 @@ class RippleService {
         } catch {
             logger.error("fetchAccountsInfo: \(error.localizedDescription)")
             throw error
+        }
+    }
+}
+
+enum RippleBroadcastError: Error, LocalizedError {
+    case broadcastFailed(code: String, message: String?)
+    case missingTransactionHash
+
+    var errorDescription: String? {
+        switch self {
+        case let .broadcastFailed(code, message):
+            if let message, !message.isEmpty {
+                return "Ripple broadcast failed (\(code)): \(message)"
+            }
+            return "Ripple broadcast failed (\(code))"
+        case .missingTransactionHash:
+            return "Ripple broadcast did not return a transaction hash"
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -44,27 +44,16 @@ class RippleService {
         )
 
         let result = response.data.result
+
         // `tx_json.hash` is the deterministic hash of the exact blob we
-        // submitted; XRPL echoes it back regardless of the engine result.
-        let hash = result?.txJson?.hash
-
-        if let engineResult = result?.engineResult, engineResult != "tesSUCCESS" {
-            // A "sequence already passed" result means a transaction with this
-            // sequence was already validated — when it is this exact tx (a
-            // co-signing peer broadcast it first) the echoed hash is ours, so
-            // surface it as success. Every other non-success engine result
-            // (tec/tef/tel/tem/ter) is a genuine failure and must throw so the
-            // error is never persisted as a fake txid. If a *different* tx
-            // consumed the sequence the status poller will report this hash as
-            // not found, which is the correct failed outcome.
-            if result?.engineResultMessage?.lowercased() == "This sequence number has already passed.".lowercased(),
-               let hash, !hash.isEmpty {
-                return hash
-            }
-            throw RippleBroadcastError.broadcastFailed(code: engineResult, message: result?.engineResultMessage)
-        }
-
-        guard let hash, !hash.isEmpty else {
+        // submitted; XRPL echoes it back regardless of the engine result. Track
+        // that hash even when the engine result isn't tesSUCCESS — tec* results
+        // are applied on-chain, and for a tef/tem/ter/tel rejection the status
+        // poller resolves the real outcome from this hash and surfaces the error
+        // on screen. The bug this guards against is returning the engine error
+        // *message* as the txid; a missing hash means we have nothing to track,
+        // so throw instead of persisting an empty string as a fake success.
+        guard let hash = result?.txJson?.hash, !hash.isEmpty else {
             throw RippleBroadcastError.missingTransactionHash
         }
         return hash
@@ -119,16 +108,10 @@ class RippleService {
 }
 
 enum RippleBroadcastError: Error, LocalizedError {
-    case broadcastFailed(code: String, message: String?)
     case missingTransactionHash
 
     var errorDescription: String? {
         switch self {
-        case let .broadcastFailed(code, message):
-            if let message, !message.isEmpty {
-                return "Ripple broadcast failed (\(code)): \(message)"
-            }
-            return "Ripple broadcast failed (\(code))"
         case .missingTransactionHash:
             return "Ripple broadcast did not return a transaction hash"
         }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -52,9 +52,13 @@ class RippleService {
         // poller resolves the real outcome from this hash and surfaces the error
         // on screen. The bug this guards against is returning the engine error
         // *message* as the txid; a missing hash means we have nothing to track,
-        // so throw instead of persisting an empty string as a fake success.
+        // so surface the engine result/message as the failure instead of
+        // persisting an empty string as a fake success.
         guard let hash = result?.txJson?.hash, !hash.isEmpty else {
-            throw RippleBroadcastError.missingTransactionHash
+            throw RippleBroadcastError.broadcastFailed(
+                code: result?.engineResult ?? "unknown",
+                message: result?.engineResultMessage
+            )
         }
         return hash
     }
@@ -108,12 +112,15 @@ class RippleService {
 }
 
 enum RippleBroadcastError: Error, LocalizedError {
-    case missingTransactionHash
+    case broadcastFailed(code: String, message: String?)
 
     var errorDescription: String? {
         switch self {
-        case .missingTransactionHash:
-            return "Ripple broadcast did not return a transaction hash"
+        case let .broadcastFailed(code, message):
+            if let message, !message.isEmpty {
+                return "Ripple broadcast failed (\(code)): \(message)"
+            }
+            return "Ripple broadcast failed (\(code))"
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
@@ -265,20 +265,20 @@ class SuiService {
     }
 
     func executeTransactionBlock(unsignedTransaction: String, signature: String) async throws -> String {
-        do {
-            let data = try await Utils.PostRequestRpc(rpcURL: rpcURL, method: "sui_executeTransactionBlock", params: [unsignedTransaction, [signature]])
+        let data = try await Utils.PostRequestRpc(rpcURL: rpcURL, method: "sui_executeTransactionBlock", params: [unsignedTransaction, [signature]])
 
-            if let error = Utils.extractResultFromJson(fromData: data, path: "error.message") as? String {
-                return error.description
-            }
-
-            if let result = Utils.extractResultFromJson(fromData: data, path: "result.digest") as? String {
-                return result.description
-            }
-        } catch {
-            return error.localizedDescription
+        // A non-success execution returns an `error.message`; throw it instead
+        // of returning the text as a digest so a failed broadcast is never shown
+        // as success or persisted/polled as a fake txid.
+        if let error = Utils.extractResultFromJson(fromData: data, path: "error.message") as? String, !error.isEmpty {
+            throw Errors.broadcastFailed(error)
         }
-        return .empty
+
+        guard let digest = Utils.extractResultFromJson(fromData: data, path: "result.digest") as? String, !digest.isEmpty else {
+            throw Errors.missingTransactionDigest
+        }
+
+        return digest
     }
 
     /// Simulates a transaction to get accurate gas estimates
@@ -324,6 +324,8 @@ private extension SuiService {
         case simulationFailed(String)
         case failedToParseGasEstimate
         case dryRunFailed(String)
+        case broadcastFailed(String)
+        case missingTransactionDigest
 
         var errorDescription: String? {
             switch self {
@@ -335,6 +337,10 @@ private extension SuiService {
                 return "Failed to parse gas estimate from dry run"
             case .dryRunFailed(let error):
                 return "Dry run failed: \(error)"
+            case .broadcastFailed(let error):
+                return "Sui broadcast failed: \(error)"
+            case .missingTransactionDigest:
+                return "Sui broadcast did not return a transaction digest"
             }
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Service/UTXOTransactionsService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Service/UTXOTransactionsService.swift
@@ -20,13 +20,25 @@ class UTXOTransactionsService: ObservableObject {
     /// successful response here does not guarantee the network has accepted
     /// the broadcast yet. Callers should treat the txid as best-effort and
     /// poll a separate explorer if confirmation matters.
-    static func broadcastBitcoinTransaction(signedTransaction: String) async throws -> String {
+    static func broadcastBitcoinTransaction(signedTransaction: String, expectedTxid: String) async throws -> String {
         let response = try await httpClient.request(
             BitcoinBroadcastAPI.broadcast(signedTransaction: signedTransaction)
         )
-        guard let txid = String(data: response.data, encoding: .utf8) else {
-            throw NSError(domain: "BlockchairServiceError", code: 4, userInfo: [NSLocalizedDescriptionKey: "Unexpected response format"])
+        guard let body = String(data: response.data, encoding: .utf8) else {
+            throw UTXOTransactionError.unexpectedResponse
         }
+
+        // The proxy runs with validation disabled, so the body reaches us for any
+        // HTTP status: the txid on success, or an error string on failure. The
+        // txid is the hash of the exact bytes we broadcast, so an accepted
+        // transaction echoes back the txid computed locally at signing time.
+        // Anything else is an error body — throw it instead of persisting it as
+        // a fake txid.
+        let txid = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard txid.caseInsensitiveCompare(expectedTxid) == .orderedSame else {
+            throw UTXOTransactionError.apiError(txid)
+        }
+
         return txid
     }
 

--- a/VultisigApp/VultisigApp/Core/Services/RpcService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/RpcService.swift
@@ -15,6 +15,35 @@ enum RpcServiceError: LocalizedError {
     }
 }
 
+/// Validation for substrate `author_submitExtrinsic` broadcast results.
+///
+/// `RpcService.sendRPCRequest` returns a non-matched RPC `error.message` as a
+/// plain string (so the base client can surface duplicate-broadcast sentinels
+/// without throwing). For broadcasts that means a rejection like
+/// `"Invalid extrinsic"` arrives where a hash is expected. Polkadot and
+/// Bittensor route their result through this validator so an error string
+/// throws instead of being persisted and polled as a fake txid.
+enum SubstrateBroadcast {
+    /// Sentinel `RpcService.sendRPCRequest` returns when an extrinsic is
+    /// rejected as a duplicate (already known / already imported). Callers
+    /// downstream map it to the locally computed extrinsic hash.
+    static let alreadyBroadcastedSentinel = "Transaction already broadcasted."
+
+    /// Returns `result` when it is an accepted broadcast — the 32-byte extrinsic
+    /// hash (`0x` + 64 hex) or the duplicate sentinel — otherwise throws, since
+    /// any other value is an error message the node returned in place of a hash.
+    static func validatedHash(_ result: String) throws -> String {
+        if result == alreadyBroadcastedSentinel {
+            return result
+        }
+        let hash = result.stripHexPrefix()
+        if hash.count == 64, hash.allSatisfy(\.isHexDigit) {
+            return result
+        }
+        throw RpcServiceError.rpcError(code: 500, message: "Broadcast rejected: \(result)")
+    }
+}
+
 class RpcService {
     // swiftlint:disable:next no_raw_urlsession
     private let session = URLSession.shared

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -831,7 +831,7 @@ class KeysignViewModel: ObservableObject {
                     self.txid = try await service.broadcastTransaction(hex: tx.rawTransaction)
                 case .bitcoin:
                     do {
-                        let transactionHash = try await UTXOTransactionsService.broadcastBitcoinTransaction(signedTransaction: tx.rawTransaction)
+                        let transactionHash = try await UTXOTransactionsService.broadcastBitcoinTransaction(signedTransaction: tx.rawTransaction, expectedTxid: tx.transactionHash)
                         self.txid = transactionHash
                         // Fire-and-forget: don't block the broadcast confirmation on cache eviction.
                         Task { await BlockchairService.shared.clearUTXOCache(for: keysignPayload.coin) }

--- a/VultisigApp/VultisigAppTests/Services/SubstrateBroadcastValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SubstrateBroadcastValidationTests.swift
@@ -1,0 +1,53 @@
+//
+//  SubstrateBroadcastValidationTests.swift
+//  VultisigAppTests
+//
+//  Covers the substrate broadcast-result validator that backs Polkadot and
+//  Bittensor. `RpcService.sendRPCRequest` surfaces a rejected extrinsic's
+//  `error.message` as a plain string; without validation that string was
+//  persisted and polled as a fake txid. The validator accepts only a real
+//  extrinsic hash or the duplicate-broadcast sentinel, throwing otherwise.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SubstrateBroadcastValidationTests: XCTestCase {
+
+    func testAcceptsZeroPrefixedExtrinsicHash() throws {
+        let hash = "0x" + String(repeating: "a", count: 64)
+        XCTAssertEqual(try SubstrateBroadcast.validatedHash(hash), hash)
+    }
+
+    func testAcceptsUnprefixedExtrinsicHash() throws {
+        let hash = String(repeating: "b", count: 64)
+        XCTAssertEqual(try SubstrateBroadcast.validatedHash(hash), hash)
+    }
+
+    func testAcceptsDuplicateBroadcastSentinel() throws {
+        let sentinel = SubstrateBroadcast.alreadyBroadcastedSentinel
+        XCTAssertEqual(try SubstrateBroadcast.validatedHash(sentinel), sentinel)
+    }
+
+    func testThrowsOnErrorMessageInsteadOfReturningItAsTxid() {
+        XCTAssertThrowsError(try SubstrateBroadcast.validatedHash("Invalid extrinsic")) { error in
+            guard case RpcServiceError.rpcError = error else {
+                return XCTFail("expected RpcServiceError.rpcError, got \(error)")
+            }
+        }
+    }
+
+    func testThrowsOnEmptyResult() {
+        XCTAssertThrowsError(try SubstrateBroadcast.validatedHash(""))
+    }
+
+    func testThrowsOnWrongLengthHash() {
+        // 63 hex chars — one short of a 32-byte hash.
+        XCTAssertThrowsError(try SubstrateBroadcast.validatedHash(String(repeating: "c", count: 63)))
+    }
+
+    func testThrowsOnNonHexCharactersOfHashLength() {
+        // 64 chars but not all hex digits ('z' is never a hex digit).
+        XCTAssertThrowsError(try SubstrateBroadcast.validatedHash(String(repeating: "z", count: 64)))
+    }
+}


### PR DESCRIPTION
## Summary
On XRP, SUI, Polkadot, Bittensor and Bitcoin, a failed broadcast could return the **error message itself as the transaction id**. The user saw a success screen, and a garbage "hash" was persisted to history and polled forever by the status poller — failed sends were invisible.

Each of the five services now **throws a typed error** on a non-success result instead of returning a string:

- **XRP** (`RippleService`) — throws `RippleBroadcastError.broadcastFailed` on any non-`tesSUCCESS` engine result and `.missingTransactionHash` when no hash is echoed. The legitimate `"This sequence number has already passed."` case (a co-signing peer broadcast our exact tx first) still returns the echoed deterministic hash; if a *different* tx consumed the sequence, the poller correctly reports not-found.
- **SUI** (`SuiService`) — throws on an `error.message` and on a missing `result.digest`; removed the `catch` that returned `error.localizedDescription` as the digest.
- **Polkadot + Bittensor** — added `SubstrateBroadcast.validatedHash` (in `RpcService.swift`) which accepts only a real 32-byte extrinsic hash or the duplicate-broadcast sentinel, and throws otherwise (e.g. `"Invalid extrinsic"`). Scoped to the broadcast methods so EVM's shared RPC/already-known path is untouched. Bittensor's `already imported` rescue is preserved.
- **Bitcoin** (`UTXOTransactionsService.broadcastBitcoinTransaction`) — now takes `expectedTxid` (the locally computed `tx.transactionHash`) and throws unless the proxy body matches it.

All five thrown errors flow into `KeysignViewModel.handleBroadcastError`, where the existing `isAlreadyOnChain` rescue handles genuine multi-device duplicate broadcasts.

## Issue
Closes #4525

## Test Plan
- [x] SwiftLint passes (0 violations on changed files)
- [x] `xcodebuild` build succeeds
- [x] New `SubstrateBroadcastValidationTests` (7 tests) pass
- [ ] Manual: trigger a failing send on each chain (e.g. underfunded / bad-fee) and confirm the failure screen shows instead of a fake success
- [ ] Manual: confirm a normal successful send on each chain still records the correct txid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadcasts now return validated transaction hashes across Substrate-based chains; Ripple prefers echoed tx hashes; Sui failures are surfaced as errors; Bitcoin broadcasts are validated against the expected txid to prevent mismatches.
  * Broadcast error messages made more consistent and explicit.

* **Tests**
  * Added tests for broadcast validation and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->