### PR TITLE
fix(cardano): enforce 1.4 ADA minimum send amount

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "cacaoUnstakeMaturityUnknownMessage" = "Einzahlungsreife konnte nicht überprüft werden. Bitte später erneut versuchen.";
 "cancel" = "Abbrechen";
 "canLoseFundsPrompt" = "Mir ist bewusst, dass ich Geld verlieren kann";
+"cardanoMinimumSendAmountError" = "Der Mindestsendebetrag beträgt %@ ADA. Cardano benötigt dies, damit das Netzwerk deine Transaktion nicht verwirft.";
 "cardanoOutputBelowMinAda" = "Nicht genug ADA, um die Netzwerkgebühr und Cardanos Mindest-UTXO-Anforderung (~1,4 ADA pro Output) zu decken. Sende zuerst mehr ADA in dieses Vault.";
 "chain" = "Blockchain";
 "chainNotAdded" = "Blockchain nicht hinzugefügt";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -143,6 +143,7 @@
 "cacaoUnstakeMaturityUnknownMessage" = "Couldn't verify deposit maturity. Try again later.";
 "cancel" = "Cancel";
 "canLoseFundsPrompt" = "I am aware that I can lose funds";
+"cardanoMinimumSendAmountError" = "Minimum send amount is %@ ADA. Cardano requires this to prevent the network from dropping your transaction.";
 "cardanoOutputBelowMinAda" = "Not enough ADA to cover the network fee and Cardano's minimum-UTXO requirement (~1.4 ADA per output). Send more ADA into this vault first.";
 "chain" = "Chain";
 "chainNotAdded" = "Chain Not Added";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "cacaoUnstakeMaturityUnknownMessage" = "No se pudo verificar la madurez del depósito. Inténtalo de nuevo más tarde.";
 "cancel" = "Cancelar";
 "canLoseFundsPrompt" = "Soy consciente de que puedo perder fondos.";
+"cardanoMinimumSendAmountError" = "El importe mínimo de envío es %@ ADA. Cardano lo exige para evitar que la red descarte tu transacción.";
 "cardanoOutputBelowMinAda" = "No hay suficiente ADA para cubrir la tarifa de red y el requisito mínimo de UTXO de Cardano (~1,4 ADA por salida). Envía más ADA a este vault primero.";
 "chain" = "Cadena";
 "chainNotAdded" = "Cadena No Añadida";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "cacaoUnstakeMaturityUnknownMessage" = "Nije moguće provjeriti zrelost depozita. Pokušajte ponovno kasnije.";
 "cancel" = "Otkaži";
 "canLoseFundsPrompt" = "Svjestan sam da mogu izgubiti sredstva";
+"cardanoMinimumSendAmountError" = "Najmanji iznos za slanje je %@ ADA. Cardano to zahtijeva kako mreža ne bi odbacila tvoju transakciju.";
 "cardanoOutputBelowMinAda" = "Nema dovoljno ADA za pokrivanje mrežne naknade i Cardanovog minimalnog UTXO zahtjeva (~1,4 ADA po izlazu). Najprije pošalji više ADA u ovaj vault.";
 "chain" = "Lanac";
 "chainNotAdded" = "Lanac Nije Dodan";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "cacaoUnstakeMaturityUnknownMessage" = "Impossibile verificare la maturità del deposito. Riprova più tardi.";
 "cancel" = "Annulla";
 "canLoseFundsPrompt" = "Sono consapevole che posso perdere fondi";
+"cardanoMinimumSendAmountError" = "L'importo minimo di invio è %@ ADA. Cardano lo richiede per evitare che la rete scarti la tua transazione.";
 "cardanoOutputBelowMinAda" = "ADA insufficienti per coprire la commissione di rete e il requisito minimo UTXO di Cardano (~1,4 ADA per output). Invia prima più ADA a questo vault.";
 "chain" = "Catena";
 "chainNotAdded" = "Catena Non Aggiunta";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "cacaoUnstakeMaturityUnknownMessage" = "Não foi possível verificar a maturidade do depósito. Tente novamente mais tarde.";
 "cancel" = "Cancelar";
 "canLoseFundsPrompt" = "Estou ciente de que posso perder fundos";
