### PR TITLE
fix(custom-rpc): restyle locked feature sheet to new Figma design (stays Silver tier)

### DIFF
--- a/VultisigApp/VultisigApp/Assets.xcassets/Icons/signal-tower.imageset/Contents.json
+++ b/VultisigApp/VultisigApp/Assets.xcassets/Icons/signal-tower.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "signal-tower.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/VultisigApp/VultisigApp/Assets.xcassets/Icons/signal-tower.imageset/signal-tower.svg
+++ b/VultisigApp/VultisigApp/Assets.xcassets/Icons/signal-tower.imageset/signal-tower.svg
@@ -1,0 +1,7 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 8.95898C10.6904 8.95898 11.25 8.39934 11.25 7.70898C11.25 7.01863 10.6904 6.45898 10 6.45898C9.30964 6.45898 8.75 7.01863 8.75 7.70898C8.75 8.39934 9.30964 8.95898 10 8.95898Z" stroke="#4879FD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.45831 17.709L9.79165 7.70898H10.2083L13.5416 17.709" stroke="#4879FD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.91669 14.791H12.0834" stroke="#4879FD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.46413 10.6244C5.06754 8.93552 5.06754 6.48001 6.46413 4.79102M13.5359 4.79102C14.9325 6.48001 14.9325 8.93552 13.5359 10.6244" stroke="#4879FD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.22076 2.29718C1.36902 5.33954 1.37083 10.0842 4.22619 13.1243M15.7734 2.29102C18.631 5.33312 18.6311 10.0821 15.7737 13.1243" stroke="#4879FD" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -284,6 +284,14 @@
 "customRPCReachable" = "Erreichbar · %d ms";
 "customRPCReachableUnverified" = "Erreichbar · %d ms — Netzwerkidentität nicht verifiziert";
 "customRPCResetToDefault" = "Auf Standard zurücksetzen";
+"customRPCsLockedBack" = "Zurück";
+"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedRequires" = "Erforderlich";
+"customRPCsLockedSubtitle" = "Richte Vultisig auf deine eigenen Nodes aus. Schnellere Abfragen, höhere Ratenlimits und volle Privatsphäre pro Chain.";
+"customRPCsLockedTierRequirement" = "$VULT %@ Tier oder höher";
+"customRPCsLockedTierSubtitle" = "Halte mindestens %@ in deinem Tresor";
+"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedYourBalance" = "Dein Guthaben";
 "customRPCTagCustom" = "eigen";
 "customRPCTagDefault" = "standard";
 "customRPCTest" = "Testen";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -285,12 +285,12 @@
 "customRPCReachableUnverified" = "Erreichbar · %d ms — Netzwerkidentität nicht verifiziert";
 "customRPCResetToDefault" = "Auf Standard zurücksetzen";
 "customRPCsLockedBack" = "Zurück";
-"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedGetVult" = "$VULT holen";
 "customRPCsLockedRequires" = "Erforderlich";
 "customRPCsLockedSubtitle" = "Richte Vultisig auf deine eigenen Nodes aus. Schnellere Abfragen, höhere Ratenlimits und volle Privatsphäre pro Chain.";
-"customRPCsLockedTierRequirement" = "$VULT %@ Tier oder höher";
+"customRPCsLockedTierRequirement" = "$VULT %@ Stufe oder höher";
 "customRPCsLockedTierSubtitle" = "Halte mindestens %@ in deinem Tresor";
-"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedTitle" = "Eigene RPCs";
 "customRPCsLockedYourBalance" = "Dein Guthaben";
 "customRPCTagCustom" = "eigen";
 "customRPCTagDefault" = "standard";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -286,6 +286,14 @@
 "customRPCReachable" = "Reachable · %d ms";
 "customRPCReachableUnverified" = "Reachable · %d ms — network identity not verified";
 "customRPCResetToDefault" = "Reset to default";
+"customRPCsLockedBack" = "Back";
+"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedRequires" = "Requires";
+"customRPCsLockedSubtitle" = "Point Vultisig at your own nodes. Faster queries, higher rate limits, and full privacy per chain.";
+"customRPCsLockedTierRequirement" = "$VULT %@ Tier or above";
+"customRPCsLockedTierSubtitle" = "Hold at least %@ in your vault";
+"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedYourBalance" = "Your balance";
 "customRPCTagCustom" = "custom";
 "customRPCTagDefault" = "default";
 "customRPCTest" = "Test";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -285,12 +285,12 @@
 "customRPCReachableUnverified" = "Accesible · %d ms — identidad de red no verificada";
 "customRPCResetToDefault" = "Restablecer a predeterminado";
 "customRPCsLockedBack" = "Atrás";
