### PR TITLE
fix(keysign): localize JoinKeysignViewModel error strings

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -303,6 +303,8 @@
 "dappRequestFrom" = "Anfrage von";
 "date" = "Datum";
 "decimalAmountError" = "Der Betrag muss eine Dezimalzahl sein.";
+"decodeCustomMessagePayloadError" = "Fehler beim Dekodieren der benutzerdefinierten Nachrichten-Payload: %@";
+"decodeKeysignMessageError" = "Fehler beim Dekodieren der Keysign-Nachricht: %@";
 "defiChainNoPositions" = "Keine Positionen gefunden";
 "defiChainPositionsCount" = "%d Positionen";
 "defiPortfolio" = "DeFi Portfolio";
@@ -520,6 +522,7 @@
 "joinKeygenViewDescription" = "Dein Vault wird ab dem Moment generiert, in dem du die Einrichtung deines Vaults auf deinem Hauptgerät abschließt.";
 "joinKeygenViewTitle" = "Warten auf den Beitritt weiterer Geräte";
 "joinKeysign" = "Keysign beitreten";
+"joinKeysignCommitteeFailed" = "Beitritt zum Keysign-Komitee fehlgeschlagen. Bitte überprüfe deine Verbindung und versuche es erneut.";
 "joinReshare" = "Erneutem Teilen beitreten";
 "joinSend" = "Senden beitreten";
 "joinSwap" = "Tausch beitreten";
@@ -559,6 +562,8 @@
 "keysign" = "Schlüsselsignatur";
 "keysignDiscoveryDisclaimer" = "Scanne den QR-Code, um die Transaktion zu signieren.";
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";
+"keysignStartResponseError" = "Bei der Verarbeitung der Keysign-Startantwort ist ein Problem aufgetreten. Bitte versuche es erneut.";
+"keysignStartVerifyFailed" = "Verifizierung des Keysign-Starts fehlgeschlagen. Fehler: %@";
 "Korean" = "Koreanisch";
 "label" = "Etikett";
 "language" = "Sprache";
@@ -652,6 +657,7 @@
 "nOfTotal" = "%d von %@";
 "noGasTokenFoundError" = "Kein Gas-Token für %@ Chain gefunden. Bitte füge den nativen Token zu deinem Vault hinzu.";
 "noLiquidityPool" = "Kein Liquiditätspool für dieses Token-Paar verfügbar. Dieser Asset wird möglicherweise nicht unterstützt.";
+"noMessagesToSign" = "Es gibt keine zu signierenden Nachrichten";
 "noPoolsAvailable" = "No pools available";
 "noPositionsFound" = "Keine Positionen gefunden";
 "noPositionsSelectedSubtitle" = "Sie haben alle Positionen für diese Kette deaktiviert. Aktivieren Sie mindestens eine Position, um Guthaben anzuzeigen und Aktionen zu verwalten.";
@@ -741,6 +747,7 @@
 "Portuguese" = "Portugiesisch";
 "position" = "Position";
 "positiveAmountError" = "Die Menge muss eine positive Zahl sein. Versuche es erneut.";
+"prepareKeysignMessagesFailed" = "Vorbereiten der Nachrichten für das Keysigning fehlgeschlagen. Fehler: %@";
 "preparingVaultText1" = "Mehrfaktor-Sicherheit, ";
 "preparingVaultText2" = "eliminiert den Single Point of Failure";
 "previewKeygenDescription" = "Scannen Sie mit Geräten, um der Tresorgenerierung beizutreten";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -305,6 +305,8 @@
 "dappRequestFrom" = "Request from";
 "date" = "Date";
 "decimalAmountError" = "The amount must be decimal.";
+"decodeCustomMessagePayloadError" = "Error decoding custom message payload: %@";
+"decodeKeysignMessageError" = "Error decoding keysign message: %@";
 "defiChainNoPositions" = "No positions found";
 "defiChainPositionsCount" = "%d positions";
 "defiPortfolio" = "DeFi Portfolio";
@@ -526,6 +528,7 @@
 "joinKeygenViewDescription" = "Your vault will start generating from the moment you finalize setting up your vault on your main device";
 "joinKeygenViewTitle" = "Waiting for other devices to join";
 "joinKeysign" = "Join Keysign";
+"joinKeysignCommitteeFailed" = "Failed to join the keysign committee. Please check your connection and try again.";
 "joinReshare" = "Join Reshare";
 "joinSend" = "Join Send";
 "joinSwap" = "Join Swap";
