### PR TITLE
feat(solana): fetch staking min-delegation dynamically from a public node

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
@@ -16,6 +16,18 @@ struct SolanaAPI: TargetType {
     /// The proxy path appended to the default host.
     static let proxyPath = "/solana/"
 
+    /// Keyless public JSON-RPC endpoints used ONLY for
+    /// `getStakeMinimumDelegation`, which the Vultisig proxy blocks. The value
+    /// is a network-global constant (identical on every mainnet node), used just
+    /// as a form-validation floor, and never touches signing — so reading it off
+    /// a public node is safe. Tried in order: PublicNode is app-friendly and
+    /// keyless; mainnet-beta is the official keyless fallback. Each is a complete
+    /// endpoint, so `usesProxyPath` is `false` when targeting them.
+    static let minDelegationPublicHosts: [URL] = [
+        URL(staticString: "https://solana-rpc.publicnode.com"),
+        URL(staticString: "https://api.mainnet-beta.solana.com")
+    ]
+
     let baseURL: URL
     /// `true` for the default Vultisig proxy (RPC under `/solana/`); `false`
     /// when a custom override supplies a complete JSON-RPC endpoint.
@@ -53,6 +65,11 @@ struct SolanaAPI: TargetType {
         case getMinimumBalanceForRentExemption(size: Int)
         /// Network inflation rate for the current epoch.
         case getInflationRate
+        /// Network minimum active delegation (lamports) enforced by the Stake
+        /// program. Takes no params. The Vultisig proxy blocks this method, so
+        /// it is read from a public node; the value is a network-global constant
+        /// used only as a form-validation floor and never touches signing.
+        case getStakeMinimumDelegation
     }
 
     enum TokenAccountFilter {
@@ -146,6 +163,8 @@ struct SolanaAPI: TargetType {
             )
         case .getInflationRate:
             return .requestParameters(rpcEnvelope(method: "getInflationRate", params: [] as [Any]), .jsonEncoding)
+        case .getStakeMinimumDelegation:
+            return .requestParameters(rpcEnvelope(method: "getStakeMinimumDelegation", params: [] as [Any]), .jsonEncoding)
         }
     }
 
