### PR TITLE
fix(swap): destination asset picker no longer shows 'No result found.' while providers load

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -23,14 +23,20 @@ class SwapCoinSelectionViewModel: ObservableObject {
     private var cancellable: AnyCancellable?
 
     @MainActor
-    init(vault: Vault, selectedCoin: Coin, isDestination: Bool) {
+    init(
+        vault: Vault,
+        selectedCoin: Coin,
+        isDestination: Bool,
+        registry: DestinationTokenRegistry? = nil
+    ) {
         self.vault = vault
         self.selectedCoin = selectedCoin
         self.isDestination = isDestination
         self.logic = SwapCoinSelectionLogic(
             vault: vault,
             selectedCoin: selectedCoin,
-            isDestination: isDestination
+            isDestination: isDestination,
+            registry: registry
         )
     }
 
@@ -117,15 +123,32 @@ class SwapCoinSelectionViewModel: ObservableObject {
 
     private func publishMerge(externalTokens: [CoinMeta], chain: Chain, forceRefresh: Bool = false) async {
         do {
+            // Destination side: publish the network-free merge (curated native +
+            // cached external list + vault coins) before awaiting the remote
+            // destination providers. The registry hop below can take seconds on
+            // first open (forced SwapKit catalog + THORChain/Maya pool fetches,
+            // awaited sequentially) and the sheet has no "loading more" state —
+            // with nothing published it renders "No result found." even though
+            // the query is empty. Serving the local list first keeps the picker
+            // browsable instantly; provider tokens append on the second publish.
+            if isDestination {
+                let local = await logic.localMerge(externalTokens: externalTokens, chain: chain)
+                try Task.checkCancellation()
+                await publish(local)
+            }
             let result = try await logic.merge(externalTokens: externalTokens, chain: chain, forceRefresh: forceRefresh)
             try Task.checkCancellation()
-            await MainActor.run {
-                self.tokens = result.tokens
-                self.filteredTokens = self.logic.filterTokens(searchText: self.searchText, tokens: result.tokens)
-            }
+            await publish(result)
         } catch {
             guard !Task.isCancelled else { return }
             await MainActor.run { self.error = error }
+        }
+    }
+
+    private func publish(_ result: SwapCoinSelectionResult) async {
+        await MainActor.run {
+            self.tokens = result.tokens
+            self.filteredTokens = self.logic.filterTokens(searchText: self.searchText, tokens: result.tokens)
         }
     }
 
@@ -185,11 +208,6 @@ struct SwapCoinSelectionLogic {
     /// model can serve a cached external list without a spinner. The vault read
     /// and `sort` (live balance reads) stay on the MainActor.
     func merge(externalTokens: [CoinMeta], chain: Chain, forceRefresh: Bool = false) async throws -> SwapCoinSelectionResult {
-        let nativeToken = TokensStore.TokenSelectionAssets.first { $0.chain == chain && $0.isNativeToken }
-
-        let baseTokens = ([nativeToken] + externalTokens).compactMap { $0 }
-        let baseUnique = baseTokens.uniqueBy { $0.ticker.lowercased() }
-
         // Destination-side picker pulls in tokens from every registered
         // DestinationTokenProvider; source-side stays vault-bounded since
         // SwapKit + sibling providers add no signal for tokens the user
@@ -200,6 +218,27 @@ struct SwapCoinSelectionLogic {
         } else {
             externalBuckets = []
         }
+        return await assemble(externalTokens: externalTokens, chain: chain, externalBuckets: externalBuckets)
+    }
+
+    /// Network-free variant of `merge` — assembles the list from what is
+    /// already local (curated native + external/preset list + vault coins),
+    /// skipping the destination-registry hop. The view model publishes this
+    /// first so the destination picker is browsable immediately while the
+    /// remote providers (SwapKit catalog, THORChain/Maya pools) are awaited.
+    func localMerge(externalTokens: [CoinMeta], chain: Chain) async -> SwapCoinSelectionResult {
+        await assemble(externalTokens: externalTokens, chain: chain, externalBuckets: [])
+    }
+
+    private func assemble(
+        externalTokens: [CoinMeta],
+        chain: Chain,
+        externalBuckets: [DestinationTokenBucket]
+    ) async -> SwapCoinSelectionResult {
+        let nativeToken = TokensStore.TokenSelectionAssets.first { $0.chain == chain && $0.isNativeToken }
+
+        let baseTokens = ([nativeToken] + externalTokens).compactMap { $0 }
+        let baseUnique = baseTokens.uniqueBy { $0.ticker.lowercased() }
 
         // Coins the vault actually holds for this chain — including user-added
         // custom tokens that aren't in the curated TokensStore / search list.

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -9,7 +9,13 @@ import Foundation
 import Combine
 
 class SwapCoinSelectionViewModel: ObservableObject {
-    @Published var isLoading: Bool = false
+    /// Starts `true` so the picker's first frame renders the loader: the view
+    /// falls back to "No result found." whenever `isLoading` is false and
+    /// `filteredTokens` is empty, and before the first publish that state
+    /// would flash even though nothing has been looked up yet. Cleared by the
+    /// first publish (or a failed cold load), after which an empty list is a
+    /// genuine no-results state.
+    @Published var isLoading: Bool = true
     @Published var tokens: [CoinMeta] = []
     @Published var filteredTokens: [CoinMeta] = []
     @Published var searchText: String = ""
@@ -56,19 +62,15 @@ class SwapCoinSelectionViewModel: ObservableObject {
     /// catalog is forced.
     func fetchCoins(chain: Chain, forceRefresh: Bool = false) async {
         // Sync peek on the MainActor: when the chain's vault-independent token
-        // list is already cached, do the cheap local merge and publish without
-        // ever flipping `isLoading` — instant, no spinner. Only a cold load
-        // (no cached entry) shows the loader.
+        // list is already cached, do the cheap local merge and publish — the
+        // first publish clears `isLoading`, so any spinner (initial state, or
+        // a prior chain's cancelled cold load) drops the moment real data
+        // lands rather than being cleared up front with nothing to show. Only
+        // a cold load (no cached entry) does a full spinner cycle.
         let cached = await MainActor.run { SwapTokenListCache.shared.cached(for: chain) }
 
         if let cached {
-            await MainActor.run {
-                error = nil
-                // A prior cold load for another chain may have been cancelled
-                // with the spinner still up — clear it so the instant-serve
-                // path is truly spinner-free.
-                isLoading = false
-            }
+            await MainActor.run { error = nil }
             await publishMerge(externalTokens: cached, chain: chain, forceRefresh: forceRefresh)
 
             // Refresh a stale entry silently in the background — still no
@@ -141,7 +143,13 @@ class SwapCoinSelectionViewModel: ObservableObject {
             await publish(result)
         } catch {
             guard !Task.isCancelled else { return }
-            await MainActor.run { self.error = error }
+            await MainActor.run {
+                self.error = error
+                // Terminal state: without a publish the spinner would stay up
+                // forever; dropping it lets the view fall back to its empty
+                // message.
+                self.isLoading = false
+            }
         }
     }
 
@@ -149,6 +157,7 @@ class SwapCoinSelectionViewModel: ObservableObject {
         await MainActor.run {
             self.tokens = result.tokens
             self.filteredTokens = self.logic.filterTokens(searchText: self.searchText, tokens: result.tokens)
+            self.isLoading = false
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -65,8 +65,10 @@ class SwapCoinSelectionViewModel: ObservableObject {
         // list is already cached, do the cheap local merge and publish — the
         // first publish clears `isLoading`, so any spinner (initial state, or
         // a prior chain's cancelled cold load) drops the moment real data
-        // lands rather than being cleared up front with nothing to show. Only
-        // a cold load (no cached entry) does a full spinner cycle.
+        // lands rather than being cleared up front with nothing to show. A
+        // cold load (no cached entry) spins only until its first publish:
+        // destination side paints the curated-native + vault-coin list right
+        // away, source side when the external list lands.
         let cached = await MainActor.run { SwapTokenListCache.shared.cached(for: chain) }
 
         if let cached {
@@ -82,20 +84,29 @@ class SwapCoinSelectionViewModel: ObservableObject {
             return
         }
 
-        // Cold load: no cached list for this chain — show the spinner.
+        // Cold load: no cached list for this chain.
         await MainActor.run {
             isLoading = true
             error = nil
         }
 
         do {
+            // Destination side: even with no external list yet, the curated
+            // native + the vault's held coins are already local — paint them
+            // immediately (the first publish drops the spinner) instead of
+            // blocking the whole picker on the external-catalog fetch plus the
+            // registry hop buried in the full merge. The enriched publish
+            // below swaps in the complete list. Source side keeps the plain
+            // spinner cycle: its list is vault-bounded and arrives in one
+            // publish as soon as the external list lands.
+            if isDestination {
+                let local = await logic.localMerge(externalTokens: [], chain: chain)
+                try Task.checkCancellation()
+                await publish(local)
+            }
             let result = try await logic.fetchCoins(chain: chain, forceRefresh: forceRefresh)
             try Task.checkCancellation()
-            await MainActor.run {
-                self.tokens = result.tokens
-                self.filteredTokens = result.tokens
-                isLoading = false
-            }
+            await publish(result)
         } catch is CancellationError {
             // Superseded by a faster chain-switch — leave state for the winner.
         } catch {

--- a/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
@@ -1,0 +1,233 @@
+//
+//  SwapCoinSelectionViewModelTests.swift
+//  VultisigAppTests
+//
+//  Pins the swap "Select asset" picker's list/filter behavior:
+//  - an empty query returns the full default list, a query filters by
+//    ticker substring, and no match yields an empty list;
+//  - the destination picker publishes the network-free local list
+//    (curated native + cached external + vault coins) BEFORE the
+//    destination-token providers return, so the sheet never sits on
+//    "No result found." while a slow provider refresh is in flight;
+//  - the source-side picker never consults the destination providers.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class SwapCoinSelectionViewModelTests: XCTestCase {
+
+    override func tearDown() {
+        SwapTokenListCache.shared.clearCache()
+        super.tearDown()
+    }
+
+    // MARK: - filterTokens
+
+    func testFilterTokensEmptyQueryReturnsDefaultList() {
+        let logic = makeLogic()
+        let tokens = [meta("ETH", isNative: true), meta("USDC"), meta("WBTC")]
+
+        let filtered = logic.filterTokens(searchText: "", tokens: tokens)
+
+        XCTAssertEqual(filtered, tokens, "Empty query must return the full default list, not an empty one")
+    }
+
+    func testFilterTokensQueryFiltersByTickerSubstring() {
+        let logic = makeLogic()
+        let tokens = [meta("ETH", isNative: true), meta("USDC"), meta("USDT"), meta("WBTC")]
+
+        let filtered = logic.filterTokens(searchText: "usd", tokens: tokens)
+
+        XCTAssertEqual(filtered.map { $0.ticker }, ["USDC", "USDT"])
+    }
+
+    func testFilterTokensNoMatchReturnsEmpty() {
+        let logic = makeLogic()
+        let tokens = [meta("ETH", isNative: true), meta("USDC")]
+
+        let filtered = logic.filterTokens(searchText: "zzz", tokens: tokens)
+
+        XCTAssertTrue(filtered.isEmpty)
+    }
+
+    // MARK: - Destination picker publishes before providers return
+
+    func testDestinationPickerPublishesLocalListBeforeProvidersReturn() async throws {
+        let novel = meta("NOVL", contract: "0x000000000000000000000000000000000000abcd")
+        let provider = GatedDestinationTokenProvider(
+            bucket: DestinationTokenBucket(chain: .ethereum, tokens: [novel], uniqueIds: [novel.uniqueId])
+        )
+        let registry = DestinationTokenRegistry()
+        registry.register(provider)
+
+        SwapTokenListCache.shared.setCached([meta("USDC")], for: .ethereum)
+
+        let vm = SwapCoinSelectionViewModel(
+            vault: makeVault(),
+            selectedCoin: makeCoin("ETH", isNative: true),
+            isDestination: true,
+            registry: registry
+        )
+
+        let fetchTask = Task { await vm.fetchCoins(chain: .ethereum, forceRefresh: true) }
+
+        // The local list must publish while the provider is still gated.
+        try await waitUntil("local list published") { !vm.filteredTokens.isEmpty }
+        XCTAssertFalse(vm.isLoading, "Cached path serves without a spinner")
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "ETH" }, "Curated native must be in the local list")
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "USDC" }, "Cached external token must be in the local list")
+        XCTAssertFalse(vm.filteredTokens.contains { $0.ticker == "NOVL" }, "Provider tokens only land on the enriched publish")
+
+        provider.release()
+        await fetchTask.value
+
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "NOVL" }, "Provider token must append once the registry returns")
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "USDC" }, "Enriched publish keeps the local tokens")
+    }
+
+    func testDestinationPickerEnrichedPublishPreservesTypedQuery() async throws {
+        let novel = meta("NOVL", contract: "0x000000000000000000000000000000000000abcd")
+        let provider = GatedDestinationTokenProvider(
+            bucket: DestinationTokenBucket(chain: .ethereum, tokens: [novel], uniqueIds: [novel.uniqueId])
+        )
+        let registry = DestinationTokenRegistry()
+        registry.register(provider)
+
+        SwapTokenListCache.shared.setCached([meta("USDC")], for: .ethereum)
+
+        let vm = SwapCoinSelectionViewModel(
+            vault: makeVault(),
+            selectedCoin: makeCoin("ETH", isNative: true),
+            isDestination: true,
+            registry: registry
+        )
+
+        let fetchTask = Task { await vm.fetchCoins(chain: .ethereum, forceRefresh: true) }
+        try await waitUntil("local list published") { !vm.filteredTokens.isEmpty }
+
+        // User types while the provider refresh is still in flight.
+        vm.searchText = "usdc"
+
+        provider.release()
+        await fetchTask.value
+
+        XCTAssertEqual(vm.filteredTokens.map { $0.ticker }, ["USDC"], "Enriched publish must re-apply the typed query")
+    }
+
+    func testSourcePickerIgnoresDestinationProviders() async throws {
+        // The gate is never released — if the source-side picker consulted the
+        // registry, fetchCoins would never complete.
+        let novel = meta("NOVL", contract: "0x000000000000000000000000000000000000abcd")
+        let provider = GatedDestinationTokenProvider(
+            bucket: DestinationTokenBucket(chain: .ethereum, tokens: [novel], uniqueIds: [novel.uniqueId])
+        )
+        let registry = DestinationTokenRegistry()
+        registry.register(provider)
+
+        SwapTokenListCache.shared.setCached([meta("USDC")], for: .ethereum)
+
+        let vm = SwapCoinSelectionViewModel(
+            vault: makeVault(),
+            selectedCoin: makeCoin("ETH", isNative: true),
+            isDestination: false,
+            registry: registry
+        )
+
+        await vm.fetchCoins(chain: .ethereum, forceRefresh: true)
+
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "ETH" })
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "USDC" })
+        XCTAssertFalse(vm.filteredTokens.contains { $0.ticker == "NOVL" }, "Source side must not pull destination-provider tokens")
+        XCTAssertFalse(provider.wasQueried, "Source side must not consult the destination registry")
+    }
+
+    // MARK: - Helpers
+
+    private func makeLogic() -> SwapCoinSelectionLogic {
+        SwapCoinSelectionLogic(
+            vault: makeVault(),
+            selectedCoin: makeCoin("ETH", isNative: true),
+            isDestination: true,
+            registry: DestinationTokenRegistry()
+        )
+    }
+
+    private func makeVault() -> Vault {
+        Vault(
+            name: "Test Vault",
+            signers: [],
+            pubKeyECDSA: "test-pub-ecdsa",
+            pubKeyEdDSA: "test-pub-eddsa",
+            keyshares: [],
+            localPartyID: "iPhone-12345",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+    }
+
+    private func makeCoin(_ ticker: String, isNative: Bool = false) -> Coin {
+        Coin(asset: meta(ticker, isNative: isNative), address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+
+    private func meta(_ ticker: String, isNative: Bool = false, contract: String = "") -> CoinMeta {
+        CoinMeta(
+            chain: .ethereum,
+            ticker: ticker,
+            logo: "",
+            decimals: isNative ? 18 : 6,
+            priceProviderId: "",
+            contractAddress: isNative ? "" : contract.isEmpty ? "0x\(ticker.lowercased())" : contract,
+            isNativeToken: isNative
+        )
+    }
+
+    private func waitUntil(
+        _ what: String,
+        timeout: TimeInterval = 5,
+        condition: () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() > deadline {
+                XCTFail("Timed out waiting for \(what)")
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+}
+
+// MARK: - GatedDestinationTokenProvider
+
+/// A `DestinationTokenProvider` that suspends inside `tokens(for:)` until the
+/// test releases it — simulating a slow remote catalog refresh so tests can
+/// assert what the picker publishes while the fetch is still in flight.
+@MainActor
+private final class GatedDestinationTokenProvider: DestinationTokenProvider {
+    let providerKind = "gatedTestProvider"
+    private(set) var wasQueried = false
+    private var released = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private let bucket: DestinationTokenBucket
+
+    init(bucket: DestinationTokenBucket) {
+        self.bucket = bucket
+    }
+
+    func tokens(for chain: Chain, forceRefresh _: Bool) async -> DestinationTokenBucket {
+        wasQueried = true
+        if !released {
+            await withCheckedContinuation { continuations.append($0) }
+        }
+        return chain == bucket.chain ? bucket : .empty(chain: chain)
+    }
+
+    func release() {
+        released = true
+        continuations.forEach { $0.resume() }
+        continuations.removeAll()
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
@@ -218,6 +218,74 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
         await fetchTask.value
     }
 
+    // MARK: - Cold cache (no SwapTokenListCache entry)
+
+    func testColdCacheDestinationPublishesLocalListBeforeProvidersReturn() async throws {
+        // Bitcoin's external-token fetch is a synchronous empty list (no
+        // 1inch/Jupiter source), so the cold path is deterministic in tests:
+        // the only slow hop left is the gated registry inside the full merge.
+        let novel = meta("NOVL", chain: .bitcoin, contract: "0x000000000000000000000000000000000000abcd")
+        let provider = GatedDestinationTokenProvider(
+            bucket: DestinationTokenBucket(chain: .bitcoin, tokens: [novel], uniqueIds: [novel.uniqueId])
+        )
+        let registry = DestinationTokenRegistry()
+        registry.register(provider)
+
+        XCTAssertNil(SwapTokenListCache.shared.cached(for: .bitcoin), "Precondition: cold cache")
+
+        let vm = SwapCoinSelectionViewModel(
+            vault: makeVault(),
+            selectedCoin: makeCoin("ETH", isNative: true),
+            isDestination: true,
+            registry: registry
+        )
+
+        let fetchTask = Task { await vm.fetchCoins(chain: .bitcoin, forceRefresh: true) }
+        defer { provider.release() }
+
+        // The curated-native + vault-coin list must paint while the registry
+        // is still gated — a cold cache must not block the first publish.
+        try await waitUntil("cold-cache local list published") { !vm.filteredTokens.isEmpty }
+        XCTAssertFalse(vm.isLoading, "The local publish clears the cold-load spinner")
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "BTC" }, "Curated native must be in the local list")
+        XCTAssertFalse(vm.filteredTokens.contains { $0.ticker == "NOVL" }, "Provider tokens only land on the enriched publish")
+
+        provider.release()
+        await fetchTask.value
+
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "NOVL" }, "Provider token must append once the registry returns")
+    }
+
+    func testColdCacheSourcePickerPublishesOnceWithoutRegistry() async throws {
+        let novel = meta("NOVL", chain: .bitcoin, contract: "0x000000000000000000000000000000000000abcd")
+        let provider = GatedDestinationTokenProvider(
+            bucket: DestinationTokenBucket(chain: .bitcoin, tokens: [novel], uniqueIds: [novel.uniqueId])
+        )
+        let registry = DestinationTokenRegistry()
+        registry.register(provider)
+
+        XCTAssertNil(SwapTokenListCache.shared.cached(for: .bitcoin), "Precondition: cold cache")
+
+        let vm = SwapCoinSelectionViewModel(
+            vault: makeVault(),
+            selectedCoin: makeCoin("ETH", isNative: true),
+            isDestination: false,
+            registry: registry
+        )
+        XCTAssertTrue(vm.isLoading, "Source-side cold open starts on the spinner")
+
+        let fetchTask = Task { await vm.fetchCoins(chain: .bitcoin, forceRefresh: true) }
+        defer { provider.release() }
+
+        try await waitUntil("source-side cold fetch to publish") { !vm.filteredTokens.isEmpty }
+
+        XCTAssertFalse(vm.isLoading)
+        XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "BTC" })
+        XCTAssertFalse(vm.filteredTokens.contains { $0.ticker == "NOVL" }, "Source side must not pull destination-provider tokens")
+        XCTAssertFalse(provider.wasQueried, "Source side must not consult the destination registry")
+        await fetchTask.value
+    }
+
     // MARK: - Helpers
 
     private func makeLogic() -> SwapCoinSelectionLogic {
@@ -247,9 +315,9 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
         Coin(asset: meta(ticker, isNative: isNative), address: "test-address-\(ticker)", hexPublicKey: "")
     }
 
