### PR TITLE
fix(ripple): compute the deterministic transaction hash for signed XRP txs

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -214,4 +214,24 @@ enum RippleHelper {
         return result
     }
 
+    /// XRPL "transaction identifying hash": SHA-512Half (the first 32 bytes of
+    /// SHA-512) over the 4-byte `TXN\0` prefix (`HashPrefix::transactionID`,
+    /// `0x54584E00`) concatenated with the serialized *signed* transaction blob.
+    /// Rendered as uppercase hex — the canonical XRPL rendering, and the same
+    /// value the `submit`/`tx` endpoints echo back as `tx_json.hash`.
+    ///
+    /// Derived purely from the already-signed output bytes; no signing input,
+    /// pre-image, or TSS state is involved.
+    ///
+    /// An empty blob yields an empty string so the hash-keyed keysign safety
+    /// nets stay disarmed rather than keying off a meaningless prefix-only hash.
+    ///
+    /// Reference: https://xrpl.org/docs/references/protocol/data-types/hash-prefixes
+    static func signedTransactionHash(signedBlob: Data) -> String {
+        guard !signedBlob.isEmpty else { return "" }
+        let transactionIDPrefix = Data([0x54, 0x58, 0x4E, 0x00]) // "TXN\0"
+        let digest = Data(Hash.sha512(data: transactionIDPrefix + signedBlob).prefix(32))
+        return digest.toHexString().uppercased()
+    }
+
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -209,7 +209,7 @@ enum RippleHelper {
 
         let result = SignedTransactionResult(
             rawTransaction: output.encoded.hexString,
-            transactionHash: "")
+            transactionHash: signedTransactionHash(signedBlob: output.encoded))
 
         return result
     }

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTransactionHashTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTransactionHashTests.swift
@@ -1,0 +1,86 @@
+//
+//  RippleTransactionHashTests.swift
+//  VultisigAppTests
+//
+//  Pins the deterministic XRPL transaction identifying hash that
+//  `RippleHelper.signedTransactionHash(signedBlob:)` computes for a signed XRP
+//  transaction: SHA-512Half of the 4-byte `TXN\0` prefix (0x54584E00) + the
+//  serialized signed blob, rendered as uppercase hex.
+//
+//  The fixtures are real mainnet transactions pulled from ledger 105416247 via
+//  the `tx` JSON-RPC method (`binary: true`) against a public XRPL endpoint. The
+//  expected value is each transaction's own on-chain hash — the canonical proof
+//  that the local computation reproduces exactly what the ledger assigns. The
+//  blob + expected hash are baked as constants so the tests run fully offline.
+//
+//  - https://xrpl.org/docs/references/protocol/data-types/hash-prefixes
+//  - https://xrpl.org/docs/concepts/transactions/finality-of-results
+//
+
+@testable import VultisigApp
+import XCTest
+import WalletCore
+
+final class RippleTransactionHashTests: XCTestCase {
+
+    // Real mainnet Payment (secp256k1-signed), ledger 105416247.
+    private let paymentBlobHex = "12000023000000DE2405F45C49614000000000000F5868400000000000000F7321026180E1CD4F966CF2BDC947F177F41CC4D7E61265CD7DEE297C098FEFC05FEDA37446304402203353A6C6EDAB6EC54B37F474570192DEC0F969B3EE528B7E5C7551807ED41FB802207DCC77F89A60D8D2C90B1AB5B89EB76A0F8C64D930F015A755FB84F637C29ACC8114E4792E06D3A514EE266E4AF5CB3795AABBE1F49D831408EF73DE114C04A3408837BF2399D1A8458A0204F9EA7D13486F72697A6F6E20426F6F7374657220466565E1F1"
+    private let paymentExpectedHash = "00D3BAABAE790E1B9F772172CB5AD486161294E7F25916CC4E52423227768A14"
+
+    // Real mainnet OfferCreate (ed25519-signed), ledger 105416247. Proves the
+    // hash is agnostic to transaction type / signature scheme — it is a pure
+    // digest of the serialized signed bytes.
+    private let offerBlobHex = "1200072200010000240617B1A020190617B19F64400000000005B7B165D44F491087F5D800524C555344000000000000000000000000000000E5E961C6A025C9404AA7B662DD1DF975BE75D13E68400000000000000C7321ED1A8CA8C2249E7695955D8B17CB3250A7DA40B6A70D5532ECF7712188642CBEBD7440A782A072DBCDF20173C2BD08CAC2BCE1C147C298C8FB19C7F0167F4D6FF0A6F00B48B2FC5E5DBA2455E532ED2DF61830ED66BE91642F081E248767478ED3A4088114DEF23F96A90D53B409ACC5F68A634A53E13D4FFD"
+    private let offerExpectedHash = "06E809490BE5C3341F9F11ED2067F168094E0BCD7AE047D37334113FE559D732"
+
+    func testMainnetPaymentBlobMatchesOnChainHash() throws {
+        let blob = try XCTUnwrap(Data(hexString: paymentBlobHex))
+        let hash = RippleHelper.signedTransactionHash(signedBlob: blob)
+        XCTAssertEqual(hash, paymentExpectedHash)
+    }
+
+    func testMainnetOfferCreateBlobMatchesOnChainHash() throws {
+        let blob = try XCTUnwrap(Data(hexString: offerBlobHex))
+        let hash = RippleHelper.signedTransactionHash(signedBlob: blob)
+        XCTAssertEqual(hash, offerExpectedHash)
+    }
+
+    func testHashIsUppercaseHex() throws {
+        let blob = try XCTUnwrap(Data(hexString: paymentBlobHex))
+        let hash = RippleHelper.signedTransactionHash(signedBlob: blob)
+        XCTAssertEqual(hash, hash.uppercased())
+        let hexCharacters = CharacterSet(charactersIn: "0123456789ABCDEF")
+        XCTAssertTrue(
+            hash.unicodeScalars.allSatisfy { hexCharacters.contains($0) },
+            "hash must be uppercase hex only"
+        )
+    }
+
+    func testHashLengthIs64Characters() throws {
+        // SHA-512Half is 32 bytes → 64 hex characters.
+        let blob = try XCTUnwrap(Data(hexString: offerBlobHex))
+        let hash = RippleHelper.signedTransactionHash(signedBlob: blob)
+        XCTAssertEqual(hash.count, 64)
+    }
+
+    func testEmptyBlobReturnsEmptyString() {
+        // An empty blob must yield an empty hash so the hash-keyed keysign
+        // safety nets stay disarmed rather than keying off a prefix-only digest.
+        XCTAssertEqual(RippleHelper.signedTransactionHash(signedBlob: Data()), "")
+    }
+
+    func testHashIsDeterministic() throws {
+        let blob = try XCTUnwrap(Data(hexString: paymentBlobHex))
+        let first = RippleHelper.signedTransactionHash(signedBlob: blob)
+        let second = RippleHelper.signedTransactionHash(signedBlob: blob)
+        XCTAssertEqual(first, second)
+    }
+
+    func testSingleByteDifferenceChangesHash() throws {
+        var mutated = try XCTUnwrap(Data(hexString: paymentBlobHex))
+        mutated[mutated.startIndex] ^= 0xFF
+        let hash = RippleHelper.signedTransactionHash(signedBlob: mutated)
+        XCTAssertNotEqual(hash, paymentExpectedHash)
+        XCTAssertEqual(hash.count, 64)
+    }
+}