@@ -565,6 +568,8 @@
 "keysign" = "Keysign";
 "keysignDiscoveryDisclaimer" = "Scan QR code to sign transaction. ";
 "keysignDiscoveryDisclaimerDevice" = "-device scan required.";
+"keysignStartResponseError" = "There was an issue processing the keysign start response. Please try again.";
+"keysignStartVerifyFailed" = "Failed to verify keysign start. Error: %@";
 "Korean" = "Korean";
 "label" = "Label";
 "language" = "Language";
@@ -659,6 +664,7 @@
 "nOfTotal" = "%d of %@";
 "noGasTokenFoundError" = "No gas token found for %@ chain. Please add the native token to your vault.";
 "noLiquidityPool" = "No liquidity pool available for this token pair. This asset may not be supported.";
+"noMessagesToSign" = "There are no messages to be signed";
 "noPoolsAvailable" = "No pools available";
 "noPositionsFound" = "No positions found";
 "noPositionsSelectedSubtitle" = "You’ve disabled all positions for this chain. Enable at least one position to view balances and manage actions.";
@@ -748,6 +754,7 @@
 "Portuguese" = "Portuguese";
 "position" = "Position";
 "positiveAmountError" = "Amount must be a positive number. Try again.";
+"prepareKeysignMessagesFailed" = "Failed to prepare messages for keysigning. Error: %@";
 "preparingVaultText1" = "Multi-factor security, ";
 "preparingVaultText2" = "removing the single-point of failure";
 "previewKeygenDescription" = "Scan with devices to join the vault generation";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -303,6 +303,8 @@
 "dappRequestFrom" = "Solicitud de";
 "date" = "Fecha";
 "decimalAmountError" = "El monto debe ser decimal.";
+"decodeCustomMessagePayloadError" = "Error al decodificar el contenido del mensaje personalizado: %@";
+"decodeKeysignMessageError" = "Error al decodificar el mensaje de keysign: %@";
 "defiChainNoPositions" = "No se encontraron posiciones";
 "defiChainPositionsCount" = "%d posiciones";
 "defiPortfolio" = "Portafolio DeFi";
@@ -520,6 +522,7 @@
 "joinKeygenViewDescription" = "Tu vault comenzará a generarse en cuanto completes la configuración en tu dispositivo principal.";
 "joinKeygenViewTitle" = "Esperando que otros dispositivos se unan";
 "joinKeysign" = "Unirse a Keysign";
+"joinKeysignCommitteeFailed" = "No se pudo unir al comité de keysign. Comprueba tu conexión e inténtalo de nuevo.";
 "joinReshare" = "Unirse al compartir";
 "joinSend" = "Unirse a Enviar";
 "joinSwap" = "Unirse al intercambio";
@@ -559,6 +562,8 @@
 "keysign" = "Firma de Clave";
 "keysignDiscoveryDisclaimer" = "Escanea el código QR para firmar la transacción.";
 "keysignDiscoveryDisclaimerDevice" = "-se requiere escanear el dispositivo.";
+"keysignStartResponseError" = "Hubo un problema al procesar la respuesta de inicio de keysign. Inténtalo de nuevo.";
+"keysignStartVerifyFailed" = "No se pudo verificar el inicio de keysign. Error: %@";
 "Korean" = "Coreano";
 "label" = "Etiqueta";
 "language" = "Idioma";
@@ -652,6 +657,7 @@
 "nOfTotal" = "%d de %@";
 "noGasTokenFoundError" = "No se encontró token de gas para la cadena %@. Por favor agrega el token nativo a tu vault.";
 "noLiquidityPool" = "No hay pool de liquidez disponible para este par de tokens. Este activo puede no estar soportado.";
+"noMessagesToSign" = "No hay mensajes para firmar";
 "noPoolsAvailable" = "No pools available";
 "noPositionsFound" = "No se encontraron posiciones";
 "noPositionsSelectedSubtitle" = "Has deshabilitado todas las posiciones para esta cadena. Habilita al menos una posición para ver saldos y administrar acciones.";
@@ -741,6 +747,7 @@
 "Portuguese" = "Portugués";
 "position" = "Posición";
 "positiveAmountError" = "La cantidad debe ser un número positivo. Intenta de nuevo.";