-    private func meta(_ ticker: String, isNative: Bool = false, contract: String = "") -> CoinMeta {
+    private func meta(_ ticker: String, isNative: Bool = false, chain: Chain = .ethereum, contract: String = "") -> CoinMeta {
         CoinMeta(
-            chain: .ethereum,
+            chain: chain,
             ticker: ticker,
             logo: "",
             decimals: isNative ? 18 : 6,

--- a/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
@@ -72,6 +72,7 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
         )
 
         let fetchTask = Task { await vm.fetchCoins(chain: .ethereum, forceRefresh: true) }
+        defer { provider.release() }
 
         // The local list must publish while the provider is still gated.
         try await waitUntil("local list published") { !vm.filteredTokens.isEmpty }
@@ -105,6 +106,8 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
         )
 
         let fetchTask = Task { await vm.fetchCoins(chain: .ethereum, forceRefresh: true) }
+        defer { provider.release() }
+
         try await waitUntil("local list published") { !vm.filteredTokens.isEmpty }
 
         // User types while the provider refresh is still in flight.
@@ -117,8 +120,9 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
     }
 
     func testSourcePickerIgnoresDestinationProviders() async throws {
-        // The gate is never released — if the source-side picker consulted the
-        // registry, fetchCoins would never complete.
+        // The gate stays closed while the fetch runs — if the source-side
+        // picker consulted the registry, the bounded wait below would fail the
+        // test, and the deferred release keeps the fetch from hanging forever.
         let novel = meta("NOVL", contract: "0x000000000000000000000000000000000000abcd")
         let provider = GatedDestinationTokenProvider(
             bucket: DestinationTokenBucket(chain: .ethereum, tokens: [novel], uniqueIds: [novel.uniqueId])
@@ -135,12 +139,16 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
             registry: registry
         )
 
-        await vm.fetchCoins(chain: .ethereum, forceRefresh: true)
+        let fetchTask = Task { await vm.fetchCoins(chain: .ethereum, forceRefresh: true) }
+        defer { provider.release() }
+
+        try await waitUntil("source-side fetch to publish without the registry") { !vm.filteredTokens.isEmpty }
 
         XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "ETH" })
         XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "USDC" })
         XCTAssertFalse(vm.filteredTokens.contains { $0.ticker == "NOVL" }, "Source side must not pull destination-provider tokens")
         XCTAssertFalse(provider.wasQueried, "Source side must not consult the destination registry")
