### PR TITLE
feat(vault): show MLDSA key in vault details screen

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -668,6 +668,7 @@
 "mintCoin" = "%@ prägen";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Geben Sie die 12 oder 24 Wörter Ihrer Seed-Phrase ein";
 "modules" = "Module";
 "monthlyBackupTitle" = "Vergessen Sie nicht, Ihre\nTresoranteile zu sichern und die Vollständigkeit zu überprüfen.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -674,6 +674,7 @@
 "mintCoin" = "Mint %@";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Enter the 12 or 24 words of your seedphrase";
 "modules" = "Modules";
 "monthlyBackupTitle" = "Don't forget to backup your\nvault shares and verify the completeness.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -668,6 +668,7 @@
 "mintCoin" = "Acuñar %@";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Ingresa las 12 o 24 palabras de tu frase semilla";
 "modules" = "Módulos";
 "monthlyBackupTitle" = "No olvides hacer una copia de seguridad de\nlas partes de tu bóveda y verificar su integridad.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -668,6 +668,7 @@
 "mintCoin" = "Kovaj %@";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Unesite 12 ili 24 riječi svoje seed fraze";
 "modules" = "Moduli";
 "monthlyBackupTitle" = "Ne zaboravite napraviti sigurnosnu kopiju\ndijelova svog trezora i provjeriti njihovu cjelovitost.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -668,6 +668,7 @@
 "mintCoin" = "Conia %@";
 "mintSecuredAsset" = "Conia Asset Garantito (SECURE+)";
 "mintTransaction" = "2. Transazione di conio asset garantito";
+"MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Inserisci le 12 o 24 parole della tua seed phrase";
 "modules" = "Moduli";
 "monthlyBackupTitle" = "Non dimenticare di eseguire il backup delle\nquote del tuo caveau e verificarne la completezza.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -668,6 +668,7 @@
 "mintCoin" = "Cunhar %@";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Digite as 12 ou 24 palavras da sua frase semente";
 "modules" = "Módulos";
 "monthlyBackupTitle" = "Não se esqueça de fazer backup\ndas partes do seu cofre e verificar sua integridade.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -668,6 +668,7 @@
 "mintCoin" = "铸造 %@";
 "mintSecuredAsset" = "铸造担保资产 (SECURE+)";
 "mintTransaction" = "2. 铸造担保资产交易";
+"MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "输入您的助记词的12个或24个单词";
 "modules" = "模块";
 "monthlyBackupTitle" = "不要忘记备份您的\n保险库份额并验证完整性";

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/VaultDetail/VaultPairDetailCard.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/VaultDetail/VaultPairDetailCard.swift
@@ -71,6 +71,10 @@ struct VaultPairDetailCard: View {
 
             vaultKeyRow(title: "ECDSA".localized, description: vault.pubKeyECDSA)
             vaultKeyRow(title: "EdDSA".localized, description: vault.pubKeyEdDSA)
+
+            if let publicKeyMLDSA44 = vault.publicKeyMLDSA44, !publicKeyMLDSA44.isEmpty {
+                vaultKeyRow(title: "MLDSA".localized, description: publicKeyMLDSA44)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The vault Details screen only rendered the ECDSA and EdDSA public keys under the **Keys** section. When a vault has an MLDSA (post-quantum) key it was not displayed, even though the data already exists on the model (`Vault.publicKeyMLDSA44`). Windows and the browser extension already show it.

This change conditionally renders an "MLDSA" key row in `vaultKeysSection` when `vault.publicKeyMLDSA44` is non-nil and non-empty, reusing the existing copyable `vaultKeyRow(title:description:)` helper. The row therefore:
- has the same copy icon + `onKeyCopy` callback behavior as the ECDSA/EdDSA rows,
- is included in the shared/exported `isForSharing` view for parity (the helper handles `isForSharing` internally — disabling copy and hiding the icon),
- is hidden entirely for vaults without an MLDSA key (no empty row).

Display only — no key generation or migration.

## Files changed

- `VultisigApp/VultisigApp/Features/Wallet/Views/VaultDetail/VaultPairDetailCard.swift` — conditional MLDSA row in `vaultKeysSection`.
- `VultisigApp/VultisigApp/Core/Localizables/{en,de,es,hr,it,pt,zh-Hans}.lproj/Localizable.strings` — added the `MLDSA` title key.

## Localization

Added one key `"MLDSA" = "MLDSA";` to all 7 locale files. This mirrors the existing convention for the sibling rows, which use the bare acronym keys `"ECDSA"` / `"EdDSA"` (kept untranslated across locales). Files were sorted with `VultisigApp/scripts/sort_localizable.py`.

## Verification

- **SwiftLint**: `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/VultisigApp/Features/Wallet/Views/VaultDetail/VaultPairDetailCard.swift` → 0 violations.
- **Build**: `xcodebuild build -project VultisigApp/VultisigApp.xcodeproj -scheme VultisigApp -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` → **BUILD SUCCEEDED** (project regenerated via `make generate` first).

Closes #4651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying an additional MLDSA key in vault details when available.
  * Expanded app translations to include the new MLDSA label across several supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->