### PR TITLE
fix(swap): remove dead Gas Limit info icon in advanced settings

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/Views/GasLimitSettingsView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/GasLimitSettingsView.swift
@@ -21,12 +21,9 @@ struct GasLimitSettingsView: View {
             AdvancedSwapSheetHeader(title: "gasLimit".localized, showBack: true, onClose: onBack)
 
             VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
-                    Text("gasLimit".localized)
-                        .font(Theme.fonts.bodySMedium)
-                        .foregroundStyle(Theme.colors.textTertiary)
-                    Icon(named: "circle-info", color: Theme.colors.textTertiary, size: 16)
-                }
+                Text("gasLimit".localized)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textTertiary)
 
                 numberField
                     .font(Theme.fonts.bodySMedium)


### PR DESCRIPTION
## Problem
In the advanced-swap **Gas Limit** sub-sheet (Swap → advanced settings → Gas Limit), the ⓘ info icon next to the "Gas Limit" label did nothing when tapped. It was a bare decorative `Icon(named: "circle-info", …)` with **no `Button`, no `.onTapGesture`, and no `HelpButton`/tooltip** — a fake interactive affordance (the universal ⓘ shape implies "tap for info", but nothing happened).

## Fix
**Drop the dead icon** rather than wire up a tooltip.

Per the maintainer's decision, the right fix here is removal, not a tooltip: there is no authored gas-limit tooltip copy, the sub-sheet already conveys its meaning (the field's `auto` placeholder + EVM-only context), and a fake-interactive icon is worse than none. Wiring a real tooltip would be net-new copy + a product decision; dropping is the surgical, correct-now change.

With the icon gone the wrapping `HStack` is redundant, so it collapses to the bare label `Text` inside the existing `VStack(alignment: .leading, spacing: 8)`.

```diff
             VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
-                    Text("gasLimit".localized)
-                        .font(Theme.fonts.bodySMedium)
-                        .foregroundStyle(Theme.colors.textTertiary)
-                    Icon(named: "circle-info", color: Theme.colors.textTertiary, size: 16)
-                }
+                Text("gasLimit".localized)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textTertiary)
```

Single file: `VultisigApp/VultisigApp/Features/Swap/Views/GasLimitSettingsView.swift` (+3 / −6). No import removed — `Icon` is an app-internal component used elsewhere.

## Other info icons — audited and deliberately kept
This was scoped by auditing every `"circle-info"` / `"info"` icon usage. Only the Gas Limit one was a dead affordance; the rest are legitimate and are **not** touched:

- `DefiChainStakedPositionView.swift` — inside `Button(action: openAutocompounderInfo)` (interactive).
- `CreateReferralDetailsView.swift` — a `ToolbarButton` (interactive).
- `YieldVaultScreen.swift` / `YieldDepositScreen.swift` / `YieldWithdrawScreen.swift` — leading icons of decorative **info banners** (icon + explanatory text, not fake-tappable).
- `VaultSettingsScreen.swift` — leading icon of a tappable settings row (the row is the tap target).
- `HelpButton.swift` — the tooltip component itself.
- The `"info"` (alertWarning/alertError) icons in the Cosmos transaction screens — decorative status icons beside warning text.

## Verification
- **Build + tests** (`xcodebuild test`, iPhone 17 Pro Max, worktree-local derivedData): **build succeeded**; **2185 tests, 1 failure** — the failure is the pre-existing locale-formatting flake `StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress` (`"12,3%"` vs `"12.3%"`), a Cosmos-staking test unrelated to this Swap view change.
- **SwiftLint**: 0 violations on the changed file.
- **Visual**: rendered `GasLimitSettingsView` and confirmed the "Gas Limit" label renders cleanly with no dangling ⓘ.

Closes #4714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the gas limit section header in Swap settings by replacing the info icon layout with a cleaner text-only label.
  * Kept the same visual styling, so the page should look more streamlined without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->