+"prepareKeysignMessagesFailed" = "No se pudieron preparar los mensajes para el keysigning. Error: %@";
 "preparingVaultText1" = "Seguridad multifactor, ";
 "preparingVaultText2" = "eliminando el punto único de fallo";
 "previewKeygenDescription" = "Escanee con dispositivos para unirse a la generación de bóveda";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -303,6 +303,8 @@
 "dappRequestFrom" = "Zahtjev od";
 "date" = "Datum";
 "decimalAmountError" = "Iznos mora biti decimalan.";
+"decodeCustomMessagePayloadError" = "Pogreška pri dekodiranju sadržaja prilagođene poruke: %@";
+"decodeKeysignMessageError" = "Pogreška pri dekodiranju keysign poruke: %@";
 "defiChainNoPositions" = "Nema pronađenih pozicija";
 "defiChainPositionsCount" = "%d pozicija";
 "defiPortfolio" = "DeFi Portfelj";
@@ -520,6 +522,7 @@
 "joinKeygenViewDescription" = "Vaš trezor će se početi generirati čim dovršite postavljanje na svom glavnom uređaju.";
 "joinKeygenViewTitle" = "Čekanje na pridruživanje drugih uređaja";
 "joinKeysign" = "Pridružite se Keysign-u";
+"joinKeysignCommitteeFailed" = "Pridruživanje keysign odboru nije uspjelo. Provjeri vezu i pokušaj ponovno.";
 "joinReshare" = "Pridruži se ponovnom dijeljenju";
 "joinSend" = "Pridruži se Slanju";
 "joinSwap" = "Pridruži se Zamjeni";
@@ -559,6 +562,8 @@
 "keysign" = "Potpis ključa";
 "keysignDiscoveryDisclaimer" = "Skenirajte QR kod kako biste potpisali transakciju.";
 "keysignDiscoveryDisclaimerDevice" = "-potrebno skeniranje uređaja.";
+"keysignStartResponseError" = "Došlo je do problema pri obradi odgovora za pokretanje keysigna. Pokušaj ponovno.";
+"keysignStartVerifyFailed" = "Provjera pokretanja keysigna nije uspjela. Pogreška: %@";
 "Korean" = "Korejski";
 "label" = "Označiti";
 "language" = "Jezik";
@@ -652,6 +657,7 @@
 "nOfTotal" = "%d od %@";
 "noGasTokenFoundError" = "Nije pronađen token za plin za %@ lanac. Molimo dodajte nativni token u vaš trezor.";
 "noLiquidityPool" = "Nema dostupnog pool likvidnosti za ovaj par tokena. Ovaj asset možda nije podržan.";
+"noMessagesToSign" = "Nema poruka za potpisivanje";
 "noPoolsAvailable" = "Nema dostupnih bazena";
 "noPositionsFound" = "Nema pronađenih pozicija";
 "noPositionsSelectedSubtitle" = "Onemogućili ste sve pozicije za ovaj lanac. Omogućite barem jednu poziciju za prikaz stanja i upravljanje akcijama.";
@@ -741,6 +747,7 @@
 "Portuguese" = "Portugalski";
 "position" = "Pozicija";
 "positiveAmountError" = "Iznos mora biti pozitivan broj. Pokušajte ponovno.";
+"prepareKeysignMessagesFailed" = "Priprema poruka za keysigning nije uspjela. Pogreška: %@";
 "preparingVaultText1" = "Višefaktorska sigurnost, ";
 "preparingVaultText2" = "uklanjanje jedne točke neuspjeha";
 "previewKeygenDescription" = "Skenirajte s uređajima za pridruživanje generaciji trezora";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -303,6 +303,8 @@
 "dappRequestFrom" = "Richiesta da";
 "date" = "Data";
 "decimalAmountError" = "L'importo deve essere decimale.";
+"decodeCustomMessagePayloadError" = "Errore durante la decodifica del payload del messaggio personalizzato: %@";
+"decodeKeysignMessageError" = "Errore durante la decodifica del messaggio di keysign: %@";
 "defiChainNoPositions" = "Nessuna posizione trovata";
 "defiChainPositionsCount" = "%d posizioni";
 "defiPortfolio" = "Portafoglio DeFi";
@@ -520,6 +522,7 @@
 "joinKeygenViewDescription" = "Il tuo vault inizierà a essere generato non appena completerai la configurazione sul tuo dispositivo principale.";
 "joinKeygenViewTitle" = "In attesa che altri dispositivi si uniscano";
 "joinKeysign" = "Partecipa a Keysign";
