### PR TITLE
fix(ripple): gate broadcast on tesSUCCESS + verify-by-hash dedup for already-submitted results

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleAPI.swift
@@ -13,6 +13,7 @@ import Foundation
 struct RippleAPI: TargetType {
     enum Endpoint {
         case submit(txBlob: String)
+        case tx(hash: String)
         case serverState
         case accountInfo(account: String)
     }
@@ -40,6 +41,14 @@ struct RippleAPI: TargetType {
         case .submit(let txBlob):
             return .requestCodable(
                 RippleRpcRequest(method: "submit", params: [RippleSubmitParams(txBlob: txBlob)]),
+                .jsonEncoding
+            )
+        case .tx(let hash):
+            return .requestCodable(
+                RippleRpcRequest(
+                    method: "tx",
+                    params: [RippleTxParams(transaction: hash, binary: false, apiVersion: 2)]
+                ),
                 .jsonEncoding
             )
         case .serverState:
@@ -73,6 +82,18 @@ struct RippleSubmitParams: Encodable {
 
     enum CodingKeys: String, CodingKey {
         case txBlob = "tx_blob"
+    }
+}
+
+struct RippleTxParams: Encodable {
+    let transaction: String
+    let binary: Bool
+    let apiVersion: Int
+
+    enum CodingKeys: String, CodingKey {
+        case transaction
+        case binary
+        case apiVersion = "api_version"
     }
 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -47,12 +47,18 @@ class RippleService {
     /// live (the shared mirror updates without a relaunch).
     private let resolver: RPCEndpointResolving
 
+    /// Backoff between `tx` lookups while resolving a verify-by-hash submit;
+    /// injectable so tests run without delay.
+    private let verifyByHashBackoff: Duration
+
     init(
         resolver: RPCEndpointResolving = CustomRPCStore.shared,
-        httpClient: HTTPClientProtocol = HTTPClient()
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        verifyByHashBackoff: Duration = .seconds(2)
     ) {
         self.resolver = resolver
         self.httpClient = httpClient
+        self.verifyByHashBackoff = verifyByHashBackoff
     }
 
     /// The override-aware XRPL host. Falls back to the default host when no
@@ -83,11 +89,77 @@ class RippleService {
         switch disposition {
         case .accepted(let hash):
             return hash
-        case .verifyByHash(let code, _, let message),
-             .rejected(let code, let message):
+        case .verifyByHash(let code, let hash, let message):
+            return try await resolveSubmitByHash(code: code, hash: hash, message: message)
+        case .rejected(let code, let message):
             logger.error("broadcast rejected by XRPL: \(code, privacy: .public)")
             throw RippleBroadcastError.broadcastFailed(code: code, message: message)
         }
+    }
+
+    /// Resolves a submit whose engine result says the transaction may already
+    /// be known to the network — a faster co-signing peer's broadcast of the
+    /// same signed blob landed first, or the server queued it for a future
+    /// ledger — by looking the echoed deterministic hash up with the `tx`
+    /// method against the same (override-aware) node the submit went to.
+    ///
+    /// `txnNotFound` is retried with a short backoff because cluster nodes can
+    /// lag a peer's submit by a few seconds; lookup errors count as failed
+    /// attempts for the same reason (the lookup is a safety net and must not
+    /// invent a new failure mode). If the transaction never shows up, the
+    /// ORIGINAL engine code is thrown — an unverified duplicate must never be
+    /// reported as a success.
+    private func resolveSubmitByHash(code: String, hash: String?, message: String?) async throws -> String {
+        guard let hash else {
+            throw RippleBroadcastError.broadcastFailed(code: code, message: message)
+        }
+
+        let maxAttempts = 3
+        for attempt in 1...maxAttempts {
+            do {
+                let response = try await httpClient.request(
+                    api(.tx(hash: hash)),
+                    responseType: RippleTransactionStatusResponse.self
+                )
+
+                switch RippleTxLookupOutcome.interpret(response.data) {
+                case .validatedSuccess:
+                    logger.info("\(code, privacy: .public) resolved as validated success: \(hash, privacy: .public)")
+                    return hash
+                case .pending:
+                    // Known to the network and in flight — return the hash and
+                    // let the status poller resolve the final outcome.
+                    logger.info("\(code, privacy: .public) resolved as in-flight: \(hash, privacy: .public)")
+                    return hash
+                case .validatedFailure(let validatedCode):
+                    // The transaction landed in a validated ledger with a final
+                    // non-success result — surface that real code.
+                    logger.error("\(code, privacy: .public) resolved as validated failure \(validatedCode, privacy: .public)")
+                    throw RippleBroadcastError.broadcastFailed(
+                        code: validatedCode,
+                        message: "The transaction was included in a validated ledger but did not succeed."
+                    )
+                case .notFound:
+                    break
+                }
+            } catch let error as RippleBroadcastError {
+                throw error
+            } catch {
+                logger.warning("verify-by-hash lookup failed (attempt \(attempt)/\(maxAttempts)): \(error.localizedDescription, privacy: .public)")
+            }
+
+            if attempt < maxAttempts {
+                do {
+                    try await Task.sleep(for: verifyByHashBackoff)
+                } catch {
+                    logger.warning("verify-by-hash backoff interrupted: \(error.localizedDescription, privacy: .public)")
+                    break
+                }
+            }
+        }
+
+        logger.error("verify-by-hash exhausted for \(code, privacy: .public): \(hash, privacy: .public) not found")
+        throw RippleBroadcastError.broadcastFailed(code: code, message: message)
     }
 
     func getBalance(address: String) async throws -> String {

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -39,7 +39,7 @@ class RippleService {
     static let shared = RippleService()
 
     private let logger = Logger(subsystem: "com.vultisig.app", category: "ripple-service")
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     /// Resolves the Ripple custom RPC override. Injected so the API values are
     /// built from a dependency rather than a global reach-in; resolution happens
@@ -47,8 +47,12 @@ class RippleService {
     /// live (the shared mirror updates without a relaunch).
     private let resolver: RPCEndpointResolving
 
-    init(resolver: RPCEndpointResolving = CustomRPCStore.shared) {
+    init(
+        resolver: RPCEndpointResolving = CustomRPCStore.shared,
+        httpClient: HTTPClientProtocol = HTTPClient()
+    ) {
         self.resolver = resolver
+        self.httpClient = httpClient
     }
 
     /// The override-aware XRPL host. Falls back to the default host when no
@@ -70,23 +74,20 @@ class RippleService {
         )
 
         let result = response.data.result
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: result?.engineResult,
+            engineResultMessage: result?.engineResultMessage,
+            hash: result?.txJson?.hash
+        )
 
-        // `tx_json.hash` is the deterministic hash of the exact blob we
-        // submitted; XRPL echoes it back regardless of the engine result. Track
-        // that hash even when the engine result isn't tesSUCCESS — tec* results
-        // are applied on-chain, and for a tef/tem/ter/tel rejection the status
-        // poller resolves the real outcome from this hash and surfaces the error
-        // on screen. The bug this guards against is returning the engine error
-        // *message* as the txid; a missing hash means we have nothing to track,
-        // so surface the engine result/message as the failure instead of
-        // persisting an empty string as a fake success.
-        guard let hash = result?.txJson?.hash, !hash.isEmpty else {
-            throw RippleBroadcastError.broadcastFailed(
-                code: result?.engineResult ?? "unknown",
-                message: result?.engineResultMessage
-            )
+        switch disposition {
+        case .accepted(let hash):
+            return hash
+        case .verifyByHash(let code, _, let message),
+             .rejected(let code, let message):
+            logger.error("broadcast rejected by XRPL: \(code, privacy: .public)")
+            throw RippleBroadcastError.broadcastFailed(code: code, message: message)
         }
-        return hash
     }
 
     func getBalance(address: String) async throws -> String {

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleSubmitDisposition.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleSubmitDisposition.swift
@@ -1,0 +1,69 @@
+//
+//  RippleSubmitDisposition.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Classification of an XRPL `submit` engine result into the action the
+/// broadcast layer must take. Mirrors the SDK broadcast resolver
+/// (vultisig-sdk `core/chain/tx/broadcast/resolvers/ripple.ts`): only
+/// `tesSUCCESS` counts as an accepted broadcast, a small set of in-flight
+/// codes is resolved by looking the transaction up by hash, and every other
+/// engine result is the ledger's authoritative rejection at preflight and
+/// must fail loudly instead of being returned as a txid that may never land.
+enum RippleSubmitDisposition: Equatable {
+
+    /// `tesSUCCESS` (or, defensively, a response missing `engine_result`)
+    /// with the echoed deterministic hash: the transaction was accepted into
+    /// the open ledger and the status poller can track it from here.
+    case accepted(hash: String)
+
+    /// The transaction may already be known to the network even though this
+    /// submit was not applied. Resolve by querying the `tx` method for the
+    /// echoed hash before deciding between success and failure.
+    case verifyByHash(code: String, hash: String?, message: String?)
+
+    /// The ledger's authoritative "no" at preflight (`tem*`/`tec*`/`tel*`/
+    /// remaining `tef*`/`ter*`), or a success response missing the hash we
+    /// need to track the transaction. Surface the real engine code — never
+    /// report a hash for a transaction the ledger did not accept.
+    case rejected(code: String, message: String?)
+
+    /// Engine results resolved by hash lookup instead of failing outright:
+    /// - `tefALREADY` / `tefPAST_SEQ`: this exact transaction (or its
+    ///   sequence) was already applied or queued — a faster co-signing peer's
+    ///   broadcast of the same signed blob probably landed first.
+    /// - `terQUEUED`: the server queued the transaction to apply in a future
+    ///   ledger — it is in flight, not rejected.
+    static let verifyByHashCodes: Set<String> = ["tefALREADY", "tefPAST_SEQ", "terQUEUED"]
+
+    /// Pure classification of a `submit` response. XRPL echoes
+    /// `tx_json.hash` — the deterministic hash of the exact submitted blob —
+    /// for every engine result, so a hash may be present even on rejection.
+    static func classify(
+        engineResult: String?,
+        engineResultMessage: String?,
+        hash: String?
+    ) -> RippleSubmitDisposition {
+        let trackableHash = hash.flatMap { $0.isEmpty ? nil : $0 }
+
+        guard let engineResult, engineResult != "tesSUCCESS" else {
+            // tesSUCCESS, or a malformed/legacy response without an engine
+            // result (defensive default shared with the SDK resolver): treat
+            // as accepted as long as there is a hash to track. A missing hash
+            // means there is nothing to poll, so surface the failure instead
+            // of persisting an empty txid as a fake success.
+            guard let trackableHash else {
+                return .rejected(code: engineResult ?? "unknown", message: engineResultMessage)
+            }
+            return .accepted(hash: trackableHash)
+        }
+
+        if verifyByHashCodes.contains(engineResult) {
+            return .verifyByHash(code: engineResult, hash: trackableHash, message: engineResultMessage)
+        }
+
+        return .rejected(code: engineResult, message: engineResultMessage)
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleSubmitDisposition.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleSubmitDisposition.swift
@@ -67,3 +67,45 @@ enum RippleSubmitDisposition: Equatable {
         return .rejected(code: engineResult, message: engineResultMessage)
     }
 }
+
+/// Outcome of the `tx` lookup that resolves a `.verifyByHash` disposition.
+/// Mirrors `RippleTransactionStatusProvider`'s reading of the same response:
+/// only a validated ledger is final, a known-but-unvalidated transaction is
+/// in flight, and anything unusable counts as not found (the lookup is a
+/// safety net — it must never invent a new failure mode).
+enum RippleTxLookupOutcome: Equatable {
+    /// The transaction is in a validated ledger with `tesSUCCESS` — final success.
+    case validatedSuccess
+    /// The transaction is in a validated ledger with a non-tes result — final failure.
+    case validatedFailure(code: String)
+    /// The transaction is known to the server but not yet validated.
+    case pending
+    /// The transaction is unknown (`txnNotFound`), or the lookup response is
+    /// unusable and carries no evidence about the transaction.
+    case notFound
+
+    /// Pure interpretation of a `tx` method response.
+    static func interpret(_ response: RippleTransactionStatusResponse) -> RippleTxLookupOutcome {
+        guard response.error == nil,
+              let result = response.result,
+              result.status != "error",
+              result.error == nil else {
+            return .notFound
+        }
+
+        guard result.validated == true else {
+            return .pending
+        }
+
+        guard let meta = result.meta else {
+            // Validated but no meta (older transactions): treated as success,
+            // matching RippleTransactionStatusProvider.
+            return .validatedSuccess
+        }
+
+        if meta.TransactionResult == "tesSUCCESS" {
+            return .validatedSuccess
+        }
+        return .validatedFailure(code: meta.TransactionResult)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleBroadcastGatingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleBroadcastGatingTests.swift
@@ -95,7 +95,121 @@ final class RippleBroadcastGatingTests: XCTestCase {
         }
     }
 
+    // MARK: - Verify-by-hash dedup (tefALREADY / tefPAST_SEQ / terQUEUED)
+
+    func testTefAlreadyResolvedAsSuccessWhenTxValidatedSuccess() async throws {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: "tefALREADY", hash: Self.txHash)
+        client.txResults = [.success(Self.txJSON(validated: true, transactionResult: "tesSUCCESS"))]
+        let service = Self.makeService(client)
+
+        let hash = try await service.broadcastTransaction(Self.txBlob)
+
+        XCTAssertEqual(hash, Self.txHash)
+        XCTAssertEqual(client.submitCallCount, 1, "must not re-broadcast a duplicate submit")
+        XCTAssertEqual(client.txCallCount, 1)
+    }
+
+    func testTefAlreadyResolvedAsSuccessWhenTxKnownPending() async throws {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: "tefALREADY", hash: Self.txHash)
+        client.txResults = [.success(Self.txJSON(validated: false))]
+        let service = Self.makeService(client)
+
+        let hash = try await service.broadcastTransaction(Self.txBlob)
+
+        XCTAssertEqual(hash, Self.txHash)
+        XCTAssertEqual(client.txCallCount, 1)
+    }
+
+    func testTerQueuedResolvedAsSuccessWhenTxKnownPending() async throws {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: "terQUEUED", hash: Self.txHash)
+        client.txResults = [.success(Self.txJSON(validated: false))]
+        let service = Self.makeService(client)
+
+        let hash = try await service.broadcastTransaction(Self.txBlob)
+
+        XCTAssertEqual(hash, Self.txHash)
+        XCTAssertEqual(client.submitCallCount, 1)
+    }
+
+    func testTefAlreadySurfacesValidatedFailureCode() async {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: "tefALREADY", hash: Self.txHash)
+        client.txResults = [.success(Self.txJSON(validated: true, transactionResult: "tecUNFUNDED_PAYMENT"))]
+        let service = Self.makeService(client)
+
+        do {
+            _ = try await service.broadcastTransaction(Self.txBlob)
+            XCTFail("Expected a validated on-chain failure to throw")
+        } catch let error as RippleBroadcastError {
+            XCTAssertTrue(error.localizedDescription.contains("tecUNFUNDED_PAYMENT"))
+            XCTAssertFalse(error.localizedDescription.contains("tefALREADY"))
+        } catch {
+            XCTFail("Expected RippleBroadcastError, got \(error)")
+        }
+    }
+
+    func testTefAlreadyThrowsOriginalCodeWhenTxNotFoundAfterRetries() async {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(
+            engineResult: "tefALREADY",
+            engineResultMessage: "The exact transaction was already in this ledger.",
+            hash: Self.txHash
+        )
+        client.txResults = [.success(Self.txNotFoundJSON())]
+        let service = Self.makeService(client)
+
+        do {
+            _ = try await service.broadcastTransaction(Self.txBlob)
+            XCTFail("Expected an unverifiable duplicate submit to throw the original code")
+        } catch let error as RippleBroadcastError {
+            XCTAssertTrue(error.localizedDescription.contains("tefALREADY"))
+            XCTAssertEqual(client.txCallCount, 3, "txnNotFound must be retried before giving up")
+        } catch {
+            XCTFail("Expected RippleBroadcastError, got \(error)")
+        }
+    }
+
+    func testTefAlreadyWithoutEchoedHashThrows() async {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: "tefALREADY", hash: nil)
+        let service = Self.makeService(client)
+
+        do {
+            _ = try await service.broadcastTransaction(Self.txBlob)
+            XCTFail("Expected a duplicate submit without a hash to throw")
+        } catch let error as RippleBroadcastError {
+            XCTAssertTrue(error.localizedDescription.contains("tefALREADY"))
+            XCTAssertEqual(client.txCallCount, 0, "nothing to verify without a hash")
+        } catch {
+            XCTFail("Expected RippleBroadcastError, got \(error)")
+        }
+    }
+
+    func testDuplicateVerifyLookupErrorFallsThroughToOriginalError() async {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: "tefPAST_SEQ", hash: Self.txHash)
+        client.txResults = [.failure(RippleStubHTTPClient.StubError.unavailable)]
+        let service = Self.makeService(client)
+
+        do {
+            _ = try await service.broadcastTransaction(Self.txBlob)
+            XCTFail("Expected lookup failures to fall through to the original engine code")
+        } catch let error as RippleBroadcastError {
+            XCTAssertTrue(error.localizedDescription.contains("tefPAST_SEQ"))
+            XCTAssertEqual(client.txCallCount, 3, "lookup errors count as failed attempts")
+        } catch {
+            XCTFail("Expected RippleBroadcastError, got \(error)")
+        }
+    }
+
     // MARK: - Fixtures
+
+    private static func makeService(_ client: RippleStubHTTPClient) -> RippleService {
+        RippleService(httpClient: client, verifyByHashBackoff: .zero)
+    }
 
     static func submitJSON(
         engineResult: String?,
@@ -120,6 +234,32 @@ final class RippleBroadcastGatingTests: XCTestCase {
         }
         return json
     }
+
+    static func txJSON(validated: Bool, transactionResult: String? = nil) -> String {
+        var result: [String: Any] = [
+            "hash": txHash,
+            "validated": validated,
+            "status": "success"
+        ]
+        if let transactionResult {
+            result["meta"] = ["TransactionResult": transactionResult, "TransactionIndex": 0]
+            result["ledger_index"] = 99
+        }
+        let body: [String: Any] = ["result": result]
+        guard let data = try? JSONSerialization.data(withJSONObject: body),
+              let json = String(data: data, encoding: .utf8) else {
+            XCTFail("Failed to build tx fixture")
+            return "{}"
+        }
+        return json
+    }
+
+    static func txNotFoundJSON() -> String {
+        """
+        {"result": {"error": "txnNotFound", "error_code": 29, \
+        "error_message": "Transaction not found.", "status": "error"}}
+        """
+    }
 }
 
 // MARK: - Test double
@@ -131,10 +271,14 @@ private final class RippleStubHTTPClient: HTTPClientProtocol, @unchecked Sendabl
 
     enum StubError: Error {
         case unexpectedRequest
+        case unavailable
     }
 
     var submitJSON: String = "{}"
+    /// Consumed one per `tx` call; the last entry repeats once exhausted.
+    var txResults: [Result<String, Error>] = []
     private(set) var submitCallCount = 0
+    private(set) var txCallCount = 0
 
     func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
         await Task.yield()
@@ -142,6 +286,14 @@ private final class RippleStubHTTPClient: HTTPClientProtocol, @unchecked Sendabl
         case "submit":
             submitCallCount += 1
             return HTTPResponse(data: Data(submitJSON.utf8), response: Self.ok)
+        case "tx":
+            txCallCount += 1
+            guard !txResults.isEmpty else {
+                throw StubError.unexpectedRequest
+            }
+            let index = min(txCallCount - 1, txResults.count - 1)
+            let json = try txResults[index].get()
+            return HTTPResponse(data: Data(json.utf8), response: Self.ok)
         default:
             throw StubError.unexpectedRequest
         }

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleBroadcastGatingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleBroadcastGatingTests.swift
@@ -1,0 +1,165 @@
+//
+//  RippleBroadcastGatingTests.swift
+//  VultisigAppTests
+//
+//  Service-level tests for the XRPL broadcast gate: `broadcastTransaction`
+//  returns the echoed deterministic hash only when the submit is accepted,
+//  and throws `RippleBroadcastError.broadcastFailed` carrying the real
+//  engine code (the string the keysign error screen renders) otherwise.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class RippleBroadcastGatingTests: XCTestCase {
+
+    private static let txHash = "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7"
+    private static let txBlob = "DEADBEEF"
+
+    func testBroadcastReturnsHashOnTesSuccess() async throws {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: "tesSUCCESS", hash: Self.txHash)
+        let service = RippleService(httpClient: client)
+
+        let hash = try await service.broadcastTransaction(Self.txBlob)
+
+        XCTAssertEqual(hash, Self.txHash)
+        XCTAssertEqual(client.submitCallCount, 1)
+    }
+
+    func testBroadcastReturnsHashWhenEngineResultMissing() async throws {
+        // Defensive default shared with the SDK resolver: a response without
+        // an engine result but with the echoed hash must not brick broadcast.
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: nil, hash: Self.txHash)
+        let service = RippleService(httpClient: client)
+
+        let hash = try await service.broadcastTransaction(Self.txBlob)
+
+        XCTAssertEqual(hash, Self.txHash)
+    }
+
+    func testBroadcastThrowsRippleBroadcastErrorWithCodeOnRejection() async {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(
+            engineResult: "temREDUNDANT",
+            engineResultMessage: "The transaction is redundant.",
+            hash: Self.txHash
+        )
+        let service = RippleService(httpClient: client)
+
+        do {
+            _ = try await service.broadcastTransaction(Self.txBlob)
+            XCTFail("Expected broadcast to throw on temREDUNDANT")
+        } catch let error as RippleBroadcastError {
+            // `localizedDescription` is the string the keysign error screen
+            // ultimately renders — it must carry the real engine code.
+            XCTAssertTrue(error.localizedDescription.contains("temREDUNDANT"))
+            XCTAssertTrue(error.localizedDescription.contains("The transaction is redundant."))
+        } catch {
+            XCTFail("Expected RippleBroadcastError, got \(error)")
+        }
+    }
+
+    func testBroadcastThrowsOnTecResult() async {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(
+            engineResult: "tecUNFUNDED_PAYMENT",
+            engineResultMessage: "Insufficient XRP balance to send.",
+            hash: Self.txHash
+        )
+        let service = RippleService(httpClient: client)
+
+        do {
+            _ = try await service.broadcastTransaction(Self.txBlob)
+            XCTFail("Expected broadcast to throw on tecUNFUNDED_PAYMENT")
+        } catch let error as RippleBroadcastError {
+            XCTAssertTrue(error.localizedDescription.contains("tecUNFUNDED_PAYMENT"))
+        } catch {
+            XCTFail("Expected RippleBroadcastError, got \(error)")
+        }
+    }
+
+    func testBroadcastThrowsWhenSuccessResponseHasNoHash() async {
+        let client = RippleStubHTTPClient()
+        client.submitJSON = Self.submitJSON(engineResult: "tesSUCCESS", hash: nil)
+        let service = RippleService(httpClient: client)
+
+        do {
+            _ = try await service.broadcastTransaction(Self.txBlob)
+            XCTFail("Expected broadcast to throw when there is no hash to track")
+        } catch let error as RippleBroadcastError {
+            XCTAssertTrue(error.localizedDescription.contains("tesSUCCESS"))
+        } catch {
+            XCTFail("Expected RippleBroadcastError, got \(error)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    static func submitJSON(
+        engineResult: String?,
+        engineResultMessage: String? = nil,
+        hash: String?
+    ) -> String {
+        var result: [String: Any] = [:]
+        if let engineResult {
+            result["engine_result"] = engineResult
+        }
+        if let engineResultMessage {
+            result["engine_result_message"] = engineResultMessage
+        }
+        if let hash {
+            result["tx_json"] = ["hash": hash]
+        }
+        let body: [String: Any] = ["result": result]
+        guard let data = try? JSONSerialization.data(withJSONObject: body),
+              let json = String(data: data, encoding: .utf8) else {
+            XCTFail("Failed to build submit fixture")
+            return "{}"
+        }
+        return json
+    }
+}
+
+// MARK: - Test double
+
+/// Stub `HTTPClientProtocol` for `RippleService`. Every XRPL JSON-RPC call
+/// posts to `/`, so requests are keyed off the `method` field in the encoded
+/// request body rather than the path.
+private final class RippleStubHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    enum StubError: Error {
+        case unexpectedRequest
+    }
+
+    var submitJSON: String = "{}"
+    private(set) var submitCallCount = 0
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        await Task.yield()
+        switch Self.rpcMethod(of: target) {
+        case "submit":
+            submitCallCount += 1
+            return HTTPResponse(data: Data(submitJSON.utf8), response: Self.ok)
+        default:
+            throw StubError.unexpectedRequest
+        }
+    }
+
+    private static func rpcMethod(of target: TargetType) -> String? {
+        guard case let .requestCodable(body, _) = target.task,
+              let data = try? JSONEncoder().encode(body),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json["method"] as? String
+    }
+
+    private static let ok = HTTPURLResponse(
+        url: URL(string: "https://example.com")!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleSubmitDispositionTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleSubmitDispositionTests.swift
@@ -1,0 +1,205 @@
+//
+//  RippleSubmitDispositionTests.swift
+//  VultisigAppTests
+//
+//  Pins the XRPL submit engine-result gate: only tesSUCCESS (or a defensive
+//  missing engine result) counts as an accepted broadcast, the peer-race and
+//  queued codes resolve by hash lookup, and every other engine result is the
+//  ledger's authoritative rejection that must surface its real code instead
+//  of being returned as a txid that may never land.
+//
+//  - https://xrpl.org/docs/references/protocol/transactions/transaction-results
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class RippleSubmitDispositionTests: XCTestCase {
+
+    private let txHash = "E08D6E9754025BA2534A78707605E0601F03ACE063687A0CA1BDDACFCD1698C7"
+
+    // MARK: - Accepted
+
+    func testTesSuccessWithHashIsAccepted() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tesSUCCESS",
+            engineResultMessage: "The transaction was applied. Only final in a validated ledger.",
+            hash: txHash
+        )
+        XCTAssertEqual(disposition, .accepted(hash: txHash))
+    }
+
+    func testMissingEngineResultWithHashIsAccepted() {
+        // Defensive default shared with the SDK resolver: a malformed or
+        // legacy response without an engine result must not brick broadcast.
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: nil,
+            engineResultMessage: nil,
+            hash: txHash
+        )
+        XCTAssertEqual(disposition, .accepted(hash: txHash))
+    }
+
+    // MARK: - Success responses without a trackable hash
+
+    func testTesSuccessWithoutHashIsRejected() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tesSUCCESS",
+            engineResultMessage: nil,
+            hash: nil
+        )
+        XCTAssertEqual(disposition, .rejected(code: "tesSUCCESS", message: nil))
+    }
+
+    func testTesSuccessWithEmptyHashIsRejected() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tesSUCCESS",
+            engineResultMessage: nil,
+            hash: ""
+        )
+        XCTAssertEqual(disposition, .rejected(code: "tesSUCCESS", message: nil))
+    }
+
+    func testMissingEngineResultWithoutHashIsRejectedAsUnknown() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: nil,
+            engineResultMessage: nil,
+            hash: nil
+        )
+        XCTAssertEqual(disposition, .rejected(code: "unknown", message: nil))
+    }
+
+    // MARK: - Verify-by-hash codes
+
+    func testTefAlreadyIsVerifyByHash() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tefALREADY",
+            engineResultMessage: "The exact transaction was already in this ledger.",
+            hash: txHash
+        )
+        XCTAssertEqual(
+            disposition,
+            .verifyByHash(
+                code: "tefALREADY",
+                hash: txHash,
+                message: "The exact transaction was already in this ledger."
+            )
+        )
+    }
+
+    func testTefPastSeqIsVerifyByHash() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tefPAST_SEQ",
+            engineResultMessage: "This sequence number has already passed.",
+            hash: txHash
+        )
+        XCTAssertEqual(
+            disposition,
+            .verifyByHash(
+                code: "tefPAST_SEQ",
+                hash: txHash,
+                message: "This sequence number has already passed."
+            )
+        )
+    }
+
+    func testTerQueuedIsVerifyByHash() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "terQUEUED",
+            engineResultMessage: "Held until escalated fee drops.",
+            hash: txHash
+        )
+        XCTAssertEqual(
+            disposition,
+            .verifyByHash(
+                code: "terQUEUED",
+                hash: txHash,
+                message: "Held until escalated fee drops."
+            )
+        )
+    }
+
+    func testVerifyByHashNormalizesEmptyEchoedHashToNil() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tefALREADY",
+            engineResultMessage: nil,
+            hash: ""
+        )
+        XCTAssertEqual(disposition, .verifyByHash(code: "tefALREADY", hash: nil, message: nil))
+    }
+
+    // MARK: - Authoritative rejections
+
+    func testTemRedundantIsRejected() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "temREDUNDANT",
+            engineResultMessage: "The transaction is redundant.",
+            hash: txHash
+        )
+        XCTAssertEqual(
+            disposition,
+            .rejected(code: "temREDUNDANT", message: "The transaction is redundant.")
+        )
+    }
+
+    func testTecClaimFailureIsRejected() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tecUNFUNDED_PAYMENT",
+            engineResultMessage: "Insufficient XRP balance to send.",
+            hash: txHash
+        )
+        XCTAssertEqual(
+            disposition,
+            .rejected(code: "tecUNFUNDED_PAYMENT", message: "Insufficient XRP balance to send.")
+        )
+    }
+
+    func testTerPreSeqIsRejected() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "terPRE_SEQ",
+            engineResultMessage: "Missing/inapplicable prior transaction.",
+            hash: txHash
+        )
+        XCTAssertEqual(
+            disposition,
+            .rejected(code: "terPRE_SEQ", message: "Missing/inapplicable prior transaction.")
+        )
+    }
+
+    func testTelLocalErrorIsRejected() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "telINSUF_FEE_P",
+            engineResultMessage: "Fee insufficient.",
+            hash: txHash
+        )
+        XCTAssertEqual(
+            disposition,
+            .rejected(code: "telINSUF_FEE_P", message: "Fee insufficient.")
+        )
+    }
+
+    func testOtherTefIsRejected() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tefMAX_LEDGER",
+            engineResultMessage: "Ledger sequence too high.",
+            hash: txHash
+        )
+        XCTAssertEqual(
+            disposition,
+            .rejected(code: "tefMAX_LEDGER", message: "Ledger sequence too high.")
+        )
+    }
+
+    func testRejectionCarriesEngineCodeAndMessage() {
+        let disposition = RippleSubmitDisposition.classify(
+            engineResult: "tecPATH_DRY",
+            engineResultMessage: "Path could not send partial amount.",
+            hash: nil
+        )
+        guard case let .rejected(code, message) = disposition else {
+            return XCTFail("Expected .rejected, got \(disposition)")
+        }
+        XCTAssertEqual(code, "tecPATH_DRY")
+        XCTAssertEqual(message, "Path could not send partial amount.")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleSubmitDispositionTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleSubmitDispositionTests.swift
@@ -203,3 +203,79 @@ final class RippleSubmitDispositionTests: XCTestCase {
         XCTAssertEqual(message, "Path could not send partial amount.")
     }
 }
