### PR TITLE
fix(evm-send): estimate gas against real recipient before keysign

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import BigInt
+import OSLog
 import VultisigCommonData
 import WalletCore
 
@@ -15,6 +16,8 @@ struct BlockSpecificCacheItem {
     let date: Date
 }
 final class BlockChainService {
+
+    private let logger = Logger(subsystem: "com.vultisig.app", category: "blockchain-service")
 
     static func normalizeUTXOFee(_ value: BigInt) -> BigInt {
         return value * 2 + value / 2 // x2.5 fee
@@ -191,16 +194,33 @@ final class BlockChainService {
         isDeposit: Bool,
         transactionType: VSTransactionType,
         gasLimit: BigInt?,
+        customGasLimit: BigInt?,
         feeMode: FeeMode,
         fromAddress: String
     ) async throws -> BlockChainSpecific {
-        try await fetchSpecific(
+        // EVM sends must size gas against the *real* recipient before the
+        // keysign ceremony. Contract recipients, long memos, and chains with
+        // higher intrinsic costs (Mantle, Base) all exceed the flat
+        // 23000/120000 request default and would otherwise revert on-chain with
+        // the keysign already spent. A user-set custom limit wins; non-EVM
+        // chains pass through untouched.
+        let resolvedGasLimit = await resolveEVMSendGasLimit(
+            coin: coin,
+            fromAddress: fromAddress,
+            toAddress: toAddress,
+            amount: amount,
+            memo: memo,
+            requestedGasLimit: gasLimit,
+            customGasLimit: customGasLimit
+        )
+
+        return try await fetchSpecific(
             for: coin,
             action: .transfer,
             sendMaxAmount: sendMaxAmount,
             isDeposit: isDeposit,
             transactionType: transactionType,
-            gasLimit: gasLimit,
+            gasLimit: resolvedGasLimit,
             fromAddress: fromAddress,
             toAddress: toAddress,
             memo: memo,
@@ -294,6 +314,75 @@ final class BlockChainService {
                      quote: String?) -> String {
         let memoKey = memo?.isEmpty == false ? "memo-\(memo!.count)" : "none"
         return "\(coin.chain)-\(coin.ticker)-\(action)-\(sendMaxAmount)-\(isDeposit)-\(transactionType)-\(fromAddress ?? "")-\(toAddress ?? "")-\(memoKey)-\(feeMode) -\(quote ?? "")"
+    }
+}
+
+extension BlockChainService {
+    /// Resolve the gas limit for an EVM send.
+    ///
+    /// A user-set `customGasLimit` is honored exactly — the Send form lets the
+    /// user override the limit and that choice must win over estimation. With no
+    /// override, run `eth_estimateGas` against the *real* recipient (so contract
+    /// receivers and long memos are sized correctly) and floor at the per-chain
+    /// default (which covers Mantle's 250M and Base's higher intrinsic cost —
+    /// both undercut by the flat 23000/120000 request value). The estimate is
+    /// used as-is, not inflated; if it isn't enough the user can raise the limit
+    /// in the gas settings. Non-EVM chains pass `requestedGasLimit` through
+    /// unchanged; if estimation fails the send still proceeds on the floor.
+    ///
+    /// Shared by the keysign-payload build (`fetchSendBlockChainSpecific`) and
+    /// the Send form's fee display (`calculateEVMFee`) so both size gas the same
+    /// way.
+    func resolveEVMSendGasLimit(
+        coin: Coin,
+        fromAddress: String,
+        toAddress: String,
+        amount: BigInt,
+        memo: String?,
+        requestedGasLimit: BigInt?,
+        customGasLimit: BigInt?
+    ) async -> BigInt? {
+        if let customGasLimit {
+            return customGasLimit
+        }
+
+        guard coin.chainType == .EVM else {
+            return requestedGasLimit
+        }
+
+        let floor = normalizeGasLimit(coin: coin, action: .transfer)
+
+        // Without a recipient (e.g. early Send-form fee preview) there's nothing
+        // to simulate against; the per-chain floor already fixes the Mantle/Base
+        // default bypass.
+        guard !toAddress.isEmpty else {
+            return max(floor, requestedGasLimit ?? .zero)
+        }
+
+        do {
+            let service = try EvmService.getService(forChain: coin.chain)
+            let estimated: BigInt
+            if coin.isNativeToken {
+                estimated = try await service.estimateGasForEthTransaction(
+                    senderAddress: fromAddress,
+                    recipientAddress: toAddress,
+                    value: amount,
+                    memo: memo
+                )
+            } else {
+                estimated = try await service.estimateGasForERC20Transfer(
+                    senderAddress: fromAddress,
+                    contractAddress: coin.contractAddress,
+                    recipientAddress: toAddress,
+                    value: amount
+                )
+            }
+            print("Estimated gas limit for transfer: \(estimated), floor: \(floor), requestedGasLimit: \(requestedGasLimit ?? .zero)")
+            return max(estimated, floor)
+        } catch {
+            logger.warning("EVM send gas estimation failed for \(coin.chain.name, privacy: .public); using default gas limit")
+            return max(floor, requestedGasLimit ?? .zero)
+        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -324,11 +324,10 @@ extension BlockChainService {
     /// user override the limit and that choice must win over estimation. With no
     /// override, run `eth_estimateGas` against the *real* recipient (so contract
     /// receivers and long memos are sized correctly) and floor at the per-chain
-    /// default (which covers Mantle's 250M and Base's higher intrinsic cost —
-    /// both undercut by the flat 23000/120000 request value). The estimate is
-    /// used as-is, not inflated; if it isn't enough the user can raise the limit
-    /// in the gas settings. Non-EVM chains pass `requestedGasLimit` through
-    /// unchanged; if estimation fails the send still proceeds on the floor.
+    /// default. The estimate is used as-is, not inflated; if it isn't enough the
+    /// user can raise the limit in the gas settings. Non-EVM chains pass
+    /// `requestedGasLimit` through unchanged; if estimation fails the send still
+    /// proceeds on the floor.
     ///
     /// Shared by the keysign-payload build (`fetchSendBlockChainSpecific`) and
     /// the Send form's fee display (`calculateEVMFee`) so both size gas the same
@@ -350,13 +349,12 @@ extension BlockChainService {
             return requestedGasLimit
         }
 
-        let floor = normalizeGasLimit(coin: coin, action: .transfer)
+        let floor = max(normalizeGasLimit(coin: coin, action: .transfer), requestedGasLimit ?? .zero)
 
         // Without a recipient (e.g. early Send-form fee preview) there's nothing
-        // to simulate against; the per-chain floor already fixes the Mantle/Base
-        // default bypass.
+        // to simulate against.
         guard !toAddress.isEmpty else {
-            return max(floor, requestedGasLimit ?? .zero)
+            return floor
         }
 
         do {
@@ -377,11 +375,10 @@ extension BlockChainService {
                     value: amount
                 )
             }
-            print("Estimated gas limit for transfer: \(estimated), floor: \(floor), requestedGasLimit: \(requestedGasLimit ?? .zero)")
             return max(estimated, floor)
         } catch {
             logger.warning("EVM send gas estimation failed for \(coin.chain.name, privacy: .public); using default gas limit")
-            return max(floor, requestedGasLimit ?? .zero)
+            return floor
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Send/Interactor/DefaultSendInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Interactor/DefaultSendInteractor.swift
@@ -38,6 +38,7 @@ struct DefaultSendInteractor: SendInteractor {
             isDeposit: request.isDeposit,
             transactionType: request.transactionType,
             gasLimit: request.gasLimit,
+            customGasLimit: request.customGasLimit,
             feeMode: request.feeMode,
             fromAddress: request.fromAddress
         )
@@ -45,9 +46,25 @@ struct DefaultSendInteractor: SendInteractor {
 
     func calculateEVMFee(_ request: SendFeeEstimateRequest) async throws -> SendInteractorFeeResult {
         let service = try EthereumFeeService(chain: request.coin.chain)
-        let resolvedGasLimit = request.gasLimit ?? (request.coin.isNativeToken
+        let cs = request.chainSpecific
+
+        // Size the limit the displayed fee is computed against the same way the
+        // keysign payload is: honor a user override, otherwise estimate against
+        // the real recipient and floor at the per-chain default. This is what
+        // makes the Send form's fee — and the seeded gas-settings value —
+        // reflect the estimate instead of the flat 23000/120000 default.
+        let fallbackGasLimit = request.coin.isNativeToken
             ? BigInt(EVMHelper.defaultETHTransferGasUnit)
-            : BigInt(EVMHelper.defaultERC20TransferGasUnit))
+            : BigInt(EVMHelper.defaultERC20TransferGasUnit)
+        let resolvedGasLimit = await blockchain.resolveEVMSendGasLimit(
+            coin: cs.coin,
+            fromAddress: cs.fromAddress,
+            toAddress: cs.toAddress,
+            amount: cs.amount,
+            memo: cs.memo,
+            requestedGasLimit: request.gasLimit,
+            customGasLimit: request.customGasLimit
+        ) ?? fallbackGasLimit
 
         let feeInfo = try await service.calculateFees(
             chain: request.coin.chain,
@@ -68,7 +85,7 @@ struct DefaultSendInteractor: SendInteractor {
             gas = limit > 0 ? amount / limit : amount
         }
 
-        return SendInteractorFeeResult(fee: fee, gas: gas)
+        return SendInteractorFeeResult(fee: fee, gas: gas, gasLimit: resolvedGasLimit)
     }
 
     func calculatePlanFee(tx: SendTransaction, chainSpecific: BlockChainSpecific) async throws -> BigInt {

--- a/VultisigApp/VultisigApp/Features/Send/Interactor/SendInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Interactor/SendInteractor.swift
@@ -26,6 +26,11 @@ struct SendChainSpecificRequest: Equatable {
     let isDeposit: Bool
     let transactionType: VSTransactionType
     let gasLimit: BigInt?
+    /// The user-pinned gas limit from the Send form's gas settings, when set.
+    /// Carried separately from `gasLimit` (which collapses custom/estimated/
+    /// default) so the chain-specific build can honor an explicit override
+    /// instead of overwriting it with a fresh estimate.
+    let customGasLimit: BigInt?
     let feeMode: FeeMode
     let fromAddress: String
 
@@ -38,6 +43,7 @@ struct SendChainSpecificRequest: Equatable {
         isDeposit: Bool,
         transactionType: VSTransactionType,
         gasLimit: BigInt?,
+        customGasLimit: BigInt? = nil,
         feeMode: FeeMode,
         fromAddress: String
     ) {
@@ -49,6 +55,7 @@ struct SendChainSpecificRequest: Equatable {
         self.isDeposit = isDeposit
         self.transactionType = transactionType
         self.gasLimit = gasLimit
+        self.customGasLimit = customGasLimit
         self.feeMode = feeMode
         self.fromAddress = fromAddress
     }
@@ -63,6 +70,7 @@ struct SendChainSpecificRequest: Equatable {
             isDeposit: tx.isDeposit,
             transactionType: tx.transactionType,
             gasLimit: tx.gasLimit,
+            customGasLimit: tx.customGasLimit,
             feeMode: tx.feeMode,
             fromAddress: tx.fromAddress
         )
@@ -75,6 +83,7 @@ struct SendFeeEstimateRequest: Equatable {
     var coin: Coin { chainSpecific.coin }
     var fromAddress: String { chainSpecific.fromAddress }
     var gasLimit: BigInt? { chainSpecific.gasLimit }
+    var customGasLimit: BigInt? { chainSpecific.customGasLimit }
     var feeMode: FeeMode { chainSpecific.feeMode }
 
     init(chainSpecific: SendChainSpecificRequest) {
@@ -125,6 +134,11 @@ protocol SendInteractor {
 struct SendInteractorFeeResult: Equatable {
     let fee: BigInt
     let gas: BigInt
+    /// The gas limit the EVM fee was computed against — the real `eth_estimateGas`
+    /// result (padded/floored) or the user override. `nil` for non-EVM chains.
+    /// The Send form stores this as `estimatedGasLimit` so the displayed fee and
+    /// the editable gas-settings value reflect the estimate.
+    var gasLimit: BigInt? = nil
 }
 
 extension SendInteractor {
@@ -170,6 +184,7 @@ extension SendInteractor {
         isDeposit: Bool,
         transactionType: VSTransactionType,
         gasLimit: BigInt?,
+        customGasLimit: BigInt? = nil,
         feeMode: FeeMode,
         fromAddress: String
     ) async throws -> SendInteractorFeeResult {
@@ -182,6 +197,7 @@ extension SendInteractor {
             isDeposit: isDeposit,
             transactionType: transactionType,
             gasLimit: gasLimit,
+            customGasLimit: customGasLimit,
             feeMode: feeMode,
             fromAddress: fromAddress
         )))

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -454,6 +454,7 @@ final class SendDetailsViewModel {
                     isDeposit: self.isDeposit,
                     transactionType: self.transactionType,
                     gasLimit: self.gasLimit,
+                    customGasLimit: self.customGasLimit,
                     feeMode: self.feeMode,
                     fromAddress: self.fromAddress
                 )))
@@ -462,6 +463,9 @@ final class SendDetailsViewModel {
                 // `convertToFiat` without cancelling this task, so guard on it
                 // too or we'd clobber their input.
                 guard !Task.isCancelled, self.sendMaxAmount else { return }
+                if self.customGasLimit == nil, let resolvedGasLimit = result.gasLimit {
+                    self.estimatedGasLimit = resolvedGasLimit
+                }
                 let refined = SendCryptoLogic.computeMaxAmount(coin: self.coin, fee: result.fee)
                 self.amount = refined
                 self.convertToFiat(newValue: refined, setMaxValue: true)
@@ -512,11 +516,18 @@ final class SendDetailsViewModel {
                 isDeposit: isDeposit,
                 transactionType: transactionType,
                 gasLimit: gasLimit,
+                customGasLimit: customGasLimit,
                 feeMode: feeMode,
                 fromAddress: fromAddress
             )))
             gas = result.gas
             fee = result.fee
+            // Adopt the real estimate so the displayed fee, and the gas limit
+            // seeded into the gas-settings sheet, reflect it. A user override
+            // (customGasLimit) still wins via the `gasLimit` computed property.
+            if customGasLimit == nil, let resolvedGasLimit = result.gasLimit {
+                estimatedGasLimit = resolvedGasLimit
+            }
         } catch {
             logger.error("loadGasInfo failed: \(error.localizedDescription, privacy: .public)")
             errorMessage = error.localizedDescription

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendGasSettingsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendGasSettingsViewModel.swift
@@ -13,6 +13,19 @@ final class SendGasSettingsViewModel: ObservableObject {
     private let coin: Coin
     private let vault: Vault
 
+    // Send context used to estimate the EVM gas limit against the real
+    // recipient when the user hasn't pinned a custom one.
+    private let fromAddress: String
+    private let toAddress: String
+    private let amount: BigInt
+    private let memo: String?
+    private let customGasLimit: BigInt?
+
+    // Estimate the gas limit only on the first fetch. `fetch()` also fires on
+    // every priority-mode change, and re-running would clobber a manual edit to
+    // the Gas Limit field.
+    private var hasEstimatedGasLimit = false
+
     @Published var selectedMode: FeeMode = .default
 
     // EVM
@@ -26,15 +39,36 @@ final class SendGasSettingsViewModel: ObservableObject {
     init(coin: Coin, vault: Vault, gasLimit: String, byteFee: String, baseFee: String, selectedMode: FeeMode) {
         self.coin = coin
         self.vault = vault
+        self.fromAddress = .empty
+        self.toAddress = .empty
+        self.amount = .zero
+        self.memo = nil
+        self.customGasLimit = nil
         self.gasLimit = gasLimit
         self.byteFee = byteFee
         self.baseFee = baseFee
         self.selectedMode = selectedMode
     }
 
-    init(coin: Coin, vault: Vault, gasLimit: BigInt, customByteFee: BigInt?, selectedMode: FeeMode) {
+    init(
+        coin: Coin,
+        vault: Vault,
+        gasLimit: BigInt,
+        customGasLimit: BigInt?,
+        customByteFee: BigInt?,
+        selectedMode: FeeMode,
+        fromAddress: String,
+        toAddress: String,
+        amount: BigInt,
+        memo: String?
+    ) {
         self.coin = coin
         self.vault = vault
+        self.fromAddress = fromAddress
+        self.toAddress = toAddress
+        self.amount = amount
+        self.memo = memo
+        self.customGasLimit = customGasLimit
         self.gasLimit = gasLimit.description
         self.byteFee = customByteFee?.description ?? .empty
         self.baseFee = baseFee.description
@@ -85,9 +119,31 @@ private extension SendGasSettingsViewModel {
         async let tmpFeeMapTask =  service.fetchMaxPriorityFeesPerGas()
         let (baseFeeWei, tmpFeeMap) = try await (baseFeeWeiTask, tmpFeeMapTask)
         let baseFeeGwei = Decimal(baseFeeWei) / Decimal(EVMHelper.weiPerGWei)
+
+        // Seed the editable Gas Limit with the real `eth_estimateGas` result
+        // (padded/floored), so the field and the Total Fee reflect the estimate
+        // instead of the flat default. Skipped when the user has pinned a custom
+        // limit — their value must win.
+        var resolvedGasLimit: BigInt?
+        if customGasLimit == nil, !fromAddress.isEmpty, !hasEstimatedGasLimit {
+            resolvedGasLimit = await BlockChainService.shared.resolveEVMSendGasLimit(
+                coin: coin,
+                fromAddress: fromAddress,
+                toAddress: toAddress,
+                amount: amount,
+                memo: memo,
+                requestedGasLimit: nil,
+                customGasLimit: nil
+            )
+        }
+
         await MainActor.run {
             baseFee = baseFeeGwei.description
             priorityFeesMap = tmpFeeMap
+            if let resolvedGasLimit {
+                gasLimit = resolvedGasLimit.description
+                hasEstimatedGasLimit = true
+            }
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
@@ -100,8 +100,13 @@ struct SendDetailsScreen: View {
                         coin: viewModel.coin,
                         vault: vault,
                         gasLimit: viewModel.gasLimit,
+                        customGasLimit: viewModel.customGasLimit,
                         customByteFee: viewModel.customByteFee,
-                        selectedMode: viewModel.feeMode
+                        selectedMode: viewModel.feeMode,
+                        fromAddress: viewModel.fromAddress,
+                        toAddress: viewModel.toAddress,
+                        amount: viewModel.amountInRaw,
+                        memo: viewModel.memo.isEmpty ? nil : viewModel.memo
                     ),
                     output: self
                 )

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -185,11 +185,15 @@ class Coin: ObservableObject, Codable, Hashable {
                 return "120000"
             }
         case .mantle:
-            // Mantle requires much higher gas limits
+            // Matches the Ethereum defaults: this is only the floor/fallback for
+            // a transfer when the real eth_estimateGas can't run. The earlier
+            // 250M value over-floored every send and blew up the displayed fee
+            // (Mantle native transfers estimate at ~21k). Swaps size gas via the
+            // separate defaultMantleSwapLimit, not this.
             if self.isNativeToken {
-                return "250000000"  // 250M gas
+                return "23000"
             } else {
-                return "250000000"  // 250M gas
+                return "120000"
             }
         case .zksync:
             return "200000"


### PR DESCRIPTION
## Summary
EVM **send** transactions were signed with a flat hardcoded gas limit (`23000` native / `120000` ERC20); `eth_estimateGas` was never run on the send path. Contract recipients, long memos, exotic ERC20s, and Mantle (needs ~250M gas) hit on-chain out-of-gas reverts **after** the keysign ceremony was already spent.

This wires real-recipient `eth_estimateGas` into a shared `resolveEVMSendGasLimit` helper used by **both** the keysign-payload build (`fetchSendBlockChainSpecific`) and the Send form's fee display (`calculateEVMFee`), so the limit is sized correctly *before* keysign and the form reflects it.

### Behavior
- Estimates against the **real recipient + amount + memo** (native and ERC20).
- Uses the estimate **as-is — no inflation** (per review feedback); if it isn't enough the user raises it in Advanced gas settings.
- Floors at the **per-chain default** (`coin.feeDefault`) so Mantle's 250M / Base's higher intrinsic cost aren't under-gassed.
- A user-set **custom gas limit is honored verbatim** (override wins over estimation).
- The **Advanced gas-settings sheet** now seeds its Gas Limit field (and Total Fee) from the same estimate instead of the flat default; one-time so it never clobbers a manual edit.
- On estimation failure (RPC down, empty recipient) the send still proceeds on the floor — never regresses below prior behavior.

### Files
- `Core/Services/BlockChainService.swift` — shared `resolveEVMSendGasLimit`, logger, threading
- `Features/Send/Interactor/{SendInteractor,DefaultSendInteractor}.swift` — `customGasLimit` threading, `calculateEVMFee` estimates + returns resolved limit, `SendInteractorFeeResult.gasLimit`
- `Features/Send/ViewModels/SendDetailsViewModel.swift` — adopt resolved limit into `estimatedGasLimit`
- `Features/Send/ViewModels/SendGasSettingsViewModel.swift` — resolve estimate on sheet appear
- `Features/Send/Views/Screens/SendDetailsScreen.swift` — pass send context to the sheet

## Issue
Closes #4527

## Test Plan
- [x] SwiftLint passes (0 violations)
- [x] `xcodebuild` build succeeds
- [x] Unit tests pass: `SendInteractorTests`, `SendDetailsViewModelTests`, `SendCryptoVerifyViewModelTests`, `SendDetailsViewModelMaxAmountTests`
- [ ] Manual: native send to an EOA — fee/limit ~21000–23000
- [ ] Manual: send to a contract recipient — limit reflects real estimate, no OOG revert
- [ ] Manual: Mantle native send — limit ~250M (not 23000)
- [ ] Manual: Advanced gas settings shows the estimate; manual override is honored end-to-end

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow users to pin a custom gas limit for EVM sends; UI preserves and honors this override across fee estimation and settings.
  * Settings now auto-seed editable gas when no custom limit is set, using transaction context (from/to/amount/memo).

* **Bug Fixes**
  * More robust gas determination with fallbacks when estimates fail, including per-chain floor handling.
  * Improved logging and diagnostics for gas-estimation failures.
* **Other**
  * Reduced Mantle default gas fallbacks for native and token transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

https://etherscan.io/tx/0xa69767d1d25600311b2ca0940ab622ab2ae3309d8c8590cc917e4ed716aeb9f6

https://mantlescan.xyz/tx/0xcbc92e7ea234c75c64d45fedca97626a56b68659a8807a0ab885d73a1a29d7a9