### PR TITLE
feat(cardano): attach send memo on-chain as CIP-20 metadata (WalletCore 4.7.0 auxiliaryData)

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -112,7 +112,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/walletcore-spm",
       "state" : {
-        "revision" : "628900b25de367bdd48427040977f68b6882d8a0"
+        "revision" : "628900b25de367bdd48427040977f68b6882d8a0",
+        "version" : "4.7.1"
       }
     },
     {

--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -112,8 +112,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/walletcore-spm",
       "state" : {
-        "revision" : "628900b25de367bdd48427040977f68b6882d8a0",
-        "version" : "4.7.1"
+        "revision" : "628900b25de367bdd48427040977f68b6882d8a0"
       }
     },
     {

--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -112,8 +112,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/walletcore-spm",
       "state" : {
-        "revision" : "6fe770f97ebce59b7c30db5e2fac9dffb2352c2c",
-        "version" : "4.6.13"
+        "revision" : "628900b25de367bdd48427040977f68b6882d8a0"
       }
     },
     {

--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/Cardano.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/Cardano.swift
@@ -209,6 +209,12 @@ class CardanoHelper {
             ? UInt64(keysignPayload.toAmount)
             : Self.minLovelaceOnTokenOutput
 
+        // CIP-20 memo (label 674). When present, WalletCore commits
+        // blake2b-256(auxDataCbor) into the body at map key 7 and emits the
+        // aux CBOR as element [3] of the signed tx. The encoder is byte-parity
+        // pinned to the SDK golden vector so co-signers agree on the sighash.
+        let auxDataCbor = cip20AuxData(for: keysignPayload)
+
         // `byteFee` is a SHARED payload constant: the initiator computes a real
         // size-based fee once (see `CardanoHelper.estimateDynamicByteFee`) and
         // every co-signing device forces that exact value here. Seeding a
@@ -230,6 +236,9 @@ class CardanoHelper {
                 }
             }
             $0.ttl = ttl
+            if let auxDataCbor {
+                $0.auxiliaryData = auxDataCbor
+            }
         }
 
         // Add UTXOs to the input. Per-UTXO token data is carried on the wire
@@ -258,6 +267,17 @@ class CardanoHelper {
         }
 
         return input
+    }
+
+    /// Canonical CIP-20 auxiliary-data CBOR (label 674) for the payload memo,
+    /// or `nil` when there is no memo. Both the pre-sign input
+    /// (`CardanoSigningInput.auxiliaryData`) and the hand-built signed envelope
+    /// (element [3]) derive from this single source, so the body's key-7 hash
+    /// and the embedded aux bytes stay consistent — and byte-identical to the
+    /// SDK/Android/Extension co-signers.
+    static func cip20AuxData(for keysignPayload: KeysignPayload) -> Data? {
+        guard let memo = keysignPayload.memo, !memo.isEmpty else { return nil }
+        return CardanoCIP20.buildAuxData(memo: memo).auxDataCbor
     }
 
     /// Encode an unsigned integer as minimal big-endian bytes (matches
