### PR TITLE
fix(ton): throw on jetton wallet resolution failure, never fall back to master

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ton/Service/TonService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Service/TonService.swift
@@ -169,8 +169,22 @@ class TonService {
         return (seqno, expireAt)
     }
 
-    func getJettonWalletAddressAsync(ownerAddress: String, masterAddress: String) async -> String? {
-        return await runGetWalletAddress(owner: ownerAddress, master: masterAddress)
+    /// Resolves the owner's jetton wallet address, retrying a few times to ride
+    /// out transient RPC failures. Returns `nil` only when every attempt fails —
+    /// callers must treat that as a hard error and never fall back to the master
+    /// contract address.
+    func resolveJettonWalletAddress(ownerAddress: String, masterAddress: String, maxAttempts: Int = 3) async -> String? {
+        for attempt in 1...max(1, maxAttempts) {
+            if let resolved = await runGetWalletAddress(owner: ownerAddress, master: masterAddress) {
+                return resolved
+            }
+            if attempt < maxAttempts {
+                logger.warning("Jetton wallet resolution failed (attempt \(attempt)/\(maxAttempts)), retrying")
+                try? await Task.sleep(nanoseconds: 500_000_000)
+            }
+        }
+        logger.error("Failed to resolve jetton wallet address after \(maxAttempts) attempts")
+        return nil
     }
 
     private func runGetWalletAddress(owner: String, master: String) async -> String? {

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -390,6 +390,7 @@
 "failToGetAccountNumber" = "Fehler beim Abrufen der Kontonummer";
 "failToGetRecentBlockHash" = "Fehler beim Abrufen des aktuellen Blockhashs";
 "failToGetSequenceNo" = "Fehler beim Abrufen der Sequenznummer";
+"failToResolveJettonWallet" = "Die Jetton-Wallet-Adresse konnte nicht aufgelöst werden. Bitte versuche es erneut.";
 "failToStartKesign" = "Fehler bei der Signatur";
 "failToStartKeygen" = "Schlüsselgenerierung kann wegen fehlender Informationen nicht gestartet werden";
 "failureReason" = "Fehlergrund";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -396,6 +396,7 @@
 "failToGetAccountNumber" = "Unable to get account number";
 "failToGetRecentBlockHash" = "Unable to get recent block hash";
 "failToGetSequenceNo" = "Unable to get sequence no";
+"failToResolveJettonWallet" = "Unable to resolve the jetton wallet address. Please try again.";
 "failToStartKesign" = "Signing Error";
 "failToStartKeygen" = "Unable to start key generation due to missing information";
 "failureReason" = "Failure Reason";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -390,6 +390,7 @@
 "failToGetAccountNumber" = "No se pudo obtener el número de cuenta";
 "failToGetRecentBlockHash" = "No se pudo obtener el hash del bloque reciente";
 "failToGetSequenceNo" = "No se pudo obtener el número de secuencia";
+"failToResolveJettonWallet" = "No se pudo resolver la dirección de la billetera jetton. Inténtalo de nuevo.";
 "failToStartKesign" = "Error de firma";
 "failToStartKeygen" = "No se pudo iniciar la generación de clave debido a información faltante";
 "failureReason" = "Motivo del error";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -390,6 +390,7 @@
 "failToGetAccountNumber" = "Nije moguće dobiti broj računa";
 "failToGetRecentBlockHash" = "Nije moguće dobiti nedavni blok hash";
 "failToGetSequenceNo" = "Nije moguće dobiti redni broj";
+"failToResolveJettonWallet" = "Nije moguće razriješiti adresu jetton novčanika. Pokušajte ponovno.";
 "failToStartKesign" = "Greška u potpisivanju";
 "failToStartKeygen" = "Nije moguće pokrenuti generiranje ključa zbog nedostatka informacija";
 "failureReason" = "Razlog greške";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -390,6 +390,7 @@
 "failToGetAccountNumber" = "Impossibile ottenere il numero dell'account";
 "failToGetRecentBlockHash" = "Impossibile ottenere l'hash del blocco recente";
 "failToGetSequenceNo" = "Impossibile ottenere il numero di sequenza";
+"failToResolveJettonWallet" = "Impossibile risolvere l'indirizzo del wallet jetton. Riprova.";
 "failToStartKesign" = "Errore di firma";
 "failToStartKeygen" = "Impossibile avviare la generazione della chiave a causa della mancanza di informazioni";
 "failureReason" = "Motivo dell'errore";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -387,6 +387,7 @@
 "failToGetAccountNumber" = "계정 번호를 가져올 수 없습니다";
 "failToGetRecentBlockHash" = "최근 블록 해시를 가져올 수 없습니다";
 "failToGetSequenceNo" = "시퀀스 번호를 가져올 수 없습니다";
+"failToResolveJettonWallet" = "제튼 지갑 주소를 확인할 수 없습니다. 다시 시도해 주세요.";
 "failToStartKesign" = "서명 오류";
 "failToStartKeygen" = "정보 누락으로 키 생성을 시작할 수 없습니다";
 "failureReason" = "실패 이유";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -390,6 +390,7 @@
 "failToGetAccountNumber" = "Falha ao obter o número da conta";
 "failToGetRecentBlockHash" = "Falha ao obter o hash do bloco recente";
 "failToGetSequenceNo" = "Falha ao obter o número de sequência";
+"failToResolveJettonWallet" = "Não foi possível resolver o endereço da carteira jetton. Tente novamente.";
 "failToStartKesign" = "Erro de assinatura";
 "failToStartKeygen" = "Não foi possível iniciar a geração de chave devido à falta de informações";
 "failureReason" = "Motivo da falha";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -390,6 +390,7 @@
 "failToGetAccountNumber" = "无法获取账户号码";
 "failToGetRecentBlockHash" = "无法获取最近的区块哈希";
 "failToGetSequenceNo" = "无法获取序列号";
+"failToResolveJettonWallet" = "无法解析 jetton 钱包地址，请重试。";
 "failToStartKesign" = "签名错误";
 "failToStartKeygen" = "由于缺少信息，无法启动密钥生成";
 "failureReason" = "失败原因";

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -35,6 +35,7 @@ final class BlockChainService {
         case failToGetSequenceNo
         case failToGetRecentBlockHash
         case failToGetAssociatedTokenAddressFrom
+        case failToResolveJettonWallet
 
         var errorDescription: String? {
             return String(NSLocalizedString(rawValue, comment: ""))
@@ -683,11 +684,15 @@ private extension BlockChainService {
                 }
             }
 
+            // For jettons we must send to the SENDER's jetton wallet, never the
+            // master contract. A failed resolution must be a hard error — falling
+            // back to the master address strands funds (tx succeeds, jettons stay put).
             var senderJettonWallet: String = coin.contractAddress
             if !coin.isNativeToken {
-                if let resolved = await TonService.shared.getJettonWalletAddressAsync(ownerAddress: coin.address, masterAddress: coin.contractAddress) {
-                    senderJettonWallet = resolved
+                guard let resolved = await ton.resolveJettonWalletAddress(ownerAddress: coin.address, masterAddress: coin.contractAddress) else {
+                    throw Errors.failToResolveJettonWallet
                 }
+                senderJettonWallet = resolved
             }
             return .Ton(sequenceNumber: seqno, expireAt: expireAt, bounceable: isBounceable, sendMaxAmount: sendMaxAmount, jettonAddress: senderJettonWallet, isActiveDestination: !isBounceable)
         case .ripple:


### PR DESCRIPTION
## Summary
- A TON jetton (token) send could broadcast "successfully" — seqno advances, the success screen shows — while the jettons never moved. Silent fund-stranding.
- Cause: when `getJettonWalletAddressAsync` returned `nil` on any RPC hiccup, the sender jetton wallet silently stayed as the jetton **master** contract address. The transfer message then went to the master, and with `ignoreActionPhaseErrors` set there was no on-chain failure signal.
- Fix: treat a failed jetton-wallet resolution as a **hard error** — `throw Errors.failToResolveJettonWallet` instead of falling back to the master address, so a send never proceeds with an unresolved jetton wallet.
- Added `TonService.resolveJettonWalletAddress(...)` which retries (3 attempts, 500ms backoff) to ride out transient RPC failures before failing. Removed the now-unused `getJettonWalletAddressAsync`.
- Added the `failToResolveJettonWallet` error string to all 8 locale files and sorted.

## Issue
Closes #4534

## Test Plan
- [ ] Send a TON jetton with a healthy RPC — resolves the sender's jetton wallet and broadcasts normally; jettons move.
- [ ] Simulate jetton-wallet resolution failure (e.g. RPC error) — send fails with a user-facing error instead of broadcasting to the master contract.
- [x] SwiftLint passes on changed files (0 violations)
- [ ] xcodebuild build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced jetton wallet address resolution with automatic retry logic to improve reliability for jetton token transfers.
  * Improved error handling when jetton wallet address lookup fails.

* **Localization**
  * Added jetton wallet resolution error messages across all supported languages (English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->