### PR TITLE
fix(swap): don't show router address as To on join keysign screen

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapRecipientVerifier.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapRecipientVerifier.swift
@@ -77,7 +77,11 @@ enum SwapRecipientVerifier {
     /// the 3rd colon-delimited field. The ASSET field never contains a colon, so
     /// splitting on `:` isolates the destination cleanly. Returns nil when the
     /// memo is malformed or the field is empty.
-    private static func memoDestination(from memo: String) -> String? {
+    ///
+    /// Also consumed by the swap confirm screens to surface an external
+    /// recipient — display and verification must agree on what the destination
+    /// is, so they share this one parser.
+    static func memoDestination(from memo: String) -> String? {
         let parts = memo.split(separator: ":", omittingEmptySubsequences: false)
         guard parts.count >= 3 else { return nil }
         let destination = String(parts[2]).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -88,7 +92,11 @@ enum SwapRecipientVerifier {
     /// checksum casing, so they compare case-insensitively; every other encoding
     /// (bech32, base58, …) is case-sensitive and must match exactly — a blanket
     /// case-insensitive compare there could false-pass two distinct addresses.
-    private static func addressesMatch(_ lhs: String, _ rhs: String) -> Bool {
+    ///
+    /// Shared with the swap confirm screens so that "is this an external
+    /// recipient?" (display) and "does the built artifact target the recipient?"
+    /// (verification) never disagree on address equality.
+    static func addressesMatch(_ lhs: String, _ rhs: String) -> Bool {
         let l = lhs.trimmingCharacters(in: .whitespacesAndNewlines)
         let r = rhs.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !l.isEmpty, !r.isEmpty else { return false }

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignPayload.swift
@@ -184,6 +184,39 @@ struct KeysignPayload: Codable, Hashable {
         )
     }
 
+    /// The address a swap ultimately delivers to, but only when the user
+    /// directed the output somewhere other than their own address on the
+    /// destination chain (the advanced-settings "external recipient"). `nil`
+    /// for the common case where funds return to the user's own address — there
+    /// is nothing meaningful to surface — and for swaps whose real output
+    /// target can't be recovered from the peer-visible payload.
+    ///
+    /// A swap confirmation must derive the destination here rather than show
+    /// `toAddress`: for a swap `toAddress` is the provider's router / inbound
+    /// contract, never a user-facing destination.
+    var swapExternalRecipient: String? {
+        guard let swapPayload else { return nil }
+
+        // THORChain / Maya bake the destination into the swap memo's DESTADDR
+        // field — the only provider family whose real output target is
+        // recoverable from the peer-visible payload today. Generic (1inch /
+        // Kyber / LiFi / Jupiter) bury it in opaque router calldata and never
+        // honor an external recipient; SwapKit's lives inside `txPayload`.
+        switch swapPayload {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
+            break
+        case .generic, .swapkit:
+            return nil
+        }
+
+        guard let memo,
+              let destination = SwapRecipientVerifier.memoDestination(from: memo),
+              !SwapRecipientVerifier.addressesMatch(destination, swapPayload.toCoin.address) else {
+            return nil
+        }
+        return destination
+    }
+
     var signAmino: SignAmino? {
         guard case let .signAmino(amino) = signData else {
             return nil

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -31,11 +31,11 @@ struct KeysignSwapConfirmView: View {
             summaryTitle
             summaryFromTo
 
-            if let toAddress = viewModel.keysignPayload?.toAddress, !toAddress.isEmpty {
+            if let externalRecipient = viewModel.keysignPayload?.swapExternalRecipient {
                 separator
                 getValueCell(
                     for: "to",
-                    with: toAddress.truncatedAddress
+                    with: externalRecipient.truncatedAddress
                 )
             }
 


### PR DESCRIPTION
## Summary
On the swap Join Keysign screen, the **To** row showed `keysignPayload.toAddress`, which for a swap is the provider's **router / inbound contract** (e.g. `0xD3…7146`) — not a user-facing destination. This surfaced a confusing, meaningless address on every swap.

Now the **To** row is shown **only when the user directed the swap output to an external recipient** (an address other than their own on the destination chain). For ordinary swaps that return funds to the user's own vault address, the row is hidden.

## Changes
- **`KeysignPayload.swapExternalRecipient`** — for THORChain/Maya swaps, parses the memo `DESTADDR` and returns it only when it differs from the user's own destination address (`swapPayload.toCoin.address`). Generic (1inch/Kyber/LiFi/Jupiter) and SwapKit routes return `nil` — their real output target isn't recoverable from the peer-visible payload.
- **`SwapRecipientVerifier`** — exposed the existing `memoDestination(from:)` and `addressesMatch(_:_:)` helpers (were `private`) so display and the security-critical recipient verification share one parser and one notion of address equality. No logic change.
- **`KeysignSwapConfirmView`** — renders `swapExternalRecipient` instead of the raw router `toAddress`.

## Behavior
- Normal swap to your own vault → no **To** row (fixes the bug).
- Swap with an external recipient → **To** row shows that recipient's address.

## Notes
- Covers THORChain/Maya (the reported case). SwapKit external recipients aren't surfaced here because the destination is buried in `txPayload` on the peer device.

## Test Plan
- [ ] Join a THORChain/Maya swap keysign with no external recipient → no **To** row shown
- [ ] Join a swap with an external recipient set → **To** row shows the recipient address
- [ ] SwiftLint passes
- [ ] xcodebuild build succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Swap confirmation screens now show the verified external recipient address instead of relying on the raw destination field.
  * Improved address matching so the displayed recipient and on-chain target stay consistent for supported swap types.
  * Swaps with unsupported providers or mismatched destinations continue to hide the recipient when it can’t be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->