+"joinKeysignCommitteeFailed" = "Impossibile unirsi al comitato di keysign. Controlla la connessione e riprova.";
 "joinReshare" = "Unisciti alla ricondivisione";
 "joinSend" = "Unisciti a Invia";
 "joinSwap" = "Partecipa a Swap";
@@ -559,6 +562,8 @@
 "keysign" = "Firma Chiave";
 "keysignDiscoveryDisclaimer" = "Scansiona il codice QR per firmare la transazione.";
 "keysignDiscoveryDisclaimerDevice" = "-scansione del dispositivo richiesta.";
+"keysignStartResponseError" = "Si è verificato un problema durante l'elaborazione della risposta di avvio del keysign. Riprova.";
+"keysignStartVerifyFailed" = "Impossibile verificare l'avvio del keysign. Errore: %@";
 "Korean" = "Coreano";
 "label" = "Etichetta";
 "language" = "Lingua";
@@ -652,6 +657,7 @@
 "nOfTotal" = "%d di %@";
 "noGasTokenFoundError" = "Token gas non trovato per la catena %@. Aggiungi il token nativo al tuo vault.";
 "noLiquidityPool" = "Nessun pool di liquidità disponibile per questa coppia di token. Questo asset potrebbe non essere supportato.";
+"noMessagesToSign" = "Non ci sono messaggi da firmare";
 "noPoolsAvailable" = "Nessuna pool disponibile";
 "noPositionsFound" = "Nessuna posizione trovata";
 "noPositionsSelectedSubtitle" = "Hai disabilitato tutte le posizioni per questa catena. Abilita almeno una posizione per visualizzare i saldi e gestire le azioni.";
@@ -741,6 +747,7 @@
 "Portuguese" = "Portoghese";
 "position" = "Posizione";
 "positiveAmountError" = "La quantità deve essere un numero positivo. Riprova.";
+"prepareKeysignMessagesFailed" = "Impossibile preparare i messaggi per il keysigning. Errore: %@";
 "preparingVaultText1" = "Sicurezza multifattoriale, ";
 "preparingVaultText2" = "eliminando il punto singolo di errore";
 "previewKeygenDescription" = "Scansiona con i dispositivi per unirsi alla generazione di Vault";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -296,6 +296,8 @@
 "customTokenErrorSubtitle" = "가능한 이유: 잘못된 계약, 지원되지 않는 체인 또는 레지스트리에서 제거된 토큰.";
 "dappRequestFrom" = "요청 출처";
 "date" = "날짜";
+"decodeCustomMessagePayloadError" = "사용자 지정 메시지 페이로드를 디코딩하는 중 오류가 발생했습니다: %@";
+"decodeKeysignMessageError" = "Keysign 메시지를 디코딩하는 중 오류가 발생했습니다: %@";
 "defiChainNoPositions" = "포지션을 찾을 수 없습니다";
 "defiChainPositionsCount" = "포지션 %d개";
 "defiPortfolio" = "DeFi 포트폴리오";
@@ -515,6 +517,7 @@
 "joinKeygenViewDescription" = "메인 기기에서 볼트 설정을 완료하는 순간부터 볼트 생성이 시작됩니다";
 "joinKeygenViewTitle" = "다른 기기가 참여하기를 기다리는 중";
 "joinKeysign" = "키사인 참여";
+"joinKeysignCommitteeFailed" = "Keysign 위원회 참여에 실패했습니다. 연결을 확인한 후 다시 시도하세요.";
 "joinReshare" = "재공유 참여";
 "joinSend" = "전송 참여";
 "joinSwap" = "스왑 참여";
@@ -554,6 +557,8 @@
 "keysign" = "키사인";
 "keysignDiscoveryDisclaimer" = "QR 코드를 스캔하여 트랜잭션에 서명하세요. ";
 "keysignDiscoveryDisclaimerDevice" = "기기 스캔이 필요합니다.";
+"keysignStartResponseError" = "Keysign 시작 응답을 처리하는 중 문제가 발생했습니다. 다시 시도하세요.";
+"keysignStartVerifyFailed" = "Keysign 시작 확인에 실패했습니다. 오류: %@";
 "Korean" = "한국어";
 "label" = "라벨";
 "language" = "언어";
