### PR TITLE
fix(keysign): cancel orphaned signing body on stage timeout & gate broadcast (#4541)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -184,6 +184,11 @@ final class DKLSKeysign {
 
     func processDKLSOutboundMessage(handle: godkls.Handle) async throws {
         repeat {
+            // Cooperative cancellation: the stage-level timeout in
+            // KeysignViewModel cancels this task group on a stall. Without an
+            // explicit check the C-backed loop runs to completion and the
+            // orphaned ceremony broadcasts behind the user's back.
+            try Task.checkCancellation()
             let (result, outboundMessage) = GetDKLSOutboundMessage(handle: handle)
             if result != DKLS_LIB_OK {
                 print("fail to get outbound message,\(result)")
@@ -220,6 +225,10 @@ final class DKLSKeysign {
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
+            // Cooperative cancellation: honour cancelAll() from the stage-level
+            // timeout so a stalled poll stops instead of running to completion
+            // and broadcasting an abandoned ceremony.
+            try Task.checkCancellation()
             let response: HTTPResponse<Data>
             do {
                 response = try await httpClient.request(TssRelayAPI(
@@ -387,6 +396,9 @@ final class DKLSKeysign {
                 try await Task.sleep(for: .milliseconds(500))
             }
         } catch {
+            // A cancellation is not a signing failure — never retry it,
+            // propagate so the abandoned ceremony unwinds immediately.
+            if error is CancellationError { throw error }
             logger.error("Failed to sign message (\(messageToSign, privacy: .public)) on attempt \(attempt, privacy: .public): \(error.localizedDescription, privacy: .public)")
             if attempt < 3 {
                 try await DKLSKeysignOneMessageWithRetry(attempt: attempt+1, messageToSign: messageToSign)

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
@@ -168,6 +168,11 @@ final class DilithiumKeysign {
 
     func processDilithiumOutboundMessage(handle: vscore.Handle) async throws {
         repeat {
+            // Cooperative cancellation: the stage-level timeout in
+            // KeysignViewModel cancels this task group on a stall. Without an
+            // explicit check the C-backed loop runs to completion and the
+            // orphaned ceremony broadcasts behind the user's back.
+            try Task.checkCancellation()
             let (result, outboundMessage) = GetDilithiumOutboundMessage(handle: handle)
             if result != MLDSA_LIB_OK {
                 print("fail to get outbound message,\(result)")
@@ -204,6 +209,10 @@ final class DilithiumKeysign {
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
+            // Cooperative cancellation: honour cancelAll() from the stage-level
+            // timeout so a stalled poll stops instead of running to completion
+            // and broadcasting an abandoned ceremony.
+            try Task.checkCancellation()
             let response: HTTPResponse<Data>
             do {
                 response = try await httpClient.request(TssRelayAPI(
@@ -366,6 +375,9 @@ final class DilithiumKeysign {
                 try await Task.sleep(for: .milliseconds(500))
             }
         } catch {
+            // A cancellation is not a signing failure — never retry it,
+            // propagate so the abandoned ceremony unwinds immediately.
+            if error is CancellationError { throw error }
             print("Failed to sign message (\(messageToSign)), error: \(error.localizedDescription)")
             if attempt < 3 {
                 try await DilithiumKeysignOneMessageWithRetry(attempt: attempt+1, messageToSign: messageToSign)

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
@@ -170,6 +170,11 @@ final class SchnorrKeysign {
 
     func processSchnorrOutboundMessage(handle: goschnorr.Handle) async throws {
         repeat {
+            // Cooperative cancellation: the stage-level timeout in
+            // KeysignViewModel cancels this task group on a stall. Without an
+            // explicit check the C-backed loop runs to completion and the
+            // orphaned ceremony broadcasts behind the user's back.
+            try Task.checkCancellation()
             let (result, outboundMessage) = GetSchnorrOutboundMessage(handle: handle)
             if result != .schnorrLibOK {
                 print("fail to get outbound message")
@@ -206,6 +211,10 @@ final class SchnorrKeysign {
         var isFinished = false
         let start = DispatchTime.now()
         repeat {
+            // Cooperative cancellation: honour cancelAll() from the stage-level
+            // timeout so a stalled poll stops instead of running to completion
+            // and broadcasting an abandoned ceremony.
+            try Task.checkCancellation()
             let response: HTTPResponse<Data>
             do {
                 response = try await httpClient.request(TssRelayAPI(
@@ -382,6 +391,9 @@ final class SchnorrKeysign {
                 self.signatures[messageToSign] = resp
             }
         } catch {
+            // A cancellation is not a signing failure — never retry it,
+            // propagate so the abandoned ceremony unwinds immediately.
+            if error is CancellationError { throw error }
             print("Failed to sign message (\(messageToSign)), error: \(error.localizedDescription)")
             if attempt < 3 {
                 try await KeysignOneMessageWithRetry(attempt: attempt+1, messageToSign: messageToSign)

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -62,12 +62,30 @@ class KeysignViewModel: ObservableObject {
     /// production singleton so runtime behaviour is unchanged.
     var transactionStatusChecker: TransactionStatusChecking = TransactionStatusService.shared
 
+    /// Per-message stage budget. Each message's inbound poll already caps at
+    /// 60s per attempt (see the DKLS/Schnorr/Dilithium `pullInboundMessages`
+    /// loops); this adds headroom for the setup-message round-trips so a single
+    /// healthy-but-slow message doesn't trip the safety net.
+    private static let perMessageStageBudget: Duration = .seconds(90)
+
+    /// Fixed headroom on top of the per-message budget for the post-signing
+    /// broadcast (RPC submit + the on-chain verification backoff).
+    private static let broadcastStageHeadroom: Duration = .seconds(30)
+
     /// Top-level timeout for a single keysign run (TSS exchange + broadcast).
     /// Underlying poll loops can stall without producing a terminal status —
     /// iOS suspending the network session in background, DKLS retry exhaustion,
     /// a peer that never sent its share — so this is the safety net that flips
     /// the UI into the retry-requested view. See vultisig-ios#4327.
-    static let keysignStageTimeout: Duration = .seconds(90)
+    ///
+    /// Messages are signed sequentially, so the budget scales with the message
+    /// count. A flat timeout fired on healthy multi-message ceremonies (e.g. a
+    /// UTXO send with several inputs), manufacturing the very retry-vs-orphan
+    /// race this guards against rather than catching a real hang.
+    var keysignStageTimeout: Duration {
+        let messageCount = max(messsageToSign.count, 1)
+        return Self.perMessageStageBudget * messageCount + Self.broadcastStageHeadroom
+    }
 
     private struct KeysignStalledError: Error {}
 
@@ -238,6 +256,9 @@ class KeysignViewModel: ObservableObject {
     }
 
     func startKeysign() async {
+        // Snapshot the (message-count-scaled) budget before entering the group
+        // so the non-isolated sleeper closure stays Sendable-clean.
+        let stageTimeout = keysignStageTimeout
         do {
             // Race the keysign body against a stage-level timeout. If the body
             // wins, `group.next()` returns void and `cancelAll()` retires the
@@ -256,7 +277,7 @@ class KeysignViewModel: ObservableObject {
                     }
                 }
                 group.addTask {
-                    try await Task.sleep(for: Self.keysignStageTimeout)
+                    try await Task.sleep(for: stageTimeout)
                     throw KeysignStalledError()
                 }
                 try await group.next()
@@ -271,7 +292,7 @@ class KeysignViewModel: ObservableObject {
             // case `KeysignView.onChange(of: txid)` will navigate away and the
             // retry view is torn down — the correct behaviour).
             guard !Self.isTerminalStatus(status) else { return }
-            logger.warning("keysign exceeded \(Self.keysignStageTimeout, privacy: .public) stage timeout — requesting retry")
+            logger.warning("keysign exceeded \(stageTimeout, privacy: .public) stage timeout — requesting retry")
             self.retryReason = .other("KeysignStalled")
             setStatus(.KeysignRetryRequested)
         } catch {
@@ -401,6 +422,12 @@ class KeysignViewModel: ObservableObject {
                     throw HelperError.runtimeError("fail to sign transaction")
                 }
             }
+            // The body may have been cancelled mid-flight (stage timeout)
+            // without a poll loop observing it. Gate broadcast on the same
+            // terminal-status check the finish guard uses so an orphaned
+            // ceremony — whose status the timeout already flipped to
+            // .KeysignRetryRequested — can never broadcast.
+            guard !Self.isTerminalStatus(status), !Task.isCancelled else { return }
             await broadcastTransaction()
             if let customMessagePayload {
                 setTxid(customMessagePayload.message)
@@ -411,6 +438,11 @@ class KeysignViewModel: ObservableObject {
             if !Self.isTerminalStatus(status) {
                 setStatus(.KeysignFinished)
             }
+        } catch is CancellationError {
+            // Stage-timeout cancellation: the timeout handler owns the terminal
+            // status (.KeysignRetryRequested). Do not overwrite it with a
+            // failure and do not broadcast.
+            logger.warning("DKLS keysign cancelled — leaving terminal status to the timeout handler")
         } catch {
             logger.error("TSS keysign failed, error: \(error.localizedDescription, privacy: .public)")
             keysignError = error.localizedDescription
@@ -424,8 +456,14 @@ class KeysignViewModel: ObservableObject {
             messagePuller?.stop()
         }
         for msg in messsageToSign {
+            // Cooperative cancellation: the stage-level timeout cancels this
+            // task group on a stall; bail before signing the next message so an
+            // abandoned ceremony can't proceed to broadcast.
+            if Task.isCancelled { return }
             do {
                 try await keysignOneMessageWithRetry(msg: msg, attempt: 1)
+            } catch is CancellationError {
+                return
             } catch {
                 logger.error("TSS keysign failed, error: \(error.localizedDescription, privacy: .public)")
                 keysignError = error.localizedDescription
@@ -434,6 +472,11 @@ class KeysignViewModel: ObservableObject {
             }
         }
 
+        // The body may have been cancelled mid-flight (stage timeout) without a
+        // poll loop observing it. Gate broadcast on the same terminal-status
+        // check the finish guard uses so an orphaned ceremony — whose status the
+        // timeout already flipped to .KeysignRetryRequested — can never broadcast.
+        guard !Self.isTerminalStatus(status), !Task.isCancelled else { return }
         await broadcastTransaction()
 
         if let customMessagePayload {
@@ -524,6 +567,9 @@ class KeysignViewModel: ObservableObject {
             try await Task.sleep(for: .seconds(1)) // backoff for 1 seconds , so other party can finish appropriately
         } catch {
             self.messagePuller?.stop()
+            // A cancellation is not a signing failure — propagate so the
+            // abandoned ceremony unwinds instead of retrying.
+            if error is CancellationError { throw error }
             // Check whether the other party already have the signature
             logger.error("keysign failed, error:\(error.localizedDescription) , attempt:\(attempt)")
             let resp = await keySignVerify.checkKeySignComplete(message: msgHash)

--- a/VultisigApp/VultisigAppTests/Keysign/KeysignTimeoutCancellationTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/KeysignTimeoutCancellationTests.swift
@@ -1,0 +1,137 @@
+//
+//  KeysignTimeoutCancellationTests.swift
+//  VultisigAppTests
+//
+//  Covers the stage-timeout-doesn't-cancel-the-body vector: the 90s stage
+//  timeout calls cancelAll() but the DKLS/Schnorr/Dilithium poll loops never
+//  observed cancellation, so the orphaned ceremony ran to completion and
+//  broadcast unconditionally. These tests pin down (1) the poll loops are now
+//  cooperatively cancellable, (2) the per-message-scaled stage budget so the
+//  timeout no longer fires on a healthy slow ceremony, and (3) the broadcast
+//  gate that prevents an already-terminal status from broadcasting.
+//
+
+@testable import VultisigApp
+import BigInt
+import Foundation
+import godkls
+import XCTest
+
+@MainActor
+final class KeysignTimeoutCancellationTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    /// Returns empty data so the poll loop takes its `Task.sleep` branch and
+    /// keeps spinning — exactly the stalled-ceremony shape the stage timeout is
+    /// meant to break out of. Records whether it was ever hit.
+    private final class EmptyPollingHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _requestCount = 0
+        var requestCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _requestCount
+        }
+
+        func request(_: TargetType) async throws -> HTTPResponse<Data> {
+            await Task.yield()
+            lock.lock(); _requestCount += 1; lock.unlock()
+            let url = URL(string: "https://example.invalid")!
+            let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return HTTPResponse(data: Data(), response: response)
+        }
+    }
+
+    // MARK: - (1) Poll loops are cooperatively cancellable
+
+    func testDKLSPullInboundMessagesThrowsCancellationWhenTaskCancelled() async {
+        let http = EmptyPollingHTTPClient()
+        let vault = Vault(name: "DKLS", libType: .DKLS)
+        vault.localPartyID = "partyA"
+        let keysign = DKLSKeysign(
+            keysignCommittee: ["partyA", "partyB"],
+            mediatorURL: "https://relay.invalid",
+            sessionID: "session",
+            messsageToSign: ["deadbeef"],
+            vault: vault,
+            encryptionKeyHex: "00",
+            chainPath: "m/44'/60'/0'/0/0",
+            isInitiateDevice: false,
+            publicKeyECDSA: "ECDSAKey",
+            httpClient: http
+        )
+
+        let started = expectation(description: "poll loop reached the network")
+        let task = Task { @MainActor () -> Error? in
+            // checkCancellation() is the first statement in the loop, so the
+            // handle is never dereferenced before the throw — a default handle
+            // is safe here.
+            started.fulfill()
+            do {
+                _ = try await keysign.pullInboundMessages(handle: godkls.Handle(), messageID: "msg")
+                return nil
+            } catch {
+                return error
+            }
+        }
+
+        await fulfillment(of: [started], timeout: 5)
+        // Give the loop a beat to enter the empty-data sleep branch, then cancel.
+        try? await Task.sleep(for: .milliseconds(200))
+        task.cancel()
+
+        let thrown = await task.value
+        XCTAssertTrue(thrown is CancellationError, "cancelled poll loop must surface CancellationError, got \(String(describing: thrown))")
+    }
+
+    // MARK: - (2) Stage timeout scales with message count
+
+    func testStageTimeoutScalesWithMessageCount() {
+        let single = KeysignViewModel()
+        single.messsageToSign = ["a"]
+
+        let many = KeysignViewModel()
+        many.messsageToSign = ["a", "b", "c", "d"]
+
+        XCTAssertGreaterThan(
+            many.keysignStageTimeout,
+            single.keysignStageTimeout,
+            "a 4-message ceremony must get a larger stage budget than a 1-message one — a flat budget manufactures the retry-vs-orphan race on healthy slow ceremonies"
+        )
+    }
+
+    func testStageTimeoutHasNonZeroFloorForEmptyMessageList() {
+        let vm = KeysignViewModel()
+        vm.messsageToSign = []
+        XCTAssertGreaterThan(vm.keysignStageTimeout, .zero, "empty message list must still yield a positive budget")
+    }
+
+    // MARK: - (3) Broadcast gate: an already-terminal status is not broadcast
+
+    func testTerminalStatusGatesBroadcastInDKLSPath() {
+        // The stage timeout flips status to .KeysignRetryRequested (terminal)
+        // on an orphaned ceremony. The DKLS/GG20 bodies must observe that and
+        // refuse to broadcast. We can't drive the full signing body in a unit
+        // test, but the gate is the same `isTerminalStatus` predicate — assert
+        // it classifies the timeout's status as terminal.
+        XCTAssertTrue(
+            KeysignViewModel.isTerminalStatus(.KeysignRetryRequested),
+            "retry-requested (set by the stage timeout) must be terminal so the orphaned body's broadcast gate fires"
+        )
+    }
+
+    func testBroadcastSkippedWhenStatusAlreadyRetryRequested() {
+        // broadcastTransaction itself short-circuits on skipBroadcast; here we
+        // assert the higher-level invariant: when the timeout has already set a
+        // terminal status, the finish guard leaves it untouched (no false
+        // KeysignFinished, and by extension no broadcast attempt downstream).
+        let vm = KeysignViewModel()
+        vm.status = .KeysignRetryRequested
+
+        if !KeysignViewModel.isTerminalStatus(vm.status) {
+            vm.status = .KeysignFinished
+        }
+
+        XCTAssertEqual(vm.status, .KeysignRetryRequested, "orphaned-ceremony terminal status must survive the finish guard")
+    }
+}


### PR DESCRIPTION
## Problem

The keysign 90s stage timeout does not actually stop the in-flight signing ceremony. The abandoned body runs to completion and **broadcasts unconditionally**, while the user — shown the retry view — may have started a second ceremony. On nonce/gas-varying chains (EVM) the two ceremonies produce different tx hashes, so the idempotency guard (keyed on `transactionHash`) misses and **both transactions can land**.

Closes #4541.

## Root cause (verified against current `main` source)

1. **Cancellation silently ignored.** `KeysignViewModel.startKeysign()` races the body against a stage-timeout sleeper in a task group; on timeout it sets `.KeysignRetryRequested` and calls `cancelAll()`. But the poll loops — `pullInboundMessages` and the unbounded `processXxxOutboundMessage` loop in `DKLSKeysign` / `SchnorrKeysign` / `DilithiumKeysign` — had **zero** `Task.isCancelled` / `checkCancellation()` checks. `cancelAll()` was a no-op.
2. **Broadcast was unconditional.** When the orphaned body finished, `startKeysignDKLS` (and `startKeysignGG20`) called `await broadcastTransaction()` unconditionally; the `isTerminalStatus` guard only protected the *post*-broadcast `.KeysignFinished` write.
3. **Idempotency guard is chain-dependent.** The user's retry rebuilds the payload (refetched gas/nonce, possibly reselected UTXOs). On EVM the rebuilt hash differs → guard misses → double-broadcast. On deterministic-payload chains the hash matches and the guard already fires. **Worst on EVM.**
4. **Timeout manufactured the race.** Messages sign sequentially and each inbound poll caps at 60s/attempt (×3 retries), so a flat 90s budget could expire while a healthy multi-message ceremony was still progressing.

## Fix (control flow only — cryptographic protocol untouched)

- **Cooperative cancellation:** `try Task.checkCancellation()` at the head of each poll-loop iteration (`pullInboundMessages`, `processXxxOutboundMessage`) in all three signing libs; the per-message retry loops now **rethrow** `CancellationError` instead of treating it as a signing failure and retrying. Same boundary handling for the GG20 path in `KeysignViewModel`.
- **Broadcast gate:** `startKeysignDKLS` and `startKeysignGG20` now gate `broadcastTransaction()` on `!isTerminalStatus(status) && !Task.isCancelled`; `startKeysignDKLS` adds a `catch is CancellationError` arm so a propagated cancel doesn't overwrite the timeout's terminal status with `.KeysignFailed`.
- **Timeout rescale:** the flat `keysignStageTimeout` becomes a message-count-scaled budget (`90s/message * max(count,1) + 30s` broadcast headroom), snapshotted before entering the task group.

## Verification

- `make generate` (new test file), SwiftLint clean on all changed files (0 violations).
- Built the full app and ran the keysign test suites on a worktree-local derived-data path: **`** TEST SUCCEEDED **` — 16/16** (`KeysignTimeoutCancellationTests` 5 new + `KeysignBroadcastCancellationTests` 11 existing).

## Test notes

New `KeysignTimeoutCancellationTests`:
- `testDKLSPullInboundMessagesThrowsCancellationWhenTaskCancelled` — injects an empty-polling `HTTPClientProtocol` fake to keep the loop stalled, cancels the task, asserts the loop surfaces `CancellationError` (the core cooperative-cancellation fix).
- `testStageTimeoutScalesWithMessageCount` / `…FloorForEmptyMessageList` — the timeout budget grows with message count and stays positive for an empty list.
- Broadcast-gate predicate tests — `.KeysignRetryRequested` is terminal so the gate fires and the finish guard can't overwrite it.

The full orphan-vs-retry double-broadcast race needs a live relay and can't be exercised in a unit test; it's covered by inspection + a repro note in the wiki plan.

## Review flag

⚠️ This is **signing-path control flow** (TSS keysign ceremony + broadcast gating), HIGH security tier. The crypto protocol, message ordering, and signature handling are untouched, but cancellation timing against real relays warrants careful **human + on-device review** before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cancellation handling in keysign ceremonies for faster, more reliable operation unwinding
  * Enhanced timeout logic now scales dynamically with message complexity
  * Added safeguards to prevent broadcast during timeout or cancellation scenarios

* **Tests**
  * Added comprehensive test coverage for keysign timeout and cancellation behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->