### PR TITLE
style(theme): soften card/panel border to Borders/Light #11284A

### DIFF
--- a/VultisigApp/VultisigApp/Core/DesignSystem/DefaultTheme/ColorSystem.swift
+++ b/VultisigApp/VultisigApp/Core/DesignSystem/DefaultTheme/ColorSystem.swift
@@ -44,7 +44,7 @@ struct ColorSystem: ColorSystemProtocol {
     var textTertiary: Color { .init(hex: "8295AE") }
     var textDark: Color { .init(hex: "02122B") }
 
-    var border: Color { .init(hex: "1B3F73") }
+    var border: Color { .init(hex: "11284A") }
     var borderLight: Color { .init(hex: "11284A") }
     var borderExtraLight: Color { .init(hex: "FFFFFF").opacity(0.03) }
 


### PR DESCRIPTION
## Summary

CW24/25 design-system update: soften card/callout/panel borders from **Borders/Normal** (`#1B3F73`, a visible blue hairline) to **Borders/Light** (`#11284A`, same as `Backgrounds/surface-2` → a near-invisible 1px hairline). Closes #4622.

## Change
Token-level, one line — `Theme.colors.border` `#1B3F73` → `#11284A` in `Core/DesignSystem/DefaultTheme/ColorSystem.swift`. This propagates to every card/panel/callout/list-row that uses the shared `border` token, exactly as the issue requests (no per-component edits). `borderLight` was already `#11284A`, confirming the target value.

## Not changed (per the issue)
- CTA / secondary button strokes (`#2155DF` / `#FFFFFF08`) — separate tokens; verified buttons do **not** use `Theme.colors.border`, so no regression.
- Success / error / accent borders — separate tokens, untouched.

## Gate
- `make build-check` → **BUILD SUCCEEDED**
- `swiftlint` → 0 violations in touched file

## Manual verification
- [ ] Cards/panels/callouts across Home, DeFi, Swap, Settings, vault cards show the softened hairline (matches the "New" Figma frame `77615-132043`)
- [ ] No card/panel still shows the old bright-blue `#1B3F73` border
- [ ] Primary/secondary buttons unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated border color styling for improved visual consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->