### PR TITLE
fix(swap): default THORChain tolerance_bps to 0 so Auto swaps aren't rejected

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -22,13 +22,11 @@ struct SwapService {
     /// and `vultisig-android` (`STREAMING_SLIPPAGE_THRESHOLD_BPS`).
     static let streamingSlippageThresholdBps = 100
 
-    /// Minimum-output tolerance (basis points) sent on every THORChain/Maya
-    /// quote request as `tolerance_bps`. The node bakes a real `LIM` into the
-    /// returned swap memo — `expected_amount_out × (1 − tolerance_bps/10_000)` —
-    /// so the signed memo carries a slippage floor instead of `LIM=0`
-    /// (unbounded). 100 bps (1%) is a conservative default aligned with the
-    /// streaming-upgrade threshold; there is no per-swap user slippage control.
-    static let defaultThorchainToleranceBps = 100
+    /// `Auto` slippage default. 0 → `tolerance_bps` is omitted, so the node sets
+    /// no `LIM` and never rejects the quote. A nonzero default blocks legitimate
+    /// swaps: the node gates `tolerance_bps` on the single-swap emit, so any swap
+    /// whose price impact exceeds it is refused. A user-set slippage overrides this.
+    static let defaultThorchainToleranceBps = 0
 
     func fetchQuote(
         amount: Decimal,

--- a/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
@@ -82,7 +82,7 @@ final class ThorchainAntiRektTests: XCTestCase {
         XCTAssertEqual(mock.callCount, 1, "Streaming must be fetched at 101 bps with a 1% threshold")
         XCTAssertEqual(
             mock.lastToleranceBps, SwapService.defaultThorchainToleranceBps,
-            "Streaming quote must carry tolerance_bps so the node bakes a minimum-output LIM into the memo"
+            "Streaming quote carries the same tolerance_bps as rapid (Auto default = 0 → omitted; node imposes no LIM)"
         )
     }
 


### PR DESCRIPTION
## Summary
- THORChain/Maya `Auto` swaps were rejected at quote time when price impact exceeded 1% (`emit asset X less than price limit Y`). Reported on v1.39.
- Root cause: the node gates `tolerance_bps` against the **single-swap (full-size) emit**, not the streamed output — so a 1% default is unreachable for any non-trivial swap. The node only reports *streamed* slippage, so no protective-but-achievable default can be derived.
- Fix: `defaultThorchainToleranceBps 100 → 0`. Auto omits `tolerance_bps` (node sets no `LIM`, never rejects); a user-set slippage still flows straight through. Slippage stays mitigated by the rapid→streaming upgrade and the node's own auto-streaming (the memo streams regardless).

## Changes
| File | Change |
|------|--------|
| `Blockchain/Swaps/Common/SwapService.swift` | `defaultThorchainToleranceBps` `100 → 0` + accurate comment |
| `VultisigAppTests/Services/ThorchainAntiRektTests.swift` | corrected the now-stale assertion message (Auto = 0 → omitted) |

## Context
- The hardcoded `tolerance_bps` was introduced in #4556 (shipped v1.39.61).
- Android (`ThorChainApi.getSwapQuotes`) and the SDK (`getNativeSwapQuote`) never sent `tolerance_bps` — this brings iOS in line; no change needed there.
- Follow-up: #4639 (wire the slippage setting → an *achievable* memo `LIM` + surface a slippage hint on price-limit errors). Sibling: vultisig-sdk#688.

## Test plan
- [x] Build + 78/78 swap unit tests pass
- [x] Live THORChain quote probe: omitting `tolerance_bps` returns a valid quote + auto-streamed memo
- [x] Real on-chain swap broadcast from a build with this behavior

## receipts

**Swap unit tests (iPhone 17 sim):**
```
Test Suite 'VultisigAppTests.xctest' passed
   Executed 78 tests, with 0 failures (0 unexpected) in 0.189s
** TEST SUCCEEDED **
```

**Real on-chain swap (ETH.USDC → RUNE) broadcast from this behavior, accepted by THORChain:**
```
tx 4d1cb2375fd3962464a8b74cd0c3773a54557ed4787876bf23dffe80f82edd3b
memo: =:r:thor1uet6cagmzqrmff5a3p74mtu3j4gunl30qz79tu::vi:0   # LIM field empty (Auto → no tolerance)
inbound_observed.completed: true   swap_status.pending: false   (no refund)
```

**Live quote probe — Auto (omitted) vs 1% on a high-impact swap:**
```
$ curl ".../thorchain/quote/swap?...&amount=500000000"            # no tolerance → 200, memo "=:e:...:0/0/105"
$ curl ".../thorchain/quote/swap?...&amount=500000000&tolerance_bps=100"
  {"code":3,"message":"failed to simulate swap: ... emit asset 14693327043 less than price limit 18630510208"}
```

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted automatic slippage tolerance for THORChain and Maya swaps to use network-default behavior when no custom tolerance is specified, allowing for more flexible quote handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->