### PR TITLE
fix(swap): gate Total Fee chevron on breakdown availability on Done screen

### DIFF
--- a/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
@@ -227,6 +227,7 @@ struct SwapDoneSummaryCard: View {
             Rectangle()
                 .frame(width: 1)
                 .foregroundStyle(Theme.colors.primaryAccent4)
+                .padding(.bottom, 16)
             expandableFees(transaction)
         }
         .frame(maxHeight: expanded ? nil : 0)

--- a/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
@@ -173,9 +173,15 @@ struct SwapDoneSummaryCard: View {
             if let transaction = fields.transaction {
                 if transaction.showTotalFees {
                     separator
-                    totalFees(transaction)
+                    if transaction.hasFeeBreakdown {
+                        totalFees(transaction)
+                        otherFees(transaction, expanded: showFees)
+                    } else {
+                        getCell(title: "totalFee", value: transaction.totalFeeString)
+                    }
+                } else {
+                    otherFees(transaction, expanded: true)
                 }
-                otherFees(transaction, expanded: transaction.showTotalFees ? showFees : true)
             } else if let networkFee = fields.cosignerNetworkFee {
                 separator
                 getCell(title: "networkFee", value: networkFee)
@@ -198,7 +204,9 @@ struct SwapDoneSummaryCard: View {
 
     private func totalFees(_ transaction: SwapTransaction) -> some View {
         Button {
-            showFees.toggle()
+            withAnimation(.easeInOut) {
+                showFees.toggle()
+            }
         } label: {
             HStack {
                 getCell(title: "totalFee", value: transaction.totalFeeString)
@@ -223,6 +231,7 @@ struct SwapDoneSummaryCard: View {
         }
         .frame(maxHeight: expanded ? nil : 0)
         .clipped()
+        .animation(.easeInOut, value: showFees)
     }
 
     private func expandableFees(_ transaction: SwapTransaction) -> some View {

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -134,6 +134,16 @@ extension SwapTransaction {
         SwapCryptoLogic.showTotalFees(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin, fee: fee)
     }
 
+    /// Whether an expandable fee breakdown has any rows to show. Mirrors the
+    /// rows the swap fee surfaces emit (swap fee and/or network gas), so a
+    /// "Total fee" chevron is only offered when expanding reveals something.
+    /// `showTotalFees` can be true while both components are suppressed — for
+    /// quote-driven EVM swaps `totalFeeString` keys off `fee` while `showGas`
+    /// keys off `gas`, a distinct gas price.
+    var hasFeeBreakdown: Bool {
+        showFees || showGas
+    }
+
     var swapFeeString: String {
         SwapCryptoLogic.swapFeeString(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
     }

--- a/VultisigApp/VultisigAppTests/Views/Done/TransactionDonePayloadTests.swift
+++ b/VultisigApp/VultisigAppTests/Views/Done/TransactionDonePayloadTests.swift
@@ -10,10 +10,79 @@
 //  pin here is data integrity.
 //
 
+import BigInt
 import XCTest
 @testable import VultisigApp
 
 final class TransactionDonePayloadTests: XCTestCase {
+
+    // MARK: - Swap Done fee-breakdown gate
+    //
+    // `SwapDoneSummaryCard` offers the "Total fee" expand chevron only when
+    // `transaction.hasFeeBreakdown` is true. The chevron renders off
+    // `showTotalFees`, but the breakdown rows render off `showFees` / `showGas`
+    // — independent flags. When the total is non-zero but both components are
+    // suppressed the chevron used to expand an empty box (the reported bug), so
+    // the card now falls back to a plain non-tappable total row instead.
+
+    func testHasFeeBreakdownTrueWhenGasPresent() {
+        // Non-zero gas drives `showGas`, so the breakdown has a network-fee row
+        // to reveal — the chevron is meaningful and should be offered.
+        let transaction = makeThorchainTransaction(gas: BigInt(10_000))
+        XCTAssertTrue(transaction.showGas)
+        XCTAssertTrue(transaction.hasFeeBreakdown)
+    }
+
+    func testHasFeeBreakdownFalseWhenComponentsSuppressed() {
+        // Zero gas + a zero-fee quote => both `showGas` and `showFees` are
+        // false, so expanding would reveal nothing. The gate must be false so
+        // the card renders the total as a plain row with no chevron.
+        let transaction = makeThorchainTransaction(gas: 0)
+        XCTAssertFalse(transaction.showGas)
+        XCTAssertFalse(transaction.showFees)
+        XCTAssertFalse(transaction.hasFeeBreakdown)
+    }
+
+    private func makeThorchainTransaction(gas: BigInt) -> SwapTransaction {
+        let rune = makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true)
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
+        let quote = ThorchainSwapQuote(
+            dustThreshold: nil,
+            expectedAmountOut: "100000000",
+            expiry: 0,
+            fees: Fees(affiliate: "0", asset: "RUNE", outbound: "0", total: "0", liquidity: nil, slippageBps: nil, totalBps: nil),
+            inboundAddress: "thor-inbound",
+            inboundConfirmationBlocks: nil,
+            inboundConfirmationSeconds: nil,
+            memo: "thor-memo",
+            notes: "",
+            outboundDelayBlocks: 0,
+            outboundDelaySeconds: 0,
+            recommendedMinAmountIn: "0",
+            slippageBps: nil,
+            totalSwapSeconds: nil,
+            warning: "",
+            router: nil,
+            maxStreamingQuantity: nil
+        )
+        return SwapTransaction(
+            fromCoin: rune,
+            toCoin: btc,
+            fromAmount: 1.0,
+            quote: .thorchain(quote),
+            gas: gas,
+            thorchainFee: 0,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: rune,
+            advancedSettings: .default
+        )
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {
+        let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: isNative)
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
 
     func testSendDefaultsVerbToSend() {
         // Default-verb behaviour preserves the pre-refactor Send /


### PR DESCRIPTION
## Description

On the swap **Done / Transaction successful** screen the Total Fee row showed an expand chevron, but tapping it did nothing.

**Root cause.** The chevron rendered whenever `transaction.showTotalFees == true`, but the expandable breakdown rows only render when `transaction.showFees` (provider/inbound fee != 0) **or** `transaction.showGas` (gas != 0). These flags are independent: for quote-driven EVM swaps `totalFeeString` keys off `fee` while `showGas` keys off `gas` (a distinct gas price). So when `showTotalFees == true` but both component flags were false, the chevron showed yet the breakdown was empty — tapping toggled the visibility of a zero-height, empty box, so nothing visible happened.

**Fix.** Mirror `SwapDetailsSummary`'s precedent (`hasExpandableFees`):
- Add `SwapTransaction.hasFeeBreakdown` = `showFees || showGas` (colocated with the flags it reads, alongside the other convenience helpers).
- In `SwapDoneSummaryCard`, gate the chevron on `hasFeeBreakdown`: when there is no breakdown, render the total as a plain **non-tappable** `totalFee` row (no chevron, no empty expander); when there is, keep the existing tappable Total Fee button + expander.
- Animate the expand/collapse and chevron rotation (`withAnimation(.easeInOut)` + `.animation(value: showFees)`) so it feels alive, matching `SwapDetailsSummary`.
- The cosigner path (flat network-fee row, no chevron) is untouched. No new localization keys, no data-layer changes.

Closes #4621

## Gate receipts

- `make generate` — OK
- `make build-check` — `** BUILD SUCCEEDED **`
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 0 violations in touched files (only a pre-existing `Chain.swift` trailing-comma warning, untouched by this PR)
- `make test` — `VultisigAppTests.xctest` **668 tests, 0 failures**. The wrapper reported `TEST FAILED` on 4 tests in the known-flaky suites (`KeysignBroadcastCancellation`, `QBTCClaim*`, `QBTCGovernance`, `SuiSign`); re-running those in isolation passed them and a *different* flaky set failed — confirmed non-deterministic and unrelated to this change.
- New tests, run in isolation: `TransactionDonePayloadTests` **6 tests, 0 failures** including `testHasFeeBreakdownTrueWhenGasPresent` and `testHasFeeBreakdownFalseWhenComponentsSuppressed`.

## Which feature is affected?
- [x] Swap

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

## Manual-verify checklist

- [ ] (a) THORChain/Maya swap with a provider fee (or non-zero gas) ⇒ Total Fee row is tappable, expansion reveals the swap fee / network fee rows, chevron rotates.
- [ ] (b) Swap where the total is non-zero but both component flags are suppressed ⇒ Total Fee row shows as a plain row with **no** chevron (no dead tap).

## Agent Metadata
- **Agent**: Claude Code
- **Issue**: #4621
- **Confidence**: high
- **Needs human review for**: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced swap “Total fee” UI: when a fee breakdown is available, users can expand/collapse fee details; otherwise, a single total fee is shown.
  * Added smooth animations for expanding/collapsing the fee breakdown.

* **Tests**
  * Added unit tests covering the fee breakdown expand behavior, including gating logic driven by whether gas and fee components are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->