@@ -648,6 +653,7 @@
 "nOfTotal" = "%d / %@";
 "noGasTokenFoundError" = "%@ 체인에 대한 가스 토큰을 찾을 수 없습니다. 볼트에 네이티브 토큰을 추가하세요.";
 "noLiquidityPool" = "이 토큰 쌍에 사용할 수 있는 유동성 풀이 없습니다. 이 자산은 지원되지 않을 수 있습니다.";
+"noMessagesToSign" = "서명할 메시지가 없습니다";
 "noPoolsAvailable" = "사용 가능한 풀 없음";
 "noPositionsFound" = "포지션을 찾을 수 없습니다";
 "noPositionsSelectedSubtitle" = "이 체인의 모든 포지션을 비활성화했습니다. 잔액을 보고 작업을 관리하려면 하나 이상의 포지션을 활성화하세요.";
@@ -737,6 +743,7 @@
 "Portuguese" = "포르투갈어";
 "position" = "포지션";
 "positiveAmountError" = "금액은 양수여야 합니다. 다시 시도하세요.";
+"prepareKeysignMessagesFailed" = "Keysigning을 위한 메시지 준비에 실패했습니다. 오류: %@";
 "preparingVaultText1" = "다중 요소 보안, ";
 "preparingVaultText2" = "단일 실패 지점 제거";
 "previewKeygenDescription" = "기기로 스캔하여 볼트 생성에 참여";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -303,6 +303,8 @@
 "dappRequestFrom" = "Pedido de";
 "date" = "Data";
 "decimalAmountError" = "O valor deve ser decimal.";
+"decodeCustomMessagePayloadError" = "Erro ao descodificar o conteúdo da mensagem personalizada: %@";
+"decodeKeysignMessageError" = "Erro ao descodificar a mensagem de keysign: %@";
 "defiChainNoPositions" = "Nenhuma posição encontrada";
 "defiChainPositionsCount" = "%d posições";
 "defiPortfolio" = "Portfólio DeFi";
@@ -520,6 +522,7 @@
 "joinKeygenViewDescription" = "Seu cofre começará a ser gerado assim que você finalizar a configuração no seu dispositivo principal.";
 "joinKeygenViewTitle" = "Aguardando outros dispositivos para entrar";
 "joinKeysign" = "Participar do Keysign";
+"joinKeysignCommitteeFailed" = "Não foi possível entrar no comité de keysign. Verifica a tua ligação e tenta novamente.";
 "joinReshare" = "Juntar-se ao compartilhamento";
 "joinSend" = "Juntar-se ao Envio";
 "joinSwap" = "Participar da troca";
@@ -559,6 +562,8 @@
 "keysign" = "Assinatura de Chave";
 "keysignDiscoveryDisclaimer" = "Escaneie o código QR para assinar a transação.";
 "keysignDiscoveryDisclaimerDevice" = "-é necessário escanear o dispositivo.";
+"keysignStartResponseError" = "Ocorreu um problema ao processar a resposta de início do keysign. Tenta novamente.";
+"keysignStartVerifyFailed" = "Não foi possível verificar o início do keysign. Erro: %@";
 "Korean" = "Coreano";
 "label" = "Rótulo";
 "language" = "Idioma";
@@ -652,6 +657,7 @@
 "nOfTotal" = "%d de %@";
 "noGasTokenFoundError" = "Token de gas não encontrado para a cadeia %@. Por favor, adicione o token nativo ao seu vault.";
 "noLiquidityPool" = "Não há pool de liquidez disponível para este par de tokens. Este ativo pode não ser suportado.";
+"noMessagesToSign" = "Não há mensagens para assinar";
 "noPoolsAvailable" = "No pools available";
 "noPositionsFound" = "Nenhuma posição encontrada";
 "noPositionsSelectedSubtitle" = "Você desabilitou todas as posições para esta cadeia. Habilite pelo menos uma posição para visualizar saldos e gerenciar ações.";
@@ -741,6 +747,7 @@
 "Portuguese" = "Português";
 "position" = "Posição";
 "positiveAmountError" = "A quantidade deve ser um número positivo. Tente novamente.";
+"prepareKeysignMessagesFailed" = "Não foi possível preparar as mensagens para o keysigning. Erro: %@";
 "preparingVaultText1" = "Segurança multifatorial, ";
 "preparingVaultText2" = "eliminando o ponto único de falha";
 "previewKeygenDescription" = "Digitalize com dispositivos para ingressar na geração do cofre";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -303,6 +303,8 @@
 "dappRequestFrom" = "请求来自";
 "date" = "日期";
 "decimalAmountError" = "金额必须为小数。";
