### PR TITLE
fix(keysign): guard against double-tap on join keysign committee

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -53,6 +53,7 @@ class JoinKeysignViewModel: ObservableObject {
     @Published var keysignCommittee = [String]()
     @Published var localPartyID: String = ""
     @Published var errorMsg: String = ""
+    @Published var isJoiningCommittee = false
     @Published var keysignPayload: KeysignPayload? = nil
     /// Set when the scanned QR has `isQbtcClaim == true`. The standard
     /// single-keysign flow steps aside while this driver runs the
@@ -128,6 +129,8 @@ class JoinKeysignViewModel: ObservableObject {
     }
 
     func joinKeysignCommittee() {
+        guard !isJoiningCommittee else { return }
+
         guard let serverURL = serverAddress else {
             return logger.error("Server URL could not be found. Please ensure you're connected to the correct network.")
         }
@@ -135,6 +138,7 @@ class JoinKeysignViewModel: ObservableObject {
             return logger.error("Session ID has not been acquired. Please scan the QR code again.")
         }
 
+        isJoiningCommittee = true
         Utils.sendRequest(
             urlString: "\(serverURL)/\(sessionID)",
             method: "POST",
@@ -142,6 +146,7 @@ class JoinKeysignViewModel: ObservableObject {
             body: [localPartyID]
         ) { success in
             DispatchQueue.main.async {
+                self.isJoiningCommittee = false
                 if success {
                     self.logger.info("Successfully joined the keysign committee.")
                     self.status = .WaitingForKeysignToStart

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignCustomMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignCustomMessageConfirmView.swift
@@ -144,9 +144,10 @@ struct KeysignCustomMessageConfirmView: View {
     }
 
     var button: some View {
-        PrimaryButton(title: "joinKeysign") {
+        PrimaryButton(title: "joinKeysign", isLoading: viewModel.isJoiningCommittee) {
             viewModel.joinKeysignCommittee()
         }
+        .disabled(viewModel.isJoiningCommittee)
         .padding(20)
     }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignMessageConfirmView.swift
@@ -41,9 +41,10 @@ struct KeysignMessageConfirmView: View {
                     securityScannerState: $viewModel.securityScannerState
                 )
 
-                PrimaryButton(title: "joinTransactionSigning") {
+                PrimaryButton(title: "joinTransactionSigning", isLoading: viewModel.isJoiningCommittee) {
                     viewModel.joinKeysignCommittee()
                 }
+                .disabled(viewModel.isJoiningCommittee)
             }
             .task {
                 async let thor: Void = viewModel.loadThorchainID()

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -52,9 +52,10 @@ struct KeysignSwapConfirmView: View {
     }
 
     var button: some View {
-        PrimaryButton(title: "joinTransactionSigning") {
+        PrimaryButton(title: "joinTransactionSigning", isLoading: viewModel.isJoiningCommittee) {
             viewModel.joinKeysignCommittee()
         }
+        .disabled(viewModel.isJoiningCommittee)
         .padding(20)
     }
 

--- a/VultisigApp/VultisigAppTests/Keysign/JoinKeysignDoubleTapGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/JoinKeysignDoubleTapGuardTests.swift
@@ -1,0 +1,145 @@
+//
+//  JoinKeysignDoubleTapGuardTests.swift
+//  VultisigAppTests
+//
+//  Pins the in-flight re-entrancy guard on `JoinKeysignViewModel.joinKeysignCommittee()`.
+//  A rapid double-tap on the peer "Join Keysign" button must fire exactly ONE
+//  join request: while the first request is in flight the `isJoiningCommittee`
+//  flag is set, so a second synchronous call returns at the guard and never
+//  issues a second `POST /{session}`. Without the guard a late/failed duplicate
+//  response could flip a successful join to a spurious "Signing Error".
+//
+//  `Utils.sendRequest` hits `URLSession.shared` directly, so we intercept it
+//  with a globally registered `URLProtocol` that counts requests and holds the
+//  first one open until both taps have been issued.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class JoinKeysignDoubleTapGuardTests: XCTestCase {
+
+    private static let stubHost = "join-keysign-double-tap-stub.local"
+
+    override func setUp() {
+        super.setUp()
+        HoldingStubProtocol.reset()
+        URLProtocol.registerClass(HoldingStubProtocol.self)
+    }
+
+    override func tearDown() {
+        HoldingStubProtocol.release()
+        URLProtocol.unregisterClass(HoldingStubProtocol.self)
+        HoldingStubProtocol.reset()
+        super.tearDown()
+    }
+
+    func testDoubleTapIssuesSingleJoinRequest() {
+        let viewModel = JoinKeysignViewModel()
+        viewModel.serverAddress = "https://\(Self.stubHost)"
+        viewModel.sessionID = "session-1"
+        viewModel.localPartyID = "party-A"
+
+        // First tap: starts the request, sets the in-flight flag.
+        viewModel.joinKeysignCommittee()
+        XCTAssertTrue(viewModel.isJoiningCommittee, "First tap must mark the join as in-flight")
+
+        // Second tap arrives while the first request is still held open by the
+        // stub. The guard must drop it before any network call is made.
+        viewModel.joinKeysignCommittee()
+
+        // The protocol holds the first request open, so by the time both taps
+        // have been issued at most one request can have reached the network.
+        XCTAssertLessThanOrEqual(
+            HoldingStubProtocol.startCount,
+            1,
+            "A double-tap while in-flight must not start a second join request"
+        )
+
+        // Release the held first request so the completion can clear the flag.
+        HoldingStubProtocol.release()
+
+        let cleared = expectation(description: "isJoiningCommittee clears on completion")
+        Task { @MainActor in
+            for _ in 0..<200 where viewModel.isJoiningCommittee {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+            cleared.fulfill()
+        }
+        wait(for: [cleared], timeout: 5)
+
+        XCTAssertFalse(viewModel.isJoiningCommittee, "Flag must clear once the join request completes")
+        XCTAssertEqual(
+            HoldingStubProtocol.startCount,
+            1,
+            "Exactly one join request must have been issued for a double-tap"
+        )
+    }
+}
+
+/// Intercepts the join `POST` and holds it open until `release()` is called, so
+/// the test can fire a second tap while the first request is genuinely in flight.
+/// Counts every request that begins loading.
+private final class HoldingStubProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var _startCount = 0
+    private static let gate = DispatchSemaphore(value: 0)
+    private static var released = false
+
+    static var startCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _startCount
+    }
+
+    static func reset() {
+        lock.lock()
+        _startCount = 0
+        released = false
+        lock.unlock()
+    }
+
+    static func release() {
+        lock.lock()
+        let alreadyReleased = released
+        released = true
+        lock.unlock()
+        if !alreadyReleased {
+            gate.signal()
+        }
+    }
+
+    // These are required `URLProtocol` class-method overrides; they cannot be `static`.
+    // swiftlint:disable static_over_final_class
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "join-keysign-double-tap-stub.local"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    // swiftlint:enable static_over_final_class
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self._startCount += 1
+        Self.lock.unlock()
+
+        // Block the URLSession worker thread until the test releases the gate,
+        // keeping this request "in flight" while the second tap is issued.
+        Self.gate.wait()
+        Self.gate.signal()
+
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(fileURLWithPath: "/"),
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )
+        if let response {
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        }
+        client?.urlProtocol(self, didLoad: Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/VultisigApp/VultisigAppTests/Keysign/JoinKeysignDoubleTapGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/JoinKeysignDoubleTapGuardTests.swift
@@ -93,6 +93,9 @@ private final class HoldingStubProtocol: URLProtocol {
     }
 
     static func reset() {
+        // Drain any leftover permits so a prior run's re-signaled `gate` can't
+        // let `startLoading()` skip its in-flight hold on the next test.
+        while gate.wait(timeout: .now()) == .success {}
         lock.lock()
         _startCount = 0
         released = false


### PR DESCRIPTION
## What

Adds an in-flight re-entrancy guard to `JoinKeysignViewModel.joinKeysignCommittee()` so a rapid double/triple-tap on the peer **"Join Keysign"** button fires exactly one `POST /{session}` join request.

## Root cause

`joinKeysignCommittee()` had no in-flight guard and no in-flight state. The join request is async; `status` stayed `.JoinKeysign` until the response returned, so tap #2 fired a second concurrent request before tap #1 resolved. Whichever response failed (or landed late, after the relay moved on) set `status = .FailedToStart`, flipping the Verify screen to a spurious **"Signing Error — Failed to join the keysign committee…"** even when the first join already succeeded. Reported on a `personal_sign` join (Venice.ai SIWE), app v1.39.61.

`PrimaryButton.isLoading` does not block taps (`Button { action() }` always fires), so the real guard must live in the view model; `.disabled(...)` is UX only.

## Fix

- `JoinKeysignViewModel`: add `@Published var isJoiningCommittee`. The VM is `@MainActor`, so a plain `Bool` gate is race-free.
  - `guard !isJoiningCommittee else { return }` at the top of `joinKeysignCommittee()`.
  - Set `isJoiningCommittee = true` **after** the existing `serverURL`/`sessionID` early guards (so a missing-server/empty-session case doesn't latch the button).
  - Clear `self.isJoiningCommittee = false` as the first statement inside the existing `DispatchQueue.main.async { … }`. The `DispatchQueue.main.async` is kept on purpose: the completion arrives off-main and can fire synchronously on a bad URL/encode failure.
- The three confirm views (`KeysignCustomMessageConfirmView`, `KeysignMessageConfirmView`, `KeysignSwapConfirmView`) pass `isLoading: viewModel.isJoiningCommittee` and add `.disabled(viewModel.isJoiningCommittee)` for UX + defense-in-depth.

No protocol/relay behavior changes — purely client re-entrancy. The hardcoded error string is intentionally left as-is (localization is tracked separately).

## Tests

Added `VultisigAppTests/Keysign/JoinKeysignDoubleTapGuardTests.swift`. Since `Utils.sendRequest` uses `URLSession.shared` directly (no injectable seam), the test registers a `URLProtocol` (same pattern as `SuiServiceGetAllCoinsTests`) that intercepts the join `POST`, counts requests, and **holds the first request open** until both taps are issued — then asserts exactly one request reached the network. Verified the test **fails (2 requests) without the guard** and **passes (1 request) with it**, so it genuinely pins the behavior.

## Verification

- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — clean for all changed/new files (0 violations in the 5 touched files; pre-existing repo-wide violations in unrelated files are unchanged).
- `xcodebuild build -project VultisigApp/VultisigApp.xcodeproj -scheme VultisigApp -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4'` — **BUILD SUCCEEDED**.
- `xcodebuild test … -only-testing:VultisigAppTests/JoinKeysignDoubleTapGuardTests` — **TEST SUCCEEDED** (and confirmed failing when the guard is removed).
- Not done in this PR: the issue's acceptance criterion of a manual `personal_sign` double-tap on a **physical iPhone** remains a maintainer step.

Fixes #4596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate “join keysign committee” submissions from rapid taps by blocking re-entrancy while a request is in progress.
  * Updated join buttons across all confirmation screens to show a loading state and disable user interaction until the join request completes.

* **Tests**
  * Added coverage to verify double-tap behavior no longer triggers multiple network requests during an in-flight join operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->