### PR TITLE
feat(keysign): show fiat value on the send amount (co-sign + initiator)

### DIFF
--- a/VultisigApp/VultisigApp/Components/Hero/HeroContent.swift
+++ b/VultisigApp/VultisigApp/Components/Hero/HeroContent.swift
@@ -36,4 +36,15 @@ struct HeroCoinAmount: Hashable {
     let amount: String
     let ticker: String
     let logo: String
+    /// Pre-formatted fiat value of `amount` (e.g. "$12.34"), rendered as a
+    /// sub-line under the amount. `nil` when no price is resolvable, or for
+    /// callers that intentionally omit fiat.
+    let fiat: String?
+
+    init(amount: String, ticker: String, logo: String, fiat: String? = nil) {
+        self.amount = amount
+        self.ticker = ticker
+        self.logo = logo
+        self.fiat = fiat
+    }
 }

--- a/VultisigApp/VultisigApp/Components/Hero/HeroContentView.swift
+++ b/VultisigApp/VultisigApp/Components/Hero/HeroContentView.swift
@@ -78,13 +78,21 @@ struct HeroContentView: View {
                     tokenChainLogo: nil
                 )
             }
-            (
-                Text(coin.amount)
-                    .foregroundStyle(Theme.colors.textPrimary) +
-                Text(" \(coin.ticker)")
-                    .foregroundStyle(Theme.colors.textTertiary)
-            )
-            .font(Theme.fonts.priceBodyL)
+            VStack(spacing: 2) {
+                (
+                    Text(coin.amount)
+                        .foregroundStyle(Theme.colors.textPrimary) +
+                    Text(" \(coin.ticker)")
+                        .foregroundStyle(Theme.colors.textTertiary)
+                )
+                .font(Theme.fonts.priceBodyL)
+
+                if let fiat = coin.fiat, !fiat.isEmpty {
+                    Text(fiat)
+                        .font(Theme.fonts.priceBodyS)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                }
+            }
         }
     }
 

