### PR TITLE
perf(defi): cache TRON account/resource data with a TTL

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -18,6 +18,15 @@ class TronService {
     // Cache for chain parameters
     private var chainParametersCache: TronChainParametersResponse?
 
+    /// Per-address TTL cache for account + resource responses, shared across
+    /// the DeFi screens so re-opening paints instantly instead of refetching.
+    private let accountCache = TronAccountCache()
+
+    /// Time-to-live for cached account/resource data, in seconds. Tunable —
+    /// short enough that balances stay fresh after a freeze/unfreeze, long
+    /// enough that navigating back into the screen serves from cache.
+    static var accountCacheTTL: TimeInterval = 60
+
     // Constants from Android implementation
     private static let BYTES_PER_COIN_TX: Int64 = 300
     private static let BYTES_PER_CONTRACT_TX: Int64 = 345
@@ -111,12 +120,42 @@ class TronService {
 
     // MARK: - Account Info
 
-    func getAccount(address: String) async throws -> TronAccountResponse {
-        return try await apiService.getAccount(address: address)
+    /// Returns the account for `address`, served from the TTL cache when a
+    /// fresh entry exists. `forceRefresh` bypasses the cache for explicit
+    /// pull-to-refresh. Concurrent callers for the same address coalesce onto
+    /// a single network request.
+    func getAccount(address: String, forceRefresh: Bool = false) async throws -> TronAccountResponse {
+        try await accountCache.account(for: address, forceRefresh: forceRefresh) {
+            try await self.apiService.getAccount(address: address)
+        }
     }
 
-    func getAccountResource(address: String) async throws -> TronAccountResourceResponse {
-        return try await apiService.getAccountResource(address: address)
+    /// Returns the account resources for `address`, served from the TTL cache
+    /// when fresh. See `getAccount(address:forceRefresh:)` for cache semantics.
+    func getAccountResource(address: String, forceRefresh: Bool = false) async throws -> TronAccountResourceResponse {
+        try await accountCache.resource(for: address, forceRefresh: forceRefresh) {
+            try await self.apiService.getAccountResource(address: address)
+        }
+    }
+
+    /// Returns the cached account for `address` only if a non-expired entry
+    /// exists, without touching the network. Lets a screen paint instantly
+    /// (no spinner) when data is fresh and fall back to a network load only
+    /// when the cache is cold or stale.
+    func cachedAccount(for address: String) async -> TronAccountResponse? {
+        await accountCache.cachedAccount(for: address)
+    }
+
+    /// Cached-resource counterpart to `cachedAccount(for:)`.
+    func cachedAccountResource(for address: String) async -> TronAccountResourceResponse? {
+        await accountCache.cachedResource(for: address)
+    }
+
+    /// Drops any cached account + resource entry for `address` so the next
+    /// load refetches. Called after a freeze/unfreeze so balances update when
+    /// the user navigates back into the DeFi screens.
+    func invalidateAccountCache(for address: String) async {
+        await accountCache.invalidate(address: address)
     }
 
     // MARK: - Private Helpers
@@ -274,5 +313,99 @@ class TronService {
         let createAccountContractFee = BigInt(chainParams.createNewAccountFeeEstimateContract)
 
         return createAccountFee + createAccountContractFee
+    }
+}
+
+// MARK: - Account Cache
+
+/// Concurrency-safe, per-address TTL cache for TRON account + resource
+/// responses, mirroring `THORChainAPICache`. Coalesces concurrent loads for
+/// the same address onto a single in-flight request so the dashboard and the
+/// resources loader opening together don't duplicate network calls.
+private actor TronAccountCache {
+
+    private struct CacheEntry<T> {
+        let value: T
+        let timestamp: Date
+
+        func isExpired(duration: TimeInterval) -> Bool {
+            Date().timeIntervalSince(timestamp) > duration
+        }
+    }
+
+    private var accounts: [String: CacheEntry<TronAccountResponse>] = [:]
+    private var resources: [String: CacheEntry<TronAccountResourceResponse>] = [:]
+    private var inFlightAccounts: [String: Task<TronAccountResponse, Error>] = [:]
+    private var inFlightResources: [String: Task<TronAccountResourceResponse, Error>] = [:]
+
+    // MARK: Account
+
+    func cachedAccount(for address: String) -> TronAccountResponse? {
+        guard let entry = accounts[address],
+              !entry.isExpired(duration: TronService.accountCacheTTL) else {
+            return nil
+        }
+        return entry.value
+    }
+
+    func account(
+        for address: String,
+        forceRefresh: Bool,
+        fetch: @escaping () async throws -> TronAccountResponse
+    ) async throws -> TronAccountResponse {
+        if !forceRefresh, let cached = cachedAccount(for: address) {
+            return cached
+        }
+
+        if let existing = inFlightAccounts[address] {
+            return try await existing.value
+        }
+
+        let task = Task { try await fetch() }
+        inFlightAccounts[address] = task
+        defer { inFlightAccounts[address] = nil }
+
+        let value = try await task.value
+        accounts[address] = CacheEntry(value: value, timestamp: Date())
+        return value
+    }
+
+    // MARK: Resource
+
+    func cachedResource(for address: String) -> TronAccountResourceResponse? {
+        guard let entry = resources[address],
+              !entry.isExpired(duration: TronService.accountCacheTTL) else {
+            return nil
+        }
+        return entry.value
+    }
+
+    func resource(
+        for address: String,
+        forceRefresh: Bool,
+        fetch: @escaping () async throws -> TronAccountResourceResponse
+    ) async throws -> TronAccountResourceResponse {
+        if !forceRefresh, let cached = cachedResource(for: address) {
+            return cached
+        }
+
+        if let existing = inFlightResources[address] {
+            return try await existing.value
+        }
+
+        let task = Task { try await fetch() }
+        inFlightResources[address] = task
+        defer { inFlightResources[address] = nil }
+
+        let value = try await task.value
+        resources[address] = CacheEntry(value: value, timestamp: Date())
+        return value
+    }
+
+    // MARK: Invalidation
+
+    func invalidate(address: String) {
+        accounts[address] = nil
+        resources[address] = nil
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeViewModel.swift
@@ -72,6 +72,12 @@ final class TronFreezeViewModel: ObservableObject, Form {
 
         let memo = "FREEZE:\(selectedResourceType.tronResourceString)"
 
+        // Drop the cached account/resource for this address so balances
+        // refresh when the user navigates back into the DeFi screens after
+        // the freeze is broadcast.
+        let address = coin.address
+        Task { await TronService.shared.invalidateAccountCache(for: address) }
+
         return SendTransaction.empty(coin: coin, vault: vault).with(
             toAddress: coin.address,
             amount: amountDecimal.description,

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronResourcesLoader.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronResourcesLoader.swift
@@ -23,21 +23,34 @@ final class TronResourcesLoader: ObservableObject {
     }
 
     @MainActor
-    func load() {
-        isLoading = true
-
+    func load(forceRefresh: Bool = false) {
+        let address = self.address
         Task {
+            // Serve fresh-cached resources without a spinner; only show
+            // loading when the cache is cold/stale or a refresh was forced.
+            let cached = forceRefresh ? nil : await TronService.shared.cachedAccountResource(for: address)
+            if let cached {
+                apply(cached)
+                return
+            }
+
+            isLoading = true
             defer { self.isLoading = false }
 
             do {
-                let resource = try await TronService.shared.getAccountResource(address: address)
-                self.availableBandwidth = resource.calculateAvailableBandwidth()
-                self.totalBandwidth = resource.freeNetLimit + resource.NetLimit
-                self.availableEnergy = resource.EnergyLimit - resource.EnergyUsed
-                self.totalEnergy = resource.EnergyLimit
+                let resource = try await TronService.shared.getAccountResource(address: address, forceRefresh: forceRefresh)
+                apply(resource)
             } catch {
                 logger.error("Failed to load Tron resources: \(error)")
             }
         }
+    }
+
+    @MainActor
+    private func apply(_ resource: TronAccountResourceResponse) {
+        availableBandwidth = resource.calculateAvailableBandwidth()
+        totalBandwidth = resource.freeNetLimit + resource.NetLimit
+        availableEnergy = resource.EnergyLimit - resource.EnergyUsed
+        totalEnergy = resource.EnergyLimit
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronScreen.swift
@@ -30,21 +30,13 @@ struct TronScreen: View {
         } else {
             Screen {
                 // Show dashboard immediately (cards show their own loading states)
-                TronDashboardView(vault: vault, model: model, onRefresh: loadData)
+                TronDashboardView(vault: vault, model: model, onRefresh: { await loadData(forceRefresh: true) })
             }
             .screenTitle("tronTitle".localized)
         }
     }
 
-    private func loadData() async {
-        // Set all loading states upfront so skeletons appear and clear previous errors
-        await MainActor.run {
-            model.isLoading = true
-            model.isLoadingBalance = true
-            model.isLoadingResources = true
-            model.error = nil
-        }
-
+    private func loadData(forceRefresh: Bool = false) async {
         // Check if vault has TRX
         guard let trxCoin = TronViewLogic.getTrxCoin(vault: vault) else {
             await MainActor.run {
@@ -56,13 +48,22 @@ struct TronScreen: View {
             return
         }
 
-        // Clear missingTrx flag when TRX is found
-        await MainActor.run {
-            model.missingTrx = false
-        }
-
         let address = trxCoin.address
         let tronService = TronService.shared
+
+        // Serve fresh-cached data immediately without a spinner. Only show
+        // loading skeletons when the cache is cold/stale or an explicit
+        // refresh was requested.
+        let cachedAccount = forceRefresh ? nil : await tronService.cachedAccount(for: address)
+        let cachedResource = forceRefresh ? nil : await tronService.cachedAccountResource(for: address)
+
+        await MainActor.run {
+            model.missingTrx = false
+            model.error = nil
+            model.isLoading = cachedAccount == nil || cachedResource == nil
+            model.isLoadingBalance = cachedAccount == nil
+            model.isLoadingResources = cachedResource == nil
+        }
 
         // Persist the frozen/unfreezing balance into `Coin.stakedBalance` so the
         // DeFi portfolio main screen (which reads the persisted value) stays in
@@ -74,7 +75,7 @@ struct TronScreen: View {
             // Task 1: Fetch account info (balance data)
             group.addTask {
                 do {
-                    let account = try await tronService.getAccount(address: address)
+                    let account = try await tronService.getAccount(address: address, forceRefresh: forceRefresh)
                     await MainActor.run {
                         // Calculate available balance (in TRX, not SUN)
                         let balanceSun = account.balance ?? 0
@@ -112,7 +113,7 @@ struct TronScreen: View {
             // Task 2: Fetch resource info (bandwidth/energy)
             group.addTask {
                 do {
-                    let resource = try await tronService.getAccountResource(address: address)
+                    let resource = try await tronService.getAccountResource(address: address, forceRefresh: forceRefresh)
                     await MainActor.run {
                         self.model.availableBandwidth = resource.calculateAvailableBandwidth()
                         self.model.totalBandwidth = resource.freeNetLimit + resource.NetLimit

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeViewModel.swift
@@ -95,6 +95,12 @@ final class TronUnfreezeViewModel: ObservableObject, Form {
 
         let memo = "UNFREEZE:\(selectedResourceType.tronResourceString)"
 
+        // Drop the cached account/resource for this address so balances
+        // refresh when the user navigates back into the DeFi screens after
+        // the unfreeze is broadcast.
+        let address = coin.address
+        Task { await TronService.shared.invalidateAccountCache(for: address) }
+
         return SendTransaction.empty(coin: coin, vault: vault).with(
             toAddress: coin.address,
             amount: amountDecimal.description,

--- a/VultisigApp/VultisigAppTests/Services/TronServiceCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceCacheTests.swift
@@ -1,0 +1,140 @@
+//
+//  TronServiceCacheTests.swift
+//  VultisigAppTests
+//
+//  Pins the TTL cache behind `TronService.getAccount` /
+//  `getAccountResource`: a fresh entry is served without a network call,
+//  an expired entry re-fetches, and `forceRefresh` bypasses a fresh entry.
+//  The DeFi screens re-fetched account + resource data on every open; this
+//  cache lets re-opening paint from cache and only hit the network when
+//  stale or explicitly refreshed.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class TronServiceCacheTests: XCTestCase {
+
+    private let address = "TKt9bGgWeFFu2yRgULxRhmiBADuoEoadq8"
+
+    override func tearDown() {
+        TronService.accountCacheTTL = 60
+        super.tearDown()
+    }
+
+    /// A second call within the TTL is served from cache — no extra network
+    /// request to either endpoint.
+    func testGetAccount_withinTTL_servesFromCacheWithoutNetwork() async throws {
+        let stub = TronCountingHTTPClient()
+        let service = TronService(httpClient: stub)
+
+        _ = try await service.getAccount(address: address)
+        _ = try await service.getAccount(address: address)
+
+        XCTAssertEqual(stub.count(for: "/wallet/getaccount"), 1)
+    }
+
+    func testGetAccountResource_withinTTL_servesFromCacheWithoutNetwork() async throws {
+        let stub = TronCountingHTTPClient()
+        let service = TronService(httpClient: stub)
+
+        _ = try await service.getAccountResource(address: address)
+        _ = try await service.getAccountResource(address: address)
+
+        XCTAssertEqual(stub.count(for: "/wallet/getaccountresource"), 1)
+    }
+
+    /// Once the entry is older than the TTL the next call re-fetches.
+    func testGetAccount_afterTTL_refetchesFromNetwork() async throws {
+        TronService.accountCacheTTL = 0 // expire immediately
+        let stub = TronCountingHTTPClient()
+        let service = TronService(httpClient: stub)
+
+        _ = try await service.getAccount(address: address)
+        _ = try await service.getAccount(address: address)
+
+        XCTAssertEqual(stub.count(for: "/wallet/getaccount"), 2)
+    }
+
+    /// `forceRefresh` bypasses an otherwise-fresh cached entry (pull-to-refresh).
+    func testGetAccount_forceRefresh_bypassesFreshCache() async throws {
+        let stub = TronCountingHTTPClient()
+        let service = TronService(httpClient: stub)
+
+        _ = try await service.getAccount(address: address)
+        _ = try await service.getAccount(address: address, forceRefresh: true)
+
+        XCTAssertEqual(stub.count(for: "/wallet/getaccount"), 2)
+    }
+
+    /// `cachedAccount(for:)` peeks a fresh entry without a network call and
+    /// returns nil before anything is cached.
+    func testCachedAccount_reflectsCacheState() async throws {
+        let stub = TronCountingHTTPClient()
+        let service = TronService(httpClient: stub)
+
+        let before = await service.cachedAccount(for: address)
+        XCTAssertNil(before)
+
+        _ = try await service.getAccount(address: address)
+
+        let after = await service.cachedAccount(for: address)
+        XCTAssertNotNil(after)
+        XCTAssertEqual(stub.count(for: "/wallet/getaccount"), 1)
+    }
+
+    /// Invalidation drops the cached entry so the next load re-fetches —
+    /// the freeze/unfreeze refresh path.
+    func testInvalidate_forcesRefetch() async throws {
+        let stub = TronCountingHTTPClient()
+        let service = TronService(httpClient: stub)
+
+        _ = try await service.getAccount(address: address)
+        await service.invalidateAccountCache(for: address)
+        _ = try await service.getAccount(address: address)
+
+        XCTAssertEqual(stub.count(for: "/wallet/getaccount"), 2)
+    }
+}
+
+// MARK: - Counting Stub HTTPClient
+
+/// Path-keyed stub that counts requests per path so cache hits/misses are
+/// observable. Returns canned valid JSON for the account + resource endpoints.
+private final class TronCountingHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var counts: [String: Int] = [:]
+
+    private let responses: [String: String] = [
+        "/wallet/getaccount": #"{"address":"TGexisting","balance":1}"#,
+        "/wallet/getaccountresource": #"{"freeNetUsed":0,"freeNetLimit":600,"NetUsed":0,"NetLimit":10000,"EnergyUsed":0,"EnergyLimit":1000000}"#
+    ]
+
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        let path = target.path
+        lock.lock()
+        counts[path, default: 0] += 1
+        lock.unlock()
+
+        guard let json = responses[path] else {
+            XCTFail("TronCountingHTTPClient has no stub for path '\(path)'")
+            throw HTTPError.invalidResponse
+        }
+        let response = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: Data(json.utf8), response: response)
+    }
+
+    func count(for path: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return counts[path, default: 0]
+    }
+}


### PR DESCRIPTION
## Summary

The TRON DeFi screens re-fetched account + resource data from the network **on every screen open**, showing a loading spinner each visit. This adds a TTL'd, concurrency-safe, **per-address** cache for `TronService.getAccount` / `getAccountResource` (mirroring `THORChainAPICache`) so re-opening the screens paints instantly from cache and only hits the network when stale or explicitly refreshed.

`closes #4649`

> Stacked on #4648 (Tron Figma-fidelity refactor) — base branch is `fix/tron-defi-figma-4647`, so this diff is only the cache work.

## Cache design

- **`TronAccountCache`** — an `actor` (nested in `TronService.swift`) with a generic `CacheEntry<T> { value; timestamp; isExpired(duration:) }`, two `[address: CacheEntry]` dictionaries (account + resource).
- **TTL** — `TronService.accountCacheTTL = 60`s, a named, tunable static constant.
- **Coalescing — yes.** Per-address in-flight `Task` dedup so the dashboard and the resources loader opening together share a single network call per endpoint.
- **forceRefresh** — `getAccount(address:forceRefresh:)` / `getAccountResource(address:forceRefresh:)` gain a `forceRefresh: Bool = false` that bypasses the cache. Wired to the dashboard's pull-to-refresh (`onRefresh` → `loadData(forceRefresh: true)`).
- **Peek** — `cachedAccount(for:)` / `cachedAccountResource(for:)` return a fresh entry without touching the network. `TronScreen.loadData` and `TronResourcesLoader.load` peek first and **skip the spinner** when data is fresh; loading/skeletons only appear on a cold/stale cache or an explicit refresh.
- **Invalidation point** — the freeze/unfreeze view models' `makeTransaction()`. That's the single point where a staking tx is initiated; invalidating the address there means when the user navigates back into `TronScreen` (whose `onAppear` reloads), the entry is cold and balances refetch. Chosen over hooking the verify/broadcast flow because it's the least-fragile, VM-local seam (no reach into the Send pipeline).
- **Signing/fee untouched** — `getTronInactiveDestinationFee` still calls `apiService.getAccount` directly (not the cached method), so the fee/activation path is unchanged. `TronHelper` consumption is untouched.

## Mock approach

Reused the existing `TronService(httpClient:)` injection seam. The test uses a `TronCountingHTTPClient: HTTPClientProtocol` that counts requests per `target.path`, so cache hits/misses are directly observable — no real network, no changes to signing paths.

## Gate

**SwiftLint** (`swiftlint lint --config VultisigApp/.swiftlint.yml` on touched files):
```
Done linting! Found 0 violations, 0 serious in 6 files.
```

**Build** (`xcodebuild -scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' build`):
```
** BUILD SUCCEEDED **
```

**Test** (`-only-testing:VultisigAppTests/TronServiceCacheTests`):
```
Executed 6 tests, with 0 failures (0 unexpected) in 0.013s -- ** TEST SUCCEEDED **
```
Covers: cache hit within TTL (no network), expiry after TTL (re-fetch), forceRefresh bypassing a fresh entry, peek state, and invalidation forcing a refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>