### PR DESCRIPTION
Closes #4747

## What was inert & why

`RippleHelper.getSignedTransaction` returned the signed XRP transaction with an **empty** hash — `SignedTransactionResult(rawTransaction: …, transactionHash: "")`. Three chain-agnostic keysign safety nets in `KeysignViewModel` key off `transactionType.transactionHash` and short-circuit on an empty string, so all three were **disarmed for XRP**:

1. **Verify-by-hash net** — `isAlreadyOnChain(...)` returns `false` immediately when the hash is empty, so an ambiguous/failed broadcast could never be rescued by confirming the tx already landed.
2. **Pre-broadcast idempotency guard** — `hasPriorBroadcastAttempt(...)` returns `false` on the empty string, so a re-entered keysign flow couldn't detect a prior broadcast of this exact tx.
3. **Cancelled-broadcast net** — falls through to the neutral "couldn't confirm" outcome with an empty txid instead of verifying whether the signed tx landed.

Populating the hash with the deterministic XRPL transaction identifier arms all three at once.

## Algorithm (pinned against mainnet)

XRPL transaction identifying hash = **SHA-512Half** (first 32 bytes of SHA-512) over the 4-byte prefix `0x54584E00` (`"TXN\0"`, `HashPrefix::transactionID`) concatenated with the serialized **signed** transaction blob (`output.encoded`), rendered as canonical **uppercase** hex. SHA-512 comes from WalletCore's `Hash.sha512` (not hand-rolled). This mirrors the existing **Polkadot** precedent, which computes its hash the same way with blake2b over `output.encoded`.

