### PR TITLE
fix(qbtc): block GG20 vaults from QBTC claim with a clear message

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -852,6 +852,8 @@
 "qbtcClaimUnavailableDetail" = "Beansprüchen ist derzeit von der Chain deaktiviert. Bitte versuche es später erneut.";
 "qbtcClaimUnavailableTitle" = "Anspruch nicht verfügbar";
 "qbtcClaimUnsupportedAddressTitle" = "Nicht unterstützte Adresse";
+"qbtcClaimUnsupportedVaultDetail" = "Das Beanspruchen von QBTC wird mit dem älteren Schlüsseltyp dieses Vaults nicht unterstützt. Aktualisiere deinen Vault und versuche es dann erneut.";
+"qbtcClaimUnsupportedVaultTitle" = "Vault-Upgrade erforderlich";
 "qbtcClaimUtxoBlockFormat" = "Block #%d";
 "qbtcClaimUtxoPending" = "Bestätigung ausstehend";
 "quantumSecurityFeatureClaimSubtitle" = "Nach der Erzeugung erscheinen deine berechtigten BTC-UTXOs im Verhältnis 1:1 als beanspruchbare QBTC.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -859,6 +859,8 @@
 "qbtcClaimUnavailableDetail" = "Claiming is currently disabled by the chain. Please try again later.";
 "qbtcClaimUnavailableTitle" = "Claim unavailable";
 "qbtcClaimUnsupportedAddressTitle" = "Unsupported address";
+"qbtcClaimUnsupportedVaultDetail" = "Claiming QBTC isn't supported on this vault's older key type. Upgrade your vault, then try claiming again.";
+"qbtcClaimUnsupportedVaultTitle" = "Vault upgrade required";
 "qbtcClaimUtxoBlockFormat" = "Block #%d";
 "qbtcClaimUtxoPending" = "Pending confirmation";
 "quantumSecurityFeatureClaimSubtitle" = "Once generated, your eligible BTC UTXOs appear as claimable QBTC at a 1:1 ratio.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -852,6 +852,8 @@
 "qbtcClaimUnavailableDetail" = "Reclamar está actualmente desactivado por la cadena. Inténtalo de nuevo más tarde.";
 "qbtcClaimUnavailableTitle" = "Reclamo no disponible";
 "qbtcClaimUnsupportedAddressTitle" = "Dirección no admitida";
+"qbtcClaimUnsupportedVaultDetail" = "Reclamar QBTC no es compatible con el tipo de clave más antiguo de esta bóveda. Actualiza tu bóveda y vuelve a intentarlo.";
+"qbtcClaimUnsupportedVaultTitle" = "Se requiere actualizar la bóveda";
 "qbtcClaimUtxoBlockFormat" = "Bloque n.º %d";
 "qbtcClaimUtxoPending" = "Pendiente de confirmación";
 "quantumSecurityFeatureClaimSubtitle" = "Una vez generada, tus UTXOs de BTC elegibles aparecen como QBTC reclamable en proporción 1:1.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -852,6 +852,8 @@
 "qbtcClaimUnavailableDetail" = "Zahtijevanje je trenutno onemogućeno na lancu. Pokušaj ponovno kasnije.";
 "qbtcClaimUnavailableTitle" = "Zahtjev nedostupan";
 "qbtcClaimUnsupportedAddressTitle" = "Nepodržana adresa";
+"qbtcClaimUnsupportedVaultDetail" = "Zahtijevanje QBTC-a nije podržano za stariji tip ključa ovog sefa. Nadogradi svoj sef pa pokušaj ponovno.";
+"qbtcClaimUnsupportedVaultTitle" = "Potrebna je nadogradnja sefa";
 "qbtcClaimUtxoBlockFormat" = "Blok #%d";
 "qbtcClaimUtxoPending" = "Čeka potvrdu";
 "quantumSecurityFeatureClaimSubtitle" = "Nakon generiranja, prihvatljivi BTC UTXO-ovi pojavljuju se kao QBTC dostupan za polaganje u omjeru 1:1.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -852,6 +852,8 @@
 "qbtcClaimUnavailableDetail" = "Il riscatto è attualmente disabilitato dalla chain. Riprova più tardi.";
 "qbtcClaimUnavailableTitle" = "Riscatto non disponibile";
 "qbtcClaimUnsupportedAddressTitle" = "Indirizzo non supportato";
