### PR TITLE
fix(sui): select coin objects by exact coinType + paginate getAllCoins

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
@@ -176,8 +176,8 @@ class SuiService {
                 )
 
                 guard let coins: [SuiCoin] = Utils.extractResultFromJson(fromData: data, path: "result.data") else {
-                    logger.error("Failed to decode coins")
-                    break
+                    logger.error("Failed to decode coin page at cursor \(cursor ?? "<start>", privacy: .public)")
+                    throw Errors.coinPageDecodeFailed(cursor: cursor)
                 }
 
                 allCoins.append(contentsOf: coins.map { suiCoin in
@@ -347,6 +347,7 @@ private extension SuiService {
         case simulationFailed(String)
         case failedToParseGasEstimate
         case dryRunFailed(String)
+        case coinPageDecodeFailed(cursor: String?)
 
         var errorDescription: String? {
             switch self {
@@ -358,6 +359,8 @@ private extension SuiService {
                 return "Failed to parse gas estimate from dry run"
             case .dryRunFailed(let error):
                 return "Dry run failed: \(error)"
+            case .coinPageDecodeFailed(let cursor):
+                return "Failed to decode coin page from suix_getAllCoins at cursor \(cursor ?? "<start>"). Aborting to avoid a truncated coin set."
             }
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
@@ -8,10 +8,13 @@
 import Foundation
 import SwiftUI
 import BigInt
+import OSLog
 import WalletCore
 
 class SuiService {
     static let shared = SuiService()
+
+    private let logger = Logger(subsystem: "com.vultisig.app", category: "sui-service")
 
     /// Default Sui JSON-RPC host.
     static let defaultRPCURL: URL = {
@@ -151,31 +154,51 @@ class SuiService {
         return BigInt.zero
     }
 
+    /// Fetches every coin object owned by the address.
+    ///
+    /// Returns all coin objects (every `coinType`) so callers can select the
+    /// exact objects they need: the precise per-purpose selection — native SUI
+    /// for a native send, the token's exact type plus SUI gas objects for a token
+    /// send — happens downstream in `SuiHelper` by exact, normalized coin type.
+    /// `suix_getAllCoins` is paginated (default page ~50), so we follow
+    /// `nextCursor`/`hasNextPage` to avoid a truncated object set on heavy wallets.
     func getAllCoins(coin: Coin) async throws -> [[String: String]] {
 
         do {
-            let data = try await Utils.PostRequestRpc(rpcURL: rpcURL, method: "suix_getAllCoins", params: [coin.address])
+            var allCoins: [[String: String]] = []
+            var cursor: String?
 
-            if let coins: [SuiCoin] = Utils.extractResultFromJson(fromData: data, path: "result.data") {
-                let allCoins = coins.filter { $0.coinType.uppercased().contains("SUI") || $0.coinType.uppercased().contains(coin.ticker.uppercased()) }.map { coin in
-                    var coinDict = [String: String]()
-                    coinDict["objectID"] = coin.coinObjectId.description
-                    coinDict["version"] = String(coin.version)
-                    coinDict["objectDigest"] = coin.digest
-                    coinDict["balance"] = String(coin.balance)
-                    coinDict["coinType"] = String(coin.coinType)
-                    return coinDict
+            repeat {
+                let data = try await Utils.PostRequestRpc(
+                    rpcURL: rpcURL,
+                    method: "suix_getAllCoins",
+                    params: [coin.address, cursor]
+                )
+
+                guard let coins: [SuiCoin] = Utils.extractResultFromJson(fromData: data, path: "result.data") else {
+                    logger.error("Failed to decode coins")
+                    break
                 }
 
-                return allCoins
-            } else {
-                print("Failed to decode coins")
-            }
+                allCoins.append(contentsOf: coins.map { suiCoin in
+                    var coinDict = [String: String]()
+                    coinDict["objectID"] = suiCoin.coinObjectId.description
+                    coinDict["version"] = String(suiCoin.version)
+                    coinDict["objectDigest"] = suiCoin.digest
+                    coinDict["balance"] = String(suiCoin.balance)
+                    coinDict["coinType"] = String(suiCoin.coinType)
+                    return coinDict
+                })
+
+                let hasNextPage = Utils.extractResultFromJson(fromData: data, path: "result.hasNextPage") as? Bool ?? false
+                cursor = hasNextPage ? Utils.extractResultFromJson(fromData: data, path: "result.nextCursor") as? String : nil
+            } while cursor != nil
+
+            return allCoins
         } catch {
-            print("Error fetching balance: \(error.localizedDescription)")
+            logger.error("Error fetching coins: \(error.localizedDescription)")
             throw error
         }
-        return []
     }
 
     func getAllTokens(address: String) async throws -> [[String: String]] {

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Signing/Sui.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Signing/Sui.swift
@@ -35,7 +35,7 @@ enum SuiHelper {
             // [["objectDigest": "", "objectID": "", "version": ""]]
             // NOT key value pair object
             // [[["objectDigest": ""], ["objectID": ""], ["version": ""]]]
-            let suiCoins = coins.filter { $0["coinType"]?.uppercased().contains(keysignPayload.coin.ticker.uppercased()) == true }.map {
+            let suiCoins = coins.filter { SuiCoinType.isNative($0["coinType"] ?? .empty) }.map {
                 var obj = SuiObjectRef()
                 obj.objectID = $0["objectID"] ?? .empty
                 obj.version = UInt64($0["version"] ?? .zero) ?? UInt64.zero
@@ -70,7 +70,11 @@ enum SuiHelper {
             // [["objectDigest": "", "objectID": "", "version": ""]]
             // NOT key value pair object
             // [[["objectDigest": ""], ["objectID": ""], ["version": ""]]]
-            let suiCoins = coins.filter { $0["coinType"]?.uppercased().contains(keysignPayload.coin.ticker.uppercased()) == true }.map {
+            let tokenCoinType = SuiCoinType.expectedType(
+                isNativeToken: keysignPayload.coin.isNativeToken,
+                contractAddress: keysignPayload.coin.contractAddress
+            )
+            let suiCoins = coins.filter { SuiCoinType.matches($0["coinType"] ?? .empty, tokenCoinType) }.map {
                 var obj = SuiObjectRef()
                 obj.objectID = $0["objectID"] ?? .empty
                 obj.version = UInt64($0["version"] ?? .zero) ?? UInt64.zero
@@ -82,7 +86,7 @@ enum SuiHelper {
                 throw HelperError.runtimeError("Non-native token transaction requires the token to be present")
             }
 
-            let suiObjectForGas = coins.filter { $0["coinType"]?.uppercased().contains("SUI") == true }.map {
+            let suiObjectForGas = coins.filter { SuiCoinType.isNative($0["coinType"] ?? .empty) }.map {
                 var obj = SuiObjectRef()
                 obj.objectID = $0["objectID"] ?? .empty
                 obj.version = UInt64($0["version"] ?? .zero) ?? UInt64.zero

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Signing/SuiConstants.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Signing/SuiConstants.swift
@@ -71,6 +71,27 @@ enum SuiCoinType {
         return matches(coinType, SuiConstants.nativeCoinType)
     }
 
+    /// Filters a set of owned coin objects down to exactly what a SUI send
+    /// serializes into the keysign payload: the native SUI objects (always
+    /// needed — they pay gas, and for a native send they are also the inputs)
+    /// plus, for a token send, the objects of the token being sent. Every other
+    /// owned object (unrelated memecoins / LSTs) is dropped so the payload — and
+    /// therefore the pairing QR and TSS relay payload — stays small.
+    ///
+    /// `getPreSignedInputData` performs the same selection on this set, so the
+    /// filtered output is exactly the inputs the signer consumes.
+    static func payloadCoins(
+        _ coins: [[String: String]],
+        isNativeToken: Bool,
+        contractAddress: String
+    ) -> [[String: String]] {
+        let tokenType = expectedType(isNativeToken: isNativeToken, contractAddress: contractAddress)
+        return coins.filter { coin in
+            let coinType = coin["coinType"] ?? .empty
+            return isNative(coinType) || matches(coinType, tokenType)
+        }
+    }
+
     /// Collapses a package-address segment to `0x` + hex with leading zeros
     /// stripped, so `0x0000…0002` and `0x2` compare equal.
     private static func normalizeAddress(_ address: String) -> String {

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Signing/SuiConstants.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Signing/SuiConstants.swift
@@ -17,4 +17,65 @@ enum SuiConstants {
 
     /// USDC decimals on SUI chain
     static let usdcDecimals = 6
+
+    /// Canonical fully-qualified type of the native SUI coin (short address form).
+    static let nativeCoinType = "0x2::sui::SUI"
+}
+
+/// Exact, normalization-aware matching for SUI coin-object types.
+///
+/// SUI coin objects are identified by a fully-qualified `address::module::struct`
+/// type. The first segment (the package address) can appear in either short form
+/// (`0x2`) or the 64-hex-digit long form the node returns from
+/// `suix_getAllCoins` (`0x0000…0002`). Matching coin objects by ticker substring
+/// is wrong: it cannot distinguish `0x2::sui::SUI` from `0x…::xsui::XSUI`, and it
+/// fails for tokens whose on-chain symbol differs from their display ticker
+/// (e.g. Wormhole-bridged `…::coin::COIN`). This enum compares the full type
+/// after normalizing only the address segment.
+enum SuiCoinType {
+
+    /// Normalizes a fully-qualified coin type for exact comparison: lowercases the
+    /// whole string and collapses the package-address segment to a canonical
+    /// `0x`-prefixed, leading-zero-stripped form. The module/struct segments are
+    /// compared case-insensitively but otherwise left intact.
+    static func normalize(_ coinType: String) -> String {
+        let lowered = coinType.lowercased()
+        let segments = lowered.split(separator: ":", omittingEmptySubsequences: false)
+        // Expected form is `address::module::struct` -> 5 segments around the two `::`.
+        guard let addressSegment = segments.first, !addressSegment.isEmpty else {
+            return lowered
+        }
+        let normalizedAddress = normalizeAddress(String(addressSegment))
+        let remainder = lowered.dropFirst(addressSegment.count)
+        return normalizedAddress + remainder
+    }
+
+    /// Returns whether two fully-qualified coin types refer to the same coin,
+    /// independent of package-address form (short `0x2` vs long `0x00…02`).
+    static func matches(_ lhs: String, _ rhs: String) -> Bool {
+        return normalize(lhs) == normalize(rhs)
+    }
+
+    /// The fully-qualified type a `Coin` record represents: its `contractAddress`
+    /// for tokens, or the canonical native SUI type when the record is native
+    /// (native SUI carries an empty `contractAddress`).
+    static func expectedType(isNativeToken: Bool, contractAddress: String) -> String {
+        if isNativeToken || contractAddress.isEmpty {
+            return SuiConstants.nativeCoinType
+        }
+        return contractAddress
+    }
+
+    /// Whether the given coin-object type is the native SUI coin.
+    static func isNative(_ coinType: String) -> Bool {
+        return matches(coinType, SuiConstants.nativeCoinType)
+    }
+
+    /// Collapses a package-address segment to `0x` + hex with leading zeros
+    /// stripped, so `0x0000…0002` and `0x2` compare equal.
+    private static func normalizeAddress(_ address: String) -> String {
+        let hex = address.hasPrefix("0x") ? String(address.dropFirst(2)) : address
+        let trimmed = String(hex.drop { $0 == "0" })
+        return "0x" + (trimmed.isEmpty ? "0" : trimmed)
+    }
 }

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -497,7 +497,17 @@ private extension BlockChainService {
             return .Solana(recentBlockHash: recentBlockHash, priorityFee: dynamicPriorityFee, priorityLimit: SolanaHelper.priorityFeeLimit, fromAddressPubKey: nil, toAddressPubKey: nil, hasProgramId: false)
 
         case .sui:
-            let (referenceGasPrice, allCoins) = try await sui.getGasInfo(coin: coin)
+            let (referenceGasPrice, ownedCoins) = try await sui.getGasInfo(coin: coin)
+
+            // The signer only needs the native SUI objects (for gas, and as the
+            // inputs of a native send) plus the objects of the token being sent.
+            // Embedding every owned object would bloat the keysign payload — and
+            // therefore the pairing QR / TSS relay payload — on heavy wallets.
+            let allCoins = SuiCoinType.payloadCoins(
+                ownedCoins,
+                isNativeToken: coin.isNativeToken,
+                contractAddress: coin.contractAddress
+            )
 
             // Calculate dynamic gas budget using dry run simulation
             let gasBudget: BigInt

--- a/VultisigApp/VultisigAppTests/Chains/SuiCoinTypeTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/SuiCoinTypeTests.swift
@@ -1,0 +1,95 @@
+//
+//  SuiCoinTypeTests.swift
+//  VultisigApp
+//
+//  Pins exact, normalization-aware SUI coin-object matching: a native SUI send
+//  must never pull in look-alike coins whose type merely contains "SUI" (LSTs
+//  like xSUI/haSUI, SUI-named memecoins), a token send must select objects by
+//  the token's fully-qualified type even when its on-chain symbol differs from
+//  the display ticker (Wormhole-bridged `…::coin::COIN`), and package-address
+//  form (short `0x2` vs long `0x00…02`) must not affect equality.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SuiCoinTypeTests: XCTestCase {
+
+    private let nativeShort = "0x2::sui::SUI"
+    private let nativeLong = "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI"
+    private let xSUI = "0xb45f7a8e2d1c4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a::xsui::XSUI"
+    // Wormhole-bridged asset: on-chain symbol/struct is COIN, not the display ticker.
+    private let bridgedCoin = "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN"
+
+    // MARK: - Native matching excludes look-alikes
+
+    func testIsNativeMatchesShortAndLongAddressForms() {
+        XCTAssertTrue(SuiCoinType.isNative(nativeShort))
+        XCTAssertTrue(SuiCoinType.isNative(nativeLong))
+    }
+
+    func testIsNativeRejectsLookAlikeLstAndMemecoins() {
+        XCTAssertFalse(SuiCoinType.isNative(xSUI))
+        XCTAssertFalse(SuiCoinType.isNative(bridgedCoin))
+        XCTAssertFalse(SuiCoinType.isNative("0xabc::sssui::SSSUI"))
+    }
+
+    // MARK: - Address-form normalization
+
+    func testNormalizeCollapsesAddressForms() {
+        XCTAssertEqual(SuiCoinType.normalize(nativeShort), SuiCoinType.normalize(nativeLong))
+        XCTAssertTrue(SuiCoinType.matches(nativeShort, nativeLong))
+    }
+
+    func testNormalizeIsCaseInsensitive() {
+        XCTAssertTrue(SuiCoinType.matches(bridgedCoin, bridgedCoin.uppercased()))
+    }
+
+    func testNormalizeLeavesNonNativeTypesDistinct() {
+        XCTAssertFalse(SuiCoinType.matches(nativeShort, xSUI))
+        XCTAssertFalse(SuiCoinType.matches(bridgedCoin, xSUI))
+    }
+
+    // MARK: - expectedType resolves the record's coin type
+
+    func testExpectedTypeForNativeRecordIsCanonicalSui() {
+        XCTAssertEqual(SuiCoinType.expectedType(isNativeToken: true, contractAddress: ""), nativeShort)
+    }
+
+    func testExpectedTypeForTokenRecordIsContractAddress() {
+        XCTAssertEqual(
+            SuiCoinType.expectedType(isNativeToken: false, contractAddress: bridgedCoin),
+            bridgedCoin
+        )
+    }
+
+    // MARK: - Selection over a heterogeneous object set
+
+    /// A wallet holding native SUI alongside an xSUI LST: a native send must
+    /// select only the native object and never the LST.
+    func testNativeSelectionExcludesXSui() {
+        let objects = [
+            ["coinType": nativeLong, "objectID": "0xnative"],
+            ["coinType": xSUI, "objectID": "0xlst"]
+        ]
+        let selected = objects.filter { SuiCoinType.isNative($0["coinType"] ?? "") }
+        XCTAssertEqual(selected.map { $0["objectID"] }, ["0xnative"])
+    }
+
+    /// A token send for a Wormhole-bridged `…::coin::COIN` asset selects its own
+    /// objects (by exact type) and a separate SUI gas object — never the xSUI LST.
+    func testBridgedTokenSelectionAndGasSplit() {
+        let objects = [
+            ["coinType": nativeLong, "objectID": "0xgas"],
+            ["coinType": bridgedCoin, "objectID": "0xtoken"],
+            ["coinType": xSUI, "objectID": "0xlst"]
+        ]
+        let tokenType = SuiCoinType.expectedType(isNativeToken: false, contractAddress: bridgedCoin)
+
+        let tokenObjects = objects.filter { SuiCoinType.matches($0["coinType"] ?? "", tokenType) }
+        let gasObjects = objects.filter { SuiCoinType.isNative($0["coinType"] ?? "") }
+
+        XCTAssertEqual(tokenObjects.map { $0["objectID"] }, ["0xtoken"])
+        XCTAssertEqual(gasObjects.map { $0["objectID"] }, ["0xgas"])
+    }
+}

--- a/VultisigApp/VultisigAppTests/Chains/SuiCoinTypeTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/SuiCoinTypeTests.swift
@@ -92,4 +92,62 @@ final class SuiCoinTypeTests: XCTestCase {
         XCTAssertEqual(tokenObjects.map { $0["objectID"] }, ["0xtoken"])
         XCTAssertEqual(gasObjects.map { $0["objectID"] }, ["0xgas"])
     }
+
+    // MARK: - Payload coin filtering (keysign payload / QR bloat guard)
+
+    /// The full set of objects a heavy wallet might own: native SUI, an LST, a
+    /// bridged token, and an unrelated memecoin.
+    private var heterogeneousWallet: [[String: String]] {
+        [
+            ["coinType": nativeLong, "objectID": "0xnative"],
+            ["coinType": xSUI, "objectID": "0xlst"],
+            ["coinType": bridgedCoin, "objectID": "0xtoken"],
+            ["coinType": "0xfeed::moon::MOON", "objectID": "0xmemecoin"]
+        ]
+    }
+
+    /// A native SUI send embeds only the native object — no LST, no bridged
+    /// token, no memecoin — so the keysign payload / QR stays small.
+    func testPayloadCoinsForNativeSendKeepsOnlyNative() {
+        let filtered = SuiCoinType.payloadCoins(
+            heterogeneousWallet,
+            isNativeToken: true,
+            contractAddress: ""
+        )
+        XCTAssertEqual(filtered.map { $0["objectID"] }, ["0xnative"])
+    }
+
+    /// A token send embeds the native SUI objects (gas) and the target token's
+    /// objects only — never other held tokens (LST, memecoin).
+    func testPayloadCoinsForTokenSendKeepsNativeUnionTargetTokenOnly() {
+        let filtered = SuiCoinType.payloadCoins(
+            heterogeneousWallet,
+            isNativeToken: false,
+            contractAddress: bridgedCoin
+        )
+        XCTAssertEqual(Set(filtered.map { $0["objectID"] }), ["0xnative", "0xtoken"])
+        XCTAssertFalse(filtered.contains { $0["objectID"] == "0xlst" })
+        XCTAssertFalse(filtered.contains { $0["objectID"] == "0xmemecoin" })
+    }
+
+    /// Multiple objects of the same target token (and multiple native gas
+    /// objects) are all preserved — filtering by type must not cap object count.
+    func testPayloadCoinsPreservesAllMatchingObjects() {
+        let wallet = [
+            ["coinType": nativeShort, "objectID": "0xgas1"],
+            ["coinType": nativeLong, "objectID": "0xgas2"],
+            ["coinType": bridgedCoin, "objectID": "0xtoken1"],
+            ["coinType": bridgedCoin, "objectID": "0xtoken2"],
+            ["coinType": xSUI, "objectID": "0xlst"]
+        ]
+        let filtered = SuiCoinType.payloadCoins(
+            wallet,
+            isNativeToken: false,
+            contractAddress: bridgedCoin
+        )
+        XCTAssertEqual(
+            Set(filtered.map { $0["objectID"] }),
+            ["0xgas1", "0xgas2", "0xtoken1", "0xtoken2"]
+        )
+    }
 }

--- a/VultisigApp/VultisigAppTests/Chains/SuiServiceGetAllCoinsTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/SuiServiceGetAllCoinsTests.swift
@@ -1,0 +1,132 @@
+//
+//  SuiServiceGetAllCoinsTests.swift
+//  VultisigApp
+//
+//  Pins the fail-loud pagination contract of `SuiService.getAllCoins`: when a
+//  page of `suix_getAllCoins` cannot be decoded mid-pagination, the call must
+//  THROW rather than return the coins decoded so far. A truncated coin set is
+//  worse than no set — downstream coin-object selection in `SuiHelper` would
+//  silently miss the SUI gas object or the token's objects and build an invalid
+//  transaction (the silent-failure class this PR exists to close). The happy
+//  path must still follow `nextCursor`/`hasNextPage` to completion.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SuiServiceGetAllCoinsTests: XCTestCase {
+
+    private static let stubHost = "sui-getallcoins-stub.local"
+
+    override func setUp() {
+        super.setUp()
+        StubRPCProtocol.pages = []
+        StubRPCProtocol.requestCount = 0
+        URLProtocol.registerClass(StubRPCProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(StubRPCProtocol.self)
+        StubRPCProtocol.pages = []
+        super.tearDown()
+    }
+
+    // MARK: - Happy path: full pagination
+
+    func testGetAllCoinsFollowsPaginationToCompletion() async throws {
+        StubRPCProtocol.pages = [
+            Self.page(coins: [Self.coinJSON(id: "0x1")], nextCursor: "cursor-1", hasNextPage: true),
+            Self.page(coins: [Self.coinJSON(id: "0x2")], nextCursor: nil, hasNextPage: false)
+        ]
+
+        let service = SuiService(resolver: StubResolver(host: Self.stubHost))
+        let coins = try await service.getAllCoins(coin: Self.makeCoin())
+
+        XCTAssertEqual(coins.count, 2, "Both pages must be merged into the result")
+        XCTAssertEqual(coins.map { $0["objectID"] }, ["0x1", "0x2"])
+        XCTAssertEqual(StubRPCProtocol.requestCount, 2, "Pagination must stop once hasNextPage is false")
+    }
+
+    // MARK: - Fail loud on a mid-pagination decode failure
+
+    func testGetAllCoinsThrowsWhenLaterPageFailsToDecode() async {
+        // Page 1 decodes and advertises a next page; page 2 is malformed
+        // (no `result.data`). A truncated set must never be returned.
+        StubRPCProtocol.pages = [
+            Self.page(coins: [Self.coinJSON(id: "0x1")], nextCursor: "cursor-1", hasNextPage: true),
+            Data(#"{"jsonrpc":"2.0","id":1,"result":{"unexpected":true}}"#.utf8)
+        ]
+
+        let service = SuiService(resolver: StubResolver(host: Self.stubHost))
+
+        do {
+            let coins = try await service.getAllCoins(coin: Self.makeCoin())
+            XCTFail("Expected a decode failure to throw, got \(coins.count) coins")
+        } catch {
+            // Success: the truncated page-1 result was not handed back.
+            XCTAssertEqual(StubRPCProtocol.requestCount, 2, "Both pages must have been fetched before failing")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static func makeCoin() -> Coin {
+        Coin(asset: TokensStore.Token.suiSUI, address: "0xowner", hexPublicKey: "pub")
+    }
+
+    private static func coinJSON(id: String) -> String {
+        """
+        {"coinType":"0x2::sui::SUI","coinObjectId":"\(id)","version":"1","digest":"digest-\(id)","balance":"100","previousTransaction":"prev"}
+        """
+    }
+
+    private static func page(coins: [String], nextCursor: String?, hasNextPage: Bool) -> Data {
+        let cursorJSON = nextCursor.map { "\"\($0)\"" } ?? "null"
+        let body = """
+        {"jsonrpc":"2.0","id":1,"result":{"data":[\(coins.joined(separator: ","))],"nextCursor":\(cursorJSON),"hasNextPage":\(hasNextPage)}}
+        """
+        return Data(body.utf8)
+    }
+}
+
+/// A resolver that points every chain at an in-process stub host so the
+/// `URLProtocol` below can intercept the request without hitting the network.
+private struct StubResolver: RPCEndpointResolving {
+    let host: String
+    func url(for _: Chain) -> String? { "https://\(host)/rpc" }
+}
+
+/// Serves canned JSON-RPC responses in order. Each call to `getAllCoins` issues
+/// one POST per page; we pop the next queued page off `pages`.
+private final class StubRPCProtocol: URLProtocol {
+    static var pages: [Data] = []
+    static var requestCount = 0
+
+    // These are required `URLProtocol` class-method overrides; they cannot be `static`.
+    // swiftlint:disable static_over_final_class
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "sui-getallcoins-stub.local"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    // swiftlint:enable static_over_final_class
+
+    override func startLoading() {
+        let index = Self.requestCount
+        Self.requestCount += 1
+
+        let body = index < Self.pages.count ? Self.pages[index] : Data("{}".utf8)
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Problem

SUI sends can fail or be impossible because coin-object selection filters by `coinType.contains(ticker)`:

1. **Native SUI sends pull in wrong objects.** A wallet that also holds any coin whose type string contains "SUI" (sSUI / haSUI and other LSTs, SUI-named memecoins) feeds non-SUI object references into the native `paySui` input → invalid tx → dry-run fails silently → broadcast fails *after* the TSS ceremony.
2. **Some tokens are unsendable.** A token whose on-chain type doesn't contain its display ticker (classic case: Wormhole-bridged assets typed `…::coin::COIN`) matches nothing → `"Non-native token transaction requires the token to be present"`, and its balance mis-displays.

`suix_getAllCoins` was also unpaginated (default page ~50 objects), truncating the object set on heavy wallets.

## Root cause

Substring matching cannot distinguish `0x2::sui::SUI` from `0x…::xsui::XSUI`, and breaks when a token's on-chain struct symbol differs from its display ticker. The three filters lived at `SuiService.getAllCoins` and the native + token branches of `SuiHelper.getPreSignedInputData`.

The `Coin` `@Model` has no `coinType` field — the fully-qualified `address::module::struct` type is carried in `Coin.contractAddress` (empty for native SUI, whose canonical type is `0x2::sui::SUI`). The coin-object dicts already carry the node's `coinType`, so exact matching is possible on both sides.

## Fix

- **`SuiCoinType`** (new, in `SuiConstants.swift`): normalization-aware exact matching. `normalize(_:)` collapses the package-address segment so the short `0x2` and long `0x0000…0002` forms compare equal; `matches`, `isNative`, and `expectedType(isNativeToken:contractAddress:)` build on it.
- Replaced all three substring filters in `Sui.swift` with exact matching (native → `isNative`; token → `matches(expectedType)`; gas → `isNative`).
- `getAllCoins` now returns **all** owned coin objects (so a token send still sees its SUI gas objects) and **paginates** via `nextCursor` / `hasNextPage`. Touched `print` calls converted to `OSLog`.
- `getAllBalances` substring filter (balance display, not object selection) left unchanged to keep the fix focused.

### `0x2` normalization

`normalize` lowercases the type, strips `0x`, drops leading zeros from the address segment, and re-prefixes `0x`, leaving module/struct intact. So both `0x2::sui::SUI` and the node's `0x0000…0002::sui::SUI` normalize identically, while `…::xsui::XSUI` stays distinct.

## Verification

- New unit test `VultisigAppTests/Chains/SuiCoinTypeTests.swift` (9 cases): native excludes xSUI / `::coin::COIN` / SUI-named look-alikes, address-form normalization (short ↔ long), bridged `::coin::COIN` token selection + native gas split. **9/9 pass** (iPhone 16 Pro sim, worktree-local derived data).
- `swiftlint` clean on all changed files; `make generate` run for the new test file.

Closes #4538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical native SUI coin type and robust coin-type matching/normalization for precise coin selection

* **Bug Fixes**
  * More accurate SUI coin selection and gas picking using normalization-aware matching
  * Improved coin fetching to follow paginated results reliably and surface decoding/RPC errors
  * SUI-specific payload now includes the correct set of coin objects for sends

* **Tests**
  * Added tests for coin-type selection and paginated coin fetching (including failure cases)

* **Chores**
  * Enhanced logging for coin retrieval failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->