### PR TITLE
feat(ripple): restore memo on plain XRP sends + destination tag & memo together

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDestinationTag.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDestinationTag.swift
@@ -83,11 +83,19 @@ enum RippleDestinationTag {
 /// join it (dApp/deeplink-originated payloads included).
 enum RippleMemoError: LocalizedError, Equatable {
     case invalidMemo(String)
+    /// A plain payment carried BOTH a first-class tag field AND a memo slot
+    /// holding a DIFFERENT canonical number — the two would read as conflicting
+    /// destination tags. Only reachable via a malformed/hand-crafted payload
+    /// (the form blocks it); the signer rejects it deterministically rather than
+    /// pick one.
+    case tagMemoConflict(tag: UInt32, memo: String)
 
     var errorDescription: String? {
         switch self {
         case .invalidMemo:
             return "xrpMemoNotDestinationTagError".localized
+        case .tagMemoConflict:
+            return "destinationTagMemoConflictError".localized
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDestinationTag.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDestinationTag.swift
@@ -108,7 +108,11 @@ enum RippleMemoError: LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .invalidMemo:
-            return "xrpMemoNotDestinationTagError".localized
+            // Now that text memos are supported again, the only payload the
+            // signer rejects here is a zero / out-of-range destination tag —
+            // reuse the accurate form-side copy instead of the stale
+            // "text memos aren't supported" message.
+            return "destinationTagInvalidError".localized
         case .tagMemoConflict:
             return "destinationTagMemoConflictError".localized
         }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDestinationTag.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDestinationTag.swift
@@ -75,6 +75,21 @@ enum RippleDestinationTag {
         }
         return payload.memo.flatMap(parseTag)
     }
+
+    /// Genuine on-chain TEXT memo to display for a plain XRP PAYMENT — the
+    /// tag+memo combo, or a memo-only send. Returns `nil` when the memo slot is
+    /// a numeric destination-tag carrier (echo / legacy workaround), for swaps,
+    /// and for non-XRP: those either surface via the Destination Tag row or keep
+    /// their own memo handling. Mirrors the signer, which routes exactly these
+    /// text memos to an on-chain `Memos` blob — so a co-signer sees the same
+    /// memo it is about to sign.
+    static func displayMemo(for payload: KeysignPayload) -> String? {
+        guard payload.coin.chain == .ripple, payload.swapPayload == nil else { return nil }
+        guard let memo = payload.memo, !memo.isEmpty else { return nil }
+        // A canonical uint32 decimal is a tag carrier, not text.
+        guard parseCanonical(memo) == nil else { return nil }
+        return memo
+    }
 }
 
 /// Typed, user-presentable rejection for XRP payloads whose memo slot

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -63,9 +63,10 @@ enum RippleHelper {
             //   must ride the on-chain `Memos` field for THORChain to read.
             if let memoValue = keysignPayload.memo, !memoValue.isEmpty {
                 guard let numericTag = UInt64(memoValue) else {
-                    return try swapMemoSigningInput(
+                    return try memoSigningInput(
                         keysignPayload: keysignPayload,
                         memoValue: memoValue,
+                        destinationTag: nil,
                         gas: gas,
                         sequence: sequence,
                         lastLedgerSequence: lastLedgerSequence,
@@ -77,33 +78,82 @@ enum RippleHelper {
                 destinationTag = nil
             }
         } else if let fieldDestinationTag {
-            // Dual-write rollout: prefer the first-class RippleSpecific
-            // `destination_tag`. The initiator writes the same value into both
-            // this field and the memo carrier, so a co-signer that reads only
-            // the memo rebuilds an identical signing input — the pre-image hash
-            // matches across mixed-version device pairs. When the field is
-            // present it wins outright (the memo is not re-validated): a
-            // divergent memo can at worst fail the ceremony on a legacy peer,
-            // never produce a signature.
+            // Plain payment WITH a first-class tag field. The initiator
+            // dual-writes the tag into the field and populates the memo slot per
+            // the send it built (empty / echoed tag / real text). Resolve the
+            // pair deterministically so every device — new field-reader and old
+            // memo-only co-signer alike — either agrees on the bytes or fails
+            // the ceremony (never signs the wrong tx):
             //
-            // A present tag of 0 is rejected exactly as the memo path rejects
-            // "0": wallet-core serialises a 0 destinationTag identically to
-            // "no tag", so signing it would produce an UNTAGGED payment while a
-            // tag was displayed — the dishonest-signing shape the contract
-            // forbids. (No wallet-core signer can produce a tagged-0 payment on
-            // any platform, so a 0 field is always malformed.)
+            // - A present tag of 0 is rejected exactly as memo "0" is:
+            //   wallet-core serialises a 0 destinationTag identically to "no
+            //   tag", so signing it would send UNTAGGED while a tag was
+            //   displayed — the dishonest-signing shape the contract forbids.
             guard fieldDestinationTag != 0 else {
                 throw RippleMemoError.invalidMemo(String(fieldDestinationTag))
             }
-            destinationTag = UInt64(fieldDestinationTag)
+
+            if let memoValue = keysignPayload.memo, !memoValue.isEmpty {
+                if memoValue == String(fieldDestinationTag) {
+                    // Dual-write ECHO: the memo carries the tag's own canonical
+                    // decimal. Build a plain tag-only payment (NO Memos) — this
+                    // is byte-identical to the tag-only path an old memo-only
+                    // co-signer produces, keeping the committee in agreement.
+                    destinationTag = UInt64(fieldDestinationTag)
+                } else if RippleDestinationTag.parseCanonical(memoValue) != nil {
+                    // A DIFFERENT canonical number can't ride alongside the tag
+                    // (the memo slot would read as a second, conflicting tag on
+                    // a legacy peer). Reject deterministically.
+                    throw RippleMemoError.tagMemoConflict(tag: fieldDestinationTag, memo: memoValue)
+                } else {
+                    // COMBO: a genuine text memo alongside the tag. XRPL carries
+                    // both as independent fields; wallet-core's typed payment has
+                    // no memo slot, so build a rawJson Payment with BOTH the
+                    // DestinationTag and a Memos blob. (An OLD co-signer with no
+                    // field reads only the text memo → builds a Memos-only tx
+                    // without the tag → hash diverges → the ceremony fails safe.
+                    // Accepted mixed-version limitation, gated by a send-form
+                    // advisory.)
+                    return try memoSigningInput(
+                        keysignPayload: keysignPayload,
+                        memoValue: memoValue,
+                        destinationTag: fieldDestinationTag,
+                        gas: gas,
+                        sequence: sequence,
+                        lastLedgerSequence: lastLedgerSequence,
+                        publicKey: publicKey
+                    )
+                }
+            } else {
+                // Tag-only (empty memo).
+                destinationTag = UInt64(fieldDestinationTag)
+            }
+        } else if let memoValue = keysignPayload.memo, !memoValue.isEmpty {
+            // Plain payment, NO field — the memo slot is the source of truth
+            // (what every legacy platform reads):
+            if RippleDestinationTag.parseCanonical(memoValue) != nil {
+                // Numeric-canonical → the legacy "type the tag into the memo"
+                // tag carrier. Unchanged from before: a canonical nonzero value
+                // becomes the destinationTag; "0" is rejected.
+                destinationTag = try RippleDestinationTag.validatePayloadMemo(memoValue).map(UInt64.init)
+            } else {
+                // Genuine text → an on-chain `Memos` blob. This RESTORES the
+                // pre-#4749 memo-only capability (memo-only sends are
+                // byte-identical old-vs-new: no field on the wire, same text in
+                // the memo slot).
+                return try memoSigningInput(
+                    keysignPayload: keysignPayload,
+                    memoValue: memoValue,
+                    destinationTag: nil,
+                    gas: gas,
+                    sequence: sequence,
+                    lastLedgerSequence: lastLedgerSequence,
+                    publicKey: publicKey
+                )
+            }
         } else {
-            // Plain payments with no field: the memo slot is the destination-tag
-            // carrier — it must be empty or a canonical uint32 decimal, and
-            // anything else rejects the payload on both sides of the ceremony
-            // (see `RippleDestinationTag`). This replaces the legacy fallback
-            // that turned non-numeric memos into an on-chain `Memos` blob, which
-            // silently dropped the tag and left exchange deposits uncredited.
-            destinationTag = try RippleDestinationTag.validatePayloadMemo(keysignPayload.memo).map(UInt64.init)
+            // No field, no memo → plain untagged payment.
+            destinationTag = nil
         }
 
         let operation = RippleOperationPayment.with {
@@ -128,20 +178,30 @@ enum RippleHelper {
         return try input.serializedData()
     }
 
-    /// Legacy raw-JSON signing input carrying the memo as an on-chain XRPL
-    /// `Memos` entry. Reachable only for swap payloads — THORChain-family
-    /// swaps route via a text memo the protocol reads on-chain. Plain sends
-    /// never take this path anymore: a text memo there was the fund-loss
-    /// shape (tag typo → Memos blob → uncredited exchange deposit).
-    private static func swapMemoSigningInput(
+    /// Raw-JSON signing input carrying a text memo as an on-chain XRPL `Memos`
+    /// entry, optionally alongside a native `DestinationTag`. wallet-core's
+    /// typed `RippleOperationPayment` has no memo field, so any transaction that
+    /// must carry an on-chain memo has to go through rawJson.
+    ///
+    /// Two callers:
+    /// - **swaps** (`destinationTag == nil`) — THORChain-family swaps route via
+    ///   a text memo the protocol reads on-chain. This branch is byte-identical
+    ///   to the legacy `swapMemoSigningInput` (same key set), so swap signing is
+    ///   unchanged.
+    /// - **plain tag + memo combo** (`destinationTag != nil`) — a plain XRP send
+    ///   carrying BOTH a destination tag and a text memo (XRPL allows both as
+    ///   independent fields). Adds a numeric `DestinationTag` next to the Memos
+    ///   blob.
+    private static func memoSigningInput(
         keysignPayload: KeysignPayload,
         memoValue: String,
+        destinationTag: UInt32?,
         gas: UInt64,
         sequence: UInt64,
         lastLedgerSequence: UInt64,
         publicKey: PublicKey
     ) throws -> Data {
-        let txJson: [String: Any] = [
+        var txJson: [String: Any] = [
             "TransactionType": "Payment",
             "Account": keysignPayload.coin.address,
             "Destination": keysignPayload.toAddress,
@@ -157,6 +217,12 @@ enum RippleHelper {
                 ]
             ]
         ]
+        // Only inserted for the combo path, so the swap dict keeps the exact key
+        // set (and therefore byte-identical serialization) it has always had.
+        // XRPL `DestinationTag` is a numeric field — emit a JSON number.
+        if let destinationTag {
+            txJson["DestinationTag"] = destinationTag
+        }
 
         let jsonData = try JSONSerialization.data(withJSONObject: txJson, options: [])
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
@@ -172,7 +238,7 @@ enum RippleHelper {
             $0.rawJson = jsonString
         }
 
-        logger.info("Creating XRP swap transaction with text memo, lastLedgerSequence: \(lastLedgerSequence)")
+        logger.info("Creating XRP rawJson payment (memo\(destinationTag != nil ? " + tag" : "", privacy: .public)), lastLedgerSequence: \(lastLedgerSequence)")
 
         return try input.serializedData()
     }

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAdditionalSection.swift
@@ -25,6 +25,9 @@ struct SendDetailsAdditionalSection: View {
             if viewModel.coin.chain.supportsDestinationTag {
                 addDestinationTagField
             }
+            if showsTagAndMemoAdvisory {
+                tagAndMemoAdvisory
+            }
         }
         .onAppear {
             if !viewModel.memo.isEmpty {
@@ -120,6 +123,32 @@ struct SendDetailsAdditionalSection: View {
             }
             .frame(height: isDestinationTagExpanded ? nil : 0, alignment: .top)
             .clipped()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// A tag+memo combo requires every signing device to be up to date (an old
+    /// co-signer reads only the memo slot and drops the tag). Non-blocking
+    /// advisory — the send still proceeds. Fires only for the REAL combo the
+    /// signer builds: a valid tag AND a genuine TEXT memo. A numeric memo is
+    /// either the tag echo or the legacy carrier — `makeTransaction` strips it
+    /// to a tag-only send, so it must not trip the advisory.
+    private var showsTagAndMemoAdvisory: Bool {
+        viewModel.coin.chain.supportsDestinationTag
+            && RippleDestinationTag.parseTag(viewModel.rippleTag.destinationTag) != nil
+            && !viewModel.memo.isEmpty
+            && RippleDestinationTag.parseCanonical(viewModel.memo) == nil
+    }
+
+    private var tagAndMemoAdvisory: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "info.circle")
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+            Text(NSLocalizedString("xrpTagAndMemoAdvisory", comment: ""))
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1451,6 +1451,7 @@
 "wrongVaultTryAgain" = "Falscher Tresor oder gekoppeltes Gerät.";
 "x" = "x";
 "xrpMemoNotDestinationTagError" = "XRP-Transaktionen unterstützen keine Text-Memos. Bei einer Einzahlung an eine Börse geben Sie das numerische Tag im Feld „Destination Tag“ ein.";
+"xrpTagAndMemoAdvisory" = "Um ein Tag und ein Memo zusammen zu senden, müssen alle Ihre Signiergeräte auf dem neuesten Stand sein.";
 "yes" = "Ja";
 "yesterday" = "Gestern";
 "yieldClaimAmount" = "%@ beanspruchen";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1450,7 +1450,6 @@
 "wrongVaultSelectedDescription" = "Der von Ihnen ausgewählte Vault stimmt nicht mit der Keygen-Sitzung überein. Bitte wählen Sie den richtigen Vault aus.";
 "wrongVaultTryAgain" = "Falscher Tresor oder gekoppeltes Gerät.";
 "x" = "x";
-"xrpMemoNotDestinationTagError" = "XRP-Transaktionen unterstützen keine Text-Memos. Bei einer Einzahlung an eine Börse geben Sie das numerische Tag im Feld „Destination Tag“ ein.";
 "xrpTagAndMemoAdvisory" = "Um ein Tag und ein Memo zusammen zu senden, müssen alle Ihre Signiergeräte auf dem neuesten Stand sein.";
 "yes" = "Ja";
 "yesterday" = "Gestern";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1448,7 +1448,6 @@
 "wrongVaultSelectedDescription" = "The vault you selected doesn't match the keygen session. Please select the correct vault.";
 "wrongVaultTryAgain" = "Wrong Vault or Pair";
 "x" = "X (Twitter)";
-"xrpMemoNotDestinationTagError" = "XRP transactions don't support text memos. If you're depositing to an exchange, enter the numeric tag in the Destination Tag field.";
 "xrpTagAndMemoAdvisory" = "Sending a tag and a memo together requires all your signing devices to be up to date.";
 "yes" = "Yes";
 "yesterday" = "Yesterday";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1449,6 +1449,7 @@
 "wrongVaultTryAgain" = "Wrong Vault or Pair";
 "x" = "X (Twitter)";
 "xrpMemoNotDestinationTagError" = "XRP transactions don't support text memos. If you're depositing to an exchange, enter the numeric tag in the Destination Tag field.";
+"xrpTagAndMemoAdvisory" = "Sending a tag and a memo together requires all your signing devices to be up to date.";
 "yes" = "Yes";
 "yesterday" = "Yesterday";
 "yieldClaimAmount" = "Claim %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1451,6 +1451,7 @@
 "wrongVaultTryAgain" = "Caja Fuerte o Dispositivo Emparejado Incorrecto.";
 "x" = "X (Twitter)";
 "xrpMemoNotDestinationTagError" = "Las transacciones XRP no admiten memorándums de texto. Si estás depositando en un exchange, introduce la etiqueta numérica en el campo Etiqueta de destino.";
+"xrpTagAndMemoAdvisory" = "Enviar una etiqueta y un memorándum juntos requiere que todos tus dispositivos de firma estén actualizados.";
 "yes" = "Sí";
 "yesterday" = "Ayer";
 "yieldClaimAmount" = "Reclamar %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1450,7 +1450,6 @@
 "wrongVaultSelectedDescription" = "El Vault que seleccionaste no coincide con la sesión de keygen. Por favor selecciona el Vault correcto.";
 "wrongVaultTryAgain" = "Caja Fuerte o Dispositivo Emparejado Incorrecto.";
 "x" = "X (Twitter)";
-"xrpMemoNotDestinationTagError" = "Las transacciones XRP no admiten memorándums de texto. Si estás depositando en un exchange, introduce la etiqueta numérica en el campo Etiqueta de destino.";
 "xrpTagAndMemoAdvisory" = "Enviar una etiqueta y un memorándum juntos requiere que todos tus dispositivos de firma estén actualizados.";
 "yes" = "Sí";
 "yesterday" = "Ayer";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1450,7 +1450,6 @@
 "wrongVaultSelectedDescription" = "Vault koji ste odabrali ne odgovara keygen sesiji. Molimo odaberite ispravan Vault.";
 "wrongVaultTryAgain" = "Pogrešan sef ili upareni uređaj.";
 "x" = "x";
-"xrpMemoNotDestinationTagError" = "XRP transakcije ne podržavaju tekstualne bilješke. Ako uplaćujete na mjenjačnicu, unesite brojčanu oznaku u polje Oznaka odredišta.";
 "xrpTagAndMemoAdvisory" = "Slanje oznake i bilješke zajedno zahtijeva da svi vaši uređaji za potpisivanje budu ažurirani.";
 "yes" = "Da";
 "yesterday" = "Jučer";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1451,6 +1451,7 @@
 "wrongVaultTryAgain" = "Pogrešan sef ili upareni uređaj.";
 "x" = "x";
 "xrpMemoNotDestinationTagError" = "XRP transakcije ne podržavaju tekstualne bilješke. Ako uplaćujete na mjenjačnicu, unesite brojčanu oznaku u polje Oznaka odredišta.";
+"xrpTagAndMemoAdvisory" = "Slanje oznake i bilješke zajedno zahtijeva da svi vaši uređaji za potpisivanje budu ažurirani.";
 "yes" = "Da";
 "yesterday" = "Jučer";
 "yieldClaimAmount" = "Preuzmi %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1450,7 +1450,6 @@
 "wrongVaultSelectedDescription" = "Il Vault che hai selezionato non corrisponde alla sessione di keygen. Si prega di selezionare il Vault corretto.";
 "wrongVaultTryAgain" = "Cassaforte o Dispositivo Accoppiato Errato.";
 "x" = "X (Twitter)";
-"xrpMemoNotDestinationTagError" = "Le transazioni XRP non supportano memo di testo. Se stai depositando su un exchange, inserisci il tag numerico nel campo Destination Tag.";
 "xrpTagAndMemoAdvisory" = "Inviare un tag e un memo insieme richiede che tutti i tuoi dispositivi di firma siano aggiornati.";
 "yes" = "Sì";
 "yesterday" = "Ieri";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1451,6 +1451,7 @@
 "wrongVaultTryAgain" = "Cassaforte o Dispositivo Accoppiato Errato.";
 "x" = "X (Twitter)";
 "xrpMemoNotDestinationTagError" = "Le transazioni XRP non supportano memo di testo. Se stai depositando su un exchange, inserisci il tag numerico nel campo Destination Tag.";
+"xrpTagAndMemoAdvisory" = "Inviare un tag e un memo insieme richiede che tutti i tuoi dispositivi di firma siano aggiornati.";
 "yes" = "Sì";
 "yesterday" = "Ieri";
 "yieldClaimAmount" = "Riscuoti %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1414,6 +1414,7 @@
 "wrongVaultTryAgain" = "잘못된 볼트 또는 쌍";
 "x" = "X (Twitter)";
 "xrpMemoNotDestinationTagError" = "XRP 거래는 텍스트 메모를 지원하지 않습니다. 거래소에 입금하는 경우 목적지 태그 필드에 숫자 태그를 입력하세요.";
+"xrpTagAndMemoAdvisory" = "태그와 메모를 함께 보내려면 모든 서명 기기가 최신 상태여야 합니다.";
 "yes" = "예";
 "yesterday" = "어제";
 "yieldClaimAmount" = "%@ 수령";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1413,7 +1413,6 @@
 "wrongVaultSelectedDescription" = "선택한 볼트가 키젠 세션과 일치하지 않습니다. 올바른 볼트를 선택하세요.";
 "wrongVaultTryAgain" = "잘못된 볼트 또는 쌍";
 "x" = "X (Twitter)";
-"xrpMemoNotDestinationTagError" = "XRP 거래는 텍스트 메모를 지원하지 않습니다. 거래소에 입금하는 경우 목적지 태그 필드에 숫자 태그를 입력하세요.";
 "xrpTagAndMemoAdvisory" = "태그와 메모를 함께 보내려면 모든 서명 기기가 최신 상태여야 합니다.";
 "yes" = "예";
 "yesterday" = "어제";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1450,7 +1450,6 @@
 "wrongVaultSelectedDescription" = "O Vault que você selecionou não corresponde à sessão de keygen. Por favor, selecione o Vault correto.";
 "wrongVaultTryAgain" = "Cofre ou Dispositivo Emparelhado Incorreto.";
 "x" = "x";
-"xrpMemoNotDestinationTagError" = "Transações XRP não suportam memorandos de texto. Se estiver depositando em uma exchange, insira a tag numérica no campo Tag de Destino.";
 "xrpTagAndMemoAdvisory" = "Enviar uma tag e um memorando juntos exige que todos os seus dispositivos de assinatura estejam atualizados.";
 "yes" = "Sim";
 "yesterday" = "Ontem";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1451,6 +1451,7 @@
 "wrongVaultTryAgain" = "Cofre ou Dispositivo Emparelhado Incorreto.";
 "x" = "x";
 "xrpMemoNotDestinationTagError" = "Transações XRP não suportam memorandos de texto. Se estiver depositando em uma exchange, insira a tag numérica no campo Tag de Destino.";
+"xrpTagAndMemoAdvisory" = "Enviar uma tag e um memorando juntos exige que todos os seus dispositivos de assinatura estejam atualizados.";
 "yes" = "Sim";
 "yesterday" = "Ontem";
 "yieldClaimAmount" = "Resgatar %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1450,7 +1450,6 @@
 "wrongVaultSelectedDescription" = "您选择的保险库与keygen会话不匹配。请选择正确的保险库。";
 "wrongVaultTryAgain" = "错误的保险库或配对";
 "x" = "X（推特）";
-"xrpMemoNotDestinationTagError" = "XRP 交易不支持文本备忘录。如果您向交易所充值，请在目标标签栏输入数字标签。";
 "xrpTagAndMemoAdvisory" = "同时发送目标标签和备注需要您的所有签名设备都为最新版本。";
 "yes" = "是";
 "yesterday" = "昨天";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1451,6 +1451,7 @@
 "wrongVaultTryAgain" = "错误的保险库或配对";
 "x" = "X（推特）";
 "xrpMemoNotDestinationTagError" = "XRP 交易不支持文本备忘录。如果您向交易所充值，请在目标标签栏输入数字标签。";
+"xrpTagAndMemoAdvisory" = "同时发送目标标签和备注需要您的所有签名设备都为最新版本。";
 "yes" = "是";
 "yesterday" = "昨天";
 "yieldClaimAmount" = "领取 %@";

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignMessageConfirmView.swift
@@ -16,12 +16,19 @@ struct KeysignMessageConfirmView: View {
                 let fees = viewModel.getCalculatedNetworkFee()
                 let lpDictionary = lpMemoDictionary(for: viewModel.keysignPayload)
                 // XRP destination tag the joiner will actually sign (field-
-                // preferred, else the canonical memo carrier). When present it
-                // owns a labeled row and the memo row is suppressed, so the tag
-                // is never shown as a numeric memo (mirrors the initiator, whose
-                // tag lives in a dedicated field, not the memo).
-                let rippleDestinationTag = viewModel.keysignPayload
-                    .flatMap { RippleDestinationTag.displayTag(for: $0) }
+                // preferred, else the canonical memo carrier). It owns a labeled
+                // row; the numeric memo CARRIER is never shown as a memo. A
+                // genuine text memo (tag+memo combo, or memo-only) still shows in
+                // the memo row alongside the tag, so the joiner sees everything
+                // it is about to sign.
+                let ripplePayload = viewModel.keysignPayload
+                let rippleDestinationTag = ripplePayload.flatMap { RippleDestinationTag.displayTag(for: $0) }
+                let rippleMemo = ripplePayload.flatMap { RippleDestinationTag.displayMemo(for: $0) }
+                // Only a PLAIN XRP payment routes its memo through the tag-aware
+                // display: the numeric tag carrier is suppressed (shown as the
+                // tag row) while a genuine text memo (combo / memo-only) shows.
+                // XRP SWAPS keep the raw memo (their on-chain routing memo).
+                let isRipplePlainPayment = ripplePayload?.coin.chain == .ripple && ripplePayload?.swapPayload == nil
                 SendCryptoVerifySummaryView(
                     input: SendCryptoVerifySummary(
                         fromName: viewModel.vault.name,
@@ -29,7 +36,7 @@ struct KeysignMessageConfirmView: View {
                         toAddress: viewModel.keysignPayload?.toAddress ?? .empty,
                         network: viewModel.keysignPayload?.coin.chain.name ?? .empty,
                         networkImage: viewModel.keysignPayload?.coin.chain.logo ?? .empty,
-                        memo: rippleDestinationTag != nil ? .empty : (viewModel.memo ?? .empty),
+                        memo: isRipplePlainPayment ? (rippleMemo ?? .empty) : (viewModel.memo ?? .empty),
                         destinationTag: rippleDestinationTag.map(String.init),
                         decodedFunctionSignature: viewModel.decodedFunctionSignature,
                         decodedFunctionArguments: viewModel.decodedFunctionArguments,

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/RippleDestinationTagViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/RippleDestinationTagViewModel.swift
@@ -26,14 +26,12 @@ final class RippleDestinationTagViewModel {
     enum TagMemoValidation: Equatable {
         case valid
         case invalidTag
-        case memoNotTag
         case tagMemoConflict
 
         var errorKey: String? {
             switch self {
             case .valid: return nil
             case .invalidTag: return "destinationTagInvalidError"
-            case .memoNotTag: return "xrpMemoNotDestinationTagError"
             case .tagMemoConflict: return "destinationTagMemoConflictError"
             }
         }
@@ -133,10 +131,12 @@ final class RippleDestinationTagViewModel {
     // MARK: - Tag / memo contract
 
     /// XRP tag/memo contract:
-    /// - the tag field must be empty or a canonical uint32 decimal;
-    /// - the memo must be empty or canonical numeric (the legacy "type the
-    ///   tag into the memo" workaround), else it's steered to the tag field;
-    /// - both set with different values is a conflict (the wire carries one).
+    /// - the tag field must be empty or a canonical nonzero uint32 decimal;
+    /// - a TEXT memo is accepted — it rides on-chain as a Memos blob (memo-only
+    ///   send, or the tag+memo combo when a tag is also set);
+    /// - a NUMERIC memo is the legacy "type the tag into the memo" carrier: on
+    ///   its own it becomes the tag (zero rejected); alongside a tag field it
+    ///   must match that tag, else it's a conflict (the wire reads two tags).
     func validateTagAndMemo(memo: String) -> TagMemoValidation {
         var fieldTag: UInt32?
         if !destinationTag.isEmpty {
@@ -146,19 +146,20 @@ final class RippleDestinationTagViewModel {
             fieldTag = tag
         }
 
-        if !memo.isEmpty {
-            guard RippleDestinationTag.parseCanonical(memo) != nil else {
-                return .memoNotTag
+        guard !memo.isEmpty else { return .valid }
+
+        // A canonical uint32 decimal in the memo is a tag carrier, not text.
+        if let memoNumber = RippleDestinationTag.parseCanonical(memo) {
+            if let fieldTag {
+                // Tag field + numeric memo: only the echo (equal value) may ride
+                // alongside; a different number reads as a second tag.
+                return memoNumber == fieldTag ? .valid : .tagMemoConflict
             }
-            guard let memoTag = RippleDestinationTag.parseTag(memo) else {
-                // Numeric but zero — same rejection as the field.
-                return .invalidTag
-            }
-            if let fieldTag, memoTag != fieldTag {
-                return .tagMemoConflict
-            }
+            // No tag field: the numeric memo IS the tag — reject a zero tag.
+            return RippleDestinationTag.parseTag(memo) == nil ? .invalidTag : .valid
         }
 
+        // Genuine text memo — restored on-chain Memos support.
         return .valid
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -172,24 +172,35 @@ struct SendCryptoVerifyLogic {
 
     // MARK: - Keysign Payload
 
-    /// Memo slot of the keysign payload. XRP encodes the destination tag
-    /// here as a canonical uint32 decimal — the cross-platform wire contract
-    /// (`RippleDestinationTag`); every co-signer's Ripple builder parses a
-    /// numeric memo into wallet-core's `destinationTag`, so the bytes match
-    /// on every shipped platform version.
+    /// Memo slot of the keysign payload. XRP populates it per the send the
+    /// initiator built (the tag rides the first-class field via
+    /// `dualWritingRippleTag`):
+    /// - a genuine text memo (tag+memo combo, or memo-only) rides the slot as
+    ///   the on-chain memo;
+    /// - a tag-only send ECHOES the tag's canonical uint32 decimal into the
+    ///   slot, so a legacy memo-only co-signer rebuilds the identical tagged
+    ///   payment (byte-parity);
+    /// - otherwise nil.
     static func payloadMemo(tx: SendTransaction) -> String? {
-        if tx.coin.chain == .ripple, let tag = tx.destinationTag {
-            return String(tag)
+        if tx.coin.chain == .ripple {
+            if !tx.memo.isEmpty {
+                return tx.memo
+            }
+            if let tag = tx.destinationTag {
+                return String(tag)
+            }
+            return nil
         }
         return tx.memo.isEmpty ? nil : tx.memo
     }
 
-    /// Dual-write half of the destination-tag rollout: copy the resolved tag
-    /// into the first-class `RippleSpecific.destination_tag` field in addition
-    /// to the memo carrier (`payloadMemo`). The tag is derived from the same
-    /// canonical memo value, so the two carriers can never disagree. A `nil`
-    /// tag leaves the field unset, which keeps memo-only sends byte-identical
-    /// for co-signers that don't read the field. No-op for non-Ripple.
+    /// Dual-write half of the destination-tag rollout: set the first-class
+    /// `RippleSpecific.destination_tag` field from the resolved tag. For a
+    /// tag-only send the memo slot echoes the same value (`payloadMemo`); for a
+    /// tag+memo combo the field holds the tag while the memo slot holds the
+    /// text; a `nil` tag leaves the field unset, keeping memo-only sends
+    /// byte-identical for co-signers that don't read the field. No-op for
+    /// non-Ripple.
     static func dualWritingRippleTag(_ chainSpecific: BlockChainSpecific, tag: UInt32?) -> BlockChainSpecific {
         guard case .Ripple(let sequence, let gas, let lastLedgerSequence, _) = chainSpecific else {
             return chainSpecific
@@ -206,13 +217,15 @@ struct SendCryptoVerifyLogic {
         do {
             var chainSpecific = try await interactor.fetchChainSpecific(tx: tx)
 
-            // Initiator-side gate on the XRP memo contract, mirrored by the
-            // signing helper on every device: fail here, before the ceremony,
-            // with the same typed error the co-signers would raise.
+            // Dual-write the resolved destination tag into the first-class
+            // RippleSpecific field. The memo slot now legitimately carries a
+            // real on-chain memo (tag+memo combo, or memo-only), so it is no
+            // longer re-validated as a tag here — the tag rides the field, and
+            // the signing helper (running on every device, initiator included)
+            // is the ultimate gate on the tag/memo pair.
             let memo = Self.payloadMemo(tx: tx)
             if tx.coin.chain == .ripple {
-                let tag = try RippleDestinationTag.validatePayloadMemo(memo)
-                chainSpecific = Self.dualWritingRippleTag(chainSpecific, tag: tag)
+                chainSpecific = Self.dualWritingRippleTag(chainSpecific, tag: tx.destinationTag)
             }
 
             let basePayload = try await interactor.buildKeysignPayload(

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -725,11 +725,10 @@ final class SendDetailsViewModel {
     /// XRP tag/memo contract, resolved at the form seam so the failure is
     /// actionable while the fields are still on screen:
     /// - the Destination Tag field must be empty or a canonical uint32 decimal;
-    /// - the memo must be empty or numeric (the long-standing "type the tag
-    ///   into the memo" workaround keeps working) — text memos no longer have
-    ///   an on-chain XRP carrier, so they're rejected with copy steering the
-    ///   user to the tag field;
-    /// - both set with different values is a conflict (the wire carries one tag).
+    /// - a TEXT memo is accepted again (restored on-chain memo support) — on its
+    ///   own, or riding alongside a tag as the tag+memo combo;
+    /// - a numeric memo alongside a DIFFERENT tag is a conflict (the wire would
+    ///   read two tags).
     func validateRippleTagAndMemo() -> Bool {
         guard coin.chain == .ripple else { return true }
 
@@ -828,11 +827,16 @@ final class SendDetailsViewModel {
         guard amount.isValidDecimal(), !toAddress.isEmpty, !amountDecimal.isZero else {
             throw MakeTransactionError.invalidForm
         }
-        // XRP: once a tag resolved (field or legacy numeric memo), the tag is
-        // the single source of truth — blank the memo so Verify shows one
-        // honest "Destination Tag" row instead of a duplicated numeric memo.
+        // XRP: keep only a genuine TEXT memo (the tag+memo combo, or a
+        // memo-only send). A numeric memo was either consumed as the tag
+        // (legacy "type the tag into the memo" workaround) or echoes the tag
+        // field, so it must NOT also ride as an on-chain memo — blank it so the
+        // tag is the single source of truth and Verify shows one honest row.
         let resolvedTag = resolvedDestinationTag
-        let effectiveMemo = (coin.chain == .ripple && resolvedTag != nil) ? "" : memo
+        let effectiveMemo: String = {
+            guard coin.chain == .ripple else { return memo }
+            return RippleDestinationTag.parseCanonical(memo) != nil ? "" : memo
+        }()
         return SendTransaction(
             coin: coin,
             vault: vault,

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagThreadingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagThreadingTests.swift
@@ -406,11 +406,19 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
     }
 
     @MainActor
-    func testPayloadMemoTagWinsOverMemoText() {
-        // Belt-and-braces: the form blocks this combination, but if a tag is
-        // present it owns the memo slot.
-        let tx = Self.makeSendTransaction(memo: "12345", destinationTag: 12345)
+    func testPayloadMemoEchoWhenTagOnly() {
+        // Tag-only send (blank memo): the memo slot echoes the tag's canonical
+        // decimal so a legacy memo-only co-signer rebuilds the identical tag.
+        let tx = Self.makeSendTransaction(memo: "", destinationTag: 12345)
         XCTAssertEqual(SendCryptoVerifyLogic.payloadMemo(tx: tx), "12345")
+    }
+
+    @MainActor
+    func testPayloadMemoTextRidesTheSlotForCombo() {
+        // Combo: a genuine text memo alongside a tag rides the memo slot as-is
+        // (the tag rides the first-class field, not the memo).
+        let tx = Self.makeSendTransaction(memo: "hello", destinationTag: 12345)
+        XCTAssertEqual(SendCryptoVerifyLogic.payloadMemo(tx: tx), "hello")
     }
 
     // MARK: - Dual-write (initiator sets BOTH carriers)
@@ -517,11 +525,41 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
     }
 
     @MainActor
-    func testRippleTextMemoBlockedWithSteeringCopy() {
+    func testRippleTextMemoRestoredAsMemoOnly() throws {
+        // #4755: a plain XRP send accepts a text memo again — it threads through
+        // as a memo-only send (no tag), restoring the on-chain Memos capability.
         let vm = Self.makeRippleForm()
         vm.memo = "thanks for lunch"
-        XCTAssertFalse(vm.validateRippleTagAndMemo())
-        XCTAssertEqual(vm.errorMessage, "xrpMemoNotDestinationTagError")
+        XCTAssertTrue(vm.validateRippleTagAndMemo())
+        let tx = try vm.makeTransaction()
+        XCTAssertNil(tx.destinationTag)
+        XCTAssertEqual(tx.memo, "thanks for lunch")
+        XCTAssertEqual(SendCryptoVerifyLogic.payloadMemo(tx: tx), "thanks for lunch")
+    }
+
+    @MainActor
+    func testRippleTagAndTextMemoThreadsAsCombo() throws {
+        // #4755 combo: a tag field AND a genuine text memo both survive to the
+        // transaction — the tag rides the dedicated field, the text rides the
+        // memo slot.
+        let vm = Self.makeRippleForm()
+        vm.rippleTag.destinationTag = "12345"
+        vm.memo = "gift for alice"
+        XCTAssertTrue(vm.validateRippleTagAndMemo())
+        let tx = try vm.makeTransaction()
+        XCTAssertEqual(tx.destinationTag, 12345)
+        XCTAssertEqual(tx.memo, "gift for alice")
+        XCTAssertEqual(SendCryptoVerifyLogic.payloadMemo(tx: tx), "gift for alice")
+
+        // End to end: the combo builds a rawJson Payment carrying BOTH fields.
+        let chainSpecific = SendCryptoVerifyLogic.dualWritingRippleTag(
+            .Ripple(sequence: 1, gas: 10, lastLedgerSequence: 100), tag: tx.destinationTag
+        )
+        guard case .Ripple(_, _, _, let fieldTag) = chainSpecific else { return XCTFail("expected Ripple") }
+        let payload = Self.makeRipplePayload(memo: SendCryptoVerifyLogic.payloadMemo(tx: tx), destinationTagField: fieldTag)
+        let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload))
+        XCTAssertTrue(input.rawJson.contains("DestinationTag"))
+        XCTAssertTrue(input.rawJson.contains("Memos"))
     }
 
     @MainActor

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagThreadingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagThreadingTests.swift
@@ -168,6 +168,29 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
         XCTAssertNil(RippleDestinationTag.displayTag(for: payload))
     }
 
+    // MARK: - Cosigner memo display (#4755 combo + memo-only)
+
+    func testDisplayMemoShowsGenuineTextMemo() {
+        // Combo: the co-signer sees BOTH the tag row AND the text memo it signs.
+        let combo = Self.makeRipplePayload(memo: "gift for alice", destinationTagField: 12345)
+        XCTAssertEqual(RippleDestinationTag.displayMemo(for: combo), "gift for alice")
+        XCTAssertEqual(RippleDestinationTag.displayTag(for: combo), 12345)
+
+        // Memo-only: text memo, no tag.
+        let memoOnly = Self.makeRipplePayload(memo: "invoice 42-b", destinationTagField: nil)
+        XCTAssertEqual(RippleDestinationTag.displayMemo(for: memoOnly), "invoice 42-b")
+        XCTAssertNil(RippleDestinationTag.displayTag(for: memoOnly))
+    }
+
+    func testDisplayMemoNilForNumericCarrierAndSwaps() {
+        // The numeric tag carrier (echo / legacy) is shown via the tag row, not
+        // as a memo.
+        XCTAssertNil(RippleDestinationTag.displayMemo(for: Self.makeRipplePayload(memo: "12345", destinationTagField: 12345)))
+        XCTAssertNil(RippleDestinationTag.displayMemo(for: Self.makeRipplePayload(memo: "777", destinationTagField: nil)))
+        // Swaps keep their own memo handling.
+        XCTAssertNil(RippleDestinationTag.displayMemo(for: Self.makeRipplePayload(memo: "=:ETH.ETH:0x1", destinationTagField: nil, withSwapPayload: true)))
+    }
+
     // MARK: - Proto round-trip (the wire the co-signer receives)
 
     func testDestinationTagSurvivesProtoRoundTrip() throws {

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagThreadingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagThreadingTests.swift
@@ -96,22 +96,33 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
         XCTAssertTrue(input.rawJson.isEmpty)
     }
 
-    func testTextMemoRejectsPayload() {
-        // Pre-change this silently became an on-chain Memos blob with NO
-        // destination tag — the uncredited-exchange-deposit shape.
-        for memo in ["tag:12345", "hello", "12345 ", "0123"] {
+    func testTextMemoRestoresMemosBlob() throws {
+        // #4755: a genuine text memo on a plain send (no tag field) is restored
+        // as an on-chain `Memos` blob — the pre-#4749 memo-only capability. It
+        // is byte-identical old-vs-new device: no field on the wire, same text
+        // in the memo slot, so every platform builds the same Memos-only tx.
+        // Anything that isn't a clean canonical uint32 (text, leading zeros,
+        // trailing space, > uint32-max) is treated as text.
+        for memo in ["tag:12345", "hello", "12345 ", "0123", "4294967296"] {
             let payload = Self.makeRipplePayload(memo: memo)
-            XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: payload), "expected rejection for \"\(memo)\"") { error in
-                XCTAssertEqual(error as? RippleMemoError, .invalidMemo(memo))
-            }
+            let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload))
+            XCTAssertFalse(input.rawJson.isEmpty, "text memo must ride an on-chain Memos blob for \"\(memo)\"")
+            XCTAssertTrue(input.rawJson.contains("Memos"))
+            XCTAssertEqual(input.opPayment.destinationTag, 0, "no destination tag for a text-memo-only send")
         }
     }
 
-    func testTagAboveU32MaxRejectsPayload() {
-        // Pre-change a 2^32..2^64 memo parsed as UInt64 and reached
-        // wallet-core, which failed the ceremony with a cryptic u32 error.
-        let payload = Self.makeRipplePayload(memo: "4294967296")
-        XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: payload))
+    func testCanonicalMemoStillBecomesTagNotMemosBlob() throws {
+        // The counterpart: a numeric-canonical memo (no field) stays the legacy
+        // tag carrier, never a Memos blob. "0" is still rejected (zero tag).
+        let tagged = Self.makeRipplePayload(memo: "12345")
+        let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: tagged))
+        XCTAssertEqual(input.opPayment.destinationTag, 12345)
+        XCTAssertTrue(input.rawJson.isEmpty)
+
+        XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: Self.makeRipplePayload(memo: "0"))) { error in
+            XCTAssertEqual(error as? RippleMemoError, .invalidMemo("0"))
+        }
     }
 
     // MARK: - Cosigner display resolution (field-preferred)
@@ -254,27 +265,34 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
         XCTAssertTrue(input.rawJson.isEmpty)
     }
 
-    func testFieldWinsOverConflictingMemo() throws {
-        // Deterministic conflict rule: when the field and memo disagree, the
-        // field wins outright (only reachable via a malformed payload — the
-        // initiator always dual-writes equal values). The signed tag is the
-        // field's value; the divergent memo is ignored.
+    func testFieldWithConflictingNumericMemoRejects() {
+        // #4755: a field tag alongside a DIFFERENT canonical number in the memo
+        // slot is a tag/memo conflict (the memo would read as a second tag).
+        // Reject deterministically — only reachable via a malformed payload; the
+        // form blocks it.
         let conflicting = Self.makeRipplePayload(memo: "111", destinationTagField: 222)
-        let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: conflicting))
-        XCTAssertEqual(input.opPayment.destinationTag, 222, "the first-class field wins over a conflicting memo")
-        XCTAssertTrue(input.rawJson.isEmpty)
+        XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: conflicting)) { error in
+            XCTAssertEqual(error as? RippleMemoError, .tagMemoConflict(tag: 222, memo: "111"))
+        }
     }
 
-    func testFieldWinsEvenWhenMemoIsNonCanonical() throws {
-        // Prefer-field short-circuits memo validation: a present field signs
-        // successfully even if the memo carrier is non-canonical. (An old
-        // memo-only peer would reject that memo and fail the ceremony — safe,
-        // never a bad signature.)
+    func testFieldWithTextMemoBuildsCombo() throws {
+        // #4755: a field tag alongside a genuine TEXT memo is the tag+memo combo
+        // — a rawJson Payment carrying BOTH DestinationTag and Memos. (An old
+        // memo-only peer reads only the text → builds a Memos-only tx without
+        // the tag → the ceremony fails safe. Accepted mixed-version limitation.)
         let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(
-            keysignPayload: Self.makeRipplePayload(memo: "not-a-tag", destinationTagField: 4321)
+            keysignPayload: Self.makeRipplePayload(memo: "gift for alice", destinationTagField: 4321)
         ))
-        XCTAssertEqual(input.opPayment.destinationTag, 4321)
-        XCTAssertTrue(input.rawJson.isEmpty)
+        XCTAssertFalse(input.rawJson.isEmpty, "combo must ride rawJson (no native memo slot)")
+        XCTAssertTrue(input.rawJson.contains("Memos"))
+        XCTAssertTrue(input.rawJson.contains("DestinationTag"))
+        XCTAssertEqual(input.opPayment.destinationTag, 0, "combo uses rawJson, not the typed opPayment tag")
+
+        // Prove the tag rode into the rawJson as the exact numeric value.
+        let json = try Self.decodeRawJson(input.rawJson)
+        XCTAssertEqual(json["DestinationTag"] as? Int, 4321)
+        XCTAssertNotNil(json["Memos"])
     }
 
     func testFieldPresentZeroRejectsPayload() {
@@ -295,6 +313,82 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
         ))
         XCTAssertEqual(input.opPayment.destinationTag, 888)
         XCTAssertTrue(input.rawJson.isEmpty)
+    }
+
+    // MARK: - #4755 tag+memo combo + echo disambiguation (byte-parity)
+
+    func testEchoMemoBuildsTagOnlyByteIdenticalToFieldOnly() throws {
+        // The dual-write ECHO: field=12345 AND memo=="12345" (the tag's own
+        // canonical decimal) must build the SAME tag-only payment as the
+        // field-only / memo-only paths — NO Memos blob. Extends the byte-parity
+        // pin to the steady-state dual-write an initiator emits for a tag-only
+        // send.
+        let fieldOnly = Self.makeRipplePayload(memo: nil, destinationTagField: 12345)
+        let echo = Self.makeRipplePayload(memo: "12345", destinationTagField: 12345)
+
+        let fieldInput = try RippleHelper.getPreSignedInputData(keysignPayload: fieldOnly)
+        let echoInput = try RippleHelper.getPreSignedInputData(keysignPayload: echo)
+        XCTAssertEqual(echoInput, fieldInput, "the echo must serialize identically to the tag-only path")
+
+        let decoded = try RippleSigningInput(serializedBytes: echoInput)
+        XCTAssertEqual(decoded.opPayment.destinationTag, 12345)
+        XCTAssertTrue(decoded.rawJson.isEmpty, "the echo must NOT produce a numeric Memos blob")
+
+        XCTAssertEqual(
+            try RippleHelper.getPreSignedImageHash(keysignPayload: echo),
+            try RippleHelper.getPreSignedImageHash(keysignPayload: fieldOnly),
+            "the committee hash must match across field-only and echo"
+        )
+    }
+
+    func testEchoSwallowsTextMemoEqualToTagDecimal() throws {
+        // Accepted edge: a field tag N with a text memo that is literally the
+        // decimal "N" is indistinguishable from the echo and is swallowed as
+        // tag-only (no Memos). Documented + accepted.
+        let payload = Self.makeRipplePayload(memo: "5", destinationTagField: 5)
+        let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload))
+        XCTAssertEqual(input.opPayment.destinationTag, 5)
+        XCTAssertTrue(input.rawJson.isEmpty, "memo \"5\" alongside tag 5 is swallowed as the echo — no Memos")
+    }
+
+    func testRawJsonHonorsDestinationTag() throws {
+        // FUND-CRITICAL: wallet-core's RippleOperationPayment has NO memo field,
+        // so the combo must go through rawJson. Prove rawJson's DestinationTag
+        // is encoded into the SIGNED bytes: a rawJson Payment with a tag hashes
+        // DIFFERENTLY from the same Payment without one, and two different tags
+        // sign differently. If wallet-core ignored the rawJson tag these would
+        // collide.
+        //
+        // We do NOT assert byte-equality with the native opPayment-tag path:
+        // wallet-core's typed builder stamps `Flags` (tfFullyCanonicalSig) on
+        // the Payment, while the rawJson path signs the JSON literally (exactly
+        // as the shipped swap rawJson path does, without that flag). The tag
+        // itself still serializes into the signed transaction — which is what
+        // this test pins.
+        let noTag = try Self.rawJsonTagOnlySigningInput(tag: nil)
+        let tag5 = try Self.rawJsonTagOnlySigningInput(tag: 5)
+        let tag6 = try Self.rawJsonTagOnlySigningInput(tag: 6)
+        XCTAssertNotEqual(try Self.preImageHash(noTag), try Self.preImageHash(tag5),
+                          "DestinationTag must enter the signed rawJson bytes")
+        XCTAssertNotEqual(try Self.preImageHash(tag5), try Self.preImageHash(tag6),
+                          "different destination tags must sign differently")
+    }
+
+    func testComboTagAffectsSignedBytes() throws {
+        // Differential proof the combo's DestinationTag enters the signed bytes:
+        // two combos identical except for the tag hash DIFFERENTLY; two identical
+        // except for the memo text hash DIFFERENTLY; and the combo differs from a
+        // memo-only send (the tag adds bytes). Together these prove BOTH fields
+        // are signed.
+        let comboTag5 = try RippleHelper.getPreSignedImageHash(keysignPayload: Self.makeRipplePayload(memo: "hi", destinationTagField: 5))
+        let comboTag6 = try RippleHelper.getPreSignedImageHash(keysignPayload: Self.makeRipplePayload(memo: "hi", destinationTagField: 6))
+        XCTAssertNotEqual(comboTag5, comboTag6, "the destination tag must affect the signed transaction")
+
+        let comboMemoA = try RippleHelper.getPreSignedImageHash(keysignPayload: Self.makeRipplePayload(memo: "aaa", destinationTagField: 5))
+        XCTAssertNotEqual(comboTag5, comboMemoA, "the memo text must affect the signed transaction")
+
+        let memoOnly = try RippleHelper.getPreSignedImageHash(keysignPayload: Self.makeRipplePayload(memo: "hi", destinationTagField: nil))
+        XCTAssertNotEqual(comboTag5, memoOnly, "the combo (tag+memo) must differ from a memo-only send")
     }
 
     // MARK: - Verify seam (SendTransaction → payload memo)
@@ -480,6 +574,50 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
     // MARK: - Fixtures
 
     private static let destination = "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh"
+    private static let account = "rPVMhWBsfF9iMXYj3aAzJVkPDTFNSyWdKy"
+    private static let publicKeyHex = "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+
+    private static func decodeRawJson(_ rawJson: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(rawJson.data(using: .utf8))
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func preImageHash(_ inputData: Data) throws -> Data {
+        let hashes = TransactionCompiler.preImageHashes(coinType: .xrp, txInputData: inputData)
+        let output = try TxCompilerPreSigningOutput(serializedBytes: hashes)
+        XCTAssertTrue(output.errorMessage.isEmpty, "wallet-core rejected the input: \(output.errorMessage)")
+        return output.dataHash
+    }
+
+    /// A rawJson Payment optionally carrying a numeric DestinationTag (no
+    /// Memos) — used to prove wallet-core's rawJson path encodes the tag into
+    /// the signed bytes.
+    private static func rawJsonTagOnlySigningInput(tag: UInt32?) throws -> Data {
+        let keyData = try XCTUnwrap(Data(hexString: publicKeyHex))
+        let publicKey = try XCTUnwrap(PublicKey(data: keyData, type: .secp256k1))
+        var txJson: [String: Any] = [
+            "TransactionType": "Payment",
+            "Account": account,
+            "Destination": destination,
+            "Amount": "1000000",
+            "Fee": "10",
+            "Sequence": 99,
+            "LastLedgerSequence": 12345678
+        ]
+        if let tag {
+            txJson["DestinationTag"] = tag
+        }
+        let jsonString = try XCTUnwrap(String(data: JSONSerialization.data(withJSONObject: txJson), encoding: .utf8))
+        let input = RippleSigningInput.with {
+            $0.fee = 10
+            $0.sequence = 99
+            $0.account = account
+            $0.publicKey = publicKey.data
+            $0.lastLedgerSequence = 12345678
+            $0.rawJson = jsonString
+        }
+        return try input.serializedData()
+    }
 
     @MainActor
     private static func makeRippleForm() -> SendDetailsViewModel {

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagViewModelTests.swift
@@ -108,11 +108,25 @@ final class RippleDestinationTagViewModelTests: XCTestCase {
         XCTAssertEqual(vm.validateTagAndMemo(memo: ""), .invalidTag)
     }
 
-    func testValidateTagAndMemoTextMemoRejected() {
+    func testValidateTagAndMemoTextMemoAcceptedAsMemoOnly() {
+        // #4755: a text memo (no tag) is valid again — it rides on-chain as a
+        // Memos blob (memo-only send).
         let vm = RippleDestinationTagViewModel()
-        let outcome = vm.validateTagAndMemo(memo: "thanks for lunch")
-        XCTAssertEqual(outcome, .memoNotTag)
-        XCTAssertEqual(outcome.errorKey, "xrpMemoNotDestinationTagError")
+        XCTAssertEqual(vm.validateTagAndMemo(memo: "thanks for lunch"), .valid)
+    }
+
+    func testValidateTagAndMemoTagPlusTextMemoIsCombo() {
+        // #4755: a tag field alongside a genuine text memo is the valid combo.
+        let vm = RippleDestinationTagViewModel()
+        vm.destinationTag = "12345"
+        XCTAssertEqual(vm.validateTagAndMemo(memo: "gift for alice"), .valid)
+    }
+
+    func testValidateTagAndMemoZeroMemoRejected() {
+        // A numeric-canonical "0" memo (no tag) is the legacy tag carrier and a
+        // zero tag can't sign — still rejected.
+        let vm = RippleDestinationTagViewModel()
+        XCTAssertEqual(vm.validateTagAndMemo(memo: "0"), .invalidTag)
     }
 
     func testValidateTagAndMemoConflict() {


### PR DESCRIPTION
Closes #4755. **Stacks on #4749** (base branch `feat/xrp-dest-tag-4742`).

#4749 made plain XRP sends **tag-only** (text memos rejected) because the memo slot was the destination tag's only carrier. Now that the tag has its own first-class field (`RippleSpecific.destination_tag`, commondata#95, consumed on #4749 via dual-write), the memo slot is free again. This **restores on-chain text-memo support** for plain XRP sends and adds a **destination tag + memo together** (combo).

## Signer resolution (plain payments — `swapPayload == nil`)

| field (`destination_tag`) | memo slot | outcome |
|---|---|---|
| present (nonzero) | empty | tag-only native `destinationTag` |
| present (nonzero) | `== String(field)` | **dual-write echo** → tag-only (NO Memos), byte-identical to the tag-only path |
| present (nonzero) | real text | **combo**: `rawJson` Payment with BOTH `DestinationTag` + `Memos` |
| present (nonzero) | different canonical number | **conflict** → reject (`tagMemoConflict`) |
| present == 0 | any | reject (zero tag can't sign; unchanged) |
| absent | empty | plain payment |
| absent | numeric-canonical | tag (legacy parse; unchanged) |
| absent | real text | **Memos** blob — restores the pre-#4749 memo-only capability |

Echo-vs-real-memo disambiguation keys on `memo == String(fieldTag)` (exact canonical match); the numeric-vs-text split keys on `parseCanonical`. The swap path is untouched: `swapMemoSigningInput` is generalized to `memoSigningInput(destinationTag:)` whose `nil`-tag branch keeps the exact key set (byte-identical serialization).

## Initiator population (dual-write preserved)
- tag-only → field = tag, memo = `canonical(tag)` [echo]
- memo-only → field absent, memo = text
- tag+memo → field = tag, memo = text (tag rides the field only)

The form accepts a text memo again; a numeric memo alongside a *different* tag is still a conflict. A non-blocking send-form **advisory** appears when both a tag and a memo are populated.

## Mixed-version handling (decided: allow the combo now)
- **tag-only** and **memo-only** are **byte-identical old-vs-new device** — safe.
- **tag+memo**: an OLD co-signer (no field reader) reads only the memo slot (text) → builds a `Memos`-only tx WITHOUT the tag → pre-image hash diverges → keysign **fails safe** (no fund loss, no wrong tx) until that device updates. **Accepted**, gated by the advisory ("Sending a tag and a memo together requires all your signing devices to be up to date.", localized in all 8 locales).

## Byte-parity proof (tests)
- **tag-only**: field-source ≡ memo-echo → identical `RippleSigningInput` bytes + hash (`testFieldSourcedTagProducesByteIdenticalInputToMemoFallback`, `testEchoMemoBuildsTagOnlyByteIdenticalToFieldOnly`).
- **memo-only**: field unset on the wire → an old memo-only co-signer builds the identical `Memos` tx.
- **combo**: `rawJson` carries both fields, and BOTH the tag and the memo enter the SIGNED pre-image (`testComboTagAffectsSignedBytes` differential hashes; `testRawJsonHonorsDestinationTag`). `RippleOperationPayment` has no native memo field, so rawJson is mandatory. rawJson-vs-native `Flags` (tfFullyCanonicalSig) divergence is documented — the combo/swap rawJson omit it, matching the shipped swap path; on-chain valid. The old-co-signer combo divergence is the accepted, advised limitation.
- **echo edge**: tag=N + a text memo literally `"N"` is swallowed as the echo (tag-only, no Memos) — asserted + accepted.
- **swap path**: unchanged (regression-asserted).

## Gate
- `make test` full suite: **2487 tests**, sole failure = the known non-en_US comma-decimal locale flake (`StakingValidatorProjectionTests`, unrelated Cosmos test). All Ripple/XRP tests pass.
- SwiftLint: 0 serious violations; none in touched files.
- Cross-model review loop (codex, read-only): per-step + whole-branch, all findings triaged/fixed.

## Draft / stacking
Draft-blocked (inherits #4749's block on commondata#95). Base = `feat/xrp-dest-tag-4742`; **rebases to `main` after #4749 and commondata#95 land**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)