### PR TITLE
fix(swap): in-band lower-gas tie-break + tighten preference band to 50bps

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapQuote+Ranking.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapQuote+Ranking.swift
@@ -16,10 +16,12 @@ extension SwapQuote {
     /// - 1inch/KyberSwap: `dstAmount` is net of swap fees.
     /// - LiFi: `dstAmount` minus integrator fee (charged on the output side).
     ///
-    /// Source-chain gas is intentionally excluded: aggregators on a given chain consume similar
-    /// gas (~200k units), so the destination output dominates the comparison. THORChain Router
-    /// gas on EVM is large but isn't exposed at quote time. A future refinement can subtract gas
-    /// once a native-token price lookup is wired in.
+    /// Source-chain gas is intentionally excluded from this destination-side metric: folding it
+    /// in would require a cross-asset price (source-native wei → destination token) the ranker
+    /// doesn't have, and it only applies to same-chain EVM aggregators — an asymmetric term that
+    /// would disadvantage THORChain/Maya (no router gas at quote time). Source gas is instead
+    /// applied as an in-band lower-gas tie-break in `selectBestQuote` via `sourceGasWei`, where
+    /// the two compared EVM quotes share the same native-wei unit and no price lookup is needed.
     func expectedNetToAmount(toCoin: Coin) -> Decimal? {
         switch self {
         case .thorchain(let quote),

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -195,16 +195,21 @@ struct SwapService {
 
     /// Width of the priority band, as a fraction of the best net output. Quotes whose net
     /// output lands within this band of the best are treated as effectively tied on rate, so
-    /// the higher-priority provider is preferred over a marginally larger raw output. 1%.
-    static let providerPreferenceBand: Decimal = 0.01
+    /// the higher-priority provider is preferred over a marginally larger raw output. 50bps.
+    static let providerPreferenceBand: Decimal = 0.005
 
     /// Pick the best quote across providers. The ranking metric is net output in `toCoin`
     /// units (every provider in a candidate set swaps to the same `toCoin`, so the
     /// destination amount is directly comparable). On top of that metric a banded
-    /// provider-preference layer applies: among quotes within `providerPreferenceBand` (1%)
-    /// of the best net output, the highest-priority provider wins instead of the raw maximum.
-    /// This keeps near-tie routes on the more trusted/integrated provider without ever
-    /// trading away a materially better rate (anything outside the band loses on output).
+    /// provider-preference layer applies: among quotes within `providerPreferenceBand` (50bps)
+    /// of the best net output — economically equivalent on net output — a lower source-chain
+    /// gas cost wins first (same-chain EVM aggregators only, where `sourceGasWei` is exposed in
+    /// the same native-wei unit), then the highest-priority provider, then the higher net
+    /// output. The lower-gas check only fires when BOTH compared quotes expose `sourceGasWei`,
+    /// so a gas-unknown quote (THORChain/Maya/SwapKit cross-chain) never falsely wins it and
+    /// instead falls through to provider preference. This keeps near-tie routes on the cheaper
+    /// or more trusted route without ever trading away a materially better rate (anything
+    /// outside the band loses on output).
     /// Falls back to the first quote (priority order from `resolveAllProviders`) when no
     /// quote produces a comparable amount.
     ///
@@ -226,12 +231,17 @@ struct SwapService {
             return quotes.first
         }
 
-        // Quotes within the band of the best net output are treated as tied on rate; among
-        // those, prefer the higher-priority (lower index) provider. Tie-break inside the same
-        // priority by higher net output (defensive — a provider rarely appears twice).
+        // Quotes within the band of the best net output are treated as tied on rate. Among
+        // those, prefer (1) lower source-chain gas when BOTH quotes expose it in the same
+        // native-wei unit (same-chain EVM aggregators) — a gas-unknown quote must not win this
+        // check, so it falls through; then (2) the higher-priority (lower index) provider; then
+        // (3) higher net output (defensive — a provider rarely appears twice).
         let floor = best.1 * (1 - providerPreferenceBand)
         let inBand = ranked.filter { $0.1 >= floor }
         let picked = inBand.min { lhs, rhs in
+            if let lhsGas = lhs.0.sourceGasWei, let rhsGas = rhs.0.sourceGasWei, lhsGas != rhsGas {
+                return lhsGas < rhsGas
+            }
             let lhsPriority = priority(of: lhs.0)
             let rhsPriority = priority(of: rhs.0)
             if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -142,6 +142,20 @@ enum SwapQuote: Hashable {
         }
     }
 
+    /// Source-chain gas cost in native wei (`gas × gasPrice`) for same-chain EVM
+    /// aggregator quotes. Used only as a tie-break among in-band quotes that both
+    /// expose it — same-unit source-native wei, no cross-asset price normalization.
+    /// `nil` for THORChain/Maya/SwapKit, which expose no router gas at quote time.
+    var sourceGasWei: BigInt? {
+        switch self {
+        case .oneinch(let quote, _), .kyberswap(let quote, _), .lifi(let quote, _, _):
+            guard let gasPrice = BigInt(quote.tx.gasPrice), gasPrice > 0 else { return nil }
+            return BigInt(quote.tx.gas) * gasPrice
+        case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain, .swapkit:
+            return nil
+        }
+    }
+
     var swapFeeTokenContract: String? {
         switch self {
         case .oneinch(let quote, _), .kyberswap(let quote, _), .lifi(let quote, _, _):

--- a/VultisigApp/VultisigAppTests/Services/SwapQuoteRankingTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapQuoteRankingTests.swift
@@ -132,35 +132,37 @@ final class SwapQuoteRankingTests: XCTestCase {
     // MARK: - Banded provider preference
 
     func test_selectBestQuote_nearTieWithinBand_priorityWins_swapKitOverLifi() {
-        // SwapKit (priority 2) and LI.FI (priority 5) within 1% of each other on net output:
+        // SwapKit (priority 2) and LI.FI (priority 5) within 50bps of each other on net output:
         // LI.FI's raw output is slightly higher but still inside the band, so the
-        // higher-priority SwapKit quote wins instead of the raw maximum.
+        // higher-priority SwapKit quote wins instead of the raw maximum. SwapKit exposes no
+        // sourceGasWei, so the lower-gas check can't fire and selection falls to priority.
         // SwapKit reports expectedBuyAmount in human units; LI.FI 0.03 ETH dstAmount in wei.
         let swapKit: SwapQuote = .swapkit(makeSwapKitResponse(expectedBuyAmount: "0.0299"), fee: nil, subProvider: "Chainflip")
         let lifi: SwapQuote = .lifi(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil, integratorFee: nil) // 0.03
 
-        // best = LI.FI 0.03, floor = 0.0297, SwapKit 0.0299 is in band → SwapKit wins on priority.
+        // best = LI.FI 0.03, floor = 0.02985, SwapKit 0.0299 is in band → SwapKit wins on priority.
         let pick = SwapService.selectBestQuote(quotes: [lifi, swapKit], toCoin: ethCoin())
 
         XCTAssertEqual(pick?.displayName, "SwapKit")
     }
 
     func test_selectBestQuote_priorityOrderingWithinBand_thorchainOverOneInch() {
-        // THORChain (priority 0) vs 1inch (priority 4) within 1%: 1inch's raw output is
-        // marginally higher but in band, so THORChain wins on priority.
+        // THORChain (priority 0) vs 1inch (priority 4) within 50bps: 1inch's raw output is
+        // marginally higher but in band, so THORChain wins on priority. THORChain exposes no
+        // sourceGasWei, so the lower-gas check can't fire and selection falls to priority.
         let thor: SwapQuote = .thorchain(makeThorQuote(expectedAmountOut: "2990000")) // 0.0299 ETH
         let oneInch: SwapQuote = .oneinch(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil) // 0.03 ETH
 
-        // best = 1inch 0.03, floor = 0.0297, THORChain 0.0299 in band → THORChain wins.
+        // best = 1inch 0.03, floor = 0.02985, THORChain 0.0299 in band → THORChain wins.
         let pick = SwapService.selectBestQuote(quotes: [oneInch, thor], toCoin: ethCoin())
 
         XCTAssertEqual(pick?.displayName, "THORChain")
     }
 
     func test_selectBestQuote_exactBandBoundaryIsInclusive() {
-        // A quote exactly at best * 0.99 is included (>= floor) and, being higher priority,
-        // wins. best = 1inch 0.03 → floor = 0.0297. THORChain at exactly 0.0297 is in band.
-        let thor: SwapQuote = .thorchain(makeThorQuote(expectedAmountOut: "2970000")) // 0.0297 ETH
+        // A quote exactly at best * 0.995 is included (>= floor) and, being higher priority,
+        // wins. best = 1inch 0.03 → floor = 0.02985. THORChain at exactly 0.02985 is in band.
+        let thor: SwapQuote = .thorchain(makeThorQuote(expectedAmountOut: "2985000")) // 0.02985 ETH
         let oneInch: SwapQuote = .oneinch(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil) // 0.03 ETH
 
         let pick = SwapService.selectBestQuote(quotes: [oneInch, thor], toCoin: ethCoin())
@@ -177,6 +179,45 @@ final class SwapQuoteRankingTests: XCTestCase {
         let pick = SwapService.selectBestQuote(quotes: [oneInch, thor], toCoin: ethCoin())
 
         XCTAssertEqual(pick?.displayName, "1Inch")
+    }
+
+    // MARK: - In-band lower-gas tie-break
+
+    func test_selectBestQuote_inBandLowerGasWins() {
+        // Two same-chain EVM quotes within 50bps on net output (economically tied): KyberSwap
+        // (priority 3) has the marginally higher net AND higher priority, but burns more source
+        // gas; 1inch (priority 4) is in band with cheaper gas. The lower-gas quote must win,
+        // beating both the higher net output and the higher provider priority.
+        let kyber: SwapQuote = .kyberswap(
+            makeEVMQuote(dstAmount: "30000000000000000", gas: 300_000, gasPrice: "20000000000"),
+            fee: nil
+        ) // 0.03 ETH, gas = 300k * 20gwei
+        let oneInch: SwapQuote = .oneinch(
+            makeEVMQuote(dstAmount: "29950000000000000", gas: 150_000, gasPrice: "20000000000"),
+            fee: nil
+        ) // 0.02995 ETH (in band; floor = 0.02985), gas = 150k * 20gwei
+
+        let pick = SwapService.selectBestQuote(quotes: [kyber, oneInch], toCoin: ethCoin())
+
+        XCTAssertEqual(pick?.displayName, "1Inch")
+    }
+
+    func test_selectBestQuote_outsideBandBetterRateWins_regardlessOfGas() {
+        // A materially better rate (outside the 50bps band) must win even when it burns far more
+        // source gas — the lower-gas tie-break only applies among in-band, economically-tied
+        // quotes and must never trade away a real rate advantage.
+        let kyber: SwapQuote = .kyberswap(
+            makeEVMQuote(dstAmount: "30000000000000000", gas: 600_000, gasPrice: "20000000000"),
+            fee: nil
+        ) // 0.03 ETH, expensive gas
+        let oneInch: SwapQuote = .oneinch(
+            makeEVMQuote(dstAmount: "29000000000000000", gas: 100_000, gasPrice: "20000000000"),
+            fee: nil
+        ) // 0.029 ETH (outside band; floor = 0.02985), cheap gas
+
+        let pick = SwapService.selectBestQuote(quotes: [oneInch, kyber], toCoin: ethCoin())
+
+        XCTAssertEqual(pick?.displayName, "KyberSwap")
     }
 
     // MARK: - Same-chain ERC20→ETH regression


### PR DESCRIPTION
## What

Improves swap-quote ranking in `SwapService.selectBestQuote` along two axes (closes #4634):

1. **In-band lower-gas tie-break.** Among quotes already within the provider-preference band — economically equivalent on net destination output — prefer the one with lower **source-chain gas** *before* falling back to provider preference. The lower-gas check fires only when **both** compared quotes expose gas in the same native-wei unit (same-chain EVM aggregators: 1inch / KyberSwap / LI.FI). A gas-unknown quote (THORChain / Maya / SwapKit, which expose no router gas at quote time) can never falsely win it; it falls through to the existing `priority(of:)` ordering, then higher net output.

2. **Tighten the preference band 100bps → 50bps.** A "preferred" provider could previously be handed up to 1% (2× the 50bps affiliate fee) over a marginally-better-rate aggregator. 50bps closes that gap.

## How

- New `SwapQuote.sourceGasWei: BigInt?` derives `gas × gasPrice` from the EVM quote tx for the `.oneinch` / `.kyberswap` / `.lifi` cases; `nil` for THOR / Maya / SwapKit.
- Gas is **not** folded into `expectedNetToAmount` — that would require a cross-asset price (source-native wei → destination token) the ranker doesn't have and would disadvantage THORChain/Maya. The destination-side net metric stays the cross-platform anchor; gas is applied only as the in-band tie-break, where the two compared EVM quotes share a unit.

## Scope

Same-chain EVM aggregators only (where source gas is comparable in the same native-wei unit). Cross-chain routes are unaffected.

## Tests

`VultisigAppTests/Services/SwapQuoteRankingTests.swift`:
- Recalibrated the band-boundary fixture for 0.5% (`best * 0.995`).
- Added `test_selectBestQuote_inBandLowerGasWins` (lower-gas in-band EVM quote beats higher net + higher priority) and `test_selectBestQuote_outsideBandBetterRateWins_regardlessOfGas` (a real rate advantage outside the band always wins, regardless of gas).
- All existing best-net / priority tests stay green unchanged.

## Gate

- `make build-check`: **BUILD SUCCEEDED**
- Ranking suite: **21/21 passing, 0 failures**
- SwiftLint: **0 violations** on the changed files (pre-existing repo-wide warnings untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved swap quote selection with gas-aware in-band tie-breaking, preferring lower source-chain gas for closely matched EVM quotes.
  * Refined in-band “effectively tied on rate” threshold and updated selection order for more consistent results.

* **Tests**
  * Updated swap quote ranking tests for the revised in-band calculation.
  * Added regression coverage to confirm lower-gas wins only within the in-band range, while better rates win outside it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->