### PR TITLE
feat(qbtc): derive Bitcoin/QBTC claim accounts on the fly (#4679)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignDiscoveryViewModel.swift
@@ -124,7 +124,10 @@ class KeysignDiscoveryViewModel: ObservableObject {
                 // both devices share the same hash. The claimer's QBTC
                 // address comes from this device's own vault.
                 let btcCoin = keysignPayload.coin
-                if let qbtcCoin = vault.nativeCoin(for: .qbtc),
+                // Resolve QBTC from this device's own vault, deriving it
+                // in-memory when the chain isn't enabled so both devices
+                // share the same claimer address (and thus the same hash).
+                if let qbtcCoin = try? QBTCClaimCoinResolver().resolve(vault: vault, chain: .qbtc),
                    let compressedPubkey = Data(hexString: btcCoin.hexPublicKey) {
                     do {
                         let hashes = try QBTCClaimHashes.computeAll(

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimCoinResolver.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimCoinResolver.swift
@@ -1,0 +1,97 @@
+//
+//  QBTCClaimCoinResolver.swift
+//  VultisigApp
+//
+//  Resolves the Bitcoin and QBTC accounts a QBTC claim is derived from.
+//  Neither chain has to be enabled in the vault: an already-enabled
+//  native coin is used as-is, otherwise the account is derived in-memory
+//  from the native-token template + the vault's own keys via the pure,
+//  non-persisting `CoinFactory.create` (the same precedent
+//  `SwapCryptoLogic.getDefaultCoin` uses). Nothing is appended to
+//  `vault.coins` or written to storage — the resolved coins stay local
+//  to the claim flow, so the deterministic claim hash is identical to
+//  the one computed when the chains are enabled.
+//
+//  Bitcoin (ECDSA) derives for any standard vault; QBTC (MLDSA) requires
+//  a non-empty `publicKeyMLDSA44`, so the only genuine failure is a
+//  non-quantum vault — surfaced as `Error.derivationFailed`.
+//
+
+import Foundation
+
+@MainActor
+struct QBTCClaimCoinResolver {
+
+    /// `nonisolated` so the resolver can be default-constructed as an
+    /// initializer argument (default arguments are evaluated in a
+    /// nonisolated context). The synthesized initializer can't be used —
+    /// it would inherit `@MainActor` and fail as a default argument — so
+    /// this explicit one is required despite looking redundant. The
+    /// stateful work (the `@Model`-reading `resolve` methods) stays
+    /// main-actor isolated.
+    nonisolated init() {} // swiftlint:disable:this unneeded_synthesized_initializer
+
+    enum Error: LocalizedError, Equatable {
+        /// The native coin for `chainName` is neither enabled nor
+        /// derivable from the vault's keys (e.g. a non-quantum vault has
+        /// no MLDSA-44 key to derive the QBTC account).
+        case derivationFailed(chainName: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .derivationFailed(let chainName):
+                return String(format: "qbtcClaimMissingCoinDetail".localized, chainName)
+            }
+        }
+    }
+
+    /// The Bitcoin and QBTC accounts a QBTC claim is derived from.
+    struct Coins: Equatable {
+        let btc: Coin
+        let qbtc: Coin
+    }
+
+    /// Resolves both accounts the claim needs. Throws on the first chain
+    /// that can't be resolved.
+    func resolve(vault: Vault) throws -> Coins {
+        Coins(
+            btc: try resolve(vault: vault, chain: .bitcoin),
+            qbtc: try resolve(vault: vault, chain: .qbtc)
+        )
+    }
+
+    /// Returns the enabled native coin for `chain` if present, otherwise
+    /// derives it in-memory. Throws `Error.derivationFailed` only when the
+    /// vault genuinely lacks the key material to derive the account.
+    func resolve(vault: Vault, chain: Chain) throws -> Coin {
+        if let enabled = vault.nativeCoin(for: chain) {
+            return enabled
+        }
+        guard let meta = Self.nativeMeta(for: chain) else {
+            throw Error.derivationFailed(chainName: chain.name)
+        }
+        let pubKey = vault.chainPublicKeys.first { $0.chain == chain }?.publicKeyHex
+        do {
+            return try CoinFactory.create(
+                asset: meta,
+                publicKeyECDSA: pubKey ?? vault.pubKeyECDSA,
+                publicKeyEdDSA: pubKey ?? vault.pubKeyEdDSA,
+                hexChainCode: vault.hexChainCode,
+                isDerived: pubKey != nil,
+                publicKeyMLDSA44: vault.publicKeyMLDSA44
+            )
+        } catch {
+            throw Error.derivationFailed(chainName: chain.name)
+        }
+    }
+
+    /// Native-token template for the chain. QBTC has a dedicated
+    /// `TokensStore.qbtc`; Bitcoin (and any other chain) resolves its
+    /// inline native entry from the asset list.
+    private static func nativeMeta(for chain: Chain) -> CoinMeta? {
+        if chain == .qbtc {
+            return TokensStore.qbtc
+        }
+        return TokensStore.TokenSelectionAssets.first { $0.chain == chain && $0.isNativeToken }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimJoinDriver.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimJoinDriver.swift
@@ -28,17 +28,11 @@ import OSLog
 import Tss
 
 enum QBTCClaimJoinDriverError: LocalizedError {
-    case missingBitcoinCoin
-    case missingQbtcCoin
     case invalidCompressedPubkey
     case round1SignatureMissing
 
     var errorDescription: String? {
         switch self {
-        case .missingBitcoinCoin:
-            return "Vault is missing the Bitcoin coin needed for QBTC claim"
-        case .missingQbtcCoin:
-            return "Vault is missing the QBTC coin needed to derive the claimer address"
         case .invalidCompressedPubkey:
             return "Bitcoin compressed public key is malformed"
         case .round1SignatureMissing:
@@ -69,8 +63,13 @@ final class QBTCClaimJoinDriver: ObservableObject {
     /// Exposed so the peer-side view can build the shared
     /// `QBTCClaimDoneScreen` once the run completes.
     let vault: Vault
+    /// The BTC + QBTC coins this peer signs against, resolved from its
+    /// own vault in `runInternal()` (derived in-memory when the chain
+    /// isn't enabled). Exposed so the done screen can render them.
+    private(set) var resolvedCoins: QBTCClaimCoinResolver.Coins?
     private let session: KeysignSessionInfo
     private let sessionService: KeysignSessionServicing
+    private let coinResolver: QBTCClaimCoinResolver
     private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-claim-join")
 
     /// Cap on how long to wait for kickoff. Generous because the
@@ -80,11 +79,13 @@ final class QBTCClaimJoinDriver: ObservableObject {
     init(
         vault: Vault,
         session: KeysignSessionInfo,
-        sessionService: KeysignSessionServicing = KeysignSessionService()
+        sessionService: KeysignSessionServicing = KeysignSessionService(),
+        coinResolver: QBTCClaimCoinResolver = QBTCClaimCoinResolver()
     ) {
         self.vault = vault
         self.session = session
         self.sessionService = sessionService
+        self.coinResolver = coinResolver
     }
 
     /// Drives the full peer-side flow. Mutates `phase` as it progresses.
@@ -103,16 +104,16 @@ final class QBTCClaimJoinDriver: ObservableObject {
     // MARK: - Internal flow
 
     private func runInternal() async throws {
-        guard let btcCoin = vault.nativeCoin(for: .bitcoin) else {
-            throw QBTCClaimJoinDriverError.missingBitcoinCoin
-        }
-        // Derive the claimer's QBTC address from the peer's own vault — both
-        // initiator and peer share the same SecureVault, so the QBTC coin
-        // (and thus its derived address) is the same across devices. No need
-        // to round-trip it through the keysign payload.
-        guard let qbtcCoin = vault.nativeCoin(for: .qbtc) else {
-            throw QBTCClaimJoinDriverError.missingQbtcCoin
-        }
+        // Resolve the BTC + QBTC coins from the peer's own vault — derived
+        // in-memory when the chain isn't enabled. Both initiator and peer
+        // share the same vault keys, so they derive identical coins and
+        // thus the same claim hash; no need to round-trip the QBTC address
+        // through the keysign payload. A genuine derivation failure (a
+        // non-quantum vault) throws and transitions the phase to `.failed`.
+        let coins = try coinResolver.resolve(vault: vault)
+        resolvedCoins = coins
+        let btcCoin = coins.btc
+        let qbtcCoin = coins.qbtc
         guard let compressedPubkey = Data(hexString: btcCoin.hexPublicKey) else {
             throw QBTCClaimJoinDriverError.invalidCompressedPubkey
         }

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/ViewModels/QBTCClaimViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/ViewModels/QBTCClaimViewModel.swift
@@ -107,24 +107,30 @@ final class QBTCClaimViewModel: ObservableObject {
     private let chainService: QBTCChainService
     private let blockchairService: BlockchairService
     private let sessionService: KeysignSessionService
+    private let coinResolver: QBTCClaimCoinResolver
     private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-claim-vm")
 
     init(
         vault: Vault,
         chainService: QBTCChainService = QBTCChainService(),
         blockchairService: BlockchairService = .shared,
-        sessionService: KeysignSessionService = KeysignSessionService()
+        sessionService: KeysignSessionService = KeysignSessionService(),
+        coinResolver: QBTCClaimCoinResolver = QBTCClaimCoinResolver()
     ) {
         self.vault = vault
         self.chainService = chainService
         self.blockchairService = blockchairService
         self.sessionService = sessionService
+        self.coinResolver = coinResolver
     }
 
     // MARK: - Computed
 
-    var btcCoin: Coin? { vault.nativeCoin(for: .bitcoin) }
-    var qbtcCoin: Coin? { vault.nativeCoin(for: .qbtc) }
+    /// The BTC + QBTC coins the claim is derived from. Resolved once by
+    /// `load()` — an enabled native coin is used as-is, otherwise it's
+    /// derived in-memory from the vault's keys (the chain need not be
+    /// enabled). `nil` until `load()` resolves them.
+    private(set) var resolvedCoins: QBTCClaimCoinResolver.Coins?
 
     var totalSatsSelected: UInt64 {
         utxos
@@ -194,14 +200,23 @@ final class QBTCClaimViewModel: ObservableObject {
             return
         }
 
-        guard let btcCoin else {
-            state = .blocked(reason: .missingCoin(chainName: "Bitcoin"))
+        // Resolve the BTC + QBTC coins. Neither chain has to be enabled —
+        // they're derived in-memory from the vault's keys when missing, so
+        // a quantum vault can claim regardless of which chains it has
+        // added. Only a genuine derivation failure (a non-quantum vault
+        // lacking the MLDSA-44 key for QBTC) still blocks.
+        let coins: QBTCClaimCoinResolver.Coins
+        do {
+            coins = try coinResolver.resolve(vault: vault)
+        } catch QBTCClaimCoinResolver.Error.derivationFailed(let chainName) {
+            state = .blocked(reason: .missingCoin(chainName: chainName))
+            return
+        } catch {
+            state = .blocked(reason: .missingCoin(chainName: Chain.qbtc.name))
             return
         }
-        guard qbtcCoin != nil else {
-            state = .blocked(reason: .missingCoin(chainName: "QBTC"))
-            return
-        }
+        resolvedCoins = coins
+        let btcCoin = coins.btc
 
         // Address-type guard — reject P2TR/testnet now rather than at
         // proof-service time.
@@ -281,14 +296,14 @@ final class QBTCClaimViewModel: ObservableObject {
             lastClaimError = "qbtcClaimEmptyPassword".localized
             return
         }
-        guard let btcCoin, let qbtcCoin else { return }
+        guard let coins = resolvedCoins else { return }
 
         let selected = utxos.filter { selectedIds.contains($0.id) }
         guard !selected.isEmpty else { return }
 
         pendingKeysignContext = QBTCClaimKeysignContext(
-            btcCoin: btcCoin,
-            qbtcCoin: qbtcCoin,
+            btcCoin: coins.btc,
+            qbtcCoin: coins.qbtc,
             selectedUtxos: selected,
             fastVaultPassword: password
         )
@@ -308,20 +323,20 @@ final class QBTCClaimViewModel: ObservableObject {
     /// context. On failure, surfaces the error in the selection
     /// banner so the user can retry.
     private func prepareSecureVaultPair() async {
-        guard let btcCoin, let qbtcCoin else { return }
+        guard let coins = resolvedCoins else { return }
         let selected = utxos.filter { selectedIds.contains($0.id) }
         guard !selected.isEmpty else { return }
 
         do {
             let session = try sessionService.newSession(vault: vault)
-            let payload = makeSecureVaultKeysignPayload(btcCoin: btcCoin)
+            let payload = makeSecureVaultKeysignPayload(btcCoin: coins.btc)
             try await sessionService.registerAsParticipant(session: session)
 
             pendingPairContext = QBTCClaimPairContext(
                 keysignPayload: payload,
                 session: session,
-                btcCoin: btcCoin,
-                qbtcCoin: qbtcCoin,
+                btcCoin: coins.btc,
+                qbtcCoin: coins.qbtc,
                 selectedUtxos: selected
             )
         } catch {

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Views/QBTCClaimJoinView.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Views/QBTCClaimJoinView.swift
@@ -37,18 +37,16 @@ struct QBTCClaimJoinView: View {
 
     @ViewBuilder
     private func doneScreen(result: QBTCClaimRunResult?) -> some View {
-        // The peer has the vault from the driver; BTC + QBTC coins are
-        // derived from it. If the tx-hash push didn't arrive in time
-        // (`result == nil`), surface the same animation the standard
-        // peer keysign flow shows on completion.
-        if let result,
-           let btcCoin = driver.vault.nativeCoin(for: .bitcoin),
-           let qbtcCoin = driver.vault.nativeCoin(for: .qbtc) {
+        // The driver resolved the BTC + QBTC coins (deriving them when the
+        // chain isn't enabled) before signing, so reuse them here. If the
+        // tx-hash push didn't arrive in time (`result == nil`), surface the
+        // same animation the standard peer keysign flow shows on completion.
+        if let result, let coins = driver.resolvedCoins {
             QBTCClaimDoneScreen(
                 result: result,
                 vault: driver.vault,
-                btcCoin: btcCoin,
-                qbtcCoin: qbtcCoin
+                btcCoin: coins.btc,
+                qbtcCoin: coins.qbtc
             )
         } else {
             SendCryptoKeysignView(coinLogo: coinLogo)

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -351,16 +351,16 @@ private extension ChainDetailScreen {
     func refreshQbtcEligibility() {
         guard QBTCConfig.isFeatureEnabled else { return }
         guard nativeCoin.chain == .bitcoin || nativeCoin.chain == .qbtc else { return }
-        let btcCoin: Coin?
-        if nativeCoin.chain == .bitcoin {
-            btcCoin = nativeCoin
-        } else {
-            btcCoin = vault.nativeCoin(for: .bitcoin)
-        }
-        guard let btcCoin else { return }
         let vaultPubKey = vault.pubKeyECDSA
         let supportsClaim = vault.supportsQbtcClaim
-        Task { await qbtcEligibility.check(btcCoin: btcCoin, vaultPubKeyECDSA: vaultPubKey, vaultSupportsClaim: supportsClaim) }
+        Task { @MainActor in
+            guard let btcCoin = viewModel.qbtcClaimBitcoinCoin() else { return }
+            await qbtcEligibility.check(
+                btcCoin: btcCoin,
+                vaultPubKeyECDSA: vaultPubKey,
+                vaultSupportsClaim: supportsClaim
+            )
+        }
     }
 
     func updateBalances() async {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
@@ -71,6 +71,23 @@ final class ChainDetailViewModel: ObservableObject {
         }
     }
 
+    /// The Bitcoin coin the QBTC claim-eligibility check runs against. On
+    /// the Bitcoin chain-detail screen the native coin is itself the BTC
+    /// coin; on the QBTC screen it's read from the vault, or derived
+    /// in-memory when the Bitcoin chain isn't enabled — so the Claim entry
+    /// point still appears for a quantum vault that hasn't added Bitcoin.
+    /// Returns nil only on a genuine derivation failure.
+    @MainActor
+    func qbtcClaimBitcoinCoin() -> Coin? {
+        if nativeCoin.chain == .bitcoin {
+            return nativeCoin
+        }
+        if let enabled = vault.nativeCoin(for: .bitcoin) {
+            return enabled
+        }
+        return try? QBTCClaimCoinResolver().resolve(vault: vault, chain: .bitcoin)
+    }
+
     private func recomputeTokens() {
         tokens = Self.computeTokens(vault: vault, nativeCoin: nativeCoin)
     }

--- a/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimCoinResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimCoinResolverTests.swift
@@ -1,0 +1,103 @@
+//
+//  QBTCClaimCoinResolverTests.swift
+//  VultisigAppTests
+//
+//  Mirrors Android's `ResolveQbtcClaimCoinsUseCaseTest` (#4679): an
+//  enabled native coin is used as-is, a missing one is derived in-memory
+//  from the vault's keys, and only a genuine derivation failure (a
+//  non-quantum vault lacking the MLDSA-44 key) throws.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class QBTCClaimCoinResolverTests: XCTestCase {
+
+    /// Valid keys that derive a Bitcoin (ECDSA) address via WalletCore.
+    private static let pubKeyECDSA = "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"
+    private static let hexChainCode = "c9b189a8232b872b8d9ccd867d0db316dd10f56e729c310fe072adf5fd204ae7"
+    /// A non-empty hex string standing in for the ML-DSA-44 public key —
+    /// QBTC address derivation hashes the raw bytes, so any valid hex works.
+    private static let publicKeyMLDSA44 = String(repeating: "ab", count: 1312)
+
+    private let resolver = QBTCClaimCoinResolver()
+
+    private func coin(chain: Chain, address: String, hexPublicKey: String = "00") -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: chain.ticker,
+            logo: chain.logo,
+            decimals: 8,
+            priceProviderId: "",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(asset: asset, address: address, hexPublicKey: hexPublicKey)
+    }
+
+    /// Already-enabled accounts are returned as-is, without deriving.
+    func testReturnsEnabledCoinsAsIs() throws {
+        let vault = Vault(name: "v")
+        vault.coins = [
+            coin(chain: .bitcoin, address: "btcAddr"),
+            coin(chain: .qbtc, address: "qbtcAddr")
+        ]
+
+        let result = try resolver.resolve(vault: vault)
+
+        XCTAssertEqual(result.btc.address, "btcAddr")
+        XCTAssertEqual(result.qbtc.address, "qbtcAddr")
+    }
+
+    /// Both accounts are derived in-memory from the native templates and
+    /// the vault's own keys when the chains aren't enabled.
+    func testDerivesMissingAccounts() throws {
+        let vault = Vault(name: "v")
+        vault.pubKeyECDSA = Self.pubKeyECDSA
+        vault.hexChainCode = Self.hexChainCode
+        vault.publicKeyMLDSA44 = Self.publicKeyMLDSA44
+
+        let result = try resolver.resolve(vault: vault)
+
+        XCTAssertEqual(result.btc.chain, .bitcoin)
+        XCTAssertTrue(result.btc.isNativeToken)
+        XCTAssertFalse(result.btc.address.isEmpty)
+        XCTAssertFalse(result.btc.hexPublicKey.isEmpty)
+
+        XCTAssertEqual(result.qbtc.chain, .qbtc)
+        XCTAssertTrue(result.qbtc.isNativeToken)
+        XCTAssertTrue(result.qbtc.address.hasPrefix("qbtc"))
+        XCTAssertFalse(result.qbtc.hexPublicKey.isEmpty)
+    }
+
+    /// `resolve(vault:chain:)` derives a single chain (the path
+    /// `KeysignDiscoveryViewModel` uses for the QBTC claimer address).
+    func testDerivesSingleChain() throws {
+        let vault = Vault(name: "v")
+        vault.pubKeyECDSA = Self.pubKeyECDSA
+        vault.hexChainCode = Self.hexChainCode
+        vault.publicKeyMLDSA44 = Self.publicKeyMLDSA44
+
+        let qbtc = try resolver.resolve(vault: vault, chain: .qbtc)
+
+        XCTAssertEqual(qbtc.chain, .qbtc)
+        XCTAssertTrue(qbtc.address.hasPrefix("qbtc"))
+    }
+
+    /// A non-quantum vault (no MLDSA-44 key) can't derive the QBTC
+    /// account — the only genuine failure — and throws `derivationFailed`.
+    func testThrowsWhenMLDSAKeyMissing() {
+        let vault = Vault(name: "v")
+        vault.pubKeyECDSA = Self.pubKeyECDSA
+        vault.hexChainCode = Self.hexChainCode
+        vault.publicKeyMLDSA44 = nil
+
+        XCTAssertThrowsError(try resolver.resolve(vault: vault)) { error in
+            XCTAssertEqual(
+                error as? QBTCClaimCoinResolver.Error,
+                .derivationFailed(chainName: Chain.qbtc.name)
+            )
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimJoinDriverTests.swift
+++ b/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimJoinDriverTests.swift
@@ -22,11 +22,18 @@ final class QBTCClaimJoinDriverTests: XCTestCase {
         serverAddr: "https://relay.vultisig.test"
     )
 
+    /// Vault keys that derive a valid BTC (ECDSA) + QBTC (MLDSA) account
+    /// on the fly, so the resolver succeeds even with empty `coins`.
+    private static let pubKeyECDSA = "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"
+    private static let hexChainCode = "c9b189a8232b872b8d9ccd867d0db316dd10f56e729c310fe072adf5fd204ae7"
+    private static let publicKeyMLDSA44 = String(repeating: "ab", count: 1312)
+
     /// Returns a vault that has BTC + QBTC coins. BTC carries a valid
     /// 33-byte compressed pubkey so `QBTCClaimHashes.computeAll` succeeds;
-    /// QBTC carries the claimer address the peer now derives from the
-    /// vault (replacing the round-tripped `QBTCClaimContext`). The driver
-    /// fails fast on either missing — we never reach the session methods.
+    /// QBTC carries the claimer address the peer derives from the vault
+    /// (replacing the round-tripped `QBTCClaimContext`). With both coins
+    /// enabled the resolver returns them as-is and the driver proceeds to
+    /// the session methods.
     private func makeVault() -> Vault {
         let vault = Vault(name: "TestVault")
         let btcAsset = CoinMeta(
@@ -61,6 +68,16 @@ final class QBTCClaimJoinDriverTests: XCTestCase {
         return vault
     }
 
+    /// A quantum-capable vault with the BTC/QBTC chains NOT enabled — the
+    /// resolver derives both accounts in-memory from these keys.
+    private func makeQuantumVaultWithoutCoins() -> Vault {
+        let vault = Vault(name: "TestVault")
+        vault.pubKeyECDSA = Self.pubKeyECDSA
+        vault.hexChainCode = Self.hexChainCode
+        vault.publicKeyMLDSA44 = Self.publicKeyMLDSA44
+        return vault
+    }
+
     func testRunRegistersAndAwaitsOnConstructorSession() async {
         let service = MockKeysignSessionService()
         // Let `registerAsParticipant` succeed; trip `awaitKeysignStart`
@@ -89,6 +106,33 @@ final class QBTCClaimJoinDriverTests: XCTestCase {
 
         if case .failed = driver.phase {
             // ok — the error transitioned the phase as expected
+        } else {
+            XCTFail("expected `.failed`, got \(driver.phase)")
+        }
+    }
+
+    /// Regression for #4679: a quantum vault without the BTC/QBTC chains
+    /// enabled no longer fails fast — the driver derives both accounts and
+    /// proceeds to the session methods (short-circuited here at kickoff).
+    func testRunDerivesCoinsWhenChainsNotEnabled() async {
+        let service = MockKeysignSessionService()
+        service.awaitError = MockSessionServiceError(message: "short-circuit before DKLS")
+
+        let driver = QBTCClaimJoinDriver(
+            vault: makeQuantumVaultWithoutCoins(),
+            session: Self.testSession,
+            sessionService: service
+        )
+
+        await driver.run()
+
+        XCTAssertEqual(
+            service.calls.count, 2,
+            "Driver must derive the coins and reach register + await — no fail-fast on missing coins"
+        )
+        XCTAssertNotNil(driver.resolvedCoins, "Driver should expose the derived coins")
+        if case .failed = driver.phase {
+            // ok — only the mocked kickoff error stopped the run, not a missing coin
         } else {
             XCTFail("expected `.failed`, got \(driver.phase)")
         }

--- a/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/QBTCClaim/QBTCClaimViewModelTests.swift
@@ -1,0 +1,38 @@
+//
+//  QBTCClaimViewModelTests.swift
+//  VultisigAppTests
+//
+//  Covers the resolver wiring in `QBTCClaimViewModel.load()` (#4679): a
+//  non-quantum vault can derive BTC but not QBTC, so the claim blocks on
+//  `.missingCoin` — the only genuine derivation failure — before any
+//  network call is made.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class QBTCClaimViewModelTests: XCTestCase {
+
+    private static let pubKeyECDSA = "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"
+    private static let hexChainCode = "c9b189a8232b872b8d9ccd867d0db316dd10f56e729c310fe072adf5fd204ae7"
+
+    /// A DKLS vault (so `supportsQbtcClaim` is true) that is NOT
+    /// quantum-capable — it has no MLDSA-44 key, so QBTC can't be derived.
+    func testBlocksOnMissingQbtcCoinForNonQuantumVault() async {
+        let vault = Vault(name: "v")
+        vault.pubKeyECDSA = Self.pubKeyECDSA
+        vault.hexChainCode = Self.hexChainCode
+        vault.publicKeyMLDSA44 = nil
+
+        let viewModel = QBTCClaimViewModel(vault: vault)
+        await viewModel.load()
+
+        XCTAssertEqual(
+            viewModel.state,
+            .blocked(reason: .missingCoin(chainName: Chain.qbtc.name)),
+            "A non-quantum vault must block on the QBTC coin it cannot derive"
+        )
+        XCTAssertNil(viewModel.resolvedCoins)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/ChainDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ChainDetailViewModelTests.swift
@@ -94,6 +94,50 @@ final class ChainDetailViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.filteredTokens.isEmpty)
     }
 
+    // MARK: - qbtcClaimBitcoinCoin (claim entry-point BTC resolution)
+
+    /// Valid keys that derive a Bitcoin (ECDSA) address via WalletCore.
+    private static let pubKeyECDSA = "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"
+    private static let hexChainCode = "c9b189a8232b872b8d9ccd867d0db316dd10f56e729c310fe072adf5fd204ae7"
+
+    func test_qbtcClaimBitcoinCoin_onBitcoinScreenReturnsNativeCoin() {
+        let btc = makeCoin(ticker: "BTC", chain: .bitcoin, isNative: true)
+        let vault = Vault(name: "test")
+        vault.coins = [btc]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: btc)
+
+        XCTAssertEqual(viewModel.qbtcClaimBitcoinCoin()?.chain, .bitcoin)
+    }
+
+    func test_qbtcClaimBitcoinCoin_onQbtcScreenUsesEnabledBtc() {
+        let btc = makeCoin(ticker: "BTC", chain: .bitcoin, isNative: true)
+        let qbtc = makeCoin(ticker: "QBTC", chain: .qbtc, isNative: true)
+        let vault = Vault(name: "test")
+        vault.coins = [btc, qbtc]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: qbtc)
+
+        XCTAssertEqual(viewModel.qbtcClaimBitcoinCoin()?.address, btc.address)
+    }
+
+    /// On the QBTC screen with the Bitcoin chain not enabled, the BTC coin
+    /// is derived in-memory so the Claim entry point still appears.
+    func test_qbtcClaimBitcoinCoin_derivesBtcWhenChainNotEnabled() {
+        let qbtc = makeCoin(ticker: "QBTC", chain: .qbtc, isNative: true)
+        let vault = Vault(name: "test")
+        vault.pubKeyECDSA = Self.pubKeyECDSA
+        vault.hexChainCode = Self.hexChainCode
+        vault.coins = [qbtc]
+
+        let viewModel = ChainDetailViewModel(vault: vault, nativeCoin: qbtc)
+
+        let derived = viewModel.qbtcClaimBitcoinCoin()
+        XCTAssertEqual(derived?.chain, .bitcoin)
+        XCTAssertEqual(derived?.isNativeToken, true)
+        XCTAssertFalse(derived?.address.isEmpty ?? true)
+    }
+
     // MARK: - Helpers
 
     private func makeCoin(ticker: String, chain: Chain, isNative: Bool) -> Coin {


### PR DESCRIPTION
## QBTC claim: derive Bitcoin/QBTC accounts on the fly

Closes #4679

Today the QBTC claim flow hard-blocks with `.missingCoin` unless the vault already has **both** the Bitcoin and QBTC chains enabled. This brings iOS to parity with Android ([vultisig-android#5065](https://github.com/vultisig/vultisig-android/pull/5065)'s `ResolveQbtcClaimCoinsUseCase`) and Windows: the two native coins are derived **in-memory** from the vault's own keys when the chain isn't enabled, and the claim blocks only on a **genuine** derivation failure (the vault lacks the key material).

Design + grounding: internal wiki plan `wiki/pages/projects/vultisig/qbtc-claim/on-the-fly-coin-derivation-4679-plan.md` (plus the QBTC-claim `overview.md` for context).

### What changed

- **New resolver** `Features/QBTCClaim/Services/QBTCClaimCoinResolver.swift`. Per chain: returns `vault.nativeCoin(for:)` if enabled; otherwise derives via the pure, **non-persisting** `CoinFactory.create(...)` from the native-token template + vault keys (the same precedent `SwapCryptoLogic.getDefaultCoin` uses); otherwise throws `Error.derivationFailed(chainName:)`. Templates: QBTC → `TokensStore.qbtc`, Bitcoin → the inline native entry in `TokensStore.TokenSelectionAssets`. Injected via initializers (default-constructed) for testability.
- **Three call sites** rerouted through the resolver (mirrors Android's three wirings):
  - Initiator `QBTCClaimViewModel` — resolves once at the top of `load()` and stores `resolvedCoins`; the address-type guard, `fetchUtxos`, `startClaim()`, `prepareSecureVaultPair()` and the keysign payload all read the stored coins. On `derivationFailed` it lands on the existing `.blocked(reason: .missingCoin(chainName:))` (reusing the existing UI + `qbtcClaimMissingCoinDetail` string — **no new locale keys**).
  - Peer `QBTCClaimJoinDriver.runInternal()` + `QBTCClaimJoinView.doneScreen` — derive from the peer's own vault; the now-unused `missingBitcoinCoin`/`missingQbtcCoin` error cases were removed.
  - `KeysignDiscoveryViewModel` — the `vault.nativeCoin(for: .qbtc)` read now resolves/derives the QBTC claimer address.
- **Entry-point parity** — `ChainDetailViewModel.qbtcClaimBitcoinCoin()` derives the Bitcoin coin in-memory for the claim-eligibility check, so the Claim button on the QBTC chain-detail screen appears even when the Bitcoin chain isn't enabled (matching the claim flow). Logic lives in the ViewModel, not the `View`.
- **Tests**: new `QBTCClaimCoinResolverTests` (enabled-as-is / derives-when-missing / blocked-on-failure / single-chain), new `QBTCClaimViewModelTests` (non-quantum vault → `.blocked(.missingCoin)`), `QBTCClaimJoinDriverTests` gains a derive-on-the-fly peer regression test, and `ChainDetailViewModelTests` covers the entry-point BTC resolution (BTC screen / QBTC-with-BTC-enabled / derive-when-not-enabled).

### Eligibility nuance

Bitcoin (ECDSA) derives for any standard vault, so it effectively never fails. QBTC (MLDSA) requires a non-empty `vault.publicKeyMLDSA44` — `CoinFactory.create` routes to `createMLDSACoin` which throws without it. So the **only** genuine derivation failure is a non-quantum vault, and the real eligibility gate is now "MLDSA-capable vault" (matching Android). The derived coins are **never** appended to `vault.coins` or inserted into Storage — they stay local to the claim flow.

### Security note

Unchanged. The claim hash is always recomputed locally from the vault's own (derived) coins, never trusted from the QR/relay. Deriving the coin in-memory yields the *identical* deterministic hash on every device (initiator and peer derive the same BTC ECDSA + QBTC MLDSA coins from the same vault keys), and the proof service's echoed hashes are still re-verified against the local values.

### KeyImport allow-list divergence (deliberate)

`CoinFactory.create` does not call `CoinService.assertChainAllowed` (that guard lives only in the persisting `addToChain` path). Deriving in-memory therefore bypasses the key-import chain allow-list. This is acceptable for the claim — it's read-only derivation, nothing is persisted — but flagging it as a deliberate divergence for review.

### Surfaced reason for a non-quantum vault

For a non-quantum vault we intentionally reuse `.missingCoin(chainName: "QBTC")` ("Your vault is missing the QBTC coin needed to claim.") — no new strings, per the plan and product sign-off. A dedicated "vault is not quantum-capable" reason can be a follow-up if desired.

### Entry-point parity (now included)

The QBTC chain-detail Claim button drives off a real BTC-UTXO eligibility check, which previously needed the Bitcoin chain to already be enabled. It now derives the Bitcoin coin in-memory (via the same resolver) when the chain isn't enabled, so a quantum vault with QBTC enabled but Bitcoin not added still surfaces the Claim entry point. Since being on the QBTC chain-detail screen implies QBTC is enabled (which requires an MLDSA vault), this path only ever derives for quantum-capable vaults. The BTC promo banner on the Bitcoin screen is unchanged (it already implies Bitcoin is enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QBTC claim flows now derive and reuse BTC/QBTC coin accounts in-memory when chains aren’t enabled (when key material is available).
  * Claim screens share the same resolved coin accounts across steps for more consistent UI and completion handling.

* **Bug Fixes**
  * Improved claim join flow so it no longer fails early due to temporarily unavailable enabled coins.
  * Enhanced QBTC eligibility checks to use the correct BTC coin source across Bitcoin vs. non-Bitcoin screens.

* **Tests**
  * Added coverage for coin resolution, join driver behavior, and blocked-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->