### PR TITLE
fix(solana): staking DeFi fixes — validator 520 fallback, position-selection gating, cache-first seed heal

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiBalanceService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiBalanceService.swift
@@ -155,12 +155,19 @@ private extension DefiBalanceService {
     /// stake accounts. `BalanceService.fetchStakedBalance(.solana)` sums the
     /// delegated lamports of every stake account and writes the total (base
     /// units) to `Coin.stakedBalance`; `stakedBalanceDecimal` divides by 10^9
-    /// to get SOL. Solana has no per-coin opt-in (a real stake is always the
-    /// vault's SOL DeFi position), so — like Tron — we don't gate on
-    /// `defiPositions`. Returning the persisted value keeps the balance stable
-    /// through a transient stake-account read failure (which writes nothing).
+    /// to get SOL. Gated on the per-vault opt-in
+    /// (`defiPositions[.solana].staking`) so a vault that hasn't selected the
+    /// staking position doesn't have its delegated balance silently rolled into
+    /// the DeFi total — matches the empty-state semantic in
+    /// `SolanaStakeDefiView` and mirrors the Cosmos staking roll-up. Returning
+    /// the persisted value keeps the balance stable through a transient
+    /// stake-account read failure (which writes nothing).
     func solanaStakingTotalBalanceFiatDecimal(for vault: Vault) -> Decimal {
-        guard let solCoin = vault.nativeCoin(for: .solana) else { return .zero }
+        guard
+            let solCoin = vault.nativeCoin(for: .solana),
+            let enabledPositions = vault.defiPositions.first(where: { $0.chain == .solana }),
+            enabledPositions.staking.contains(solCoin.toCoinMeta())
+        else { return .zero }
         return solCoin.fiat(decimal: solCoin.stakedBalanceDecimal)
     }
 
@@ -282,9 +289,13 @@ private extension DefiBalanceService {
     /// badge counts position *types* with a balance (mirrors Tron's single
     /// frozen-TRX position); the exact per-stake-account breakdown — Solana can
     /// hold N accounts — is rendered as individual rows in `SolanaStakeDefiView`.
-    /// Ungated (no per-coin opt-in), matching the balance roll-up above.
+    /// Gated on the per-coin opt-in, matching the balance roll-up above.
     func solanaStakingPositionCount(for vault: Vault) -> Int {
-        guard let solCoin = vault.nativeCoin(for: .solana) else { return 0 }
+        guard
+            let solCoin = vault.nativeCoin(for: .solana),
+            let enabledPositions = vault.defiPositions.first(where: { $0.chain == .solana }),
+            enabledPositions.staking.contains(solCoin.toCoinMeta())
+        else { return 0 }
         return solCoin.stakedBalanceDecimal > 0 ? 1 : 0
     }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -284,12 +284,18 @@ struct DefiChainMainScreen: View {
     /// Solana native-staking stake-segment renderer. Per-stake-account rows;
     /// the user-facing actions route through the shared
     /// `FunctionTransactionType.solana*` cases — the function-call router takes
-    /// it from there. No claim action: Solana rewards auto-compound.
+    /// it from there. No claim action: Solana rewards auto-compound. Gated on
+    /// the per-vault position opt-in exactly like the Cosmos stake segment.
     private func solanaStakeView(coin: Coin) -> some View {
         let fiatAmount = RateProvider.shared.fiatBalance(value: solanaStakeViewModel.totalStaked, coin: coin)
+        let isPositionEnabled = vault.defiPositions
+            .first(where: { $0.chain == chain })?
+            .staking
+            .contains(where: { $0.ticker == coin.ticker }) ?? false
         return SolanaStakeDefiView(
             coin: coin,
             totalFiat: fiatAmount.formatToFiat(includeCurrencySymbol: true),
+            isPositionEnabled: isPositionEnabled,
             viewModel: solanaStakeViewModel,
             onDelegate: { coin in
                 onTransactionToPresent(.solanaDelegate(coin: coin.toCoinMeta()))
@@ -320,7 +326,8 @@ struct DefiChainMainScreen: View {
                     stakeAccount: stakeAccount.pubkey,
                     amount: withdrawableAmount.formatToDecimal(digits: coin.decimals)
                 ))
-            }
+            },
+            emptyStateView: { emptyStateView }
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
@@ -165,9 +165,17 @@ final class StakePosition {
     }
 
     /// Updates everything except the lookup key (`coin`) and the persistent `id`.
-    /// `stakeAccountPubkey` is part of the `id`, so it is intentionally NOT
-    /// reassigned here (a matched row already shares it).
+    /// `stakeAccountPubkey` is only BACKFILLED when missing: rows written by an
+    /// earlier build carry the pubkey in the `id` suffix but a nil field, which
+    /// permanently broke the cache-first seed (`seedFromPersistedSnapshot`
+    /// drops rows without a pubkey) because the id-keyed upsert always matched
+    /// and this method never healed the field. The upsert matches by `id` and
+    /// the `id` embeds the pubkey, so the DTO's value is by construction the
+    /// same suffix — a non-nil field is never rewritten.
     func apply(_ dto: StakePositionData) {
+        if stakeAccountPubkey?.isEmpty != false {
+            stakeAccountPubkey = dto.stakeAccountPubkey
+        }
         type = dto.type
         amount = dto.amount
         availableToUnstake = dto.availableToUnstake

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
@@ -121,9 +121,12 @@ struct DefiChainSelectPositionsScreen: View {
         }
 
         // Mirror the enable/disable into persisted position rows so the user sees a row with its
-        // CTA immediately (zero amount) — the next refresh updates the amount.
+        // CTA immediately (zero amount) — the next refresh updates the amount. Solana is skipped:
+        // its rows are per-stake-account and discovered on-chain (`upsert(solanaStake:for:)`),
+        // so a coin-keyed zero row would alias every account onto one id, and its segment
+        // renders the total card + Delegate CTA without needing a placeholder row.
         let storage = DefiPositionsStorageService()
-        for added in newStaking.subtracting(previousStaking) {
+        for added in newStaking.subtracting(previousStaking) where added.chain != .solana {
             do {
                 try storage.addZero(stakeCoin: added, to: vault)
             } catch {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/SolanaStakeDefiView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/SolanaStakeDefiView.swift
@@ -71,9 +71,12 @@ struct SolanaStakeDefiView<EmptyState: View>: View {
             if !viewModel.rows.isEmpty {
                 stakeAccountsCard
             } else if viewModel.isLoading {
-                ProgressView()
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, 8)
+                // Genuine first-ever load (nothing seeded from the persisted
+                // snapshot): show the same skeleton placeholder the persisted
+                // THOR/Maya/TON stake path uses, not a bare spinner. Warm
+                // stores never reach this branch — the seed paints rows before
+                // any network call.
+                DefiChainStakedPositionSkeletonView()
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/SolanaStakeDefiView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/SolanaStakeDefiView.swift
@@ -36,22 +36,36 @@ private enum SolanaStakeDefiFormatters {
     }()
 }
 
-struct SolanaStakeDefiView: View {
+struct SolanaStakeDefiView<EmptyState: View>: View {
     let coin: Coin
     let totalFiat: String
+    let isPositionEnabled: Bool
     @ObservedObject var viewModel: SolanaStakeDefiViewModel
     var onDelegate: (Coin) -> Void
     var onUnstake: (SolanaStakeAccountRow) -> Void
     var onWithdraw: (SolanaStakeAccountRow) -> Void
+    @ViewBuilder var emptyStateView: () -> EmptyState
 
-    // The total-staked card (and its "Delegate to New Validator" CTA) ALWAYS
-    // renders — Solana staking has no empty state, so a user with zero stake
-    // accounts can still start staking, and the card must never vanish on a
-    // pull-to-refresh or background load (cache-first: persist + refresh, never
-    // blank). The per-account list appears once the wallet holds stake accounts;
-    // only a first-ever cold load with no cached rows shows a non-blocking
-    // spinner beneath the card — a refresh of existing data leaves it in place.
+    // Gated on the per-vault position opt-in (`defiPositions[.solana].staking`),
+    // exactly like the THOR/Maya/Cosmos stake segments: until the user selects
+    // the SOL staking position under "Manage positions", only the empty-state
+    // banner shows. Once enabled, the total-staked card (and its "Delegate to
+    // New Validator" CTA) ALWAYS renders — a user with zero stake accounts can
+    // still start staking, and the card must never vanish on a pull-to-refresh
+    // or background load (cache-first: persist + refresh, never blank). The
+    // per-account list appears once the wallet holds stake accounts.
     var body: some View {
+        Group {
+            if !isPositionEnabled {
+                emptyStateView()
+            } else {
+                populatedState
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var populatedState: some View {
         VStack(spacing: 16) {
             totalStakedCard
             if !viewModel.rows.isEmpty {

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakeDefiViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakeDefiViewModelTests.swift
@@ -286,6 +286,40 @@ final class SolanaStakeDefiViewModelTests: XCTestCase {
         XCTAssertEqual(vm.rows.first?.isActionable, false)
     }
 
+    /// A legacy persisted row (pubkey embedded in the id but a nil
+    /// `stakeAccountPubkey` field — written by an earlier build) can't seed,
+    /// but one successful refresh must HEAL it via the apply() backfill so the
+    /// next screen entry paints cache-first instead of spinning.
+    func testRefreshHealsLegacyRowSoNextSeedPaints() async throws {
+        let legacy = StakePosition(
+            coin: solMeta,
+            type: .stake,
+            amount: 1,
+            stakeAccountPubkey: "A",
+            vault: vault
+        )
+        legacy.stakeAccountPubkey = nil
+        Storage.shared.modelContext.insert(legacy)
+        try Storage.shared.save()
+
+        let service = FakeStakingService(
+            accounts: [account(pubkey: "A", vote: "V1", stake: 1_000_000_000, activationEpoch: 700)],
+            validators: [validator(vote: "V1", commission: 5)]
+        )
+
+        // The poisoned row cannot seed — this entry still starts empty.
+        let first = makeViewModel(service: service)
+        XCTAssertTrue(first.rows.isEmpty)
+
+        await first.refresh(owner: "Owner", decimals: 9)
+        XCTAssertEqual(solanaPositions().first?.stakeAccountPubkey, "A", "apply() must backfill the legacy row.")
+
+        // A fresh VM (new screen entry) now paints from the healed snapshot.
+        let second = makeViewModel(service: service)
+        XCTAssertEqual(second.rows.count, 1)
+        XCTAssertEqual(second.rows.first?.id, "A")
+    }
+
     /// A successful refresh writes the per-account snapshot back to SwiftData.
     func testSuccessfulRefreshUpsertsSnapshot() async {
         let service = FakeStakingService(

--- a/VultisigApp/VultisigAppTests/Defi/DefiBalanceServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiBalanceServiceTests.swift
@@ -266,12 +266,21 @@ final class DefiBalanceServiceTests: XCTestCase {
         return coin
     }
 
+    /// Enables the per-vault SOL staking opt-in, mirroring what
+    /// `DefiChainSelectPositionsScreen` persists on save.
+    private func enableSolanaStaking(for coin: Coin) {
+        vault.defiPositions = [
+            DefiPositions(chain: .solana, bonds: [], staking: [coin.toCoinMeta()], lps: [])
+        ]
+    }
+
     /// Staked SOL (summed delegated lamports written to `Coin.stakedBalance`)
-    /// rolls into the DeFi total ungated — like Tron, no per-coin opt-in.
+    /// rolls into the DeFi total once the staking position is opted in.
     func testSolanaTotalBalanceFiatReadsStakedNotWallet() throws {
         // 10 SOL wallet, 4 SOL delegated.
         let sol = makeSolanaCoin(rawBalance: "10000000000", stakedBalance: "4000000000")
         vault.coins = [sol]
+        enableSolanaStaking(for: sol)
         try RateProvider.shared.save(rates: [
             Rate(fiat: SettingsCurrency.current.rawValue, crypto: "solana", value: 3)
         ])
@@ -285,9 +294,24 @@ final class DefiBalanceServiceTests: XCTestCase {
         XCTAssertEqual(service.totalBalanceInFiat(for: .solana, vault: vault), .zero)
     }
 
+    /// Without the per-vault staking opt-in the delegated balance must not
+    /// leak into the DeFi roll-up — the exact semantic the THOR/Maya/Cosmos
+    /// segments already have.
+    func testSolanaTotalBalanceAndCountZeroWithoutPositionOptIn() throws {
+        let sol = makeSolanaCoin(rawBalance: "10000000000", stakedBalance: "4000000000")
+        vault.coins = [sol]
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: "solana", value: 3)
+        ])
+
+        XCTAssertEqual(service.totalBalanceInFiat(for: .solana, vault: vault), .zero)
+        XCTAssertEqual(service.defiPositionCount(for: .solana, vault: vault), 0)
+    }
+
     func testSolanaTotalBalanceZeroWhenStakedBalanceUnset() throws {
         let sol = makeSolanaCoin(rawBalance: "10000000000", stakedBalance: "")
         vault.coins = [sol]
+        enableSolanaStaking(for: sol)
         try RateProvider.shared.save(rates: [
             Rate(fiat: SettingsCurrency.current.rawValue, crypto: "solana", value: 3)
         ])
@@ -299,12 +323,14 @@ final class DefiBalanceServiceTests: XCTestCase {
     func testSolanaPositionCountOneWhenAnyStaked() {
         let sol = makeSolanaCoin(rawBalance: "0", stakedBalance: "1")
         vault.coins = [sol]
+        enableSolanaStaking(for: sol)
         XCTAssertEqual(service.defiPositionCount(for: .solana, vault: vault), 1)
     }
 
     func testSolanaPositionCountZeroWhenNoStake() {
         let sol = makeSolanaCoin(rawBalance: "10000000000", stakedBalance: "0")
         vault.coins = [sol]
+        enableSolanaStaking(for: sol)
         XCTAssertEqual(service.defiPositionCount(for: .solana, vault: vault), 0)
     }
 

--- a/VultisigApp/VultisigAppTests/Defi/DefiPositionsStorageServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiPositionsStorageServiceTests.swift
@@ -110,6 +110,35 @@ final class DefiPositionsStorageServiceTests: XCTestCase {
         )
     }
 
+    func testUpsertSolanaStakeBackfillsMissingPubkeyOnLegacyRow() throws {
+        let solMeta = CoinMeta.make(chain: .solana, ticker: "SOL", decimals: 9)
+
+        // A row written by an earlier build: the pubkey is embedded in the id
+        // suffix but the dedicated field is nil — the state that permanently
+        // broke the cache-first seed (which drops rows without a pubkey).
+        let legacy = StakePosition(
+            coin: solMeta,
+            type: .stake,
+            amount: 1,
+            stakeAccountPubkey: "LEGACY",
+            vault: vault
+        )
+        legacy.stakeAccountPubkey = nil
+        Storage.shared.modelContext.insert(legacy)
+        try Storage.shared.save()
+
+        // The id-keyed upsert matches the legacy row, so apply() runs — it must
+        // backfill the missing field so the next seed paints the row.
+        try service.upsert(solanaStake: [
+            StakePositionData(coin: solMeta, type: .stake, amount: 2, stakeAccountPubkey: "LEGACY", activationState: "active")
+        ], for: vault)
+
+        let solana = vault.stakePositions.filter { $0.coin.chain == .solana }
+        XCTAssertEqual(solana.count, 1, "The legacy row is matched by id and updated, not duplicated.")
+        XCTAssertEqual(solana.first?.stakeAccountPubkey, "LEGACY")
+        XCTAssertEqual(solana.first?.amount, 2)
+    }
+
     func testNonSolanaStakePositionIDFormatUnchanged() throws {
         // Pins the historical coin-keyed id format so the optional Solana segment
         // can never drift a non-Solana id (which would orphan persisted rows).


### PR DESCRIPTION
Three user-reported Solana staking issues on the DeFi tab, each root-caused with endpoint-level and simulator evidence. Issue 1 turned out to be server-side and was fixed at the proxy origin; issues 2 and 3 are fixed here. None of the changes touches signing/keysign byte construction — everything is presentation or display-persistence.

## 1. Validators screen: "Validator fetch failed: HTTP status code: 520" — resolved server-side, no client change

**Root cause.** The picker reads `getVoteAccounts` from the Vultisig proxy (`api.vultisig.com/solana/`), whose origin persistently returned a Cloudflare 520 for this one method — verified with curl: 3/3 failures with body `error code: 520`, unaffected by browser-like headers, while `getEpochInfo` / `getInflationRate` / `getProgramAccounts` on the same proxy returned 200. With no last-known list, the picker rendered a dead error screen, and the stake rows lost their validator names (metadata enrichment is keyed onto the empty validator list).

**Resolution.** The proxy origin was fixed server-side by @johnnyluo on 2026-07-06 — re-verified 3/3 × HTTP 200 (~310 KB, ~1.6 s) through `api.vultisig.com/solana/`. This PR originally carried a client-side public-node fallback + stale-cache serve for this path; per the discussion below, that commit was dropped to keep the client proxy-only and lean, so the validator fetch is exactly as on `main`.

## 2. Solana staking card ignored the DeFi position selection

**Root cause.** `DefiChainMainScreen.solanaStakeView` rendered the card unconditionally, and the Solana balance/count roll-ups in `DefiBalanceService` were deliberately ungated ("like Tron"). A vault that never selected the SOL staking position under `DefiChainSelectPositionsScreen` still saw the full card (reproduced in the simulator against a vault with staked SOL and no `DefiPositions` row for Solana).

**Fix** — mirror the LUNA/LUNC (Cosmos) opt-in pattern end to end:
- `solanaStakeView` computes `isPositionEnabled` from `vault.defiPositions[chain].staking` (identical to `cosmosStakeView`) and passes the shared manage-positions empty state through.
- `SolanaStakeDefiView` is generic over the empty state and renders it until the position is opted in (exactly `CosmosStakeDefiView`'s shape).
- `solanaStakingTotalBalanceFiatDecimal` / `solanaStakingPositionCount` gate on the same opt-in, so an un-opted-in vault's delegated SOL no longer leaks into the DeFi total or the chain cell badge.
- Enabling SOL no longer inserts the coin-keyed zero-amount placeholder row (Solana rows are per-stake-account and on-chain-discovered; the placeholder would alias every account onto one coin-keyed id).

**Runtime verification:** un-opted-in vault now sees the "No positions selected" banner; selecting the position via Manage Positions brings the card up with the stake accounts.

## 3. Stake segment showed a loading state on every entry

**Root cause.** The cache-first seed (`seedFromPersistedSnapshot`) never painted: stores written by an earlier build carry the stake-account pubkey in the persisted row's `id` suffix but `NULL` in the `stakeAccountPubkey` column, and the seed drops rows without a pubkey. Because `upsert(solanaStake:)` matches rows by `id` and `StakePosition.apply()` deliberately skipped the field, successful refreshes updated the row in place forever without healing it — verified live: after three successful refreshes on main, the column was still NULL (sqlite inspection), and every screen entry spun for 1.5–5.5 s.

**Fix:**
- `StakePosition.apply()` backfills a nil/empty `stakeAccountPubkey` from the DTO. The upsert matches by `id` and the `id` embeds the pubkey, so the DTO value is by construction the same suffix — an existing non-nil field is never rewritten. One successful refresh heals the store; every subsequent entry paints instantly from the seed and refreshes in the background.
- A genuine first-ever load (nothing to seed) now shows the `DefiChainStakedPositionSkeletonView` placeholder used by the persisted THOR/Maya/TON stake path, not a bare spinner.

**Runtime verification:** after one refresh on the fixed build, the store's pubkey column is backfilled and re-entering the screen paints the stake accounts instantly with no spinner.

## Tests
- Balance/count zero without the opt-in even with delegated SOL; existing Solana balance tests opt in first.
- Storage-level pubkey backfill on a legacy row; VM-level heal-then-seed (first entry can't seed → refresh heals → fresh VM paints).

## Notes
- Pre-existing, unrelated: the `VultisigAppUITests` target does not compile on `main` (`AccessibilityID` isn't in its sources and CI never runs `ui_test`). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Solana staking views now respect vault opt-in settings, showing staking details only when enabled.
  * Validator and stake data can now recover more reliably from network issues by trying fallback RPC endpoints.

* **Bug Fixes**
  * Improved Solana staking resilience when the primary RPC endpoint fails.
  * Restored missing stake-account identifiers for older staking records, helping cached data load correctly.
  * Stale cached validator data can now still be shown if refresh attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
