### PR TITLE
fix(custom-rpc): show Polygon once and alias polygonV2 overrides (#4606)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Stores/CustomRPCStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/CustomRPCStore.swift
@@ -42,7 +42,7 @@ final class CustomRPCStore: @unchecked Sendable {
     func url(for chain: Chain) -> String? {
         lock.lock()
         defer { lock.unlock() }
-        return mirror[chain.rawValue]
+        return mirror[storageKey(for: chain)]
     }
 
     // MARK: - Write path (MainActor + SwiftData)
@@ -56,7 +56,7 @@ final class CustomRPCStore: @unchecked Sendable {
         }
 
         let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
-        let chainRaw = chain.rawValue
+        let chainRaw = storageKey(for: chain)
 
         do {
             let descriptor = FetchDescriptor<CustomRPCOverride>(
@@ -83,7 +83,7 @@ final class CustomRPCStore: @unchecked Sendable {
             return
         }
 
-        let chainRaw = chain.rawValue
+        let chainRaw = storageKey(for: chain)
 
         do {
             let descriptor = FetchDescriptor<CustomRPCOverride>(
@@ -109,7 +109,8 @@ final class CustomRPCStore: @unchecked Sendable {
         }
 
         do {
-            let overrides = try context.fetch(FetchDescriptor<CustomRPCOverride>())
+            var overrides = try context.fetch(FetchDescriptor<CustomRPCOverride>())
+            migrateLegacyPolygonV2(in: &overrides, context: context)
             let snapshot = Dictionary(
                 overrides.map { ($0.chainRaw, $0.url) },
                 uniquingKeysWith: { _, last in last }
@@ -123,6 +124,37 @@ final class CustomRPCStore: @unchecked Sendable {
         }
     }
 
+    // MARK: - Migration
+
+    /// Folds any legacy `polygonV2`-keyed override onto the canonical `polygon`
+    /// key and deletes the orphaned row. Earlier builds keyed overrides by the
+    /// enum case name, so a Polygon override could land under either case; both
+    /// chains now resolve through `storageKey(for:)` to the `polygon` key, and a
+    /// stale `polygonV2` row would otherwise be unreachable (and could collide
+    /// with the `.unique` constraint). When both rows exist, `polygon` wins.
+    @MainActor
+    private func migrateLegacyPolygonV2(in overrides: inout [CustomRPCOverride], context: ModelContext) {
+        let legacyKey = Chain.polygonV2.rawValue
+        guard let legacyIndex = overrides.firstIndex(where: { $0.chainRaw == legacyKey }) else {
+            return
+        }
+
+        let canonicalKey = Chain.polygon.rawValue
+        let legacy = overrides[legacyIndex]
+        if !overrides.contains(where: { $0.chainRaw == canonicalKey }) {
+            context.insert(CustomRPCOverride(chainRaw: canonicalKey, url: legacy.url))
+        }
+        context.delete(legacy)
+        overrides.remove(at: legacyIndex)
+
+        do {
+            try context.save()
+            overrides = try context.fetch(FetchDescriptor<CustomRPCOverride>())
+        } catch {
+            logger.error("Failed to migrate legacy polygonV2 override: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - Mirror helpers
 
     private func updateMirror(chainRaw: String, url: String?) {
@@ -132,6 +164,18 @@ final class CustomRPCStore: @unchecked Sendable {
             mirror[chainRaw] = url
         } else {
             mirror.removeValue(forKey: chainRaw)
+        }
+    }
+
+    /// Normalizes a chain to the single persistence key used for its override.
+    /// `.polygon` and `.polygonV2` are the same network (chainId 137, shown once
+    /// in the picker), so both share one override slot keyed by `.polygon`.
+    private func storageKey(for chain: Chain) -> String {
+        switch chain {
+        case .polygonV2:
+            return Chain.polygon.rawValue
+        default:
+            return chain.rawValue
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/CustomRPC/Model/CustomRPCSupportedChains.swift
+++ b/VultisigApp/VultisigApp/Features/CustomRPC/Model/CustomRPCSupportedChains.swift
@@ -28,7 +28,6 @@ enum CustomRPCSupportedChains {
         .base,
         .arbitrum,
         .polygon,
-        .polygonV2,
         .optimism,
         .blast,
         .cronosChain,

--- a/VultisigApp/VultisigAppTests/Services/CustomRPCResolutionTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/CustomRPCResolutionTests.swift
@@ -4,6 +4,7 @@
 //
 
 @testable import VultisigApp
+import SwiftData
 import XCTest
 
 /// A fake `RPCEndpointResolving` that returns a fixed override per chain. Lets
@@ -317,5 +318,52 @@ final class CustomRPCResolutionTests: XCTestCase {
         // Polkadot proxy default baked at init
         XCTAssertEqual(PolkadotService.rpcEndpoint, "https://api.vultisig.com/dot/")
         XCTAssertEqual(Endpoint.polkadotServiceRpc, "https://api.vultisig.com/dot/")
+    }
+}
+
+/// EVM funnel tests that exercise the real `CustomRPCStore` so Polygon aliasing
+/// (`.polygon` / `.polygonV2` sharing one override slot) is observable — the
+/// pure `FakeRPCResolver` keys verbatim and cannot reproduce the normalizer.
+@MainActor
+final class CustomRPCPolygonFunnelTests: XCTestCase {
+
+    private var token: TestContextToken?
+    private let store = CustomRPCStore.shared
+
+    override func setUp() async throws {
+        try await super.setUp()
+        token = try TestStore.installInMemoryContainer()
+        store.reloadFromStore()
+        store.reset(.polygon)
+    }
+
+    override func tearDown() async throws {
+        store.reset(.polygon)
+        TestStore.restore(token)
+        token = nil
+        try await super.tearDown()
+    }
+
+    func test_evmConfig_polygonOverride_appliesToPolygonV2() throws {
+        store.set("https://my-polygon-node.example/rpc", for: .polygon)
+        let config = try EvmServiceConfig.getConfig(forChain: .polygonV2, resolver: store)
+        XCTAssertEqual(config.rpcEndpoint, "https://my-polygon-node.example/rpc")
+    }
+
+    func test_evmConfig_polygonV2Override_appliesToPolygon() throws {
+        store.set("https://my-polygon-node.example/rpc", for: .polygonV2)
+        let config = try EvmServiceConfig.getConfig(forChain: .polygon, resolver: store)
+        XCTAssertEqual(config.rpcEndpoint, "https://my-polygon-node.example/rpc")
+    }
+
+    func test_evmConfig_polygon_noOverride_returnsDefaultForBothCases() throws {
+        XCTAssertEqual(
+            try EvmServiceConfig.getConfig(forChain: .polygon, resolver: store).rpcEndpoint,
+            Endpoint.polygonServiceRpcService
+        )
+        XCTAssertEqual(
+            try EvmServiceConfig.getConfig(forChain: .polygonV2, resolver: store).rpcEndpoint,
+            Endpoint.polygonServiceRpcService
+        )
     }
 }

--- a/VultisigApp/VultisigAppTests/Services/CustomRPCSelectChainFilterTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/CustomRPCSelectChainFilterTests.swift
@@ -64,4 +64,17 @@ final class CustomRPCSelectChainFilterTests: XCTestCase {
         viewModel.searchText = "  ethereum  "
         XCTAssertTrue(viewModel.filteredChains.contains(.ethereum))
     }
+
+    // MARK: - Dedup invariant (no two rows share a display name)
+
+    func test_supportedChains_haveNoDuplicateDisplayNames() {
+        let names = CustomRPCSupportedChains.all.map(\.name)
+        XCTAssertEqual(Set(names).count, names.count)
+    }
+
+    func test_supportedChains_includePolygonOnce_notPolygonV2() {
+        XCTAssertTrue(CustomRPCSupportedChains.all.contains(.polygon))
+        XCTAssertFalse(CustomRPCSupportedChains.all.contains(.polygonV2))
+        XCTAssertEqual(CustomRPCSupportedChains.all.filter { $0 == .polygon }.count, 1)
+    }
 }

--- a/VultisigApp/VultisigAppTests/Services/CustomRPCStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/CustomRPCStoreTests.swift
@@ -20,11 +20,13 @@ final class CustomRPCStoreTests: XCTestCase {
         // Ensure a clean slate for the chains under test.
         store.reset(.ethereum)
         store.reset(.solana)
+        store.reset(.polygon)
     }
 
     override func tearDown() async throws {
         store.reset(.ethereum)
         store.reset(.solana)
+        store.reset(.polygon)
         TestStore.restore(token)
         token = nil
         try await super.tearDown()
@@ -78,5 +80,69 @@ final class CustomRPCStoreTests: XCTestCase {
         )
         let rows = (try? context.fetch(descriptor)) ?? []
         XCTAssertEqual(rows.count, 1)
+    }
+
+    // MARK: - Polygon aliasing (.polygon and .polygonV2 share one override slot)
+
+    func test_polygonOverride_isVisibleUnderPolygonV2() {
+        store.set("https://my-polygon.example/rpc", for: .polygon)
+        XCTAssertEqual(store.url(for: .polygon), "https://my-polygon.example/rpc")
+        XCTAssertEqual(store.url(for: .polygonV2), "https://my-polygon.example/rpc")
+    }
+
+    func test_polygonV2Override_isVisibleUnderPolygon() {
+        store.set("https://my-polygon.example/rpc", for: .polygonV2)
+        XCTAssertEqual(store.url(for: .polygon), "https://my-polygon.example/rpc")
+        XCTAssertEqual(store.url(for: .polygonV2), "https://my-polygon.example/rpc")
+    }
+
+    func test_resetPolygon_clearsBothCases() {
+        store.set("https://my-polygon.example/rpc", for: .polygonV2)
+        store.reset(.polygon)
+        XCTAssertNil(store.url(for: .polygon))
+        XCTAssertNil(store.url(for: .polygonV2))
+    }
+
+    func test_polygonOverride_persistsUnderCanonicalKey() throws {
+        store.set("https://my-polygon.example/rpc", for: .polygonV2)
+
+        // The persisted row carries the canonical `polygon` key, never `polygonV2`.
+        let context = try XCTUnwrap(Storage.shared.modelContext)
+        let rows = try context.fetch(FetchDescriptor<CustomRPCOverride>())
+        XCTAssertTrue(rows.contains { $0.chainRaw == Chain.polygon.rawValue })
+        XCTAssertFalse(rows.contains { $0.chainRaw == Chain.polygonV2.rawValue })
+    }
+
+    // MARK: - Legacy polygonV2 migration
+
+    func test_reloadFromStore_migratesLegacyPolygonV2RowOntoPolygon() throws {
+        let context = try XCTUnwrap(Storage.shared.modelContext)
+        context.insert(CustomRPCOverride(chainRaw: Chain.polygonV2.rawValue, url: "https://legacy-polygon.example"))
+        try context.save()
+
+        store.reloadFromStore()
+
+        // Surfaces under both Polygon lookups...
+        XCTAssertEqual(store.url(for: .polygon), "https://legacy-polygon.example")
+        XCTAssertEqual(store.url(for: .polygonV2), "https://legacy-polygon.example")
+
+        // ...and the orphaned polygonV2 row is gone, replaced by a polygon row.
+        let rows = try context.fetch(FetchDescriptor<CustomRPCOverride>())
+        XCTAssertFalse(rows.contains { $0.chainRaw == Chain.polygonV2.rawValue })
+        XCTAssertTrue(rows.contains { $0.chainRaw == Chain.polygon.rawValue })
+    }
+
+    func test_reloadFromStore_legacyMigration_prefersExistingPolygonRow() throws {
+        let context = try XCTUnwrap(Storage.shared.modelContext)
+        context.insert(CustomRPCOverride(chainRaw: Chain.polygon.rawValue, url: "https://keep-polygon.example"))
+        context.insert(CustomRPCOverride(chainRaw: Chain.polygonV2.rawValue, url: "https://drop-v2.example"))
+        try context.save()
+
+        store.reloadFromStore()
+
+        XCTAssertEqual(store.url(for: .polygon), "https://keep-polygon.example")
+        let rows = try context.fetch(FetchDescriptor<CustomRPCOverride>())
+        XCTAssertFalse(rows.contains { $0.chainRaw == Chain.polygonV2.rawValue })
+        XCTAssertEqual(rows.filter { $0.chainRaw == Chain.polygon.rawValue }.count, 1)
     }
 }


### PR DESCRIPTION
## Summary

Custom RPC Endpoints (Settings → Advanced) listed **Polygon twice**. This shows it once and makes a single override apply to Polygon RPC traffic regardless of which internal Polygon enum case a coin runs as.

## Root cause

`.polygon` and `.polygonV2` are the same network (both `Chain.name` = "Polygon", both icon "matic", both chainId 137 — they differ only by ticker MATIC vs POL). `CustomRPCSupportedChains.all` listed both back-to-back and the picker did not de-dup, so two identical "Polygon" rows rendered (Figma shows one).

The subtler bug: the override store is keyed by `Chain.rawValue` (the enum **case name**), not by chainId. `CustomRPCOverride.chainRaw` is `@Attribute(.unique)`, and `CustomRPCStore.url(for:)` / `set` / `reset` all key on `chain.rawValue`. Because `"polygon" != "polygonV2"`, the two cases held **independent override slots**. Real EVM traffic can resolve through either case (`EvmService.forChain(coin.chain)` → `EvmServiceConfig.getConfig(forChain:resolver:)` → `resolver.url(for: chain)`), so naively deleting `.polygonV2` from the list would fix the visuals but silently drop overrides for a Polygon coin running as `.polygonV2`.

## Fix

- Removed `.polygonV2` from `CustomRPCSupportedChains.all` — one "Polygon" row, matching Figma.
- Added a `storageKey(for:)` normalizer in `CustomRPCStore` that maps `.polygonV2 → Chain.polygon.rawValue`, applied at all three key sites (`url(for:)`, `set`, `reset`). Aliasing lives in the **store** — the single choke point used by both RPC resolution and the UI badge/editor state — so one override covers both cases and the badge logic isn't blind to the V2 case.
- One-time migration in `reloadFromStore()`: a legacy `polygonV2`-keyed row is folded onto the canonical `polygon` key and the orphan row is deleted (required — `chainRaw` is `.unique`, so a stale dup would be unreachable and risk the constraint). When both rows exist, `polygon` wins.
- `CustomRPCDefaultEndpoint.string(for:)` left as-is (both polygon cases already map to `Endpoint.polygonServiceRpcService`).

Closes #4606

## Gate receipts

- `make generate` — Created project ✅
- `make build-check` — **BUILD SUCCEEDED** ✅
- `make test` — **1048 tests, 1 failure**: only `QBTCClaimSecureVaultRoundDriverTests.testRunBtcRoundDoesNotReKickoff` (on the known-flaky list; passed **3/3 in isolation**, fails only under full-suite timing contention; unrelated to this change). All CustomRPC suites (52 tests) pass ✅
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 0 violations in touched files (71 pre-existing warnings elsewhere, e.g. `Chain.swift` trailing comma — not introduced here) ✅

## Tests added

- **Store aliasing** (`CustomRPCStoreTests`): override on `.polygon` is visible via `url(for: .polygonV2)` and vice-versa; `reset(.polygon)` clears both; persisted row always carries the canonical `polygon` key.
- **Migration** (`CustomRPCStoreTests`): a persisted `polygonV2` row surfaces under the `.polygon` lookup after `reloadFromStore()` and the orphan row is removed; both-exist case prefers the existing `polygon` row.
- **EVM funnel** (`CustomRPCPolygonFunnelTests`, real store): override stored under polygon applies to `getConfig(forChain: .polygonV2)` and vice-versa; no override → default for both.
- **Dedup invariant** (`CustomRPCSelectChainFilterTests`): `Set(all.map(\.name)).count == all.count`; list contains `.polygon` exactly once, not `.polygonV2`.

## Manual verify

- Custom RPC list shows a single Polygon row.
- Setting an override on it applies to Polygon RPC calls.
- An override previously set on the old V2 row is preserved after upgrade (migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified Polygon and PolygonV2 custom RPC overrides to share a single storage slot, ensuring consistent settings across both identifiers.
  * Removed PolygonV2 from supported chains list to establish a single source of truth.

* **Data Migration**
  * Automatic migration of legacy PolygonV2 custom RPC configurations to the consolidated Polygon storage on startup.

* **Tests**
  * Enhanced test coverage for Polygon/PolygonV2 aliasing and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->