### PR TITLE
fix(swap): stop double-counting LI.FI integrator fee in ranking

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapQuote+Ranking.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapQuote+Ranking.swift
@@ -14,7 +14,8 @@ extension SwapQuote {
     ///
     /// - THORChain/Maya: `expectedAmountOut` is already net of inbound + swap + outbound fees.
     /// - 1inch/KyberSwap: `dstAmount` is net of swap fees.
-    /// - LiFi: `dstAmount` minus integrator fee (charged on the output side).
+    /// - LiFi: `dstAmount` is already net of the integrator fee, which LI.FI takes from the
+    ///   source token (`fromToken`) and reflects in `estimate.toAmount` (`included: true`).
     ///
     /// Source-chain gas is intentionally excluded from this destination-side metric: folding it
     /// in would require a cross-asset price (source-native wei → destination token) the ranker
@@ -32,15 +33,10 @@ extension SwapQuote {
             return raw / toCoin.thorswapMultiplier
 
         case .oneinch(let quote, _),
-             .kyberswap(let quote, _):
+             .kyberswap(let quote, _),
+             .lifi(let quote, _, _):
             guard let raw = BigInt(quote.dstAmount), raw > 0 else { return nil }
             return toCoin.decimal(for: raw)
-
-        case .lifi(let quote, _, let integratorFee):
-            guard let raw = BigInt(quote.dstAmount), raw > 0 else { return nil }
-            let amount = toCoin.decimal(for: raw)
-            let fee = amount * (integratorFee ?? 0)
-            return amount - fee
 
         case .swapkit(let response, _, _):
             // SwapKit's `expectedBuyAmount` is already a decimal string in

--- a/VultisigApp/VultisigAppTests/Services/SwapQuoteRankingTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapQuoteRankingTests.swift
@@ -41,11 +41,12 @@ final class SwapQuoteRankingTests: XCTestCase {
         XCTAssertEqual(quote.expectedNetToAmount(toCoin: ethCoin()), Decimal(string: "0.03"))
     }
 
-    func test_expectedNetToAmount_lifi_subtractsIntegratorFeeFromOutput() {
-        // 0.03 ETH × (1 - 0.005) = 0.02985 ETH.
+    func test_expectedNetToAmount_lifi_dstAmountIsAlreadyNetOfIntegratorFee() {
+        // LI.FI's `toAmount`/`dstAmount` is already net of the integrator fee
+        // (taken from the source token), so it passes through unchanged.
         let quote: SwapQuote = .lifi(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil, integratorFee: Decimal(string: "0.005"))
 
-        XCTAssertEqual(quote.expectedNetToAmount(toCoin: ethCoin()), Decimal(string: "0.02985"))
+        XCTAssertEqual(quote.expectedNetToAmount(toCoin: ethCoin()), Decimal(string: "0.03"))
     }
 
     func test_expectedNetToAmount_lifi_nilIntegratorFee_returnsRawOutput() {


### PR DESCRIPTION
## Summary
- LI.FI's `estimate.toAmount` (our `dstAmount`) is **already net** of the integrator fee — LI.FI takes the fee from the source token (`fromToken`) and marks it `included: true`. The ranking branch in `SwapQuote+Ranking.swift` subtracted it a second time, understating LI.FI's ranked value by ~0.5%.
- This penalized LI.FI on cross-provider near-ties right at the in-band preference boundary, so provider selection could flip away from LI.FI incorrectly.
- Fold the `.lifi` case into the `.oneinch`/`.kyberswap` branch so `dstAmount` passes through unchanged; update the doc comment to reflect LI.FI's amount is already net.
- Replace the ranking test vector that encoded the double-counted value with one asserting the pass-through amount.

## Issue
Closes #4674

## Test Plan
- [x] SwiftLint passes (0 violations)
- [x] `SwapQuoteRankingTests` + `SwapProviderSelectionTests` pass (30 tests, 0 failures)
- [ ] xcodebuild build succeeds (test target built & ran clean)

## Cross-platform
Same defect exists on Android (`SwapQuoteManager.comparableDstFiat`, vultisig/vultisig-android#5045) and the SDK; the shared iOS test vectors propagated the error to both platforms.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap quote amount handling for LI.FI routes so the destination amount now matches the value shown in the quote, without an extra fee reduction being applied.
  * Updated related validation to reflect the corrected net amount calculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->