### PR TITLE
fix(doge): apply fee tier + Android-aligned base instead of flat /10 divisor

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -20,6 +20,20 @@ final class BlockChainService {
         return value * 2 + value / 2 // x2.5 fee
     }
 
+    /// Dogecoin's `suggested_transaction_fee_per_byte_sat` from Blockchair is
+    /// reported at the chain's relay-floor scale (~500k sats/byte), an order of
+    /// magnitude above the rate other UTXO chains report. Android scales it by
+    /// 0.25 (`gas * 5 / 20`) to land on a sane next-block rate; this base
+    /// multiplier reproduces that intent and the fee mode tier is applied on
+    /// top, so Low/Normal/Fast actually differ. At a live 500k sats/byte:
+    /// Low ≈ 93,750, Normal = 125,000 (== Android), Fast = 312,500 sats/byte.
+    static let dogeBaseFeeMultiplier: Float = 0.25
+
+    static func dogeByteFee(suggestedSatsPerByte sats: BigInt, feeMode: FeeMode) -> BigInt {
+        let prioritized = Float(sats) * dogeBaseFeeMultiplier * feeMode.utxoMultiplier
+        return BigInt(prioritized)
+    }
+
     static func normalizeEVMFee(_ value: BigInt) -> BigInt {
         let normalized = value + value / 2 // x1.5 fee
         return max(normalized, 1) // To avoid 0 miner tips
@@ -252,12 +266,11 @@ final class BlockChainService {
     func fetchUTXOFee(coin: Coin, feeMode: FeeMode) async throws -> BigInt {
         let sats = try await utxo.fetchSatsPrice(coin: coin)
 
-        // DOGE has extremely high base fees from API, need to reduce significantly
         let result: BigInt
         if coin.chain == .dogecoin {
-            // For DOGE, the API returns 500k sats/byte which is too high for WalletCore
-            // Use a much lower value that WalletCore can work with: divide by 10
-            result = sats / 10 // 500k / 10 = 50k sats/byte (still high but workable)
+            // DOGE reports its rate at the relay-floor scale; rescale to a sane
+            // next-block rate and apply the fee mode tier (see dogeByteFee).
+            result = Self.dogeByteFee(suggestedSatsPerByte: sats, feeMode: feeMode)
         } else {
             // For other chains, use normal normalization and multipliers
             let normalized = Self.normalizeUTXOFee(sats)

--- a/VultisigApp/VultisigAppTests/Blockchain/DogeFeeTierTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/DogeFeeTierTests.swift
@@ -1,0 +1,62 @@
+//
+//  DogeFeeTierTests.swift
+//  VultisigAppTests
+//
+//  Pins the Dogecoin byte-fee math. Before this, DOGE used a flat `sats / 10`
+//  divisor that ignored the user's fee tier (Low/Normal/Fast all identical) and
+//  underpriced vs Android by ~2.5x. Blockchair reports DOGE at the relay-floor
+//  scale (~500k sats/byte); Android rescales by 0.25 (`gas * 5 / 20`) and lands
+//  on a 125k sats/byte next-block rate. `dogeByteFee` reproduces that 0.25 base
+//  and applies the fee mode tier on top so the tiers actually differ.
+//
+
+@testable import VultisigApp
+import XCTest
+import BigInt
+
+final class DogeFeeTierTests: XCTestCase {
+
+    /// Live DOGE `suggested_transaction_fee_per_byte_sat` sits at the chain's
+    /// relay-floor scale.
+    private let liveSuggestedRate = BigInt(500_000)
+
+    /// At the live rate, `.normal` reproduces Android's 0.25x intent exactly
+    /// (500k * 0.25 * 1 = 125,000 sats/byte == Android `gas * 5 / 20`).
+    func testNormalTierMatchesAndroidIntent() {
+        let fee = BlockChainService.dogeByteFee(
+            suggestedSatsPerByte: liveSuggestedRate,
+            feeMode: .normal
+        )
+        XCTAssertEqual(fee, BigInt(125_000))
+    }
+
+    /// Low / Normal / Fast must produce distinct fees — the bug being fixed was
+    /// that the flat `/10` made the tier selector a no-op.
+    func testTiersProduceDistinctFees() {
+        let low = BlockChainService.dogeByteFee(suggestedSatsPerByte: liveSuggestedRate, feeMode: .safeLow)
+        let normal = BlockChainService.dogeByteFee(suggestedSatsPerByte: liveSuggestedRate, feeMode: .normal)
+        let fast = BlockChainService.dogeByteFee(suggestedSatsPerByte: liveSuggestedRate, feeMode: .fast)
+
+        XCTAssertEqual(low, BigInt(93_750))    // 500k * 0.25 * 0.75
+        XCTAssertEqual(normal, BigInt(125_000)) // 500k * 0.25 * 1.0
+        XCTAssertEqual(fast, BigInt(312_500))   // 500k * 0.25 * 2.5
+
+        XCTAssertLessThan(low, normal)
+        XCTAssertLessThan(normal, fast)
+    }
+
+    /// The fix raises the default (`.fast`) fee above the old flat `/10` path
+    /// (50,000 sats/byte) so DOGE is no longer ~2.5x cheaper than Android.
+    func testFixIsPricierThanOldFlatDivisor() {
+        let oldFlat = liveSuggestedRate / 10 // 50,000
+        let fast = BlockChainService.dogeByteFee(suggestedSatsPerByte: liveSuggestedRate, feeMode: .fast)
+        XCTAssertGreaterThan(fast, oldFlat)
+    }
+
+    /// Even the highest tier stays below the raw suggested rate, keeping the
+    /// absolute byte fee economically reasonable.
+    func testFastTierStaysBelowRawSuggestedRate() {
+        let fast = BlockChainService.dogeByteFee(suggestedSatsPerByte: liveSuggestedRate, feeMode: .fast)
+        XCTAssertLessThan(fast, liveSuggestedRate)
+    }
+}


### PR DESCRIPTION
## Problem

Dogecoin sends use a bespoke fee path that (a) ignores the user's fee tier — Low/Normal/Fast all produce the **same** fee — and (b) underprices vs Android by ~2.5×. On DOGE, underpaying risks slow/stuck confirmations.

## Root cause

`BlockChainService.fetchUTXOFee` special-cased DOGE with `result = sats / 10` (≈0.1×) and never applied `feeMode.utxoMultiplier`, so the tier selector was a no-op. Android (`UtxoFeeService.kt`) uses `gas.multiply(5).divide(20)` = **0.25×** for DOGE, so iOS at 0.1× was ~2.5× cheaper.

> Note: the issue's premise that the else-branch is "now a clean tier-only model (post-#4543)" does **not** hold against current `main` — PR #4543 was **closed unmerged**, so the else-branch still has the 6.25× double-multiply bug (#4529). #4545 is scoped to DOGE only, so this PR makes the DOGE branch self-contained rather than mirroring the still-buggy else-branch. The non-DOGE double-multiply is explicitly out of scope.

## Fix

Replace the magic `/10` with a pure, tier-aware helper:

```swift
static let dogeBaseFeeMultiplier: Float = 0.25
static func dogeByteFee(suggestedSatsPerByte sats: BigInt, feeMode: FeeMode) -> BigInt {
    let prioritized = Float(sats) * dogeBaseFeeMultiplier * feeMode.utxoMultiplier
    return BigInt(prioritized)
}
```

Base = **0.25** matches Android's DOGE rate; iOS `.normal` has `utxoMultiplier = 1.0`, so `.normal` lands exactly on Android's number and Low/Fast fan out around it.

## sat/byte cross-check vs live next-block rate

Live `suggested_transaction_fee_per_byte_sat` for dogecoin (fetched 2026-06-11): **500,000**.

| Path | Multiplier | sat/byte @ 500k |
|------|-----------|------------------|
| Raw API suggestion | 1.0× | 500,000 |
| iOS **old** (`/10`) | 0.1× | 50,000 |
| Android DOGE (`gas*5/20`) | 0.25× | 125,000 |
| **New** `.safeLow` (0.25 × 0.75) | 0.1875× | 93,750 |
| **New** `.normal` (0.25 × 1.0) | 0.25× | **125,000** (= Android) |
| **New** `.fast`, default (0.25 × 2.5) | 0.625× | 312,500 |

`.normal` reproduces Android's 0.25× exactly; tiers now differ; default `.fast` is no longer underpriced. Max tier (312,500) stays below the raw 500k.

**WalletCore constraint:** the old "/10 because raw is too high for WalletCore" comment does not hold — `UTXOChainsHelper` casts `byteFee` to `Int64` (no cap, 500k fits trivially); the divisor was just an undocumented underprice.

## Verification

- `swiftlint` — 0 violations on changed files.
- `make generate` re-ran (new test file).
- `xcodebuild test -only-testing:VultisigAppTests/DogeFeeTierTests` (worktree-local `-derivedDataPath`): **4/4 pass**, full app target compiled (`** TEST SUCCEEDED **`).
- New `DogeFeeTierTests`: `.normal` == Android 125k; tiers distinct; fix pricier than old `/10`; `.fast` below raw rate.

## Risks

- 0.25× base validated against a **single** live snapshot (500k sats/byte, 2026-06-11). If Blockchair ever reports DOGE at a different (already-normalized) scale, 0.25× could mis-price — but Android applies the identical 0.25× against the same endpoint, so iOS/Android stay in lockstep regardless of absolute scale.
- Does not fix the non-DOGE 6.25× double-multiply (out of scope; #4529 / closed PR #4543).

Closes #4545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dogecoin transaction fee calculation with refined tier-based fee scaling for more accurate fee estimates.

* **Tests**
  * Added comprehensive test suite validating Dogecoin fee tier calculations across all fee modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->