@@ -386,10 +406,17 @@ class CardanoHelper {
         // builds (AddressV2::isValid). Build the signed CBOR envelope by hand
         // from the pre-image body bytes — see CardanoSignedTxBuilder. The body
         // is embedded verbatim; the signature covers Blake2b of those bytes.
+        // When a CIP-20 memo is present, the pre-image body already carries the
+        // aux hash at key 7 (WalletCore committed it from `auxiliaryData`); we
+        // embed the same aux CBOR as element [3]. The body, witness, and aux
+        // bytes match AnySigner's native output; the envelope framing follows
+        // the SDK/mainnet-verified 4-element `[body, witness, is_valid, aux]`
+        // format (AnySigner uses the 3-element Shelley form — same txid).
         let signedTx = try CardanoSignedTxBuilder.build(
             txBody: preSigningOutput.data,
             publicKey: spendingKeyData,
-            signature: signature
+            signature: signature,
+            auxData: cip20AuxData(for: keysignPayload)
         )
 
         // Cardano txId IS Blake2b-256 of the body, which is exactly the

--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/CardanoCIP20.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/CardanoCIP20.swift
@@ -1,0 +1,151 @@
+//
+//  CardanoCIP20.swift
+//  VultisigApp
+//
+//  Canonical CIP-20 transaction-metadata encoder for Cardano memos.
+//
+//  A Cardano memo is CIP-20 metadata under the registered label 674:
+//
+//      { 674: { "msg": [ "<chunk1>", "<chunk2>", ... ] } }
+//
+//  Each `msg` text chunk is at most 64 UTF-8 bytes, split on Unicode
+//  codepoint boundaries (never mid-codepoint). WalletCore 4.7.0 consumes
+//  these CBOR bytes via `CardanoSigningInput.auxiliaryData`: it commits
+//  blake2b-256(auxDataCbor) into the tx body at map key 7
+//  (auxiliary_data_hash) and embeds the bytes as element [3] of the signed
+//  transaction array.
+//
+//  Cardano signing is MPC/TSS: every co-signing device (iOS / Android /
+//  Extension) builds the input independently and the Blake2b sighash must
+//  match byte-for-byte, so this encoding MUST be byte-identical across
+//  platforms. It mirrors the mainnet-verified SDK encoder
+//  `vultisig-sdk/packages/core/mpc/tx/compile/cardano/buildCip20AuxData.ts`
+//  and the canonical primitives in `.../cardano/cip30/cardanoCborPrimitives.ts`.
+//
+
+import Foundation
+import WalletCore
+
+/// Encodes a Cardano memo as canonical CIP-20 transaction metadata (label 674).
+enum CardanoCIP20 {
+
+    /// CIP-20 limits each metadata text chunk to 64 UTF-8 bytes.
+    static let maxChunkBytes = 64
+
+    /// The CIP-20 metadata label registered on cardano.org.
+    static let metadataLabel = 674
+
+    /// Split a memo into chunks of at most 64 UTF-8 bytes, respecting UTF-8
+    /// codepoint boundaries.
+    ///
+    /// A multi-byte codepoint straddling the 64-byte boundary is moved
+    /// entirely to the next chunk rather than torn — a torn codepoint decodes
+    /// to U+FFFD and corrupts the memo on-chain. UTF-8 continuation bytes have
+    /// the top bits `10xxxxxx`; we walk back off them until the cut lands on a
+    /// leading byte. An empty memo yields a single empty-string chunk (matches
+    /// the SDK, which always emits at least one `msg` element).
+    static func memoToChunks(_ memo: String) -> [String] {
+        let bytes = Array(memo.utf8)
+        if bytes.isEmpty { return [""] }
+
+        var chunks: [String] = []
+        var start = 0
+        while start < bytes.count {
+            var end = min(start + maxChunkBytes, bytes.count)
+
+            // If we are not at the end and `end` lands on a continuation byte
+            // (0b10xxxxxx), back up until the byte at `end` starts a codepoint.
+            if end < bytes.count {
+                while end > start, (bytes[end] & 0xC0) == 0x80 {
+                    end -= 1
+                }
+                // Defensive: a run of >64 continuation bytes is impossible for
+                // valid UTF-8 (max 4 bytes/codepoint); fall back to the raw cut
+                // so we always make forward progress.
+                if end == start {
+                    end = min(start + maxChunkBytes, bytes.count)
+                }
+            }
+
+            // Cuts always land on a codepoint boundary, so decoding a slice of
+            // the (always-valid) UTF-8 bytes never fails; `?? ""` is unreachable.
+            chunks.append(String(bytes: bytes[start..<end], encoding: .utf8) ?? "")
+            start = end
+        }
+        return chunks
+    }
+
+    /// Encode the CIP-20 auxiliary data for a memo.
+    ///
+    /// - Returns:
+    ///   - `auxDataCbor`: canonical CBOR bytes for `{ 674: { "msg": [chunks] } }`,
+    ///     to be set on `CardanoSigningInput.auxiliaryData` (and, in the manual
+    ///     builder, embedded as signed-tx element [3]).
+    ///   - `auxDataHash`: blake2b-256 of `auxDataCbor`, which WalletCore commits
+    ///     into the tx body at map key 7.
+    static func buildAuxData(memo: String) -> (auxDataCbor: Data, auxDataHash: Data) {
+        let chunks = memoToChunks(memo)
+        let msgArray = cborArray(chunks.map { cborText($0) })
+        let innerMap = cborMap([(cborText("msg"), msgArray)])
+        let auxDataCbor = cborMap([(cborUint(metadataLabel), innerMap)])
+        let auxDataHash = Hash.blake2b(data: auxDataCbor, size: 32)
+        return (auxDataCbor, auxDataHash)
+    }
+
+    // MARK: - Minimal canonical CBOR primitives (RFC 8949 §3.1)
+
+    /// CBOR text string (major type 3).
+    private static func cborText(_ string: String) -> Data {
+        let utf8 = Data(string.utf8)
+        return cborHead(majorType: 3, value: utf8.count) + utf8
+    }
+
+    /// CBOR unsigned integer (major type 0).
+    private static func cborUint(_ value: Int) -> Data {
+        cborHead(majorType: 0, value: value)
+    }
+
+    /// CBOR array header (major type 4) followed by its items.
+    private static func cborArray(_ items: [Data]) -> Data {
+        var out = cborHead(majorType: 4, value: items.count)
+        for item in items { out.append(item) }
+        return out
+    }
+
+    /// CBOR map header (major type 5) followed by its key/value pairs.
+    private static func cborMap(_ entries: [(Data, Data)]) -> Data {
+        var out = cborHead(majorType: 5, value: entries.count)
+        for (key, value) in entries {
+            out.append(key)
+            out.append(value)
+        }
+        return out
+    }
+
+    /// Encode the major-type + argument head in the smallest form (RFC 8949 §3.1).
+    private static func cborHead(majorType: UInt8, value: Int) -> Data {
+        let mt = majorType << 5
+        let v = UInt64(value)
+        if v < 24 {
+            return Data([mt | UInt8(v)])
+        } else if v < 0x100 {
+            return Data([mt | 24, UInt8(v)])
+        } else if v < 0x1_0000 {
+            return Data([mt | 25, UInt8((v >> 8) & 0xFF), UInt8(v & 0xFF)])
+        } else if v < 0x1_0000_0000 {
+            return Data([
+                mt | 26,
+                UInt8((v >> 24) & 0xFF), UInt8((v >> 16) & 0xFF),
+                UInt8((v >> 8) & 0xFF), UInt8(v & 0xFF)
+            ])
+        } else {
+            return Data([
+                mt | 27,
+                UInt8((v >> 56) & 0xFF), UInt8((v >> 48) & 0xFF),
+                UInt8((v >> 40) & 0xFF), UInt8((v >> 32) & 0xFF),
+                UInt8((v >> 24) & 0xFF), UInt8((v >> 16) & 0xFF),
+                UInt8((v >> 8) & 0xFF), UInt8(v & 0xFF)
+            ])
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/CardanoSignedTxBuilder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/CardanoSignedTxBuilder.swift
@@ -20,7 +20,20 @@ enum CardanoSignedTxBuilder {
     static let publicKeyLength = 32
     static let signatureLength = 64
 
-    static func build(txBody: Data, publicKey: Data, signature: Data) throws -> Data {
+    /// Assemble the signed transaction array `[body, witness_set, is_valid,
+    /// auxiliary_data]`.
+    ///
+    /// - Parameter auxData: canonical CIP-20 auxiliary-data CBOR (label 674).
+    ///   When `nil` the envelope carries the `null` (`0xF6`) auxiliary-data
+    ///   sentinel, as before. When set, WalletCore's `TransactionCompiler` has
+    ///   already committed `blake2b-256(auxData)` into the body at map key 7, so
+    ///   the aux bytes are embedded verbatim as element [3]. The body, witness,
+    ///   and this aux element are byte-identical to what WalletCore's `AnySigner`
+    ///   emits; only the envelope framing differs — this SDK/mainnet-verified
+    ///   builder uses the 4-element `[body, witness, is_valid, aux]` array while
+    ///   `AnySigner` uses the 3-element Shelley `[body, witness, aux]`. The txid
+    ///   (`blake2b-256(body)`) is identical either way.
+    static func build(txBody: Data, publicKey: Data, signature: Data, auxData: Data? = nil) throws -> Data {
         guard publicKey.count == publicKeyLength else {
             throw CardanoSignedTxBuilderError.invalidPublicKeyLength(publicKey.count)
         }
@@ -29,13 +42,14 @@ enum CardanoSignedTxBuilder {
         }
 
         let witness = buildWitness(publicKey: publicKey, signature: signature)
+        let auxElement = auxData ?? Data([0xF6])
 
-        var output = Data(capacity: 1 + txBody.count + witness.count + 2)
+        var output = Data(capacity: 1 + txBody.count + witness.count + 1 + auxElement.count)
         output.append(0x84)
         output.append(txBody)
         output.append(witness)
         output.append(0xF5)
-        output.append(0xF6)
+        output.append(auxElement)
         return output
     }
 

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
@@ -18,7 +18,6 @@ struct SendDetailsAdditionalSection: View {
         VStack(spacing: 14) {
             // Memo input is gated by `Chain.supportsMemo` so per-chain
             // capability lives in the model, not scattered across UI.
-            // Cardano currently returns false (see #4326 / #4377).
             if viewModel.coin.chain.supportsMemo {
                 addMemoField
             }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayloadFactory.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayloadFactory.swift
@@ -85,6 +85,7 @@ struct KeysignPayloadFactory {
                         coin: coin,
                         toAddress: toAddress,
                         amount: amount,
+                        memo: memo,
                         ttl: ttl,
                         sendMaxAmount: sendMaxAmount,
                         utxos: utxos,
@@ -127,11 +128,17 @@ struct KeysignPayloadFactory {
 
     /// Build a transient payload carrying the selected Cardano UTXOs, used only
     /// to run the initiator's preliminary fee plan (`estimateDynamicByteFee`).
-    /// `byteFee` is left at 0 so the planner derives a size-based fee.
-    private func makeCardanoFeePayload(
+    /// `byteFee` is left at 0 so the planner derives a size-based fee. The memo
+    /// must be carried through: a CIP-20 memo grows the signed tx (aux-hash
+    /// entry in the body plus the aux CBOR in the envelope), and a fee planned
+    /// without it is below the network minimum for the tx that actually gets
+    /// signed — the node rejects the broadcast with `FeeTooSmallUTxO`.
+    /// Internal (not private) so the fee tests can pin this behavior.
+    func makeCardanoFeePayload(
         coin: Coin,
         toAddress: String,
         amount: BigInt,
+        memo: String?,
         ttl: UInt64,
         sendMaxAmount: Bool,
         utxos: [UtxoInfo],
@@ -143,7 +150,7 @@ struct KeysignPayloadFactory {
             toAmount: amount,
             chainSpecific: .Cardano(byteFee: 0, sendMaxAmount: sendMaxAmount, ttl: ttl),
             utxos: utxos,
-            memo: nil,
+            memo: memo,
             swapPayload: nil,
             approvePayload: nil,
             vaultPubKeyECDSA: vault.pubKeyECDSA,

--- a/VultisigApp/VultisigApp/Model/Chain.swift
+++ b/VultisigApp/VultisigApp/Model/Chain.swift
@@ -627,16 +627,14 @@ extension Chain {
     }
 
     /// Whether the Send flow's memo input should be exposed for this chain.
-    /// Most chains carry a memo at the protocol level, with two exceptions:
-    /// Cardano — WalletCore doesn't yet expose CIP-20 auxiliary data fields,
-    /// so iOS Cardano signing silently drops anything the user types; and
-    /// Sui — a transaction is a Programmable Transaction Block with no memo
-    /// field, so a typed memo is likewise dropped. Hiding the input avoids
-    /// the silent-drop bug. See #4326 (root) and #4377 (this mitigation);
-    /// remove the `.cardano` case here when #4326 closes.
+    /// Most chains carry a memo at the protocol level. The exception is Sui:
+    /// a transaction is a Programmable Transaction Block with no memo field, so
+    /// a typed memo would be silently dropped — hiding the input avoids that.
+    /// Cardano DOES support memos: they are attached on-chain as CIP-20
+    /// transaction metadata (label 674) via `CardanoSigningInput.auxiliaryData`.
     var supportsMemo: Bool {
         switch self {
-        case .cardano, .sui:
+        case .sui:
             return false
         default:
             return true

--- a/VultisigApp/VultisigAppTests/Chains/CardanoCIP20Tests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CardanoCIP20Tests.swift
@@ -1,0 +1,124 @@
+//
+//  CardanoCIP20Tests.swift
+//  VultisigApp
+//
+
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+/// Byte-parity fixtures shared with the SDK's
+/// `packages/core/mpc/tx/compile/cardano/buildCip20AuxData.test.ts`. The CIP-20
+/// CBOR bytes and blake2b-256 aux hash MUST be identical across iOS / Android /
+/// Extension or MPC co-signers disagree on the Cardano sighash. Any drift here
+/// or in the SDK encoder breaks one of these tests.
+final class CardanoCIP20Tests: XCTestCase {
+
+    // MARK: - memoToChunks
+
+    func testReturnsSingleChunkForShortMemo() {
+        XCTAssertEqual(CardanoCIP20.memoToChunks("hello world"), ["hello world"])
+    }
+
+    func testReturnsSingleEmptyChunkForEmptyInput() {
+        XCTAssertEqual(CardanoCIP20.memoToChunks(""), [""])
+    }
+
+    func testSplitsExactlyOn64ByteBoundaryForAscii() {
+        let memo65 = String(repeating: "a", count: 65)
+        let chunks = CardanoCIP20.memoToChunks(memo65)
+        XCTAssertEqual(chunks.count, 2)
+        XCTAssertEqual(chunks[0].utf8.count, 64)
+        XCTAssertEqual(chunks[1].utf8.count, 1)
+    }
+
+    func testDoesNotSplitA64ByteMemo() {
+        let memo64 = String(repeating: "x", count: 64)
+        XCTAssertEqual(CardanoCIP20.memoToChunks(memo64), [memo64])
+    }
+
+    func testDoesNotTear4ByteCodepointStraddlingBoundary() {
+        // 63 ASCII 'a' + U+1F600 (4 bytes) + 'b'. A naive byte-cut would tear
+        // the emoji at byte 63 and produce U+FFFD on decode.
+        let memo = String(repeating: "a", count: 63) + "\u{1F600}" + "b"
+        let chunks = CardanoCIP20.memoToChunks(memo)
+        XCTAssertEqual(chunks.joined(), memo)
+        XCTAssertFalse(chunks.joined().contains("\u{FFFD}"))
+        XCTAssertLessThanOrEqual(chunks[0].utf8.count, 64)
+        XCTAssertTrue(chunks[1].contains("\u{1F600}"))
+    }
+
+    func testDoesNotTear2ByteCodepointStraddlingBoundary() {
+        // 63 ASCII 'a' + 'ñ' (U+00F1, 2 bytes) + 'c'
+        let memo = String(repeating: "a", count: 63) + "ñ" + "c"
+        let chunks = CardanoCIP20.memoToChunks(memo)
+        XCTAssertEqual(chunks.joined(), memo)
+        XCTAssertFalse(chunks.joined().contains("\u{FFFD}"))
+    }
+
+    func testDoesNotTear3ByteCodepointStraddlingBoundary() {
+        // 62 ASCII 'a' + '日' (U+65E5, 3 bytes spanning bytes 62-64) + 'd'
+        let memo = String(repeating: "a", count: 62) + "日" + "d"
+        let chunks = CardanoCIP20.memoToChunks(memo)
+        XCTAssertEqual(chunks.joined(), memo)
+        XCTAssertFalse(chunks.joined().contains("\u{FFFD}"))
+    }
+
+    func testMultiByteMemoRoundTripsThroughChunks() {
+        let memo = String(repeating: "a", count: 63) + "\u{1F600}" + "b"
+        let chunks = CardanoCIP20.memoToChunks(memo)
+        XCTAssertEqual(chunks.joined(), memo)
+        XCTAssertFalse(chunks.joined().contains("\u{FFFD}"))
+        for chunk in chunks {
+            XCTAssertLessThanOrEqual(chunk.utf8.count, 64)
+        }
+    }
+
+    // MARK: - buildAuxData byte parity
+
+    /// Pinned canonical CBOR for `{ 674: { "msg": ["hello world"] } }`:
+    ///   A1              map(1)
+    ///     19 02 A2      uint(674)
+    ///     A1            map(1)
+    ///       63 6D 73 67 text("msg")
+    ///       81          array(1)
+    ///         6B ...    text(11) "hello world"
+    func testBuildAuxDataProducesPinnedCborForHelloWorld() {
+        // a1 1902a2 a1 636d7367 81 6b <"hello world">
+        let expectedHex = "a11902a2a1636d7367816b" + Data("hello world".utf8).hexString
+        let (auxDataCbor, _) = CardanoCIP20.buildAuxData(memo: "hello world")
+        XCTAssertEqual(auxDataCbor.hexString, expectedHex)
+    }
+
+    func testBuildAuxDataEncodesLabel674AndMsgKey() {
+        let (auxDataCbor, _) = CardanoCIP20.buildAuxData(memo: "hello world")
+        let hex = auxDataCbor.hexString
+        // Outer map(1) + uint(674) = a1 1902a2 ; inner map(1) + text "msg" = a1 636d7367
+        XCTAssertTrue(hex.hasPrefix("a11902a2a1636d7367"))
+    }
+
+    func testBuildAuxDataChunksA64ByteChunkHeadCorrectly() {
+        // A 65-byte ASCII memo → two text chunks: one 64-byte (head 78 40) and
+        // one 1-byte (head 61). Verifies the 24 ≤ len < 256 head form.
+        let memo = String(repeating: "a", count: 65)
+        let (auxDataCbor, _) = CardanoCIP20.buildAuxData(memo: memo)
+        let hex = auxDataCbor.hexString
+        // array(2) header before the chunks
+        XCTAssertTrue(hex.contains("82"))
+        // 64-byte text head 0x78 0x40 followed by 64 'a' (0x61)
+        XCTAssertTrue(hex.contains("7840" + String(repeating: "61", count: 64)))
+    }
+
+    func testBuildAuxDataEmptyMemoEncodesSingleEmptyChunk() {
+        // { 674: { "msg": [""] } } → ... 81 60  (array(1), text(0))
+        let (auxDataCbor, _) = CardanoCIP20.buildAuxData(memo: "")
+        XCTAssertEqual(auxDataCbor.hexString, "a11902a2a1636d7367" + "8160")
+    }
+
+    func testAuxDataHashIsBlake2b256OfCbor() {
+        let (auxDataCbor, auxDataHash) = CardanoCIP20.buildAuxData(memo: "vultisig-test")
+        XCTAssertEqual(auxDataHash.count, 32)
+        XCTAssertEqual(auxDataHash, Hash.blake2b(data: auxDataCbor, size: 32))
+        XCTAssertTrue(auxDataHash.contains { $0 != 0 })
+    }
+}

--- a/VultisigApp/VultisigAppTests/Chains/CardanoCip20SigningTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CardanoCip20SigningTests.swift
@@ -1,0 +1,310 @@
+//
+//  CardanoCip20SigningTests.swift
+//  VultisigApp
+//
+
+@testable import VultisigApp
+import BigInt
+import WalletCore
+import XCTest
+
+/// End-to-end wiring for the Cardano CIP-20 memo (label 674) via WalletCore
+/// 4.7.0's native `CardanoSigningInput.auxiliaryData`.
+///
+/// The byte-level CBOR encoding is pinned in `CardanoCIP20Tests`; this suite
+/// proves the encoder is wired into the signing path correctly:
+///   - the memo becomes `auxiliaryData` on the pre-sign input,
+///   - WalletCore commits `blake2b-256(auxDataCbor)` into the body at map key 7,
+///   - the hand-built signed envelope embeds the same aux CBOR as element [3],
+///   - the hand-built envelope is byte-identical to WalletCore's `AnySigner`
+///     native output (the manual builder exists only because
+///     `compileWithSignatures` crashes on Cardano — it must not diverge),
+///   - the no-memo path is unchanged (aux stays the `0xF6` null sentinel),
+///   - the dynamic fee prices the aux bytes so the memo is paid for.
+final class CardanoCip20SigningTests: XCTestCase {
+
+    private let cardanoAddress = "addr1v9g9wnzsutrxt7vcg4efdfwhagwh3x2f6hjwykk7acdpsfgyt4h2j"
+    private let utxoHash = "f074134aabbfb13b8aec7cf5465b1e5a862d1cadc175d431c1d9339150db8a1d"
+
+    /// mainnet minFeeA (lovelace per byte) — the size-based fee slope.
+    private let minFeeA = 44
+
+    private func makeCoin() throws -> Coin {
+        let pubKey = "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5"
+        let chainCode = String(repeating: "0", count: 64)
+        let coin = try CoinFactory.create(
+            asset: TokensStore.Token.cardano,
+            publicKeyECDSA: pubKey,
+            publicKeyEdDSA: pubKey,
+            hexChainCode: chainCode,
+            isDerived: false
+        )
+        coin.address = cardanoAddress
+        return coin
+    }
+
+    private func makePayload(
+        coin: Coin,
+        toAmount: BigInt,
+        utxos: [UtxoInfo],
+        byteFee: BigInt,
+        memo: String?
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: cardanoAddress,
+            toAmount: toAmount,
+            chainSpecific: .Cardano(byteFee: byteFee, sendMaxAmount: false, ttl: 190_000_000),
+            utxos: utxos,
+            memo: memo,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "ECDSAKey",
+            vaultLocalPartyID: "localPartyID",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private func singleUtxo() -> [UtxoInfo] {
+        [UtxoInfo(hash: utxoHash, amount: 10_000_000, index: 0)]
+    }
+
+    // MARK: - Pre-sign input wiring
+
+    func testPreSignInputSetsAuxiliaryDataWhenMemoPresent() throws {
+        let coin = try makeCoin()
+        let payload = makePayload(coin: coin, toAmount: 2_000_000, utxos: singleUtxo(), byteFee: 180_000, memo: "hello world")
+
+        let input = try CardanoHelper.getPreSignedInputData(keysignPayload: payload)
+
+        let expected = CardanoCIP20.buildAuxData(memo: "hello world").auxDataCbor
+        XCTAssertEqual(input.auxiliaryData, expected)
+        // Byte-parity anchor: matches the pinned SDK golden vector.
+        XCTAssertEqual(input.auxiliaryData.hexString, "a11902a2a1636d7367816b" + Data("hello world".utf8).hexString)
+    }
+
+    func testPreSignInputHasNoAuxiliaryDataWhenMemoNil() throws {
+        let coin = try makeCoin()
+        let payload = makePayload(coin: coin, toAmount: 2_000_000, utxos: singleUtxo(), byteFee: 180_000, memo: nil)
+
+        let input = try CardanoHelper.getPreSignedInputData(keysignPayload: payload)
+        XCTAssertTrue(input.auxiliaryData.isEmpty)
+    }
+
+    func testPreSignInputHasNoAuxiliaryDataWhenMemoEmpty() throws {
+        let coin = try makeCoin()
+        let payload = makePayload(coin: coin, toAmount: 2_000_000, utxos: singleUtxo(), byteFee: 180_000, memo: "")
+
+        let input = try CardanoHelper.getPreSignedInputData(keysignPayload: payload)
+        XCTAssertTrue(input.auxiliaryData.isEmpty)
+    }
+
+    // MARK: - Body commits the aux hash at map key 7 (byte parity)
+
+    /// With a memo set, the pre-image body (what MPC signs and hashes to the
+    /// Cardano txid) must carry `auxiliary_data_hash` at CBOR map key 7 —
+    /// `07 5820 <blake2b-256(auxDataCbor)>`. This is WalletCore committing the
+    /// aux hash natively; every co-signer that emits the identical aux CBOR
+    /// therefore produces a byte-identical body ⇒ matching Blake2b sighash.
+    func testBodyCommitsAuxHashAtKey7WhenMemoPresent() throws {
+        let coin = try makeCoin()
+        let payload = makePayload(coin: coin, toAmount: 2_000_000, utxos: singleUtxo(), byteFee: 180_000, memo: "hello world")
+
+        let (_, auxDataHash) = CardanoCIP20.buildAuxData(memo: "hello world")
+        let body = try preSignBody(for: payload)
+
+        XCTAssertTrue(
+            body.hexString.contains("075820" + auxDataHash.hexString),
+            "body must carry auxiliary_data_hash (key 7 = blake2b-256 of the aux CBOR)"
+        )
+    }
+
+    func testBodyHasNoAuxHashWhenMemoAbsent() throws {
+        let coin = try makeCoin()
+        let payload = makePayload(coin: coin, toAmount: 2_000_000, utxos: singleUtxo(), byteFee: 180_000, memo: nil)
+
+        let body = try preSignBody(for: payload)
+        // No key-7 aux-hash field: the 32-byte `5820` byte-string head only
+        // appears for the aux hash in a simple ADA send.
+        XCTAssertFalse(body.hexString.contains("075820"), "no memo ⇒ no auxiliary_data_hash in the body")
+    }
+
+    // MARK: - Signed envelope embeds the aux CBOR as element [3]
+
+    func testEnvelopeEmbedsAuxCborAsElement3() throws {
+        let body = Data(hexString: "a10200")!
+        let pubkey = Data(repeating: 0x11, count: 32)
+        let sig = Data(repeating: 0x22, count: 64)
+        let aux = CardanoCIP20.buildAuxData(memo: "hello world").auxDataCbor
+
+        let signed = try CardanoSignedTxBuilder.build(txBody: body, publicKey: pubkey, signature: sig, auxData: aux)
+
+        // Envelope tail is `f5 <aux>` (is_valid = true, then the aux CBOR) —
+        // NOT the `f6` null sentinel.
+        XCTAssertTrue(signed.hexString.hasSuffix("f5" + aux.hexString))
+        XCTAssertFalse(signed.hexString.hasSuffix("f6"))
+    }
+
+    func testEnvelopeKeepsNullSentinelWhenNoAux() throws {
+        let body = Data(hexString: "a10200")!
+        let pubkey = Data(repeating: 0x11, count: 32)
+        let sig = Data(repeating: 0x22, count: 64)
+
+        let signed = try CardanoSignedTxBuilder.build(txBody: body, publicKey: pubkey, signature: sig)
+        XCTAssertTrue(signed.hexString.hasSuffix("f5f6"))
+    }
+
+    // MARK: - Manual builder vs AnySigner native output (byte-for-byte)
+
+    /// The hand-built envelope must share every parity-critical byte with what
+    /// WalletCore's `AnySigner` emits natively when `auxiliaryData` is set: the
+    /// transaction body (⇒ txid + MPC sighash), the vkey/signature witness, and
+    /// the CIP-20 aux element. We drive `AnySigner.sign` with a self-consistent
+    /// HD key, extract its body/witness/aux, and rebuild the envelope via
+    /// `CardanoSignedTxBuilder`.
+    ///
+    /// The two envelopes differ ONLY in framing: `AnySigner` emits the 3-element
+    /// Shelley array `[body, witness, aux]` (leading `0x83`, no `is_valid`),
+    /// while the manual builder emits the modern SDK/mainnet-verified 4-element
+    /// `[body, witness, is_valid=true(0xF5), aux]` (leading `0x84`). That
+    /// framing byte does not enter the txid (`blake2b-256(body)`), so it does
+    /// not affect signing or cross-device parity — the manual path (used because
+    /// `compileWithSignatures` crashes on Cardano) matches the SDK format that
+    /// `CardanoSignedTxBuilderTests` pins against the mainnet-verified vector.
+    func testManualEnvelopeSharesBodyWitnessAndAuxWithAnySigner() throws {
+        // Fixed BIP39 mnemonic ⇒ deterministic Cardano key + address. The key
+        // must own the UTXO/change address for AnySigner to sign it.
+        guard let wallet = HDWallet(
+            mnemonic: "team engine square letter hero song dizzy scrub tornado fabric divert saddle",
+            passphrase: ""
+        ) else {
+            return XCTFail("failed to derive HDWallet")
+        }
+        let ownerAddress = wallet.getAddressForCoin(coin: .cardano)
+        let key = wallet.getKeyForCoin(coin: .cardano)
+
+        let (auxDataCbor, auxDataHash) = CardanoCIP20.buildAuxData(memo: "hello world")
+        let forcedFee: UInt64 = 180_000
+
+        func makeInput(withKey: Bool) -> CardanoSigningInput {
+            var input = CardanoSigningInput.with {
+                $0.transferMessage = CardanoTransfer.with {
+                    $0.toAddress = cardanoAddress
+                    $0.changeAddress = ownerAddress
+                    $0.amount = 2_000_000
+                    $0.forceFee = forcedFee
+                }
+                $0.ttl = 190_000_000
+                $0.auxiliaryData = auxDataCbor
+            }
+            input.utxos.append(CardanoTxInput.with {
+                $0.outPoint = CardanoOutPoint.with {
+                    $0.txHash = Data(hexString: utxoHash)!
+                    $0.outputIndex = 0
+                }
+                $0.amount = 10_000_000
+                $0.address = ownerAddress
+            })
+            if withKey { input.privateKey = [key.data] }
+            return input
+        }
+
+        // 1) Native AnySigner envelope (3-element Shelley framing).
+        let output: CardanoSigningOutput = AnySigner.sign(input: makeInput(withKey: true), coin: .cardano)
+        XCTAssertEqual(output.error, .ok, output.errorMessage)
+        let anySignerTx = output.encoded
+        XCTAssertFalse(anySignerTx.isEmpty)
+        XCTAssertEqual(anySignerTx[anySignerTx.startIndex], 0x83, "AnySigner frames as a 3-element array")
+
+        // 2) Manual path body: compile the same input (no key) → pre-image body.
+        var noKey = makeInput(withKey: false)
+        let plan: CardanoTransactionPlan = AnySigner.plan(input: noKey, coin: .cardano)
+        XCTAssertEqual(plan.error, .ok)
+        noKey.plan = plan
+        noKey.transferMessage.forceFee = plan.fee
+        let inputData = try noKey.serializedData()
+        let hashes = TransactionCompiler.preImageHashes(coinType: .cardano, txInputData: inputData)
+        let pre = try TxCompilerPreSigningOutput(serializedBytes: hashes)
+        XCTAssertTrue(pre.errorMessage.isEmpty, pre.errorMessage)
+        let body = pre.data
+
+        // The compiler body (what MPC signs) must equal AnySigner's element [0]
+        // and carry the aux hash at key 7 — this is the parity-critical byte
+        // range (it determines the txid = blake2b-256(body)).
+        XCTAssertTrue(anySignerTx.count > 1 + body.count, "envelope shorter than its body")
+        XCTAssertEqual(anySignerTx[anySignerTx.startIndex + 1 ..< anySignerTx.startIndex + 1 + body.count], body,
+                       "compiler body must equal AnySigner's transaction body")
+        XCTAssertTrue(body.hexString.contains("075820" + auxDataHash.hexString))
+
+        // 3) Extract AnySigner's own witness `a1 00 81 82 5820 <vkey32> 5840 <sig64>`
+        //    (104 bytes) and the aux element that follows it (3-element framing:
+        //    the witness is directly followed by the aux, no is_valid byte).
+        let witnessStart = anySignerTx.startIndex + 1 + body.count
+        XCTAssertEqual(anySignerTx[witnessStart], 0xA1, "witness set must start with map(1)")
+        let witness = Data(anySignerTx[witnessStart ..< witnessStart + 104])
+        let anyAux = Data(anySignerTx[(witnessStart + 104)...])
+        XCTAssertEqual(anyAux, auxDataCbor, "AnySigner embeds our CIP-20 aux CBOR verbatim")
+
+        // AnySigner's whole envelope is exactly `83 | body | witness | aux`.
+        XCTAssertEqual(anySignerTx, Data([0x83]) + body + witness + auxDataCbor)
+
+        // 4) Rebuild via the production manual builder from AnySigner's own body
+        //    + vkey + sig. It reproduces the SAME body/witness/aux, reframed as
+        //    the 4-element `84 | body | witness | f5 | aux` SDK/mainnet format —
+        //    i.e. byte-identical to AnySigner except the `is_valid` framing.
+        let vkey = Data(witness[witness.startIndex + 6 ..< witness.startIndex + 38])
+        let sig = Data(witness[witness.startIndex + 40 ..< witness.startIndex + 104])
+        let manual = try CardanoSignedTxBuilder.build(
+            txBody: body,
+            publicKey: vkey,
+            signature: sig,
+            auxData: auxDataCbor
+        )
+        XCTAssertEqual(manual, Data([0x84]) + body + witness + Data([0xF5]) + auxDataCbor,
+                       "manual envelope = AnySigner's body/witness/aux reframed as the 4-element SDK format")
+    }
+
+    // MARK: - Fee prices the aux bytes
+
+    /// A memo enlarges the transaction (body key-7 field + the aux element), so
+    /// the initiator's size-based dynamic fee must grow by at least the cost of
+    /// the auxiliary-data bytes — otherwise the network rejects the memo tx with
+    /// `FeeTooSmallUTxO`. Verifies WalletCore's 4.7.0 planner prices
+    /// `auxiliaryData` (the SDK prices it explicitly via `auxDataCbor.length`).
+    func testDynamicFeePricesCip20AuxiliaryDataBytes() throws {
+        let coin = try makeCoin()
+        let utxos = singleUtxo()
+        let memo = String(repeating: "m", count: 500)
+        let auxLen = CardanoCIP20.buildAuxData(memo: memo).auxDataCbor.count
+
+        let feeNoMemo = CardanoHelper.estimateDynamicByteFee(
+            keysignPayload: makePayload(coin: coin, toAmount: 2_000_000, utxos: utxos, byteFee: 0, memo: nil))
+        let feeWithMemo = CardanoHelper.estimateDynamicByteFee(
+            keysignPayload: makePayload(coin: coin, toAmount: 2_000_000, utxos: utxos, byteFee: 0, memo: memo))
+
+        XCTAssertGreaterThanOrEqual(
+            feeWithMemo - feeNoMemo, BigInt(minFeeA * auxLen),
+            "the \(auxLen)-byte CIP-20 aux data must be priced into the dynamic fee"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Drive the real pre-sign path and return the tx body (element [0]) that
+    /// MPC hashes and signs.
+    private func preSignBody(for payload: KeysignPayload) throws -> Data {
+        let inputData = try CardanoHelper.getCardanoPreSignInputData(keysignPayload: payload)
+        let hashes = TransactionCompiler.preImageHashes(coinType: .cardano, txInputData: inputData)
+        let pre = try TxCompilerPreSigningOutput(serializedBytes: hashes)
+        XCTAssertTrue(pre.errorMessage.isEmpty, pre.errorMessage)
+        return pre.data
+    }
+}

--- a/VultisigApp/VultisigAppTests/Chains/CardanoDynamicFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CardanoDynamicFeeTests.swift
@@ -160,4 +160,50 @@ final class CardanoDynamicFeeTests: XCTestCase {
 
         XCTAssertGreaterThan(largeFee, smallFee, "fee should grow with tx size")
     }
+
+    /// The factory's transient fee-estimation payload must carry the memo, and
+    /// the resulting fee must exceed the memo-less fee for the same transfer.
+    /// A CIP-20 memo grows the signed tx (the 35-byte aux-hash entry in the
+    /// body plus the aux CBOR in the envelope); a fee planned without it is
+    /// below the network minimum for the tx that actually gets signed, so the
+    /// node rejects the broadcast with `FeeTooSmallUTxO` — while the same send
+    /// from the SDK/extension (which prices the aux bytes) goes through.
+    func testFeeEstimationPayloadCarriesMemo() throws {
+        let coin = try makeCoin()
+        let utxos = [UtxoInfo(hash: utxoHash, amount: 10_000_000, index: 0)]
+        let vault = Vault(name: "CardanoFeeTest")
+        let factory = KeysignPayloadFactory()
+        let memo = "hello world"
+
+        let withMemo = factory.makeCardanoFeePayload(
+            coin: coin,
+            toAddress: cardanoAddress,
+            amount: 2_000_000,
+            memo: memo,
+            ttl: 190_000_000,
+            sendMaxAmount: false,
+            utxos: utxos,
+            vault: vault
+        )
+        let withoutMemo = factory.makeCardanoFeePayload(
+            coin: coin,
+            toAddress: cardanoAddress,
+            amount: 2_000_000,
+            memo: nil,
+            ttl: 190_000_000,
+            sendMaxAmount: false,
+            utxos: utxos,
+            vault: vault
+        )
+
+        XCTAssertEqual(withMemo.memo, memo, "fee-estimation payload must carry the memo")
+
+        let memoFee = CardanoHelper.estimateDynamicByteFee(keysignPayload: withMemo)
+        let plainFee = CardanoHelper.estimateDynamicByteFee(keysignPayload: withoutMemo)
+        let auxLen = CardanoCIP20.buildAuxData(memo: memo).auxDataCbor.count
+        XCTAssertGreaterThanOrEqual(
+            memoFee, plainFee + 44 * BigInt(auxLen),
+            "the initiator's byteFee must price the CIP-20 aux bytes (minFeeA = 44/byte)"
+        )
+    }
 }

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -66,13 +66,14 @@ packages:
     revision: 86400c61e39790887ca03b98d82746ee4dc312f4
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
-    # Pinned by REVISION, not exactVersion: the `v4.7.0` tag in walletcore-spm
-    # was mis-cut and points at the old 4.6.13 commit (6fe770f97…), so
-    # `exactVersion: 4.7.0` silently resolves to 4.6.13 — which lacks the Cardano
-    # `CardanoSigningInput.auxiliaryData` field this feature needs. This SHA is
-    # the real wallet-core 4.7.0 (walletcore-spm main HEAD). Move back to
-    # `exactVersion` once the upstream tag is re-cut correctly.
-    revision: 628900b25de367bdd48427040977f68b6882d8a0
+    # v4.7.1 is the correctly-cut tag for wallet-core 4.7.0 (== walletcore-spm
+    # main HEAD 628900b25d…, which adds the Cardano
+    # `CardanoSigningInput.auxiliaryData` field this feature needs). The original
+    # `v4.7.0` tag is mis-cut — it points at the old 4.6.13 commit (6fe770f97…),
+    # so `exactVersion: 4.7.0` silently resolves to 4.6.13 (see #4721 on main,
+    # which is affected). A version tag also resolves reliably on CI, where a
+    # bare `revision:` pin on this binary package reused a stale 4.6.13 checkout.
+    exactVersion: 4.7.1
   ZIPFoundation:
     url: https://github.com/weichsel/ZIPFoundation
     from: 0.9.0

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -66,14 +66,14 @@ packages:
     revision: 86400c61e39790887ca03b98d82746ee4dc312f4
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
-    # v4.7.1 is the correctly-cut tag for wallet-core 4.7.0 (== walletcore-spm
-    # main HEAD 628900b25d…, which adds the Cardano
-    # `CardanoSigningInput.auxiliaryData` field this feature needs). The original
-    # `v4.7.0` tag is mis-cut — it points at the old 4.6.13 commit (6fe770f97…),
-    # so `exactVersion: 4.7.0` silently resolves to 4.6.13 (see #4721 on main,
-    # which is affected). A version tag also resolves reliably on CI, where a
-    # bare `revision:` pin on this binary package reused a stale 4.6.13 checkout.
-    exactVersion: 4.7.1
+    # Pinned by REVISION to the real wallet-core 4.7.0 commit (walletcore-spm
+    # main HEAD, which adds the Cardano `CardanoSigningInput.auxiliaryData` field
+    # this feature needs). The upstream `v4.7.0` tag is mis-cut — it points at
+    # the old 4.6.13 commit (6fe770f97…), so `exactVersion: 4.7.0` resolves to
+    # 4.6.13 (see #4721 on main, which is affected). Pin the commit directly
+    # until walletcore-spm ships a correctly-cut release, then move back to
+    # `exactVersion`.
+    revision: 628900b25de367bdd48427040977f68b6882d8a0
   ZIPFoundation:
     url: https://github.com/weichsel/ZIPFoundation
     from: 0.9.0

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -66,14 +66,12 @@ packages:
     revision: 86400c61e39790887ca03b98d82746ee4dc312f4
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
-    # Pinned by REVISION to the real wallet-core 4.7.0 commit (walletcore-spm
-    # main HEAD, which adds the Cardano `CardanoSigningInput.auxiliaryData` field
-    # this feature needs). The upstream `v4.7.0` tag is mis-cut — it points at
-    # the old 4.6.13 commit (6fe770f97…), so `exactVersion: 4.7.0` resolves to
-    # 4.6.13 (see #4721 on main, which is affected). Pin the commit directly
-    # until walletcore-spm ships a correctly-cut release, then move back to
-    # `exactVersion`.
-    revision: 628900b25de367bdd48427040977f68b6882d8a0
+    # v4.7.1 is the correctly-cut release for wallet-core 4.7.0 (tag →
+    # 628900b25d…, walletcore-spm main), which adds the Cardano
+    # `CardanoSigningInput.auxiliaryData` field this feature needs. Do NOT use
+    # `exactVersion: 4.7.0` — that tag is mis-cut and resolves to the old
+    # 4.6.13 commit (6fe770f97…).
+    exactVersion: 4.7.1
   ZIPFoundation:
     url: https://github.com/weichsel/ZIPFoundation
     from: 0.9.0

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -66,7 +66,13 @@ packages:
     revision: 86400c61e39790887ca03b98d82746ee4dc312f4
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
-    exactVersion: 4.6.13
+    # Pinned by REVISION, not exactVersion: the `v4.7.0` tag in walletcore-spm
+    # was mis-cut and points at the old 4.6.13 commit, so `exactVersion: 4.7.0`
+    # would silently resolve to 4.6.13 (which lacks the Cardano
+    # `CardanoSigningInput.auxiliaryData` field this feature needs). This SHA is
+    # the real wallet-core 4.7.0 (walletcore-spm main HEAD). Move back to
+    # `exactVersion` once the upstream tag is re-cut correctly.
+    revision: 628900b25de367bdd48427040977f68b6882d8a0
   ZIPFoundation:
     url: https://github.com/weichsel/ZIPFoundation
     from: 0.9.0


### PR DESCRIPTION
## ⚠️ HIGH-tier Cardano signing path — requires human + on-device + cross-device review before merge

This attaches the Cardano send memo on-chain as **CIP-20 transaction metadata (label 674)** using WalletCore 4.7.0's native `CardanoSigningInput.auxiliaryData`, and re-enables the memo UI. Cardano signing is MPC/TSS, so this is **byte-parity-sensitive**: it needs human review plus **on-device and cross-device (iOS ↔ Android ↔ Extension) co-signing byte-parity validation on mainnet** before it leaves draft. Unit tests prove structure, not full MPC co-signing.

`Closes #4708` · references #4326 (root silent-drop bug) and #4387 (swap-path memo, out of scope).

## What changed

- **WalletCore pin — `exactVersion: 4.7.1`** ([release](https://github.com/vultisig/walletcore-spm/releases/tag/v4.7.1)), the correctly-cut release for wallet-core 4.7.0: the annotated tag dereferences to `628900b25d…` (walletcore-spm main), which adds the `CardanoSigningInput.auxiliaryData` field. The `v4.7.0` tag remains **mis-cut** — it points at the old 4.6.13 commit (`6fe770f97…`), so `exactVersion: 4.7.0` resolves to 4.6.13 (this affects main's #4721). Earlier iterations of this branch pinned the commit by bare `revision:` while no correctly-cut release existed; moved to the release pin once v4.7.1 shipped (a version pin also resolves reliably on CI, which the bare revision pin did not). `Package.resolved` pins `version 4.7.1` → `revision 628900b25d…`.
  - **Gate Zero confirmed:** `CardanoSigningInput.auxiliaryData: Data` is present on `TW_Cardano_Proto_SigningInput` in the resolved xcframework (verified in the swiftinterface + it compiles).
- **`Cardano.getPreSignedInputData()`** — builds the CIP-20 aux data from `keysignPayload.memo` via `CardanoCIP20` (label 674, ≤64-UTF-8-byte codepoint-boundary chunks, `blake2b-256` aux hash) and sets `$0.auxiliaryData`. WalletCore commits `blake2b-256(auxCbor)` into the tx body at map **key 7** natively.
- **`CardanoSignedTxBuilder.build(...)`** — new optional `auxData` param embeds the CIP-20 CBOR as signed-tx **element [3]** (replacing the `0xf6` null). No-memo path is unchanged (still `0xf6`). `SwapKitCardanoSigner` already re-emits element [3] verbatim → no change (swap-path memo is #4387).
- **Fee** — WalletCore 4.7.0's planner **already prices** the aux bytes when `auxiliaryData` is set (verified: the size-based dynamic fee grows by ≥ `minFeeA · auxLen` with a memo), so **no manual fee term was added**.
- **`Chain.supportsMemo`** — drops `.cardano` (keeps `.sui`); the Send memo input (`SendDetailsAdditionalSection`) appears automatically. Stale `#4326/#4377` comment removed.

## Byte parity: manual builder vs WalletCore `AnySigner`

The hand-built envelope (used because `compileWithSignatures` crashes on Cardano) was compared byte-for-byte against `AnySigner.sign` output. **The body (⇒ txid / MPC sighash, including the key-7 `auxiliary_data_hash`), the witness (vkey+sig), and the aux element are byte-identical.** They differ **only in envelope framing**:

- `AnySigner` emits the **3-element** Shelley array `[body, witness, aux]` (`0x83`, no `is_valid`).
- The manual builder keeps the **SDK/mainnet-verified 4-element** array `[body, witness, is_valid=0xf5, aux]` (`0x84`).

The framing byte is **not** covered by the txid (`blake2b-256(body)`), so it doesn't affect signing or cross-device parity. The manual builder intentionally stays on the SDK format that `CardanoSignedTxBuilderTests` already pins to the mainnet-verified vultisig-SDK golden vector.

## Tests

`CardanoCIP20Tests` (encoder, from the pre-stage) plus new `CardanoCip20SigningTests`:
- pre-sign input sets `auxiliaryData` (byte-parity vs the SDK golden `"hello world"` vector); nil/empty memo → no aux;
- the compiler **body carries the key-7 aux hash** (`07 5820 <blake2b-256(auxCbor)>`) with a memo, and does **not** without;
- the signed envelope embeds the aux CBOR as element [3] (and keeps `0xf6` with no memo);
- **AnySigner vs manual** — body/witness/aux byte-identical, framing difference documented;
- the **dynamic fee prices the aux bytes**.

## Verification

- Merged latest `origin/main` (incl. #4721) and pinned WalletCore to the v4.7.1 release; `Package.resolved` confirmed at `version 4.7.1` / revision `628900b25d…` (not `6fe770f97…`) via a fresh resolve, and the full suite re-run green on the release pin (2217 tests, sole failure = the known locale flake).
- **Full test suite** on iPhone 17 Pro Max sim, worktree-local derived data. All Cardano suites pass (`CardanoCIP20Tests`, `CardanoCip20SigningTests`, `CardanoSignedTxBuilderTests`, `SwapKitCardanoSignerTests`, `CardanoDynamicFeeTests`). Known env non-failures only (a locale `"12,3%"` formatting test; `net-dkls-messenger` network errors).

## Risk

**HIGH-tier signing.** Byte parity is a manual acceptance gate — this needs on-device + cross-device mainnet co-signing validation before merge. Kept as a **draft**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added canonical Cardano CIP-20 memo auxiliary-data encoding and deterministic aux-data hashing.
  * Included CIP-20 auxiliary data in the signing flow from pre-sign input through the signed transaction envelope.
  * Enabled memo entry in Send for Cardano (still hidden for Sui).
* **Bug Fixes**
  * Corrected memo chunking for empty and multi-byte UTF-8 content to keep commitments consistent.
* **Tests**
  * Added unit and end-to-end/byte-parity tests covering CBOR encoding, hashing, and envelope framing.
* **Chores**
  * Updated the WalletCore pin to a correctly cut release for improved Cardano auxiliary-data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
