### PR TITLE
fix(keysign): fill signing progress bar for swap & custom message

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -111,6 +111,26 @@ class KeysignViewModel: ObservableObject {
         txid.isEmpty && !(keysignPayload?.skipBroadcast ?? false)
     }
 
+    /// Drives the keysign Rive animation's `progessPercentage` bar (0–100). The
+    /// bar fills as signing advances through its phases, mirroring the Android
+    /// client. Without an explicit value the bar stays empty regardless of the
+    /// flow (custom message and swap signing reported this), since nothing else
+    /// binds the property.
+    var signingProgress: Float {
+        switch status {
+        case .CreatingInstance:
+            return 0
+        case .KeysignECDSA:
+            return 33
+        case .KeysignEdDSA, .KeysignMLDSA:
+            return 66
+        case .KeysignFinished:
+            return 100
+        case .KeysignFailed, .KeysignRetryRequested, .KeysignVaultMismatch, .KeysignBroadcastUnconfirmed:
+            return 0
+        }
+    }
+
     var memo: String? {
         guard let decodedMemo = decodedMemo, !decodedMemo.isEmpty else {
             return keysignPayload?.memo

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignAnimationView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignAnimationView.swift
@@ -13,10 +13,15 @@ struct KeysignAnimationView: View {
 
     @Binding var connected: Bool
     var coinLogo: String?
+    /// Signing progress on a 0–100 scale, bound to the Rive `progessPercentage`
+    /// property so the bar fills as signing advances. Defaults to 0.
+    var progress: Float = 0
 
     @State private var animationVM: RiveViewModel?
     @State private var animationVMInstance: RiveDataBindingViewModel.Instance?
     @State private var coinLogoTask: Task<Void, Never>?
+    @State private var displayedProgress: Float = 0
+    @State private var progressAnimationTimer: Timer?
 
     var body: some View {
         ZStack {
@@ -32,12 +37,17 @@ struct KeysignAnimationView: View {
         .onChange(of: coinLogo) { _, newValue in
             applyCoinLogo(newValue)
         }
+        .onChange(of: progress) { _, newValue in
+            animateProgress(to: newValue)
+        }
         .onAppear {
             setupAnimation()
         }
         .onDisappear {
             animationVM?.stop()
             coinLogoTask?.cancel()
+            progressAnimationTimer?.invalidate()
+            progressAnimationTimer = nil
         }
     }
 
@@ -52,9 +62,50 @@ struct KeysignAnimationView: View {
                 animationVMInstance = instance
                 instance.booleanProperty(fromPath: "Connected")?.value = connected
                 applyCoinLogo(coinLogo)
+                displayedProgress = progress
+                updateRiveProgress(progress)
             }
         }
         animationVM = vm
+    }
+
+    private func animateProgress(to targetValue: Float) {
+        progressAnimationTimer?.invalidate()
+
+        let duration: TimeInterval = 1.0
+        let frameRate: TimeInterval = 1.0 / 60.0
+        let totalSteps = Int(duration / frameRate)
+        let startValue = displayedProgress
+        let delta = targetValue - startValue
+
+        guard delta != 0, totalSteps > 0 else {
+            displayedProgress = targetValue
+            updateRiveProgress(targetValue)
+            return
+        }
+
+        var currentStep = 0
+
+        progressAnimationTimer = Timer.scheduledTimer(withTimeInterval: frameRate, repeats: true) { timer in
+            currentStep += 1
+            let stepProgress = Float(currentStep) / Float(totalSteps)
+            let easedProgress = 1 - pow(1 - stepProgress, 3)
+            let newValue = startValue + delta * easedProgress
+
+            displayedProgress = newValue
+            updateRiveProgress(newValue)
+
+            if currentStep >= totalSteps {
+                timer.invalidate()
+                progressAnimationTimer = nil
+                displayedProgress = targetValue
+                updateRiveProgress(targetValue)
+            }
+        }
+    }
+
+    private func updateRiveProgress(_ value: Float) {
+        animationVMInstance?.numberProperty(fromPath: "progessPercentage")?.value = value
     }
 
     private func applyCoinLogo(_ logo: String?) {

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignView.swift
@@ -77,7 +77,7 @@ struct KeysignView: View {
                     .KeysignECDSA,
                     .KeysignEdDSA,
                     .KeysignMLDSA:
-                SendCryptoKeysignView(coinLogo: keysignPayload?.coin.logo)
+                SendCryptoKeysignView(coinLogo: keysignPayload?.coin.logo, progress: viewModel.signingProgress)
             case .KeysignFinished:
                 keysignFinished
             case .KeysignFailed:

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoKeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoKeysignView.swift
@@ -12,6 +12,7 @@ struct SendCryptoKeysignView: View {
     var title: String? = nil
     var showError = false
     var coinLogo: String? = nil
+    var progress: Float = 0
     var errorButtonTitle: String? = nil
     var errorAction: (() -> Void)? = nil
 
@@ -24,7 +25,7 @@ struct SendCryptoKeysignView: View {
             if showError {
                 errorView
             } else {
-                KeysignAnimationView(connected: .constant(true), coinLogo: coinLogo)
+                KeysignAnimationView(connected: .constant(true), coinLogo: coinLogo, progress: progress)
             }
         }
     }


### PR DESCRIPTION
## Problem

Closes #4620

The progress bar above the **Signing** label never filled for **custom message signing** and **swap signing**. Standard Send appeared to work only because its coin-logo glow populated that area.

## Root cause

The keysign Rive animation (`keysign.riv`) exposes a `progessPercentage` bar property, but `KeysignAnimationView` never bound it — only `KeygenAnimationView` did. So the bar sat at its default (empty) value for every flow; flows without a prominent coin logo (swap, custom message) made the emptiness obvious.

### Transaction hash
https://orbmarkets.io/tx/3eGbY5fiWVHL2qJJjj6Jm6xULC3z3CbvsLYbyAyuD5hAZuDX4VKE8vUU5hjpTHAGgkdUpzTR2Vc6UGiALgFagkyV

### Screenshot
<img width="460" height="1000"  src="https://github.com/user-attachments/assets/a27c0baf-3f55-4565-aae1-afdca02b8dbd" />




## Fix

Drive the bar from the signing phase, mirroring the Android client (`CreatingInstance 0 → ECDSA 33 → EdDSA/MLDSA 66 → Finished 100`), animated smoothly with the same eased timer approach already used by `KeygenAnimationView`.

- **`KeysignViewModel`** — add `signingProgress` (0–100) computed from `status`
- **`KeysignAnimationView`** — bind + animate the `progessPercentage` Rive property
- **`SendCryptoKeysignView`** — pass-through `progress` parameter (defaults to 0)
- **`KeysignView`** — feed `viewModel.signingProgress` into the signing view

Because all four signing states share one `SendCryptoKeysignView` instance and `status` is `@Published`, the bar now fills as the ceremony advances — for all flows, including swap and custom-message signing.

## Testing

- `make build-check` → **BUILD SUCCEEDED**
- SwiftLint on changed files → **0 violations**
- Launched on iPhone 17 Pro Max simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an animated progress indicator that displays throughout the key signing process, smoothly transitioning through signing stages from initialization to completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->