+"cardanoMinimumSendAmountError" = "O valor mínimo de envio é %@ ADA. A Cardano exige isto para evitar que a rede descarte a sua transação.";
 "cardanoOutputBelowMinAda" = "ADA insuficiente para cobrir a taxa de rede e o requisito mínimo de UTXO da Cardano (~1,4 ADA por saída). Envie mais ADA para este vault primeiro.";
 "chain" = "Cadeia";
 "chainNotAdded" = "Cadeia Não Adicionada";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -135,6 +135,7 @@
 "cacaoUnstakeMaturityUnknownMessage" = "无法验证存款到期状态，请稍后重试。";
 "cancel" = "取消";
 "canLoseFundsPrompt" = "我知道我可能会失去资金";
+"cardanoMinimumSendAmountError" = "最低发送金额为 %@ ADA。Cardano 要求此金额，以防止网络丢弃你的交易。";
 "cardanoOutputBelowMinAda" = "ADA 不足以支付网络费用和 Cardano 的最低 UTXO 要求（每个输出约 1.4 ADA）。请先向此保险库转入更多 ADA。";
 "chain" = "链";
 "chainNotAdded" = "链未添加";

--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -93,19 +93,19 @@ enum SendCryptoLogic {
         return remainingBalance > .zero && remainingBalance < existentialDeposit
     }
 
