### PR TITLE
fix(swap): SwapKit provider gate fail-closed on cold cache miss + token catalog refresh-on-open

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -543,8 +543,10 @@ private extension SwapService {
         recipientAddress: String?
     ) async throws -> SwapQuote {
         // Provider-cache gate — refuse to call `/v3/quote` for a chain SwapKit
-        // doesn't enable. Fails open if the cache can't be loaded so we don't
-        // silently disable the aggregator on a bad network day.
+        // doesn't enable. Fails CLOSED on the no-snapshot edge (throws
+        // `providerNotEnabled`) rather than offering routes that fail
+        // downstream; once a snapshot exists, `SwapKitProviderCache` serves it
+        // as last-good so a transient network blip doesn't disable SwapKit.
         let fromEnabled = await service.isChainEnabled(fromCoin.chain)
         let toEnabled = await service.isChainEnabled(toCoin.chain)
         guard fromEnabled, toEnabled else {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
@@ -42,9 +42,10 @@ actor SwapKitProviderCache {
 
     /// Returns a cached or freshly-fetched provider list, refreshing when the
     /// snapshot is older than `SwapKitConfig.providerCacheTTL`. Returns `nil`
-    /// when the fetch fails *and* we have no prior snapshot — callers should
-    /// treat that as "skip the SwapKit gate" rather than blocking the swap
-    /// flow.
+    /// when the fetch fails *and* we have no prior snapshot. Callers choose
+    /// their own fallback policy for that edge: `isEnabled` fails closed for
+    /// offer gating, while `isPairSupported` fails open for error-label
+    /// remapping.
     func providers(now: Date = Date()) async -> [SwapKitProvider]? {
         if let snapshot, now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.providerCacheTTL {
             return snapshot.providers

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitProviderCache.swift
@@ -84,11 +84,20 @@ actor SwapKitProviderCache {
     }
 
     /// Async variant — refreshes the cache and returns whether the chain has
-    /// at least one non-filtered provider enabled. Returns `true` when the
-    /// providers list can't be loaded (fail-open: better to attempt the
-    /// fetcher and let `/v3/quote` decide than to silently disable SwapKit).
+    /// at least one non-filtered provider enabled. Fails CLOSED (`false`) when
+    /// the providers list can't be loaded at all (a cold-launch `/providers`
+    /// fetch failure with no prior snapshot): SwapKit is simply not offered for
+    /// the chain until a refresh succeeds, rather than offering routes that
+    /// will fail downstream. Other providers still populate the picker, and
+    /// `SwapService.fetchSwapKitQuote` throws `providerNotEnabled` cleanly.
+    /// Once a snapshot exists, `providers(now:)` serves it as last-good on a
+    /// later fetch failure, so this only bites the genuine no-data edge.
+    ///
+    /// Note the asymmetry with `isPairSupported(...)`, which fails OPEN on the
+    /// same edge: that predicate only governs an error-label re-mapping, so
+    /// failing it closed would merely degrade a message, not block a swap.
     func isEnabled(chain: Chain, now: Date = Date()) async -> Bool {
-        guard let providers = await providers(now: now) else { return true }
+        guard let providers = await providers(now: now) else { return false }
         return Self.chainEnabled(chain, in: providers)
     }
 
@@ -120,8 +129,16 @@ actor SwapKitProviderCache {
     /// Async variant — refreshes the cache and returns whether the (from, to)
     /// chain pair has at least one non-filtered provider that enables both
     /// chains. Returns `true` when the providers list can't be loaded
-    /// (fail-open, mirroring `isEnabled(chain:)`) — the caller treats this
-    /// as "could plausibly be supported" when re-classifying error codes.
+    /// (fail-OPEN) — the caller treats this as "could plausibly be supported"
+    /// when re-classifying error codes.
+    ///
+    /// This deliberately differs from `isEnabled(chain:)`, which fails CLOSED
+    /// on the same no-snapshot edge. The asymmetry is intentional: `isEnabled`
+    /// gates whether SwapKit is *offered* at all, so the safe default is to
+    /// withhold it; `isPairSupported` only chooses between two error labels
+    /// (a `noRoutesFound` 404 re-mapped to `amountBelowProviderMinimum`), so
+    /// failing it closed would merely show a less specific error message
+    /// rather than prevent a bad swap — not worth withholding the better label.
     func isPairSupported(fromChain: Chain, toChain: Chain, now: Date = Date()) async -> Bool {
         guard let providers = await providers(now: now) else { return true }
         return Self.pairEnabled(fromChain: fromChain, toChain: toChain, in: providers)

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -148,9 +148,10 @@ struct SwapKitService {
     }
 
     /// Whether SwapKit should be offered as a provider for `chain` based on
-    /// the cached `/v3/providers` snapshot. Falls back to "yes" when the cache
-    /// can't be loaded — `/v3/quote` will surface a useful error if the chain
-    /// is genuinely unsupported.
+    /// the cached `/v3/providers` snapshot. Fails CLOSED (returns "no") when
+    /// the snapshot can't be loaded at all — see `SwapKitProviderCache.isEnabled`
+    /// for the rationale and the last-good fallback that limits this to the
+    /// genuine no-data edge.
     func isChainEnabled(_ chain: Chain) async -> Bool {
         await providerCache.isEnabled(chain: chain)
     }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
@@ -52,24 +52,31 @@ final class SwapKitTokensCache: DestinationTokenProvider {
     ///  - SwapKit has no tokens on this chain (cache built, bucket missing).
     /// The picker treats "empty bucket" identically to "no SwapKit unlock"
     /// and falls back to the curated + 1inch + Jupiter list it has today.
-    func tokens(for chain: Chain) async -> DestinationTokenBucket {
-        await tokens(for: chain, now: Date())
+    func tokens(for chain: Chain, forceRefresh: Bool) async -> DestinationTokenBucket {
+        await tokens(for: chain, forceRefresh: forceRefresh, now: Date())
     }
 
     /// Date-injectable variant used by tests / TTL-sensitive callers.
-    func tokens(for chain: Chain, now: Date) async -> DestinationTokenBucket {
+    func tokens(for chain: Chain, forceRefresh: Bool = false, now: Date) async -> DestinationTokenBucket {
         guard SwapKitConfig.isFeatureEnabled else {
             return .empty(chain: chain)
         }
-        let buckets = await ensureSnapshot(now: now)
+        let buckets = await ensureSnapshot(now: now, forceRefresh: forceRefresh)
         return buckets?[chain] ?? .empty(chain: chain)
     }
 
     /// Coalescing fetch — concurrent callers share one in-flight Task to
     /// avoid stampeding the proxy on first picker open. Returns the cached
     /// snapshot when fresh; otherwise refreshes.
-    private func ensureSnapshot(now: Date) async -> [Chain: DestinationTokenBucket]? {
-        if let snapshot, now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.tokensCacheTTL {
+    ///
+    /// `forceRefresh` skips the TTL-fresh early-return so the caller always
+    /// triggers a re-fetch, but still rides the `inFlight` coalescing (so
+    /// concurrent force-refreshes share one request) and the last-good
+    /// fallback (so a failed forced fetch keeps the prior snapshot on screen).
+    private func ensureSnapshot(now: Date, forceRefresh: Bool) async -> [Chain: DestinationTokenBucket]? {
+        if !forceRefresh,
+           let snapshot,
+           now.timeIntervalSince(snapshot.fetchedAt) < SwapKitConfig.tokensCacheTTL {
             return snapshot.buckets
         }
         if let inFlight {

--- a/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenProvider.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenProvider.swift
@@ -28,5 +28,18 @@ protocol DestinationTokenProvider: AnyObject {
     /// the provider is disabled, doesn't support the chain, or its data
     /// isn't yet warmed. Concrete conformers short-circuit on feature
     /// flags / catalog absence as appropriate.
-    func tokens(for chain: Chain) async -> DestinationTokenBucket
+    ///
+    /// `forceRefresh` asks the provider to bypass its freshness/TTL early-return
+    /// and re-fetch its catalog, while still coalescing concurrent callers and
+    /// serving last-good on failure. The picker passes `true` only on its first
+    /// open per presentation so users see an up-to-date catalog; in-session
+    /// re-merges (search debounce, chain re-select) pass `false` to stay
+    /// instant/offline. Providers without a refreshable catalog ignore it.
+    func tokens(for chain: Chain, forceRefresh: Bool) async -> DestinationTokenBucket
+}
+
+extension DestinationTokenProvider {
+    func tokens(for chain: Chain) async -> DestinationTokenBucket {
+        await tokens(for: chain, forceRefresh: false)
+    }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenRegistry.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Services/DestinationTokenRegistry.swift
@@ -40,15 +40,17 @@ final class DestinationTokenRegistry {
     }
 
     /// Aggregate destination tokens from every registered provider for
-    /// `chain`.
+    /// `chain`. `forceRefresh` is forwarded to each provider so the picker's
+    /// first open per presentation can re-fetch catalogs while in-session
+    /// re-merges stay on cached data.
     ///
     /// Concurrency: providers are awaited sequentially — the picker
     /// already serialises on `MainActor`, and the registered-provider
     /// count is O(1-3) today. If that changes, swap to a `TaskGroup`.
-    func tokens(for chain: Chain) async -> [DestinationTokenBucket] {
+    func tokens(for chain: Chain, forceRefresh: Bool = false) async -> [DestinationTokenBucket] {
         var buckets: [DestinationTokenBucket] = []
         for provider in providers {
-            let bucket = await provider.tokens(for: chain)
+            let bucket = await provider.tokens(for: chain, forceRefresh: forceRefresh)
             buckets.append(bucket)
         }
         return buckets

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -43,7 +43,12 @@ class SwapCoinSelectionViewModel: ObservableObject {
             }
     }
 
-    func fetchCoins(chain: Chain) async {
+    /// `forceRefresh` is passed to the destination-token registry so the
+    /// SwapKit token catalog is re-fetched on the picker's first open per
+    /// presentation. The external (curated/1inch/Jupiter) list keeps its own
+    /// `SwapTokenListCache` freshness logic — only the destination-registry
+    /// catalog is forced.
+    func fetchCoins(chain: Chain, forceRefresh: Bool = false) async {
         // Sync peek on the MainActor: when the chain's vault-independent token
         // list is already cached, do the cheap local merge and publish without
         // ever flipping `isLoading` — instant, no spinner. Only a cold load
@@ -58,7 +63,7 @@ class SwapCoinSelectionViewModel: ObservableObject {
                 // path is truly spinner-free.
                 isLoading = false
             }
-            await publishMerge(externalTokens: cached, chain: chain)
+            await publishMerge(externalTokens: cached, chain: chain, forceRefresh: forceRefresh)
 
             // Refresh a stale entry silently in the background — still no
             // spinner. The cache coalesces + fail-opens, so this is cheap.
@@ -76,7 +81,7 @@ class SwapCoinSelectionViewModel: ObservableObject {
         }
 
         do {
-            let result = try await logic.fetchCoins(chain: chain)
+            let result = try await logic.fetchCoins(chain: chain, forceRefresh: forceRefresh)
             try Task.checkCancellation()
             await MainActor.run {
                 self.tokens = result.tokens
@@ -110,9 +115,9 @@ class SwapCoinSelectionViewModel: ObservableObject {
         }
     }
 
-    private func publishMerge(externalTokens: [CoinMeta], chain: Chain) async {
+    private func publishMerge(externalTokens: [CoinMeta], chain: Chain, forceRefresh: Bool = false) async {
         do {
-            let result = try await logic.merge(externalTokens: externalTokens, chain: chain)
+            let result = try await logic.merge(externalTokens: externalTokens, chain: chain, forceRefresh: forceRefresh)
             try Task.checkCancellation()
             await MainActor.run {
                 self.tokens = result.tokens
@@ -168,10 +173,10 @@ struct SwapCoinSelectionLogic {
         self.registry = registry ?? DestinationTokenRegistry.shared
     }
 
-    func fetchCoins(chain: Chain) async throws -> SwapCoinSelectionResult {
+    func fetchCoins(chain: Chain, forceRefresh: Bool = false) async throws -> SwapCoinSelectionResult {
         // Propagate errors instead of swallowing with try?
         let externalTokens = try await service.loadTokens(for: chain)
-        return try await merge(externalTokens: externalTokens, chain: chain)
+        return try await merge(externalTokens: externalTokens, chain: chain, forceRefresh: forceRefresh)
     }
 
     /// Builds the picker-ready list from an already-fetched external token list
@@ -179,7 +184,7 @@ struct SwapCoinSelectionLogic {
     /// coins, deduped + sorted). Separated from the network fetch so the view
     /// model can serve a cached external list without a spinner. The vault read
     /// and `sort` (live balance reads) stay on the MainActor.
-    func merge(externalTokens: [CoinMeta], chain: Chain) async throws -> SwapCoinSelectionResult {
+    func merge(externalTokens: [CoinMeta], chain: Chain, forceRefresh: Bool = false) async throws -> SwapCoinSelectionResult {
         let nativeToken = TokensStore.TokenSelectionAssets.first { $0.chain == chain && $0.isNativeToken }
 
         let baseTokens = ([nativeToken] + externalTokens).compactMap { $0 }
@@ -191,7 +196,7 @@ struct SwapCoinSelectionLogic {
         // doesn't actually hold.
         let externalBuckets: [DestinationTokenBucket]
         if isDestination {
-            externalBuckets = await registry.tokens(for: chain)
+            externalBuckets = await registry.tokens(for: chain, forceRefresh: forceRefresh)
         } else {
             externalBuckets = []
         }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -91,7 +91,10 @@ struct SwapCoinPickerView: View {
         }
         .onLoad {
             viewModel.setup()
-            reloadCoins()
+            // First open per presentation forces a SwapKit catalog refresh so a
+            // stale token list (or one that missed the cold-launch fetch) is
+            // re-fetched. In-session chain re-selects stay on cached data.
+            reloadCoins(forceRefresh: true)
         }
         .onChange(of: selectedChain) { _, _ in
             reloadCoins()
@@ -226,13 +229,13 @@ struct SwapCoinPickerView: View {
             .filter { vault.availableChains.contains($0) }
     }
 
-    private func reloadCoins() {
+    private func reloadCoins(forceRefresh: Bool = false) {
         // Cancel any in-flight load so a fast chain-switch superseding a cold
         // fetch can't publish results for the wrong chain.
         reloadTask?.cancel()
         reloadTask = Task {
             guard let selectedChain else { return }
-            await viewModel.fetchCoins(chain: selectedChain)
+            await viewModel.fetchCoins(chain: selectedChain, forceRefresh: forceRefresh)
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/DestinationTokenRegistryTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/DestinationTokenRegistryTests.swift
@@ -134,7 +134,7 @@ private final class FakeProvider: DestinationTokenProvider {
         self.buckets = buckets
     }
 
-    func tokens(for chain: Chain) async -> DestinationTokenBucket {
+    func tokens(for chain: Chain, forceRefresh _: Bool) async -> DestinationTokenBucket {
         buckets[chain] ?? .empty(chain: chain)
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitProviderCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitProviderCacheTests.swift
@@ -245,18 +245,51 @@ final class SwapKitProviderCacheTests: XCTestCase {
         )
     }
 
-    /// Async fail-open: when the cache has nothing in its snapshot AND the
+    /// Async fail-OPEN: when the cache has nothing in its snapshot AND the
     /// HTTPClient refuses to fetch, the actor reports the pair as "could be
-    /// supported" so the reclassification path still triggers. The trade-off
-    /// is documented in the wiki plan: degrading to "amount too small" is
-    /// strictly better UX than today's "unexpected error" fallback.
-    func testIsPairSupported_emptySnapshotAsyncFailsOpen() async {
+    /// supported" so the reclassification path still triggers. `isPairSupported`
+    /// only chooses between two error labels, so failing it open just keeps the
+    /// more specific "amount too small" label available — deliberately the
+    /// opposite default from `isEnabled` below.
+    func testIsPairSupported_noSnapshotFetchFails_failsOpen() async {
         let cache = SwapKitProviderCache(httpClient: FailingHTTPClient())
         let supported = await cache.isPairSupported(
             fromChain: .bitcoinCash,
             toChain: .ethereum
         )
         XCTAssertTrue(supported)
+    }
+
+    // MARK: - Provider gate (isEnabled) — fail-closed on the no-snapshot edge
+
+    /// Async fail-CLOSED: on a cold launch where the first `/providers` fetch
+    /// fails and there is no prior snapshot, the gate must report the chain as
+    /// NOT enabled. SwapKit is simply not offered until a refresh succeeds,
+    /// rather than offering routes that fail downstream. Other providers still
+    /// populate the picker and `fetchSwapKitQuote` throws cleanly.
+    func testIsEnabled_noSnapshotFetchFails_failsClosed() async {
+        let cache = SwapKitProviderCache(httpClient: FailingHTTPClient())
+        let enabled = await cache.isEnabled(chain: .ethereum)
+        XCTAssertFalse(enabled, "No snapshot + failed fetch must fail closed")
+    }
+
+    /// Once a snapshot exists, a later fetch failure must serve the last-good
+    /// providers rather than collapsing to fail-closed. Guards against
+    /// over-correcting the no-snapshot fix into "any fetch failure disables
+    /// SwapKit": seed a snapshot via `setSnapshot`, then drive `isEnabled`
+    /// through a failing client past the TTL and assert the chain is still
+    /// enabled from the retained snapshot.
+    func testIsEnabled_fetchFailsWithPriorSnapshot_servesLastGood() async {
+        let cache = SwapKitProviderCache(httpClient: FailingHTTPClient())
+        let fetchedAt = Date()
+        await cache.setSnapshot(
+            SwapKitProvidersSnapshot(providers: providers, fetchedAt: fetchedAt)
+        )
+        // Advance well past providerCacheTTL so the snapshot is stale and the
+        // cache attempts a refresh — which fails — falling back to last-good.
+        let later = fetchedAt.addingTimeInterval(SwapKitConfig.providerCacheTTL + 1)
+        let enabled = await cache.isEnabled(chain: .ethereum, now: later)
+        XCTAssertTrue(enabled, "Stale-but-present snapshot must serve last-good, not fail closed")
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensCacheTests.swift
@@ -1,0 +1,186 @@
+//
+//  SwapKitTokensCacheTests.swift
+//  VultisigAppTests
+//
+//  Freshness behaviour for the SwapKit destination-token catalog cache.
+//  Covers the `forceRefresh` path the destination picker uses on its first
+//  open per presentation: it bypasses the TTL-fresh early-return, still
+//  coalesces concurrent callers onto one in-flight fetch, and still serves
+//  the last-good snapshot when a forced fetch fails.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class SwapKitTokensCacheTests: XCTestCase {
+
+    // MARK: - forceRefresh bypasses fresh TTL
+
+    /// A fresh snapshot (within `tokensCacheTTL`) is normally served without a
+    /// network hit. `forceRefresh: true` must skip that early-return and issue
+    /// a new fetch even though the snapshot is fresh.
+    func testForceRefresh_bypassesFreshTTL_refetches() async {
+        let client = StubHTTPClient()
+        let cache = SwapKitTokensCache(httpClient: client, providerCache: makeProviderCache(client))
+        let now = Date()
+
+        // Warm the cache (one fetch fans out to one provider → one /tokens call).
+        _ = await cache.tokens(for: .ethereum, forceRefresh: false, now: now)
+        XCTAssertEqual(client.tokensCallCount, 1)
+
+        // A fresh, non-forced read must NOT refetch.
+        _ = await cache.tokens(for: .ethereum, forceRefresh: false, now: now)
+        XCTAssertEqual(client.tokensCallCount, 1, "Fresh snapshot must be served without a refetch")
+
+        // A forced read on the still-fresh snapshot must refetch.
+        _ = await cache.tokens(for: .ethereum, forceRefresh: true, now: now)
+        XCTAssertEqual(client.tokensCallCount, 2, "forceRefresh must bypass fresh-TTL early-return")
+    }
+
+    // MARK: - forceRefresh coalesces concurrent callers
+
+    /// Concurrent forced reads must share a single in-flight fetch rather than
+    /// stampeding the proxy with one /tokens call each.
+    func testForceRefresh_coalescesConcurrentCalls() async {
+        let client = StubHTTPClient()
+        client.artificialDelay = true
+        let cache = SwapKitTokensCache(httpClient: client, providerCache: makeProviderCache(client))
+        let now = Date()
+
+        async let a = cache.tokens(for: .ethereum, forceRefresh: true, now: now)
+        async let b = cache.tokens(for: .ethereum, forceRefresh: true, now: now)
+        async let c = cache.tokens(for: .ethereum, forceRefresh: true, now: now)
+        let results = await [a, b, c]
+
+        XCTAssertEqual(client.tokensCallCount, 1, "Concurrent forced reads must coalesce onto one fetch")
+        for bucket in results {
+            XCTAssertEqual(bucket.tokens.first?.ticker, "USDC")
+        }
+    }
+
+    // MARK: - forceRefresh serves last-good on failure
+
+    /// A forced read whose fetch fails entirely (no provider snapshot to fan
+    /// out against) must keep serving the prior snapshot rather than collapsing
+    /// to an empty bucket. Seed a known-good snapshot, then force a refresh
+    /// through a failing client whose provider cache has no snapshot — the
+    /// fan-out short-circuits to `nil` and the cache falls back to last-good.
+    func testForceRefresh_servesLastGoodWhenFetchFails() async {
+        let usdc = CoinMeta(
+            chain: .ethereum,
+            ticker: "USDC",
+            logo: "",
+            decimals: 6,
+            priceProviderId: "usd-coin",
+            contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            isNativeToken: false
+        )
+        let bucket = DestinationTokenBucket(
+            chain: .ethereum,
+            tokens: [usdc],
+            uniqueIds: [usdc.uniqueId]
+        )
+
+        let failingClient = StubHTTPClient()
+        failingClient.failAll = true
+        let cache = SwapKitTokensCache(
+            httpClient: failingClient,
+            providerCache: SwapKitProviderCache(httpClient: failingClient)
+        )
+        cache.setSnapshot(buckets: [.ethereum: bucket], fetchedAt: Date(timeIntervalSince1970: 0))
+
+        // Force a refresh well past the TTL — the snapshot is stale, the fetch
+        // fails (no provider snapshot), so last-good must be served.
+        let degraded = await cache.tokens(for: .ethereum, forceRefresh: true, now: Date())
+        XCTAssertEqual(degraded.tokens.first?.ticker, "USDC", "Failed forced fetch must serve last-good snapshot")
+    }
+
+    // MARK: - Helpers
+
+    /// A provider cache that resolves through the same stub client so the
+    /// tokens cache fans out against a known single-provider snapshot.
+    private func makeProviderCache(_ client: StubHTTPClient) -> SwapKitProviderCache {
+        SwapKitProviderCache(httpClient: client)
+    }
+}
+
+// MARK: - Test double
+
+/// Stub `HTTPClientProtocol` that answers `/providers` with one ETH-enabled
+/// provider and `/tokens` with a single ETH USDC entry. Counts `/tokens`
+/// hits (for coalescing assertions) and can be flipped to fail every request.
+@MainActor
+private final class StubHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+    private enum StubError: Error { case unavailable }
+
+    var failAll = false
+    var artificialDelay = false
+    private(set) var tokensCallCount = 0
+
+    private static let providersJSON = """
+    [
+      {
+        "name": "PROVIDER_X",
+        "provider": "PROVIDER_X",
+        "displayName": "Provider X",
+        "displayNameLong": "Provider X Long",
+        "count": 1,
+        "enabledChainIds": ["1"],
+        "supportedChainIds": ["1"],
+        "supportedActions": ["swap"]
+      }
+    ]
+    """
+
+    private static let tokensJSON = """
+    {
+      "provider": "PROVIDER_X",
+      "count": 1,
+      "tokens": [
+        {
+          "chain": "ETH",
+          "chainId": "1",
+          "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          "ticker": "USDC",
+          "identifier": "ETH.USDC-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          "name": "USD Coin",
+          "decimals": 6,
+          "logoURI": null,
+          "coingeckoId": "usd-coin"
+        }
+      ]
+    }
+    """
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        if artificialDelay {
+            // Hold the in-flight fetch open long enough for concurrent callers
+            // to coalesce onto it before it resolves.
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        } else {
+            await Task.yield()
+        }
+
+        if failAll {
+            throw StubError.unavailable
+        }
+
+        let path = target.path
+        if path == "/providers" {
+            return HTTPResponse(data: Data(Self.providersJSON.utf8), response: Self.ok)
+        }
+        if path == "/tokens" {
+            tokensCallCount += 1
+            return HTTPResponse(data: Data(Self.tokensJSON.utf8), response: Self.ok)
+        }
+        throw StubError.unavailable
+    }
+
+    private static let ok = HTTPURLResponse(
+        url: URL(string: "https://example.com")!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}


### PR DESCRIPTION
## Summary
Two SwapKit cache reliability fixes for #4635.

### 1. Provider gate fails CLOSED on the no-snapshot edge
`SwapKitProviderCache.isEnabled(chain:)` previously returned `true` when the providers list couldn't be loaded at all. On a cold launch where the first `/providers` fetch fails and there is no prior snapshot, SwapKit was advertised for the chain and offered routes that fail downstream.

Now it fails **closed** (`false`) on that edge: SwapKit simply isn't offered for the chain until a refresh succeeds. Other providers still populate the picker, and `SwapService.fetchSwapKitQuote` throws `providerNotEnabled` cleanly. This matches Android's already-fail-closed behavior.

- `isPairSupported(...)` deliberately stays **fail-OPEN** on the same edge — it only governs a `noRoutesFound` 404 -> `amountBelowProviderMinimum` error re-label, so failing it closed would merely degrade a message, not block a swap. The asymmetry is documented in code.
- The fetch-fail-**with**-prior-snapshot last-good path is untouched (benign, correct degraded behavior).

### 2. Token catalog refresh-on-picker-open
Threaded a `forceRefresh` flag through `SwapKitTokensCache.tokens(for:forceRefresh:)` -> `ensureSnapshot`, the `DestinationTokenProvider` protocol, `DestinationTokenRegistry`, and the picker view model. When `true` it skips the TTL-fresh early-return but **keeps** `inFlight` coalescing + last-good fallback.

The destination picker's **first open per presentation** passes `forceRefresh: true` (so a stale catalog, or one that missed the cold-launch fetch, is re-fetched). In-session re-merges (search debounce, chain re-select) stay `false` (instant/offline). `tokensCacheTTL` stays 5m as the background floor.

## Tests
- `SwapKitProviderCacheTests`: no-snapshot fetch-fail now asserts **fail-closed**; added a prior-snapshot **last-good** guard against over-correcting; renamed the pair-support no-snapshot test (still fail-open).
- New `SwapKitTokensCacheTests`: `forceRefresh` bypasses fresh TTL, coalesces concurrent calls, and serves last-good on failure.

## Gate
- `make build-check`: BUILD SUCCEEDED
- `make test`: TEST SUCCEEDED, 0 failures
- `swiftlint`: no new warnings in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Coin picker now forces a token refresh on initial sheet load for fresher swap options, while keeping cached data for later in-session picks.
  * Token and destination-token fetching support a `forceRefresh` option that bypasses freshness checks, coalesces concurrent requests, and continues serving the last known good snapshot if refresh fails.
  * Provider availability gating is now more conservative when no prior data exists (fail-closed), improving reliability of SwapKit enablement.
* **Tests**
  * Updated and added coverage for `forceRefresh`, last-good fallback, provider gating edge cases, and concurrent request coalescing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->