### PR TITLE
fix(tokens): show sub-cent token prices instead of $0.00

### DIFF
--- a/VultisigApp/VultisigApp/Core/Extensions/DecimalExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/DecimalExtension.swift
@@ -19,7 +19,7 @@ extension Decimal {
     }
 
     /// Base method for formatting fiat values with configurable decimal places
-    private func formatToFiat(includeCurrencySymbol: Bool = true, maximumFractionDigits: Int) -> String {
+    private func formatToFiat(includeCurrencySymbol: Bool = true, maximumFractionDigits: Int, roundingMode: NumberFormatter.RoundingMode = .down) -> String {
         let formatter = NumberFormatter()
         if includeCurrencySymbol {
             formatter.numberStyle = .currency
@@ -31,7 +31,7 @@ extension Decimal {
         formatter.minimumFractionDigits = 2
         formatter.decimalSeparator = Locale.current.decimalSeparator ?? "."
         formatter.groupingSeparator = Locale.current.groupingSeparator ?? ","
-        formatter.roundingMode = .down
+        formatter.roundingMode = roundingMode
 
         let number = NSDecimalNumber(decimal: self)
         return formatter.string(from: number) ?? ""
@@ -45,6 +45,34 @@ extension Decimal {
     /// Format fiat value for fee display with more decimal places to show small fees
     func formatToFiatForFee(includeCurrencySymbol: Bool = true) -> String {
         return formatToFiat(includeCurrencySymbol: includeCurrencySymbol, maximumFractionDigits: 5)
+    }
+
+    /// Format a per-token unit price, revealing the leading significant figures of a sub-cent
+    /// price instead of collapsing it to the currency's standard 2 decimal places. A tiny price
+    /// like LUNC's `0.00006` displays as `$0.00006` rather than `$0.00`; prices of one cent or
+    /// more, and zero, use standard formatting.
+    func formatToFiatPrice(includeCurrencySymbol: Bool = true) -> String {
+        let subUnit = Decimal(sign: .plus, exponent: -2, significand: 1)
+        let absValue = abs(self)
+        guard absValue > 0, absValue < subUnit else {
+            return formatToFiat(includeCurrencySymbol: includeCurrencySymbol)
+        }
+        // Count the zeros between the decimal point and the first significant digit, then extend
+        // precision just far enough to reveal two significant figures (capped at 8 fraction digits).
+        var scaled = absValue
+        var firstSignificantPlace = 0
+        while scaled < 1 {
+            scaled *= 10
+            firstSignificantPlace += 1
+        }
+        let leadingZeros = firstSignificantPlace - 1
+        let maximumFractionDigits = min(leadingZeros + PriceFormatting.significantDigits, PriceFormatting.maxFractionDigits)
+        return formatToFiat(includeCurrencySymbol: includeCurrencySymbol, maximumFractionDigits: maximumFractionDigits, roundingMode: .halfUp)
+    }
+
+    private enum PriceFormatting {
+        static let significantDigits = 2
+        static let maxFractionDigits = 8
     }
 
     func formatDecimalToLocale(locale: Locale = Locale.current) -> String {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/TokenCellView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/TokenCellView.swift
@@ -25,7 +25,7 @@ struct TokenCellView: View {
                     Text(coin.ticker)
                         .font(Theme.fonts.bodySMedium)
                         .foregroundStyle(Theme.colors.textPrimary)
-                    Text(Decimal(coin.price).formatToFiat())
+                    Text(Decimal(coin.price).formatToFiatPrice())
                         .font(Theme.fonts.caption12)
                         .foregroundStyle(Theme.colors.textSecondary)
                         .padding(.vertical, 3)

--- a/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
@@ -71,7 +71,7 @@ struct CoinDetailScreen: View {
                 }
                 CoinPriceNetworkView(
                     chainName: coin.chain.name,
-                    price: Decimal(coin.price).formatToFiat()
+                    price: Decimal(coin.price).formatToFiatPrice()
                 )
             }
             .padding(.horizontal, 24)

--- a/VultisigApp/VultisigAppTests/Extensions/DecimalExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/DecimalExtensionTests.swift
@@ -1,0 +1,59 @@
+//
+//  DecimalExtensionTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class DecimalExtensionTests: XCTestCase {
+
+    private let separator = Locale.current.decimalSeparator ?? "."
+
+    /// Builds an expected string using the host locale's decimal separator so the
+    /// assertions hold regardless of where the suite runs.
+    private func expected(_ value: String) -> String {
+        value.replacingOccurrences(of: ".", with: separator)
+    }
+
+    private func price(_ value: String) -> String {
+        Decimal(string: value)!.formatToFiatPrice(includeCurrencySymbol: false)
+    }
+
+    func test_formatToFiatPrice_revealsSubCentPriceInsteadOfZero() {
+        // LUNC-like price: standard 2dp formatting would show 0.00.
+        XCTAssertEqual(price("0.00006"), expected("0.00006"))
+    }
+
+    func test_formatToFiatPrice_revealsTwoSignificantFiguresOfLongSubCentPrice() {
+        XCTAssertEqual(price("0.00006123"), expected("0.000061"))
+    }
+
+    func test_formatToFiatPrice_showsTwoSignificantFiguresForMidSubCentPrice() {
+        // USTC-like price.
+        XCTAssertEqual(price("0.0054"), expected("0.0054"))
+    }
+
+    func test_formatToFiatPrice_capsPrecisionAtEightFractionDigits() {
+        // Two significant figures would need 9 digits; capped to 8 -> 0.00000012.
+        XCTAssertEqual(price("0.000000123"), expected("0.00000012"))
+    }
+
+    func test_formatToFiatPrice_fallsBackToStandardAtExactlyOneCent() {
+        let value = Decimal(string: "0.01")!
+        XCTAssertEqual(value.formatToFiatPrice(includeCurrencySymbol: false), value.formatToFiat(includeCurrencySymbol: false))
+        XCTAssertEqual(value.formatToFiatPrice(includeCurrencySymbol: false), expected("0.01"))
+    }
+
+    func test_formatToFiatPrice_fallsBackToStandardAboveOneCent() {
+        let value = Decimal(string: "1.50")!
+        XCTAssertEqual(value.formatToFiatPrice(includeCurrencySymbol: false), value.formatToFiat(includeCurrencySymbol: false))
+        XCTAssertEqual(value.formatToFiatPrice(includeCurrencySymbol: false), expected("1.50"))
+    }
+
+    func test_formatToFiatPrice_fallsBackToStandardForZero() {
+        let value = Decimal(0)
+        XCTAssertEqual(value.formatToFiatPrice(includeCurrencySymbol: false), value.formatToFiat(includeCurrencySymbol: false))
+        XCTAssertEqual(value.formatToFiatPrice(includeCurrencySymbol: false), expected("0.00"))
+    }
+}


### PR DESCRIPTION
## Summary

Per-token unit prices below one currency sub-unit (e.g. **LUNC ~\$0.00006**, **USTC ~\$0.0054**) were displayed as `$0.00`, hiding the real price from users. Closes #4688. Parity with Android [#5111](https://github.com/vultisig/vultisig-android/pull/5111).

### Root cause
iOS truncates at the **display layer**: `Decimal.formatToFiat()` (`Core/Extensions/DecimalExtension.swift`) hardcodes `maximumFractionDigits = 2`, so `0.00006 → "$0.00"`. Unlike Android, iOS does **not** pre-scale the rate at the data source — `Rate.value`/`DatabaseRate.value` stay full-precision — so there is no data-layer change to make here.

### Fix
- **`DecimalExtension.swift`** — new `formatToFiatPrice()`. For a sub-cent value it extends fraction digits just far enough to reveal the first **2 significant figures** (capped at **8** fraction digits, `.halfUp`); values ≥ one sub-unit and zero fall through to standard 2dp formatting. The private base formatter gains a `roundingMode` param (default `.down`, so existing callers — incl. `formatToFiatForFee` — are unchanged).
- Apply `formatToFiatPrice()` at the **2** per-token price display sites: `TokenCellView` (chain tokens list) and `CoinDetailScreen` (token detail).

Prices ≥ one sub-unit are unaffected; **balances/holdings are unaffected** — a tiny holding correctly still shows `$0.00`.

## Behavior (matches Android byte-for-byte)
| Input price | Before | After |
|---|---|---|
| `0.00006` (LUNC) | `$0.00` | `$0.00006` |
| `0.0054` (USTC) | `$0.00` | `$0.0054` |
| `0.00006123` | `$0.00` | `$0.000061` |
| `0.000000123` | `$0.00` | `$0.00000012` (8-digit cap) |
| `0.01` / `1.50` / `0` | unchanged | unchanged |

## Test plan
- [x] `make test` — full unit suite green (`** TEST SUCCEEDED **`)
- [x] New `DecimalExtensionTests` (7 cases ported from Android `FiatValueToStringMapperImplTest`): sub-cent reveal, 2-sig-fig, mid sub-cent (USTC), 8-digit cap, ≥1¢ fallback, zero
- [x] SwiftLint clean (0 violations)
- [ ] Device check: Terra Classic vault — LUNC price pill shows `$0.00006…` in the token list and on the token detail screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fiat price display for very small values, so sub-cent prices now show more meaningful precision instead of rounding to zero.
  * Updated coin and token price displays to use the enhanced pricing format.

* **Tests**
  * Added coverage for small-value, boundary, and zero-price formatting to ensure consistent display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->