+"decodeCustomMessagePayloadError" = "解码自定义消息负载时出错：%@";
+"decodeKeysignMessageError" = "解码 keysign 消息时出错：%@";
 "defiChainNoPositions" = "未找到任何持仓";
 "defiChainPositionsCount" = "%d 个持仓";
 "defiPortfolio" = "DeFi 投资组合";
@@ -520,6 +522,7 @@
 "joinKeygenViewDescription" = "从您在主设备上完成设置保险库的那一刻起，您的保险库将开始生成";
 "joinKeygenViewTitle" = "等待其他设备加入";
 "joinKeysign" = "加入密钥签名";
+"joinKeysignCommitteeFailed" = "加入 keysign 委员会失败。请检查网络连接后重试。";
 "joinReshare" = "加入重新共享";
 "joinSend" = "加入发送";
 "joinSwap" = "加入交换";
@@ -559,6 +562,8 @@
 "keysign" = "密钥签名";
 "keysignDiscoveryDisclaimer" = "扫描二维码以签署交易";
 "keysignDiscoveryDisclaimerDevice" = "-需要设备扫描";
+"keysignStartResponseError" = "处理 keysign 启动响应时出现问题。请重试。";
+"keysignStartVerifyFailed" = "验证 keysign 启动失败。错误：%@";
 "Korean" = "韩语";
 "label" = "标签";
 "language" = "语言";
@@ -652,6 +657,7 @@
 "nOfTotal" = "%d / %@";
 "noGasTokenFoundError" = "未找到 %@ 链的燃料代币。请将原生代币添加到您的保险库";
 "noLiquidityPool" = "此代币对没有可用的流动性池。此资产可能不受支持";
+"noMessagesToSign" = "没有需要签名的消息";
 "noPoolsAvailable" = "没有可用的资金池";
 "noPositionsFound" = "未找到任何持仓";
 "noPositionsSelectedSubtitle" = "您已禁用此链的所有仓位。启用至少一个仓位以查看余额并管理操作";
@@ -742,6 +748,7 @@
 "Portuguese" = "葡萄牙语";
 "position" = "仓位";
 "positiveAmountError" = "金额必须是正数。请重试";
+"prepareKeysignMessagesFailed" = "为 keysigning 准备消息失败。错误：%@";
 "preparingVaultText1" = "多因素安全，";
 "preparingVaultText2" = "消除单点故障";
 "previewKeygenDescription" = "使用设备扫描以加入保险库生成";

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -146,7 +146,7 @@ class JoinKeysignViewModel: ObservableObject {
                     self.logger.info("Successfully joined the keysign committee.")
                     self.status = .WaitingForKeysignToStart
                 } else {
-                    self.errorMsg = "Failed to join the keysign committee. Please check your connection and try again."
+                    self.errorMsg = "joinKeysignCommitteeFailed".localized
                     self.status = .FailedToStart
                 }
             }
@@ -204,7 +204,7 @@ class JoinKeysignViewModel: ObservableObject {
                             self.logger.info("Keysign process has started successfully.")
                         }
                     } catch {
-                        self.errorMsg = "There was an issue processing the keysign start response. Please try again."
+                        self.errorMsg = "keysignStartResponseError".localized
                         self.status = .FailedToStart
                     }
                 }
@@ -214,7 +214,7 @@ class JoinKeysignViewModel: ObservableObject {
                     self.logger.info("Waiting for keysign to start. Please stand by.")
                 } else {
                     DispatchQueue.main.async {
-                        self.errorMsg = "Failed to verify keysign start. Error: \(error.localizedDescription)"
+                        self.errorMsg = String(format: "keysignStartVerifyFailed".localized, error.localizedDescription)
                         self.status = .FailedToStart
                     }
                 }
@@ -248,11 +248,11 @@ class JoinKeysignViewModel: ObservableObject {
             self.logger.info("Successfully prepared messages for keysigning.")
             self.keysignMessages = preSignedImageHash.sorted()
             if self.keysignMessages.isEmpty {
-                self.errorMsg = "There is no messages to be signed"
+                self.errorMsg = "noMessagesToSign".localized
                 self.status = .FailedToStart
             }
         } catch {
-            self.errorMsg = "Failed to prepare messages for keysigning. Error: \(error.localizedDescription)"
+            self.errorMsg = String(format: "prepareKeysignMessagesFailed".localized, error.localizedDescription)
             self.status = .FailedToStart
         }
     }
