### PR TITLE
fix(keygen): iPad local-mode join no longer hangs on "Discovering" (Local Network check + error/retry + iPad back button)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tss/ServiceDelegate.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/ServiceDelegate.swift
@@ -10,6 +10,15 @@ import SwiftUI
 final class ServiceDelegate: NSObject, NetServiceDelegate, ObservableObject {
     private let logger = Logger(subsystem: "service-delegate", category: "communication")
     @Published var serverURL: String?
+    /// Set when local-mode Bonjour resolution fails or times out. Observed by the
+    /// join flow to surface a recoverable error instead of hanging on "Discovering".
+    @Published var didFailToResolve: Bool = false
+
+    /// Clears prior discovery state so a Retry starts from a clean slate.
+    func reset() {
+        serverURL = nil
+        didFailToResolve = false
+    }
 
     public func netServiceDidResolveAddress(_ sender: NetService) {
         var ipAddress: String?
@@ -37,5 +46,8 @@ final class ServiceDelegate: NSObject, NetServiceDelegate, ObservableObject {
 
     public func netService(_ sender: NetService, didNotResolve errorDict: [String: NSNumber]) {
         logger.error("Failed to resolve service: \(sender.name) with error: \(errorDict)")
+        DispatchQueue.main.async {
+            self.didFailToResolve = true
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Components/NoLocalNetworkPermissionView.swift
+++ b/VultisigApp/VultisigApp/Components/NoLocalNetworkPermissionView.swift
@@ -1,0 +1,51 @@
+//
+//  NoLocalNetworkPermissionView.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Shown when local (LAN / Bonjour) peer discovery can't reach the other device
+/// — most often because iOS **Local Network** access is off for Vultisig, or the
+/// two devices aren't on the same Wi-Fi. Offers a deep link to Settings (where
+/// the Local Network toggle lives) plus a Retry that re-runs discovery.
+struct NoLocalNetworkPermissionView: View {
+    var onRetry: () -> Void
+
+    var body: some View {
+        ErrorView(
+            type: .warning,
+            title: "noLocalNetworkPermissionTitle".localized,
+            description: "noLocalNetworkPermissionDescription".localized,
+            buttonTitle: "openSettings".localized,
+            secondaryButtonTitle: "tryAgain".localized,
+            action: openSettings,
+            secondaryAction: onRetry
+        )
+    }
+}
+
+#Preview {
+    NoLocalNetworkPermissionView(onRetry: {})
+}
+
+#if os(iOS)
+extension NoLocalNetworkPermissionView {
+    func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}
+#endif
+
+#if os(macOS)
+import Cocoa
+
+extension NoLocalNetworkPermissionView {
+    func openSettings() {
+        if let url = URL(string: "x-apple.systempreferences:") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -721,6 +721,8 @@
 "nOfTotal" = "%d von %@";
 "noGasTokenFoundError" = "Kein Gas-Token für %@ Chain gefunden. Bitte füge den nativen Token zu deinem Vault hinzu.";
 "noLiquidityPool" = "Kein Liquiditätspool für dieses Token-Paar verfügbar. Dieser Asset wird möglicherweise nicht unterstützt.";
+"noLocalNetworkPermissionDescription" = "Vultisig benötigt Zugriff auf das lokale Netzwerk, um deine anderen Geräte im selben WLAN zu finden. Aktiviere ihn in den Einstellungen, stelle sicher, dass beide Geräte im selben Netzwerk sind, und versuche es erneut.";
+"noLocalNetworkPermissionTitle" = "Keine Geräte in der Nähe gefunden";
 "noMessagesToSign" = "Es gibt keine zu signierenden Nachrichten";
 "noPoolsAvailable" = "No pools available";
 "noPositionsFound" = "Keine Positionen gefunden";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -719,6 +719,8 @@
 "nOfTotal" = "%d of %@";
 "noGasTokenFoundError" = "No gas token found for %@ chain. Please add the native token to your vault.";
 "noLiquidityPool" = "No liquidity pool available for this token pair. This asset may not be supported.";
+"noLocalNetworkPermissionDescription" = "Vultisig needs Local Network access to find your other devices on the same Wi-Fi. Enable it in Settings, make sure both devices are on the same network, then try again.";
+"noLocalNetworkPermissionTitle" = "Can't find nearby devices";
 "noMessagesToSign" = "There are no messages to be signed";
 "noPoolsAvailable" = "No pools available";
 "noPositionsFound" = "No positions found";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -721,6 +721,8 @@
 "nOfTotal" = "%d de %@";
 "noGasTokenFoundError" = "No se encontró token de gas para la cadena %@. Por favor agrega el token nativo a tu vault.";
 "noLiquidityPool" = "No hay pool de liquidez disponible para este par de tokens. Este activo puede no estar soportado.";
+"noLocalNetworkPermissionDescription" = "Vultisig necesita acceso a la red local para encontrar tus otros dispositivos en la misma red Wi-Fi. Actívalo en Ajustes, asegúrate de que ambos dispositivos estén en la misma red y vuelve a intentarlo.";
+"noLocalNetworkPermissionTitle" = "No se encuentran dispositivos cercanos";
 "noMessagesToSign" = "No hay mensajes para firmar";
 "noPoolsAvailable" = "No pools available";
 "noPositionsFound" = "No se encontraron posiciones";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -721,6 +721,8 @@
 "nOfTotal" = "%d od %@";
 "noGasTokenFoundError" = "Nije pronađen token za plin za %@ lanac. Molimo dodajte nativni token u vaš trezor.";
 "noLiquidityPool" = "Nema dostupnog pool likvidnosti za ovaj par tokena. Ovaj asset možda nije podržan.";
+"noLocalNetworkPermissionDescription" = "Vultisig treba pristup lokalnoj mreži kako bi pronašao vaše druge uređaje na istoj Wi-Fi mreži. Omogućite ga u Postavkama, provjerite jesu li oba uređaja na istoj mreži i pokušajte ponovno.";
+"noLocalNetworkPermissionTitle" = "Nije moguće pronaći uređaje u blizini";
 "noMessagesToSign" = "Nema poruka za potpisivanje";
 "noPoolsAvailable" = "Nema dostupnih bazena";
 "noPositionsFound" = "Nema pronađenih pozicija";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -721,6 +721,8 @@
 "nOfTotal" = "%d di %@";
 "noGasTokenFoundError" = "Token gas non trovato per la catena %@. Aggiungi il token nativo al tuo vault.";
 "noLiquidityPool" = "Nessun pool di liquidità disponibile per questa coppia di token. Questo asset potrebbe non essere supportato.";
+"noLocalNetworkPermissionDescription" = "Vultisig ha bisogno dell'accesso alla rete locale per trovare gli altri dispositivi sulla stessa rete Wi-Fi. Abilitalo nelle Impostazioni, assicurati che entrambi i dispositivi siano sulla stessa rete e riprova.";
+"noLocalNetworkPermissionTitle" = "Impossibile trovare dispositivi nelle vicinanze";
 "noMessagesToSign" = "Non ci sono messaggi da firmare";
 "noPoolsAvailable" = "Nessuna pool disponibile";
 "noPositionsFound" = "Nessuna posizione trovata";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -719,6 +719,8 @@
 "nOfTotal" = "%d / %@";
 "noGasTokenFoundError" = "%@ 체인에 대한 가스 토큰을 찾을 수 없습니다. 볼트에 네이티브 토큰을 추가하세요.";
 "noLiquidityPool" = "이 토큰 쌍에 사용할 수 있는 유동성 풀이 없습니다. 이 자산은 지원되지 않을 수 있습니다.";
+"noLocalNetworkPermissionDescription" = "Vultisig가 같은 Wi-Fi에 연결된 다른 기기를 찾으려면 로컬 네트워크 접근 권한이 필요합니다. 설정에서 이를 활성화하고 두 기기가 같은 네트워크에 있는지 확인한 후 다시 시도하세요.";
+"noLocalNetworkPermissionTitle" = "근처 기기를 찾을 수 없습니다";
 "noMessagesToSign" = "서명할 메시지가 없습니다";
 "noPoolsAvailable" = "사용 가능한 풀 없음";
 "noPositionsFound" = "포지션을 찾을 수 없습니다";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -721,6 +721,8 @@
 "nOfTotal" = "%d de %@";
 "noGasTokenFoundError" = "Token de gas não encontrado para a cadeia %@. Por favor, adicione o token nativo ao seu vault.";
 "noLiquidityPool" = "Não há pool de liquidez disponível para este par de tokens. Este ativo pode não ser suportado.";
+"noLocalNetworkPermissionDescription" = "O Vultisig precisa de acesso à Rede Local para encontrar os seus outros dispositivos na mesma rede Wi-Fi. Ative-o nas Configurações, verifique se ambos os dispositivos estão na mesma rede e tente novamente.";
+"noLocalNetworkPermissionTitle" = "Não é possível encontrar dispositivos próximos";
 "noMessagesToSign" = "Não há mensagens para assinar";
 "noPoolsAvailable" = "No pools available";
 "noPositionsFound" = "Nenhuma posição encontrada";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -721,6 +721,8 @@
 "nOfTotal" = "%d / %@";
 "noGasTokenFoundError" = "未找到 %@ 链的燃料代币。请将原生代币添加到您的保险库";
 "noLiquidityPool" = "此代币对没有可用的流动性池。此资产可能不受支持";
+"noLocalNetworkPermissionDescription" = "Vultisig 需要本地网络访问权限才能找到同一 Wi-Fi 下的其他设备。请在“设置”中开启该权限，确保两台设备连接到同一网络，然后重试。";
+"noLocalNetworkPermissionTitle" = "找不到附近的设备";
 "noMessagesToSign" = "没有需要签名的消息";
 "noPoolsAvailable" = "没有可用的资金池";
 "noPositionsFound" = "未找到任何持仓";

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift
@@ -50,7 +50,15 @@ enum LocalNetworkAuthorization {
 /// locking is required.
 private final class Prober: NSObject, NetServiceDelegate, @unchecked Sendable {
     private let logger = Logger(subsystem: "com.vultisig.app", category: "local-network-authorization")
-    private let serviceType = "_vultisig-lnp._tcp"
+    /// The probe type MUST be one of the app's declared `NSBonjourServices`
+    /// entries. iOS refuses to publish or browse an undeclared type even when
+    /// Local Network access is *granted* — `NetService` fails with
+    /// `NSNetServicesMissingRequiredConfigurationError` (-72008) and
+    /// `NWBrowser`/DNSServiceBrowse returns `NoAuth` (-65555) — which the probe
+    /// would misread as `.denied`. `_lnp._tcp` is declared in Info.plist and is
+    /// otherwise unused, so it's a dedicated, authorized throwaway type that
+    /// doesn't collide with the app's real `_http._tcp.` discovery.
+    private let serviceType = "_lnp._tcp"
 
     private var browser: NWBrowser?
     private var service: NetService?
@@ -77,9 +85,10 @@ private final class Prober: NSObject, NetServiceDelegate, @unchecked Sendable {
         self.browser = browser
         browser.start(queue: .main)
 
-        // NWBrowser wants the bare service type (no trailing dot); NetService
-        // conventionally wants the trailing-dot form. Advertising with the wrong
-        // form can make the browser never see the service → false timeout/deny.
+        // NWBrowser wants the bare service type (`_lnp._tcp`); NetService wants
+        // the trailing-dot form (`_lnp._tcp.`), which also matches the Info.plist
+        // NSBonjourServices entry. Advertising with the wrong form can make the
+        // browser never see the service → false timeout/deny.
         let service = NetService(domain: "local.", type: serviceType + ".", name: "VultisigLocalNetwork", port: 1100)
         service.delegate = self
         self.service = service

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift
@@ -77,7 +77,10 @@ private final class Prober: NSObject, NetServiceDelegate, @unchecked Sendable {
         self.browser = browser
         browser.start(queue: .main)
 
-        let service = NetService(domain: "local.", type: serviceType, name: "VultisigLocalNetwork", port: 1100)
+        // NWBrowser wants the bare service type (no trailing dot); NetService
+        // conventionally wants the trailing-dot form. Advertising with the wrong
+        // form can make the browser never see the service → false timeout/deny.
+        let service = NetService(domain: "local.", type: serviceType + ".", name: "VultisigLocalNetwork", port: 1100)
         service.delegate = self
         self.service = service
         service.publish()

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift
@@ -1,0 +1,128 @@
+//
+//  LocalNetworkAuthorization.swift
+//  VultisigApp
+//
+
+#if os(iOS)
+import Foundation
+import Network
+import OSLog
+
+/// Probes the app's iOS **Local Network** authorization.
+///
+/// iOS exposes no API to read Local Network permission directly, so the
+/// established technique (credited to Apple DTS) is to advertise a throwaway
+/// Bonjour service while simultaneously browsing the local network:
+///
+/// - Advertising the service succeeds only when access is **granted**
+///   (`netServiceDidPublish`) → `.authorized`.
+/// - Browsing enters its `.waiting` state (or fails) when the system has
+///   **denied** access → `.denied`.
+///
+/// Starting the probe also triggers the system permission prompt the first time
+/// it runs. A short timeout backstops the rare case where neither signal
+/// arrives; it resolves `.denied` so the caller surfaces a recoverable,
+/// retryable error instead of hanging on "Discovering".
+///
+/// > Caveat: on the very first run, while the system prompt is still on screen,
+/// > neither signal has fired yet. If the user takes longer than `timeout` to
+/// > respond, the probe reports `.denied`; the caller's Retry re-runs it and
+/// > then observes the real decision. The common real-world case this fixes —
+/// > access previously denied / toggled off — resolves in well under a second.
+enum LocalNetworkAuthorization {
+    enum Status: Equatable {
+        case authorized
+        case denied
+    }
+
+    /// Runs the probe once. Safe to call repeatedly (e.g. from a Retry button).
+    /// - Parameter timeout: how long to wait before treating an inconclusive
+    ///   probe as `.denied` (kept short so the UX never stalls).
+    static func status(timeout: TimeInterval = 3) async -> Status {
+        await Prober().status(timeout: timeout)
+    }
+}
+
+/// Coordinates the advertiser + browser + timeout, funnelling the first decisive
+/// signal into a single-shot continuation. All state is confined to the main run
+/// loop: `NetService` publishing is run-loop driven and its delegate callbacks
+/// need a live run loop, and the browser/timeout are scheduled there too so no
+/// locking is required.
+private final class Prober: NSObject, NetServiceDelegate, @unchecked Sendable {
+    private let logger = Logger(subsystem: "com.vultisig.app", category: "local-network-authorization")
+    private let serviceType = "_vultisig-lnp._tcp"
+
+    private var browser: NWBrowser?
+    private var service: NetService?
+    private var continuation: CheckedContinuation<LocalNetworkAuthorization.Status, Never>?
+    private var didFinish = false
+
+    func status(timeout: TimeInterval) async -> LocalNetworkAuthorization.Status {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { [self] in
+                self.continuation = continuation
+                start(timeout: timeout)
+            }
+        }
+    }
+
+    private func start(timeout: TimeInterval) {
+        let parameters = NWParameters()
+        parameters.includePeerToPeer = true
+
+        let browser = NWBrowser(for: .bonjour(type: serviceType, domain: nil), using: parameters)
+        browser.stateUpdateHandler = { [weak self] state in
+            self?.handleBrowser(state)
+        }
+        self.browser = browser
+        browser.start(queue: .main)
+
+        let service = NetService(domain: "local.", type: serviceType, name: "VultisigLocalNetwork", port: 1100)
+        service.delegate = self
+        self.service = service
+        service.publish()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) { [weak self] in
+            guard let self, !self.didFinish else { return }
+            self.logger.info("Local Network probe timed out; treating as denied")
+            self.finish(.denied)
+        }
+    }
+
+    private func handleBrowser(_ state: NWBrowser.State) {
+        switch state {
+        case let .waiting(error):
+            logger.error("Local Network denied (browser waiting): \(String(describing: error))")
+            finish(.denied)
+        case let .failed(error):
+            logger.error("Local Network browser failed: \(String(describing: error))")
+            finish(.denied)
+        default:
+            break
+        }
+    }
+
+    // MARK: - NetServiceDelegate
+
+    func netServiceDidPublish(_: NetService) {
+        logger.info("Local Network authorized (service published)")
+        finish(.authorized)
+    }
+
+    func netService(_: NetService, didNotPublish errorDict: [String: NSNumber]) {
+        logger.error("Local Network service failed to publish: \(errorDict)")
+        finish(.denied)
+    }
+
+    private func finish(_ status: LocalNetworkAuthorization.Status) {
+        guard !didFinish else { return }
+        didFinish = true
+        browser?.cancel()
+        service?.stop()
+        browser = nil
+        service = nil
+        continuation?.resume(returning: status)
+        continuation = nil
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
@@ -19,6 +19,7 @@ enum JoinKeygenStatus {
     case KeygenStarted
     case FailToStart
     case NoCameraAccess
+    case NoLocalNetworkPermission
 }
 
 @MainActor
@@ -96,6 +97,24 @@ class JoinKeygenViewModel: ObservableObject {
 
     func setStatus(status: JoinKeygenStatus) {
         self.status = status
+    }
+
+    /// Entry point for local (LAN / Bonjour) discovery. On iOS it first probes
+    /// Local Network authorization: if the user has denied it, `NetService`
+    /// resolution silently never completes, so instead of hanging on
+    /// "Discovering" we transition to a recoverable error that points the user
+    /// at Settings. When authorized (or on macOS, which has no such permission)
+    /// it proceeds to resolve the mediator service as before.
+    func startLocalDiscovery() async {
+        #if os(iOS)
+        let authorization = await LocalNetworkAuthorization.status()
+        guard authorization == .authorized else {
+            logger.error("Local Network permission denied; cannot discover mediator service")
+            status = .NoLocalNetworkPermission
+            return
+        }
+        #endif
+        discoverService()
     }
 
     func discoverService() {

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
@@ -68,6 +68,8 @@ struct JoinKeygenView: View {
                 failToStartKeygen
             case .NoCameraAccess:
                 cameraErrorView
+            case .NoLocalNetworkPermission:
+                noLocalNetworkPermissionView
             }
         }
         .if(viewModel.status != .KeygenStarted) {
@@ -172,14 +174,20 @@ struct JoinKeygenView: View {
         .foregroundStyle(Theme.colors.textPrimary)
         .multilineTextAlignment(.center)
         .padding(.vertical, 30)
-        .onAppear {
+        .task {
             logger.info("Start to discover service")
-            viewModel.discoverService()
-
+            await viewModel.startLocalDiscovery()
+        }
+        .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
                 withAnimation {
                     showInformationNote = true
                 }
+            }
+        }
+        .onChange(of: serviceDelegate.didFailToResolve) { _, failed in
+            if failed {
+                viewModel.setStatus(status: .NoLocalNetworkPermission)
             }
         }
     }
@@ -264,6 +272,13 @@ struct JoinKeygenView: View {
         NoCameraPermissionView()
     }
 
+    var noLocalNetworkPermissionView: some View {
+        NoLocalNetworkPermissionView {
+            serviceDelegate.reset()
+            viewModel.setStatus(status: .DiscoverService)
+        }
+    }
+
     var informationNote: some View {
         InformationNote()
             .padding(.bottom, 50)
@@ -345,12 +360,28 @@ extension JoinKeygenView {
         }
         .navigationTitle(NSLocalizedString("joinKeygen", comment: "Join keygen/reshare"))
         .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(hideBackButton)
+        // iPhone relies on the system back button; on iPad the system control can
+        // be absent on this pushed screen, which trapped users on "Discovering".
+        // Render an explicit back button there (and hide the system one so there
+        // is never a duplicate) whenever a back affordance is expected.
+        .navigationBarBackButtonHidden(hideBackButton || showsIPadBackButton)
         .toolbar {
+            if showsIPadBackButton {
+                ToolbarItem(placement: Placement.topBarLeading.getPlacement()) {
+                    NavigationBackButton()
+                }
+            }
             ToolbarItem(placement: Placement.topBarTrailing.getPlacement()) {
                 NavigationHelpButton()
             }
         }
+    }
+
+    /// Show an explicit back button on iPad while a back affordance is expected —
+    /// i.e. everywhere except the terminal keygen run, and only when the flow
+    /// itself hasn't asked for the back button to be hidden.
+    private var showsIPadBackButton: Bool {
+        isIPadOS && !hideBackButton && viewModel.status != .KeygenStarted
     }
 
     var main: some View {


### PR DESCRIPTION
## Problem

Joining a **Local-mode** (Bonjour/LAN) keygen on **iPad** hangs forever on "Discovering" — Mac+iPhone works, Mac+iPad doesn't (`#4712`). The iPad sits on the spinner with no error and no way out.

The proximate cause is that `NetService.resolve` silently never completes and `ServiceDelegate.netService(_:didNotResolve:)` **only logged** — nothing was observable (only success was, via `serverURL`). So the `.DiscoverService` state spun indefinitely. This PR makes that failure visible and self-serviceable, and adds an iPad-specific escape hatch.

## Root cause of the false permission denial (found via on-device logs)

The first cut of the Local Network detector advertised/browsed a **throwaway Bonjour type that was not declared in `NSBonjourServices`** (`_vultisig-lnp._tcp`). On-device logs from a permission-**granted** iPad that *still* hit the error view showed:

- `NetService publish failed: NSNetServicesErrorCode -72008` = `NSNetServicesMissingRequiredConfigurationError` — the advertised type isn't in `NSBonjourServices`.
- `DNSServiceBrowse failed: NoAuth (-65555)` — browsing that undeclared type is refused too.

iOS refuses to publish **or** browse an undeclared Bonjour type **even when Local Network access is granted**. So the probe's publish + browse were both blocked regardless of the real permission state, the probe timed out, and it resolved to a **false `.denied`** — surfacing the error view on devices where Local Network was actually authorized.

**Fix (one line + comment, no Info.plist change):** advertise/browse `_lnp._tcp`, which is **already declared** in `NSBonjourServices` (as `_lnp._tcp.`) and is otherwise unused in the codebase — a dedicated, authorized throwaway probe type that doesn't collide with the app's real `_http._tcp.` discovery. Per Apple/CodeRabbit convention the two APIs take different forms: `NWBrowser` uses the bare `_lnp._tcp`, `NetService` uses the trailing-dot `_lnp._tcp.` (matching the plist entry).

## Fix — make the failure visible and self-serviceable

- **Local Network authorization detector** (`Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift`, `#if os(iOS)`): iOS has no API to read Local Network status, so it uses the established Apple-DTS ("Quinn") probe — advertise a throwaway Bonjour service (`_lnp._tcp`, declared in `NSBonjourServices`) via `NetService.publish()` **and** browse for it with `NWBrowser` (peer-to-peer). **Publish success (`netServiceDidPublish`) = authorized; browser `.waiting`/`.failed` = denied**; a short (~3s) timeout backstops to `.denied`. Callbacks are the primary signals (fast + accurate for the real "previously denied" case), timeout is only a safety net. Single-shot continuation, cancels advertiser+browser on first result (no leak). Also triggers the system prompt on first use.
- **Wired into the join flow**: `JoinKeygenViewModel.startLocalDiscovery()` awaits the probe; denied → `.NoLocalNetworkPermission` instead of hanging; else → `discoverService()` as before. Independently, `ServiceDelegate` now publishes `didFailToResolve` (+ `reset()`), so a **resolve timeout/failure even when permission is granted** (e.g. a Wi-Fi / cross-SSID / AP client-isolation issue) also routes to the same recoverable error. Relay/internet-mode path unchanged.
- **Error view** (`Components/NoLocalNetworkPermissionView.swift`) mirroring `NoCameraPermissionView` on the shared `ErrorView`: **"Open Settings"** deep link (`UIApplication.openSettingsURLString` → the app's Settings page where the Local Network toggle lives) + **"Try Again"** retry. New copy localized in all 8 `Localizable.strings`.
- **iPad back button**: `JoinKeygenView` relied on the **system** nav-bar back button (fine on iPhone) — on iPad that control could be absent on this pushed screen, trapping the user. Render an explicit `.topBarLeading` `NavigationBackButton` on iPad (hiding the system one to avoid a duplicate) while a back affordance is expected (`isIPadOS && !hideBackButton && status != .KeygenStarted`). iPhone/macOS unchanged.

macOS keeps compiling via `#if os(iOS)` guards (no Local Network permission concept there; it takes the pre-existing path).

## Honest framing of the two distinct failures

There are two separate things this PR now handles correctly:

1. **The detector's own false denial** (above) — a bug in the first cut of this PR: an undeclared probe type made the detector report `.denied` on *authorized* devices. Fixed by reusing the declared `_lnp._tcp`.
2. **The original #4712 hang on a permission-granted device** — that is a real **discovery/network failure** of the app's actual `_http._tcp.` resolution (Wi-Fi, cross-SSID, or AP client-isolation), **not** a permission problem. It is now surfaced by `ServiceDelegate.didFailToResolve` as a recoverable error + Retry instead of an infinite silent spinner. This change does **not** make discovery succeed where the network can't — it converts the hang into a clear, retryable error that also points the user at Settings, plus guarantees an iPad escape hatch.

There is a documented first-run edge: if the user is slower than the timeout to answer the very first system prompt, the probe reports denied; Retry then observes the real decision.

## Verification

- **iOS build (generic iOS Simulator): `** BUILD SUCCEEDED **`.**
- **macOS build (`#if os(iOS)` guards): `** BUILD SUCCEEDED **`.**
- **SwiftLint: clean** on all changed files.
- Earlier full iOS test run: 2439 passed, 1 pre-existing locale-artifact failure (`StakingValidatorProjectionTests` `"12,3%"`, untouched file).

**Runtime-verified vs code/preview-only (honest):** the build/compile on iOS **and** macOS ran green, and the root-cause `_lnp._tcp` fix was confirmed against real on-device `-72008`/`NoAuth` logs. The permission **deny → error view → Settings** flow and the **iPad back button** are **code-/preview-audited**; `NoLocalNetworkPermissionView` reuses the already-shipping `ErrorView` and has a `#Preview`; the Settings URL is the standard `UIApplication.openSettingsURLString`.

Closes #4712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a recovery screen for local network permission/discovery failures, including a retry action and a shortcut to system settings.
  * Updated the device-discovery flow to check local network authorization before proceeding.
* **Bug Fixes**
  * Prevented discovery from getting stuck when local network resolution fails; users are now shown a recoverable state.
  * Improved iPad back-button handling for more consistent navigation.
* **Localization**
  * Added localized strings for the “no local network permission / no nearby devices found” messaging in multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