-"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedGetVult" = "Obtén $VULT";
 "customRPCsLockedRequires" = "Requiere";
 "customRPCsLockedSubtitle" = "Apunta Vultisig a tus propios nodos. Consultas más rápidas, mayores límites de tasa y privacidad total por cadena.";
-"customRPCsLockedTierRequirement" = "$VULT %@ Tier o superior";
+"customRPCsLockedTierRequirement" = "$VULT %@ Nivel o superior";
 "customRPCsLockedTierSubtitle" = "Mantén al menos %@ en tu bóveda";
-"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedTitle" = "RPCs personalizados";
 "customRPCsLockedYourBalance" = "Tu saldo";
 "customRPCTagCustom" = "personalizado";
 "customRPCTagDefault" = "predeterminado";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -284,6 +284,14 @@
 "customRPCReachable" = "Accesible · %d ms";
 "customRPCReachableUnverified" = "Accesible · %d ms — identidad de red no verificada";
 "customRPCResetToDefault" = "Restablecer a predeterminado";
+"customRPCsLockedBack" = "Atrás";
+"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedRequires" = "Requiere";
+"customRPCsLockedSubtitle" = "Apunta Vultisig a tus propios nodos. Consultas más rápidas, mayores límites de tasa y privacidad total por cadena.";
+"customRPCsLockedTierRequirement" = "$VULT %@ Tier o superior";
+"customRPCsLockedTierSubtitle" = "Mantén al menos %@ en tu bóveda";
+"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedYourBalance" = "Tu saldo";
 "customRPCTagCustom" = "personalizado";
 "customRPCTagDefault" = "predeterminado";
 "customRPCTest" = "Probar";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -285,12 +285,12 @@
 "customRPCReachableUnverified" = "Dostupno · %d ms — mrežni identitet nije potvrđen";
 "customRPCResetToDefault" = "Vrati na zadano";
 "customRPCsLockedBack" = "Natrag";
-"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedGetVult" = "Nabavi $VULT";
 "customRPCsLockedRequires" = "Zahtijeva";
 "customRPCsLockedSubtitle" = "Usmjeri Vultisig na vlastite čvorove. Brži upiti, viša ograničenja i potpuna privatnost po lancu.";
 "customRPCsLockedTierRequirement" = "$VULT %@ razina ili viša";
 "customRPCsLockedTierSubtitle" = "Drži barem %@ u svom trezoru";
-"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedTitle" = "Prilagođeni RPC-ovi";
 "customRPCsLockedYourBalance" = "Tvoj saldo";
 "customRPCTagCustom" = "prilagođeno";
 "customRPCTagDefault" = "zadano";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -284,6 +284,14 @@
 "customRPCReachable" = "Dostupno · %d ms";
 "customRPCReachableUnverified" = "Dostupno · %d ms — mrežni identitet nije potvrđen";
 "customRPCResetToDefault" = "Vrati na zadano";
+"customRPCsLockedBack" = "Natrag";
+"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedRequires" = "Zahtijeva";
+"customRPCsLockedSubtitle" = "Usmjeri Vultisig na vlastite čvorove. Brži upiti, viša ograničenja i potpuna privatnost po lancu.";
+"customRPCsLockedTierRequirement" = "$VULT %@ razina ili viša";
+"customRPCsLockedTierSubtitle" = "Drži barem %@ u svom trezoru";
+"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedYourBalance" = "Tvoj saldo";
 "customRPCTagCustom" = "prilagođeno";
 "customRPCTagDefault" = "zadano";
 "customRPCTest" = "Testiraj";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -284,6 +284,14 @@
 "customRPCReachable" = "Raggiungibile · %d ms";
 "customRPCReachableUnverified" = "Raggiungibile · %d ms — identità di rete non verificata";
 "customRPCResetToDefault" = "Ripristina predefinito";
