### PR TITLE
fix(ripple): owner-aware reserve for MAX send — remove the double-counted static 1 XRP

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -423,7 +423,7 @@ enum RippleSendError: Error, LocalizedError {
         case .destinationNotActivated(let minimumXRP):
             return String(format: "xrpDestinationNotActivatedError".localized, minimumXRP)
         case .destinationLookupFailed(let code):
-            return "XRP destination lookup failed (\(code))"
+            return String(format: "xrpDestinationLookupFailedError".localized, code)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -274,6 +274,17 @@ class RippleService {
                     throw HelperError.runtimeError("RippleService deallocated")
                 }
                 let ledger = try await self.fetchServerState(host: host)?.result?.state?.validatedLedger
+                // A server that is up but still syncing answers HTTP 200 with
+                // `validated_ledger == null`, so both reserve fields come back
+                // nil. Caching that fully-empty response would pin the seeds for
+                // the whole 24h TTL and never refetch, even after the node
+                // recovers. Throw instead so TTLCache keeps serving the last-good
+                // snapshot (or the caller seeds) and retries next time — a thrown
+                // error is not cached. A partial response with at least one real
+                // field is still worth caching, seeds filling the gap.
+                guard ledger?.reserveBase != nil || ledger?.reserveInc != nil else {
+                    throw HelperError.runtimeError("server_state returned no reserve values (validated_ledger unavailable)")
+                }
                 return RippleReserveValues(reserveBase: ledger?.reserveBase, reserveInc: ledger?.reserveInc)
             }
         } catch is CancellationError {
@@ -288,20 +299,38 @@ class RippleService {
     /// would create the destination with less than the base reserve is
     /// rejected on-chain (`tecNO_DST_INSUF_XRP`) — after the ceremony, with
     /// the fee burned. Throws `RippleSendError.destinationNotActivated` when
-    /// the destination is unfunded and `amountDrops` is below the live base
-    /// reserve. A lookup failure also throws (fail closed, matching the
-    /// SDK/Android companions) so the ceremony never starts on an
-    /// unverifiable destination.
+    /// the destination is unfunded (a definitive `actNotFound`) and
+    /// `amountDrops` is below the live base reserve.
+    ///
+    /// The block fires ONLY on proof the destination is unfunded. A transport
+    /// or RPC error (offline, timeout, 429/5xx, an exhausted node-error retry)
+    /// is NOT such proof: before this guard existed the same send to a funded
+    /// address proceeded, so a transient lookup failure must not start blocking
+    /// it — fail open and let the on-chain guard remain the backstop. Only a
+    /// successful-but-uninterpretable response (HTTP 200, no account data, no
+    /// `actNotFound`) fails closed, with a localized message.
     func validateDestinationActivation(address: String, amountDrops: BigInt) async throws {
-        let result = try await fetchAccountsInfo(for: address)?.result
+        let result: RippleAccountResponse.Result?
+        do {
+            result = try await fetchAccountsInfo(for: address)?.result
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            // Transport/RPC error — not evidence the destination is unfunded.
+            // Don't gate an otherwise-valid send behind a fresh, uncached
+            // account_info call whose transient failure would block it.
+            logger.warning("validateDestinationActivation: destination lookup failed, allowing send: \(error.localizedDescription)")
+            return
+        }
+
         guard result?.accountData == nil else {
             return // Funded destination — any amount is valid.
         }
 
-        // Only a definitive `actNotFound` means "unfunded". Any other
-        // account_data-less shape — rate limiting, a malformed address, a
-        // proxy error page decoding to all-nils — is an unverifiable
-        // destination and fails closed, exactly like a transport error.
+        // No account data: only a definitive `actNotFound` proves the account
+        // is unfunded. Any other account_data-less-but-successful shape (a
+        // proxy error page decoding to all-nils, an unexpected token) is
+        // unverifiable, so fail closed with a localized message.
         guard result?.error == "actNotFound" else {
             throw RippleSendError.destinationLookupFailed(code: result?.error ?? "unknown")
         }
@@ -316,7 +345,10 @@ class RippleService {
             reserveInc: reserveValues?.reserveInc
         )
         if amountDrops < baseReserve {
-            let minimumXRP = (Decimal(string: baseReserve.description) ?? 1) / pow(10, 6)
+            // drops → XRP. `toDecimal(decimals:)` only truncates, so divide to
+            // scale (the getMaxValue / SwapDetailsScreen idiom); reserves are
+            // always positive, so no fallback default is needed.
+            let minimumXRP = baseReserve.toDecimal(decimals: 6) / pow(10, 6)
             throw RippleSendError.destinationNotActivated(minimumXRP: minimumXRP.description)
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -34,6 +34,36 @@ enum RippleFee {
     }
 }
 
+/// Owner-aware XRPL account-reserve math. The reserve floor is
+/// `reserve_base + OwnerCount × reserve_inc` — every ledger object the account
+/// owns (trustline, offer, ticket, escrow, …) adds one increment. The floor
+/// applies to the Payment amount only; the transaction fee is exempt and may
+/// take the account below the reserve.
+/// - https://xrpl.org/docs/concepts/accounts/reserves
+enum RippleReserve {
+    /// Mainnet base reserve — 1 XRP (validator vote, Dec 2024). Last-resort
+    /// seed only; live values come from `server_state`.
+    static let seedReserveBaseDrops = BigInt(1_000_000)
+    /// Mainnet per-object owner reserve — 0.2 XRP (validator vote, Dec 2024).
+    /// Seed only, as above.
+    static let seedReserveIncDrops = BigInt(200_000)
+
+    /// Total reserved balance in drops: `reserve_base + OwnerCount × reserve_inc`.
+    /// Missing `server_state` fields fall back to the mainnet seeds; a missing
+    /// owner count counts as zero owned objects.
+    static func reservedDrops(ownerCount: Int?, reserveBase: Int?, reserveInc: Int?) -> BigInt {
+        let base = reserveBase.map { BigInt($0) } ?? seedReserveBaseDrops
+        let inc = reserveInc.map { BigInt($0) } ?? seedReserveIncDrops
+        return base + BigInt(ownerCount ?? 0) * inc
+    }
+
+    /// Spendable balance in drops: `max(total − reservedDrops, 0)`.
+    static func availableDrops(totalDrops: BigInt, ownerCount: Int?, reserveBase: Int?, reserveInc: Int?) -> BigInt {
+        let reserved = reservedDrops(ownerCount: ownerCount, reserveBase: reserveBase, reserveInc: reserveInc)
+        return max(totalDrops - reserved, BigInt(0))
+    }
+}
+
 class RippleService {
 
     static let shared = RippleService()
@@ -100,12 +130,13 @@ class RippleService {
             return "0"
         }
 
-        let ownerCount = BigInt(accountInfo?.result?.accountData?.ownerCount ?? 0)
-        let reservedBase = BigInt(serverState?.result?.state?.validatedLedger?.reserveBase ?? 1000000)
-        let reserveInc = BigInt(serverState?.result?.state?.validatedLedger?.reserveInc ?? 200000)
-
-        let reservedBalance = reservedBase + (ownerCount * reserveInc)
-        let availableBalance = max(totalBalance - reservedBalance, BigInt(0))
+        let validatedLedger = serverState?.result?.state?.validatedLedger
+        let availableBalance = RippleReserve.availableDrops(
+            totalDrops: totalBalance,
+            ownerCount: accountInfo?.result?.accountData?.ownerCount,
+            reserveBase: validatedLedger?.reserveBase,
+            reserveInc: validatedLedger?.reserveInc
+        )
 
         return availableBalance.description
     }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -64,12 +64,19 @@ enum RippleReserve {
     }
 }
 
+/// Reserve values reported by `server_state`. Fields stay optional so a
+/// partial response still caches, with `RippleReserve` seeding the gaps.
+struct RippleReserveValues {
+    let reserveBase: Int?
+    let reserveInc: Int?
+}
+
 class RippleService {
 
     static let shared = RippleService()
 
     private let logger = Logger(subsystem: "com.vultisig.app", category: "ripple-service")
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+    private let httpClient: HTTPClientProtocol
 
     /// Resolves the Ripple custom RPC override. Injected so the API values are
     /// built from a dependency rather than a global reach-in; resolution happens
@@ -77,8 +84,28 @@ class RippleService {
     /// live (the shared mirror updates without a relaunch).
     private let resolver: RPCEndpointResolving
 
-    init(resolver: RPCEndpointResolving = CustomRPCStore.shared) {
+    /// Last-good `server_state` reserve values. Reserves change only by rare
+    /// validator vote, so a generous TTL is safe; `TTLCache` coalesces
+    /// concurrent refreshes and fails open to the last-good snapshot when a
+    /// refresh throws. Internal (not `private`) together with the key so tests
+    /// can seed stale entries via `setCached`.
+    let reserveValuesCache = TTLCache<String, RippleReserveValues>()
+    private static let reserveValuesTTL: TimeInterval = 60 * 60 * 24
+
+    /// Cache key for the reserve values, scoped to a resolved host: a custom
+    /// RPC override can point at a network with different reserves (e.g. a
+    /// testnet), so a snapshot cached for one endpoint must never be served
+    /// for another after a runtime override change.
+    static func reserveValuesCacheKey(for host: URL) -> String {
+        "xrpl-reserve-values|\(host.absoluteString)"
+    }
+
+    init(
+        resolver: RPCEndpointResolving = CustomRPCStore.shared,
+        httpClient: HTTPClientProtocol = HTTPClient()
+    ) {
         self.resolver = resolver
+        self.httpClient = httpClient
     }
 
     /// The override-aware XRPL host. Falls back to the default host when no
@@ -121,24 +148,60 @@ class RippleService {
 
     func getBalance(address: String) async throws -> String {
         async let accountInfoTask = fetchAccountsInfo(for: address)
-        async let serverStateTask = fetchServerState()
+        async let reserveValuesTask = fetchReserveValues()
 
-        let (accountInfo, serverState) = try await (accountInfoTask, serverStateTask)
+        // Only the account read is fatal — there is no balance without it. The
+        // reserve read has its own live → cache → seed fallback chain, so a
+        // transient `server_state` outage no longer fails the balance refresh
+        // (it only rethrows cancellation).
+        let accountInfo = try await accountInfoTask
+        let reserveValues = try await reserveValuesTask
 
         guard let totalBalanceStr = accountInfo?.result?.accountData?.balance,
               let totalBalance = BigInt(totalBalanceStr) else {
             return "0"
         }
 
-        let validatedLedger = serverState?.result?.state?.validatedLedger
         let availableBalance = RippleReserve.availableDrops(
             totalDrops: totalBalance,
             ownerCount: accountInfo?.result?.accountData?.ownerCount,
-            reserveBase: validatedLedger?.reserveBase,
-            reserveInc: validatedLedger?.reserveInc
+            reserveBase: reserveValues?.reserveBase,
+            reserveInc: reserveValues?.reserveInc
         )
 
         return availableBalance.description
+    }
+
+    /// Resolves the XRPL reserve values: live `server_state` → cached
+    /// last-good snapshot → `nil` (callers fall back to the `RippleReserve`
+    /// seeds). Mirrors the Solana min-delegation chain: the values are
+    /// validation/display inputs, never signing inputs, so serving a stale or
+    /// seeded snapshot is safe while failing the caller is not. The only error
+    /// that escapes is `CancellationError` — the caller is tearing down, and
+    /// a seeded value must not mask the cancel.
+    func fetchReserveValues() async throws -> RippleReserveValues? {
+        // Resolve the host once so the cache key and the fetch always agree —
+        // a custom-RPC change landing between two resolutions must not store
+        // one host's reserves under another host's key.
+        let host = resolvedHost
+        do {
+            return try await reserveValuesCache.value(
+                for: Self.reserveValuesCacheKey(for: host),
+                now: Date(),
+                ttl: Self.reserveValuesTTL
+            ) { [weak self] in
+                guard let self else {
+                    throw HelperError.runtimeError("RippleService deallocated")
+                }
+                let ledger = try await self.fetchServerState(host: host)?.result?.state?.validatedLedger
+                return RippleReserveValues(reserveBase: ledger?.reserveBase, reserveInc: ledger?.reserveInc)
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            logger.warning("fetchReserveValues: no live or cached values, seeding defaults: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     /// Resolves the fee (in drops) for an XRPL Payment.
@@ -163,10 +226,14 @@ class RippleService {
         }
     }
 
-    func fetchServerState() async throws -> RippleServerStateResponse? {
+    /// Fetches `server_state`, optionally pinned to an explicit `host` so a
+    /// caller can keep one request consistent with other host-derived state
+    /// (e.g. the reserve cache key); `nil` resolves the override-aware host
+    /// per request as usual.
+    func fetchServerState(host: URL? = nil) async throws -> RippleServerStateResponse? {
         do {
             let response = try await httpClient.request(
-                api(.serverState),
+                RippleAPI(.serverState, host: host ?? resolvedHost),
                 responseType: RippleServerStateResponse.self
             )
             return response.data

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -204,6 +204,43 @@ class RippleService {
         }
     }
 
+    /// Pre-ceremony guard for the destination account: an XRPL Payment that
+    /// would create the destination with less than the base reserve is
+    /// rejected on-chain (`tecNO_DST_INSUF_XRP`) — after the ceremony, with
+    /// the fee burned. Throws `RippleSendError.destinationNotActivated` when
+    /// the destination is unfunded and `amountDrops` is below the live base
+    /// reserve. A lookup failure also throws (fail closed, matching the
+    /// SDK/Android companions) so the ceremony never starts on an
+    /// unverifiable destination.
+    func validateDestinationActivation(address: String, amountDrops: BigInt) async throws {
+        let result = try await fetchAccountsInfo(for: address)?.result
+        guard result?.accountData == nil else {
+            return // Funded destination — any amount is valid.
+        }
+
+        // Only a definitive `actNotFound` means "unfunded". Any other
+        // account_data-less shape — rate limiting, a malformed address, a
+        // proxy error page decoding to all-nils — is an unverifiable
+        // destination and fails closed, exactly like a transport error.
+        guard result?.error == "actNotFound" else {
+            throw RippleSendError.destinationLookupFailed(code: result?.error ?? "unknown")
+        }
+
+        // The destination does not exist yet, so the payment must fund at
+        // least the base reserve. OwnerCount is 0 by definition for an
+        // account being created.
+        let reserveValues = try await fetchReserveValues()
+        let baseReserve = RippleReserve.reservedDrops(
+            ownerCount: 0,
+            reserveBase: reserveValues?.reserveBase,
+            reserveInc: reserveValues?.reserveInc
+        )
+        if amountDrops < baseReserve {
+            let minimumXRP = (Decimal(string: baseReserve.description) ?? 1) / pow(10, 6)
+            throw RippleSendError.destinationNotActivated(minimumXRP: minimumXRP.description)
+        }
+    }
+
     /// Resolves the fee (in drops) for an XRPL Payment.
     ///
     /// The XRPL reference fee is 10 drops; servers escalate it under load via
@@ -257,6 +294,27 @@ class RippleService {
     }
 }
 
+enum RippleSendError: Error, LocalizedError {
+    /// The destination account does not exist and the amount is below the
+    /// base reserve needed to create it. Carries the minimum in whole XRP,
+    /// ready for user-facing copy.
+    case destinationNotActivated(minimumXRP: String)
+    /// `account_info` answered without account data and without a definitive
+    /// `actNotFound` — the destination cannot be verified, so the send is
+    /// blocked (fail closed). Technical copy, same style as
+    /// `RippleBroadcastError`.
+    case destinationLookupFailed(code: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .destinationNotActivated(let minimumXRP):
+            return String(format: "xrpDestinationNotActivatedError".localized, minimumXRP)
+        case .destinationLookupFailed(let code):
+            return "XRP destination lookup failed (\(code))"
+        }
+    }
+}
+
 enum RippleBroadcastError: Error, LocalizedError {
     case broadcastFailed(code: String, message: String?)
 
@@ -280,6 +338,9 @@ struct RippleAccountResponse: Codable {
         let queueData: QueueData?
         let status: String?
         let validated: Bool?
+        /// rippled error token for failed lookups (HTTP 200 + error body),
+        /// e.g. `actNotFound` for a non-existent account.
+        let error: String?
 
         enum CodingKeys: String, CodingKey {
             case accountData = "account_data"
@@ -287,6 +348,7 @@ struct RippleAccountResponse: Codable {
             case queueData = "queue_data"
             case status
             case validated
+            case error
         }
     }
 

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -12,12 +12,6 @@ import WalletCore
 
 enum RippleHelper {
 
-    /*
-     https://xrpl.org/docs/concepts/accounts/reserves
-     Ripple deletes your account if less than 1 XRP
-     */
-    static let defaultExistentialDeposit: BigInt = pow(10, 6).description.toBigInt() // 1 XRP
-
     static func getSwapPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
         // For XRP swaps, we use the same logic as regular transactions but with swap memo
         return try getPreSignedInputData(keysignPayload: keysignPayload)

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "Der von Ihnen ausgewählte Vault stimmt nicht mit der Keygen-Sitzung überein. Bitte wählen Sie den richtigen Vault aus.";
 "wrongVaultTryAgain" = "Falscher Tresor oder gekoppeltes Gerät.";
 "x" = "x";
+"xrpDestinationLookupFailedError" = "Das XRP-Zielkonto konnte nicht überprüft werden (%@). Bitte versuchen Sie es erneut.";
 "xrpDestinationNotActivatedError" = "Die XRP-Zieladresse ist noch nicht aktiviert. Eine erste Überweisung an sie muss mindestens %@ XRP betragen (die Basisreserve des Netzwerks). Erhöhen Sie den Betrag oder überprüfen Sie die Adresse.";
 "yes" = "Ja";
 "yesterday" = "Gestern";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "Der von Ihnen ausgewählte Vault stimmt nicht mit der Keygen-Sitzung überein. Bitte wählen Sie den richtigen Vault aus.";
 "wrongVaultTryAgain" = "Falscher Tresor oder gekoppeltes Gerät.";
 "x" = "x";
+"xrpDestinationNotActivatedError" = "Die XRP-Zieladresse ist noch nicht aktiviert. Eine erste Überweisung an sie muss mindestens %@ XRP betragen (die Basisreserve des Netzwerks). Erhöhen Sie den Betrag oder überprüfen Sie die Adresse.";
 "yes" = "Ja";
 "yesterday" = "Gestern";
 "yieldClaimAmount" = "%@ beanspruchen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1438,6 +1438,7 @@
 "wrongVaultSelectedDescription" = "The vault you selected doesn't match the keygen session. Please select the correct vault.";
 "wrongVaultTryAgain" = "Wrong Vault or Pair";
 "x" = "X (Twitter)";
+"xrpDestinationLookupFailedError" = "The destination XRP account couldn't be verified (%@). Please try again.";
 "xrpDestinationNotActivatedError" = "The destination XRP address is not activated yet. A first transfer to it must be at least %@ XRP (the network base reserve). Increase the amount or double-check the address.";
 "yes" = "Yes";
 "yesterday" = "Yesterday";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1438,6 +1438,7 @@
 "wrongVaultSelectedDescription" = "The vault you selected doesn't match the keygen session. Please select the correct vault.";
 "wrongVaultTryAgain" = "Wrong Vault or Pair";
 "x" = "X (Twitter)";
+"xrpDestinationNotActivatedError" = "The destination XRP address is not activated yet. A first transfer to it must be at least %@ XRP (the network base reserve). Increase the amount or double-check the address.";
 "yes" = "Yes";
 "yesterday" = "Yesterday";
 "yieldClaimAmount" = "Claim %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "El Vault que seleccionaste no coincide con la sesión de keygen. Por favor selecciona el Vault correcto.";
 "wrongVaultTryAgain" = "Caja Fuerte o Dispositivo Emparejado Incorrecto.";
 "x" = "X (Twitter)";
+"xrpDestinationNotActivatedError" = "La dirección XRP de destino aún no está activada. Una primera transferencia debe ser de al menos %@ XRP (la reserva base de la red). Aumenta el importe o verifica la dirección.";
 "yes" = "Sí";
 "yesterday" = "Ayer";
 "yieldClaimAmount" = "Reclamar %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "El Vault que seleccionaste no coincide con la sesión de keygen. Por favor selecciona el Vault correcto.";
 "wrongVaultTryAgain" = "Caja Fuerte o Dispositivo Emparejado Incorrecto.";
 "x" = "X (Twitter)";
+"xrpDestinationLookupFailedError" = "No se pudo verificar la cuenta XRP de destino (%@). Inténtalo de nuevo.";
 "xrpDestinationNotActivatedError" = "La dirección XRP de destino aún no está activada. Una primera transferencia debe ser de al menos %@ XRP (la reserva base de la red). Aumenta el importe o verifica la dirección.";
 "yes" = "Sí";
 "yesterday" = "Ayer";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "Vault koji ste odabrali ne odgovara keygen sesiji. Molimo odaberite ispravan Vault.";
 "wrongVaultTryAgain" = "Pogrešan sef ili upareni uređaj.";
 "x" = "x";
+"xrpDestinationLookupFailedError" = "Odredišni XRP račun nije bilo moguće provjeriti (%@). Pokušajte ponovno.";
 "xrpDestinationNotActivatedError" = "Odredišna XRP adresa još nije aktivirana. Prvi prijenos na nju mora iznositi najmanje %@ XRP (osnovna rezerva mreže). Povećajte iznos ili provjerite adresu.";
 "yes" = "Da";
 "yesterday" = "Jučer";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "Vault koji ste odabrali ne odgovara keygen sesiji. Molimo odaberite ispravan Vault.";
 "wrongVaultTryAgain" = "Pogrešan sef ili upareni uređaj.";
 "x" = "x";
+"xrpDestinationNotActivatedError" = "Odredišna XRP adresa još nije aktivirana. Prvi prijenos na nju mora iznositi najmanje %@ XRP (osnovna rezerva mreže). Povećajte iznos ili provjerite adresu.";
 "yes" = "Da";
 "yesterday" = "Jučer";
 "yieldClaimAmount" = "Preuzmi %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "Il Vault che hai selezionato non corrisponde alla sessione di keygen. Si prega di selezionare il Vault corretto.";
 "wrongVaultTryAgain" = "Cassaforte o Dispositivo Accoppiato Errato.";
 "x" = "X (Twitter)";
+"xrpDestinationLookupFailedError" = "Impossibile verificare l'account XRP di destinazione (%@). Riprova.";
 "xrpDestinationNotActivatedError" = "L'indirizzo XRP di destinazione non è ancora attivato. Un primo trasferimento deve essere di almeno %@ XRP (la riserva base della rete). Aumenta l'importo o verifica l'indirizzo.";
 "yes" = "Sì";
 "yesterday" = "Ieri";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "Il Vault che hai selezionato non corrisponde alla sessione di keygen. Si prega di selezionare il Vault corretto.";
 "wrongVaultTryAgain" = "Cassaforte o Dispositivo Accoppiato Errato.";
 "x" = "X (Twitter)";
+"xrpDestinationNotActivatedError" = "L'indirizzo XRP di destinazione non è ancora attivato. Un primo trasferimento deve essere di almeno %@ XRP (la riserva base della rete). Aumenta l'importo o verifica l'indirizzo.";
 "yes" = "Sì";
 "yesterday" = "Ieri";
 "yieldClaimAmount" = "Riscuoti %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1403,6 +1403,7 @@
 "wrongVaultSelectedDescription" = "선택한 볼트가 키젠 세션과 일치하지 않습니다. 올바른 볼트를 선택하세요.";
 "wrongVaultTryAgain" = "잘못된 볼트 또는 쌍";
 "x" = "X (Twitter)";
+"xrpDestinationNotActivatedError" = "대상 XRP 주소가 아직 활성화되지 않았습니다. 첫 송금은 최소 %@ XRP(네트워크 기본 준비금) 이상이어야 합니다. 금액을 늘리거나 주소를 다시 확인하세요.";
 "yes" = "예";
 "yesterday" = "어제";
 "yieldClaimAmount" = "%@ 수령";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1403,6 +1403,7 @@
 "wrongVaultSelectedDescription" = "선택한 볼트가 키젠 세션과 일치하지 않습니다. 올바른 볼트를 선택하세요.";
 "wrongVaultTryAgain" = "잘못된 볼트 또는 쌍";
 "x" = "X (Twitter)";
+"xrpDestinationLookupFailedError" = "대상 XRP 계정을 확인할 수 없습니다 (%@). 다시 시도해 주세요.";
 "xrpDestinationNotActivatedError" = "대상 XRP 주소가 아직 활성화되지 않았습니다. 첫 송금은 최소 %@ XRP(네트워크 기본 준비금) 이상이어야 합니다. 금액을 늘리거나 주소를 다시 확인하세요.";
 "yes" = "예";
 "yesterday" = "어제";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "O Vault que você selecionou não corresponde à sessão de keygen. Por favor, selecione o Vault correto.";
 "wrongVaultTryAgain" = "Cofre ou Dispositivo Emparelhado Incorreto.";
 "x" = "x";
+"xrpDestinationLookupFailedError" = "Não foi possível verificar a conta XRP de destino (%@). Tente novamente.";
 "xrpDestinationNotActivatedError" = "O endereço XRP de destino ainda não está ativado. Uma primeira transferência deve ser de pelo menos %@ XRP (a reserva base da rede). Aumente o valor ou verifique o endereço.";
 "yes" = "Sim";
 "yesterday" = "Ontem";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "O Vault que você selecionou não corresponde à sessão de keygen. Por favor, selecione o Vault correto.";
 "wrongVaultTryAgain" = "Cofre ou Dispositivo Emparelhado Incorreto.";
 "x" = "x";
+"xrpDestinationNotActivatedError" = "O endereço XRP de destino ainda não está ativado. Uma primeira transferência deve ser de pelo menos %@ XRP (a reserva base da rede). Aumente o valor ou verifique o endereço.";
 "yes" = "Sim";
 "yesterday" = "Ontem";
 "yieldClaimAmount" = "Resgatar %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "您选择的保险库与keygen会话不匹配。请选择正确的保险库。";
 "wrongVaultTryAgain" = "错误的保险库或配对";
 "x" = "X（推特）";
+"xrpDestinationLookupFailedError" = "无法验证目标 XRP 账户 (%@)。请重试。";
 "xrpDestinationNotActivatedError" = "目标 XRP 地址尚未激活。首次向其转账必须至少为 %@ XRP（网络基础准备金）。请增加金额或核对地址。";
 "yes" = "是";
 "yesterday" = "昨天";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1440,6 +1440,7 @@
 "wrongVaultSelectedDescription" = "您选择的保险库与keygen会话不匹配。请选择正确的保险库。";
 "wrongVaultTryAgain" = "错误的保险库或配对";
 "x" = "X（推特）";
+"xrpDestinationNotActivatedError" = "目标 XRP 地址尚未激活。首次向其转账必须至少为 %@ XRP（网络基础准备金）。请增加金额或核对地址。";
 "yes" = "是";
 "yesterday" = "昨天";
 "yieldClaimAmount" = "领取 %@";

--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -66,22 +66,31 @@ enum SendCryptoLogic {
     /// don't reap. Scoped by `chain`, NOT `chainType`: Bittensor (TAO) shares
     /// `chainType == .Polkadot` with DOT but signs `transfer_allow_death`, so it
     /// permits full-balance sends and has no enforced ED here.
+    ///
+    /// XRP deliberately reserves nothing here: its `rawBalance` is already the
+    /// reserve-net available balance — owner-aware, computed live in
+    /// `RippleService.getBalance` via `RippleReserve` — so reserving a second
+    /// static 1 XRP double-counts the reserve and strands funds on MAX send.
+    /// The XRPL fee is exempt from the reserve floor, so MAX = available − fee
+    /// (landing exactly at the reserve is valid).
     static func existentialDeposit(for coin: Coin) -> BigInt {
         switch coin.chain {
         case .polkadot:
             return PolkadotHelper.defaultExistentialDeposit
-        case .ripple:
-            return RippleHelper.defaultExistentialDeposit
         default:
             return .zero
         }
     }
 
-    /// Polkadot + Ripple have an existential deposit: the chain reaps accounts
-    /// whose remaining balance falls below it (and the app signs
+    /// Polkadot has an existential deposit: the chain reaps accounts whose
+    /// remaining balance falls below it (and the app signs
     /// `transfer_keep_alive` on DOT, which the chain rejects outright when it
-    /// would reap the sender). Other chains never reap. Returns true when the
-    /// requested send would leave the *sender* below the existential deposit.
+    /// would reap the sender). Other chains never reap — XRPL included: its
+    /// reserve is a spending floor, not a deletion threshold, and it is
+    /// already netted out of `rawBalance`, so for XRP "would drop below the
+    /// reserve" is exactly `amount + fee > rawBalance`, which the
+    /// amount-exceeded checks block. Returns true when the requested send
+    /// would leave the *sender* below the existential deposit.
     static func canBeReaped(coin: Coin, amount: String, gas: BigInt) -> Bool {
         let existentialDeposit = existentialDeposit(for: coin)
         guard existentialDeposit > .zero else { return false }
@@ -161,8 +170,9 @@ enum SendCryptoLogic {
             // Reserve the existential deposit on chains that reap the sender (DOT
             // signs `transfer_keep_alive`, which fails outright if the send would
             // drop the sender below ED). Reserved on top of the fee so max-send
-            // settles at `balance − fee − ED`. Zero for every other chain,
-            // including Bittensor/TAO (`transfer_allow_death`).
+            // settles at `balance − fee − ED`. Zero for every other chain:
+            // Bittensor/TAO signs `transfer_allow_death`, and XRP's rawBalance
+            // is already reserve-net, so both settle at `balance − fee`.
             maxValue = coin.getMaxValue(fee + existentialDeposit(for: coin))
         }
         let digits = coin.decimals > 8 ? 8 : coin.decimals

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -191,6 +191,12 @@ struct SendCryptoVerifyLogic {
                 address: tx.toAddress,
                 amountDrops: tx.amountInRaw
             )
+        } catch is CancellationError {
+            // A cancelled lookup (the screen is tearing down, or the load pass
+            // was superseded) must propagate as a cancel — never be rewrapped
+            // into a destination error that the load-time guard would surface
+            // as a spurious balance error.
+            throw CancellationError()
         } catch {
             // The Verify screen's alert plumbing presents only `HelperError`
             // (`error as? HelperError`), so rewrap — same convention as

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -102,8 +102,10 @@ struct SendCryptoVerifyLogic {
             }
 
             // Existential-deposit guard for chains that reap the *sender*
-            // (DOT/XRP). DOT signs `transfer_keep_alive`, which fails on-chain
+            // (DOT). It signs `transfer_keep_alive`, which fails on-chain
             // after the ceremony if the send would drop the sender below ED.
+            // Inert for XRP: its rawBalance is already reserve-net, so the
+            // balance checks above are the reserve guard.
             if SendCryptoLogic.canBeReaped(coin: tx.coin, amount: tx.amount, gas: tx.fee) {
                 return BalanceValidationResult(isValid: false, errorMessage: "belowExistentialDepositError".localized)
             }

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -14,9 +14,14 @@ struct SendCryptoVerifyLogic {
     // MARK: - Dependencies
 
     let interactor: SendInteractor
+    private let rippleService: RippleService
 
-    init(interactor: SendInteractor = DefaultSendInteractor.live) {
+    init(
+        interactor: SendInteractor = DefaultSendInteractor.live,
+        rippleService: RippleService = .shared
+    ) {
         self.interactor = interactor
+        self.rippleService = rippleService
     }
 
     // MARK: - Fee Calculation
@@ -170,6 +175,28 @@ struct SendCryptoVerifyLogic {
 
     func validateUtxosIfNeeded(tx: SendTransaction) async throws {
         try await interactor.validateUtxosIfNeeded(coin: tx.coin)
+    }
+
+    // MARK: - Destination Validation
+
+    /// XRPL rejects a Payment that would create the destination account with
+    /// less than the base reserve (`tecNO_DST_INSUF_XRP`) — on-chain, after
+    /// the keysign ceremony, with the fee burned. Gate it here so the failure
+    /// surfaces before signing starts; no-op for every other chain. Matches
+    /// the guard the SDK and Android run at submit time.
+    func validateDestinationIfNeeded(tx: SendTransaction) async throws {
+        guard tx.coin.chain == .ripple, tx.coin.isNativeToken else { return }
+        do {
+            try await rippleService.validateDestinationActivation(
+                address: tx.toAddress,
+                amountDrops: tx.amountInRaw
+            )
+        } catch {
+            // The Verify screen's alert plumbing presents only `HelperError`
+            // (`error as? HelperError`), so rewrap — same convention as
+            // `buildKeysignPayload` — or the guard would block silently.
+            throw HelperError.runtimeError(error.localizedDescription)
+        }
     }
 
     // MARK: - Keysign Payload

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -140,7 +140,14 @@ class SendCryptoVerifyViewModel: ObservableObject {
             // Keep isLoading true across the async destination guard so Sign
             // stays disabled until the load-time validation fully settles —
             // otherwise Sign briefly re-enables while account_info is in flight.
-            await validateDestinationActivationIfNeeded()
+            try await validateDestinationActivationIfNeeded()
+            isLoading = false
+        } catch is CancellationError {
+            // The load pass was cancelled/superseded. Abort quietly — don't
+            // flag an error and don't mark the load complete; just release the
+            // transient flags. Cancellation propagates here instead of being
+            // swallowed mid-guard, so a cancelled load doesn't read as success.
+            isCalculatingFee = false
             isLoading = false
         } catch {
             print("DEBUG: Error calculating fee: \(error)")
@@ -160,14 +167,15 @@ class SendCryptoVerifyViewModel: ObservableObject {
     /// logic guards on the chain, so nothing hits the network) and for
     /// pre-built-payload flows; skipped when a balance error already owns the
     /// alert so the two guards don't stack.
-    private func validateDestinationActivationIfNeeded() async {
+    private func validateDestinationActivationIfNeeded() async throws {
         guard prebuiltKeysignPayload == nil, !hasBalanceError else { return }
         do {
             try await logic.validateDestinationIfNeeded(tx: transaction)
         } catch is CancellationError {
-            // The load pass was cancelled (screen tearing down) — leave the UI
-            // state untouched rather than flagging a spurious balance error.
-            return
+            // Propagate — a cancelled load must abort the whole load pass (its
+            // caller returns without running post-load work), not be swallowed
+            // here and not become a spurious balance error.
+            throw CancellationError()
         } catch {
             errorMessage = error.localizedDescription
             showAlert = true

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -190,6 +190,7 @@ class SendCryptoVerifyViewModel: ObservableObject {
             return prebuiltKeysignPayload
         }
 
+        try await logic.validateDestinationIfNeeded(tx: transaction)
         try await logic.validateUtxosIfNeeded(tx: transaction)
         let keysignPayload = try await logic.buildKeysignPayload(tx: transaction, vault: transaction.vault)
         return keysignPayload

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -112,7 +112,9 @@ class SendCryptoVerifyViewModel: ObservableObject {
                 let balance = transaction.coin.rawBalance.toBigInt(decimals: transaction.coin.decimals)
                 // Reserve the existential deposit so a DOT max-send settles at
                 // `balance − fee − ED`; `transfer_keep_alive` rejects a transfer
-                // that would reap the sender. Zero for non-ED chains (incl. TAO).
+                // that would reap the sender. Zero for non-ED chains — including
+                // TAO (`transfer_allow_death`) and XRP, whose rawBalance is
+                // already reserve-net, so its max settles at `balance − fee`.
                 let existentialDeposit = SendCryptoLogic.existentialDeposit(for: transaction.coin)
                 let candidate = balance - feeResult.fee - existentialDeposit
                 if candidate > 0 {

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -74,11 +74,12 @@ class SendCryptoVerifyViewModel: ObservableObject {
     init(
         transaction: SendTransaction,
         interactor: SendInteractor = DefaultSendInteractor.live,
-        prebuiltKeysignPayload: KeysignPayload? = nil
+        prebuiltKeysignPayload: KeysignPayload? = nil,
+        rippleService: RippleService = .shared
     ) {
         self.transaction = transaction
         self.interactor = interactor
-        self.logic = SendCryptoVerifyLogic(interactor: interactor)
+        self.logic = SendCryptoVerifyLogic(interactor: interactor, rippleService: rippleService)
         self.prebuiltKeysignPayload = prebuiltKeysignPayload
     }
 
@@ -134,15 +135,40 @@ class SendCryptoVerifyViewModel: ObservableObject {
             }
 
             isCalculatingFee = false
-            isLoading = false
 
             validateBalanceWithFee()
+            // Keep isLoading true across the async destination guard so Sign
+            // stays disabled until the load-time validation fully settles —
+            // otherwise Sign briefly re-enables while account_info is in flight.
+            await validateDestinationActivationIfNeeded()
+            isLoading = false
         } catch {
             print("DEBUG: Error calculating fee: \(error)")
             errorMessage = error.localizedDescription
             showAlert = true
             isCalculatingFee = false
             isLoading = false
+        }
+    }
+
+    /// Load-time destination-activation guard. XRPL rejects a Payment that
+    /// would create the destination account with less than the base reserve
+    /// (`tecNO_DST_INSUF_XRP`) — on-chain, after the ceremony, with the fee
+    /// burned. Run it in the same load pass as the amount/balance checks so an
+    /// unfunded sub-reserve destination shows the error and disables Sign on
+    /// load, not only when Sign is tapped. No-op for every non-XRP send (the
+    /// logic guards on the chain, so nothing hits the network) and for
+    /// pre-built-payload flows; skipped when a balance error already owns the
+    /// alert so the two guards don't stack.
+    private func validateDestinationActivationIfNeeded() async {
+        guard prebuiltKeysignPayload == nil, !hasBalanceError else { return }
+        do {
+            try await logic.validateDestinationIfNeeded(tx: transaction)
+        } catch {
+            errorMessage = error.localizedDescription
+            showAlert = true
+            isAmountCorrect = false
+            hasBalanceError = true
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -164,6 +164,10 @@ class SendCryptoVerifyViewModel: ObservableObject {
         guard prebuiltKeysignPayload == nil, !hasBalanceError else { return }
         do {
             try await logic.validateDestinationIfNeeded(tx: transaction)
+        } catch is CancellationError {
+            // The load pass was cancelled (screen tearing down) — leave the UI
+            // state untouched rather than flagging a spurious balance error.
+            return
         } catch {
             errorMessage = error.localizedDescription
             showAlert = true

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -641,11 +641,13 @@ final class SendDetailsViewModel {
             return false
         }
 
-        // Existential-deposit guard for ED-bearing chains (DOT/XRP) that reap
+        // Existential-deposit guard for ED-bearing chains (DOT) that reap
         // the *sender*. Block here — before the keysign ceremony — rather than
         // letting `transfer_keep_alive` fail on-chain with the fee already
         // charged. Skipped for non-native tokens (ED applies to the native
-        // account, not token transfers).
+        // account, not token transfers). Inert for XRP: its rawBalance is
+        // already reserve-net, so the amount-exceeded check is the reserve
+        // guard and a remainder below 1 XRP spendable is valid on-chain.
         if coin.isNativeToken {
             if SendCryptoLogic.canBeReaped(coin: coin, amount: amount, gas: fee) {
                 setAmountError(message: "belowExistentialDepositError".localized)

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationActivationTests.swift
@@ -5,8 +5,11 @@
 //  Covers the pre-ceremony destination-activation guard: an XRPL Payment that
 //  would create the destination account with less than the base reserve fails
 //  on-chain (tecNO_DST_INSUF_XRP) after the fee is burned, so the app blocks
-//  it before the keysign ceremony starts. Funded destinations pass untouched;
-//  a lookup failure fails closed, matching the SDK and Android companions.
+//  it before the keysign ceremony starts. Funded destinations pass untouched.
+//  The block fires only on proof the destination is unfunded (a definitive
+//  actNotFound): a transport/RPC lookup error or an exhausted node-error retry
+//  fails OPEN (the on-chain guard is the backstop), while a successful-but-
+//  uninterpretable response fails closed. A cancelled lookup propagates.
 //
 
 @testable import VultisigApp
@@ -124,6 +127,23 @@ final class RippleDestinationActivationTests: XCTestCase {
             XCTAssertNotNil(error.errorDescription, "the fail-closed message must be presentable")
         } catch {
             XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    func testDestinationLookupCancellationPropagates() async {
+        // A cancelled lookup (screen tearing down) must propagate as a cancel —
+        // never fail open OR closed, so the caller's cancellation contract holds.
+        let client = DestinationScriptedHTTPClient()
+        client.accountInfoResult = .failure(CancellationError())
+        let service = makeService(client: client)
+
+        do {
+            try await service.validateDestinationActivation(address: "rX", amountDrops: BigInt(10_000_000))
+            XCTFail("cancellation must propagate, not be swallowed")
+        } catch is CancellationError {
+            // expected
+        } catch {
+            XCTFail("expected CancellationError, got \(error)")
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationActivationTests.swift
@@ -181,7 +181,7 @@ private final class DestinationScriptedHTTPClient: HTTPClientProtocol, @unchecke
             return try respond(accountInfoResult)
         case .serverState:
             return try respond(serverStateResult)
-        case .submit:
+        case .submit, .tx:
             throw URLError(.unsupportedURL)
         }
     }

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationActivationTests.swift
@@ -1,0 +1,180 @@
+//
+//  RippleDestinationActivationTests.swift
+//  VultisigAppTests
+//
+//  Covers the pre-ceremony destination-activation guard: an XRPL Payment that
+//  would create the destination account with less than the base reserve fails
+//  on-chain (tecNO_DST_INSUF_XRP) after the fee is burned, so the app blocks
+//  it before the keysign ceremony starts. Funded destinations pass untouched;
+//  a lookup failure fails closed, matching the SDK and Android companions.
+//
+
+@testable import VultisigApp
+import XCTest
+import BigInt
+
+final class RippleDestinationActivationTests: XCTestCase {
+
+    func testFundedDestinationPassesAnyAmount() async throws {
+        let client = DestinationScriptedHTTPClient()
+        client.accountInfoResult = .success(fundedAccountJSON(balance: "20000000"))
+        let service = makeService(client: client)
+
+        // 1 drop to an existing account is valid — no activation needed.
+        try await service.validateDestinationActivation(address: "rFunded", amountDrops: BigInt(1))
+    }
+
+    func testUnfundedDestinationBelowBaseReserveThrows() async {
+        let client = DestinationScriptedHTTPClient()
+        client.accountInfoResult = .success(actNotFoundJSON())
+        client.serverStateResult = .success(serverStateJSON(reserveBase: 1_000_000, reserveInc: 200_000))
+        let service = makeService(client: client)
+
+        do {
+            try await service.validateDestinationActivation(address: "rUnfunded", amountDrops: BigInt(999_999))
+            XCTFail("an unfunded destination below the base reserve must be blocked")
+        } catch let error as RippleSendError {
+            guard case .destinationNotActivated(let minimumXRP) = error else {
+                return XCTFail("unexpected RippleSendError: \(error)")
+            }
+            XCTAssertEqual(minimumXRP, "1")
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    func testUnfundedDestinationAtBaseReservePasses() async throws {
+        let client = DestinationScriptedHTTPClient()
+        client.accountInfoResult = .success(actNotFoundJSON())
+        client.serverStateResult = .success(serverStateJSON(reserveBase: 1_000_000, reserveInc: 200_000))
+        let service = makeService(client: client)
+
+        // Exactly the base reserve activates the account — allowed.
+        try await service.validateDestinationActivation(address: "rUnfunded", amountDrops: BigInt(1_000_000))
+    }
+
+    func testUnfundedDestinationThresholdTracksLiveBaseReserve() async {
+        // A validator vote can raise the base reserve; the guard must follow
+        // the live value, not the 1 XRP seed.
+        let client = DestinationScriptedHTTPClient()
+        client.accountInfoResult = .success(actNotFoundJSON())
+        client.serverStateResult = .success(serverStateJSON(reserveBase: 5_000_000, reserveInc: 1_000_000))
+        let service = makeService(client: client)
+
+        do {
+            try await service.validateDestinationActivation(address: "rUnfunded", amountDrops: BigInt(2_000_000))
+            XCTFail("2 XRP must be blocked when the live base reserve is 5 XRP")
+        } catch let error as RippleSendError {
+            guard case .destinationNotActivated(let minimumXRP) = error else {
+                return XCTFail("unexpected RippleSendError: \(error)")
+            }
+            XCTAssertEqual(minimumXRP, "5")
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    func testDestinationLookupFailureFailsClosed() async {
+        let client = DestinationScriptedHTTPClient()
+        client.accountInfoResult = .failure(URLError(.notConnectedToInternet))
+        let service = makeService(client: client)
+
+        do {
+            try await service.validateDestinationActivation(address: "rUnknown", amountDrops: BigInt(10_000_000))
+            XCTFail("an unverifiable destination must block the ceremony (fail closed)")
+        } catch {
+            XCTAssertTrue(error is URLError)
+        }
+    }
+
+    func testNonActNotFoundLookupErrorFailsClosedEvenAboveReserve() async {
+        // A rate-limit (or any RPC-level error) also decodes with no
+        // account_data — that is NOT proof the destination is unfunded, so it
+        // must fail closed rather than run the activation threshold.
+        let client = DestinationScriptedHTTPClient()
+        client.accountInfoResult = .success(Data("""
+        {"result":{"error":"slowDown","error_message":"You are placing too much load on the server.","status":"error"}}
+        """.utf8))
+        let service = makeService(client: client)
+
+        do {
+            try await service.validateDestinationActivation(address: "rUnknown", amountDrops: BigInt(10_000_000))
+            XCTFail("a non-actNotFound lookup error must block the ceremony (fail closed)")
+        } catch let error as RippleSendError {
+            guard case .destinationLookupFailed(let code) = error else {
+                return XCTFail("unexpected RippleSendError: \(error)")
+            }
+            XCTAssertEqual(code, "slowDown")
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func makeService(client: HTTPClientProtocol) -> RippleService {
+        RippleService(resolver: NoOverrideResolver(), httpClient: client)
+    }
+
+    private func fundedAccountJSON(balance: String) -> Data {
+        Data("""
+        {"result":{"account_data":{"Account":"rFunded","Balance":"\(balance)","OwnerCount":0,"Sequence":7},"status":"success","validated":true}}
+        """.utf8)
+    }
+
+    /// The rippled response for a non-existent account: HTTP 200 with an
+    /// `actNotFound` error payload and no `account_data`.
+    private func actNotFoundJSON() -> Data {
+        Data("""
+        {"result":{"error":"actNotFound","error_code":19,"error_message":"Account not found.","status":"error","validated":false}}
+        """.utf8)
+    }
+
+    private func serverStateJSON(reserveBase: Int, reserveInc: Int) -> Data {
+        Data("""
+        {"result":{"state":{"load_base":256,"load_factor":256,"validated_ledger":{"base_fee":10,"reserve_base":\(reserveBase),"reserve_inc":\(reserveInc)}}}}
+        """.utf8)
+    }
+}
+
+// MARK: - Test doubles
+
+private struct NoOverrideResolver: RPCEndpointResolving {
+    // swiftlint:disable:next unused_parameter
+    func url(for chain: Chain) -> String? { nil }
+}
+
+// `async` is required by `HTTPClientProtocol`; the stub answers synchronously.
+// swiftlint:disable async_without_await
+
+/// Scripted HTTP client keyed on the `RippleAPI` endpoint.
+private final class DestinationScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    var accountInfoResult: Result<Data, Error> = .failure(URLError(.badServerResponse))
+    var serverStateResult: Result<Data, Error> = .failure(URLError(.badServerResponse))
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        guard let api = target as? RippleAPI else {
+            throw URLError(.unsupportedURL)
+        }
+        switch api.endpoint {
+        case .accountInfo:
+            return try respond(accountInfoResult)
+        case .serverState:
+            return try respond(serverStateResult)
+        case .submit:
+            throw URLError(.unsupportedURL)
+        }
+    }
+
+    private func respond(_ result: Result<Data, Error>) throws -> HTTPResponse<Data> {
+        let data = try result.get()
+        guard let url = URL(string: "https://xrplcluster.com"),
+              let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil) else {
+            throw URLError(.badURL)
+        }
+        return HTTPResponse(data: data, response: response)
+    }
+}
+
+// swiftlint:enable async_without_await

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationActivationTests.swift
@@ -74,37 +74,54 @@ final class RippleDestinationActivationTests: XCTestCase {
         }
     }
 
-    func testDestinationLookupFailureFailsClosed() async {
+    func testDestinationTransportErrorFailsOpen() async throws {
+        // A transport blip (offline, timeout, 429/5xx) is NOT proof the
+        // destination is unfunded. Before this guard existed the same send to a
+        // funded address proceeded, so a transient lookup failure must fail open
+        // rather than start blocking every native XRP send; the on-chain
+        // tecNO_DST_INSUF_XRP guard remains the backstop.
         let client = DestinationScriptedHTTPClient()
         client.accountInfoResult = .failure(URLError(.notConnectedToInternet))
         let service = makeService(client: client)
 
-        do {
-            try await service.validateDestinationActivation(address: "rUnknown", amountDrops: BigInt(10_000_000))
-            XCTFail("an unverifiable destination must block the ceremony (fail closed)")
-        } catch {
-            XCTAssertTrue(error is URLError)
-        }
+        // Must not throw — the send is allowed.
+        try await service.validateDestinationActivation(address: "rUnknown", amountDrops: BigInt(10_000_000))
     }
 
-    func testNonActNotFoundLookupErrorFailsClosedEvenAboveReserve() async {
-        // A rate-limit (or any RPC-level error) also decodes with no
-        // account_data — that is NOT proof the destination is unfunded, so it
-        // must fail closed rather than run the activation threshold.
+    func testDestinationRetryableRpcErrorFailsOpen() async throws {
+        // A retryable node error (rate-limit / stale pool backend) that survives
+        // the bounded same-host retry surfaces as a thrown RippleRetryError — a
+        // transport-class failure, not proof the destination is unfunded. Fail
+        // open, same as a raw transport error.
         let client = DestinationScriptedHTTPClient()
         client.accountInfoResult = .success(Data("""
         {"result":{"error":"slowDown","error_message":"You are placing too much load on the server.","status":"error"}}
         """.utf8))
         let service = makeService(client: client)
 
+        try await service.validateDestinationActivation(address: "rUnknown", amountDrops: BigInt(10_000_000))
+    }
+
+    func testAmbiguousLookupFailsClosedWithLocalizedError() async {
+        // HTTP 200, no account_data, and a non-retryable, non-actNotFound token
+        // (a malformed request, a proxy error page): a *successful* response the
+        // guard cannot interpret as funded or unfunded, so fail closed — with a
+        // localized, non-nil description.
+        let client = DestinationScriptedHTTPClient()
+        client.accountInfoResult = .success(Data("""
+        {"result":{"error":"invalidParams","error_message":"Invalid parameters.","status":"error"}}
+        """.utf8))
+        let service = makeService(client: client)
+
         do {
             try await service.validateDestinationActivation(address: "rUnknown", amountDrops: BigInt(10_000_000))
-            XCTFail("a non-actNotFound lookup error must block the ceremony (fail closed)")
+            XCTFail("an uninterpretable successful lookup must fail closed")
         } catch let error as RippleSendError {
             guard case .destinationLookupFailed(let code) = error else {
                 return XCTFail("unexpected RippleSendError: \(error)")
             }
-            XCTAssertEqual(code, "slowDown")
+            XCTAssertEqual(code, "invalidParams")
+            XCTAssertNotNil(error.errorDescription, "the fail-closed message must be presentable")
         } catch {
             XCTFail("unexpected error type: \(error)")
         }
@@ -113,7 +130,9 @@ final class RippleDestinationActivationTests: XCTestCase {
     // MARK: - Fixtures
 
     private func makeService(client: HTTPClientProtocol) -> RippleService {
-        RippleService(resolver: NoOverrideResolver(), httpClient: client)
+        // No-op sleeper so the bounded retry on retryable node errors runs
+        // without real backoff delays in the test.
+        RippleService(resolver: NoOverrideResolver(), httpClient: client, sleep: { _ in })
     }
 
     private func fundedAccountJSON(balance: String) -> Data {

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleReserveFallbackTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleReserveFallbackTests.swift
@@ -193,7 +193,7 @@ private final class RippleScriptedHTTPClient: HTTPClientProtocol, @unchecked Sen
         case .serverState:
             queue.sync { _serverStateCalls += 1 }
             return try respond(serverStateResult)
-        case .submit:
+        case .submit, .tx:
             throw URLError(.unsupportedURL)
         }
     }

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleReserveFallbackTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleReserveFallbackTests.swift
@@ -1,0 +1,188 @@
+//
+//  RippleReserveFallbackTests.swift
+//  VultisigAppTests
+//
+//  Covers the reserve-value sourcing chain behind `RippleService.getBalance`:
+//  live `server_state` → cached last-good snapshot → `RippleReserve` seeds.
+//  Reserve values change only by rare validator vote, so a transient
+//  `server_state` outage must never fail the whole balance read — only a
+//  failed `account_info` is fatal (there is no balance without it).
+//
+
+@testable import VultisigApp
+import XCTest
+import BigInt
+
+final class RippleReserveFallbackTests: XCTestCase {
+
+    func testGetBalanceUsesLiveReserveValues() async throws {
+        let client = RippleScriptedHTTPClient()
+        client.accountInfoResult = .success(accountInfoJSON(balance: "10000000", ownerCount: 2))
+        client.serverStateResult = .success(serverStateJSON(reserveBase: 1_000_000, reserveInc: 200_000))
+        let service = makeService(client: client)
+
+        let balance = try await service.getBalance(address: "rSender")
+
+        // 10 XRP − (1 + 2 × 0.2) XRP reserve = 8.6 XRP.
+        XCTAssertEqual(balance, "8600000")
+    }
+
+    func testGetBalanceServesCachedReserveValuesWhenServerStateFails() async throws {
+        let client = RippleScriptedHTTPClient()
+        client.accountInfoResult = .success(accountInfoJSON(balance: "10000000", ownerCount: 0))
+        client.serverStateResult = .failure(URLError(.notConnectedToInternet))
+        let service = makeService(client: client)
+        // Seed a stale last-good snapshot: the expired TTL forces a refetch,
+        // the refetch fails, and the cache fails open to this entry. The seeded
+        // base differs from both the live and the seed constants so the
+        // assertion can only pass via the cached path.
+        await service.reserveValuesCache.setCached(
+            RippleReserveValues(reserveBase: 5_000_000, reserveInc: 1_000_000),
+            for: RippleService.reserveValuesCacheKey(for: RippleAPI.defaultHost),
+            fetchedAt: Date(timeIntervalSinceNow: -60 * 60 * 48)
+        )
+
+        let balance = try await service.getBalance(address: "rSender")
+
+        // 10 XRP − cached 5 XRP base (ownerCount 0) = 5 XRP.
+        XCTAssertEqual(balance, "5000000")
+    }
+
+    func testGetBalanceFallsBackToSeedsWhenServerStateFailsWithColdCache() async throws {
+        let client = RippleScriptedHTTPClient()
+        client.accountInfoResult = .success(accountInfoJSON(balance: "10000000", ownerCount: 0))
+        client.serverStateResult = .failure(URLError(.notConnectedToInternet))
+        let service = makeService(client: client)
+
+        let balance = try await service.getBalance(address: "rSender")
+
+        // 10 XRP − seed 1 XRP base reserve = 9 XRP.
+        XCTAssertEqual(balance, "9000000")
+    }
+
+    func testGetBalanceThrowsWhenAccountInfoFails() async {
+        let client = RippleScriptedHTTPClient()
+        client.accountInfoResult = .failure(URLError(.notConnectedToInternet))
+        client.serverStateResult = .success(serverStateJSON(reserveBase: 1_000_000, reserveInc: 200_000))
+        let service = makeService(client: client)
+
+        do {
+            _ = try await service.getBalance(address: "rSender")
+            XCTFail("getBalance must rethrow an account_info failure — a reserve fallback cannot invent a balance")
+        } catch {
+            XCTAssertTrue(error is URLError)
+        }
+    }
+
+    func testGetBalanceReusesCachedReserveValuesWithinTTL() async throws {
+        let client = RippleScriptedHTTPClient()
+        client.accountInfoResult = .success(accountInfoJSON(balance: "10000000", ownerCount: 1))
+        client.serverStateResult = .success(serverStateJSON(reserveBase: 1_000_000, reserveInc: 200_000))
+        let service = makeService(client: client)
+
+        _ = try await service.getBalance(address: "rSender")
+        let second = try await service.getBalance(address: "rSender")
+
+        XCTAssertEqual(second, "8800000")
+        XCTAssertEqual(client.serverStateCallCount, 1, "reserve values are a rare-vote constant — one fetch per TTL window")
+    }
+
+    func testReserveValuesCacheIsScopedToResolvedHost() async throws {
+        let client = RippleScriptedHTTPClient()
+        client.accountInfoResult = .success(accountInfoJSON(balance: "10000000", ownerCount: 0))
+        client.serverStateResult = .success(serverStateJSON(reserveBase: 5_000_000, reserveInc: 1_000_000))
+        let resolver = MutableResolver()
+        let service = RippleService(resolver: resolver, httpClient: client)
+
+        // Warm the cache against the default host with non-mainnet reserves.
+        let first = try await service.getBalance(address: "rSender")
+        XCTAssertEqual(first, "5000000")
+
+        // Switch the custom RPC override: the old host's snapshot must not
+        // carry over. With the new host's server_state failing and its cache
+        // cold, the seeds apply (10 − 1 XRP), not the cached 5 XRP base.
+        resolver.override = "https://xrpl.example.org"
+        client.serverStateResult = .failure(URLError(.notConnectedToInternet))
+        let second = try await service.getBalance(address: "rSender")
+        XCTAssertEqual(second, "9000000")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeService(client: HTTPClientProtocol) -> RippleService {
+        RippleService(resolver: NoOverrideResolver(), httpClient: client)
+    }
+
+    /// Raw JSON keeps the test on the production decoder (`RippleAccountResponse`).
+    private func accountInfoJSON(balance: String, ownerCount: Int) -> Data {
+        Data("""
+        {"result":{"account_data":{"Account":"rSender","Balance":"\(balance)","OwnerCount":\(ownerCount),"Sequence":1},"status":"success","validated":true}}
+        """.utf8)
+    }
+
+    private func serverStateJSON(reserveBase: Int, reserveInc: Int) -> Data {
+        Data("""
+        {"result":{"state":{"load_base":256,"load_factor":256,"validated_ledger":{"base_fee":10,"reserve_base":\(reserveBase),"reserve_inc":\(reserveInc)}}}}
+        """.utf8)
+    }
+}
+
+// MARK: - Test doubles
+
+private struct NoOverrideResolver: RPCEndpointResolving {
+    // swiftlint:disable:next unused_parameter
+    func url(for chain: Chain) -> String? { nil }
+}
+
+/// Resolver whose override can be flipped mid-test, modelling a runtime custom
+/// RPC change against one long-lived service instance.
+private final class MutableResolver: RPCEndpointResolving, @unchecked Sendable {
+    var override: String?
+
+    // swiftlint:disable:next unused_parameter
+    func url(for chain: Chain) -> String? { override }
+}
+
+// `async` is required by `HTTPClientProtocol`; the stub answers synchronously.
+// swiftlint:disable async_without_await
+
+/// Scripted HTTP client keyed on the `RippleAPI` endpoint, so each XRPL RPC
+/// can succeed or fail independently.
+private final class RippleScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    var accountInfoResult: Result<Data, Error> = .failure(URLError(.badServerResponse))
+    var serverStateResult: Result<Data, Error> = .failure(URLError(.badServerResponse))
+
+    private let queue = DispatchQueue(label: "RippleScriptedHTTPClient.queue")
+    private var _serverStateCalls = 0
+
+    var serverStateCallCount: Int {
+        queue.sync { _serverStateCalls }
+    }
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        guard let api = target as? RippleAPI else {
+            throw URLError(.unsupportedURL)
+        }
+        switch api.endpoint {
+        case .accountInfo:
+            return try respond(accountInfoResult)
+        case .serverState:
+            queue.sync { _serverStateCalls += 1 }
+            return try respond(serverStateResult)
+        case .submit:
+            throw URLError(.unsupportedURL)
+        }
+    }
+
+    private func respond(_ result: Result<Data, Error>) throws -> HTTPResponse<Data> {
+        let data = try result.get()
+        guard let url = URL(string: "https://xrplcluster.com"),
+              let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil) else {
+            throw URLError(.badURL)
+        }
+        return HTTPResponse(data: data, response: response)
+    }
+}
+
+// swiftlint:enable async_without_await

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleReserveFallbackTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleReserveFallbackTests.swift
@@ -87,6 +87,29 @@ final class RippleReserveFallbackTests: XCTestCase {
         XCTAssertEqual(client.serverStateCallCount, 1, "reserve values are a rare-vote constant — one fetch per TTL window")
     }
 
+    func testGetBalanceDoesNotCacheAllNilServerState() async throws {
+        // A server that is up but still syncing answers HTTP 200 with
+        // `validated_ledger == null`, so both reserve fields are nil. That
+        // fully-empty response must NOT be cached as authoritative for the 24h
+        // TTL — caching it would pin the seeds and never refetch, even after the
+        // node recovers. getBalance seeds this time and refetches next time.
+        let client = RippleScriptedHTTPClient()
+        client.accountInfoResult = .success(accountInfoJSON(balance: "10000000", ownerCount: 0))
+        client.serverStateResult = .success(Data("""
+        {"result":{"state":{"load_base":256,"load_factor":256,"validated_ledger":null}}}
+        """.utf8))
+        let service = makeService(client: client)
+
+        let first = try await service.getBalance(address: "rSender")
+        let second = try await service.getBalance(address: "rSender")
+
+        // 10 XRP − seed 1 XRP base reserve (ownerCount 0) = 9 XRP, both times.
+        XCTAssertEqual(first, "9000000")
+        XCTAssertEqual(second, "9000000")
+        XCTAssertEqual(client.serverStateCallCount, 2,
+                       "an all-nil server_state must not be cached — each refresh refetches until real values arrive")
+    }
+
     func testReserveValuesCacheIsScopedToResolvedHost() async throws {
         let client = RippleScriptedHTTPClient()
         client.accountInfoResult = .success(accountInfoJSON(balance: "10000000", ownerCount: 0))

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleReserveTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleReserveTests.swift
@@ -1,0 +1,87 @@
+//
+//  RippleReserveTests.swift
+//  VultisigAppTests
+//
+//  Pins the owner-aware XRPL reserve math: the reserve floor is
+//  `reserve_base + OwnerCount × reserve_inc`, and the spendable balance is the
+//  total minus that floor, clamped at zero. This is the single source of truth
+//  the balance calc (and, via `rawBalance`, the MAX-send path) consume.
+//
+//  - https://xrpl.org/docs/concepts/accounts/reserves
+//
+
+@testable import VultisigApp
+import XCTest
+import BigInt
+
+final class RippleReserveTests: XCTestCase {
+
+    // MARK: - reservedDrops
+
+    func testReservedDropsBaseOnlyWhenOwnerCountZero() {
+        // No owned objects → the floor is the base reserve alone (1 XRP).
+        let reserved = RippleReserve.reservedDrops(ownerCount: 0, reserveBase: 1_000_000, reserveInc: 200_000)
+        XCTAssertEqual(reserved, BigInt(1_000_000))
+    }
+
+    func testReservedDropsAddsIncrementPerOwnedObject() {
+        // Acceptance case: OwnerCount > 0. Five owned objects (trustlines,
+        // offers, tickets, …) → 1 XRP base + 5 × 0.2 XRP = 2 XRP.
+        let reserved = RippleReserve.reservedDrops(ownerCount: 5, reserveBase: 1_000_000, reserveInc: 200_000)
+        XCTAssertEqual(reserved, BigInt(2_000_000))
+    }
+
+    func testReservedDropsUsesSeedsWhenServerStateFieldsMissing() {
+        // Missing server_state fields fall back to the mainnet seeds; a
+        // missing owner count counts as zero owned objects.
+        XCTAssertEqual(
+            RippleReserve.reservedDrops(ownerCount: nil, reserveBase: nil, reserveInc: nil),
+            RippleReserve.seedReserveBaseDrops
+        )
+        XCTAssertEqual(
+            RippleReserve.reservedDrops(ownerCount: 3, reserveBase: nil, reserveInc: nil),
+            RippleReserve.seedReserveBaseDrops + 3 * RippleReserve.seedReserveIncDrops
+        )
+    }
+
+    func testReservedDropsTracksLiveServerStateValues() {
+        // A validator vote can change the reserves; the math must follow the
+        // live values, not the seeds.
+        let reserved = RippleReserve.reservedDrops(ownerCount: 2, reserveBase: 10_000_000, reserveInc: 2_000_000)
+        XCTAssertEqual(reserved, BigInt(14_000_000))
+    }
+
+    // MARK: - availableDrops
+
+    func testAvailableDropsClampsToZeroBelowReserve() {
+        // Total below the floor → 0 spendable, never negative.
+        let available = RippleReserve.availableDrops(
+            totalDrops: BigInt(900_000),
+            ownerCount: 0,
+            reserveBase: 1_000_000,
+            reserveInc: 200_000
+        )
+        XCTAssertEqual(available, BigInt(0))
+    }
+
+    func testAvailableDropsSubtractsOwnerAwareReserve() {
+        // 10 XRP total, 3 owned objects → 10 − (1 + 3 × 0.2) = 8.4 XRP.
+        let available = RippleReserve.availableDrops(
+            totalDrops: BigInt(10_000_000),
+            ownerCount: 3,
+            reserveBase: 1_000_000,
+            reserveInc: 200_000
+        )
+        XCTAssertEqual(available, BigInt(8_400_000))
+    }
+
+    func testAvailableDropsEqualsTotalMinusBaseWhenNoOwnedObjects() {
+        let available = RippleReserve.availableDrops(
+            totalDrops: BigInt(5_000_000),
+            ownerCount: nil,
+            reserveBase: 1_000_000,
+            reserveInc: 200_000
+        )
+        XCTAssertEqual(available, BigInt(4_000_000))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -582,6 +582,51 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         XCTAssertEqual(vm.transaction.gasLimit, BigInt(50_000))
     }
 
+    // MARK: - loadGasInfoForSending — XRP destination-activation guard (load-time)
+
+    func testLoadGasInfoBlocksUnfundedXrpDestinationOnLoad() async throws {
+        // 0.1 XRP (100,000 drops) to an unfunded (actNotFound) destination is
+        // below the 1 XRP base reserve, so on-chain the Payment fails with
+        // tecNO_DST_INSUF_XRP after the fee is burned. The load pass must
+        // surface that — error shown, Sign disabled — not defer it to the Sign
+        // tap.
+        let client = VerifyScriptedHTTPClient()
+        client.accountInfoResult = .success(Data("""
+        {"result":{"error":"actNotFound","error_code":19,"error_message":"Account not found.","status":"error","validated":false}}
+        """.utf8))
+        client.serverStateResult = .success(Data("""
+        {"result":{"state":{"load_base":256,"load_factor":256,"validated_ledger":{"base_fee":10,"reserve_base":1000000,"reserve_inc":200000}}}}
+        """.utf8))
+        let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6, isNative: true, rawBalance: "100000000")
+        let tx = try makeTransaction(coin: xrp, amount: "0.1")
+        let rippleService = RippleService(resolver: NoOverrideResolver(), httpClient: client, sleep: { _ in })
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: MockSendInteractor(), rippleService: rippleService)
+
+        await vm.loadGasInfoForSending()
+
+        XCTAssertTrue(vm.hasBalanceError, "an unfunded sub-reserve XRP destination must be flagged on load")
+        XCTAssertTrue(vm.showAlert)
+        XCTAssertFalse(vm.errorMessage.isEmpty, "the destination-activation copy must reach the alert")
+        XCTAssertTrue(vm.signButtonDisabled, "Sign must be disabled while the destination is invalid")
+    }
+
+    func testLoadGasInfoAllowsFundedXrpDestinationOnLoad() async throws {
+        // A funded destination (has account_data) accepts any amount — the
+        // load-time guard must not block it.
+        let client = VerifyScriptedHTTPClient()
+        client.accountInfoResult = .success(Data("""
+        {"result":{"account_data":{"Account":"rFunded","Balance":"20000000","OwnerCount":0,"Sequence":7},"status":"success","validated":true}}
+        """.utf8))
+        let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6, isNative: true, rawBalance: "100000000")
+        let tx = try makeTransaction(coin: xrp, amount: "0.1")
+        let rippleService = RippleService(resolver: NoOverrideResolver(), httpClient: client, sleep: { _ in })
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: MockSendInteractor(), rippleService: rippleService)
+
+        await vm.loadGasInfoForSending()
+
+        XCTAssertFalse(vm.hasBalanceError, "a funded XRP destination must not be blocked on load")
+    }
+
     // MARK: - validateForm
 
     func testValidateFormThrowsWhenChecksMissing() async throws {
@@ -836,3 +881,46 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         )
     }
 }
+
+// MARK: - Test doubles
+
+private struct NoOverrideResolver: RPCEndpointResolving {
+    // swiftlint:disable:next unused_parameter
+    func url(for chain: Chain) -> String? { nil }
+}
+
+// `async` is required by `HTTPClientProtocol`; the stub answers synchronously.
+// swiftlint:disable async_without_await
+
+/// Scripted HTTP client keyed on the `RippleAPI` endpoint, so the Verify-load
+/// destination lookup can be driven without the network.
+private final class VerifyScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    var accountInfoResult: Result<Data, Error> = .failure(URLError(.badServerResponse))
+    var serverStateResult: Result<Data, Error> = .failure(URLError(.badServerResponse))
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        guard let api = target as? RippleAPI else {
+            throw URLError(.unsupportedURL)
+        }
+        switch api.endpoint {
+        case .accountInfo:
+            return try respond(accountInfoResult)
+        case .serverState:
+            return try respond(serverStateResult)
+        case .submit, .tx:
+            throw URLError(.unsupportedURL)
+        }
+    }
+
+    private func respond(_ result: Result<Data, Error>) throws -> HTTPResponse<Data> {
+        let data = try result.get()
+        guard let url = URL(string: "https://xrplcluster.com"),
+              let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil) else {
+            throw URLError(.badURL)
+        }
+        return HTTPResponse(data: data, response: response)
+    }
+}
+
+// swiftlint:enable async_without_await

--- a/VultisigApp/VultisigAppTests/Send/SendRippleDestinationGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendRippleDestinationGuardTests.swift
@@ -159,7 +159,7 @@ private final class TrippingHTTPClient: HTTPClientProtocol, @unchecked Sendable 
             return try respond(accountInfoResult)
         case .serverState:
             return try respond(serverStateResult)
-        case .submit:
+        case .submit, .tx:
             throw URLError(.unsupportedURL)
         }
     }

--- a/VultisigApp/VultisigAppTests/Send/SendRippleDestinationGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendRippleDestinationGuardTests.swift
@@ -1,0 +1,177 @@
+//
+//  SendRippleDestinationGuardTests.swift
+//  VultisigAppTests
+//
+//  Covers the Verify-stage wiring of the XRP destination-activation guard:
+//  `SendCryptoVerifyLogic.validateDestinationIfNeeded` runs the RippleService
+//  check for native XRP sends only — every other chain must pass through
+//  without touching the network.
+//
+
+import BigInt
+import XCTest
+import VultisigCommonData
+@testable import VultisigApp
+
+@MainActor
+final class SendRippleDestinationGuardTests: XCTestCase {
+
+    private var token: TestContextToken?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        token = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() async throws {
+        TestStore.restore(token)
+        token = nil
+        try await super.tearDown()
+    }
+
+    func testNonRippleSendSkipsDestinationLookup() async throws {
+        // The client trips on ANY request — passing proves no network access.
+        let client = TrippingHTTPClient()
+        let logic = makeLogic(client: client)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18)
+        let tx = makeTransaction(coin: eth, amount: "0.1")
+
+        try await logic.validateDestinationIfNeeded(tx: tx)
+        XCTAssertEqual(client.requestCount, 0)
+    }
+
+    func testRippleSendToFundedDestinationPasses() async throws {
+        let client = TrippingHTTPClient()
+        client.accountInfoResult = .success(Data("""
+        {"result":{"account_data":{"Account":"rFunded","Balance":"20000000","OwnerCount":0,"Sequence":7},"status":"success","validated":true}}
+        """.utf8))
+        let logic = makeLogic(client: client)
+        let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6)
+        let tx = makeTransaction(coin: xrp, amount: "0.5")
+
+        try await logic.validateDestinationIfNeeded(tx: tx)
+        XCTAssertEqual(client.requestCount, 1)
+    }
+
+    func testRippleSendToUnfundedDestinationBelowReserveThrows() async throws {
+        let client = TrippingHTTPClient()
+        client.accountInfoResult = .success(Data("""
+        {"result":{"error":"actNotFound","error_code":19,"error_message":"Account not found.","status":"error","validated":false}}
+        """.utf8))
+        client.serverStateResult = .success(Data("""
+        {"result":{"state":{"load_base":256,"load_factor":256,"validated_ledger":{"base_fee":10,"reserve_base":1000000,"reserve_inc":200000}}}}
+        """.utf8))
+        let logic = makeLogic(client: client)
+        let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6)
+        // 0.5 XRP = 500,000 drops < the 1 XRP base reserve.
+        let tx = makeTransaction(coin: xrp, amount: "0.5")
+
+        do {
+            try await logic.validateDestinationIfNeeded(tx: tx)
+            XCTFail("a sub-reserve send to an unfunded XRP destination must be blocked before the ceremony")
+        } catch let error as HelperError {
+            // Rewrapped for the Verify screen's alert plumbing, which presents
+            // only HelperError; the message must carry the localized copy.
+            guard case .runtimeError(let message) = error else {
+                return XCTFail("unexpected HelperError: \(error)")
+            }
+            XCTAssertTrue(message.contains("XRP"), "expected the destination-activation copy, got: \(message)")
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func makeLogic(client: HTTPClientProtocol) -> SendCryptoVerifyLogic {
+        SendCryptoVerifyLogic(
+            interactor: MockSendInteractor(),
+            rippleService: RippleService(resolver: NoOverrideResolver(), httpClient: client)
+        )
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int) -> Coin {
+        var asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: true)
+        asset.priceProviderId = "dest-guard-\(ticker)-\(UUID().uuidString)"
+        let coin = Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+        coin.rawBalance = "100000000"
+        return coin
+    }
+
+    private func makeTransaction(coin: Coin, amount: String) -> SendTransaction {
+        let vault = TestStore.makeVault()
+        return SendTransaction(
+            coin: coin,
+            vault: vault,
+            fromAddress: coin.address,
+            toAddress: "rDestinationAddressUnderTest",
+            toAddressLabel: nil,
+            amount: amount,
+            amountInFiat: "",
+            memo: "",
+            gas: BigInt.zero,
+            fee: BigInt(20),
+            feeMode: .default,
+            estimatedGasLimit: nil,
+            customGasLimit: nil,
+            customByteFee: nil,
+            sendMaxAmount: false,
+            isStakingOperation: false,
+            transactionType: .unspecified,
+            memoFunctionDictionary: [:],
+            wasmContractPayload: nil,
+            feeCoin: coin
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+private struct NoOverrideResolver: RPCEndpointResolving {
+    // swiftlint:disable:next unused_parameter
+    func url(for chain: Chain) -> String? { nil }
+}
+
+// `async` is required by `HTTPClientProtocol`; the stub answers synchronously.
+// swiftlint:disable async_without_await
+
+/// Scripted client that counts requests and fails on anything unscripted, so a
+/// test can prove a code path never touches the network.
+private final class TrippingHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    var accountInfoResult: Result<Data, Error> = .failure(URLError(.badServerResponse))
+    var serverStateResult: Result<Data, Error> = .failure(URLError(.badServerResponse))
+
+    private let queue = DispatchQueue(label: "TrippingHTTPClient.queue")
+    private var _requestCount = 0
+
+    var requestCount: Int {
+        queue.sync { _requestCount }
+    }
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        queue.sync { _requestCount += 1 }
+        guard let api = target as? RippleAPI else {
+            throw URLError(.unsupportedURL)
+        }
+        switch api.endpoint {
+        case .accountInfo:
+            return try respond(accountInfoResult)
+        case .serverState:
+            return try respond(serverStateResult)
+        case .submit:
+            throw URLError(.unsupportedURL)
+        }
+    }
+
+    private func respond(_ result: Result<Data, Error>) throws -> HTTPResponse<Data> {
+        let data = try result.get()
+        guard let url = URL(string: "https://xrplcluster.com"),
+              let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil) else {
+            throw URLError(.badURL)
+        }
+        return HTTPResponse(data: data, response: response)
+    }
+}
+
+// swiftlint:enable async_without_await

--- a/VultisigApp/VultisigAppTests/Send/SendRippleDestinationGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendRippleDestinationGuardTests.swift
@@ -81,6 +81,26 @@ final class SendRippleDestinationGuardTests: XCTestCase {
         }
     }
 
+    func testRippleDestinationCancellationPropagatesNotRewrapped() async throws {
+        // A cancelled lookup must propagate as CancellationError, NOT be
+        // rewrapped as HelperError — otherwise the load-time guard would turn a
+        // torn-down screen into a spurious balance error.
+        let client = TrippingHTTPClient()
+        client.accountInfoResult = .failure(CancellationError())
+        let logic = makeLogic(client: client)
+        let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6)
+        let tx = makeTransaction(coin: xrp, amount: "0.5")
+
+        do {
+            try await logic.validateDestinationIfNeeded(tx: tx)
+            XCTFail("cancellation must propagate")
+        } catch is CancellationError {
+            // expected — not rewrapped
+        } catch {
+            XCTFail("expected CancellationError, got \(error)")
+        }
+    }
+
     // MARK: - Fixtures
 
     private func makeLogic(client: HTTPClientProtocol) -> SendCryptoVerifyLogic {

--- a/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
@@ -212,10 +212,37 @@ final class SendValidationTests: XCTestCase {
         XCTAssertFalse(SendCryptoLogic.canBeReaped(coin: dot, amount: amountStr, gas: rawGas))
     }
 
-    func testCanBeReapedTrueForRippleWhenRemainderBelowExistentialDeposit() {
+    func testCanBeReapedFalseForRippleReserveNetBalance() {
+        // XRP's rawBalance is already reserve-net (owner-aware, computed live
+        // by RippleService via RippleReserve), so a partial send leaving less
+        // than 1 XRP *spendable* is valid on-chain — the full reserve still
+        // backs the account and XRPL never reaps. This flips the old
+        // expectation that pinned the double-count false positive.
         let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6, isNative: true,
-                           rawBalance: "11000000") // 11 XRP
-        XCTAssertTrue(SendCryptoLogic.canBeReaped(coin: xrp, amount: amount("10.999"), gas: BigInt(1)))
+                           rawBalance: "11000000") // 11 XRP spendable, reserve already netted out
+        XCTAssertFalse(SendCryptoLogic.canBeReaped(coin: xrp, amount: amount("10.999"), gas: BigInt(1)))
+    }
+
+    func testExistentialDepositZeroForRipple() {
+        // The send path must not re-reserve what the balance calc already
+        // subtracted — the owner-aware reserve lives in RippleReserve alone.
+        let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6, isNative: true)
+        XCTAssertEqual(SendCryptoLogic.existentialDeposit(for: xrp), .zero)
+    }
+
+    func testComputeMaxAmountForRippleSubtractsOnlyFee() {
+        // Acceptance: the MAX-send reserve equals the balance-calc reserve.
+        // Fixture models an OwnerCount > 0 account — total 12 XRP with a
+        // 1 + 5 × 0.2 = 2 XRP reserve nets rawBalance 8.6 XRP (drops are
+        // 6-decimals; getMaxValue truncates to 5 dp). With the reserve-net
+        // balance R and fee f, MAX == R − f exactly — no second static 1 XRP.
+        let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6, isNative: true,
+                           rawBalance: "8600000")
+        let fee = BigInt(20) // drops
+        let maxAmount = SendCryptoLogic.computeMaxAmount(coin: xrp, fee: fee)
+        XCTAssertEqual(maxAmount.toDecimal(), amount("8.59998").toDecimal())
+        // And the max-send itself is never blocked as a reap.
+        XCTAssertFalse(SendCryptoLogic.canBeReaped(coin: xrp, amount: maxAmount, gas: fee))
     }
 
     // MARK: - isBelowMinimumSendAmount


### PR DESCRIPTION
## Root cause — the reserve was counted twice

XRP's `coin.rawBalance` is **already the reserve-net available balance**: `RippleService.getBalance` (main @ `VultisigApp/Blockchain/Ripple/Service/RippleService.swift:103-108`) fetches `account_info` + `server_state` and returns `total − (reserve_base + OwnerCount × reserve_inc)` — owner-aware, live values. `BalanceService` routes `.ripple` straight to it, so every consumer (wallet display, send, swap) sees the spendable balance.

The send path then subtracted a **second, static 1 XRP** on top of that reserve-net balance:

- `RippleHelper.defaultExistentialDeposit` (main @ `VultisigApp/Blockchain/Ripple/Signing/Ripple.swift:19`) — hardcoded `1 XRP`.
- `SendCryptoLogic.existentialDeposit(for:)` (main @ `VultisigApp/Features/Send/Logic/SendCryptoLogic.swift:73-74`) returned it for `.ripple`, feeding:
  - MAX-send math `computeMaxAmount` (`SendCryptoLogic.swift:166`): `MAX = rawBalance − fee − 1 XRP` → **exactly 1 XRP of spendable funds stranded** — the UI showed an "available" balance the user could never send.
  - the Verify-screen recompute (`SendCryptoVerifyViewModel.swift:117`): same double-count on refine.
  - the reap guard `canBeReaped` (`SendCryptoLogic.swift:85-94`), hard-wired in Details (`SendDetailsViewModel.swift:650`) and Verify (`SendCryptoVerifyLogic.swift:107`): **valid partial sends** leaving < 1 XRP *spendable* were blocked with `belowExistentialDepositError`, even though the account keeps its full reserve on-chain and XRPL never deletes accounts (the reserve is a floor, not a deletion threshold).

Per the XRPL reserve rules (https://xrpl.org/docs/concepts/accounts/reserves), the reserve floor applies to the Payment **amount** only — the **fee is exempt** and may even take the account below the reserve. So the true max is exactly `available − fee`, and landing exactly at the reserve is valid.

> Note: the issue cites `RippleService.swift:104` as a static-1-XRP site; on current `main` that line is the `?? 1000000` **seed fallback inside the already-correct owner-aware calc** — the line refs drifted. The real static sites are the ones above.

## Fix design (one commit per step, codex-review-loop gated)

1. **`refactor(ripple): extract owner-aware reserve math into RippleReserve`** — pure enum (sibling of `RippleFee`): `reservedDrops(ownerCount:reserveBase:reserveInc:)` / `availableDrops(...)`, with the mainnet values (1 XRP base / 0.2 XRP per owned object, Dec 2024 validator vote) as named last-resort seeds. `getBalance` delegates; zero behavior change. New `RippleReserveTests` pin the formula (incl. the OwnerCount > 0 acceptance case), seed fallbacks, and the zero clamp.
2. **`feat(ripple): live-cache-seed fallback for server_state reserve values`** — reserve values must come live from `server_state`, but a transient outage of that one RPC used to throw away the whole balance refresh. Now: live → cached last-good (24h `TTLCache`, host-scoped key so a custom-RPC change never reuses another endpoint's snapshot) → `RippleReserve` seeds; only an `account_info` failure stays fatal; cancellation propagates. `httpClient` injected for testability (mirrors the Solana min-delegation pattern). `RippleReserveFallbackTests` cover live/warm-cache/cold-cache/fatal/host-scoping/TTL-reuse.
3. **`fix(ripple): stop double-reserving the XRP MAX send`** — **the actual fix.** `existentialDeposit(for: .ripple)` → `.zero` (with a load-bearing rationale comment); `RippleHelper.defaultExistentialDeposit` deleted. MAX settles at `available − fee` in both the Details fill and the Verify recompute (they share `existentialDeposit(for:)`). `canBeReaped` becomes structurally inert for XRP — correct by design: with a reserve-net balance, "would drop below the reserve" is exactly `amount + fee > rawBalance`, which `isAmountExceeded` / `validateBalanceWithFee` already block. DOT (total-balance model, `transfer_keep_alive`) untouched.
4. **`feat(ripple): block sub-reserve sends to unfunded XRP destinations`** — Sign-time guard: destination `account_info` lookup; unfunded + `amount < live base reserve` fails with localized `xrpDestinationNotActivatedError` *before* the ceremony (on-chain this is `tecNO_DST_INSUF_XRP`, after the fee burns). Funded destinations pass untouched; exactly the base reserve activates; lookup failures fail closed. Errors are rewrapped as `HelperError` so the Verify screen's alert plumbing actually presents them. Copy added to all 8 locales, sorted.

## Intentional test flip

`SendValidationTests.testCanBeReapedTrueForRippleWhenRemainderBelowExistentialDeposit` asserted the buggy double-count behavior (partial send leaving < 1 XRP spendable must be blocked). It flips to `testCanBeReapedFalseForRippleReserveNetBalance`, plus new pins: `testExistentialDepositZeroForRipple` and `testComputeMaxAmountForRippleSubtractsOnlyFee` (MAX == R − f exactly, OwnerCount > 0 fixture). DOT and TAO expectations unchanged and green.

## Cross-platform parity

- **vultisig-sdk#959**: iOS never had the fee-side bug (`BlockChainService` builds `.Ripple(gas:)` from the network fee only); what iOS lacked was the unfunded-destination guard — folded in here (commit 4).
- **vultisig-android#5148 / PR #5180**: same destination guard shipped there (static base reserve). Android's *sender-side* XRP reserve still has the same double-count pattern this PR fixes (`checkIsReapable` static 1 XRP vs. its own reserve-net `RippleApi.getBalance`) — a parity note for tracker vultisig-sdk#979 follows once this lands.
- Converged semantics: **MAX = (total − reserve_base − OwnerCount × reserve_inc) − fee, values live from `server_state`**.

## Gate

- Full unit suite (`make test`, iPhone 17 Pro Max / iOS 26.5, en_US): **2389 tests, 0 failures — TEST SUCCEEDED**
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/`: 43 warnings, all pre-existing in untouched files — 0 new.
- Codex cross-review: 4 per-step gates (2 rounds max) + whole-branch pass; all findings fixed or ledgered.

**Runtime note:** the on-chain acceptance item ("MAX send from an account holding N objects succeeds") needs a real device broadcast — the owner-aware math is pinned by unit fixtures modelling OwnerCount > 0; a mainnet probe of `RippleReserve.reservedDrops` matches explorer reserve figures for the current 1 / 0.2 XRP parameters.

Closes #4744

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reserve-aware XRP spendable balance calculation using live network reserve values.
  * Added pre-send XRP destination activation verification with clearer, reserve-based thresholds.
  * Added localized XRP destination error messages (activation required / lookup failed) across multiple languages.
* **Bug Fixes**
  * Improved XRP max-send and balance validation to correctly reflect reserve-net behavior.
  * Enhanced fail-open vs fail-closed handling for destination checks when network data is missing or ambiguous.
* **Tests**
  * Added/expanded unit tests for XRP reserve math, caching/fallback behavior, and destination activation guard flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->