@@ -282,6 +301,16 @@ struct SolanaEpochInfo: Codable, Hashable {
 
 struct SolanaGetMinimumBalanceForRentExemptionResponse: Decodable {
     let result: UInt64
+}
+
+/// `getStakeMinimumDelegation` payload. `result.value` is the minimum active
+/// delegation in lamports.
+struct SolanaGetStakeMinimumDelegationResponse: Decodable {
+    let result: Result
+
+    struct Result: Decodable {
+        let value: UInt64
+    }
 }
 
 struct SolanaGetInflationRateResponse: Decodable {

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -544,9 +544,13 @@ class SolanaService {
     /// Live epoch info. Cached 45s so a screen refresh doesn't re-hit RPC on
     /// every appear while still tracking the ~2-day epoch closely.
     private var epochInfoCache = ThreadSafeDictionary<String, (data: SolanaEpochInfo, timestamp: Date)>()
+    /// Network minimum active delegation (lamports). Changes only on a rare
+    /// feature-gate activation, so it is cached 24h like the rent reserve.
+    private var minDelegationCache = ThreadSafeDictionary<String, (data: UInt64, timestamp: Date)>()
 
     private static let rentReserveTTL: TimeInterval = 60 * 60 * 24
     private static let epochInfoTTL: TimeInterval = 45
+    private static let minDelegationTTL: TimeInterval = 60 * 60 * 24
 
     /// All validators (vote accounts), tagged with their delinquent bucket.
     func fetchSolanaValidators() async throws -> [SolanaValidator] {
@@ -609,6 +613,36 @@ class SolanaService {
         let reserve = response.data.result
         rentReserveCache.set(cacheKey, (data: reserve, timestamp: Date()))
         return reserve
+    }
+
+    /// Network minimum active delegation (lamports), cached 24h. The Vultisig
+    /// proxy blocks `getStakeMinimumDelegation`, so this reads directly from a
+    /// public node (PublicNode, then mainnet-beta as fallback). The value is a
+    /// network-global constant used only as a form-validation floor and never
+    /// touches signing, so the off-proxy read is safe. Throws when every public
+    /// host fails; the caller falls back to the documented
+    /// `SolanaStakingConfig.minDelegationFloorLamports`.
+    func fetchSolanaMinDelegation() async throws -> UInt64 {
+        let cacheKey = "solana-min-delegation"
+        if let cached: UInt64 = Utils.getCachedData(cacheKey: cacheKey, cache: minDelegationCache, timeInSeconds: Self.minDelegationTTL) {
+            return cached
+        }
+        var lastError: Error?
+        for host in SolanaAPI.minDelegationPublicHosts {
+            do {
+                let response = try await httpClient.request(
+                    SolanaAPI(baseURL: host, usesProxyPath: false, rpcMethod: .getStakeMinimumDelegation),
+                    responseType: SolanaGetStakeMinimumDelegationResponse.self
+                )
+                let minimum = response.data.result.value
+                minDelegationCache.set(cacheKey, (data: minimum, timestamp: Date()))
+                return minimum
+            } catch {
+                lastError = error
+                logger.warning("getStakeMinimumDelegation failed on \(host.absoluteString, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        throw lastError ?? SolanaServiceError.rpcError(message: "getStakeMinimumDelegation: no public host responded", code: -1)
     }
 
     /// Drops the short-lived epoch-info cache so the next read reflects a freshly

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingService.swift
@@ -23,6 +23,7 @@ protocol SolanaStakingServiceProtocol: Sendable {
     func fetchStakeAccounts(owner: String) async throws -> [SolanaStakeAccount]
     func fetchEpochInfo() async throws -> SolanaEpochInfo
     func fetchRentReserve() async throws -> UInt64
+    func fetchMinDelegation() async throws -> UInt64
     func fetchInflationRate() async throws -> Double
 }
 
@@ -34,6 +35,7 @@ protocol SolanaStakingReading {
     func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount]
     func fetchSolanaEpochInfo() async throws -> SolanaEpochInfo
     func fetchSolanaRentReserve() async throws -> UInt64
+    func fetchSolanaMinDelegation() async throws -> UInt64
     func fetchSolanaInflationRate() async throws -> Double
 }
 
@@ -98,6 +100,12 @@ actor SolanaStakingService: SolanaStakingServiceProtocol {
 
     func fetchRentReserve() async throws -> UInt64 {
         try await solanaService.fetchSolanaRentReserve()
+    }
+
+    func fetchMinDelegation() async throws -> UInt64 {
+        // Caching (24h) lives on `SolanaService`, same as the rent reserve, so
+        // this stays a thin pass-through.
+        try await solanaService.fetchSolanaMinDelegation()
     }
 
     func fetchInflationRate() async throws -> Double {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/SolanaDelegateTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Solana/SolanaDelegateTransactionViewModel.swift
@@ -28,6 +28,12 @@ final class SolanaDelegateTransactionViewModel: ObservableObject, Form {
     // getMinimumBalanceForRentExemption read returns; overwritten on load.
     @Published private(set) var rentReserve: Decimal =
         Decimal(SolanaStakingConfig.rentExemptReserveLamports) / Decimal(SolanaStakingConfig.lamportsPerSol)
+    // Seeded with the documented 1 SOL floor so the minimum guard is correct
+    // before the live getStakeMinimumDelegation read returns; overwritten on
+    // load, and kept as the fallback if that read fails (proxy blocks it, so it
+    // is fetched from a public node).
+    @Published private(set) var minimumDelegationLamports: UInt64 =
+        SolanaStakingConfig.minDelegationFloorLamports
 
     @Published var amountField = FormField(
         label: "amount".localized,
@@ -63,6 +69,7 @@ final class SolanaDelegateTransactionViewModel: ObservableObject, Form {
         setupForm()
         refreshAmountValidators()
         Task { await loadRentReserve() }
+        Task { await loadMinDelegation() }
     }
 
     /// (Re)builds the amount-field validators against the CURRENT
@@ -76,12 +83,12 @@ final class SolanaDelegateTransactionViewModel: ObservableObject, Form {
             RequiredValidator(errorMessage: "emptyAmountField".localized),
             AmountBalanceValidator(balance: stakeableBalance),
             // Minimum-delegation guard. The user enters the amount they want
-            // ACTIVELY staked; the Solana mainnet minimum delegation is 1 SOL
-            // (getStakeMinimumDelegation), enforced by the Stake program — a
-            // DelegateStake below it reverts with StakeError.InsufficientDelegation
-            // (custom error 12). The rent-exempt reserve is added on top
-            // automatically in `transactionBuilder`, so the user only needs to
-            // enter >= 1 SOL.
+            // ACTIVELY staked; the network minimum delegation (live
+            // getStakeMinimumDelegation, 1 SOL fallback) is enforced by the
+            // Stake program — a DelegateStake below it reverts with
+            // StakeError.InsufficientDelegation (custom error 12). The rent-exempt
+            // reserve is added on top automatically in `transactionBuilder`, so
+            // the user only needs to enter >= the minimum.
             ClosureValidator { [weak self] value in
                 guard let self else { return }
                 guard value.toDecimal() >= self.minimumDelegationDecimal else {
@@ -91,11 +98,30 @@ final class SolanaDelegateTransactionViewModel: ObservableObject, Form {
         ]
     }
 
-    /// Minimum amount the user may enter — the 1 SOL program minimum delegation.
-    /// This is the ACTIVE stake; the rent reserve is funded on top separately, so
-    /// the user is not asked to do the "1 SOL + rent" math.
+    /// Minimum amount the user may enter — the network minimum delegation (live
+    /// value, 1 SOL fallback). This is the ACTIVE stake; the rent reserve is
+    /// funded on top separately, so the user is not asked to do the
+    /// "minimum + rent" math.
     var minimumDelegationDecimal: Decimal {
-        Decimal(SolanaStakingConfig.minDelegationFloorLamports) / pow(Decimal(10), coin.decimals)
+        Decimal(minimumDelegationLamports) / pow(Decimal(10), coin.decimals)
+    }
+
+    /// Fetches the live network minimum delegation and rebuilds the amount guard
+    /// against it. On failure the seeded 1 SOL fallback stays in place, so the
+    /// form still enforces a safe floor offline. Internal so it can be awaited
+    /// deterministically in tests (mirrors `SolanaStakeDefiViewModel.refresh`).
+    func loadMinDelegation() async {
+        do {
+            let lamports = try await stakingService.fetchMinDelegation()
+            minimumDelegationLamports = lamports
+            refreshAmountValidators()
+            if amountField.touched {
+                validateErrors()
+                validForm = form.allSatisfy { $0.valid }
+            }
+        } catch {
+            logger.error("Min delegation fetch failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func loadRentReserve() async {

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaDelegateTransactionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaDelegateTransactionViewModelTests.swift
@@ -1,0 +1,102 @@
+//
+//  SolanaDelegateTransactionViewModelTests.swift
+//  VultisigAppTests
+//
+//  Pins the dynamic minimum-delegation contract: the delegate form seeds the
+//  documented 1 SOL floor, adopts the live getStakeMinimumDelegation value when
+//  the fetch succeeds, and keeps the seeded floor when the fetch fails (the
+//  Vultisig proxy blocks the method, so it is read off a public node that may be
+//  unreachable).
+//
+
+@testable import VultisigApp
+import XCTest
+
+// Protocol conformance forces `async throws` signatures the fake doesn't await
+// on the no-op reads.
+// swiftlint:disable async_without_await unused_parameter
+private final class FakeDelegateStakingService: SolanaStakingServiceProtocol, @unchecked Sendable {
+    var minDelegation: UInt64 = 1_000_000_000
+    var minDelegationError: Error?
+
+    func fetchValidators() async throws -> [SolanaValidator] { [] }
+    func fetchStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] { [] }
+    func fetchEpochInfo() async throws -> SolanaEpochInfo {
+        SolanaEpochInfo(epoch: 800, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
+    }
+    func fetchRentReserve() async throws -> UInt64 { 2_282_880 }
+    func fetchMinDelegation() async throws -> UInt64 {
+        if let minDelegationError { throw minDelegationError }
+        return minDelegation
+    }
+    func fetchInflationRate() async throws -> Double { 0.07 }
+}
+// swiftlint:enable async_without_await unused_parameter
+
+private enum FakeRPCError: Error { case unavailable }
+
+@MainActor
+final class SolanaDelegateTransactionViewModelTests: XCTestCase {
+
+    private var storeToken: TestContextToken!
+    private var vault: Vault!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+        vault = TestStore.makeVault()
+    }
+
+    override func tearDown() async throws {
+        vault = nil
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
+    private func solCoin() -> Coin {
+        let meta = CoinMeta(
+            chain: .solana, ticker: "SOL", logo: "solana", decimals: 9,
+            priceProviderId: "solana", contractAddress: "", isNativeToken: true
+        )
+        return Coin(asset: meta, address: "Owner", hexPublicKey: "00")
+    }
+
+    private func makeViewModel(
+        service: SolanaStakingServiceProtocol
+    ) -> SolanaDelegateTransactionViewModel {
+        SolanaDelegateTransactionViewModel(
+            coin: solCoin(),
+            vault: vault,
+            stakingService: service
+        )
+    }
+
+    func testSeedsDocumentedFloorBeforeFetch() {
+        let vm = makeViewModel(service: FakeDelegateStakingService())
+        XCTAssertEqual(vm.minimumDelegationLamports, SolanaStakingConfig.minDelegationFloorLamports)
+        XCTAssertEqual(vm.minimumDelegationDecimal, 1)
+    }
+
+    func testAdoptsLiveMinimumWhenFetchSucceeds() async {
+        let service = FakeDelegateStakingService()
+        service.minDelegation = 2_000_000_000 // 2 SOL — a hypothetical feature-gate bump
+        let vm = makeViewModel(service: service)
+
+        await vm.loadMinDelegation()
+
+        XCTAssertEqual(vm.minimumDelegationLamports, 2_000_000_000)
+        XCTAssertEqual(vm.minimumDelegationDecimal, 2)
+    }
+
+    func testKeepsSeededFloorWhenFetchFails() async {
+        let service = FakeDelegateStakingService()
+        service.minDelegationError = FakeRPCError.unavailable
+        let vm = makeViewModel(service: service)
+
+        await vm.loadMinDelegation()
+
+        XCTAssertEqual(vm.minimumDelegationLamports, SolanaStakingConfig.minDelegationFloorLamports)
+        XCTAssertEqual(vm.minimumDelegationDecimal, 1)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakeDefiViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakeDefiViewModelTests.swift
@@ -59,6 +59,7 @@ private final class FakeStakingService: SolanaStakingServiceProtocol, @unchecked
 
     func fetchEpochInfo() async throws -> SolanaEpochInfo { epoch }
     func fetchRentReserve() async throws -> UInt64 { rentReserve }
+    func fetchMinDelegation() async throws -> UInt64 { 1_000_000_000 }
     func fetchInflationRate() async throws -> Double { inflation }
 }
 
@@ -81,6 +82,7 @@ private final class CountingReader: SolanaStakingReading, @unchecked Sendable {
         SolanaEpochInfo(epoch: 800, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
     }
     func fetchSolanaRentReserve() async throws -> UInt64 { 2_282_880 }
+    func fetchSolanaMinDelegation() async throws -> UInt64 { 1_000_000_000 }
     func fetchSolanaInflationRate() async throws -> Double { 0.07 }
 }
 

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingAPITests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingAPITests.swift
@@ -79,6 +79,23 @@ final class SolanaStakingAPITests: XCTestCase {
         XCTAssertEqual(envelope["method"] as? String, "getVoteAccounts")
     }
 
+    func testStakeMinimumDelegationMethodTakesNoParams() throws {
+        let envelope = try params(for: .getStakeMinimumDelegation)
+        XCTAssertEqual(envelope["method"] as? String, "getStakeMinimumDelegation")
+        let rpcParams = try XCTUnwrap(envelope["params"] as? [Any])
+        XCTAssertTrue(rpcParams.isEmpty)
+    }
+
+    func testMinDelegationPublicHostsDropTheProxyPath() {
+        // The public endpoints are complete JSON-RPC URLs, so the `/solana/`
+        // proxy path must not be appended.
+        for host in SolanaAPI.minDelegationPublicHosts {
+            let api = SolanaAPI(baseURL: host, usesProxyPath: false, rpcMethod: .getStakeMinimumDelegation)
+            XCTAssertEqual(api.path, "")
+        }
+        XCTAssertFalse(SolanaAPI.minDelegationPublicHosts.isEmpty)
+    }
+
     // MARK: - Response decoding
 
     func testEpochInfoResponseDecodes() throws {
@@ -97,6 +114,16 @@ final class SolanaStakingAPITests: XCTestCase {
             from: Data(#"{ "result": 2282880 }"#.utf8)
         )
         XCTAssertEqual(response.result, 2_282_880)
+    }
+
+    func testStakeMinimumDelegationResponseDecodes() throws {
+        // Shape returned by public nodes: `result` wraps `context` + `value`.
+        let json = #"{ "jsonrpc": "2.0", "result": { "context": { "slot": 429993219 }, "value": 1000000000 }, "id": 1 }"#
+        let response = try JSONDecoder().decode(
+            SolanaGetStakeMinimumDelegationResponse.self,
+            from: Data(json.utf8)
+        )
+        XCTAssertEqual(response.result.value, 1_000_000_000)
     }
 
     func testVoteAccountsResponseDecodesAndTagsDelinquency() throws {

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingServiceCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingServiceCacheTests.swift
@@ -50,6 +50,8 @@ private final class CountingReader: SolanaStakingReading, @unchecked Sendable {
 
     func fetchSolanaRentReserve() async throws -> UInt64 { 2_282_880 }
 
+    func fetchSolanaMinDelegation() async throws -> UInt64 { 1_000_000_000 }
+
     func fetchSolanaInflationRate() async throws -> Double {
         lock.withLock { inflationCalls += 1 }
         return 0.0377

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaWithdrawTransactionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaWithdrawTransactionViewModelTests.swift
@@ -24,6 +24,7 @@ private final class FakeWithdrawStakingService: SolanaStakingServiceProtocol, @u
         SolanaEpochInfo(epoch: 800, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
     }
     func fetchRentReserve() async throws -> UInt64 { 2_282_880 }
+    func fetchMinDelegation() async throws -> UInt64 { 1_000_000_000 }
     func fetchInflationRate() async throws -> Double { 0.07 }
 }
 // swiftlint:enable async_without_await unused_parameter


### PR DESCRIPTION
## What & why

Closes #4694.

The Solana delegate form enforced a **hardcoded 1 SOL** minimum active delegation. That value is a **feature-gate-activated network constant**, not a permanent one — and the Vultisig RPC proxy (`api.vultisig.com/solana/`) **blocks** `getStakeMinimumDelegation`:

```
→ -32600 "Unsupported method: getStakeMinimumDelegation on SOLANA_MAINNET"
```

so it can't be read through the normal path. If the network minimum changes, the stale hardcode either rejects valid stakes or lets through amounts that revert on-chain (`StakeError.InsufficientDelegation`).

## Approach

The method is standard (Solana ≥1.14) and **public nodes serve it keyless** (verified live):

| Endpoint | `getStakeMinimumDelegation` |
|---|---|
| `api.vultisig.com/solana/` (proxy) | ❌ unsupported |
| `solana-rpc.publicnode.com` | ✅ `1000000000` (primary) |
| `api.mainnet-beta.solana.com` | ✅ `1000000000` (fallback) |

So this reads the value **directly from a public node**, cached 24h, with the 1 SOL constant kept as the offline fallback.

The min-delegation is **network-global** and used **only as a form-validation floor** — it never touches the keysign payload or MPC byte-parity. It is deliberately **not** routed through the custom-RPC override (`resolver.resolvedURL(for: .solana)`), which would repoint *all* Solana RPC including `sendTransaction`; instead a dedicated read targets a hardcoded public host with `usesProxyPath: false`.

## Changes

- **`SolanaAPI`** — `getStakeMinimumDelegation` method (no params) + envelope; `minDelegationPublicHosts` (PublicNode → mainnet-beta); `SolanaGetStakeMinimumDelegationResponse`.
- **`SolanaService.fetchSolanaMinDelegation()`** — 24h cache, iterates public hosts, throws only if all fail.
- **`SolanaStakingService`** — `fetchMinDelegation()` pass-through on both protocols (caching lives on `SolanaService`).
- **`SolanaDelegateTransactionViewModel`** — `minimumDelegationLamports` seeded to the 1 SOL floor, adopted live in `onLoad`, **falls back to the floor on failure**.
- **Tests** — envelope + DTO decode; VM adopt/fallback/seed; updated 3 staking-service fakes.

## Acceptance criteria (#4694)

- [x] App fetches the minimum dynamically (public node, since the proxy blocks it)
- [x] Cached (~24h)
- [x] Graceful fallback when RPC unavailable (documented 1 SOL floor)
- [x] Delegate form reflects the live value

> Note: the issue's option 1 (unblock the method on the Vultisig proxy) is a **backend** change and remains a nice-to-have. This PR unblocks the iOS side without it; if the proxy later allows the method, the host list just gets the proxy prepended and the public nodes stay as fallback.

## Testing

- SwiftLint: **0 violations** (9 changed files).
- `make test` (full iOS suite): all 6 new tests pass + the whole Solana staking suite passes. One **pre-existing, unrelated** failure remains — `StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress` (host-locale decimal separator: asserts `"12.3%"`, gets `"12,3%"`; a Cosmos APY formatting flake outside this diff).
- Pending: on-device delegate-form check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading Solana’s live minimum stake delegation value.
  * Staking screens now use the network value to validate delegation amounts, with a fallback if the network lookup fails.

* **Bug Fixes**
  * Improved validation so delegation amounts stay accurate even when the live value changes.
  * Added safer fallback behavior to keep staking actions usable offline or during RPC failures.

* **Tests**
  * Expanded automated coverage for staking minimum delegation fetching, decoding, caching, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->