### PR TITLE
fix(swap): include SwapKit chainId in tracker links

### DIFF
--- a/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
@@ -42,7 +42,7 @@ enum ExplorerLinkBuilder {
             // Phase 1 ships the explorer-link fallback; `/track` polling is
             // covered by the follow-up tx-history plan. `track.swapkit.dev`
             // accepts on-chain hashes for the source chain.
-            return swapkitTracker(txid: txHash)
+            return swapkitTracker(txid: txHash, chain: fromChain)
         case .oneinch, .kyberswap, .none:
             return getExplorerURL(chain: fromChain, txid: txHash)
         }
@@ -65,15 +65,15 @@ enum ExplorerLinkBuilder {
             case .lifi:
                 return lifiTracker(txid: txHash)
             case .swapkit:
-                return swapkitTracker(txid: txHash)
+                return swapkitTracker(txid: txHash, chain: payload.fromCoin.chain)
             case .oneInch, .kyberSwap, .unknown:
                 return getExplorerURL(chain: payload.fromCoin.chain, txid: txHash)
             }
-        case .swapkit:
+        case .swapkit(let payload):
             // Phase 2 ships explorer-link fallback for BTC PSBT routes.
             // `/track` polling integration is covered by the follow-up
             // tx-history plan; track.swapkit.dev accepts the on-chain hash.
-            return swapkitTracker(txid: txHash)
+            return swapkitTracker(txid: txHash, chain: payload.fromCoin.chain)
         case .none:
             return nil
         }
@@ -97,7 +97,7 @@ enum ExplorerLinkBuilder {
             case "lifi":
                 return URL(string: lifiTracker(txid: txHash))
             case "swapkit":
-                return URL(string: swapkitTracker(txid: txHash))
+                return URL(string: swapkitTracker(txid: txHash, chain: Chain(rawValue: chainRawValue)))
             case "maya", "mayachain", "mayaprotocol":
                 return URL(string: mayaTracker(txid: txHash))
             case "thorchainstagenet":
@@ -310,8 +310,16 @@ enum ExplorerLinkBuilder {
         "https://scan.li.fi/tx/\(txid)"
     }
 
-    private static func swapkitTracker(txid: String) -> String {
-        "https://track.swapkit.dev/?hash=\(txid)"
+    /// `track.swapkit.dev` resolves a hash faster when it knows which chain
+    /// to look on, so we append the SwapKit chainId whenever the source chain
+    /// maps to one. Falls back to the hash-only link for chains outside the
+    /// SwapKit route catalogue.
+    private static func swapkitTracker(txid: String, chain: Chain?) -> String {
+        let base = "https://track.swapkit.dev/?hash=\(txid)"
+        guard let chain, let chainId = SwapKitChainIdentifier.chainId(for: chain) else {
+            return base
+        }
+        return "\(base)&chainId=\(chainId)"
     }
 
     private static func mayaTracker(txid: String) -> String {

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryData.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryData.swift
@@ -148,7 +148,14 @@ extension TransactionHistoryData {
               let hash = tracking.broadcastHash, !hash.isEmpty else {
             return nil
         }
-        return URL(string: "https://track.swapkit.dev/?hash=\(hash)")
+        // Append the SwapKit chainId so the tracker resolves the hash on the
+        // right chain; fall back to hash-only for chains it doesn't map.
+        let base = "https://track.swapkit.dev/?hash=\(hash)"
+        guard let chain = Chain(rawValue: chainRawValue),
+              let chainId = SwapKitChainIdentifier.chainId(for: chain) else {
+            return URL(string: base)
+        }
+        return URL(string: "\(base)&chainId=\(chainId)")
     }
 }
 


### PR DESCRIPTION
## Summary
- Append the SwapKit `chainId` to `track.swapkit.dev` links so the tracker resolves a transaction hash on the correct source chain rather than searching across all chains.
- Updated both link builders: `ExplorerLinkBuilder.swapkitTracker(txid:chain:)` and `TransactionHistoryData`'s SwapKit tracker URL.
- Falls back to the existing hash-only link for chains outside the SwapKit route catalogue (when `SwapKitChainIdentifier.chainId(for:)` returns `nil`).

## Test Plan
- [ ] Broadcast a SwapKit swap and confirm the tracker link includes `&chainId=...` for the source chain
- [ ] Confirm chains without a SwapKit mapping still produce a valid hash-only link
- [x] SwiftLint passes (0 violations)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * SwapKit transaction tracking links now include blockchain chain identifiers when available, significantly improving transaction lookup accuracy within the transaction history. This enhancement provides better support for multi-chain swap operations.
  * Tracking functionality includes automatic fallback to basic hash-only tracking when chain information cannot be determined, ensuring compatibility across all transaction types and use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->