### PR TITLE
feat(tiers): migrate $VULT discount basis from held VULT to staked sVULT (#4589)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 "customRPCsLockedRequires" = "Erforderlich";
 "customRPCsLockedSubtitle" = "Richte Vultisig auf deine eigenen Nodes aus. Schnellere Abfragen, höhere Ratenlimits und volle Privatsphäre pro Chain.";
 "customRPCsLockedTierRequirement" = "$VULT %@ Stufe oder höher";
-"customRPCsLockedTierSubtitle" = "Halte mindestens %@ in deinem Tresor";
+"customRPCsLockedTierSubtitle" = "Stake mindestens %@";
 "customRPCsLockedTitle" = "Eigene RPCs";
 "customRPCsLockedYourBalance" = "Dein Guthaben";
 "customRPCSubtitle" = "Nutze eigene Nodes pro Chain";
@@ -1175,8 +1175,9 @@
 "unlimited" = "Unbegrenzt";
 "unlocked" = "Freigeschaltet";
 "unlockTier" = "Stufe freischalten";
+"unlockUltimateTierDescription" = "Durch das Staken von %@ $VULT schalten Sie die Ultimate Stufe frei und erhalten einen vollständigen Erlass der Vultisig-Gebühren auf alle Swaps.";
 "unlockXTier" = "%@ Stufe freischalten";
-"unlockXTierDescription" = "Durch das Halten von %@ $VULT schalten Sie die %@ Stufe frei und erhalten einen Rabatt von %@ bps auf alle Swaps.";
+"unlockXTierDescription" = "Durch das Staken von %@ $VULT schalten Sie die %@ Stufe frei und erhalten einen Rabatt von %@ bps auf alle Swaps.";
 "unlockXTierDescriptionHighlighted" = "%@ bps Handelsgebührenrabatt";
 "unrelatedQRCode" = "Unbekannter QR-Code";
 "unrelatedQRCodeMessage" = "Es wurde ein nicht zugehöriger QR-Code gescannt.";
@@ -1296,9 +1297,9 @@
 "vultCooldownNote" = "Das Entstaken startet eine Wartezeit. Dein VULT wird nach deren Ablauf beanspruchbar.";
 "vultDiscount" = "Rabatt: %dbps";
 "vultDiscountHeroSubtitle" = "erhalte einen Handelsrabatt";
-"vultDiscountHeroTitle" = "Hold $VULT";
+"vultDiscountHeroTitle" = "Stake $VULT";
 "vultDiscountTiers" = "$VULT Rabattstufen";
-"vultDiscountTiersDescription" = "Halten Sie $VULT, um niedrigere Handelsgebühren freizuschalten.";
+"vultDiscountTiersDescription" = "Staken Sie $VULT, um niedrigere Handelsgebühren freizuschalten.";
 "vultEthereumRequired" = "Ethereum erforderlich";
 "vultEthereumRequiredDescription" = "Füge deiner Vault eine Ethereum-Adresse hinzu, um VULT zu staken.";
 "vultiserverPassword" = "Vultiserver-Passwort";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -294,7 +294,7 @@
 "customRPCsLockedRequires" = "Requires";
 "customRPCsLockedSubtitle" = "Point Vultisig at your own nodes. Faster queries, higher rate limits, and full privacy per chain.";
 "customRPCsLockedTierRequirement" = "$VULT %@ Tier or above";
-"customRPCsLockedTierSubtitle" = "Hold at least %@ in your vault";
+"customRPCsLockedTierSubtitle" = "Stake at least %@";
 "customRPCsLockedTitle" = "Custom RPCs";
 "customRPCsLockedYourBalance" = "Your balance";
 "customRPCSubtitle" = "Use your own nodes per chain";
@@ -1187,10 +1187,10 @@
 "unlimited" = "Unlimited";
 "unlocked" = "Unlocked";
 "unlockTier" = "Unlock Tier";
-"unlockUltimateTierDescription" = "By holding %@ $VULT, you’ll unlock the Ultimate Tier and receive a complete Vultisig fee waiver on all swaps.";
+"unlockUltimateTierDescription" = "By staking %@ $VULT, you’ll unlock the Ultimate Tier and receive a complete Vultisig fee waiver on all swaps.";
 "unlockUltimateTierDescriptionHighlighted" = "complete Vultisig fee waiver on all swaps.";
 "unlockXTier" = "Unlock %@ Tier";
-"unlockXTierDescription" = "By holding %@ $VULT, you’ll unlock the %@ Tier and receive a %@ bps trading fee discount on all swaps.";
+"unlockXTierDescription" = "By staking %@ $VULT, you’ll unlock the %@ Tier and receive a %@ bps trading fee discount on all swaps.";
 "unlockXTierDescriptionHighlighted" = "%@ bps trading fee discount";
 "unrelatedQRCode" = "Unrelated QR Code";
 "unrelatedQRCodeMessage" = "Unrelated QR code is scanned.";
@@ -1310,9 +1310,9 @@
 "vultCooldownNote" = "Unstaking starts a cooldown. Your VULT becomes claimable once it ends.";
 "vultDiscount" = "Discount: %dbps";
 "vultDiscountHeroSubtitle" = "receive a trading discount";
-"vultDiscountHeroTitle" = "Hold $VULT";
+"vultDiscountHeroTitle" = "Stake $VULT";
 "vultDiscountTiers" = "$VULT Discount Tiers";
-"vultDiscountTiersDescription" = "Hold $VULT to unlock lower trading fees.";
+"vultDiscountTiersDescription" = "Stake $VULT to unlock lower trading fees.";
 "vultEthereumRequired" = "Ethereum required";
 "vultEthereumRequiredDescription" = "Add an Ethereum address to your vault to stake VULT.";
 "vultiserverPassword" = "Vultiserver Password";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 "customRPCsLockedRequires" = "Requiere";
 "customRPCsLockedSubtitle" = "Apunta Vultisig a tus propios nodos. Consultas más rápidas, mayores límites de tasa y privacidad total por cadena.";
 "customRPCsLockedTierRequirement" = "$VULT %@ Nivel o superior";
-"customRPCsLockedTierSubtitle" = "Mantén al menos %@ en tu bóveda";
+"customRPCsLockedTierSubtitle" = "Haz staking de al menos %@";
 "customRPCsLockedTitle" = "RPCs personalizados";
 "customRPCsLockedYourBalance" = "Tu saldo";
 "customRPCSubtitle" = "Usa tus propios nodos por cadena";
@@ -1175,8 +1175,9 @@
 "unlimited" = "Ilimitado";
 "unlocked" = "Desbloqueado";
 "unlockTier" = "Desbloquear Nivel";
+"unlockUltimateTierDescription" = "Al hacer staking de %@ $VULT, desbloquearás el Nivel Ultimate y recibirás una exención completa de las comisiones de Vultisig en todos los swaps.";
 "unlockXTier" = "Desbloquear Nivel %@";
-"unlockXTierDescription" = "Al mantener %@ $VULT, desbloquearás el Nivel %@ y recibirás un descuento de %@ bps en comisiones de trading en todos los swaps.";
+"unlockXTierDescription" = "Al hacer staking de %@ $VULT, desbloquearás el Nivel %@ y recibirás un descuento de %@ bps en comisiones de trading en todos los swaps.";
 "unlockXTierDescriptionHighlighted" = "descuento de %@ bps en comisiones de trading";
 "unrelatedQRCode" = "Código QR no relacionado";
 "unrelatedQRCodeMessage" = "Se escaneó un código QR no relacionado.";
@@ -1296,9 +1297,9 @@
 "vultCooldownNote" = "El retiro inicia un periodo de espera. Tu VULT podrá reclamarse al finalizar.";
 "vultDiscount" = "Descuento: %dbps";
 "vultDiscountHeroSubtitle" = "recibe un descuento de trading";
-"vultDiscountHeroTitle" = "Hold $VULT";
+"vultDiscountHeroTitle" = "Stake $VULT";
 "vultDiscountTiers" = "Niveles de Descuento $VULT";
-"vultDiscountTiersDescription" = "Mantén $VULT para desbloquear comisiones de trading más bajas.";
+"vultDiscountTiersDescription" = "Haz staking de $VULT para desbloquear comisiones de trading más bajas.";
 "vultEthereumRequired" = "Se requiere Ethereum";
 "vultEthereumRequiredDescription" = "Añade una dirección de Ethereum a tu bóveda para hacer staking de VULT.";
 "vultiserverPassword" = "Contraseña de Vultiserver";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 "customRPCsLockedRequires" = "Zahtijeva";
 "customRPCsLockedSubtitle" = "Usmjeri Vultisig na vlastite čvorove. Brži upiti, viša ograničenja i potpuna privatnost po lancu.";
 "customRPCsLockedTierRequirement" = "$VULT %@ razina ili viša";
-"customRPCsLockedTierSubtitle" = "Drži barem %@ u svom trezoru";
+"customRPCsLockedTierSubtitle" = "Uloži barem %@";
 "customRPCsLockedTitle" = "Prilagođeni RPC-ovi";
 "customRPCsLockedYourBalance" = "Tvoj saldo";
 "customRPCSubtitle" = "Koristi vlastite čvorove po lancu";
@@ -1175,8 +1175,9 @@
 "unlimited" = "Neograničeno";
 "unlocked" = "Otključano";
 "unlockTier" = "Otključaj razinu";
+"unlockUltimateTierDescription" = "Ulaganjem %@ $VULT otključat ćete Ultimate razinu i primiti potpuno oslobođenje od Vultisig naknada na svim swapovima.";
 "unlockXTier" = "Otključaj %@ razinu";
-"unlockXTierDescription" = "Držanjem %@ $VULT otključat ćete %@ razinu i primiti popust od %@ bps na naknade za trgovanje na svim swapovima.";
+"unlockXTierDescription" = "Ulaganjem %@ $VULT otključat ćete %@ razinu i primiti popust od %@ bps na naknade za trgovanje na svim swapovima.";
 "unlockXTierDescriptionHighlighted" = "popust od %@ bps na naknade za trgovanje";
 "unrelatedQRCode" = "Nepovezani QR kod";
 "unrelatedQRCodeMessage" = "Skeniran je nepovezani QR kod.";
@@ -1296,9 +1297,9 @@
 "vultCooldownNote" = "Unstake pokreće razdoblje čekanja. VULT možeš preuzeti nakon što istekne.";
 "vultDiscount" = "Popust: %dbps";
 "vultDiscountHeroSubtitle" = "ostvari popust na trgovanje";
-"vultDiscountHeroTitle" = "Hold $VULT";
+"vultDiscountHeroTitle" = "Stake $VULT";
 "vultDiscountTiers" = "$VULT Razine Popusta";
-"vultDiscountTiersDescription" = "Držite $VULT da biste otključali niže naknade za trgovanje.";
+"vultDiscountTiersDescription" = "Uložite $VULT da biste otključali niže naknade za trgovanje.";
 "vultEthereumRequired" = "Potreban Ethereum";
 "vultEthereumRequiredDescription" = "Dodaj Ethereum adresu u svoj sef za stakeanje VULT-a.";
 "vultiserverPassword" = "Vultiserver lozinka";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 "customRPCsLockedRequires" = "Richiede";
 "customRPCsLockedSubtitle" = "Punta Vultisig sui tuoi nodi. Query più veloci, limiti più alti e piena privacy per ogni catena.";
 "customRPCsLockedTierRequirement" = "$VULT %@ livello o superiore";
-"customRPCsLockedTierSubtitle" = "Detieni almeno %@ nella tua cassaforte";
+"customRPCsLockedTierSubtitle" = "Fai staking di almeno %@";
 "customRPCsLockedTitle" = "RPC personalizzati";
 "customRPCsLockedYourBalance" = "Il tuo saldo";
 "customRPCSubtitle" = "Usa i tuoi nodi per ogni catena";
@@ -1175,8 +1175,9 @@
 "unlimited" = "Illimitato";
 "unlocked" = "Sbloccato";
 "unlockTier" = "Sblocca livello";
+"unlockUltimateTierDescription" = "Facendo staking di %@ $VULT, sbloccherai il livello Ultimate e riceverai un'esenzione totale dalle commissioni Vultisig su tutti gli swap.";
 "unlockXTier" = "Sblocca livello %@";
-"unlockXTierDescription" = "Tenendo %@ $VULT, sbloccherai il livello %@ e riceverai uno sconto di %@ bps sulle commissioni di trading su tutti gli swap.";
+"unlockXTierDescription" = "Facendo staking di %@ $VULT, sbloccherai il livello %@ e riceverai uno sconto di %@ bps sulle commissioni di trading su tutti gli swap.";
 "unlockXTierDescriptionHighlighted" = "sconto di %@ bps sulle commissioni di trading";
 "unrelatedQRCode" = "Codice QR non correlato";
 "unrelatedQRCodeMessage" = "È stato scansionato un codice QR non correlato.";
@@ -1296,9 +1297,9 @@
 "vultCooldownNote" = "L'unstake avvia un periodo di attesa. Il tuo VULT sarà riscuotibile al termine.";
 "vultDiscount" = "Sconto: %dbps";
 "vultDiscountHeroSubtitle" = "ricevi uno sconto sul trading";
-"vultDiscountHeroTitle" = "Hold $VULT";
+"vultDiscountHeroTitle" = "Stake $VULT";
 "vultDiscountTiers" = "Livelli di Sconto $VULT";
-"vultDiscountTiersDescription" = "Mantieni $VULT per sbloccare commissioni di trading più basse.";
+"vultDiscountTiersDescription" = "Fai staking di $VULT per sbloccare commissioni di trading più basse.";
 "vultEthereumRequired" = "Ethereum richiesto";
 "vultEthereumRequiredDescription" = "Aggiungi un indirizzo Ethereum al tuo vault per mettere in staking VULT.";
 "vultiserverPassword" = "Password Vultiserver";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -287,7 +287,7 @@
 "customRPCsLockedRequires" = "필요 조건";
 "customRPCsLockedSubtitle" = "Vultisig를 직접 운영하는 노드로 연결하세요. 더 빠른 조회, 더 높은 속도 제한, 체인별 완전한 프라이버시.";
 "customRPCsLockedTierRequirement" = "$VULT %@ 등급 이상";
-"customRPCsLockedTierSubtitle" = "볼트에 최소 %@ 보유";
+"customRPCsLockedTierSubtitle" = "최소 %@ 스테이킹";
 "customRPCsLockedTitle" = "사용자 지정 RPC";
 "customRPCsLockedYourBalance" = "내 잔액";
 "customRPCSubtitle" = "체인별로 직접 운영하는 노드 사용";
@@ -1154,10 +1154,10 @@
 "unlimited" = "무제한";
 "unlocked" = "잠금 해제됨";
 "unlockTier" = "티어 잠금 해제";
-"unlockUltimateTierDescription" = "%@ $VULT를 보유하면 Ultimate 티어를 잠금 해제하고 모든 스왑에서 Vultisig 수수료를 완전히 면제받을 수 있습니다.";
+"unlockUltimateTierDescription" = "%@ $VULT를 스테이킹하면 Ultimate 티어를 잠금 해제하고 모든 스왑에서 Vultisig 수수료를 완전히 면제받을 수 있습니다.";
 "unlockUltimateTierDescriptionHighlighted" = "모든 스왑에서 Vultisig 수수료 완전 면제.";
 "unlockXTier" = "%@ 티어 잠금 해제";
-"unlockXTierDescription" = "%@ $VULT를 보유하면 %@ 티어를 잠금 해제하고 모든 스왑에서 %@ bps 거래 수수료 할인을 받을 수 있습니다.";
+"unlockXTierDescription" = "%@ $VULT를 스테이킹하면 %@ 티어를 잠금 해제하고 모든 스왑에서 %@ bps 거래 수수료 할인을 받을 수 있습니다.";
 "unlockXTierDescriptionHighlighted" = "%@ bps 거래 수수료 할인";
 "unrelatedQRCode" = "관련 없는 QR 코드";
 "unrelatedQRCodeMessage" = "관련 없는 QR 코드가 스캔되었습니다.";
@@ -1275,9 +1275,9 @@
 "vultCooldownNote" = "언스테이킹은 대기 기간을 시작합니다. 기간이 끝나면 VULT를 청구할 수 있습니다.";
 "vultDiscount" = "할인: %dbps";
 "vultDiscountHeroSubtitle" = "거래 할인을 받으세요";
-"vultDiscountHeroTitle" = "Hold $VULT";
+"vultDiscountHeroTitle" = "Stake $VULT";
 "vultDiscountTiers" = "$VULT 할인 티어";
-"vultDiscountTiersDescription" = "$VULT를 보유하여 더 낮은 거래 수수료를 잠금 해제하세요.";
+"vultDiscountTiersDescription" = "$VULT를 스테이킹하여 더 낮은 거래 수수료를 잠금 해제하세요.";
 "vultEthereumRequired" = "이더리움 필요";
 "vultEthereumRequiredDescription" = "VULT를 스테이킹하려면 볼트에 이더리움 주소를 추가하세요.";
 "vultiserverPassword" = "Vultiserver 비밀번호";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 "customRPCsLockedRequires" = "Requer";
 "customRPCsLockedSubtitle" = "Aponte o Vultisig para os seus próprios nós. Consultas mais rápidas, limites maiores e total privacidade por cadeia.";
 "customRPCsLockedTierRequirement" = "$VULT %@ nível ou superior";
-"customRPCsLockedTierSubtitle" = "Mantenha pelo menos %@ no seu cofre";
+"customRPCsLockedTierSubtitle" = "Faça staking de pelo menos %@";
 "customRPCsLockedTitle" = "RPCs personalizados";
 "customRPCsLockedYourBalance" = "Seu saldo";
 "customRPCSubtitle" = "Use os seus próprios nós por cadeia";
@@ -1175,8 +1175,9 @@
 "unlimited" = "Ilimitado";
 "unlocked" = "Desbloqueado";
 "unlockTier" = "Desbloquear nível";
+"unlockUltimateTierDescription" = "Ao fazer staking de %@ $VULT, você desbloqueará o nível Ultimate e receberá uma isenção completa das taxas da Vultisig em todos os swaps.";
 "unlockXTier" = "Desbloquear nível %@";
-"unlockXTierDescription" = "Ao manter %@ $VULT, você desbloqueará o nível %@ e receberá um desconto de %@ bps nas taxas de negociação em todos os swaps.";
+"unlockXTierDescription" = "Ao fazer staking de %@ $VULT, você desbloqueará o nível %@ e receberá um desconto de %@ bps nas taxas de negociação em todos os swaps.";
 "unlockXTierDescriptionHighlighted" = "desconto de %@ bps nas taxas de negociação";
 "unrelatedQRCode" = "Código QR não relacionado";
 "unrelatedQRCodeMessage" = "Foi escaneado um código QR não relacionado.";
@@ -1296,9 +1297,9 @@
 "vultCooldownNote" = "O unstake inicia um período de espera. Seu VULT poderá ser reivindicado ao terminar.";
 "vultDiscount" = "Desconto: %dbps";
 "vultDiscountHeroSubtitle" = "receba um desconto de negociação";
-"vultDiscountHeroTitle" = "Hold $VULT";
+"vultDiscountHeroTitle" = "Stake $VULT";
 "vultDiscountTiers" = "Níveis de Desconto $VULT";
-"vultDiscountTiersDescription" = "Mantenha $VULT para desbloquear taxas de negociação mais baixas.";
+"vultDiscountTiersDescription" = "Faça staking de $VULT para desbloquear taxas de negociação mais baixas.";
 "vultEthereumRequired" = "Ethereum necessário";
 "vultEthereumRequiredDescription" = "Adicione um endereço Ethereum ao seu cofre para fazer stake de VULT.";
 "vultiserverPassword" = "Senha do Vultiserver";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -292,7 +292,7 @@
 "customRPCsLockedRequires" = "需要";
 "customRPCsLockedSubtitle" = "将 Vultisig 指向您自己的节点。每条链上更快的查询、更高的速率限制和完全的隐私。";
 "customRPCsLockedTierRequirement" = "$VULT %@ 等级或以上";
-"customRPCsLockedTierSubtitle" = "在您的金库中持有至少 %@";
+"customRPCsLockedTierSubtitle" = "至少质押 %@";
 "customRPCsLockedTitle" = "自定义 RPC";
 "customRPCsLockedYourBalance" = "您的余额";
 "customRPCSubtitle" = "为每条链使用您自己的节点";
@@ -1175,8 +1175,9 @@
 "unlimited" = "无限制";
 "unlocked" = "已解锁";
 "unlockTier" = "解锁等级";
+"unlockUltimateTierDescription" = "通过质押 %@ $VULT，您将解锁 Ultimate 等级并在所有交换中获得 Vultisig 费用的完全豁免";
 "unlockXTier" = "解锁 %@ 等级";
-"unlockXTierDescription" = "通过持有 %@ $VULT，您将解锁 %@ 等级并在所有交换中获得 %@ 个基点的交易费折扣";
+"unlockXTierDescription" = "通过质押 %@ $VULT，您将解锁 %@ 等级并在所有交换中获得 %@ 个基点的交易费折扣";
 "unlockXTierDescriptionHighlighted" = "%@ 个基点交易费折扣";
 "unrelatedQRCode" = "无关的二维码";
 "unrelatedQRCodeMessage" = "扫描到无关的二维码。";
@@ -1297,9 +1298,9 @@
 "vultCooldownNote" = "取消质押会启动冷却期。冷却期结束后即可领取您的 VULT。";
 "vultDiscount" = "折扣：%d 个基点";
 "vultDiscountHeroSubtitle" = "获享交易折扣";
-"vultDiscountHeroTitle" = "Hold $VULT";
+"vultDiscountHeroTitle" = "Stake $VULT";
 "vultDiscountTiers" = "$VULT 折扣等级";
-"vultDiscountTiersDescription" = "持有 $VULT 以解锁较低的交易费用";
+"vultDiscountTiersDescription" = "质押 $VULT 以解锁较低的交易费用";
 "vultEthereumRequired" = "需要以太坊";
 "vultEthereumRequiredDescription" = "将以太坊地址添加到您的保险库以质押 VULT。";
 "vultiserverPassword" = "Vultiserver 密码";

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
@@ -13,23 +13,30 @@ import SwiftUI
 private let logger = Logger(subsystem: "com.vultisig.app", category: "vult-tier-service")
 
 struct VultTierService {
+    /// Raw, unstaked VULT — the asset the user buys and the routing `toCoin` for
+    /// the buy-VULT swap. **Not** the discount-tier basis.
     let vultTicker = "VULT"
+    /// Staked VULT (the 1:1 sVULT wrapper). This is the discount-tier basis: tiers
+    /// are unlocked by *staking*, so the resolved balance comes from sVULT, not raw
+    /// VULT. Same 18 decimals and identical thresholds (1:1 wrap).
+    let stakedVultTicker = "sVULT"
     let thorguardContractAddress = "0xa98b29a8f5a247802149c268ecf860b8308b7291"
 
-    @AppStorage("vult_balance_cache") private var cacheEntries: [CacheEntry] = []
+    @AppStorage("svult_tier_balance_cache") private var cacheEntries: [CacheEntry] = []
     private static let cacheValidityDuration: TimeInterval = 3 * 60 // 3 minutes
 
-    /// Per-wallet cache of the fully-resolved discount tier (VULT balance result
-    /// + Thorguard boost), keyed by vault id and held for the process lifetime.
-    /// The tier doesn't change during a swap session, so once resolved it's read
-    /// back without re-running the Thorguard NFT `eth_call` on every quote fetch.
-    /// Switching vaults resolves fresh because the cache is keyed per vault; a
-    /// VULT/Thorguard balance change for the *same* vault isn't reflected until
-    /// the next app launch, which is acceptable for a discount-tier hint.
+    /// Per-wallet cache of the fully-resolved discount tier (staked sVULT balance
+    /// result + Thorguard boost), keyed by vault id and held for the process
+    /// lifetime. The tier doesn't change during a swap session, so once resolved
+    /// it's read back without re-running the Thorguard NFT `eth_call` on every
+    /// quote fetch. Switching vaults resolves fresh because the cache is keyed per
+    /// vault; a staked-balance/Thorguard change for the *same* vault isn't
+    /// reflected until the next app launch, which is acceptable for a discount-tier
+    /// hint.
     private static let sessionCache = SessionTierCache()
 
     func fetchDiscountTier(for vault: Vault, cached: Bool = false) async -> VultDiscountTier? {
-        let balance = cached ? (getVultToken(for: vault)?.balanceDecimal ?? 0) : await fetchVultBalance(for: vault)
+        let balance = cached ? (getStakedVultToken(for: vault)?.balanceDecimal ?? 0) : await fetchStakedVultBalance(for: vault)
         var tier = VultDiscountTier.allCases
             .sorted { $0.balanceToUnlock > $1.balanceToUnlock }
             .first { balance >= $0.balanceToUnlock }
@@ -57,8 +64,17 @@ struct VultTierService {
         }
     }
 
+    /// Raw, unstaked VULT held by the vault. Used for the buy-VULT routing `toCoin`
+    /// (you buy VULT, then stake it) and the nudge to stake held VULT — **not** the
+    /// tier basis. Keep distinct from `getStakedVultToken`.
     func getVultToken(for vault: Vault) -> Coin? {
         vault.coins.first(where: { $0.chain == .ethereum && $0.ticker == vultTicker })
+    }
+
+    /// Staked VULT (sVULT) held by the vault — the discount-tier basis. The tier
+    /// balance is read off this tracked coin's `balanceDecimal`.
+    func getStakedVultToken(for vault: Vault) -> Coin? {
+        vault.coins.first(where: { $0.chain == .ethereum && $0.ticker == stakedVultTicker })
     }
 
     /// Clears the cached timestamp for a specific vault
@@ -74,11 +90,11 @@ struct VultTierService {
     /// Checks if we recently fetched the balance (within cache validity duration)
     func shouldFetchBalance(for vault: Vault) -> Bool {
         guard let cacheEntry = cacheEntries.first(where: { $0.vaultId == vault.pubKeyEdDSA }) else {
-            logger.debug("Getting $VULT balance from network")
+            logger.debug("Getting staked $VULT balance from network")
             return true
         }
         let shouldFetch = Date().timeIntervalSince(cacheEntry.lastFetchDate) >= Self.cacheValidityDuration
-        logger.debug("Getting $VULT balance from cache: \(shouldFetch)")
+        logger.debug("Getting staked $VULT balance from cache: \(shouldFetch)")
         return shouldFetch
     }
 
@@ -133,14 +149,17 @@ private extension VultTierService {
         let lastFetchDate: Date
     }
 
-    func fetchVultBalance(for vault: Vault) async -> Decimal {
+    /// Resolves the staked-VULT (sVULT) balance that drives the discount tier.
+    /// Adds the sVULT token to the vault if absent, refreshes it, and returns the
+    /// tracked coin's balance.
+    func fetchStakedVultBalance(for vault: Vault) async -> Decimal {
         // Check if we need to fetch fresh balance
         if shouldFetchBalance(for: vault) {
             // Fetch fresh balance
             await addEthChainIfNeeded(for: vault)
-            let vultToken = await getOrAddVultTokenIfNeeded(to: vault)
-            if let vultToken {
-                await BalanceService.shared.updateBalance(for: vultToken)
+            let stakedVultToken = await getOrAddStakedVultTokenIfNeeded(to: vault)
+            if let stakedVultToken {
+                await BalanceService.shared.updateBalance(for: stakedVultToken)
             }
 
             // Update the cache entry
@@ -149,24 +168,24 @@ private extension VultTierService {
         }
 
         // Return the balance from the coin (fresh or cached)
-        guard let vultToken = getVultToken(for: vault) else { return .zero }
-        return vultToken.balanceDecimal
+        guard let stakedVultToken = getStakedVultToken(for: vault) else { return .zero }
+        return stakedVultToken.balanceDecimal
     }
 
-    func getOrAddVultTokenIfNeeded(to vault: Vault) async -> Coin? {
-        var vultToken = getVultToken(for: vault)
-        if vultToken == nil {
-            await addVultToken(to: vault)
-            vultToken = getVultToken(for: vault)
+    func getOrAddStakedVultTokenIfNeeded(to vault: Vault) async -> Coin? {
+        var stakedVultToken = getStakedVultToken(for: vault)
+        if stakedVultToken == nil {
+            await addStakedVultToken(to: vault)
+            stakedVultToken = getStakedVultToken(for: vault)
         }
 
-        return vultToken
+        return stakedVultToken
     }
 
-    func addVultToken(to vault: Vault) async {
-        let vultTokenMeta = TokensStore.TokenSelectionAssets.first(where: { $0.chain == .ethereum && $0.ticker == vultTicker })
-        guard let vultTokenMeta else { return }
-        try? await CoinService.addToChain(assets: [vultTokenMeta], to: vault)
+    func addStakedVultToken(to vault: Vault) async {
+        let stakedVultTokenMeta = TokensStore.TokenSelectionAssets.first(where: { $0.chain == .ethereum && $0.ticker == stakedVultTicker })
+        guard let stakedVultTokenMeta else { return }
+        try? await CoinService.addToChain(assets: [stakedVultTokenMeta], to: vault)
     }
 
     func addEthChainIfNeeded(for vault: Vault) async {

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/ViewModel/LockedFeatureSheetViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/ViewModel/LockedFeatureSheetViewModel.swift
@@ -5,18 +5,19 @@
 
 import Foundation
 
-/// Drives the generic tier-locked feature sheet: resolves the live $VULT balance
-/// for the vault and exposes whether it clears the feature's required tier
-/// threshold.
+/// Drives the generic tier-locked feature sheet: resolves the live staked $VULT
+/// balance for the vault and exposes whether it clears the feature's required
+/// tier threshold.
 ///
 /// The required tier, its threshold amount, and the balance comparison are all
 /// sourced from the existing tier system (`VultDiscountTier` / `VultTierService`)
-/// via the `LockedFeature` descriptor — never from the design mock.
+/// via the `LockedFeature` descriptor — never from the design mock. Tiers are
+/// unlocked by staking, so the balance is the staked sVULT balance.
 @MainActor
 final class LockedFeatureSheetViewModel: ObservableObject {
     let feature: LockedFeature
 
-    /// Live $VULT balance held by the vault, refreshed on appear.
+    /// Live staked $VULT balance held by the vault, refreshed on appear.
     @Published private(set) var balance: Decimal = 0
 
     private let service: VultTierService
@@ -57,9 +58,10 @@ final class LockedFeatureSheetViewModel: ObservableObject {
         "\(balance.formatForDisplay(skipAbbreviation: true)) VULT"
     }
 
-    /// Reads the already-cached $VULT balance from the vault's token — no network
-    /// refresh. The balance is kept current by the app's existing fetch paths.
+    /// Reads the already-cached staked $VULT (sVULT) balance from the vault's
+    /// token — no network refresh. The balance is kept current by the app's
+    /// existing fetch paths.
     func loadBalance(for vault: Vault) {
-        balance = service.getVultToken(for: vault)?.balanceDecimal ?? 0
+        balance = service.getStakedVultToken(for: vault)?.balanceDecimal ?? 0
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -136,8 +136,8 @@ class VaultDetailViewModel: ObservableObject {
     }
 
     private func hasReachedSilverTier(vault: Vault) -> Bool {
-        let vultBalance = VultTierService().getVultToken(for: vault)?.balanceDecimal ?? 0
-        return vultBalance >= VultDiscountTier.silver.balanceToUnlock
+        let stakedVultBalance = VultTierService().getStakedVultToken(for: vault)?.balanceDecimal ?? 0
+        return stakedVultBalance >= VultDiscountTier.silver.balanceToUnlock
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Features/VultTierServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/VultTierServiceTests.swift
@@ -1,0 +1,178 @@
+//
+//  VultTierServiceTests.swift
+//  VultisigAppTests
+//
+//  Pins the discount-tier *basis* migration: tiers resolve from the staked sVULT
+//  balance, not raw held VULT. Raw VULT stays reachable for buy-routing, and the
+//  thresholds / bps mapping / Thorguard ladder are unchanged by the migration.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class VultTierServiceTests: XCTestCase {
+
+    private let service = VultTierService()
+
+    // MARK: - Token accessors are distinct (sVULT basis vs raw VULT routing)
+
+    func test_getStakedVultToken_returnsSVULT_notRawVULT() {
+        let vault = makeVault(stakedSVULT: 5_000, rawVULT: 12_345)
+
+        let staked = service.getStakedVultToken(for: vault)
+        XCTAssertEqual(staked?.ticker, "sVULT")
+        XCTAssertEqual(staked?.balanceDecimal, 5_000)
+    }
+
+    func test_getVultToken_stillReturnsRawVULT_forBuyRouting() {
+        // #4590 + the buy-VULT routing call sites depend on raw VULT staying
+        // reachable; the migration must not repurpose `getVultToken`.
+        let vault = makeVault(stakedSVULT: 5_000, rawVULT: 12_345)
+
+        let raw = service.getVultToken(for: vault)
+        XCTAssertEqual(raw?.ticker, "VULT")
+        XCTAssertEqual(raw?.balanceDecimal, 12_345)
+    }
+
+    func test_accessors_resolveDifferentCoins() {
+        let vault = makeVault(stakedSVULT: 1, rawVULT: 2)
+        XCTAssertNotEqual(service.getStakedVultToken(for: vault), service.getVultToken(for: vault))
+    }
+
+    // MARK: - Tier resolves from the STAKED balance
+
+    func test_cachedTier_resolvesFromStakedBalance_notRawVULT() async {
+        // sVULT clears Diamond (mid-band, clear of the 100k/1M thresholds so the
+        // 18-dp base-unit round-trip can't drift across a boundary); raw VULT is
+        // empty. The tier must come from sVULT. Diamond is non-upgradeable, so no
+        // Thorguard eth_call fires.
+        let vault = makeVault(stakedSVULT: 250_000, rawVULT: 0)
+
+        let tier = await service.fetchDiscountTier(for: vault, cached: true)
+
+        XCTAssertEqual(tier, .diamond)
+    }
+
+    func test_cachedBasis_ignoresRawVULT_staleHeldValueCannotBleedIn() {
+        // The migration's failure mode: a large *held* VULT balance must NOT feed
+        // the tier basis once it's staked. The cached tier reads
+        // `getStakedVultToken(...).balanceDecimal`, which is 0 here despite the
+        // 1,000,000 raw VULT that previously would have unlocked Ultimate — and a
+        // 0 basis maps to no tier. (Asserted at the balance accessor to keep the
+        // case network-free; the nil-tier path would otherwise probe Thorguard.)
+        let vault = makeVault(stakedSVULT: 0, rawVULT: 1_000_000)
+
+        let basis = service.getStakedVultToken(for: vault)?.balanceDecimal ?? 0
+        XCTAssertEqual(basis, 0)
+        XCTAssertNil(tier(for: basis))
+    }
+
+    func test_cachedTier_resolvesUltimate_fromTopStakedBalance() async {
+        // Clear of the 1M threshold so the base-unit round-trip can't drift below
+        // it; Ultimate is non-upgradeable, so no Thorguard eth_call fires.
+        let vault = makeVault(stakedSVULT: 2_000_000, rawVULT: 0)
+
+        let tier = await service.fetchDiscountTier(for: vault, cached: true)
+
+        XCTAssertEqual(tier, .ultimate)
+    }
+
+    // MARK: - Thresholds + bps mapping unchanged by the basis migration
+
+    func test_thresholds_unchanged() {
+        XCTAssertEqual(VultDiscountTier.bronze.balanceToUnlock, 1_500)
+        XCTAssertEqual(VultDiscountTier.silver.balanceToUnlock, 3_000)
+        XCTAssertEqual(VultDiscountTier.gold.balanceToUnlock, 7_500)
+        XCTAssertEqual(VultDiscountTier.platinum.balanceToUnlock, 15_000)
+        XCTAssertEqual(VultDiscountTier.diamond.balanceToUnlock, 100_000)
+        XCTAssertEqual(VultDiscountTier.ultimate.balanceToUnlock, 1_000_000)
+    }
+
+    func test_bpsMapping_unchanged() {
+        XCTAssertEqual(VultDiscountTier.bronze.bpsDiscount, 5)
+        XCTAssertEqual(VultDiscountTier.silver.bpsDiscount, 10)
+        XCTAssertEqual(VultDiscountTier.gold.bpsDiscount, 20)
+        XCTAssertEqual(VultDiscountTier.platinum.bpsDiscount, 25)
+        XCTAssertEqual(VultDiscountTier.diamond.bpsDiscount, 35)
+        XCTAssertEqual(VultDiscountTier.ultimate.bpsDiscount, .max)
+    }
+
+    /// The balance→tier selection is the migration's only moving part; the
+    /// expression itself (highest threshold a balance clears) is basis-agnostic
+    /// and must be unchanged. Mirrors `fetchDiscountTier`'s mapping.
+    func test_balanceToTierMapping_isUnchanged() {
+        XCTAssertNil(tier(for: 0))
+        XCTAssertNil(tier(for: 1_499))
+        XCTAssertEqual(tier(for: 1_500), .bronze)
+        XCTAssertEqual(tier(for: 2_999), .bronze)
+        XCTAssertEqual(tier(for: 3_000), .silver)
+        XCTAssertEqual(tier(for: 7_500), .gold)
+        XCTAssertEqual(tier(for: 15_000), .platinum)
+        XCTAssertEqual(tier(for: 99_999), .platinum)
+        XCTAssertEqual(tier(for: 100_000), .diamond)
+        XCTAssertEqual(tier(for: 1_000_000), .ultimate)
+    }
+
+    // MARK: - Thorguard NFT bump is left intact
+
+    func test_thorguardContractAddress_unchanged() {
+        // The Thorguard boost is a separate eth_call at its own address and must
+        // not be touched by the staking-basis migration.
+        XCTAssertEqual(
+            service.thorguardContractAddress,
+            "0xa98b29a8f5a247802149c268ecf860b8308b7291"
+        )
+    }
+
+    // MARK: - Fixtures
+
+    private func makeVault(stakedSVULT: Decimal, rawVULT: Decimal) -> Vault {
+        let vault = Vault(
+            name: "Tier Test Vault",
+            signers: [],
+            pubKeyECDSA: "tier-pub-ecdsa",
+            pubKeyEdDSA: "tier-pub-eddsa-\(stakedSVULT)-\(rawVULT)",
+            keyshares: [],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        vault.coins = [
+            ethCoin(ticker: "sVULT", balance: stakedSVULT),
+            ethCoin(ticker: "VULT", balance: rawVULT)
+        ]
+        return vault
+    }
+
+    /// Builds an 18-decimal Ethereum ERC-20 coin carrying `balance` (whole units).
+    private func ethCoin(ticker: String, balance: Decimal) -> Coin {
+        let meta = CoinMeta(
+            chain: .ethereum,
+            ticker: ticker,
+            logo: "vult",
+            decimals: 18,
+            priceProviderId: "vultisig",
+            contractAddress: "\(ticker)-contract",
+            isNativeToken: false
+        )
+        let coin = Coin(asset: meta, address: "0xtest-\(ticker)", hexPublicKey: "")
+        coin.rawBalance = rawBalanceString(for: balance, decimals: 18)
+        return coin
+    }
+
+    /// `Decimal` whole units → base-unit string, matching `balanceDecimal`'s
+    /// `rawBalance / 10^decimals`.
+    private func rawBalanceString(for whole: Decimal, decimals: Int) -> String {
+        let scaled = whole * pow(Decimal(10), decimals)
+        return NSDecimalNumber(decimal: scaled).stringValue
+    }
+
+    /// The exact balance→tier selection `fetchDiscountTier` performs.
+    private func tier(for balance: Decimal) -> VultDiscountTier? {
+        VultDiscountTier.allCases
+            .sorted { $0.balanceToUnlock > $1.balanceToUnlock }
+            .first { balance >= $0.balanceToUnlock }
+    }
+}


### PR DESCRIPTION
## What & why

Closes #4589. Switches the **$VULT discount-tier basis from raw *held* VULT to *staked* sVULT** (`0x11113d73…`, the 1:1 wrapper), and changes all "hold" → "stake" copy. Because sVULT wraps VULT 1:1 at the same 18 decimals, **every threshold and the entire bps → affiliate-fee pipeline are identical** — only the balance *source* moves.

Stacked on #4588 (VULT staking, PR #4593). **Base branch: `feat/vult-staking-4588`** — reuses its primitives (sVULT `CoinMeta` in `TokensStore`, `VultReadService.balanceOf`), does not re-add them.

> ⚠️ **Must not reach users before staking is live.** With the basis on sVULT and no stake path, every existing holder's tier drops to zero until they stake. The #4590 nudge banner is the comms vehicle for the transition (locked decision, proposal §Decisions 1). Keep this behind the staking rollout.

## The mechanic change

The tier balance is **not** a `balanceOf` eth_call — it's read off a *tracked* `Coin`'s `balanceDecimal`. So the migration adds a **separate** staked-coin accessor and points tier resolution at it:

- `VultTierService`: tier now resolves from sVULT via `getStakedVultToken` / `fetchStakedVultBalance` (tracked-coin read, mirroring the old VULT path, adding sVULT to the vault on demand).
- **`getVultToken` (raw VULT) kept intact** — the buy-VULT routing `toCoin` (you buy VULT, then stake it) and #4590 still need raw VULT. Untouched at `TierGatedTap`, `VaultMainScreen`, `VaultAdvancedSettingsScreen`.
- The two **tier-balance read** sites moved to the staked coin: `LockedFeatureSheetViewModel.loadBalance` and `VaultDetailViewModel.hasReachedSilverTier`.
- Renamed the freshness cache key `vult_balance_cache` → `svult_tier_balance_cache` so a stale held-VULT timestamp can't bleed into the staked read on first launch post-deploy.

## Unchanged (confirmed by test)

- `VultDiscountTier` thresholds: 1.5K / 3K / 7.5K / 15K / 100K / 1M.
- bps mapping: 5 / 10 / 20 / 25 / 35 / `.max`, and `SwapService.vultTierDiscount` → affiliate-fee pipeline.
- **Thorguard NFT** bump — a separate `fetchERC20TokenBalance` eth_call at its own address (`0xa98b…7291`), untouched.

## Copy — "hold" → "stake" (all 8 locales)

`de, en, es, hr, it, ko, pt, zh-Hans` — using each locale's established staking verb:

- `vultDiscountTiersDescription`, `unlockXTierDescription` — all 8.
- `unlockUltimateTierDescription` — **backfilled into all 8** (was en + ko only).
- `vultDiscountHeroTitle` ("Hold $VULT" → "Stake $VULT"), `customRPCsLockedTierSubtitle` ("Hold at least %@…" → "Stake at least %@") — all 8.
- **Not** changed: `vultDiscountTiers` (title), `unlockTier`, `unlockXTier`, any `*Highlighted` key. Ran `sort_localizable.py`.

**Display label** kept as "VULT" where the staked number renders — the "VULT vs sVULT" wording is an open Figma call.

## Tests

New `VultTierServiceTests` (10): tier resolves from the **sVULT** balance; raw `getVultToken` still returns VULT; a large held-VULT value **cannot** grant a tier; thresholds + bps + Thorguard address unchanged. Existing `LockedFeatureSheetViewModel`, `VultDiscountTierComparable`, `TierGatedTap`, `DefaultSwapInteractor` (swap-discount) suites still pass.

## Gate

- iOS build (sim): ✅
- macOS build: ✅
- `xcodebuild test` (tier + swap-discount suites, 35 tests): ✅ 0 failures
- SwiftLint: ✅ clean

## Note for reviewers

`Coin.balanceDecimal` parses `rawBalance` through `NumberFormatter`, which loses precision past ~15 significant digits — pre-existing, shared by the raw-VULT and sVULT paths, not introduced here. The tier-resolution tests use mid-band balances clear of threshold boundaries so they assert the *basis* (sVULT), not that float artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)