### PR TITLE
chore(deps): bump WalletCore to 4.6.13

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -112,8 +112,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/walletcore-spm",
       "state" : {
-        "revision" : "d15efc71eda9f29dc183931276244e504bdf5716",
-        "version" : "4.3.19"
+        "revision" : "6fe770f97ebce59b7c30db5e2fac9dffb2352c2c",
+        "version" : "4.6.13"
       }
     },
     {

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -66,7 +66,7 @@ packages:
     revision: 86400c61e39790887ca03b98d82746ee4dc312f4
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
-    exactVersion: 4.3.19
+    exactVersion: 4.6.13
   ZIPFoundation:
     url: https://github.com/weichsel/ZIPFoundation
     from: 0.9.0


### PR DESCRIPTION
## Summary
- Bump the `WalletCore` SPM dependency from `4.3.19` to the released version `4.6.13` (tag `v4.6.13`).
- Updated `project.yml` (`exactVersion: 4.6.13`) and regenerated the project; `Package.resolved` now pins the matching revision.

## Test Plan
- [ ] `make generate` regenerates project cleanly
- [ ] SPM resolves `walletcore-spm` to `4.6.13`
- [ ] xcodebuild build succeeds against the new WalletCore version
- [ ] Smoke-test keygen/keysign and address derivation across chains

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WalletCore dependency to version 4.6.13 (from 4.3.19).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->