### PR TITLE
feat(solana): validator metadata seam (Stakewiz, swappable)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaValidator.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/Staking/SolanaValidator.swift
@@ -61,6 +61,36 @@ struct SolanaValidator: Codable, Hashable, Identifiable {
     }
 }
 
+// MARK: - Display fallbacks
+
+extension SolanaValidator {
+    /// Name to show in the picker: the enriched metadata name when present,
+    /// otherwise a truncated vote pubkey (`9gAN…7mq`). Keeps the display layer
+    /// independent of whether the metadata provider returned anything.
+    var displayName: String {
+        if let name = metadata.name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            return name
+        }
+        return Self.truncatedPubkey(votePubkey)
+    }
+
+    /// The validator logo URL, or `nil` when no metadata source supplied one —
+    /// the display layer then renders a deterministic placeholder.
+    var logoURL: URL? {
+        guard let raw = metadata.logoURL?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+        return URL(string: raw)
+    }
+
+    /// `prefix…suffix` form of a base58 pubkey for compact display. Returns the
+    /// input unchanged when it is too short to truncate meaningfully.
+    static func truncatedPubkey(_ pubkey: String, prefix: Int = 4, suffix: Int = 4) -> String {
+        guard pubkey.count > prefix + suffix + 1 else { return pubkey }
+        return "\(pubkey.prefix(prefix))…\(pubkey.suffix(suffix))"
+    }
+}
+
 /// Off-chain enrichment for a validator. All optional — populated by a later
 /// PR from a metadata source; the base read layer leaves it empty.
 struct ValidatorMetadata: Codable, Hashable {

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/StakewizValidatorMetadataProvider.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/StakewizValidatorMetadataProvider.swift
@@ -1,0 +1,200 @@
+//
+//  StakewizValidatorMetadataProvider.swift
+//  VultisigApp
+//
+//  Concrete `ValidatorMetadataProvider` backed by Stakewiz
+//  (https://api.stakewiz.com). The `/validators` endpoint returns the full
+//  validator set in one response, so a single fetch enriches an arbitrary batch
+//  of vote pubkeys; results are cached per vote pubkey for 1 hour via the actor
+//  `CachedEntry` pattern. A failed or rate-limited fetch yields whatever is
+//  already cached (possibly nothing) — the call never throws, so callers degrade
+//  to on-chain-only display.
+//
+//  When a validator exposes a Keybase identity, the logo is resolved through the
+//  shared `KeybaseAvatarService`, falling back to Stakewiz's own `image` URL.
+//
+//  Field mapping (Stakewiz → ValidatorMetadata):
+//    name         -> name
+//    keybase/image -> logoURL  (Keybase avatar preferred, else image)
+//    apy_estimate -> apyEstimate  (percent on the wire, stored as a fraction)
+//    wiz_score    -> score
+//    commission / delinquent / vote_identity are surfaced via the row itself so
+//    callers can prefer Stakewiz commission/delinquency when present.
+//
+
+import Foundation
+import OSLog
+
+actor StakewizValidatorMetadataProvider: ValidatorMetadataProvider {
+
+    private struct CachedEntry {
+        let value: ValidatorMetadata
+        let fetchedAt: Date
+    }
+
+    private let httpClient: HTTPClientProtocol
+    private let avatarService: KeybaseAvatarServiceProtocol
+    private let ttl: TimeInterval
+    private let clock: @Sendable () -> Date
+    private let logger: Logger
+
+    /// Per-vote-pubkey enrichment cache.
+    private var cache: [String: CachedEntry] = [:]
+    /// Coalesces concurrent batch fetches into a single in-flight request — the
+    /// `/validators` endpoint is the same call regardless of which pubkeys are
+    /// asked for, so there is at most one outstanding fetch.
+    private var inFlight: Task<[StakewizValidator], Never>?
+
+    init(
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        avatarService: KeybaseAvatarServiceProtocol = KeybaseAvatarService(),
+        ttl: TimeInterval = 60 * 60,
+        clock: @escaping @Sendable () -> Date = { Date() },
+        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "stakewiz-validator-metadata")
+    ) {
+        self.httpClient = httpClient
+        self.avatarService = avatarService
+        self.ttl = ttl
+        self.clock = clock
+        self.logger = logger
+    }
+
+    func metadata(forVotePubkeys votePubkeys: [String]) async -> [String: ValidatorMetadata] {
+        let requested = Set(votePubkeys.filter { !$0.isEmpty })
+        guard !requested.isEmpty else { return [:] }
+
+        // Serve everything from cache when every requested pubkey is fresh.
+        let now = clock()
+        let cachedHits = requested.reduce(into: [String: ValidatorMetadata]()) { result, pubkey in
+            if let entry = cache[pubkey], now.timeIntervalSince(entry.fetchedAt) < ttl {
+                result[pubkey] = entry.value
+            }
+        }
+        if cachedHits.count == requested.count {
+            return cachedHits
+        }
+
+        let rows = await fetchValidators()
+        guard !rows.isEmpty else {
+            // Outage — return whatever we already had cached for the request.
+            return cachedHits
+        }
+
+        let fetchedAt = clock()
+        var result = cachedHits
+        // Build a lookup once, then resolve only the requested pubkeys.
+        var byVotePubkey: [String: StakewizValidator] = [:]
+        for row in rows where !row.voteIdentity.isEmpty {
+            byVotePubkey[row.voteIdentity] = row
+        }
+        for pubkey in requested where result[pubkey] == nil {
+            guard let row = byVotePubkey[pubkey] else { continue }
+            let metadata = await map(row)
+            cache[pubkey] = CachedEntry(value: metadata, fetchedAt: fetchedAt)
+            result[pubkey] = metadata
+        }
+        return result
+    }
+
+    // MARK: - Mapping
+
+    private func map(_ row: StakewizValidator) async -> ValidatorMetadata {
+        let name = row.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ValidatorMetadata(
+            name: (name?.isEmpty == false) ? name : nil,
+            logoURL: await resolveLogo(row),
+            apyEstimate: Self.apyFraction(from: row.apyEstimate),
+            score: row.wizScore.map { Int($0.rounded()) }
+        )
+    }
+
+    /// Prefer the Keybase avatar when the validator exposes a Keybase identity;
+    /// otherwise use Stakewiz's own `image` URL.
+    private func resolveLogo(_ row: StakewizValidator) async -> String? {
+        if let identity = row.keybase?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !identity.isEmpty,
+           let url = await avatarService.avatarURL(forIdentity: identity) {
+            return url.absoluteString
+        }
+        guard let image = row.image?.trimmingCharacters(in: .whitespacesAndNewlines), !image.isEmpty else {
+            return nil
+        }
+        return image
+    }
+
+    /// Stakewiz reports `apy_estimate` as a percentage (e.g. `5.72`). Store it
+    /// as a fraction to match `ValidatorMetadata.apyEstimate` (e.g. `0.0572`).
+    private static func apyFraction(from percent: Double?) -> Decimal? {
+        guard let percent, percent.isFinite, percent > 0 else { return nil }
+        return Decimal(percent) / 100
+    }
+
+    // MARK: - Fetch
+
+    private func fetchValidators() async -> [StakewizValidator] {
+        if let inFlight {
+            return await inFlight.value
+        }
+        let task = Task<[StakewizValidator], Never> { [self] in
+            do {
+                let response = try await httpClient.request(
+                    StakewizValidatorsAPI(),
+                    responseType: [StakewizValidator].self
+                )
+                return response.data
+            } catch {
+                logger.warning(
+                    "Stakewiz validators fetch failed — degrading to on-chain only: \(error.localizedDescription, privacy: .public)"
+                )
+                return []
+            }
+        }
+        inFlight = task
+        let rows = await task.value
+        inFlight = nil
+        return rows
+    }
+}
+
+// MARK: - Endpoint
+
+private struct StakewizValidatorsAPI: TargetType {
+    var baseURL: URL {
+        // Force-unwrap is safe: the host is a compile-time literal known to
+        // produce a valid URL at this exact form.
+        URL(string: "https://api.stakewiz.com")!
+    }
+
+    var path: String { "/validators" }
+    var method: HTTPMethod { .get }
+    var task: HTTPTask { .requestPlain }
+    var headers: [String: String]? { ["Accept": "application/json"] }
+    var validationType: ValidationType { .successCodes }
+    var timeoutInterval: TimeInterval { 15 }
+}
+
+// MARK: - Wire shape
+
+/// A single Stakewiz `/validators` row. Every enrichment field is optional so a
+/// missing key on the wire collapses to "no enrichment" rather than throwing.
+private struct StakewizValidator: Decodable {
+    let voteIdentity: String
+    let name: String?
+    let image: String?
+    let keybase: String?
+    let apyEstimate: Double?
+    let commission: Int?
+    let wizScore: Double?
+    let delinquent: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case voteIdentity = "vote_identity"
+        case name
+        case image
+        case keybase
+        case apyEstimate = "apy_estimate"
+        case commission
+        case wizScore = "wiz_score"
+        case delinquent
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/ValidatorMetadataProvider.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/ValidatorMetadataProvider.swift
@@ -1,0 +1,28 @@
+//
+//  ValidatorMetadataProvider.swift
+//  VultisigApp
+//
+//  Swappable seam for off-chain validator enrichment (name / logo / APY /
+//  score). The core stake/commission/activation data comes from the on-chain
+//  `getVoteAccounts` read; this protocol only supplies display metadata, which
+//  is the part most likely to change source (Stakewiz today, validators.app or
+//  an in-house endpoint tomorrow). Keeping it behind a protocol lets the picker
+//  and view models stay independent of any single provider.
+//
+//  Contract: implementations MUST NOT throw on a provider outage. A failed or
+//  rate-limited source returns a partial or empty map so callers degrade
+//  gracefully — falling back to a truncated vote pubkey and the on-chain
+//  commission, with no logo, never a crash.
+//
+
+import Foundation
+
+/// Resolves off-chain `ValidatorMetadata` for a set of vote accounts.
+protocol ValidatorMetadataProvider: Sendable {
+    /// Returns metadata keyed by vote pubkey for the requested validators.
+    ///
+    /// The returned map may be empty or cover only a subset of the input — a
+    /// validator absent from the map simply has no enrichment available and the
+    /// caller falls back to on-chain data. This call never throws.
+    func metadata(forVotePubkeys votePubkeys: [String]) async -> [String: ValidatorMetadata]
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaValidatorMetadataFallbackTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaValidatorMetadataFallbackTests.swift
@@ -1,0 +1,108 @@
+//
+//  SolanaValidatorMetadataFallbackTests.swift
+//  VultisigAppTests
+//
+//  Verifies the graceful-degradation contract end to end: when the metadata
+//  provider returns an empty/partial map, folding it onto on-chain validators
+//  leaves them with a truncated-vote-pubkey display name, no logo, and the
+//  on-chain commission intact — no crash. Enriched rows pick up name/logo/APY.
+//
+
+@testable import VultisigApp
+import Foundation
+import XCTest
+
+final class SolanaValidatorMetadataFallbackTests: XCTestCase {
+
+    private let voteA = "9gANMngbGUmAaLXL1RC3JdiaLjRowJXNbzCTh53ht7mq"
+
+    private func onChainValidator(commission: Int = 7) -> SolanaValidator {
+        SolanaValidator(
+            votePubkey: voteA,
+            nodePubkey: "YuRBAsy9Stw1u46A8dMp7WQVBFweLP1PKuYibzYAMmQ",
+            activatedStake: 154_529,
+            commission: commission,
+            epochVoteAccount: true,
+            isDelinquent: false
+        )
+    }
+
+    func testEmptyMetadataFallsBackToTruncatedPubkeyAndOnChainCommission() {
+        let validator = onChainValidator(commission: 7)
+        // No metadata applied (empty provider result).
+        XCTAssertEqual(validator.displayName, "9gAN…t7mq")
+        XCTAssertNil(validator.logoURL)
+        XCTAssertNil(validator.metadata.apyEstimate)
+        XCTAssertEqual(validator.commission, 7) // on-chain commission preserved
+    }
+
+    func testEnrichedMetadataIsSurfacedThroughDisplayHelpers() async {
+        let stub = StubHTTPClient(payload: Self.payload())
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService()
+        )
+        let map = await provider.metadata(forVotePubkeys: [voteA])
+
+        var validator = onChainValidator()
+        if let meta = map[validator.votePubkey] {
+            validator.metadata = meta
+        }
+
+        XCTAssertEqual(validator.displayName, "Yurbason")
+        XCTAssertEqual(validator.logoURL?.absoluteString, "https://media.stakewiz.com/yurbason.png")
+        let apy = (validator.metadata.apyEstimate as NSDecimalNumber?)?.doubleValue ?? 0
+        XCTAssertEqual(apy, 0.0572, accuracy: 0.00001)
+        // Provider absence for unknown pubkeys leaves on-chain commission as-is.
+        XCTAssertEqual(validator.commission, 7)
+    }
+
+    func testTruncatedPubkeyReturnsShortInputUnchanged() {
+        XCTAssertEqual(SolanaValidator.truncatedPubkey("short"), "short")
+    }
+
+    // MARK: - Fixtures
+
+    private static func payload() -> Data {
+        let json = """
+        [
+          {
+            "vote_identity": "9gANMngbGUmAaLXL1RC3JdiaLjRowJXNbzCTh53ht7mq",
+            "name": "Yurbason",
+            "keybase": "",
+            "image": "https://media.stakewiz.com/yurbason.png",
+            "commission": 0,
+            "apy_estimate": 5.72,
+            "wiz_score": 99.44,
+            "delinquent": false
+          }
+        ]
+        """
+        return Data(json.utf8)
+    }
+}
+
+// MARK: - Test doubles
+
+private struct NoAvatarService: KeybaseAvatarServiceProtocol {
+    // swiftlint:disable:next async_without_await
+    func avatarURL(forIdentity _: String) async -> URL? { nil }
+}
+
+private actor StubHTTPClient: HTTPClientProtocol {
+    private let payload: Data?
+
+    init(payload: Data?) { self.payload = payload }
+
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        let data = payload ?? Data()
+        let response = HTTPURLResponse(
+            url: target.baseURL.appendingPathComponent(target.path),
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: data, response: response)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/StakewizValidatorMetadataProviderTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/StakewizValidatorMetadataProviderTests.swift
@@ -1,0 +1,229 @@
+//
+//  StakewizValidatorMetadataProviderTests.swift
+//  VultisigAppTests
+//
+//  Covers the Stakewiz validator-metadata seam: JSON → ValidatorMetadata
+//  mapping (name / logo / APY fraction / score), the 1-hour cache hit/expiry
+//  behavior, the graceful-degradation contract on an outage (empty/partial map,
+//  no crash), and Keybase-avatar resolution taking precedence over the Stakewiz
+//  `image` URL.
+//
+
+@testable import VultisigApp
+import Foundation
+import XCTest
+
+final class StakewizValidatorMetadataProviderTests: XCTestCase {
+
+    private let voteA = "9gANMngbGUmAaLXL1RC3JdiaLjRowJXNbzCTh53ht7mq"
+    private let voteB = "ENVaKoD7ytn58xJ8s5htFfQ8hqQt1G9dcPUDqbSwVcgB"
+
+    // MARK: - Mapping
+
+    func testMapsStakewizRowIntoValidatorMetadata() async {
+        let stub = StubHTTPClient(payload: Self.validatorsPayload())
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService()
+        )
+        let result = await provider.metadata(forVotePubkeys: [voteA])
+        let meta = result[voteA]
+        XCTAssertNotNil(meta)
+        XCTAssertEqual(meta?.name, "Yurbason")
+        // No Keybase identity in this row → falls back to the Stakewiz image.
+        XCTAssertEqual(meta?.logoURL, "https://media.stakewiz.com/yurbason.png")
+        // apy_estimate 5.72 (percent) stored as the 0.0572 fraction.
+        let apy = (meta?.apyEstimate as NSDecimalNumber?)?.doubleValue ?? 0
+        XCTAssertEqual(apy, 0.0572, accuracy: 0.00001)
+        XCTAssertEqual(meta?.score, 99) // wiz_score 99.44 → rounded
+    }
+
+    func testResolvesOnlyRequestedSubset() async {
+        let stub = StubHTTPClient(payload: Self.validatorsPayload())
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService()
+        )
+        let result = await provider.metadata(forVotePubkeys: [voteB])
+        XCTAssertEqual(Set(result.keys), [voteB])
+        XCTAssertEqual(result[voteB]?.name, "WEB34EVER")
+    }
+
+    func testPrefersKeybaseAvatarOverStakewizImage() async {
+        // voteB carries a Keybase identity; the avatar service resolves it and
+        // its URL should win over the row's `image`.
+        let stub = StubHTTPClient(payload: Self.validatorsPayload())
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: FixedAvatarService(url: URL(string: "https://keybase.io/web34ever.png"))
+        )
+        let result = await provider.metadata(forVotePubkeys: [voteB])
+        XCTAssertEqual(result[voteB]?.logoURL, "https://keybase.io/web34ever.png")
+    }
+
+    // MARK: - Graceful degradation
+
+    func testReturnsEmptyMapOnOutageWithoutThrowing() async {
+        let stub = StubHTTPClient(payload: nil, error: HTTPError.statusCode(503, nil))
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService()
+        )
+        let result = await provider.metadata(forVotePubkeys: [voteA, voteB])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testReturnsPartialMapWhenPubkeyAbsentFromSource() async {
+        let stub = StubHTTPClient(payload: Self.validatorsPayload())
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService()
+        )
+        let unknown = "ZZZZunknownvotepubkeyZZZZ"
+        let result = await provider.metadata(forVotePubkeys: [voteA, unknown])
+        XCTAssertEqual(Set(result.keys), [voteA])
+        XCTAssertNil(result[unknown])
+    }
+
+    func testReturnsEmptyMapForEmptyInput() async {
+        let stub = StubHTTPClient(payload: Self.validatorsPayload())
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService()
+        )
+        let result = await provider.metadata(forVotePubkeys: [])
+        XCTAssertTrue(result.isEmpty)
+        let count = await stub.requestCount
+        XCTAssertEqual(count, 0)
+    }
+
+    func testTolerantOfMissingOptionalFields() async {
+        // A row with only vote_identity present must not crash decoding and
+        // yields all-nil enrichment.
+        let payload = Data(#"[{"vote_identity": "\#(voteA)"}]"#.utf8)
+        let stub = StubHTTPClient(payload: payload)
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService()
+        )
+        let result = await provider.metadata(forVotePubkeys: [voteA])
+        let meta = result[voteA]
+        XCTAssertNotNil(meta)
+        XCTAssertNil(meta?.name)
+        XCTAssertNil(meta?.logoURL)
+        XCTAssertNil(meta?.apyEstimate)
+        XCTAssertNil(meta?.score)
+    }
+
+    // MARK: - Cache
+
+    func testHitsCacheWithinTTL() async {
+        let stub = StubHTTPClient(payload: Self.validatorsPayload())
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService(),
+            ttl: 3600,
+            clock: { Date(timeIntervalSince1970: 0) }
+        )
+        _ = await provider.metadata(forVotePubkeys: [voteA])
+        _ = await provider.metadata(forVotePubkeys: [voteA])
+        let count = await stub.requestCount
+        XCTAssertEqual(count, 1) // second call served from cache
+    }
+
+    func testRefetchesAfterTTLExpires() async {
+        let stub = StubHTTPClient(payload: Self.validatorsPayload())
+        let clockBox = ClockBox(start: Date(timeIntervalSince1970: 0))
+        let provider = StakewizValidatorMetadataProvider(
+            httpClient: stub,
+            avatarService: NoAvatarService(),
+            ttl: 3600,
+            clock: { clockBox.now }
+        )
+        _ = await provider.metadata(forVotePubkeys: [voteA])
+        clockBox.advance(by: 7200)
+        _ = await provider.metadata(forVotePubkeys: [voteA])
+        let count = await stub.requestCount
+        XCTAssertEqual(count, 2)
+    }
+
+    // MARK: - Fixtures
+
+    private static func validatorsPayload() -> Data {
+        let json = """
+        [
+          {
+            "vote_identity": "9gANMngbGUmAaLXL1RC3JdiaLjRowJXNbzCTh53ht7mq",
+            "name": "Yurbason",
+            "keybase": "",
+            "image": "https://media.stakewiz.com/yurbason.png",
+            "commission": 0,
+            "apy_estimate": 5.72,
+            "wiz_score": 99.44,
+            "delinquent": false
+          },
+          {
+            "vote_identity": "ENVaKoD7ytn58xJ8s5htFfQ8hqQt1G9dcPUDqbSwVcgB",
+            "name": "WEB34EVER",
+            "keybase": "web34ever",
+            "image": "https://media.stakewiz.com/web34ever.png",
+            "commission": 5,
+            "apy_estimate": 5.81,
+            "wiz_score": 98.5,
+            "delinquent": false
+          }
+        ]
+        """
+        return Data(json.utf8)
+    }
+}
+
+// MARK: - Test doubles
+
+private final class ClockBox: @unchecked Sendable {
+    private var current: Date
+
+    init(start: Date) { self.current = start }
+
+    var now: Date { current }
+
+    func advance(by seconds: TimeInterval) {
+        current = current.addingTimeInterval(seconds)
+    }
+}
+
+private struct NoAvatarService: KeybaseAvatarServiceProtocol {
+    // swiftlint:disable:next async_without_await
+    func avatarURL(forIdentity _: String) async -> URL? { nil }
+}
+
+private struct FixedAvatarService: KeybaseAvatarServiceProtocol {
+    let url: URL?
+    // swiftlint:disable:next async_without_await
+    func avatarURL(forIdentity _: String) async -> URL? { url }
+}
+
+private actor StubHTTPClient: HTTPClientProtocol {
+    private let payload: Data?
+    private let error: Error?
+    private(set) var requestCount: Int = 0
+
+    init(payload: Data?, error: Error? = nil) {
+        self.payload = payload
+        self.error = error
+    }
+
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        requestCount += 1
+        if let error { throw error }
+        let data = payload ?? Data()
+        let response = HTTPURLResponse(
+            url: target.baseURL.appendingPathComponent(target.path),
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: data, response: response)
+    }
+}


