### PR TITLE
fix(vault): reject empty/whitespace vault names in Rename Vault

### DIFF
--- a/VultisigApp/VultisigApp/Components/Validators/VaultNameValidator.swift
+++ b/VultisigApp/VultisigApp/Components/Validators/VaultNameValidator.swift
@@ -14,15 +14,24 @@ struct VaultNameValidator: FormFieldValidator {
     init() {
         let descriptor = FetchDescriptor<Vault>()
         let vaults = (try? Storage.shared.modelContext.fetch(descriptor)) ?? []
-        vaultNames = Set(vaults.map { $0.name.lowercased() })
+        self.init(existingNames: vaults.map(\.name))
+    }
+
+    init(existingNames: [String]) {
+        vaultNames = Set(existingNames.map { Self.normalize($0) })
     }
 
     func validate(value: String) throws {
-        guard !value.isEmpty else {
+        let name = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
             throw HelperError.runtimeError("enterVaultName".localized)
         }
-        guard !vaultNames.contains(value.lowercased()) else {
-            throw HelperError.runtimeError("vaultNameExists".localized.replacingOccurrences(of: "%s", with: value))
+        guard !vaultNames.contains(Self.normalize(name)) else {
+            throw HelperError.runtimeError("vaultNameExists".localized.replacingOccurrences(of: "%s", with: name))
         }
+    }
+
+    private static func normalize(_ name: String) -> String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/RenameVaultView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/RenameVaultView.swift
@@ -48,6 +48,11 @@ struct RenameVaultView: View {
         PrimaryButton(title: "save") {
             rename()
         }
+        .disabled(trimmedName.isEmpty)
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func setData() {
@@ -55,20 +60,33 @@ struct RenameVaultView: View {
     }
 
     private func rename() {
-        // make sure the same vault name has not been occupied
-        if vaults.contains(where: { $0.name == name && $0.pubKeyECDSA != vault.pubKeyECDSA && $0.pubKeyEdDSA != vault.pubKeyEdDSA}) {
-            name = vault.name
-            errorMessage = NSLocalizedString("vaultNameExists", comment: "").replacingOccurrences(of: "%s", with: name)
+        let oldName = vault.name
+        let newName = trimmedName
+
+        // Keeping the current name is always a no-op, even if legacy data
+        // contains a case-insensitive duplicate of it
+        guard newName != oldName else {
+            router.navigateBack()
+            return
+        }
+
+        // Same rules as vault creation: non-empty and not taken by another vault
+        let otherVaultNames = vaults
+            .filter { $0.pubKeyECDSA != vault.pubKeyECDSA && $0.pubKeyEdDSA != vault.pubKeyEdDSA }
+            .map(\.name)
+
+        do {
+            try VaultNameValidator(existingNames: otherVaultNames).validate(value: newName)
+        } catch {
+            errorMessage = error.localizedDescription
             showAlert = true
             return
         }
 
-        let oldName = vault.name
-
-        vault.name = name
+        vault.name = newName
         appViewModel.set(selectedVault: vault, restartNavigation: false)
 
-        checkForFolder(oldName: oldName, newName: name)
+        checkForFolder(oldName: oldName, newName: newName)
         router.navigateBack()
     }
 

--- a/VultisigApp/VultisigAppTests/Wallet/VaultNameValidatorTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultNameValidatorTests.swift
@@ -1,0 +1,66 @@
+//
+//  VaultNameValidatorTests.swift
+//  VultisigAppTests
+//
+//  Pins the shared vault-name validation used by vault creation and
+//  Vault Settings -> Rename: empty and whitespace-only names are rejected,
+//  and names already taken by another vault are rejected case-insensitively.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class VaultNameValidatorTests: XCTestCase {
+
+    private let existingNames = ["Main Vault", "Treasury"]
+
+    private func makeValidator() -> VaultNameValidator {
+        VaultNameValidator(existingNames: existingNames)
+    }
+
+    // MARK: - Empty / whitespace
+
+    func testEmptyNameRejected() {
+        XCTAssertFalse(makeValidator().validateNonThrowable(value: ""))
+    }
+
+    func testWhitespaceOnlyNameRejected() {
+        XCTAssertFalse(makeValidator().validateNonThrowable(value: "   "))
+        XCTAssertFalse(makeValidator().validateNonThrowable(value: "\n\t "))
+    }
+
+    // MARK: - Valid names
+
+    func testValidNameAccepted() {
+        XCTAssertTrue(makeValidator().validateNonThrowable(value: "Savings"))
+    }
+
+    func testValidNameWithSurroundingWhitespaceAccepted() {
+        XCTAssertTrue(makeValidator().validateNonThrowable(value: "  Savings  "))
+    }
+
+    func testValidNameAcceptedWhenNoExistingVaults() {
+        let validator = VaultNameValidator(existingNames: [])
+        XCTAssertTrue(validator.validateNonThrowable(value: "Savings"))
+    }
+
+    // MARK: - Duplicates
+
+    func testDuplicateNameRejected() {
+        XCTAssertFalse(makeValidator().validateNonThrowable(value: "Main Vault"))
+    }
+
+    func testDuplicateNameRejectedCaseInsensitively() {
+        XCTAssertFalse(makeValidator().validateNonThrowable(value: "main vault"))
+        XCTAssertFalse(makeValidator().validateNonThrowable(value: "TREASURY"))
+    }
+
+    func testDuplicateNameRejectedWhenSurroundedByWhitespace() {
+        XCTAssertFalse(makeValidator().validateNonThrowable(value: "  Treasury "))
+    }
+
+    func testDuplicateDetectedWhenExistingNameHasWhitespacePadding() {
+        let validator = VaultNameValidator(existingNames: [" Treasury "])
+        XCTAssertFalse(validator.validateNonThrowable(value: "Treasury"))
+    }
+}


### PR DESCRIPTION
# Problem

Vault Settings → Rename accepts an empty vault name: with the text field cleared (⊗), **Save stays enabled and persists the empty string**. The vault then shows a blank name in Vault Details and the home vault selector, and reopening Rename shows only the "Type here" placeholder. Reproduced 3× in release QA on v1.41.64.

# Root cause

`RenameVaultView` had its own inline save logic with **no empty-name check** — only a case-sensitive duplicate-name check — while vault **creation** validates names through `VaultNameValidator` (non-empty + case-insensitive uniqueness). The two paths had diverged, so rename happily wrote `""` into `vault.name`.

# Fix

Reuse the creation validation path instead of inventing a rename-only rule:

- **`VaultNameValidator`** now trims whitespace before both the empty and duplicate checks (whitespace-only names are rejected everywhere, including creation), and gains an injectable `init(existingNames:)` — the Storage-fetching `init()` delegates to it — so it can validate against an arbitrary name set and be unit-tested without SwiftData.
- **`RenameVaultView`**:
  - Save is **disabled** while the trimmed name is empty (covers empty and whitespace-only).
  - On save, the name is validated with `VaultNameValidator` built from the *other* vaults' names (same pubkey-based self-exclusion as before), so the duplicate check is now **case-insensitive, matching creation**, and the existing `vaultNameExists` alert is shown from the validator's error.
  - The persisted name is **trimmed**; renaming to the unchanged name is a no-op (navigate back — this also avoids appending a duplicate entry to `Folder.containedVaultNames`).
- No new user-facing strings: `enterVaultName` and `vaultNameExists` already exist in all locales.

# Tests

New `VaultNameValidatorTests` (9 tests, camelCase): empty rejected, whitespace-only rejected, valid accepted (incl. padded and empty-store cases), duplicate rejected, case-insensitive duplicate rejected, padded duplicate rejected both directions.

# Verification

- Full unit suite (`xcodebuild test`, VultisigApp scheme, iPhone 17 Pro Max sim): **2270 tests executed, 1 failure** — `StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress` (`"12,3%" != "12.3%"`), the known pre-existing decimal-comma locale flake on `main`, unrelated to this change. The suite was run twice — on the initial commit and again on the final amended commit — with identical results (2270 executed, only that flake failing).
- **Not simulator-verified end-to-end**: exercising Vault Settings → Rename requires a provisioned vault (keygen), which wasn't practical under the parallel build load on this machine. The behavioral change is covered by the validator unit tests; the UI change is a standard `.disabled(...)` on `PrimaryButton`, the same pattern used by sibling screens.
- Cross-model review (Codex `exec --sandbox read-only`, 2 rounds):
  - Fixed: the no-op (unchanged name) guard now runs **before** duplicate validation, so a legacy case-insensitive duplicate of the vault's own name can still be saved unchanged.
  - Deferred (pre-existing / intentional, see follow-ups): creation persists the untrimmed field value; `checkForFolder` append-only staleness.
  - Rejected: "add rename view integration tests" — the name rules live in `VaultNameValidator` (unit-tested); the remaining view code is thin SwiftUI glue, and a `RenameVaultViewModel` extraction is out of scope for this fix.

# Possible follow-ups (intentionally out of scope)

- Creation still *persists* the untrimmed field value (`VaultSetupViewModel.vaultName`); only validation trims.
- `checkForFolder` never removes the old vault name from `Folder.containedVaultNames` on rename (pre-existing).

Closes #4729

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault name handling to treat leading/trailing spaces and case differences consistently.
  * Prevented renaming a vault to the same trimmed name, avoiding unnecessary validation and updates.
  * Added clearer validation feedback when a vault name is invalid or already in use.

* **Tests**
  * Added coverage for empty names, whitespace-only input, duplicate detection, and valid names with surrounding spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->