+        await fetchTask.value
     }
 
     // MARK: - Helpers
@@ -184,6 +192,11 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
         )
     }
 
+    private struct WaitTimeout: Error {}
+
+    /// Polls `condition`, throwing on timeout so the calling test exits
+    /// immediately (its `defer { provider.release() }` then unblocks any
+    /// still-gated fetch) instead of running follow-up awaits that could hang.
     private func waitUntil(
         _ what: String,
         timeout: TimeInterval = 5,
@@ -193,7 +206,7 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
         while !condition() {
             if Date() > deadline {
                 XCTFail("Timed out waiting for \(what)")
-                return
+                throw WaitTimeout()
             }
             try await Task.sleep(nanoseconds: 10_000_000)
         }

--- a/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
@@ -52,6 +52,69 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
         XCTAssertTrue(filtered.isEmpty)
     }
 
+    // MARK: - Initial state defaults to loading
+
+    func testInitialStateIsLoadingSoEmptyStateCannotRenderBeforeFirstPublish() async throws {
+        let novel = meta("NOVL", contract: "0x000000000000000000000000000000000000abcd")
+        let provider = GatedDestinationTokenProvider(
+            bucket: DestinationTokenBucket(chain: .ethereum, tokens: [novel], uniqueIds: [novel.uniqueId])
+        )
+        let registry = DestinationTokenRegistry()
+        registry.register(provider)
+
+        SwapTokenListCache.shared.setCached([meta("USDC")], for: .ethereum)
+
+        let vm = SwapCoinSelectionViewModel(
+            vault: makeVault(),
+            selectedCoin: makeCoin("ETH", isNative: true),
+            isDestination: true,
+            registry: registry
+        )
+
+        // Before any fetch, the view must resolve to the loader — never the
+        // empty message — so the first frame cannot flash "No result found.".
+        XCTAssertTrue(vm.isLoading, "A fresh view model must default to loading")
+        XCTAssertTrue(vm.filteredTokens.isEmpty)
+
+        let fetchTask = Task { await vm.fetchCoins(chain: .ethereum, forceRefresh: true) }
+        defer { provider.release() }
+
+        // At every observable point up to the first publish, the view must be
+        // able to render either the loader or a non-empty list — never the
+        // empty state.
+        try await waitUntil("first publish") {
+            XCTAssertTrue(
+                vm.isLoading || !vm.filteredTokens.isEmpty,
+                "Empty state must be unreachable before the first publish"
+            )
+            return !vm.filteredTokens.isEmpty
+        }
+
+        XCTAssertFalse(vm.isLoading, "The first publish must clear the loading state")
+        _ = fetchTask
+    }
+
+    func testNoMatchQueryAfterLoadStillShowsEmptyState() async throws {
+        // After the first publish, a query with no match must land in the
+        // genuine no-results state: not loading, nothing filtered.
+        let registry = DestinationTokenRegistry()
+        SwapTokenListCache.shared.setCached([meta("USDC")], for: .ethereum)
+
+        let vm = SwapCoinSelectionViewModel(
+            vault: makeVault(),
+            selectedCoin: makeCoin("ETH", isNative: true),
+            isDestination: true,
+            registry: registry
+        )
+        vm.searchText = "zzz"
+
+        await vm.fetchCoins(chain: .ethereum, forceRefresh: true)
+
+        XCTAssertFalse(vm.isLoading, "Load finished — the empty state must be reachable again")
+        XCTAssertTrue(vm.filteredTokens.isEmpty, "No ticker matches the query")
+        XCTAssertFalse(vm.tokens.isEmpty, "The unfiltered list did load")
+    }
+
     // MARK: - Destination picker publishes before providers return
 
     func testDestinationPickerPublishesLocalListBeforeProvidersReturn() async throws {
@@ -76,7 +139,7 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
 
         // The local list must publish while the provider is still gated.
         try await waitUntil("local list published") { !vm.filteredTokens.isEmpty }
-        XCTAssertFalse(vm.isLoading, "Cached path serves without a spinner")
+        XCTAssertFalse(vm.isLoading, "The first (local) publish clears the loading state")
         XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "ETH" }, "Curated native must be in the local list")
         XCTAssertTrue(vm.filteredTokens.contains { $0.ticker == "USDC" }, "Cached external token must be in the local list")
         XCTAssertFalse(vm.filteredTokens.contains { $0.ticker == "NOVL" }, "Provider tokens only land on the enriched publish")