-    /// Cardano enforces a protocol minimum UTXO value (~1.4 ADA) on every
-    /// output. A native-ADA send below this floor is accepted by the wallet but
-    /// silently dropped by the node, so block it here — before the keysign
-    /// ceremony — to match Android. Token (CNT) sends carry their own ADA floor
-    /// on the bundled output and are exempt. `amount` is the recipient output in
-    /// both cases — for MAX sends `computeMaxAmount` already nets out the fee —
-    /// so this also blocks a MAX send when the whole vault holds less than the
-    /// floor.
-    static func isBelowCardanoMinimum(coin: Coin, amount: String) -> Bool {
-        guard coin.chain == .cardano, coin.isNativeToken else {
+    /// Some chains enforce a protocol minimum value on every output (e.g.
+    /// Cardano's ~1.4 ADA UTXO floor). A native send below the chain's floor is
+    /// accepted by the wallet but silently dropped by the node, so block it
+    /// here — before the keysign ceremony — to match Android. Token sends carry
+    /// their own floor on the bundled output and are exempt. `amount` is the
+    /// recipient output in both cases — for MAX sends `computeMaxAmount` already
+    /// nets out the fee — so this also blocks a MAX send when the whole vault
+    /// holds less than the floor.
+    static func isBelowMinimumSendAmount(coin: Coin, amount: String) -> Bool {
+        guard coin.isNativeToken, let minimum = coin.chain.minimumSendAmount else {
             return false
         }
-        return amountInRaw(coin: coin, amount: amount) < CardanoHelper.defaultMinUTXOValue
+        return amountInRaw(coin: coin, amount: amount) < minimum
     }
 
     /// A send is a "deposit" (memo-bearing function call) iff the memo

--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -93,6 +93,21 @@ enum SendCryptoLogic {
         return remainingBalance > .zero && remainingBalance < existentialDeposit
     }
 
+    /// Cardano enforces a protocol minimum UTXO value (~1.4 ADA) on every
+    /// output. A native-ADA send below this floor is accepted by the wallet but
+    /// silently dropped by the node, so block it here — before the keysign
+    /// ceremony — to match Android. Token (CNT) sends carry their own ADA floor
+    /// on the bundled output and are exempt. `amount` is the recipient output in
+    /// both cases — for MAX sends `computeMaxAmount` already nets out the fee —
+    /// so this also blocks a MAX send when the whole vault holds less than the
+    /// floor.
+    static func isBelowCardanoMinimum(coin: Coin, amount: String) -> Bool {
+        guard coin.chain == .cardano, coin.isNativeToken else {
+            return false
+        }
+        return amountInRaw(coin: coin, amount: amount) < CardanoHelper.defaultMinUTXOValue
+    }
+
     /// A send is a "deposit" (memo-bearing function call) iff the memo
     /// dictionary carries entries AND the chain supports memos. UTXO, Ripple,
     /// and Solana sends never carry function-call memos in this flow.

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -107,6 +107,14 @@ struct SendCryptoVerifyLogic {
             if SendCryptoLogic.canBeReaped(coin: tx.coin, amount: tx.amount, gas: tx.fee) {
                 return BalanceValidationResult(isValid: false, errorMessage: "belowExistentialDepositError".localized)
             }
+
+            // Cardano protocol minimum UTXO floor (~1.4 ADA): a native-ADA send
+            // below it is silently dropped by the node. Mirror the Details-screen
+            // guard so the ceremony never starts on an amount the node rejects.
+            if SendCryptoLogic.isBelowCardanoMinimum(coin: tx.coin, amount: tx.amount) {
+                let minAmount = CardanoHelper.defaultMinUTXOValue.toADAString
+                return BalanceValidationResult(isValid: false, errorMessage: String(format: "cardanoMinimumSendAmountError".localized, minAmount))
+            }
         } else if tx.coin.chain == .terraClassic
                     && TerraClassicTax.isBankDenom(
                         contractAddress: tx.coin.contractAddress,

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -108,11 +108,13 @@ struct SendCryptoVerifyLogic {
                 return BalanceValidationResult(isValid: false, errorMessage: "belowExistentialDepositError".localized)
             }
 
-            // Cardano protocol minimum UTXO floor (~1.4 ADA): a native-ADA send
-            // below it is silently dropped by the node. Mirror the Details-screen
-            // guard so the ceremony never starts on an amount the node rejects.
-            if SendCryptoLogic.isBelowCardanoMinimum(coin: tx.coin, amount: tx.amount) {
-                let minAmount = CardanoHelper.defaultMinUTXOValue.toADAString
+            // Protocol minimum send floor (e.g. Cardano's ~1.4 ADA UTXO): a
+            // native send below it is silently dropped by the node. Mirror the
+            // Details-screen guard so the ceremony never starts on an amount the
+            // node rejects.
+            if SendCryptoLogic.isBelowMinimumSendAmount(coin: tx.coin, amount: tx.amount),
+               let minimum = tx.coin.chain.minimumSendAmount {
+                let minAmount = tx.coin.decimal(for: minimum).description
                 return BalanceValidationResult(isValid: false, errorMessage: String(format: "cardanoMinimumSendAmountError".localized, minAmount))
             }
         } else if tx.coin.chain == .terraClassic

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -653,11 +653,12 @@ final class SendDetailsViewModel {
             }
         }
 
-        // Cardano enforces a protocol minimum UTXO value on every output; a
-        // native-ADA send below it is silently dropped by the node. Match
-        // Android by blocking it here before the keysign ceremony.
-        if SendCryptoLogic.isBelowCardanoMinimum(coin: coin, amount: amount) {
-            let minAmount = CardanoHelper.defaultMinUTXOValue.toADAString
+        // Some chains enforce a protocol minimum value on every output; a
+        // native send below it is silently dropped by the node. Match Android
+        // by blocking it here before the keysign ceremony.
+        if SendCryptoLogic.isBelowMinimumSendAmount(coin: coin, amount: amount),
+           let minimum = coin.chain.minimumSendAmount {
+            let minAmount = coin.decimal(for: minimum).description
             setAmountError(message: String(format: "cardanoMinimumSendAmountError".localized, minAmount))
             return false
         }

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -653,6 +653,15 @@ final class SendDetailsViewModel {
             }
         }
 
+        // Cardano enforces a protocol minimum UTXO value on every output; a
+        // native-ADA send below it is silently dropped by the node. Match
+        // Android by blocking it here before the keysign ceremony.
+        if SendCryptoLogic.isBelowCardanoMinimum(coin: coin, amount: amount) {
+            let minAmount = CardanoHelper.defaultMinUTXOValue.toADAString
+            setAmountError(message: String(format: "cardanoMinimumSendAmountError".localized, minAmount))
+            return false
+        }
+
         return validateERC20GasBalance()
     }
 

--- a/VultisigApp/VultisigApp/Model/Chain+extensions.swift
+++ b/VultisigApp/VultisigApp/Model/Chain+extensions.swift
@@ -6,6 +6,22 @@
 //
 
 import Foundation
+import BigInt
+
+extension Chain {
+    /// Protocol-enforced minimum value (in the chain's base units) that every
+    /// native output must carry, or `nil` when the chain imposes no such floor.
+    /// Cardano requires ~1.4 ADA per UTXO; a smaller output is accepted by the
+    /// wallet but silently dropped by the node.
+    var minimumSendAmount: BigInt? {
+        switch self {
+        case .cardano:
+            return CardanoHelper.defaultMinUTXOValue
+        default:
+            return nil
+        }
+    }
+}
 
 extension Chain {
     init?(name: String) {

--- a/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
@@ -218,6 +218,61 @@ final class SendValidationTests: XCTestCase {
         XCTAssertTrue(SendCryptoLogic.canBeReaped(coin: xrp, amount: amount("10.999"), gas: BigInt(1)))
     }
 
+    // MARK: - isBelowCardanoMinimum
+
+    func testIsBelowCardanoMinimumTrueWhenNativeAdaBelowFloor() {
+        let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
+                           rawBalance: "10000000") // 10 ADA
+        // 1.0 ADA < 1.4 ADA protocol minimum UTXO floor.
+        XCTAssertTrue(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: "1"))
+    }
+
+    func testIsBelowCardanoMinimumFalseAtFloor() {
+        let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
+                           rawBalance: "10000000") // 10 ADA
+        // Exactly 1.4 ADA meets the minimum.
+        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: "1.4"))
+    }
+
+    func testIsBelowCardanoMinimumFalseAboveFloor() {
+        let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
+                           rawBalance: "10000000")
+        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: "2"))
+    }
+
+    func testIsBelowCardanoMinimumTrueForMaxSendBelowFloor() {
+        // For a MAX send, `amount` is the computed recipient output (balance −
+        // fee). When the whole vault holds less than the floor the MAX output is
+        // still below the minimum and must be blocked, not exempted.
+        let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
+                           rawBalance: "1300000") // 1.3 ADA total
+        let fee = BigInt(170_000) // ~0.17 ADA
+        let maxAmount = SendCryptoLogic.computeMaxAmount(coin: ada, fee: fee) // ~1.13 ADA
+        XCTAssertTrue(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: maxAmount))
+    }
+
+    func testIsBelowCardanoMinimumFalseForMaxSendAboveFloor() {
+        let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
+                           rawBalance: "10000000") // 10 ADA total
+        let fee = BigInt(170_000)
+        let maxAmount = SendCryptoLogic.computeMaxAmount(coin: ada, fee: fee) // ~9.83 ADA
+        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: maxAmount))
+    }
+
+    func testIsBelowCardanoMinimumFalseForNonNativeToken() {
+        // Cardano native tokens (CNT) carry their own ADA floor on the bundled
+        // output and are exempt from the native-ADA minimum.
+        let cnt = makeCoin(.cardano, ticker: "SNEK", decimals: 0, isNative: false,
+                           rawBalance: "1000")
+        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: cnt, amount: "1"))
+    }
+
+    func testIsBelowCardanoMinimumFalseForOtherChains() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true,
+                           rawBalance: "100000000")
+        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: btc, amount: "0.00001"))
+    }
+
     // MARK: - isDeposit
 
     func testIsDepositFalseWhenMemoEmpty() {

--- a/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
@@ -218,26 +218,26 @@ final class SendValidationTests: XCTestCase {
         XCTAssertTrue(SendCryptoLogic.canBeReaped(coin: xrp, amount: amount("10.999"), gas: BigInt(1)))
     }
 
-    // MARK: - isBelowCardanoMinimum
+    // MARK: - isBelowMinimumSendAmount
 
     func testIsBelowCardanoMinimumTrueWhenNativeAdaBelowFloor() {
         let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
                            rawBalance: "10000000") // 10 ADA
         // 1.0 ADA < 1.4 ADA protocol minimum UTXO floor.
-        XCTAssertTrue(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: "1"))
+        XCTAssertTrue(SendCryptoLogic.isBelowMinimumSendAmount(coin: ada, amount: "1"))
     }
 
     func testIsBelowCardanoMinimumFalseAtFloor() {
         let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
                            rawBalance: "10000000") // 10 ADA
         // Exactly 1.4 ADA meets the minimum.
