### PR TITLE
refactor: replace deprecated `.foregroundColor` with `.foregroundStyle`

### DIFF
--- a/VultisigApp/VultisigApp/Components/AddressBook/AddressBookTextField.swift
+++ b/VultisigApp/VultisigApp/Components/AddressBook/AddressBookTextField.swift
@@ -54,7 +54,7 @@ struct AddressBookTextField: View {
 
             Text(NSLocalizedString("dropFileHere", comment: ""))
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
     }
 

--- a/VultisigApp/VultisigApp/Components/Buttons/ActionButton.swift
+++ b/VultisigApp/VultisigApp/Components/Buttons/ActionButton.swift
@@ -14,7 +14,7 @@ struct ActionButton: View {
     var body: some View {
         Text(NSLocalizedString(title, comment: "").uppercased())
             .font(Theme.fonts.buttonSSemibold)
-            .foregroundColor(fontColor)
+            .foregroundStyle(fontColor)
             .padding(.vertical, 5)
             .frame(maxWidth: .infinity)
             .background(Theme.colors.bgSurface2)

--- a/VultisigApp/VultisigApp/Components/Buttons/IconButton/IconButtonStyle.swift
+++ b/VultisigApp/VultisigApp/Components/Buttons/IconButton/IconButtonStyle.swift
@@ -17,7 +17,7 @@ struct IconButtonStyle: ButtonStyle {
             .font(font(for: size))
             .padding(padding(for: size))
             .background(backgroundColor(for: type, isPressed: configuration.isPressed, isEnabled: isEnabled))
-            .foregroundColor(foregroundColor(for: type, isEnabled: isEnabled))
+            .foregroundStyle(foregroundColor(for: type, isEnabled: isEnabled))
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius(for: size))
                     .stroke(borderColor(for: type, isEnabled: isEnabled),

--- a/VultisigApp/VultisigApp/Components/Buttons/PrimaryButton/PrimaryButtonStyle.swift
+++ b/VultisigApp/VultisigApp/Components/Buttons/PrimaryButton/PrimaryButtonStyle.swift
@@ -40,7 +40,7 @@ struct PrimaryButtonStyle: ButtonStyle {
                         .scaleEffect(CGSize(width: progress, height: 1), anchor: .leading)
                 }
             )
-            .foregroundColor(foregroundColor(for: type, isEnabled: isEnabled))
+            .foregroundStyle(foregroundColor(for: type, isEnabled: isEnabled))
             .overlay(
                     RoundedRectangle(cornerRadius: cornerRadius(for: size))
                         .stroke(borderColor(for: type, isEnabled: isEnabled),

--- a/VultisigApp/VultisigApp/Components/Cells/AddressBookCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/AddressBookCell.swift
@@ -72,7 +72,7 @@ struct AddressBookCell: View {
 
     var titleContent: some View {
         Text(address.title)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodySMedium)
             .lineLimit(1)
             .truncationMode(.tail)
@@ -80,7 +80,7 @@ struct AddressBookCell: View {
 
     var addressContent: some View {
         Text(address.address)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.caption12)
             .lineLimit(1)
             .truncationMode(.middle)

--- a/VultisigApp/VultisigApp/Components/Cells/CoinPickerCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/CoinPickerCell.swift
@@ -33,11 +33,11 @@ struct CoinPickerCell: View {
                     Text(coin.balanceInFiatForDisplay)
                 }
                 .font(Theme.fonts.bodyMMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
                 Text(coin.address)
                     .font(Theme.fonts.caption12)
-                    .foregroundColor(Theme.colors.bgButtonPrimary)
+                    .foregroundStyle(Theme.colors.bgButtonPrimary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .lineLimit(1)
                     .truncationMode(.middle)

--- a/VultisigApp/VultisigApp/Components/Cells/FolderCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/FolderCell.swift
@@ -30,7 +30,7 @@ struct FolderCell: View {
     var rearrange: some View {
         Image(systemName: "line.3.horizontal")
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(maxWidth: isEditing ? nil : 0)
             .clipped()
     }
@@ -38,13 +38,13 @@ struct FolderCell: View {
     var folderIcon: some View {
         Image(systemName: "folder")
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var title: some View {
         Text(folder.folderName.capitalized)
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .multilineTextAlignment(.leading)
             .lineLimit(1)
@@ -53,7 +53,7 @@ struct FolderCell: View {
     var chevron: some View {
         Image(systemName: "chevron.right")
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(maxWidth: isEditing ? 0 : nil)
             .clipped()
     }

--- a/VultisigApp/VultisigApp/Components/Cells/FolderVaultCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/FolderVaultCell.swift
@@ -39,7 +39,7 @@ struct FolderVaultCell: View {
 
     var text: some View {
         Text(vault.name)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodySMedium)
     }
 

--- a/VultisigApp/VultisigApp/Components/Cells/ImportFileCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/ImportFileCell.swift
@@ -31,7 +31,7 @@ struct ImportFileCell: View {
     func fileName(_ name: String) -> some View {
         Text(name)
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var closeButton: some View {
@@ -40,7 +40,7 @@ struct ImportFileCell: View {
         } label: {
             Image(systemName: "xmark")
                 .font(Theme.fonts.bodyMMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .padding(8)
         }
         .buttonStyle(PlainButtonStyle())

--- a/VultisigApp/VultisigApp/Components/Cells/NetworkPromptCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/NetworkPromptCell.swift
@@ -19,11 +19,11 @@ struct NetworkPromptCell: View {
         HStack(spacing: 8) {
             network.getImage()
                 .font(Theme.fonts.bodySRegular)
-                .foregroundColor(Theme.colors.bgButtonPrimary)
+                .foregroundStyle(Theme.colors.bgButtonPrimary)
 
             Text(NSLocalizedString(network.rawValue, comment: ""))
                 .font(Theme.fonts.caption10)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
@@ -36,11 +36,11 @@ struct NetworkPromptCell: View {
         HStack(spacing: 8) {
             network.getImage()
                 .font(Theme.fonts.bodyLRegular)
-                .foregroundColor(Theme.colors.bgButtonPrimary)
+                .foregroundStyle(Theme.colors.bgButtonPrimary)
 
             Text(NSLocalizedString(network.rawValue, comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)

--- a/VultisigApp/VultisigApp/Components/Cells/ReviewDeviceCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/ReviewDeviceCell.swift
@@ -39,7 +39,7 @@ struct ReviewDeviceCell: View {
             if isThisDevice {
                 Text("\(deviceName) ") +
                 Text("(\(NSLocalizedString("thisDevice", comment: "").lowercased()))")
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
             } else {
                 Text(deviceName)
             }

--- a/VultisigApp/VultisigApp/Components/Cells/SendCryptoAddressBookCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SendCryptoAddressBookCell.swift
@@ -39,12 +39,12 @@ struct SendCryptoAddressBookCell: View {
         VStack(alignment: .leading, spacing: 6) {
             Text(title)
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .lineLimit(1)
 
             Text(description)
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
         }
@@ -73,7 +73,7 @@ struct SendCryptoAddressBookCell: View {
 
             Text(title.prefix(1).uppercased())
                 .font(Theme.fonts.bodyMMedium)
-                .foregroundColor(color)
+                .foregroundStyle(color)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Components/Cells/SettingCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SettingCell.swift
@@ -32,25 +32,25 @@ struct SettingCell: View {
     var iconBlock: some View {
         Image(systemName: icon)
             .font(Theme.fonts.bodyLRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var titleBlock: some View {
         Text(NSLocalizedString(title, comment: ""))
             .font(Theme.fonts.bodySRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var chevron: some View {
         Image(systemName: "chevron.right")
             .font(Theme.fonts.bodyMRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     func getSelectionBlock(_ value: String) -> some View {
         Text(value)
             .font(Theme.fonts.bodySRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 }
 

--- a/VultisigApp/VultisigApp/Components/Cells/SettingFAQCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SettingFAQCell.swift
@@ -37,13 +37,13 @@ struct SettingFAQCell: View {
     var title: some View {
         Text(NSLocalizedString(question, comment: "Question"))
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
     }
 
     var description: some View {
         Text(NSLocalizedString(answer, comment: "Answer"))
             .font(Theme.fonts.footnote)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var chevron: some View {

--- a/VultisigApp/VultisigApp/Components/Cells/SettingPickerCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SettingPickerCell.swift
@@ -32,10 +32,10 @@ struct SettingPickerCell<Selection: Hashable>: View {
         HStack(spacing: 12) {
             Image(systemName: icon)
                 .font(Theme.fonts.bodyLRegular)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
             Text(title)
                 .font(Theme.fonts.bodySRegular)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
             Spacer()
             Menu {
                 Picker(title, selection: $selection) {
@@ -47,10 +47,10 @@ struct SettingPickerCell<Selection: Hashable>: View {
                 HStack(spacing: 4) {
                     Text(currentLabel)
                         .font(Theme.fonts.bodySRegular)
-                        .foregroundColor(Theme.colors.textPrimary)
+                        .foregroundStyle(Theme.colors.textPrimary)
                     Image(systemName: "chevron.up.chevron.down")
                         .font(Theme.fonts.caption12)
-                        .foregroundColor(Theme.colors.textPrimary)
+                        .foregroundStyle(Theme.colors.textPrimary)
                 }
             }
         }

--- a/VultisigApp/VultisigApp/Components/Cells/SettingSelectionCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SettingSelectionCell.swift
@@ -47,7 +47,7 @@ struct SettingSelectionCell: View {
     var titleBlock: some View {
         Text(title)
             .font(Theme.fonts.bodySRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var chevron: some View {
@@ -56,7 +56,7 @@ struct SettingSelectionCell: View {
             .aspectRatio(contentMode: .fit)
             .frame(width: 6, height: 6)
             .padding(5)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .background(Circle().fill(Theme.colors.primaryAccent3))
             .showIf(isSelected)
     }
@@ -64,7 +64,7 @@ struct SettingSelectionCell: View {
     private func getDescriptionBlock(_ value: String) -> some View {
         Text(value)
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
     }
 }
 

--- a/VultisigApp/VultisigApp/Components/Cells/SettingToggleCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SettingToggleCell.swift
@@ -31,13 +31,13 @@ struct SettingToggleCell: View {
     var iconBlock: some View {
         Image(systemName: icon)
             .font(Theme.fonts.bodyLRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var titleBlock: some View {
         Text(NSLocalizedString(title, comment: ""))
             .font(Theme.fonts.bodySRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var toggle: some View {

--- a/VultisigApp/VultisigApp/Components/Cells/SwapChainCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SwapChainCell.swift
@@ -56,13 +56,13 @@ struct SwapChainCell: View {
     var title: some View {
         Text(chain.name)
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var balanceInfo: some View {
         Text(balance)
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     private func setData() {

--- a/VultisigApp/VultisigApp/Components/Cells/SwapCoinCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SwapCoinCell.swift
@@ -70,12 +70,12 @@ struct SwapCoinCell: View {
     var title: some View {
         Text(coin.ticker)
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var chain: some View {
         Text(coin.chain.name)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
             .font(Theme.fonts.caption10)
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
@@ -90,10 +90,10 @@ struct SwapCoinCell: View {
         if let balance, let balanceFiat {
             VStack(alignment: .trailing, spacing: 4) {
                 Text(balance)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
 
                 Text(balanceFiat)
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
             }
             .font(Theme.fonts.caption12)
         }

--- a/VultisigApp/VultisigApp/Components/Cells/TransactionCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/TransactionCell.swift
@@ -43,19 +43,19 @@ struct TransactionCell: View {
             Text(NSLocalizedString(title, comment: "Transaction ID"))
         }
         .font(Theme.fonts.bodyLMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var content: some View {
         Text(id)
             .font(Theme.fonts.footnote)
-            .foregroundColor(Theme.colors.bgButtonPrimary)
+            .foregroundStyle(Theme.colors.bgButtonPrimary)
             .multilineTextAlignment(.leading)
     }
 
     var chevron: some View {
         Image(systemName: "chevron.forward")
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodyLMedium)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Cells/UTXOTransactionCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/UTXOTransactionCell.swift
@@ -120,6 +120,6 @@ struct UTXOTransactionCell: View {
         }
         .frame(height: 32)
         .font(Theme.fonts.bodyMMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Cells/VaultCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/VaultCell.swift
@@ -41,7 +41,7 @@ struct VaultCell: View {
     var rearrange: some View {
         Image(systemName: "line.3.horizontal")
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(maxWidth: isEditing ? nil : 0)
             .clipped()
     }
@@ -49,7 +49,7 @@ struct VaultCell: View {
     var title: some View {
         Text(vault.name.capitalized)
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .multilineTextAlignment(.leading)
             .lineLimit(1)
@@ -67,13 +67,13 @@ struct VaultCell: View {
             Text("\(viewModel.totalSigners)")
         }
         .font(Theme.fonts.bodySRegular)
-        .foregroundColor(Theme.colors.textSecondary)
+        .foregroundStyle(Theme.colors.textSecondary)
     }
 
     var fastVaultLabel: some View {
         Text(NSLocalizedString("fastModeTitle", comment: "").capitalized)
             .font(Theme.fonts.bodySRegular)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
             .padding(4)
             .padding(.horizontal, 2)
             .background(Theme.colors.border)
@@ -84,7 +84,7 @@ struct VaultCell: View {
     var selectOption: some View {
         Image(systemName: "chevron.right")
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(maxWidth: isEditing ? 0 : nil)
             .clipped()
     }

--- a/VultisigApp/VultisigApp/Components/Checkbox.swift
+++ b/VultisigApp/VultisigApp/Components/Checkbox.swift
@@ -49,7 +49,7 @@ struct Checkbox: View {
     var check: some View {
         Image(systemName: "checkmark")
             .font(Theme.fonts.caption12)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .frame(width: 24, height: 24)
             .background(bgColor)
             .cornerRadius(20)
@@ -73,7 +73,7 @@ struct Checkbox: View {
         if let text {
             Text(NSLocalizedString(text, comment: "Checkbox description"))
                 .font(font)
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
                 .multilineTextAlignment(alignment)
         }
     }

--- a/VultisigApp/VultisigApp/Components/CounterView.swift
+++ b/VultisigApp/VultisigApp/Components/CounterView.swift
@@ -57,7 +57,7 @@ struct CounterView: View {
         ZStack {
             content()
         }
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
         .cornerRadius(12)
         .overlay(
             RoundedRectangle(cornerRadius: 12)

--- a/VultisigApp/VultisigApp/Components/ErrorMessage.swift
+++ b/VultisigApp/VultisigApp/Components/ErrorMessage.swift
@@ -21,13 +21,13 @@ struct ErrorMessage: View {
     var logo: some View {
         Image(systemName: "exclamationmark.circle.fill")
             .font(Theme.fonts.title2)
-            .foregroundColor(Theme.colors.alertWarning)
+            .foregroundStyle(Theme.colors.alertWarning)
     }
 
     var title: some View {
         Text(NSLocalizedString(text, comment: ""))
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.alertWarning)
+            .foregroundStyle(Theme.colors.alertWarning)
             .frame(maxWidth: width)
             .multilineTextAlignment(.center)
     }

--- a/VultisigApp/VultisigApp/Components/FileQRCodeImporterMac.swift
+++ b/VultisigApp/VultisigApp/Components/FileQRCodeImporterMac.swift
@@ -73,13 +73,13 @@ struct FileQRCodeImporterMac: View {
     var icon: some View {
         Image(systemName: "desktopcomputer.and.arrow.down")
             .font(Theme.fonts.display)
-            .foregroundColor(Theme.colors.bgButtonPrimary)
+            .foregroundStyle(Theme.colors.bgButtonPrimary)
     }
 
     var title: some View {
         Text(NSLocalizedString(isUploading ? "dropFileHere" : "uploadQRCodeImage", comment: "Upload backup file"))
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .animation(.none, value: isUploading)
     }
 

--- a/VultisigApp/VultisigApp/Components/FormSectionHeader.swift
+++ b/VultisigApp/VultisigApp/Components/FormSectionHeader.swift
@@ -41,9 +41,9 @@ struct FormSectionHeader<ValueView: View>: View {
                         Spacer()
                         HStack {
                             Image(systemName: "checkmark.circle")
-                                .foregroundColor(Theme.colors.alertSuccess)
+                                .foregroundStyle(Theme.colors.alertSuccess)
                             Image(systemName: "pencil")
-                                .foregroundColor(Theme.colors.textPrimary)
+                                .foregroundStyle(Theme.colors.textPrimary)
                         }
                     }
                 case .picker:

--- a/VultisigApp/VultisigApp/Components/Forms/AmountTextField.swift
+++ b/VultisigApp/VultisigApp/Components/Forms/AmountTextField.swift
@@ -106,7 +106,7 @@ struct AmountTextField<CustomView: View>: View {
             VStack(spacing: 12) {
                 if let error {
                     Text(error.localized)
-                        .foregroundColor(Theme.colors.alertError)
+                        .foregroundStyle(Theme.colors.alertError)
                         .font(Theme.fonts.footnote)
                         .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true)

--- a/VultisigApp/VultisigApp/Components/FunctionCallContractSelectorDropDown.swift
+++ b/VultisigApp/VultisigApp/Components/FunctionCallContractSelectorDropDown.swift
@@ -52,7 +52,7 @@ struct FunctionCallContractSelectorDropDown: View {
         }
         .redacted(reason: selected.rawValue.isEmpty ? .placeholder : [])
         .font(Theme.fonts.bodyMRegular)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
         .frame(height: 48)
     }
 
@@ -73,14 +73,14 @@ struct FunctionCallContractSelectorDropDown: View {
         HStack(spacing: 12) {
             Text(item.getDescription(for: coin))
                 .font(Theme.fonts.bodyMRegular)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             Spacer()
 
             if selected == item {
                 Image(systemName: "checkmark")
                     .font(Theme.fonts.bodyMRegular)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
             }
         }
         .frame(height: 48)

--- a/VultisigApp/VultisigApp/Components/FunctionCallSelectorDropdown.swift
+++ b/VultisigApp/VultisigApp/Components/FunctionCallSelectorDropdown.swift
@@ -44,7 +44,7 @@ struct FunctionCallSelectorDropdown: View {
         }
         .redacted(reason: selected.rawValue.isEmpty ? .placeholder : [])
         .font(Theme.fonts.bodyMRegular)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
         .frame(height: 48)
     }
 
@@ -65,14 +65,14 @@ struct FunctionCallSelectorDropdown: View {
         HStack(spacing: 12) {
             Text(item.display())
                 .font(Theme.fonts.bodyMRegular)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             Spacer()
 
             if selected == item {
                 Image(systemName: "checkmark")
                     .font(Theme.fonts.bodyMRegular)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
             }
         }
         .frame(height: 48)

--- a/VultisigApp/VultisigApp/Components/GeneralQRImportMacView.swift
+++ b/VultisigApp/VultisigApp/Components/GeneralQRImportMacView.swift
@@ -63,7 +63,7 @@ struct GeneralQRImportMacView: View {
     var title: some View {
         Text(getDescription())
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var uploadSection: some View {

--- a/VultisigApp/VultisigApp/Components/GenericSelectorDropDown.swift
+++ b/VultisigApp/VultisigApp/Components/GenericSelectorDropDown.swift
@@ -42,7 +42,7 @@ struct GenericSelectorDropDown<T: Identifiable & Equatable>: View {
             if !items.contains(selected) {
                 Text(mandatoryMessage ?? "")
                     .font(Theme.fonts.bodySMedium)
-                    .foregroundColor(.red)
+                    .foregroundStyle(.red)
             }
 
             Spacer()
@@ -53,7 +53,7 @@ struct GenericSelectorDropDown<T: Identifiable & Equatable>: View {
         }
         .redacted(reason: descriptionProvider(selected).isEmpty ? .placeholder : [])
         .font(Theme.fonts.bodyMRegular)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
         .frame(height: 48)
     }
 
@@ -74,14 +74,14 @@ struct GenericSelectorDropDown<T: Identifiable & Equatable>: View {
         HStack(spacing: 12) {
             Text(descriptionProvider(item))
                 .font(Theme.fonts.bodyMRegular)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             Spacer()
 
             if selected == item {
                 Image(systemName: "checkmark")
                     .font(Theme.fonts.bodyMRegular)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
             }
         }
         .frame(height: 48)

--- a/VultisigApp/VultisigApp/Components/GradientSeparator.swift
+++ b/VultisigApp/VultisigApp/Components/GradientSeparator.swift
@@ -25,7 +25,7 @@ struct GradientSeparator: View {
         .mask(
             Rectangle()
                 .frame(height: 1)
-                .foregroundColor(color)
+                .foregroundStyle(color)
                 .opacity(opacity)
         )
         .frame(height: 24)

--- a/VultisigApp/VultisigApp/Components/HiddenTextField.swift
+++ b/VultisigApp/VultisigApp/Components/HiddenTextField.swift
@@ -32,7 +32,7 @@ struct HiddenTextField: View {
     var error: some View {
         Text(NSLocalizedString(errorMessage, comment: ""))
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.alertError)
+            .foregroundStyle(Theme.colors.alertError)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -59,7 +59,7 @@ struct HiddenTextField: View {
             if password.isEmpty {
                 HStack {
                     Text(NSLocalizedString(placeholder, comment: ""))
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                     Spacer()
                 }
             }
@@ -75,7 +75,7 @@ struct HiddenTextField: View {
         .submitLabel(.done)
         .colorScheme(.dark)
         .font(Theme.fonts.bodyMMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var button: some View {
@@ -87,7 +87,7 @@ struct HiddenTextField: View {
             },
             label: {
                 Image(systemName: isPasswordVisible ? "eye": "eye.slash")
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
             }
         )
         .buttonStyle(.plain)

--- a/VultisigApp/VultisigApp/Components/IconCapsule.swift
+++ b/VultisigApp/VultisigApp/Components/IconCapsule.swift
@@ -31,13 +31,13 @@ struct IconCapsule: View {
 
     var titleContent: some View {
         Text(NSLocalizedString(title, comment: ""))
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
             .font(Theme.fonts.caption12)
     }
 
     func iconContent(_ icon: String) -> some View {
         Image(systemName: icon)
-            .foregroundColor(Theme.colors.bgButtonPrimary)
+            .foregroundStyle(Theme.colors.bgButtonPrimary)
             .font(Theme.fonts.bodyMMedium)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Icons/Icon.swift
+++ b/VultisigApp/VultisigApp/Components/Icons/Icon.swift
@@ -26,13 +26,13 @@ struct Icon: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: size, height: size)
-                .foregroundColor(color)
+                .foregroundColor(color) // foregroundColor (deprecated) accepts an optional Color; foregroundStyle requires non-optional
         } else {
             Image(name)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: size, height: size)
-                .foregroundColor(color)
+                .foregroundColor(color) // foregroundColor (deprecated) accepts an optional Color; foregroundStyle requires non-optional
         }
     }
 }

--- a/VultisigApp/VultisigApp/Components/ImageView/AsyncImageView.swift
+++ b/VultisigApp/VultisigApp/Components/ImageView/AsyncImageView.swift
@@ -91,7 +91,7 @@ struct AsyncImageView: View {
             .font(Theme.fonts.bodyMMedium)
             .frame(width: size.width, height: size.height)
             .background(Color.white)
-            .foregroundColor(Theme.colors.bgSurface1)
+            .foregroundStyle(Theme.colors.bgSurface1)
             .cornerRadius(100)
     }
 }

--- a/VultisigApp/VultisigApp/Components/ImportWalletUploadSection.swift
+++ b/VultisigApp/VultisigApp/Components/ImportWalletUploadSection.swift
@@ -57,7 +57,7 @@ struct ImportWalletUploadSection: View {
 
             Text(NSLocalizedString("dropFileHere", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
     }
 
@@ -68,7 +68,7 @@ struct ImportWalletUploadSection: View {
             Text(NSLocalizedString(viewModel.alertTitle, comment: ""))
                 .font(Theme.fonts.bodySMedium)
         }
-        .foregroundColor(Theme.colors.alertError)
+        .foregroundStyle(Theme.colors.alertError)
         .onAppear {
             withAnimation {
                 backgroundColor = Theme.colors.alertError
@@ -82,14 +82,14 @@ struct ImportWalletUploadSection: View {
 
             Text(NSLocalizedString("importYourVaultShare", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
     }
 
     private func textFile(for text: String) -> some View {
         Text(text)
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .padding(12)
     }
 
@@ -112,7 +112,7 @@ struct ImportWalletUploadSection: View {
             Text(filename)
                 .font(Theme.fonts.bodySMedium)
         }
-        .foregroundColor(Theme.colors.alertInfo)
+        .foregroundStyle(Theme.colors.alertInfo)
         .onAppear {
             withAnimation {
                 backgroundColor = Theme.colors.bgButtonPrimary
@@ -122,7 +122,7 @@ struct ImportWalletUploadSection: View {
 
     private func getIcon(isFileUploaded: Bool = false, tint: Color) -> some View {
         Image(systemName: isFileUploaded ? "text.document" : "icloud.and.arrow.up")
-            .foregroundColor(tint)
+            .foregroundStyle(tint)
             .font(Theme.fonts.largeTitle)
     }
 }

--- a/VultisigApp/VultisigApp/Components/InformationNote.swift
+++ b/VultisigApp/VultisigApp/Components/InformationNote.swift
@@ -27,19 +27,19 @@ struct InformationNote: View {
 
     var icon: some View {
         Image(systemName: "exclamationmark.triangle")
-            .foregroundColor(Theme.colors.bgAlert)
+            .foregroundStyle(Theme.colors.bgAlert)
     }
 
     var text: some View {
         if message == nil {
             Text(NSLocalizedString("joinKeygenConnectionDisclaimer", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .font(Theme.fonts.caption12)
                 .lineSpacing(8)
                 .multilineTextAlignment(.leading)
         } else {
             Text(message ?? "")
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .font(Theme.fonts.caption12)
                 .lineSpacing(8)
                 .multilineTextAlignment(.leading)

--- a/VultisigApp/VultisigApp/Components/Loaders/Loader.swift
+++ b/VultisigApp/VultisigApp/Components/Loaders/Loader.swift
@@ -28,7 +28,7 @@ struct Loader: View {
 
             Text(NSLocalizedString("pleaseWait", comment: ""))
                 .font(Theme.fonts.bodyMMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
         .frame(width: 180, height: 120)
         .background(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Components/Navigation Header/AddressBookHeader.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Header/AddressBookHeader.swift
@@ -30,7 +30,7 @@ struct AddressBookHeader: View {
 
     var text: some View {
         Text(NSLocalizedString("addressBook", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(.title3)
     }
 
@@ -64,7 +64,7 @@ struct AddressBookHeader: View {
 
     var doneButton: some View {
         Text(NSLocalizedString("done", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodyLRegular)
     }
 

--- a/VultisigApp/VultisigApp/Components/Navigation Header/AddressQRCodeHeader.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Header/AddressQRCodeHeader.swift
@@ -31,7 +31,7 @@ struct AddressQRCodeHeader: View {
 
     var text: some View {
         Text(NSLocalizedString("address", comment: "AddressQRCodeView title"))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(.title3)
     }
 

--- a/VultisigApp/VultisigApp/Components/Navigation Header/FolderDetailHeader.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Header/FolderDetailHeader.swift
@@ -31,7 +31,7 @@ struct FolderDetailHeader: View {
 
     var text: some View {
         Text(title)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(.title3)
     }
 
@@ -51,13 +51,13 @@ struct FolderDetailHeader: View {
 
     var editIcon: some View {
         Image(systemName: "square.and.pencil")
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodyLMedium)
     }
 
     var doneLabel: some View {
         Text(NSLocalizedString("done", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodyLMedium)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Navigation Header/JoinKeygenHeader.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Header/JoinKeygenHeader.swift
@@ -31,7 +31,7 @@ struct JoinKeygenHeader: View {
 
     var text: some View {
         Text(NSLocalizedString(title, comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(.title3)
     }
 

--- a/VultisigApp/VultisigApp/Components/Navigation Header/SettingsHeader.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Header/SettingsHeader.swift
@@ -20,7 +20,7 @@ struct SettingsHeader: View {
 
     var text: some View {
         Text(NSLocalizedString("settings", comment: "Settings"))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(.title3)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Navigation Items/NavigationBackSheetButton.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Items/NavigationBackSheetButton.swift
@@ -19,7 +19,7 @@ struct NavigationBackSheetButton: View {
             label: {
                 Image(systemName: "chevron.backward")
                     .font(Theme.fonts.bodyLMedium)
-                    .foregroundColor(tint)
+                    .foregroundStyle(tint)
             }
         )
     }

--- a/VultisigApp/VultisigApp/Components/Navigation Items/NavigationBlankBackButton.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Items/NavigationBlankBackButton.swift
@@ -13,7 +13,7 @@ struct NavigationBlankBackButton: View {
     var body: some View {
         Image(systemName: "chevron.backward")
             .font(Theme.fonts.bodyLMedium)
-            .foregroundColor(tint)
+            .foregroundStyle(tint)
     }
 }
 

--- a/VultisigApp/VultisigApp/Components/Navigation Items/NavigationHelpButton.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Items/NavigationHelpButton.swift
@@ -19,7 +19,7 @@ struct NavigationHelpButton: View {
     var image: some View {
         Image(systemName: "questionmark.circle")
             .font(Theme.fonts.bodyLMedium)
-            .foregroundColor(tint)
+            .foregroundStyle(tint)
     }
 }
 

--- a/VultisigApp/VultisigApp/Components/Navigation Items/NavigationHomeEditButton.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Items/NavigationHomeEditButton.swift
@@ -86,13 +86,13 @@ struct NavigationHomeEditButton: View {
         } label: {
             Image(.trash)
                 .font(Theme.fonts.bodyLMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
     }
 
     var doneButton: some View {
         Text(NSLocalizedString("done", comment: ""))
-            .foregroundColor(tint)
+            .foregroundStyle(tint)
             .font(Theme.fonts.bodyLMedium)
     }
 

--- a/VultisigApp/VultisigApp/Components/Navigation Items/NavigationMenuButton.swift
+++ b/VultisigApp/VultisigApp/Components/Navigation Items/NavigationMenuButton.swift
@@ -13,7 +13,7 @@ struct NavigationMenuButton: View {
     var body: some View {
         Image("MenuIcon")
             .font(Theme.fonts.bodyLMedium)
-            .foregroundColor(tint)
+            .foregroundStyle(tint)
     }
 }
 

--- a/VultisigApp/VultisigApp/Components/New Wallet/FastVaultPasswordDisclaimer.swift
+++ b/VultisigApp/VultisigApp/Components/New Wallet/FastVaultPasswordDisclaimer.swift
@@ -22,7 +22,7 @@ struct FastVaultPasswordDisclaimer: View {
             info
         }
         .font(Theme.fonts.bodySMedium)
-        .foregroundColor(Theme.colors.alertWarning)
+        .foregroundStyle(Theme.colors.alertWarning)
         .padding(16)
         .background(Theme.colors.bgAlert)
         .cornerRadius(12)
@@ -79,7 +79,7 @@ struct FastVaultPasswordDisclaimer: View {
     var title: some View {
         HStack {
             Text(NSLocalizedString("moreInfo", comment: ""))
-                .foregroundColor(Theme.colors.textDark)
+                .foregroundStyle(Theme.colors.textDark)
 
             Spacer()
             closeButton
@@ -92,13 +92,13 @@ struct FastVaultPasswordDisclaimer: View {
             showTooltip = false
         } label: {
             Image(systemName: "xmark")
-                .foregroundColor(Theme.colors.textButtonDisabled)
+                .foregroundStyle(Theme.colors.textButtonDisabled)
         }
     }
 
     var description: some View {
         Text(NSLocalizedString("moreInfoDescription", comment: ""))
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
             .font(Theme.fonts.bodySMedium)
             .multilineTextAlignment(.leading)
             .lineLimit(nil)

--- a/VultisigApp/VultisigApp/Components/OutlinedDisclaimer.swift
+++ b/VultisigApp/VultisigApp/Components/OutlinedDisclaimer.swift
@@ -24,7 +24,7 @@ struct OutlinedDisclaimer: View {
 
             Text(text)
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .lineSpacing(4)
                 .multilineTextAlignment(alignment)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/VultisigApp/VultisigApp/Components/PickReferralCode.swift
+++ b/VultisigApp/VultisigApp/Components/PickReferralCode.swift
@@ -26,7 +26,7 @@ struct PickReferralCode: View {
 
     var pickReferralTitle: some View {
         Text(NSLocalizedString("pickReferralCode", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodySMedium)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -61,12 +61,12 @@ struct PickReferralCode: View {
         if let status = viewModel.availabilityStatus {
             HStack {
                 Text(NSLocalizedString("status", comment: ""))
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
 
                 Spacer()
 
                 Text(status.description)
-                    .foregroundColor(status.color)
+                    .foregroundStyle(status.color)
                     .padding(.vertical, 8)
                     .padding(.horizontal, 12)
                     .cornerRadius(24)

--- a/VultisigApp/VultisigApp/Components/PopupCapsule.swift
+++ b/VultisigApp/VultisigApp/Components/PopupCapsule.swift
@@ -28,7 +28,7 @@ struct PopupCapsule: View {
 
     var capsule: some View {
         Text(showText ? NSLocalizedString(text, comment: "") : "")
-            .foregroundColor(Theme.colors.textPrimary.opacity(showText ? 1 : 0))
+            .foregroundStyle(Theme.colors.textPrimary.opacity(showText ? 1 : 0))
             .font(Theme.fonts.bodySMedium)
             .padding()
             .padding(.horizontal, showText ? 16 : 8)

--- a/VultisigApp/VultisigApp/Components/ReferralOnboardingBanner.swift
+++ b/VultisigApp/VultisigApp/Components/ReferralOnboardingBanner.swift
@@ -40,11 +40,11 @@ struct ReferralOnboardingBanner: View {
     var title: some View {
         Group {
             Text(NSLocalizedString("referralOnboardingBannerTitle1", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary) +
+                .foregroundStyle(Theme.colors.textPrimary) +
             Text(NSLocalizedString("referralOnboardingBannerTitle2", comment: ""))
                 .foregroundStyle(LinearGradient.primaryGradient) +
             Text(NSLocalizedString("referralOnboardingBannerTitle3", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
         .font(Theme.fonts.title2)
         .multilineTextAlignment(.center)
@@ -82,7 +82,7 @@ struct ReferralOnboardingBanner: View {
     var closeLabel: some View {
         Image(systemName: "xmark")
             .font(Theme.fonts.title2)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     private func handleTap() {

--- a/VultisigApp/VultisigApp/Components/ReferralTextField.swift
+++ b/VultisigApp/VultisigApp/Components/ReferralTextField.swift
@@ -64,7 +64,7 @@ struct ReferralTextField: View {
             }
         }
         .font(Theme.fonts.bodyMRegular)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var copyButton: some View {

--- a/VultisigApp/VultisigApp/Components/SecurityScanner/SecurityScannerBottomSheet.swift
+++ b/VultisigApp/VultisigApp/Components/SecurityScanner/SecurityScannerBottomSheet.swift
@@ -35,11 +35,11 @@ struct SecurityScannerBottomSheetContent: View {
         VStack(spacing: 24) {
             Image(systemName: contentStyle.image)
                 .font(.system(size: 24, weight: .semibold))
-                .foregroundColor(contentStyle.imageColor)
+                .foregroundStyle(contentStyle.imageColor)
 
             VStack(spacing: 12) {
                 Text(contentStyle.title)
-                    .foregroundColor(contentStyle.imageColor)
+                    .foregroundStyle(contentStyle.imageColor)
                     .font(Theme.fonts.title2)
                     .multilineTextAlignment(.center)
 

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
@@ -43,7 +43,7 @@ struct SendDetailsAdditionalSection: View {
 
     var chevronIcon: some View {
         Image(systemName: "chevron.down")
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodySMedium)
             .rotationEffect(.degrees(isMemoExpanded ? 180 : 0))
             .animation(.easeInOut, value: isMemoExpanded)
@@ -73,6 +73,6 @@ struct SendDetailsAdditionalSection: View {
     private func getFieldTitle(_ title: String) -> some View {
         Text(NSLocalizedString(title, comment: ""))
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
@@ -24,7 +24,7 @@ struct SendDetailsAddressFields: View {
         VStack(spacing: 12) {
             Text("from".localized)
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)
             fromDetailsField
         }
@@ -34,11 +34,11 @@ struct SendDetailsAddressFields: View {
         VStack(alignment: .leading, spacing: 2) {
             if let vaultName = appViewModel.selectedVault?.name {
                 Text(vaultName)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
             }
 
             Text(viewModel.fromAddress)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .lineLimit(1)
                 .truncationMode(.middle)
         }

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressTab.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressTab.swift
@@ -36,7 +36,7 @@ struct SendDetailsAddressTab: View {
         HStack {
             Text(NSLocalizedString("address", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             if viewModel.addressSetupDone {
                 selectedAddress
@@ -59,7 +59,7 @@ struct SendDetailsAddressTab: View {
     var selectedAddress: some View {
         Text("\(viewModel.toAddress)")
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
             .lineLimit(1)
             .truncationMode(.middle)
     }

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTab.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTab.swift
@@ -50,7 +50,7 @@ struct SendDetailsAmountTab: View {
         HStack {
             Text(NSLocalizedString("amount", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             Spacer()
 
@@ -82,7 +82,7 @@ struct SendDetailsAmountTab: View {
 
     var editLabel: some View {
         Image(systemName: "fuelpump")
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodyMMedium)
     }
 
@@ -112,7 +112,7 @@ struct SendDetailsAmountTab: View {
             Text(viewModel.coin.balanceString + " " + viewModel.coin.ticker)
         }
         .font(Theme.fonts.bodySMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
         .padding(12)
         .padding(.vertical, 8)
         .background(Theme.colors.bgSurface1)
@@ -126,7 +126,7 @@ struct SendDetailsAmountTab: View {
     var errorText: some View {
         Text(NSLocalizedString(viewModel.errorMessage ?? .empty, comment: ""))
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.alertWarning)
+            .foregroundStyle(Theme.colors.alertWarning)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTextField.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTextField.swift
@@ -56,7 +56,7 @@ struct SendDetailsAmountTextField: View {
     var selectorOvelay: some View {
         Circle()
             .frame(width: 32, height: 32)
-            .foregroundColor(Theme.colors.bgButtonTertiary)
+            .foregroundStyle(Theme.colors.bgButtonTertiary)
             .offset(y: isCryptoSelected ? -16 : 16)
     }
 
@@ -141,20 +141,20 @@ struct SendDetailsAmountTextField: View {
     private func getUnit(for unit: String) -> some View {
         Text(unit)
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     private func getDescriptionText(for value: String) -> some View {
         Text(value)
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
             .padding(.top, 8)
     }
 
     private func getSelector(for icon: String) -> some View {
         Image(systemName: icon)
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(width: 32, height: 32)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAssetTab.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAssetTab.swift
@@ -55,7 +55,7 @@ struct SendDetailsAssetTab: View {
         HStack {
             Text(NSLocalizedString("asset", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             if viewModel.assetSetupDone {
                 doneSelectedAsset
@@ -101,7 +101,7 @@ struct SendDetailsAssetTab: View {
     var chainSelectionTitle: some View {
         Text(NSLocalizedString("from", comment: ""))
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
     }
 
     var selectedChainCell: some View {
@@ -132,11 +132,11 @@ struct SendDetailsAssetTab: View {
                 Text(viewModel.coin.balanceString)
             }
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
 
             Text(viewModel.coin.balanceInFiat)
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
@@ -152,7 +152,7 @@ struct SendDetailsAssetTab: View {
 
             Text("\(viewModel.coin.ticker)")
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
         }
     }
 

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsTabEditTools.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsTabEditTools.swift
@@ -21,7 +21,7 @@ struct SendDetailsTabEditTools: View {
 
     var checkmark: some View {
         Image(systemName: "checkmark.circle")
-            .foregroundColor(Theme.colors.alertSuccess)
+            .foregroundStyle(Theme.colors.alertSuccess)
     }
 
     var editButton: some View {
@@ -34,6 +34,6 @@ struct SendDetailsTabEditTools: View {
 
     var editLabel: some View {
         Image(systemName: "pencil")
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Separator.swift
+++ b/VultisigApp/VultisigApp/Components/Separator.swift
@@ -14,7 +14,7 @@ struct Separator: View {
     var body: some View {
         Rectangle()
             .frame(height: 1)
-            .foregroundColor(color)
+            .foregroundStyle(color)
             .opacity(opacity)
     }
 }

--- a/VultisigApp/VultisigApp/Components/StepsAnimationView.swift
+++ b/VultisigApp/VultisigApp/Components/StepsAnimationView.swift
@@ -57,7 +57,7 @@ struct StepsAnimationView<Header: View, CellContent: View>: View {
         if height.isFinite && height > 0 {
             Rectangle()
                 .frame(width: 3, height: height)
-                .foregroundColor(Theme.colors.borderLight)
+                .foregroundStyle(Theme.colors.borderLight)
                 .offset(x: 1)
         }
     }
@@ -88,7 +88,7 @@ struct StepsAnimationView<Header: View, CellContent: View>: View {
 
     var titleView: some View {
         Text(title)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.largeTitle)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, 24)
@@ -97,7 +97,7 @@ struct StepsAnimationView<Header: View, CellContent: View>: View {
     var shadow: some View {
         Circle()
             .frame(width: 360, height: 360)
-            .foregroundColor(Theme.colors.alertInfo)
+            .foregroundStyle(Theme.colors.alertInfo)
             .opacity(0.05)
             .blur(radius: 20)
     }
@@ -116,7 +116,7 @@ struct StepsAnimationView<Header: View, CellContent: View>: View {
         HStack(spacing: 0) {
             Rectangle()
                 .frame(width: 22, height: 3)
-                .foregroundColor(Theme.colors.borderLight)
+                .foregroundStyle(Theme.colors.borderLight)
 
             cellContent(index)
                 .padding(16)

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -157,12 +157,12 @@ struct SwapDetailsSummary: View {
     var affiliateFee: some View {
         HStack {
             Text(vm.swapFeeLabel)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
 
             Spacer()
 
             Text(vm.baseAffiliateFee)
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
         }
         .font(Theme.fonts.caption12)
     }
@@ -172,13 +172,13 @@ struct SwapDetailsSummary: View {
             vultTierIcon
 
             Text(vm.vultDiscountLabel)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .font(Theme.fonts.caption12)
 
             Spacer()
 
             Text(vm.vultDiscount)
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
                 .font(Theme.fonts.caption12)
         }
     }
@@ -193,7 +193,7 @@ struct SwapDetailsSummary: View {
         } else {
             Image(systemName: "star.circle.fill")
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.turquoise)
+                .foregroundStyle(Theme.colors.turquoise)
         }
     }
 
@@ -208,16 +208,16 @@ struct SwapDetailsSummary: View {
         HStack {
             Image(systemName: "megaphone.fill")
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.primaryAccent4)
+                .foregroundStyle(Theme.colors.primaryAccent4)
 
             Text(vm.referralDiscountLabel)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .font(Theme.fonts.caption12)
 
             Spacer()
 
             Text(vm.referralDiscount)
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
                 .font(Theme.fonts.caption12)
         }
     }
@@ -225,12 +225,12 @@ struct SwapDetailsSummary: View {
     var priceImpact: some View {
         HStack {
             Text(NSLocalizedString("swap.price_impact", comment: "Price Impact"))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
 
             Spacer()
 
             Text(vm.priceImpactString)
-                .foregroundColor(vm.priceImpactColor)
+                .foregroundStyle(vm.priceImpactColor)
         }
         .font(Theme.fonts.caption12)
     }
@@ -238,12 +238,12 @@ struct SwapDetailsSummary: View {
     private func getSummaryCell(leadingText: String, trailingText: String) -> some View {
         HStack {
             Text(NSLocalizedString(leadingText, comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
 
             Spacer()
 
             Text(trailingText)
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
                 .redacted(reason: detailsViewModel.isLoading ? .placeholder : [])
         }
         .font(Theme.fonts.caption12)
@@ -258,7 +258,7 @@ struct SwapDetailsSummary: View {
     private func getErrorCell(text: String) -> some View {
         HStack {
             Text(text)
-                .foregroundColor(Theme.colors.alertError)
+                .foregroundStyle(Theme.colors.alertError)
                 .font(Theme.fonts.caption12)
                 .multilineTextAlignment(.leading)
                 .lineSpacing(4)

--- a/VultisigApp/VultisigApp/Components/Swap/SwapFromToChain.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapFromToChain.swift
@@ -27,13 +27,13 @@ struct SwapFromToChain: View {
     var title: some View {
         Text(chain?.name ?? "")
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var chevron: some View {
         Image(systemName: "chevron.down")
             .font(Theme.fonts.caption10)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .cornerRadius(32)
             .bold()
     }

--- a/VultisigApp/VultisigApp/Components/Swap/SwapFromToCoin.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapFromToCoin.swift
@@ -34,19 +34,19 @@ struct SwapFromToCoin: View {
         VStack(alignment: .leading, spacing: 0) {
             Text("\(coin.ticker)")
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             if coin.isNativeToken {
                 Text("Native")
                     .font(Theme.fonts.caption10)
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
             }
         }
     }
 
     var chevron: some View {
         Image(systemName: "chevron.right")
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.caption12)
             .bold()
             .padding(.trailing, 8)

--- a/VultisigApp/VultisigApp/Components/Swap/SwapFromToField.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapFromToField.swift
@@ -57,13 +57,13 @@ struct SwapFromToField: View {
     var fromToLabel: some View {
         Text(NSLocalizedString(title, comment: ""))
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
     }
 
     var balance: some View {
         Text("\(coin.balanceString) \(coin.ticker)")
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
     }
 
     var unevenRectangle: some View {
@@ -75,7 +75,7 @@ struct SwapFromToField: View {
                 topTrailing: 24
             )
         )
-        .foregroundColor(Theme.colors.bgSurface1)
+        .foregroundStyle(Theme.colors.bgSurface1)
         .rotationEffect(.degrees(title=="from" ? 0 : 180))
     }
 
@@ -141,7 +141,7 @@ struct SwapFromToField: View {
     var fiatBalance: some View {
         Text(fiatAmount.formatToFiat(includeCurrencySymbol: true))
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
             .frame(maxWidth: .infinity, alignment: .trailing)
             .opacity(isFiatVisible() ? 1 : 0)
             .animation(.easeInOut(duration: 0.25), value: fiatAmount)

--- a/VultisigApp/VultisigApp/Components/Swap/SwapPercentageButtons.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapPercentageButtons.swift
@@ -59,7 +59,7 @@ extension SwapPercentageButtons {
     func getPercentageCell(for text: String, isSelected: Bool) -> some View {
         Text(text + "%")
             .font(Theme.fonts.caption12)
-            .foregroundColor(isSelected ? Color.white : Theme.colors.textPrimary)
+            .foregroundStyle(isSelected ? Color.white : Theme.colors.textPrimary)
             .padding(.horizontal, 8)
             .padding(.vertical, 10)
             .background(isSelected ? Theme.colors.bgPrimary : Theme.colors.bgSurface1)
@@ -83,7 +83,7 @@ extension SwapPercentageButtons {
     var separator: some View {
         Rectangle()
             .frame(height: 1)
-            .foregroundColor(Theme.colors.bgSurface2)
+            .foregroundStyle(Theme.colors.bgSurface2)
     }
 
     var buttons: some View {
@@ -110,7 +110,7 @@ extension SwapPercentageButtons {
     func getPercentageCell(for text: String, isSelected: Bool) -> some View {
         Text(text + "%")
             .font(Theme.fonts.caption12)
-            .foregroundColor(isSelected ? Color.white : Theme.colors.textPrimary)
+            .foregroundStyle(isSelected ? Color.white : Theme.colors.textPrimary)
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
             .background(isSelected ? Theme.colors.bgPrimary : Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Components/Swap/SwapRefreshQuoteCounter.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapRefreshQuoteCounter.swift
@@ -28,7 +28,7 @@ struct SwapRefreshQuoteCounter: View {
             Text(String(format: "%02d", timer))
         }
         .font(Theme.fonts.caption12)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var loader: some View {

--- a/VultisigApp/VultisigApp/Components/TabBar/VultiTabBar.swift
+++ b/VultisigApp/VultisigApp/Components/TabBar/VultiTabBar.swift
@@ -241,11 +241,11 @@ private extension VultiTabBar {
         switch item {
         case .wallet:
             Color.blue.ignoresSafeArea()
-                .overlay(Text("Wallet").foregroundColor(.white))
+                .overlay(Text("Wallet").foregroundStyle(.white))
                 .tag(HomeTab.wallet)
         case .defi:
             Color.green.ignoresSafeArea()
-                .overlay(Text("Earn").foregroundColor(.white))
+                .overlay(Text("Earn").foregroundStyle(.white))
                 .tag(HomeTab.defi)
         case .camera:
             EmptyView()

--- a/VultisigApp/VultisigApp/Components/Text/HighlightedTextWithImage.swift
+++ b/VultisigApp/VultisigApp/Components/Text/HighlightedTextWithImage.swift
@@ -25,12 +25,12 @@ struct HighlightedTextWithImage: View {
                 if !beforeText.isEmpty {
                     Text(beforeText)
                         .font(font)
-                        .foregroundColor(foregroundColor)
+                        .foregroundStyle(foregroundColor)
                 }
 
                 Text(highlightedText)
                     .font(font)
-                    .foregroundColor(.clear)
+                    .foregroundStyle(.clear)
                     .overlay {
                         Image(imageName)
                             .resizable()
@@ -44,14 +44,14 @@ struct HighlightedTextWithImage: View {
                 if !afterText.isEmpty {
                     Text(afterText)
                         .font(font)
-                        .foregroundColor(foregroundColor)
+                        .foregroundStyle(foregroundColor)
                 }
             }
         } else {
             // Fallback if highlighted text not found
             Text(text)
                 .font(font)
-                .foregroundColor(foregroundColor)
+                .foregroundStyle(foregroundColor)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Components/TextEditor/CommonTextEditor.swift
+++ b/VultisigApp/VultisigApp/Components/TextEditor/CommonTextEditor.swift
@@ -45,7 +45,7 @@ struct CommonTextEditor: View {
                     TextEditor(text: $value)
                         .textEditorStyle(.plain)
                         .scrollContentBackground(.hidden)
-                        .foregroundColor(Theme.colors.textPrimary)
+                        .foregroundStyle(Theme.colors.textPrimary)
                         .font(Theme.fonts.bodyMMedium)
                         .submitLabel(.continue)
                         .autocorrectionDisabled()
@@ -64,7 +64,7 @@ struct CommonTextEditor: View {
                 }
                 if value.isEmpty {
                     Text(placeholder)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                         .font(Theme.fonts.bodyMMedium)
                         .padding(.leading, 6)
                         .padding(.top, isMacOS ? 0 : 8)
@@ -76,7 +76,7 @@ struct CommonTextEditor: View {
                         HStack {
                             Spacer()
                             Text(accessory)
-                                .foregroundColor(Theme.colors.textTertiary)
+                                .foregroundStyle(Theme.colors.textTertiary)
                                 .font(Theme.fonts.caption12)
                         }
                     }
@@ -95,7 +95,7 @@ struct CommonTextEditor: View {
 
             if let error, showErrorText {
                 Text(error.localized)
-                    .foregroundColor(Theme.colors.alertError)
+                    .foregroundStyle(Theme.colors.alertError)
                     .font(Theme.fonts.footnote)
                     .multilineTextAlignment(.leading)
                     .fixedSize(horizontal: false, vertical: true)
@@ -118,7 +118,7 @@ struct CommonTextEditor: View {
             value = ""
         } label: {
             Image(systemName: "xmark.circle.fill")
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Components/TextField/CommonTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextField/CommonTextField.swift
@@ -83,7 +83,7 @@ struct CommonTextField<TrailingView: View>: View {
         VStack(alignment: .leading, spacing: 8) {
             if let label {
                 Text(label)
-                    .foregroundColor(labelColor)
+                    .foregroundStyle(labelColor)
                     .font(labelFont)
             }
 
@@ -91,7 +91,7 @@ struct CommonTextField<TrailingView: View>: View {
                 HStack {
                     textFieldContainer
                         .font(Theme.fonts.bodyMRegular)
-                        .foregroundColor(Theme.colors.textPrimary)
+                        .foregroundStyle(Theme.colors.textPrimary)
                         .submitLabel(.done)
                         .colorScheme(.dark)
                         .frame(maxWidth: .infinity)
@@ -115,7 +115,7 @@ struct CommonTextField<TrailingView: View>: View {
 
                 if let error, showErrorText {
                     Text(error.localized)
-                        .foregroundColor(Theme.colors.alertError)
+                        .foregroundStyle(Theme.colors.alertError)
                         .font(Theme.fonts.footnote)
                         .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true)

--- a/VultisigApp/VultisigApp/Components/TextField/SearchTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextField/SearchTextField.swift
@@ -39,7 +39,7 @@ struct SearchTextField: View {
             )
             TextField(placeholder, text: $value)
                 .font(Theme.fonts.bodyMMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .disableAutocorrection(true)
                 .borderlessTextFieldStyle()
                 .colorScheme(.dark)
@@ -75,7 +75,7 @@ struct SearchTextField: View {
             isFocused = false
         } label: {
             Image(systemName: "xmark.circle.fill")
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
         }
         .buttonStyle(.plain)
     }

--- a/VultisigApp/VultisigApp/Components/TextField/SecureTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextField/SecureTextField.swift
@@ -47,7 +47,7 @@ struct SecureTextField: View {
                     },
                     label: {
                         Image(systemName: isSecure ? "eye.slash": "eye")
-                            .foregroundColor(Theme.colors.textPrimary)
+                            .foregroundStyle(Theme.colors.textPrimary)
                     }
                 )
                 .buttonStyle(.plain)

--- a/VultisigApp/VultisigApp/Components/TextFields/MemoTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/MemoTextField.swift
@@ -39,7 +39,7 @@ struct MemoTextField: View {
             .submitLabel(.next)
             .disableAutocorrection(true)
             .textFieldStyle(TappableTextFieldStyle())
-            .foregroundColor(isEnabled ? Theme.colors.textPrimary : Theme.colors.textSecondary)
+            .foregroundStyle(isEnabled ? Theme.colors.textPrimary : Theme.colors.textSecondary)
     }
 
     var pasteButton: some View {

--- a/VultisigApp/VultisigApp/Components/TextFields/SendCryptoAmountTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/SendCryptoAmountTextField.swift
@@ -43,7 +43,7 @@ struct SendCryptoAmountTextField: View {
         .font(Theme.fonts.largeTitle)
         .disableAutocorrection(true)
         .textFieldStyle(TappableTextFieldStyle())
-        .foregroundColor(isEnabled ? Theme.colors.textPrimary : Theme.colors.textSecondary)
+        .foregroundStyle(isEnabled ? Theme.colors.textPrimary : Theme.colors.textSecondary)
         .maxLength(Binding<String>(
             get: { amount },
             set: {
@@ -65,7 +65,7 @@ struct SendCryptoAmountTextField: View {
         Button { onMaxPressed?() } label: {
             Text(NSLocalizedString("max", comment: "").uppercased())
                 .font(Theme.fonts.bodyMMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .frame(width: 40, height: 40)
         }
     }

--- a/VultisigApp/VultisigApp/Components/TextFields/StyledFloatingPointField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/StyledFloatingPointField.swift
@@ -24,11 +24,11 @@ struct StyledFloatingPointField: View {
             HStack {
                 Text("\(label)\(optionalMessage)")
                     .font(Theme.fonts.bodySMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                 if !localIsValid {
                     Text("*")
                         .font(Theme.fonts.caption10)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
             }
 
@@ -41,10 +41,10 @@ struct StyledFloatingPointField: View {
         TextField("", text: $textFieldValue)
             .placeholder(when: textFieldValue.isEmpty) {
                 Text(placeholder.capitalized)
-                    .foregroundColor(.gray)
+                    .foregroundStyle(.gray)
             }
             .font(Theme.fonts.bodyMRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .submitLabel(.done)
             .padding(12)
             .background(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Components/TextFields/StyledNumberField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/StyledNumberField.swift
@@ -23,11 +23,11 @@ struct StyledIntegerField<Value: BinaryInteger & Codable>: View {
             HStack {
                 Text("\(placeholder)\(optionalMessage)")
                     .font(Theme.fonts.bodySMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                 if !localIsValid {
                     Text("*")
                         .font(Theme.fonts.bodySMedium)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
             }
 
@@ -38,7 +38,7 @@ struct StyledIntegerField<Value: BinaryInteger & Codable>: View {
     var textField: some View {
         TextField(placeholder.capitalized, value: customBinding, format: format)
             .font(Theme.fonts.bodyMRegular)
-            .foregroundColor(foregroundColor)
+            .foregroundStyle(foregroundColor)
             .submitLabel(.done)
             .padding(12)
             .background(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Components/TextFields/StyledTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/StyledTextField.swift
@@ -22,17 +22,17 @@ struct StyledTextField: View {
             HStack {
                 Text("\(placeholder)\(optionalMessage)")
                     .font(Theme.fonts.bodySMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                 if !localIsValid {
                     Text("*")
                         .font(Theme.fonts.bodySMedium)
-                        .foregroundColor(.red)
+                        .foregroundStyle(.red)
                 }
             }
 
             TextField(placeholder.capitalized, text: customBinding)
                 .font(Theme.fonts.bodyMRegular)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .submitLabel(.done)
                 .padding(12)
                 .background(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Components/TextFields/SwapCryptoAmountTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/SwapCryptoAmountTextField.swift
@@ -27,7 +27,7 @@ struct SwapCryptoAmountTextField: View {
     var textField: some View {
         field
             .font(Theme.fonts.bodyLMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var field: some View {
@@ -55,7 +55,7 @@ struct SwapCryptoAmountTextField: View {
             .disableAutocorrection(true)
             .textFieldStyle(TappableTextFieldStyle())
             .borderlessTextFieldStyle()
-            .foregroundColor(isEnabled ? Theme.colors.textPrimary : Theme.colors.textSecondary)
+            .foregroundStyle(isEnabled ? Theme.colors.textPrimary : Theme.colors.textSecondary)
             .multilineTextAlignment(.trailing)
     }
 }

--- a/VultisigApp/VultisigApp/Components/TransactionDone/TransactionDoneHashRowView.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/TransactionDoneHashRowView.swift
@@ -20,7 +20,7 @@ struct TransactionDoneHashRowView: View {
     var body: some View {
         HStack(spacing: 32) {
             Text(NSLocalizedString("transactionHash", comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .lineLimit(1)
                 .truncationMode(.tail)
 
@@ -49,7 +49,7 @@ struct TransactionDoneHashRowView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 16, height: 16)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
     }
 
@@ -63,14 +63,14 @@ struct TransactionDoneHashRowView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 16, height: 16)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
             }
         }
     }
 
     var hashView: some View {
         Text(hash)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .lineLimit(1)
             .truncationMode(.middle)
     }

--- a/VultisigApp/VultisigApp/Components/WarningView.swift
+++ b/VultisigApp/VultisigApp/Components/WarningView.swift
@@ -33,13 +33,13 @@ struct WarningView: View {
     var icon: some View {
         Image(systemName: "exclamationmark.triangle")
             .font(Theme.fonts.title2)
-            .foregroundColor(Theme.colors.alertError)
+            .foregroundStyle(Theme.colors.alertError)
     }
 
     var title: some View {
         Text(text)
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .multilineTextAlignment(.center)
             .frame(maxWidth: .infinity)
     }

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/OpenGalleryButton.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/OpenGalleryButton.swift
@@ -25,11 +25,11 @@ struct OpenButton: View {
         HStack(spacing: 10) {
             Image(systemName: buttonIcon)
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.bgSurface1)
+                .foregroundStyle(Theme.colors.bgSurface1)
 
             Text(NSLocalizedString(buttonLabel, comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.bgSurface1)
+                .foregroundStyle(Theme.colors.bgSurface1)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
         }

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacAddressScannerView+macOS.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacAddressScannerView+macOS.swift
@@ -221,7 +221,7 @@ struct MacAddressScannerView: View {
             HStack(spacing: 20) {
                 Text(NSLocalizedString("initializingCamera", comment: ""))
                     .font(Theme.fonts.bodyMMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
 
                 ProgressView()
                     .preferredColorScheme(.dark)

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacScannerView.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/MacScannerView.swift
@@ -194,7 +194,7 @@ struct MacScannerView: View {
             HStack(spacing: 20) {
                 Text(NSLocalizedString("initializingCamera", comment: ""))
                     .font(Theme.fonts.bodyMMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
 
                 ProgressView()
                     .preferredColorScheme(.dark)

--- a/VultisigApp/VultisigApp/Features/AddressBook/Views/AddressBookChainCellView.swift
+++ b/VultisigApp/VultisigApp/Features/AddressBook/Views/AddressBookChainCellView.swift
@@ -29,6 +29,6 @@ struct AddressBookChainCellView: View {
     var nameText: some View {
         Text(chain.name)
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 }

--- a/VultisigApp/VultisigApp/Features/AddressBook/Views/AddressBookChainSelector.swift
+++ b/VultisigApp/VultisigApp/Features/AddressBook/Views/AddressBookChainSelector.swift
@@ -17,7 +17,7 @@ struct AddressBookChainSelector: View {
         } label: {
             VStack(alignment: .leading, spacing: 8) {
                 Text("chain".localized)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                     .font(Theme.fonts.bodySMedium)
                 ContainerView {
                     HStack {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/AssetSelectionList/AssetSelectionListScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/AssetSelectionList/AssetSelectionListScreen.swift
@@ -78,7 +78,7 @@ struct AssetSelectionListScreen: View {
 
             Text(NSLocalizedString("loading", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.top, 48)

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/BondMaya/BondMayaTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/BondMaya/BondMayaTransactionScreen.swift
@@ -76,11 +76,11 @@ struct BondMayaTransactionScreen: View {
                         HStack {
                             Text("availableLPUnits".localized)
                                 .font(Theme.fonts.caption12)
-                                .foregroundColor(Theme.colors.textTertiary)
+                                .foregroundStyle(Theme.colors.textTertiary)
                             Spacer()
                             Text(availableUnits)
                                 .font(Theme.fonts.caption12)
-                                .foregroundColor(Theme.colors.textPrimary)
+                                .foregroundStyle(Theme.colors.textPrimary)
                             Button(
                                 action: {
                                     viewModel.lpUnitsField.value = availableUnits
@@ -88,7 +88,7 @@ struct BondMayaTransactionScreen: View {
                                 label: {
                                     Text("max".localized)
                                         .font(Theme.fonts.caption12)
-                                        .foregroundColor(Theme.colors.alertInfo)
+                                        .foregroundStyle(Theme.colors.alertInfo)
                                 }
                             )
                         }
@@ -99,11 +99,11 @@ struct BondMayaTransactionScreen: View {
                         HStack {
                             Text("estimatedBondValue".localized)
                                 .font(Theme.fonts.caption12)
-                                .foregroundColor(Theme.colors.textTertiary)
+                                .foregroundStyle(Theme.colors.textTertiary)
                             Spacer()
                             Text("\(cacaoValue.formatted()) CACAO")
                                 .font(Theme.fonts.caption12)
-                                .foregroundColor(Theme.colors.textPrimary)
+                                .foregroundStyle(Theme.colors.textPrimary)
                         }
                     }
                 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/UnbondMaya/UnbondMayaTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/UnbondMaya/UnbondMayaTransactionScreen.swift
@@ -76,11 +76,11 @@ struct UnbondMayaTransactionScreen: View {
                         HStack {
                             Text("bondedLPUnits".localized)
                                 .font(Theme.fonts.caption12)
-                                .foregroundColor(Theme.colors.textTertiary)
+                                .foregroundStyle(Theme.colors.textTertiary)
                             Spacer()
                             Text(bondedUnits)
                                 .font(Theme.fonts.caption12)
-                                .foregroundColor(Theme.colors.textPrimary)
+                                .foregroundStyle(Theme.colors.textPrimary)
                             Button(
                                 action: {
                                     viewModel.lpUnitsField.value = bondedUnits
@@ -88,7 +88,7 @@ struct UnbondMayaTransactionScreen: View {
                                 label: {
                                     Text("max".localized)
                                         .font(Theme.fonts.caption12)
-                                        .foregroundColor(Theme.colors.alertInfo)
+                                        .foregroundStyle(Theme.colors.alertInfo)
                                 }
                             )
                         }
@@ -99,11 +99,11 @@ struct UnbondMayaTransactionScreen: View {
                         HStack {
                             Text("estimatedCacaoValue".localized)
                                 .font(Theme.fonts.caption12)
-                                .foregroundColor(Theme.colors.textTertiary)
+                                .foregroundStyle(Theme.colors.textTertiary)
                             Spacer()
                             Text("\(cacaoValue.formatted()) CACAO")
                                 .font(Theme.fonts.caption12)
-                                .foregroundColor(Theme.colors.textPrimary)
+                                .foregroundStyle(Theme.colors.textPrimary)
                         }
                     }
                 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Thorchain/AddLP/AddLPTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Thorchain/AddLP/AddLPTransactionScreen.swift
@@ -39,15 +39,15 @@ struct AddLPTransactionScreen: View {
         if viewModel.showAsymmetricDepositInfo {
             HStack(spacing: 8) {
                 Image(systemName: "info.circle")
-                    .foregroundColor(Theme.colors.alertInfo)
+                    .foregroundStyle(Theme.colors.alertInfo)
                     .font(Theme.fonts.caption12)
                 VStack(alignment: .leading, spacing: 4) {
                     Text("asymmetricDeposit".localized)
                         .font(Theme.fonts.caption12)
-                        .foregroundColor(Theme.colors.textPrimary)
+                        .foregroundStyle(Theme.colors.textPrimary)
                     Text(viewModel.asymmetricDepositMessage)
                         .font(Theme.fonts.caption12)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                 }
                 Spacer()
             }

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/FastVaultEnterPasswordView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/FastVaultEnterPasswordView.swift
@@ -41,7 +41,7 @@ struct FastVaultEnterPasswordView: View {
             // Title
             Text("enterYourPassword".localized)
                 .font(Theme.fonts.title2)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .padding(.vertical, 10)
 
             // Password field
@@ -61,7 +61,7 @@ struct FastVaultEnterPasswordView: View {
                     HStack(spacing: 4) {
                         Text("showHint".localized)
                             .font(Theme.fonts.caption12)
-                            .foregroundColor(Theme.colors.textTertiary)
+                            .foregroundStyle(Theme.colors.textTertiary)
 
                         Icon(named: "chevron-down", color: Theme.colors.textTertiary, size: 16)
                             .rotationEffect(.degrees(showHint ? 180 : 0))
@@ -74,7 +74,7 @@ struct FastVaultEnterPasswordView: View {
                 // Hint text
                 Text(hint)
                     .font(.system(size: 12, weight: .medium).italic())
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .opacity(showHint ? 1 : 0)
             }

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
@@ -113,7 +113,7 @@ struct JoinKeygenView: View {
     var keygenErrorText: some View {
         Text(NSLocalizedString("failToStartKeygen", comment: "Unable to start key generation due to missing information"))
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .multilineTextAlignment(.center)
     }
 
@@ -169,7 +169,7 @@ struct JoinKeygenView: View {
             }
         }
         .font(Theme.fonts.bodyMMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
         .multilineTextAlignment(.center)
         .padding(.vertical, 30)
         .onAppear {
@@ -214,7 +214,7 @@ struct JoinKeygenView: View {
     var shadow: some View {
         Circle()
             .frame(width: 360, height: 360)
-            .foregroundColor(Theme.colors.alertInfo)
+            .foregroundStyle(Theme.colors.alertInfo)
             .opacity(0.05)
             .blur(radius: 20)
     }
@@ -307,11 +307,11 @@ struct JoinKeygenView: View {
     private func getKeygenCardContent(_ title: String) -> some View {
         VStack(spacing: 12) {
             Text(NSLocalizedString(title, comment: ""))
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .font(Theme.fonts.title1)
 
             Text(NSLocalizedString("joinKeygenViewDescription", comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .font(Theme.fonts.bodySMedium)
         }
         .multilineTextAlignment(.center)

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/KeygenView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/KeygenView.swift
@@ -227,7 +227,7 @@ struct KeygenView: View {
             VStack(spacing: 24) {
                 VStack {
                     Text(NSLocalizedString("vaultCreated", comment: ""))
-                        .foregroundColor(Theme.colors.textPrimary)
+                        .foregroundStyle(Theme.colors.textPrimary)
                     Text(NSLocalizedString("successfully", comment: ""))
                         .foregroundStyle(LinearGradient.primaryGradient)
                 }

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
@@ -264,7 +264,7 @@ struct PeerDiscoveryScreen: View {
                 failureText
             }
         }
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
         .blur(radius: showInfoSheet ? 1 : 0)
         .animation(.easeInOut, value: showInfoSheet)
     }
@@ -505,7 +505,7 @@ struct PeerDiscoveryScreen: View {
             Text(self.viewModel.errorMessage)
                 .font(Theme.fonts.bodyMMedium)
                 .multilineTextAlignment(.center)
-                .foregroundColor(.red)
+                .foregroundStyle(.red)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/UpgradingVaultView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/UpgradingVaultView.swift
@@ -34,7 +34,7 @@ struct UpgradingVaultView: View {
     var shadow: some View {
         Circle()
             .frame(width: 360, height: 360)
-            .foregroundColor(Theme.colors.alertInfo)
+            .foregroundStyle(Theme.colors.alertInfo)
             .opacity(0.05)
             .blur(radius: 20)
     }
@@ -46,14 +46,14 @@ struct UpgradingVaultView: View {
 
     var title: some View {
         Text(NSLocalizedString("upgradingVault", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.title2)
     }
 
     var appVersion: some View {
         Text(Bundle.main.appVersionString)
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
             .padding(.bottom, 30)
     }
 

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
@@ -77,7 +77,7 @@ struct JoinKeysignView: View {
             } else {
                 Text(NSLocalizedString("unableToStartKeysignProcess", comment: ""))
                     .font(Theme.fonts.bodyMMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 30)
             }

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignCustomMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignCustomMessageConfirmView.swift
@@ -19,7 +19,7 @@ struct KeysignCustomMessageConfirmView: View {
                 summary
                 button
             }
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .task {
                 await viewModel.loadFunctionName()
             }
@@ -68,7 +68,7 @@ struct KeysignCustomMessageConfirmView: View {
         if let title = viewModel.decodedFunctionName {
             Text(title)
                 .font(Theme.fonts.bodyLMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .frame(maxWidth: .infinity, alignment: .center)
         }
     }
@@ -97,7 +97,7 @@ struct KeysignCustomMessageConfirmView: View {
                 HStack(alignment: .center) {
                     Text(NSLocalizedString("message", comment: "") + ":")
                         .font(Theme.fonts.bodySMedium)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                     Spacer()
                     Icon(named: "chevron-down", color: Theme.colors.textTertiary, size: 16)
                         .rotationEffect(.degrees(isMessageExpanded ? 180 : 0))
@@ -110,7 +110,7 @@ struct KeysignCustomMessageConfirmView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text(formattedMessage)
                             .font(Theme.fonts.bodySMedium)
-                            .foregroundColor(Theme.colors.textPrimary)
+                            .foregroundStyle(Theme.colors.textPrimary)
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(16)
@@ -161,7 +161,7 @@ struct KeysignCustomMessageConfirmView: View {
                 HStack(alignment: .center) {
                     Text("transactionDetails".localized)
                         .font(Theme.fonts.bodySMedium)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                     Spacer()
                     Icon(named: "chevron-down", color: Theme.colors.textTertiary, size: 16)
                         .rotationEffect(.degrees(isTransactionDetailsExpanded ? 180 : 0))
@@ -193,11 +193,11 @@ struct KeysignCustomMessageConfirmView: View {
         return VStack(alignment: .leading, spacing: 12) {
             Text(NSLocalizedString(title, comment: "") + ":")
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
             HStack(spacing: 6) {
                 Text(value)
                     .font(Theme.fonts.bodySMedium)
-                    .foregroundColor(textColor)
+                    .foregroundStyle(textColor)
                 if isWarning {
                     Icon(named: "triangle-alert", color: textColor, size: 14)
                 }
@@ -213,6 +213,6 @@ struct KeysignCustomMessageConfirmView: View {
             Text(value)
         }
         .font(Theme.fonts.bodyMMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoverServiceView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoverServiceView.swift
@@ -19,7 +19,7 @@ struct KeysignDiscoverServiceView: View {
             Text(NSLocalizedString("discoveringMediator", comment: "Discovering mediator service, please wait..."))
         }
         .font(Theme.fonts.bodyMMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
         .multilineTextAlignment(.center)
         .padding(30)
         .background(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -70,7 +70,7 @@ struct KeysignSwapConfirmView: View {
     var summaryTitle: some View {
         Text(NSLocalizedString("youreSwapping", comment: ""))
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -92,7 +92,7 @@ struct KeysignSwapConfirmView: View {
         Rectangle()
             .frame(width: 1)
             .frame(idealHeight: 80, maxHeight: 100)
-            .foregroundColor(Theme.colors.bgSurface2)
+            .foregroundStyle(Theme.colors.bgSurface2)
     }
 
     var summaryFromTo: some View {
@@ -131,7 +131,7 @@ struct KeysignSwapConfirmView: View {
     var chevronIcon: some View {
         Image(systemName: "arrow.down")
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.primaryAccent4)
+            .foregroundStyle(Theme.colors.primaryAccent4)
             .padding(6)
             .background(Theme.colors.bgSurface2)
             .cornerRadius(32)
@@ -146,7 +146,7 @@ struct KeysignSwapConfirmView: View {
     ) -> some View {
         HStack(spacing: 4) {
             Text(NSLocalizedString(title, comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
 
             Spacer()
 
@@ -157,11 +157,11 @@ struct KeysignSwapConfirmView: View {
             }
 
             Text(value)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             if let bracketValue {
                 Text(bracketValue)
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
             }
 
         }
@@ -176,18 +176,18 @@ struct KeysignSwapConfirmView: View {
     private func getFeeCell(title: String, fees: (feeCrypto: String, feeFiat: String)) -> some View {
         HStack(spacing: 4) {
             Text(NSLocalizedString(title, comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .font(Theme.fonts.bodySMedium)
 
             Spacer()
 
             VStack(alignment: .trailing, spacing: 2) {
                 Text(fees.feeCrypto)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                     .font(Theme.fonts.bodySMedium)
 
                 Text(fees.feeFiat)
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                     .font(Theme.fonts.caption12)
             }
         }
@@ -207,24 +207,24 @@ struct KeysignSwapConfirmView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("minPayout".localized)
                     .font(Theme.fonts.caption12)
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                     .opacity(isTo ? 1 : 0)
 
                 Text(amount ?? "")
                     .font(Theme.fonts.bodyLMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
 
                 HStack(spacing: 0) {
                     Text(fiatValue)
                         .font(Theme.fonts.caption12)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                     Spacer()
                     if let chain {
                         HStack(spacing: 2) {
                             Spacer()
 
                             Text(NSLocalizedString("on", comment: ""))
-                                .foregroundColor(Theme.colors.textTertiary)
+                                .foregroundStyle(Theme.colors.textTertiary)
                                 .padding(.trailing, 4)
 
                             Image(chain.logo)
@@ -232,7 +232,7 @@ struct KeysignSwapConfirmView: View {
                                 .frame(width: 12, height: 12)
 
                             Text(chain.name)
-                                .foregroundColor(Theme.colors.textPrimary)
+                                .foregroundStyle(Theme.colors.textPrimary)
                         }
                         .font(Theme.fonts.caption10)
                         .offset(x: 2)

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/Main/Views/ImportVaultShareScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/Main/Views/ImportVaultShareScreen.swift
@@ -62,7 +62,7 @@ struct ImportVaultShareScreen: View {
     var instruction: some View {
         Text(NSLocalizedString("supportedFileTypesUpload", comment: ""))
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 

--- a/VultisigApp/VultisigApp/Features/Onboarding/Views/OnboardingTextCard.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/Views/OnboardingTextCard.swift
@@ -18,13 +18,13 @@ struct OnboardingTextCard: View {
     var body: some View {
         Group {
             Text(NSLocalizedString("\(textPrefix)\(index+1)Text1", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary) +
+                .foregroundStyle(Theme.colors.textPrimary) +
             Text(deviceCount ?? "")
-                .foregroundColor(Theme.colors.textPrimary) +
+                .foregroundStyle(Theme.colors.textPrimary) +
             Text(NSLocalizedString("\(textPrefix)\(index+1)Text2", comment: ""))
                 .foregroundStyle(LinearGradient.primaryGradient) +
             Text(NSLocalizedString("\(textPrefix)\(index+1)Text3", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary) +
+                .foregroundStyle(Theme.colors.textPrimary) +
             Text(NSLocalizedString("\(textPrefix)\(index+1)Text4", comment: ""))
                 .foregroundStyle(LinearGradient.primaryGradient)
         }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/CreateReferralDetailsView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/CreateReferralDetailsView.swift
@@ -70,7 +70,7 @@ struct CreateReferralDetailsView: View {
 
     var setExpirationTitle: some View {
         Text(NSLocalizedString("setExpiration(inYears)", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodySMedium)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -135,24 +135,24 @@ struct CreateReferralDetailsView: View {
 
             Text("rune".localized)
                 .font(Theme.fonts.bodyMMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
     }
 
     var infoLabel: some View {
         Image(systemName: "info.circle")
             .font(Theme.fonts.bodyLMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var tooltip: some View {
         VStack(alignment: .leading) {
             Text(NSLocalizedString("referralProgram", comment: ""))
-                .foregroundColor(Theme.colors.textDark)
+                .foregroundStyle(Theme.colors.textDark)
                 .font(Theme.fonts.bodyMMedium)
 
              Text(NSLocalizedString("referralProgramTooltipDescription", comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                     .font(Theme.fonts.bodySMedium)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -168,17 +168,17 @@ struct CreateReferralDetailsView: View {
     private func getCell(title: String, description1: String, description2: String, isPlaceholder: Bool) -> some View {
         HStack {
             Text(NSLocalizedString(title, comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
 
             Spacer()
 
             VStack(alignment: .trailing, spacing: 0) {
                 Text(description1)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
 
                 if !description2.isEmpty {
                     Text(description2)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                 }
             }
             .redacted(reason: isPlaceholder ? .placeholder : [])

--- a/VultisigApp/VultisigApp/Features/Referral/Views/EditReferralDetailsView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/EditReferralDetailsView.swift
@@ -67,7 +67,7 @@ struct EditReferralDetailsView: View {
     var yourReferralCodeSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("yourReferralCode".localized)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .font(Theme.fonts.bodySMedium)
                 .frame(maxWidth: .infinity, alignment: .leading)
             ReferralTextField(
@@ -89,7 +89,7 @@ struct EditReferralDetailsView: View {
 
     var setExpirationTitle: some View {
         Text(NSLocalizedString("extendExpiration(inYears)", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodySMedium)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -113,7 +113,7 @@ struct EditReferralDetailsView: View {
 
     var choosePayoutAssetTitle: some View {
         Text(NSLocalizedString("choosePayoutAsset", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodySMedium)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -172,14 +172,14 @@ struct EditReferralDetailsView: View {
 
             Text(viewModel.preferredAsset?.asset.ticker ?? "RUNE")
                 .font(Theme.fonts.bodyMMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
     }
 
     var infoLabel: some View {
         Image(systemName: "info.circle")
             .font(Theme.fonts.bodyLMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     private func getCell(
@@ -192,17 +192,17 @@ struct EditReferralDetailsView: View {
     ) -> some View {
         HStack {
             Text(NSLocalizedString(title, comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
 
             Spacer()
 
             VStack(alignment: .trailing, spacing: 0) {
                 RedactedText(description1, redactedText: redactedDesc1, isLoading: isPlaceholder)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
 
                 if !description2.isEmpty {
                     RedactedText(description2, redactedText: redactedDesc2, isLoading: isPlaceholder)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                 }
             }
         }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/PreferredAssetSelectionView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/PreferredAssetSelectionView.swift
@@ -66,7 +66,7 @@ struct PreferredAssetSelectionView: View {
 
             Text(NSLocalizedString("loading", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.top, 48)

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferralSendOverviewView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferralSendOverviewView.swift
@@ -34,7 +34,7 @@ struct ReferralSendOverviewView: View {
         Text(NSLocalizedString("youreSending", comment: ""))
             .frame(maxWidth: .infinity, alignment: .leading)
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
     }
 
     var assetDetail: some View {
@@ -45,10 +45,10 @@ struct ReferralSendOverviewView: View {
                 .cornerRadius(32)
 
             Text("\(transaction.amount)")
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             Text("RUNE")
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
 
             Spacer()
         }
@@ -97,7 +97,7 @@ struct ReferralSendOverviewView: View {
     private func getCell(title: String, description: String, bracketValue: String? = nil, icon: String? = nil, isForMemo: Bool = false) -> some View {
         HStack(spacing: 2) {
             Text(NSLocalizedString(title, comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .lineLimit(1)
                 .truncationMode(.tail)
 
@@ -111,13 +111,13 @@ struct ReferralSendOverviewView: View {
             }
 
             Text(description)
-                .foregroundColor(isForMemo ? Theme.colors.textTertiary : Theme.colors.textPrimary)
+                .foregroundStyle(isForMemo ? Theme.colors.textTertiary : Theme.colors.textPrimary)
                 .lineLimit(isForMemo ? 2 : 1)
                 .truncationMode(.tail)
 
             if let bracketValue {
                 Text("(\(bracketValue))")
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferredCodeFormScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferredCodeFormScreen.swift
@@ -47,7 +47,7 @@ struct ReferredCodeFormScreen: View {
                 textField
             }
         }
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var textField: some View {

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferredOnboardingView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferredOnboardingView.swift
@@ -30,7 +30,7 @@ struct ReferredOnboardingView: View {
     var shadow: some View {
         Circle()
             .frame(width: 360, height: 360)
-            .foregroundColor(Theme.colors.alertInfo)
+            .foregroundStyle(Theme.colors.alertInfo)
             .opacity(0.05)
             .blur(radius: 20)
     }
@@ -76,7 +76,7 @@ struct ReferredOnboardingView: View {
     func cellView(icon: String, title: String, description: String) -> some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
-                .foregroundColor(Theme.colors.primaryAccent4)
+                .foregroundStyle(Theme.colors.primaryAccent4)
                 .font(Theme.fonts.bodyLMedium)
 
             VStack(alignment: .leading, spacing: 4) {
@@ -86,7 +86,7 @@ struct ReferredOnboardingView: View {
                 Text(NSLocalizedString(description, comment: ""))
                     .font(Theme.fonts.caption10)
             }
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
@@ -94,9 +94,9 @@ struct ReferredOnboardingView: View {
     var animationHeader: some View {
         HStack {
             Image(systemName: "horn")
-                .foregroundColor(Theme.colors.alertInfo)
+                .foregroundStyle(Theme.colors.alertInfo)
             Text(NSLocalizedString("referralProgram", comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .font(Theme.fonts.caption12)
         }
         .padding(.vertical, 8)

--- a/VultisigApp/VultisigApp/Features/Reshare/Views/ReshareView.swift
+++ b/VultisigApp/VultisigApp/Features/Reshare/Views/ReshareView.swift
@@ -90,11 +90,11 @@ struct ReshareView: View {
         VStack(spacing: 16) {
             Text(NSLocalizedString("reshareLabelTitle", comment: ""))
                 .font(Theme.fonts.title2)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             Text(NSLocalizedString("reshareLabelSubtitle", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textSecondary)
+                .foregroundStyle(Theme.colors.textSecondary)
                 .multilineTextAlignment(.center)
         }
         .padding(.horizontal, 36)

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignAminoDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignAminoDisplayView.swift
@@ -22,7 +22,7 @@ struct SignAminoDisplayView: View {
                 HStack(alignment: .center) {
                     Text("aminoSign".localized)
                         .font(Theme.fonts.bodySMedium)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                     Spacer()
                     Icon(named: "chevron-down", color: Theme.colors.textTertiary, size: 16)
                         .rotationEffect(.degrees(isExpanded ? 180 : 0))
@@ -35,7 +35,7 @@ struct SignAminoDisplayView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text(formatSignAminoData())
                             .font(Theme.fonts.bodySRegular)
-                            .foregroundColor(Theme.colors.textPrimary)
+                            .foregroundStyle(Theme.colors.textPrimary)
                             .padding(16)
                     }
                 }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignDirectDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignDirectDisplayView.swift
@@ -22,7 +22,7 @@ struct SignDirectDisplayView: View {
                 HStack(alignment: .center) {
                     Text("directSign".localized)
                         .font(Theme.fonts.bodySMedium)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                     Spacer()
                     Icon(named: "chevron-down", color: Theme.colors.textTertiary, size: 16)
                         .rotationEffect(.degrees(isExpanded ? 180 : 0))
@@ -40,7 +40,7 @@ struct SignDirectDisplayView: View {
                         }
                     }
                     .font(Theme.fonts.bodySRegular)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                     .padding(16)
                 }
                 .frame(maxHeight: 300)

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoAddressBookView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoAddressBookView.swift
@@ -130,14 +130,14 @@ struct SendCryptoAddressBookView: View {
     var errorMessage: some View {
         Text(NSLocalizedString("noSavedAddresses", comment: ""))
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
             .padding(.top, 32)
     }
 
     private func getCell(for title: String, isSelected: Bool) -> some View {
         Text(NSLocalizedString(title, comment: ""))
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
             .frame(maxWidth: .infinity)
             .frame(height: 42)
             .background(isSelected ? Theme.colors.bgButtonTertiary : .clear)

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoDone/SendCryptoTransactionDetailsRow.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoDone/SendCryptoTransactionDetailsRow.swift
@@ -35,7 +35,7 @@ struct SendCryptoTransactionDetailsRow<AccessoryView: View>: View {
         VStack(alignment: .trailing, spacing: 16) {
             HStack(spacing: 2) {
                 Text(NSLocalizedString(title, comment: ""))
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .frame(minWidth: 52, alignment: .leading)
@@ -87,7 +87,7 @@ struct SendCryptoTransactionDetailsRow<AccessoryView: View>: View {
             accessoryView()
         }
         .font(Theme.fonts.bodySMedium)
-        .foregroundColor(Theme.colors.textPrimary)
+        .foregroundStyle(Theme.colors.textPrimary)
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendGasSettingsView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendGasSettingsView.swift
@@ -95,7 +95,7 @@ struct SendGasSettingsView: View {
         HStack {
             Text(text)
                 .font(Theme.fonts.bodySRegular)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
 
             Spacer()
         }
@@ -107,7 +107,7 @@ struct SendGasSettingsView: View {
             HStack {
                 Text(text.isEmpty ? title : text)
                     .font(Theme.fonts.bodyMRegular)
-                    .foregroundColor(Theme.colors.textSecondary)
+                    .foregroundStyle(Theme.colors.textSecondary)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 16)
 
@@ -117,7 +117,7 @@ struct SendGasSettingsView: View {
         }
         .background(
             RoundedRectangle(cornerSize: .init(width: 5, height: 5))
-                .foregroundColor(Theme.colors.bgSurface1)
+                .foregroundStyle(Theme.colors.bgSurface1)
         )
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 16)
@@ -137,7 +137,7 @@ struct SendGasSettingsView: View {
             label: {
                 Image("x")
                     .font(Theme.fonts.bodyLMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
             }
         )
     }
@@ -205,9 +205,9 @@ extension SendGasSettingsView {
     func textField(title: String, text: Binding<String>, label: String? = nil, disabled: Bool = false) -> some View {
         VStack {
             HStack {
-                TextField("", text: text, prompt: Text(title).foregroundColor(Theme.colors.textSecondary))
+                TextField("", text: text, prompt: Text(title).foregroundStyle(Theme.colors.textSecondary))
                     .borderlessTextFieldStyle()
-                    .foregroundColor(disabled ? Theme.colors.textSecondary : Theme.colors.textPrimary)
+                    .foregroundStyle(disabled ? Theme.colors.textSecondary : Theme.colors.textPrimary)
                     .tint(Theme.colors.textPrimary)
                     .font(Theme.fonts.bodyMRegular)
                     .submitLabel(.next)
@@ -220,7 +220,7 @@ extension SendGasSettingsView {
 
                 if let label {
                     Text(label)
-                        .foregroundColor(Theme.colors.textSecondary)
+                        .foregroundStyle(Theme.colors.textSecondary)
                         .font(Theme.fonts.bodyMRegular)
                 }
             }
@@ -229,7 +229,7 @@ extension SendGasSettingsView {
         }
         .background(
             RoundedRectangle(cornerSize: .init(width: 5, height: 5))
-                .foregroundColor(Theme.colors.bgSurface1)
+                .foregroundStyle(Theme.colors.bgSurface1)
         )
         .padding(.horizontal, 16)
     }
@@ -259,9 +259,9 @@ extension SendGasSettingsView {
     func textField(title: String, text: Binding<String>, label: String? = nil, disabled: Bool = false) -> some View {
         VStack {
             HStack {
-                TextField("", text: text, prompt: Text(title).foregroundColor(Theme.colors.textSecondary))
+                TextField("", text: text, prompt: Text(title).foregroundStyle(Theme.colors.textSecondary))
                     .borderlessTextFieldStyle()
-                    .foregroundColor(disabled ? Theme.colors.textSecondary : Theme.colors.textPrimary)
+                    .foregroundStyle(disabled ? Theme.colors.textSecondary : Theme.colors.textPrimary)
                     .tint(Theme.colors.textPrimary)
                     .font(Theme.fonts.bodyMRegular)
                     .submitLabel(.next)
@@ -273,7 +273,7 @@ extension SendGasSettingsView {
 
                 if let label {
                     Text(label)
-                        .foregroundColor(Theme.colors.textSecondary)
+                        .foregroundStyle(Theme.colors.textSecondary)
                         .font(Theme.fonts.bodyMRegular)
                 }
             }
@@ -282,7 +282,7 @@ extension SendGasSettingsView {
         }
         .background(
             RoundedRectangle(cornerSize: .init(width: 5, height: 5))
-                .foregroundColor(Theme.colors.bgSurface1)
+                .foregroundStyle(Theme.colors.bgSurface1)
         )
         .padding(.horizontal, 16)
     }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
@@ -91,10 +91,10 @@ struct SettingsCustomMessageView: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(title)
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
             Text(value)
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
@@ -137,7 +137,7 @@ struct SettingsCustomMessageView: View {
         HStack {
             Text(text)
                 .font(Theme.fonts.bodySRegular)
-                .foregroundColor(.white)
+                .foregroundStyle(.white)
 
             Spacer()
         }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsMainScreen/SettingsMainScreen.swift
@@ -178,7 +178,7 @@ struct SettingsMainScreen: View {
     var appVersion: some View {
         Text(Bundle.main.appVersionString)
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
             .scaleEffect(scale)
             .onTapGesture {
                 handleVersionTap()

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsPasswordHintScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsPasswordHintScreen.swift
@@ -21,12 +21,12 @@ struct SettingsPasswordHintScreen: View {
                     VStack(alignment: .leading, spacing: 16) {
                         Text("editPasswordHintTitle".localized)
                             .font(Theme.fonts.largeTitle)
-                            .foregroundColor(Theme.colors.textPrimary)
+                            .foregroundStyle(Theme.colors.textPrimary)
                             .padding(.top, 12)
 
                         Text("editPasswordHintSubtitle".localized)
                             .font(Theme.fonts.bodySMedium)
-                            .foregroundColor(Theme.colors.textTertiary)
+                            .foregroundStyle(Theme.colors.textTertiary)
 
                         CommonTextEditor(
                             value: $viewModel.hint,

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -251,7 +251,7 @@ struct SwapDetailsScreen: View {
     var filler: some View {
         Rectangle()
             .frame(width: 12, height: 10)
-            .foregroundColor(Theme.colors.bgPrimary)
+            .foregroundStyle(Theme.colors.bgPrimary)
     }
 
     var summary: some View {

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -195,7 +195,7 @@ struct SwapVerifyScreen: View {
         Rectangle()
             .frame(width: 1)
             .frame(idealHeight: 80, maxHeight: 100)
-            .foregroundColor(Theme.colors.bgSurface2)
+            .foregroundStyle(Theme.colors.bgSurface2)
     }
 
     var summaryFromTo: some View {
@@ -225,7 +225,7 @@ struct SwapVerifyScreen: View {
     var chevronIcon: some View {
         Image(systemName: "arrow.down")
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.primaryAccent4)
+            .foregroundStyle(Theme.colors.primaryAccent4)
             .padding(6)
             .background(Theme.colors.bgSurface2)
             .cornerRadius(32)
@@ -235,7 +235,7 @@ struct SwapVerifyScreen: View {
     var summaryTitle: some View {
         Text(NSLocalizedString("youreSwapping", comment: ""))
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textSecondary)
+            .foregroundStyle(Theme.colors.textSecondary)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -335,7 +335,7 @@ struct SwapVerifyScreen: View {
     ) -> some View {
         HStack(spacing: 4) {
             Text(NSLocalizedString(title, comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
 
             Spacer()
 
@@ -346,7 +346,7 @@ struct SwapVerifyScreen: View {
             }
 
             Text(value)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             if let bracketValue {
                 Group {
@@ -354,7 +354,7 @@ struct SwapVerifyScreen: View {
                     Text(bracketValue) +
                     Text(")")
                 }
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
             }
         }
         .font(Theme.fonts.bodySMedium)
@@ -367,18 +367,18 @@ struct SwapVerifyScreen: View {
     ) -> some View {
         HStack(spacing: 4) {
             Text(NSLocalizedString("networkFee", comment: ""))
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .font(Theme.fonts.bodySMedium)
 
             Spacer()
 
             VStack(alignment: .trailing, spacing: 2) {
                 Text(cryptoAmount)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                     .font(Theme.fonts.bodySMedium)
 
                 Text(fiatAmount)
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                     .font(Theme.fonts.caption12)
             }
         }
@@ -399,28 +399,28 @@ struct SwapVerifyScreen: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("minPayout".localized)
                     .font(Theme.fonts.caption12)
-                    .foregroundColor(Theme.colors.textTertiary)
+                    .foregroundStyle(Theme.colors.textTertiary)
                     .opacity(isTo ? 1 : 0)
                 Group {
                     Text(amount)
-                        .foregroundColor(Theme.colors.textPrimary) +
+                        .foregroundStyle(Theme.colors.textPrimary) +
                     Text(" ") +
                     Text(ticker)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                 }
                 .font(Theme.fonts.bodyLMedium)
 
                 HStack(spacing: 0) {
                     Text(fiatValue)
                         .font(Theme.fonts.caption12)
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                     Spacer()
                     if let chain {
                         HStack(spacing: 2) {
                             Spacer()
 
                             Text(NSLocalizedString("on", comment: ""))
-                                .foregroundColor(Theme.colors.textTertiary)
+                                .foregroundStyle(Theme.colors.textTertiary)
                                 .padding(.trailing, 4)
 
                             Image(chain.logo)
@@ -428,7 +428,7 @@ struct SwapVerifyScreen: View {
                                 .frame(width: 12, height: 12)
 
                             Text(chain.name)
-                                .foregroundColor(Theme.colors.textPrimary)
+                                .foregroundStyle(Theme.colors.textPrimary)
                         }
                         .font(Theme.fonts.caption10)
                         .offset(x: 2)

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapChainPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapChainPickerView.swift
@@ -71,12 +71,12 @@ struct SwapChainPickerView: View {
         HStack {
             Text(NSLocalizedString("chain", comment: ""))
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Spacer()
             Text(NSLocalizedString("balance", comment: ""))
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .frame(maxWidth: .infinity, alignment: .trailing)
         }
         .padding(.horizontal, 24)

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -118,7 +118,7 @@ struct SwapCoinPickerView: View {
 
             Text(NSLocalizedString("loading", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.top, 48)
@@ -195,7 +195,7 @@ struct SwapCoinPickerView: View {
                             .frame(height: 28)
                         Text(chain.name)
                             .font(Theme.fonts.caption12)
-                            .foregroundColor(isSelected ? Theme.colors.textPrimary : Theme.colors.textTertiary)
+                            .foregroundStyle(isSelected ? Theme.colors.textPrimary : Theme.colors.textTertiary)
                             .fixedSize(horizontal: true, vertical: false)
                             .minimumScaleFactor(0.5)
                     }

--- a/VultisigApp/VultisigApp/Features/UpdateCheck/Views/PhoneCheckUpdateView.swift
+++ b/VultisigApp/VultisigApp/Features/UpdateCheck/Views/PhoneCheckUpdateView.swift
@@ -63,7 +63,7 @@ struct PhoneCheckUpdateView: View {
     var checkUpdateLabel: some View {
         Text(NSLocalizedString("checkingForUpdate", comment: ""))
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var tryAgainButton: some View {

--- a/VultisigApp/VultisigApp/Features/UpdateCheck/Views/UpdateCheckUpToDateView.swift
+++ b/VultisigApp/VultisigApp/Features/UpdateCheck/Views/UpdateCheckUpToDateView.swift
@@ -37,14 +37,14 @@ struct UpdateCheckUpToDateView: View {
     var upToDateTitle: some View {
         Text(NSLocalizedString("appUpToDate", comment: ""))
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .padding(.top, 24)
     }
 
     var upToDateDescription: some View {
         Text(currentVersion)
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textTertiary)
+            .foregroundStyle(Theme.colors.textTertiary)
     }
 
     #if os(macOS)

--- a/VultisigApp/VultisigApp/Features/UpdateCheck/Views/UpdateCheckUpdateNowView.swift
+++ b/VultisigApp/VultisigApp/Features/UpdateCheck/Views/UpdateCheckUpdateNowView.swift
@@ -40,14 +40,14 @@ struct UpdateCheckUpdateNowView: View {
     var updateTitle: some View {
         Text(NSLocalizedString("newUpdateAvailable", comment: ""))
             .font(Theme.fonts.bodyMMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .padding(.top, 24)
     }
 
     var updateDescription: some View {
         Text(latestVersion)
             .font(Theme.fonts.bodySRegular)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 
     var updateButton: some View {

--- a/VultisigApp/VultisigApp/Features/UpgradeFromGG20/Views/AllDevicesUpgradeView.swift
+++ b/VultisigApp/VultisigApp/Features/UpgradeFromGG20/Views/AllDevicesUpgradeView.swift
@@ -49,11 +49,11 @@ struct AllDevicesUpgradeView: View {
     var description: some View {
         Group {
             Text(NSLocalizedString("allDevicesUpgradeTitle1", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary) +
+                .foregroundStyle(Theme.colors.textPrimary) +
             Text(NSLocalizedString("allDevicesUpgradeTitle2", comment: ""))
                 .foregroundStyle(LinearGradient.primaryGradient) +
             Text(NSLocalizedString("allDevicesUpgradeTitle3", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
         .multilineTextAlignment(.center)
         .font(Theme.fonts.title1)

--- a/VultisigApp/VultisigApp/Features/UpgradeFromGG20/Views/UpgradeYourVaultView.swift
+++ b/VultisigApp/VultisigApp/Features/UpgradeFromGG20/Views/UpgradeYourVaultView.swift
@@ -38,7 +38,7 @@ struct UpgradeYourVaultView: View {
 
     var title: some View {
         Text(NSLocalizedString("upgradeYourVault", comment: ""))
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .font(Theme.fonts.bodyLMedium)
     }
 
@@ -49,11 +49,11 @@ struct UpgradeYourVaultView: View {
     var description: some View {
         Group {
             Text(NSLocalizedString("upgradeYourVaultTitle1", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary) +
+                .foregroundStyle(Theme.colors.textPrimary) +
             Text(NSLocalizedString("upgradeYourVaultTitle2", comment: ""))
                 .foregroundStyle(LinearGradient.primaryGradient) +
             Text(NSLocalizedString("upgradeYourVaultTitle3", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
         .multilineTextAlignment(.center)
         .font(Theme.fonts.title1)

--- a/VultisigApp/VultisigApp/Features/UpgradeFromGG20/Views/VaultShareBackupsView.swift
+++ b/VultisigApp/VultisigApp/Features/UpgradeFromGG20/Views/VaultShareBackupsView.swift
@@ -33,7 +33,7 @@ struct VaultShareBackupsView: View {
             Text(NSLocalizedString("vaultShareBackupsViewTitle1", comment: ""))
                 .foregroundStyle(LinearGradient.primaryGradient) +
             Text(NSLocalizedString("vaultShareBackupsViewTitle2", comment: ""))
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
         }
         .multilineTextAlignment(.center)
         .font(Theme.fonts.title1)

--- a/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ReceiveChainSelectionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ReceiveChainSelectionScreen.swift
@@ -128,7 +128,7 @@ struct ReceiveChainSelectionRowView: View {
     var nameText: some View {
         Text(chain.name)
             .font(Theme.fonts.bodySMedium)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/AddressQRCodeView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/AddressQRCodeView.swift
@@ -40,7 +40,7 @@ struct AddressQRCodeView: View {
     var address: some View {
         Text(addressData)
             .font(Theme.fonts.caption12)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .multilineTextAlignment(.center)
             .padding(.horizontal, padding)
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/Backup/VaultBackupPasswordOptionsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/Backup/VaultBackupPasswordOptionsScreen.swift
@@ -43,7 +43,7 @@ struct VaultBackupPasswordOptionsScreen: View {
     var icon: some View {
         Image(systemName: "person.badge.key")
             .font(Theme.fonts.title1)
-            .foregroundColor(Theme.colors.textPrimary)
+            .foregroundStyle(Theme.colors.textPrimary)
             .frame(width: 64, height: 64)
             .background(Theme.colors.bgSurface2)
             .cornerRadius(16)
@@ -53,7 +53,7 @@ struct VaultBackupPasswordOptionsScreen: View {
         VStack(spacing: 16) {
             Text("backupOptionsTitle".localized)
                 .font(Theme.fonts.title2)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
                 .multilineTextAlignment(.center)
 
             boxedText("backupOptionsBox1".localized, highlighted: "backupOptionsBox1Highlighted".localized, icon: "lock-keyhole-open")

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/Backup/VaultBackupPasswordScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/Backup/VaultBackupPasswordScreen.swift
@@ -73,7 +73,7 @@ struct VaultBackupPasswordScreen: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(NSLocalizedString("optionalPasswordProtectBackup", comment: ""))
                 .font(Theme.fonts.bodySMedium)
-                .foregroundColor(Theme.colors.textPrimary)
+                .foregroundStyle(Theme.colors.textPrimary)
 
             textfield
             verifyTextfield

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/CoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/CoinPickerView.swift
@@ -42,11 +42,11 @@ struct CoinPickerView: View {
         HStack(spacing: 0) {
             Image(systemName: "magnifyingglass")
                 .font(Theme.fonts.bodyLMedium)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
 
             TextField(NSLocalizedString("search...", comment: "Search...").toFormattedTitleCase(), text: $searchText)
                 .font(Theme.fonts.caption12)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .submitLabel(.next)
                 .disableAutocorrection(true)
                 .textContentType(.oneTimeCode)
@@ -62,9 +62,9 @@ struct CoinPickerView: View {
                     isSearching = false
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(Theme.colors.textTertiary)
+                        .foregroundStyle(Theme.colors.textTertiary)
                 }
-                .foregroundColor(.blue)
+                .foregroundStyle(.blue)
                 .font(Theme.fonts.caption12)
             }
         }
@@ -151,7 +151,7 @@ extension CoinPickerView {
                     label: {
                         Image(systemName: "chevron.backward")
                             .font(Theme.fonts.bodyLMedium)
-                            .foregroundColor(Theme.colors.textPrimary)
+                            .foregroundStyle(Theme.colors.textPrimary)
                     }
                 )
             }

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/MonthlyBackupView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/MonthlyBackupView.swift
@@ -48,7 +48,7 @@ struct MonthlyBackupView: View {
 
             VStack {
                 Text(NSLocalizedString("monthlyBackupTitle", comment: ""))
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                     .font(Theme.fonts.bodyMMedium)
                     .multilineTextAlignment(.center)
 

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/VaultDeletionConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/VaultDeletionConfirmView.swift
@@ -58,7 +58,7 @@ struct VaultDeletionConfirmView: View {
 
             Text("youArePermanentlyDeletingVault".localized)
                 .font(Theme.fonts.footnote)
-                .foregroundColor(Theme.colors.textTertiary)
+                .foregroundStyle(Theme.colors.textTertiary)
                 .multilineTextAlignment(.center)
         }
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/VaultDetail/VaultPairDetailCard.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/VaultDetail/VaultPairDetailCard.swift
@@ -29,7 +29,7 @@ struct VaultPairDetailCard: View {
                 Image("vultisig-logo")
                     .resizable()
                     .frame(width: 48, height: 48)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                     .padding(.top, 24)
             }
 
@@ -41,7 +41,7 @@ struct VaultPairDetailCard: View {
                 // Footer for sharing
                 Text("vultisig.com")
                     .font(Theme.fonts.bodyLMedium)
-                    .foregroundColor(Theme.colors.textPrimary)
+                    .foregroundStyle(Theme.colors.textPrimary)
                     .padding(.bottom, 24)
             }
         }


### PR DESCRIPTION
Closes #4703 — Phase A (convention sweeps) of the iOS code-quality audit. Addresses **Mandatory Rule 6** (use `.foregroundStyle()`, not deprecated `.foregroundColor()`).

## What
Mechanical 1:1 swap `.foregroundColor(` → `.foregroundStyle(` across **139 files / 378 sites**. Behavior-identical — `Color` conforms to `ShapeStyle`.

## Deliberately not changed (2 exceptions)
- **`foregroundColor(for:isEnabled:)` helper funcs** in `PrimaryButtonStyle` / `IconButtonStyle` — not the SwiftUI modifier (protected via a `(?!for:)` guard).
- **`Icon.swift` (×2)** — `Icon.color` is `Color?`; `.foregroundStyle` requires a non-optional `ShapeStyle`, so the optional-accepting deprecated API is the behavior-preserving choice (nil = no tint). Commented inline.

`Text` concatenation (`Text(a).foregroundStyle(x) + Text(b)`) and `TextField(prompt:)` cases compile fine — SwiftUI's `Text.foregroundStyle` has a `Text`-returning overload.

## Out of scope (follow-up — A2b)
Hardcoded colors surfaced by this sweep (`.foregroundStyle(.white)`, `Color(hex:)`) → migrate to `Theme.colors.*` tokens.

## Verification
- `make generate` clean
- `make test`: **2045 tests, 0 failures** — TEST SUCCEEDED
- SwiftLint: 0 new warnings (71, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated many screens and components to use a newer SwiftUI styling approach for text and icon colors.
  * Improved consistency across buttons, forms, lists, headers, and transaction-related views.
  * Preserved existing layouts, interactions, and displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->