### PR TITLE
fix(send): render broadcasted-state animation on tx status header

### DIFF
--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoDone/TransactionStatusHeaderView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoDone/TransactionStatusHeaderView.swift
@@ -30,11 +30,14 @@ struct TransactionStatusHeaderView: View {
             updateAnimation()
         }
         .onLoad {
-            pendingAnimationVM = RiveViewModel(fileName: "transaction_pending", autoPlay: false)
+            // `autoPlay: true` so each animation starts when its Rive view
+            // mounts — including the seed status, which never triggers
+            // `.onChange` and so would otherwise sit on a blank first frame.
+            pendingAnimationVM = RiveViewModel(fileName: "transaction_pending", autoPlay: true)
             pendingAnimationVM?.fit = .contain
-            successAnimationVM = RiveViewModel(fileName: "vault_created", autoPlay: false)
+            successAnimationVM = RiveViewModel(fileName: "vault_created", autoPlay: true)
             successAnimationVM?.fit = .contain
-            errorAnimationVM = RiveViewModel(fileName: "transaction_error", autoPlay: false)
+            errorAnimationVM = RiveViewModel(fileName: "transaction_error", autoPlay: true)
             errorAnimationVM?.fit = .contain
         }
     }


### PR DESCRIPTION
## What

`TransactionStatusHeaderView` shows no animation while the status is `.broadcasted` — the area above "Transaction broadcasted" is blank. Other states animate fine.

## Root cause

The Rive view models were created with `autoPlay: false`, and `.play()` was only triggered from `.onChange(of: status)`. SwiftUI's `onChange` does not fire for a view's **initial** value, and `DoneStatusService` seeds its status from `poller.initialStatus` (= `.broadcasted` for a fresh tx). So the broadcasted animation was never played. The other states animate only because they're reached via a *transition*, which does fire `onChange`.

## Fix

Create the view models with `autoPlay: true` — the idiom used by every other Rive animation in the app — so each animation starts when its Rive view **mounts**, including the seed status. `onChange`/`updateAnimation()` stay, so the one-shot success/error animations still replay on transition.

3-line change (`autoPlay: false → true` on the three view models).

## Verification (simulator, runtime)

- **Before:** OSLog instrumentation showed `onLoad` ran with `seed status=broadcasted` but `updateAnimation()` was never called; the animation region was blank, and 5 screenshots over time were byte-identical (static).
- An intermediate attempt that called `.play()` from `onLoad` logged the play call but still rendered nothing — `.play()` fires before the Rive view mounts, so the command is lost. (Caught by the multi-frame check, not shipped.)
- **After (`autoPlay: true`):** 5 screenshots over time are all distinct (animating), and the pulsing radar animation renders correctly above the status text.
- SwiftLint clean; Debug build succeeds. All diagnostic instrumentation/harness removed.

Fixes #4598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction status animations to display automatically when the completion view loads, ensuring proper visual feedback for pending, success, and error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->