### PR TITLE
fix(ui): round the consent-checkbox circle on Send/Swap verify (#4715)

### DIFF
--- a/VultisigApp/VultisigApp/Components/Checkbox.swift
+++ b/VultisigApp/VultisigApp/Components/Checkbox.swift
@@ -56,7 +56,7 @@ struct Checkbox: View {
             .opacity(isChecked ? 1 : 0)
             .overlay(
                 Circle()
-                    .stroke(color, lineWidth: 1)
+                    .strokeBorder(color, lineWidth: 1)
             )
     }
 


### PR DESCRIPTION
## Problem

The green circular checkmark ring next to the consent checkboxes on the Send/Swap **verify** screens was clipped on its left edge — a flat left side instead of a fully round circle.

## Root cause (two compounding factors)

1. **Stroke overflow** — `Components/Checkbox.swift` `check` draws the ring as a 24×24 frame with `.overlay(Circle().stroke(color, lineWidth: 1))`. `.stroke` centers the 1pt line on the circle path, so ~0.5pt of the stroke spills **outside** the 24×24 frame on every side.
2. **Flush row clipped by the ScrollView** — the consent checkboxes are the bottom content of the verify scroll area with no left inset, so the checkbox frame sits flush at x≈0 of the scroll container and the ~0.5pt sliver at x<0 lands outside the bounds, which the ScrollView clips → flat left edge.

### Confirmed clipping ancestor
- **Send:** the `ScrollView` in `SendCryptoVerifySummaryView.fields` (`Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift:42-51`). Its inner `VStack { summary; contentFooter() }` uses `.padding(.horizontal, contentPadding)` where `contentPadding` defaults to **0** and the Send call site passes none → the checkbox footer is flush and the ScrollView clips the overflow.
- **Swap:** the Swap verify screen does **not** use `SendCryptoVerifySummaryView`; it has its own inline `summary`/`checkboxes` inside a `ScrollView` in `SwapVerifyScreen.fields` (`Features/Swap/Views/Screens/SwapVerifyScreen.swift:94-102`). Same mechanism.

## Fix

`Checkbox.swift`: `Circle().stroke(color, lineWidth: 1)` → `Circle().strokeBorder(color, lineWidth: 1)`. `strokeBorder` insets the stroke so it draws **inside** the 24×24 bounds and never overflows to be clipped, fixing the clip regardless of ancestor padding, for all `Checkbox` usages (Send verify, Swap verify, VaultDeletionConfirm, VaultBackupNow). The ring's outer diameter becomes exactly 24 (was 24+1) — imperceptible elsewhere, and the intended behavior.

One-line change, no layout touched.

## Visual verification (render-time)

Reproduced the clipping ancestor with a SwiftUI `ImageRenderer` harness (no app changes committed): with `.stroke` the ring clips flat against the flush-left boundary (a "D" shape); with `.strokeBorder` it renders fully round and contained.

> Before/after render PNG is available locally (`checkbox_before_after.png`) and can be drag-dropped into this PR for inline display. Summary: `.stroke` → ring clipped flat on the left; `.strokeBorder` → ring fully round and contained.

## Tests

No snapshot regression test added: a device-layout perceptual snapshot (repo convention, 0.99999 precision) would not reliably catch a sub-pixel edge clip on a 24pt ring, and a tight strict-pixel snapshot of an anti-aliased circle risks CI flakiness across machines/renderers. The `strokeBorder` change is self-evidently correct and covered by the visual before/after above.

## Gate

`xcodebuild test` (VultisigApp scheme, iPhone 17 Pro Max, worktree-local derived data) + SwiftLint on the touched file. Build SUCCEEDED; the only failing test is the known `"12,3%"` locale non-failure (`StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress`), unrelated to this change.

Closes #4715

🤖 Generated with [Claude Code](https://claude.com/claude-code)
