### PR TITLE
fix(keysign): show fast-sign animation immediately, never the peer screen

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignDiscoveryViewModel.swift
@@ -82,6 +82,15 @@ class KeysignDiscoveryViewModel: ObservableObject {
         self.customMessagePayload = customMessagePayload
         self.participantDiscovery = participantDiscovery
 
+        // For a fast vault the server co-signs automatically, so the manual
+        // peer-discovery screen must never appear. Flip to the fast-signing
+        // state synchronously, before any `await` below (mediator start,
+        // message generation, Solana blockhash refresh), otherwise the peer
+        // screen lingers for the duration of those calls.
+        if fastVaultPassword != nil {
+            self.status = .WaitingForFast
+        }
+
         if let presetSession {
             self.sessionID = presetSession.sessionId
             self.serviceName = presetSession.serviceName
@@ -172,11 +181,6 @@ class KeysignDiscoveryViewModel: ObservableObject {
         if let fastVaultPassword, let coin {
             // when fast sign, always using relay server
             serverAddr = Endpoint.vultisigRelay
-
-            if vault.signers.count <= 3 {
-                // skip device lookup if possible
-                status = .WaitingForFast
-            }
 
             do {
                 try await fastVaultService.sign(


### PR DESCRIPTION
## Summary
- Fast vaults intermittently showed the manual "Waiting for devices to connect" peer-discovery screen instead of the fast-signing animation.
- `KeysignDiscoveryViewModel.status` defaulted to `.WaitingForDevices` and only flipped to `.WaitingForFast` partway through `setData()` — after several `await`s (mediator start, message generation, Solana blockhash refresh) — and only when `vault.signers.count <= 3`. The peer screen lingered for the duration of those calls (network-variance dependent), and fast vaults with >3 signers stayed on it entirely.
- Now set `status = .WaitingForFast` synchronously at the top of `setData()` when a fast vault password is present, before any `await`, and removed the late, signer-count-gated flip.
- Downstream `.FailToStart` assignments (empty messages, QBTC hash failure, `fastVaultService.sign` throw) still run after and correctly override the early state, so real failures are not masked.

## Issue
Closes #4604

## Test Plan
- [ ] Fast-sign with a fast vault (incl. one with >3 signers): fast-signing animation shows from the first frame, peer screen never appears.
- [ ] Fast-sign a Solana tx (forces a blockhash-refresh `await` before signing): no peer-screen flash.
- [ ] Manual (non-fast) keysign still shows the peer-discovery screen as before.
- [ ] SwiftLint passes

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fast-vault key signing now displays the correct UI state during signing operations without showing incorrect interface elements
  * Improved fast-vault status handling to ensure consistent, reliable behavior across all signing scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->