+"qbtcClaimUnsupportedVaultDetail" = "Il riscatto di QBTC non è supportato con il tipo di chiave più vecchio di questo vault. Aggiorna il tuo vault e riprova.";
+"qbtcClaimUnsupportedVaultTitle" = "Aggiornamento del vault richiesto";
 "qbtcClaimUtxoBlockFormat" = "Blocco #%d";
 "qbtcClaimUtxoPending" = "In attesa di conferma";
 "quantumSecurityFeatureClaimSubtitle" = "Una volta generata, i tuoi UTXO BTC idonei compaiono come QBTC reclamabili con rapporto 1:1.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -837,6 +837,8 @@
 "qbtcClaimUnavailableDetail" = "현재 체인에서 청구가 비활성화되어 있습니다. 나중에 다시 시도하세요.";
 "qbtcClaimUnavailableTitle" = "청구 불가";
 "qbtcClaimUnsupportedAddressTitle" = "지원되지 않는 주소";
+"qbtcClaimUnsupportedVaultDetail" = "이 보관함의 이전 키 유형에서는 QBTC 청구가 지원되지 않습니다. 보관함을 업그레이드한 후 다시 시도하세요.";
+"qbtcClaimUnsupportedVaultTitle" = "보관함 업그레이드 필요";
 "rawPayload" = "원시 페이로드";
 "ready" = "준비 완료";
 "Rebond" = "재본드";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -852,6 +852,8 @@
 "qbtcClaimUnavailableDetail" = "O resgate está atualmente desativado pela chain. Tente novamente mais tarde.";
 "qbtcClaimUnavailableTitle" = "Resgate indisponível";
 "qbtcClaimUnsupportedAddressTitle" = "Endereço não suportado";
+"qbtcClaimUnsupportedVaultDetail" = "O resgate de QBTC não é suportado com o tipo de chave mais antigo deste cofre. Atualize o seu cofre e tente resgatar novamente.";
+"qbtcClaimUnsupportedVaultTitle" = "Atualização do cofre necessária";
 "qbtcClaimUtxoBlockFormat" = "Bloco #%d";
 "qbtcClaimUtxoPending" = "Aguardando confirmação";
 "quantumSecurityFeatureClaimSubtitle" = "Uma vez gerada, seus UTXOs de BTC elegíveis aparecem como QBTC reivindicáveis na proporção 1:1.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -853,6 +853,8 @@
 "qbtcClaimUnavailableDetail" = "认领目前在链上被禁用。请稍后再试。";
 "qbtcClaimUnavailableTitle" = "认领不可用";
 "qbtcClaimUnsupportedAddressTitle" = "不支持的地址";
