### PR TITLE
fix(swap): size EVM SwapKit network fee per source token

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -201,33 +201,24 @@ extension SwapKitService {
     /// row, the Total Fee (fiat), and the gas-coin sufficiency check in
     /// `SwapCryptoLogic.balanceError`.
     ///
-    /// EVM sources derive the fee from `tx.gas × tx.gasPrice` rather than the
-    /// wire `inbound` `fees[]` entry. The `inbound` amount is a per-provider
-    /// estimate: ONEINCH reports a plausible gas figure there, but FLASHNET-on-EVM
-    /// returns a near-zero placeholder (~hundreds of wei) that renders as garbage
-    /// like `0.00000000000000013 ETH` and a `$0.00` total. See `evmNetworkFee` for
-    /// the gas normalisation — the same `gas × gasPrice` convention KyberSwap /
-    /// 1inch / LI.FI use for their own `fee` BigInt.
-    ///
-    /// An ERC-20 source executes the swap as two signed transactions — a token
-    /// approval then the swap — and pays gas for both, so the approval's
-    /// `gasLimit × gasPrice` is added when SwapKit returns an `approvalTx`. Native
-    /// sources need no approval.
+    /// EVM sources derive the fee from the realised `tx.gas × tx.gasPrice`
+    /// rather than the wire `inbound` `fees[]` entry. The `inbound` amount is a
+    /// per-provider estimate: ONEINCH reports a plausible gas figure there, but
+    /// FLASHNET-on-EVM returns a near-zero placeholder (~hundreds of wei) that
+    /// renders as garbage like `0.00000000000000013 ETH` and a `$0.00` total.
+    /// `gas × gasPrice` is the value the keysign path actually commits to
+    /// (`SwapPayloadBuilder.buildEVMQuoteFromSwapKit`), so the displayed fee
+    /// matches what the user is charged for every EVM sub-provider — the same
+    /// convention KyberSwap / 1inch / LI.FI use for their own `fee` BigInt.
     ///
     /// Non-EVM sources keep the `inbound`-decimal path: the BTC PSBT, Solana,
     /// and TRON fixtures all report the real native miner/network fee there as
     /// a decimal native amount (e.g. "0.000005" SOL).
     func inboundFee(from response: SwapKitSwapResponse, fromCoin: Coin) -> BigInt? {
-        guard case let .evm(tx) = response.tx else {
-            return inboundFeeFromWire(response: response, fromCoin: fromCoin)
+        if case let .evm(tx) = response.tx {
+            return evmNetworkFee(from: tx, isNativeSource: fromCoin.isNativeToken)
         }
-        guard let swapFee = evmNetworkFee(from: tx, isNativeSource: fromCoin.isNativeToken) else {
-            return nil
-        }
-        guard !fromCoin.isNativeToken, let approvalTx = response.approvalTx else {
-            return swapFee
-        }
-        return swapFee + approvalNetworkFee(from: approvalTx)
+        return inboundFeeFromWire(response: response, fromCoin: fromCoin)
     }
 
     /// EVM network fee = `gasPrice × gas` in wei, parsing the hex `SwapKitEvmTx`
@@ -246,15 +237,6 @@ extension SwapKitService {
         let gas = parsedGas == .zero ? fallbackGas : parsedGas
         let fee = gasPrice * gas
         return fee == .zero ? nil : fee
-    }
-
-    /// Approval-leg network fee = `gasPrice × gasLimit` in wei. The approval tx
-    /// always carries an explicit `gasLimit` (unlike the swap tx's `gas`), so
-    /// there's no fallback — a missing/zero limit contributes nothing.
-    private func approvalNetworkFee(from tx: SwapKitApprovalTx) -> BigInt {
-        let gasPrice = BigInt(tx.gasPrice.stripHexPrefix(), radix: 16) ?? .zero
-        let gasLimit = BigInt(tx.gasLimit.stripHexPrefix(), radix: 16) ?? .zero
-        return gasPrice * gasLimit
     }
 
     private func inboundFeeFromWire(response: SwapKitSwapResponse, fromCoin: Coin) -> BigInt? {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -201,24 +201,33 @@ extension SwapKitService {
     /// row, the Total Fee (fiat), and the gas-coin sufficiency check in
     /// `SwapCryptoLogic.balanceError`.
     ///
-    /// EVM sources derive the fee from the realised `tx.gas × tx.gasPrice`
-    /// rather than the wire `inbound` `fees[]` entry. The `inbound` amount is a
-    /// per-provider estimate: ONEINCH reports a plausible gas figure there, but
-    /// FLASHNET-on-EVM returns a near-zero placeholder (~hundreds of wei) that
-    /// renders as garbage like `0.00000000000000013 ETH` and a `$0.00` total.
-    /// `gas × gasPrice` is the value the keysign path actually commits to
-    /// (`SwapPayloadBuilder.buildEVMQuoteFromSwapKit`), so the displayed fee
-    /// matches what the user is charged for every EVM sub-provider — the same
-    /// convention KyberSwap / 1inch / LI.FI use for their own `fee` BigInt.
+    /// EVM sources derive the fee from `tx.gas × tx.gasPrice` rather than the
+    /// wire `inbound` `fees[]` entry. The `inbound` amount is a per-provider
+    /// estimate: ONEINCH reports a plausible gas figure there, but FLASHNET-on-EVM
+    /// returns a near-zero placeholder (~hundreds of wei) that renders as garbage
+    /// like `0.00000000000000013 ETH` and a `$0.00` total. See `evmNetworkFee` for
+    /// the gas normalisation — the same `gas × gasPrice` convention KyberSwap /
+    /// 1inch / LI.FI use for their own `fee` BigInt.
+    ///
+    /// An ERC-20 source executes the swap as two signed transactions — a token
+    /// approval then the swap — and pays gas for both, so the approval's
+    /// `gasLimit × gasPrice` is added when SwapKit returns an `approvalTx`. Native
+    /// sources need no approval.
     ///
     /// Non-EVM sources keep the `inbound`-decimal path: the BTC PSBT, Solana,
     /// and TRON fixtures all report the real native miner/network fee there as
     /// a decimal native amount (e.g. "0.000005" SOL).
     func inboundFee(from response: SwapKitSwapResponse, fromCoin: Coin) -> BigInt? {
-        if case let .evm(tx) = response.tx {
-            return evmNetworkFee(from: tx, isNativeSource: fromCoin.isNativeToken)
+        guard case let .evm(tx) = response.tx else {
+            return inboundFeeFromWire(response: response, fromCoin: fromCoin)
         }
-        return inboundFeeFromWire(response: response, fromCoin: fromCoin)
+        guard let swapFee = evmNetworkFee(from: tx, isNativeSource: fromCoin.isNativeToken) else {
+            return nil
+        }
+        guard !fromCoin.isNativeToken, let approvalTx = response.approvalTx else {
+            return swapFee
+        }
+        return swapFee + approvalNetworkFee(from: approvalTx)
     }
 
     /// EVM network fee = `gasPrice × gas` in wei, parsing the hex `SwapKitEvmTx`
@@ -237,6 +246,15 @@ extension SwapKitService {
         let gas = parsedGas == .zero ? fallbackGas : parsedGas
         let fee = gasPrice * gas
         return fee == .zero ? nil : fee
+    }
+
+    /// Approval-leg network fee = `gasPrice × gasLimit` in wei. The approval tx
+    /// always carries an explicit `gasLimit` (unlike the swap tx's `gas`), so
+    /// there's no fallback — a missing/zero limit contributes nothing.
+    private func approvalNetworkFee(from tx: SwapKitApprovalTx) -> BigInt {
+        let gasPrice = BigInt(tx.gasPrice.stripHexPrefix(), radix: 16) ?? .zero
+        let gasLimit = BigInt(tx.gasLimit.stripHexPrefix(), radix: 16) ?? .zero
+        return gasPrice * gasLimit
     }
 
     private func inboundFeeFromWire(response: SwapKitSwapResponse, fromCoin: Coin) -> BigInt? {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -216,20 +216,25 @@ extension SwapKitService {
     /// a decimal native amount (e.g. "0.000005" SOL).
     func inboundFee(from response: SwapKitSwapResponse, fromCoin: Coin) -> BigInt? {
         if case let .evm(tx) = response.tx {
-            return evmNetworkFee(from: tx)
+            return evmNetworkFee(from: tx, isNativeSource: fromCoin.isNativeToken)
         }
         return inboundFeeFromWire(response: response, fromCoin: fromCoin)
     }
 
-    /// Realised EVM network fee = `gasPrice × gas` in wei, parsing the hex
-    /// `SwapKitEvmTx` fields exactly as the keysign path does. A zero/missing
-    /// `gas` falls back to `EVMHelper.defaultETHSwapGasUnit` so a route that
-    /// omits the limit still shows a representative fee instead of zero —
-    /// identical normalisation to `buildEVMQuoteFromSwapKit`.
-    func evmNetworkFee(from tx: SwapKitEvmTx) -> BigInt? {
+    /// EVM network fee = `gasPrice × gas` in wei, parsing the hex `SwapKitEvmTx`
+    /// fields. SwapKit's reported `tx.gas` is respected whenever it's present —
+    /// the same convention 1inch / Kyber / LI.FI use for their own `fee`. Only a
+    /// route that omits the limit (`gas == 0`) falls back to a default so the row
+    /// shows a representative fee instead of zero: native sources to the swap gas
+    /// unit, ERC-20 sources (which need a token approval) to the token-transfer
+    /// unit.
+    func evmNetworkFee(from tx: SwapKitEvmTx, isNativeSource: Bool) -> BigInt? {
         let gasPrice = BigInt(tx.gasPrice.stripHexPrefix(), radix: 16) ?? .zero
         let parsedGas = BigInt(tx.gas.stripHexPrefix(), radix: 16) ?? .zero
-        let gas = parsedGas == .zero ? BigInt(EVMHelper.defaultETHSwapGasUnit) : parsedGas
+        let fallbackGas = isNativeSource
+            ? BigInt(EVMHelper.defaultETHSwapGasUnit)
+            : BigInt(EVMHelper.defaultERC20TransferGasUnit)
+        let gas = parsedGas == .zero ? fallbackGas : parsedGas
         let fee = gasPrice * gas
         return fee == .zero ? nil : fee
     }

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
@@ -44,8 +44,6 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
         // Fixture tx: gas 0x55730 (350_000) × gasPrice 0x2aaa0b23 (715_787_043 wei)
         // = 250_525_465_050_000 wei. The wire `inbound` entry on this fixture is a
         // smaller estimate (0.000098846611703085 ETH); we deliberately ignore it.
-        // A native source pays no token approval, so the fixture's `approvalTx`
-        // is not added here.
         XCTAssertEqual(fee, BigInt("250525465050000"))
     }
 
@@ -63,12 +61,9 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
         // (18dp gas units), independent of the sell token's decimals.
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
         let fee = service.inboundFee(from: response, fromCoin: usdc)
-        // ERC-20 source: swap + approval gas.
-        //   swap:     gas 0x33450 (210_000) × gasPrice 0x3b9aca00 (1 gwei) = 210_000_000_000_000
-        //   approval: gasLimit 0xbf28 (48_936) × 1 gwei                    =  48_936_000_000_000
-        //   total                                                          = 258_936_000_000_000 (0.000258936 ETH)
-        // NOT the 130-wei placeholder.
-        XCTAssertEqual(fee, BigInt("258936000000000"))
+        // Fixture tx: gas 0x33450 (210_000) × gasPrice 0x3b9aca00 (1 gwei)
+        // = 210_000_000_000_000 wei (0.00021 ETH). NOT the 130-wei placeholder.
+        XCTAssertEqual(fee, BigInt("210000000000000"))
         XCTAssertNotEqual(fee, BigInt(130), "Must not regress to the inbound placeholder (~130 wei)")
     }
 
@@ -156,23 +151,19 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
         XCTAssertEqual(fee, BigInt(13_373_500))
     }
 
-    func testErc20SourceFeeIncludesApprovalGas() throws {
-        // An ERC-20 source executes the swap as two signed txs — a token approval
-        // then the swap — and pays gas for both. The fee is denominated in the
+    func testEvmFeeIsIndependentOfSellTokenDecimals() throws {
+        // The EVM fee is `tx.gas × tx.gasPrice` in wei — denominated in the
         // chain's native gas coin (ETH, 18dp) regardless of the sell token's
-        // decimals (USDC, 6dp).
+        // decimals. An ERC-20 source (USDC, 6dp) must produce the identical fee
+        // as the native ETH source for the same fixture tx.
         let response = try SwapKitFixtureLoader.decode(
             SwapKitSwapResponse.self,
             from: "v3-erc20-erc20-swap"
         )
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
         let fee = service.inboundFee(from: response, fromCoin: usdc)
-        // swap:     gas 0x55730 (350_000) × gasPrice 0x2aaa0b23 (715_787_043) = 250_525_465_050_000
-        // approval: gasLimit 0xbf28 (48_936) × 0x2aaa0b23                     =  35_027_754_736_248
-        // total                                                              = 285_553_219_786_248
-        XCTAssertEqual(fee, BigInt("285553219786248"))
-        // Strictly greater than the swap-only fee a native source would pay.
-        XCTAssertGreaterThan(fee ?? .zero, BigInt("250525465050000"))
+        // Same gas × gasPrice as testEvmFeeDerivedFromGasTimesGasPrice (native ETH source).
+        XCTAssertEqual(fee, BigInt("250525465050000"))
     }
 
     func testWrongChainPrefixDoesNotMatch() throws {

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
@@ -44,6 +44,8 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
         // Fixture tx: gas 0x55730 (350_000) × gasPrice 0x2aaa0b23 (715_787_043 wei)
         // = 250_525_465_050_000 wei. The wire `inbound` entry on this fixture is a
         // smaller estimate (0.000098846611703085 ETH); we deliberately ignore it.
+        // A native source pays no token approval, so the fixture's `approvalTx`
+        // is not added here.
         XCTAssertEqual(fee, BigInt("250525465050000"))
     }
 
@@ -61,9 +63,12 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
         // (18dp gas units), independent of the sell token's decimals.
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
         let fee = service.inboundFee(from: response, fromCoin: usdc)
-        // Fixture tx: gas 0x33450 (210_000) × gasPrice 0x3b9aca00 (1 gwei)
-        // = 210_000_000_000_000 wei (0.00021 ETH). NOT the 130-wei placeholder.
-        XCTAssertEqual(fee, BigInt("210000000000000"))
+        // ERC-20 source: swap + approval gas.
+        //   swap:     gas 0x33450 (210_000) × gasPrice 0x3b9aca00 (1 gwei) = 210_000_000_000_000
+        //   approval: gasLimit 0xbf28 (48_936) × 1 gwei                    =  48_936_000_000_000
+        //   total                                                          = 258_936_000_000_000 (0.000258936 ETH)
+        // NOT the 130-wei placeholder.
+        XCTAssertEqual(fee, BigInt("258936000000000"))
         XCTAssertNotEqual(fee, BigInt(130), "Must not regress to the inbound placeholder (~130 wei)")
     }
 
@@ -151,19 +156,23 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
         XCTAssertEqual(fee, BigInt(13_373_500))
     }
 
-    func testEvmFeeIsIndependentOfSellTokenDecimals() throws {
-        // The EVM fee is `tx.gas × tx.gasPrice` in wei — denominated in the
+    func testErc20SourceFeeIncludesApprovalGas() throws {
+        // An ERC-20 source executes the swap as two signed txs — a token approval
+        // then the swap — and pays gas for both. The fee is denominated in the
         // chain's native gas coin (ETH, 18dp) regardless of the sell token's
-        // decimals. An ERC-20 source (USDC, 6dp) must produce the identical fee
-        // as the native ETH source for the same fixture tx.
+        // decimals (USDC, 6dp).
         let response = try SwapKitFixtureLoader.decode(
             SwapKitSwapResponse.self,
             from: "v3-erc20-erc20-swap"
         )
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
         let fee = service.inboundFee(from: response, fromCoin: usdc)
-        // Same gas × gasPrice as testEvmFeeDerivedFromGasTimesGasPrice (native ETH source).
-        XCTAssertEqual(fee, BigInt("250525465050000"))
+        // swap:     gas 0x55730 (350_000) × gasPrice 0x2aaa0b23 (715_787_043) = 250_525_465_050_000
+        // approval: gasLimit 0xbf28 (48_936) × 0x2aaa0b23                     =  35_027_754_736_248
+        // total                                                              = 285_553_219_786_248
+        XCTAssertEqual(fee, BigInt("285553219786248"))
+        // Strictly greater than the swap-only fee a native source would pay.
+        XCTAssertGreaterThan(fee ?? .zero, BigInt("250525465050000"))
     }
 
     func testWrongChainPrefixDoesNotMatch() throws {

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitServiceInboundFeeTests.swift
@@ -68,7 +68,7 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
     }
 
     func testEvmFeeFallsBackToDefaultGasUnitWhenGasZero() throws {
-        // A route that omits the gas limit (gas == 0) must still surface a
+        // A native route that omits the gas limit (gas == 0) must still surface a
         // representative fee using `EVMHelper.defaultETHSwapGasUnit`, mirroring
         // the keysign-path normalisation, rather than collapsing to zero.
         let tx = SwapKitEvmTx(
@@ -79,9 +79,40 @@ final class SwapKitServiceInboundFeeTests: XCTestCase {
             gas: "0x0",
             gasPrice: "0x3b9aca00" // 1 gwei
         )
-        let fee = service.evmNetworkFee(from: tx)
+        let fee = service.evmNetworkFee(from: tx, isNativeSource: true)
         let expected = BigInt(EVMHelper.defaultETHSwapGasUnit) * BigInt(1_000_000_000)
         XCTAssertEqual(fee, expected)
+    }
+
+    func testEvmFeeFallsBackToErc20UnitWhenGasZeroForTokenSource() throws {
+        // An ERC-20 route that omits the gas limit falls back to the token
+        // operation unit rather than the native swap unit.
+        let tx = SwapKitEvmTx(
+            from: "0xfrom",
+            to: "0xto",
+            value: "0",
+            data: "0x",
+            gas: "0x0",
+            gasPrice: "0x3b9aca00" // 1 gwei
+        )
+        let fee = service.evmNetworkFee(from: tx, isNativeSource: false)
+        let expected = BigInt(EVMHelper.defaultERC20TransferGasUnit) * BigInt(1_000_000_000)
+        XCTAssertEqual(fee, expected)
+    }
+
+    func testEvmFeeRespectsReportedGasWhenNonZero() throws {
+        // SwapKit's reported gas is respected verbatim when present — we don't
+        // floor or substitute it, even for an ERC-20 source.
+        let tx = SwapKitEvmTx(
+            from: "0xfrom",
+            to: "0xto",
+            value: "0",
+            data: "0x",
+            gas: "0x33450", // 210_000
+            gasPrice: "0x3b9aca00" // 1 gwei
+        )
+        let fee = service.evmNetworkFee(from: tx, isNativeSource: false)
+        XCTAssertEqual(fee, BigInt(210_000) * BigInt(1_000_000_000))
     }
 
     func testSolanaInboundFeeParsedAsLamports() throws {


### PR DESCRIPTION
## Summary
- SwapKit EVM swaps derived the displayed Network Fee from the reported `tx.gas`. When an ERC-20 source omitted the gas limit, the fee collapsed toward zero / a misleading figure.
- `evmNetworkFee` now takes the source's native-vs-token nature. A **missing (zero)** gas falls back to the swap gas unit (`defaultETHSwapGasUnit`) for native sources and the token-transfer unit (`defaultERC20TransferGasUnit`) for ERC-20 sources.
- A **reported non-zero** gas is respected verbatim — matching the 1inch / Kyber / LI.FI convention (their quote `fee` already carries a realistic provider gas estimate; only SwapKit needed the source-aware fallback).
- The signed tx remains safe regardless: the keysign reserves the inflated swap gas limit via `chainSpecific`.

## Issue
Closes #4605

## Test Plan
- [x] SwiftLint passes (changed files, 0 violations)
- [x] `SwapKitServiceInboundFeeTests` passes (10/10), incl. new `testEvmFeeFallsBackToErc20UnitWhenGasZeroForTokenSource` and `testEvmFeeRespectsReportedGasWhenNonZero`
- [ ] xcodebuild build succeeds
- [ ] Manual: USDC → ETH SwapKit swap shows a sane Network Fee on the verify screen

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM inbound fee calculation for swap flows by distinguishing native-source vs ERC-20-source routes when reported gas parses to zero.
  * Updated the gas-unit fallback behavior accordingly (native uses the default ETH swap gas unit; ERC-20 uses the default ERC-20 transfer gas unit), while keeping fee computation as gasPrice × gas and returning `nil` for zero fees.
* **Tests**
  * Expanded coverage for native vs ERC-20 gas=0 fallback and verified correct fee computation when gas is non-zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->