### PR TITLE
feat(solana): delegate (stake) flow

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingSignDataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingSignDataResolver.swift
@@ -1,0 +1,121 @@
+//
+//  SolanaStakingSignDataResolver.swift
+//  VultisigApp
+//
+//  Produces the `SignSolana` artefact for a Solana native-staking operation.
+//  Consumed by the Verify → KeysignPayload bridge whenever
+//  `SendTransaction.solanaStakingPayload != nil`. Analog of
+//  `CosmosStakingSignDataResolver`.
+//
+//  Unlike the transfer path — where every co-signing device rebuilds the
+//  signing input from fields that all round-trip through proto — a delegate's
+//  validator pubkey + amount live on the LOCAL-ONLY `solanaStakingPayload`,
+//  which the peer never receives. So the resolver builds the unsigned
+//  transaction ONCE here (pinning the recent blockhash and the
+//  wallet-core-derived stake-account address) and relays the raw bytes via
+//  `SignSolana.rawTransactions`. Every device then signs the byte-identical
+//  message through the raw-transaction path — the MPC byte-parity guarantee.
+//
+//  Validator preflight (base58 ed25519 + optional known-vote-set membership)
+//  is enforced HERE, before any pre-image bytes are produced, so an invalid
+//  validator throws at build time rather than burning an MPC ceremony on a
+//  chain-rejected tx.
+//
+
+import Foundation
+import OSLog
+
+enum SolanaStakingSignDataResolver {
+
+    enum Errors: Error, LocalizedError {
+        case missingPayload
+        case wrongOpType(SolanaStakingOpType)
+        case missingChainSpecific
+        case missingPayloadField(String)
+        case validatorPreflightFailed(String)
+        case insufficientForRentReserve(required: UInt64, available: UInt64)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingPayload:
+                return "solanaStakingErrorMissingPayload".localized
+            case .wrongOpType:
+                return "solanaStakingErrorWrongOpType".localized
+            case .missingChainSpecific:
+                return "solanaStakingErrorMissingChainSpecific".localized
+            case .missingPayloadField(let field):
+                return String(format: "solanaStakingErrorMissingPayloadField".localized, field)
+            case .validatorPreflightFailed(let reason):
+                return String(format: "solanaStakingErrorValidatorPreflightFailed".localized, reason)
+            case .insufficientForRentReserve:
+                return "solanaStakingErrorInsufficientForRentReserve".localized
+            }
+        }
+    }
+
+    private static let logger = Logger(
+        subsystem: "com.vultisig.app",
+        category: "solana-staking-sign-resolver"
+    )
+
+    /// Resolves the `SignSolana` artefact for a delegate payload.
+    ///
+    /// - Parameters:
+    ///   - basePayload: the transfer-shaped payload produced by the keysign
+    ///     factory, already carrying `coin` / `chainSpecific` / `solanaStakingPayload`.
+    ///   - rentReserve: the rent-exempt reserve (lamports) from the live read
+    ///     layer (`getMinimumBalanceForRentExemption`). The new stake account must
+    ///     be funded with this on top of the delegated amount.
+    ///   - knownVotePubkeys: cached `getVoteAccounts` vote pubkeys for the
+    ///     membership preflight; empty skips the membership check.
+    ///   - balance: the signer's spendable lamports, used for the rent-reserve
+    ///     accounting guard.
+    static func resolve(
+        basePayload: KeysignPayload,
+        rentReserve: UInt64,
+        knownVotePubkeys: Set<String>,
+        balance: UInt64
+    ) throws -> SignSolana {
+        guard let payload = basePayload.solanaStakingPayload else {
+            throw Errors.missingPayload
+        }
+        guard payload.opType == .delegate else {
+            throw Errors.wrongOpType(payload.opType)
+        }
+        guard case .Solana = basePayload.chainSpecific else {
+            throw Errors.missingChainSpecific
+        }
+        guard let votePubkey = payload.votePubkey, !votePubkey.isEmpty else {
+            throw Errors.missingPayloadField("votePubkey")
+        }
+        guard let lamports = payload.lamports, lamports > 0 else {
+            throw Errors.missingPayloadField("lamports")
+        }
+
+        do {
+            try SolanaValidatorPreflight.validate(votePubkey, knownVotePubkeys: knownVotePubkeys)
+        } catch {
+            throw Errors.validatorPreflightFailed(error.localizedDescription)
+        }
+
+        // Rent-reserve accounting: a new stake account must hold the delegated
+        // amount AND the rent-exempt reserve. Both come from the signer's
+        // balance, so reject up front when the balance can't cover both —
+        // otherwise the ceremony signs a tx the chain rejects.
+        let (required, overflow) = lamports.addingReportingOverflow(rentReserve)
+        if overflow || required > balance {
+            throw Errors.insufficientForRentReserve(required: overflow ? .max : required, available: balance)
+        }
+
+        let rawTransaction = try SolanaHelper.buildDelegateUnsignedTransaction(keysignPayload: basePayload)
+
+        logger.info(
+            """
+            Built Solana delegate tx: lamports=\(lamports) rentReserve=\(rentReserve) \
+            validator=\(votePubkey, privacy: .public)
+            """
+        )
+
+        return SignSolana(rawTransactions: [rawTransaction])
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaValidatorPreflight.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaValidatorPreflight.swift
@@ -1,0 +1,68 @@
+//
+//  SolanaValidatorPreflight.swift
+//  VultisigApp
+//
+//  Sanity-checks a Solana validator vote pubkey before the MPC ceremony
+//  spends a signing round on a delegate tx the chain would reject
+//  post-broadcast. Analog of the Cosmos `ValidatorBech32Preflight` — same
+//  posture: validate at build time so an invalid validator throws before any
+//  pre-image bytes are produced.
+//
+//  Two checks:
+//
+//    1. The vote pubkey is a valid base58 ed25519 Solana address — WalletCore's
+//       `AnyAddress(string:coin:)` is the same validator `AddressService` uses
+//       for every Solana address, so a malformed or wrong-curve key is rejected
+//       here.
+//
+//    2. (Optional) The vote pubkey is present in a caller-supplied known-vote
+//       set (from the cached `getVoteAccounts` read). When the set is empty the
+//       check is skipped — the address-shape guard still applies — so the
+//       preflight degrades gracefully if the validator list is briefly
+//       unavailable rather than blocking a legitimate delegate.
+//
+
+import Foundation
+import WalletCore
+
+enum SolanaValidatorPreflight {
+
+    enum SolanaValidatorError: Error, LocalizedError, Equatable {
+        case empty
+        case invalidVotePubkey
+        case unknownValidator
+
+        var errorDescription: String? {
+            switch self {
+            case .empty:
+                return "solanaValidatorErrorEmpty".localized
+            case .invalidVotePubkey:
+                return "solanaValidatorErrorInvalidVotePubkey".localized
+            case .unknownValidator:
+                return "solanaValidatorErrorUnknownValidator".localized
+            }
+        }
+    }
+
+    /// Validates the vote pubkey's shape and, when `knownVotePubkeys` is
+    /// non-empty, its membership in the cached vote-account set.
+    ///
+    /// - Parameters:
+    ///   - votePubkey: the validator vote account the user is delegating to.
+    ///   - knownVotePubkeys: vote pubkeys from the cached `getVoteAccounts`
+    ///     read. Pass an empty set to skip the membership check (shape-only).
+    static func validate(
+        _ votePubkey: String,
+        knownVotePubkeys: Set<String> = []
+    ) throws {
+        guard !votePubkey.isEmpty else { throw SolanaValidatorError.empty }
+
+        guard AnyAddress(string: votePubkey, coin: .solana) != nil else {
+            throw SolanaValidatorError.invalidVotePubkey
+        }
+
+        guard knownVotePubkeys.isEmpty || knownVotePubkeys.contains(votePubkey) else {
+            throw SolanaValidatorError.unknownValidator
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
@@ -39,6 +39,22 @@ enum SolanaHelper {
         }
         let priorityFeeLimitValue = UInt32(truncatingIfNeeded: effectivePriorityLimit)
 
+        // Native stake delegate rides the same compiler plumbing as a transfer —
+        // only the transaction-type oneof differs. Built from the local-only
+        // `solanaStakingPayload`; the wallet-core stake builder derives the
+        // stake-account address and emits create + initialize + delegate in a
+        // single transaction (`stakeAccount` deliberately omitted).
+        if let stakingPayload = keysignPayload.solanaStakingPayload,
+           stakingPayload.opType == .delegate {
+            return try buildDelegateInputData(
+                payload: stakingPayload,
+                sender: keysignPayload.coin.address,
+                recentBlockHash: recentBlockHash,
+                priorityFeePrice: effectivePriorityFeePrice,
+                priorityFeeLimit: priorityFeeLimitValue
+            )
+        }
+
         if keysignPayload.coin.isNativeToken {
             let input = SolanaSigningInput.with {
                 $0.v0Msg = true
@@ -146,6 +162,84 @@ enum SolanaHelper {
             throw HelperError.runtimeError("SPL token transfer failed: sender's associated token account not found. Please ensure you have this token in your wallet.")
 
         }
+    }
+
+    // MARK: - Native staking (delegate)
+
+    /// Builds the `SolanaSigningInput` for a native stake delegate. `stakeAccount`
+    /// is intentionally omitted so wallet-core derives the stake-account address
+    /// deterministically and emits create + initialize + delegate in one tx.
+    private static func buildDelegateInputData(
+        payload: SolanaStakingPayload,
+        sender: String,
+        recentBlockHash: String,
+        priorityFeePrice: UInt64,
+        priorityFeeLimit: UInt32
+    ) throws -> Data {
+        guard let votePubkey = payload.votePubkey, !votePubkey.isEmpty else {
+            throw HelperError.runtimeError("solana delegate: missing validator vote pubkey")
+        }
+        guard let lamports = payload.lamports, lamports > 0 else {
+            throw HelperError.runtimeError("solana delegate: missing or zero delegation amount")
+        }
+        guard AnyAddress(string: votePubkey, coin: .solana) != nil else {
+            throw HelperError.runtimeError("solana delegate: invalid validator vote pubkey")
+        }
+
+        let input = SolanaSigningInput.with {
+            $0.v0Msg = true
+            $0.delegateStakeTransaction = SolanaDelegateStake.with {
+                $0.validatorPubkey = votePubkey
+                $0.value = lamports
+            }
+            $0.recentBlockhash = recentBlockHash
+            $0.sender = sender
+            $0.priorityFeePrice = SolanaPriorityFeePrice.with {
+                $0.price = priorityFeePrice
+            }
+            $0.priorityFeeLimit = SolanaPriorityFeeLimit.with {
+                $0.limit = priorityFeeLimit
+            }
+        }
+        return try input.serializedData()
+    }
+
+    /// Compiles the unsigned delegate transaction (zero-signature envelope) and
+    /// returns it base64-encoded. This is the byte-parity contract for native
+    /// staking: the initiating device builds these bytes once — pinning the
+    /// recent blockhash and the wallet-core-derived stake-account address — and
+    /// relays them via `SignSolana.rawTransactions`. Every co-signing device
+    /// then signs the IDENTICAL message bytes through the raw-transaction path,
+    /// so no device rebuilds the input from a non-round-tripped staking payload.
+    static func buildDelegateUnsignedTransaction(keysignPayload: KeysignPayload) throws -> String {
+        guard let publicKey = PublicKey(
+            data: Data(hex: keysignPayload.coin.hexPublicKey),
+            type: .ed25519
+        ) else {
+            throw HelperError.runtimeError("solana delegate: invalid signer public key")
+        }
+        let inputData = try getPreSignedInputData(keysignPayload: keysignPayload)
+        let allSignatures = DataVector()
+        let publicKeys = DataVector()
+        allSignatures.add(data: Data(hex: Array(repeating: "0", count: 128).joined()))
+        publicKeys.add(data: publicKey.data)
+        let compiled = TransactionCompiler.compileWithSignatures(
+            coinType: .solana,
+            txInputData: inputData,
+            signatures: allSignatures,
+            publicKeys: publicKeys
+        )
+        let output = try SolanaSigningOutput(serializedBytes: compiled)
+        if !output.errorMessage.isEmpty {
+            throw HelperError.runtimeError(output.errorMessage)
+        }
+        // WalletCore emits base58 (the signing input never sets `txEncoding`).
+        // Normalize to base64 — the encoding `SignSolana.rawTransactions` and
+        // the raw-signing path consume.
+        guard let txData = Base58.decodeNoCheck(string: output.encoded) else {
+            throw HelperError.runtimeError("solana delegate: failed to decode unsigned transaction")
+        }
+        return txData.base64EncodedString()
     }
 
     static func getPreSignedImageHash(keysignPayload: KeysignPayload) throws -> [String] {

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1057,6 +1057,15 @@
 "slippageHelperText" = "Begrenzt, wie stark sich der Preis ändern darf, bevor die Ausführung abgebrochen wird.";
 "slippageMaxNote" = "Slippage ist auf %@ begrenzt.";
 "slippageTolerance" = "Slippage-Toleranz";
+"solanaStakingErrorInsufficientForRentReserve" = "Nicht genügend SOL, um den Stake-Betrag plus die mietfreie Reserve zu decken.";
+"solanaStakingErrorMissingChainSpecific" = "Solana-Chain-spezifische Daten für das Staking fehlen.";
+"solanaStakingErrorMissingPayload" = "Solana-Staking-Payload fehlt.";
+"solanaStakingErrorMissingPayloadField" = "Solana-Staking-Payload fehlt erforderliches Feld: %@";
+"solanaStakingErrorValidatorPreflightFailed" = "Validator-Prüfung fehlgeschlagen: %@";
+"solanaStakingErrorWrongOpType" = "Nicht unterstützte Solana-Staking-Operation.";
+"solanaValidatorErrorEmpty" = "Validator-Vote-Adresse ist leer.";
+"solanaValidatorErrorInvalidVotePubkey" = "Ungültige Solana-Validator-Vote-Adresse.";
+"solanaValidatorErrorUnknownValidator" = "Validator nicht im aktuellen Vote-Account-Satz gefunden.";
 "somethingsWrong" = "Etwas stimmt nicht";
 "somethingWentWrongTryAgain" = "Etwas ist schiefgelaufen, bitte versuche es erneut.";
 "sourceValidator" = "Quell-Validator";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1063,6 +1063,15 @@
 "slippageHelperText" = "Limits how much the price can change before execution is canceled.";
 "slippageMaxNote" = "Slippage is capped at %@.";
 "slippageTolerance" = "Slippage Tolerance";
+"solanaStakingErrorInsufficientForRentReserve" = "Insufficient SOL to cover the staked amount plus the rent-exempt reserve.";
+"solanaStakingErrorMissingChainSpecific" = "Missing Solana chain-specific data for staking.";
+"solanaStakingErrorMissingPayload" = "Solana staking payload is missing.";
+"solanaStakingErrorMissingPayloadField" = "Solana staking payload missing required field: %@";
+"solanaStakingErrorValidatorPreflightFailed" = "Validator validation failed: %@";
+"solanaStakingErrorWrongOpType" = "Unsupported Solana staking operation.";
+"solanaValidatorErrorEmpty" = "Validator vote address is empty.";
+"solanaValidatorErrorInvalidVotePubkey" = "Invalid Solana validator vote address.";
+"solanaValidatorErrorUnknownValidator" = "Validator not found in the current vote-account set.";
 "somethingsWrong" = "Something's wrong";
 "somethingWentWrongTryAgain" = "Something went wrong, please try again.";
 "sourceValidator" = "Source Validator";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1057,6 +1057,15 @@
 "slippageHelperText" = "Limita cuánto puede cambiar el precio antes de cancelar la ejecución.";
 "slippageMaxNote" = "El deslizamiento está limitado a %@.";
 "slippageTolerance" = "Tolerancia de deslizamiento";
+"solanaStakingErrorInsufficientForRentReserve" = "SOL insuficiente para cubrir el monto en stake más la reserva de renta exenta.";
+"solanaStakingErrorMissingChainSpecific" = "Faltan datos específicos de la cadena Solana para el staking.";
+"solanaStakingErrorMissingPayload" = "Falta el payload de staking de Solana.";
+"solanaStakingErrorMissingPayloadField" = "Al payload de staking de Solana le falta un campo requerido: %@";
+"solanaStakingErrorValidatorPreflightFailed" = "Falló la validación del validador: %@";
+"solanaStakingErrorWrongOpType" = "Operación de staking de Solana no soportada.";
+"solanaValidatorErrorEmpty" = "La dirección de voto del validador está vacía.";
+"solanaValidatorErrorInvalidVotePubkey" = "Dirección de voto del validador de Solana inválida.";
+"solanaValidatorErrorUnknownValidator" = "Validador no encontrado en el conjunto actual de cuentas de voto.";
 "somethingsWrong" = "Algo está mal";
 "somethingWentWrongTryAgain" = "Algo salió mal, por favor intenta de nuevo.";
 "sourceValidator" = "Validador origen";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1057,6 +1057,15 @@
 "slippageHelperText" = "Ograničava koliko se cijena može promijeniti prije nego se izvršenje otkaže.";
 "slippageMaxNote" = "Klizanje je ograničeno na %@.";
 "slippageTolerance" = "Tolerancija klizanja";
+"solanaStakingErrorInsufficientForRentReserve" = "Nedovoljno SOL-a za pokrivanje uloženog iznosa i pričuve za najam.";
+"solanaStakingErrorMissingChainSpecific" = "Nedostaju podaci specifični za Solana lanac za staking.";
+"solanaStakingErrorMissingPayload" = "Nedostaje Solana staking payload.";
+"solanaStakingErrorMissingPayloadField" = "Solana staking payload nedostaje obavezno polje: %@";
+"solanaStakingErrorValidatorPreflightFailed" = "Provjera validatora nije uspjela: %@";
+"solanaStakingErrorWrongOpType" = "Nepodržana Solana staking operacija.";
+"solanaValidatorErrorEmpty" = "Adresa glasanja validatora je prazna.";
+"solanaValidatorErrorInvalidVotePubkey" = "Nevažeća Solana adresa glasanja validatora.";
+"solanaValidatorErrorUnknownValidator" = "Validator nije pronađen u trenutnom skupu računa za glasanje.";
 "somethingsWrong" = "Nešto nije u redu";
 "somethingWentWrongTryAgain" = "Nešto je pošlo po zlu, pokušajte ponovo.";
 "sourceValidator" = "Izvorni validator";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1057,6 +1057,15 @@
 "slippageHelperText" = "Limita quanto il prezzo può cambiare prima che l'esecuzione venga annullata.";
 "slippageMaxNote" = "Lo slippage è limitato a %@.";
 "slippageTolerance" = "Tolleranza di slippage";
+"solanaStakingErrorInsufficientForRentReserve" = "SOL insufficiente per coprire l'importo in stake più la riserva esente da affitto.";
+"solanaStakingErrorMissingChainSpecific" = "Dati specifici della catena Solana per lo staking mancanti.";
+"solanaStakingErrorMissingPayload" = "Payload di staking Solana mancante.";
+"solanaStakingErrorMissingPayloadField" = "Al payload di staking Solana manca un campo obbligatorio: %@";
+"solanaStakingErrorValidatorPreflightFailed" = "Validazione del validatore non riuscita: %@";
+"solanaStakingErrorWrongOpType" = "Operazione di staking Solana non supportata.";
+"solanaValidatorErrorEmpty" = "L'indirizzo di voto del validatore è vuoto.";
+"solanaValidatorErrorInvalidVotePubkey" = "Indirizzo di voto del validatore Solana non valido.";
+"solanaValidatorErrorUnknownValidator" = "Validatore non trovato nell'insieme attuale di account di voto.";
 "somethingsWrong" = "Qualcosa non va";
 "somethingWentWrongTryAgain" = "Qualcosa è andato storto, riprova.";
 "sourceValidator" = "Validatore di origine";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1057,6 +1057,15 @@
 "slippageHelperText" = "Limita quanto o preço pode mudar antes que a execução seja cancelada.";
 "slippageMaxNote" = "O slippage é limitado a %@.";
 "slippageTolerance" = "Tolerância de slippage";
+"solanaStakingErrorInsufficientForRentReserve" = "SOL insuficiente para cobrir o valor em stake mais a reserva isenta de aluguel.";
+"solanaStakingErrorMissingChainSpecific" = "Dados específicos da cadeia Solana para staking ausentes.";
+"solanaStakingErrorMissingPayload" = "Payload de staking da Solana ausente.";
+"solanaStakingErrorMissingPayloadField" = "Falta um campo obrigatório no payload de staking da Solana: %@";
+"solanaStakingErrorValidatorPreflightFailed" = "Falha na validação do validador: %@";
+"solanaStakingErrorWrongOpType" = "Operação de staking da Solana não suportada.";
+"solanaValidatorErrorEmpty" = "O endereço de voto do validador está vazio.";
+"solanaValidatorErrorInvalidVotePubkey" = "Endereço de voto do validador da Solana inválido.";
+"solanaValidatorErrorUnknownValidator" = "Validador não encontrado no conjunto atual de contas de voto.";
 "somethingsWrong" = "Algo está errado";
 "somethingWentWrongTryAgain" = "Algo deu errado, por favor tente novamente.";
 "sourceValidator" = "Validador de origem";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1057,6 +1057,15 @@
 "slippageHelperText" = "限制价格在执行被取消前可以变动的幅度。";
 "slippageMaxNote" = "滑点上限为 %@。";
 "slippageTolerance" = "滑点容差";
+"solanaStakingErrorInsufficientForRentReserve" = "SOL 不足以支付质押金额加上免租金储备金。";
+"solanaStakingErrorMissingChainSpecific" = "缺少用于质押的 Solana 链特定数据。";
+"solanaStakingErrorMissingPayload" = "缺少 Solana 质押载荷。";
+"solanaStakingErrorMissingPayloadField" = "Solana 质押载荷缺少必填字段：%@";
+"solanaStakingErrorValidatorPreflightFailed" = "验证者校验失败：%@";
+"solanaStakingErrorWrongOpType" = "不支持的 Solana 质押操作。";
+"solanaValidatorErrorEmpty" = "验证者投票地址为空。";
+"solanaValidatorErrorInvalidVotePubkey" = "无效的 Solana 验证者投票地址。";
+"solanaValidatorErrorUnknownValidator" = "在当前投票账户集合中未找到该验证者。";
 "somethingsWrong" = "有问题";
 "somethingWentWrongTryAgain" = "出了点问题，请重试";
 "sourceValidator" = "来源验证人";

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallVerifyViewModel.swift
@@ -125,6 +125,28 @@ class FunctionCallVerifyViewModel: ObservableObject {
                 return basePayload.withSignData(.signDirect(signDirect))
             }
 
+            // Solana native-staking branch — build the unsigned delegate tx
+            // once (pinned blockhash + derived stake-account address) and relay
+            // it via `signData = .signSolana`, the field that round-trips so the
+            // peer device signs byte-identical message bytes. Mirrors
+            // `SendCryptoVerifyLogic`.
+            if let solanaStakingPayload = tx.solanaStakingPayload {
+                let payloadWithStaking = basePayload.withSolanaStakingPayload(solanaStakingPayload)
+                let stakingService = SolanaStakingService()
+                let rentReserve = try await stakingService.fetchRentReserve()
+                let knownVotePubkeys = Set(
+                    ((try? await stakingService.fetchValidators()) ?? []).map(\.votePubkey)
+                )
+                let balance = UInt64(tx.coin.rawBalance) ?? 0
+                let signSolana = try SolanaStakingSignDataResolver.resolve(
+                    basePayload: payloadWithStaking,
+                    rentReserve: rentReserve,
+                    knownVotePubkeys: knownVotePubkeys,
+                    balance: balance
+                )
+                return payloadWithStaking.withSignData(.signSolana(signSolana))
+            }
+
             return basePayload
         } catch {
             let errorMessage: String

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Model/FunctionTransactionType.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Common/Model/FunctionTransactionType.swift
@@ -21,6 +21,9 @@ enum FunctionTransactionType: Hashable {
     case cosmosUndelegate(coin: CoinMeta, validatorAddress: String, validatorMoniker: String, stakedAmount: Decimal)
     case cosmosRedelegate(coin: CoinMeta, validatorAddress: String, validatorMoniker: String, stakedAmount: Decimal)
     case cosmosWithdrawRewards(coin: CoinMeta, validators: [CosmosWithdrawRewardsCandidate])
+    /// Solana native-staking delegate (stake). The user picks a validator vote
+    /// account and amount; the app builds + signs a create-and-delegate tx.
+    case solanaDelegate(coin: CoinMeta)
     /// TON nominator-pool stake. `poolAddress`/`poolImplementation` are the
     /// existing pool for add-more, or `nil` for a first-time stake (the picker
     /// supplies the pool, whose implementation resolves the deposit comment).
@@ -57,6 +60,8 @@ enum FunctionTransactionType: Hashable {
         case .cosmosRedelegate(let coin, _, _, _):
             return [coin]
         case .cosmosWithdrawRewards(let coin, _):
+            return [coin]
+        case .solanaDelegate(let coin):
             return [coin]
         case .tonStake(let coin, _, _):
             return [coin]

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -186,6 +186,13 @@ struct FunctionTransactionScreen: View {
                         onVerify: onVerify
                     )
                 }
+            case .solanaDelegate(let coin):
+                resolvingCoin(coinMeta: coin) { coin in
+                    SolanaDelegateTransactionScreen(
+                        viewModel: SolanaDelegateTransactionViewModel(coin: coin, vault: vault),
+                        onVerify: onVerify
+                    )
+                }
             case .tonStake(let coin, let poolAddress, let poolImplementation):
                 resolvingCoin(coinMeta: coin) { coin in
                     TonStakeTransactionScreen(

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/SolanaDelegateTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/SolanaDelegateTransactionScreen.swift
@@ -1,0 +1,123 @@
+//
+//  SolanaDelegateTransactionScreen.swift
+//  VultisigApp
+//
+//  Delegate input form for Solana native staking. Two sections — amount (uses
+//  the existing `AmountTextField`) and a validator picker (opens the
+//  `SolanaValidatorSelectionScreen` sheet). Mirrors
+//  `CosmosDelegateTransactionScreen`.
+//
+
+import SwiftUI
+
+struct SolanaDelegateTransactionScreen: View {
+    enum FocusedField {
+        case amount
+    }
+
+    @StateObject private var viewModel: SolanaDelegateTransactionViewModel
+    let onVerify: (TransactionBuilder) -> Void
+
+    init(
+        viewModel: SolanaDelegateTransactionViewModel,
+        onVerify: @escaping (TransactionBuilder) -> Void
+    ) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.onVerify = onVerify
+    }
+
+    @State private var focusedFieldBinding: FocusedField?
+    @FocusState private var focusedField: FocusedField?
+    @State private var percentageSelected: Double?
+    @State private var showValidatorPicker: Bool = false
+
+    var body: some View {
+        FormScreen(
+            title: String(format: "cosmosStakingDelegateTitle".localized, viewModel.coin.ticker),
+            validForm: $viewModel.validForm,
+            isContinueDisabled: !viewModel.hasSufficientBalanceForFee,
+            onContinue: onContinue
+        ) {
+            FormExpandableSection(
+                title: viewModel.amountField.label ?? .empty,
+                isValid: viewModel.amountField.valid,
+                value: .empty,
+                showValue: false,
+                focusedField: $focusedFieldBinding,
+                focusedFieldEquals: .amount
+            ) {
+                focusedFieldBinding = $0 ? .amount : nil
+            } content: {
+                AmountTextField(
+                    amount: $viewModel.amountField.value,
+                    error: $viewModel.amountField.error,
+                    ticker: viewModel.coin.ticker,
+                    type: .button,
+                    availableAmount: viewModel.stakeableBalance,
+                    decimals: viewModel.coin.decimals,
+                    percentage: $percentageSelected
+                )
+                .focused($focusedField, equals: .amount)
+            }
+
+            FormPickerSection(
+                title: "cosmosStakingValidatorPicker".localized,
+                isValid: viewModel.selectedValidator != nil,
+                onTap: { showValidatorPicker = true },
+                valueView: { selectedValidatorPreview }
+            )
+
+            if !viewModel.hasSufficientBalanceForFee {
+                InsufficientFeeNotice(ticker: viewModel.coin.ticker)
+            }
+        }
+        .crossPlatformSheet(isPresented: $showValidatorPicker) {
+            SolanaValidatorSelectionScreen(
+                isPresented: $showValidatorPicker,
+                selectedValidator: $viewModel.selectedValidator,
+                chainTicker: viewModel.coin.ticker,
+                chainDecimals: viewModel.coin.decimals
+            )
+        }
+        .onLoad {
+            viewModel.onLoad()
+            focusedFieldBinding = .amount
+        }
+        .onChange(of: percentageSelected) { _, newValue in
+            guard let newValue else { return }
+            viewModel.onPercentage(newValue)
+        }
+        .onChange(of: viewModel.selectedValidator) { _, _ in
+            focusedFieldBinding = .amount
+        }
+        .onChange(of: focusedFieldBinding) { _, newValue in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                focusedField = newValue
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var selectedValidatorPreview: some View {
+        if let validator = viewModel.selectedValidator {
+            HStack(spacing: 8) {
+                Text(validator.displayName)
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        } else {
+            EmptyView()
+        }
+    }
+
+    private func onContinue() {
+        guard viewModel.selectedValidator != nil else {
+            showValidatorPicker = true
+            return
+        }
+        guard let transactionBuilder = viewModel.transactionBuilder else { return }
+        onVerify(transactionBuilder)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/SolanaDelegateTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/SolanaDelegateTransactionViewModel.swift
@@ -1,0 +1,112 @@
+//
+//  SolanaDelegateTransactionViewModel.swift
+//  VultisigApp
+//
+//  Form view-model for the Solana delegate flow. Same `Form` + `[FormField]` +
+//  `transactionBuilder` shape as `CosmosDelegateTransactionViewModel` — the
+//  view holds only `@FocusState` and cosmetic state, every business field
+//  lives here.
+//
+//  Stakeable balance reserves BOTH the network fee AND the rent-exempt reserve
+//  the new stake account must hold, so `amount + fee + rentReserve` can never
+//  exceed the spendable balance.
+//
+
+import Foundation
+import Combine
+import OSLog
+
+@MainActor
+final class SolanaDelegateTransactionViewModel: ObservableObject, Form {
+    let coin: Coin
+    let vault: Vault
+
+    @Published var validForm: Bool = false
+    @Published var selectedValidator: SolanaValidator?
+    @Published private(set) var rentReserve: Decimal = 0
+
+    @Published var amountField = FormField(
+        label: "amount".localized,
+        placeholder: "0",
+        validators: [
+            RequiredValidator(errorMessage: "emptyAmountField".localized)
+        ]
+    )
+
+    private(set) var isMaxAmount: Bool = false
+    private(set) lazy var form: [FormField] = [amountField]
+
+    var formCancellable: AnyCancellable?
+    var cancellables = Set<AnyCancellable>()
+
+    private let stakingService: SolanaStakingServiceProtocol
+    private let logger = Logger(
+        subsystem: "com.vultisig.app",
+        category: "solana-delegate-vm"
+    )
+
+    init(
+        coin: Coin,
+        vault: Vault,
+        stakingService: SolanaStakingServiceProtocol = SolanaStakingService()
+    ) {
+        self.coin = coin
+        self.vault = vault
+        self.stakingService = stakingService
+    }
+
+    func onLoad() {
+        setupForm()
+        amountField.validators.append(AmountBalanceValidator(balance: stakeableBalance))
+        Task { await loadRentReserve() }
+    }
+
+    private func loadRentReserve() async {
+        do {
+            let reserveLamports = try await stakingService.fetchRentReserve()
+            let divisor = pow(Decimal(10), coin.decimals)
+            rentReserve = Decimal(reserveLamports) / divisor
+        } catch {
+            logger.error("Rent reserve fetch failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Headroom-aware stakeable balance — reserves the network fee AND the
+    /// rent-exempt reserve the new stake account must hold, both drawn from the
+    /// liquid SOL balance, before letting the user delegate up to "max".
+    var stakeableBalance: Decimal {
+        let remaining = coin.balanceDecimal - feeDecimal - rentReserve
+        return remaining > 0 ? remaining : 0
+    }
+
+    /// Network fee for a delegate tx in human-decimal SOL. The delegate builds
+    /// create + initialize + delegate in one transaction; the base lamport fee
+    /// plus the priority fee is the same flat fee the transfer path uses.
+    var feeDecimal: Decimal {
+        let divisor = pow(Decimal(10), coin.decimals)
+        return Decimal(string: SolanaHelper.defaultFeeInLamports.description).map { $0 / divisor } ?? 0
+    }
+
+    /// Insufficient-funds pre-flight. When the spendable balance can't cover the
+    /// fee + rent reserve, `stakeableBalance` collapses to 0 and the amount
+    /// validator would reject every input with a misleading "amount exceeded";
+    /// this gates the builder and drives a clear inline message instead.
+    var hasSufficientBalanceForFee: Bool {
+        coin.balanceDecimal >= feeDecimal + rentReserve
+    }
+
+    var transactionBuilder: TransactionBuilder? {
+        validateErrors()
+        guard validForm, hasSufficientBalanceForFee, let validator = selectedValidator else { return nil }
+        return SolanaDelegateTransactionBuilder(
+            coin: coin,
+            amount: amountField.value.formatToDecimal(digits: coin.decimals),
+            sendMaxAmount: isMaxAmount,
+            votePubkey: validator.votePubkey
+        )
+    }
+
+    func onPercentage(_ percentage: Double) {
+        isMaxAmount = percentage == 100
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/ValidatorSelection/SolanaValidatorCard.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/ValidatorSelection/SolanaValidatorCard.swift
@@ -1,0 +1,125 @@
+//
+//  SolanaValidatorCard.swift
+//  VultisigApp
+//
+//  Per-validator row in the Solana validator-picker sheet. Mirrors the Cosmos
+//  `ValidatorCard` layout — avatar, name, activated stake as the subline,
+//  commission % on the right, optional check on selection — adapted for Solana
+//  vote-account rows. The avatar shows the metadata logo when present, else a
+//  deterministic monogram (same gradient circle as `KeybaseAvatarView`).
+//
+
+import SwiftUI
+
+struct SolanaValidatorCard: View {
+    let validator: SolanaValidator
+    let chainTicker: String
+    let chainDecimals: Int
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 12) {
+                avatar
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(validator.displayName)
+                        .font(Theme.fonts.bodySMedium)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                        .lineLimit(1)
+                    Text(activatedStakeText)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 8)
+                Text(commissionText)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .lineLimit(1)
+                if isSelected {
+                    Icon(named: "check", color: Theme.colors.alertSuccess, size: 16)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(background)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var avatar: some View {
+        ZStack {
+            monogramAvatar
+            if let url = validator.logoURL {
+                CachedAsyncImage(url: url, urlCache: .imageCache) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: 36, height: 36)
+                        .clipShape(Circle())
+                } placeholder: {
+                    Color.clear
+                }
+            }
+        }
+        .frame(width: 36, height: 36)
+    }
+
+    private var monogramAvatar: some View {
+        ZStack {
+            Circle()
+                .fill(
+                    LinearGradient(
+                        colors: [Theme.colors.primaryAccent3, Theme.colors.primaryAccent4],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            Text(monogram)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+        }
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        if isSelected {
+            Theme.colors.bgSurface1
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Theme.colors.alertSuccess.opacity(0.5), lineWidth: 1)
+                )
+        } else {
+            Theme.colors.bgSurface1
+        }
+    }
+
+    private var monogram: String {
+        String(validator.displayName.prefix(1)).uppercased()
+    }
+
+    private var activatedStakeText: String {
+        let display = formatStake(validator.activatedStake, decimals: chainDecimals)
+        return "\(display) \(chainTicker)"
+    }
+
+    private var commissionText: String {
+        "\(validator.commission)%"
+    }
+
+    /// Activated stake arrives in lamports; scale down by the chain's native
+    /// decimals and round to whole tokens for the subline.
+    private func formatStake(_ value: UInt64, decimals: Int) -> String {
+        let divisor = pow(Decimal(10), decimals)
+        let scaled = Decimal(value) / divisor
+        let nsNumber = NSDecimalNumber(decimal: scaled)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: nsNumber) ?? "0"
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/ValidatorSelection/SolanaValidatorSelectionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/ValidatorSelection/SolanaValidatorSelectionScreen.swift
@@ -1,0 +1,134 @@
+//
+//  SolanaValidatorSelectionScreen.swift
+//  VultisigApp
+//
+//  Validator-picker sheet for the Solana delegate flow. `SearchTextField` +
+//  scrollable `LazyVStack` of `SolanaValidatorCard`s with the selected-state
+//  stroke variant. Mirrors the Cosmos `ValidatorSelectionScreen` — tapping a
+//  row highlights it, then after a short delay commits the selection to the
+//  parent's binding and dismisses the sheet.
+//
+
+import SwiftUI
+
+struct SolanaValidatorSelectionScreen: View {
+    @Binding var isPresented: Bool
+    @Binding var selectedValidator: SolanaValidator?
+    let chainTicker: String
+    let chainDecimals: Int
+    @StateObject private var viewModel: SolanaValidatorSelectionViewModel
+    /// The highlighted row. Set immediately on tap so the selection is visible
+    /// during the brief delay before the sheet dismisses.
+    @State private var pickedValidator: SolanaValidator?
+    /// Drives the select-then-dismiss delay; cancelled if the user taps again
+    /// or closes the sheet before it fires.
+    @State private var selectionTask: Task<Void, Never>?
+
+    init(
+        isPresented: Binding<Bool>,
+        selectedValidator: Binding<SolanaValidator?>,
+        chainTicker: String,
+        chainDecimals: Int
+    ) {
+        self._isPresented = isPresented
+        self._selectedValidator = selectedValidator
+        self.chainTicker = chainTicker
+        self.chainDecimals = chainDecimals
+        self._viewModel = .init(wrappedValue: SolanaValidatorSelectionViewModel())
+    }
+
+    var body: some View {
+        content.sheetContainer()
+    }
+
+    private var content: some View {
+        Screen {
+            VStack(spacing: 8) {
+                SearchTextField(value: $viewModel.searchText)
+                columnHeader
+                ScrollView {
+                    if viewModel.isLoading {
+                        loadingView
+                    } else if let error = viewModel.error {
+                        ErrorMessage(text: error)
+                            .padding(.top, 48)
+                    } else if !viewModel.filteredValidators.isEmpty {
+                        list
+                    } else {
+                        ErrorMessage(text: "cosmosStakingNoValidatorsFound".localized)
+                            .padding(.top, 48)
+                    }
+                }
+                .cornerRadius(12)
+            }
+        }
+        .screenTitle("cosmosStakingSelectValidator".localized)
+        .screenBackButtonHidden()
+        .screenToolbar {
+            CustomToolbarItem(placement: .leading) {
+                ToolbarButton(image: "x") {
+                    isPresented.toggle()
+                }
+            }
+        }
+        .sheetStyle()
+        .onDisappear {
+            viewModel.searchText = ""
+            selectionTask?.cancel()
+        }
+        .onLoad {
+            pickedValidator = selectedValidator
+            Task { await viewModel.load() }
+        }
+    }
+
+    private var columnHeader: some View {
+        HStack {
+            Text("cosmosStakingValidatorPicker".localized)
+            Spacer()
+            Text("cosmosStakingValidatorCommission".localized)
+        }
+        .font(Theme.fonts.caption12)
+        .foregroundStyle(Theme.colors.textTertiary)
+        .padding(.horizontal, 14)
+    }
+
+    private var list: some View {
+        LazyVStack(spacing: 8) {
+            ForEach(viewModel.filteredValidators, id: \.votePubkey) { validator in
+                SolanaValidatorCard(
+                    validator: validator,
+                    chainTicker: chainTicker,
+                    chainDecimals: chainDecimals,
+                    isSelected: pickedValidator?.votePubkey == validator.votePubkey
+                ) {
+                    select(validator)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func select(_ validator: SolanaValidator) {
+        pickedValidator = validator
+        selectionTask?.cancel()
+        selectionTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            selectedValidator = validator
+            isPresented = false
+        }
+    }
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            SpinningLineLoader()
+                .scaleEffect(1.2)
+            Text("loading".localized)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textTertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, 48)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/ValidatorSelection/SolanaValidatorSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/ValidatorSelection/SolanaValidatorSelectionViewModel.swift
@@ -1,0 +1,77 @@
+//
+//  SolanaValidatorSelectionViewModel.swift
+//  VultisigApp
+//
+//  Backs the Solana validator-picker sheet. Loads the vote-account set from
+//  `SolanaStakingService`, enriches it with off-chain metadata via the
+//  swappable `ValidatorMetadataProvider` seam, filters delinquent validators
+//  out, sorts by activated stake descending, and surfaces search + selection
+//  state. Mirrors the Cosmos `ValidatorSelectionViewModel`.
+//
+
+import Foundation
+import OSLog
+
+@MainActor
+final class SolanaValidatorSelectionViewModel: ObservableObject {
+    @Published var searchText: String = ""
+    @Published private(set) var validators: [SolanaValidator] = []
+    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var error: String?
+
+    private let service: SolanaStakingServiceProtocol
+    private let metadataProvider: ValidatorMetadataProvider
+    private let logger = Logger(
+        subsystem: "com.vultisig.app",
+        category: "solana-validator-selection"
+    )
+
+    init(
+        service: SolanaStakingServiceProtocol = SolanaStakingService(),
+        metadataProvider: ValidatorMetadataProvider = StakewizValidatorMetadataProvider()
+    ) {
+        self.service = service
+        self.metadataProvider = metadataProvider
+    }
+
+    var filteredValidators: [SolanaValidator] {
+        guard searchText.isNotEmpty else { return validators }
+        let needle = searchText.lowercased()
+        return validators.filter { validator in
+            validator.displayName.lowercased().contains(needle)
+                || validator.votePubkey.lowercased().contains(needle)
+        }
+    }
+
+    func load() async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            let raw = try await service.fetchValidators()
+            let sorted = Self.sortAndFilter(raw)
+            // Enrichment never throws (provider contract) — degrade to the
+            // on-chain rows when metadata is unavailable.
+            let metadata = await metadataProvider.metadata(forVotePubkeys: sorted.map(\.votePubkey))
+            validators = sorted.map { validator in
+                guard let enrichment = metadata[validator.votePubkey] else { return validator }
+                var enriched = validator
+                enriched.metadata = enrichment
+                return enriched
+            }
+        } catch {
+            logger.error("Validator fetch failed: \(error.localizedDescription, privacy: .public)")
+            self.error = error.localizedDescription
+        }
+    }
+
+    /// Keeps non-delinquent validators that voted in the current epoch, sorted
+    /// by descending activated stake. Static so tests can pin the contract
+    /// independent of the network layer.
+    static func sortAndFilter(_ raw: [SolanaValidator]) -> [SolanaValidator] {
+        raw
+            .filter { !$0.isDelinquent && $0.epochVoteAccount }
+            .sorted { $0.activatedStake > $1.activatedStake }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Solana/DelegateTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Solana/DelegateTransactionBuilder.swift
@@ -1,0 +1,51 @@
+//
+//  DelegateTransactionBuilder.swift
+//  VultisigApp
+//
+//  Per-flow builder for a Solana native-staking delegate. A pure value-type
+//  carrier; the unsigned transaction bytes are produced lazily by
+//  `SolanaStakingSignDataResolver.resolve(...)` at Verify → KeysignPayload
+//  bridge time so the recent blockhash is always fresh. Analog of
+//  `CosmosDelegateTransactionBuilder`.
+//
+//  `memo = ""`, `transactionType = .unspecified` — the real intent travels via
+//  the `solanaStakingPayload` accessor.
+//
+
+import BigInt
+import Foundation
+import VultisigCommonData
+
+struct SolanaDelegateTransactionBuilder: TransactionBuilder {
+    let coin: Coin
+    let amount: String
+    let sendMaxAmount: Bool
+    let votePubkey: String
+
+    var memo: String { "" }
+
+    var memoFunctionDictionary: ThreadSafeDictionary<String, String> {
+        ThreadSafeDictionary<String, String>()
+    }
+
+    var transactionType: VSTransactionType { .unspecified }
+    var wasmContractPayload: WasmExecuteContractPayload? { nil }
+
+    /// `toAddress` doubles as the verify-screen "destination" — for a delegate
+    /// the validator vote account is what the user is staking to.
+    var toAddress: String { votePubkey }
+
+    var solanaStakingPayload: SolanaStakingPayload? {
+        let lamports = lamports(from: amount, decimals: coin.decimals)
+        return SolanaStakingPayload.delegate(votePubkey: votePubkey, lamports: lamports)
+    }
+
+    /// Converts a human-decimal SOL amount into lamports. Uses `BigInt` to
+    /// avoid `Double` rounding at the 9-decimal scale, then clamps to the
+    /// `UInt64` range the wallet-core stake proto expects.
+    private func lamports(from amount: String, decimals: Int) -> UInt64 {
+        let raw = amount.toBigInt(decimals: decimals)
+        guard raw > 0, raw <= BigInt(UInt64.max) else { return 0 }
+        return UInt64(raw)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/TransactionBuilder.swift
@@ -20,6 +20,10 @@ protocol TransactionBuilder {
     /// the per-flow Cosmos staking builders (delegate, undelegate, redelegate,
     /// withdrawRewards); every other builder uses the default `nil`.
     var cosmosStakingPayload: CosmosStakingPayload? { get }
+    /// Solana native-staking operation intent. Populated only by the Solana
+    /// staking builders (delegate today); every other builder uses the default
+    /// `nil`.
+    var solanaStakingPayload: SolanaStakingPayload? { get }
 }
 
 extension TransactionBuilder {
@@ -27,6 +31,9 @@ extension TransactionBuilder {
     /// requirement defaulted means every existing `TransactionBuilder`
     /// conformer compiles unchanged.
     var cosmosStakingPayload: CosmosStakingPayload? { nil }
+
+    /// Default — only Solana staking builders override this.
+    var solanaStakingPayload: SolanaStakingPayload? { nil }
 
     /// Builds the immutable `SendTransaction` struct directly. `gas` /
     /// `fee` and runtime-only fields default to the construction-time
@@ -49,12 +56,13 @@ extension TransactionBuilder {
             customGasLimit: nil,
             customByteFee: nil,
             sendMaxAmount: sendMaxAmount,
-            isStakingOperation: cosmosStakingPayload != nil,
+            isStakingOperation: cosmosStakingPayload != nil || solanaStakingPayload != nil,
             transactionType: transactionType,
             memoFunctionDictionary: memoFunctionDictionary.allItems(),
             wasmContractPayload: wasmContractPayload,
             feeCoin: SendTransaction.resolveFeeCoin(coin: coin, vault: vault),
-            cosmosStakingPayload: cosmosStakingPayload
+            cosmosStakingPayload: cosmosStakingPayload,
+            solanaStakingPayload: solanaStakingPayload
         )
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -127,6 +127,12 @@ extension KeysignPayload: ProtoMappable {
         // see nil and simply sign the relayed message hashes without claim UX.
         self.qbtcClaimPayload = nil
 
+        // Solana staking intent is local-only — signing rides the wallet-core
+        // signing-input bytes relayed via `signData = .signSolana`, so the peer
+        // device sees nil and signs those raw bytes directly. No commondata
+        // change is needed for the delegate flow.
+        self.solanaStakingPayload = nil
+
         // `isQbtcClaim` round-trips: the peer needs to know this is a claim
         // so it can derive the claimer's QBTC address from its own vault
         // (same SecureVault → same QBTC coin) and compute the BTC ECDSA hash

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
@@ -33,6 +33,13 @@ struct KeysignPayload: Codable, Hashable {
     /// and computes the message hash locally, refusing to blind-sign
     /// whatever the initiator asks for.
     let isQbtcClaim: Bool
+    /// Set on the initiating device when constructing a Solana native-staking
+    /// delegate. Local-only: not round-tripped through the proto `KeysignPayload`
+    /// (signing rides the wallet-core signing-input bytes relayed via
+    /// `signData = .signSolana`, not a relay field). The initiator reads it to
+    /// build the unsigned transaction once; peer devices see nil and sign the
+    /// relayed raw bytes. See `SolanaStakingSignDataResolver`.
+    let solanaStakingPayload: SolanaStakingPayload?
     let skipBroadcast: Bool
     let signData: SignData?
     let dappMetadata: DAppMetadata?
@@ -58,6 +65,7 @@ struct KeysignPayload: Codable, Hashable {
         tronTransferAssetContractPayload: TronTransferAssetContractPayload?,
         qbtcClaimPayload: QBTCClaimPayload?,
         isQbtcClaim: Bool,
+        solanaStakingPayload: SolanaStakingPayload? = nil,
         skipBroadcast: Bool,
         signData: SignData?,
         dappMetadata: DAppMetadata? = nil
@@ -79,6 +87,7 @@ struct KeysignPayload: Codable, Hashable {
         self.tronTransferAssetContractPayload = tronTransferAssetContractPayload
         self.qbtcClaimPayload = qbtcClaimPayload
         self.isQbtcClaim = isQbtcClaim
+        self.solanaStakingPayload = solanaStakingPayload
         self.skipBroadcast = skipBroadcast
         self.signData = signData
         self.dappMetadata = dappMetadata
@@ -108,6 +117,38 @@ struct KeysignPayload: Codable, Hashable {
             tronTransferAssetContractPayload: tronTransferAssetContractPayload,
             qbtcClaimPayload: qbtcClaimPayload,
             isQbtcClaim: isQbtcClaim,
+            solanaStakingPayload: solanaStakingPayload,
+            skipBroadcast: skipBroadcast,
+            signData: signData,
+            dappMetadata: dappMetadata
+        )
+    }
+
+    /// Returns a copy of the payload carrying the local-only Solana staking
+    /// intent. Used by the Verify → KeysignPayload bridge so the
+    /// transfer-shaped base payload from the keysign factory can be re-emitted
+    /// with the delegate payload (which drives the unsigned-tx build) without
+    /// duplicating the memberwise init at the call site.
+    func withSolanaStakingPayload(_ payload: SolanaStakingPayload) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: toAddress,
+            toAmount: toAmount,
+            chainSpecific: chainSpecific,
+            utxos: utxos,
+            memo: memo,
+            swapPayload: swapPayload,
+            approvePayload: approvePayload,
+            vaultPubKeyECDSA: vaultPubKeyECDSA,
+            vaultLocalPartyID: vaultLocalPartyID,
+            libType: libType,
+            wasmExecuteContractPayload: wasmExecuteContractPayload,
+            tronTransferContractPayload: tronTransferContractPayload,
+            tronTriggerSmartContractPayload: tronTriggerSmartContractPayload,
+            tronTransferAssetContractPayload: tronTransferAssetContractPayload,
+            qbtcClaimPayload: qbtcClaimPayload,
+            isQbtcClaim: isQbtcClaim,
+            solanaStakingPayload: payload,
             skipBroadcast: skipBroadcast,
             signData: signData,
             dappMetadata: dappMetadata
@@ -136,6 +177,7 @@ struct KeysignPayload: Codable, Hashable {
             tronTransferAssetContractPayload: tronTransferAssetContractPayload,
             qbtcClaimPayload: qbtcClaimPayload,
             isQbtcClaim: isQbtcClaim,
+            solanaStakingPayload: solanaStakingPayload,
             skipBroadcast: skipBroadcast,
             signData: signData,
             dappMetadata: dappMetadata
@@ -268,6 +310,7 @@ struct KeysignPayload: Codable, Hashable {
         tronTransferAssetContractPayload: nil,
         qbtcClaimPayload: nil,
         isQbtcClaim: false,
+        solanaStakingPayload: nil,
         skipBroadcast: false,
         signData: nil,
         dappMetadata: nil

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/SignSolana.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/SignSolana.swift
@@ -10,6 +10,10 @@ import VultisigCommonData
 struct SignSolana: Codable, Hashable {
     let rawTransactions: [String]  // base64 encoded
 
+    init(rawTransactions: [String]) {
+        self.rawTransactions = rawTransactions
+    }
+
     init(proto: VSSignSolana) {
         self.rawTransactions = proto.rawTransactions
     }

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -203,6 +203,13 @@ struct SendTransaction: Hashable {
     /// Local-only on iOS — does not round-trip through the proto-mappable
     /// `KeysignMessage` bridge (same posture as `qbtcClaimPayload`).
     let cosmosStakingPayload: CosmosStakingPayload?
+
+    /// Solana native-staking operation intent. Non-nil only for the Solana
+    /// delegate flow; populated by the per-flow `TransactionBuilder` and
+    /// consumed by the Verify → KeysignPayload bridge to produce the unsigned
+    /// transaction bytes. Local-only on iOS — same posture as
+    /// `cosmosStakingPayload`.
+    let solanaStakingPayload: SolanaStakingPayload?
 }
 
 extension SendTransaction {
@@ -227,7 +234,8 @@ extension SendTransaction {
             lhs.memoFunctionDictionary == rhs.memoFunctionDictionary &&
             lhs.wasmContractPayload == rhs.wasmContractPayload &&
             lhs.feeCoinSnapshot == rhs.feeCoinSnapshot &&
-            lhs.cosmosStakingPayload == rhs.cosmosStakingPayload
+            lhs.cosmosStakingPayload == rhs.cosmosStakingPayload &&
+            lhs.solanaStakingPayload == rhs.solanaStakingPayload
     }
 
     func hash(into hasher: inout Hasher) {
@@ -252,6 +260,7 @@ extension SendTransaction {
         hasher.combine(wasmContractPayload)
         hasher.combine(feeCoinSnapshot)
         hasher.combine(cosmosStakingPayload)
+        hasher.combine(solanaStakingPayload)
     }
 }
 
@@ -277,7 +286,8 @@ extension SendTransaction {
         memoFunctionDictionary: [String: String],
         wasmContractPayload: WasmExecuteContractPayload?,
         feeCoin: Coin,
-        cosmosStakingPayload: CosmosStakingPayload? = nil
+        cosmosStakingPayload: CosmosStakingPayload? = nil,
+        solanaStakingPayload: SolanaStakingPayload? = nil
     ) {
         self.coin = coin
         self.vault = vault
@@ -303,6 +313,7 @@ extension SendTransaction {
         self.feeCoin = feeCoin
         self.feeCoinSnapshot = SendCoinSnapshot(coin: feeCoin)
         self.cosmosStakingPayload = cosmosStakingPayload
+        self.solanaStakingPayload = solanaStakingPayload
     }
 }
 
@@ -370,7 +381,8 @@ extension SendTransaction {
         memoFunctionDictionary: [String: String]? = nil,
         wasmContractPayload: SendTransactionUpdate<WasmExecuteContractPayload?>? = nil,
         feeCoin: Coin? = nil,
-        cosmosStakingPayload: SendTransactionUpdate<CosmosStakingPayload?>? = nil
+        cosmosStakingPayload: SendTransactionUpdate<CosmosStakingPayload?>? = nil,
+        solanaStakingPayload: SendTransactionUpdate<SolanaStakingPayload?>? = nil
     ) -> SendTransaction {
         let resolvedVault = vault ?? self.vault
         let resolvedCoin = coin ?? self.coin
@@ -398,6 +410,10 @@ extension SendTransaction {
             guard let cosmosStakingPayload else { return self.cosmosStakingPayload }
             return cosmosStakingPayload.value
         }()
+        let resolvedSolanaStakingPayload: SolanaStakingPayload? = {
+            guard let solanaStakingPayload else { return self.solanaStakingPayload }
+            return solanaStakingPayload.value
+        }()
         return SendTransaction(
             coin: resolvedCoin,
             vault: resolvedVault,
@@ -419,7 +435,8 @@ extension SendTransaction {
             memoFunctionDictionary: memoFunctionDictionary ?? self.memoFunctionDictionary,
             wasmContractPayload: resolvedWasmContractPayload,
             feeCoin: feeCoin ?? self.feeCoin,
-            cosmosStakingPayload: resolvedCosmosStakingPayload
+            cosmosStakingPayload: resolvedCosmosStakingPayload,
+            solanaStakingPayload: resolvedSolanaStakingPayload
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -201,6 +201,30 @@ struct SendCryptoVerifyLogic {
                 return basePayload.withSignData(.signDirect(signDirect))
             }
 
+            // Solana native-staking branch — the per-flow builder produced a
+            // `solanaStakingPayload`. Build the unsigned delegate transaction
+            // once (pinning the recent blockhash + derived stake-account
+            // address) and relay it via `signData = .signSolana`. The local-only
+            // `solanaStakingPayload` is also attached so the verify summary and
+            // the initiator's helper have the intent, but byte parity rides the
+            // relayed raw bytes — peer devices sign those without the payload.
+            if let solanaStakingPayload = tx.solanaStakingPayload {
+                let payloadWithStaking = basePayload.withSolanaStakingPayload(solanaStakingPayload)
+                let stakingService = SolanaStakingService()
+                let rentReserve = try await stakingService.fetchRentReserve()
+                let knownVotePubkeys = Set(
+                    ((try? await stakingService.fetchValidators()) ?? []).map(\.votePubkey)
+                )
+                let balance = UInt64(tx.coin.rawBalance) ?? 0
+                let signSolana = try SolanaStakingSignDataResolver.resolve(
+                    basePayload: payloadWithStaking,
+                    rentReserve: rentReserve,
+                    knownVotePubkeys: knownVotePubkeys,
+                    balance: balance
+                )
+                return payloadWithStaking.withSignData(.signSolana(signSolana))
+            }
+
             return basePayload
 
         } catch {

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaDelegateByteParityTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaDelegateByteParityTests.swift
@@ -1,0 +1,164 @@
+//
+//  SolanaDelegateByteParityTests.swift
+//  VultisigAppTests
+//
+//  MPC byte-parity contract for the Solana delegate (stake) flow. Two
+//  independent builds of the same delegate input — built from a pinned recent
+//  blockhash and the wallet-core-derived stake-account address — must produce
+//  identical pre-image bytes, so both co-signing devices compute the same hash
+//  and the TSS ceremony proceeds. Also pins the delegate signing input wiring
+//  (oneof = delegateStakeTransaction, stake_account omitted).
+//
+
+@testable import VultisigApp
+import BigInt
+import WalletCore
+import XCTest
+
+final class SolanaDelegateByteParityTests: XCTestCase {
+
+    private let signerPrivateKeyHex = "8778cc93c6596387e751d2dc693bbd93e434bd233bc5b68a826c56131821cb63"
+    private let recentBlockHash = "11111111111111111111111111111111"
+
+    // MARK: - Fixtures
+
+    private func makeSignerKey() throws -> PrivateKey {
+        let keyData = try XCTUnwrap(Data(hexString: signerPrivateKeyHex))
+        return try XCTUnwrap(PrivateKey(data: keyData))
+    }
+
+    private func makeCoin(privateKey: PrivateKey) -> Coin {
+        let publicKey = privateKey.getPublicKeyEd25519()
+        let meta = CoinMeta(
+            chain: .solana,
+            ticker: "SOL",
+            logo: "solana",
+            decimals: 9,
+            priceProviderId: "solana",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(
+            asset: meta,
+            address: AnyAddress(publicKey: publicKey, coin: .solana).description,
+            hexPublicKey: publicKey.data.hexString
+        )
+    }
+
+    /// A structurally valid validator vote pubkey: a base58 ed25519 address
+    /// derived from a deterministic key. Distinct from the signer.
+    private func makeValidatorVotePubkey() throws -> String {
+        let keyData = Data(repeating: 0x37, count: 32)
+        let key = try XCTUnwrap(PrivateKey(data: keyData))
+        return AnyAddress(publicKey: key.getPublicKeyEd25519(), coin: .solana).description
+    }
+
+    private func makeDelegatePayload(privateKey: PrivateKey, votePubkey: String) -> KeysignPayload {
+        KeysignPayload(
+            coin: makeCoin(privateKey: privateKey),
+            toAddress: votePubkey,
+            toAmount: 2_000_000_000,
+            chainSpecific: .Solana(
+                recentBlockHash: recentBlockHash,
+                priorityFee: 1_000_000,
+                priorityLimit: 100_000,
+                fromAddressPubKey: nil,
+                toAddressPubKey: nil,
+                hasProgramId: false
+            ),
+            utxos: [],
+            memo: nil,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            vaultLocalPartyID: "localPartyID",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            solanaStakingPayload: .delegate(votePubkey: votePubkey, lamports: 2_000_000_000),
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    // MARK: - Byte parity
+
+    /// The core MPC guarantee: two independent builds of the same delegate input
+    /// produce identical pre-image bytes (the message both peers hash and sign).
+    func testTwoIndependentBuildsProduceIdenticalPreImageBytes() throws {
+        let privateKey = try makeSignerKey()
+        let votePubkey = try makeValidatorVotePubkey()
+
+        let payloadA = makeDelegatePayload(privateKey: privateKey, votePubkey: votePubkey)
+        let payloadB = makeDelegatePayload(privateKey: privateKey, votePubkey: votePubkey)
+
+        let hashesA = try SolanaHelper.getPreSignedImageHash(keysignPayload: payloadA)
+        let hashesB = try SolanaHelper.getPreSignedImageHash(keysignPayload: payloadB)
+
+        XCTAssertFalse(hashesA.isEmpty)
+        XCTAssertEqual(hashesA, hashesB)
+    }
+
+    /// The relayed-bytes contract: the unsigned transaction the resolver builds
+    /// (relayed via SignSolana) yields the SAME pre-image as the input-rebuild
+    /// path. This is what makes a peer device — which has no
+    /// `solanaStakingPayload`, only the relayed raw bytes — compute the same
+    /// hash as the initiator.
+    func testRelayedUnsignedTransactionMatchesInputRebuildPreImage() throws {
+        let privateKey = try makeSignerKey()
+        let votePubkey = try makeValidatorVotePubkey()
+        let payload = makeDelegatePayload(privateKey: privateKey, votePubkey: votePubkey)
+
+        // Initiator path: rebuild the input from the staking payload.
+        let initiatorHashes = try SolanaHelper.getPreSignedImageHash(keysignPayload: payload)
+
+        // Peer path: only the relayed raw bytes, no staking payload.
+        let rawTx = try SolanaHelper.buildDelegateUnsignedTransaction(keysignPayload: payload)
+        let peerHashes = try SolanaHelper.getPreSignedImageHashForRaw(base64Transaction: rawTx)
+
+        XCTAssertEqual(initiatorHashes, peerHashes)
+    }
+
+    // MARK: - Signing-input wiring
+
+    /// Pins the delegate oneof and the omitted stake_account — wallet-core
+    /// derives the stake-account address, so we must NOT set it.
+    func testDelegateSigningInputSetsOneofAndOmitsStakeAccount() throws {
+        let privateKey = try makeSignerKey()
+        let votePubkey = try makeValidatorVotePubkey()
+        let payload = makeDelegatePayload(privateKey: privateKey, votePubkey: votePubkey)
+
+        let inputData = try SolanaHelper.getPreSignedInputData(keysignPayload: payload)
+        let input = try SolanaSigningInput(serializedBytes: inputData)
+
+        guard case .delegateStakeTransaction(let delegate)? = input.transactionType else {
+            return XCTFail("expected delegateStakeTransaction oneof")
+        }
+        XCTAssertEqual(delegate.validatorPubkey, votePubkey)
+        XCTAssertEqual(delegate.value, 2_000_000_000)
+        XCTAssertTrue(delegate.stakeAccount.isEmpty, "stake_account must be omitted — wallet-core derives it")
+        XCTAssertEqual(input.recentBlockhash, recentBlockHash)
+        XCTAssertEqual(input.sender, payload.coin.address)
+    }
+
+    /// A different validator or amount must change the pre-image — guards
+    /// against a build that ignores the staking payload.
+    func testDistinctInputsProduceDistinctPreImages() throws {
+        let privateKey = try makeSignerKey()
+        let votePubkey = try makeValidatorVotePubkey()
+
+        let payload = makeDelegatePayload(privateKey: privateKey, votePubkey: votePubkey)
+        let baseHashes = try SolanaHelper.getPreSignedImageHash(keysignPayload: payload)
+
+        let otherPayload = payload.withSolanaStakingPayload(
+            .delegate(votePubkey: votePubkey, lamports: 3_000_000_000)
+        )
+        let otherHashes = try SolanaHelper.getPreSignedImageHash(keysignPayload: otherPayload)
+
+        XCTAssertNotEqual(baseHashes, otherHashes)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingSignDataResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingSignDataResolverTests.swift
@@ -1,0 +1,126 @@
+//
+//  SolanaStakingSignDataResolverTests.swift
+//  VultisigAppTests
+//
+//  Pins the delegate resolver: preflight gating, rent-reserve accounting, and
+//  that it emits a `SignSolana` carrying exactly one relayed raw transaction
+//  whose pre-image matches the input-rebuild path (byte parity).
+//
+
+@testable import VultisigApp
+import BigInt
+import WalletCore
+import XCTest
+
+final class SolanaStakingSignDataResolverTests: XCTestCase {
+
+    private let recentBlockHash = "11111111111111111111111111111111"
+
+    private func makeSignerKey() throws -> PrivateKey {
+        try XCTUnwrap(PrivateKey(data: Data(hexString: "8778cc93c6596387e751d2dc693bbd93e434bd233bc5b68a826c56131821cb63")!))
+    }
+
+    private func validatorVotePubkey() throws -> String {
+        let key = try XCTUnwrap(PrivateKey(data: Data(repeating: 0x37, count: 32)))
+        return AnyAddress(publicKey: key.getPublicKeyEd25519(), coin: .solana).description
+    }
+
+    private func makeCoin(privateKey: PrivateKey, rawBalance: String) -> Coin {
+        let publicKey = privateKey.getPublicKeyEd25519()
+        let meta = CoinMeta(
+            chain: .solana, ticker: "SOL", logo: "solana", decimals: 9,
+            priceProviderId: "solana", contractAddress: "", isNativeToken: true
+        )
+        let coin = Coin(
+            asset: meta,
+            address: AnyAddress(publicKey: publicKey, coin: .solana).description,
+            hexPublicKey: publicKey.data.hexString
+        )
+        coin.rawBalance = rawBalance
+        return coin
+    }
+
+    private func makePayload(
+        privateKey: PrivateKey,
+        votePubkey: String,
+        lamports: UInt64,
+        rawBalance: String
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: makeCoin(privateKey: privateKey, rawBalance: rawBalance),
+            toAddress: votePubkey,
+            toAmount: BigInt(lamports),
+            chainSpecific: .Solana(
+                recentBlockHash: recentBlockHash, priorityFee: 1_000_000, priorityLimit: 100_000,
+                fromAddressPubKey: nil, toAddressPubKey: nil, hasProgramId: false
+            ),
+            utxos: [], memo: nil, swapPayload: nil, approvePayload: nil,
+            vaultPubKeyECDSA: "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            vaultLocalPartyID: "localPartyID", libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil, tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil, tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil, isQbtcClaim: false,
+            solanaStakingPayload: .delegate(votePubkey: votePubkey, lamports: lamports),
+            skipBroadcast: false, signData: nil
+        )
+    }
+
+    func testResolveEmitsSingleRelayedTransactionWithMatchingPreImage() throws {
+        let privateKey = try makeSignerKey()
+        let votePubkey = try validatorVotePubkey()
+        let payload = makePayload(
+            privateKey: privateKey, votePubkey: votePubkey,
+            lamports: 2_000_000_000, rawBalance: "5000000000"
+        )
+
+        let signSolana = try SolanaStakingSignDataResolver.resolve(
+            basePayload: payload,
+            rentReserve: 2_282_880,
+            knownVotePubkeys: [votePubkey],
+            balance: 5_000_000_000
+        )
+
+        XCTAssertEqual(signSolana.rawTransactions.count, 1)
+        let relayedHashes = try SolanaHelper.getPreSignedImageHashForRaw(
+            base64Transaction: try XCTUnwrap(signSolana.rawTransactions.first)
+        )
+        let rebuildHashes = try SolanaHelper.getPreSignedImageHash(keysignPayload: payload)
+        XCTAssertEqual(relayedHashes, rebuildHashes)
+    }
+
+    func testRejectsWhenBalanceCannotCoverAmountPlusRentReserve() throws {
+        let privateKey = try makeSignerKey()
+        let votePubkey = try validatorVotePubkey()
+        let payload = makePayload(
+            privateKey: privateKey, votePubkey: votePubkey,
+            lamports: 2_000_000_000, rawBalance: "2000000000"
+        )
+
+        XCTAssertThrowsError(
+            try SolanaStakingSignDataResolver.resolve(
+                basePayload: payload,
+                rentReserve: 2_282_880,
+                knownVotePubkeys: [votePubkey],
+                balance: 2_000_000_000 // exactly the amount, no room for rent reserve
+            )
+        )
+    }
+
+    func testRejectsUnknownValidator() throws {
+        let privateKey = try makeSignerKey()
+        let votePubkey = try validatorVotePubkey()
+        let payload = makePayload(
+            privateKey: privateKey, votePubkey: votePubkey,
+            lamports: 2_000_000_000, rawBalance: "5000000000"
+        )
+
+        XCTAssertThrowsError(
+            try SolanaStakingSignDataResolver.resolve(
+                basePayload: payload,
+                rentReserve: 2_282_880,
+                knownVotePubkeys: ["SomeOtherValidator1111111111111111111111111"],
+                balance: 5_000_000_000
+            )
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaValidatorPreflightTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaValidatorPreflightTests.swift
@@ -1,0 +1,51 @@
+//
+//  SolanaValidatorPreflightTests.swift
+//  VultisigAppTests
+//
+//  Pins the vote-pubkey preflight: shape (base58 ed25519) + optional
+//  known-vote-set membership.
+//
+
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+final class SolanaValidatorPreflightTests: XCTestCase {
+
+    private func validVotePubkey() throws -> String {
+        let key = try XCTUnwrap(PrivateKey(data: Data(repeating: 0x37, count: 32)))
+        return AnyAddress(publicKey: key.getPublicKeyEd25519(), coin: .solana).description
+    }
+
+    func testValidAddressPassesShapeCheck() throws {
+        XCTAssertNoThrow(try SolanaValidatorPreflight.validate(try validVotePubkey()))
+    }
+
+    func testEmptyThrows() {
+        XCTAssertThrowsError(try SolanaValidatorPreflight.validate("")) { error in
+            XCTAssertEqual(error as? SolanaValidatorPreflight.SolanaValidatorError, .empty)
+        }
+    }
+
+    func testInvalidBase58Throws() {
+        // `0`, `O`, `I`, `l` are not in the base58 alphabet.
+        XCTAssertThrowsError(try SolanaValidatorPreflight.validate("not_a_valid_address_0OIl")) { error in
+            XCTAssertEqual(error as? SolanaValidatorPreflight.SolanaValidatorError, .invalidVotePubkey)
+        }
+    }
+
+    func testKnownSetMembershipEnforcedWhenProvided() throws {
+        let pubkey = try validVotePubkey()
+        XCTAssertNoThrow(try SolanaValidatorPreflight.validate(pubkey, knownVotePubkeys: [pubkey]))
+        XCTAssertThrowsError(
+            try SolanaValidatorPreflight.validate(pubkey, knownVotePubkeys: ["SomethingElse111111111111111111111111111111"])
+        ) { error in
+            XCTAssertEqual(error as? SolanaValidatorPreflight.SolanaValidatorError, .unknownValidator)
+        }
+    }
+
+    func testEmptyKnownSetSkipsMembership() throws {
+        let pubkey = try validVotePubkey()
+        XCTAssertNoThrow(try SolanaValidatorPreflight.validate(pubkey, knownVotePubkeys: []))
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of the Solana staking feature — the **first end-to-end signed** Solana native-staking operation. The user picks a validator vote account and amount; the app builds and signs a create-and-delegate transaction through the existing MPC keysign pipeline.

Closes #4661

Stacked on #4666 → #4665; base retargets to main as parents merge.

## Signing path

- **`SolanaHelper`** gains a stake-oneof builder alongside the transfer path: sets `SolanaSigningInput.delegateStakeTransaction = DelegateStake{ validatorPubkey, value }` with `stake_account` **omitted**, so wallet-core 4.6.13 derives the stake-account address and emits create + initialize + delegate in one transaction. Reuses `TransactionCompiler.preImageHashes` + `compileWithSignatures` unchanged.
- **`SolanaStakingSignDataResolver`** builds the unsigned delegate transaction once on the initiator — enforcing preflight + rent-reserve accounting (rent reserve from `getMinimumBalanceForRentExemption`, already in the read layer) — and relays it via `signData = .signSolana(rawTransactions)`.
- **`SolanaValidatorPreflight`** validates the vote pubkey is base58 ed25519 and, when the cached `getVoteAccounts` set is available, present in it.
- `KeysignPayload` / `SendTransaction` / `TransactionBuilder` gain a **local-only** `solanaStakingPayload` field (nil in `init(proto:)`), OR'd into `isStakingOperation`.
- UI: `SolanaDelegateTransactionScreen` + `…ViewModel`, with a Solana-adapted validator picker (`SolanaValidatorSelectionScreen` / `SolanaValidatorCard`) enriched via the `ValidatorMetadataProvider` seam from #4660.

## MPC byte-parity guarantee

Both co-signing devices must produce identical transaction bytes. The local-only `solanaStakingPayload` (validator + lamports) is **not** round-tripped to the peer. Instead the resolver pins the recent blockhash and the wallet-core-derived stake-account address into a single unsigned transaction and relays the raw bytes through the existing `signData.signSolana` field, which **does** round-trip. Every device then signs the byte-identical message via the existing, cross-platform-safe raw-Solana path — peer devices never rebuild the input from a non-round-tripped payload.

A byte-parity test asserts (1) two independent builds of the same delegate input produce identical pre-image bytes, and (2) the relayed-bytes path matches the input-rebuild path.

## No commondata change

Confirmed: signing rides the wallet-core Solana signing-input bytes relayed via the existing `signData.signSolana` field — **not** a new relay field. No `commondata` bump is needed for the delegate flow. `Blockchain/Tss/` is untouched; the stake path only sets the Solana signing input and reuses the keysign drivers as-is.

## Gate results

- **SwiftLint** (`--config VultisigApp/.swiftlint.yml`, all changed files): 0 violations, 0 serious.
- **`xcodebuild -scheme VultisigApp -destination 'platform=iOS Simulator,name=iPhone 16' build`**: **BUILD SUCCEEDED**. (One pre-existing `Form`-conformance main-actor-isolation *warning* on the new VM, identical to the established pattern in `CosmosDelegateTransactionViewModel` and the other staking VMs — not a new warning class.)
- **Tests**: 12/12 pass — `SolanaDelegateByteParityTests` (4, incl. the byte-parity assertion), `SolanaValidatorPreflightTests` (5), `SolanaStakingSignDataResolverTests` (3).
- `make generate` run after adding files.

## Deferred

- **Manual on-device e2e** (delegate SOL from a FastVault, verify the new stake account on a block explorer) — human step, not runnable here. Deferred.
- No DeFi-tab registration, no deactivate/withdraw/move-stake, no rewards-claim path (later PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)