+"customRPCsLockedBack" = "Indietro";
+"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedRequires" = "Richiede";
+"customRPCsLockedSubtitle" = "Punta Vultisig sui tuoi nodi. Query più veloci, limiti più alti e piena privacy per ogni catena.";
+"customRPCsLockedTierRequirement" = "$VULT %@ Tier o superiore";
+"customRPCsLockedTierSubtitle" = "Detieni almeno %@ nella tua cassaforte";
+"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedYourBalance" = "Il tuo saldo";
 "customRPCTagCustom" = "personalizzato";
 "customRPCTagDefault" = "predefinito";
 "customRPCTest" = "Test";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -285,12 +285,12 @@
 "customRPCReachableUnverified" = "Raggiungibile · %d ms — identità di rete non verificata";
 "customRPCResetToDefault" = "Ripristina predefinito";
 "customRPCsLockedBack" = "Indietro";
-"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedGetVult" = "Ottieni $VULT";
 "customRPCsLockedRequires" = "Richiede";
 "customRPCsLockedSubtitle" = "Punta Vultisig sui tuoi nodi. Query più veloci, limiti più alti e piena privacy per ogni catena.";
-"customRPCsLockedTierRequirement" = "$VULT %@ Tier o superiore";
+"customRPCsLockedTierRequirement" = "$VULT %@ livello o superiore";
 "customRPCsLockedTierSubtitle" = "Detieni almeno %@ nella tua cassaforte";
-"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedTitle" = "RPC personalizzati";
 "customRPCsLockedYourBalance" = "Il tuo saldo";
 "customRPCTagCustom" = "personalizzato";
 "customRPCTagDefault" = "predefinito";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -279,6 +279,14 @@
 "customRPCReachable" = "연결 가능 · %d ms";
 "customRPCReachableUnverified" = "연결 가능 · %d ms — 네트워크 신원 미확인";
 "customRPCResetToDefault" = "기본값으로 재설정";
+"customRPCsLockedBack" = "뒤로";
+"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedRequires" = "필요 조건";
+"customRPCsLockedSubtitle" = "Vultisig를 직접 운영하는 노드로 연결하세요. 더 빠른 조회, 더 높은 속도 제한, 체인별 완전한 프라이버시.";
+"customRPCsLockedTierRequirement" = "$VULT %@ 등급 이상";
+"customRPCsLockedTierSubtitle" = "볼트에 최소 %@ 보유";
+"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedYourBalance" = "내 잔액";
 "customRPCTagCustom" = "사용자 지정";
 "customRPCTagDefault" = "기본";
 "customRPCTest" = "테스트";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -280,12 +280,12 @@
 "customRPCReachableUnverified" = "연결 가능 · %d ms — 네트워크 신원 미확인";
 "customRPCResetToDefault" = "기본값으로 재설정";
 "customRPCsLockedBack" = "뒤로";
-"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedGetVult" = "$VULT 받기";
 "customRPCsLockedRequires" = "필요 조건";
 "customRPCsLockedSubtitle" = "Vultisig를 직접 운영하는 노드로 연결하세요. 더 빠른 조회, 더 높은 속도 제한, 체인별 완전한 프라이버시.";
 "customRPCsLockedTierRequirement" = "$VULT %@ 등급 이상";
 "customRPCsLockedTierSubtitle" = "볼트에 최소 %@ 보유";
-"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedTitle" = "사용자 지정 RPC";
 "customRPCsLockedYourBalance" = "내 잔액";
 "customRPCTagCustom" = "사용자 지정";
 "customRPCTagDefault" = "기본";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -284,6 +284,14 @@
 "customRPCReachable" = "Acessível · %d ms";
 "customRPCReachableUnverified" = "Acessível · %d ms — identidade de rede não verificada";
 "customRPCResetToDefault" = "Repor predefinição";
+"customRPCsLockedBack" = "Voltar";
+"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedRequires" = "Requer";
+"customRPCsLockedSubtitle" = "Aponte o Vultisig para os seus próprios nós. Consultas mais rápidas, limites maiores e total privacidade por cadeia.";
+"customRPCsLockedTierRequirement" = "$VULT %@ Tier ou superior";
+"customRPCsLockedTierSubtitle" = "Mantenha pelo menos %@ no seu cofre";
+"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedYourBalance" = "Seu saldo";
 "customRPCTagCustom" = "personalizado";
 "customRPCTagDefault" = "padrão";
 "customRPCTest" = "Testar";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -285,12 +285,12 @@
 "customRPCReachableUnverified" = "Acessível · %d ms — identidade de rede não verificada";
 "customRPCResetToDefault" = "Repor predefinição";
 "customRPCsLockedBack" = "Voltar";
