### PR TITLE
fix(ripple): retry XRPL requests on transient node errors (amendmentBlocked)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleAPI.swift
@@ -99,15 +99,23 @@ struct RippleSubmitResponse: Decodable {
         let engineResult: String?
         let engineResultMessage: String?
         let txJson: TxJson?
+        /// Node-level error (e.g. `amendmentBlocked`) returned in an HTTP-200
+        /// body when the backend can't process the request at all.
+        let error: String?
 
         enum CodingKeys: String, CodingKey {
             case engineResult = "engine_result"
             case engineResultMessage = "engine_result_message"
             case txJson = "tx_json"
+            case error
         }
 
         struct TxJson: Decodable {
             let hash: String?
         }
     }
+}
+
+extension RippleSubmitResponse: RippleRPCResponse {
+    var rpcError: String? { result?.error }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleRetryPolicy.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleRetryPolicy.swift
@@ -1,0 +1,167 @@
+//
+//  RippleRetryPolicy.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+
+/// A decoded XRPL JSON-RPC response body that can surface a node-level error.
+///
+/// XRPL returns node/server errors (e.g. `amendmentBlocked`) as **HTTP 200**
+/// with the error nested in the body (`result.error`), so retry detection reads
+/// the decoded body rather than the HTTP status.
+protocol RippleRPCResponse {
+    /// The JSON-RPC error string the node returned, or `nil` on success.
+    var rpcError: String? { get }
+}
+
+/// Pure classifier for "should this XRPL request be retried on the same host?".
+///
+/// The default XRPL host (`xrplcluster.com`) is a load-balanced **pool**, so a
+/// retry against the same host is routed to a different backend — which is
+/// almost always healthy. That is why the fix is a bounded same-host retry and
+/// deliberately does NOT add a fallback host list.
+enum RippleRetryPolicy {
+    /// Total attempts for a request = one initial try plus up to
+    /// `maxAttempts - 1` retries. Kept small so the post-signing broadcast
+    /// window stays responsive.
+    static let maxAttempts = 3
+
+    /// JSON-RPC `result.error` values that indicate a transient/stale backend in
+    /// the pool. A same-host retry routes to a different (healthy) node.
+    ///
+    /// `tooBusy` / `slowDown` are per-backend overload signals emitted by the
+    /// node (not the pool edge), so a pool retry lands on a different node; they
+    /// stay bounded by `maxAttempts` and the backoff, so including them is safe.
+    static let retryableRPCErrors: Set<String> = [
+        "amendmentBlocked",
+        "noNetwork",
+        "noCurrent",
+        "noClosed",
+        "tooBusy",
+        "slowDown",
+        // Clio forwards write/server commands (submit, server_state, fee) to a
+        // rippled backend; a forwarding failure is a transient per-node fault a
+        // same-host pool retry can route around.
+        "failedToForward"
+    ]
+
+    /// Whether a decoded node error warrants a same-host retry. Business errors
+    /// (`actNotFound`, `txnNotFound`, `invalidParams`, engine `tef*`/`tec*`
+    /// codes, …) are not transient and pass through unchanged.
+    static func isRetryable(rpcError: String?) -> Bool {
+        guard let rpcError else { return false }
+        return retryableRPCErrors.contains(rpcError)
+    }
+
+    /// Whether a thrown transport error is transient and worth a retry. A
+    /// cancellation is never retried, even when wrapped in `.networkError`.
+    static func isRetryable(transportError error: Error) -> Bool {
+        if isCancellation(error) { return false }
+        guard let httpError = error as? HTTPError else { return false }
+        switch httpError {
+        case .timeout:
+            return true
+        case .networkError(let underlying):
+            return !isCancellation(underlying)
+        case .statusCode(let code, _):
+            return (500...599).contains(code)
+        default:
+            return false
+        }
+    }
+
+    /// Task cancellation in any of its forms, which must never be retried.
+    private static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+        return false
+    }
+
+    /// Linear backoff before the given retry (1-based over the retries):
+    /// retry 1 → 0.25s, retry 2 → 0.5s. Short enough to keep added latency low
+    /// in the time-sensitive broadcast window.
+    static func backoff(forAttempt attempt: Int) -> Duration {
+        .milliseconds(250 * max(attempt, 1))
+    }
+}
+
+/// Raised when the bounded same-host retry is exhausted and the node still
+/// returned a transient error. Surfacing it (rather than returning the stale
+/// body) stops callers that don't inspect `rpcError` from treating an
+/// `amendmentBlocked` reply as valid data (e.g. a `0` XRP balance).
+enum RippleRetryError: Error, LocalizedError {
+    case exhausted(rpcError: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .exhausted(let rpcError):
+            return "XRPL request failed after retries (\(rpcError))"
+        }
+    }
+}
+
+/// Wraps `HTTPClientProtocol` request execution with the bounded same-host
+/// retry defined by `RippleRetryPolicy`. Shared by `RippleService` and
+/// `RippleTransactionStatusProvider` so broadcast, status, and reads all
+/// benefit. The sleeper is injected so tests drive it with a no-op clock.
+struct RippleRequestRetrier {
+    typealias Sleeper = @Sendable (Duration) async throws -> Void
+
+    /// Production sleeper: suspends for the requested duration.
+    static let defaultSleep: Sleeper = { try await Task.sleep(for: $0) }
+
+    private let httpClient: HTTPClientProtocol
+    private let sleep: Sleeper
+    private let logger: Logger
+
+    init(
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        sleep: @escaping Sleeper = RippleRequestRetrier.defaultSleep,
+        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "ripple-retry")
+    ) {
+        self.httpClient = httpClient
+        self.sleep = sleep
+        self.logger = logger
+    }
+
+    /// Performs `target`, retrying on the SAME host while the decoded body or a
+    /// thrown transport error is transient, up to `RippleRetryPolicy.maxAttempts`.
+    /// A non-retryable node error is returned as-is so the caller surfaces it
+    /// exactly as before; a *retryable* error that survives the whole budget is
+    /// thrown as `RippleRetryError.exhausted` rather than returned as data.
+    func request<T: Decodable & RippleRPCResponse>(
+        _ target: TargetType,
+        responseType: T.Type
+    ) async throws -> T {
+        let retryCap = RippleRetryPolicy.maxAttempts - 1
+        var attempt = 1
+        while true {
+            do {
+                let body = try await httpClient.request(target, responseType: responseType).data
+                guard let rpcError = body.rpcError,
+                      RippleRetryPolicy.isRetryable(rpcError: rpcError) else {
+                    return body
+                }
+                guard attempt < RippleRetryPolicy.maxAttempts else {
+                    logger.error("XRPL request exhausted \(retryCap, privacy: .public) retries; surfacing node error '\(rpcError, privacy: .public)'")
+                    throw RippleRetryError.exhausted(rpcError: rpcError)
+                }
+                logger.info("Retrying XRPL request after node error '\(rpcError, privacy: .public)' (retry \(attempt, privacy: .public)/\(retryCap, privacy: .public))")
+                try await sleep(RippleRetryPolicy.backoff(forAttempt: attempt))
+                attempt += 1
+            } catch let retryError as RippleRetryError {
+                throw retryError
+            } catch {
+                guard RippleRetryPolicy.isRetryable(transportError: error),
+                      attempt < RippleRetryPolicy.maxAttempts else {
+                    throw error
+                }
+                logger.info("Retrying XRPL request after transport error (retry \(attempt, privacy: .public)/\(retryCap, privacy: .public)): \(error.localizedDescription, privacy: .public)")
+                try await sleep(RippleRetryPolicy.backoff(forAttempt: attempt))
+                attempt += 1
+            }
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -39,7 +39,12 @@ class RippleService {
     static let shared = RippleService()
 
     private let logger = Logger(subsystem: "com.vultisig.app", category: "ripple-service")
-    private let httpClient: HTTPClientProtocol = HTTPClient()
+
+    /// Executes requests with a bounded same-host retry on transient node
+    /// errors (`amendmentBlocked` and the node-unavailable family). Because the
+    /// resolved host is a load-balanced pool, a same-host retry routes to a
+    /// different (healthy) backend — no fallback host list is needed.
+    private let retrier: RippleRequestRetrier
 
     /// Resolves the Ripple custom RPC override. Injected so the API values are
     /// built from a dependency rather than a global reach-in; resolution happens
@@ -47,8 +52,13 @@ class RippleService {
     /// live (the shared mirror updates without a relaunch).
     private let resolver: RPCEndpointResolving
 
-    init(resolver: RPCEndpointResolving = CustomRPCStore.shared) {
+    init(
+        resolver: RPCEndpointResolving = CustomRPCStore.shared,
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        sleep: @escaping RippleRequestRetrier.Sleeper = RippleRequestRetrier.defaultSleep
+    ) {
         self.resolver = resolver
+        self.retrier = RippleRequestRetrier(httpClient: httpClient, sleep: sleep)
     }
 
     /// The override-aware XRPL host. Falls back to the default host when no
@@ -64,12 +74,12 @@ class RippleService {
     }
 
     func broadcastTransaction(_ hex: String) async throws -> String {
-        let response = try await httpClient.request(
+        let response = try await retrier.request(
             api(.submit(txBlob: hex)),
             responseType: RippleSubmitResponse.self
         )
 
-        let result = response.data.result
+        let result = response.result
 
         // `tx_json.hash` is the deterministic hash of the exact blob we
         // submitted; XRPL echoes it back regardless of the engine result. Track
@@ -134,11 +144,10 @@ class RippleService {
 
     func fetchServerState() async throws -> RippleServerStateResponse? {
         do {
-            let response = try await httpClient.request(
+            return try await retrier.request(
                 api(.serverState),
                 responseType: RippleServerStateResponse.self
             )
-            return response.data
         } catch {
             logger.error("fetchServerState: \(error.localizedDescription)")
             throw error
@@ -147,11 +156,10 @@ class RippleService {
 
     func fetchAccountsInfo(for walletAddress: String) async throws -> RippleAccountResponse? {
         do {
-            let response = try await httpClient.request(
+            return try await retrier.request(
                 api(.accountInfo(account: walletAddress)),
                 responseType: RippleAccountResponse.self
             )
-            return response.data
         } catch {
             logger.error("fetchAccountsInfo: \(error.localizedDescription)")
             throw error
@@ -182,6 +190,10 @@ struct RippleAccountResponse: Codable {
         let queueData: QueueData?
         let status: String?
         let validated: Bool?
+        /// Node-level error (e.g. `amendmentBlocked`) returned in an HTTP-200
+        /// body. Distinct from `actNotFound`, which is a valid "unfunded
+        /// account" outcome and is intentionally not retryable.
+        let error: String?
 
         enum CodingKeys: String, CodingKey {
             case accountData = "account_data"
@@ -189,6 +201,7 @@ struct RippleAccountResponse: Codable {
             case queueData = "queue_data"
             case status
             case validated
+            case error
         }
     }
 
@@ -258,9 +271,13 @@ struct RippleServerStateResponse: Codable {
 
     struct Result: Codable {
         let state: State?
+        /// Node-level error (e.g. `amendmentBlocked`) returned in an HTTP-200
+        /// body when the backend can't serve `server_state`.
+        let error: String?
 
         enum CodingKeys: String, CodingKey {
             case state
+            case error
         }
     }
 
@@ -287,4 +304,12 @@ struct RippleServerStateResponse: Codable {
             case reserveInc = "reserve_inc"
         }
     }
+}
+
+extension RippleAccountResponse: RippleRPCResponse {
+    var rpcError: String? { result?.error }
+}
+
+extension RippleServerStateResponse: RippleRPCResponse {
+    var rpcError: String? { result?.error }
 }

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/RippleTransactionStatusResponse.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Models/RippleTransactionStatusResponse.swift
@@ -7,12 +7,16 @@
 
 import Foundation
 
-struct RippleTransactionStatusResponse: Codable {
+struct RippleTransactionStatusResponse: Codable, RippleRPCResponse {
     let result: RippleResult?
     let error: String?  // "txnNotFound" when transaction doesn't exist
     let error_code: Int?
     let error_message: String?
     let status: String?  // "error" when there's an error
+
+    /// The node error string, whether XRPL returned it at the top level or
+    /// nested in `result`. Drives the shared same-host retry.
+    var rpcError: String? { error ?? result?.error }
 
     struct RippleResult: Codable {
         let Account: String?

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/RippleTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/RippleTransactionStatusProvider.swift
@@ -13,18 +13,24 @@ import Foundation
 /// - Parses `TransactionResult` to determine success/failure
 struct RippleTransactionStatusProvider: TransactionStatusProvider {
     private let retrier: RippleRequestRetrier
+    /// Resolves the Ripple custom RPC override so the status lookup targets the
+    /// same host as broadcast/reads (`RippleService`).
+    private let resolver: RPCEndpointResolving
 
     init(
         httpClient: HTTPClientProtocol = HTTPClient(),
-        sleep: @escaping RippleRequestRetrier.Sleeper = RippleRequestRetrier.defaultSleep
+        sleep: @escaping RippleRequestRetrier.Sleeper = RippleRequestRetrier.defaultSleep,
+        resolver: RPCEndpointResolving = CustomRPCStore.shared
     ) {
         self.retrier = RippleRequestRetrier(httpClient: httpClient, sleep: sleep)
+        self.resolver = resolver
     }
 
     func checkStatus(query: TransactionStatusQuery) async throws -> TransactionStatusResult {
         do {
+            let host = resolver.resolvedURL(for: .ripple, default: RippleAPI.defaultHost)
             let response = try await retrier.request(
-                RippleTransactionStatusAPI.getTx(txHash: query.txHash),
+                RippleTransactionStatusAPI.getTx(txHash: query.txHash, host: host),
                 responseType: RippleTransactionStatusResponse.self
             )
 

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/RippleTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/RippleTransactionStatusProvider.swift
@@ -12,21 +12,24 @@ import Foundation
 /// - Checks `validated` field to confirm transaction finality
 /// - Parses `TransactionResult` to determine success/failure
 struct RippleTransactionStatusProvider: TransactionStatusProvider {
-    private let httpClient: HTTPClientProtocol
+    private let retrier: RippleRequestRetrier
 
-    init(httpClient: HTTPClientProtocol = HTTPClient()) {
-        self.httpClient = httpClient
+    init(
+        httpClient: HTTPClientProtocol = HTTPClient(),
+        sleep: @escaping RippleRequestRetrier.Sleeper = RippleRequestRetrier.defaultSleep
+    ) {
+        self.retrier = RippleRequestRetrier(httpClient: httpClient, sleep: sleep)
     }
 
     func checkStatus(query: TransactionStatusQuery) async throws -> TransactionStatusResult {
         do {
-            let response = try await httpClient.request(
+            let response = try await retrier.request(
                 RippleTransactionStatusAPI.getTx(txHash: query.txHash),
                 responseType: RippleTransactionStatusResponse.self
             )
 
             // Check for error response
-            if let error = response.data.error {
+            if let error = response.error {
                 if error == "txnNotFound" {
                     return TransactionStatusResult(
                         status: .notFound,
@@ -35,7 +38,7 @@ struct RippleTransactionStatusProvider: TransactionStatusProvider {
                     )
                 }
                 // Other errors
-                let message = response.data.error_message ?? error
+                let message = response.error_message ?? error
                 return TransactionStatusResult(
                     status: .failed(reason: message),
                     blockNumber: nil,
@@ -44,7 +47,7 @@ struct RippleTransactionStatusProvider: TransactionStatusProvider {
             }
 
             // Parse successful result
-            guard let result = response.data.result else {
+            guard let result = response.result else {
                 return TransactionStatusResult(
                     status: .notFound,
                     blockNumber: nil,

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TargetType/RippleTransactionStatusAPI.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TargetType/RippleTransactionStatusAPI.swift
@@ -8,10 +8,16 @@
 import Foundation
 
 enum RippleTransactionStatusAPI: TargetType {
-    case getTx(txHash: String)
+    /// The resolved XRPL host (override-aware) is baked in by the provider so
+    /// the status lookup uses the SAME host as broadcast/reads — a same-host
+    /// retry then stays on the user's configured node, not the default pool.
+    case getTx(txHash: String, host: URL)
 
     var baseURL: URL {
-        URL(string: "https://xrplcluster.com")!
+        switch self {
+        case .getTx(_, let host):
+            return host
+        }
     }
 
     var path: String {
@@ -24,7 +30,7 @@ enum RippleTransactionStatusAPI: TargetType {
 
     var task: HTTPTask {
         switch self {
-        case .getTx(let txHash):
+        case .getTx(let txHash, _):
             // XRP Ledger JSON-RPC format
             let body: [String: Any] = [
                 "method": "tx",

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleRetryTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleRetryTests.swift
@@ -289,7 +289,9 @@ final class RippleRetryTests: XCTestCase {
         stub.enqueue(Self.decode(RippleTransactionStatusResponse.self, Self.statusAmendmentBlockedBody))
         stub.enqueue(Self.decode(RippleTransactionStatusResponse.self, Self.statusConfirmedBody))
         let sleeper = RecordingSleeper()
-        let provider = RippleTransactionStatusProvider(httpClient: stub, sleep: sleeper.sleep)
+        let provider = RippleTransactionStatusProvider(
+            httpClient: stub, sleep: sleeper.sleep, resolver: NoOverrideResolver()
+        )
 
         let result = try await provider.checkStatus(
             query: TransactionStatusQuery(txHash: "ABC123", chain: .ripple)
@@ -299,6 +301,57 @@ final class RippleRetryTests: XCTestCase {
         XCTAssertEqual(stub.callCount, 2)
         XCTAssertEqual(sleeper.count, 1)
         assertSameHost(stub, expected: RippleAPI.defaultHost)
+    }
+
+    func testStatusLookupHttp404ReturnsNotFoundWithoutRetry() async throws {
+        // 404 is non-retryable; the provider maps it to .notFound as before.
+        let stub = SequencedHTTPClient()
+        stub.enqueueError(HTTPError.statusCode(404, Data()))
+        let sleeper = RecordingSleeper()
+        let provider = RippleTransactionStatusProvider(
+            httpClient: stub, sleep: sleeper.sleep, resolver: NoOverrideResolver()
+        )
+
+        let result = try await provider.checkStatus(
+            query: TransactionStatusQuery(txHash: "ABC123", chain: .ripple)
+        )
+
+        XCTAssertEqual(result.status, .notFound)
+        XCTAssertEqual(stub.callCount, 1, "404 must not be retried")
+    }
+
+    func testStatusLookupTxnNotFoundReturnsNotFoundWithoutRetry() async throws {
+        // txnNotFound is a real outcome, not a transient node fault.
+        let stub = SequencedHTTPClient()
+        stub.enqueue(Self.decode(RippleTransactionStatusResponse.self, Self.statusTxnNotFoundBody))
+        let sleeper = RecordingSleeper()
+        let provider = RippleTransactionStatusProvider(
+            httpClient: stub, sleep: sleeper.sleep, resolver: NoOverrideResolver()
+        )
+
+        let result = try await provider.checkStatus(
+            query: TransactionStatusQuery(txHash: "ABC123", chain: .ripple)
+        )
+
+        XCTAssertEqual(result.status, .notFound)
+        XCTAssertEqual(stub.callCount, 1, "txnNotFound must not be retried")
+    }
+
+    func testStatusLookupEngineFailureReturnsFailedWithoutRetry() async throws {
+        // A validated tx with a non-tesSUCCESS result is a real on-chain failure.
+        let stub = SequencedHTTPClient()
+        stub.enqueue(Self.decode(RippleTransactionStatusResponse.self, Self.statusEngineFailureBody))
+        let sleeper = RecordingSleeper()
+        let provider = RippleTransactionStatusProvider(
+            httpClient: stub, sleep: sleeper.sleep, resolver: NoOverrideResolver()
+        )
+
+        let result = try await provider.checkStatus(
+            query: TransactionStatusQuery(txHash: "ABC123", chain: .ripple)
+        )
+
+        XCTAssertEqual(result.status, .failed(reason: "tecUNFUNDED_PAYMENT"))
+        XCTAssertEqual(stub.callCount, 1, "an engine failure must not be retried")
     }
 
     // MARK: - Helpers
@@ -333,6 +386,10 @@ final class RippleRetryTests: XCTestCase {
     private static let statusAmendmentBlockedBody = #"{"result":{"error":"amendmentBlocked","status":"error"}}"#
     private static let statusConfirmedBody = #"""
     {"result":{"validated":true,"ledger_index":123,"meta":{"TransactionResult":"tesSUCCESS"}}}
+    """#
+    private static let statusTxnNotFoundBody = #"{"result":{"error":"txnNotFound","status":"error"}}"#
+    private static let statusEngineFailureBody = #"""
+    {"result":{"validated":true,"ledger_index":50,"meta":{"TransactionResult":"tecUNFUNDED_PAYMENT"}}}
     """#
 
     private static func decode<T: Decodable>(_: T.Type, _ json: String) -> T {

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleRetryTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleRetryTests.swift
@@ -1,0 +1,440 @@
+//
+//  RippleRetryTests.swift
+//  VultisigAppTests
+//
+//  Pins the bounded same-host retry for transient XRPL node errors. The default
+//  XRPL host (xrplcluster.com) is a load-balanced pool; some backends run stale
+//  rippled and answer `amendmentBlocked` (HTTP 200 with `result.error`). A
+//  same-host retry routes to a different, healthy backend — so the fix retries
+//  the same host and deliberately adds no fallback host list. These tests use an
+//  injected no-op clock (no real sleeps) and a sequenced HTTP stub.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class RippleRetryTests: XCTestCase {
+
+    // MARK: - Policy: JSON-RPC body errors
+
+    func testAmendmentBlockedIsRetryable() {
+        XCTAssertTrue(RippleRetryPolicy.isRetryable(rpcError: "amendmentBlocked"))
+    }
+
+    func testNodeUnavailableFamilyIsRetryable() {
+        // Includes the Clio forwarding failure (submit/server_state are forwarded).
+        for code in ["noNetwork", "noCurrent", "noClosed", "failedToForward"] {
+            XCTAssertTrue(RippleRetryPolicy.isRetryable(rpcError: code), "\(code) should be retryable")
+        }
+    }
+
+    func testBusyAndSlowDownAreRetryable() {
+        // Per-backend overload signals; a pool retry lands on a different node.
+        XCTAssertTrue(RippleRetryPolicy.isRetryable(rpcError: "tooBusy"))
+        XCTAssertTrue(RippleRetryPolicy.isRetryable(rpcError: "slowDown"))
+    }
+
+    func testBusinessErrorsAreNotRetryable() {
+        // These are real outcomes, not transient node faults — never retry them.
+        for code in ["actNotFound", "txnNotFound", "invalidParams", "tefALREADY", "tecUNFUNDED_PAYMENT"] {
+            XCTAssertFalse(RippleRetryPolicy.isRetryable(rpcError: code), "\(code) should NOT be retryable")
+        }
+    }
+
+    func testNilRpcErrorIsNotRetryable() {
+        XCTAssertFalse(RippleRetryPolicy.isRetryable(rpcError: nil))
+    }
+
+    // MARK: - Policy: transport errors
+
+    func testTransientTransportErrorsAreRetryable() {
+        XCTAssertTrue(RippleRetryPolicy.isRetryable(transportError: HTTPError.timeout))
+        XCTAssertTrue(RippleRetryPolicy.isRetryable(transportError: HTTPError.networkError(HTTPError.noData)))
+        XCTAssertTrue(RippleRetryPolicy.isRetryable(transportError: HTTPError.statusCode(503, nil)))
+        XCTAssertTrue(RippleRetryPolicy.isRetryable(transportError: HTTPError.statusCode(500, nil)))
+    }
+
+    func testClientErrorsAndCancellationAreNotRetryable() {
+        XCTAssertFalse(RippleRetryPolicy.isRetryable(transportError: HTTPError.statusCode(404, nil)))
+        XCTAssertFalse(RippleRetryPolicy.isRetryable(transportError: HTTPError.statusCode(400, nil)))
+        XCTAssertFalse(RippleRetryPolicy.isRetryable(transportError: HTTPError.decodingFailed(HTTPError.noData)))
+        XCTAssertFalse(RippleRetryPolicy.isRetryable(transportError: CancellationError()))
+    }
+
+    func testWrappedCancellationIsNotRetryable() {
+        // Cancellation must never be retried, even wrapped in `.networkError`.
+        XCTAssertFalse(RippleRetryPolicy.isRetryable(transportError: HTTPError.networkError(CancellationError())))
+        XCTAssertFalse(RippleRetryPolicy.isRetryable(transportError: HTTPError.networkError(URLError(.cancelled))))
+        // A genuine transport failure wrapped in `.networkError` still retries.
+        XCTAssertTrue(RippleRetryPolicy.isRetryable(transportError: HTTPError.networkError(URLError(.networkConnectionLost))))
+    }
+
+    // MARK: - Policy: backoff
+
+    func testBackoffIsPositiveMonotonicAndBounded() {
+        let first = RippleRetryPolicy.backoff(forAttempt: 1)
+        let second = RippleRetryPolicy.backoff(forAttempt: 2)
+        XCTAssertEqual(first, .milliseconds(250))
+        XCTAssertEqual(second, .milliseconds(500))
+        XCTAssertLessThan(first, second)
+        // Bounded: the largest backoff within the retry budget stays sub-second.
+        let last = RippleRetryPolicy.backoff(forAttempt: RippleRetryPolicy.maxAttempts - 1)
+        XCTAssertLessThanOrEqual(last, .milliseconds(500))
+    }
+
+    // MARK: - Retrier: generic behavior
+
+    func testRetryableRpcErrorThenSuccessIsRetried() async throws {
+        let stub = SequencedHTTPClient()
+        stub.enqueue(FakeRippleResponse(rpcError: "amendmentBlocked", tag: "stale"))
+        stub.enqueue(FakeRippleResponse(rpcError: nil, tag: "ok"))
+        let sleeper = RecordingSleeper()
+        let retrier = RippleRequestRetrier(httpClient: stub, sleep: sleeper.sleep)
+
+        let body = try await retrier.request(AnyTarget(), responseType: FakeRippleResponse.self)
+
+        XCTAssertEqual(body.tag, "ok")
+        XCTAssertEqual(stub.callCount, 2, "one initial call + one retry")
+        XCTAssertEqual(sleeper.count, 1, "one backoff before the single retry")
+        assertSameHost(stub, expected: RippleAPI.defaultHost)
+    }
+
+    func testNonRetryableErrorSurfacedWithoutRetry() async throws {
+        let stub = SequencedHTTPClient()
+        stub.enqueue(FakeRippleResponse(rpcError: "actNotFound", tag: "unfunded"))
+        let sleeper = RecordingSleeper()
+        let retrier = RippleRequestRetrier(httpClient: stub, sleep: sleeper.sleep)
+
+        let body = try await retrier.request(AnyTarget(), responseType: FakeRippleResponse.self)
+
+        XCTAssertEqual(body.rpcError, "actNotFound", "surfaced unchanged")
+        XCTAssertEqual(stub.callCount, 1, "must not retry a business error")
+        XCTAssertEqual(sleeper.count, 0)
+    }
+
+    func testRetriesExhaustedThrowsLastError() async {
+        let stub = SequencedHTTPClient()
+        // Distinct retryable errors so the surfaced value can only be the LAST
+        // attempted one — not the first or a hard-coded value. A trailing extra
+        // is queued to prove the loop stops at the cap and never reaches it.
+        stub.enqueue(FakeRippleResponse(rpcError: "noNetwork", tag: "a"))
+        stub.enqueue(FakeRippleResponse(rpcError: "tooBusy", tag: "b"))
+        stub.enqueue(FakeRippleResponse(rpcError: "amendmentBlocked", tag: "c"))
+        stub.enqueue(FakeRippleResponse(rpcError: "slowDown", tag: "unreached"))
+        let sleeper = RecordingSleeper()
+        let retrier = RippleRequestRetrier(httpClient: stub, sleep: sleeper.sleep)
+
+        do {
+            _ = try await retrier.request(AnyTarget(), responseType: FakeRippleResponse.self)
+            XCTFail("Expected exhaustion to throw rather than return stale data")
+        } catch let error as RippleRetryError {
+            guard case .exhausted(let rpcError) = error else {
+                return XCTFail("Unexpected RippleRetryError: \(error)")
+            }
+            XCTAssertEqual(rpcError, "amendmentBlocked", "the LAST attempted error is surfaced")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(stub.callCount, RippleRetryPolicy.maxAttempts, "bounded: 1 try + (maxAttempts - 1) retries")
+        XCTAssertEqual(sleeper.count, RippleRetryPolicy.maxAttempts - 1)
+        assertSameHost(stub, expected: RippleAPI.defaultHost)
+    }
+
+    func testTransientTransportErrorThenSuccessIsRetried() async throws {
+        let stub = SequencedHTTPClient()
+        stub.enqueueError(HTTPError.timeout)
+        stub.enqueue(FakeRippleResponse(rpcError: nil, tag: "ok"))
+        let sleeper = RecordingSleeper()
+        let retrier = RippleRequestRetrier(httpClient: stub, sleep: sleeper.sleep)
+
+        let body = try await retrier.request(AnyTarget(), responseType: FakeRippleResponse.self)
+
+        XCTAssertEqual(body.tag, "ok")
+        XCTAssertEqual(stub.callCount, 2)
+        XCTAssertEqual(sleeper.count, 1)
+    }
+
+    func testNonRetryableTransportErrorSurfacedWithoutRetry() async {
+        let stub = SequencedHTTPClient()
+        stub.enqueueError(HTTPError.statusCode(404, nil))
+        let sleeper = RecordingSleeper()
+        let retrier = RippleRequestRetrier(httpClient: stub, sleep: sleeper.sleep)
+
+        do {
+            _ = try await retrier.request(AnyTarget(), responseType: FakeRippleResponse.self)
+            XCTFail("Expected the 404 to propagate")
+        } catch let error as HTTPError {
+            if case .statusCode(let code, _) = error {
+                XCTAssertEqual(code, 404)
+            } else {
+                XCTFail("Unexpected HTTPError: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(stub.callCount, 1)
+        XCTAssertEqual(sleeper.count, 0)
+    }
+
+    func testCancellationIsNotRetried() async {
+        let stub = SequencedHTTPClient()
+        stub.enqueueError(CancellationError())
+        let sleeper = RecordingSleeper()
+        let retrier = RippleRequestRetrier(httpClient: stub, sleep: sleeper.sleep)
+
+        do {
+            _ = try await retrier.request(AnyTarget(), responseType: FakeRippleResponse.self)
+            XCTFail("Expected the cancellation to propagate")
+        } catch is CancellationError {
+            // expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(stub.callCount, 1, "cancellation must never be retried")
+    }
+
+    // MARK: - Broadcast idempotency (real RippleSubmitResponse)
+
+    func testBroadcastRetriesAmendmentBlockedThenReturnsHash() async throws {
+        let stub = SequencedHTTPClient()
+        stub.enqueue(Self.decode(RippleSubmitResponse.self, Self.amendmentBlockedBody))
+        stub.enqueue(Self.decode(RippleSubmitResponse.self, Self.submitSuccessBody))
+        let sleeper = RecordingSleeper()
+        let service = RippleService(resolver: NoOverrideResolver(), httpClient: stub, sleep: sleeper.sleep)
+
+        let hash = try await service.broadcastTransaction("DEADBEEF")
+
+        XCTAssertEqual(hash, "ABC123")
+        XCTAssertEqual(stub.callCount, 2, "one blocked submit + one healthy submit — no duplicate submit")
+        assertSameHost(stub, expected: RippleAPI.defaultHost)
+    }
+
+    func testBroadcastExhaustedIsBoundedAndThrows() async {
+        let stub = SequencedHTTPClient()
+        for _ in 0..<10 { stub.enqueue(Self.decode(RippleSubmitResponse.self, Self.amendmentBlockedBody)) }
+        let sleeper = RecordingSleeper()
+        let service = RippleService(resolver: NoOverrideResolver(), httpClient: stub, sleep: sleeper.sleep)
+
+        do {
+            _ = try await service.broadcastTransaction("DEADBEEF")
+            XCTFail("Expected broadcast to surface the node error after the cap")
+        } catch let error as RippleRetryError {
+            guard case .exhausted(let rpcError) = error else {
+                return XCTFail("Unexpected RippleRetryError: \(error)")
+            }
+            XCTAssertEqual(rpcError, "amendmentBlocked")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(stub.callCount, RippleRetryPolicy.maxAttempts, "broadcast must not submit beyond the retry bound")
+    }
+
+    // MARK: - Read paths (server_state / account_info)
+
+    func testFetchServerStateRetriesAmendmentBlockedThenSucceeds() async throws {
+        let stub = SequencedHTTPClient()
+        stub.enqueue(Self.decode(RippleServerStateResponse.self, Self.amendmentBlockedBody))
+        stub.enqueue(Self.decode(RippleServerStateResponse.self, Self.serverStateBody))
+        let sleeper = RecordingSleeper()
+        let service = RippleService(resolver: NoOverrideResolver(), httpClient: stub, sleep: sleeper.sleep)
+
+        let state = try await service.fetchServerState()
+
+        XCTAssertEqual(state?.result?.state?.validatedLedger?.baseFee, 10)
+        XCTAssertEqual(stub.callCount, 2)
+        assertSameHost(stub, expected: RippleAPI.defaultHost)
+    }
+
+    func testFetchAccountsInfoRetriesAmendmentBlockedThenSucceeds() async throws {
+        let stub = SequencedHTTPClient()
+        stub.enqueue(Self.decode(RippleAccountResponse.self, Self.amendmentBlockedBody))
+        stub.enqueue(Self.decode(RippleAccountResponse.self, Self.accountInfoBody))
+        let sleeper = RecordingSleeper()
+        let service = RippleService(resolver: NoOverrideResolver(), httpClient: stub, sleep: sleeper.sleep)
+
+        let info = try await service.fetchAccountsInfo(for: "rTestAccount")
+
+        XCTAssertEqual(info?.result?.accountData?.balance, "5000000")
+        XCTAssertEqual(stub.callCount, 2)
+    }
+
+    func testFetchAccountsInfoExhaustedThrowsRatherThanReturningEmptyBody() async {
+        // Pins the Step 1 fix: a persistent amendmentBlocked must NOT resolve to
+        // an empty account body (which would make getBalance report "0").
+        let stub = SequencedHTTPClient()
+        for _ in 0..<10 { stub.enqueue(Self.decode(RippleAccountResponse.self, Self.amendmentBlockedBody)) }
+        let sleeper = RecordingSleeper()
+        let service = RippleService(resolver: NoOverrideResolver(), httpClient: stub, sleep: sleeper.sleep)
+
+        do {
+            _ = try await service.fetchAccountsInfo(for: "rTestAccount")
+            XCTFail("Expected exhaustion to throw rather than return an empty account body")
+        } catch let error as RippleRetryError {
+            guard case .exhausted(let rpcError) = error else {
+                return XCTFail("Unexpected RippleRetryError: \(error)")
+            }
+            XCTAssertEqual(rpcError, "amendmentBlocked")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(stub.callCount, RippleRetryPolicy.maxAttempts)
+    }
+
+    // MARK: - Status lookup (the reported failure path)
+
+    func testStatusLookupRetriesAmendmentBlockedThenConfirms() async throws {
+        // Reproduces the reported bug: the tx already succeeded on-chain, but the
+        // status check hit a stale backend and surfaced amendmentBlocked.
+        let stub = SequencedHTTPClient()
+        stub.enqueue(Self.decode(RippleTransactionStatusResponse.self, Self.statusAmendmentBlockedBody))
+        stub.enqueue(Self.decode(RippleTransactionStatusResponse.self, Self.statusConfirmedBody))
+        let sleeper = RecordingSleeper()
+        let provider = RippleTransactionStatusProvider(httpClient: stub, sleep: sleeper.sleep)
+
+        let result = try await provider.checkStatus(
+            query: TransactionStatusQuery(txHash: "ABC123", chain: .ripple)
+        )
+
+        XCTAssertEqual(result.status, .confirmed)
+        XCTAssertEqual(stub.callCount, 2)
+        XCTAssertEqual(sleeper.count, 1)
+        assertSameHost(stub, expected: RippleAPI.defaultHost)
+    }
+
+    // MARK: - Helpers
+
+    /// Every request (initial + retries) must go to the same host — the fix is a
+    /// same-host retry with no fallback list.
+    private func assertSameHost(
+        _ stub: SequencedHTTPClient,
+        expected: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertFalse(stub.requestedHosts.isEmpty, "no request was made", file: file, line: line)
+        XCTAssertEqual(Set(stub.requestedHosts).count, 1, "a retry switched hosts", file: file, line: line)
+        for host in stub.requestedHosts {
+            XCTAssertEqual(host, expected, file: file, line: line)
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static let amendmentBlockedBody = #"{"result":{"error":"amendmentBlocked","status":"error"}}"#
+    private static let submitSuccessBody = #"""
+    {"result":{"engine_result":"tesSUCCESS","engine_result_message":"ok","tx_json":{"hash":"ABC123"}}}
+    """#
+    private static let serverStateBody = #"""
+    {"result":{"state":{"load_base":256,"load_factor":256,"validated_ledger":{"base_fee":10,"reserve_base":1000000,"reserve_inc":200000}}}}
+    """#
+    private static let accountInfoBody = #"""
+    {"result":{"account_data":{"Account":"rTestAccount","Balance":"5000000","OwnerCount":0}}}
+    """#
+    private static let statusAmendmentBlockedBody = #"{"result":{"error":"amendmentBlocked","status":"error"}}"#
+    private static let statusConfirmedBody = #"""
+    {"result":{"validated":true,"ledger_index":123,"meta":{"TransactionResult":"tesSUCCESS"}}}
+    """#
+
+    private static func decode<T: Decodable>(_: T.Type, _ json: String) -> T {
+        // swiftlint:disable:next force_try
+        try! JSONDecoder().decode(T.self, from: Data(json.utf8))
+    }
+}
+
+// MARK: - Test doubles
+
+/// A minimal `RippleRPCResponse` for exercising the retry loop independently of
+/// the concrete Ripple response types.
+private struct FakeRippleResponse: Decodable, RippleRPCResponse {
+    let rpcError: String?
+    let tag: String
+}
+
+/// Records backoff calls without sleeping, so retry tests run instantly.
+private final class RecordingSleeper: @unchecked Sendable {
+    private(set) var count = 0
+    private(set) var durations: [Duration] = []
+
+    var sleep: RippleRequestRetrier.Sleeper {
+        { [self] duration in
+            count += 1
+            durations.append(duration)
+        }
+    }
+}
+
+/// Resolver that never overrides — the service falls back to the default host.
+private struct NoOverrideResolver: RPCEndpointResolving {
+    func url(for _: Chain) -> String? { nil }
+}
+
+/// A trivial `TargetType` for driving the retrier in isolation.
+private struct AnyTarget: TargetType {
+    var baseURL: URL { RippleAPI.defaultHost }
+    var path: String { "/" }
+    var method: HTTPMethod { .post }
+    var task: HTTPTask { .requestPlain }
+}
+
+/// Returns queued decoded values / errors in FIFO order and counts calls.
+private final class SequencedHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    private enum Item {
+        case value(Any)
+        case error(Error)
+    }
+
+    private var items: [Item] = []
+    private(set) var callCount = 0
+    /// The base URL of every request the retrier issued, in order. Used to pin
+    /// the SAME-HOST guarantee: a retry must reuse the same host (no fallback).
+    private(set) var requestedHosts: [URL] = []
+
+    func enqueue<T>(_ value: T) {
+        items.append(.value(value))
+    }
+
+    func enqueueError(_ error: Error) {
+        items.append(.error(error))
+    }
+
+    // SwiftLint can't see across the protocol conformance; the bodies are sync.
+    // swiftlint:disable async_without_await
+    func request(_: TargetType) async throws -> HTTPResponse<Data> {
+        throw HTTPError.invalidResponse
+    }
+
+    func request<T: Decodable>(
+        _ target: TargetType,
+        responseType _: T.Type
+    ) async throws -> HTTPResponse<T> {
+        callCount += 1
+        requestedHosts.append(target.baseURL)
+        guard !items.isEmpty else {
+            XCTFail("SequencedHTTPClient exhausted after \(callCount) calls")
+            throw HTTPError.invalidResponse
+        }
+        let item = items.removeFirst()
+        switch item {
+        case .error(let error):
+            throw error
+        case .value(let raw):
+            guard let typed = raw as? T else {
+                XCTFail("Queued value type \(Swift.type(of: raw)) does not match \(T.self)")
+                throw HTTPError.invalidResponse
+            }
+            let stub = HTTPURLResponse(
+                url: RippleAPI.defaultHost,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return HTTPResponse(data: typed, response: stub)
+        }
+    }
+
+    func requestEmpty(_: TargetType) async throws -> HTTPResponse<EmptyResponse> {
+        throw HTTPError.invalidResponse
+    }
+    // swiftlint:enable async_without_await
+}


### PR DESCRIPTION
Closes #4752

## Problem

XRP requests hit a single host (`xrplcluster.com` by default, or a custom override) with **no retry**. `xrplcluster.com` is a load-balanced **pool**; some backend nodes run outdated `rippled` and answer `amendmentBlocked` (error_code 14, returned as **HTTP 200** with `{"result":{"error":"amendmentBlocked",...}}`). One request lands on a stale backend and the error bubbles straight up — intermittently, "from time to time."

Observed on a `tx` status lookup after a send: the transaction had **already succeeded on-chain** (`tesSUCCESS`, validated), but the status check hit a bad backend and surfaced `amendmentBlocked`, so the app showed an error / unconfirmed state for a send that actually landed. The same pool-node issue can transiently affect broadcast, status, and account/fee/server_state reads.

## Fix — bounded SAME-HOST retry, no fallback list

**Retry the same resolved host on transient node errors — NO fallback host list.** Because the host is a pool, a retry hits a different backend, which is almost always healthy. Unlike Solana, we deliberately do **not** add a `publicFallbackHosts`-style list; this stays a bounded same-host retry.

- Detection reads the **decoded JSON-RPC body** (`result.error`), not the HTTP status — `amendmentBlocked` comes back as HTTP 200.
- Applied at the `RippleService` request layer via a shared `RippleRequestRetrier`, so **broadcast (`submit`), status (`tx`), and reads (`account_info`, `server_state`, fee)** all benefit.
- **Bounded:** 3 attempts total (1 try + up to 2 retries), linear backoff (0.25s, 0.5s). Added latency stays low in the time-sensitive post-signing window.
- No signing-path changes — request/transport resiliency only.

### Retryable set (from the decoded body's `result.error`)

`amendmentBlocked`, `noNetwork`, `noCurrent`, `noClosed`, `tooBusy`, `slowDown`, and `failedToForward`.

- `tooBusy` / `slowDown` are per-backend overload signals emitted by the node (not the pool edge), so a pool retry lands on a different node; bounded by the attempt cap + backoff, so including them is safe.
- `failedToForward` (Clio's forwarding-failure error on exactly the forwarded commands — `submit`/`server_state`/`fee`) was added on cross-model review: it's squarely a transient per-node fault the same-host pool retry routes around.

Transient **transport** failures are also retried: `HTTPError.timeout`, `HTTPError.networkError`, `HTTPError.statusCode(5xx)`. Task cancellation is **never** retried (even wrapped in `.networkError`).

**Non-retryable** JSON-RPC errors pass through UNCHANGED: `actNotFound`, `txnNotFound`, `invalidParams`, engine `tef*`/`tec*`/`tem*`/`ter*`/`tel*` codes, etc. They're real outcomes, not transient node faults. When the retryable set is exhausted, the last transient error is surfaced as `RippleRetryError.exhausted` rather than silently returned as data (which would e.g. make a persistently-`amendmentBlocked` balance read report `0`).

### Also (whole-branch review)

`RippleTransactionStatusAPI` hard-coded `xrplcluster.com`, so a custom Ripple RPC override sent submit/reads to the configured node but the status lookup (and its retry) to the default pool. The status API now takes the resolver-resolved host, so the "same **resolved** host" guarantee holds for status too (default `xrplcluster.com` when no override → behavior-preserving).

## Broadcast idempotency (safety)

Resubmitting the same signed blob is safe: XRPL `submit` is deterministic on the blob → same tx hash; an already-applied tx returns `tefALREADY`/`tesSUCCESS` (non-retryable, handled downstream). The retry re-sends identical bytes, never generates a new signature, and is bounded by the attempt cap — no double-spend. `amendmentBlocked` on `submit` means the blocked backend didn't apply the tx, so the retry is the first real apply. This **composes with, but is independent of,** the broadcast result-code classification work (#4746) — this PR is off `main`.

## Test coverage

New `RippleRetryTests` (24 tests, injected no-op clock — no real sleeps; sequenced `HTTPClientProtocol` stub):
- Policy: each retryable rpc code → retried; `actNotFound`/`txnNotFound`/`invalidParams`/`tef*` → not retried; transport timeout/networkError/5xx → retried; 4xx/decode/cancellation (incl. wrapped) → not; backoff monotonic + bounded.
- Retrier: retryable → retried → success; non-retryable surfaced without retry; exhaustion throws the **last** transient error (distinct errors queued to prove it) and is bounded to the attempt cap; transient transport retried; every retry stays on the **same host** (no fallback).
- Broadcast: `amendmentBlocked` → retried → returns the hash; exhausted → throws, no submit beyond the bound.
- Reads: `fetchServerState` / `fetchAccountsInfo` retry then succeed; exhausted `account_info` throws rather than returning an empty body.
- Status: `amendmentBlocked` → retried → confirmed; preserved behaviors pinned — HTTP 404 → notFound, `txnNotFound` → notFound, validated non-`tesSUCCESS` → failed, each without retrying.

## Gate

Full `make test` on a dedicated iPhone 17 Pro Max (iOS 26.5, en_US): **2389 tests, 0 failures — TEST SUCCEEDED.** SwiftLint clean on all changed files. Cross-model (Codex) review loop: per-commit + whole-branch passes, all findings triaged (fixed/justified) with a final clean pass.

## Not done

- On-device / two-device broadcast + status pass on XRP (simulate a stale-backend hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded same-host retries for Ripple JSON-RPC calls, with linear backoff and improved resilience for transient node/network issues.
  * Ripple transaction status and service requests now route through the shared retry mechanism.

* **Bug Fixes**
  * Enhanced decoding of node-level RPC errors from successful (HTTP-200) responses and surfaced them consistently across Ripple responses.
  * Improved status lookup parsing to read the correct result field and handle missing results as “not found”.

* **Tests**
  * Added retry policy/backoff coverage, retrier exhaustion behavior, cancellation non-retry rules, and end-to-end Ripple service/provider flow tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->