### PR TITLE
fix(ios): clarify privacy usage descriptions for App Store review

### DIFF
--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -147,12 +147,12 @@ targets:
         # Info.plist keys (merged at build time because GENERATE_INFOPLIST_FILE=YES)
         INFOPLIST_KEY_CFBundleDisplayName: Vultisig
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.finance
-        INFOPLIST_KEY_NSCameraUsageDescription: Vultisig uses the camera to scan QR codes so you can pair devices for vault setup, import vaults and wallet addresses, and confirm transaction details when signing.
+        INFOPLIST_KEY_NSCameraUsageDescription: Allow access to your camera to scan QR codes so you can pair devices for vault setup, import vaults and wallet addresses, and confirm transaction details when signing.
         INFOPLIST_KEY_NSFaceIDUsageDescription: Secure your Vault using Face ID
-        INFOPLIST_KEY_NSFileProviderDomainUsageDescription: Vultisig accesses your files so you can back up your vault to and restore it from your chosen file storage.
+        INFOPLIST_KEY_NSFileProviderDomainUsageDescription: Allow access to your files to back up your vault to and restore it from your chosen file storage.
         INFOPLIST_KEY_NSHumanReadableCopyright: ""
-        INFOPLIST_KEY_NSLocalNetworkUsageDescription: Vultisig uses the local network to discover and connect to your other devices on the same Wi-Fi so they can pair and sign transactions together.
-        INFOPLIST_KEY_NSPhotoLibraryUsageDescription: Vultisig accesses your photo library so you can save vault backup QR codes and select saved QR code images to import vaults or addresses.
+        INFOPLIST_KEY_NSLocalNetworkUsageDescription: Allow access to your local network to discover and connect to your other devices on the same Wi-Fi so they can pair and sign transactions together.
+        INFOPLIST_KEY_NSPhotoLibraryUsageDescription: Allow access to your photo library to save vault backup QR codes and select saved QR code images to import vaults or addresses.
         "INFOPLIST_KEY_NSScreenCaptureUsageDescription[sdk=macosx*]": "Vultisig needs screen recording permission to scan QR codes displayed on your screen."
         "INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]": YES
         "INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]": YES

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -147,7 +147,7 @@ targets:
         # Info.plist keys (merged at build time because GENERATE_INFOPLIST_FILE=YES)
         INFOPLIST_KEY_CFBundleDisplayName: Vultisig
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.finance
-        INFOPLIST_KEY_NSCameraUsageDescription: We need to scan QR Codes.
+        INFOPLIST_KEY_NSCameraUsageDescription: Vultisig uses the camera to scan QR codes so you can pair devices for vault setup, import vaults and wallet addresses, and confirm transaction details when signing.
         INFOPLIST_KEY_NSFaceIDUsageDescription: Secure your Vault using Face ID
         INFOPLIST_KEY_NSFileProviderDomainUsageDescription: We need to access your files.
         INFOPLIST_KEY_NSHumanReadableCopyright: ""

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -149,10 +149,10 @@ targets:
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.finance
         INFOPLIST_KEY_NSCameraUsageDescription: Vultisig uses the camera to scan QR codes so you can pair devices for vault setup, import vaults and wallet addresses, and confirm transaction details when signing.
         INFOPLIST_KEY_NSFaceIDUsageDescription: Secure your Vault using Face ID
-        INFOPLIST_KEY_NSFileProviderDomainUsageDescription: We need to access your files.
+        INFOPLIST_KEY_NSFileProviderDomainUsageDescription: Vultisig accesses your files so you can back up your vault to and restore it from your chosen file storage.
         INFOPLIST_KEY_NSHumanReadableCopyright: ""
-        INFOPLIST_KEY_NSLocalNetworkUsageDescription: We need access to the local network to discover services.
-        INFOPLIST_KEY_NSPhotoLibraryUsageDescription: We need access to your photo library to save photos.
+        INFOPLIST_KEY_NSLocalNetworkUsageDescription: Vultisig uses the local network to discover and connect to your other devices on the same Wi-Fi so they can pair and sign transactions together.
+        INFOPLIST_KEY_NSPhotoLibraryUsageDescription: Vultisig accesses your photo library so you can save vault backup QR codes and select saved QR code images to import vaults or addresses.
         "INFOPLIST_KEY_NSScreenCaptureUsageDescription[sdk=macosx*]": "Vultisig needs screen recording permission to scan QR codes displayed on your screen."
         "INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]": YES
         "INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]": YES


### PR DESCRIPTION
## Summary
Apple flagged our `NSCameraUsageDescription` ("We need to scan QR Codes.") during review for not explaining *how* the camera data is used (Guideline 5.1.1 — purpose strings must clearly describe usage). This PR rewrites that string and brings the other privacy purpose strings up to the same standard, using Apple's recommended "Allow access to your … to …" phrasing.

Updated in `VultisigApp/project.yml`:

- **NSCameraUsageDescription** — Allow access to your camera to scan QR codes so you can pair devices for vault setup, import vaults and wallet addresses, and confirm transaction details when signing.
- **NSFileProviderDomainUsageDescription** — Allow access to your files to back up your vault to and restore it from your chosen file storage.
- **NSLocalNetworkUsageDescription** — Allow access to your local network to discover and connect to your other devices on the same Wi-Fi so they can pair and sign transactions together.
- **NSPhotoLibraryUsageDescription** — Allow access to your photo library to save vault backup QR codes and select saved QR code images to import vaults or addresses.

## Notes
- Strings live in `project.yml` (XcodeGen spec). The `.xcodeproj`/`project.pbxproj` is generated and gitignored, so only `project.yml` is committed. Ran `make generate` to confirm values propagate to both Debug and Release configs.

## Test Plan
- [x] `make generate` succeeds; new strings appear in generated `project.pbxproj` (Debug + Release)
- [ ] Verify each updated prompt text appears when the app first requests the corresponding permission

Co-Authored-By: Claude <noreply@anthropic.com>