### PR TITLE
fix(swap): surface THORNode errors + guard secured-asset swap destination

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -436,8 +436,14 @@ private extension SwapService {
             // External recipient (when set) becomes the swap's `destination` — the
             // node encodes it into the returned memo, so the swapped funds land at
             // the external address instead of the user's own. Defaults to the
-            // user's own destination address.
-            let destination = recipientAddress ?? toCoin.address
+            // user's own destination address. For a THORChain secured-asset
+            // `toCoin` the mint settles on THORChain, so the destination must be a
+            // THORChain (`thor1…`) address — enforced here so a non-THORChain
+            // destination surfaces a clear error instead of a collapsed quote.
+            let destination = try Self.resolveThorchainDestination(
+                toCoin: toCoin,
+                recipientAddress: recipientAddress
+            )
 
             let rapidQuote = try await service.fetchSwapQuotes(
                 address: destination,
@@ -641,6 +647,42 @@ private extension SwapService {
     }
 }
 
+// MARK: - THORChain swap destination
+
+extension SwapService {
+    /// Resolve the `destination` for a native THORChain/MAYAChain swap quote.
+    ///
+    /// The existing contract is preserved: an explicit external recipient (when
+    /// set) becomes the destination; otherwise it's the user's own receiving
+    /// address for `toCoin`.
+    ///
+    /// The one addition is a guard for THORChain **secured assets**. A secured
+    /// asset is minted *on THORChain* (quote memo `=:ETH-USDC:thor1…:0/1/0`), so
+    /// its destination must be a THORChain (`thor1…`) address. For a
+    /// `chain == .thorChain` `toCoin` that is exactly `toCoin.address` — derived
+    /// from the vault key, independent of the secured denom in `contractAddress`.
+    /// If that resolved destination is somehow not a THORChain address (e.g. an
+    /// empty or L1 `0x…` value), THORNode rejects the quote with "swap
+    /// destination address is not the same chain as the target asset"; we reject
+    /// it up front with a clear, message-bearing error instead of letting it
+    /// collapse into a generic `routeUnavailable`. Non-secured and external-
+    /// recipient paths are unchanged.
+    static func resolveThorchainDestination(toCoin: Coin, recipientAddress: String?) throws -> String {
+        let destination = recipientAddress ?? toCoin.address
+
+        if recipientAddress == nil,
+           THORChainHelper.isSecuredAsset(coin: toCoin),
+           !THORChainHelper.isValidThorchainAddress(destination, chain: toCoin.chain) {
+            throw SwapError.serverError(
+                message: "Secured-asset swap destination is not a THORChain address "
+                    + "(\(destination.nilIfEmpty ?? "empty")); expected the vault's THORChain address."
+            )
+        }
+
+        return destination
+    }
+}
+
 // MARK: - Upstream error mapping
 
 extension SwapService {
@@ -686,17 +728,20 @@ extension SwapService {
 
     /// Translate a decoded THORChain quote error into the user-facing `SwapError`.
     /// A trading halt is detected on any code so a paused chain surfaces as a
-    /// retryable message instead of `routeUnavailable`; otherwise the existing
-    /// code-3 classification (fees / unsupported pair / raw server message) and
-    /// the non-code-3 `routeUnavailable` fallback are preserved.
+    /// retryable message. Otherwise the known dust/fee/missing-pool classes are
+    /// mapped to their typed errors and anything else relays THORNode's own
+    /// message — so a specific, actionable failure (e.g. code 2 "swap
+    /// destination address is not the same chain as the target asset") is
+    /// diagnosable instead of collapsing into a generic `routeUnavailable`. Only
+    /// a truly empty message falls back to `routeUnavailable`.
     static func mapThorchainSwapError(_ error: ThorchainSwapError) -> SwapError {
         if isTradingHalted(error.message) {
             return .tradingHalted
         }
-        if error.code == 3 {
-            return classifyNativeQuoteError(error.message) ?? .serverError(message: error.message)
+        if let classified = classifyNativeQuoteError(error.message) {
+            return classified
         }
-        return .routeUnavailable
+        return error.message.isEmpty ? .routeUnavailable : .serverError(message: error.message)
     }
 
     /// Translate a decoded MAYAChain quote error into the user-facing `SwapError`.

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -674,8 +674,11 @@ extension SwapService {
            THORChainHelper.isSecuredAsset(coin: toCoin),
            !THORChainHelper.isValidThorchainAddress(destination, chain: toCoin.chain) {
             throw SwapError.serverError(
-                message: "Secured-asset swap destination is not a THORChain address "
-                    + "(\(destination.nilIfEmpty ?? "empty")); expected the vault's THORChain address."
+                message: String(
+                    format: "swapSecuredAssetInvalidDestination".localized,
+                    THORChainHelper.expectedAddressPrefix(for: toCoin.chain),
+                    destination.nilIfEmpty ?? "empty"
+                )
             )
         }
 

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/thorchain.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/thorchain.swift
@@ -30,6 +30,15 @@ enum THORChainHelper {
         }
     }
 
+    /// Non-throwing check that `address` is a valid THORChain address for the
+    /// given THORChain network (mainnet `thor1…`, chainnet `cthor1…`, stagenet
+    /// `sthor1…`). Used to reject a swap destination that would not settle on
+    /// THORChain before the request leaves the device.
+    static func isValidThorchainAddress(_ address: String, chain: Chain) -> Bool {
+        guard !address.isEmpty else { return false }
+        return (try? validateThorchainAddress(address, chain: chain)) != nil
+    }
+
     static func getSwapPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
         guard case .THORChain(let accountNumber, let sequence, _, _, _) = keysignPayload.chainSpecific else {
             throw HelperError.runtimeError("fail to get account number, sequence, or fee")

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/thorchain.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/thorchain.swift
@@ -39,6 +39,17 @@ enum THORChainHelper {
         return (try? validateThorchainAddress(address, chain: chain)) != nil
     }
 
+    /// Human-readable expected address prefix for a THORChain network, for use
+    /// in user-facing diagnostics: mainnet `thor1…`, chainnet `cthor1…`,
+    /// stagenet `sthor1…`.
+    static func expectedAddressPrefix(for chain: Chain) -> String {
+        switch chain {
+        case .thorChainChainnet: return "cthor1…"
+        case .thorChainStagenet: return "sthor1…"
+        default: return "thor1…"
+        }
+    }
+
     static func getSwapPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
         guard case .THORChain(let accountNumber, let sequence, _, _, _) = keysignPayload.chainSpecific else {
             throw HelperError.runtimeError("fail to get account number, sequence, or fee")

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1186,6 +1186,7 @@
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Tauschroute nicht verfügbar";
 "swaps" = "Swaps";
+"swapSecuredAssetInvalidDestination" = "Ziel des Secured-Asset-Swaps ist keine gültige %1$@-Adresse (%2$@).";
 "swapTrackingLink" = "Tauschverfolgungslink";
 "swapTradingHalted" = "Der Handel für diesen Vermögenswert ist vorübergehend ausgesetzt. Bitte versuche es später erneut.";
 "swapTXHash" = "Tausch-Tx-Hash";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1184,6 +1184,7 @@
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Swap route not available";
 "swaps" = "Swaps";
+"swapSecuredAssetInvalidDestination" = "Secured-asset swap destination is not a valid %1$@ address (%2$@).";
 "swapTrackingLink" = "Swap tracking link";
 "swapTradingHalted" = "Trading for this asset is temporarily halted. Please try again later.";
 "swapTXHash" = "Swap Tx Hash";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1186,6 +1186,7 @@
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Ruta de intercambio no disponible";
 "swaps" = "Intercambios";
+"swapSecuredAssetInvalidDestination" = "El destino del swap de activo asegurado no es una dirección %1$@ válida (%2$@).";
 "swapTrackingLink" = "Enlace de seguimiento del intercambio";
 "swapTradingHalted" = "La negociación de este activo está suspendida temporalmente. Inténtalo de nuevo más tarde.";
 "swapTXHash" = "Hash de la transacción de intercambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1186,6 +1186,7 @@
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Ruta zamjene nije dostupna";
 "swaps" = "Zamjene";
+"swapSecuredAssetInvalidDestination" = "Odredište zamjene osiguranog sredstva nije valjana %1$@ adresa (%2$@).";
 "swapTrackingLink" = "Poveznica za praćenje zamjene";
 "swapTradingHalted" = "Trgovanje ovom imovinom privremeno je zaustavljeno. Pokušajte ponovno kasnije.";
 "swapTXHash" = "Zamjenski Tx hash";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1186,6 +1186,7 @@
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Percorso di scambio non disponibile";
 "swaps" = "Scambi";
+"swapSecuredAssetInvalidDestination" = "La destinazione dello swap dell'asset protetto non è un indirizzo %1$@ valido (%2$@).";
 "swapTrackingLink" = "Link di tracciamento dello scambio";
 "swapTradingHalted" = "La negoziazione di questo asset è temporaneamente sospesa. Riprova più tardi.";
 "swapTXHash" = "Hash Tx dello scambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1149,6 +1149,7 @@
 "swapRouteEta" = "~%ld초";
 "swapRouteNotAvailable" = "스왑 경로를 사용할 수 없습니다";
 "swaps" = "스왑";
+"swapSecuredAssetInvalidDestination" = "보안 자산 스왑 대상이 유효한 %1$@ 주소가 아닙니다 (%2$@).";
 "swapTrackingLink" = "스왑 추적 링크";
 "swapTradingHalted" = "이 자산의 거래가 일시적으로 중단되었습니다. 나중에 다시 시도해 주세요.";
 "swapTXHash" = "스왑 Tx 해시";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1186,6 +1186,7 @@
 "swapRouteEta" = "~%lds";
 "swapRouteNotAvailable" = "Rota de troca não disponível";
 "swaps" = "Trocas";
+"swapSecuredAssetInvalidDestination" = "O destino do swap de ativo protegido não é um endereço %1$@ válido (%2$@).";
 "swapTrackingLink" = "Link de rastreamento da troca";
 "swapTradingHalted" = "A negociação deste ativo está temporariamente suspensa. Tente novamente mais tarde.";
 "swapTXHash" = "Hash da Tx da troca";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1186,6 +1186,7 @@
 "swapRouteEta" = "~%ld秒";
 "swapRouteNotAvailable" = "交换路由不可用";
 "swaps" = "兑换";
+"swapSecuredAssetInvalidDestination" = "受保护资产兑换的目标地址不是有效的 %1$@ 地址（%2$@）。";
 "swapTrackingLink" = "交换跟踪链接";
 "swapTradingHalted" = "该资产的交易已暂时停止，请稍后再试。";
 "swapTXHash" = "交换交易哈希";

--- a/VultisigApp/VultisigAppTests/Swap/SwapErrorMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapErrorMappingTests.swift
@@ -70,8 +70,26 @@ final class SwapErrorMappingTests: XCTestCase {
         XCTAssertEqual(SwapService.mapThorchainSwapError(error).errorDescription, "totally novel server complaint")
     }
 
-    func testNonCode3RelaysRouteUnavailable() {
+    func testNonCode3SurfacesServerMessage() {
+        // A non-code-3 error with a message must relay that message, not collapse
+        // into a generic "route unavailable" — this is what previously hid the
+        // secured-asset destination failure (code 2).
         let error = ThorchainSwapError(code: 5, message: "some other upstream failure")
+        XCTAssertEqual(SwapService.mapThorchainSwapError(error).errorDescription, "some other upstream failure")
+    }
+
+    func testDestinationChainMismatchSurfacesRealMessage() {
+        // The exact THORNode rejection for a secured-asset swap with a
+        // non-THORChain destination must reach the user/logs verbatim.
+        let message = "swap destination address is not the same chain as the target asset"
+        let error = ThorchainSwapError(code: 2, message: message)
+        XCTAssertEqual(SwapService.mapThorchainSwapError(error).errorDescription, message)
+    }
+
+    func testEmptyMessageFallsBackToRouteUnavailable() {
+        // With no message to relay there is nothing actionable to show, so the
+        // generic route-unavailable fallback is kept.
+        let error = ThorchainSwapError(code: 5, message: "")
         XCTAssertEqual(SwapService.mapThorchainSwapError(error).errorDescription, "swapRouteNotAvailable".localized)
     }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapServiceTradingHaltedTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapServiceTradingHaltedTests.swift
@@ -70,11 +70,16 @@ final class SwapServiceTradingHaltedTests: XCTestCase {
         )
     }
 
-    func testThorchainNonCode3StillMapsToRouteUnavailable() {
+    func testThorchainNonCode3SurfacesServerMessage() {
+        // Non-code-3 errors now relay THORNode's real message instead of
+        // collapsing into `.routeUnavailable`, so a specific failure (e.g. the
+        // secured-asset "…not the same chain as the target asset" rejection)
+        // stays diagnosable. A halt still short-circuits above; only an empty
+        // message falls back to route-unavailable.
         let error = ThorchainSwapError(code: 5, message: "some other upstream failure")
         XCTAssertEqual(
             SwapService.mapThorchainSwapError(error).errorDescription,
-            "swapRouteNotAvailable".localized
+            "some other upstream failure"
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapThorchainDestinationTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapThorchainDestinationTests.swift
@@ -1,0 +1,158 @@
+//
+//  SwapThorchainDestinationTests.swift
+//  VultisigAppTests
+//
+//  Locks the THORChain swap `destination` contract, in particular for secured
+//  assets: the mint settles on THORChain, so the destination must be a
+//  THORChain (`thor1…`) address (the vault's own). A non-THORChain destination
+//  (empty / L1 `0x…`) is what THORNode rejects with "swap destination address
+//  is not the same chain as the target asset", so it must fail up front with a
+//  clear error instead of a collapsed quote. Non-secured and external-recipient
+//  paths stay unchanged.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class SwapThorchainDestinationTests: XCTestCase {
+
+    /// A checksum-valid THORChain mainnet address (the vault's own thor address).
+    private let validThorAddress = "thor147fr229jewf063mv5w398e5dld00ytu2y8snmh"
+
+    // MARK: - Secured-asset destination
+
+    func testSecuredEthUsdcResolvesToVaultThorchainAddress() throws {
+        let coin = makeCoin(
+            ticker: "USDC",
+            chain: .thorChain,
+            contractAddress: "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            isNative: false,
+            address: validThorAddress
+        )
+
+        let destination = try SwapService.resolveThorchainDestination(toCoin: coin, recipientAddress: nil)
+        XCTAssertEqual(destination, validThorAddress)
+    }
+
+    func testSecuredBtcResolvesToVaultThorchainAddress() throws {
+        // A different secured denom (`securedAssetChain` == BTC) still mints on
+        // THORChain, so the destination is the same vault thor address.
+        let coin = makeCoin(
+            ticker: "BTC",
+            chain: .thorChain,
+            contractAddress: "btc-btc",
+            isNative: false,
+            address: validThorAddress
+        )
+
+        let destination = try SwapService.resolveThorchainDestination(toCoin: coin, recipientAddress: nil)
+        XCTAssertEqual(destination, validThorAddress)
+    }
+
+    func testSecuredToCoinWithEmptyAddressThrows() {
+        let coin = makeCoin(
+            ticker: "USDC",
+            chain: .thorChain,
+            contractAddress: "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            isNative: false,
+            address: ""
+        )
+
+        XCTAssertThrowsError(try SwapService.resolveThorchainDestination(toCoin: coin, recipientAddress: nil))
+    }
+
+    func testSecuredToCoinWithL1AddressThrows() {
+        // An Ethereum `0x…` value is exactly what THORNode rejects; catch it here.
+        let coin = makeCoin(
+            ticker: "USDC",
+            chain: .thorChain,
+            contractAddress: "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            isNative: false,
+            address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        )
+
+        XCTAssertThrowsError(try SwapService.resolveThorchainDestination(toCoin: coin, recipientAddress: nil))
+    }
+
+    // MARK: - Non-secured / recipient regression guards (unchanged behaviour)
+
+    func testNativeRuneReturnsAddressUnchanged() throws {
+        // Swap-to RUNE (and the swap-from-secured path, where RUNE is the toCoin)
+        // is not a secured asset — destination is the address as-is.
+        let coin = makeCoin(
+            ticker: "RUNE",
+            chain: .thorChain,
+            contractAddress: "",
+            isNative: true,
+            address: validThorAddress
+        )
+
+        let destination = try SwapService.resolveThorchainDestination(toCoin: coin, recipientAddress: nil)
+        XCTAssertEqual(destination, validThorAddress)
+    }
+
+    func testNonThorchainTokenReturnsAddressUnchanged() throws {
+        // A regular L1 destination (e.g. ETH-side token) keeps its own `0x…`
+        // address; the secured guard never applies off THORChain.
+        let ethAddress = "0x1234567890abcdef1234567890abcdef12345678"
+        let coin = makeCoin(
+            ticker: "USDC",
+            chain: .ethereum,
+            contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            isNative: false,
+            address: ethAddress
+        )
+
+        let destination = try SwapService.resolveThorchainDestination(toCoin: coin, recipientAddress: nil)
+        XCTAssertEqual(destination, ethAddress)
+    }
+
+    func testExternalRecipientIsUsedUnchanged() throws {
+        // An explicit external recipient wins and is passed through verbatim,
+        // even for a secured toCoin — the recipient path is unchanged.
+        let coin = makeCoin(
+            ticker: "USDC",
+            chain: .thorChain,
+            contractAddress: "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            isNative: false,
+            address: validThorAddress
+        )
+        let recipient = "thor1kkmnmgvd85puk8zsvqfxx36cqy9mxqret39t8z"
+
+        let destination = try SwapService.resolveThorchainDestination(toCoin: coin, recipientAddress: recipient)
+        XCTAssertEqual(destination, recipient)
+    }
+
+    // MARK: - Address validator
+
+    func testIsValidThorchainAddress() {
+        XCTAssertTrue(THORChainHelper.isValidThorchainAddress(validThorAddress, chain: .thorChain))
+        XCTAssertFalse(THORChainHelper.isValidThorchainAddress("", chain: .thorChain))
+        XCTAssertFalse(THORChainHelper.isValidThorchainAddress(
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            chain: .thorChain
+        ))
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoin(
+        ticker: String,
+        chain: Chain,
+        contractAddress: String,
+        isNative: Bool,
+        address: String
+    ) -> Coin {
+        let meta = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "",
+            decimals: 8,
+            priceProviderId: "",
+            contractAddress: contractAddress,
+            isNativeToken: isNative
+        )
+        return Coin(asset: meta, address: address, hexPublicKey: "test")
+    }
+}


### PR DESCRIPTION
## Problem

Swapping **into** a THORChain Secured Asset (e.g. `ETH-USDC`) from RUNE/BTC failed with a generic error, while swapping **out** worked.

## Root cause (API-verified) + a Step-0 code-trace correction

THORChain Secured Assets settle **on THORChain**: a swap-in mints the asset to a `thor1…` address (quote memo `=:ETH-USDC:thor1…:0/1/0`). Live mainnet testing confirmed THORNode accepts every notation the app builds (`eth-usdc-0x…`, `ETH-USDC`, `ETH-USDC-0X…`) and returns a valid quote — **but only with a valid `thor1…` destination**; a non-`thor1` destination is rejected with `code 2: "swap destination address is not the same chain as the target asset"`. So `Coin.swapAsset` is fine and needs no change.

The issue text assumed `toCoin.address` was empty / an L1 `0x…`. **The code trace shows otherwise:** a secured `toCoin` is `chain == .thorChain`, and its `.address` is derived purely from the vault key (`CoinFactory` → `CoinType.thorchain`), **independent of the secured denom** — so it already resolves to the vault's `thor1…` address (same as RUNE). The keysign memo is taken verbatim from `quote.memo` (`$0.memo = keysignPayload.memo` for THORChain-source, OP_RETURN for BTC-source), so display == signed by construction.

Given that, the thing that actually made this failure class **undiagnosable** is the error collapse: `mapThorchainSwapError` mapped every non-code-3 THORNode error to `routeUnavailable`, swallowing the real message (incl. the code-2 destination error).

## Changes

- **`SwapService.resolveThorchainDestination(toCoin:recipientAddress:)`** (new, unit-tested): preserves the existing contract (`recipientAddress ?? toCoin.address`) and, for a secured `toCoin` with no external recipient, **guards** that the resolved destination is a valid THORChain address — otherwise throws a clear, message-bearing `SwapError.serverError` instead of sending a doomed quote. Wired into `fetchCrossChainQuote` (covers both the rapid and the streaming quote, which reuse the same `destination`). Defense-in-depth on the exact failure class: a non-THORChain destination for a secured mint can never leave the device silently.
- **`THORChainHelper.isValidThorchainAddress(_:chain:)`** (new): non-throwing wrapper over the existing `validateThorchainAddress` (mainnet/chainnet/stagenet hrp).
- **`mapThorchainSwapError`**: stop collapsing non-code-3 errors to `routeUnavailable`; classify the known dust/pool/fee cases, otherwise **relay THORNode's real message** via `.serverError(message:)` (only a truly empty message falls back to `routeUnavailable`). This surfaces the code-2 destination error and any future edge case.

The from-secured, non-secured, and external-recipient paths are byte-identical.

## Tests

- `SwapThorchainDestinationTests` (new): secured ETH-USDC and a secured `btc-…` denom both resolve to the vault's `thor1…`; empty and `0x…` destinations throw; native RUNE, an EVM L1 token, and an external recipient are returned unchanged; `isValidThorchainAddress` validity check.
- `SwapErrorMappingTests` (updated): a non-code-3 error and the code-2 destination error now surface their real message; empty message still falls back to `routeUnavailable`. Existing halt / dust / pool mappings unchanged.

## Verification

- Local gate: `xcodebuild test` on `VultisigApp` (iOS Simulator, iPhone 16), worktree-local `-derivedDataPath .build-dd`. Build succeeded; **2195 tests**, the only failure being the pre-existing `"12,3%"` locale test (`StakingValidatorProjectionTests`, unrelated to this change). The three affected swap suites (`SwapThorchainDestinationTests`, `SwapErrorMappingTests`, `SwapServiceTradingHaltedTests`) re-ran green (`** TEST SUCCEEDED **`). SwiftLint clean on changed files.

## ⚠️ Needs on-device validation (manual acceptance) — THORChain swap/signing-adjacent

Please validate on a real device against live THORChain:
- RUNE → ETH-USDC and BTC → ETH-USDC complete (displayed target == signed memo target `=:ETH-USDC:thor1…`).
- From-ETH-USDC still works.
- If a swap-in still fails, the new error surfacing will now show THORNode's real message — capture it to confirm the true on-device failure mode.

Refs #4321 — not auto-closing: given the reframe (the destination is already valid in `main`, so this is defense-in-depth + diagnosability rather than a confirmed behavioral fix), this needs **on-device confirmation of the actual failure mode** (and that the swap now completes / reports a real error) before the issue is closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved THORChain swap destination handling for secured assets by validating/deriving the correct vault destination and blocking invalid THORChain-formatted addresses.
  * Enhanced swap error mapping so non-code-3 failures can display the original upstream error message when available, while still using clear fallbacks when messages are empty.
  * Added localized messaging for invalid secured-asset swap destinations.
* **Tests**
  * Expanded coverage for THORChain destination resolution and swap error mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->