### PR TITLE
feat(solana): staking foundation — models + RPC read layer

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaStakeAccount.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaStakeAccount.swift
@@ -1,0 +1,202 @@
+//
+//  SolanaStakeAccount.swift
+//  VultisigApp
+//
+//  Parsed Solana stake account — the read-side model the staking UI binds to
+//  (delegation amount, validator, activation state, withdraw authority). One
+//  stake account delegates to exactly one validator; a wallet can hold N.
+//
+//  Decoded from a `getAccountInfo` / `getProgramAccounts` `jsonParsed` row
+//  (`value.data.parsed.info.{meta,stake}`). The on-chain numbers
+//  (`activationEpoch`, `deactivationEpoch`, `stake`, `rentExemptReserve`) are
+//  serialized as decimal STRINGS in jsonParsed — they're u64 and exceed JSON's
+//  safe-integer range — so the wire model keeps them as strings and the public
+//  model converts to `UInt64`.
+//
+
+import Foundation
+
+/// Activation lifecycle of a stake delegation, derived from the account's
+/// `activationEpoch` / `deactivationEpoch` relative to the current epoch.
+/// Solana stake activates at the next epoch boundary and cools down ~1 epoch
+/// after a deactivate before the funds can be withdrawn.
+enum SolanaStakeActivationState: String, Codable, Hashable {
+    /// Delegated this epoch — warming up, not yet fully effective.
+    case activating
+    /// Fully delegated and earning rewards.
+    case active
+    /// Deactivate submitted — cooling down this epoch, not yet withdrawable.
+    case deactivating
+    /// No active delegation — either never delegated or fully cooled down.
+    case inactive
+}
+
+struct SolanaStakeAccount: Codable, Hashable, Identifiable {
+    /// Stake account address (its own pubkey, not the owner's).
+    let pubkey: String
+    /// The account's total lamports (delegated stake + rent reserve + any
+    /// undelegated lamports).
+    let lamports: UInt64
+    /// Rent-exempt reserve held by the account — not part of the delegated /
+    /// withdrawable stake.
+    let rentExemptReserve: UInt64
+    /// Authority allowed to delegate / deactivate the stake.
+    let staker: String
+    /// Authority allowed to withdraw the stake.
+    let withdrawer: String
+    /// The delegation, or `nil` for an initialized-but-undelegated account
+    /// (`parsed.type == "initialized"`, no `stake.delegation`).
+    let delegation: Delegation?
+
+    var id: String { pubkey }
+
+    struct Delegation: Codable, Hashable {
+        /// Vote account this stake is delegated to.
+        let votePubkey: String
+        /// Epoch the delegation began activating.
+        let activationEpoch: UInt64
+        /// Epoch the delegation began deactivating, or `UInt64.max` while
+        /// active (the Stake program's "not deactivating" sentinel).
+        let deactivationEpoch: UInt64
+        /// Delegated lamports.
+        let stake: UInt64
+
+        /// `true` when no deactivation has been scheduled.
+        var isDeactivationSentinel: Bool {
+            deactivationEpoch == SolanaStakingConfig.epochSentinel
+        }
+    }
+
+    /// Derives the lifecycle state from the current epoch. Pure so the cooldown
+    /// gate and the UI share one definition.
+    ///
+    /// - activating: delegation began this epoch and is not deactivating.
+    /// - deactivating: a deactivation was scheduled and the current epoch has
+    ///   not yet passed it.
+    /// - active: delegated in a prior epoch and not deactivating.
+    /// - inactive: no delegation, or the deactivation epoch has passed.
+    func activationState(currentEpoch: UInt64) -> SolanaStakeActivationState {
+        guard let delegation else { return .inactive }
+
+        if !delegation.isDeactivationSentinel {
+            // A deactivation is scheduled. Still cooling down until the current
+            // epoch passes the deactivation epoch; inactive afterwards.
+            return currentEpoch <= delegation.deactivationEpoch ? .deactivating : .inactive
+        }
+
+        // No deactivation scheduled — activating in its first epoch, active after.
+        return currentEpoch <= delegation.activationEpoch ? .activating : .active
+    }
+}
+
+// MARK: - jsonParsed wire decoding
+
+/// Mirrors the `jsonParsed` Stake-program account shape so the parsed-info tree
+/// decodes straight off the RPC envelope. `init(from:)` on `SolanaStakeAccount`
+/// folds this wire tree into the flat public model, converting the u64 string
+/// fields to `UInt64`.
+extension SolanaStakeAccount {
+
+    /// Builds the model from a decoded `getProgramAccounts` row
+    /// (`{ pubkey, account }`). Returns `nil` when the account is not a parsed
+    /// stake account (e.g. a `dataSlice`d pubkey-only row, or a non-stake
+    /// program account) — callers fetch full `jsonParsed` info separately for
+    /// those.
+    init?(programAccount: SolanaStakeProgramAccount) {
+        guard let parsed = programAccount.account.data.parsed else { return nil }
+        self.init(pubkey: programAccount.pubkey, lamports: programAccount.account.lamports, parsed: parsed)
+    }
+
+    /// Builds the model from a `getAccountInfo` value plus the account's own
+    /// pubkey (which `getAccountInfo` does not echo back).
+    init?(pubkey: String, accountInfo: SolanaStakeAccountInfoValue) {
+        guard let parsed = accountInfo.data.parsed else { return nil }
+        self.init(pubkey: pubkey, lamports: accountInfo.lamports, parsed: parsed)
+    }
+
+    private init?(pubkey: String, lamports: UInt64, parsed: SolanaStakeParsed) {
+        let info = parsed.info
+        let rentReserve = UInt64(info.meta.rentExemptReserve) ?? 0
+
+        var delegation: Delegation?
+        if let stake = info.stake {
+            let d = stake.delegation
+            guard
+                let activation = UInt64(d.activationEpoch),
+                let deactivation = UInt64(d.deactivationEpoch),
+                let stakeLamports = UInt64(d.stake)
+            else { return nil }
+            delegation = Delegation(
+                votePubkey: d.voter,
+                activationEpoch: activation,
+                deactivationEpoch: deactivation,
+                stake: stakeLamports
+            )
+        }
+
+        self.pubkey = pubkey
+        self.lamports = lamports
+        self.rentExemptReserve = rentReserve
+        self.staker = info.meta.authorized.staker
+        self.withdrawer = info.meta.authorized.withdrawer
+        self.delegation = delegation
+    }
+}
+
+// MARK: - jsonParsed wire types
+
+/// A `getProgramAccounts` result row for the Stake program.
+struct SolanaStakeProgramAccount: Decodable {
+    let pubkey: String
+    let account: Account
+
+    struct Account: Decodable {
+        let lamports: UInt64
+        let data: SolanaStakeAccountData
+    }
+}
+
+/// The `value` of a `getAccountInfo` result for a Stake-program account.
+struct SolanaStakeAccountInfoValue: Decodable {
+    let lamports: UInt64
+    let data: SolanaStakeAccountData
+}
+
+/// `account.data` in jsonParsed form. `parsed` is absent when the data was
+/// requested as base64 / dataSliced rather than jsonParsed.
+struct SolanaStakeAccountData: Decodable {
+    let parsed: SolanaStakeParsed?
+}
+
+struct SolanaStakeParsed: Decodable {
+    /// `"delegated"`, `"initialized"`, etc. Kept for future copy; not required
+    /// for parsing since `stake` presence already discriminates delegation.
+    let type: String?
+    let info: Info
+
+    struct Info: Decodable {
+        let meta: Meta
+        let stake: Stake?
+
+        struct Meta: Decodable {
+            let rentExemptReserve: String
+            let authorized: Authorized
+
+            struct Authorized: Decodable {
+                let staker: String
+                let withdrawer: String
+            }
+        }
+
+        struct Stake: Decodable {
+            let delegation: Delegation
+
+            struct Delegation: Decodable {
+                let voter: String
+                let stake: String
+                let activationEpoch: String
+                let deactivationEpoch: String
+            }
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaStakingConfig.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaStakingConfig.swift
@@ -1,0 +1,69 @@
+//
+//  SolanaStakingConfig.swift
+//  VultisigApp
+//
+//  Constants for Solana native staking (Stake program) reads. The Stake
+//  program account layout and the staker-authority memcmp offset are protocol
+//  facts, not per-chain config, so this is a single flat constant set rather
+//  than the per-chain `[Chain: Entry]` table that `CosmosStakingConfig` keeps —
+//  but the shape (one config enum, an `isStakingSupported` predicate) mirrors
+//  it so the two read layers stay legible side by side.
+//
+//  The min-delegation RPC (`getStakeMinimumDelegation`) is blocked by the
+//  Vultisig proxy, and the 1 SOL program minimum is feature-gated / inactive on
+//  mainnet today. So delegation-floor preflight uses the rent-exempt reserve
+//  (fetched live via `getMinimumBalanceForRentExemption(200)`) plus the
+//  documented `minDelegationFloorLamports` constant below as the substitute.
+//
+
+import Foundation
+
+enum SolanaStakingConfig {
+    /// The on-chain Stake program. Every stake account is owned by this program;
+    /// it is also the `programId` argument to the stake-filtered
+    /// `getProgramAccounts` scan.
+    static let stakeProgramId = "Stake11111111111111111111111111111111111111"
+
+    /// Byte size of a fully-initialized stake account (`StakeStateV2`). The
+    /// `getProgramAccounts` scan filters on `dataSize: 200` to exclude
+    /// uninitialized / rewards-pool accounts before the memcmp narrows to the
+    /// owner's accounts.
+    static let stakeStateSize = 200
+
+    /// Offset of the staker authority pubkey inside the stake-account data, used
+    /// as the `memcmp` offset to fetch only a given owner's stake accounts.
+    /// Layout: 4-byte state enum discriminant + 8-byte `rentExemptReserve`
+    /// (`Meta.rent_exempt_reserve`) = 12 bytes precede `Meta.authorized.staker`.
+    static let stakerMemcmpOffset = 12
+
+    /// Offset of the delegation `voter` (vote account) pubkey inside the
+    /// stake-account data. Available for vote-account-scoped scans; the
+    /// owner-scoped read uses `stakerMemcmpOffset`.
+    static let voterMemcmpOffset = 124
+
+    /// Documented substitute for the blocked min-delegation RPC. 1 SOL in
+    /// lamports — the historical program minimum the feature gate would activate
+    /// to. Used together with the live rent-exempt reserve as the delegation
+    /// floor; kept as a named constant so the substitution is explicit rather
+    /// than a magic number at the call site.
+    static let minDelegationFloorLamports: UInt64 = 1_000_000_000
+
+    /// Lamports per SOL (9 decimals). Shared by the staking read/format layer.
+    static let lamportsPerSol: UInt64 = 1_000_000_000
+
+    /// Mainnet schedule: 432,000 slots per epoch (~2 days). Informational —
+    /// the live value is read from `getEpochInfo.slotsInEpoch`; this is the
+    /// documented fallback for activation/cooldown copy.
+    static let slotsPerEpoch: UInt64 = 432_000
+
+    /// `u64::MAX` sentinel the Stake program writes into `deactivationEpoch`
+    /// while a delegation is active (not deactivating). Parsed stake accounts
+    /// carry this verbatim; the activation-state derivation treats it as
+    /// "no deactivation scheduled".
+    static let epochSentinel: UInt64 = .max
+
+    /// Native SOL staking is supported only on the Solana chain.
+    static func isStakingSupported(_ chain: Chain) -> Bool {
+        chain.isSolanaStakingChain
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaStakingPayload.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaStakingPayload.swift
@@ -1,0 +1,83 @@
+//
+//  SolanaStakingPayload.swift
+//  VultisigApp
+//
+//  Carries the Solana staking-operation intent from a future build-keysign
+//  step into the signing layer (wallet-core's Solana stake proto:
+//  delegate / deactivate / withdraw / move-stake). Data-only here — no signing
+//  is wired in this PR. Analog: `CosmosStakingPayload`.
+//
+//  Discriminated by `opType`. Field set per op:
+//    .delegate       → votePubkey, lamports
+//    .unstake        → stakeAccount            (deactivate; no amount)
+//    .withdraw       → stakeAccount, lamports
+//    .moveStakeStep  → stakeAccount, destinationStakeAccount, votePubkey, lamports
+//
+
+import Foundation
+
+enum SolanaStakingOpType: String, Codable, Hashable {
+    case delegate
+    case unstake
+    case withdraw
+    case moveStakeStep
+}
+
+struct SolanaStakingPayload: Codable, Hashable {
+    let opType: SolanaStakingOpType
+    /// Vote account to delegate to (`.delegate`) or the move-stake destination's
+    /// delegation target (`.moveStakeStep`).
+    let votePubkey: String?
+    /// Source stake account for `.unstake` / `.withdraw` / `.moveStakeStep`.
+    let stakeAccount: String?
+    /// Destination stake account for a `.moveStakeStep`.
+    let destinationStakeAccount: String?
+    /// Lamports for `.delegate` / `.withdraw` / `.moveStakeStep`. `nil` for
+    /// `.unstake` (deactivate carries no amount — the whole account cools down).
+    let lamports: UInt64?
+
+    static func delegate(votePubkey: String, lamports: UInt64) -> SolanaStakingPayload {
+        SolanaStakingPayload(
+            opType: .delegate,
+            votePubkey: votePubkey,
+            stakeAccount: nil,
+            destinationStakeAccount: nil,
+            lamports: lamports
+        )
+    }
+
+    static func unstake(stakeAccount: String) -> SolanaStakingPayload {
+        SolanaStakingPayload(
+            opType: .unstake,
+            votePubkey: nil,
+            stakeAccount: stakeAccount,
+            destinationStakeAccount: nil,
+            lamports: nil
+        )
+    }
+
+    static func withdraw(stakeAccount: String, lamports: UInt64) -> SolanaStakingPayload {
+        SolanaStakingPayload(
+            opType: .withdraw,
+            votePubkey: nil,
+            stakeAccount: stakeAccount,
+            destinationStakeAccount: nil,
+            lamports: lamports
+        )
+    }
+
+    static func moveStakeStep(
+        stakeAccount: String,
+        destinationStakeAccount: String,
+        votePubkey: String,
+        lamports: UInt64
+    ) -> SolanaStakingPayload {
+        SolanaStakingPayload(
+            opType: .moveStakeStep,
+            votePubkey: votePubkey,
+            stakeAccount: stakeAccount,
+            destinationStakeAccount: destinationStakeAccount,
+            lamports: lamports
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaValidator.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaValidator.swift
@@ -1,0 +1,100 @@
+//
+//  SolanaValidator.swift
+//  VultisigApp
+//
+//  A validator row from `getVoteAccounts` plus an optional metadata enrichment
+//  struct (name / logo / APY / score) populated by a later PR. The base row is
+//  decoded straight off the RPC; `ValidatorMetadata` starts empty so the
+//  read layer can ship before the enrichment source is wired.
+//
+
+import Foundation
+
+struct SolanaValidator: Codable, Hashable, Identifiable {
+    /// Vote account address — the delegation target a stake account points at.
+    let votePubkey: String
+    /// The validator's identity (node) pubkey.
+    let nodePubkey: String
+    /// Total active stake delegated to this validator, in lamports.
+    let activatedStake: UInt64
+    /// Commission percentage (0–100) the validator takes from rewards.
+    let commission: Int
+    /// Whether this vote account has voted in the current epoch.
+    let epochVoteAccount: Bool
+    /// `true` when the validator is in the delinquent set (not voting). Carried
+    /// from which `getVoteAccounts` bucket the row came from, not the wire.
+    let isDelinquent: Bool
+    /// Enrichment populated in a later PR — name, logo, APY estimate, score.
+    var metadata: ValidatorMetadata
+
+    var id: String { votePubkey }
+
+    init(
+        votePubkey: String,
+        nodePubkey: String,
+        activatedStake: UInt64,
+        commission: Int,
+        epochVoteAccount: Bool,
+        isDelinquent: Bool,
+        metadata: ValidatorMetadata = ValidatorMetadata()
+    ) {
+        self.votePubkey = votePubkey
+        self.nodePubkey = nodePubkey
+        self.activatedStake = activatedStake
+        self.commission = commission
+        self.epochVoteAccount = epochVoteAccount
+        self.isDelinquent = isDelinquent
+        self.metadata = metadata
+    }
+
+    /// Builds from a decoded `getVoteAccounts` row, tagging it with the
+    /// delinquent flag derived from its bucket (`current` vs `delinquent`).
+    init(voteAccount: SolanaVoteAccount, isDelinquent: Bool) {
+        self.init(
+            votePubkey: voteAccount.votePubkey,
+            nodePubkey: voteAccount.nodePubkey,
+            activatedStake: voteAccount.activatedStake,
+            commission: voteAccount.commission,
+            epochVoteAccount: voteAccount.epochVoteAccount,
+            isDelinquent: isDelinquent
+        )
+    }
+}
+
+/// Off-chain enrichment for a validator. All optional — populated by a later
+/// PR from a metadata source; the base read layer leaves it empty.
+struct ValidatorMetadata: Codable, Hashable {
+    var name: String?
+    var logoURL: String?
+    /// Estimated APY as a fraction (e.g. 0.067 for 6.7%).
+    var apyEstimate: Decimal?
+    /// A 0–100 quality score from the metadata source.
+    var score: Int?
+
+    init(name: String? = nil, logoURL: String? = nil, apyEstimate: Decimal? = nil, score: Int? = nil) {
+        self.name = name
+        self.logoURL = logoURL
+        self.apyEstimate = apyEstimate
+        self.score = score
+    }
+}
+
+// MARK: - getVoteAccounts wire types
+
+/// A single row of the `getVoteAccounts` `current` / `delinquent` arrays.
+struct SolanaVoteAccount: Decodable {
+    let votePubkey: String
+    let nodePubkey: String
+    let activatedStake: UInt64
+    let commission: Int
+    let epochVoteAccount: Bool
+}
+
+struct SolanaVoteAccountsResult: Decodable {
+    let current: [SolanaVoteAccount]
+    let delinquent: [SolanaVoteAccount]
+}
+
+struct SolanaGetVoteAccountsResponse: Decodable {
+    let result: SolanaVoteAccountsResult
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
@@ -29,6 +29,22 @@ struct SolanaAPI: TargetType {
         case getLatestBlockhash
         case getTokenAccountsByOwner(walletAddress: String, filter: TokenAccountFilter)
         case getAccountInfo(address: String)
+        /// All validators (vote accounts), `current` + `delinquent`.
+        case getVoteAccounts
+        /// Stake-program accounts owned by `staker`. `dataSize:200` excludes
+        /// non-stake-state accounts; the `memcmp{offset:12}` narrows to the
+        /// owner's accounts. `jsonParsed` returns the full parsed delegation;
+        /// the pubkey-only variant (`dataSlice{0,0}`) returns just addresses.
+        case getStakeAccountsByOwner(staker: String, pubkeyOnly: Bool)
+        /// Full `jsonParsed` info for a single stake account.
+        case getStakeAccountInfo(address: String)
+        /// Current epoch + slot progress.
+        case getEpochInfo
+        /// Minimum lamports for a `size`-byte account to be rent-exempt. Stake
+        /// accounts pass `200`.
+        case getMinimumBalanceForRentExemption(size: Int)
+        /// Network inflation rate for the current epoch.
+        case getInflationRate
     }
 
     enum TokenAccountFilter {
@@ -82,7 +98,57 @@ struct SolanaAPI: TargetType {
                 rpcEnvelope(method: "getAccountInfo", params: [address, ["encoding": "jsonParsed"]]),
                 .jsonEncoding
             )
+        case .getVoteAccounts:
+            return .requestParameters(
+                rpcEnvelope(method: "getVoteAccounts", params: [["commitment": "finalized"]]),
+                .jsonEncoding
+            )
+        case .getStakeAccountsByOwner(let staker, let pubkeyOnly):
+            return .requestParameters(
+                rpcEnvelope(
+                    method: "getProgramAccounts",
+                    params: [SolanaStakingConfig.stakeProgramId, programAccountsConfig(staker: staker, pubkeyOnly: pubkeyOnly)]
+                ),
+                .jsonEncoding
+            )
+        case .getStakeAccountInfo(let address):
+            return .requestParameters(
+                rpcEnvelope(method: "getAccountInfo", params: [address, ["encoding": "jsonParsed"]]),
+                .jsonEncoding
+            )
+        case .getEpochInfo:
+            return .requestParameters(rpcEnvelope(method: "getEpochInfo", params: [] as [Any]), .jsonEncoding)
+        case .getMinimumBalanceForRentExemption(let size):
+            return .requestParameters(
+                rpcEnvelope(method: "getMinimumBalanceForRentExemption", params: [size]),
+                .jsonEncoding
+            )
+        case .getInflationRate:
+            return .requestParameters(rpcEnvelope(method: "getInflationRate", params: [] as [Any]), .jsonEncoding)
         }
+    }
+
+    /// The `getProgramAccounts` config object for the stake-by-owner scan:
+    /// `dataSize:200` + a `memcmp` on the staker authority. When `pubkeyOnly`
+    /// the data is sliced to zero bytes (`dataSlice{0,0}`, base64) since only
+    /// the addresses are needed; otherwise the full delegation is returned
+    /// `jsonParsed`.
+    private func programAccountsConfig(staker: String, pubkeyOnly: Bool) -> [String: Any] {
+        let filters: [[String: Any]] = [
+            ["dataSize": SolanaStakingConfig.stakeStateSize],
+            ["memcmp": ["offset": SolanaStakingConfig.stakerMemcmpOffset, "bytes": staker]]
+        ]
+        if pubkeyOnly {
+            return [
+                "encoding": "base64",
+                "dataSlice": ["offset": 0, "length": 0],
+                "filters": filters
+            ]
+        }
+        return [
+            "encoding": "jsonParsed",
+            "filters": filters
+        ]
     }
 
     private func rpcEnvelope(method: String, params: [Any]) -> [String: Any] {
@@ -139,5 +205,47 @@ struct SolanaGetAccountInfoResponse: Decodable {
         struct Value: Decodable {
             let owner: String
         }
+    }
+}
+
+// MARK: - Staking RPC responses
+
+/// `getProgramAccounts` result — a flat array of rows.
+struct SolanaGetProgramAccountsResponse: Decodable {
+    let result: [SolanaStakeProgramAccount]
+}
+
+/// `getAccountInfo` (jsonParsed) for a stake account.
+struct SolanaGetStakeAccountInfoResponse: Decodable {
+    let result: Result
+
+    struct Result: Decodable {
+        let value: SolanaStakeAccountInfoValue?
+    }
+}
+
+struct SolanaGetEpochInfoResponse: Decodable {
+    let result: SolanaEpochInfo
+}
+
+/// `getEpochInfo` payload. `epoch` / slot fields drive activation/cooldown math.
+struct SolanaEpochInfo: Codable, Hashable {
+    let epoch: UInt64
+    let slotIndex: UInt64
+    let slotsInEpoch: UInt64
+    let absoluteSlot: UInt64
+}
+
+struct SolanaGetMinimumBalanceForRentExemptionResponse: Decodable {
+    let result: UInt64
+}
+
+struct SolanaGetInflationRateResponse: Decodable {
+    let result: Result
+
+    struct Result: Decodable {
+        let total: Double
+        let validator: Double
+        let epoch: UInt64
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -506,4 +506,89 @@ class SolanaService {
         return (true, isToken2022)
     }
 
+    // MARK: - Native staking reads
+
+    /// Rent-exempt reserve for a 200-byte stake account. Rent params change
+    /// rarely, so it is cached 24h via `Utils.getCachedData`.
+    private var rentReserveCache = ThreadSafeDictionary<String, (data: UInt64, timestamp: Date)>()
+    /// Live epoch info. Cached 45s so a screen refresh doesn't re-hit RPC on
+    /// every appear while still tracking the ~2-day epoch closely.
+    private var epochInfoCache = ThreadSafeDictionary<String, (data: SolanaEpochInfo, timestamp: Date)>()
+
+    private static let rentReserveTTL: TimeInterval = 60 * 60 * 24
+    private static let epochInfoTTL: TimeInterval = 45
+
+    /// All validators (vote accounts), tagged with their delinquent bucket.
+    func fetchSolanaValidators() async throws -> [SolanaValidator] {
+        let response = try await httpClient.request(
+            api(.getVoteAccounts),
+            responseType: SolanaGetVoteAccountsResponse.self
+        )
+        let current = response.data.result.current.map { SolanaValidator(voteAccount: $0, isDelinquent: false) }
+        let delinquent = response.data.result.delinquent.map { SolanaValidator(voteAccount: $0, isDelinquent: true) }
+        return current + delinquent
+    }
+
+    /// Parsed stake accounts delegated by `owner` (the staker authority). Uses
+    /// the `dataSize:200 + memcmp{offset:12}` filter and `jsonParsed` encoding.
+    /// Not cached — must reflect a just-submitted stake/unstake and freshly
+    /// accrued rewards; the UI refreshes on appear.
+    func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] {
+        let response = try await httpClient.request(
+            api(.getStakeAccountsByOwner(staker: owner, pubkeyOnly: false)),
+            responseType: SolanaGetProgramAccountsResponse.self
+        )
+        return response.data.result.compactMap { SolanaStakeAccount(programAccount: $0) }
+    }
+
+    /// Full parsed info for a single stake account.
+    func fetchSolanaStakeAccount(address: String) async throws -> SolanaStakeAccount? {
+        let response = try await httpClient.request(
+            api(.getStakeAccountInfo(address: address)),
+            responseType: SolanaGetStakeAccountInfoResponse.self
+        )
+        guard let value = response.data.result.value else { return nil }
+        return SolanaStakeAccount(pubkey: address, accountInfo: value)
+    }
+
+    /// Current epoch info, cached 45s.
+    func fetchSolanaEpochInfo() async throws -> SolanaEpochInfo {
+        let cacheKey = "solana-epoch-info"
+        if let cached: SolanaEpochInfo = Utils.getCachedData(cacheKey: cacheKey, cache: epochInfoCache, timeInSeconds: Self.epochInfoTTL) {
+            return cached
+        }
+        let response = try await httpClient.request(
+            api(.getEpochInfo),
+            responseType: SolanaGetEpochInfoResponse.self
+        )
+        let info = response.data.result
+        epochInfoCache.set(cacheKey, (data: info, timestamp: Date()))
+        return info
+    }
+
+    /// Rent-exempt reserve (lamports) for a 200-byte stake account, cached 24h.
+    func fetchSolanaRentReserve() async throws -> UInt64 {
+        let cacheKey = "solana-rent-reserve-\(SolanaStakingConfig.stakeStateSize)"
+        if let cached: UInt64 = Utils.getCachedData(cacheKey: cacheKey, cache: rentReserveCache, timeInSeconds: Self.rentReserveTTL) {
+            return cached
+        }
+        let response = try await httpClient.request(
+            api(.getMinimumBalanceForRentExemption(size: SolanaStakingConfig.stakeStateSize)),
+            responseType: SolanaGetMinimumBalanceForRentExemptionResponse.self
+        )
+        let reserve = response.data.result
+        rentReserveCache.set(cacheKey, (data: reserve, timestamp: Date()))
+        return reserve
+    }
+
+    /// Network total inflation rate for the current epoch (fraction, e.g.
+    /// 0.0377). Caching is owned by `SolanaStakingService` (10 min, actor).
+    func fetchSolanaInflationRate() async throws -> Double {
+        let response = try await httpClient.request(
+            api(.getInflationRate),
+            responseType: SolanaGetInflationRateResponse.self
+        )
+        return response.data.result.total
+    }
+
 }

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaEpochCooldownGate.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaEpochCooldownGate.swift
@@ -1,0 +1,49 @@
+//
+//  SolanaEpochCooldownGate.swift
+//  VultisigApp
+//
+//  Gates a stake-account withdraw on the deactivation cooldown. After a
+//  deactivate, the stake cools down for ~1 epoch: the lamports become
+//  withdrawable only once the network epoch has advanced PAST the account's
+//  `deactivationEpoch`. Evaluating this before a (future) withdraw keysign
+//  avoids surprising the user with a transaction the Stake program would
+//  reject. Analog: `CosmosRedelegationCooldownGate`.
+//
+
+import Foundation
+
+enum SolanaEpochCooldownState: Equatable {
+    /// Stake is fully cooled down (or was never deactivating) — withdraw is
+    /// allowed.
+    case available
+    /// Still cooling down — withdraw unlocks at `unlocksAtEpoch`.
+    case blocked(unlocksAtEpoch: UInt64)
+}
+
+enum SolanaEpochCooldownGate {
+    /// Evaluates whether `stakeAccount`'s deactivated stake can be withdrawn at
+    /// `currentEpoch`. Pure function over the parsed delegation + the live
+    /// epoch so the unit tests can pin the boundary deterministically.
+    ///
+    /// - A non-deactivating account (sentinel `deactivationEpoch`) is `available`
+    ///   — there is nothing cooling down. (Whether it's still *delegated* is a
+    ///   separate concern handled by the delegate/unstake flows.)
+    /// - A deactivating account unlocks once the network advances past its
+    ///   deactivation epoch, i.e. at `deactivationEpoch + 1`.
+    static func evaluate(
+        stakeAccount: SolanaStakeAccount,
+        currentEpoch: UInt64
+    ) -> SolanaEpochCooldownState {
+        guard let delegation = stakeAccount.delegation else {
+            return .available
+        }
+        if delegation.isDeactivationSentinel {
+            return .available
+        }
+        if currentEpoch > delegation.deactivationEpoch {
+            return .available
+        }
+        // `deactivationEpoch` is < .max here (not the sentinel), so +1 is safe.
+        return .blocked(unlocksAtEpoch: delegation.deactivationEpoch + 1)
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingService.swift
@@ -1,0 +1,103 @@
+//
+//  SolanaStakingService.swift
+//  VultisigApp
+//
+//  Read-side service for Solana native staking. Fans the four staking reads
+//  (validators, stake accounts, epoch info, rent reserve) through the existing
+//  `SolanaService` RPC layer and owns the validator-set / inflation caches that
+//  don't belong on the per-call RPC service. Analog: `CosmosStakingService`.
+//
+//  Cache TTLs (per the staking spec):
+//    - validator set: 10 min  -> actor `CachedEntry` (here)
+//    - inflation:     10 min  -> actor `CachedEntry` (here)
+//    - epoch info:    ~45 s   -> `SolanaService` (`Utils.getCachedData`)
+//    - rent reserve:  24 h    -> `SolanaService` (`Utils.getCachedData`)
+//    - stake accounts: NOT cached — must reflect just-submitted txs + rewards.
+//
+
+import Foundation
+import OSLog
+
+protocol SolanaStakingServiceProtocol: Sendable {
+    func fetchValidators() async throws -> [SolanaValidator]
+    func fetchStakeAccounts(owner: String) async throws -> [SolanaStakeAccount]
+    func fetchEpochInfo() async throws -> SolanaEpochInfo
+    func fetchRentReserve() async throws -> UInt64
+    func fetchInflationRate() async throws -> Double
+}
+
+/// The narrow set of Solana RPC reads the staking service composes. Lets the
+/// service be tested against a fake without standing up the whole RPC stack —
+/// `SolanaService` is the production conformer.
+protocol SolanaStakingReading {
+    func fetchSolanaValidators() async throws -> [SolanaValidator]
+    func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount]
+    func fetchSolanaEpochInfo() async throws -> SolanaEpochInfo
+    func fetchSolanaRentReserve() async throws -> UInt64
+    func fetchSolanaInflationRate() async throws -> Double
+}
+
+extension SolanaService: SolanaStakingReading {}
+
+actor SolanaStakingService: SolanaStakingServiceProtocol {
+
+    private struct CachedEntry<Value> {
+        let value: Value
+        let fetchedAt: Date
+    }
+
+    private let solanaService: SolanaStakingReading
+    private let validatorTTL: TimeInterval
+    private let inflationTTL: TimeInterval
+    private let clock: @Sendable () -> Date
+    private let logger: Logger
+
+    private var validatorCache: CachedEntry<[SolanaValidator]>?
+    private var inflationCache: CachedEntry<Double>?
+
+    init(
+        solanaService: SolanaStakingReading = SolanaService.shared,
+        validatorTTL: TimeInterval = 10 * 60,
+        inflationTTL: TimeInterval = 10 * 60,
+        clock: @escaping @Sendable () -> Date = { Date() },
+        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "solana-staking-service")
+    ) {
+        self.solanaService = solanaService
+        self.validatorTTL = validatorTTL
+        self.inflationTTL = inflationTTL
+        self.clock = clock
+        self.logger = logger
+    }
+
+    func fetchValidators() async throws -> [SolanaValidator] {
+        if let cache = validatorCache, clock().timeIntervalSince(cache.fetchedAt) < validatorTTL {
+            return cache.value
+        }
+        let validators = try await solanaService.fetchSolanaValidators()
+        validatorCache = CachedEntry(value: validators, fetchedAt: clock())
+        return validators
+    }
+
+    func fetchStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] {
+        // Intentionally uncached — stake accounts must reflect a just-submitted
+        // stake/unstake and newly accrued (auto-compounded) rewards.
+        try await solanaService.fetchSolanaStakeAccounts(owner: owner)
+    }
+
+    func fetchEpochInfo() async throws -> SolanaEpochInfo {
+        try await solanaService.fetchSolanaEpochInfo()
+    }
+
+    func fetchRentReserve() async throws -> UInt64 {
+        try await solanaService.fetchSolanaRentReserve()
+    }
+
+    func fetchInflationRate() async throws -> Double {
+        if let cache = inflationCache, clock().timeIntervalSince(cache.fetchedAt) < inflationTTL {
+            return cache.value
+        }
+        let rate = try await solanaService.fetchSolanaInflationRate()
+        inflationCache = CachedEntry(value: rate, fetchedAt: clock())
+        return rate
+    }
+}

--- a/VultisigApp/VultisigApp/Model/Chain.swift
+++ b/VultisigApp/VultisigApp/Model/Chain.swift
@@ -570,6 +570,12 @@ enum Chain: String, Codable, Hashable, CaseIterable {
         }
     }
 
+    /// Solana native staking via the on-chain Stake program (delegate /
+    /// deactivate / withdraw / move-stake). Only Solana today.
+    var isSolanaStakingChain: Bool {
+        self == .solana
+    }
+
     var type: ChainType {
         switch self {
         case .thorChain, .thorChainChainnet, .thorChainStagenet, .mayaChain:

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaEpochCooldownGateTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaEpochCooldownGateTests.swift
@@ -1,0 +1,74 @@
+//
+//  SolanaEpochCooldownGateTests.swift
+//  VultisigAppTests
+//
+//  Pins the deactivation-cooldown epoch math: a withdraw unlocks only once the
+//  network epoch advances PAST the stake account's deactivationEpoch.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SolanaEpochCooldownGateTests: XCTestCase {
+
+    private func account(deactivationEpoch: UInt64, activationEpoch: UInt64 = 100) -> SolanaStakeAccount {
+        SolanaStakeAccount(
+            pubkey: "Stake1",
+            lamports: 5_000_000_000,
+            rentExemptReserve: 2_282_880,
+            staker: "Owner",
+            withdrawer: "Owner",
+            delegation: SolanaStakeAccount.Delegation(
+                votePubkey: "Vote1",
+                activationEpoch: activationEpoch,
+                deactivationEpoch: deactivationEpoch,
+                stake: 5_000_000_000
+            )
+        )
+    }
+
+    func testActiveDelegationIsAvailable() {
+        // Sentinel deactivation epoch => not deactivating => nothing to gate.
+        let acc = account(deactivationEpoch: .max)
+        XCTAssertEqual(SolanaEpochCooldownGate.evaluate(stakeAccount: acc, currentEpoch: 993), .available)
+    }
+
+    func testUndelegatedAccountIsAvailable() {
+        let acc = SolanaStakeAccount(
+            pubkey: "Stake1", lamports: 2_282_880, rentExemptReserve: 2_282_880,
+            staker: "Owner", withdrawer: "Owner", delegation: nil
+        )
+        XCTAssertEqual(SolanaEpochCooldownGate.evaluate(stakeAccount: acc, currentEpoch: 993), .available)
+    }
+
+    func testBlockedDuringDeactivationEpoch() {
+        // Deactivated at epoch 500; current epoch is still 500 -> cooling down.
+        let acc = account(deactivationEpoch: 500)
+        XCTAssertEqual(
+            SolanaEpochCooldownGate.evaluate(stakeAccount: acc, currentEpoch: 500),
+            .blocked(unlocksAtEpoch: 501)
+        )
+    }
+
+    func testBlockedBeforeDeactivationEpoch() {
+        // Deactivation scheduled for epoch 600, current epoch 550.
+        let acc = account(deactivationEpoch: 600)
+        XCTAssertEqual(
+            SolanaEpochCooldownGate.evaluate(stakeAccount: acc, currentEpoch: 550),
+            .blocked(unlocksAtEpoch: 601)
+        )
+    }
+
+    func testAvailableAfterDeactivationEpochPasses() {
+        // Deactivated at 500; network advanced to 501 -> withdrawable.
+        let acc = account(deactivationEpoch: 500)
+        XCTAssertEqual(SolanaEpochCooldownGate.evaluate(stakeAccount: acc, currentEpoch: 501), .available)
+    }
+
+    func testDeactivatingActivationStateMatchesGate() {
+        // The model's activationState and the gate must agree about "deactivating".
+        let acc = account(deactivationEpoch: 500)
+        XCTAssertEqual(acc.activationState(currentEpoch: 500), .deactivating)
+        XCTAssertEqual(acc.activationState(currentEpoch: 501), .inactive)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakeAccountParseTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakeAccountParseTests.swift
@@ -1,0 +1,148 @@
+//
+//  SolanaStakeAccountParseTests.swift
+//  VultisigAppTests
+//
+//  Pins jsonParsed -> SolanaStakeAccount parsing against a real mainnet
+//  getProgramAccounts row (account 13JTejwnGAKdeSL4LvZnFjQwVYaJ9WseqMGGeSRTugn2,
+//  captured live from api.vultisig.com/solana). The u64 fields arrive as
+//  decimal strings and the deactivation sentinel is u64::MAX.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SolanaStakeAccountParseTests: XCTestCase {
+
+    /// A real `getProgramAccounts` (jsonParsed) row for an active delegation.
+    private let delegatedRowJSON = """
+    {
+      "pubkey": "13JTejwnGAKdeSL4LvZnFjQwVYaJ9WseqMGGeSRTugn2",
+      "account": {
+        "data": {
+          "parsed": {
+            "info": {
+              "meta": {
+                "authorized": {
+                  "staker": "5S2YKfAvT5r3NGmreYUqAskXFygNnmGsEu78hX9fGJg9",
+                  "withdrawer": "5S2YKfAvT5r3NGmreYUqAskXFygNnmGsEu78hX9fGJg9"
+                },
+                "lockup": { "custodian": "11111111111111111111111111111111", "epoch": 0, "unixTimestamp": 0 },
+                "rentExemptReserve": "2282880"
+              },
+              "stake": {
+                "creditsObserved": 2204706881,
+                "delegation": {
+                  "activationEpoch": "732",
+                  "deactivationEpoch": "18446744073709551615",
+                  "stake": "1752172116988",
+                  "voter": "2g2QU1NDRax6i2mKzRwgRfdBFoDkMC6bj7Zp5Q3i8sCq",
+                  "warmupCooldownRate": 0.25
+                }
+              }
+            },
+            "type": "delegated"
+          },
+          "program": "stake",
+          "space": 200
+        },
+        "executable": false,
+        "lamports": 1752216432947,
+        "owner": "Stake11111111111111111111111111111111111111",
+        "rentEpoch": 18446744073709551615,
+        "space": 200
+      }
+    }
+    """
+
+    /// An initialized-but-undelegated account: meta present, no `stake`.
+    private let initializedRowJSON = """
+    {
+      "pubkey": "InitOnlyStakeAccount1111111111111111111111",
+      "account": {
+        "data": {
+          "parsed": {
+            "info": {
+              "meta": {
+                "authorized": { "staker": "OwnerAaaa", "withdrawer": "OwnerWwww" },
+                "rentExemptReserve": "2282880"
+              }
+            },
+            "type": "initialized"
+          },
+          "program": "stake",
+          "space": 200
+        },
+        "lamports": 2282880,
+        "owner": "Stake11111111111111111111111111111111111111",
+        "executable": false,
+        "rentEpoch": 0,
+        "space": 200
+      }
+    }
+    """
+
+    private func decodeRow(_ json: String) throws -> SolanaStakeProgramAccount {
+        try JSONDecoder().decode(SolanaStakeProgramAccount.self, from: Data(json.utf8))
+    }
+
+    func testDelegatedRowParsesToModel() throws {
+        let row = try decodeRow(delegatedRowJSON)
+        let account = try XCTUnwrap(SolanaStakeAccount(programAccount: row))
+
+        XCTAssertEqual(account.pubkey, "13JTejwnGAKdeSL4LvZnFjQwVYaJ9WseqMGGeSRTugn2")
+        XCTAssertEqual(account.lamports, 1_752_216_432_947)
+        XCTAssertEqual(account.rentExemptReserve, 2_282_880)
+        XCTAssertEqual(account.staker, "5S2YKfAvT5r3NGmreYUqAskXFygNnmGsEu78hX9fGJg9")
+        XCTAssertEqual(account.withdrawer, "5S2YKfAvT5r3NGmreYUqAskXFygNnmGsEu78hX9fGJg9")
+
+        let delegation = try XCTUnwrap(account.delegation)
+        XCTAssertEqual(delegation.votePubkey, "2g2QU1NDRax6i2mKzRwgRfdBFoDkMC6bj7Zp5Q3i8sCq")
+        XCTAssertEqual(delegation.activationEpoch, 732)
+        XCTAssertEqual(delegation.stake, 1_752_172_116_988)
+        // u64::MAX sentinel must round-trip exactly — a Double parse would lose it.
+        XCTAssertEqual(delegation.deactivationEpoch, UInt64.max)
+        XCTAssertTrue(delegation.isDeactivationSentinel)
+    }
+
+    func testActiveDelegationStateAfterActivationEpoch() throws {
+        let account = try XCTUnwrap(SolanaStakeAccount(programAccount: try decodeRow(delegatedRowJSON)))
+        // Current epoch (993) is well past activation (732) and not deactivating.
+        XCTAssertEqual(account.activationState(currentEpoch: 993), .active)
+    }
+
+    func testActivatingInFirstEpoch() throws {
+        let account = try XCTUnwrap(SolanaStakeAccount(programAccount: try decodeRow(delegatedRowJSON)))
+        // At the activation epoch itself the stake is still warming up.
+        XCTAssertEqual(account.activationState(currentEpoch: 732), .activating)
+    }
+
+    func testInitializedRowHasNoDelegationAndIsInactive() throws {
+        let account = try XCTUnwrap(SolanaStakeAccount(programAccount: try decodeRow(initializedRowJSON)))
+        XCTAssertNil(account.delegation)
+        XCTAssertEqual(account.activationState(currentEpoch: 993), .inactive)
+        XCTAssertEqual(account.rentExemptReserve, 2_282_880)
+    }
+
+    func testPubkeyOnlyRowIsSkipped() throws {
+        // A dataSlice{0,0} base64 row carries no `parsed` — the model init
+        // returns nil so the owner-scoped fetch can compactMap them out.
+        let pubkeyOnlyJSON = """
+        {
+          "pubkey": "SomeStakeAccount",
+          "account": {
+            "data": ["", "base64"],
+            "lamports": 1,
+            "owner": "Stake11111111111111111111111111111111111111",
+            "executable": false,
+            "rentEpoch": 0,
+            "space": 0
+          }
+        }
+        """
+        // base64 data is `["", "base64"]` (an array, not an object) — decoding
+        // the row itself fails because `data` is modeled as an object. The
+        // owner-scoped read uses jsonParsed, so this only documents that the
+        // pubkey-only shape is a different decode path entirely.
+        XCTAssertThrowsError(try decodeRow(pubkeyOnlyJSON))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingAPITests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingAPITests.swift
@@ -1,0 +1,125 @@
+//
+//  SolanaStakingAPITests.swift
+//  VultisigAppTests
+//
+//  Pins the JSON-RPC envelope + the stake-filtered getProgramAccounts shape
+//  (dataSize:200 + memcmp{offset:12, bytes:owner} + dataSlice for pubkey-only).
+//  These params are the contract with the RPC node, so they're asserted
+//  structurally rather than by golden string.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SolanaStakingAPITests: XCTestCase {
+
+    private let owner = "5S2YKfAvT5r3NGmreYUqAskXFygNnmGsEu78hX9fGJg9"
+
+    private func params(for method: SolanaAPI.Method) throws -> [String: Any] {
+        let api = SolanaAPI(baseURL: SolanaAPI.rpcBaseURL, usesProxyPath: true, rpcMethod: method)
+        guard case .requestParameters(let envelope, _) = api.task else {
+            XCTFail("expected requestParameters task")
+            return [:]
+        }
+        return envelope
+    }
+
+    func testStakeAccountsByOwnerJsonParsedFilterShape() throws {
+        let envelope = try params(for: .getStakeAccountsByOwner(staker: owner, pubkeyOnly: false))
+
+        XCTAssertEqual(envelope["method"] as? String, "getProgramAccounts")
+        let rpcParams = try XCTUnwrap(envelope["params"] as? [Any])
+        XCTAssertEqual(rpcParams.first as? String, SolanaStakingConfig.stakeProgramId)
+
+        let config = try XCTUnwrap(rpcParams[1] as? [String: Any])
+        XCTAssertEqual(config["encoding"] as? String, "jsonParsed")
+
+        let filters = try XCTUnwrap(config["filters"] as? [[String: Any]])
+        XCTAssertEqual(filters.count, 2)
+
+        let dataSizeFilter = try XCTUnwrap(filters.first { $0["dataSize"] != nil })
+        XCTAssertEqual(dataSizeFilter["dataSize"] as? Int, 200)
+
+        let memcmpFilter = try XCTUnwrap(filters.first { $0["memcmp"] != nil })
+        let memcmp = try XCTUnwrap(memcmpFilter["memcmp"] as? [String: Any])
+        XCTAssertEqual(memcmp["offset"] as? Int, 12)
+        XCTAssertEqual(memcmp["bytes"] as? String, owner)
+    }
+
+    func testStakeAccountsByOwnerPubkeyOnlyUsesZeroLengthDataSlice() throws {
+        let envelope = try params(for: .getStakeAccountsByOwner(staker: owner, pubkeyOnly: true))
+        let rpcParams = try XCTUnwrap(envelope["params"] as? [Any])
+        let config = try XCTUnwrap(rpcParams[1] as? [String: Any])
+
+        XCTAssertEqual(config["encoding"] as? String, "base64")
+        let dataSlice = try XCTUnwrap(config["dataSlice"] as? [String: Any])
+        XCTAssertEqual(dataSlice["offset"] as? Int, 0)
+        XCTAssertEqual(dataSlice["length"] as? Int, 0)
+        // The owner memcmp must still be present so the slice doesn't widen the scan.
+        let filters = try XCTUnwrap(config["filters"] as? [[String: Any]])
+        XCTAssertTrue(filters.contains { ($0["memcmp"] as? [String: Any])?["bytes"] as? String == owner })
+    }
+
+    func testMinimumBalanceForRentExemptionParam() throws {
+        let envelope = try params(for: .getMinimumBalanceForRentExemption(size: 200))
+        XCTAssertEqual(envelope["method"] as? String, "getMinimumBalanceForRentExemption")
+        let rpcParams = try XCTUnwrap(envelope["params"] as? [Any])
+        XCTAssertEqual(rpcParams.first as? Int, 200)
+    }
+
+    func testEpochInfoMethod() throws {
+        let envelope = try params(for: .getEpochInfo)
+        XCTAssertEqual(envelope["method"] as? String, "getEpochInfo")
+    }
+
+    func testVoteAccountsMethod() throws {
+        let envelope = try params(for: .getVoteAccounts)
+        XCTAssertEqual(envelope["method"] as? String, "getVoteAccounts")
+    }
+
+    // MARK: - Response decoding
+
+    func testEpochInfoResponseDecodes() throws {
+        let json = """
+        { "result": { "absoluteSlot": 429032115, "blockHeight": 407107405, "epoch": 993, "slotIndex": 56115, "slotsInEpoch": 432000, "transactionCount": 523987433358 } }
+        """
+        let response = try JSONDecoder().decode(SolanaGetEpochInfoResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(response.result.epoch, 993)
+        XCTAssertEqual(response.result.slotsInEpoch, 432_000)
+        XCTAssertEqual(response.result.slotIndex, 56_115)
+    }
+
+    func testRentExemptionResponseDecodes() throws {
+        let response = try JSONDecoder().decode(
+            SolanaGetMinimumBalanceForRentExemptionResponse.self,
+            from: Data(#"{ "result": 2282880 }"#.utf8)
+        )
+        XCTAssertEqual(response.result, 2_282_880)
+    }
+
+    func testVoteAccountsResponseDecodesAndTagsDelinquency() throws {
+        let json = """
+        {
+          "result": {
+            "current": [
+              { "votePubkey": "VoteA", "nodePubkey": "NodeA", "activatedStake": 191497989337835, "commission": 0, "epochVoteAccount": true, "lastVote": 1, "rootSlot": 1 }
+            ],
+            "delinquent": [
+              { "votePubkey": "VoteB", "nodePubkey": "NodeB", "activatedStake": 5, "commission": 100, "epochVoteAccount": false, "lastVote": 1, "rootSlot": 1 }
+            ]
+          }
+        }
+        """
+        let response = try JSONDecoder().decode(SolanaGetVoteAccountsResponse.self, from: Data(json.utf8))
+        let current = response.result.current.map { SolanaValidator(voteAccount: $0, isDelinquent: false) }
+        let delinquent = response.result.delinquent.map { SolanaValidator(voteAccount: $0, isDelinquent: true) }
+
+        XCTAssertEqual(current.first?.votePubkey, "VoteA")
+        XCTAssertEqual(current.first?.activatedStake, 191_497_989_337_835)
+        XCTAssertFalse(current.first?.isDelinquent ?? true)
+        XCTAssertTrue(delinquent.first?.isDelinquent ?? false)
+        XCTAssertEqual(delinquent.first?.commission, 100)
+        // Metadata starts empty (enrichment lands in a later PR).
+        XCTAssertNil(current.first?.metadata.name)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingConfigTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingConfigTests.swift
@@ -1,0 +1,39 @@
+//
+//  SolanaStakingConfigTests.swift
+//  VultisigAppTests
+//
+//  Pins the Solana staking constants — Stake program id, account size, the
+//  staker memcmp offset, and the documented min-delegation floor substitute.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SolanaStakingConfigTests: XCTestCase {
+
+    func testStakeProgramConstants() {
+        XCTAssertEqual(SolanaStakingConfig.stakeProgramId, "Stake11111111111111111111111111111111111111")
+        XCTAssertEqual(SolanaStakingConfig.stakeStateSize, 200)
+        XCTAssertEqual(SolanaStakingConfig.stakerMemcmpOffset, 12)
+        XCTAssertEqual(SolanaStakingConfig.voterMemcmpOffset, 124)
+    }
+
+    func testDelegationFloorAndLamports() {
+        // 1 SOL substitute for the proxy-blocked min-delegation RPC.
+        XCTAssertEqual(SolanaStakingConfig.minDelegationFloorLamports, 1_000_000_000)
+        XCTAssertEqual(SolanaStakingConfig.lamportsPerSol, 1_000_000_000)
+    }
+
+    func testEpochSentinelIsUInt64Max() {
+        XCTAssertEqual(SolanaStakingConfig.epochSentinel, UInt64.max)
+        XCTAssertEqual(SolanaStakingConfig.slotsPerEpoch, 432_000)
+    }
+
+    func testStakingSupportedOnlyForSolana() {
+        XCTAssertTrue(SolanaStakingConfig.isStakingSupported(.solana))
+        XCTAssertTrue(Chain.solana.isSolanaStakingChain)
+        XCTAssertFalse(SolanaStakingConfig.isStakingSupported(.ethereum))
+        XCTAssertFalse(Chain.ethereum.isSolanaStakingChain)
+        XCTAssertFalse(SolanaStakingConfig.isStakingSupported(.terra))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingPayloadTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingPayloadTests.swift
@@ -1,0 +1,63 @@
+//
+//  SolanaStakingPayloadTests.swift
+//  VultisigAppTests
+//
+//  Pins the staking-payload factories + Codable/Hashable round-trip.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SolanaStakingPayloadTests: XCTestCase {
+
+    func testDelegateFactory() {
+        let payload = SolanaStakingPayload.delegate(votePubkey: "Vote1", lamports: 2_000_000_000)
+        XCTAssertEqual(payload.opType, .delegate)
+        XCTAssertEqual(payload.votePubkey, "Vote1")
+        XCTAssertEqual(payload.lamports, 2_000_000_000)
+        XCTAssertNil(payload.stakeAccount)
+        XCTAssertNil(payload.destinationStakeAccount)
+    }
+
+    func testUnstakeFactoryCarriesNoAmount() {
+        let payload = SolanaStakingPayload.unstake(stakeAccount: "Stake1")
+        XCTAssertEqual(payload.opType, .unstake)
+        XCTAssertEqual(payload.stakeAccount, "Stake1")
+        XCTAssertNil(payload.lamports)
+        XCTAssertNil(payload.votePubkey)
+    }
+
+    func testWithdrawFactory() {
+        let payload = SolanaStakingPayload.withdraw(stakeAccount: "Stake1", lamports: 5)
+        XCTAssertEqual(payload.opType, .withdraw)
+        XCTAssertEqual(payload.stakeAccount, "Stake1")
+        XCTAssertEqual(payload.lamports, 5)
+    }
+
+    func testMoveStakeStepFactory() {
+        let payload = SolanaStakingPayload.moveStakeStep(
+            stakeAccount: "Src", destinationStakeAccount: "Dst", votePubkey: "Vote1", lamports: 7
+        )
+        XCTAssertEqual(payload.opType, .moveStakeStep)
+        XCTAssertEqual(payload.stakeAccount, "Src")
+        XCTAssertEqual(payload.destinationStakeAccount, "Dst")
+        XCTAssertEqual(payload.votePubkey, "Vote1")
+        XCTAssertEqual(payload.lamports, 7)
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = SolanaStakingPayload.moveStakeStep(
+            stakeAccount: "Src", destinationStakeAccount: "Dst", votePubkey: "Vote1", lamports: 7
+        )
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SolanaStakingPayload.self, from: encoded)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testHashableDistinguishesOps() {
+        let delegate = SolanaStakingPayload.delegate(votePubkey: "Vote1", lamports: 1)
+        let withdraw = SolanaStakingPayload.withdraw(stakeAccount: "Vote1", lamports: 1)
+        XCTAssertNotEqual(delegate, withdraw)
+        XCTAssertNotEqual(Set([delegate, withdraw]).count, 1)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingServiceCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingServiceCacheTests.swift
@@ -1,0 +1,112 @@
+//
+//  SolanaStakingServiceCacheTests.swift
+//  VultisigAppTests
+//
+//  Pins the actor-cache TTL behavior: validator set + inflation are cached
+//  (10 min) and refetch after the TTL; stake accounts are never cached.
+//
+
+@testable import VultisigApp
+import Foundation
+import XCTest
+
+private final class MovableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seconds: TimeInterval
+
+    init(start: TimeInterval) { self.seconds = start }
+
+    var value: Date { lock.withLock { Date(timeIntervalSince1970: seconds) } }
+
+    func advance(to seconds: TimeInterval) {
+        lock.withLock { self.seconds = seconds }
+    }
+}
+
+// Protocol conformance forces `async throws` signatures the fakes don't await.
+// swiftlint:disable async_without_await unused_parameter
+private final class CountingReader: SolanaStakingReading, @unchecked Sendable {
+    private(set) var validatorCalls = 0
+    private(set) var stakeAccountCalls = 0
+    private(set) var inflationCalls = 0
+    private let lock = NSLock()
+
+    func fetchSolanaValidators() async throws -> [SolanaValidator] {
+        lock.withLock { validatorCalls += 1 }
+        return [SolanaValidator(
+            votePubkey: "Vote1", nodePubkey: "Node1", activatedStake: 1,
+            commission: 0, epochVoteAccount: true, isDelinquent: false
+        )]
+    }
+
+    func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] {
+        lock.withLock { stakeAccountCalls += 1 }
+        return []
+    }
+
+    func fetchSolanaEpochInfo() async throws -> SolanaEpochInfo {
+        SolanaEpochInfo(epoch: 993, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
+    }
+
+    func fetchSolanaRentReserve() async throws -> UInt64 { 2_282_880 }
+
+    func fetchSolanaInflationRate() async throws -> Double {
+        lock.withLock { inflationCalls += 1 }
+        return 0.0377
+    }
+}
+// swiftlint:enable async_without_await unused_parameter
+
+final class SolanaStakingServiceCacheTests: XCTestCase {
+
+    func testValidatorSetServedFromCacheWithinTTL() async throws {
+        let reader = CountingReader()
+        let service = SolanaStakingService(
+            solanaService: reader,
+            validatorTTL: 600,
+            clock: { Date(timeIntervalSince1970: 0) }
+        )
+        _ = try await service.fetchValidators()
+        _ = try await service.fetchValidators()
+        XCTAssertEqual(reader.validatorCalls, 1)
+    }
+
+    func testValidatorSetRefetchesAfterTTL() async throws {
+        let reader = CountingReader()
+        let now = MovableClock(start: 0)
+        let service = SolanaStakingService(
+            solanaService: reader,
+            validatorTTL: 600,
+            clock: { now.value }
+        )
+        _ = try await service.fetchValidators()
+        now.advance(to: 601) // past the 10-min TTL
+        _ = try await service.fetchValidators()
+        XCTAssertEqual(reader.validatorCalls, 2)
+    }
+
+    func testInflationCachedWithinTTL() async throws {
+        let reader = CountingReader()
+        let service = SolanaStakingService(
+            solanaService: reader,
+            inflationTTL: 600,
+            clock: { Date(timeIntervalSince1970: 0) }
+        )
+        _ = try await service.fetchInflationRate()
+        _ = try await service.fetchInflationRate()
+        XCTAssertEqual(reader.inflationCalls, 1)
+    }
+
+    func testStakeAccountsNeverCached() async throws {
+        let reader = CountingReader()
+        let service = SolanaStakingService(
+            solanaService: reader,
+            clock: { Date(timeIntervalSince1970: 0) }
+        )
+        _ = try await service.fetchStakeAccounts(owner: "Owner")
+        _ = try await service.fetchStakeAccounts(owner: "Owner")
+        // Must hit RPC every time — a just-submitted stake/unstake and freshly
+        // accrued rewards have to be visible immediately.
+        XCTAssertEqual(reader.stakeAccountCalls, 2)
+    }
+}


### PR DESCRIPTION
First PR of **Solana native staking** for the DeFi tab — the data foundation only. **No UI, no signing, no DeFi-tab registration** (those build on top in later PRs). No rewards-claim path (rewards auto-compound), `Blockchain/Tss/` untouched, and `getStakeMinimumDelegation` is **not** used (proxy-blocked).

## What's in this layer

**Models** (`Blockchain/Solana/Models/Staking/`)
- `SolanaStakeAccount` — parsed stake account from `jsonParsed`: `authorized.{staker,withdrawer}`, `rentExemptReserve`, `delegation.{votePubkey, activationEpoch, deactivationEpoch, stake}`, plus a derived `activating / active / deactivating / inactive` state. u64 fields decode from decimal strings, so the `deactivationEpoch = u64::MAX` "not deactivating" sentinel round-trips exactly.
- `SolanaValidator` (+ `ValidatorMetadata`) — a `getVoteAccounts` row tagged with its `current`/`delinquent` bucket; metadata (name/logo/APY/score) starts empty for a later PR.
- `SolanaStakingConfig` — Stake program id `Stake11111111111111111111111111111111111111`, stake-state size `200`, staker memcmp offset `12`, and a documented `minDelegationFloorLamports` (1 SOL) substitute for the blocked min-delegation RPC.
- `SolanaStakingPayload` — `delegate / unstake / withdraw / moveStakeStep`, Codable + Hashable.
- `Chain.isSolanaStakingChain`.

**RPC methods** (extended on `SolanaAPI.Method` + `SolanaService`, all via `TargetType`)
| Method | Notes |
|---|---|
| `getVoteAccounts` | all validators, current + delinquent |
| `getProgramAccounts` (stake-filtered) | `dataSize:200` + `memcmp{offset:12, bytes:owner}`; `jsonParsed` or `dataSlice{0,0}` pubkey-only |
| `getAccountInfo` (jsonParsed) | single stake account |
| `getEpochInfo` | current epoch + slot progress |
| `getMinimumBalanceForRentExemption` | param `[200]` |
| `getInflationRate` | network inflation |

`getStakeMinimumDelegation` intentionally **not** added.

**Services**
- `SolanaStakingService` (actor) — `fetchValidators / fetchStakeAccounts(owner:) / fetchEpochInfo / fetchRentReserve / fetchInflationRate`.
- `SolanaEpochCooldownGate` — `.available` / `.blocked(unlocksAtEpoch:)` from the live epoch + a stake account's `deactivationEpoch` (unlocks at `deactivationEpoch + 1`).

**Cache TTLs** (reusing existing helpers, no new cache invented)
| Data | TTL | Mechanism |
|---|---|---|
| validator set | 10 min | actor `CachedEntry` |
| inflation | 10 min | actor `CachedEntry` |
| epoch info | 45 s | `Utils.getCachedData` |
| rent reserve | 24 h | `Utils.getCachedData` |
| stake accounts | **not cached** | always live (reflects just-submitted tx + accrued rewards) |

All RPC request/response shapes were smoke-tested live against `https://api.vultisig.com/solana/`; the stake-account parse test uses a real mainnet `getProgramAccounts` row.

## Gate results
- **swiftlint** (`swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/`): **0 new violations** in the added/changed staking code (pre-existing repo violations untouched).
- **xcodebuild** (`-scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' build`): **BUILD SUCCEEDED**.
- **Tests**: 33 new tests — **all passing** (jsonParsed→model parse, memcmp filter shape, cooldown-gate epoch math, cache TTL behavior, config, payload, validator decode).

Closes #4659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana staking support, including validator, stake account, epoch, rent, and inflation data.
  * Introduced staking actions for delegation, unstaking, withdrawing, and moving stake.
  * Added support for showing staking status and cooldown/withdrawal availability.

* **Bug Fixes**
  * Improved handling of parsed Solana stake account data, including inactive and deactivating states.
  * Added caching for frequently used staking data to reduce repeated network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->