-        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: "1.4"))
+        XCTAssertFalse(SendCryptoLogic.isBelowMinimumSendAmount(coin: ada, amount: amount("1.4")))
     }
 
     func testIsBelowCardanoMinimumFalseAboveFloor() {
         let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
                            rawBalance: "10000000")
-        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: "2"))
+        XCTAssertFalse(SendCryptoLogic.isBelowMinimumSendAmount(coin: ada, amount: "2"))
     }
 
     func testIsBelowCardanoMinimumTrueForMaxSendBelowFloor() {
@@ -248,7 +248,7 @@ final class SendValidationTests: XCTestCase {
                            rawBalance: "1300000") // 1.3 ADA total
         let fee = BigInt(170_000) // ~0.17 ADA
         let maxAmount = SendCryptoLogic.computeMaxAmount(coin: ada, fee: fee) // ~1.13 ADA
-        XCTAssertTrue(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: maxAmount))
+        XCTAssertTrue(SendCryptoLogic.isBelowMinimumSendAmount(coin: ada, amount: maxAmount))
     }
 
     func testIsBelowCardanoMinimumFalseForMaxSendAboveFloor() {
@@ -256,7 +256,7 @@ final class SendValidationTests: XCTestCase {
                            rawBalance: "10000000") // 10 ADA total
         let fee = BigInt(170_000)
         let maxAmount = SendCryptoLogic.computeMaxAmount(coin: ada, fee: fee) // ~9.83 ADA
-        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: ada, amount: maxAmount))
+        XCTAssertFalse(SendCryptoLogic.isBelowMinimumSendAmount(coin: ada, amount: maxAmount))
     }
 
     func testIsBelowCardanoMinimumFalseForNonNativeToken() {
@@ -264,13 +264,13 @@ final class SendValidationTests: XCTestCase {
         // output and are exempt from the native-ADA minimum.
         let cnt = makeCoin(.cardano, ticker: "SNEK", decimals: 0, isNative: false,
                            rawBalance: "1000")
-        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: cnt, amount: "1"))
+        XCTAssertFalse(SendCryptoLogic.isBelowMinimumSendAmount(coin: cnt, amount: "1"))
     }
 
     func testIsBelowCardanoMinimumFalseForOtherChains() {
         let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true,
                            rawBalance: "100000000")
