### PR TITLE
fix(swap): don't let SwapKit's transient error mask core providers (#4595)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -129,12 +129,35 @@ struct SwapService {
             return SwapQuotes(best: best, ranked: ranked.isEmpty ? [best] : ranked)
         }
 
-        let firstError = results.compactMap { result -> Error? in
+        let errors = results.compactMap { result -> Error? in
             if case .failure(let error) = result { return error }
             return nil
-        }.first
+        }
 
-        throw firstError ?? SwapError.routeUnavailable
+        throw Self.surfacedQuoteError(from: errors) ?? SwapError.routeUnavailable
+    }
+
+    /// Pick which provider error to surface once every eligible provider failed
+    /// to produce a usable quote.
+    ///
+    /// SwapKit is an *optional* aggregator layered on top of the core routing
+    /// providers (THORChain/Maya/1inch/KyberSwap/LI.FI). Its failures must never
+    /// degrade the experience versus not having SwapKit at all. The motivating
+    /// case: SwapKit's `/v3/quote` AML screening intermittently returns
+    /// `addressScreeningFailed` ("Address screening failed — contact support")
+    /// when its screening provider has an outage. The providers run in parallel
+    /// and each failure is collected independently, so when that transient error
+    /// wins the task-completion race it gets surfaced as the user-facing error —
+    /// making a pair that routes fine elsewhere (e.g. ETH→GRT via KyberSwap) look
+    /// permanently broken and telling the user to "contact support".
+    ///
+    /// So prefer any non-SwapKit error: those come from the core providers and
+    /// describe the real routing outcome (no route, amount too small, etc.). Fall
+    /// back to a SwapKit error only when SwapKit was the sole provider attempted
+    /// (e.g. TON/Cardano/Sui pairs), where it's the only signal available.
+    static func surfacedQuoteError(from errors: [Error]) -> Error? {
+        let coreProviderErrors = errors.filter { !($0 is SwapKitError) }
+        return coreProviderErrors.first ?? errors.first
     }
 
     /// Restrict the candidate provider set so a quote can never be ranked/selected

--- a/VultisigApp/VultisigAppTests/Swap/SwapServiceErrorSurfacingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapServiceErrorSurfacingTests.swift
@@ -1,0 +1,66 @@
+//
+//  SwapServiceErrorSurfacingTests.swift
+//  VultisigAppTests
+//
+//  Locks the error-surfacing rule used when every eligible swap provider fails
+//  to return a usable quote. SwapKit is an optional aggregator layered on top
+//  of the core routing providers (THORChain/Maya/1inch/KyberSwap/LI.FI); its
+//  transient infra errors — most notably `addressScreeningFailed` ("Address
+//  screening failed — contact support") — must never mask a core provider's
+//  more meaningful error and make a routable pair (e.g. ETH→GRT via KyberSwap)
+//  look permanently broken.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapServiceErrorSurfacingTests: XCTestCase {
+
+    func testPrefersCoreProviderErrorOverSwapKitScreeningError() {
+        // The reported case: SwapKit's screening error wins the task-completion
+        // race, but a core provider also failed with a real routing error. The
+        // core provider's error must surface, not SwapKit's "contact support".
+        let errors: [Error] = [
+            SwapKitError.addressScreeningFailed,
+            SwapError.routeUnavailable
+        ]
+        let surfaced = SwapService.surfacedQuoteError(from: errors)
+        XCTAssertTrue(surfaced is SwapError)
+        XCTAssertEqual((surfaced as? SwapError), .routeUnavailable)
+    }
+
+    func testPrefersCoreProviderErrorRegardlessOfOrder() {
+        // Task-completion order is non-deterministic; the SwapKit error must be
+        // skipped even when it's collected first.
+        let swapKitFirst: [Error] = [
+            SwapKitError.addressScreeningFailed,
+            SwapError.swapAmountTooSmall
+        ]
+        let swapKitLast: [Error] = [
+            SwapError.swapAmountTooSmall,
+            SwapKitError.addressScreeningFailed
+        ]
+        XCTAssertEqual(SwapService.surfacedQuoteError(from: swapKitFirst) as? SwapError, .swapAmountTooSmall)
+        XCTAssertEqual(SwapService.surfacedQuoteError(from: swapKitLast) as? SwapError, .swapAmountTooSmall)
+    }
+
+    func testFallsBackToSwapKitErrorWhenItIsTheOnlyProvider() {
+        // SwapKit-only pairs (TON/Cardano/Sui) have no core provider to fall back
+        // on, so the SwapKit error is the only meaningful signal and must surface.
+        let errors: [Error] = [SwapKitError.noRoutesFound]
+        let surfaced = SwapService.surfacedQuoteError(from: errors)
+        XCTAssertEqual(surfaced as? SwapKitError, .noRoutesFound)
+    }
+
+    func testReturnsNilWhenNoErrors() {
+        XCTAssertNil(SwapService.surfacedQuoteError(from: []))
+    }
+
+    func testMultipleSwapKitErrorsSurfaceFirstWhenNoCoreError() {
+        let errors: [Error] = [
+            SwapKitError.addressScreeningFailed,
+            SwapKitError.unableToBuildTransaction
+        ]
+        XCTAssertEqual(SwapService.surfacedQuoteError(from: errors) as? SwapKitError, .addressScreeningFailed)
+    }
+}


### PR DESCRIPTION
## Summary

Improves swap error handling so an optional aggregator's failure can no longer mask the real routing outcome.

When every eligible provider fails to return a quote, the swap screen previously surfaced whichever provider error finished first in the parallel fetch — a non-deterministic choice. This could surface a SwapKit-specific error (e.g. a transient screening failure) even when the core routing providers had more meaningful errors, making a routable pair look broken.

The fix prefers a core-provider error and only falls back to a SwapKit error when SwapKit is the sole provider for the pair.

### Transaction hash
https://etherscan.io/tx/0xa54f8f1e81fefcb1b7d54be567164788693f23d52e4c98b1387cdc7d2625f13a

Fixes #4595.



## Testing

- Added unit tests covering the error-surfacing rule.
- SwiftLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)