### PR TITLE
feat(wallet): support adding custom CW20 tokens on Terra / Terra Classic

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosAPI.swift
@@ -22,6 +22,7 @@ struct CosmosAPI: TargetType {
         case broadcastTransaction(body: Data)
         case simulate(body: Data)
         case wasmTokenBalance(contractAddress: String, base64Payload: String)
+        case wasmTokenInfo(contractAddress: String)
         case ibcDenomTrace(hash: String)
         case denomMetadata(denom: String)
         case allDenomsMetadata
@@ -42,11 +43,12 @@ struct CosmosAPI: TargetType {
         case .simulate:
             return "/cosmos/tx/v1beta1/simulate"
         case .wasmTokenBalance(let contractAddress, let base64Payload):
-            // Base64 can include `/` and `=`, which the URL parser would
-            // otherwise treat as path separators / query delimiters.
-            let allowed = CharacterSet.urlPathAllowed.subtracting(CharacterSet(charactersIn: "/"))
-            let encodedPayload = base64Payload.addingPercentEncoding(withAllowedCharacters: allowed) ?? base64Payload
-            return "/cosmwasm/wasm/v1/contract/\(contractAddress)/smart/\(encodedPayload)"
+            return Self.wasmSmartQueryPath(contractAddress: contractAddress, base64Payload: base64Payload)
+        case .wasmTokenInfo(let contractAddress):
+            // CW20 metadata query. The payload is the constant `{"token_info":{}}`
+            // smart query, matching the SDK's `getCw20MetaFromLCD`.
+            let base64Payload = Data("{\"token_info\":{}}".utf8).base64EncodedString()
+            return Self.wasmSmartQueryPath(contractAddress: contractAddress, base64Payload: base64Payload)
         case .ibcDenomTrace(let hash):
             return "/ibc/apps/transfer/v1/denom_traces/\(hash)"
         case .denomMetadata(let denom):
@@ -97,6 +99,15 @@ struct CosmosAPI: TargetType {
             return .requestPlain
         }
     }
+
+    /// Builds the `/cosmwasm/.../smart/{payload}` path for a wasm smart query.
+    /// Base64 can include `/` and `=`, which the URL parser would otherwise
+    /// treat as path separators / query delimiters, so `/` is percent-encoded.
+    private static func wasmSmartQueryPath(contractAddress: String, base64Payload: String) -> String {
+        let allowed = CharacterSet.urlPathAllowed.subtracting(CharacterSet(charactersIn: "/"))
+        let encodedPayload = base64Payload.addingPercentEncoding(withAllowedCharacters: allowed) ?? base64Payload
+        return "/cosmwasm/wasm/v1/contract/\(contractAddress)/smart/\(encodedPayload)"
+    }
 }
 
 // MARK: - Response types