+"qbtcClaimUnsupportedVaultDetail" = "此保险库使用的旧密钥类型不支持认领 QBTC。请升级你的保险库后再试。";
+"qbtcClaimUnsupportedVaultTitle" = "需要升级保险库";
 "qbtcClaimUtxoBlockFormat" = "区块 #%d";
 "qbtcClaimUtxoPending" = "等待确认";
 "quantumSecurityFeatureClaimSubtitle" = "生成后，符合条件的 BTC UTXO 会以 1:1 比例显示为可领取的 QBTC。";

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimEligibilityChecker.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimEligibilityChecker.swift
@@ -138,7 +138,18 @@ final class QBTCClaimEligibilityChecker: ObservableObject {
     ///   - vaultPubKeyECDSA: Vault identifier scoping the cache so two
     ///     vaults with the same BTC address (rare but possible) can't
     ///     contaminate each other's cached state.
-    func check(btcCoin: Coin, vaultPubKeyECDSA: String) async {
+    ///   - vaultSupportsClaim: Whether the vault can run the DKLS BTC
+    ///     signing round the claim requires. GG20 vaults can't, so the
+    ///     banner / Claim button stay hidden for them.
+    func check(btcCoin: Coin, vaultPubKeyECDSA: String, vaultSupportsClaim: Bool = true) async {
+        // GG20 vaults can't complete the claim's DKLS round — keep the
+        // banner / Claim button hidden rather than surfacing an entry point
+        // that dead-ends at a keysign failure.
+        guard vaultSupportsClaim else {
+            state = .ineligible
+            return
+        }
+
         if let inFlightTask {
             await inFlightTask.value
             return

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/ViewModels/QBTCClaimViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/ViewModels/QBTCClaimViewModel.swift
@@ -27,6 +27,9 @@ enum QBTCClaimScreenState: Hashable {
 }
 
 enum QBTCClaimBlockedReason: Hashable {
+    /// The vault uses GG20 keyshares, which can't take part in the DKLS
+    /// BTC signing round the claim flow requires.
+    case unsupportedVaultType
     /// Chain returned `ClaimWithProofDisabled > 0`. Or query failed —
     /// fail-closed.
     case killSwitchClosed
@@ -182,6 +185,14 @@ final class QBTCClaimViewModel: ObservableObject {
             lastClaimError = nil
         }
         defer { isLoading = false }
+
+        // GG20 vaults can't run the DKLS BTC signing round the claim flow
+        // requires — block up front with a clear message instead of letting
+        // the user reach keysign and hit a cryptic DKLS retry failure.
+        guard vault.supportsQbtcClaim else {
+            state = .blocked(reason: .unsupportedVaultType)
+            return
+        }
 
         guard let btcCoin else {
             state = .blocked(reason: .missingCoin(chainName: "Bitcoin"))

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Views/QBTCClaimBlockedView.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Views/QBTCClaimBlockedView.swift
@@ -32,6 +32,8 @@ struct QBTCClaimBlockedView: View {
 
     private var iconName: String {
         switch reason {
+        case .unsupportedVaultType:
+            return "exclamationmark.shield.fill"
         case .unsupportedBtcAddress:
             return "exclamationmark.triangle.fill"
         case .killSwitchClosed, .utxoFetchFailed:
@@ -47,6 +49,8 @@ struct QBTCClaimBlockedView: View {
 
     private var title: String {
         switch reason {
+        case .unsupportedVaultType:
+            return "qbtcClaimUnsupportedVaultTitle".localized
         case .killSwitchClosed:
             return "qbtcClaimUnavailableTitle".localized
         case .missingCoin:
@@ -64,6 +68,8 @@ struct QBTCClaimBlockedView: View {
 
     private var detail: String {
         switch reason {
+        case .unsupportedVaultType:
+            return "qbtcClaimUnsupportedVaultDetail".localized
         case .killSwitchClosed:
             return "qbtcClaimUnavailableDetail".localized
         case .missingCoin(let chainName):

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -359,7 +359,8 @@ private extension ChainDetailScreen {
         }
         guard let btcCoin else { return }
         let vaultPubKey = vault.pubKeyECDSA
-        Task { await qbtcEligibility.check(btcCoin: btcCoin, vaultPubKeyECDSA: vaultPubKey) }
+        let supportsClaim = vault.supportsQbtcClaim
+        Task { await qbtcEligibility.check(btcCoin: btcCoin, vaultPubKeyECDSA: vaultPubKey, vaultSupportsClaim: supportsClaim) }
     }
 
     func updateBalances() async {

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -251,6 +251,21 @@ final class Vault: ObservableObject, Codable {
         }
     }
 
+    /// The QBTC claim signs its BTC ECDSA round exclusively via DKLS (see
+    /// `QBTCClaimRoundRunner`). GG20 keyshares can't take part in that
+    /// ceremony — a GG20 vault that tries to claim hangs and fails with a
+    /// DKLS "fail to download setup message" error — so the claim flow is
+    /// limited to DKLS-family vaults. A nil `libType` is a legacy GG20
+    /// vault and is therefore unsupported.
+    var supportsQbtcClaim: Bool {
+        switch libType {
+        case .DKLS, .KeyImport:
+            true
+        case .GG20, nil:
+            false
+        }
+    }
+
     func coins(for chain: Chain) -> [Coin] {
         coins.filter { $0.chain == chain }
     }

--- a/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimEligibilityCheckerTests.swift
+++ b/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimEligibilityCheckerTests.swift
@@ -119,6 +119,28 @@ final class QBTCClaimEligibilityCheckerTests: XCTestCase {
         XCTAssertEqual(chain.killSwitchCallCount, 1)
     }
 
+    // MARK: - 3b. Ineligible — vault can't run the DKLS claim round (GG20)
+
+    func testIneligibleWhenVaultUnsupported() async {
+        let blockchair = MockBlockchairService()
+        let chain = MockQBTCChainService()
+        blockchair.fetchHandler = { _, _ in [Self.utxoA, Self.utxoB] }
+        let checker = makeChecker(blockchair: blockchair, chain: chain)
+
+        await checker.check(
+            btcCoin: makeBtcCoin(),
+            vaultPubKeyECDSA: Self.testVaultPubKey,
+            vaultSupportsClaim: false
+        )
+
+        // GG20 vaults short-circuit to ineligible before any network work,
+        // so the banner / Claim button never appear and no calls are made.
+        XCTAssertEqual(checker.state, .ineligible)
+        XCTAssertFalse(checker.hasClaimableUtxos)
+        XCTAssertEqual(blockchair.fetchCallCount, 0)
+        XCTAssertEqual(chain.killSwitchCallCount, 0)
+    }
+
     // MARK: - 4. Ineligible — no UTXOs at all
 
     func testIneligibleWhenNoUtxos() async {


### PR DESCRIPTION
## Summary
GG20 vaults could reach the QBTC claim keysign stage and fail with the cryptic error **"DKLS sign message exhaust retries: fail to download setup message after 10 retry"**.

**Root cause:** the claim flow signs its BTC ECDSA round exclusively via DKLS (`QBTCClaimRoundRunner` / `QBTCClaimSecureVaultRoundDriver`), ignoring the vault's `libType`. A GG20 keyshare never produces the DKLS setup message, so the initiator's DKLS keysign loops on the relay and dies after 10 retries. Nothing gated the entry points on `libType`, so GG20 users only discovered the incompatibility at keysign time.

**Fix:** gate GG20 vaults up front at both entry points with a clear "upgrade your vault" message instead of a dead-end keysign failure.

- Add `Vault.supportsQbtcClaim` (DKLS/KeyImport only; GG20 / nil → unsupported).
- `QBTCClaimViewModel.load()` blocks GG20 early with a new `.unsupportedVaultType` reason, rendered by `QBTCClaimBlockedView`.
- `QBTCClaimEligibilityChecker.check` short-circuits to `.ineligible` with **zero** network calls (new defaulted `vaultSupportsClaim` param), so the promo banner and Claim button never appear for GG20 vaults.
- `ChainDetailScreen` passes `vault.supportsQbtcClaim`.
- New `qbtcClaimUnsupportedVaultTitle` / `...Detail` localized across all 8 locale files (sorted).

This is a deliberate product limitation: GG20 users must upgrade/reshare their vault to DKLS before claiming QBTC. The alternative (a GG20 signing branch in the claim runner) was considered and deferred.

## Test Plan
- [x] SwiftLint passes
- [x] Added `testIneligibleWhenVaultUnsupported` — GG20 → `.ineligible` with no network calls
- [ ] Manual: open QBTC/BTC chain detail on a GG20 vault → no promo banner / Claim button
- [ ] Manual: enter the claim screen on a GG20 vault → "Vault upgrade required" blocked message (no keysign attempt)
- [ ] Manual: DKLS vault still sees banner/button and can claim as before
- [ ] xcodebuild build succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized messages for QBTC claim flows in multiple languages.

* **Bug Fixes**
  * QBTC claim now clearly blocks unsupported vault types and shows a dedicated upgrade-required message.
  * Eligibility checks now stop early for incompatible vaults, avoiding unnecessary loading or failed claim attempts.
  * Wallet screens now reflect when a vault must be upgraded before claiming QBTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->