### PR TITLE
fix(solana): confirmed blockhash commitment + client-side rebroadcast loop

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
@@ -60,7 +60,11 @@ struct SolanaAPI: TargetType {
         case .getRecentPrioritizationFees:
             return .requestParameters(rpcEnvelope(method: "getRecentPrioritizationFees", params: [] as [Any]), .jsonEncoding)
         case .getLatestBlockhash:
-            return .requestParameters(rpcEnvelope(method: "getLatestBlockhash", params: [["commitment": "finalized"]]), .jsonEncoding)
+            // `confirmed` is the standard commitment for sending: it tracks the
+            // tip closely, whereas `finalized` lags ~32 slots (~13s) behind and
+            // burns that much of the ~60–90s blockhash validity window before
+            // the keysign ceremony even starts.
+            return .requestParameters(rpcEnvelope(method: "getLatestBlockhash", params: [["commitment": "confirmed"]]), .jsonEncoding)
         case .getTokenAccountsByOwner(let walletAddress, let filter):
             let filterDict: [String: String]
             switch filter {

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -36,7 +36,7 @@ class SolanaService {
     static let shared = SolanaService()
 
     private let logger = Logger(subsystem: "com.vultisig.app", category: "solana-service")
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     /// Resolves the Solana custom RPC override. Injected so the API values are
     /// built from a dependency rather than a global reach-in; resolution happens
@@ -44,8 +44,20 @@ class SolanaService {
     /// live (the shared mirror updates without a relaunch).
     private let resolver: RPCEndpointResolving
 
-    init(resolver: RPCEndpointResolving = CustomRPCStore.shared) {
+    /// Backoff between client-side rebroadcast attempts. Injectable so tests can
+    /// drive the resend loop without real-time delays.
+    private let broadcastRetryBackoff: Duration
+
+    /// Number of times a signed transaction is resent when the RPC node reports
+    /// the blockhash as not yet seen (propagation lag, not true expiry).
+    private static let maxBroadcastAttempts = 3
+
+    init(resolver: RPCEndpointResolving = CustomRPCStore.shared,
+         httpClient: HTTPClientProtocol = HTTPClient(),
+         broadcastRetryBackoff: Duration = .seconds(2)) {
         self.resolver = resolver
+        self.httpClient = httpClient
+        self.broadcastRetryBackoff = broadcastRetryBackoff
     }
 
     /// Builds a pure `SolanaAPI` value with the resolved host and proxy-path
@@ -75,23 +87,45 @@ class SolanaService {
     private let cacheExpirationTime: TimeInterval = 86400 * 30 // 30 days - token accounts don't change once created
 
     func sendSolanaTransaction(encodedTransaction: String) async throws -> String? {
-        let response = try await httpClient.request(
-            api(.sendTransaction(encodedTransaction: encodedTransaction)),
-            responseType: SolanaSendTransactionResponse.self
-        )
+        for attempt in 1...Self.maxBroadcastAttempts {
+            let response = try await httpClient.request(
+                api(.sendTransaction(encodedTransaction: encodedTransaction)),
+                responseType: SolanaSendTransactionResponse.self
+            )
 
-        if let error = response.data.error {
+            guard let error = response.data.error else {
+                return response.data.result
+            }
+
             // -32002 is Solana's generic preflight-failure code, not specific
             // to expired blockhashes — match on the message instead.
             let lowered = error.message.lowercased()
+
+            // "Blockhash not found" right after signing is usually propagation
+            // lag: the RPC node we hit hasn't observed our (confirmed) blockhash
+            // yet. Resending the same signed tx after a short backoff typically
+            // clears it without escalating to a full keysign-ceremony retry.
+            if lowered.contains("blockhash not found"), attempt < Self.maxBroadcastAttempts {
+                logger.warning("solana broadcast attempt \(attempt)/\(Self.maxBroadcastAttempts) hit transient blockhash-not-found; resending after backoff")
+                try await Task.sleep(for: broadcastRetryBackoff)
+                continue
+            }
+
+            // "Block height exceeded" (or an exhausted blockhash-not-found
+            // retry) means the blockhash has expired — resending the same tx
+            // can't help, so surface it as retryable to re-sign with a fresh
+            // blockhash.
             if lowered.contains("blockhash not found") ||
                 lowered.contains("block height exceeded") {
                 throw SolanaRetryableError.blockhashExpired(message: error.message)
             }
+
             throw SolanaServiceError.rpcError(message: error.message, code: error.code)
         }
 
-        return response.data.result
+        // Unreachable: the loop either returns a result or throws on the final
+        // attempt. Present to satisfy the non-optional control-flow analysis.
+        return nil
     }
 
     func getSolanaBalance(coin: Coin) async throws -> String {

--- a/VultisigApp/VultisigAppTests/Chains/SolanaServiceBroadcastTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/SolanaServiceBroadcastTests.swift
@@ -1,0 +1,160 @@
+//
+//  SolanaServiceBroadcastTests.swift
+//  VultisigAppTests
+//
+//  Covers the Solana client-side rebroadcast loop in
+//  `SolanaService.sendSolanaTransaction`. The loop resends the same signed tx
+//  on a transient "blockhash not found" (the receiving RPC node hasn't yet
+//  observed our `confirmed` blockhash) but escalates a true expiry
+//  ("block height exceeded") as a retryable error so the keysign ceremony
+//  re-signs with a fresh blockhash.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SolanaServiceBroadcastTests: XCTestCase {
+
+    private func makeService(_ stub: SolanaStubHTTPClient) -> SolanaService {
+        SolanaService(
+            resolver: NoOverrideResolver(),
+            httpClient: stub,
+            broadcastRetryBackoff: .zero
+        )
+    }
+
+    func test_send_returnsSignature_onFirstAttempt() async throws {
+        let stub = SolanaStubHTTPClient(results: [.success("sig123")])
+        let service = makeService(stub)
+
+        let txid = try await service.sendSolanaTransaction(encodedTransaction: "tx")
+
+        XCTAssertEqual(txid, "sig123")
+        XCTAssertEqual(stub.callCount, 1)
+    }
+
+    func test_send_resendsOnTransientBlockhashNotFound_thenSucceeds() async throws {
+        let stub = SolanaStubHTTPClient(results: [
+            .error(code: -32002, message: "Transaction simulation failed: Blockhash not found"),
+            .success("sigRetry")
+        ])
+        let service = makeService(stub)
+
+        let txid = try await service.sendSolanaTransaction(encodedTransaction: "tx")
+
+        XCTAssertEqual(txid, "sigRetry")
+        XCTAssertEqual(stub.callCount, 2)
+    }
+
+    func test_send_exhaustsBlockhashNotFound_throwsRetryable() async {
+        let stub = SolanaStubHTTPClient(results: [
+            .error(code: -32002, message: "Blockhash not found"),
+            .error(code: -32002, message: "Blockhash not found"),
+            .error(code: -32002, message: "Blockhash not found")
+        ])
+        let service = makeService(stub)
+
+        do {
+            _ = try await service.sendSolanaTransaction(encodedTransaction: "tx")
+            XCTFail("expected blockhashExpired to be thrown")
+        } catch let error as SolanaRetryableError {
+            guard case .blockhashExpired = error else {
+                return XCTFail("unexpected retryable case: \(error)")
+            }
+            XCTAssertEqual(error.retryReason, .staleBlockhash)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(stub.callCount, 3)
+    }
+
+    func test_send_blockHeightExceeded_throwsRetryableWithoutResending() async {
+        let stub = SolanaStubHTTPClient(results: [
+            .error(code: -32002, message: "Transaction's block height exceeded the last valid block height")
+        ])
+        let service = makeService(stub)
+
+        do {
+            _ = try await service.sendSolanaTransaction(encodedTransaction: "tx")
+            XCTFail("expected blockhashExpired to be thrown")
+        } catch let error as SolanaRetryableError {
+            guard case .blockhashExpired = error else {
+                return XCTFail("unexpected retryable case: \(error)")
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        // True expiry must not be retried — resending the same tx can't help.
+        XCTAssertEqual(stub.callCount, 1)
+    }
+
+    func test_send_genericRpcError_throwsImmediately() async {
+        let stub = SolanaStubHTTPClient(results: [
+            .error(code: -32003, message: "Transaction signature verification failure")
+        ])
+        let service = makeService(stub)
+
+        do {
+            _ = try await service.sendSolanaTransaction(encodedTransaction: "tx")
+            XCTFail("expected rpcError to be thrown")
+        } catch let error as SolanaServiceError {
+            guard case .rpcError(_, let code) = error else {
+                return XCTFail("unexpected service error: \(error)")
+            }
+            XCTAssertEqual(code, -32003)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+        XCTAssertEqual(stub.callCount, 1)
+    }
+}
+
+// MARK: - Test doubles
+
+private struct NoOverrideResolver: RPCEndpointResolving {
+    // swiftlint:disable:next unused_parameter
+    func url(for chain: Chain) -> String? { nil }
+}
+
+/// Replays a scripted sequence of JSON-RPC `sendTransaction` outcomes, one per
+/// call, so the rebroadcast loop can be exercised deterministically.
+private final class SolanaStubHTTPClient: HTTPClientProtocol {
+
+    enum Outcome {
+        case success(String)
+        case error(code: Int, message: String)
+    }
+
+    private let results: [Outcome]
+    private(set) var callCount = 0
+
+    init(results: [Outcome]) {
+        self.results = results
+    }
+
+    // Protocol requires `async`; the body is sync. Silence the lint here.
+    // swiftlint:disable:next async_without_await unused_parameter
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        defer { callCount += 1 }
+        guard callCount < results.count else {
+            XCTFail("SolanaStubHTTPClient ran out of scripted results (call #\(callCount + 1))")
+            throw HTTPError.invalidResponse
+        }
+
+        let json: String
+        switch results[callCount] {
+        case .success(let signature):
+            json = #"{"jsonrpc":"2.0","id":1,"result":"\#(signature)"}"#
+        case .error(let code, let message):
+            json = #"{"jsonrpc":"2.0","id":1,"error":{"code":\#(code),"message":"\#(message)"}}"#
+        }
+
+        let response = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: Data(json.utf8), response: response)
+    }
+}


### PR DESCRIPTION
## Summary
- Fetch the latest Solana blockhash with `confirmed` instead of `finalized`. `finalized` lags the tip by ~32 slots (~13s), burning that much of the ~60–90s blockhash validity window before the keysign ceremony even starts.
- Replace the one-shot broadcast in `SolanaService.sendSolanaTransaction` with a bounded client-side rebroadcast loop:
  - **"Blockhash not found"** → treated as propagation lag (the RPC node hasn't observed our just-fetched `confirmed` blockhash yet). Resends the same signed tx up to 3 attempts with backoff, instead of escalating straight to a full keysign-ceremony retry.
  - **"Block height exceeded"** (or exhausted retries) → true expiry; surfaced as a `RetryableBroadcastError` so the ceremony re-signs with a fresh blockhash. Not resent.
  - Other RPC errors → thrown immediately (unchanged).
- `SolanaService.init` now injects `httpClient` and `broadcastRetryBackoff` (production defaults preserved) to make the loop testable.

## Issue
Closes #4532

## Out of scope (follow-ups)
- Threading `lastValidBlockHeight` through for a precise expiry-bounded loop would require a `KeysignMessage` proto change (it travels in `BlockChainSpecific.Solana` and must match across devices + Fast Vault server) — warrants its own cross-platform PR.
- Durable nonces for the long-pairing case.

## Test Plan
- [x] New `SolanaServiceBroadcastTests` (5 cases: first-attempt success, transient-then-success, exhausted retries, block-height-exceeded no-resend, generic RPC error) — all pass
- [x] SwiftLint passes on changed files
- [x] Test target compiles (xcodebuild test succeeds)
- [ ] Manual: Solana send + Solana swap broadcast end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction broadcast reliability on Solana with automatic retry logic for transient failures and improved blockhash handling.

* **Tests**
  * Added comprehensive test coverage for transaction broadcast retry scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->