### PR TITLE
fix(substrate): prefix locally computed tx hash with 0x

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Bittensor/Signing/BittensorHelper.swift
@@ -246,7 +246,10 @@ enum BittensorHelper {
             callData: callData
         )
 
-        let transactionHash = Hash.blake2b(data: extrinsic, size: 32).toHexString()
+        // Prefix with `0x` to match the hash the node returns from
+        // `author_submitExtrinsic`, so the locally computed hash stays
+        // consistent whichever device broadcasts (vs. gets the duplicate).
+        let transactionHash = "0x" + Hash.blake2b(data: extrinsic, size: 32).toHexString()
         return SignedTransactionResult(
             rawTransaction: extrinsic.hexString,
             transactionHash: transactionHash

--- a/VultisigApp/VultisigApp/Blockchain/Polkadot/Signing/Polkadot.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Polkadot/Signing/Polkadot.swift
@@ -154,7 +154,10 @@ enum PolkadotHelper {
                                                                              signatures: allSignatures,
                                                                              publicKeys: publicKeys)
         let output = try PolkadotSigningOutput(serializedBytes: compileWithSignature)
-        let transactionHash = Hash.blake2b(data: output.encoded, size: 32).toHexString()
+        // Prefix with `0x` to match the hash the node returns from
+        // `author_submitExtrinsic`, so the locally computed hash stays
+        // consistent whichever device broadcasts (vs. gets the duplicate).
+        let transactionHash = "0x" + Hash.blake2b(data: output.encoded, size: 32).toHexString()
         let result = SignedTransactionResult(rawTransaction: output.encoded.hexString,
                                              transactionHash: transactionHash)
         return result


### PR DESCRIPTION
## Summary
On the keysign **Done** screen, paired devices could display the transaction hash in different formats: `0x…` on one device and bare hex on the other.

**Root cause:** `txid` comes from two different sources depending on broadcast timing.
- The device that **broadcasts first** receives the hash from the node (`author_submitExtrinsic`), which is **`0x`-prefixed**.
- The other device gets a `"Transaction already broadcasted."` / "already imported" duplicate response, so `KeysignViewModel` falls back to the **locally computed** hash (`transactionType.transactionHash`).

For Polkadot and Bittensor that local hash was `Hash.blake2b(...).toHexString()` — **without** the `0x` prefix — so the two devices disagreed.

**Fix:** prefix the locally computed extrinsic hash with `0x` for both Substrate chains so it matches the node's format. Both devices now show `0x…` regardless of which one broadcast.

As a bonus this aligns the idempotency-guard lookup key (`transactionType.transactionHash`) with the stored `txid` (`0x…`), which were previously mismatched for these chains.

## Changes
- `Blockchain/Polkadot/Signing/Polkadot.swift`
- `Blockchain/Bittensor/Signing/BittensorHelper.swift`

## Test Plan
- [x] SwiftLint passes (0 violations on changed files)
- [x] `xcodebuild build` succeeds
- [ ] Manual: send a DOT (Polkadot Asset Hub) tx from a paired vault and confirm the hash on **both** the main and pair device Done screens starts with `0x` and matches
- [ ] Manual: repeat for a Bittensor (TAO) send

## Notes
The Polkadot transaction-status provider already strips the `0x` prefix before matching, so it is unaffected. No existing tests asserted the un-prefixed form.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction hash formatting for Bittensor and Polkadot blockchains to ensure consistency with blockchain network standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->