### PR TITLE
fix(zcash): re-plan memo txs to the ZIP-317 conventional fee

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapHaltGate.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapHaltGate.swift
@@ -20,6 +20,6 @@ enum SwapHaltGate {
         guard let entry = inbound.first(where: { $0.chain.caseInsensitiveCompare(chainName) == .orderedSame }) else {
             return false
         }
-        return entry.halted || entry.global_trading_paused || entry.chain_trading_paused
+        return entry.halted || (entry.global_trading_paused ?? false) || (entry.chain_trading_paused ?? false)
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/InboundAddress.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/InboundAddress.swift
@@ -28,9 +28,9 @@ struct InboundAddress: Codable {
     let address: String
     let router: String? // Router address for ERC20 tokens
     let halted: Bool
-    let global_trading_paused: Bool
-    let chain_trading_paused: Bool
-    let chain_lp_actions_paused: Bool
+    let global_trading_paused: Bool?
+    let chain_trading_paused: Bool?
+    let chain_lp_actions_paused: Bool?
     let gas_rate: String
     let gas_rate_units: String
     let dust_threshold: String? // Dust threshold for the chain

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
@@ -47,6 +47,77 @@ class UTXOChainsHelper {
         plan.branchID = try zcashBranchID(keysignPayload: keysignPayload)
     }
 
+    /// Max non-ZIP-317 re-plans before giving up raising the Zcash fee.
+    /// Matches the SDK's cap so every co-signing device fails identically
+    /// instead of diverging on the plan.
+    private static let maxZcashFeeBumps = 5
+
+    /// Plan the transaction, guarding Zcash plans against WalletCore's
+    /// underpaying ZIP-317 mode. Every other coin plans directly.
+    private func planTransaction(_ input: inout BitcoinSigningInput) throws -> BitcoinTransactionPlan {
+        guard coin == .zcash else {
+            return AnySigner.plan(input: input, coin: coin)
+        }
+        return try planZcashConventionalFee(&input)
+    }
+
+    /// Produce a Zcash plan whose fee meets the ZIP-317 conventional fee.
+    ///
+    /// WalletCore's `zip0317` planner sizes an OP_RETURN output as a flat ~34
+    /// bytes and ignores `byteFee`, so memo transactions (MayaChain-routed
+    /// swaps carry the swap instruction in an OP_RETURN; sends with memo too)
+    /// plan one logical action short — e.g. 15,000 zats where the network
+    /// requires 20,000 — with no way to raise the fee in that mode. When the
+    /// `zip0317` plan underpays the byte-accurate conventional fee, re-plan
+    /// with `zip0317` off — where WalletCore honours `byteFee` — and bump
+    /// `byteFee` until the fee clears. Plain (no-memo) sends already meet the
+    /// fee and keep the `zip0317` plan.
+    ///
+    /// An empty plan (no selected UTXOs) is returned untouched: coin selection
+    /// produced nothing (insufficient funds), and that flow owns the outcome.
+    ///
+    /// Byte-parity port of the SDK's `planZcashConventionalFee` — every
+    /// co-signing device must derive the same plan or the MPC preimage
+    /// digests diverge and keysign fails. Keep in lockstep with the SDK.
+    private func planZcashConventionalFee(_ input: inout BitcoinSigningInput) throws -> BitcoinTransactionPlan {
+        let memoSize = input.outputOpReturn.count
+
+        func conventionalFee(for plan: BitcoinTransactionPlan) -> Int64 {
+            ZcashConventionalFee.conventionalFee(
+                inputCount: plan.utxos.count,
+                outputSizes: ZcashConventionalFee.transparentOutputSizes(change: plan.change, memoSize: memoSize)
+            )
+        }
+
+        // An empty plan has no shape to charge for; leave the fee flow to the caller.
+        func meetsConventionalFee(_ plan: BitcoinTransactionPlan) -> Bool {
+            plan.utxos.isEmpty || plan.fee >= conventionalFee(for: plan)
+        }
+
+        let zipPlan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
+        if meetsConventionalFee(zipPlan) {
+            return zipPlan
+        }
+
+        input.zip0317 = false
+        var byteFee: Int64 = 1
+        var plan = zipPlan
+        for _ in 0..<Self.maxZcashFeeBumps {
+            input.byteFee = byteFee
+            plan = AnySigner.plan(input: input, coin: coin)
+            if meetsConventionalFee(plan) {
+                return plan
+            }
+
+            // byteFee mode scales fee linearly with vsize; derive the byteFee that
+            // clears the conventional fee for this plan's (byteFee-independent) vsize.
+            let plannerVsize = plan.fee > 0 ? plan.fee / byteFee : 1
+            byteFee = max(ZcashConventionalFee.ceilDiv(conventionalFee(for: plan), plannerVsize), byteFee + 1)
+        }
+
+        throw HelperError.runtimeError("Failed to meet the Zcash minimum network fee (ZIP-317): planned \(plan.fee) zats, required \(conventionalFee(for: plan))")
+    }
+
     static func getHelper(coin: Coin) -> UTXOChainsHelper? {
         switch coin.chainType {
         case .UTXO:
@@ -121,8 +192,8 @@ class UTXOChainsHelper {
         input.hashType = BitcoinScript.hashTypeForCoin(coinType: coin)
         input.useMaxAmount = sendMaxAmount
         // Zcash enforces ZIP-317: the fee must cover the tx's logical actions,
-        // not just its byte size. Enable it so the planner below computes a
-        // conforming fee and the node doesn't reject the swap broadcast.
+        // not just its byte size. `planTransaction` starts from this mode and
+        // re-plans when WalletCore's ZIP-317 fee underpays for memo txs.
         input.zip0317 = coin == .zcash
         for inputUtxo in keysignPayload.utxos {
             let lockScript = BitcoinScript.lockScriptForAddress(address: keysignPayload.coin.address, coin: coin)
@@ -159,7 +230,7 @@ class UTXOChainsHelper {
             input.utxo.append(utxo)
         }
 
-        var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
+        var plan = try planTransaction(&input)
         try applyZcashBranchID(to: &plan, keysignPayload: keysignPayload)
 
         input.plan = plan
@@ -179,9 +250,9 @@ class UTXOChainsHelper {
             $0.changeAddress = keysignPayload.coin.address
             $0.byteFee = Int64(byteFee)
             // Zcash enforces ZIP-317 fees: the fee must cover the tx's logical
-            // actions, not just its byte size. Enabling this lets WalletCore's
-            // planner compute a conforming fee and avoids node rejection
-            // ("tx unpaid action limit exceeds limit of 0").
+            // actions, not just its byte size. `planTransaction` starts from
+            // this mode and re-plans when WalletCore's ZIP-317 fee underpays
+            // for memo txs ("tx unpaid action limit exceeds limit of 0").
             $0.zip0317 = coin == .zcash
             $0.coinType = coin.rawValue
             if let memoData = keysignPayload.memo?.data(using: .utf8) {
@@ -229,7 +300,7 @@ class UTXOChainsHelper {
 
     func getBitcoinPreSigningInputData(keysignPayload: KeysignPayload) throws -> Data {
         var input = try getBitcoinSigningInput(keysignPayload: keysignPayload)
-        var plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
+        var plan = try planTransaction(&input)
 
         // Check for transaction plan errors
         if plan.error != .ok {
@@ -243,13 +314,12 @@ class UTXOChainsHelper {
     }
 
     func getBitcoinTransactionPlan(keysignPayload: KeysignPayload) throws -> BitcoinTransactionPlan {
-        let input = try getBitcoinSigningInput(keysignPayload: keysignPayload)
+        var input = try getBitcoinSigningInput(keysignPayload: keysignPayload)
         // The branch id only affects the ZIP-243 sighash digest, not the
         // planned amount/fee/change this method exposes for fee display, so it
         // is deliberately not set here (avoids forcing an RPC resolve on the
         // fee-preview path).
-        let plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
-        return plan
+        return try planTransaction(&input)
     }
 
     func getSignedTransaction(keysignPayload: KeysignPayload, signatures: [String: TssKeysignResponse]) throws -> SignedTransactionResult {
@@ -298,10 +368,10 @@ class UTXOChainsHelper {
         }
     }
     func getUnsignedTransactionHex(keysignPayload: KeysignPayload) throws -> String {
-        let input = try getBitcoinSigningInput(keysignPayload: keysignPayload)
+        var input = try getBitcoinSigningInput(keysignPayload: keysignPayload)
         // Placeholder tx for Blockaid analysis: only plan amount/change are read
         // below, so the ZIP-243 branch id (sighash-only) is irrelevant here.
-        let plan: BitcoinTransactionPlan = AnySigner.plan(input: input, coin: coin)
+        let plan = try planTransaction(&input)
 
         // Build raw transaction manually using plan data
         var rawTx = Data()

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/ZcashConventionalFee.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/ZcashConventionalFee.swift
@@ -1,0 +1,89 @@
+//
+//  ZcashConventionalFee.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// ZIP-317 conventional fee for a transparent-only Zcash transaction.
+/// Nodes relay zero "unpaid actions" by default, so any tx paying less is
+/// rejected at broadcast with "tx unpaid action limit exceeded".
+///
+/// Byte-parity port of the SDK's canonical implementation
+/// (`packages/core/chain/chains/utxo/fee/zip317.ts`): every co-signing
+/// device must derive the same fee from the same transaction shape, or the
+/// MPC preimage digests diverge and keysign fails. Keep the math in lockstep
+/// with the SDK when touching this file.
+/// https://zips.z.cash/zip-0317
+enum ZcashConventionalFee {
+    static let marginalFee: Int64 = 5_000
+    static let graceActions: Int64 = 2
+    /// Serialized size of a signed transparent P2PKH input (ZIP-317 section 3.1).
+    private static let p2pkhInputSize: Int64 = 148
+    private static let inputActionSize: Int64 = 150
+    private static let outputActionSize: Int64 = 34
+    /// Serialized tx_out size of a P2PKH output: 8 value + 1 scriptLen + 25 script.
+    private static let p2pkhOutputSize: Int64 = 34
+
+    /// Ceiling division: smallest n such that n * divisor >= value.
+    static func ceilDiv(_ value: Int64, _ divisor: Int64) -> Int64 {
+        (value + divisor - 1) / divisor
+    }
+
+    /// Minimum fee the Zcash network relays for a transparent tx of the given
+    /// shape: 5,000 zats per logical action with a two-action grace window,
+    /// where logical actions = max(ceil(tx_in bytes / 150), ceil(tx_out bytes / 34)).
+    static func conventionalFee(inputCount: Int, outputSizes: [Int64]) -> Int64 {
+        let inputActions = ceilDiv(Int64(inputCount) * p2pkhInputSize, inputActionSize)
+        let outputActions = ceilDiv(outputSizes.reduce(0, +), outputActionSize)
+        let logicalActions = max(inputActions, outputActions)
+        return marginalFee * max(graceActions, logicalActions)
+    }
+
+    /// Serialized tx_out size of an OP_RETURN output carrying `memoSize` bytes:
+    /// 8 value + scriptLen CompactSize + script (OP_RETURN + push opcode(s) + data).
+    /// WalletCore's planner sizes this output as a flat ~34 bytes regardless of
+    /// memo length, so longer memos make its plan undercount ZIP-317 actions.
+    /// Models the push opcode (direct / PUSHDATA1 / PUSHDATA2 / PUSHDATA4) and
+    /// the script-length CompactSize so long memos are not undercharged.
+    static func opReturnOutputSize(memoSize: Int) -> Int64 {
+        let dataSize = Int64(memoSize)
+
+        // OP_RETURN (1 byte) + push opcode bytes for `dataSize`.
+        let pushOverhead: Int64
+        switch dataSize {
+        case ...75: pushOverhead = 2
+        case ...0xff: pushOverhead = 3
+        case ...0xffff: pushOverhead = 4
+        default: pushOverhead = 6
+        }
+        let scriptSize = pushOverhead + dataSize
+
+        // CompactSize encoding of the script length prefix.
+        let scriptLengthSize: Int64
+        switch scriptSize {
+        case ..<0xfd: scriptLengthSize = 1
+        case ...0xffff: scriptLengthSize = 3
+        case ...0xffff_ffff: scriptLengthSize = 5
+        default: scriptLengthSize = 9
+        }
+
+        return 8 + scriptLengthSize + scriptSize
+    }
+
+    /// Serialized tx_out sizes for a transparent Zcash send: recipient P2PKH,
+    /// optional change P2PKH (only when change is positive), and an optional
+    /// OP_RETURN memo (only when `memoSize` is positive). Feed into
+    /// `conventionalFee(inputCount:outputSizes:)` to size the conventional
+    /// fee by real bytes.
+    static func transparentOutputSizes(change: Int64, memoSize: Int) -> [Int64] {
+        var sizes = [p2pkhOutputSize]
+        if change > 0 {
+            sizes.append(p2pkhOutputSize)
+        }
+        if memoSize > 0 {
+            sizes.append(opReturnOutputSize(memoSize: memoSize))
+        }
+        return sizes
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -141,7 +141,7 @@ final class FunctionCallAddThorLP {
         // `toAddress` empty so `isTheFormValid` blocks submission — otherwise
         // signing proceeds with an empty destination and wallet-core rejects
         // it with the raw `Error_invalid_address` enum.
-        if inbound.halted || inbound.global_trading_paused || inbound.chain_trading_paused || inbound.chain_lp_actions_paused {
+        if inbound.halted || inbound.global_trading_paused ?? false || inbound.chain_trading_paused ?? false || inbound.chain_lp_actions_paused ?? false {
             customErrorMessage = String(format: "inboundPaused".localized, inbound.chain)
             return
         }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosSwitch.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosSwitch.swift
@@ -62,8 +62,8 @@ final class FunctionCallCosmosSwitch {
         let addresses = await ThorchainService.shared.fetchThorchainInboundAddress()
         if let match = addresses.first(where: { $0.chain.uppercased() == "GAIA" }) {
             let halted = match.halted
-            let globalPaused = match.global_trading_paused
-            let chainPaused = match.chain_trading_paused
+            let globalPaused = match.global_trading_paused ?? false
+            let chainPaused = match.chain_trading_paused ?? false
 
             if halted || globalPaused || chainPaused {
                 logger.warning("Chain is halted or paused. Cannot proceed with switch.")

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
@@ -97,7 +97,7 @@ final class FunctionCallSecuredAsset {
         // A halted/paused source chain has no usable inbound vault; leave
         // `toAddress` empty so the form blocks submission instead of signing
         // with an empty destination (raw `Error_invalid_address` at sign time).
-        if inbound.halted || inbound.global_trading_paused || inbound.chain_trading_paused || inbound.chain_lp_actions_paused {
+        if inbound.halted || inbound.global_trading_paused ?? false || inbound.chain_trading_paused ?? false || inbound.chain_lp_actions_paused ?? false {
             inboundStateError = String(format: "inboundPaused".localized, inbound.chain)
             updateErrorMessage()
             return

--- a/VultisigApp/VultisigAppTests/Chains/ZcashConventionalFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ZcashConventionalFeeTests.swift
@@ -1,0 +1,92 @@
+//
+//  ZcashConventionalFeeTests.swift
+//  VultisigAppTests
+//
+//  Golden vectors mirrored from the SDK's zip317.test.ts
+//  (packages/core/chain/chains/utxo/fee/zip317.test.ts) — the two
+//  implementations must stay byte-identical for MPC co-signing.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class ZcashConventionalFeeTests: XCTestCase {
+    private let p2pkhOutput: Int64 = 34
+
+    // MARK: - conventionalFee
+
+    func testReturnsTheTenThousandZatFloorForASimpleOneInTwoOutSend() {
+        XCTAssertEqual(
+            ZcashConventionalFee.conventionalFee(inputCount: 1, outputSizes: [p2pkhOutput, p2pkhOutput]),
+            10_000
+        )
+    }
+
+    func testScalesWithInputCountBeyondTheGraceWindow() {
+        XCTAssertEqual(
+            ZcashConventionalFee.conventionalFee(inputCount: 4, outputSizes: [p2pkhOutput, p2pkhOutput]),
+            20_000
+        )
+    }
+
+    func testChargesInputActionsFromSerializedBytesNotRawCount() {
+        // 75 P2PKH inputs: ceil(75 * 148 / 150) = 74 actions, not 75.
+        XCTAssertEqual(
+            ZcashConventionalFee.conventionalFee(inputCount: 75, outputSizes: [p2pkhOutput, p2pkhOutput]),
+            370_000
+        )
+    }
+
+    func testCountsLargeOpReturnOutputsAsMultipleActions() {
+        // 80-byte memo output: 92 bytes serialized -> with two p2pkh outputs,
+        // ceil(160 / 34) = 5 actions -> 25,000 zats.
+        XCTAssertEqual(
+            ZcashConventionalFee.conventionalFee(inputCount: 1, outputSizes: [p2pkhOutput, p2pkhOutput, 92]),
+            25_000
+        )
+    }
+
+    // MARK: - opReturnOutputSize
+
+    func testSizesAShortMemoWithASingleBytePush() {
+        // 9 fixed bytes + 2 push overhead + data length.
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 40), 51)
+    }
+
+    func testAddsAByteOfPushOverheadOnceTheMemoExceeds75Bytes() {
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 75), 86)
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 76), 88)
+    }
+
+    func testHandlesCompactSizeAndPushdataBoundariesForLongMemos() {
+        // 250-byte memo: script length 253 crosses the CompactSize 1->3 byte threshold.
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 249), 261)
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 250), 264)
+        // 256-byte memo: push opcode crosses PUSHDATA1 -> PUSHDATA2.
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 255), 269)
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 256), 271)
+    }
+
+    // MARK: - transparentOutputSizes
+
+    func testReturnsRecipientOnlyWhenThereIsNoChangeAndNoMemo() {
+        XCTAssertEqual(ZcashConventionalFee.transparentOutputSizes(change: 0, memoSize: 0), [34])
+    }
+
+    func testAddsAChangeOutputOnlyWhenChangeIsPositive() {
+        XCTAssertEqual(ZcashConventionalFee.transparentOutputSizes(change: 1, memoSize: 0), [34, 34])
+    }
+
+    func testAppendsTheOpReturnSizeForAMemoSend() {
+        XCTAssertEqual(ZcashConventionalFee.transparentOutputSizes(change: 1, memoSize: 40), [34, 34, 51])
+    }
+
+    // MARK: - ceilDiv
+
+    func testCeilDivRoundsUpToTheSmallestClearingMultiple() {
+        XCTAssertEqual(ZcashConventionalFee.ceilDiv(0, 34), 0)
+        XCTAssertEqual(ZcashConventionalFee.ceilDiv(34, 34), 1)
+        XCTAssertEqual(ZcashConventionalFee.ceilDiv(35, 34), 2)
+        XCTAssertEqual(ZcashConventionalFee.ceilDiv(20_000, 260), 77)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Chains/ZcashConventionalFeeTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ZcashConventionalFeeTests.swift
@@ -67,6 +67,19 @@ final class ZcashConventionalFeeTests: XCTestCase {
         XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 256), 271)
     }
 
+    func testHandlesUpperCompactSizeAndPushdataBoundaries() {
+        // Beyond the SDK's vectors: pin the upper thresholds so the Swift
+        // switch statements provably match the TS ternary chain.
+        // Script length 65535 -> 65536 crosses the CompactSize 3 -> 5 byte
+        // threshold (memo 65531 -> script 65535; memo 65532 -> script 65536).
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 65_531), 65_546)
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 65_532), 65_549)
+        // Memo 65535 -> 65536 crosses the PUSHDATA2 -> PUSHDATA4 threshold
+        // (push overhead 4 -> 6 bytes).
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 65_535), 65_552)
+        XCTAssertEqual(ZcashConventionalFee.opReturnOutputSize(memoSize: 65_536), 65_555)
+    }
+
     // MARK: - transparentOutputSizes
 
     func testReturnsRecipientOnlyWhenThereIsNoChangeAndNoMemo() {

--- a/VultisigApp/VultisigAppTests/Chains/ZcashZip317PlanTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ZcashZip317PlanTests.swift
@@ -1,0 +1,208 @@
+//
+//  ZcashZip317PlanTests.swift
+//  VultisigAppTests
+//
+//  Real-WalletCore regression for the Zcash ZIP-317 conventional-fee guard in
+//  UTXOChainsHelper. WalletCore's zip0317 planner flat-sizes OP_RETURN and
+//  ignores byteFee, so memo txs plan one logical action short; the helper
+//  re-plans with zip0317 off until the fee clears the conventional fee.
+//
+//  Golden vectors were extracted from a live run of the SDK resolver
+//  (getUtxoSigningInputs + planZcashConventionalFee in
+//  packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts, real
+//  wallet-core WASM 4.7.0 — the same version walletcore-spm pins). The
+//  planned fee/change must be byte-identical across platforms or MPC
+//  co-signing devices derive different preimage digests and keysign fails.
+//
+
+import BigInt
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+final class ZcashZip317PlanTests: XCTestCase {
+    private let zcashAddress = "t1PoLLLwEcVhqMBhk53tANtSepnPXAQJkPM"
+    private let branchIdHex = "30f33754"
+
+    // MARK: - Send path (getBitcoinPreSigningInputData / getBitcoinTransactionPlan)
+
+    func testPlainSendKeepsTheZip0317PlanAtTheFloor() throws {
+        let input = try presignInput(amount: 5_000_000, balance: 8_300_000, memo: nil)
+
+        XCTAssertEqual(input.plan.fee, 10_000)
+        XCTAssertEqual(input.plan.amount, 5_000_000)
+        XCTAssertEqual(input.plan.change, 3_290_000)
+        XCTAssertTrue(input.zip0317)
+        XCTAssertEqual(input.byteFee, 100)
+    }
+
+    func testMemoSendReplansToMeetTheConventionalFee() throws {
+        // SDK golden: reported live failure shape — zip0317 plans 15,000 where
+        // ZIP-317 requires 20,000; the guard re-plans to 20,020 at byteFee 77.
+        let input = try presignInput(amount: 5_000_000, balance: 8_300_000, memo: String(repeating: "m", count: 40))
+
+        XCTAssertEqual(input.plan.fee, 20_020)
+        XCTAssertEqual(input.plan.amount, 5_000_000)
+        XCTAssertEqual(input.plan.change, 3_279_980)
+        XCTAssertFalse(input.zip0317)
+        XCTAssertEqual(input.byteFee, 77)
+        XCTAssertEqual(input.plan.branchID.hexString, branchIdHex)
+    }
+
+    func testSendMaxMemoSendReplansToMeetTheConventionalFee() throws {
+        let input = try presignInput(
+            amount: 2_200_000,
+            balance: 2_200_000,
+            memo: String(repeating: "m", count: 40),
+            sendMax: true
+        )
+
+        XCTAssertEqual(input.plan.fee, 15_142)
+        XCTAssertEqual(input.plan.amount, 2_184_858)
+        XCTAssertEqual(input.plan.change, 0)
+        XCTAssertFalse(input.zip0317)
+        XCTAssertEqual(input.byteFee, 67)
+    }
+
+    func testLongMemoSpanningExtraActionsClearsTheConventionalFee() throws {
+        let input = try presignInput(amount: 5_000_000, balance: 8_300_000, memo: String(repeating: "m", count: 200))
+
+        XCTAssertEqual(input.plan.fee, 45_240)
+        XCTAssertEqual(input.plan.change, 3_254_760)
+        XCTAssertFalse(input.zip0317)
+        XCTAssertEqual(input.byteFee, 174)
+    }
+
+    func testMayaSwapShapedMemoReplansToMeetTheConventionalFee() throws {
+        // Maya-native ZEC swaps ride the plain send path with the swap
+        // instruction as the memo; this is the live shape the issue reports.
+        let memo = "=:ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48:0x92009f858E52D5C48CBaBFE0EE9AB05EF5eEC865:1494322902:vi:35"
+        let input = try presignInput(amount: 5_000_000, balance: 8_300_000, memo: memo)
+
+        XCTAssertEqual(input.plan.fee, 30_160)
+        XCTAssertEqual(input.plan.change, 3_269_840)
+        XCTAssertFalse(input.zip0317)
+        XCTAssertEqual(input.byteFee, 116)
+    }
+
+    func testInsufficientFundsPlanPassesThroughUntouched() throws {
+        // Balance can't cover amount + fee + dust, so WalletCore selects no
+        // UTXOs. The conventional-fee guard must not hijack this with a
+        // ZIP-317 error — the send flow owns the insufficient-funds outcome.
+        let helper = UTXOChainsHelper(coin: .zcash)
+        let plan = try helper.getBitcoinTransactionPlan(
+            keysignPayload: makePayload(amount: 90_000, balance: 100_000, memo: String(repeating: "m", count: 40))
+        )
+
+        XCTAssertTrue(plan.utxos.isEmpty)
+        XCTAssertEqual(plan.fee, 0)
+    }
+
+    func testFeePreviewPlanMatchesTheSignedFee() throws {
+        // KeysignPayloadFactory (UTXO selection), the send/swap fee displays,
+        // and the co-signer gas view all read getBitcoinTransactionPlan; it
+        // must agree with the plan that gets signed.
+        let memo = String(repeating: "m", count: 40)
+        let helper = UTXOChainsHelper(coin: .zcash)
+        let previewPlan = try helper.getBitcoinTransactionPlan(
+            keysignPayload: makePayload(amount: 5_000_000, balance: 8_300_000, memo: memo)
+        )
+        let signedInput = try presignInput(amount: 5_000_000, balance: 8_300_000, memo: memo)
+
+        XCTAssertEqual(previewPlan.fee, signedInput.plan.fee)
+        XCTAssertEqual(previewPlan.change, signedInput.plan.change)
+    }
+
+    // MARK: - Swap-input path (getSigningInputData)
+
+    func testSwapSigningInputDataReplansToMeetTheConventionalFee() throws {
+        let memo = String(repeating: "m", count: 40)
+        let payload = makePayload(
+            amount: 5_000_000,
+            balance: 8_300_000,
+            memo: memo,
+            swapPayload: .thorchain(makeSwapPayload(amount: 5_000_000))
+        )
+        let helper = UTXOChainsHelper(coin: .zcash)
+        let swapInput = try helper.getSwapPreSignedInputData(keysignPayload: payload)
+        let inputData = try helper.getSigningInputData(keysignPayload: payload, signingInput: swapInput)
+        let input = try BitcoinSigningInput(serializedBytes: inputData)
+
+        // Same tx shape as the send-path memo golden vector, so the same plan.
+        XCTAssertEqual(input.plan.fee, 20_020)
+        XCTAssertEqual(input.plan.change, 3_279_980)
+        XCTAssertFalse(input.zip0317)
+        XCTAssertEqual(input.plan.branchID.hexString, branchIdHex)
+    }
+
+    // MARK: - Helpers
+
+    private func presignInput(
+        amount: BigInt,
+        balance: Int64,
+        memo: String?,
+        sendMax: Bool = false
+    ) throws -> BitcoinSigningInput {
+        let helper = UTXOChainsHelper(coin: .zcash)
+        let inputData = try helper.getBitcoinPreSigningInputData(
+            keysignPayload: makePayload(amount: amount, balance: balance, memo: memo, sendMax: sendMax)
+        )
+        return try BitcoinSigningInput(serializedBytes: inputData)
+    }
+
+    private func makeZcashCoin() -> Coin {
+        let meta = CoinMeta.make(chain: .zcash, ticker: "ZEC", decimals: 8, isNativeToken: true)
+        return Coin(asset: meta, address: zcashAddress, hexPublicKey: "")
+    }
+
+    private func makeSwapPayload(amount: BigInt) -> THORChainSwapPayload {
+        THORChainSwapPayload(
+            fromAddress: zcashAddress,
+            fromCoin: makeZcashCoin(),
+            toCoin: makeZcashCoin(),
+            vaultAddress: zcashAddress,
+            routerAddress: nil,
+            fromAmount: amount,
+            toAmountDecimal: 0,
+            toAmountLimit: "0",
+            streamingInterval: "1",
+            streamingQuantity: "0",
+            expirationTime: 0,
+            isAffiliate: false
+        )
+    }
+
+    private func makePayload(
+        amount: BigInt,
+        balance: Int64,
+        memo: String?,
+        sendMax: Bool = false,
+        swapPayload: SwapPayload? = nil
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: makeZcashCoin(),
+            toAddress: zcashAddress,
+            toAmount: amount,
+            chainSpecific: BlockChainSpecific.UTXO(
+                byteFee: 100,
+                sendMaxAmount: sendMax,
+                zcashBranchId: branchIdHex
+            ),
+            utxos: [UtxoInfo(hash: String(repeating: "00", count: 32), amount: balance, index: 0)],
+            memo: memo,
+            swapPayload: swapPayload,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "ECDSAKey",
+            vaultLocalPartyID: "localPartyID",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Chains/ZcashZip317PlanTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ZcashZip317PlanTests.swift
@@ -85,6 +85,21 @@ final class ZcashZip317PlanTests: XCTestCase {
         XCTAssertEqual(input.byteFee, 116)
     }
 
+    func testNonAsciiMemoIsChargedByUtf8ByteLength() throws {
+        // SDK golden: TextEncoder().encode(memo) and Swift's UTF-8 encoding of
+        // outputOpReturn must agree on the byte length that sizes the
+        // OP_RETURN — this memo is 17 characters but 34 UTF-8 bytes.
+        let memo = "меморандум-🚀-мемо"
+        XCTAssertEqual(memo.utf8.count, 34)
+
+        let input = try presignInput(amount: 5_000_000, balance: 8_300_000, memo: memo)
+
+        XCTAssertEqual(input.plan.fee, 20_020)
+        XCTAssertEqual(input.plan.change, 3_279_980)
+        XCTAssertFalse(input.zip0317)
+        XCTAssertEqual(input.byteFee, 77)
+    }
+
     func testInsufficientFundsPlanPassesThroughUntouched() throws {
         // Balance can't cover amount + fee + dust, so WalletCore selects no
         // UTXOs. The conventional-fee guard must not hijack this with a

--- a/VultisigApp/VultisigAppTests/Swap/SwapHaltGateTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapHaltGateTests.swift
@@ -56,4 +56,57 @@ final class SwapHaltGateTests: XCTestCase {
         let list = [inbound(chain: "BTC", halted: true)]
         XCTAssertFalse(SwapHaltGate.isHalted(chain: .ethereum, in: list))
     }
+
+    /// MayaChain's inbound entries carry no pause flags at all; nil must read
+    /// as not-paused so `halted` remains the only halt signal there.
+    func testNilPauseFlagsAreNotHalted() {
+        let entry = InboundAddress(
+            chain: "ZEC",
+            address: "t1RBkNhHAwZcrhN3YmJ9J6f1Jt2QW9dyn1b",
+            router: nil,
+            halted: false,
+            global_trading_paused: nil,
+            chain_trading_paused: nil,
+            chain_lp_actions_paused: nil,
+            gas_rate: "20",
+            gas_rate_units: "satsperbyte",
+            dust_threshold: "10000",
+            outbound_fee: nil,
+            outbound_tx_size: nil
+        )
+        XCTAssertFalse(SwapHaltGate.isHalted(chain: .zcash, in: [entry]))
+    }
+
+    /// The exact field set mayanode serves on `/mayachain/inbound_addresses`:
+    /// no `router` and none of the THORChain pause flags. Decoding this shape
+    /// must succeed — requiring those keys broke the Maya inbound fetch and
+    /// with it every Maya-route swap (the ZEC memo path most visibly).
+    func testDecodesMayaShapedInboundWithoutPauseFlags() throws {
+        let mayaJson = Data("""
+        [{
+            "chain": "ZEC",
+            "pub_key": "mayapub1addwnpepq0000000000000000000000000000000000000000000000000000000000",
+            "address": "t1RBkNhHAwZcrhN3YmJ9J6f1Jt2QW9dyn1b",
+            "halted": false,
+            "gas_rate": "20",
+            "gas_rate_units": "satsperbyte",
+            "outbound_tx_size": "1000",
+            "outbound_fee": "60000",
+            "dust_threshold": "10000",
+            "observed_fee_rate": "20"
+        }]
+        """.utf8)
+
+        let decoded = try JSONDecoder().decode([InboundAddress].self, from: mayaJson)
+
+        XCTAssertEqual(decoded.count, 1)
+        let entry = try XCTUnwrap(decoded.first)
+        XCTAssertEqual(entry.chain, "ZEC")
+        XCTAssertFalse(entry.halted)
+        XCTAssertNil(entry.global_trading_paused)
+        XCTAssertNil(entry.chain_trading_paused)
+        XCTAssertNil(entry.chain_lp_actions_paused)
+        XCTAssertEqual(entry.gas_rate, "20")
+        XCTAssertFalse(SwapHaltGate.isHalted(chain: .zcash, in: decoded))
+    }
 }


### PR DESCRIPTION
## Summary

Closes #4726

ZEC transactions **with a memo** — MayaChain-routed ZEC swaps (the swap instruction rides in an OP_RETURN) and plain sends with memo — were planned with an underpaying ZIP-317 fee on iOS:

- **Extension-initiated swap, iOS co-signs → keysign fails every time** (the SDK plans the correct higher fee; iOS plans WalletCore's underpaying `zip0317` fee → different fee → different change output → preimage-hash mismatch → MPC cannot converge).
- **Mobile-only signing → network rejects at broadcast** (`tx unpaid action limit exceeded` — fee below the ZIP-317 conventional minimum).

## Root cause

WalletCore's `zip_0317` planner sizes an OP_RETURN output at a flat ~34 bytes — one logical action short of what ZIP-317 charges — and **ignores `byteFee` in that mode** (verified against real WalletCore in vultisig/vultisig-windows#4145 / #4153; WalletCore 4.7.0 does not fix it). So any memo tx plans exactly one action short (e.g. 15,000 zats planned vs 20,000 required). The TS SDK fixed this in vultisig/vultisig-sdk#773; iOS never got the equivalent.

Traced iOS path: Maya-native ZEC swaps ride `SwapPayload.mayachain` + native token → `KeysignMessageFactory` falls through to the **plain UTXO send path** (`UTXOChainsHelper.getBitcoinPreSigningInputData`) with the swap memo in `outputOpReturn` — that path (and the fee-preview/UTXO-selection path) planned once with `zip0317 = true` and no conventional-fee check.

## Fix — byte-parity port of the SDK guard

1. `ZcashConventionalFee` (new): ZIP-317 conventional-fee math ported from the SDK's canonical `packages/core/chain/chains/utxo/fee/zip317.ts` — 5,000 zats per logical action, two-action grace, logical actions = max(ceil(tx_in bytes/150), ceil(tx_out bytes/34)), OP_RETURN sized byte-accurately with PUSHDATA + CompactSize thresholds.
2. `UTXOChainsHelper.planZcashConventionalFee` (ported from `planZcashConventionalFee` in the SDK's `packages/core/mpc/keysign/signingInputs/resolvers/utxo.ts`): plan with `zip0317` as today; if the planned fee underpays the conventional fee for the planned shape, re-plan with `zip0317 = false` (where WalletCore honours `byteFee`), bumping `byteFee` from 1 using the planner's byteFee-independent vsize, max 5 bumps (same cap as the SDK), then throw. Plain no-memo sends keep the `zip0317` plan; empty (insufficient-funds) plans pass through untouched.
3. All four `AnySigner.plan` call sites route through one choke point, so the presign path, the THORChain-style swap path, fee preview / UTXO selection (`getBitcoinTransactionPlan` — used by `KeysignPayloadFactory`, `DefaultSendInteractor`, `JoinKeysignGasViewModel`, `SwapPayloadBuilder`), and the Blockaid placeholder all agree. Non-Zcash coins take the early exit — zero behaviour change.
4. `SwapKitZcashSigner` deliberately untouched (frozen plan from the SwapKit PSBT).

## Byte-parity argument (why co-signs converge)

The MPC preimage digests derive from the WalletCore *plan* (selected UTXOs, amount, fee, change). Both platforms pin **WalletCore 4.7.0** (iOS `walletcore-spm` exactVersion 4.7.0; SDK `@trustwallet/wallet-core` 4.7.0) and identical dust floors (1,000 zats), and the loop is an exact port (initial byteFee 1, same bump formula, same cap, same empty-plan pass-through). Pinned with golden vectors **extracted from a live run of the SDK resolver** (`getUtxoSigningInputs` on real wallet-core WASM 4.7.0, from `utxo.zcashFee.test.ts` scenarios):

| scenario (byteFee 100, 1 UTXO) | fee | change | final byteFee | zip0317 |
|---|---|---|---|---|
| plain send 5,000,000 / 8,300,000 | 10,000 | 3,290,000 | 100 (untouched) | true |
| memo `m`×40 | 20,020 | 3,279,980 | 77 | false |
| memo `m`×40, sendMax 2,200,000 | 15,142 | 0 (amount 2,184,858) | 67 | false |
| memo `m`×200 | 45,240 | 3,254,760 | 174 | false |
| Maya-shaped 109-char memo | 30,160 | 3,269,840 | 116 | false |
| non-ASCII memo (34 UTF-8 bytes) | 20,020 | 3,279,980 | 77 | false |
| insufficient 90,000 / 100,000 + memo | 0 (empty plan pass-through) | 0 | 100 (untouched) | true |

iOS reproduces every value exactly (`ZcashZip317PlanTests`, real WalletCore). Math vectors mirror the SDK's `zip317.test.ts` one-for-one plus upper PUSHDATA2→4 / CompactSize 3→5 boundaries (`ZcashConventionalFeeTests`).

## Gate

- `make test`: **2282 tests, 1 failure** — the failure is the known pre-existing decimal-comma locale flake (`StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress`, `("12,3%") != ("12.3%")`), unrelated to this change. All 26 new Zcash tests pass.
- SwiftLint (`VultisigApp/.swiftlint.yml` over `VultisigApp/`): zero warnings in touched files (43 pre-existing repo-wide, none in this diff).
- Cross-model review: per-commit + whole-branch Codex passes — no findings on the final branch (boundary vectors and UTF-8 byte counts independently recalculated).

## ⚠️ HIGH-tier signing path — review requirements

This changes fee planning inside the MPC signing path. Divergence between co-signing devices moves the keysign failure instead of fixing it. Before merge this needs:
- **Human review** of the parity argument above.
- **Cross-device validation on a real Maya ZEC swap**: initiate on the extension (0.2.22+, carries sdk#773), co-sign on an iOS build with this patch — keysign must converge and the broadcast must be accepted; plus a mobile-only ZEC send with memo.

## Follow-ups (out of scope here)

- Add a ZEC-memo vector to the cross-platform signing-vector net (vultisig/commondata#94).
- Upstream the OP_RETURN action-count correction to trustwallet/wallet-core so all platforms converge without workarounds.
- Android sibling (`UtxoHelper.kt`) tracked on vultisig-android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zcash-specific conventional-fee replanning to ensure memo/payload-based transactions are planned correctly.
* **Bug Fixes**
  * Prevented Zcash from producing fees below the required conventional minimum.
  * Made pause/halt detection more resilient when pause flags are missing, treating absent values as unpaused.
* **Tests**
  * Added coverage for Zcash conventional-fee calculation, memo sizing, ZIP-317 planning, and swap-style payload behavior.
  * Expanded halt/pause gate tests for nil pause-flag decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->