-"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedGetVult" = "Obter $VULT";
 "customRPCsLockedRequires" = "Requer";
 "customRPCsLockedSubtitle" = "Aponte o Vultisig para os seus próprios nós. Consultas mais rápidas, limites maiores e total privacidade por cadeia.";
-"customRPCsLockedTierRequirement" = "$VULT %@ Tier ou superior";
+"customRPCsLockedTierRequirement" = "$VULT %@ nível ou superior";
 "customRPCsLockedTierSubtitle" = "Mantenha pelo menos %@ no seu cofre";
-"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedTitle" = "RPCs personalizados";
 "customRPCsLockedYourBalance" = "Seu saldo";
 "customRPCTagCustom" = "personalizado";
 "customRPCTagDefault" = "padrão";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -285,12 +285,12 @@
 "customRPCReachableUnverified" = "可访问 · %d ms — 网络身份未验证";
 "customRPCResetToDefault" = "重置为默认";
 "customRPCsLockedBack" = "返回";
-"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedGetVult" = "获取 $VULT";
 "customRPCsLockedRequires" = "需要";
 "customRPCsLockedSubtitle" = "将 Vultisig 指向您自己的节点。每条链上更快的查询、更高的速率限制和完全的隐私。";
 "customRPCsLockedTierRequirement" = "$VULT %@ 等级或以上";
 "customRPCsLockedTierSubtitle" = "在您的金库中持有至少 %@";
-"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedTitle" = "自定义 RPC";
 "customRPCsLockedYourBalance" = "您的余额";
 "customRPCTagCustom" = "自定义";
 "customRPCTagDefault" = "默认";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -284,6 +284,14 @@
 "customRPCReachable" = "可访问 · %d ms";
 "customRPCReachableUnverified" = "可访问 · %d ms — 网络身份未验证";
 "customRPCResetToDefault" = "重置为默认";
