### PR TITLE
fix: replace dead kujira publicnode rest endpoints with polkachu

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosServiceConfig.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosServiceConfig.swift
@@ -43,7 +43,7 @@ struct CosmosServiceConfig {
         case .dydx:
             return URL(string: "https://dydx-rest.publicnode.com")
         case .kujira:
-            return URL(string: "https://kujira-rest.publicnode.com")
+            return URL(string: "https://kujira-api.polkachu.com")
         case .osmosis:
             return URL(string: "https://osmosis-rest.publicnode.com")
         case .terra:

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TargetType/CosmosTransactionStatusAPI.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TargetType/CosmosTransactionStatusAPI.swift
@@ -41,7 +41,7 @@ enum CosmosTransactionStatusAPI: TargetType {
         case .gaiaChain:
             return "https://cosmos-rest.publicnode.com"
         case .kujira:
-            return "https://kujira-rest.publicnode.com"
+            return "https://kujira-api.polkachu.com"
         case .osmosis:
             return "https://osmosis-rest.publicnode.com"
         case .terra:


### PR DESCRIPTION
Closes vultisig/vultisig-ios#4576

## what

Replace `kujira-rest.publicnode.com` with `kujira-api.polkachu.com` in the two places the iOS app configures Kujira's LCD/REST host. No RPC endpoint for Kujira was present in this repo.

## why

publicnode now returns HTTP 403 "unsupported platform" for all Kujira REST requests, breaking KUJI balance reads and tx-status lookups. Polkachu is the same provider Noble already uses in this codebase and the one the vultisig-sdk's `getCosmosAccountInfo` targets for Kujira - same paths, drop-in replacement.

## receipts

**Dead endpoint (publicnode) - HTTP 403:**
```
$ curl -s -o /dev/null -w "%{http_code}\n" \
  "https://kujira-rest.publicnode.com/cosmos/bank/v1beta1/balances/kujira18c8ca2h8a3pcwc5j0vd26kfwl2fch5xl8tdxmk"
403
```

**New endpoint (polkachu) - HTTP 200 with balance:**
```
$ curl -s "https://kujira-api.polkachu.com/cosmos/bank/v1beta1/balances/kujira18c8ca2h8a3pcwc5j0vd26kfwl2fch5xl8tdxmk"
{"balances":[{"denom":"ukuji","amount":"195561951"}],"pagination":{"next_key":null,"total":"1"}}
```

🤖 Agent-generated