### PR TITLE
feat(banners): global TTL-based promo-banner dismissal

### DIFF
--- a/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
@@ -75,7 +75,8 @@ struct AppMigrationService {
     private func getAllMigrations() -> [AppMigration] {
         return [
             THORChainDuplicateTokensMigration(),
-            TonGramRebrandMigration()
+            TonGramRebrandMigration(),
+            PromoBannerDismissalMigration()
         ]
     }
 }

--- a/VultisigApp/VultisigApp/Core/Migration/Migrations/PromoBannerDismissalMigration.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/Migrations/PromoBannerDismissalMigration.swift
@@ -3,6 +3,7 @@
 //  VultisigApp
 //
 
+import Foundation
 import SwiftData
 
 /// Seeds the global `PromoBannerDismissalStore` from the two legacy permanent

--- a/VultisigApp/VultisigApp/Core/Migration/Migrations/PromoBannerDismissalMigration.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/Migrations/PromoBannerDismissalMigration.swift
@@ -25,6 +25,13 @@ import SwiftData
 /// Idempotency comes from `AppMigrationService` (Keychain-versioned, runs once)
 /// and is reinforced by the store's seed-if-absent semantics.
 struct PromoBannerDismissalMigration: @MainActor AppMigration {
+    /// Surfaced when the legacy per-vault store cannot be read. Throwing leaves
+    /// the migration version un-bumped so `AppMigrationService` retries on the
+    /// next launch rather than marking the carry-over as done with no data.
+    private enum MigrationError: Error {
+        case missingModelContext
+    }
+
     let version: Int = 2
 
     let description: String = "Seeding global promo-banner dismissals from legacy per-vault/app-wide storage"
@@ -43,7 +50,7 @@ struct PromoBannerDismissalMigration: @MainActor AppMigration {
     @MainActor
     func migrate() throws {
         let legacyAppBanners = readLegacyAppBanners()
-        let legacyVaultBanners = readLegacyVaultBanners()
+        let legacyVaultBanners = try readLegacyVaultBanners()
 
         store.migrateLegacyDismissals(
             legacyAppBanners: legacyAppBanners,
@@ -64,14 +71,12 @@ struct PromoBannerDismissalMigration: @MainActor AppMigration {
     }
 
     @MainActor
-    private func readLegacyVaultBanners() -> [String] {
+    private func readLegacyVaultBanners() throws -> [String] {
         guard let modelContext = Storage.shared.modelContext else {
-            return []
+            throw MigrationError.missingModelContext
         }
         let descriptor = FetchDescriptor<Vault>()
-        guard let vaults = try? modelContext.fetch(descriptor) else {
-            return []
-        }
+        let vaults = try modelContext.fetch(descriptor)
         var union = Set<String>()
         for vault in vaults {
             union.formUnion(vault.closedBanners)

--- a/VultisigApp/VultisigApp/Core/Migration/Migrations/PromoBannerDismissalMigration.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/Migrations/PromoBannerDismissalMigration.swift
@@ -1,0 +1,80 @@
+//
+//  PromoBannerDismissalMigration.swift
+//  VultisigApp
+//
+
+import SwiftData
+
+/// Seeds the global `PromoBannerDismissalStore` from the two legacy permanent
+/// dismissal stores so upgraders are not re-spammed:
+///
+/// - `appClosedBanners` (app-wide `UserDefaults`, JSON-encoded `[String]`) held
+///   the `followVultisig` dismissal.
+/// - `Vault.closedBanners` (per-vault SwiftData) held `upgradeVault` / `buyVult`
+///   (and the now-session-scoped `backupVault`).
+///
+/// Each TTL banner present in any legacy source is seeded with
+/// `dismissedAt = now`, so its TTL countdown restarts at upgrade time rather
+/// than firing immediately. The per-vault data is collapsed to global storage
+/// with OR-semantics (dismissed in any vault ⇒ globally dismissed) — the
+/// alternative re-spams multi-vault users. `backupVault` is intentionally not
+/// carried: it is now a session-scoped banner and should resurface once after
+/// upgrade while the vault is still un-backed-up.
+///
+/// Idempotency comes from `AppMigrationService` (Keychain-versioned, runs once)
+/// and is reinforced by the store's seed-if-absent semantics.
+struct PromoBannerDismissalMigration: @MainActor AppMigration {
+    let version: Int = 2
+
+    let description: String = "Seeding global promo-banner dismissals from legacy per-vault/app-wide storage"
+
+    private let store: PromoBannerDismissalStoring
+    private let defaults: UserDefaults
+
+    init(
+        store: PromoBannerDismissalStoring = PromoBannerDismissalStore.shared,
+        defaults: UserDefaults = .standard
+    ) {
+        self.store = store
+        self.defaults = defaults
+    }
+
+    @MainActor
+    func migrate() throws {
+        let legacyAppBanners = readLegacyAppBanners()
+        let legacyVaultBanners = readLegacyVaultBanners()
+
+        store.migrateLegacyDismissals(
+            legacyAppBanners: legacyAppBanners,
+            legacyVaultBanners: legacyVaultBanners,
+            now: Date()
+        )
+    }
+
+    /// `appClosedBanners` was written via `@AppStorage` over the retroactive
+    /// `Array: RawRepresentable` conformance, i.e. a JSON string under the key.
+    private func readLegacyAppBanners() -> [String] {
+        guard let raw = defaults.string(forKey: "appClosedBanners"),
+              let data = raw.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+        return decoded
+    }
+
+    @MainActor
+    private func readLegacyVaultBanners() -> [String] {
+        guard let modelContext = Storage.shared.modelContext else {
+            return []
+        }
+        let descriptor = FetchDescriptor<Vault>()
+        guard let vaults = try? modelContext.fetch(descriptor) else {
+            return []
+        }
+        var union = Set<String>()
+        for vault in vaults {
+            union.formUnion(vault.closedBanners)
+        }
+        return Array(union)
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Stores/PromoBannerDismissalStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/PromoBannerDismissalStore.swift
@@ -1,0 +1,121 @@
+//
+//  PromoBannerDismissalStore.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// App-wide, per-device record of which promo banners the user has dismissed.
+///
+/// Keyed by the banner's stable `dismissalID` (intent), never by vault — so a
+/// dismissal made on one vault is honored on every vault, and switching vaults
+/// can never resurface a banner before its rule allows it.
+///
+/// Two backends, chosen per banner by `BannerDismissalRule`:
+///
+/// - **TTL banners** persist `dismissalID -> dismissedAt` as JSON in
+///   `UserDefaults`. `isDismissed` is true while `now < dismissedAt + interval`.
+/// - **Session banners** (the backup reminder) route into an in-memory set that
+///   is never persisted. It starts empty every cold launch, so the banner
+///   reappears on the next launch while it is still eligible. Hidden for the
+///   rest of the current session so the many `setupBanners` re-runs
+///   (pull-to-refresh, throttled appear, vault switch, currency change) don't
+///   pop it straight back.
+protocol PromoBannerDismissalStoring: AnyObject {
+    func isDismissed(_ banner: VaultBannerType, now: Date) -> Bool
+    func dismiss(_ banner: VaultBannerType, now: Date)
+    /// Seeds the persistent store from legacy permanent dismissals so upgraders
+    /// are not re-spammed. Idempotent: never overwrites an existing entry.
+    func migrateLegacyDismissals(legacyAppBanners: [String], legacyVaultBanners: [String], now: Date)
+}
+
+final class PromoBannerDismissalStore: PromoBannerDismissalStoring, @unchecked Sendable {
+
+    static let shared = PromoBannerDismissalStore()
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let lock = NSLock()
+    /// In-memory, process-scoped dismissals for `.session`-ruled banners. Never
+    /// written to `defaults`, so it resets on every cold launch.
+    private var sessionDismissed: Set<String> = []
+
+    init(defaults: UserDefaults = .standard, storageKey: String = "promoBannerDismissals") {
+        self.defaults = defaults
+        self.storageKey = storageKey
+    }
+
+    func isDismissed(_ banner: VaultBannerType, now: Date) -> Bool {
+        switch banner.dismissalRule {
+        case .session:
+            lock.lock()
+            defer { lock.unlock() }
+            return sessionDismissed.contains(banner.dismissalID)
+        case .ttl(let interval):
+            guard let dismissedAt = persistentDismissals()[banner.dismissalID] else {
+                return false
+            }
+            return now < dismissedAt.addingTimeInterval(interval)
+        }
+    }
+
+    func dismiss(_ banner: VaultBannerType, now: Date) {
+        switch banner.dismissalRule {
+        case .session:
+            lock.lock()
+            sessionDismissed.insert(banner.dismissalID)
+            lock.unlock()
+        case .ttl:
+            var dict = persistentDismissals()
+            dict[banner.dismissalID] = now
+            persist(dict)
+        }
+    }
+
+    func migrateLegacyDismissals(legacyAppBanners: [String], legacyVaultBanners: [String], now: Date) {
+        // Only TTL banners carry over. The backup reminder is session-scoped:
+        // per product it should resurface each session while backup is missing,
+        // so its legacy permanent dismissal is intentionally dropped.
+        for banner in VaultBannerType.allCases {
+            let legacySources: [String]
+            switch banner {
+            case .followVultisig:
+                legacySources = legacyAppBanners
+            case .upgradeVault, .buyVult:
+                legacySources = legacyVaultBanners
+            case .backupVault:
+                continue
+            }
+            guard legacySources.contains(banner.rawValue) else { continue }
+            seedDismissedIfAbsent(banner, now: now)
+        }
+    }
+
+    // MARK: - Private
+
+    /// Writes `dismissedAt = now` only if no entry exists yet, so re-running the
+    /// migration never resets a countdown that already started.
+    private func seedDismissedIfAbsent(_ banner: VaultBannerType, now: Date) {
+        var dict = persistentDismissals()
+        guard dict[banner.dismissalID] == nil else { return }
+        dict[banner.dismissalID] = now
+        persist(dict)
+    }
+
+    private func persistentDismissals() -> [String: Date] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let data = defaults.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([String: Date].self, from: data) else {
+            return [:]
+        }
+        return decoded
+    }
+
+    private func persist(_ dict: [String: Date]) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let data = try? JSONEncoder().encode(dict) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Stores/PromoBannerDismissalStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/PromoBannerDismissalStore.swift
@@ -66,9 +66,9 @@ final class PromoBannerDismissalStore: PromoBannerDismissalStoring, @unchecked S
             sessionDismissed.insert(banner.dismissalID)
             lock.unlock()
         case .ttl:
-            var dict = persistentDismissals()
-            dict[banner.dismissalID] = now
-            persist(dict)
+            mutatePersistentDismissals { dict in
+                dict[banner.dismissalID] = now
+            }
         }
     }
 
@@ -96,26 +96,38 @@ final class PromoBannerDismissalStore: PromoBannerDismissalStoring, @unchecked S
     /// Writes `dismissedAt = now` only if no entry exists yet, so re-running the
     /// migration never resets a countdown that already started.
     private func seedDismissedIfAbsent(_ banner: VaultBannerType, now: Date) {
-        var dict = persistentDismissals()
-        guard dict[banner.dismissalID] == nil else { return }
-        dict[banner.dismissalID] = now
-        persist(dict)
+        mutatePersistentDismissals { dict in
+            guard dict[banner.dismissalID] == nil else { return }
+            dict[banner.dismissalID] = now
+        }
+    }
+
+    /// Loads, mutates, and persists the dismissal dictionary inside a single
+    /// lock scope so concurrent writers can't lose each other's updates across
+    /// a separate read-then-write window.
+    private func mutatePersistentDismissals(_ body: (inout [String: Date]) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var dict = decodePersistentDismissals()
+        body(&dict)
+
+        guard let data = try? JSONEncoder().encode(dict) else { return }
+        defaults.set(data, forKey: storageKey)
     }
 
     private func persistentDismissals() -> [String: Date] {
         lock.lock()
         defer { lock.unlock() }
+        return decodePersistentDismissals()
+    }
+
+    /// Decodes the persisted dictionary. Callers must already hold `lock`.
+    private func decodePersistentDismissals() -> [String: Date] {
         guard let data = defaults.data(forKey: storageKey),
               let decoded = try? JSONDecoder().decode([String: Date].self, from: data) else {
             return [:]
         }
         return decoded
-    }
-
-    private func persist(_ dict: [String: Date]) {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let data = try? JSONEncoder().encode(dict) else { return }
-        defaults.set(data, forKey: storageKey)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
@@ -15,12 +15,34 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
         rawValue
     }
 
-    var isAppBanner: Bool {
+    /// Stable, storage-facing identifier for this banner's dismissal intent.
+    /// Decoupled from `rawValue` so renaming a case never invalidates a
+    /// persisted dismissal.
+    var dismissalID: String {
         switch self {
-        case .upgradeVault, .backupVault, .buyVult:
-            return false
+        case .backupVault:
+            return "backup_vault_share"
+        case .upgradeVault:
+            return "upgrade_vault_dkls"
+        case .buyVult:
+            return "buy_vult_swap"
         case .followVultisig:
-            return true
+            return "follow_x_vultisig"
+        }
+    }
+
+    /// How long a dismissal of this banner is honored. `buyVult` resurfaces a
+    /// week later; `upgradeVault`/`followVultisig` a fortnight later; the
+    /// backup reminder is session-scoped and reappears each cold launch while
+    /// the vault is still un-backed-up.
+    var dismissalRule: BannerDismissalRule {
+        switch self {
+        case .buyVult:
+            return .ttl(.days(7))
+        case .backupVault:
+            return .session
+        case .upgradeVault, .followVultisig:
+            return .ttl(.days(15))
         }
     }
 
@@ -86,5 +108,22 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
         case .followVultisig:
             "follow-vultisig-banner-background"
         }
+    }
+}
+
+/// Per-banner rule governing how long a dismissal suppresses a promo banner.
+enum BannerDismissalRule: Equatable {
+    /// Suppressed until `dismissedAt + interval`; reappears once the interval
+    /// elapses. Backed by persistent (per-device) storage.
+    case ttl(TimeInterval)
+    /// Suppressed only for the current app session; reappears on the next cold
+    /// launch. Never persisted.
+    case session
+}
+
+extension TimeInterval {
+    /// A whole number of days expressed as a `TimeInterval` (seconds).
+    static func days(_ count: Int) -> TimeInterval {
+        TimeInterval(count) * 24 * 60 * 60
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -30,7 +30,11 @@ class VaultDetailViewModel: ObservableObject {
     // until the async refresh lands (~250ms debounce + network round trip).
     private var chainsVaultPubKeyECDSA: String?
 
-    @AppStorage("appClosedBanners") private var appClosedBanners: [String] = []
+    private let bannerStore: PromoBannerDismissalStoring
+
+    init(bannerStore: PromoBannerDismissalStoring = PromoBannerDismissalStore.shared) {
+        self.bannerStore = bannerStore
+    }
 
     func filteredChains(in vault: Vault) -> [Chain] {
         logic.filteredChains(searchText: searchText, chains: chains, vault: vault)
@@ -102,42 +106,18 @@ class VaultDetailViewModel: ObservableObject {
     }
 
     func setupBanners(for vault: Vault) {
-        vaultBanners = logic.setupBanners(for: vault, appClosedBanners: appClosedBanners)
+        vaultBanners = logic.setupBanners(for: vault, store: bannerStore)
     }
 
     @MainActor
     func removeBanner(for vault: Vault, banner: VaultBannerType) {
-        guard !banner.isAppBanner else {
-            appClosedBanners.append(banner.rawValue)
-            setupBanners(for: vault)
-            return
-        }
-
-        // `.buyVult` is only dismissed permanently once the vault holds at least
-        // the Silver-tier VULT amount. Below that, skip persistence so the banner
-        // returns the next time the user opens the vault screen (the carousel has
-        // already hidden it for the current visit).
-        if banner == .buyVult, !hasReachedSilverTier(vault: vault) {
-            return
-        }
-
-        vault.closedBanners = Array(Set(vault.closedBanners + [banner.rawValue]))
-        do {
-            try Storage.shared.save()
-            setupBanners(for: vault)
-        } catch {
-            print("Error while saving closedBanners for vault", error.localizedDescription)
-        }
+        bannerStore.dismiss(banner, now: Date())
+        setupBanners(for: vault)
     }
 
     func canShowChainSelection(vault: Vault) -> Bool {
         // Vault cannot change chains for KeyImport for now
         vault.libType != .KeyImport
-    }
-
-    private func hasReachedSilverTier(vault: Vault) -> Bool {
-        let vultBalance = VultTierService().getVultToken(for: vault)?.balanceDecimal ?? 0
-        return vultBalance >= VultDiscountTier.silver.balanceToUnlock
     }
 }
 
@@ -215,23 +195,21 @@ struct VaultDetailLogic {
         return chains.first
     }
 
-    func setupBanners(for vault: Vault, appClosedBanners: [String]) -> [VaultBannerType] {
+    func setupBanners(
+        for vault: Vault,
+        store: PromoBannerDismissalStoring,
+        now: Date = Date()
+    ) -> [VaultBannerType] {
         return VaultBannerType.allCases
             .filter { banner in
-                if banner.isAppBanner && appClosedBanners.contains(banner.rawValue) {
-                    return false
-                } else if vault.closedBanners.contains(banner.rawValue) {
-                    return false
-                }
+                guard !store.isDismissed(banner, now: now) else { return false }
 
                 switch banner {
                 case .backupVault:
                     return !vault.isBackedUp
                 case .upgradeVault:
                     return vault.libType == .GG20
-                case .buyVult:
-                    return true
-                case .followVultisig:
+                case .buyVult, .followVultisig:
                     return true
                 }
             }

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -25,6 +25,10 @@ final class Vault: ObservableObject, Codable {
     var order: Int = 0
     var isBackedUp: Bool = false
     var libType: LibType? = LibType.GG20
+    /// Deprecated: legacy per-vault promo-banner dismissals. Superseded by the
+    /// app-wide `PromoBannerDismissalStore`; read only once at launch by
+    /// `PromoBannerDismissalMigration`. Kept in the schema to avoid a SwiftData
+    /// migration; remove behind a versioned schema stage in a later release.
     var closedBanners: [String] = []
     var defiChains: [Chain] = []
     var isCircleEnabled: Bool = true  // Controls Circle visibility in DeFi section

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -27,6 +27,7 @@
 //       equal inputs are `==` (Equatable rows).
 //
 
+import Foundation
 import XCTest
 @testable import VultisigApp
 

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -205,7 +205,192 @@ final class VaultDetailViewModelTests: XCTestCase {
                       "Chain still resolves by name")
     }
 
+    // MARK: - Promo banner dismissal: global store + per-banner rule
+
+    /// AC: a dismissal made against one vault must not resurface when the user
+    /// switches to a different vault. The store is keyed by intent, never by
+    /// vault, so this holds structurally.
+    func testDismissedBanner_doesNotResurfaceOnVaultSwitch() {
+        let store = makeStore()
+        let logic = VaultDetailLogic()
+        let vaultA = makeVault(pubKey: "vault-a", chains: [.bitcoin])
+        let vaultB = makeVault(pubKey: "vault-b", chains: [.solana])
+
+        store.dismiss(.buyVult, now: fixedNow)
+
+        let bannersA = logic.setupBanners(for: vaultA, store: store, now: fixedNow)
+        let bannersB = logic.setupBanners(for: vaultB, store: store, now: fixedNow)
+
+        XCTAssertFalse(bannersA.contains(.buyVult))
+        XCTAssertFalse(bannersB.contains(.buyVult),
+                       "A dismissal must hold across vaults — the store has no vault key")
+    }
+
+    /// AC: different intents are independent — dismissing one banner does not
+    /// suppress another.
+    func testDismiss_isPerIntent_doesNotSuppressOtherBanners() {
+        let store = makeStore()
+
+        store.dismiss(.buyVult, now: fixedNow)
+
+        XCTAssertTrue(store.isDismissed(.buyVult, now: fixedNow))
+        XCTAssertFalse(store.isDismissed(.followVultisig, now: fixedNow),
+                       "Follow banner must stay visible when only buyVult was dismissed")
+    }
+
+    /// AC: per-banner TTL. buyVult is 7 days — dismissed at day 6, shown again
+    /// at day 8. The boundary (exactly dismissedAt + interval) re-shows.
+    func testBuyVultTTL_sevenDayBoundary() {
+        let store = makeStore()
+        store.dismiss(.buyVult, now: fixedNow)
+
+        XCTAssertTrue(store.isDismissed(.buyVult, now: fixedNow.addingTimeInterval(.days(6))))
+        XCTAssertFalse(store.isDismissed(.buyVult, now: fixedNow.addingTimeInterval(.days(7))),
+                       "At exactly dismissedAt + TTL the banner re-shows")
+        XCTAssertFalse(store.isDismissed(.buyVult, now: fixedNow.addingTimeInterval(.days(8))))
+    }
+
+    /// AC: per-banner TTL. upgrade and follow are 15 days.
+    func testUpgradeAndFollowTTL_fifteenDayBoundary() {
+        let store = makeStore()
+        store.dismiss(.upgradeVault, now: fixedNow)
+        store.dismiss(.followVultisig, now: fixedNow)
+
+        for banner in [VaultBannerType.upgradeVault, .followVultisig] {
+            XCTAssertTrue(store.isDismissed(banner, now: fixedNow.addingTimeInterval(.days(14))))
+            XCTAssertFalse(store.isDismissed(banner, now: fixedNow.addingTimeInterval(.days(15))),
+                           "At exactly dismissedAt + TTL the banner re-shows")
+            XCTAssertFalse(store.isDismissed(banner, now: fixedNow.addingTimeInterval(.days(16))))
+        }
+    }
+
+    /// AC: an expired dismissal is ignored and the banner shows again
+    /// (eligibility permitting).
+    func testExpiredDismissal_showsBannerAgain() {
+        let store = makeStore()
+        let logic = VaultDetailLogic()
+        let vault = makeVault(pubKey: "vault-a", chains: [.bitcoin])
+
+        store.dismiss(.buyVult, now: fixedNow)
+
+        let withinTTL = logic.setupBanners(for: vault, store: store, now: fixedNow.addingTimeInterval(.days(6)))
+        XCTAssertFalse(withinTTL.contains(.buyVult), "Still suppressed inside the 7-day window")
+
+        let afterTTL = logic.setupBanners(for: vault, store: store, now: fixedNow.addingTimeInterval(.days(8)))
+        XCTAssertTrue(afterTTL.contains(.buyVult), "Expired dismissal must let the banner show again")
+    }
+
+    /// Backup session rule: dismissed for the rest of the session, but a fresh
+    /// store instance (a new cold launch) does not see it — it never persists.
+    func testBackupSessionRule_hidesWithinSession_resetsOnNewSession() {
+        let defaults = makeDefaults()
+        let session1 = makeStore(defaults: defaults)
+        let logic = VaultDetailLogic()
+        let vault = makeVault(pubKey: "vault-a", chains: [.bitcoin]) // not backed up
+
+        XCTAssertTrue(logic.setupBanners(for: vault, store: session1, now: fixedNow).contains(.backupVault))
+
+        session1.dismiss(.backupVault, now: fixedNow)
+        XCTAssertTrue(session1.isDismissed(.backupVault, now: fixedNow))
+        XCTAssertFalse(logic.setupBanners(for: vault, store: session1, now: fixedNow).contains(.backupVault),
+                       "Backup banner is hidden for the rest of the session after dismissal")
+
+        // New cold launch == new store instance over the SAME persisted defaults.
+        let session2 = makeStore(defaults: defaults)
+        XCTAssertFalse(session2.isDismissed(.backupVault, now: fixedNow),
+                       "Session dismissals never persist, so a new launch re-shows the backup banner")
+        XCTAssertTrue(logic.setupBanners(for: vault, store: session2, now: fixedNow).contains(.backupVault))
+    }
+
+    /// Eligibility still gates the backup banner: a backed-up vault never shows
+    /// it, even before any dismissal.
+    func testBackupBanner_backedUpVaultNeverShows() {
+        let store = makeStore()
+        let logic = VaultDetailLogic()
+        let vault = makeVault(pubKey: "vault-a", chains: [.bitcoin])
+        vault.isBackedUp = true
+
+        XCTAssertFalse(logic.setupBanners(for: vault, store: store, now: fixedNow).contains(.backupVault),
+                       "A backed-up vault must never show the backup reminder")
+    }
+
+    // MARK: - Promo banner dismissal: migration
+
+    /// AC: migration is safe. Legacy app-wide `followVultisig` becomes a 15-day
+    /// TTL dismissal, suppressed inside the window and shown again after it.
+    func testMigration_seedsFollowFromLegacyAppBanners() {
+        let store = makeStore()
+
+        store.migrateLegacyDismissals(legacyAppBanners: ["followVultisig"], legacyVaultBanners: [], now: fixedNow)
+
+        XCTAssertTrue(store.isDismissed(.followVultisig, now: fixedNow.addingTimeInterval(.days(14))))
+        XCTAssertFalse(store.isDismissed(.followVultisig, now: fixedNow.addingTimeInterval(.days(16))))
+    }
+
+    /// AC: per-vault legacy data collapses to global with OR-semantics — a
+    /// banner dismissed in any vault is globally suppressed.
+    func testMigration_seedsUpgradeAndBuyVultFromVaultUnion() {
+        let store = makeStore()
+        let logic = VaultDetailLogic()
+        let vault = makeVault(pubKey: "vault-x", chains: [.bitcoin])
+
+        store.migrateLegacyDismissals(legacyAppBanners: [],
+                                      legacyVaultBanners: ["buyVult", "upgradeVault"],
+                                      now: fixedNow)
+
+        XCTAssertTrue(store.isDismissed(.buyVult, now: fixedNow))
+        XCTAssertTrue(store.isDismissed(.upgradeVault, now: fixedNow))
+        XCTAssertFalse(logic.setupBanners(for: vault, store: store, now: fixedNow).contains(.buyVult))
+    }
+
+    /// Legacy `backupVault` dismissal is intentionally NOT carried — backup is
+    /// session-scoped and should resurface after upgrade while still missing.
+    func testMigration_skipsLegacyBackupDismissal() {
+        let store = makeStore()
+        let logic = VaultDetailLogic()
+        let vault = makeVault(pubKey: "vault-a", chains: [.bitcoin]) // not backed up
+
+        store.migrateLegacyDismissals(legacyAppBanners: [], legacyVaultBanners: ["backupVault"], now: fixedNow)
+
+        XCTAssertFalse(store.isDismissed(.backupVault, now: fixedNow),
+                       "Legacy backup dismissal must not carry into the session store")
+        XCTAssertTrue(logic.setupBanners(for: vault, store: store, now: fixedNow).contains(.backupVault))
+    }
+
+    /// AC: migration runs once and must not reset timestamps. A second run at a
+    /// later instant leaves the original countdown intact.
+    func testMigration_isIdempotent_doesNotResetTimestamps() {
+        let store = makeStore()
+
+        store.migrateLegacyDismissals(legacyAppBanners: [], legacyVaultBanners: ["buyVult"], now: fixedNow)
+        // Re-run 3 days later — must NOT restart the 7-day countdown.
+        store.migrateLegacyDismissals(legacyAppBanners: [],
+                                      legacyVaultBanners: ["buyVult"],
+                                      now: fixedNow.addingTimeInterval(.days(3)))
+
+        // 8 days after the FIRST seed it is expired. Had the second run reset
+        // the timestamp to day 3, it would still be suppressed here (day 3 + 7).
+        XCTAssertFalse(store.isDismissed(.buyVult, now: fixedNow.addingTimeInterval(.days(8))),
+                       "Second migration run must not restart the TTL countdown")
+    }
+
     // MARK: - Helpers
+
+    /// A fixed reference instant so TTL boundary math is deterministic.
+    private var fixedNow: Date { Date(timeIntervalSince1970: 1_700_000_000) }
+
+    /// A fresh, empty `UserDefaults` domain per call so tests never collide with
+    /// each other or with `.standard`.
+    private func makeDefaults(_ name: String = UUID().uuidString) -> UserDefaults {
+        let suite = "promo-banner-tests-\(name)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private func makeStore(defaults: UserDefaults? = nil) -> PromoBannerDismissalStore {
+        PromoBannerDismissalStore(defaults: defaults ?? makeDefaults(), storageKey: "promoBannerDismissals")
+    }
 
     /// Build a Vault populated with native coins for the requested chains.
     /// `chainsWithCoins` is what `VaultDetailLogic.sortedChains(vault:)` reads


### PR DESCRIPTION
## Problem
Promo-banner dismissal was split across two permanent stores: an app-wide `@AppStorage("appClosedBanners")` (UserDefaults) and a per-vault `Vault.closedBanners` (SwiftData). The same banner could reappear when switching vaults, others never came back, and there was no cooldown/TTL concept.

## Current mixed-storage map (before)
| Banner | Stored in | Lifetime |
|---|---|---|
| `followVultisig` (`isAppBanner`) | `appClosedBanners` (app-wide) | permanent |
| `upgradeVault` | `vault.closedBanners` (per-vault) | permanent |
| `buyVult` | `vault.closedBanners` if Silver+, else not persisted | permanent (Silver+) / session-ish (below) |
| `backupVault` | `vault.closedBanners` (per-vault) | permanent |

## Fix
- **Global store** — new `PromoBannerDismissalStore` keyed by a stable banner intent id (`backup_vault_share` / `upgrade_vault_dkls` / `buy_vult_swap` / `follow_x_vultisig`), decoupled from the enum `rawValue`. No vault component, so switching vaults can never resurface a dismissed banner. Persistent `[id: dismissedAt]` JSON lives under a **new** UserDefaults key `promoBannerDismissals` (no collision with `CircleSetupView`'s reuse of `appClosedBanners`).
- **Per-banner TTL** — rule lives on `VaultBannerType.dismissalRule`: `buyVult` = 7d, `upgrade`/`follow` = 15d, `backup` = session. `isDismissed` is `now < dismissedAt + interval` (boundary re-shows).
- **Backup session rule** — `backupVault` dismissal routes into an in-memory, process-scoped `Set` that is **never** persisted; hidden for the rest of the current session (so the many `setupBanners` re-runs from pull-to-refresh / throttled appear / vault switch / currency change don't pop it straight back), and re-shown on the next cold launch while `!vault.isBackedUp`. The existing eligibility gate still suppresses it entirely for backed-up vaults.
- **Pure logic** — `setupBanners`/`removeBanner` are now pure over `(vault, store, now)`. Dropped the `isAppBanner` branch and the below-Silver `buyVult` special-case (`buyVult` is now uniformly 7d; the tier gate is gone). `VaultBannerType.isAppBanner` and `VaultDetailViewModel.hasReachedSilverTier` were removed (`VultTierService` stays — still used for tier display + swap).
- **Migration** — one-shot, via the existing `AppMigrationService` (Keychain-versioned, idempotent, runs once at launch) as migration **v2**. Seeds `follow_x_vultisig` from legacy `appClosedBanners`, OR-unions every vault's `closedBanners` to seed `upgrade`/`buyVult` at `dismissedAt = now`, and **skips** legacy `backupVault` (its session resurfacing is intended). Seed-if-absent semantics reinforce idempotency.
- `Vault.closedBanners` is **kept** (deprecated comment, read once at migration). Removing a stored SwiftData attribute is a schema change with no current versioned-schema stage for it; deferred to a later PR.

## Product choice to confirm (resolved-but-confirmable)
The backup "session" rule is implemented as **cold-launch = new process** (the plan's recommendation): a foreground-from-background does **not** re-show the backup banner, only a fresh launch does. The more aggressive alternative (reset the session set on every `scenePhase -> .active`) is a one-line change if product prefers it. Flagging for confirmation.

## Verification status
- `swiftlint --config VultisigApp/.swiftlint.yml` clean on all changed/new files.
- `make generate` re-run (new sources); `project.pbxproj` is gitignored.
- Local `make test` intentionally not run (shared build SIGTERMs under parallel load). Relying on GitHub CI ("Build & analyze (macOS)" + "Build, analyze & test (iOS)") — see checks on this PR.
- Tests extend `VaultDetailViewModelTests` covering all 5 acceptance checks: vault-switch non-resurfacing, per-banner TTL boundaries, expired-vs-active, backup session reset on new session + eligibility gate, and migration safety/idempotency (using an injected in-memory `UserDefaults` + fixed `now`).

Closes #4678

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promo banners now use consistent, per-banner dismissal rules: some hide for a time-limited period, while others hide only for the current session.
  * Banner dismissal is now managed centrally, so hiding can carry across vault switches.

* **Bug Fixes**
  * Legacy banner dismissals are migrated during updates to prevent previously dismissed banners from unexpectedly reappearing.
  * Dismissal timing follows precise TTL boundaries (including correct behavior right at expiry).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->