### PR TITLE
fix(keygen): pad "Use standard mode" link on iPad Pair screen

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
@@ -427,7 +427,9 @@ struct PeerDiscoveryScreen: View {
     var switchLink: some View {
         SwitchToLocalLink(isForKeygen: true, selectedNetwork: $viewModel.selectedNetwork)
             .disabled(viewModel.isLoading)
-#if os(macOS)
+#if os(iOS)
+            .padding(.bottom, idiom == .phone ? 10 : 30)
+#else
             .padding(.bottom, 24)
 #endif
     }


### PR DESCRIPTION
## Problem

On iPad, the **"Use standard mode"** button (`SwitchToLocalLink`) at the bottom of the keygen **Pair** screen in local mode sits flush against the bottom edge with no bottom padding.

## Root cause

`Features/Keygen/Views/PeerDiscoveryScreen.swift` — the `switchLink` computed var applied bottom padding **only under `#if os(macOS)`** (`.padding(.bottom, 24)`), so iOS/iPadOS got **zero** bottom padding. On iPhone the home-indicator safe-area inset masks the missing padding; on iPad the bottom safe-area inset is ~0, so the link hugs the screen edge.

The primary button directly above it (`bottomButton`) already handles iOS correctly with `.padding(.bottom, idiom == .phone ? 10 : 30)`.

## Fix

Give `switchLink` the same idiom-aware iOS padding the button above already uses, while preserving the existing macOS value (24):

```swift
var switchLink: some View {
    SwitchToLocalLink(isForKeygen: true, selectedNetwork: $viewModel.selectedNetwork)
        .disabled(viewModel.isLoading)
#if os(iOS)
        .padding(.bottom, idiom == .phone ? 10 : 30)
#else
        .padding(.bottom, 24)
#endif
}
```

`idiom` is an existing property of the view. Single-computed-var change (+3/−1); `bottomButton` and everything else untouched.

## Verification

- **iPad build** (`iPad Pro 11-inch (M5)`, worktree-local `-derivedDataPath`): `** BUILD SUCCEEDED **` — the core check for this padding change.
- **Full unit suite** (iPhone 16 Pro host, CI/reference environment): 2185 tests, **1 failure** — the pre-existing `"12,3%"` locale flake in `StakingValidatorProjectionTests` (`"12,3%" != "12.3%"`), unrelated to this change.
- On an iPad test host, 3 `CreateVaultSnapshotTests` (unrelated `CreateVaultView`/`WelcomeView`, strict `precision: 0.99999`) also flagged as host-rendering artifacts; they pass on the iPhone reference host.
- SwiftLint: 0 violations on the changed file.

The fix applies the exact idiom-aware padding the adjacent primary button already uses correctly — iPhone keeps 10pt (symmetric with the button above), iPad now gets 30pt above the edge.

Closes #4713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom spacing on the peer discovery screen so the link placement now looks better across iPhone, iPad, and other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->