### PR TITLE
chore(deps): pin WalletCore to exactVersion 4.7.1 (real 4.7.0; v4.7.0 tag mis-cut to 4.6.13)

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -112,8 +112,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/walletcore-spm",
       "state" : {
-        "revision" : "6fe770f97ebce59b7c30db5e2fac9dffb2352c2c",
-        "version" : "4.7.0"
+        "revision" : "628900b25de367bdd48427040977f68b6882d8a0",
+        "version" : "4.7.1"
       }
     },
     {

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -66,7 +66,10 @@ packages:
     revision: 86400c61e39790887ca03b98d82746ee4dc312f4
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
-    exactVersion: 4.7.0
+    # v4.7.1 is the correctly-cut walletcore-spm tag for wallet-core 4.7.0.
+    # The v4.7.0 tag is mis-cut — it points at the old 4.6.13 commit
+    # (6fe770f97…), so `exactVersion: 4.7.0` silently resolved to 4.6.13.
+    exactVersion: 4.7.1
   ZIPFoundation:
     url: https://github.com/weichsel/ZIPFoundation
     from: 0.9.0


### PR DESCRIPTION
## What & why

`main` pinned `WalletCore: exactVersion: 4.7.0` (#4721), but the `v4.7.0` tag in `vultisig/walletcore-spm` is **mis-cut** — it points at the OLD **4.6.13** commit `6fe770f97…`. So `exactVersion: 4.7.0` silently resolved to **wallet-core 4.6.13**: `main` was labeled "4.7.0" while actually running 4.6.13.

The correctly-cut tag is **`v4.7.1` → `628900b25de367bdd48427040977f68b6882d8a0`** (the real wallet-core 4.7.0 = walletcore-spm `main` HEAD, which adds `CardanoSigningInput.auxiliaryData`). This PR moves `main` onto the real 4.7.0.

## Changes (2 files)

1. **`VultisigApp/project.yml`** — `WalletCore` dep `exactVersion: 4.7.0` → **`exactVersion: 4.7.1`**, with a comment documenting the mis-cut tag.
2. **`Package.resolved`** — regenerated via a fresh, cache-cleared resolve (deleted the walletcore-spm SPM repo cache so SPM re-fetched). The walletcore-spm entry now shows `"version": "4.7.1"` and `"revision": "628900b25de367bdd48427040977f68b6882d8a0"` — **not** `6fe770f97…`.

No source-code changes.

## This is a genuine 4.6.13 → 4.7.0 bump

Because `main` was actually on 4.6.13, this swaps in the real 4.7.0 binaries, which affects **all** signing/chains, not just Cardano. Verified against the full suite:

- Resolved WalletCore confirmed at `628900b25d` / `4.7.1`; app compiles against it.
- **Full gate:** `xcodebuild test` (iPhone 17 Pro Max, worktree-local DerivedData) — **`** TEST FAILED **` only due to the known env flake:** `2195 tests executed, 1 failure (0 unexpected)`. The sole failure is the pre-existing `"12,3%"` decimal-comma locale flake (`StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress`, an APY display-formatting assertion — unrelated to WalletCore) that also fails on the CI-green base tip.
- **All signing/keysign/byte-parity suites PASSED**, including `SwapKitCardanoSignerTests` (real 4.7.0 Cardano path), `SuiSignSuiTests`, `SolanaDelegateByteParityTests` / `SolanaDeactivateWithdrawByteParityTests`, `QBTCVoteWeightedByteEqualityTests`, `QBTCStakingSignDataResolverTests`, `CosmosStakingSignDataResolverTests`, `CustomMessageSignatureTests`, and the `Keysign*` suites. No signing regression under 4.7.0.

## Follow-on

This also lets #4709 (Cardano) and other WalletCore consumers rely on a correct `exactVersion` pin instead of the mislabeled one.

## CI note

The CI DerivedData cache was cleared earlier, so CI should resolve/build fresh against `628900b25d`. If CI instead shows a stale `auxiliaryData` / 4.6.13 error, the poisoned SPM cache has resurfaced and needs clearing again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s Swift package dependency to a newer wallet core release.
  * Aligned dependency configuration to use the corrected `4.7.1` version.
  * Refreshed the resolved package lock so builds use the latest pinned dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->