### PR TITLE
fix(zcash): fetch live ZIP-243 branch id at send time

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Models/ZcashRpcModels.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Models/ZcashRpcModels.swift
@@ -1,0 +1,27 @@
+//
+//  ZcashRpcModels.swift
+//  VultisigApp
+//
+//  Decodes the Zcash `getblockchaininfo` JSON-RPC response. Only the
+//  `consensus.nextblock` branch id is consumed; every other field the node
+//  returns is ignored by the decoder.
+//
+
+import Foundation
+
+struct ZcashBlockchainInfoResponse: Decodable {
+    let result: ZcashBlockchainInfoResult?
+}
+
+struct ZcashBlockchainInfoResult: Decodable {
+    let consensus: ZcashConsensus?
+}
+
+struct ZcashConsensus: Decodable {
+    /// Branch id active for the chain tip (big-endian hex).
+    let chaintip: String?
+    /// Branch id active for the next block (big-endian hex, e.g. `5437f330`);
+    /// the value signing must use so a tx mined after an upcoming upgrade is
+    /// still accepted.
+    let nextblock: String?
+}

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Service/ZcashAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Service/ZcashAPI.swift
@@ -1,0 +1,42 @@
+//
+//  ZcashAPI.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Zcash JSON-RPC endpoints proxied through `api.vultisig.com/zcash`.
+enum ZcashAPI: TargetType {
+    /// `getblockchaininfo` — used to read the active ZIP-243 consensus branch id
+    /// (`consensus.nextblock`).
+    case getBlockchainInfo
+
+    var baseURL: URL {
+        URL(string: "https://api.vultisig.com")!
+    }
+
+    var path: String {
+        "/zcash/"
+    }
+
+    var method: HTTPMethod {
+        .post
+    }
+
+    var task: HTTPTask {
+        switch self {
+        case .getBlockchainInfo:
+            let body: [String: Any] = [
+                "jsonrpc": "1.0",
+                "id": "vultisig",
+                "method": "getblockchaininfo",
+                "params": [String]()
+            ]
+            return .requestParameters(body, .jsonEncoding)
+        }
+    }
+
+    var headers: [String: String]? {
+        ["Content-Type": "application/json"]
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Service/ZcashService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Service/ZcashService.swift
@@ -1,0 +1,106 @@
+//
+//  ZcashService.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "zcash-service")
+
+/// Resolves the active ZIP-243 consensus branch id WalletCore needs on the
+/// Zcash transaction plan. The branch id changes at every Zcash network
+/// upgrade, so a compiled-in constant goes stale and makes every ZEC send /
+/// SwapKit swap sign with the wrong id and get rejected chain-wide until the
+/// app ships a new release. Resolving it from the node at send time keeps
+/// signing correct across upgrades with no code change.
+actor ZcashService {
+
+    static let shared = ZcashService()
+
+    private let rpc = RpcService(Endpoint.zcashServiceRpc)
+    private var cachedBranchId: String?
+    private var cachedAt: Date?
+    private var inFlight: Task<String?, Never>?
+
+    /// One hour: the branch id only changes at a network upgrade, so a single
+    /// keysign's preimage-hash and final-compile passes (and repeated sends)
+    /// all read the same cached value, keeping the digest stable across them.
+    private let cacheTTL: TimeInterval = 60 * 60
+
+    /// Resolves the active ZIP-243 consensus branch id for the next block, as
+    /// the little-endian hex string WalletCore expects on the plan (e.g.
+    /// `30f33754`). The node reports it big-endian (`consensus.nextblock`, e.g.
+    /// `5437f330`); this reverses the four bytes.
+    ///
+    /// Returns `nil` when the RPC is unreachable or the response is malformed;
+    /// signing then refuses to proceed (there is no compiled-in fallback, since
+    /// a stale branch id yields a network-rejected tx). The branch id is a
+    /// network-global fact, so every device that resolves it at signing time
+    /// agrees, keeping MPC co-signers in sync.
+    func getConsensusBranchIdHex() async -> String? {
+        if let cached = freshCachedBranchId() {
+            return cached
+        }
+        // Dedupe concurrent co-sign rounds so they issue a single network call.
+        if let inFlight {
+            return await inFlight.value
+        }
+        let task = Task { await fetchBranchId() }
+        inFlight = task
+        let fetched = await task.value
+        inFlight = nil
+        // Only cache successful fetches so a transient RPC failure doesn't pin
+        // the wallet to that failure for a whole hour.
+        if let fetched {
+            cachedBranchId = fetched
+            cachedAt = Date()
+        }
+        return fetched
+    }
+
+    private func freshCachedBranchId() -> String? {
+        guard let cachedBranchId, let cachedAt,
+              Date().timeIntervalSince(cachedAt) < cacheTTL else {
+            return nil
+        }
+        return cachedBranchId
+    }
+
+    private func fetchBranchId() async -> String? {
+        do {
+            let nextBlock: String? = try await rpc.sendRPCRequest(
+                method: "getblockchaininfo",
+                params: []
+            ) { result in
+                guard let dict = result as? [String: Any],
+                      let consensus = dict["consensus"] as? [String: Any] else {
+                    return nil
+                }
+                return consensus["nextblock"] as? String
+            }
+            guard let nextBlock, !nextBlock.isEmpty else {
+                logger.warning("Zcash getblockchaininfo returned no consensus.nextblock branch id")
+                return nil
+            }
+            return Self.reverseHexBytes(nextBlock)
+        } catch {
+            logger.error("Failed to fetch Zcash consensus branch id: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Reverses the byte order of a 4-byte (8 hex char) big-endian branch id
+    /// into the little-endian form WalletCore reads from the plan. Returns
+    /// `nil` for any input that is not exactly four hex bytes so a malformed
+    /// RPC response makes signing refuse rather than use a bad sighash.
+    static func reverseHexBytes(_ hex: String) -> String? {
+        guard hex.count == 8, hex.allSatisfy(\.isHexDigit) else {
+            logger.warning("Zcash branch id '\(hex)' is not a 4-byte hex value")
+            return nil
+        }
+        let chars = Array(hex)
+        let bytes = stride(from: 0, to: chars.count, by: 2).map { String(chars[$0...$0 + 1]) }
+        return bytes.reversed().joined().lowercased()
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Service/ZcashService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Service/ZcashService.swift
@@ -18,10 +18,14 @@ actor ZcashService {
 
     static let shared = ZcashService()
 
-    private let rpc = RpcService(Endpoint.zcashServiceRpc)
+    private let httpClient: HTTPClientProtocol
     private var cachedBranchId: String?
     private var cachedAt: Date?
     private var inFlight: Task<String?, Never>?
+
+    init(httpClient: HTTPClientProtocol = HTTPClient()) {
+        self.httpClient = httpClient
+    }
 
     /// One hour: the branch id only changes at a network upgrade, so a single
     /// keysign's preimage-hash and final-compile passes (and repeated sends)
@@ -69,17 +73,11 @@ actor ZcashService {
 
     private func fetchBranchId() async -> String? {
         do {
-            let nextBlock: String? = try await rpc.sendRPCRequest(
-                method: "getblockchaininfo",
-                params: []
-            ) { result in
-                guard let dict = result as? [String: Any],
-                      let consensus = dict["consensus"] as? [String: Any] else {
-                    return nil
-                }
-                return consensus["nextblock"] as? String
-            }
-            guard let nextBlock, !nextBlock.isEmpty else {
+            let response = try await httpClient.request(
+                ZcashAPI.getBlockchainInfo,
+                responseType: ZcashBlockchainInfoResponse.self
+            )
+            guard let nextBlock = response.data.result?.consensus?.nextblock, !nextBlock.isEmpty else {
                 logger.warning("Zcash getblockchaininfo returned no consensus.nextblock branch id")
                 return nil
             }

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitZcashSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitZcashSigner.swift
@@ -12,11 +12,11 @@
 //
 //  Sighash: WalletCore's ZEC signer implements ZIP-243 (the Sapling
 //  signature digest with the personalised Blake2b-256). It reads the branch
-//  ID from `BitcoinTransactionPlan.branchID` — the existing native ZEC
-//  send (`UTXOChainsHelper.swift:138-139`) uses `30f33754`, and we match
-//  that here so the digest output is identical to a manually-sent ZEC
-//  transaction. (Deviating to the Sapling-v4 spec ID `0x76b809bb` would
-//  produce a different digest that the chain rejects.)
+//  ID from `BitcoinTransactionPlan.branchID` — we feed it the live consensus
+//  branch id resolved at send time (the same value the native ZEC send uses),
+//  so the digest output is identical to a manually-sent ZEC transaction.
+//  (Deviating to the Sapling-v4 spec ID `0x76b809bb` would produce a
+//  different digest that the chain rejects.)
 //
 //  Real fixture: captured during the ZEC source-chain spike (`ZEC.ZEC →
 //  ETH.USDC`, funded `t1bnxtY7aLCjWx9Ru1YcGwRWch3eEWUFK7u` source). The
@@ -54,19 +54,16 @@ private let saplingVersionGroupID: UInt32 = 0x892F2085
 private let saplingTxVersion: UInt32 = 0x80000004
 /// NU5 consensus group ID — we hard-reject this until SwapKit's wire flips.
 private let nu5VersionGroupID: UInt32 = 0x26A7270A
-/// Branch ID matches the existing native ZEC send
-/// (`UTXOChainsHelper.swift:138-139`). WalletCore reads it as the branch
-/// identifier for ZIP-243's personalised Blake2b. Diverging to the
-/// Sapling-v4-spec `0x76b809bb` would produce a digest the network rejects.
-private let zcashBranchID: Data = Data(hexString: "30f33754")!
 
 enum SwapKitZcashSigner {
 
     /// ZIP-243 preimage hashes for every input. WalletCore handles the per-
     /// input personalised Blake2b construction via `CoinType.zcash` + the
-    /// branchID injected on the frozen plan.
-    static func preSigningHashes(payload: SwapKitSwapPayload) throws -> [String] {
-        let input = try Self.buildSigningInput(payload: payload)
+    /// branchID injected on the frozen plan. `zcashBranchId` is the live branch
+    /// id resolved at send time (carried on the source-chain payload's UTXO
+    /// specific); refuses when absent (no compiled-in fallback).
+    static func preSigningHashes(payload: SwapKitSwapPayload, zcashBranchId: String?) throws -> [String] {
+        let input = try Self.buildSigningInput(payload: payload, zcashBranchId: zcashBranchId)
         let serialized = try input.serializedData()
         let preHashesBytes = TransactionCompiler.preImageHashes(coinType: .zcash, txInputData: serialized)
         let preSignOutputs = try BitcoinPreSigningOutput(serializedBytes: preHashesBytes)
@@ -83,14 +80,15 @@ enum SwapKitZcashSigner {
     static func compileSignedTransaction(
         payload: SwapKitSwapPayload,
         signatures: [String: TssKeysignResponse],
-        pubKeyHex: String
+        pubKeyHex: String,
+        zcashBranchId: String?
     ) throws -> SignedTransactionResult {
         guard let pubkeyData = Data(hexString: pubKeyHex),
               let publicKey = PublicKey(data: pubkeyData, type: .secp256k1)
         else {
             throw SwapKitZcashSignerError.underlying(.invalidPublicKey(pubKeyHex))
         }
-        let input = try Self.buildSigningInput(payload: payload)
+        let input = try Self.buildSigningInput(payload: payload, zcashBranchId: zcashBranchId)
         let serialized = try input.serializedData()
         let preHashesBytes = TransactionCompiler.preImageHashes(coinType: .zcash, txInputData: serialized)
         let preSignOutputs = try BitcoinPreSigningOutput(serializedBytes: preHashesBytes)
@@ -126,20 +124,29 @@ enum SwapKitZcashSigner {
     }
 
     /// Exposed for unit tests: build the WalletCore signing input with the
-    /// frozen Sapling plan + branchID set.
-    static func buildSigningInput(payload: SwapKitSwapPayload) throws -> BitcoinSigningInput {
+    /// frozen Sapling plan + branchID set. `zcashBranchId` is the live branch id
+    /// resolved at send time; refuses when absent (no compiled-in fallback).
+    static func buildSigningInput(payload: SwapKitSwapPayload, zcashBranchId: String?) throws -> BitcoinSigningInput {
         let parsed = try parseSaplingPSBT(
             payload.txPayload,
-            targetAddress: payload.targetAddress
+            targetAddress: payload.targetAddress,
+            zcashBranchId: zcashBranchId
         )
-        var input = parsed.input
-        // ZEC ZIP-243 needs `branchID` on the plan — WalletCore reads it
-        // during preimage construction. Mirror the value the native send
-        // path uses so digest derivation is identical.
-        var plan = input.plan
-        plan.branchID = zcashBranchID
-        input.plan = plan
-        return input
+        return parsed.input
+    }
+
+    /// Validates and converts the live ZIP-243 branch id. WalletCore reads it
+    /// on the plan during preimage construction; there is no compiled-in
+    /// fallback because signing with a stale id produces a tx the network
+    /// rejects, so refuse up front when it could not be resolved.
+    private static func branchIDData(_ zcashBranchId: String?) throws -> Data {
+        guard let zcashBranchId, !zcashBranchId.isEmpty,
+              let data = Data(hexString: zcashBranchId) else {
+            throw SwapKitZcashSignerError.underlying(.planError(
+                "Zcash ZIP-243 consensus branch id is unavailable; cannot sign the SwapKit ZEC transaction without the live branch id"
+            ))
+        }
+        return data
     }
 
     /// Exposed for unit tests so callers can pin the Sapling-header parser
@@ -210,7 +217,7 @@ enum SwapKitZcashSigner {
         let input: BitcoinSigningInput
     }
 
-    private static func parseSaplingPSBT(_ psbtBytes: Data, targetAddress: String) throws -> ParsedSaplingPSBT {
+    private static func parseSaplingPSBT(_ psbtBytes: Data, targetAddress: String, zcashBranchId: String?) throws -> ParsedSaplingPSBT {
         // 1. Parse BIP-174 framing.
         let framingPrefix: (cursor: PSBTCursor, globals: [Data: Data], unsignedTxBytes: Data)
         do {
@@ -268,7 +275,8 @@ enum SwapKitZcashSigner {
             inputs: legacyInputs,
             outputs: parsedTx.outputs,
             expiryHeight: parsedTx.expiryHeight,
-            targetAddress: targetAddress
+            targetAddress: targetAddress,
+            zcashBranchId: zcashBranchId
         )
         return ParsedSaplingPSBT(input: input)
     }
@@ -340,8 +348,12 @@ enum SwapKitZcashSigner {
         inputs: [LegacyP2PKHInput],
         outputs: [LegacyP2PKHOutput],
         expiryHeight _: UInt32,
-        targetAddress: String
+        targetAddress: String,
+        zcashBranchId: String?
     ) throws -> BitcoinSigningInput {
+        // Validate the live branch id up front so an unresolved id refuses
+        // before we do the (otherwise wasted) plan-assembly work.
+        let branchID = try branchIDData(zcashBranchId)
         guard !inputs.isEmpty, !outputs.isEmpty else {
             throw SwapKitZcashSignerError.underlying(.planError("empty inputs or outputs"))
         }
@@ -414,7 +426,7 @@ enum SwapKitZcashSigner {
             $0.fee = fee
             $0.change = changeAmount
             $0.utxos = utxos
-            $0.branchID = zcashBranchID
+            $0.branchID = branchID
         }
 
         var scripts: [String: Data] = [:]

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
@@ -39,6 +39,14 @@ class UTXOChainsHelper {
         return branchData
     }
 
+    /// Stamp the live ZIP-243 branch id onto a Zcash plan before signing.
+    /// No-op for every other UTXO coin; throws when ZEC's branch id could not
+    /// be resolved so signing refuses rather than producing a rejectable tx.
+    private func applyZcashBranchID(to plan: inout BitcoinTransactionPlan, keysignPayload: KeysignPayload) throws {
+        guard coin == .zcash else { return }
+        plan.branchID = try zcashBranchID(keysignPayload: keysignPayload)
+    }
+
     static func getHelper(coin: Coin) -> UTXOChainsHelper? {
         switch coin.chainType {
         case .UTXO:
@@ -152,10 +160,7 @@ class UTXOChainsHelper {
         }
 
         var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
-
-        if coin == .zcash {
-            plan.branchID = try zcashBranchID(keysignPayload: keysignPayload)
-        }
+        try applyZcashBranchID(to: &plan, keysignPayload: keysignPayload)
 
         input.plan = plan
         return try input.serializedData()
@@ -231,9 +236,7 @@ class UTXOChainsHelper {
             throw HelperError.runtimeError("Transaction plan error: \(plan.error)")
         }
 
-        if coin == .zcash {
-            plan.branchID = try zcashBranchID(keysignPayload: keysignPayload)
-        }
+        try applyZcashBranchID(to: &plan, keysignPayload: keysignPayload)
 
         input.plan = plan
         return try input.serializedData()

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
@@ -24,6 +24,21 @@ class UTXOChainsHelper {
         self.coin = coin
     }
 
+    /// Live ZIP-243 branch id WalletCore reads off the plan during preimage
+    /// construction. Resolved at send time and carried on the payload's UTXO
+    /// specific — the initiator stamps it (BlockChainService), the co-signer
+    /// re-resolves the same network-global value (JoinKeysignViewModel). There
+    /// is no compiled-in fallback: signing with a stale branch id produces a tx
+    /// the network rejects, so refuse to sign when it could not be resolved.
+    private func zcashBranchID(keysignPayload: KeysignPayload) throws -> Data {
+        guard let branchId = keysignPayload.chainSpecific.zcashBranchId,
+              !branchId.isEmpty,
+              let branchData = Data(hexString: branchId) else {
+            throw HelperError.runtimeError("Zcash ZIP-243 consensus branch id is unavailable; cannot sign the ZEC transaction without the live branch id")
+        }
+        return branchData
+    }
+
     static func getHelper(coin: Coin) -> UTXOChainsHelper? {
         switch coin.chainType {
         case .UTXO:
@@ -90,7 +105,7 @@ class UTXOChainsHelper {
     }
 
     func getSigningInputData(keysignPayload: KeysignPayload, signingInput: BitcoinSigningInput) throws -> Data {
-        guard case .UTXO(let byteFee, let sendMaxAmount) = keysignPayload.chainSpecific else {
+        guard case .UTXO(let byteFee, let sendMaxAmount, _) = keysignPayload.chainSpecific else {
             throw HelperError.runtimeError("fail to get UTXO chain specific byte fee")
         }
         var input = signingInput
@@ -139,7 +154,7 @@ class UTXOChainsHelper {
         var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
 
         if coin == .zcash {
-            plan.branchID = Data(hexString: "30f33754")!
+            plan.branchID = try zcashBranchID(keysignPayload: keysignPayload)
         }
 
         input.plan = plan
@@ -147,7 +162,7 @@ class UTXOChainsHelper {
     }
 
     func getBitcoinSigningInput(keysignPayload: KeysignPayload) throws -> BitcoinSigningInput {
-        guard case .UTXO(let byteFee, let sendMaxAmount) = keysignPayload.chainSpecific else {
+        guard case .UTXO(let byteFee, let sendMaxAmount, _) = keysignPayload.chainSpecific else {
             throw HelperError.runtimeError("fail to get UTXO chain specific byte fee")
         }
 
@@ -217,7 +232,7 @@ class UTXOChainsHelper {
         }
 
         if coin == .zcash {
-            plan.branchID = Data(hexString: "30f33754")!
+            plan.branchID = try zcashBranchID(keysignPayload: keysignPayload)
         }
 
         input.plan = plan
@@ -226,12 +241,11 @@ class UTXOChainsHelper {
 
     func getBitcoinTransactionPlan(keysignPayload: KeysignPayload) throws -> BitcoinTransactionPlan {
         let input = try getBitcoinSigningInput(keysignPayload: keysignPayload)
-        var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
-
-        if coin == .zcash {
-            plan.branchID = Data(hexString: "30f33754")!
-        }
-
+        // The branch id only affects the ZIP-243 sighash digest, not the
+        // planned amount/fee/change this method exposes for fee display, so it
+        // is deliberately not set here (avoids forcing an RPC resolve on the
+        // fee-preview path).
+        let plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
         return plan
     }
 
@@ -282,11 +296,9 @@ class UTXOChainsHelper {
     }
     func getUnsignedTransactionHex(keysignPayload: KeysignPayload) throws -> String {
         let input = try getBitcoinSigningInput(keysignPayload: keysignPayload)
-        var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
-
-        if coin == .zcash {
-            plan.branchID = Data(hexString: "30f33754")!
-        }
+        // Placeholder tx for Blockaid analysis: only plan amount/change are read
+        // below, so the ZIP-243 branch id (sighash-only) is irrelevant here.
+        let plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
 
         // Build raw transaction manually using plan data
         var rawTx = Data()

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -379,7 +379,12 @@ private extension BlockChainService {
                        amount: BigInt?) async throws -> BlockChainSpecific {
         switch coin.chain {
         case .zcash:
-            return .UTXO(byteFee: coin.feeDefault.toBigInt(), sendMaxAmount: sendMaxAmount)
+            // Resolve the live ZIP-243 branch id at build time so it travels
+            // with the payload to the signing helpers (covers native sends and
+            // SwapKit ZEC swaps). nil when the RPC is down — signing then
+            // refuses rather than producing a network-rejected tx.
+            let zcashBranchId = await ZcashService.shared.getConsensusBranchIdHex()
+            return .UTXO(byteFee: coin.feeDefault.toBigInt(), sendMaxAmount: sendMaxAmount, zcashBranchId: zcashBranchId)
         case .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash:
             let  byteFeeValue = try await fetchUTXOFee(coin: coin, feeMode: feeMode)
             return .UTXO(byteFee: byteFeeValue, sendMaxAmount: sendMaxAmount)

--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -487,8 +487,6 @@ class Endpoint {
     static let tronEvmServiceRpc = "https://api.vultisig.com/tron-rpc"
     static let tronWalletApi = "https://api.vultisig.com/tron"
 
-    static let zcashServiceRpc = "https://api.vultisig.com/zcash/"
-
     static func getExplorerByCoinURL(coin: Coin) -> String? {
         // For native tokens, show the address page
         guard !coin.isNativeToken else {

--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -487,6 +487,8 @@ class Endpoint {
     static let tronEvmServiceRpc = "https://api.vultisig.com/tron-rpc"
     static let tronWalletApi = "https://api.vultisig.com/tron"
 
+    static let zcashServiceRpc = "https://api.vultisig.com/zcash/"
+
     static func getExplorerByCoinURL(coin: Coin) -> String? {
         // For native tokens, show the address page
         guard !coin.isNativeToken else {

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
@@ -10,7 +10,13 @@ import BigInt
 import VultisigCommonData
 
 enum BlockChainSpecific: Codable, Hashable {
-    case UTXO(byteFee: BigInt, sendMaxAmount: Bool)
+    /// `zcashBranchId` is the live ZIP-243 consensus branch id (little-endian
+    /// hex, e.g. `30f33754`) fetched at send time for Zcash; nil for every
+    /// other UTXO chain and when the RPC was unreachable. Transient: it is NOT
+    /// carried by the proto `UTXOSpecific`, so a co-signing device that rebuilds
+    /// the payload from proto must repopulate it (see JoinKeysignViewModel)
+    /// before signing.
+    case UTXO(byteFee: BigInt, sendMaxAmount: Bool, zcashBranchId: String? = nil)
     case Cardano(byteFee: BigInt, sendMaxAmount: Bool, ttl: UInt64)
     case Ethereum(maxFeePerGasWei: BigInt, priorityFeeWei: BigInt, nonce: Int64, gasLimit: BigInt)
     case THORChain(accountNumber: UInt64, sequence: UInt64, fee: UInt64, isDeposit: Bool, transactionType: Int = 0)
@@ -36,7 +42,7 @@ enum BlockChainSpecific: Codable, Hashable {
 
     var gas: BigInt {
         switch self {
-        case .UTXO(let byteFee, _):
+        case .UTXO(let byteFee, _, _):
             return byteFee
         case .Cardano(let byteFee, _, _):
             return byteFee
@@ -92,5 +98,14 @@ enum BlockChainSpecific: Codable, Hashable {
         case .UTXO, .Cardano, .THORChain, .MayaChain, .Cosmos, .Solana, .Sui, .Polkadot, .Ton, .Ripple, .Tron:
             return nil
         }
+    }
+
+    /// Live ZIP-243 branch id carried on a Zcash payload's UTXO specific, or nil
+    /// for non-Zcash payloads and when the RPC was unreachable.
+    var zcashBranchId: String? {
+        guard case .UTXO(_, _, let zcashBranchId) = self else {
+            return nil
+        }
+        return zcashBranchId
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -510,7 +510,10 @@ extension BlockChainSpecific {
 
     func mapToProtobuff() -> VSKeysignPayload.OneOf_BlockchainSpecific {
         switch self {
-        case .UTXO(let byteFee, let sendMaxAmount):
+        case .UTXO(let byteFee, let sendMaxAmount, _):
+            // The live ZEC branch id is intentionally not carried by the proto:
+            // it is a network-global fact each device re-resolves at signing
+            // time (see JoinKeysignViewModel), so it never travels on the wire.
             return .utxoSpecific(.with {
                 $0.byteFee = byteFee.description
                 $0.sendMaxAmount = sendMaxAmount

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessageFactory.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessageFactory.swift
@@ -76,7 +76,7 @@ struct KeysignMessageFactory {
                 case "PSBT_DASH":
                     messages += try SwapKitDashSigner.preSigningHashes(payload: swapKitPayload)
                 case "PSBT_ZEC":
-                    messages += try SwapKitZcashSigner.preSigningHashes(payload: swapKitPayload)
+                    messages += try SwapKitZcashSigner.preSigningHashes(payload: swapKitPayload, zcashBranchId: payload.chainSpecific.zcashBranchId)
                 case "SUI":
                     messages += try SwapKitSuiSigner.preSigningHashes(payload: swapKitPayload)
                 case "TRON":

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
@@ -114,6 +114,34 @@ struct KeysignPayload: Codable, Hashable {
         )
     }
 
+    /// Returns a copy of the payload with `chainSpecific` swapped. Used by the
+    /// co-signer to re-stamp the live ZEC ZIP-243 branch id onto a payload
+    /// rebuilt from proto (the proto can't carry it) before computing sighashes.
+    func withChainSpecific(_ chainSpecific: BlockChainSpecific) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: toAddress,
+            toAmount: toAmount,
+            chainSpecific: chainSpecific,
+            utxos: utxos,
+            memo: memo,
+            swapPayload: swapPayload,
+            approvePayload: approvePayload,
+            vaultPubKeyECDSA: vaultPubKeyECDSA,
+            vaultLocalPartyID: vaultLocalPartyID,
+            libType: libType,
+            wasmExecuteContractPayload: wasmExecuteContractPayload,
+            tronTransferContractPayload: tronTransferContractPayload,
+            tronTriggerSmartContractPayload: tronTriggerSmartContractPayload,
+            tronTransferAssetContractPayload: tronTransferAssetContractPayload,
+            qbtcClaimPayload: qbtcClaimPayload,
+            isQbtcClaim: isQbtcClaim,
+            skipBroadcast: skipBroadcast,
+            signData: signData,
+            dappMetadata: dappMetadata
+        )
+    }
+
     var signAmino: SignAmino? {
         guard case let .signAmino(amino) = signData else {
             return nil

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -222,7 +222,7 @@ class JoinKeysignViewModel: ObservableObject {
         })
     }
 
-    func prepareKeysignMessages(keysignPayload: KeysignPayload) {
+    func prepareKeysignMessages(keysignPayload: KeysignPayload) async {
         // QBTC claim payloads are flagged with `isQbtcClaim` and don't have
         // a standard tx body; the QBTCClaimJoinDriver computes the round-1
         // message hash itself. Skip the standard factory so it doesn't
@@ -235,6 +235,13 @@ class JoinKeysignViewModel: ObservableObject {
             }
             return
         }
+        // The proto UTXOSpecific can't carry the live ZEC branch id, so a
+        // payload rebuilt from the initiator's QR/relay proto arrives with it
+        // nil. Re-resolve the same network-global value the initiator used
+        // before computing sighashes so this co-signer's ZIP-243 digest matches
+        // the rest of the committee.
+        let keysignPayload = await withZcashBranchId(keysignPayload)
+        self.keysignPayload = keysignPayload
         do {
             let keysignFactory = KeysignMessageFactory(payload: keysignPayload)
             let preSignedImageHash = try keysignFactory.getKeysignMessages()
@@ -252,6 +259,19 @@ class JoinKeysignViewModel: ObservableObject {
 
     func prepareKeysignMessages(customMessagePayload: CustomMessagePayload) {
         self.keysignMessages = customMessagePayload.keysignMessages
+    }
+
+    /// Re-stamps the live ZIP-243 branch id onto a Zcash UTXO payload rebuilt
+    /// from proto. Returns the payload unchanged for non-Zcash chains, non-UTXO
+    /// specifics, or when the RPC is unreachable (the signing helpers then
+    /// refuse rather than sign with a stale id).
+    private func withZcashBranchId(_ payload: KeysignPayload) async -> KeysignPayload {
+        guard payload.coin.chain == .zcash,
+              case .UTXO(let byteFee, let sendMaxAmount, _) = payload.chainSpecific,
+              let branchId = await ZcashService.shared.getConsensusBranchIdHex() else {
+            return payload
+        }
+        return payload.withChainSpecific(.UTXO(byteFee: byteFee, sendMaxAmount: sendMaxAmount, zcashBranchId: branchId))
     }
 
     func handleQrCodeSuccessResult(data: String?) async {
@@ -274,7 +294,7 @@ class JoinKeysignViewModel: ObservableObject {
                 vaultPublicKeyECDSAInQrCode = keysignPayload.vaultPubKeyECDSA
             }
             if let payload = keysignMsg.payload {
-                self.prepareKeysignMessages(keysignPayload: payload)
+                await self.prepareKeysignMessages(keysignPayload: payload)
             }
             if let payload = keysignMsg.customMessagePayload {
                 self.prepareKeysignMessages(customMessagePayload: payload)
@@ -391,7 +411,7 @@ class JoinKeysignViewModel: ObservableObject {
             let payload = try await payloadService.getPayload(hash: self.payloadID)
             let kp: KeysignPayload = try ProtoSerializer.deserialize(base64EncodedString: payload)
             self.keysignPayload = kp
-            self.prepareKeysignMessages(keysignPayload: kp)
+            await self.prepareKeysignMessages(keysignPayload: kp)
         } catch {
             self.errorMsg = "Error decoding keysign message: \(error.localizedDescription)"
             self.status = .FailedToStart

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -633,7 +633,8 @@ class KeysignViewModel: ObservableObject {
                     let tx = try SwapKitZcashSigner.compileSignedTransaction(
                         payload: payload,
                         signatures: signatures,
-                        pubKeyHex: keysignPayload.coin.hexPublicKey
+                        pubKeyHex: keysignPayload.coin.hexPublicKey,
+                        zcashBranchId: keysignPayload.chainSpecific.zcashBranchId
                     )
                     signedTransactions.append(tx)
                 case "SUI":

--- a/VultisigApp/VultisigAppTests/Services/ZcashServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ZcashServiceTests.swift
@@ -1,0 +1,35 @@
+//
+//  ZcashServiceTests.swift
+//  VultisigAppTests
+//
+//  Pins the ZIP-243 branch-id byte-reversal: the Zcash node reports
+//  `consensus.nextblock` big-endian, but WalletCore reads it little-endian off
+//  the plan. Getting this wrong yields a digest the network rejects.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class ZcashServiceTests: XCTestCase {
+
+    func testReversesBigEndianNextblockToLittleEndian() {
+        XCTAssertEqual(ZcashService.reverseHexBytes("5437f330"), "30f33754")
+    }
+
+    func testLowercasesUppercaseHex() {
+        XCTAssertEqual(ZcashService.reverseHexBytes("5437F330"), "30f33754")
+    }
+
+    func testReturnsNilForNonHexValue() {
+        XCTAssertNil(ZcashService.reverseHexBytes("not-hex!"))
+    }
+
+    func testReturnsNilForWrongByteLength() {
+        XCTAssertNil(ZcashService.reverseHexBytes("5437f3"))
+        XCTAssertNil(ZcashService.reverseHexBytes("5437f33042"))
+    }
+
+    func testReturnsNilForEmptyString() {
+        XCTAssertNil(ZcashService.reverseHexBytes(""))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitZcashTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitZcashTests.swift
@@ -27,6 +27,11 @@ import XCTest
 @MainActor
 final class SwapKitZcashTests: XCTestCase {
 
+    /// Sample little-endian ZIP-243 branch id passed into the signer in place of
+    /// the (now removed) compiled-in constant; the signer must land it verbatim
+    /// on the plan.
+    private let testBranchID = "30f33754"
+
     // MARK: - Decoder
 
     func testZcashSwapFixtureDecodesAsZcashPsbt() throws {
@@ -122,7 +127,7 @@ final class SwapKitZcashTests: XCTestCase {
 
     func testZcashSignerProducesOneHashPerInput() throws {
         let payload = try makePayload()
-        let hashes = try SwapKitZcashSigner.preSigningHashes(payload: payload)
+        let hashes = try SwapKitZcashSigner.preSigningHashes(payload: payload, zcashBranchId: testBranchID)
         XCTAssertEqual(hashes.count, 1, "Fixture has 1 input → 1 preimage hash")
         for hash in hashes {
             XCTAssertEqual(hash.count, 64)
@@ -131,14 +136,25 @@ final class SwapKitZcashTests: XCTestCase {
 
     func testZcashSignerBuildsBitcoinSigningInputWithSaplingBranchID() throws {
         let payload = try makePayload()
-        let input = try SwapKitZcashSigner.buildSigningInput(payload: payload)
+        let input = try SwapKitZcashSigner.buildSigningInput(payload: payload, zcashBranchId: testBranchID)
         XCTAssertEqual(input.coinType, CoinType.zcash.rawValue)
         XCTAssertEqual(input.utxo.count, 1)
         XCTAssertEqual(input.plan.utxos.count, 1)
-        // BranchID matches the existing native ZEC send path
-        // (`UTXOChainsHelper.swift:138-139`). Diverging would produce a
-        // digest the network rejects.
-        XCTAssertEqual(input.plan.branchID.hexString, "30f33754")
+        // The branch id passed in must land verbatim on the plan, or WalletCore
+        // derives the wrong ZIP-243 digest.
+        XCTAssertEqual(input.plan.branchID.hexString, testBranchID)
+    }
+
+    func testZcashSignerRejectsMissingBranchID() throws {
+        // No branch id supplied (RPC unavailable) — must refuse rather than sign
+        // with a stale value (there is no compiled-in fallback).
+        let payload = try makePayload()
+        XCTAssertThrowsError(try SwapKitZcashSigner.buildSigningInput(payload: payload, zcashBranchId: nil)) { err in
+            guard case SwapKitZcashSignerError.underlying(let inner) = err else {
+                return XCTFail("expected underlying plan error, got \(err)")
+            }
+            XCTAssertTrue(inner.errorDescription?.contains("branch id is unavailable") ?? false)
+        }
     }
 
     func testZcashSignerDerivesToAddressFromPSBTOutputScriptNotTargetAddress() throws {
@@ -154,7 +170,7 @@ final class SwapKitZcashTests: XCTestCase {
         // PSBT's actual scriptPubKeys or the signed tx routes funds to
         // the wrong recipient. Regression pin.
         let payload = try makePayload()
-        let input = try SwapKitZcashSigner.buildSigningInput(payload: payload)
+        let input = try SwapKitZcashSigner.buildSigningInput(payload: payload, zcashBranchId: testBranchID)
         XCTAssertEqual(
             input.toAddress, "t1LEzADVN42PMeGGE8y2AxPydsdFNyAvpE3",
             "toAddress must be derived from PSBT output 0's hash160 (not from SwapKit's targetAddress)"


### PR DESCRIPTION
## Summary

The transparent ZEC sighash used a **hardcoded** ZIP-243 consensus branch id (`30f33754`). At each Zcash network upgrade the branch id changes, so every native ZEC send and SwapKit ZEC swap would sign with the wrong id and be rejected chain-wide until someone manually edited the constant and shipped a release.

This resolves the active branch id from the Zcash RPC at send time and carries it on the payload, with **no compiled-in fallback** — if the value can't be resolved, signing refuses rather than producing a network-rejectable transaction.

iOS port of vultisig/vultisig-android#4879.

## How it works

- **`ZcashService`** (`api.vultisig.com/zcash`) calls `getblockchaininfo`, reads `consensus.nextblock` (big-endian, e.g. `5437f330`) and reverses the four bytes to the little-endian form WalletCore expects (`30f33754`). Cached in memory for **1 hour** (the id only changes at an upgrade); concurrent co-sign rounds are deduped to one network call.
- The branch id rides on **`BlockChainSpecific.UTXO.zcashBranchId`** instead of being threaded through signing-helper params:
  - **Initiator**: stamped in `BlockChainService.fetchSpecific` (covers native sends and SwapKit swaps).
  - **Co-signer**: the proto `UTXOSpecific` can't carry the field, so a payload rebuilt from the initiator's QR/relay proto arrives with it nil. `JoinKeysignViewModel` re-resolves the same network-global value before computing sighashes, so the whole committee agrees.
  - `UTXOChainsHelper` / `SwapKitZcashSigner` read it straight off the payload.
- **Fail-loud**: `UTXOChainsHelper` and `SwapKitZcashSigner` throw when the branch id is nil/empty rather than falling back to a stale constant. The hardcoded constant is removed. The unused branch-id assignments on the fee-preview / Blockaid-placeholder paths (sighash-only field, never consumed there) are dropped.

## Trade-off

A reachable Zcash RPC is now a hard requirement for ZEC signing. If `api.vultisig.com/zcash` is briefly unavailable, ZEC sends/swaps fail with a descriptive error until it recovers — deliberate: fail loud over sign-stale.

## Test Plan

- [x] New `ZcashServiceTests` (5): byte-reversal, uppercase, malformed, wrong length, empty.
- [x] Updated `SwapKitZcashTests`: branch id lands verbatim on the plan; new missing-branch-id rejection test (no fallback).
- [x] `SwapKitZcashTests` + `ZcashServiceTests` green (15 tests, 0 failures).
- [x] SwiftLint passes (0 violations on changed files).
- [x] `xcodebuild build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zcash signing now fetches and uses a live ZIP-243 consensus branch ID (cached for one hour) and stamps it into ZEC signing payloads at signing time.

* **Bug Fixes**
  * Removed hardcoded ZEC branch ID; signing now fails early if a valid live branch ID cannot be resolved.
  * Keysigned messages and transaction compilation now include the resolved branch ID when available.

* **Tests**
  * Added tests for branch-id byte-reversal, validation, and signer behavior when the branch ID is missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->