+
+/// Pins the pure interpretation of the `tx` lookup that resolves a
+/// `.verifyByHash` disposition: only a validated ledger is final, a known
+/// but unvalidated transaction is in flight, and unusable responses carry
+/// no evidence about the transaction.
+final class RippleTxLookupOutcomeTests: XCTestCase {
+
+    func testValidatedTesSuccessIsValidatedSuccess() throws {
+        let response = try decodeTxResponse("""
+        {"result": {"hash": "ABC", "validated": true, "ledger_index": 99,
+                    "meta": {"TransactionResult": "tesSUCCESS", "TransactionIndex": 0},
+                    "status": "success"}}
+        """)
+        XCTAssertEqual(RippleTxLookupOutcome.interpret(response), .validatedSuccess)
+    }
+
+    func testValidatedNonTesIsValidatedFailureWithCode() throws {
+        let response = try decodeTxResponse("""
+        {"result": {"hash": "ABC", "validated": true, "ledger_index": 99,
+                    "meta": {"TransactionResult": "tecUNFUNDED_PAYMENT", "TransactionIndex": 0},
+                    "status": "success"}}
+        """)
+        XCTAssertEqual(
+            RippleTxLookupOutcome.interpret(response),
+            .validatedFailure(code: "tecUNFUNDED_PAYMENT")
+        )
+    }
+
+    func testValidatedWithoutMetaIsValidatedSuccess() throws {
+        let response = try decodeTxResponse("""
+        {"result": {"hash": "ABC", "validated": true, "status": "success"}}
+        """)
+        XCTAssertEqual(RippleTxLookupOutcome.interpret(response), .validatedSuccess)
+    }
+
+    func testKnownUnvalidatedIsPending() throws {
+        let response = try decodeTxResponse("""
+        {"result": {"hash": "ABC", "validated": false, "status": "success"}}
+        """)
+        XCTAssertEqual(RippleTxLookupOutcome.interpret(response), .pending)
+    }
+
+    func testResultLevelTxnNotFoundIsNotFound() throws {
+        let response = try decodeTxResponse("""
+        {"result": {"error": "txnNotFound", "error_code": 29,
+                    "error_message": "Transaction not found.", "status": "error"}}
+        """)
+        XCTAssertEqual(RippleTxLookupOutcome.interpret(response), .notFound)
+    }
+
+    func testTopLevelTxnNotFoundIsNotFound() throws {
+        let response = try decodeTxResponse("""
+        {"error": "txnNotFound", "error_code": 29, "error_message": "Transaction not found.", "status": "error"}
+        """)
+        XCTAssertEqual(RippleTxLookupOutcome.interpret(response), .notFound)
+    }
+
+    func testOtherLookupErrorIsNotFound() throws {
+        // A lookup failure that says nothing about the transaction (bad
+        // params, unsupported method) must not masquerade as evidence.
+        let response = try decodeTxResponse("""
+        {"result": {"error": "notImpl", "error_code": 38,
+                    "error_message": "Not implemented.", "status": "error"}}
+        """)
+        XCTAssertEqual(RippleTxLookupOutcome.interpret(response), .notFound)
+    }
+
+    func testMissingResultIsNotFound() throws {
+        let response = try decodeTxResponse("{}")
+        XCTAssertEqual(RippleTxLookupOutcome.interpret(response), .notFound)
+    }
+
+    private func decodeTxResponse(_ json: String) throws -> RippleTransactionStatusResponse {
+        try JSONDecoder().decode(RippleTransactionStatusResponse.self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## Root cause

`RippleService.broadcastTransaction` gated success on **hash presence only**: any submit response carrying `result.tx_json.hash` was returned as a successful broadcast. But the XRPL `submit` method echoes `tx_json.hash` — the deterministic hash of the exact submitted blob — for **every** engine result, including `temREDUNDANT`, `tefPAST_SEQ`, `telINSUF_FEE_P`, and every other rejection. The code's own comment documented the echo behavior while relying on it as a success signal.

Consequences of the old gate:

- Any `tef*`/`tem*`/`tel*`/`ter*` rejection was reported to the user as a **successful broadcast** with a success screen and explorer link.
- Since a rejected transaction is never applied to any ledger, the persisted hash resolved to `txnNotFound` forever — an untrackable, dead txid ("silent success").
- `engine_result` was decoded but never consulted for the success/failure decision.

## Fix design

Ports the semantics of the SDK broadcast resolver (`vultisig-sdk` `packages/core/chain/tx/broadcast/resolvers/ripple.ts`) into the iOS broadcast layer. Everything lives in `Blockchain/Ripple/Service/` — no signing-path or `KeysignViewModel` changes.

**1. Pure classifier — `RippleSubmitDisposition.classify`** (new file):

| Engine result | Disposition |
|---|---|
| `tesSUCCESS` (or defensively-missing `engine_result`, SDK parity) + echoed hash | `.accepted(hash:)` — return the hash |
| `tesSUCCESS`/missing, but no hash | `.rejected` — never persist an empty txid as a fake success (preserves the existing guard) |
| `tefALREADY`, `tefPAST_SEQ`, `terQUEUED` | `.verifyByHash` — resolve by `tx` lookup |
| everything else (`tem*`/`tec*`/`tel*`/remaining `tef*`/`ter*`) | `.rejected(code:message:)` — throw |

Rejections throw the existing `RippleBroadcastError.broadcastFailed(code:message:)`, which flows through `handleBroadcastError` to the keysign friendly-error screen with the **real engine code and message** rendered — no ViewModel changes needed.

**2. Verify-by-hash resolution — `RippleService.resolveSubmitByHash`**: `tefALREADY`/`tefPAST_SEQ` mean this exact transaction (or its sequence) was already applied or queued — for an MPC wallet that almost always means a **faster co-signing peer landed the same signed blob first**, so it must not surface as a failure. The echoed deterministic hash is looked up with the `tx` method via a new `RippleAPI.tx` endpoint — against the same **custom-RPC-override-aware** node the submit went to (the existing status provider hardcodes `xrplcluster.com`, which would risk cross-node propagation false negatives):

- validated `tesSUCCESS` → return the hash (idempotent success; asserted single submit, no double-broadcast)
- known but unvalidated → return the hash; the existing status poller resolves the final outcome
- validated non-`tes` result → throw with that final on-chain code
- `txnNotFound` / lookup errors → 3 attempts × 2 s backoff (cluster nodes can lag a peer's submit; injectable backoff for tests), then throw the **original** engine code — an unverified duplicate is never converted into success

**terQUEUED deviation from the SDK (deliberate):** the SDK throws on all `ter*`. `terQUEUED`, however, means the server queued the transaction to apply in a **future ledger** — it is in flight and likely to land. Hard-failing would show a false failure screen for a transaction that lands seconds later, and the error screen's "Try Again" restarts the flow: the user would re-sign with a fresh sequence and could **double-send** once the queued original also applies. Routing `terQUEUED` through the same verify-by-hash path returns the trackable hash when the network knows the transaction (poller resolves the outcome) and still falls back to the real engine code if it genuinely can't be found. All other `ter*` codes keep SDK parity and hard-fail.

**Interpretation parity:** the new pure `RippleTxLookupOutcome.interpret` mirrors `RippleTransactionStatusProvider`'s reading of the `tx` response (validated-only finality, known-but-unvalidated = pending, unusable responses carry no evidence).

## Test coverage

35 new tests in `VultisigAppTests/Blockchain/Ripple/`:

- `RippleSubmitDispositionTests` (15) — exhaustive classifier matrix: `tesSUCCESS` ± hash, missing engine result ± hash (defensive default), `tefALREADY`/`tefPAST_SEQ`/`terQUEUED`, `tem`/`tec`/`ter`/`tel`/other `tef` rejections, code+message propagation, empty-hash normalization.
- `RippleTxLookupOutcomeTests` (8) — pure `tx`-lookup interpretation: validated success/failure, validated-without-meta, known-pending, result-level and top-level `txnNotFound`, non-evidence lookup errors, empty response.
- `RippleBroadcastGatingTests` (12) — service-level via stub `HTTPClientProtocol`: hash returned on `tesSUCCESS`, rejection throws with the engine code in `localizedDescription` (the string the error screen renders), dedup resolution for validated-success / known-pending (incl. `terQUEUED`), validated-failure surfacing, `txnNotFound` ×3 retry then original code, missing echoed hash, lookup errors falling through to the original error.

## Gate

- `make test` (full suite): **2400 tests, 0 failures** (iPhone 17 Pro Max, iOS 26.5).
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/`: **0 new warnings** (0 in touched files).
- Cross-model review loop: 2 per-commit Codex reviews + whole-branch pass — all clean, no findings.

Closes #4743

Part of the XRP chain-hardening set (tracker: vultisig-sdk#979).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved XRP transaction handling with better follow-up checks after broadcast submissions.
  * Added support for looking up transaction details by hash.

* **Bug Fixes**
  * More reliably returns the correct transaction hash after submission.
  * Better handles duplicate or queued transactions by checking their final on-chain status.
  * Clearer errors are shown when a transaction is rejected or cannot be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->