+"customRPCsLockedBack" = "返回";
+"customRPCsLockedGetVult" = "Get $VULT";
+"customRPCsLockedRequires" = "需要";
+"customRPCsLockedSubtitle" = "将 Vultisig 指向您自己的节点。每条链上更快的查询、更高的速率限制和完全的隐私。";
+"customRPCsLockedTierRequirement" = "$VULT %@ 等级或以上";
+"customRPCsLockedTierSubtitle" = "在您的金库中持有至少 %@";
+"customRPCsLockedTitle" = "Custom RPCs";
+"customRPCsLockedYourBalance" = "您的余额";
 "customRPCTagCustom" = "自定义";
 "customRPCTagDefault" = "默认";
 "customRPCTest" = "测试";

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
@@ -19,6 +19,8 @@ struct SettingsMainScreen: View {
     @State var showReferralBannerSheet = false
     @State private var customRPCTierSheet: VultDiscountTier?
 
+    private let tierService = VultTierService()
+
     var groups: [SettingsOptionGroup] {
         var generalOptions: [SettingsOption] = [
             .notifications,
@@ -102,7 +104,23 @@ struct SettingsMainScreen: View {
                 showReferralBannerSheet = false
             }.presentationDetents([.height(400)])
         }
-        .tierGated(presentedTier: $customRPCTierSheet, vault: vault)
+        .crossPlatformSheet(item: $customRPCTierSheet) { tier in
+            CustomRPCLockedSheet(
+                vault: vault,
+                requiredTier: tier,
+                isPresented: Binding(
+                    get: { customRPCTierSheet != nil },
+                    set: { _ in customRPCTierSheet = nil }
+                )
+            ) {
+                customRPCTierSheet = nil
+                router.navigate(to: VaultRoute.swap(
+                    fromCoin: vault.nativeCoin(for: .ethereum),
+                    toCoin: tierService.getVultToken(for: vault),
+                    vault: vault
+                ))
+            }
+        }
     }
 
     func groupView(for group: SettingsOptionGroup) -> some View {

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/CustomRPCLockedSheet.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/CustomRPCLockedSheet.swift
@@ -1,0 +1,169 @@
+//
+//  CustomRPCLockedSheet.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Locked-state feature sheet for Custom RPCs, shown to vaults below the
+/// required tier. Presents the requirement and a path to unlock, sourcing the
+/// tier, threshold, and balance comparison from the tier system.
+struct CustomRPCLockedSheet: View {
+    @ObservedObject var vault: Vault
+    @Binding var isPresented: Bool
+    var onGetVult: () -> Void
+
+    @StateObject private var viewModel: CustomRPCLockedSheetViewModel
+    @State private var width: CGFloat = 0
+
+    init(
+        vault: Vault,
+        requiredTier: VultDiscountTier,
+        isPresented: Binding<Bool>,
+        onGetVult: @escaping () -> Void
+    ) {
+        self.vault = vault
+        self._isPresented = isPresented
+        self.onGetVult = onGetVult
+        self._viewModel = StateObject(
+            wrappedValue: CustomRPCLockedSheetViewModel(requiredTier: requiredTier)
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            header
+            requiresCard
+            buttons
+        }
+        .padding(.top, 40)
+        .padding(.horizontal, 24)
+        .padding(.bottom, 24)
+        #if os(macOS)
+        .applySheetSize(400, 540)
+        #endif
+        .background(ModalBackgroundView(width: width))
+        .presentationBackground(Theme.colors.bgSurface1)
+        .presentationDetents([.height(540)])
+        .presentationDragIndicator(.visible)
+        .readSize { width = $0.width }
+        .task { await viewModel.loadBalance(for: vault) }
+    }
+
+    private var header: some View {
+        VStack(spacing: 32) {
+            iconBadge
+            VStack(spacing: 16) {
+                Text("customRPCsLockedTitle".localized)
+                    .font(Theme.fonts.title2)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .multilineTextAlignment(.center)
+                Text("customRPCsLockedSubtitle".localized)
+                    .font(Theme.fonts.bodySRegular)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+
+    private var iconBadge: some View {
+        Icon(named: "signal-tower", color: Theme.colors.primaryAccent4, size: 20)
+            .frame(width: 40, height: 40)
+            .background(Theme.colors.primaryAccent4.opacity(0.12))
+            .clipShape(Circle())
+            .overlay(
+                Circle().stroke(Theme.colors.primaryAccent4.opacity(0.5), lineWidth: 1)
+            )
+    }
+
+    private var requiresCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("customRPCsLockedRequires".localized)
+                .font(Theme.fonts.priceFootnote)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 12) {
+                VultDiscountTierIcon(tier: viewModel.requiredTier, size: .small)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(
+                        String(
+                            format: "customRPCsLockedTierRequirement".localized,
+                            viewModel.requiredTier.name.localized
+                        )
+                    )
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    Text(
+                        String(
+                            format: "customRPCsLockedTierSubtitle".localized,
+                            viewModel.thresholdText
+                        )
+                    )
+                    .font(Theme.fonts.priceFootnote)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                }
+                Spacer(minLength: 0)
+            }
+
+            balanceRow
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Theme.colors.bgSurface1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+    }
+
+    private var balanceRow: some View {
+        HStack(spacing: 6) {
+            HStack(spacing: 6) {
+                Icon(named: "wallet-4", color: Theme.colors.textTertiary, size: 16)
+                Text("customRPCsLockedYourBalance".localized)
+                    .font(Theme.fonts.priceFootnote)
+                    .foregroundStyle(Theme.colors.textTertiary)
+            }
+            Spacer(minLength: 0)
+            Text(viewModel.balanceText)
+                .font(Theme.fonts.priceFootnote)
+                .foregroundStyle(
+                    viewModel.isBelowThreshold
+                        ? Theme.colors.alertWarning
+                        : Theme.colors.textPrimary
+                )
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Theme.colors.bgSurface12)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+    }
+
+    private var buttons: some View {
+        VStack(spacing: 12) {
+            PrimaryButton(title: "customRPCsLockedGetVult".localized) {
+                onGetVult()
+            }
+            PrimaryButton(title: "customRPCsLockedBack".localized, type: .secondary) {
+                isPresented = false
+            }
+        }
+    }
+}
+
+#Preview {
+    CustomRPCLockedSheet(
+        vault: .example,
+        requiredTier: .silver,
+        isPresented: .constant(true)
+    ) {}
+}

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/ViewModel/CustomRPCLockedSheetViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/ViewModel/CustomRPCLockedSheetViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  CustomRPCLockedSheetViewModel.swift
+//  VultisigApp
+//
+
+import Foundation
+import SwiftUI
+
+/// Drives the Custom RPCs locked feature sheet: resolves the live $VULT balance
+/// for the vault and exposes whether it clears the required tier threshold.
+///
+/// The required tier, its threshold amount, and the balance comparison are all
+/// sourced from the existing tier system (`VultDiscountTier` / `VultTierService`)
+/// — never from the design mock.
+@MainActor
+final class CustomRPCLockedSheetViewModel: ObservableObject {
+    /// The minimum tier the locked feature requires. Sourced from the gate, not
+    /// the design mock.
+    let requiredTier: VultDiscountTier
+
+    /// Live $VULT balance held by the vault, refreshed on appear.
+    @Published private(set) var balance: Decimal = 0
+
+    private let service: VultTierService
+
+    init(requiredTier: VultDiscountTier, service: VultTierService = VultTierService()) {
+        self.requiredTier = requiredTier
+        self.service = service
+    }
+
+    /// The $VULT amount required to reach `requiredTier`, from the tier config.
+    var threshold: Decimal {
+        requiredTier.balanceToUnlock
+    }
+
+    /// `true` when the vault's balance is below the required tier threshold —
+    /// drives the warning color on the balance row.
+    var isBelowThreshold: Bool {
+        Self.isBelow(balance: balance, threshold: threshold)
+    }
+
+    /// Pure threshold comparison: `true` when `balance` is strictly below
+    /// `threshold`. Extracted so the warning-state logic is testable without a
+    /// live balance fetch.
+    static func isBelow(balance: Decimal, threshold: Decimal) -> Bool {
+        balance < threshold
+    }
+
+    var thresholdText: String {
+        "\(threshold.formatForDisplay(skipAbbreviation: true)) VULT"
+    }
+
+    var balanceText: String {
+        "\(balance.formatForDisplay(skipAbbreviation: true)) VULT"
+    }
+
+    func loadBalance(for vault: Vault) async {
+        balance = service.getVultToken(for: vault)?.balanceDecimal ?? 0
+        _ = await service.fetchDiscountTier(for: vault, cached: false)
+        balance = service.getVultToken(for: vault)?.balanceDecimal ?? 0
+    }
+}

--- a/VultisigApp/VultisigAppTests/Features/CustomRPCLockedSheetViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/CustomRPCLockedSheetViewModelTests.swift
@@ -1,0 +1,44 @@
+//
+//  CustomRPCLockedSheetViewModelTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class CustomRPCLockedSheetViewModelTests: XCTestCase {
+
+    func test_threshold_comesFromTierConfig_notMock() {
+        // The Figma mock labels this Gold / 7,500 VULT — the sheet must source
+        // the threshold from the tier system instead. Custom RPC stays Silver.
+        let viewModel = CustomRPCLockedSheetViewModel(requiredTier: .silver)
+        XCTAssertEqual(viewModel.requiredTier, .silver)
+        XCTAssertEqual(viewModel.threshold, VultDiscountTier.silver.balanceToUnlock)
+        XCTAssertEqual(viewModel.threshold, 3_000)
+        XCTAssertNotEqual(viewModel.threshold, 7_500)
+    }
+
+    func test_isBelow_trueWhenBalanceUnderThreshold() {
+        XCTAssertTrue(
+            CustomRPCLockedSheetViewModel.isBelow(balance: 2_340, threshold: 3_000)
+        )
+    }
+
+    func test_isBelow_falseWhenBalanceAtThreshold() {
+        XCTAssertFalse(
+            CustomRPCLockedSheetViewModel.isBelow(balance: 3_000, threshold: 3_000)
+        )
+    }
+
+    func test_isBelow_falseWhenBalanceAboveThreshold() {
+        XCTAssertFalse(
+            CustomRPCLockedSheetViewModel.isBelow(balance: 5_000, threshold: 3_000)
+        )
+    }
+
+    func test_isBelowThreshold_defaultsTrueWithZeroBalance() {
+        let viewModel = CustomRPCLockedSheetViewModel(requiredTier: .silver)
+        XCTAssertTrue(viewModel.isBelowThreshold)
+    }
+}