--- a/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapCoinSelectionViewModelTests.swift
@@ -91,7 +91,11 @@ final class SwapCoinSelectionViewModelTests: XCTestCase {
         }
 
         XCTAssertFalse(vm.isLoading, "The first publish must clear the loading state")
-        _ = fetchTask
+
+        // Finish the gated fetch inside the test so the enriched publish
+        // can't run after the test exits (the defer above is then a no-op).
+        provider.release()
+        await fetchTask.value
     }
 
     func testNoMatchQueryAfterLoadStillShowsEmptyState() async throws {


### PR DESCRIPTION
## Problem

On v1.41.64, the swap **To-asset picker** ("Select asset" sheet) opens showing **"No result found."** with an empty search query. The chain's asset list doesn't appear until (seemingly) the user types — breaking asset discovery and release-QA flows 87/89/90.

## Root cause

The picker's view model has an unrepresentable "empty while fetching" state on its cached path:

1. `SwapDetailsViewModel.load` prefetches `SwapTokenListCache` for the from/to chains, so the picker's `fetchCoins` takes the **cached path**, which immediately sets `isLoading = false` (the "instant serve, no spinner" design).
2. The first publish, however, only happens after `SwapCoinSelectionLogic.merge` awaits `DestinationTokenRegistry.tokens(for:forceRefresh: true)` — a **sequential, TTL-bypassed network hop** on every first open: SwapKit `/providers` + `/tokens?provider=…` fan-out, then THORChain `/thorchain/pools`, then Maya `/mayachain/pools`.
3. Until that returns, the state is `isLoading == false && filteredTokens == []`. `SwapCoinPickerView` renders exactly three states (loader / list / "No result found."), so it shows the empty message for the entire fetch. When the merge finally lands, `filteredTokens` is recomputed with whatever was typed meanwhile — making it look like typing populated the list.

**Regression commit:** the picker view/VM are byte-identical between v1.40.63 and v1.41.64 (only a `.foregroundStyle` cosmetic change); the hazard (spinner cleared before first publish, from #4633/#4643) already existed, but its window was one parallel SwapKit fan-out. `1917b6a12` (#4616, "dynamic THORChain/Maya swap eligibility", first shipped in v1.41.64) registered two additional always-network `NativePoolTokenProvider`s that the registry awaits **sequentially**, stretching the pre-publish window to many seconds and making the empty state deterministic.

Source-side pickers are unaffected (`isDestination == false` never hits the registry).

## Fix

Two-phase publish in `SwapCoinSelectionViewModel.publishMerge` (destination side only), honoring the original instant-serve intent:

1. **Instant:** merge + publish the network-free list — curated native + cached external list (1inch/Jupiter/preset) + vault-held coins — via a new `SwapCoinSelectionLogic.localMerge` (the existing merge body split into an `assemble` core).
2. **Enrich:** await the registry as before, re-merge, re-publish. Provider tokens append (deduped, re-sorted), and a typed query is preserved via `filterTokens(searchText:)`.

Also threads an optional `DestinationTokenRegistry` through the VM initializer (defaults to `.shared`, mirroring the existing seam on the logic struct) so tests can drive the flow with a controlled provider.

## Tests

New `SwapCoinSelectionViewModelTests` (camelCase):
- `testFilterTokensEmptyQueryReturnsDefaultList` — empty query returns the full default list
- `testFilterTokensQueryFiltersByTickerSubstring` — query filters
- `testFilterTokensNoMatchReturnsEmpty` — no match → empty
- `testDestinationPickerPublishesLocalListBeforeProvidersReturn` — **regression test**: with a continuation-gated slow provider and a seeded cache, `filteredTokens` is non-empty *before* the provider completes; the provider token appears after release
- `testDestinationPickerEnrichedPublishPreservesTypedQuery` — typing mid-refresh is preserved on the enriched publish
- `testSourcePickerIgnoresDestinationProviders` — source side never consults the registry (gate never released; fetch still completes)

## Follow-up: first-frame flash of the empty state

QA on the initial fix reported a ~1-frame flash of "No result found." before the first list render: the view model initialized with `isLoading = false` and an empty list, so the sheet's very first frame(s) matched the empty-state branch until the local merge published.

`c04dd2063` makes the loading state the default:
- `isLoading` starts `true`, so the view resolves to the loader — never the empty message — until the first publish.
- Every publish clears it; a failed cold load or merge failure also clears it (terminal states), so no path can spin forever.
- The cached path no longer force-clears a stale spinner up front — the first publish clears it with actual content.
- Genuine empty states unchanged: a no-match query after load still shows "No result found.".

New tests: initial state is loading with the empty state asserted unreachable at every poll until the first publish; the first publish flips it; no-match-after-load still lands in the empty state.

## Follow-up: cold-cache destination opens (CodeRabbit)

CodeRabbit correctly noted the local-first publish only covered the warm `SwapTokenListCache` path — a cold cache still blocked the first publish behind the external-catalog fetch plus the registry hop inside the full merge. `53ca161e5` publishes `localMerge(externalTokens: [], chain:)` at the top of the cold destination path, so the curated-native + vault-coin list paints immediately (first publish clears the spinner) and the enriched result swaps in when the fetch + registry merge lands. The cold success now also routes through the shared `publish(_:)`, so a query typed mid-load is preserved. Source-side cold behavior unchanged (single publish, registry never consulted). New tests cover both cold paths hermetically (Bitcoin: its external fetch is synchronously empty).

## Verification

- **Full unit suite on final HEAD `05856e75b`** (`xcodebuild test`, scheme `VultisigApp`, iPhone 17 Pro Max sim, worktree-local derived data): **2268 passed, 1 failed** — the sole failure is `StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress` (`"12,3%" != "12.3%"`), the known pre-existing decimal-comma locale flake on `main`, unrelated to this change. An earlier run under 3-way parallel build load also flaked two async-timing tests (`KeysignBroadcastCancellationTests.testURLErrorCancelledIsClassifiedAsCancellation`, `QBTCClaimSecureVaultRoundDriverTests.testRunBtcRoundDoesNotReKickoff`); both pass on subsequent runs.
- All 8 `SwapCoinSelectionViewModelTests` pass in the full run.
- SwiftLint clean on changed files.
- **Not simulator-verified interactively**: this Mac was saturated by parallel builds/test runs, so the swap picker was not driven by hand in the simulator. The root cause and fix are pinned at the view-model level by the gated-provider regression test (pre-fix code times out the local-list wait).
- Cross-model review loop: Codex reviewed each commit (step 1: no findings; step 2: one P2 test-robustness finding, fixed in a follow-up commit; loading-default follow-up: one P3 test-determinism finding, fixed in a follow-up commit) plus a whole-branch pass (no findings).

QA: please re-run release flows **87/89/90** against this branch — this is user-facing swap UX.

Closes #4730

🤖 Generated with [Claude Code](https://claude.com/claude-code)