--- a/VultisigApp/VultisigApp/Components/Hero/HeroContentView.swift
+++ b/VultisigApp/VultisigApp/Components/Hero/HeroContentView.swift
@@ -69,7 +69,7 @@ struct HeroContentView: View {
 
     @ViewBuilder
     private func coinRow(_ coin: HeroCoinAmount, iconSize: CGFloat) -> some View {
-        VStack(spacing: 8) {
+        HStack(spacing: 8) {
             if !coin.logo.isEmpty {
                 AsyncImageView(
                     logo: coin.logo,
@@ -78,21 +78,8 @@ struct HeroContentView: View {
                     tokenChainLogo: nil
                 )
             }
-            VStack(spacing: 2) {
-                (
-                    Text(coin.amount)
-                        .foregroundStyle(Theme.colors.textPrimary) +
-                    Text(" \(coin.ticker)")
-                        .foregroundStyle(Theme.colors.textTertiary)
-                )
-                .font(Theme.fonts.priceBodyL)
-
-                if let fiat = coin.fiat, !fiat.isEmpty {
-                    Text(fiat)
-                        .font(Theme.fonts.priceBodyS)
-                        .foregroundStyle(Theme.colors.textTertiary)
-                }
-            }
+            CoinAmountFiatLabel(amount: coin.amount, ticker: coin.ticker, fiat: coin.fiat)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/VultisigApp/VultisigApp/Components/Text/CoinAmountFiatLabel.swift
+++ b/VultisigApp/VultisigApp/Components/Text/CoinAmountFiatLabel.swift
@@ -1,0 +1,36 @@
+//
+//  CoinAmountFiatLabel.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Amount + ticker with an optional fiat sub-line, in the swap verify asset
+/// cell's typography and layout (`bodyLMedium` amount, `caption12` fiat —
+/// see `SwapVerifyScreen.getSwapAssetCell`). Shared by the send verify
+/// surfaces (initiator + co-sign, hero and non-hero headers) so amounts
+/// render with the same UX as the swap screens and the surfaces can't drift.
+struct CoinAmountFiatLabel: View {
+    let amount: String
+    let ticker: String
+    let fiat: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Group {
+                Text(amount)
+                    .foregroundStyle(Theme.colors.textPrimary) +
+                Text(" ") +
+                Text(ticker)
+                    .foregroundStyle(Theme.colors.textTertiary)
+            }
+            .font(Theme.fonts.bodyLMedium)
+
+            if let fiat, !fiat.isEmpty {
+                Text(fiat)
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textTertiary)
+            }
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Services/TonOperationExtractor.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TonOperationExtractor.swift
@@ -26,6 +26,18 @@ enum TonOperationExtractor {
         let ticker: String
         let logo: String
         let display: String      // pre-joined "1.234 TICKER" string
+        /// Pre-formatted fiat value of the jetton amount (e.g. "$12.34"),
+        /// resolved against the moving coin's `RateProvider` rate. `nil` when
+        /// the jetton has no price, so the hero omits the fiat sub-line.
+        let fiat: String?
+
+        init(amountText: String, ticker: String, logo: String, display: String, fiat: String? = nil) {
+            self.amountText = amountText
+            self.ticker = ticker
+            self.logo = logo
+            self.display = display
+            self.fiat = fiat
+        }
     }
 
     /// Run the extractor against a list of messages. Returns the first
@@ -69,25 +81,31 @@ enum TonOperationExtractor {
             return nil
         }
 
-        let resolved: (ticker: String, logo: String, decimals: Int)?
-        if let vaultMatch = vault.coins.first(where: { coin in
+        guard let vaultMatch = vault.coins.first(where: { coin in
             coin.chain == .ton
                 && !coin.isNativeToken
                 && normalize(address: coin.address) == normalizedWallet
-        }) {
-            resolved = (vaultMatch.ticker, vaultMatch.logo, vaultMatch.decimals)
-        } else {
-            resolved = nil
+        }) else {
+            return nil
         }
 
-        guard let resolved else { return nil }
-        let formatted = formatAmount(rawAmount: rawAmount, decimals: resolved.decimals)
+        let formatted = formatAmount(rawAmount: rawAmount, decimals: vaultMatch.decimals)
         return Display(
             amountText: formatted,
-            ticker: resolved.ticker,
-            logo: resolved.logo,
-            display: "\(formatted) \(resolved.ticker)"
+            ticker: vaultMatch.ticker,
+            logo: vaultMatch.logo,
+            display: "\(formatted) \(vaultMatch.ticker)",
+            fiat: resolveFiat(rawAmount: rawAmount, coin: vaultMatch)
         )
+    }
+
+    /// Best-effort fiat for the moving jetton amount, sharing the send/fee
+    /// `RateProvider` price source. Returns `nil` when the jetton has no rate.
+    private static func resolveFiat(rawAmount: String, coin: Coin) -> String? {
+        guard RateProvider.shared.hasRate(for: coin) else { return nil }
+        let amountDecimal = (Decimal(string: rawAmount) ?? .zero) / pow(Decimal(10), coin.decimals)
+        let fiat = coin.fiat(decimal: amountDecimal).formatToFiat(includeCurrencySymbol: true)
+        return fiat.isEmpty ? nil : fiat
     }
 
     private static func normalize(address: String) -> String? {

--- a/VultisigApp/VultisigApp/Core/Services/TonOperationExtractor.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TonOperationExtractor.swift
@@ -99,12 +99,13 @@ enum TonOperationExtractor {
         )
     }
 
-    /// Best-effort fiat for the moving jetton amount, sharing the send/fee
-    /// `RateProvider` price source. Returns `nil` when the jetton has no rate.
+    /// Best-effort fiat for the moving jetton amount via the shared
+    /// `CryptoAmountFormatter.amountInFiat` (same `RateProvider` price source
+    /// as the send/fee surfaces). Returns `nil` when the jetton has no rate
+    /// or the amount is zero.
     private static func resolveFiat(rawAmount: String, coin: Coin) -> String? {
-        guard RateProvider.shared.hasRate(for: coin) else { return nil }
         let amountDecimal = (Decimal(string: rawAmount) ?? .zero) / pow(Decimal(10), coin.decimals)
-        let fiat = coin.fiat(decimal: amountDecimal).formatToFiat(includeCurrencySymbol: true)
+        let fiat = CryptoAmountFormatter.amountInFiat(coin: coin, amount: amountDecimal)
         return fiat.isEmpty ? nil : fiat
     }
 

--- a/VultisigApp/VultisigApp/Core/Utils/Formatters/CryptoAmountFormatter.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Formatters/CryptoAmountFormatter.swift
@@ -5,6 +5,8 @@
 //  Created by Gaston Mazzeo on 13/08/2025.
 //
 
+import Foundation
+
 enum CryptoAmountFormatter {
     /// Decision 2 win: vault is non-optional on SendTransaction, so the
     /// `vault:` parameter goes away — read it off `tx.vault` directly.
@@ -13,5 +15,21 @@ enum CryptoAmountFormatter {
         let fee = nativeCoin.decimal(for: tx.fee)
         // Use fee-specific formatting with more decimal places (5 instead of 2)
         return RateProvider.shared.fiatFeeString(value: fee, coin: nativeCoin)
+    }
+
+    /// Formatted fiat value of a coin amount for the verify/summary surfaces
+    /// (e.g. "$12.34"), sharing the fee's `RateProvider` price source
+    /// (`Coin.fiat(decimal:)`). Returns empty for a non-positive amount,
+    /// when no rate is available, or when the fiat value is below one cent —
+    /// the standard 2-decimal fiat formatter rounds down, so a priced dust
+    /// amount would otherwise still render as a misleading "$0.00". Single
+    /// source for the amount-fiat semantics on the initiator send verify
+    /// header, the co-sign summary, and the keysign hero rows.
+    static func amountInFiat(coin: Coin, amount: Decimal) -> String {
+        guard amount > 0, RateProvider.shared.hasRate(for: coin) else { return .empty }
+        let fiat = coin.fiat(decimal: amount)
+        let oneCent = Decimal(sign: .plus, exponent: -2, significand: 1)
+        guard fiat >= oneCent else { return .empty }
+        return fiat.formatToFiat(includeCurrencySymbol: true)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/BlockaidSimulationInfo+HeroContent.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/BlockaidSimulationInfo+HeroContent.swift
@@ -1,0 +1,81 @@
+//
+//  BlockaidSimulationInfo+HeroContent.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Maps a resolved Blockaid simulation to the hero rendered above the verify
+/// summary. Shared by the initiator (`KeysignViewModel`) and the co-signer
+/// (`JoinKeysignViewModel`) so the two devices render — and price — the same
+/// hero and can't drift.
+extension BlockaidSimulationInfo {
+
+    /// Hero for this simulation: a single coin row for transfers, from/to
+    /// rows for swaps. Fiat sub-lines are resolved best-effort against
+    /// `vaultCoins` (see `heroFiat(for:amount:vaultCoins:)`).
+    func heroContent(title: String?, vaultCoins: [Coin]) -> HeroContent {
+        switch self {
+        case .transfer(let coin, _):
+            return .send(
+                title: title,
+                coin: HeroCoinAmount(
+                    amount: heroAmountText,
+                    ticker: coin.ticker,
+                    logo: coin.logo,
+                    fiat: Self.heroFiat(for: coin, amount: fromAmountDecimal, vaultCoins: vaultCoins)
+                )
+            )
+        case .swap(let from, let to, _, _):
+            return .swap(
+                title: title,
+                from: HeroCoinAmount(
+                    amount: heroAmountText,
+                    ticker: from.ticker,
+                    logo: from.logo,
+                    fiat: Self.heroFiat(for: from, amount: fromAmountDecimal, vaultCoins: vaultCoins)
+                ),
+                to: HeroCoinAmount(
+                    amount: heroToAmountText ?? "",
+                    ticker: to.ticker,
+                    logo: to.logo,
+                    fiat: Self.heroFiat(for: to, amount: toAmountDecimal ?? .zero, vaultCoins: vaultCoins)
+                )
+            )
+        }
+    }
+
+    /// Best-effort fiat for a hero coin row, resolved against the active
+    /// vault's coins so it shares the amount/fee `RateProvider` price source.
+    /// Matches the simulated coin by chain + contract address (native when
+    /// the address is nil/empty, or is a chain's native-asset sentinel).
+    /// Returns `nil` when the coin isn't in the vault, has no rate, or the
+    /// amount is zero — the hero simply omits the fiat sub-line rather than
+    /// rendering a misleading value.
+    private static func heroFiat(
+        for simCoin: BlockaidSimulationCoin,
+        amount: Decimal,
+        vaultCoins: [Coin]
+    ) -> String? {
+        let match = vaultCoins.first { coin in
+            guard coin.chain == simCoin.chain else { return false }
+            guard let address = simCoin.address?.lowercased(),
+                  !address.isEmpty,
+                  !isNativeSentinel(address: address, chain: simCoin.chain) else {
+                return coin.isNativeToken
+            }
+            return coin.contractAddress.lowercased() == address
+        }
+        guard let match else { return nil }
+        let fiat = CryptoAmountFormatter.amountInFiat(coin: match, amount: amount)
+        return fiat.isEmpty ? nil : fiat
+    }
+
+    /// The Blockaid parser encodes native SOL with the wrapped-SOL mint
+    /// rather than an empty address (see `BlockaidSimulationParser`), while
+    /// the vault's native SOL coin carries no contract address — so the
+    /// sentinel must map back to the chain's native coin when matching.
+    private static func isNativeSentinel(address: String, chain: Chain) -> Bool {
+        chain == .solana && address == BlockaidSimulationParser.wrappedSolMint.lowercased()
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -74,6 +74,7 @@ class JoinKeysignViewModel: ObservableObject {
     @Published var decodedTokenAmount: String?
     @Published var decodedTokenTicker: String?
     @Published var decodedTokenLogo: String?
+    @Published var decodedTokenFiat: String?
     @Published var blockaidSimulation: BlockaidSimulationInfo?
     @Published var securityScannerState: SecurityScannerState = .idle
     @Published var didLoadSimulation: Bool = false
@@ -480,6 +481,7 @@ class JoinKeysignViewModel: ObservableObject {
             self.decodedTokenAmount = display?.amountText
             self.decodedTokenTicker = display?.ticker
             self.decodedTokenLogo = display?.logo
+            self.decodedTokenFiat = display?.fiat
             self.decodedTokenIsUnlimited = false
             return
         }
@@ -670,7 +672,8 @@ class JoinKeysignViewModel: ObservableObject {
                     coin: HeroCoinAmount(
                         amount: sim.heroAmountText,
                         ticker: coin.ticker,
-                        logo: coin.logo
+                        logo: coin.logo,
+                        fiat: heroCoinFiat(chain: coin.chain, address: coin.address, amount: sim.fromAmountDecimal)
                     )
                 )
             case .swap(let from, let to, _, _):
@@ -679,12 +682,14 @@ class JoinKeysignViewModel: ObservableObject {
                     from: HeroCoinAmount(
                         amount: sim.heroAmountText,
                         ticker: from.ticker,
-                        logo: from.logo
+                        logo: from.logo,
+                        fiat: heroCoinFiat(chain: from.chain, address: from.address, amount: sim.fromAmountDecimal)
                     ),
                     to: HeroCoinAmount(
                         amount: sim.heroToAmountText ?? "",
                         ticker: to.ticker,
-                        logo: to.logo
+                        logo: to.logo,
+                        fiat: heroCoinFiat(chain: to.chain, address: to.address, amount: sim.toAmountDecimal ?? .zero)
                     )
                 )
             }
@@ -698,7 +703,7 @@ class JoinKeysignViewModel: ObservableObject {
            !amount.isEmpty {
             return .send(
                 title: decodedFunctionName,
-                coin: HeroCoinAmount(amount: amount, ticker: ticker, logo: logo)
+                coin: HeroCoinAmount(amount: amount, ticker: ticker, logo: logo, fiat: decodedTokenFiat)
             )
         }
 
@@ -756,6 +761,43 @@ class JoinKeysignViewModel: ObservableObject {
         guard let payload = keysignPayload?.swapPayload else { return .empty }
         let fiatDecimal = payload.toCoin.fiat(decimal: payload.toAmountDecimal)
         return fiatDecimal.formatToFiat(includeCurrencySymbol: true)
+    }
+
+    /// Fiat value of a plain send amount for the verify header, mirroring the
+    /// swap `getFromFiatAmount()` and sharing the fee's `RateProvider` price
+    /// source (`Coin.fiat(decimal:)`). Returns empty for swaps (fiat is carried
+    /// on the hero from/to rows), for contract-call / approval decodes (the
+    /// amount row shows a decoded token, not a coin transfer), for zero-value
+    /// sends, or when no rate is available — so nothing misleading renders.
+    func getAmountFiat() -> String {
+        guard let payload = keysignPayload else { return .empty }
+        guard payload.swapPayload == nil,
+              decodedTokenDisplay == nil,
+              payload.toAmount > 0,
+              RateProvider.shared.hasRate(for: payload.coin) else {
+            return .empty
+        }
+        return payload.coin.fiat(decimal: payload.toAmountDecimal)
+            .formatToFiat(includeCurrencySymbol: true)
+    }
+
+    /// Best-effort fiat for a hero coin row, resolved against the active vault
+    /// so it shares the amount/fee `RateProvider` price source. Matches the
+    /// simulated coin by chain + contract address (native when `address` is
+    /// nil/empty). Returns `nil` when the coin isn't in the vault or has no
+    /// rate, so the hero simply omits the fiat sub-line.
+    private func heroCoinFiat(chain: Chain, address: String?, amount: Decimal) -> String? {
+        let normalizedAddress = address?.lowercased()
+        let match = vault.coins.first { coin in
+            guard coin.chain == chain else { return false }
+            if let normalizedAddress, !normalizedAddress.isEmpty {
+                return coin.contractAddress.lowercased() == normalizedAddress
+            }
+            return coin.isNativeToken
+        }
+        guard let match, RateProvider.shared.hasRate(for: match) else { return nil }
+        let fiat = match.fiat(decimal: amount).formatToFiat(includeCurrencySymbol: true)
+        return fiat.isEmpty ? nil : fiat
     }
 
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -665,34 +665,7 @@ class JoinKeysignViewModel: ObservableObject {
     /// display with an "unverified function" caption for 4byte-only decodes.
     var heroContent: HeroContent? {
         if let sim = blockaidSimulation {
-            switch sim {
-            case .transfer(let coin, _):
-                return .send(
-                    title: decodedFunctionName,
-                    coin: HeroCoinAmount(
-                        amount: sim.heroAmountText,
-                        ticker: coin.ticker,
-                        logo: coin.logo,
-                        fiat: heroCoinFiat(chain: coin.chain, address: coin.address, amount: sim.fromAmountDecimal)
-                    )
-                )
-            case .swap(let from, let to, _, _):
-                return .swap(
-                    title: decodedFunctionName,
-                    from: HeroCoinAmount(
-                        amount: sim.heroAmountText,
-                        ticker: from.ticker,
-                        logo: from.logo,
-                        fiat: heroCoinFiat(chain: from.chain, address: from.address, amount: sim.fromAmountDecimal)
-                    ),
-                    to: HeroCoinAmount(
-                        amount: sim.heroToAmountText ?? "",
-                        ticker: to.ticker,
-                        logo: to.logo,
-                        fiat: heroCoinFiat(chain: to.chain, address: to.address, amount: sim.toAmountDecimal ?? .zero)
-                    )
-                )
-            }
+            return sim.heroContent(title: decodedFunctionName, vaultCoins: vault.coins)
         }
 
         // TON-side fallback: when the BOC decoder resolved a jetton hero we
@@ -764,40 +737,19 @@ class JoinKeysignViewModel: ObservableObject {
     }
 
     /// Fiat value of a plain send amount for the verify header, mirroring the
-    /// swap `getFromFiatAmount()` and sharing the fee's `RateProvider` price
-    /// source (`Coin.fiat(decimal:)`). Returns empty for swaps (fiat is carried
-    /// on the hero from/to rows), for contract-call / approval decodes (the
-    /// amount row shows a decoded token, not a coin transfer), for zero-value
-    /// sends, or when no rate is available — so nothing misleading renders.
+    /// swap `getFromFiatAmount()` via the shared
+    /// `CryptoAmountFormatter.amountInFiat` (same `RateProvider` price source
+    /// as the fee, empty for zero-value sends or no rate). Additionally empty
+    /// for swaps (fiat is carried on the hero from/to rows) and for
+    /// contract-call / approval decodes (the amount row shows a decoded
+    /// token, not a coin transfer) — so nothing misleading renders.
     func getAmountFiat() -> String {
-        guard let payload = keysignPayload else { return .empty }
-        guard payload.swapPayload == nil,
-              decodedTokenDisplay == nil,
-              payload.toAmount > 0,
-              RateProvider.shared.hasRate(for: payload.coin) else {
+        guard let payload = keysignPayload,
+              payload.swapPayload == nil,
+              decodedTokenDisplay == nil else {
             return .empty
         }
-        return payload.coin.fiat(decimal: payload.toAmountDecimal)
-            .formatToFiat(includeCurrencySymbol: true)
-    }
-
-    /// Best-effort fiat for a hero coin row, resolved against the active vault
-    /// so it shares the amount/fee `RateProvider` price source. Matches the
-    /// simulated coin by chain + contract address (native when `address` is
-    /// nil/empty). Returns `nil` when the coin isn't in the vault or has no
-    /// rate, so the hero simply omits the fiat sub-line.
-    private func heroCoinFiat(chain: Chain, address: String?, amount: Decimal) -> String? {
-        let normalizedAddress = address?.lowercased()
-        let match = vault.coins.first { coin in
-            guard coin.chain == chain else { return false }
-            if let normalizedAddress, !normalizedAddress.isEmpty {
-                return coin.contractAddress.lowercased() == normalizedAddress
-            }
-            return coin.isNativeToken
-        }
-        guard let match, RateProvider.shared.hasRate(for: match) else { return nil }
-        let fiat = match.fiat(decimal: amount).formatToFiat(includeCurrencySymbol: true)
-        return fiat.isEmpty ? nil : fiat
+        return CryptoAmountFormatter.amountInFiat(coin: payload.coin, amount: payload.toAmountDecimal)
     }
 
 }

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -224,31 +224,7 @@ class KeysignViewModel: ObservableObject {
     /// display with an "unverified function" caption for 4byte-only decodes.
     var heroContent: HeroContent? {
         if let sim = blockaidSimulation {
-            switch sim {
-            case .transfer(let coin, _):
-                return .send(
-                    title: decodedFunctionName,
-                    coin: HeroCoinAmount(
-                        amount: sim.heroAmountText,
-                        ticker: coin.ticker,
-                        logo: coin.logo
-                    )
-                )
-            case .swap(let from, let to, _, _):
-                return .swap(
-                    title: decodedFunctionName,
-                    from: HeroCoinAmount(
-                        amount: sim.heroAmountText,
-                        ticker: from.ticker,
-                        logo: from.logo
-                    ),
-                    to: HeroCoinAmount(
-                        amount: sim.heroToAmountText ?? "",
-                        ticker: to.ticker,
-                        logo: to.logo
-                    )
-                )
-            }
+            return sim.heroContent(title: decodedFunctionName, vaultCoins: vault.coins)
         }
 
         if didLoadSimulation,

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignMessageConfirmView.swift
@@ -30,6 +30,9 @@ struct KeysignMessageConfirmView: View {
                         feeFiat: fees.feeFiat,
                         coinImage: viewModel.keysignPayload?.coin.logo ?? .empty,
                         amount: lpAmountTitle(for: viewModel.keysignPayload, lpDictionary: lpDictionary),
+                        // LP memos render a compound "<amt> <ticker> → <pool> LP"
+                        // title, so their fiat would be misleading — suppress it.
+                        amountFiat: lpDictionary == nil ? viewModel.getAmountFiat() : "",
                         coinTicker: viewModel.keysignPayload?.coin.ticker ?? .empty,
                         keysignPayload: viewModel.keysignPayload,
                         hero: viewModel.heroContent,

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -58,6 +58,19 @@ class SendCryptoVerifyViewModel: ObservableObject {
     /// mirroring the swap approve flow.
     var isApproveRequired: Bool { prebuiltKeysignPayload?.approvePayload != nil }
 
+    /// Fiat value of the send amount for the verify header — the same price
+    /// source and empty-on-edge-case semantics as the co-sign summary
+    /// (`CryptoAmountFormatter.amountInFiat`): empty for a zero amount or when
+    /// no rate is available, never a misleading "$0.00". Derived live from the
+    /// coin's current rate rather than the Details screen's `amountInFiat`
+    /// input text, which is unformatted (no currency symbol), truncated typing
+    /// state. Independent of the fee calculation, so it stays visible while
+    /// `isCalculatingFee` blurs the fee row; a max-send amount adjustment
+    /// republishes `transaction` and recomputes this along with it.
+    var amountFiat: String {
+        CryptoAmountFormatter.amountInFiat(coin: transaction.coin, amount: transaction.amountDecimal)
+    }
+
     init(
         transaction: SendTransaction,
         interactor: SendInteractor = DefaultSendInteractor.live,

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
@@ -115,6 +115,7 @@ struct SendVerifyScreen: View {
                 isCalculatingFee: sendCryptoVerifyViewModel.isCalculatingFee,
                 coinImage: tx.coin.logo,
                 amount: tx.amount,
+                amountFiat: sendCryptoVerifyViewModel.amountFiat,
                 coinTicker: tx.coin.ticker,
                 keysignPayload: sendCryptoVerifyViewModel.verifyKeysignPayload
             ),

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummary.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummary.swift
@@ -21,6 +21,12 @@ struct SendCryptoVerifySummary {
     let isCalculatingFee: Bool
     let coinImage: String
     let amount: String
+    /// Pre-formatted fiat value of `amount` (e.g. "$12.34"), rendered as a
+    /// sub-line under the amount in the non-hero send header. Empty when the
+    /// amount doesn't map to a single priced coin transfer (swap / contract
+    /// call / LP) or when no price is available. Defaults to empty so existing
+    /// construction sites are unaffected.
+    let amountFiat: String
     let coinTicker: String
     let keysignPayload: KeysignPayload?
     let hero: HeroContent?
@@ -54,6 +60,7 @@ struct SendCryptoVerifySummary {
         isCalculatingFee: Bool = false,
         coinImage: String,
         amount: String,
+        amountFiat: String = "",
         coinTicker: String,
         keysignPayload: KeysignPayload? = nil,
         hero: HeroContent? = nil,
@@ -77,6 +84,7 @@ struct SendCryptoVerifySummary {
         self.isCalculatingFee = isCalculatingFee
         self.coinImage = coinImage
         self.amount = amount
+        self.amountFiat = amountFiat
         self.coinTicker = coinTicker
         self.keysignPayload = keysignPayload
         self.hero = hero

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -258,6 +258,13 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
                     Spacer()
                 }
                 .font(Theme.fonts.bodyLMedium)
+
+                if input.amountFiat.isNotEmpty {
+                    Text(input.amountFiat)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .font(Theme.fonts.priceBodyS)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
             .padding(.bottom, 8)
         }

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -249,21 +249,12 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
                         .frame(width: 24, height: 24)
                         .cornerRadius(32)
 
-                    Text(input.amount)
-                        .foregroundStyle(Theme.colors.textPrimary)
-
-                    Text(input.coinTicker)
-                        .foregroundStyle(Theme.colors.textTertiary)
-
-                    Spacer()
-                }
-                .font(Theme.fonts.bodyLMedium)
-
-                if input.amountFiat.isNotEmpty {
-                    Text(input.amountFiat)
-                        .foregroundStyle(Theme.colors.textTertiary)
-                        .font(Theme.fonts.priceBodyS)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    CoinAmountFiatLabel(
+                        amount: input.amount,
+                        ticker: input.coinTicker,
+                        fiat: input.amountFiat
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
             .padding(.bottom, 8)
@@ -362,6 +353,7 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
             feeFiat: "US$ 0.10",
             coinImage: "rune",
             amount: "30",
+            amountFiat: "US$ 90.00",
             coinTicker: "RUNE",
             keysignPayload: nil
         ),
@@ -382,6 +374,7 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
             feeFiat: "US$ 0.10",
             coinImage: "ltc",
             amount: "0.03",
+            amountFiat: "US$ 2.60",
             coinTicker: "LTC",
             keysignPayload: KeysignPayload(
                 coin: .example,

--- a/VultisigApp/VultisigAppTests/Keysign/InitiatorAmountFiatTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/InitiatorAmountFiatTests.swift
@@ -1,0 +1,244 @@
+//
+//  InitiatorAmountFiatTests.swift
+//  VultisigAppTests
+//
+//  Pins the initiating device's amount fiat, the counterpart of
+//  `JoinKeysignAmountFiatTests`: the send verify header
+//  (`SendCryptoVerifyViewModel.amountFiat`) and the keysign hero
+//  (`KeysignViewModel.heroContent`, via the shared
+//  `BlockaidSimulationInfo.heroContent(title:vaultCoins:)`). Both must share
+//  the co-sign path's price source and empty-on-edge-case semantics — a fiat
+//  string only for a priced, non-zero amount; empty/nil otherwise, never a
+//  misleading "$0.00". Display-only: nothing here affects signing bytes.
+//
+
+@testable import VultisigApp
+import BigInt
+import VultisigCommonData
+import XCTest
+
+@MainActor
+final class InitiatorAmountFiatTests: XCTestCase {
+
+    // MARK: - Send verify header (SendCryptoVerifyViewModel.amountFiat)
+
+    func testSendVerifyAmountFiatUsesCoinPriceAndAmount() {
+        let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: coin)
+        // 3 ETH at $2 = $6.
+        let vm = makeVerifyViewModel(coin: coin, amount: "3")
+
+        let fiat = vm.amountFiat
+        XCTAssertFalse(fiat.isEmpty, "A seeded rate should produce a fiat string")
+        XCTAssertTrue(fiat.contains("6"), "3 ETH at $2 should render as 6, got \(fiat)")
+    }
+
+    func testSendVerifyAmountFiatEmptyWithoutRate() {
+        // Unique ticker → unique priceProviderId that nothing seeds a rate for.
+        let coin = makeCoin(.ethereum, ticker: "NORATESENDZZ", decimals: 18, isNative: true)
+        let vm = makeVerifyViewModel(coin: coin, amount: "1")
+        XCTAssertEqual(vm.amountFiat, "", "No rate → empty, never a misleading $0.00")
+    }
+
+    func testSendVerifyAmountFiatEmptyForZeroAmount() {
+        let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: coin)
+        let vm = makeVerifyViewModel(coin: coin, amount: "0")
+        XCTAssertEqual(vm.amountFiat, "", "A zero-value send maps to no meaningful fiat")
+    }
+
+    func testSendVerifyAmountFiatEmptyForSubCentFiat() {
+        let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: coin)
+        // 0.001 ETH at $2 = $0.002 — the 2-decimal fiat formatter rounds down,
+        // so this must stay empty rather than render "$0.00". The amount is a
+        // user-typed string parsed with the device locale, so build it with
+        // the current locale's decimal separator.
+        let separator = Locale.current.decimalSeparator ?? "."
+        let vm = makeVerifyViewModel(coin: coin, amount: "0\(separator)001")
+        XCTAssertEqual(vm.amountFiat, "", "A sub-cent fiat value must not render as $0.00")
+    }
+
+    // MARK: - Initiator keysign hero (KeysignViewModel.heroContent)
+
+    func testInitiatorHeroSendResolvesFiatAgainstVaultCoins() {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: eth)
+        let vm = makeKeysignViewModel(vaultCoins: [eth])
+        // 3 ETH at $2 = $6.
+        vm.blockaidSimulation = .transfer(
+            fromCoin: simCoin(ticker: "ETH", decimals: 18),
+            fromAmount: BigInt("3000000000000000000")
+        )
+
+        guard case .send(_, let coin) = vm.heroContent else {
+            return XCTFail("A transfer simulation should produce a send hero")
+        }
+        XCTAssertNotNil(coin.fiat, "A vault-held, priced coin should resolve hero fiat")
+        XCTAssertTrue(coin.fiat?.contains("6") == true, "3 ETH at $2 should render as 6, got \(coin.fiat ?? "nil")")
+    }
+
+    func testInitiatorHeroSwapResolvesFiatForBothRows() {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: "0xusdc")
+        setPrice(2.0, for: eth)
+        setPrice(1.0, for: usdc)
+        let vm = makeKeysignViewModel(vaultCoins: [eth, usdc])
+        // 1 ETH at $2 = $2 → 5 USDC at $1 = $5. The mixed-case simulation
+        // address must still match the vault's lowercase contract address.
+        vm.blockaidSimulation = .swap(
+            fromCoin: simCoin(ticker: "ETH", decimals: 18),
+            toCoin: simCoin(address: "0xUSDC", ticker: "USDC", decimals: 6),
+            fromAmount: BigInt("1000000000000000000"),
+            toAmount: BigInt("5000000")
+        )
+
+        guard case .swap(_, let from, let to) = vm.heroContent else {
+            return XCTFail("A swap simulation should produce a swap hero")
+        }
+        XCTAssertTrue(from.fiat?.contains("2") == true, "1 ETH at $2 should render as 2, got \(from.fiat ?? "nil")")
+        XCTAssertTrue(to.fiat?.contains("5") == true, "5 USDC at $1 should render as 5, got \(to.fiat ?? "nil")")
+    }
+
+    func testInitiatorHeroFiatNilWhenCoinNotInVault() {
+        let vm = makeKeysignViewModel(vaultCoins: [])
+        vm.blockaidSimulation = .transfer(
+            fromCoin: simCoin(ticker: "ETH", decimals: 18),
+            fromAmount: BigInt("1000000000000000000")
+        )
+
+        guard case .send(_, let coin) = vm.heroContent else {
+            return XCTFail("A transfer simulation should produce a send hero")
+        }
+        XCTAssertNil(coin.fiat, "No vault match → the hero omits the fiat sub-line")
+    }
+
+    func testInitiatorHeroFiatNilWithoutRate() {
+        let coin = makeCoin(.ethereum, ticker: "NORATEHEROZZ", decimals: 18, isNative: true)
+        let vm = makeKeysignViewModel(vaultCoins: [coin])
+        vm.blockaidSimulation = .transfer(
+            fromCoin: simCoin(ticker: "NORATEHEROZZ", decimals: 18),
+            fromAmount: BigInt("1000000000000000000")
+        )
+
+        guard case .send(_, let hero) = vm.heroContent else {
+            return XCTFail("A transfer simulation should produce a send hero")
+        }
+        XCTAssertNil(hero.fiat, "No rate → the hero omits the fiat sub-line, never $0.00")
+    }
+
+    func testInitiatorHeroSolNativeSentinelResolvesFiat() {
+        let sol = makeCoin(.solana, ticker: "SOL", decimals: 9, isNative: true)
+        setPrice(3.0, for: sol)
+        let vm = makeKeysignViewModel(vaultCoins: [sol])
+        // The Blockaid parser encodes native SOL with the wrapped-SOL mint
+        // sentinel, not an empty address — it must still match the vault's
+        // native SOL coin. 2 SOL at $3 = $6.
+        vm.blockaidSimulation = .transfer(
+            fromCoin: simCoin(
+                chain: .solana,
+                address: BlockaidSimulationParser.wrappedSolMint,
+                ticker: "SOL",
+                decimals: 9
+            ),
+            fromAmount: BigInt("2000000000")
+        )
+
+        guard case .send(_, let coin) = vm.heroContent else {
+            return XCTFail("A transfer simulation should produce a send hero")
+        }
+        XCTAssertNotNil(coin.fiat, "The wrapped-SOL sentinel should resolve the vault's native SOL")
+        XCTAssertTrue(coin.fiat?.contains("6") == true, "2 SOL at $3 should render as 6, got \(coin.fiat ?? "nil")")
+    }
+
+    func testInitiatorHeroFiatNilForZeroAmount() {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: eth)
+        let vm = makeKeysignViewModel(vaultCoins: [eth])
+        vm.blockaidSimulation = .transfer(
+            fromCoin: simCoin(ticker: "ETH", decimals: 18),
+            fromAmount: .zero
+        )
+
+        guard case .send(_, let coin) = vm.heroContent else {
+            return XCTFail("A transfer simulation should produce a send hero")
+        }
+        XCTAssertNil(coin.fiat, "A zero simulated amount maps to no meaningful fiat")
+    }
+
+    // MARK: - Helpers
+
+    private func makeKeysignViewModel(vaultCoins: [Coin]) -> KeysignViewModel {
+        let vm = KeysignViewModel()
+        vm.vault = makeVault(coins: vaultCoins)
+        return vm
+    }
+
+    private func makeVerifyViewModel(coin: Coin, amount: String) -> SendCryptoVerifyViewModel {
+        SendCryptoVerifyViewModel(
+            transaction: makeTransaction(coin: coin, amount: amount),
+            interactor: MockSendInteractor()
+        )
+    }
+
+    private func makeTransaction(coin: Coin, amount: String) -> SendTransaction {
+        SendTransaction(
+            coin: coin,
+            vault: makeVault(coins: [coin]),
+            fromAddress: coin.address,
+            toAddress: "0x0000000000000000000000000000000000000001",
+            toAddressLabel: nil,
+            amount: amount,
+            amountInFiat: "",
+            memo: "",
+            gas: .zero,
+            fee: .zero,
+            feeMode: .default,
+            estimatedGasLimit: nil,
+            customGasLimit: nil,
+            customByteFee: nil,
+            sendMaxAmount: false,
+            isStakingOperation: false,
+            transactionType: .unspecified,
+            memoFunctionDictionary: [:],
+            wasmContractPayload: nil,
+            feeCoin: coin
+        )
+    }
+
+    private func makeVault(coins: [Coin]) -> Vault {
+        let vault = Vault(name: "initiator-fiat-test-vault")
+        vault.coins = coins
+        return vault
+    }
+
+    private func simCoin(chain: Chain = .ethereum, address: String? = nil, ticker: String, decimals: Int) -> BlockaidSimulationCoin {
+        BlockaidSimulationCoin(
+            chain: chain,
+            address: address,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals
+        )
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, contract: String = "") -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals,
+            priceProviderId: ticker.lowercased(),
+            contractAddress: contract,
+            isNativeToken: isNative
+        )
+        return Coin(asset: asset, address: "test-\(ticker)", hexPublicKey: "")
+    }
+
+    private func setPrice(_ value: Double, for coin: Coin) {
+        let cryptoId = RateProvider.cryptoId(for: coin.toCoinMeta()).id
+        try? RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: cryptoId, value: value)
+        ])
+    }
+}

--- a/VultisigApp/VultisigAppTests/Keysign/JoinKeysignAmountFiatTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/JoinKeysignAmountFiatTests.swift
@@ -1,0 +1,155 @@
+//
+//  JoinKeysignAmountFiatTests.swift
+//  VultisigAppTests
+//
+//  Pins `JoinKeysignViewModel.getAmountFiat()` — the co-sign "Send overview"
+//  amount fiat that renders under the send amount, consistent with the network
+//  fee. Display-only: `getAmountFiat` derives from the already-signed
+//  `toAmount` + the shared `RateProvider` price and never affects signing
+//  bytes. The helper must produce a fiat string only for a plain, priced coin
+//  send and stay empty for swaps, contract-call/approval decodes, zero-value
+//  sends, and coins without a rate — so nothing misleading renders.
+//
+
+@testable import VultisigApp
+import BigInt
+import XCTest
+
+@MainActor
+final class JoinKeysignAmountFiatTests: XCTestCase {
+
+    func testAmountFiatUsesCoinPriceAndAmount() {
+        let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: coin)
+        // 3 ETH at $2 = $6.
+        let vm = makeViewModel(payload: makePayload(coin: coin, toAmount: BigInt("3000000000000000000")))
+
+        let fiat = vm.getAmountFiat()
+        XCTAssertFalse(fiat.isEmpty, "A seeded rate should produce a fiat string")
+        XCTAssertTrue(fiat.contains("6"), "3 ETH at $2 should render as 6, got \(fiat)")
+    }
+
+    func testAmountFiatScalesWithAmount() {
+        let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: coin)
+        // 5 ETH at $2 = $10.
+        let vm = makeViewModel(payload: makePayload(coin: coin, toAmount: BigInt("5000000000000000000")))
+
+        let fiat = vm.getAmountFiat()
+        XCTAssertTrue(fiat.contains("10"), "5 ETH at $2 should render as 10, got \(fiat)")
+    }
+
+    func testAmountFiatEmptyWithoutRate() {
+        // Unique ticker → unique priceProviderId that nothing seeds a rate for.
+        let coin = makeCoin(.ethereum, ticker: "NORATEZZ", decimals: 18, isNative: true)
+        let vm = makeViewModel(payload: makePayload(coin: coin, toAmount: BigInt("1000000000000000000")))
+        XCTAssertEqual(vm.getAmountFiat(), "", "No rate → empty, never a misleading $0.00")
+    }
+
+    func testAmountFiatEmptyForZeroAmount() {
+        let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: coin)
+        let vm = makeViewModel(payload: makePayload(coin: coin, toAmount: 0))
+        XCTAssertEqual(vm.getAmountFiat(), "", "A zero-value send maps to no meaningful fiat")
+    }
+
+    func testAmountFiatEmptyForContractCallTokenDisplay() {
+        let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: coin)
+        let vm = makeViewModel(payload: makePayload(coin: coin, toAmount: BigInt("3000000000000000000")))
+        // A resolved contract-call / approval token display means the amount row
+        // shows a decoded token, not the native coin transfer.
+        vm.decodedTokenDisplay = "0.3 USDC"
+        XCTAssertEqual(vm.getAmountFiat(), "", "Contract-call decodes carry their own display, not amount fiat")
+    }
+
+    func testAmountFiatEmptyForSwap() {
+        let from = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        setPrice(2.0, for: from)
+        let swap = SwapPayload.generic(makeGenericSwapPayload(from: from))
+        let vm = makeViewModel(payload: makePayload(
+            coin: from,
+            toAmount: BigInt("3000000000000000000"),
+            swapPayload: swap
+        ))
+        XCTAssertEqual(vm.getAmountFiat(), "", "Swaps show fiat on the hero from/to rows, not the amount field")
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(payload: KeysignPayload) -> JoinKeysignViewModel {
+        let vm = JoinKeysignViewModel()
+        vm.keysignPayload = payload
+        return vm
+    }
+
+    private func makePayload(coin: Coin, toAmount: BigInt, swapPayload: SwapPayload? = nil) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: "0xrecipient",
+            toAmount: toAmount,
+            chainSpecific: .Ethereum(maxFeePerGasWei: 0, priorityFeeWei: 0, nonce: 0, gasLimit: 21000),
+            utxos: [],
+            memo: nil,
+            swapPayload: swapPayload,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "",
+            vaultLocalPartyID: "",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private func makeGenericSwapPayload(from: Coin) -> GenericSwapPayload {
+        GenericSwapPayload(
+            fromCoin: from,
+            toCoin: makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, contract: "0xusdc"),
+            fromAmount: BigInt("3000000000000000000"),
+            toAmountDecimal: 3000,
+            quote: EVMQuote(
+                dstAmount: "3000000000",
+                tx: EVMQuote.Transaction(
+                    from: "0xFrom",
+                    to: "0xRouter",
+                    data: "0x",
+                    value: "0",
+                    gasPrice: "1",
+                    gas: 100_000,
+                    swapFee: "0",
+                    swapFeeTokenContract: ""
+                )
+            ),
+            provider: .oneInch,
+            swapFeeChain: nil,
+            swapFeeTokenId: nil,
+            swapFeeDecimals: nil
+        )
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, contract: String = "") -> Coin {
+        let asset = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "logo",
+            decimals: decimals,
+            priceProviderId: ticker.lowercased(),
+            contractAddress: contract,
+            isNativeToken: isNative
+        )
+        return Coin(asset: asset, address: "test-\(ticker)", hexPublicKey: "")
+    }
+
+    private func setPrice(_ value: Double, for coin: Coin) {
+        let cryptoId = RateProvider.cryptoId(for: coin.toCoinMeta()).id
+        try? RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: cryptoId, value: value)
+        ])
+    }
+}


### PR DESCRIPTION
## What & why

On the co-sign **"Send overview"** / **"Join transaction signing"** screen, the network **fee** already renders as `crypto · $fiat`, but the **amount** had no fiat — a co-signer couldn't sanity-check the dollar value of what they were about to sign.

### Structural gap
The co-sign screen renders through the shared `SendCryptoVerifySummary` model + `HeroContentView`/`HeroCoinAmount`, both of which carried fiat for the fee (`feeFiat`) but not for the amount. `JoinKeysignViewModel.heroContent` built `HeroCoinAmount(...)` with no fiat, and the co-sign builder in `KeysignMessageConfirmView` passed `feeFiat` but no amount fiat.

### The fix (display-only)
Add an amount fiat sub-line, reusing the **same price source as the fee** — `Coin.fiat(decimal:)` → `RateProvider` rate → `Decimal.formatToFiat(...)` (identical to the swap `getFromFiatAmount()`):

- **`HeroCoinAmount`** gains an optional `fiat` string, rendered as a sub-line under the amount in `HeroContentView.coinRow` (covers `.send` + both `.swap` rows).
- **`SendCryptoVerifySummary`** gains `amountFiat` (defaulted to `""` in the init), rendered under the amount in the non-hero send header when non-empty.
- **`JoinKeysignViewModel.getAmountFiat()`** mirrors `getFromFiatAmount()`, guarded to a plain, priced coin send.
- Hero fiat resolved best-effort against the vault's coins for the Blockaid `.send`/`.swap` heroes, and inside `TonOperationExtractor` for TON jettons.

### Initiator coverage (this PR, follow-up commits)
The initiating device's surfaces are covered too, with the same semantics:

- **Send verify header** — `SendVerifyScreen` now passes `amountFiat` from the new `SendCryptoVerifyViewModel.amountFiat`, derived **live** from the coin's current rate (like the fee) rather than the Details screen's `amountInFiat` typing state (unformatted, truncated). It is independent of `isCalculatingFee` (the amount is fixed user input), and a max-send amount adjustment republishes the transaction so the fiat recomputes with it.
- **Initiator keysign hero** — `KeysignViewModel.heroContent` resolves fiat for the Blockaid `.send`/`.swap` heroes exactly like the co-sign side.

**Shared helpers (anti-drift):**
- `CryptoAmountFormatter.amountInFiat(coin:amount:)` — the single source for amount-fiat semantics (positive amount + available rate + **fiat ≥ one cent**, else empty). Used by the initiator header, the co-sign `getAmountFiat()`, the hero rows, and the TON jetton extractor.
- `BlockaidSimulationInfo.heroContent(title:vaultCoins:)` — the Blockaid sim → `HeroContent` mapping (including vault-coin fiat resolution) extracted from `JoinKeysignViewModel` and now used by **both** keysign view models. Also handles the wrapped-SOL mint sentinel the Blockaid parser uses for native SOL, so native SOL heroes price correctly.

### Unified rendering (swap-cell UX)
The amount + fiat block now renders through a shared `CoinAmountFiatLabel` styled like the swap verify asset cells (`SwapVerifyScreen.getSwapAssetCell`): leading coin icon in an `HStack(spacing: 8)`, `bodyLMedium` amount + tertiary ticker, `caption12` tertiary fiat sub-line directly under the amount. Used by `HeroContentView.coinRow` and the non-hero "You're sending" header, so the co-sign and initiator surfaces read exactly like the swap screens and can't drift. Verified via an `ImageRenderer` harness (stripped before commit): non-hero header, hero `.send`, hero `.swap`, and the no-fiat case (sub-line simply absent — no orphan gap).

### Edge cases → empty (nothing misleading renders)
- Swaps (fiat is carried on the hero from/to rows)
- Contract-call / approval decodes (`decodedTokenDisplay != nil` — the amount row shows a decoded token)
- LP memos (compound `"<amt> <ticker> → <pool> LP"` title)
- Zero-value sends
- No rate available, or a sub-cent fiat value that would round down to `$0.00` (never a misleading `$0.00`)

## Display-only / safety
Renders on the verify/confirm screens only, derived from the already-built transaction amounts and the **same** `RateProvider` feed as the fee. **No signing/keysign logic, keysign message construction, fee computation, or signed bytes change.** `FunctionCallVerifyScreen` intentionally stays fiat-free (function-call amounts are an explicit no-fiat edge case).

## Tests
- `JoinKeysignAmountFiatTests` — co-sign `getAmountFiat()`: known price×amount → `$…`; scales with amount; empty for no-rate / zero / contract-call / swap.
- `InitiatorAmountFiatTests` — initiator paths: verify-header fiat (price×amount; empty for no-rate / zero / sub-cent), initiator hero resolution (send + swap rows resolve against vault coins; wrapped-SOL sentinel maps to native SOL; nil for out-of-vault / no-rate / zero).

Gate: `make test` — **2201 tests, 1 failure = the known `"12,3%"` comma-decimal locale flake** (`StakingValidatorProjectionTests`, pre-existing/env, unrelated); all 16 amount-fiat tests pass; SwiftLint clean (no new warnings).

Closes #4716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new fiat-aware amount label to display fiat as an optional secondary line next to crypto amounts across send verification and signing flows when pricing is available.

* **Bug Fixes**
  * Improved fiat resolution for simulated transfer/swap scenarios (including native SOL handling) and ensured fiat is omitted when unavailable, sub-cent, zero, or potentially misleading (e.g., LP memos).

* **Other**
  * Enhanced fiat formatting via a shared formatter and extended related rendering logic; added test coverage for amountFiat/hero fiat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
