### PR TITLE
fix: replace dead Hyperliquid explorer liquidscan.io with hypurrscan.io

### DIFF
--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -569,7 +569,7 @@ class Endpoint {
         case .mantle:
             return "https://mantlescan.xyz/token/\(contractAddress)"
         case .hyperliquid:
-            return "https://liquidscan.io/token/\(contractAddress)"
+            return "https://hypurrscan.io/token/\(contractAddress)"
         case .sei:
             return "https://seiscan.io/token/\(contractAddress)"
         case .qbtc:
@@ -654,7 +654,7 @@ class Endpoint {
         case .mantle:
             return "https://mantlescan.xyz/address/\(address)"
         case .hyperliquid:
-            return "https://liquidscan.io/address/\(address)"
+            return "https://hypurrscan.io/address/\(address)"
         case .sei:
             return "https://seiscan.io/address/\(address)"
         case .qbtc:

--- a/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
@@ -204,7 +204,7 @@ enum ExplorerLinkBuilder {
         case .mantle:
             return "https://explorer.mantle.xyz/tx/\(txid)"
         case .hyperliquid:
-            return "https://liquidscan.io/tx/\(txid)"
+            return "https://hypurrscan.io/tx/\(txid)"
         case .sei:
             return "https://seiscan.io/tx/\(txid)"
         case .qbtc:
@@ -291,7 +291,7 @@ enum ExplorerLinkBuilder {
         case .mantle:
             return "https://mantlescan.xyz/address/\(address)"
         case .hyperliquid:
-            return "https://liquidscan.io/address/\(address)"
+            return "https://hypurrscan.io/address/\(address)"
         case .sei:
             return "https://seiscan.io/address/\(address)"
         case .bittensor:


### PR DESCRIPTION
## Summary
- `liquidscan.io` (Hyperliquid explorer) is dead — DNS no longer resolves, so every Hyperliquid tx/address/token explorer link in the app 404s at the network level
- Replace with `hypurrscan.io`, which serves the same `/tx/`, `/address/`, `/token/` path structure

## Changes
| File | Change |
|------|--------|
| `VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift` | Hyperliquid tx + address explorer base → hypurrscan.io |
| `VultisigApp/VultisigApp/Core/Utils/Endpoint.swift` | Hyperliquid token + address explorer base → hypurrscan.io |

## Context
Closes #4568. Dead link example: https://liquidscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF → working replacement: https://hypurrscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF

## Test plan
- [x] swiftlint clean on both changed files
- [x] Old/new explorer reachability verified via curl (see receipts)
- [ ] Tap explorer link from a Hyperliquid tx on device

## receipts
```bash
$ curl -sS -o /dev/null -w "%{http_code}\n" "https://liquidscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF"
curl: (6) Could not resolve host: liquidscan.io

$ curl -sS -o /dev/null -w "address: %{http_code}\n" -L "https://hypurrscan.io/address/0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF"
address: 200
```
URL-constant-only change; no logic touched.

Generated with [Claude Code](https://claude.com/claude-code)