### PR DESCRIPTION
Closes #4575

Restyles the iOS **Custom RPCs locked feature sheet** (shown to vaults below the required tier) to the new Figma design — node `77059:110340`, sheet `77085:74129` (`Custom RPCs Locked`).

## ⚠️ Tier stays Silver — Figma's tier values are NOT followed
The Figma mock labels this "Gold Tier / 7,500 VULT". That is **ignored**. Custom RPC remains gated at **Silver** (per #4458). Only the visual design is applied. The required tier (`.silver`), the threshold (`VultDiscountTier.silver.balanceToUnlock` = 3,000 VULT), and the balance comparison are sourced from the existing tier system (`VultDiscountTier` / `VultTierService`) — never hardcoded from the mock. Pinned by `test_threshold_comesFromTierConfig_notMock` (asserts threshold == 3,000, ≠ 7,500).

## What changed
New Figma-styled sheet:
- **Icon**: `signal-tower` (exported from the Figma `IconSignalTower` component) in a circular accent badge.
- **Title** "Custom RPCs" (22 → `Theme.fonts.title2`) + **subtitle** (`bodySRegular`).
- **"Requires" card**: the **Silver** tier badge (`VultDiscountTierIcon(tier: .silver, size: .small)`), `$VULT Silver Tier or above`, requirement subtitle with the **Silver** threshold from tier config, and a **Your balance** row showing the **live $VULT balance** — colored `Theme.colors.alertWarning` (`#FFC25C`, the issue's one specified exception) when below the threshold.
- **Buttons**: primary `Get $VULT` (wired to the buy-VULT swap, same nav as the old `TierGatedModifier`) · secondary `Back` (dismisses).
- Presented as an iOS sheet (grabber, rounded top corners, dimmed backdrop) via `crossPlatformSheet`.

## Shared-sheet decision
The old locked sheet `VultDiscountTierBottomSheet` is presented by the shared `.tierGated(...)` modifier at **two** call sites: the Custom RPC settings row **and** `VultDiscountTiersScreen` (which presents the upsell for *any* tier the user taps). The new design is **Custom-RPC-specific**.

**Decision: add a NEW dedicated `CustomRPCLockedSheet`; do NOT restyle the shared sheet.** Making the shared sheet look completely different for one feature would bloat it and risk regressing the generic discount-tiers screen. So `SettingsMainScreen`'s Custom RPC locked branch now presents `CustomRPCLockedSheet` (reusing the same `TierGatedTap.handle` decision logic), while `VultDiscountTiersScreen` keeps `.tierGated` / `VultDiscountTierBottomSheet` **unchanged**. The at/above-Silver path is untouched — the row still opens the real Custom RPC settings (#4458 behavior).

## Files
- New: `Features/VultDiscountTiers/View/CustomRPCLockedSheet.swift`, `Features/VultDiscountTiers/ViewModel/CustomRPCLockedSheetViewModel.swift`, `Assets.xcassets/Icons/signal-tower.imageset/`, `VultisigAppTests/Features/CustomRPCLockedSheetViewModelTests.swift`.
- Edited: `Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift`, 8 locale files (`customRPCsLocked*` keys).

## Type token mapping (Figma → Theme)
| Figma | Token |
|---|---|
| Title 22/Title2 | `Theme.fonts.title2` |
| Subtitle 14 | `Theme.fonts.bodySRegular` |
| "Requires" / tier subtitle / balance 13 (Satoshi) | `Theme.fonts.priceFootnote` |
| Tier row title 14 | `Theme.fonts.bodySMedium` |
| Warning balance color `#FFC25C` | `Theme.colors.alertWarning` |

## Gate
- **Build**: `make build-check` → `** BUILD SUCCEEDED **`
- **Lint**: `swiftlint` → 0 violations on changed files
- **Tests**: 7/7 pass (5 new `CustomRPCLockedSheetViewModelTests` + 2 `TierGatedTapTests`) → `** TEST SUCCEEDED **`

## iOS only
No Android/Windows changes.

## Needs human eyes
On-device / simulator visual Figma-parity check (sheet height detent, badge glow, card spacing). The Figma badge shows a gold/warning border around the tier icon; this PR uses the **Silver** `VultDiscountTierIcon` per the hard tier constraint, so the badge intentionally reads silver, not gold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Custom RPCs” locked-state sheet showing tier requirements and your balance (with visual below/at/above threshold indication).
  * Improved the Settings flow to route users from the locked prompt to the tier-resolved token swap path.

* **Localization**
  * Added new localized strings for the Custom RPCs locked UI in German, English, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.

* **Bug Fixes**
  * Fixed the balance/requirement messaging to use up-to-date tier configuration.

* **Tests**
  * Added unit tests covering locked-state tier and threshold logic.

* **Chores**
  * Added the signal tower icon asset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->