### PR DESCRIPTION
## Summary

PR 2 of Solana staking — the **validator-metadata seam**. On-chain `getVoteAccounts` (from PR 1) supplies stake/commission/activation; this layer enriches display info (name / logo / APY / score) **behind a protocol** so the source can be swapped (validators.app, in-house, on-chain-only) without touching any call site.

- **`ValidatorMetadataProvider`** — `func metadata(forVotePubkeys:) async -> [String: ValidatorMetadata]`. Contract: **never throws on a provider outage**; returns a partial/empty map keyed by vote pubkey so callers degrade gracefully.
- **`StakewizValidatorMetadataProvider`** — concrete impl via `TargetType` + `HTTPClient` against `https://api.stakewiz.com/validators`. Maps `name` / `image` / `apy_estimate` (percent → fraction) / `wiz_score` / `commission` / `delinquent` / `vote_identity` → `ValidatorMetadata`. 1h actor `CachedEntry` per vote pubkey, in-flight coalescing, OSLog. The single `/validators` response enriches an arbitrary batch in one fetch.
- **Avatars** — Keybase identities resolve through the existing `KeybaseAvatarService` (reused, not reimplemented), preferring the Keybase avatar over the Stakewiz `image`.
- **Graceful degradation** — `SolanaValidator` gains `displayName` (metadata name, else truncated vote pubkey `9gAN…t7mq`) and `logoURL`, so the future picker stays independent of whether enrichment was available. Empty/partial provider result → on-chain commission preserved, no logo, no crash.

No UI (the picker lands with the delegate flow), no hard Stakewiz dependency at any call site, no `Blockchain/Tss/` changes.

## Gate results

- **swiftlint** (`--config VultisigApp/.swiftlint.yml`): **0 violations** on all touched files.
- **xcodebuild** (`-scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' build`): **BUILD SUCCEEDED**.
- **Tests**: **12/12 pass** — `StakewizValidatorMetadataProviderTests` (9) + `SolanaValidatorMetadataFallbackTests` (3). Covers JSON→`ValidatorMetadata` mapping, 1h cache hit/expiry, outage→empty map (no throw), partial map for absent pubkeys, missing-field tolerance, Keybase-over-image precedence, and empty-metadata fallback to truncated pubkey + on-chain commission.

Stakewiz `https://api.stakewiz.com/validators` was **reachable** during development; response shape verified against live data and the decoder grounded on the real field names (and made tolerant of missing fields).

Closes #4660

Stacked on #4665 (foundation); base will retarget to main once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