-        XCTAssertFalse(SendCryptoLogic.isBelowCardanoMinimum(coin: btc, amount: "0.00001"))
+        XCTAssertFalse(SendCryptoLogic.isBelowMinimumSendAmount(coin: btc, amount: "0.00001"))
     }
 
     // MARK: - isDeposit


### PR DESCRIPTION
## Summary
- Native-ADA sends below Cardano's protocol minimum UTXO value (~1.4 ADA) were accepted by the iOS/macOS send form but silently **dropped by the node**. The validation logic existed in `CardanoHelper` but was never wired into the send flow. Android already enforces this.
- Added `SendCryptoLogic.isBelowCardanoMinimum(coin:amount:)` and called it from both validation layers before the keysign ceremony:
  - `SendDetailsViewModel.validateBalance` (Details screen)
  - `SendCryptoVerifyLogic.validateBalanceWithFee` (Verify screen)
- The check validates the **recipient output amount**, so it also blocks **MAX sends** when the whole vault holds less than the floor (`computeMaxAmount` already nets out the fee).
- CNT (Cardano native token) sends carry their own ADA floor on the bundled output and are exempt; non-Cardano chains are unaffected.
- Added a localized `cardanoMinimumSendAmountError` string to all 7 locales (sorted via `sort_localizable.py`).

## Behavior
| Scenario | Result |
|---|---|
| Send 1.0 ADA | Blocked |
| Send ≥ 1.4 ADA | Allowed |
| MAX send, vault < 1.4 ADA | Blocked |
| MAX send, vault ≥ 1.4 ADA (+fee) | Allowed |
| CNT token / non-Cardano | Unaffected |

## Test Plan
- [x] SwiftLint passes (changed files)
- [x] `xcodebuild` build succeeds
- [x] `SendValidationTests` — 42/42 pass, incl. 7 new `isBelowCardanoMinimum` cases (below/at/above floor, MAX below/above floor, CNT token, non-Cardano)
- [x] Manual: attempt a sub-1.4 ADA ADA send → blocked with error; attempt MAX from a vault holding < 1.4 ADA → blocked

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Cardano-native transaction validation to prevent sending amounts below the network minimum send amount.

* **Documentation**
  * Added localized error messaging for the “minimum send amount” rule (English, German, Spanish, Croatian, Italian, Portuguese, and Simplified Chinese).

* **Tests**
  * Added unit tests covering minimum-send behavior across Cardano ADA, MAX scenarios, and non-native/exempt and non-Cardano cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="2662" height="1970" alt="CleanShot 2026-06-16 at 18 38 31@2x" src="https://github.com/user-attachments/assets/c5e0aa2f-a291-4a91-b1c6-cfa8f2247b28" />
