### PR TITLE
fix(vault-selector): pin Add folder footer with measured height (#4609)

### DIFF
--- a/VultisigApp/VultisigApp/Components/List/ListBottomSection.swift
+++ b/VultisigApp/VultisigApp/Components/List/ListBottomSection.swift
@@ -9,6 +9,16 @@ import SwiftUI
 
 struct ListBottomSection<Content: View>: View {
     var content: () -> Content
+    var onHeightChange: ((CGFloat) -> Void)?
+
+    init(
+        @ViewBuilder content: @escaping () -> Content,
+        onHeightChange: ((CGFloat) -> Void)? = nil
+    ) {
+        self.content = content
+        self.onHeightChange = onHeightChange
+    }
+
     var body: some View {
         content()
             .padding(.bottom, bottomPadding)
@@ -25,6 +35,7 @@ struct ListBottomSection<Content: View>: View {
                 )
             )
             .edgesIgnoringSafeArea(.bottom)
+            .readSize { onHeightChange?($0.height) }
     }
 
     var bottomPadding: CGFloat {

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Screens/AddFolderScreen.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Screens/AddFolderScreen.swift
@@ -21,6 +21,8 @@ struct AddFolderScreen: View {
     @Environment(\.modelContext) private var modelContext
     @EnvironmentObject var viewModel: HomeViewModel
 
+    @State private var footerHeight: CGFloat = 0
+
     var body: some View {
         view
             .padding(.top, 24)
@@ -54,7 +56,7 @@ struct AddFolderScreen: View {
             .scrollContentBackground(.hidden)
             .scrollIndicators(.hidden)
             .background(Theme.colors.bgPrimary)
-            .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: 100) })
+            .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: footerHeight) })
         }
     }
 
@@ -72,12 +74,12 @@ struct AddFolderScreen: View {
     }
 
     var saveButton: some View {
-        ListBottomSection {
+        ListBottomSection(content: {
             PrimaryButton(title: "save") {
                 saveFolder()
             }
             .disabled(folderViewModel.saveButtonDisabled)
-        }
+        }, onHeightChange: { footerHeight = $0 })
     }
 
     var header: some View {

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Screens/EditFolderScreen.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Screens/EditFolderScreen.swift
@@ -18,6 +18,7 @@ struct EditFolderScreen: View {
 
     @State var folderName: String = ""
     @State var disableSelection: Bool = false
+    @State private var footerHeight: CGFloat = 0
     @StateObject var folderViewModel = FolderDetailViewModel()
 
     @Environment(\.modelContext) private var modelContext
@@ -65,7 +66,7 @@ struct EditFolderScreen: View {
             .scrollContentBackground(.hidden)
             .scrollIndicators(.hidden)
             .background(Theme.colors.bgPrimary)
-            .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: 100) })
+            .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: footerHeight) })
             .animation(.interpolatingSpring, value: folder.containedVaultNames)
         }
     }
@@ -99,12 +100,12 @@ struct EditFolderScreen: View {
     }
 
     var saveButton: some View {
-        ListBottomSection {
+        ListBottomSection(content: {
             PrimaryButton(title: "saveChanges") {
                 saveFolder()
             }
             .disabled(saveButtonDisabled)
-        }
+        }, onHeightChange: { footerHeight = $0 })
     }
 
     var alert: Alert {

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Views/VaultListView.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Views/VaultListView.swift
@@ -23,6 +23,8 @@ struct VaultListView: View {
     @EnvironmentObject var homeViewModel: HomeViewModel
     @EnvironmentObject var appViewModel: AppViewModel
 
+    @State private var footerHeight: CGFloat = 0
+
     var filteredVaults: [Vault] {
         homeViewModel.getFilteredVaults(vaults: vaults, folders: folders)
     }
@@ -59,7 +61,7 @@ struct VaultListView: View {
                 .scrollContentBackground(.hidden)
                 .scrollIndicators(.hidden)
                 .background(Theme.colors.bgPrimary)
-                .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: isEditing ? 100 : 0) })
+                .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: isEditing ? footerHeight : 0) })
                 .background(Theme.colors.bgPrimary)
             }
             addFolderButton
@@ -160,14 +162,14 @@ struct VaultListView: View {
     }
 
     var addFolderButton: some View {
-        ListBottomSection {
+        ListBottomSection(content: {
             PrimaryButton(
                 title: "addFolder",
                 leadingIcon: "folder-add",
                 type: .secondary,
                 action: onAddFolder
             )
-        }
+        }, onHeightChange: { footerHeight = $0 })
         .opacity(isEditing ? 1 : 0)
         .animation(.interpolatingSpring.delay(0.3), value: isEditing)
     }


### PR DESCRIPTION
## Description

In Edit Vaults mode the floating "Add folder" footer reserved a hard-coded **100pt** of bottom inset that did not match its real occupied height (~114pt on a notched iPhone). As a result the bottom vault row scrolled into the gradient-fade zone and rendered below/through the button.

### Root cause
`ListBottomSection` (`PrimaryButton` + `.padding(.top, 32)` + the bottom safe-area extension from `.edgesIgnoringSafeArea(.bottom)`, plus 16pt on macOS) occupies a device-dependent height. The three screens that float it reserved a fixed `100pt` via `.safeAreaInset(edge: .bottom)`, which is always wrong on notched devices and macOS.

### The fix
`ListBottomSection` now measures its own rendered height — including the top padding, the gradient background, and the bottom safe-area bleed — using the existing `readSize` modifier, and reports it through a new optional `onHeightChange` callback. The three call sites feed that measured height into their `safeAreaInset`, replacing the magic `100`:

- `Features/VaultSelector/Views/VaultListView.swift` (Edit Vaults — Add folder footer)
- `Features/VaultSelector/Screens/AddFolderScreen.swift` (Save)
- `Features/VaultSelector/Screens/EditFolderScreen.swift` (Save changes)

The footer stays a floating ZStack sibling, so the gradient-overlay-on-scrolling-content design and `edgesIgnoringSafeArea(.bottom)` are preserved — it is NOT moved into the inset (which would reserve opaque space and kill the fade).

Fixes #4609
Closes #4609

## Which feature is affected?
None of the listed flows (pure layout fix in the vault selector / folder screens).

## GATE RECEIPTS
- `make generate` — OK (project regenerated)
- `make build-check` — **BUILD SUCCEEDED** (SwiftLint + xcodebuild)
- `make test` — **TEST SUCCEEDED**, executed **1873 tests, 0 failures**
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — clean for touched files (the only repo violation is pre-existing `Model/Chain.swift:58` trailing comma, unrelated to this change)

## Manual verification checklist
- [ ] Notched simulator (e.g. iPhone 15 Pro): enter Edit Vaults, scroll to the bottom — last vault row clears the Add folder button.
- [ ] Add folder screen: scroll the vault list to the bottom — last row clears the Save button.
- [ ] Edit folder screen: scroll to the bottom — last row clears the Save changes button.
- [ ] macOS build: footer height (with the +16pt bottom padding) is reserved correctly.
- [ ] Non-notched device: no excessive bottom gap.

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — N/A: pure SwiftUI layout change, not meaningfully unit-testable; verified via build + lint + the manual checklist above.

## Agent Metadata
- **Agent**: Claude Code (Opus 4.8 1M)
- **Issue**: #4609
- **Confidence**: high
- **Needs human review for**: visual confirmation on a notched device + macOS (manual checklist)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized layout handling for bottom sections to dynamically calculate and apply spacing based on actual rendered content height rather than fixed values, improving accuracy and responsiveness.
  * Enhanced consistency of bottom navigation elements and buttons across multiple screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->