### PR TITLE
fix(polkadot): check tx status via node RPC instead of Subscan

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/PolkadotTransactionStatusResponse.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/PolkadotTransactionStatusResponse.swift
@@ -7,13 +7,29 @@
 
 import Foundation
 
-/// JSON-RPC response for `author_pendingExtrinsics`.
+/// JSON-RPC response for `chain_getBlock`.
 ///
-/// `result` is the list of hex-encoded extrinsics currently in the node's
-/// transaction pool. `error` is populated when the node rejects the call.
+/// `result.block` carries the signed block: `extrinsics` is the list of
+/// hex-encoded extrinsics in the block (each blake2b-256 hashed to match a tx
+/// hash), and `header.parentHash` links to the previous block so the status
+/// provider can walk the chain backwards. `error` is populated when the node
+/// rejects the call.
 struct PolkadotTransactionStatusResponse: Codable {
-    let result: [String]?
+    let result: PolkadotBlockResult?
     let error: PolkadotRPCError?
+
+    struct PolkadotBlockResult: Codable {
+        let block: PolkadotBlock
+    }
+
+    struct PolkadotBlock: Codable {
+        let header: PolkadotBlockHeader
+        let extrinsics: [String]
+    }
+
+    struct PolkadotBlockHeader: Codable {
+        let parentHash: String
+    }
 
     struct PolkadotRPCError: Codable {
         let code: Int

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/PolkadotTransactionStatusResponse.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/PolkadotTransactionStatusResponse.swift
@@ -7,31 +7,16 @@
 
 import Foundation
 
-/// Subscan API response for /api/scan/extrinsic
+/// JSON-RPC response for `author_pendingExtrinsics`.
+///
+/// `result` is the list of hex-encoded extrinsics currently in the node's
+/// transaction pool. `error` is populated when the node rejects the call.
 struct PolkadotTransactionStatusResponse: Codable {
-    let code: Int  // 0 = success, non-zero = error
-    let message: String  // "Success" or error message
-    let data: PolkadotExtrinsicData?
+    let result: [String]?
+    let error: PolkadotRPCError?
 
-    struct PolkadotExtrinsicData: Codable {
-        let extrinsic_hash: String?
-        let success: Bool  // true = successful, false = failed (only meaningful when pending = false)
-        let block_num: Int?  // Block number
-        let block_timestamp: Int?  // Unix timestamp
-        let call_module: String?  // e.g., "balances"
-        let call_module_function: String?  // e.g., "transfer"
-        let account_id: String?  // Sender address
-        let signature: String?
-        let nonce: Int?
-        let finalized: Bool?  // Whether the transaction is finalized
-        let pending: Bool?  // IMPORTANT: true = still being processed, false = completed
-        let error: PolkadotExtrinsicError?  // Present when success = false
-        let fee: String?
-    }
-
-    struct PolkadotExtrinsicError: Codable {
-        let module: String?
-        let name: String?
-        let doc: [String]?  // Error description
+    struct PolkadotRPCError: Codable {
+        let code: Int
+        let message: String
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/PolkadotTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/PolkadotTransactionStatusProvider.swift
@@ -10,18 +10,28 @@ import WalletCore
 
 /// Polkadot Asset Hub transaction status via node RPC.
 ///
-/// A bare Substrate node does not index extrinsics by hash, so status is derived
-/// from the transaction pool: `author_pendingExtrinsics` returns the extrinsics
-/// still awaiting inclusion. The submitted extrinsic hash is the blake2b-256 of
-/// its SCALE-encoded bytes, so we hash each pending extrinsic and look for a match.
+/// A bare Substrate node does not index extrinsics by hash, so inclusion is
+/// proven by scanning blocks: starting from the best head, walk back along
+/// `parentHash` and blake2b-256 each block's extrinsics, looking for a match.
+/// The hash is the same value `author_submitExtrinsic` returns. This reads real
+/// blocks rather than the node-local mempool, so it stays correct behind the
+/// load-balanced proxy.
 ///
-/// - Hash found in the pool → still `pending`.
-/// - Hash absent → it has left the pool (included in a block) → `confirmed`.
+/// - Hash found in a scanned block → `confirmed`.
+/// - Not found within the scan window → `pending` (the poll loop retries).
 ///
-/// Node RPC cannot replay an already-included extrinsic's events, so on-chain
-/// dispatch failures are not distinguished here; the node rejects malformed or
-/// invalid extrinsics at broadcast time (`author_submitExtrinsic`) instead.
+/// The walk is bounded to one mortal era (`PolkadotHelper` builds extrinsics
+/// with `period = 64`): beyond that window a mortal extrinsic can no longer be
+/// included, and the bound covers the foreground poll window for Polkadot
+/// (`ChainStatusConfig` caps it at 5 minutes ≈ 50 blocks at 6s/block). A
+/// long-delayed check whose inclusion block has fallen outside the window stays
+/// `pending` until the poll times out rather than being read from an indexer.
 struct PolkadotTransactionStatusProvider: TransactionStatusProvider {
+    /// One mortal era (`period = 64`). The signed extrinsic can only be included
+    /// within this many blocks of its checkpoint, so scanning further back can
+    /// never find it; it also bounds the walk on a genuinely pending/dropped tx.
+    private static let maxScanDepth = 64
+
     private let httpClient: HTTPClientProtocol
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
@@ -29,32 +39,59 @@ struct PolkadotTransactionStatusProvider: TransactionStatusProvider {
     }
 
     func checkStatus(query: TransactionStatusQuery) async throws -> TransactionStatusResult {
+        let targetHash = query.txHash.stripHexPrefix().lowercased()
+        guard !targetHash.isEmpty else {
+            return TransactionStatusResult(status: .notFound, blockNumber: nil, confirmations: nil)
+        }
+
+        let isConfirmed = try await isExtrinsicInChain(targetHash: targetHash)
+        return TransactionStatusResult(
+            status: isConfirmed ? .confirmed : .pending,
+            blockNumber: nil,
+            confirmations: nil
+        )
+    }
+
+    /// Walks the best chain from the head along `parentHash`, up to
+    /// `maxScanDepth` blocks, returning `true` as soon as a block contains an
+    /// extrinsic whose hash matches `targetHash`. A block that fails to load
+    /// ends the walk (returns `false`) so the surrounding poll keeps retrying
+    /// rather than declaring a terminal state on a transient RPC gap.
+    private func isExtrinsicInChain(targetHash: String) async throws -> Bool {
+        var blockHash: String?
+        var scanned = 0
+
+        while scanned < Self.maxScanDepth {
+            guard let block = try await fetchBlock(blockHash: blockHash) else {
+                return false
+            }
+            if block.extrinsics.contains(where: { extrinsicHash(forHex: $0) == targetHash }) {
+                return true
+            }
+            blockHash = block.header.parentHash
+            scanned += 1
+        }
+        return false
+    }
+
+    /// Fetches a block by hash (or the best head when `blockHash` is `nil`).
+    /// Throws on an explicit RPC error; returns `nil` when the node has no block
+    /// for the hash (end of the walk).
+    private func fetchBlock(blockHash: String?) async throws -> PolkadotTransactionStatusResponse.PolkadotBlock? {
         let response = try await httpClient.request(
-            PolkadotTransactionStatusAPI.pendingExtrinsics,
+            PolkadotTransactionStatusAPI.getBlock(blockHash: blockHash),
             responseType: PolkadotTransactionStatusResponse.self
         ).data
 
         if let error = response.error {
             throw RpcServiceError.rpcError(code: error.code, message: error.message)
         }
-
-        let pendingExtrinsics = response.result ?? []
-        let targetHash = query.txHash.stripHexPrefix().lowercased()
-
-        let isPending = pendingExtrinsics.contains { extrinsic in
-            extrinsicHash(forHex: extrinsic) == targetHash
-        }
-
-        return TransactionStatusResult(
-            status: isPending ? .pending : .confirmed,
-            blockNumber: nil,
-            confirmations: nil
-        )
+        return response.result?.block
     }
 
     /// blake2b-256 of the SCALE-encoded extrinsic bytes, lowercased and without
-    /// the `0x` prefix — the same value `author_submitExtrinsic` returns as the
-    /// extrinsic hash. Returns `nil` for hex that cannot be decoded.
+    /// the `0x` prefix — the canonical Substrate extrinsic hash. Returns `nil`
+    /// for hex that cannot be decoded.
     private func extrinsicHash(forHex hex: String) -> String? {
         guard let bytes = Data(hexString: hex.stripHexPrefix()) else {
             return nil

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/PolkadotTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/PolkadotTransactionStatusProvider.swift
@@ -6,12 +6,21 @@
 //
 
 import Foundation
+import WalletCore
 
-/// Polkadot Transaction Status Logic:
-/// - Uses Subscan API for AssetHub Polkadot transaction status checking
-/// - Endpoint: https://assethub-polkadot.api.subscan.io/api/scan/extrinsic
-/// - Gets detailed status including success/failure from indexed data
-/// - Checks `pending` field before `success` to properly detect pending transactions
+/// Polkadot Asset Hub transaction status via node RPC.
+///
+/// A bare Substrate node does not index extrinsics by hash, so status is derived
+/// from the transaction pool: `author_pendingExtrinsics` returns the extrinsics
+/// still awaiting inclusion. The submitted extrinsic hash is the blake2b-256 of
+/// its SCALE-encoded bytes, so we hash each pending extrinsic and look for a match.
+///
+/// - Hash found in the pool → still `pending`.
+/// - Hash absent → it has left the pool (included in a block) → `confirmed`.
+///
+/// Node RPC cannot replay an already-included extrinsic's events, so on-chain
+/// dispatch failures are not distinguished here; the node rejects malformed or
+/// invalid extrinsics at broadcast time (`author_submitExtrinsic`) instead.
 struct PolkadotTransactionStatusProvider: TransactionStatusProvider {
     private let httpClient: HTTPClientProtocol
 
@@ -21,98 +30,35 @@ struct PolkadotTransactionStatusProvider: TransactionStatusProvider {
 
     func checkStatus(query: TransactionStatusQuery) async throws -> TransactionStatusResult {
         let response = try await httpClient.request(
-            PolkadotTransactionStatusAPI.getExtrinsicByHash(extrinsicHash: query.txHash),
+            PolkadotTransactionStatusAPI.pendingExtrinsics,
             responseType: PolkadotTransactionStatusResponse.self
+        ).data
+
+        if let error = response.error {
+            throw RpcServiceError.rpcError(code: error.code, message: error.message)
+        }
+
+        let pendingExtrinsics = response.result ?? []
+        let targetHash = query.txHash.stripHexPrefix().lowercased()
+
+        let isPending = pendingExtrinsics.contains { extrinsic in
+            extrinsicHash(forHex: extrinsic) == targetHash
+        }
+
+        return TransactionStatusResult(
+            status: isPending ? .pending : .confirmed,
+            blockNumber: nil,
+            confirmations: nil
         )
-
-        return processResponse(response: response.data)
     }
 
-    /// Process Subscan API response
-    private func processResponse(response: PolkadotTransactionStatusResponse) -> TransactionStatusResult {
-        // Check API response code
-        if response.code != 0 {
-            // Non-zero code means transaction not found in Subscan
-            return TransactionStatusResult(
-                status: .notFound,
-                blockNumber: nil,
-                confirmations: nil
-            )
+    /// blake2b-256 of the SCALE-encoded extrinsic bytes, lowercased and without
+    /// the `0x` prefix — the same value `author_submitExtrinsic` returns as the
+    /// extrinsic hash. Returns `nil` for hex that cannot be decoded.
+    private func extrinsicHash(forHex hex: String) -> String? {
+        guard let bytes = Data(hexString: hex.stripHexPrefix()) else {
+            return nil
         }
-
-        // Check if extrinsic data exists
-        guard let extrinsicData = response.data else {
-            // code: 0 with data: null means transaction not indexed yet (pending)
-            return TransactionStatusResult(
-                status: .pending,
-                blockNumber: nil,
-                confirmations: nil
-            )
-        }
-
-        let blockNumber = extrinsicData.block_num
-
-        // CRITICAL: Check pending field first!
-        // pending=true means transaction is still being processed
-        if let pending = extrinsicData.pending, pending {
-            return TransactionStatusResult(
-                status: .pending,
-                blockNumber: blockNumber,
-                confirmations: nil
-            )
-        }
-
-        // Check if extrinsic is finalized (secondary check)
-        if let finalized = extrinsicData.finalized, !finalized {
-            return TransactionStatusResult(
-                status: .pending,
-                blockNumber: blockNumber,
-                confirmations: nil
-            )
-        }
-
-        // Now check success/failure (only after confirming it's not pending)
-        if extrinsicData.success {
-            return TransactionStatusResult(
-                status: .confirmed,
-                blockNumber: blockNumber,
-                confirmations: nil
-            )
-        } else {
-            // Only treat as failed if error exists or explicitly not pending
-            let failureReason = buildFailureReason(error: extrinsicData.error)
-            return TransactionStatusResult(
-                status: .failed(reason: failureReason),
-                blockNumber: blockNumber,
-                confirmations: nil
-            )
-        }
-    }
-
-    private func buildFailureReason(error: PolkadotTransactionStatusResponse.PolkadotExtrinsicError?) -> String {
-        guard let error = error else {
-            return "Transaction failed"
-        }
-
-        var reason = ""
-        if let module = error.module {
-            reason += module
-        }
-        if let name = error.name {
-            if !reason.isEmpty {
-                reason += "."
-            }
-            reason += name
-        }
-
-        if let doc = error.doc, !doc.isEmpty {
-            let docString = doc.joined(separator: " ")
-            if !reason.isEmpty {
-                reason += ": "
-            }
-            reason += docString
-        }
-
-        return reason.isEmpty ? "Transaction failed" : reason
+        return Hash.blake2b(data: bytes, size: 32).toHexString().lowercased()
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TargetType/PolkadotTransactionStatusAPI.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TargetType/PolkadotTransactionStatusAPI.swift
@@ -7,18 +7,22 @@
 
 import Foundation
 
-/// Polkadot Transaction Status API
-/// - Uses Subscan API format for AssetHub Polkadot
-/// - Endpoint: https://assethub-polkadot.api.subscan.io/api/scan/extrinsic
+/// Polkadot Asset Hub transaction status API.
+///
+/// Queries the Vultisig node RPC proxy (`https://api.vultisig.com/dot/`) — the
+/// same node `PolkadotService` broadcasts to — instead of an external indexer.
+/// `author_pendingExtrinsics` returns the extrinsics still sitting in the node's
+/// transaction pool, which is enough to tell a pending transfer from an included
+/// one without an API-key-gated indexer.
 enum PolkadotTransactionStatusAPI: TargetType {
-    case getExtrinsicByHash(extrinsicHash: String)
+    case pendingExtrinsics
 
     var baseURL: URL {
-        URL(string: Endpoint.polkadotTransactionStatusRpc)!
+        URL(string: Endpoint.polkadotServiceRpc)!
     }
 
     var path: String {
-        "api/scan/extrinsic"
+        ""
     }
 
     var method: HTTPMethod {
@@ -27,9 +31,12 @@ enum PolkadotTransactionStatusAPI: TargetType {
 
     var task: HTTPTask {
         switch self {
-        case .getExtrinsicByHash(let extrinsicHash):
+        case .pendingExtrinsics:
             let body: [String: Any] = [
-                "hash": extrinsicHash
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "author_pendingExtrinsics",
+                "params": []
             ]
             return .requestParameters(body, .jsonEncoding)
         }

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TargetType/PolkadotTransactionStatusAPI.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TargetType/PolkadotTransactionStatusAPI.swift
@@ -11,11 +11,11 @@ import Foundation
 ///
 /// Queries the Vultisig node RPC proxy (`https://api.vultisig.com/dot/`) — the
 /// same node `PolkadotService` broadcasts to — instead of an external indexer.
-/// `author_pendingExtrinsics` returns the extrinsics still sitting in the node's
-/// transaction pool, which is enough to tell a pending transfer from an included
-/// one without an API-key-gated indexer.
+/// Substrate nodes have no "get extrinsic by hash" RPC, so inclusion is proven
+/// by reading blocks (`chain_getBlock`) and matching the extrinsic hash; passing
+/// no block hash returns the current best-head block to start the walk from.
 enum PolkadotTransactionStatusAPI: TargetType {
-    case pendingExtrinsics
+    case getBlock(blockHash: String?)
 
     var baseURL: URL {
         URL(string: Endpoint.polkadotServiceRpc)!
@@ -31,12 +31,13 @@ enum PolkadotTransactionStatusAPI: TargetType {
 
     var task: HTTPTask {
         switch self {
-        case .pendingExtrinsics:
+        case .getBlock(let blockHash):
+            let params: [Any] = blockHash.map { [$0] } ?? []
             let body: [String: Any] = [
                 "jsonrpc": "2.0",
                 "id": 1,
-                "method": "author_pendingExtrinsics",
-                "params": []
+                "method": "chain_getBlock",
+                "params": params
             ]
             return .requestParameters(body, .jsonEncoding)
         }

--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -376,13 +376,9 @@ class Endpoint {
 
     static let suiServiceRpc = "https://sui-rpc.publicnode.com"
 
-    /// Polkadot RPC endpoint for JSON-RPC calls
+    /// Polkadot Asset Hub RPC endpoint for JSON-RPC calls (balance, broadcast,
+    /// transaction status via `author_pendingExtrinsics`).
     static let polkadotServiceRpc = "https://api.vultisig.com/dot/"
-
-    // Polkadot transaction status endpoint - AssetHub Polkadot (where DOT/USDT/USDC transactions happen)
-    // Using public Subscan API temporarily
-    // TODO: Switch to Vultisig proxy once ready: "https://api.vultisig.com/dot/"
-    static let polkadotTransactionStatusRpc = "https://assethub-polkadot.api.subscan.io"
 
     /// Bittensor RPC endpoint for JSON-RPC calls (nonce, blockHash, specVersion, etc.)
     static let bittensorServiceRpc = "https://bittensor-finney.api.onfinality.io/public"

--- a/VultisigApp/VultisigAppTests/Services/PolkadotTransactionStatusProviderTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/PolkadotTransactionStatusProviderTests.swift
@@ -1,0 +1,152 @@
+//
+//  PolkadotTransactionStatusProviderTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+/// Locks the Polkadot Asset Hub status logic against the node-RPC
+/// `author_pendingExtrinsics` pool check: an extrinsic still in the pool is
+/// pending, one that has left the pool is treated as confirmed. The match keys
+/// off blake2b-256 of the extrinsic bytes and is `0x`/case-insensitive.
+final class PolkadotTransactionStatusProviderTests: XCTestCase {
+
+    private var http: StubHTTPClient!
+    private var provider: PolkadotTransactionStatusProvider!
+
+    override func setUp() {
+        super.setUp()
+        http = StubHTTPClient()
+        provider = PolkadotTransactionStatusProvider(httpClient: http)
+    }
+
+    override func tearDown() {
+        http = nil
+        provider = nil
+        super.tearDown()
+    }
+
+    // Extrinsic bytes 0x0a0b0c0d and its blake2b-256 (the value the node returns
+    // as the extrinsic hash from `author_submitExtrinsic`).
+    private static let extrinsicHex = "0x0a0b0c0d"
+    private static let extrinsicHash = "0xcff0a3a65280d9d25957db5bf48473ccc86a6ddfb1492797ac6c8f8de635e72a"
+
+    private static func query(txHash: String) -> TransactionStatusQuery {
+        TransactionStatusQuery(txHash: txHash, chain: .polkadot)
+    }
+
+    // MARK: - Pending (still in the pool)
+
+    func test_checkStatus_hashInPool_returnsPending() async throws {
+        http.queueDecoded(PolkadotTransactionStatusResponse(result: [Self.extrinsicHex], error: nil))
+        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
+        XCTAssertEqual(result.status, .pending)
+    }
+
+    func test_checkStatus_hashInPool_isPrefixAndCaseInsensitive() async throws {
+        http.queueDecoded(PolkadotTransactionStatusResponse(result: [Self.extrinsicHex], error: nil))
+        let noPrefixUpper = Self.extrinsicHash.stripHexPrefix().uppercased()
+        let result = try await provider.checkStatus(query: Self.query(txHash: noPrefixUpper))
+        XCTAssertEqual(result.status, .pending)
+    }
+
+    // MARK: - Confirmed (left the pool)
+
+    func test_checkStatus_hashNotInPool_returnsConfirmed() async throws {
+        http.queueDecoded(PolkadotTransactionStatusResponse(result: ["0xdeadbeef"], error: nil))
+        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
+        XCTAssertEqual(result.status, .confirmed)
+    }
+
+    func test_checkStatus_emptyPool_returnsConfirmed() async throws {
+        http.queueDecoded(PolkadotTransactionStatusResponse(result: [], error: nil))
+        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
+        XCTAssertEqual(result.status, .confirmed)
+    }
+
+    func test_checkStatus_nilResult_returnsConfirmed() async throws {
+        http.queueDecoded(PolkadotTransactionStatusResponse(result: nil, error: nil))
+        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
+        XCTAssertEqual(result.status, .confirmed)
+    }
+
+    // MARK: - RPC error
+
+    func test_checkStatus_rpcError_throws() async {
+        http.queueDecoded(PolkadotTransactionStatusResponse(
+            result: nil,
+            error: .init(code: -32000, message: "boom")
+        ))
+        do {
+            _ = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
+            XCTFail("Expected RPC error to propagate")
+        } catch let error as RpcServiceError {
+            if case .rpcError(let code, _) = error {
+                XCTAssertEqual(code, -32000)
+            } else {
+                XCTFail("Unexpected RpcServiceError variant: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}
+
+// MARK: - Test double
+
+private final class StubHTTPClient: HTTPClientProtocol {
+
+    private enum Queued {
+        case value(Any)
+        case error(Error)
+    }
+
+    private var pending: Queued?
+
+    func queueDecoded<T>(_ value: T) {
+        pending = .value(value)
+    }
+
+    func queueError(_ error: Error) {
+        pending = .error(error)
+    }
+
+    // swiftlint:disable async_without_await
+    func request(_: TargetType) async throws -> HTTPResponse<Data> {
+        throw HTTPError.invalidResponse
+    }
+
+    func request<T: Decodable>(
+        _: TargetType,
+        responseType _: T.Type
+    ) async throws -> HTTPResponse<T> {
+        guard let pending else {
+            XCTFail("StubHTTPClient called with no queued response")
+            throw HTTPError.invalidResponse
+        }
+        self.pending = nil
+
+        switch pending {
+        case .error(let error):
+            throw error
+        case .value(let raw):
+            guard let typed = raw as? T else {
+                XCTFail("Queued value type \(type(of: raw)) does not match \(T.self)")
+                throw HTTPError.invalidResponse
+            }
+            let stub = HTTPURLResponse(
+                url: URL(string: "https://test.local")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return HTTPResponse(data: typed, response: stub)
+        }
+    }
+
+    func requestEmpty(_: TargetType) async throws -> HTTPResponse<EmptyResponse> {
+        throw HTTPError.invalidResponse
+    }
+    // swiftlint:enable async_without_await
+}

--- a/VultisigApp/VultisigAppTests/Services/PolkadotTransactionStatusProviderTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/PolkadotTransactionStatusProviderTests.swift
@@ -6,10 +6,10 @@
 @testable import VultisigApp
 import XCTest
 
-/// Locks the Polkadot Asset Hub status logic against the node-RPC
-/// `author_pendingExtrinsics` pool check: an extrinsic still in the pool is
-/// pending, one that has left the pool is treated as confirmed. The match keys
-/// off blake2b-256 of the extrinsic bytes and is `0x`/case-insensitive.
+/// Locks the Polkadot Asset Hub status logic against the node-RPC block scan:
+/// the provider walks blocks from the head along `parentHash` and matches the
+/// blake2b-256 extrinsic hash. Found in a scanned block → confirmed; not found
+/// within the window → pending. Matching is `0x`/case-insensitive.
 final class PolkadotTransactionStatusProviderTests: XCTestCase {
 
     private var http: StubHTTPClient!
@@ -31,53 +31,67 @@ final class PolkadotTransactionStatusProviderTests: XCTestCase {
     // as the extrinsic hash from `author_submitExtrinsic`).
     private static let extrinsicHex = "0x0a0b0c0d"
     private static let extrinsicHash = "0xcff0a3a65280d9d25957db5bf48473ccc86a6ddfb1492797ac6c8f8de635e72a"
+    private static let otherExtrinsic = "0xdeadbeef"
 
     private static func query(txHash: String) -> TransactionStatusQuery {
         TransactionStatusQuery(txHash: txHash, chain: .polkadot)
     }
 
-    // MARK: - Pending (still in the pool)
-
-    func test_checkStatus_hashInPool_returnsPending() async throws {
-        http.queueDecoded(PolkadotTransactionStatusResponse(result: [Self.extrinsicHex], error: nil))
-        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
-        XCTAssertEqual(result.status, .pending)
+    private static func block(extrinsics: [String], parentHash: String) -> PolkadotTransactionStatusResponse {
+        PolkadotTransactionStatusResponse(
+            result: .init(block: .init(header: .init(parentHash: parentHash), extrinsics: extrinsics)),
+            error: nil
+        )
     }
 
-    func test_checkStatus_hashInPool_isPrefixAndCaseInsensitive() async throws {
-        http.queueDecoded(PolkadotTransactionStatusResponse(result: [Self.extrinsicHex], error: nil))
+    /// `chain_getBlock` returning a null result — the node has no block for the
+    /// requested hash, which ends the backward walk.
+    private static func emptyBlock() -> PolkadotTransactionStatusResponse {
+        PolkadotTransactionStatusResponse(result: nil, error: nil)
+    }
+
+    // MARK: - Confirmed (extrinsic found in a scanned block)
+
+    func test_checkStatus_extrinsicInHeadBlock_returnsConfirmed() async throws {
+        http.queue(Self.block(extrinsics: [Self.extrinsicHex], parentHash: "0xparent"))
+        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
+        XCTAssertEqual(result.status, .confirmed)
+    }
+
+    func test_checkStatus_extrinsicInParentBlock_returnsConfirmed() async throws {
+        // Head block doesn't contain it; the walk follows parentHash and finds it.
+        http.queue(Self.block(extrinsics: [Self.otherExtrinsic], parentHash: "0xparent1"))
+        http.queue(Self.block(extrinsics: [Self.extrinsicHex], parentHash: "0xparent2"))
+        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
+        XCTAssertEqual(result.status, .confirmed)
+    }
+
+    func test_checkStatus_matchIsPrefixAndCaseInsensitive() async throws {
+        http.queue(Self.block(extrinsics: [Self.extrinsicHex], parentHash: "0xparent"))
         let noPrefixUpper = Self.extrinsicHash.stripHexPrefix().uppercased()
         let result = try await provider.checkStatus(query: Self.query(txHash: noPrefixUpper))
+        XCTAssertEqual(result.status, .confirmed)
+    }
+
+    // MARK: - Pending (not found within the scanned window)
+
+    func test_checkStatus_notFoundBeforeWalkEnds_returnsPending() async throws {
+        // One block without the extrinsic, then the walk hits a null block (end).
+        http.queue(Self.block(extrinsics: [Self.otherExtrinsic], parentHash: "0xparent1"))
+        http.queue(Self.emptyBlock())
+        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
         XCTAssertEqual(result.status, .pending)
     }
 
-    // MARK: - Confirmed (left the pool)
-
-    func test_checkStatus_hashNotInPool_returnsConfirmed() async throws {
-        http.queueDecoded(PolkadotTransactionStatusResponse(result: ["0xdeadbeef"], error: nil))
-        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
-        XCTAssertEqual(result.status, .confirmed)
-    }
-
-    func test_checkStatus_emptyPool_returnsConfirmed() async throws {
-        http.queueDecoded(PolkadotTransactionStatusResponse(result: [], error: nil))
-        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
-        XCTAssertEqual(result.status, .confirmed)
-    }
-
-    func test_checkStatus_nilResult_returnsConfirmed() async throws {
-        http.queueDecoded(PolkadotTransactionStatusResponse(result: nil, error: nil))
-        let result = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
-        XCTAssertEqual(result.status, .confirmed)
+    func test_checkStatus_emptyHash_returnsNotFoundWithoutRequest() async throws {
+        let result = try await provider.checkStatus(query: Self.query(txHash: ""))
+        XCTAssertEqual(result.status, .notFound)
     }
 
     // MARK: - RPC error
 
     func test_checkStatus_rpcError_throws() async {
-        http.queueDecoded(PolkadotTransactionStatusResponse(
-            result: nil,
-            error: .init(code: -32000, message: "boom")
-        ))
+        http.queue(PolkadotTransactionStatusResponse(result: nil, error: .init(code: -32000, message: "boom")))
         do {
             _ = try await provider.checkStatus(query: Self.query(txHash: Self.extrinsicHash))
             XCTFail("Expected RPC error to propagate")
@@ -95,21 +109,15 @@ final class PolkadotTransactionStatusProviderTests: XCTestCase {
 
 // MARK: - Test double
 
+/// Minimal stub conforming to `HTTPClientProtocol`. Tests queue decoded values
+/// (FIFO) returned via the typed `request<T>` overload, since the provider's
+/// chain walk issues several `chain_getBlock` calls per check.
 private final class StubHTTPClient: HTTPClientProtocol {
 
-    private enum Queued {
-        case value(Any)
-        case error(Error)
-    }
+    private var pending: [Any] = []
 
-    private var pending: Queued?
-
-    func queueDecoded<T>(_ value: T) {
-        pending = .value(value)
-    }
-
-    func queueError(_ error: Error) {
-        pending = .error(error)
+    func queue<T>(_ value: T) {
+        pending.append(value)
     }
 
     // swiftlint:disable async_without_await
@@ -121,28 +129,23 @@ private final class StubHTTPClient: HTTPClientProtocol {
         _: TargetType,
         responseType _: T.Type
     ) async throws -> HTTPResponse<T> {
-        guard let pending else {
+        guard !pending.isEmpty else {
             XCTFail("StubHTTPClient called with no queued response")
             throw HTTPError.invalidResponse
         }
-        self.pending = nil
+        let raw = pending.removeFirst()
 
-        switch pending {
-        case .error(let error):
-            throw error
-        case .value(let raw):
-            guard let typed = raw as? T else {
-                XCTFail("Queued value type \(type(of: raw)) does not match \(T.self)")
-                throw HTTPError.invalidResponse
-            }
-            let stub = HTTPURLResponse(
-                url: URL(string: "https://test.local")!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return HTTPResponse(data: typed, response: stub)
+        guard let typed = raw as? T else {
+            XCTFail("Queued value type \(type(of: raw)) does not match \(T.self)")
+            throw HTTPError.invalidResponse
         }
+        let stub = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: typed, response: stub)
     }
 
     func requestEmpty(_: TargetType) async throws -> HTTPResponse<EmptyResponse> {


### PR DESCRIPTION
## Summary
- Subscan's `assethub-polkadot.api.subscan.io` endpoint now requires an API key, breaking Polkadot Asset Hub transaction-status checks.
- Switches status checks to the Vultisig node-RPC proxy `https://api.vultisig.com/dot/` — the same node `PolkadotService` already uses for balances and broadcasting (verified live as "Polkadot Asset Hub").
- A bare Substrate node doesn't index extrinsics by hash, so status is derived from the transaction pool via `author_pendingExtrinsics`: each pending extrinsic is blake2b-256 hashed (the value `author_submitExtrinsic` returns) and matched against the tx hash.
  - **In the pool** → `pending`
  - **Gone from the pool** (included in a block) → `confirmed`
- Removed the dead Subscan `polkadotTransactionStatusRpc` endpoint constant.

## Behavior note / tradeoff
Node RPC can't replay an already-included extrinsic's events, so on-chain dispatch *failures* are no longer distinguished (the previous Subscan path could surface a `failed` reason). The node still rejects malformed/invalid extrinsics at broadcast time via `author_submitExtrinsic`. Detecting post-inclusion failures would require block/event scanning — a heavier follow-up.

## Test Plan
- [x] Added `PolkadotTransactionStatusProviderTests` (6 cases: in-pool→pending, prefix/case-insensitive match, not-in-pool/empty/nil→confirmed, RPC error→throws) — all passing
- [x] SwiftLint passes (0 violations on changed files)
- [ ] Manual: send a Polkadot/DOT tx and confirm the status screen transitions pending → confirmed

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Polkadot transaction status: now verifies against node RPC block data to reduce false "not found"/"failed" results.

* **Tests**
  * Added tests covering confirmed/pending detection, case- and prefix-insensitive hash matching, empty-hash handling, and RPC error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->