### PR TITLE
fix(swap): send tolerance_bps so THORChain/Maya swaps carry a minimum-output limit

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -22,6 +22,14 @@ struct SwapService {
     /// and `vultisig-android` (`STREAMING_SLIPPAGE_THRESHOLD_BPS`).
     static let streamingSlippageThresholdBps = 100
 
+    /// Minimum-output tolerance (basis points) sent on every THORChain/Maya
+    /// quote request as `tolerance_bps`. The node bakes a real `LIM` into the
+    /// returned swap memo — `expected_amount_out × (1 − tolerance_bps/10_000)` —
+    /// so the signed memo carries a slippage floor instead of `LIM=0`
+    /// (unbounded). 100 bps (1%) is a conservative default aligned with the
+    /// streaming-upgrade threshold; there is no per-swap user slippage control.
+    static let defaultThorchainToleranceBps = 100
+
     func fetchQuote(
         amount: Decimal,
         fromCoin: Coin,
@@ -318,6 +326,7 @@ private extension SwapService {
                 toAsset: toCoin.swapAsset,
                 amount: truncatedAmount.description,
                 interval: provider.streamingInterval,
+                toleranceBps: Self.defaultThorchainToleranceBps,
                 referredCode: referredCode,
                 vultTierDiscount: vultTierDiscount
             )
@@ -610,6 +619,7 @@ extension SwapService {
                 amount: amount,
                 interval: 1,
                 streamingQuantity: streamingQuantity,
+                toleranceBps: Self.defaultThorchainToleranceBps,
                 referredCode: referredCode,
                 vultTierDiscount: vultTierDiscount
             )

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainAPI.swift
@@ -28,7 +28,8 @@ struct MayaChainAPI: TargetType {
             streamingInterval: String,
             streamingQuantity: String?,
             affiliate: String?,
-            affiliateBps: String?
+            affiliateBps: String?,
+            toleranceBps: String?
         )
         case broadcast(body: Data)
         case pools
@@ -73,7 +74,7 @@ struct MayaChainAPI: TargetType {
         switch endpoint {
         case .balances, .accountNumber, .pools:
             return .requestPlain
-        case .swapQuote(let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliate, let affiliateBps):
+        case .swapQuote(let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliate, let affiliateBps, let toleranceBps):
             var params: [String: Any] = [
                 "from_asset": from,
                 "to_asset": to,
@@ -84,6 +85,7 @@ struct MayaChainAPI: TargetType {
             if let streamingQuantity = streamingQuantity { params["streaming_quantity"] = streamingQuantity }
             if let affiliate = affiliate { params["affiliate"] = affiliate }
             if let affiliateBps = affiliateBps { params["affiliate_bps"] = affiliateBps }
+            if let toleranceBps = toleranceBps { params["tolerance_bps"] = toleranceBps }
             return .requestParameters(params, .urlEncoding)
         case .broadcast(let body):
             return .requestData(body)

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
@@ -110,6 +110,7 @@ class MayachainService: ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
+        toleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -127,7 +128,8 @@ class MayachainService: ThorchainSwapProvider {
             streamingInterval: String(interval),
             streamingQuantity: streamingQuantityParam,
             affiliate: affiliate,
-            affiliateBps: affiliateBps
+            affiliateBps: affiliateBps,
+            toleranceBps: toleranceBps > 0 ? String(toleranceBps) : nil
         ))
 
         // Maya sometimes returns a structured swap error body with a

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainMainnetAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainMainnetAPI.swift
@@ -54,7 +54,8 @@ struct ThorchainMainnetAPI: TargetType {
             streamingInterval: String,
             streamingQuantity: String?,
             affiliates: String?,
-            affiliateBps: String?
+            affiliateBps: String?,
+            toleranceBps: String?
         )
         case tcyStaker(address: String)
 
@@ -153,7 +154,7 @@ struct ThorchainMainnetAPI: TargetType {
         case .allDenomMetadata:
             return .requestParameters(["pagination.limit": "1000"], .urlEncoding)
 
-        case .swapQuote(let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliates, let affiliateBps):
+        case .swapQuote(let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliates, let affiliateBps, let toleranceBps):
             var params: [String: Any] = [
                 "from_asset": from,
                 "to_asset": to,
@@ -164,6 +165,7 @@ struct ThorchainMainnetAPI: TargetType {
             if let streamingQuantity = streamingQuantity { params["streaming_quantity"] = streamingQuantity }
             if let affiliates = affiliates { params["affiliate"] = affiliates }
             if let affiliateBps = affiliateBps { params["affiliate_bps"] = affiliateBps }
+            if let toleranceBps = toleranceBps { params["tolerance_bps"] = toleranceBps }
             return .requestParameters(params, .urlEncoding)
 
         case .rujiGraphQL(let query):

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
@@ -148,6 +148,7 @@ class ThorchainService: ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
+        toleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -164,7 +165,8 @@ class ThorchainService: ThorchainSwapProvider {
             streamingInterval: String(interval),
             streamingQuantity: streamingQuantity > 0 ? String(streamingQuantity) : nil,
             affiliates: affiliates,
-            affiliateBps: affiliateBps
+            affiliateBps: affiliateBps,
+            toleranceBps: toleranceBps > 0 ? String(toleranceBps) : nil
         ))
 
         // THORChain returns a typed swap-error body (sometimes with HTTP 200,

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenet2Service.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenet2Service.swift
@@ -123,6 +123,7 @@ class ThorchainStagenetService: ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
+        toleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -140,7 +141,8 @@ class ThorchainStagenetService: ThorchainSwapProvider {
             streamingInterval: String(interval),
             streamingQuantity: streamingQuantity > 0 ? String(streamingQuantity) : nil,
             affiliates: affiliates,
-            affiliateBps: affiliateBps
+            affiliateBps: affiliateBps,
+            toleranceBps: toleranceBps > 0 ? String(toleranceBps) : nil
         )
 
         do {

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetAPI.swift
@@ -65,7 +65,8 @@ enum ThorchainStagenetAPI: TargetType {
         streamingInterval: String,
         streamingQuantity: String?,
         affiliates: String?,
-        affiliateBps: String?
+        affiliateBps: String?,
+        toleranceBps: String?
     )
     case broadcast(env: Environment, body: Data)
 
@@ -82,7 +83,7 @@ enum ThorchainStagenetAPI: TargetType {
              .networkInfo(let env), .inboundAddresses(let env),
              .poolInfo(let env, _), .pools(let env),
              .poolLiquidityProvider(let env, _, _),
-             .swapQuote(let env, _, _, _, _, _, _, _, _),
+             .swapQuote(let env, _, _, _, _, _, _, _, _, _),
              .broadcast(let env, _):
             return env.thornodeHost
 
@@ -148,7 +149,7 @@ enum ThorchainStagenetAPI: TargetType {
         case .allDenomMetadata:
             return .requestParameters(["pagination.limit": "1000"], .urlEncoding)
 
-        case .swapQuote(_, let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliates, let affiliateBps):
+        case .swapQuote(_, let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliates, let affiliateBps, let toleranceBps):
             var params: [String: Any] = [
                 "from_asset": from,
                 "to_asset": to,
@@ -159,6 +160,7 @@ enum ThorchainStagenetAPI: TargetType {
             if let streamingQuantity = streamingQuantity { params["streaming_quantity"] = streamingQuantity }
             if let affiliates = affiliates { params["affiliate"] = affiliates }
             if let affiliateBps = affiliateBps { params["affiliate_bps"] = affiliateBps }
+            if let toleranceBps = toleranceBps { params["tolerance_bps"] = toleranceBps }
             return .requestParameters(params, .urlEncoding)
 
         case .broadcast(_, let body):

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetService.swift
@@ -125,6 +125,7 @@ class ThorchainChainnetService: ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
+        toleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -142,7 +143,8 @@ class ThorchainChainnetService: ThorchainSwapProvider {
             streamingInterval: String(interval),
             streamingQuantity: streamingQuantity > 0 ? String(streamingQuantity) : nil,
             affiliates: affiliates,
-            affiliateBps: affiliateBps
+            affiliateBps: affiliateBps,
+            toleranceBps: toleranceBps > 0 ? String(toleranceBps) : nil
         )
 
         do {

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainSwapProvider.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainSwapProvider.swift
@@ -15,6 +15,7 @@ protocol ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
+        toleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote
@@ -27,6 +28,7 @@ extension ThorchainSwapProvider {
         toAsset: String,
         amount: String,
         interval: Int,
+        toleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -37,6 +39,7 @@ extension ThorchainSwapProvider {
             amount: amount,
             interval: interval,
             streamingQuantity: 0,
+            toleranceBps: toleranceBps,
             referredCode: referredCode,
             vultTierDiscount: vultTierDiscount
         )

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -80,6 +80,13 @@ extension SwapCryptoLogic {
 
     /// Build the THORChain/MayaChain swap payload from primitives + selected quote.
     /// `now` parameterised so tests can pin the 15-minute expiration deterministically.
+    ///
+    /// The on-chain minimum-output floor is enforced by the `LIM` field inside
+    /// the node-returned `quote.memo` (driven by the `tolerance_bps` we send on
+    /// the quote request); that memo is what gets signed verbatim. The
+    /// `toAmountLimit` / `streamingQuantity` fields here travel in the proto
+    /// payload for cross-device display — we mirror the node's derivation so
+    /// they stay consistent with the signed memo instead of reading `0`.
     static func buildThorchainSwapPayload(
         fromCoin: Coin,
         toCoin: Coin,
@@ -87,10 +94,16 @@ extension SwapCryptoLogic {
         toAmountDecimal: Decimal,
         quote: ThorchainSwapQuote,
         provider: SwapProvider,
+        toleranceBps: Int = SwapService.defaultThorchainToleranceBps,
         now: Date = Date()
     ) -> THORChainSwapPayload {
         let vaultAddress = quote.inboundAddress ?? fromCoin.address
         let expirationTime = now.addingTimeInterval(60 * 15)
+        let toAmountLimit = thorchainToAmountLimit(
+            expectedAmountOut: quote.expectedAmountOut,
+            toleranceBps: toleranceBps
+        )
+        let streamingQuantity = quote.maxStreamingQuantity.map(String.init) ?? "0"
         return THORChainSwapPayload(
             fromAddress: fromCoin.address,
             fromCoin: fromCoin,
@@ -99,12 +112,26 @@ extension SwapCryptoLogic {
             routerAddress: quote.router,
             fromAmount: fromAmountInCoin,
             toAmountDecimal: toAmountDecimal,
-            toAmountLimit: "0",
+            toAmountLimit: toAmountLimit,
             streamingInterval: String(provider.streamingInterval),
-            streamingQuantity: "0",
+            streamingQuantity: streamingQuantity,
             expirationTime: UInt64(expirationTime.timeIntervalSince1970),
             isAffiliate: SwapCryptoLogic.isAffiliate
         )
+    }
+
+    /// Minimum acceptable output, mirroring the node's `LIM` derivation:
+    /// `floor(expectedAmountOut × (10_000 − toleranceBps) / 10_000)`.
+    /// `expectedAmountOut` is the quote's raw integer output (THORChain 1e8
+    /// units). Returns `"0"` when the input can't be parsed or tolerance is out
+    /// of range — the node-side memo `LIM` remains the authoritative floor.
+    static func thorchainToAmountLimit(expectedAmountOut: String, toleranceBps: Int) -> String {
+        guard toleranceBps >= 0, toleranceBps < 10_000,
+              let expected = BigInt(expectedAmountOut), expected > 0 else {
+            return "0"
+        }
+        let limit = expected * BigInt(10_000 - toleranceBps) / BigInt(10_000)
+        return String(limit)
     }
 
     /// Assemble the final `KeysignPayload` for a swap given a finalised

--- a/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
@@ -80,6 +80,10 @@ final class ThorchainAntiRektTests: XCTestCase {
 
         XCTAssertEqual(result.expectedAmountOut, streaming.expectedAmountOut)
         XCTAssertEqual(mock.callCount, 1, "Streaming must be fetched at 101 bps with a 1% threshold")
+        XCTAssertEqual(
+            mock.lastToleranceBps, SwapService.defaultThorchainToleranceBps,
+            "Streaming quote must carry tolerance_bps so the node bakes a minimum-output LIM into the memo"
+        )
     }
 
     func test_rapidSlippageBps_zeroFees_returnsZero() {
@@ -259,6 +263,7 @@ private final class MockSwapProvider: ThorchainSwapProvider {
     private(set) var callCount = 0
     private(set) var lastInterval: Int?
     private(set) var lastStreamingQuantity: Int?
+    private(set) var lastToleranceBps: Int?
 
     init(response: Result<ThorchainSwapQuote, Error>) {
         self.response = response
@@ -271,6 +276,7 @@ private final class MockSwapProvider: ThorchainSwapProvider {
         amount _: String,
         interval: Int,
         streamingQuantity: Int,
+        toleranceBps: Int,
         referredCode _: String,
         vultTierDiscount _: Int
     ) async throws -> ThorchainSwapQuote {
@@ -278,6 +284,7 @@ private final class MockSwapProvider: ThorchainSwapProvider {
         callCount += 1
         lastInterval = interval
         lastStreamingQuantity = streamingQuantity
+        lastToleranceBps = toleranceBps
         return try response.get()
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
@@ -66,6 +66,64 @@ final class SwapPayloadBuilderTests: XCTestCase {
         XCTAssertEqual(payload.toAddress, "thor-router")
     }
 
+    // MARK: - Minimum-output limit (toAmountLimit) derivation
+
+    func testThorchainToAmountLimitAppliesTolerance() {
+        // 1% (100 bps) tolerance off 100_000_000 → 99_000_000.
+        let limit = SwapCryptoLogic.thorchainToAmountLimit(
+            expectedAmountOut: "100000000",
+            toleranceBps: 100
+        )
+        XCTAssertEqual(limit, "99000000")
+    }
+
+    func testThorchainToAmountLimitFloorsFractionalResult() {
+        // 100 bps off 12_345 = 12_221.55 → floored to 12_221.
+        let limit = SwapCryptoLogic.thorchainToAmountLimit(
+            expectedAmountOut: "12345",
+            toleranceBps: 100
+        )
+        XCTAssertEqual(limit, "12221")
+    }
+
+    func testThorchainToAmountLimitZeroToleranceKeepsFullAmount() {
+        let limit = SwapCryptoLogic.thorchainToAmountLimit(
+            expectedAmountOut: "500",
+            toleranceBps: 0
+        )
+        XCTAssertEqual(limit, "500")
+    }
+
+    func testThorchainToAmountLimitFallsBackToZeroOnBadInput() {
+        XCTAssertEqual(
+            SwapCryptoLogic.thorchainToAmountLimit(expectedAmountOut: "not-a-number", toleranceBps: 100),
+            "0"
+        )
+        XCTAssertEqual(
+            SwapCryptoLogic.thorchainToAmountLimit(expectedAmountOut: "0", toleranceBps: 100),
+            "0"
+        )
+        XCTAssertEqual(
+            SwapCryptoLogic.thorchainToAmountLimit(expectedAmountOut: "1000", toleranceBps: 10_000),
+            "0",
+            "100% tolerance is out of range and must not zero the floor silently to a wrong value"
+        )
+    }
+
+    func testBuildThorchainSwapPayloadSetsNonZeroLimit() {
+        let payload = SwapCryptoLogic.buildThorchainSwapPayload(
+            fromCoin: makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true),
+            toCoin: makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true),
+            fromAmountInCoin: BigInt(100_000_000),
+            toAmountDecimal: 1,
+            quote: makeThorQuote(inboundAddress: "thor-vault", router: nil),
+            provider: .thorchain,
+            toleranceBps: 100,
+            now: fixedNow
+        )
+        XCTAssertNotEqual(payload.toAmountLimit, "0", "Payload must carry a real minimum-output limit, not 0")
+    }
+
     // MARK: - MayaChain
 
     func testMayachainPayloadRoutesThroughInboundForNativeSource() async throws {


### PR DESCRIPTION
## Problem

THORChain and MayaChain swaps are signed with **no minimum-output limit** — the swap fills at whatever the pool gives, with no slippage floor. Combined with the 30s+ ceremony and unbounded pairing time, price can move arbitrarily between quote and execution. This is the largest fund-protection gap in the swap stack.

## Root cause

The signed swap memo is the THORChain/Maya-returned `memo` string, verbatim, on every source chain (RUNE `thorchain.swift`, UTXO `UTXOChainsHelper.swift`, EVM router `evm.swift`). The on-chain minimum-output floor lives in the memo's `LIM` field.

The quote request never sent `tolerance_bps` (`ThorchainMainnetAPI`/`MayaChainAPI`/`ThorchainStagenetAPI` `swapQuote` built only asset/amount/destination/streaming/affiliate), so the node returned a memo with `LIM=0` (unbounded). The proto payload's `toAmountLimit`/`streamingQuantity` were hardcoded to `"0"`, but those fields do **not** rebuild the signed memo — iOS does not use WalletCore's native `THORChainSwap.build` path — so patching only those would be cosmetic.

## Fix

- Add `tolerance_bps` to the `swapQuote` endpoint of all three THORChain/Maya API targets and thread a `toleranceBps` parameter through `ThorchainSwapProvider.fetchSwapQuotes` and every service impl (THORChain, Maya, both stagenet services).
- `SwapService` passes `defaultThorchainToleranceBps` (100 bps / 1%) on both the rapid and streaming quote fetches, so the node bakes a real `LIM` into the returned memo. This also gives streaming swaps an abort-and-refund floor.
- `buildThorchainSwapPayload` now derives a matching `toAmountLimit` and a real `streamingQuantity` for the proto payload (previously `"0"`) so cross-device display stays consistent with the signed memo.

## Derivation

Node-authoritative: `LIM = expected_amount_out × (1 − tolerance_bps/10_000)`, baked into the memo by THORChain when `tolerance_bps` is present. Preferred over computing `LIM` client-side and rewriting the memo string (which would risk drift from the node's trimming/streaming-suffix format and reintroduce a sign-vs-display mismatch). The payload's `toAmountLimit` mirrors that formula (`floor`).

No per-swap user slippage UI exists for swaps; 100 bps matches the existing anti-rekt streaming threshold and is a conservative default.

## Cross-platform parity (verified, not assumed)

All three platforms share the **same** gap and the **same** anti-rekt streaming-upgrade mechanism, and **none** sent `tolerance_bps`:
- **SDK/Windows** (`packages/core` `getNativeSwapQuote.ts`): no `tolerance_bps`; `nativeSwapQuoteToSwapPayload.ts` hardcodes `toAmountLimit: '0'`; keysign signs `native: ({ memo }) => memo`.
- **Android** (`ThorChainQuoteSource` + swap `build.ts`): same 1% streaming cutoff; memo signed verbatim.
- **iOS**: as above.

So this is not iOS-specific divergence — there was no "correct" platform to copy a derivation from. iOS leads; SDK and Android need the same change in follow-ups.

## Verification

- `swiftlint` clean on all changed files.
- `xcodebuild test` (worktree-local derivedDataPath, iPhone 16 / iOS 18.4): `SwapPayloadBuilderTests` + `ThorchainAntiRektTests` — **33 tests, 0 failures**, including 5 new limit-math/tolerance assertions.

## Risk

The default tolerance value (100 bps) is a product decision — it matches the streaming threshold and is a conservative floor, but Product should confirm the exact number and whether it should eventually be user-configurable.

Closes #4539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed swap quote requests to enforce configurable slippage tolerance, preventing unbounded minimum output floors on THORChain and MayaChain swaps.

* **New Features**
  * Swap payloads now calculate protective minimum output amounts based on tolerance thresholds, improving protection against unfavorable price execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->