### PR TITLE
fix(terraClassic): price send fee at the dynamic gas limit so Verify matches the signed fee

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/TerraClassicTax.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/TerraClassicTax.swift
@@ -73,54 +73,36 @@ enum TerraClassicTax {
     /// the signer denominates in `uusd`.
     static let uusdBaseGas: UInt64 = 225000
 
-    /// Base gas number for a Terra Classic send, in the SAME denom the signer
-    /// uses for the fee (see `TerraHelperStruct.getPreSignedInputData`). Bank
-    /// denoms (USTC / `uusd`) get the `uusd` base; everything else — native LUNC,
-    /// CW20 and IBC — gets the `uluna` base. Gating both this and the signed fee
-    /// denom on `isBankDenom` keeps the gas number and the fee denom in lockstep.
-    static func baseGas(contractAddress: String, isNativeToken: Bool) -> UInt64 {
-        isBankDenom(contractAddress: contractAddress, isNativeToken: isNativeToken)
-            ? uusdBaseGas
-            : ulunaBaseGas
-    }
-
-    /// The static gas limit that `ulunaBaseGas` / `uusdBaseGas` are priced at
-    /// (300k gas × the per-gas price). Mirrors `TerraHelperStruct.GasLimit`; the
-    /// signer re-derives the fee amount by scaling the base from this limit to
-    /// the effective (relayed) limit.
+    /// The gas limit that `ulunaBaseGas` / `uusdBaseGas` are priced at (300k gas
+    /// × the per-gas price). Mirrors `TerraHelperStruct.GasLimit`; `baseGas`
+    /// scales the per-gas price from this reference limit to the effective one.
     static let staticGasLimit: UInt64 = 300_000
 
-    /// Re-derive the Terra Classic send fee amount for a (possibly dynamic)
-    /// `gasLimit`, preserving any burn tax folded into the upstream `staticFee`.
+    /// Base gas fee for a Terra Classic send at `gasLimit`, in the SAME denom the
+    /// signer uses for the fee (see `TerraHelperStruct.getPreSignedInputData`).
+    /// Bank denoms (USTC / `uusd`) are priced off the `uusd` base; everything
+    /// else — native LUNC, CW20 and IBC — off the `uluna` base. Gating both this
+    /// and the signed fee denom on `isBankDenom` keeps the gas number and the fee
+    /// denom in lockstep.
     ///
-    /// The signer honors a relayed dynamic `gas_wanted` (`effectiveGasLimit`) but
-    /// `staticFee` (`chainSpecific.gas`) is priced for the static 300k limit, so
-    /// once the relayed limit exceeds 300k the signed fee undershoots Terra
-    /// Classic's `fee >= gas_wanted × price (+ tax)` ante check (on-chain
-    /// `code 13`). This scales the BASE gas portion with the gas limit at the
-    /// chain's per-gas price (`ulunaBaseGas` / `uusdBaseGas` are `price × 300k`,
-    /// so scaling by the limit ratio is `ceil(gasLimit × price)`), while the burn
-    /// tax — a fixed proportion of the SEND amount, independent of gas — is
-    /// carried over unchanged. At `gasLimit == staticGasLimit` it returns
-    /// `staticFee` verbatim, so the non-simulated path is byte-identical.
-    ///
-    /// Pure function of `staticFee`, the relayed limit and static constants, so
-    /// every co-signer derives the identical fee.
-    static func scaledSendFee(
-        staticFee: UInt64,
-        contractAddress: String,
-        isNativeToken: Bool,
-        gasLimit: UInt64
-    ) -> UInt64 {
-        let base = baseGas(contractAddress: contractAddress, isNativeToken: isNativeToken)
-        // Burn tax folded into `staticFee` upstream (0 for CW20 / IBC, which pay
-        // no folded tax). Guarded against underflow.
-        let tax = staticFee > base ? staticFee - base : 0
-        let scaledBase = CosmosGasPricedFee.scaled(
+    /// Terra Classic prices its fee as `gasLimit × pricePerGas`. `ulunaBaseGas` /
+    /// `uusdBaseGas` are `pricePerGas × staticGasLimit`, so scaling by the limit
+    /// ratio yields `ceil(gasLimit × pricePerGas)` — the ante handler's required
+    /// minimum at the signed `gas_wanted` — without hardcoding the per-gas price.
+    /// The signer honors a relayed dynamic `gas_wanted`, so pricing the base at
+    /// that same limit up front keeps the stored fee equal to the signed fee (and
+    /// the fee shown on Verify) instead of undershooting the ante check once the
+    /// dynamic limit exceeds 300k. At `gasLimit == staticGasLimit` it returns the
+    /// unscaled base, so the non-simulated path is byte-identical. Pure function
+    /// of the limit and static constants, so every co-signer derives it identically.
+    static func baseGas(contractAddress: String, isNativeToken: Bool, gasLimit: UInt64) -> UInt64 {
+        let base = isBankDenom(contractAddress: contractAddress, isNativeToken: isNativeToken)
+            ? uusdBaseGas
+            : ulunaBaseGas
+        return CosmosGasPricedFee.scaled(
             base: base,
             fromGasLimit: staticGasLimit,
             toGasLimit: gasLimit
         )
-        return scaledBase + tax
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/TerraHelperStruct.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/TerraHelperStruct.swift
@@ -29,30 +29,14 @@ struct TerraHelperStruct {
         // they must resolve to the identical limit.
         let effectiveGasLimit = relayedGasLimit ?? GasLimit
 
-        // Re-derive the fee AMOUNT from the same effectiveGasLimit that gets
-        // signed. Terra Classic prices its fee as `gasLimit × price (+ burn
-        // tax)` (`TerraClassicTax.baseGas`), so the static `gas` amount in
-        // chainSpecific is priced for the static 300k limit; when a relayed
-        // simulated limit is honored above 300k the amount must scale with it, or
-        // the signed fee undershoots Terra Classic's `fee >= gas_wanted × price
-        // (+ tax)` ante check ("insufficient fee"). Byte-identical to
-        // `String(gas)` when no limit is relayed (effectiveGasLimit == 300k), so
-        // the non-simulated path is unchanged.
-        //
-        // Plain Terra (phoenix-1) is NOT priced this way — it pays a flat fee
-        // comfortably above its minimum gas price — so its amount stays the
-        // static `gas` value, keeping the signed bytes unchanged for it.
-        let feeAmount: String
-        if chain == .terraClassic {
-            feeAmount = String(TerraClassicTax.scaledSendFee(
-                staticFee: gas,
-                contractAddress: keysignPayload.coin.contractAddress,
-                isNativeToken: keysignPayload.coin.isNativeToken,
-                gasLimit: effectiveGasLimit
-            ))
-        } else {
-            feeAmount = String(gas)
-        }
+        // `gas` already carries the fee AMOUNT priced for the same
+        // effectiveGasLimit that gets signed: Terra Classic prices its fee as
+        // `gasLimit × price (+ burn tax)`, and the initiator pins the base to the
+        // effective (relayed dynamic, else 300k) limit up front
+        // (`TerraClassicTax.baseGas` in BlockChainService). Plain Terra
+        // (phoenix-1) pays a flat fee. Either way the signed amount is `gas`
+        // verbatim, matching the fee shown on the Verify screen.
+        let feeAmount = String(gas)
 
         if
             let signDataMessages = try CosmosSignDataBuilder.getMessages(keysignPayload: keysignPayload),

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -797,29 +797,6 @@ private extension BlockChainService {
                 }
             }
 
-            // Chain-specific gas values
-            var gas: UInt64
-            switch coin.chain {
-            case .terraClassic:
-                // Base gas fee, denominated in the FEE denom the signer uses for
-                // this send (see TerraHelperStruct.getPreSignedInputData). Only a
-                // bank denom (USTC / uusd) pays its fee in its OWN denom, so it
-                // gets the uusd base; native LUNC, CW20 (`terra1…`) and IBC
-                // (`ibc/…`) all pay the fee in uluna and share the uluna base.
-                // Both this gas number and the signed fee denom are gated on the
-                // shared isBankDenom helper so they can't drift apart.
-                gas = TerraClassicTax.baseGas(
-                    contractAddress: coin.contractAddress,
-                    isNativeToken: coin.isNativeToken
-                )
-            case .dydx:
-                gas = 2500000000000000
-            case .noble:
-                gas = 20000
-            default:
-                gas = 7500
-            }
-
             // Optionally simulate to derive a dynamic per-tx gas limit the
             // initiator relays to co-signers (CosmosSpecific.gas_limit). Gated
             // OFF by default (see CosmosGasEstimationConfig): the relayed limit
@@ -844,6 +821,37 @@ private extension BlockChainService {
                     sequence: sequence,
                     service: service
                 )
+            }
+
+            // Chain-specific gas values
+            var gas: UInt64
+            switch coin.chain {
+            case .terraClassic:
+                // Base gas fee, denominated in the FEE denom the signer uses for
+                // this send (see TerraHelperStruct.getPreSignedInputData). Only a
+                // bank denom (USTC / uusd) pays its fee in its OWN denom, so it
+                // gets the uusd base; native LUNC, CW20 (`terra1…`) and IBC
+                // (`ibc/…`) all pay the fee in uluna and share the uluna base.
+                // Both this gas number and the signed fee denom are gated on the
+                // shared isBankDenom helper so they can't drift apart.
+                //
+                // Terra Classic prices its fee as `gasLimit × price`, and the
+                // signer signs the relayed dynamic `gas_wanted`, so price the base
+                // at that same effective limit (the relayed dynamic limit, else
+                // the static 300k) up front. That keeps the stored `gas` — which
+                // feeds both the Verify/keysign fee display and the signing input
+                // — equal to the signed fee, instead of a stale fixed-limit value.
+                gas = TerraClassicTax.baseGas(
+                    contractAddress: coin.contractAddress,
+                    isNativeToken: coin.isNativeToken,
+                    gasLimit: dynamicGasLimit ?? TerraClassicTax.staticGasLimit
+                )
+            case .dydx:
+                gas = 2500000000000000
+            case .noble:
+                gas = 20000
+            default:
+                gas = 7500
             }
 
             // Enforce the per-chain Cosmos fee floor at the effective gas limit:

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Signing/CosmosGasPricedFeeScalingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Signing/CosmosGasPricedFeeScalingTests.swift
@@ -5,19 +5,22 @@
 //  Regression tests for the Terra Classic / dYdX insufficient-fee bug.
 //
 //  These chains sign a DYNAMIC `gas_wanted` (the relayed simulated limit) but
-//  their fee AMOUNT (`chainSpecific.gas`) is priced for the static per-chain
-//  limit and is NOT re-derived by `CosmosFeeFloorConfig.flooredFee` (they are
-//  absent from that table). Once the simulated limit exceeds the static one the
-//  signed fee undershoots the ante handler's `fee >= gas_wanted × min gas price`
-//  check and the tx is rejected on-chain ("insufficient fee", code 13).
+//  their fee AMOUNT is priced per unit of gas and is NOT re-derived by
+//  `CosmosFeeFloorConfig.flooredFee` (they are absent from that table). If the
+//  amount stays priced at the static per-chain limit while the simulated limit
+//  exceeds it, the signed fee undershoots the ante handler's
+//  `fee >= gas_wanted × min gas price` check and the tx is rejected on-chain
+//  ("insufficient fee", code 13) — and the amount shown on Verify no longer
+//  matches the signed one.
 //
-//  The fix re-derives the fee amount from the same `effectiveGasLimit` that gets
-//  signed by scaling the (known-sufficient) static amount by the gas-limit ratio
-//  — `ceil(base × effectiveGasLimit / staticGasLimit)` — while preserving any
-//  burn tax folded in for Terra Classic. At the static limit the re-derivation
-//  returns the static amount verbatim, so the non-simulated path is byte
-//  identical, and it is a pure function of the relayed limit + static constants,
-//  so co-signers stay byte-parity consistent.
+//  Terra Classic pins the base to the effective (relayed dynamic, else static)
+//  gas limit up front in `TerraClassicTax.baseGas` (called by BlockChainService),
+//  so `chainSpecific.gas` is the final fee: the signer echoes it verbatim and the
+//  Verify/keysign screens display it directly. dYdX still re-derives its amount
+//  in its signer via `CosmosGasPricedFee.scaled`. Both use `ceil(base ×
+//  effectiveGasLimit / staticGasLimit)`; at the static limit it returns the base
+//  verbatim (non-simulated path byte-identical), and it is a pure function of the
+//  relayed limit + static constants, so co-signers stay byte-parity consistent.
 //
 
 @testable import VultisigApp
@@ -52,51 +55,45 @@ final class CosmosGasPricedFeeScalingTests: XCTestCase {
         XCTAssertEqual(CosmosGasPricedFee.scaled(base: 100, fromGasLimit: 0, toGasLimit: 500), 100)
     }
 
-    // MARK: - TerraClassicTax.scaledSendFee (base scales, folded burn tax preserved)
+    // MARK: - TerraClassicTax.baseGas (base priced at the effective gas limit)
 
-    func testTerraScaledFeeStaticLimitIsByteIdentical() {
-        // At the static 300k limit the re-derived amount MUST equal the upstream
-        // static value exactly (base + folded tax), for every token class.
-        let luncStatic = TerraClassicTax.ulunaBaseGas + 5_000 // base + burn tax
+    func testBaseGasAtStaticLimitIsUnscaled() {
+        // At the static 300k limit the base is unscaled, for every token class,
+        // so the non-simulated path is byte-identical to the pre-fix fee.
         XCTAssertEqual(
-            TerraClassicTax.scaledSendFee(staticFee: luncStatic, contractAddress: "", isNativeToken: true, gasLimit: 300_000),
-            luncStatic
+            TerraClassicTax.baseGas(contractAddress: "", isNativeToken: true, gasLimit: 300_000),
+            TerraClassicTax.ulunaBaseGas
         )
-        let ustcStatic = TerraClassicTax.uusdBaseGas + 3_000
         XCTAssertEqual(
-            TerraClassicTax.scaledSendFee(staticFee: ustcStatic, contractAddress: "uusd", isNativeToken: false, gasLimit: 300_000),
-            ustcStatic
+            TerraClassicTax.baseGas(contractAddress: "uusd", isNativeToken: false, gasLimit: 300_000),
+            TerraClassicTax.uusdBaseGas
         )
     }
 
-    func testTerraNativeScaledFeeScalesBaseKeepsTax() {
-        // LUNC: base 8_497_500 + burn tax 5_000. Scaling to 390k must scale ONLY
-        // the base (28.325/gas) and carry the tax through unchanged.
-        let tax: UInt64 = 5_000
-        let staticFee = TerraClassicTax.ulunaBaseGas + tax
-        let fee = TerraClassicTax.scaledSendFee(staticFee: staticFee, contractAddress: "", isNativeToken: true, gasLimit: 390_000)
-        XCTAssertEqual(fee, 11_046_750 + tax)
-        // Satisfies the chain's `fee >= gas_wanted × price + tax` check…
-        XCTAssertGreaterThanOrEqual(fee, 11_046_750 + tax)
-        // …which the OLD static amount did NOT (this is the bug).
-        XCTAssertLessThan(staticFee, 11_046_750 + tax)
+    func testBaseGasNativeScalesWithLimit() {
+        // LUNC base 8_497_500 (= 300k × 28.325 uluna/gas) priced at 390k = × 1.3.
+        let scaled = TerraClassicTax.baseGas(contractAddress: "", isNativeToken: true, gasLimit: 390_000)
+        XCTAssertEqual(scaled, 11_046_750)
+        // …which exceeds the pre-fix static base that undershot the ante check.
+        XCTAssertGreaterThan(scaled, TerraClassicTax.ulunaBaseGas)
     }
 
-    func testTerraBankDenomScaledFeeUsesUusdBase() {
-        // USTC (uusd) is priced at the uusd base (0.75/gas), NOT the uluna base.
-        let tax: UInt64 = 3_000
-        let staticFee = TerraClassicTax.uusdBaseGas + tax // 225_000 + 3_000
-        let fee = TerraClassicTax.scaledSendFee(staticFee: staticFee, contractAddress: "uusd", isNativeToken: false, gasLimit: 360_000)
-        // 225_000 × 360k/300k = 270_000, + 3_000 tax.
-        XCTAssertEqual(fee, 270_000 + tax)
+    func testBaseGasBankDenomUsesUusdBase() {
+        // USTC (uusd) is priced at the uusd base (0.75/gas), NOT the uluna base:
+        // 225_000 × 360k/300k = 270_000.
+        XCTAssertEqual(
+            TerraClassicTax.baseGas(contractAddress: "uusd", isNativeToken: false, gasLimit: 360_000),
+            270_000
+        )
     }
 
-    func testTerraCW20ScaledFeeHasNoTax() {
-        // CW20 (terra1…) pays its fee in uluna with no folded tax, so the whole
-        // amount scales.
+    func testBaseGasCW20UsesUlunaBase() {
+        // CW20 (terra1…) pays its fee in uluna, so it shares the uluna base.
         let cw20 = "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
-        let fee = TerraClassicTax.scaledSendFee(staticFee: TerraClassicTax.ulunaBaseGas, contractAddress: cw20, isNativeToken: false, gasLimit: 390_000)
-        XCTAssertEqual(fee, 11_046_750)
+        XCTAssertEqual(
+            TerraClassicTax.baseGas(contractAddress: cw20, isNativeToken: false, gasLimit: 390_000),
+            11_046_750
+        )
     }
 
     // MARK: - Terra Classic signing input (end-to-end via TerraHelperStruct)
@@ -151,17 +148,18 @@ final class CosmosGasPricedFeeScalingTests: XCTestCase {
         return try CosmosSigningInput(serializedBytes: inputData).fee
     }
 
-    func testTerraClassicSimulatedLimitScalesSignedFeeAmount() throws {
-        // A simulated relayed limit above 300k: the signed gas_wanted rises to
-        // 390k and the fee amount must scale with it (base 28.325/gas + tax),
-        // instead of staying at the short static value that caused code 13.
+    func testTerraClassicSignerEchoesPricedFeeAmount() throws {
+        // With a simulated limit above 300k the initiator prices `gas` at that
+        // limit up front (base 28.325/gas @390k + tax), so the signer echoes it
+        // verbatim and honors the relayed 390k gas_wanted — no longer the short
+        // static value that caused code 13.
         let tax: UInt64 = 5_000
-        let staticGas = TerraClassicTax.ulunaBaseGas + tax
-        let fee = try terraFee(coin: luncCoin(), gas: staticGas, gasLimit: 390_000)
+        let pricedGas = 11_046_750 + tax // TerraClassicTax.baseGas(@390k) + burn tax
+        let fee = try terraFee(coin: luncCoin(), gas: pricedGas, gasLimit: 390_000)
 
         XCTAssertEqual(fee.gas, 390_000, "signed gas_wanted must be the relayed limit")
         let amount = UInt64(fee.amounts.first?.amount ?? "0") ?? 0
-        XCTAssertEqual(amount, 11_046_750 + tax, "fee amount must track the signed gas_wanted")
+        XCTAssertEqual(amount, pricedGas, "fee amount must be `gas` verbatim")
         XCTAssertGreaterThanOrEqual(amount, fee.gas * 28_325 / 1_000 + tax,
                                     "fee must satisfy gas_wanted × 28.325 uluna/gas + tax")
         XCTAssertEqual(fee.amounts.first?.denom, "uluna")
@@ -184,20 +182,22 @@ final class CosmosGasPricedFeeScalingTests: XCTestCase {
         XCTAssertEqual(nilInput, staticInput, "nil and explicit static limit must yield byte-identical SignDoc input")
     }
 
-    func testTerraClassicBankDenomScalesSignedFeeAmount() throws {
-        // USTC (uusd bank denom): fee is denominated in uusd and scales off the
-        // uusd base, preserving the folded burn tax.
+    func testTerraClassicBankDenomSignerEchoesPricedFee() throws {
+        // USTC (uusd bank denom): fee is denominated in uusd. The initiator
+        // prices `gas` off the uusd base at the effective limit (preserving the
+        // folded burn tax); the signer echoes it in uusd.
         let meta = CoinMeta(chain: .terraClassic, ticker: "USTC", logo: "ustc", decimals: 6, priceProviderId: "", contractAddress: "uusd", isNativeToken: false)
         let coin = Coin(asset: meta, address: "terra1from", hexPublicKey: "02" + String(repeating: "0", count: 64))
         let tax: UInt64 = 3_000
-        let staticGas = TerraClassicTax.uusdBaseGas + tax
+        let pricedGas = 270_000 + tax // TerraClassicTax.baseGas(uusd, @360k) + burn tax
 
-        let fee = try terraFee(coin: coin, gas: staticGas, gasLimit: 360_000)
+        let fee = try terraFee(coin: coin, gas: pricedGas, gasLimit: 360_000)
         XCTAssertEqual(fee.gas, 360_000)
-        XCTAssertEqual(UInt64(fee.amounts.first?.amount ?? "0"), 270_000 + tax)
+        XCTAssertEqual(UInt64(fee.amounts.first?.amount ?? "0"), pricedGas)
         XCTAssertEqual(fee.amounts.first?.denom, "uusd")
 
-        // Non-simulated path unchanged.
+        // Non-simulated path: `gas` echoed verbatim.
+        let staticGas = TerraClassicTax.uusdBaseGas + tax
         let nilFee = try terraFee(coin: coin, gas: staticGas, gasLimit: nil)
         XCTAssertEqual(UInt64(nilFee.amounts.first?.amount ?? "0"), staticGas)
     }
@@ -205,9 +205,10 @@ final class CosmosGasPricedFeeScalingTests: XCTestCase {
     func testPlainTerraFeeAmountStaysFlatRegardlessOfRelayedLimit() throws {
         // Plain Terra (phoenix-1) pays a FLAT fee, not `gasLimit × price`, so a
         // relayed limit must move the signed gas_wanted but NOT the fee amount.
-        // TerraHelperStruct serves both Terra and Terra Classic; only Terra
-        // Classic re-derives. (Guards the `.terraClassic` gate and mirrors the
-        // pinned ChainHelperTests Terra hashes.)
+        // The signer echoes `gas` verbatim, and plain Terra's `gas` is the flat
+        // fee (never repriced by TerraClassicTax.baseGas), so a relayed limit
+        // leaves the amount unchanged. (Mirrors the pinned ChainHelperTests
+        // Terra hashes.)
         let meta = CoinMeta(chain: .terra, ticker: "LUNA", logo: "luna", decimals: 6, priceProviderId: "", contractAddress: "", isNativeToken: true)
         let coin = Coin(asset: meta, address: "terra1from", hexPublicKey: "02" + String(repeating: "0", count: 64))
         let gas: UInt64 = 7_500

--- a/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Signing/TerraClassicTaxTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cosmos/Signing/TerraClassicTaxTests.swift
@@ -94,12 +94,15 @@ final class TerraClassicTaxTests: XCTestCase {
     }
 
     // MARK: - baseGas (the gas NUMBER must match the signer's fee denom)
+    //
+    // At the static gas limit `baseGas` is unscaled, so it returns the raw
+    // per-denom base; these assert the denom SELECTION (uusd vs uluna).
 
     func testBaseGasUstcGetsUusdNumber() {
         // USTC (uusd bank denom) signs its fee in uusd, so the gas number is the
         // uusd base (300k gas x 0.75 uusd/gas), NOT the much larger uluna base.
         XCTAssertEqual(
-            TerraClassicTax.baseGas(contractAddress: "uusd", isNativeToken: false),
+            TerraClassicTax.baseGas(contractAddress: "uusd", isNativeToken: false, gasLimit: TerraClassicTax.staticGasLimit),
             TerraClassicTax.uusdBaseGas
         )
         XCTAssertEqual(TerraClassicTax.uusdBaseGas, 225000)
@@ -107,7 +110,7 @@ final class TerraClassicTaxTests: XCTestCase {
 
     func testBaseGasNativeLuncGetsUlunaNumber() {
         XCTAssertEqual(
-            TerraClassicTax.baseGas(contractAddress: "", isNativeToken: true),
+            TerraClassicTax.baseGas(contractAddress: "", isNativeToken: true, gasLimit: TerraClassicTax.staticGasLimit),
             TerraClassicTax.ulunaBaseGas
         )
         XCTAssertEqual(TerraClassicTax.ulunaBaseGas, 8497500)
@@ -118,7 +121,7 @@ final class TerraClassicTaxTests: XCTestCase {
         // number — not the uusd number, which would underpay gas ~444x.
         let cw20 = "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
         XCTAssertEqual(
-            TerraClassicTax.baseGas(contractAddress: cw20, isNativeToken: false),
+            TerraClassicTax.baseGas(contractAddress: cw20, isNativeToken: false, gasLimit: TerraClassicTax.staticGasLimit),
             TerraClassicTax.ulunaBaseGas
         )
     }
@@ -126,7 +129,7 @@ final class TerraClassicTaxTests: XCTestCase {
     func testBaseGasIBCGetsUlunaNumber() {
         let ibc = "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B"
         XCTAssertEqual(
-            TerraClassicTax.baseGas(contractAddress: ibc, isNativeToken: false),
+            TerraClassicTax.baseGas(contractAddress: ibc, isNativeToken: false, gasLimit: TerraClassicTax.staticGasLimit),
             TerraClassicTax.ulunaBaseGas
         )
     }


### PR DESCRIPTION
## Problem

When sending **LUNC on Terra Classic**, the **Send Verify** screen shows a gas fee computed from a **fixed 300k gas limit**, not the dynamic (simulated) limit the transaction actually signs.

Cosmos gas used to be hardcoded, so a fixed base gas was fine. We recently switched to **simulating a dynamic per-tx gas limit** (`CosmosSpecific.gas_limit`), and the signer honors that relayed `gas_wanted`. But `BlockChainService.fetchSpecific` still priced `chainSpecific.gas` via `TerraClassicTax.baseGas`, which was pinned to the **static 300k limit**.

The signer papered over this by re-deriving the amount at signing time (`TerraClassicTax.scaledSendFee`), so the **signed** fee was correct — but every fee **display** (Send Verify, Send Details, keysign-confirm) reads `chainSpecific.gas` directly and therefore showed the stale fixed-limit fee, diverging from what actually gets signed.

## Fix

Price the base at the **effective gas limit once, up front**, so `chainSpecific.gas` is the final fee everywhere — no re-derivation at signing or display time (per review feedback, `scaledSendFee` was unnecessary).

- `TerraClassicTax.baseGas` now takes `gasLimit` and returns the base scaled to it (`ceil(base × gasLimit / 300k)`, per denom: `uluna` for LUNC/CW20/IBC, `uusd` for USTC). `scaledSendFee` is removed.
- `BlockChainService` computes the dynamic limit **before** the gas switch and passes `dynamicGasLimit ?? staticGasLimit` into `baseGas`. The burn tax is still folded on top.
- `TerraHelperStruct` uses `gas` verbatim as the fee amount (no re-scaling), still honoring the relayed `gas_wanted`.

Result: the fee shown on Verify / Send Details / keysign-confirm now equals the signed fee.

## Parity / safety

- At the static 300k limit the base is **unscaled**, so the non-simulated path is **byte-identical** and cross-device MPC parity is unchanged.
- `dynamicGasLimit` is relayed in the proto, so co-signers derive the identical `gas`/`gas_wanted`.
- Plain Terra (phoenix-1) pays a flat fee (never repriced) — unchanged.
- dYdX has the same latent display gap (still re-derives in its signer via `CosmosGasPricedFee.scaled`); left as a separate follow-up since this change is scoped to Terra Classic.

## Tests

`CosmosGasPricedFeeScalingTests` updated: `baseGas` scaling per denom + at the static limit, and the signer echoing the priced `gas` verbatim under a relayed limit. `TerraClassicTaxTests` updated for the new signature. **34 tests pass** on iPhone 16 sim; SwiftLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Terra Classic fee handling so displayed and signed fees stay aligned with the actual gas limit used.
  * Fixed fee calculation for Terra Classic transactions across native, bank-denom, and contract-based transfers.
  * Updated signing behavior so the app now echoes the correctly priced fee amount instead of recomputing it inconsistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->