@@ -360,7 +360,7 @@ class JoinKeysignViewModel: ObservableObject {
                 Task { await driver.run() }
             }
         } catch {
-            self.errorMsg = "Error decoding keysign message: \(error.localizedDescription)"
+            self.errorMsg = String(format: "decodeKeysignMessageError".localized, error.localizedDescription)
             self.status = .FailedToStart
         }
     }
@@ -413,7 +413,7 @@ class JoinKeysignViewModel: ObservableObject {
             self.keysignPayload = kp
             await self.prepareKeysignMessages(keysignPayload: kp)
         } catch {
-            self.errorMsg = "Error decoding keysign message: \(error.localizedDescription)"
+            self.errorMsg = String(format: "decodeKeysignMessageError".localized, error.localizedDescription)
             self.status = .FailedToStart
         }
     }
@@ -433,7 +433,7 @@ class JoinKeysignViewModel: ObservableObject {
             self.customMessagePayload = cmp
             self.prepareKeysignMessages(customMessagePayload: cmp)
         } catch {
-            self.errorMsg = "Error decoding custom message payload: \(error.localizedDescription)"
+            self.errorMsg = String(format: "decodeCustomMessagePayloadError".localized, error.localizedDescription)
             self.status = .FailedToStart
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #4596. Routes the eight hardcoded user-facing `errorMsg` literals in `JoinKeysignViewModel` through the project's `"key".localized` convention so non-English users no longer see raw English on the "Signing Error" screen.

- Plain keys use `"key".localized`; the strings interpolating `error.localizedDescription` use `String(format: "key".localized, error.localizedDescription)` with a bare `%@` specifier.
- Grammar fix on the "no messages" string: "There is no messages to be signed" -> "There are no messages to be signed".
- The two existing `qbtcClaimDisabledFromAdvanced` localized lines and all `logger.*` strings are left untouched.

### Keys added

| Key | Type |
|-----|------|
| `joinKeysignCommitteeFailed` | plain |
| `keysignStartResponseError` | plain |
| `keysignStartVerifyFailed` | format (`%@`) |
| `noMessagesToSign` | plain (grammar fixed) |
| `prepareKeysignMessagesFailed` | format (`%@`) |
| `decodeKeysignMessageError` | format (`%@`) — covers both occurrences (both interpolate `error.localizedDescription`) |
| `decodeCustomMessagePayloadError` | format (`%@`) |

All seven keys were added with **real per-locale translations** (not English fallback) to **all eight maintained** `Localizable.strings` files: en, de, es, hr, it, **ko**, pt, zh-Hans, then re-sorted with `python3 VultisigApp/scripts/sort_localizable.py`.

> Note: the repo docs (`CLAUDE.md` / `.claude/rules/localization.md`) still say 7 locales, but `ko.lproj` is fully maintained (e.g. `qbtcClaimDisabledFromAdvanced` is translated there), so this PR updates all 8. Worth a separate housekeeping PR to fix the docs.

## Files changed

- `VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift`
- `VultisigApp/VultisigApp/Core/Localizables/{en,de,es,hr,it,ko,pt,zh-Hans}.lproj/Localizable.strings`

## Verification

- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — clean on the changed file (the 71 pre-existing repo-wide warnings, 0 serious, are unrelated and not in `JoinKeysignViewModel.swift`).
- Build: `xcodebuild build -project VultisigApp/VultisigApp.xcodeproj -scheme VultisigApp -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'` — **BUILD SUCCEEDED**.
- Sort script is idempotent (re-running produces no diff); each of the 7 keys greps to exactly 8 locale files.
- No new files, so no `make generate` needed for review.

## Rebase note

This stacks on / conflicts with #4596, which edits the same method (`joinKeysignCommittee()`) around line 149. **After #4596 merges, this branch must be rebased** — it's a one-line conflict on the `joinKeysignCommitteeFailed` literal inside #4596's guarded completion closure.

Fixes #4597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Implemented comprehensive localized error messaging across German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese. Error notifications throughout the signing workflow now display in the user's preferred language, improving clarity for issues related to message decoding, committee operations, and transaction preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->