### PR TITLE
fix(swap): charge VULT-discounted LiFi integrator fee on Solana routes

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/Actions/Coin+Swaps.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Actions/Coin+Swaps.swift
@@ -204,7 +204,12 @@ extension Coin {
 
     var isLifiFeesSupported: Bool {
         switch chain.chainType {
-        case .EVM:
+        case .EVM, .Solana:
+            // LI.FI now honours the `integrator`/`fee` params on Solana routes,
+            // so Solana swaps charge the same VULT-discounted affiliate fee as
+            // EVM. They were previously excluded because LI.FI rejected those
+            // params on Solana, which left Solana routes uncharged while the UI
+            // still displayed a fee — a display/charge mismatch.
             return true
         default:
             return false

--- a/VultisigApp/VultisigAppTests/Swap/LiFiFeesSupportedTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/LiFiFeesSupportedTests.swift
@@ -1,0 +1,42 @@
+//
+//  LiFiFeesSupportedTests.swift
+//  VultisigAppTests
+//
+//  Pins `Coin.isLifiFeesSupported`, the gate that decides whether the
+//  `integrator`/`fee` params are sent on a LI.FI quote. The VULT-discounted
+//  affiliate fee must be charged on EVM **and** Solana routes; non-LI.FI
+//  source chains stay excluded. Solana was previously omitted because LI.FI
+//  rejected the fee params on those routes — that limitation no longer applies,
+//  so a Solana source must now opt in like EVM.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class LiFiFeesSupportedTests: XCTestCase {
+
+    func testEVMSourcesChargeFee() {
+        // Sanity baseline: classic EVM plus the two non-obvious EVM chains that
+        // also route through LI.FI (Cronos, Hyperliquid) all charge the fee.
+        for chain in [Chain.ethereum, .arbitrum, .base, .cronosChain, .hyperliquid] {
+            XCTAssertTrue(makeCoin(chain).isLifiFeesSupported, "\(chain) is EVM and must charge the LI.FI fee")
+        }
+    }
+
+    func testSolanaSourceChargesFee() {
+        // The fix: Solana LI.FI routes now charge the same VULT-discounted
+        // affiliate fee as EVM, instead of displaying a fee that was never sent.
+        XCTAssertTrue(makeCoin(.solana).isLifiFeesSupported, "Solana must charge the LI.FI fee")
+    }
+
+    func testNonLiFiSourcesDoNotChargeFee() {
+        for chain in [Chain.bitcoin, .thorChain, .ton, .cardano] {
+            XCTAssertFalse(makeCoin(chain).isLifiFeesSupported, "\(chain) must not charge a LI.FI fee")
+        }
+    }
+
+    private func makeCoin(_ chain: Chain) -> Coin {
+        let asset = CoinMeta.make(chain: chain, ticker: chain.ticker, decimals: 18, isNativeToken: true)
+        return Coin(asset: asset, address: "test-address", hexPublicKey: "")
+    }
+}


### PR DESCRIPTION
## Summary

Ports [vultisig-android#5017](https://github.com/vultisig/vultisig-android/pull/5017) to iOS: charge the VULT-discounted LiFi integrator fee on **Solana** routes.

### Problem

LiFi swaps **sourced from Solana** never charged the Vultisig integrator fee, and VULT holders got **no discount** on those routes — while EVM swaps did.

Root cause: the fee gate `Coin.isLifiFeesSupported` returned `true` only for `.EVM` chains, so for a Solana source the `integrator`/`fee` query params were dropped from the LiFi quote request:

```swift
let integrator = fromCoin.isLifiFeesSupported ? integratorName : nil
let integratorFee = fromCoin.isLifiFeesSupported ? bps(for: vultTierDiscount) : nil
```

Side effect: the UI still computed and displayed a ~0.5% fee via `integratorFee` that was never actually collected (a display/charge mismatch), and the VULT tier discount didn't apply.

This is the iOS analog of Android's `if (!isSolanaChainInvolved)` guard. The original exclusion existed because LiFi rejected the fee params on Solana routes; that limitation no longer applies (verified live on the Android side against `li.quest/v1/quote`).

### Fix

Include `.Solana` in the `isLifiFeesSupported` gate so Solana routes send the same VULT-discounted affiliate fee as EVM:

```swift
case .EVM, .Solana:
    return true
```

- Solana LiFi swaps now charge the affiliate fee (recovering revenue) with the VULT tier discount applied, at parity with EVM.
- The displayed fee now matches what is actually collected.
- EVM-source routes (including Cronos / Hyperliquid, which are `.EVM` chainType) already charged the fee and are unchanged. `.solana`, `.hyperliquid` and `.cronosChain` are the only non-curated LiFi source chains, and the latter two were already covered — so Solana was the sole gap.

### Tests

- New `LiFiFeesSupportedTests`: EVM (incl. Cronos/Hyperliquid) **and** Solana charge the fee; non-LiFi sources (BTC/THOR/TON/ADA) stay excluded.
- `make generate` + targeted `xcodebuild test`: **TEST SUCCEEDED**, 0 failures.
- `swiftlint`: 0 violations in touched files.

### Out of scope

The Jupiter (native Solana) half of the original issue is infrastructure-blocked on both platforms (no Vultisig fee baseline exists to discount) and is tracked separately, matching the Android PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled LI.FI fees support for Solana transactions, resolving previous fee display and charge inconsistencies.

* **Tests**
  * Added test coverage for LI.FI fees support across multiple blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->