@@ -118,6 +129,20 @@ struct CosmosWasmTokenBalanceResponse: Decodable {
 
     struct BalanceData: Decodable {
         let balance: String
+    }
+}
+
+/// Response for a CW20 `{"token_info":{}}` smart query. The CW20 spec
+/// mandates all three fields, but they are decoded as optionals so a
+/// contract that answers the query with a partial/non-standard blob is
+/// treated as "not a CW20 token" instead of failing decode.
+struct CosmosCw20TokenInfoResponse: Decodable {
+    let data: TokenInfo
+
+    struct TokenInfo: Decodable {
+        let name: String?
+        let symbol: String?
+        let decimals: Int?
     }
 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
@@ -151,11 +151,17 @@ actor CosmosTokenMetadataResolver {
 
     /// Resolve CW20 token metadata (`name`, `symbol`, `decimals`) for a wasm
     /// contract via the `{"token_info":{}}` smart query — the same lookup the
-    /// SDK's `getCw20MetaFromLCD` performs. Returns `nil` when the contract
-    /// doesn't answer the query like a CW20 token (non-CW20 contract, unknown
-    /// address, malformed response) or on network failure; the caller surfaces
-    /// its own not-found UX and may retry.
-    func cw20TokenInfo(chain: Chain, contractAddress: String) async -> CosmosCw20TokenInfo? {
+    /// SDK's `getCw20MetaFromLCD` performs.
+    ///
+    /// Returns `nil` only when the address is *definitively* not a CW20 token:
+    /// the LCD rejects the smart query (wallet addresses, non-CW20 contracts,
+    /// unknown addresses) or the reply fails token_info validation. Transport
+    /// failures — rate limiting (HTTP 429), network errors, timeouts — THROW
+    /// instead: they say nothing about the address, and the caller's error UX
+    /// (rate-limit copy, retry) must not collapse into "token not found".
+    /// Failures are never cached either way: the entry is evicted so the next
+    /// call retries.
+    func cw20TokenInfo(chain: Chain, contractAddress: String) async throws -> CosmosCw20TokenInfo? {
         let key = cacheKey(chain: chain, value: contractAddress)
 
         if let cached = cw20Cache[key], !isExpired(storedAt: cached.storedAt) {
@@ -167,7 +173,7 @@ actor CosmosTokenMetadataResolver {
                 return nil
             } catch {
                 cw20Cache.removeValue(forKey: key)
-                return nil
+                throw error
             }
         }
 
@@ -186,7 +192,7 @@ actor CosmosTokenMetadataResolver {
         } catch {
             logger.warning("CW20 token_info lookup failed for \(contractAddress, privacy: .public) on \(chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .public)")
             cw20Cache.removeValue(forKey: key)
-            return nil
+            throw error
         }
     }
 
@@ -282,12 +288,23 @@ actor CosmosTokenMetadataResolver {
     /// as `u8` and 18 is the de-facto ceiling for real tokens.
     private static let cw20DecimalsRange = 0...36
 
+    /// HTTP statuses that signal a transient gateway/overload condition
+    /// rather than a verdict on the queried contract: request timeout, too
+    /// early, rate limited, bad gateway, service unavailable, gateway
+    /// timeout. These rethrow so the caller can show a retryable error.
+    /// Notably 500 is NOT here: Terra LCDs answer the smart query with 500
+    /// for wallet addresses and non-CW20 contracts, so it means not-found.
+    private static let transientHTTPStatuses: Set<Int> = [408, 425, 429, 502, 503, 504]
+
     /// Fetches and validates a CW20 `token_info` response. Mirrors the SDK's
     /// validation: the symbol must be non-empty after trimming and the
     /// decimals an integer within ``cw20DecimalsRange``, otherwise the
-    /// contract is treated as not-a-CW20-token (`nil`). Network/decode errors
-    /// propagate so the caller's cache eviction kicks in and a later retry
-    /// can succeed.
+    /// contract is treated as not-a-CW20-token (`nil`). LCD error statuses
+    /// outside ``transientHTTPStatuses`` and unparseable replies also mean
+    /// not-a-CW20-token — that is how the LCD answers the smart query for
+    /// wallet addresses and non-CW20 contracts. Transient statuses and
+    /// network-layer errors propagate: they are transport failures, not a
+    /// verdict on the address.
     private static func fetchCw20TokenInfo(
         httpClient: HTTPClientProtocol,
         chain: Chain,
@@ -298,10 +315,20 @@ actor CosmosTokenMetadataResolver {
             return nil
         }
 
-        let response = try await httpClient.request(
-            CosmosAPI(baseURL: baseURL, endpoint: .wasmTokenInfo(contractAddress: contractAddress)),
-            responseType: CosmosCw20TokenInfoResponse.self
-        )
+        let response: HTTPResponse<CosmosCw20TokenInfoResponse>
+        do {
+            response = try await httpClient.request(
+                CosmosAPI(baseURL: baseURL, endpoint: .wasmTokenInfo(contractAddress: contractAddress)),
+                responseType: CosmosCw20TokenInfoResponse.self
+            )
+        } catch HTTPError.statusCode(let code, let data) {
+            guard !transientHTTPStatuses.contains(code) else {
+                throw HTTPError.statusCode(code, data)
+            }
+            return nil
+        } catch HTTPError.decodingFailed {
+            return nil
+        }
 
         let info = response.data.data
         guard let symbol = info.symbol?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
@@ -21,6 +21,14 @@
 import Foundation
 import OSLog
 
+/// Validated CW20 token metadata as answered by a `{"token_info":{}}` wasm
+/// smart query: the fields a custom-token flow needs to build a `CoinMeta`.
+struct CosmosCw20TokenInfo: Equatable {
+    let name: String
+    let symbol: String
+    let decimals: Int
+}
+
 actor CosmosTokenMetadataResolver {
 
     static let shared = CosmosTokenMetadataResolver()
@@ -44,6 +52,7 @@ actor CosmosTokenMetadataResolver {
 
     private var metadataCache: [String: CachedTask<CosmosDenomMetadata>] = [:]
     private var traceCache: [String: CachedTask<CosmosIbcDenomTraceDenomTrace>] = [:]
+    private var cw20Cache: [String: CachedTask<CosmosCw20TokenInfo>] = [:]
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.httpClient = httpClient
@@ -140,11 +149,53 @@ actor CosmosTokenMetadataResolver {
         }
     }
 
+    /// Resolve CW20 token metadata (`name`, `symbol`, `decimals`) for a wasm
+    /// contract via the `{"token_info":{}}` smart query — the same lookup the
+    /// SDK's `getCw20MetaFromLCD` performs. Returns `nil` when the contract
+    /// doesn't answer the query like a CW20 token (non-CW20 contract, unknown
+    /// address, malformed response) or on network failure; the caller surfaces
+    /// its own not-found UX and may retry.
+    func cw20TokenInfo(chain: Chain, contractAddress: String) async -> CosmosCw20TokenInfo? {
+        let key = cacheKey(chain: chain, value: contractAddress)
+
+        if let cached = cw20Cache[key], !isExpired(storedAt: cached.storedAt) {
+            do {
+                if let value = try await cached.task.value {
+                    return value
+                }
+                cw20Cache.removeValue(forKey: key)
+                return nil
+            } catch {
+                cw20Cache.removeValue(forKey: key)
+                return nil
+            }
+        }
+
+        let httpClient = self.httpClient
+        let task = Task<CosmosCw20TokenInfo?, Error> {
+            try await Self.fetchCw20TokenInfo(httpClient: httpClient, chain: chain, contractAddress: contractAddress)
+        }
+        cw20Cache[key] = CachedTask(task: task, storedAt: Date())
+
+        do {
+            if let value = try await task.value {
+                return value
+            }
+            cw20Cache.removeValue(forKey: key)
+            return nil
+        } catch {
+            logger.warning("CW20 token_info lookup failed for \(contractAddress, privacy: .public) on \(chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            cw20Cache.removeValue(forKey: key)
+            return nil
+        }
+    }
+
     /// Public test seam. Production callers use the singleton and never
     /// need to flush.
     func clearCacheForTests() {
         metadataCache.removeAll()
         traceCache.removeAll()
+        cw20Cache.removeAll()
     }
 
     // MARK: - Decoders (pure)
@@ -222,6 +273,49 @@ actor CosmosTokenMetadataResolver {
             responseType: CosmosDenomMetadatasResponse.self
         )
         return list.data.metadatas?.first(where: { $0.base == denom })
+    }
+
+    /// Upper bound on accepted CW20 `decimals`. The value is contract-
+    /// controlled (untrusted), and downstream formatting computes
+    /// `BigInt(10).power(decimals)` — the same reason the ERC-20 metadata
+    /// resolver bounds decimals to this range. The CW20 spec types decimals
+    /// as `u8` and 18 is the de-facto ceiling for real tokens.
+    private static let cw20DecimalsRange = 0...36
+
+    /// Fetches and validates a CW20 `token_info` response. Mirrors the SDK's
+    /// validation: the symbol must be non-empty after trimming and the
+    /// decimals an integer within ``cw20DecimalsRange``, otherwise the
+    /// contract is treated as not-a-CW20-token (`nil`). Network/decode errors
+    /// propagate so the caller's cache eviction kicks in and a later retry
+    /// can succeed.
+    private static func fetchCw20TokenInfo(
+        httpClient: HTTPClientProtocol,
+        chain: Chain,
+        contractAddress: String
+    ) async throws -> CosmosCw20TokenInfo? {
+        guard let config = try? CosmosServiceConfig.getConfig(forChain: chain),
+              let baseURL = config.baseURL else {
+            return nil
+        }
+
+        let response = try await httpClient.request(
+            CosmosAPI(baseURL: baseURL, endpoint: .wasmTokenInfo(contractAddress: contractAddress)),
+            responseType: CosmosCw20TokenInfoResponse.self
+        )
+
+        let info = response.data.data
+        guard let symbol = info.symbol?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !symbol.isEmpty,
+              let decimals = info.decimals, cw20DecimalsRange.contains(decimals) else {
+            return nil
+        }
+
+        let name = info.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return CosmosCw20TokenInfo(
+            name: name.isEmpty ? symbol : name,
+            symbol: symbol,
+            decimals: decimals
+        )
     }
 
     private static func fetchIbcDenomTrace(

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Cw20CustomTokenResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Cw20CustomTokenResolver.swift
@@ -56,19 +56,22 @@ enum Cw20CustomTokenResolver {
     /// logo and no price id — the same behavior as custom tokens on every
     /// other chain.
     ///
-    /// - Returns: The resolved `CoinMeta`, or `nil` when the address doesn't
-    ///   answer the query like a CW20 token (wallet address, non-CW20
-    ///   contract, unknown address) or the lookup fails.
+    /// - Returns: The resolved `CoinMeta`, or `nil` when the address is
+    ///   definitively not a CW20 token (wallet address, non-CW20 contract,
+    ///   unknown address).
+    /// - Throws: Transport failures (rate limiting, network errors) from the
+    ///   metadata lookup, so the caller can distinguish "try again later"
+    ///   from "token not found".
     static func resolve(
         contractAddress: String,
         chain: Chain,
         metadataResolver: CosmosTokenMetadataResolver = .shared
-    ) async -> CoinMeta? {
+    ) async throws -> CoinMeta? {
         guard isValidInput(contractAddress, chain: chain) else {
             return nil
         }
 
-        guard let info = await metadataResolver.cw20TokenInfo(
+        guard let info = try await metadataResolver.cw20TokenInfo(
             chain: chain,
             contractAddress: contractAddress
         ) else {

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Cw20CustomTokenResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Cw20CustomTokenResolver.swift
@@ -1,0 +1,89 @@
+//
+//  Cw20CustomTokenResolver.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Resolves a user-pasted CW20 contract address into a ``CoinMeta`` for the
+/// custom-token flow on Terra and Terra Classic.
+///
+/// CW20 tokens are CosmWasm contracts, not bank denoms, so their metadata
+/// comes from the `{"token_info":{}}` smart query (via
+/// ``CosmosTokenMetadataResolver/cw20TokenInfo(chain:contractAddress:)``)
+/// rather than `denoms_metadata`. Input validation is a bech32 *shape* check
+/// mirroring the SDK's `isCosmosWasmTokenId`: contract addresses can be
+/// 20-byte (Terra Classic pre-migration contracts, indistinguishable from
+/// wallet addresses) or 32-byte, so only the LCD query itself can tell a
+/// contract from a wallet — a plausible-but-wrong address resolves to
+/// not-found, never to a bogus token.
+enum Cw20CustomTokenResolver {
+
+    /// Bech32 prefix expected for CW20 contract addresses on this chain, or
+    /// `nil` when the chain has no CW20 custom-token support.
+    static func contractAddressPrefix(for chain: Chain) -> String? {
+        switch chain {
+        case .terra, .terraClassic:
+            return "terra1"
+        default:
+            return nil
+        }
+    }
+
+    /// Validates that the input is plausibly a CW20 contract address for the
+    /// given chain, without hitting the network. Mirrors the SDK's
+    /// `isCosmosWasmTokenId` shape (`prefix` + 20–80 lowercase-alphanumeric
+    /// characters); `ibc/…` and `factory/…` denoms are bank denoms, not
+    /// contracts, and are rejected.
+    static func isValidInput(_ input: String, chain: Chain) -> Bool {
+        guard let prefix = contractAddressPrefix(for: chain),
+              input.hasPrefix(prefix) else {
+            return false
+        }
+        let payload = input.dropFirst(prefix.count)
+        guard (20...80).contains(payload.count) else {
+            return false
+        }
+        return payload.allSatisfy { character in
+            character.isASCII && ((character.isLetter && character.isLowercase) || character.isNumber)
+        }
+    }
+
+    /// Resolves a CW20 contract address to a ``CoinMeta`` via the
+    /// `token_info` smart query on the chain's LCD. A curated ``TokensStore``
+    /// entry (matched by contract address) is preferred so known tokens keep
+    /// their real logo and `priceProviderId`; unknown tokens get an empty
+    /// logo and no price id — the same behavior as custom tokens on every
+    /// other chain.
+    ///
+    /// - Returns: The resolved `CoinMeta`, or `nil` when the address doesn't
+    ///   answer the query like a CW20 token (wallet address, non-CW20
+    ///   contract, unknown address) or the lookup fails.
+    static func resolve(
+        contractAddress: String,
+        chain: Chain,
+        metadataResolver: CosmosTokenMetadataResolver = .shared
+    ) async -> CoinMeta? {
+        guard isValidInput(contractAddress, chain: chain) else {
+            return nil
+        }
+
+        guard let info = await metadataResolver.cw20TokenInfo(
+            chain: chain,
+            contractAddress: contractAddress
+        ) else {
+            return nil
+        }
+
+        return TokensStore.findTokenMeta(chain: chain, contractAddress: contractAddress)
+            ?? CoinMeta(
+                chain: chain,
+                ticker: info.symbol,
+                logo: .empty,
+                decimals: info.decimals,
+                priceProviderId: .empty,
+                contractAddress: contractAddress,
+                isNativeToken: false
+            )
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/CustomTokenScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/CustomTokenScreen.swift
@@ -147,8 +147,8 @@ struct CustomTokenScreen: View {
     }
 
     /// Looks up token metadata for the current ``contractAddress`` by dispatching to the appropriate
-    /// chain-specific service (THORChain bank denom, Cardano, EVM, Solana, Tron, or TON). On success,
-    /// populates the token preview; on failure, sets the ``error`` state.
+    /// chain-specific service (THORChain bank denom, Cardano, Terra CW20, EVM, Solana, Tron, or TON).
+    /// On success, populates the token preview; on failure, sets the ``error`` state.
     private func fetchTokenInfo() async {
         guard !contractAddress.isEmpty else { return }
 
@@ -202,6 +202,28 @@ struct CustomTokenScreen: View {
                         contractAddress: metadata.assetId,
                         isNativeToken: false
                     )
+                self.token = coinMeta
+                self.tokenName = coinMeta.ticker
+                self.tokenSymbol = coinMeta.ticker
+                self.tokenDecimals = coinMeta.decimals
+                self.showTokenInfo = true
+                self.isLoading = false
+
+            } else if chain == .terra || chain == .terraClassic {
+
+                // Terra CW20 tokens are CosmWasm contracts; metadata comes from
+                // the `{"token_info":{}}` smart query on the selected chain's
+                // LCD. A wallet address or non-CW20 contract makes the LCD
+                // reject the query and resolves to not-found. Curated catalog
+                // entries are preferred for the logo and price provider.
+                guard let coinMeta = await Cw20CustomTokenResolver.resolve(
+                    contractAddress: contractAddress,
+                    chain: chain
+                ) else {
+                    self.error = TokenNotFoundError()
+                    self.isLoading = false
+                    return
+                }
                 self.token = coinMeta
                 self.tokenName = coinMeta.ticker
                 self.tokenSymbol = coinMeta.ticker
@@ -309,6 +331,8 @@ struct CustomTokenScreen: View {
     /// tokens are bank denoms, not pool assets), so we validate that shape rather than a
     /// `thor1…` account address — the shared `AddressService.validateAddress` is reserved
     /// for real send/receive addresses and must keep rejecting token identifiers.
+    /// For Terra and Terra Classic, the input is a CW20 contract address, validated by
+    /// bech32 shape (contract payloads differ from account addresses).
     /// Other chains validate the input as a contract/account address.
     /// Updates ``isValidAddress`` accordingly.
     /// - Parameter address: The raw input string.
@@ -317,6 +341,12 @@ struct CustomTokenScreen: View {
             isValidAddress = (try? CardanoAssetId.parse(address)) != nil
         } else if chain == .thorChain {
             isValidAddress = ThorchainCustomTokenResolver.isValidInput(address)
+        } else if chain == .terra || chain == .terraClassic {
+            // CW20 contract addresses are not account addresses (Terra 2
+            // contracts carry 32-byte payloads, and 20-byte Terra Classic
+            // contracts are shape-identical to wallets), so validate the
+            // bech32 contract shape instead of a send/receive address.
+            isValidAddress = Cw20CustomTokenResolver.isValidInput(address, chain: chain)
         } else {
             isValidAddress = AddressService.validateAddress(address: address, chain: chain)
         }

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/CustomTokenScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/CustomTokenScreen.swift
@@ -214,9 +214,11 @@ struct CustomTokenScreen: View {
                 // Terra CW20 tokens are CosmWasm contracts; metadata comes from
                 // the `{"token_info":{}}` smart query on the selected chain's
                 // LCD. A wallet address or non-CW20 contract makes the LCD
-                // reject the query and resolves to not-found. Curated catalog
+                // reject the query and resolves to not-found; transport
+                // failures (rate limit, network) throw into the shared catch
+                // below instead of masquerading as not-found. Curated catalog
                 // entries are preferred for the logo and price provider.
-                guard let coinMeta = await Cw20CustomTokenResolver.resolve(
+                guard let coinMeta = try await Cw20CustomTokenResolver.resolve(
                     contractAddress: contractAddress,
                     chain: chain
                 ) else {
@@ -302,6 +304,15 @@ struct CustomTokenScreen: View {
 
             }
 
+        } catch HTTPError.statusCode(429, _) {
+            // HTTPClient-based lookups (Terra CW20) surface rate limiting as a
+            // typed status-code error rather than an NSError with code 429.
+            self.error = RateLimitError()
+            self.isLoading = false
+        } catch is CancellationError {
+            // A cancelled lookup is not a failure the user needs to see;
+            // just stop the spinner.
+            self.isLoading = false
         } catch let error as NSError {
             // Check for rate limit error
             if error.code == 429 {

--- a/VultisigApp/VultisigAppTests/Chains/CosmosCw20TokenInfoTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CosmosCw20TokenInfoTests.swift
@@ -43,12 +43,12 @@ final class CosmosCw20TokenInfoTests: XCTestCase {
 
     // MARK: - Resolver success
 
-    func testCw20TokenInfoDecodesTokenInfoResponse() async {
+    func testCw20TokenInfoDecodesTokenInfoResponse() async throws {
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .success(name: "Eris Amplified LUNA", symbol: "ampLUNA", decimals: 6)
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertEqual(
             info,
@@ -56,28 +56,28 @@ final class CosmosCw20TokenInfoTests: XCTestCase {
         )
     }
 
-    func testCw20TokenInfoAcceptsZeroDecimals() async {
+    func testCw20TokenInfoAcceptsZeroDecimals() async throws {
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .success(name: "Whole Token", symbol: "WHOLE", decimals: 0)
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertEqual(info?.decimals, 0)
     }
 
-    func testCw20TokenInfoNameFallsBackToSymbol() async {
+    func testCw20TokenInfoNameFallsBackToSymbol() async throws {
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .json(["data": ["symbol": "NONAME", "decimals": 6]])
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertEqual(info?.name, "NONAME")
         XCTAssertEqual(info?.symbol, "NONAME")
     }
 
-    func testCw20TokenInfoQueriesTheSelectedChainLcd() async {
+    func testCw20TokenInfoQueriesTheSelectedChainLcd() async throws {
         // Chain selection must drive which LCD host is queried: the same
         // `terra1…` contract resolves against the Terra Classic LCD when the
         // user picked Terra Classic.
@@ -85,20 +85,20 @@ final class CosmosCw20TokenInfoTests: XCTestCase {
         stub.result = .success(name: "Astroport Classic", symbol: "ASTROC", decimals: 6)
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        _ = await resolver.cw20TokenInfo(
+        _ = try await resolver.cw20TokenInfo(
             chain: .terraClassic,
             contractAddress: "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
         )
 
         XCTAssertEqual(stub.requestedBaseURLs.last?.host, "terra-classic-lcd.publicnode.com")
 
-        _ = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        _ = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
         XCTAssertEqual(stub.requestedBaseURLs.last?.host, "terra-lcd.publicnode.com")
     }
 
-    // MARK: - Resolver failure
+    // MARK: - Not-a-CW20 (nil) outcomes
 
-    func testCw20TokenInfoReturnsNilOnLcdError() async {
+    func testCw20TokenInfoReturnsNilOnLcdError() async throws {
         // A non-CW20 contract (or a wallet address) makes the LCD answer the
         // smart query with an error status — the resolver maps that to nil so
         // the caller can surface its not-found UX.
@@ -106,52 +106,65 @@ final class CosmosCw20TokenInfoTests: XCTestCase {
         stub.result = .httpError(500)
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertNil(info)
     }
 
-    func testCw20TokenInfoReturnsNilForMissingSymbol() async {
+    func testCw20TokenInfoReturnsNilForUnparseableReply() async throws {
+        // A 200 whose body doesn't decode as a token_info reply is a contract
+        // answering with something else — not a CW20 token, not a transport
+        // failure.
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .json(["data": 42])
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertNil(info)
+    }
+
+    func testCw20TokenInfoReturnsNilForMissingSymbol() async throws {
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .json(["data": ["name": "Some Contract State", "decimals": 6]])
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertNil(info)
     }
 
-    func testCw20TokenInfoReturnsNilForBlankSymbol() async {
+    func testCw20TokenInfoReturnsNilForBlankSymbol() async throws {
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .json(["data": ["name": "Blank", "symbol": "  ", "decimals": 6]])
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertNil(info)
     }
 
-    func testCw20TokenInfoReturnsNilForMissingDecimals() async {
+    func testCw20TokenInfoReturnsNilForMissingDecimals() async throws {
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .json(["data": ["name": "No Decimals", "symbol": "NODEC"]])
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertNil(info)
     }
 
-    func testCw20TokenInfoReturnsNilForNegativeDecimals() async {
+    func testCw20TokenInfoReturnsNilForNegativeDecimals() async throws {
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .json(["data": ["name": "Bad", "symbol": "BAD", "decimals": -1]])
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertNil(info)
     }
 
-    func testCw20TokenInfoReturnsNilForExcessiveDecimals() async {
+    func testCw20TokenInfoReturnsNilForExcessiveDecimals() async throws {
         // Contract-controlled decimals feed BigInt(10).power(decimals) in
         // downstream formatting; a hostile contract must not smuggle in a
         // huge exponent (same 0...36 bound as the ERC-20 metadata resolver).
@@ -159,52 +172,130 @@ final class CosmosCw20TokenInfoTests: XCTestCase {
         stub.result = .json(["data": ["name": "Hostile", "symbol": "EVIL", "decimals": 65535]])
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertNil(info)
     }
 
-    func testCw20TokenInfoReturnsNilForUnsupportedChain() async {
+    func testCw20TokenInfoReturnsNilForUnsupportedChain() async throws {
         // Chains without a Cosmos LCD config can't run a wasm smart query;
         // the resolver must bail out without touching the network.
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .success(name: "X", symbol: "X", decimals: 6)
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let info = await resolver.cw20TokenInfo(chain: .ethereum, contractAddress: astroContract)
+        let info = try await resolver.cw20TokenInfo(chain: .ethereum, contractAddress: astroContract)
 
         XCTAssertNil(info)
         XCTAssertEqual(stub.callCount, 0)
     }
 
+    // MARK: - Transport failures (thrown)
+
+    func testCw20TokenInfoThrowsOnRateLimit() async {
+        // Rate limiting says nothing about the address; it must NOT collapse
+        // into not-found. The typed 429 propagates so the custom-token screen
+        // can show its dedicated rate-limit copy.
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .httpError(429)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        do {
+            _ = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+            XCTFail("Expected a thrown rate-limit error")
+        } catch HTTPError.statusCode(let code, _) {
+            XCTAssertEqual(code, 429)
+        } catch {
+            XCTFail("Expected HTTPError.statusCode(429), got \(error)")
+        }
+    }
+
+    func testCw20TokenInfoThrowsOnRetryableServerStatus() async {
+        // Gateway/overload statuses (502/503/504/408) are transient — they
+        // must propagate as retryable errors, not collapse into not-found.
+        // (500 stays not-found: Terra LCDs use it for semantic smart-query
+        // failures on wallet addresses / non-CW20 contracts.)
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .httpError(503)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        do {
+            _ = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+            XCTFail("Expected a thrown transient-status error")
+        } catch HTTPError.statusCode(let code, _) {
+            XCTAssertEqual(code, 503)
+        } catch {
+            XCTFail("Expected HTTPError.statusCode(503), got \(error)")
+        }
+    }
+
+    func testCw20TokenInfoThrowsOnNetworkError() async {
+        // Network-layer failures (offline, DNS, connection reset) are
+        // transient — propagate them so the screen shows the error and offers
+        // retry instead of declaring the token nonexistent.
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .transportError(HTTPError.networkError(URLError(.notConnectedToInternet)))
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        do {
+            _ = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+            XCTFail("Expected a thrown network error")
+        } catch HTTPError.networkError {
+            // expected
+        } catch {
+            XCTFail("Expected HTTPError.networkError, got \(error)")
+        }
+    }
+
     // MARK: - Cache semantics
 
-    func testCw20TokenInfoCachesSuccessfulLookup() async {
+    func testCw20TokenInfoCachesSuccessfulLookup() async throws {
         let stub = Cw20ScriptedHTTPClient()
         stub.result = .success(name: "Astroport", symbol: "ASTRO", decimals: 6)
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let first = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
-        let second = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let first = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let second = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
         XCTAssertEqual(first, second)
         XCTAssertEqual(stub.callCount, 1, "Second lookup must be served from the cache")
     }
 
-    func testCw20TokenInfoEvictsCacheOnFailure() async {
-        // A transient LCD failure must NOT poison the cache: after a failed
-        // call the next call retries (and succeeds once the LCD recovers).
+    func testCw20TokenInfoEvictsCacheOnTransportFailure() async throws {
+        // A transient LCD failure must NOT poison the cache: after a thrown
+        // transport error the next call retries (and succeeds once the LCD
+        // recovers).
         let stub = Cw20ScriptedHTTPClient()
-        stub.result = .httpError(503)
+        stub.result = .transportError(HTTPError.timeout)
         let resolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let first = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        do {
+            _ = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+            XCTFail("Expected a thrown transport error")
+        } catch {
+            // expected — the entry must have been evicted
+        }
+
+        stub.result = .success(name: "Astroport", symbol: "ASTRO", decimals: 6)
+        let second = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertEqual(second?.symbol, "ASTRO", "Cache eviction on error must let the retry succeed")
+    }
+
+    func testCw20TokenInfoEvictsCacheOnNotFound() async throws {
+        // A not-found verdict is not cached either: if the LCD (or a flaky
+        // proxy) wrongly 500s once, the next attempt retries.
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .httpError(500)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let first = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
         XCTAssertNil(first)
 
         stub.result = .success(name: "Astroport", symbol: "ASTRO", decimals: 6)
-        let second = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let second = try await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
 
-        XCTAssertEqual(second?.symbol, "ASTRO", "Cache eviction on error must let the retry succeed")
+        XCTAssertEqual(second?.symbol, "ASTRO", "Cache eviction on nil must let the retry succeed")
     }
 }
 
@@ -212,13 +303,15 @@ final class CosmosCw20TokenInfoTests: XCTestCase {
 
 /// Scripted HTTP client for CW20 `token_info` lookups. Responses are
 /// assembled as JSON and run through the production `JSONDecoder`, so the
-/// test exercises the real decode path.
+/// test exercises the real decode path — including the protocol extension's
+/// `HTTPError.decodingFailed` wrapping.
 private final class Cw20ScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable {
 
     enum ScriptedResult {
         case success(name: String, symbol: String, decimals: Int)
         case json([String: Any])
         case httpError(Int)
+        case transportError(Error)
     }
 
     var result: ScriptedResult = .httpError(500)
@@ -260,10 +353,19 @@ private final class Cw20ScriptedHTTPClient: HTTPClientProtocol, @unchecked Senda
             json = payload
         case .httpError(let code):
             throw HTTPError.statusCode(code, nil)
+        case .transportError(let error):
+            throw error
         }
 
         let data = try JSONSerialization.data(withJSONObject: json)
-        let decoded = try JSONDecoder().decode(T.self, from: data)
+        let decoded: T
+        do {
+            decoded = try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            // Mirror the production HTTPClientProtocol extension, which wraps
+            // decode failures of a 200 response in `.decodingFailed`.
+            throw HTTPError.decodingFailed(error)
+        }
         let response = HTTPURLResponse(
             url: URL(string: "https://test.local")!,
             statusCode: 200,

--- a/VultisigApp/VultisigAppTests/Chains/CosmosCw20TokenInfoTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CosmosCw20TokenInfoTests.swift
@@ -1,0 +1,280 @@
+//
+//  CosmosCw20TokenInfoTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class CosmosCw20TokenInfoTests: XCTestCase {
+
+    // ASTRO on Terra — a real 32-byte CW20 contract address.
+    private let astroContract = "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
+
+    // MARK: - Endpoint
+
+    func testWasmTokenInfoEndpointPathEncodesTokenInfoQuery() {
+        // The payload must be the base64 of `{"token_info":{}}` — byte-for-byte
+        // the same URL the SDK's `getCw20MetaFromLCD` queries.
+        let api = CosmosAPI(
+            baseURL: URL(string: "https://terra-lcd.publicnode.com")!,
+            endpoint: .wasmTokenInfo(contractAddress: astroContract)
+        )
+        XCTAssertEqual(
+            api.path,
+            "/cosmwasm/wasm/v1/contract/\(astroContract)/smart/eyJ0b2tlbl9pbmZvIjp7fX0="
+        )
+        XCTAssertEqual(api.method, .get)
+    }
+
+    func testWasmTokenBalancePathUnchangedBySharedHelper() {
+        // The smart-query path builder is shared with the pre-existing balance
+        // endpoint; its output must stay byte-identical (slashes in the base64
+        // payload percent-encoded, `=` untouched).
+        let api = CosmosAPI(
+            baseURL: URL(string: "https://terra-lcd.publicnode.com")!,
+            endpoint: .wasmTokenBalance(contractAddress: astroContract, base64Payload: "aGVsbG8/d29ybGQ=")
+        )
+        XCTAssertEqual(
+            api.path,
+            "/cosmwasm/wasm/v1/contract/\(astroContract)/smart/aGVsbG8%2Fd29ybGQ="
+        )
+    }
+
+    // MARK: - Resolver success
+
+    func testCw20TokenInfoDecodesTokenInfoResponse() async {
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .success(name: "Eris Amplified LUNA", symbol: "ampLUNA", decimals: 6)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertEqual(
+            info,
+            CosmosCw20TokenInfo(name: "Eris Amplified LUNA", symbol: "ampLUNA", decimals: 6)
+        )
+    }
+
+    func testCw20TokenInfoAcceptsZeroDecimals() async {
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .success(name: "Whole Token", symbol: "WHOLE", decimals: 0)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertEqual(info?.decimals, 0)
+    }
+
+    func testCw20TokenInfoNameFallsBackToSymbol() async {
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .json(["data": ["symbol": "NONAME", "decimals": 6]])
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertEqual(info?.name, "NONAME")
+        XCTAssertEqual(info?.symbol, "NONAME")
+    }
+
+    func testCw20TokenInfoQueriesTheSelectedChainLcd() async {
+        // Chain selection must drive which LCD host is queried: the same
+        // `terra1…` contract resolves against the Terra Classic LCD when the
+        // user picked Terra Classic.
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .success(name: "Astroport Classic", symbol: "ASTROC", decimals: 6)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        _ = await resolver.cw20TokenInfo(
+            chain: .terraClassic,
+            contractAddress: "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+        )
+
+        XCTAssertEqual(stub.requestedBaseURLs.last?.host, "terra-classic-lcd.publicnode.com")
+
+        _ = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        XCTAssertEqual(stub.requestedBaseURLs.last?.host, "terra-lcd.publicnode.com")
+    }
+
+    // MARK: - Resolver failure
+
+    func testCw20TokenInfoReturnsNilOnLcdError() async {
+        // A non-CW20 contract (or a wallet address) makes the LCD answer the
+        // smart query with an error status — the resolver maps that to nil so
+        // the caller can surface its not-found UX.
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .httpError(500)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertNil(info)
+    }
+
+    func testCw20TokenInfoReturnsNilForMissingSymbol() async {
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .json(["data": ["name": "Some Contract State", "decimals": 6]])
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertNil(info)
+    }
+
+    func testCw20TokenInfoReturnsNilForBlankSymbol() async {
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .json(["data": ["name": "Blank", "symbol": "  ", "decimals": 6]])
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertNil(info)
+    }
+
+    func testCw20TokenInfoReturnsNilForMissingDecimals() async {
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .json(["data": ["name": "No Decimals", "symbol": "NODEC"]])
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertNil(info)
+    }
+
+    func testCw20TokenInfoReturnsNilForNegativeDecimals() async {
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .json(["data": ["name": "Bad", "symbol": "BAD", "decimals": -1]])
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertNil(info)
+    }
+
+    func testCw20TokenInfoReturnsNilForExcessiveDecimals() async {
+        // Contract-controlled decimals feed BigInt(10).power(decimals) in
+        // downstream formatting; a hostile contract must not smuggle in a
+        // huge exponent (same 0...36 bound as the ERC-20 metadata resolver).
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .json(["data": ["name": "Hostile", "symbol": "EVIL", "decimals": 65535]])
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertNil(info)
+    }
+
+    func testCw20TokenInfoReturnsNilForUnsupportedChain() async {
+        // Chains without a Cosmos LCD config can't run a wasm smart query;
+        // the resolver must bail out without touching the network.
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .success(name: "X", symbol: "X", decimals: 6)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let info = await resolver.cw20TokenInfo(chain: .ethereum, contractAddress: astroContract)
+
+        XCTAssertNil(info)
+        XCTAssertEqual(stub.callCount, 0)
+    }
+
+    // MARK: - Cache semantics
+
+    func testCw20TokenInfoCachesSuccessfulLookup() async {
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .success(name: "Astroport", symbol: "ASTRO", decimals: 6)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let first = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        let second = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(stub.callCount, 1, "Second lookup must be served from the cache")
+    }
+
+    func testCw20TokenInfoEvictsCacheOnFailure() async {
+        // A transient LCD failure must NOT poison the cache: after a failed
+        // call the next call retries (and succeeds once the LCD recovers).
+        let stub = Cw20ScriptedHTTPClient()
+        stub.result = .httpError(503)
+        let resolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let first = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+        XCTAssertNil(first)
+
+        stub.result = .success(name: "Astroport", symbol: "ASTRO", decimals: 6)
+        let second = await resolver.cw20TokenInfo(chain: .terra, contractAddress: astroContract)
+
+        XCTAssertEqual(second?.symbol, "ASTRO", "Cache eviction on error must let the retry succeed")
+    }
+}
+
+// MARK: - Stub HTTP client
+
+/// Scripted HTTP client for CW20 `token_info` lookups. Responses are
+/// assembled as JSON and run through the production `JSONDecoder`, so the
+/// test exercises the real decode path.
+private final class Cw20ScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    enum ScriptedResult {
+        case success(name: String, symbol: String, decimals: Int)
+        case json([String: Any])
+        case httpError(Int)
+    }
+
+    var result: ScriptedResult = .httpError(500)
+
+    private let queue = DispatchQueue(label: "Cw20ScriptedHTTPClient.queue")
+    private var _requestedBaseURLs: [URL] = []
+    private var _callCount = 0
+
+    var requestedBaseURLs: [URL] {
+        queue.sync { _requestedBaseURLs }
+    }
+
+    var callCount: Int {
+        queue.sync { _callCount }
+    }
+
+    // swiftlint:disable async_without_await
+    func request(_: TargetType) async throws -> HTTPResponse<Data> {
+        throw HTTPError.invalidResponse
+    }
+
+    func request<T: Decodable>(
+        _ target: TargetType,
+        responseType _: T.Type
+    ) async throws -> HTTPResponse<T> {
+        guard let api = target as? CosmosAPI else {
+            throw HTTPError.invalidResponse
+        }
+        queue.sync {
+            _callCount += 1
+            _requestedBaseURLs.append(api.baseURL)
+        }
+
+        let json: [String: Any]
+        switch result {
+        case .success(let name, let symbol, let decimals):
+            json = ["data": ["name": name, "symbol": symbol, "decimals": decimals, "total_supply": "1000000"]]
+        case .json(let payload):
+            json = payload
+        case .httpError(let code):
+            throw HTTPError.statusCode(code, nil)
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let decoded = try JSONDecoder().decode(T.self, from: data)
+        let response = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: decoded, response: response)
+    }
+
+    func requestEmpty(_: TargetType) async throws -> HTTPResponse<EmptyResponse> {
+        throw HTTPError.invalidResponse
+    }
+    // swiftlint:enable async_without_await
+}

--- a/VultisigApp/VultisigAppTests/Chains/Cw20CustomTokenResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/Cw20CustomTokenResolverTests.swift
@@ -1,0 +1,216 @@
+//
+//  Cw20CustomTokenResolverTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class Cw20CustomTokenResolverTests: XCTestCase {
+
+    // ASTRO on Terra — a 32-byte CW20 contract address (post-migration shape).
+    private let astroContract = "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
+    // ASTROC on Terra Classic — a 20-byte contract, shape-identical to a wallet address.
+    private let astrocContract = "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+
+    // MARK: - Input validation
+
+    func testIsValidInputAcceptsLongContractOnTerra() {
+        XCTAssertTrue(Cw20CustomTokenResolver.isValidInput(astroContract, chain: .terra))
+    }
+
+    func testIsValidInputAcceptsLongContractOnTerraClassic() {
+        XCTAssertTrue(Cw20CustomTokenResolver.isValidInput(astroContract, chain: .terraClassic))
+    }
+
+    func testIsValidInputAcceptsShortContractOnTerraClassic() {
+        // Pre-migration Terra Classic contracts are 20-byte bech32 — the same
+        // shape as wallet addresses. They must pass; only the LCD query can
+        // tell a contract from a wallet.
+        XCTAssertTrue(Cw20CustomTokenResolver.isValidInput(astrocContract, chain: .terraClassic))
+    }
+
+    func testIsValidInputRejectsNonTerraChains() {
+        XCTAssertFalse(Cw20CustomTokenResolver.isValidInput(astroContract, chain: .gaiaChain))
+        XCTAssertFalse(Cw20CustomTokenResolver.isValidInput(astroContract, chain: .osmosis))
+        XCTAssertFalse(Cw20CustomTokenResolver.isValidInput(astroContract, chain: .ethereum))
+    }
+
+    func testIsValidInputRejectsForeignAddressShapes() {
+        XCTAssertFalse(
+            Cw20CustomTokenResolver.isValidInput("0x1a44076050125825900e736c501f859c50fE728c", chain: .terra)
+        )
+        XCTAssertFalse(
+            Cw20CustomTokenResolver.isValidInput("thor1z53wwe7md6cewz9sqwqzn0aavpaun0gw0exn2r", chain: .terra)
+        )
+    }
+
+    func testIsValidInputRejectsBankDenoms() {
+        XCTAssertFalse(
+            Cw20CustomTokenResolver.isValidInput(
+                "ibc/8D8A7F7253615E5F76CB6252A1E1BD921D5EDB7BBAAF8913FB1C77FF125D9995",
+                chain: .terra
+            )
+        )
+        XCTAssertFalse(
+            Cw20CustomTokenResolver.isValidInput("factory/terra1abc/uxyz", chain: .terra)
+        )
+        XCTAssertFalse(Cw20CustomTokenResolver.isValidInput("uusd", chain: .terraClassic))
+    }
+
+    func testIsValidInputRejectsMalformedInput() {
+        XCTAssertFalse(Cw20CustomTokenResolver.isValidInput("", chain: .terra))
+        XCTAssertFalse(Cw20CustomTokenResolver.isValidInput("terra1", chain: .terra))
+        XCTAssertFalse(Cw20CustomTokenResolver.isValidInput("terra1tooshort", chain: .terra))
+        XCTAssertFalse(
+            Cw20CustomTokenResolver.isValidInput(astroContract.uppercased(), chain: .terra),
+            "Bech32 is lowercase-only"
+        )
+        XCTAssertFalse(
+            Cw20CustomTokenResolver.isValidInput(" \(astroContract)", chain: .terra),
+            "Whitespace-padded input is rejected, matching the other chains' validators"
+        )
+        XCTAssertFalse(
+            Cw20CustomTokenResolver.isValidInput("terra1" + String(repeating: "a", count: 81), chain: .terra)
+        )
+    }
+
+    // MARK: - Resolution
+
+    func testResolveUnknownContractBuildsCoinMetaFromTokenInfo() async {
+        let stub = Cw20ResolverScriptedHTTPClient()
+        stub.result = .success(name: "Eris Amplified LUNA", symbol: "ampLUNA", decimals: 6)
+        let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
+        // A contract that is NOT in the curated TokensStore catalog.
+        let contract = "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct"
+
+        let meta = await Cw20CustomTokenResolver.resolve(
+            contractAddress: contract,
+            chain: .terra,
+            metadataResolver: metadataResolver
+        )
+
+        XCTAssertEqual(
+            meta,
+            CoinMeta(
+                chain: .terra,
+                ticker: "ampLUNA",
+                logo: "",
+                decimals: 6,
+                priceProviderId: "",
+                contractAddress: contract,
+                isNativeToken: false
+            )
+        )
+    }
+
+    func testResolveCuratedContractPrefersTokensStoreEntry() async {
+        // Pasting a catalog token's contract must keep the curated logo and
+        // priceProviderId instead of the bare LCD metadata.
+        let stub = Cw20ResolverScriptedHTTPClient()
+        stub.result = .success(name: "Astroport", symbol: "ASTRO", decimals: 6)
+        let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let meta = await Cw20CustomTokenResolver.resolve(
+            contractAddress: astroContract,
+            chain: .terra,
+            metadataResolver: metadataResolver
+        )
+
+        XCTAssertEqual(meta?.ticker, "ASTRO")
+        XCTAssertEqual(meta?.logo, "terra-astroport")
+        XCTAssertEqual(meta?.priceProviderId, "astroport-fi")
+        XCTAssertEqual(meta?.contractAddress, astroContract)
+    }
+
+    func testResolveReturnsNilWhenLcdRejectsQuery() async {
+        // A wallet address / non-CW20 contract makes the LCD reject the
+        // token_info query — the resolver must answer nil (not-found UX).
+        let stub = Cw20ResolverScriptedHTTPClient()
+        stub.result = .httpError(500)
+        let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let meta = await Cw20CustomTokenResolver.resolve(
+            contractAddress: astrocContract,
+            chain: .terraClassic,
+            metadataResolver: metadataResolver
+        )
+
+        XCTAssertNil(meta)
+    }
+
+    func testResolveReturnsNilWithoutNetworkCallForInvalidInput() async {
+        let stub = Cw20ResolverScriptedHTTPClient()
+        stub.result = .success(name: "X", symbol: "X", decimals: 6)
+        let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        let meta = await Cw20CustomTokenResolver.resolve(
+            contractAddress: "0x1a44076050125825900e736c501f859c50fE728c",
+            chain: .terra,
+            metadataResolver: metadataResolver
+        )
+
+        XCTAssertNil(meta)
+        XCTAssertEqual(stub.callCount, 0, "Invalid input must short-circuit before any LCD call")
+    }
+}
+
+// MARK: - Stub HTTP client
+
+/// Scripted HTTP client for CW20 resolution tests: answers every request
+/// with one scripted result, running success payloads through the real
+/// `JSONDecoder` path.
+private final class Cw20ResolverScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    enum ScriptedResult {
+        case success(name: String, symbol: String, decimals: Int)
+        case httpError(Int)
+    }
+
+    var result: ScriptedResult = .httpError(500)
+
+    private let queue = DispatchQueue(label: "Cw20ResolverScriptedHTTPClient.queue")
+    private var _callCount = 0
+
+    var callCount: Int {
+        queue.sync { _callCount }
+    }
+
+    // swiftlint:disable async_without_await
+    func request(_: TargetType) async throws -> HTTPResponse<Data> {
+        throw HTTPError.invalidResponse
+    }
+
+    func request<T: Decodable>(
+        _ target: TargetType,
+        responseType _: T.Type
+    ) async throws -> HTTPResponse<T> {
+        guard target is CosmosAPI else {
+            throw HTTPError.invalidResponse
+        }
+        queue.sync { _callCount += 1 }
+
+        switch result {
+        case .success(let name, let symbol, let decimals):
+            let json: [String: Any] = [
+                "data": ["name": name, "symbol": symbol, "decimals": decimals, "total_supply": "1000000"]
+            ]
+            let data = try JSONSerialization.data(withJSONObject: json)
+            let decoded = try JSONDecoder().decode(T.self, from: data)
+            let response = HTTPURLResponse(
+                url: URL(string: "https://test.local")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return HTTPResponse(data: decoded, response: response)
+        case .httpError(let code):
+            throw HTTPError.statusCode(code, nil)
+        }
+    }
+
+    func requestEmpty(_: TargetType) async throws -> HTTPResponse<EmptyResponse> {
+        throw HTTPError.invalidResponse
+    }
+    // swiftlint:enable async_without_await
+}

--- a/VultisigApp/VultisigAppTests/Chains/Cw20CustomTokenResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/Cw20CustomTokenResolverTests.swift
@@ -77,14 +77,14 @@ final class Cw20CustomTokenResolverTests: XCTestCase {
 
     // MARK: - Resolution
 
-    func testResolveUnknownContractBuildsCoinMetaFromTokenInfo() async {
+    func testResolveUnknownContractBuildsCoinMetaFromTokenInfo() async throws {
         let stub = Cw20ResolverScriptedHTTPClient()
         stub.result = .success(name: "Eris Amplified LUNA", symbol: "ampLUNA", decimals: 6)
         let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
         // A contract that is NOT in the curated TokensStore catalog.
         let contract = "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct"
 
-        let meta = await Cw20CustomTokenResolver.resolve(
+        let meta = try await Cw20CustomTokenResolver.resolve(
             contractAddress: contract,
             chain: .terra,
             metadataResolver: metadataResolver
@@ -104,14 +104,14 @@ final class Cw20CustomTokenResolverTests: XCTestCase {
         )
     }
 
-    func testResolveCuratedContractPrefersTokensStoreEntry() async {
+    func testResolveCuratedContractPrefersTokensStoreEntry() async throws {
         // Pasting a catalog token's contract must keep the curated logo and
         // priceProviderId instead of the bare LCD metadata.
         let stub = Cw20ResolverScriptedHTTPClient()
         stub.result = .success(name: "Astroport", symbol: "ASTRO", decimals: 6)
         let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let meta = await Cw20CustomTokenResolver.resolve(
+        let meta = try await Cw20CustomTokenResolver.resolve(
             contractAddress: astroContract,
             chain: .terra,
             metadataResolver: metadataResolver
@@ -123,14 +123,14 @@ final class Cw20CustomTokenResolverTests: XCTestCase {
         XCTAssertEqual(meta?.contractAddress, astroContract)
     }
 
-    func testResolveReturnsNilWhenLcdRejectsQuery() async {
+    func testResolveReturnsNilWhenLcdRejectsQuery() async throws {
         // A wallet address / non-CW20 contract makes the LCD reject the
         // token_info query — the resolver must answer nil (not-found UX).
         let stub = Cw20ResolverScriptedHTTPClient()
         stub.result = .httpError(500)
         let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let meta = await Cw20CustomTokenResolver.resolve(
+        let meta = try await Cw20CustomTokenResolver.resolve(
             contractAddress: astrocContract,
             chain: .terraClassic,
             metadataResolver: metadataResolver
@@ -139,12 +139,12 @@ final class Cw20CustomTokenResolverTests: XCTestCase {
         XCTAssertNil(meta)
     }
 
-    func testResolveReturnsNilWithoutNetworkCallForInvalidInput() async {
+    func testResolveReturnsNilWithoutNetworkCallForInvalidInput() async throws {
         let stub = Cw20ResolverScriptedHTTPClient()
         stub.result = .success(name: "X", symbol: "X", decimals: 6)
         let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
 
-        let meta = await Cw20CustomTokenResolver.resolve(
+        let meta = try await Cw20CustomTokenResolver.resolve(
             contractAddress: "0x1a44076050125825900e736c501f859c50fE728c",
             chain: .terra,
             metadataResolver: metadataResolver
@@ -152,6 +152,49 @@ final class Cw20CustomTokenResolverTests: XCTestCase {
 
         XCTAssertNil(meta)
         XCTAssertEqual(stub.callCount, 0, "Invalid input must short-circuit before any LCD call")
+    }
+
+    func testResolvePropagatesRateLimitError() async {
+        // Rate limiting must NOT collapse into not-found: the typed 429
+        // propagates so CustomTokenScreen shows its RateLimitError copy
+        // (which also hides the retry button).
+        let stub = Cw20ResolverScriptedHTTPClient()
+        stub.result = .httpError(429)
+        let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        do {
+            _ = try await Cw20CustomTokenResolver.resolve(
+                contractAddress: astroContract,
+                chain: .terra,
+                metadataResolver: metadataResolver
+            )
+            XCTFail("Expected a thrown rate-limit error")
+        } catch HTTPError.statusCode(let code, _) {
+            XCTAssertEqual(code, 429)
+        } catch {
+            XCTFail("Expected HTTPError.statusCode(429), got \(error)")
+        }
+    }
+
+    func testResolvePropagatesNetworkError() async {
+        // Transient network failures surface as errors (screen shows the
+        // message + retry), not as a false "token not found" verdict.
+        let stub = Cw20ResolverScriptedHTTPClient()
+        stub.result = .transportError(HTTPError.networkError(URLError(.notConnectedToInternet)))
+        let metadataResolver = CosmosTokenMetadataResolver(httpClient: stub)
+
+        do {
+            _ = try await Cw20CustomTokenResolver.resolve(
+                contractAddress: astroContract,
+                chain: .terra,
+                metadataResolver: metadataResolver
+            )
+            XCTFail("Expected a thrown network error")
+        } catch HTTPError.networkError {
+            // expected
+        } catch {
+            XCTFail("Expected HTTPError.networkError, got \(error)")
+        }
     }
 }
 
@@ -165,6 +208,7 @@ private final class Cw20ResolverScriptedHTTPClient: HTTPClientProtocol, @uncheck
     enum ScriptedResult {
         case success(name: String, symbol: String, decimals: Int)
         case httpError(Int)
+        case transportError(Error)
     }
 
     var result: ScriptedResult = .httpError(500)
@@ -206,6 +250,8 @@ private final class Cw20ResolverScriptedHTTPClient: HTTPClientProtocol, @uncheck
             return HTTPResponse(data: decoded, response: response)
         case .httpError(let code):
             throw HTTPError.statusCode(code, nil)
+        case .transportError(let error):
+            throw error
         }
     }
 


### PR DESCRIPTION
## Problem

The custom-token button already shows for Terra and Terra Classic, but pasting a CW20 contract address (e.g. ASTRO `terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26`) dies with **Token Not Found**: `CustomTokenScreen.fetchTokenInfo()` had no Cosmos branch, and no CW20 metadata query existed (`CosmosTokenMetadataResolver` only did bank `denoms_metadata` + IBC traces). The extension/SDK already support this via `getCw20MetaFromLCD`.

CW20 already works end-to-end for **catalog** tokens (ASTRO, TPT, ASTROC): balances via the `{"balance":{address}}` wasm smart query, send/sign via `MsgExecuteContract{transfer}`. Only the custom-token *resolution* path was missing.

## What was added

**Commit 1 — CW20 `token_info` metadata query (`Blockchain/Cosmos`)**
- `CosmosAPI`: new `.wasmTokenInfo(contractAddress:)` endpoint — GET `/cosmwasm/wasm/v1/contract/{addr}/smart/eyJ0b2tlbl9pbmZvIjp7fX0=` (base64 of `{"token_info":{}}`, byte-identical to the SDK's URL). The smart-query path builder is shared with the pre-existing balance endpoint (extracted helper, output unchanged).
- `CosmosTokenMetadataResolver.cw20TokenInfo(chain:contractAddress:)`: follows the file's existing cache-task pattern (24h TTL, shared in-flight request, evict-on-nil/error so a transient LCD blip can't poison the cache). SDK-parity validation: trimmed non-empty `symbol`, `decimals` bounded to `0...36` (contract-controlled value; same bound as the ERC-20 metadata resolver, since downstream formatting computes `BigInt(10).power(decimals)`).
- Chain selection drives the LCD: `.terra` → `terra-lcd.publicnode.com`, `.terraClassic` → `terra-classic-lcd.publicnode.com` (custom-RPC override respected via `CosmosServiceConfig`).

**Commit 2 — screen wiring (`Cw20CustomTokenResolver` + `CustomTokenScreen`)**
- New `Cw20CustomTokenResolver` (sibling of `ThorchainCustomTokenResolver`):
  - `isValidInput`: bech32 **shape** validation mirroring the SDK's `isCosmosWasmTokenId` — `terra1` + 20–80 lowercase alphanumerics. Terra Classic pre-migration contracts are 20-byte and shape-identical to wallet addresses, so only the LCD query can disambiguate; `ibc/…`/`factory/…` bank denoms and foreign address shapes are rejected. (WalletCore's `coinType.validate` is for account addresses and isn't specified for 32-byte contract payloads — not used here.)
  - `resolve`: builds the `CoinMeta`, preferring a curated `TokensStore` entry (real logo + `priceProviderId`) when the pasted contract is a catalog token; unknown tokens get `logo: ""` / `priceProviderId: ""` — no invented pricing, same as custom tokens on every other chain.
- `CustomTokenScreen`: `terra`/`terraClassic` branch in `fetchTokenInfo()` and `validateAddress()`. A wallet address or non-CW20 contract surfaces the existing not-found/retry UX.

**Out of scope (per issue):** CW20 auto-discovery; balance/send/signing paths (untouched).

## Verification

- **Full unit-test suite** (`make test`-equivalent invocation, isolated derived data to coexist with parallel builds): 2,280 test cases executed, **1 failure — the known pre-existing decimal-comma locale flake** (`StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress`, `"12,3%" != "12.3%"`), in a staking file this branch does not touch; it fails on main too.
- **26 new unit tests** (15 metadata query/decode/cache + 11 validation/resolution), all passing; scripted responses run through the production `JSONDecoder` path.
- **SwiftLint** clean on all changed files.
- **Live LCD verified at the endpoint level (not a full simulator UI walkthrough):** the exact URL the code builds (asserted byte-for-byte in a unit test) was probed against both live LCDs — Terra ASTRO and Terra Classic ASTROC both return `{"data":{"name":…,"symbol":…,"decimals":6,…}}`, which decodes with the added response type; a wallet-shaped address returns HTTP 500 → the not-found UX. A full simulator add-token walkthrough was **not** run (this Mac was saturated by parallel iOS builds) — worth a quick manual pass before merge.
- **Cross-model review loop:** Codex reviewed each commit read-only (commit 1: one Medium finding — unbounded contract-controlled `decimals` — fixed with the `0...36` bound + test; commit 2: no findings) plus a whole-branch pass.

> ⚠️ This PR touches no signing code, but adding-then-**sending** a custom CW20 token deserves an on-device send test before merge — the send path has only ever been exercised with catalog CW20 tokens.

## Manual test candidates (live-verified 2026-07-03)

All four contracts were probed against the live LCDs on 2026-07-03 — each returns a `token_info` payload that decodes with the response type added in this PR:

| Token | Chain | Contract | Path exercised |
|---|---|---|---|
| **ROAR** (Lion DAO) | Terra | `terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv` | **Pure custom path** — not in the catalog; name/symbol/decimals (6) come entirely from the new `token_info` query. Expect no logo and no price — correct behavior. |
| **ampLUNA** (Eris) | Terra | `terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct` | Pure custom path, second data point (decimals 6). |
| **ASTRO** (Astroport) | Terra | `terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26` | **Catalog-merge path** — resolver should prefer the curated `TokensStore` entry, returning the real logo + `priceProviderId`. |
| **ASTROC** (Astroport Classic) | Terra Classic | `terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3` | Terra **Classic** LCD + the 20-byte legacy contract-address shape (other half of the bech32 validation). |

Suggested sequence: ROAR first (the truly-custom case this issue is about), then ASTROC (Classic + short address form), then ASTRO (curated merge). Negative case: paste a wallet-shaped `terra1…` address → existing not-found UX.

Closes #4727

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Terra and Terra Classic CW20 custom token resolution from contract addresses.
  * Added CW20 `token_info` metadata fetching (name, symbol, decimals) with resilient decoding.
* **Bug Fixes**
  * Improved validation for CW20 contract inputs (chain-specific prefix, payload format/length).
  * Enhanced token lookup error handling, including explicit rate-limit (429) behavior.
* **Tests**
  * Expanded test coverage for CW20 metadata lookup, smart-query path formatting, caching semantics, and Terra/Terra Classic resolution/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