The algorithm is pinned by offline fixture tests against two **real mainnet** transactions from ledger `105416247` (fetched via the `tx` JSON-RPC method with `binary: true` from a public XRPL endpoint), asserting the local computation reproduces each tx's own on-chain hash:

| type | on-chain hash (== computed) |
|---|---|
| Payment (secp256k1) | `00D3BAABAE790E1B9F772172CB5AD486161294E7F25916CC4E52423227768A14` |
| OfferCreate (ed25519) | `06E809490BE5C3341F9F11ED2067F168094E0BCD7AE047D37334113FE559D732` |

The OfferCreate vector demonstrates the hash is agnostic to transaction type and signature scheme — it is a pure digest of the serialized signed bytes.

## Security boundary (HIGH-tier repo)

The hash is derived **only** from the already-signed `output.encoded` bytes. **No** signing input, `SigningInput` proto, pre-image hashing, or TSS/keysign flow is touched — the bytes that get signed and broadcast are byte-for-byte unchanged. The diff is the hash computation + populating `transactionHash` + tests. An empty blob yields an empty string, so if the compiled output were ever empty the nets stay disarmed rather than keying off a meaningless prefix-only digest (no behavior regression vs. today).

## Which nets arm & composition with #4746

Once `transactionHash` is populated, the three generic nets above become active for XRP with zero further wiring. This composes with the broadcast-layer dedup in #4746 (broadcast gating): that work leaned on the `tx_json.hash` **echoed** by the `submit` response precisely because the signing helper didn't populate this value. With this fix the locally-computed hash and the echoed hash are identical, and the RPC-level-error broadcast case (network blip during submit) also becomes recoverable via the generic nets. Note: #4746 may not be merged yet; the tests here do **not** depend on its code.

## Parity

- **vultisig-sdk** already computes this locally from the signed bytes: `getRippleTxHash({ encoded }) => hashes.hashSignedTx(hex(encoded))` (`packages/core/chain/tx/hash/resolvers/ripple.ts`), delegating to the canonical `xrpl` lib (same `0x54584E00` prefix + SHA-512Half). This iOS change ports that exact behavior.
- **vultisig-android** has the **same** latent gap — `RippleHelper.getSignedTransaction` returns `transactionHash = ""` (`RippleHelpter.kt:153-155`). Parity note only; not changed here.

## Gate

- `make test` on a dedicated iPhone 17 Pro Max (iOS 26.5, en_US) simulator: **2372 tests, 0 failures** (7 new `RippleTransactionHashTests`, including the two mainnet vectors).
- SwiftLint (repo config): changed files clean, no new warnings.
- Cross-model review: Codex (gpt-5.5 high, read-only) gated each commit + a whole-branch pass — **no findings** in any round.

Part of the XRP chain-hardening set (tracker vultisig-sdk#979).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Fable 5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction signing now returns a real Ripple transaction hash instead of an empty value.
  * Hashes are now formatted consistently in uppercase and match expected XRPL length and behavior.
  
* **Tests**
  * Added coverage for Ripple transaction hash generation using real signed transaction examples.
  * Verified deterministic hashing, empty-input handling, and sensitivity to byte changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->