### PR TITLE
feat(keysign): fast vaults skip the pairing screen → Verify straight to Keysign

### DIFF
--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRoute.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRoute.swift
@@ -9,6 +9,7 @@ enum FunctionCallRoute: Hashable {
     case details(defaultCoin: Coin?, vault: Vault)
     case verify(tx: SendTransaction, vault: Vault)
     case pair(vault: Vault, tx: SendTransaction, keysignPayload: KeysignPayload, fastVaultPassword: String?)
+    case fastKeysign(vault: Vault, tx: SendTransaction, keysignPayload: KeysignPayload, fastVaultPassword: String)
     case keysign(input: KeysignInput, tx: SendTransaction, retrySignal: SendRetrySignal)
     case functionTransaction(vault: Vault, transactionType: FunctionTransactionType)
 }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRouteBuilder.swift
@@ -41,6 +41,25 @@ struct FunctionCallRouteBuilder {
     }
 
     @ViewBuilder
+    func buildFastKeysignScreen(
+        vault: Vault,
+        tx: SendTransaction,
+        keysignPayload: KeysignPayload,
+        fastVaultPassword: String
+    ) -> some View {
+        // Reuses the Send fast keysign screen (like the paired path reuses
+        // SendKeysignScreen). The retry signal isn't consumed by
+        // FunctionCall's verify screen, so a fresh one is fine.
+        SendFastKeysignScreen(
+            vault: vault,
+            keysignPayload: keysignPayload,
+            tx: tx,
+            retrySignal: SendRetrySignal(),
+            fastVaultPassword: fastVaultPassword
+        )
+    }
+
+    @ViewBuilder
     func buildKeysignScreen(input: KeysignInput, tx: SendTransaction, retrySignal: SendRetrySignal) -> some View {
         SendKeysignScreen(input: input, tx: tx, retrySignal: retrySignal)
     }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRouter.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallRouter.swift
@@ -27,6 +27,13 @@ struct FunctionCallRouter {
                 keysignPayload: keysignPayload,
                 fastVaultPassword: fastVaultPassword
             )
+        case .fastKeysign(let vault, let tx, let keysignPayload, let fastVaultPassword):
+            viewBuilder.buildFastKeysignScreen(
+                vault: vault,
+                tx: tx,
+                keysignPayload: keysignPayload,
+                fastVaultPassword: fastVaultPassword
+            )
         case .keysign(let input, let tx, let retrySignal):
             viewBuilder.buildKeysignScreen(input: input, tx: tx, retrySignal: retrySignal)
         case .functionTransaction(let vault, let transactionType):

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallVerifyScreen.swift
@@ -142,12 +142,26 @@ struct FunctionCallVerifyScreen: View {
             do {
                 let result = try await depositVerifyViewModel.createKeysignPayload(tx: transaction)
                 await MainActor.run {
-                    router.navigate(to: FunctionCallRoute.pair(
-                        vault: vault,
-                        tx: transaction,
-                        keysignPayload: result,
-                        fastVaultPassword: fastVaultPassword.nilIfEmpty
-                    ))
+                    // Fast vaults sign server-side with no peer to pair with,
+                    // so route straight into keysign (the bootstrap runs there)
+                    // and skip the pairing screen. A present fast password is
+                    // the fast-sign signal; an empty one means paired-sign,
+                    // which keeps the QR pairing screen.
+                    if let fastPassword = fastVaultPassword.nilIfEmpty {
+                        router.navigate(to: FunctionCallRoute.fastKeysign(
+                            vault: vault,
+                            tx: transaction,
+                            keysignPayload: result,
+                            fastVaultPassword: fastPassword
+                        ))
+                    } else {
+                        router.navigate(to: FunctionCallRoute.pair(
+                            vault: vault,
+                            tx: transaction,
+                            keysignPayload: result,
+                            fastVaultPassword: nil
+                        ))
+                    }
                 }
             } catch {
                 await MainActor.run {

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/FastVaultKeysignBootstrap.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/FastVaultKeysignBootstrap.swift
@@ -1,0 +1,169 @@
+//
+//  FastVaultKeysignBootstrap.swift
+//  VultisigApp
+//
+//  Off-screen relay-session bootstrap for the fast-vault signing path.
+//  A fast vault's `KeysignInput` can't be built up front: every field is
+//  known except `keysignCommittee`, which only materializes once the
+//  Vultiserver joins the relay session. This helper runs the same
+//  wake -> await -> kickoff sequence the pairing screen used to run
+//  (and that `QBTCClaimRoundRunner` runs), then assembles the finished
+//  `KeysignInput`. It lets Send / Swap / FunctionCall / CustomMessage
+//  route straight from Verify into Keysign without mounting the pairing
+//  screen. Built on the view-free `KeysignSessionService`.
+//
+
+import Foundation
+import OSLog
+
+/// Session-bootstrap surface the fast-vault helper depends on. The
+/// production conformer is `KeysignSessionService`; tests inject a mock
+/// to assert the call ordering + `KeysignInput` assembly without
+/// touching the relay.
+@MainActor
+protocol FastVaultKeysignSessionProviding {
+    func newSession(vault: Vault, serviceName: String?) throws -> KeysignSessionInfo
+    func registerAsParticipant(session: KeysignSessionInfo) async throws
+    func wakeFastVaultServer(
+        publicKeyEcdsa: String,
+        keysignMessages: [String],
+        session: KeysignSessionInfo,
+        derivePath: String,
+        isECDSA: Bool,
+        vaultPassword: String,
+        chain: String,
+        isMldsa: Bool
+    ) async throws
+    func awaitFastVaultPeer(
+        discovery: ParticipantDiscovery,
+        session: KeysignSessionInfo,
+        timeout: TimeInterval
+    ) async throws -> [String]
+    func kickoffCommittee(session: KeysignSessionInfo, participants: [String]) async throws
+}
+
+extension KeysignSessionService: FastVaultKeysignSessionProviding {}
+
+enum FastVaultKeysignBootstrapError: LocalizedError {
+    case missingSigningCoin
+    case noMessagesToSign
+    case missingPayload
+
+    var errorDescription: String? {
+        switch self {
+        case .missingSigningCoin:
+            return "Could not resolve the signing coin for this vault."
+        case .noMessagesToSign:
+            return "No messages to sign."
+        case .missingPayload:
+            return "No keysign payload or custom message to sign."
+        }
+    }
+}
+
+/// Runs the fast-vault relay-session bootstrap and returns a ready-to-use
+/// `KeysignInput`. Mirrors the fast branch of
+/// `KeysignDiscoveryViewModel.setData` (Solana blockhash refresh, message
+/// generation, wake) and `QBTCClaimRoundRunner.runBtcRound` (register ->
+/// wake -> await -> kickoff), consolidating the three former copies of
+/// that logic onto one path.
+@MainActor
+struct FastVaultKeysignBootstrap {
+    /// Cap on how long to wait for Vultiserver to register as a peer
+    /// after the wake POST. It typically joins within a few seconds; the
+    /// cap is a safety net. Matches `QBTCClaimRoundRunner`.
+    static let fastVaultPeerWaitSeconds: TimeInterval = 60
+
+    private let sessionService: FastVaultKeysignSessionProviding
+    private let logger = Logger(subsystem: "com.vultisig.app", category: "fast-vault-keysign-bootstrap")
+
+    init(sessionService: FastVaultKeysignSessionProviding = KeysignSessionService()) {
+        self.sessionService = sessionService
+    }
+
+    /// Provisions a session, wakes Vultiserver, awaits its join, kicks off
+    /// the committee, and assembles the `KeysignInput`. Throws on any
+    /// bootstrap failure (wrong password surfaces as a peer timeout).
+    func makeKeysignInput(
+        vault: Vault,
+        keysignPayload: KeysignPayload?,
+        customMessagePayload: CustomMessagePayload?,
+        fastVaultPassword: String
+    ) async throws -> KeysignInput {
+        let session = try sessionService.newSession(vault: vault, serviceName: nil)
+
+        // Resolve the signing coin + pre-signed messages. Mirrors the
+        // coin/message resolution in `KeysignDiscoveryViewModel.setData`.
+        let coin: Coin
+        var finalPayload = keysignPayload
+        let keysignMessages: [String]
+
+        if let payload = keysignPayload {
+            var workingPayload = payload
+            // Refresh the Solana blockhash BEFORE generating messages so
+            // this device and the Vultiserver share the same fresh hash.
+            if payload.coin.chain == .solana {
+                workingPayload = try await BlockChainService.shared.refreshSolanaBlockhash(for: payload)
+                logger.info("Refreshed Solana blockhash before generating keysign messages")
+            }
+            finalPayload = workingPayload
+            keysignMessages = try KeysignMessageFactory(payload: workingPayload).getKeysignMessages().sorted()
+            coin = workingPayload.coin
+        } else if let customMessagePayload {
+            keysignMessages = customMessagePayload.keysignMessages
+            guard let resolved = vault.nativeCoin(for: Chain(name: customMessagePayload.chain) ?? .ethereum) else {
+                throw FastVaultKeysignBootstrapError.missingSigningCoin
+            }
+            coin = resolved
+        } else {
+            throw FastVaultKeysignBootstrapError.missingPayload
+        }
+
+        guard !keysignMessages.isEmpty else {
+            throw FastVaultKeysignBootstrapError.noMessagesToSign
+        }
+
+        // Register on the relay BEFORE waking Vultiserver — without this
+        // POST the relay may never queue the server's outbound MPC
+        // messages to this device. Mirrors `QBTCClaimRoundRunner`.
+        try await sessionService.registerAsParticipant(session: session)
+
+        try await sessionService.wakeFastVaultServer(
+            publicKeyEcdsa: vault.pubKeyECDSA,
+            keysignMessages: keysignMessages,
+            session: session,
+            derivePath: coin.coinType.derivationPath(),
+            isECDSA: coin.chain.isECDSA,
+            vaultPassword: fastVaultPassword,
+            chain: coin.chain.name,
+            isMldsa: coin.chain.signingKeyType == .MLDSA
+        )
+
+        let participants = try await sessionService.awaitFastVaultPeer(
+            discovery: ParticipantDiscovery(),
+            session: session,
+            timeout: Self.fastVaultPeerWaitSeconds
+        )
+
+        try await sessionService.kickoffCommittee(session: session, participants: participants)
+
+        // Derive the signing key type from the resolved coin so a
+        // custom message on a non-ECDSA chain (which carries no
+        // `keysignPayload`) still matches the key type the server was
+        // woken for. For the payload path this equals
+        // `keysignPayload.coin.chain.signingKeyType`.
+        let keysignType: KeyType = coin.chain.signingKeyType
+        return KeysignInput(
+            vault: vault,
+            keysignCommittee: participants,
+            mediatorURL: session.serverAddr,
+            sessionID: session.sessionId,
+            keysignType: keysignType,
+            messsageToSign: keysignMessages,
+            keysignPayload: finalPayload,
+            customMessagePayload: customMessagePayload,
+            encryptionKeyHex: session.encryptionKeyHex,
+            isInitiateDevice: true
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/FastKeysignBootstrapView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/FastKeysignBootstrapView.swift
@@ -1,0 +1,77 @@
+//
+//  FastKeysignBootstrapView.swift
+//  VultisigApp
+//
+//  Shared keysign-hosted wait wrapper for the fast-vault signing path.
+//  A fast vault has no one to pair with, so instead of mounting the
+//  pairing screen it lands here: the off-screen session bootstrap runs
+//  in `.task` (showing the signing animation while Vultiserver joins),
+//  and once the `KeysignInput` is ready it drives the standard
+//  `KeysignView`. The bootstrap wait and the keysign ceremony render the
+//  same `KeysignAnimationView`, so the transition is seamless. Errors
+//  surface through the existing keysign error surface with a retry that
+//  re-runs the bootstrap — no new error UI. Used by Send / Swap /
+//  FunctionCall / CustomMessage.
+//
+
+import SwiftUI
+
+struct FastKeysignBootstrapView: View {
+    let vault: Vault
+    let keysignPayload: KeysignPayload?
+    let customMessagePayload: CustomMessagePayload?
+    let fastVaultPassword: String
+    let transferViewModel: TransferViewModel?
+
+    @State private var input: KeysignInput?
+    @State private var errorMessage: String?
+
+    var body: some View {
+        ZStack {
+            if let input {
+                KeysignView(
+                    vault: input.vault,
+                    keysignCommittee: input.keysignCommittee,
+                    mediatorURL: input.mediatorURL,
+                    sessionID: input.sessionID,
+                    keysignType: input.keysignType,
+                    messsageToSign: input.messsageToSign,
+                    keysignPayload: input.keysignPayload,
+                    customMessagePayload: input.customMessagePayload,
+                    transferViewModel: transferViewModel,
+                    encryptionKeyHex: input.encryptionKeyHex,
+                    isInitiateDevice: input.isInitiateDevice
+                )
+            } else {
+                // While bootstrapping: `errorMessage == nil` so this shows
+                // the signing animation. On failure it flips to the shared
+                // keysign error surface with a retry that re-runs bootstrap.
+                SendCryptoKeysignView(
+                    title: errorMessage,
+                    showError: errorMessage != nil,
+                    coinLogo: keysignPayload?.coin.logo,
+                    errorButtonTitle: "tryAgain".localized,
+                    errorAction: { Task { await runBootstrap() } }
+                )
+            }
+        }
+        .task { await runBootstrap() }
+    }
+
+    @MainActor
+    private func runBootstrap() async {
+        errorMessage = nil
+        do {
+            let bootstrap = FastVaultKeysignBootstrap()
+            input = try await bootstrap.makeKeysignInput(
+                vault: vault,
+                keysignPayload: keysignPayload,
+                customMessagePayload: customMessagePayload,
+                fastVaultPassword: fastVaultPassword
+            )
+        } catch {
+            input = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/FastKeysignBootstrapView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/FastKeysignBootstrapView.swift
@@ -22,6 +22,12 @@ struct FastKeysignBootstrapView: View {
     let customMessagePayload: CustomMessagePayload?
     let fastVaultPassword: String
     let transferViewModel: TransferViewModel?
+    /// Fires once the bootstrap has assembled the `KeysignInput`. Callers
+    /// that navigate on completion (Send/FunctionCall done screens) use it
+    /// to read the actually-signed payload — the bootstrap can replace the
+    /// input payload before signing (e.g. Solana blockhash refresh), so the
+    /// original route payload can diverge from what was signed.
+    var onKeysignInputResolved: ((KeysignInput) -> Void)?
 
     @State private var input: KeysignInput?
     @State private var errorMessage: String?
@@ -63,12 +69,14 @@ struct FastKeysignBootstrapView: View {
         errorMessage = nil
         do {
             let bootstrap = FastVaultKeysignBootstrap()
-            input = try await bootstrap.makeKeysignInput(
+            let resolved = try await bootstrap.makeKeysignInput(
                 vault: vault,
                 keysignPayload: keysignPayload,
                 customMessagePayload: customMessagePayload,
                 fastVaultPassword: fastVaultPassword
             )
+            input = resolved
+            onKeysignInputResolved?(resolved)
         } catch {
             input = nil
             errorMessage = error.localizedDescription

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/NavigationRouter+KeysignVerify.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/NavigationRouter+KeysignVerify.swift
@@ -1,0 +1,29 @@
+//
+//  NavigationRouter+KeysignVerify.swift
+//  VultisigApp
+//
+//  Shared retry-pop for the Send-family keysign screens. Both
+//  `SendKeysignScreen` (paired) and `SendFastKeysignScreen` (fast) are
+//  reused by the FunctionCall flow, whose stack uses `FunctionCallRoute`
+//  rather than `SendRoute`. On a broadcast retry the user should land
+//  back on their verify screen, so match either flow's `.verify`.
+//  Predicate-based (not a hardcoded pop count) so it's correct for both
+//  the paired stack (verify -> pairing -> keysign) and the pair-less
+//  fast stack (verify -> keysign).
+//
+
+import Foundation
+
+extension NavigationRouter {
+    func navigateBackToKeysignVerify() {
+        navigateBack { destination in
+            if let route = destination as? SendRoute, case .verify = route {
+                return true
+            }
+            if let route = destination as? FunctionCallRoute, case .verify = route {
+                return true
+            }
+            return false
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRoute.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRoute.swift
@@ -9,6 +9,7 @@ enum SendRoute: Hashable {
     case details(seed: SendDetailsSeed)
     case verify(tx: SendTransaction, retrySignal: SendRetrySignal, vault: Vault, prebuiltKeysignPayload: KeysignPayload? = nil)
     case pairing(vault: Vault, tx: SendTransaction, retrySignal: SendRetrySignal, keysignPayload: KeysignPayload, fastVaultPassword: String?)
+    case fastKeysign(vault: Vault, keysignPayload: KeysignPayload, tx: SendTransaction, retrySignal: SendRetrySignal, fastVaultPassword: String)
     case keysign(input: KeysignInput, tx: SendTransaction, retrySignal: SendRetrySignal)
     case done(vault: Vault, hash: String, chain: Chain, tx: SendTransaction?, keysignPayload: KeysignPayload?)
     case transactionDetails(input: TransactionDonePayload)

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouteBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouteBuilder.swift
@@ -54,6 +54,23 @@ struct SendRouteBuilder {
     }
 
     @ViewBuilder
+    func buildFastKeysignScreen(
+        vault: Vault,
+        keysignPayload: KeysignPayload,
+        tx: SendTransaction,
+        retrySignal: SendRetrySignal,
+        fastVaultPassword: String
+    ) -> some View {
+        SendFastKeysignScreen(
+            vault: vault,
+            keysignPayload: keysignPayload,
+            tx: tx,
+            retrySignal: retrySignal,
+            fastVaultPassword: fastVaultPassword
+        )
+    }
+
+    @ViewBuilder
     func buildKeysignScreen(input: KeysignInput, tx: SendTransaction, retrySignal: SendRetrySignal) -> some View {
         SendKeysignScreen(input: input, tx: tx, retrySignal: retrySignal)
     }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouter.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Navigation/SendRouter.swift
@@ -31,6 +31,14 @@ struct SendRouter {
                 keysignPayload: keysignPayload,
                 fastVaultPassword: fastVaultPassword
             )
+        case .fastKeysign(let vault, let keysignPayload, let tx, let retrySignal, let fastVaultPassword):
+            viewBuilder.buildFastKeysignScreen(
+                vault: vault,
+                keysignPayload: keysignPayload,
+                tx: tx,
+                retrySignal: retrySignal,
+                fastVaultPassword: fastVaultPassword
+            )
         case .keysign(let input, let tx, let retrySignal):
             viewBuilder.buildKeysignScreen(input: input, tx: tx, retrySignal: retrySignal)
         case .done(let vault, let hash, let chain, let tx, let keysignPayload):

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendFastKeysignScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendFastKeysignScreen.swift
@@ -1,0 +1,54 @@
+//
+//  SendFastKeysignScreen.swift
+//  VultisigApp
+//
+//  Fast-vault Send keysign screen. Reached directly from Verify (no
+//  pairing screen) for fast vaults: it hosts `FastKeysignBootstrapView`,
+//  which provisions the relay session off-screen and then drives the
+//  standard `KeysignView`. Mirrors `SendKeysignScreen`'s done-navigation
+//  and retry handling; the only difference is that the `KeysignInput`
+//  is produced by the bootstrap rather than handed in pre-built.
+//
+
+import SwiftUI
+
+struct SendFastKeysignScreen: View {
+    @Environment(\.router) var router
+
+    let vault: Vault
+    let keysignPayload: KeysignPayload
+    let tx: SendTransaction
+    let retrySignal: SendRetrySignal
+    let fastVaultPassword: String
+    @StateObject var viewModel = SendKeysignViewModel()
+
+    var body: some View {
+        Screen {
+            FastKeysignBootstrapView(
+                vault: vault,
+                keysignPayload: keysignPayload,
+                customMessagePayload: nil,
+                fastVaultPassword: fastVaultPassword,
+                transferViewModel: viewModel
+            )
+        }
+        .screenNavigationBarHidden()
+        .screenEdgeInsets(.zero)
+        .onChange(of: viewModel.keysignFinished) { _, finished in
+            guard finished, let hash = viewModel.hash else { return }
+            router.navigate(to: SendRoute.done(
+                vault: vault,
+                hash: hash,
+                chain: keysignPayload.coin.chain,
+                tx: tx,
+                keysignPayload: keysignPayload
+            ))
+        }
+        .onChange(of: viewModel.pendingRetryReason) { _, reason in
+            guard let reason else { return }
+            retrySignal.pendingRetryReason = reason
+            viewModel.pendingRetryReason = nil
+            router.navigateBackToKeysignVerify()
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendFastKeysignScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendFastKeysignScreen.swift
@@ -21,6 +21,10 @@ struct SendFastKeysignScreen: View {
     let retrySignal: SendRetrySignal
     let fastVaultPassword: String
     @StateObject var viewModel = SendKeysignViewModel()
+    /// The payload the bootstrap actually signed. It can differ from the
+    /// route's `keysignPayload` (e.g. Solana blockhash refresh), so the
+    /// done screen shows the signed payload, matching the paired path.
+    @State private var signedPayload: KeysignPayload?
 
     var body: some View {
         Screen {
@@ -29,19 +33,21 @@ struct SendFastKeysignScreen: View {
                 keysignPayload: keysignPayload,
                 customMessagePayload: nil,
                 fastVaultPassword: fastVaultPassword,
-                transferViewModel: viewModel
+                transferViewModel: viewModel,
+                onKeysignInputResolved: { signedPayload = $0.keysignPayload }
             )
         }
         .screenNavigationBarHidden()
         .screenEdgeInsets(.zero)
         .onChange(of: viewModel.keysignFinished) { _, finished in
             guard finished, let hash = viewModel.hash else { return }
+            let payload = signedPayload ?? keysignPayload
             router.navigate(to: SendRoute.done(
                 vault: vault,
                 hash: hash,
-                chain: keysignPayload.coin.chain,
+                chain: payload.coin.chain,
                 tx: tx,
-                keysignPayload: keysignPayload
+                keysignPayload: payload
             ))
         }
         .onChange(of: viewModel.pendingRetryReason) { _, reason in

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendFastKeysignScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendFastKeysignScreen.swift
@@ -20,7 +20,7 @@ struct SendFastKeysignScreen: View {
     let tx: SendTransaction
     let retrySignal: SendRetrySignal
     let fastVaultPassword: String
-    @StateObject var viewModel = SendKeysignViewModel()
+    @StateObject private var viewModel = SendKeysignViewModel()
     /// The payload the bootstrap actually signed. It can differ from the
     /// route's `keysignPayload` (e.g. Solana blockhash refresh), so the
     /// done screen shows the signed payload, matching the paired path.

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendKeysignScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendKeysignScreen.swift
@@ -53,9 +53,7 @@ struct SendKeysignScreen: View {
             guard let reason else { return }
             retrySignal.pendingRetryReason = reason
             viewModel.pendingRetryReason = nil
-            // Stack: details -> verify -> pairing -> keysign. Pop pairing + keysign.
-            let popCount = min(2, router.navPath.count)
-            router.navPath.removeLast(popCount)
+            router.navigateBackToKeysignVerify()
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
@@ -155,13 +155,28 @@ struct SendVerifyScreen: View {
             do {
                 let result = try await sendCryptoVerifyViewModel.validateForm()
                 await MainActor.run {
-                    router.navigate(to: SendRoute.pairing(
-                        vault: vault,
-                        tx: sendCryptoVerifyViewModel.transaction,
-                        retrySignal: retrySignal,
-                        keysignPayload: result,
-                        fastVaultPassword: sendCryptoVerifyViewModel.fastVaultPassword.nilIfEmpty
-                    ))
+                    // Fast vaults sign server-side with no peer to pair with,
+                    // so route straight into keysign (the bootstrap runs there)
+                    // and never mount the pairing screen. A present fast
+                    // password is the fast-sign signal; an empty one means the
+                    // user chose paired-sign, which keeps the QR pairing screen.
+                    if let fastPassword = sendCryptoVerifyViewModel.fastVaultPassword.nilIfEmpty {
+                        router.navigate(to: SendRoute.fastKeysign(
+                            vault: vault,
+                            keysignPayload: result,
+                            tx: sendCryptoVerifyViewModel.transaction,
+                            retrySignal: retrySignal,
+                            fastVaultPassword: fastPassword
+                        ))
+                    } else {
+                        router.navigate(to: SendRoute.pairing(
+                            vault: vault,
+                            tx: sendCryptoVerifyViewModel.transaction,
+                            retrySignal: retrySignal,
+                            keysignPayload: result,
+                            fastVaultPassword: nil
+                        ))
+                    }
                 }
             } catch {
                 await MainActor.run {

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
@@ -108,7 +108,18 @@ struct SettingsCustomMessageView: View {
 
     var keysign: some View {
         ZStack {
-            if let keysignView = keysignView {
+            if let fastPassword = fastVaultPassword.nilIfEmpty {
+                // Fast vaults skip the pair screen: the off-screen
+                // bootstrap runs here and then drives KeysignView, showing
+                // the signing animation throughout.
+                FastKeysignBootstrapView(
+                    vault: vault,
+                    keysignPayload: nil,
+                    customMessagePayload: customMessagePayload,
+                    fastVaultPassword: fastPassword,
+                    transferViewModel: viewModel
+                )
+            } else if let keysignView = keysignView {
                 keysignView
             } else {
                 signingErrorView
@@ -226,5 +237,13 @@ struct SettingsCustomMessageView: View {
 
     func onSignPress() {
         viewModel.moveToNextView()
+        // Fast vaults have no peer to pair with, so skip the pair state and
+        // land on keysign, where the off-screen bootstrap runs. A present
+        // fast password is the fast-sign signal; paired-sign (empty
+        // password) keeps the pair state and its QR screen. Advancing to
+        // keysign also hides the back button during signing (canGoBack()).
+        if fastVaultPassword.nilIfEmpty != nil {
+            viewModel.moveToNextView()
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Navigation/SwapRoute.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Navigation/SwapRoute.swift
@@ -12,6 +12,7 @@ enum SwapRoute: Hashable {
     case root(fromCoinID: String?, toCoinID: String?, vaultPubKeyECDSA: String)
     case verify(transaction: SwapTransaction, retrySignal: SwapRetrySignal, vaultPubKeyECDSA: String)
     case pair(vaultPubKeyECDSA: String, transaction: SwapTransaction, retrySignal: SwapRetrySignal, keysignPayload: KeysignPayload, fastVaultPassword: String?)
+    case fastKeysign(vaultPubKeyECDSA: String, keysignPayload: KeysignPayload, transaction: SwapTransaction, retrySignal: SwapRetrySignal, fastVaultPassword: String)
     case keysign(input: KeysignInput, transaction: SwapTransaction, retrySignal: SwapRetrySignal)
     case done(vaultPubKeyECDSA: String, hash: String, approveHash: String?, chain: Chain, transaction: SwapTransaction, progressLink: String?)
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Navigation/SwapRouter.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Navigation/SwapRouter.swift
@@ -32,6 +32,16 @@ struct SwapRouter {
                     fastVaultPassword: fastVaultPassword
                 )
             }
+        case .fastKeysign(let vaultPubKeyECDSA, let keysignPayload, let transaction, let retrySignal, let fastVaultPassword):
+            if let vault = lookupVault(pubKeyECDSA: vaultPubKeyECDSA) {
+                buildFastKeysignScreen(
+                    vault: vault,
+                    keysignPayload: keysignPayload,
+                    transaction: transaction,
+                    retrySignal: retrySignal,
+                    fastVaultPassword: fastVaultPassword
+                )
+            }
         case .keysign(let input, let transaction, let retrySignal):
             buildKeysignScreen(input: input, transaction: transaction, retrySignal: retrySignal)
         case .done(let vaultPubKeyECDSA, let hash, let approveHash, let chain, let transaction, let progressLink):
@@ -71,6 +81,23 @@ struct SwapRouter {
             transaction: transaction,
             retrySignal: retrySignal,
             keysignPayload: keysignPayload,
+            fastVaultPassword: fastVaultPassword
+        )
+    }
+
+    @ViewBuilder
+    func buildFastKeysignScreen(
+        vault: Vault,
+        keysignPayload: KeysignPayload,
+        transaction: SwapTransaction,
+        retrySignal: SwapRetrySignal,
+        fastVaultPassword: String
+    ) -> some View {
+        SwapFastKeysignScreen(
+            vault: vault,
+            keysignPayload: keysignPayload,
+            transaction: transaction,
+            retrySignal: retrySignal,
             fastVaultPassword: fastVaultPassword
         )
     }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapFastKeysignScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapFastKeysignScreen.swift
@@ -1,0 +1,77 @@
+//
+//  SwapFastKeysignScreen.swift
+//  VultisigApp
+//
+//  Fast-vault Swap keysign screen. Reached directly from Verify (no
+//  pairing screen) for fast vaults: it hosts `FastKeysignBootstrapView`,
+//  which provisions the relay session off-screen and then drives the
+//  standard `KeysignView`. Mirrors `SwapKeysignScreen`'s done-navigation
+//  and predicate-based retry handling.
+//
+
+import SwiftUI
+
+struct SwapFastKeysignScreen: View {
+    @Environment(\.router) var router
+
+    let vault: Vault
+    let keysignPayload: KeysignPayload
+    let transaction: SwapTransaction
+    let retrySignal: SwapRetrySignal
+    let fastVaultPassword: String
+    @State var viewModel: SwapKeysignViewModel
+
+    init(
+        vault: Vault,
+        keysignPayload: KeysignPayload,
+        transaction: SwapTransaction,
+        retrySignal: SwapRetrySignal,
+        fastVaultPassword: String
+    ) {
+        self.vault = vault
+        self.keysignPayload = keysignPayload
+        self.transaction = transaction
+        self.retrySignal = retrySignal
+        self.fastVaultPassword = fastVaultPassword
+        self._viewModel = State(initialValue: SwapKeysignViewModel(retrySignal: retrySignal))
+    }
+
+    var body: some View {
+        Screen {
+            FastKeysignBootstrapView(
+                vault: vault,
+                keysignPayload: keysignPayload,
+                customMessagePayload: nil,
+                fastVaultPassword: fastVaultPassword,
+                transferViewModel: viewModel
+            )
+        }
+        .screenNavigationBarHidden()
+        .screenEdgeInsets(.zero)
+        .onChange(of: viewModel.keysignFinished) { _, finished in
+            guard finished, let hash = viewModel.hash else { return }
+            let chain = transaction.fromCoin.chain
+            router.navigate(to: SwapRoute.done(
+                vaultPubKeyECDSA: vault.pubKeyECDSA,
+                hash: hash,
+                approveHash: viewModel.approveHash,
+                chain: chain,
+                transaction: transaction,
+                progressLink: transaction.progressLink(hash: hash)
+            ))
+        }
+        .onChange(of: retrySignal.pendingRetryReason) { _, reason in
+            guard reason != nil else { return }
+            // Pop back to the verify screen — robust to deep-links that add
+            // routes before .root. Fast stack: root -> verify -> keysign.
+            router.navigateBack { destination in
+                guard let route = destination as? SwapRoute else { return false }
+                if case .verify = route { return true }
+                return false
+            }
+        }
+        .onDisappear {
+            viewModel.stopMediator()
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapFastKeysignScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapFastKeysignScreen.swift
@@ -19,7 +19,7 @@ struct SwapFastKeysignScreen: View {
     let transaction: SwapTransaction
     let retrySignal: SwapRetrySignal
     let fastVaultPassword: String
-    @State var viewModel: SwapKeysignViewModel
+    @State private var viewModel: SwapKeysignViewModel
 
     init(
         vault: Vault,

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -301,13 +301,28 @@ struct SwapVerifyScreen: View {
             }
             if let payload = await verifyViewModel.buildSwapKeysignPayload(vault: vault) {
                 await MainActor.run {
-                    router.navigate(to: SwapRoute.pair(
-                        vaultPubKeyECDSA: vault.pubKeyECDSA,
-                        transaction: currentTransaction,
-                        retrySignal: retrySignal,
-                        keysignPayload: payload,
-                        fastVaultPassword: fastVaultPassword.nilIfEmpty
-                    ))
+                    // Fast vaults sign server-side with no peer to pair with,
+                    // so route straight into keysign (the bootstrap runs there)
+                    // and skip the pairing screen. A present fast password is
+                    // the fast-sign signal; an empty one means paired-sign,
+                    // which keeps the QR pairing screen.
+                    if let fastPassword = fastVaultPassword.nilIfEmpty {
+                        router.navigate(to: SwapRoute.fastKeysign(
+                            vaultPubKeyECDSA: vault.pubKeyECDSA,
+                            keysignPayload: payload,
+                            transaction: currentTransaction,
+                            retrySignal: retrySignal,
+                            fastVaultPassword: fastPassword
+                        ))
+                    } else {
+                        router.navigate(to: SwapRoute.pair(
+                            vaultPubKeyECDSA: vault.pubKeyECDSA,
+                            transaction: currentTransaction,
+                            retrySignal: retrySignal,
+                            keysignPayload: payload,
+                            fastVaultPassword: nil
+                        ))
+                    }
                 }
             }
             await MainActor.run { signButtonDisabled = false }

--- a/VultisigApp/VultisigAppTests/Keysign/FastVaultKeysignBootstrapTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/FastVaultKeysignBootstrapTests.swift
@@ -1,0 +1,230 @@
+//
+//  FastVaultKeysignBootstrapTests.swift
+//  VultisigAppTests
+//
+//  Covers the off-screen fast-vault session bootstrap: it must run the
+//  relay calls in the QBTC-proven order (register -> wake -> await ->
+//  kickoff) and assemble a `KeysignInput` whose committee/session fields
+//  come from the joined peers + the provisioned session. Uses the
+//  custom-message path so message generation is pure (no relay / no
+//  chain RPC) and the assertions stay deterministic.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class FastVaultKeysignBootstrapTests: XCTestCase {
+
+    private static let session = KeysignSessionInfo(
+        sessionId: "session-abc",
+        encryptionKeyHex: String(repeating: "ab", count: 32),
+        serviceName: "Vultisig-Test",
+        localPartyId: "iPhone-A",
+        serverAddr: "https://relay.vultisig.test"
+    )
+
+    private static let participants = ["iPhone-A", "server-1"]
+
+    private func makeVaultWithEthereum() -> Vault {
+        let vault = Vault(name: "TestVault")
+        let ethCoin = Coin(
+            asset: CoinMeta(
+                chain: .ethereum,
+                ticker: "ETH",
+                logo: "eth",
+                decimals: 18,
+                priceProviderId: "ethereum",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: "0x0000000000000000000000000000000000000000",
+            hexPublicKey: "04"
+        )
+        vault.coins = [ethCoin]
+        return vault
+    }
+
+    private func makeCustomMessagePayload(for vault: Vault) -> CustomMessagePayload {
+        CustomMessagePayload(
+            method: "personal_sign",
+            message: "0xdeadbeef",
+            vaultPublicKeyECDSA: vault.pubKeyECDSA,
+            vaultLocalPartyID: vault.localPartyID,
+            chain: Chain.ethereum.name,
+            decodedMessage: nil
+        )
+    }
+
+    func testMakeKeysignInputRunsBootstrapInOrderAndAssemblesInput() async throws {
+        let mock = MockFastVaultSessionProvider(session: Self.session, participants: Self.participants)
+        let vault = makeVaultWithEthereum()
+        let payload = makeCustomMessagePayload(for: vault)
+        let bootstrap = FastVaultKeysignBootstrap(sessionService: mock)
+
+        let input = try await bootstrap.makeKeysignInput(
+            vault: vault,
+            keysignPayload: nil,
+            customMessagePayload: payload,
+            fastVaultPassword: "hunter2"
+        )
+
+        // Bootstrap must register on the relay BEFORE waking Vultiserver,
+        // then await the peer, then kick off — the QBTC-proven order.
+        XCTAssertEqual(
+            mock.calls.map(\.name),
+            ["newSession", "register", "wake", "awaitPeer", "kickoff"]
+        )
+
+        // Committee + session identity flow from the joined peers and the
+        // provisioned session, not from anything the caller built up front.
+        XCTAssertEqual(input.keysignCommittee, Self.participants)
+        XCTAssertEqual(input.sessionID, Self.session.sessionId)
+        XCTAssertEqual(input.mediatorURL, Self.session.serverAddr)
+        XCTAssertEqual(input.encryptionKeyHex, Self.session.encryptionKeyHex)
+        XCTAssertTrue(input.isInitiateDevice)
+        XCTAssertNil(input.keysignPayload)
+        XCTAssertEqual(input.customMessagePayload, payload)
+        XCTAssertEqual(input.messsageToSign, payload.keysignMessages)
+        XCTAssertFalse(input.messsageToSign.isEmpty)
+        if case .ECDSA = input.keysignType {} else {
+            XCTFail("Custom-message (Ethereum) signing should use ECDSA, got \(input.keysignType)")
+        }
+
+        // The wake POST must carry the same messages + coin metadata.
+        XCTAssertEqual(mock.wakeMessages, payload.keysignMessages)
+        XCTAssertEqual(mock.wakeChain, Chain.ethereum.name)
+        XCTAssertEqual(mock.wakeVaultPassword, "hunter2")
+        XCTAssertEqual(mock.wakeIsECDSA, true)
+        XCTAssertEqual(mock.wakeIsMldsa, false)
+
+        // The committee we kick off with is exactly the awaited peer set.
+        XCTAssertEqual(mock.kickoffParticipants, Self.participants)
+    }
+
+    func testMakeKeysignInputPropagatesPeerTimeout() async {
+        let mock = MockFastVaultSessionProvider(session: Self.session, participants: Self.participants)
+        mock.awaitError = KeysignSessionServiceError.fastVaultPeerTimeout
+        let vault = makeVaultWithEthereum()
+        let payload = makeCustomMessagePayload(for: vault)
+        let bootstrap = FastVaultKeysignBootstrap(sessionService: mock)
+
+        do {
+            _ = try await bootstrap.makeKeysignInput(
+                vault: vault,
+                keysignPayload: nil,
+                customMessagePayload: payload,
+                fastVaultPassword: "hunter2"
+            )
+            XCTFail("Expected the peer timeout to propagate")
+        } catch {
+            // Kickoff must not run once the peer never joined.
+            XCTAssertFalse(mock.calls.map(\.name).contains("kickoff"))
+        }
+    }
+
+    func testMakeKeysignInputThrowsWhenNothingToSign() async {
+        let mock = MockFastVaultSessionProvider(session: Self.session, participants: Self.participants)
+        let vault = makeVaultWithEthereum()
+        let bootstrap = FastVaultKeysignBootstrap(sessionService: mock)
+
+        do {
+            _ = try await bootstrap.makeKeysignInput(
+                vault: vault,
+                keysignPayload: nil,
+                customMessagePayload: nil,
+                fastVaultPassword: "hunter2"
+            )
+            XCTFail("Expected a missing-payload error")
+        } catch let error as FastVaultKeysignBootstrapError {
+            XCTAssertEqual(error, .missingPayload)
+            XCTAssertTrue(mock.calls.map(\.name).allSatisfy { $0 == "newSession" })
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}
+
+extension FastVaultKeysignBootstrapError: Equatable {
+    public static func == (lhs: FastVaultKeysignBootstrapError, rhs: FastVaultKeysignBootstrapError) -> Bool {
+        switch (lhs, rhs) {
+        case (.missingSigningCoin, .missingSigningCoin),
+             (.noMessagesToSign, .noMessagesToSign),
+             (.missingPayload, .missingPayload):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// swiftlint:disable async_without_await
+@MainActor
+private final class MockFastVaultSessionProvider: FastVaultKeysignSessionProviding {
+
+    struct Call {
+        let name: String
+    }
+
+    private(set) var calls: [Call] = []
+    private let session: KeysignSessionInfo
+    var participants: [String]
+    var awaitError: Error?
+
+    // Captured wake arguments for assertions.
+    private(set) var wakeMessages: [String] = []
+    private(set) var wakeChain: String = ""
+    private(set) var wakeVaultPassword: String = ""
+    private(set) var wakeIsECDSA: Bool = false
+    private(set) var wakeIsMldsa: Bool = false
+    private(set) var kickoffParticipants: [String] = []
+
+    init(session: KeysignSessionInfo, participants: [String]) {
+        self.session = session
+        self.participants = participants
+    }
+
+    func newSession(vault _: Vault, serviceName _: String?) throws -> KeysignSessionInfo {
+        calls.append(Call(name: "newSession"))
+        return session
+    }
+
+    func registerAsParticipant(session _: KeysignSessionInfo) async throws {
+        calls.append(Call(name: "register"))
+    }
+
+    func wakeFastVaultServer(
+        publicKeyEcdsa _: String,
+        keysignMessages: [String],
+        session _: KeysignSessionInfo,
+        derivePath _: String,
+        isECDSA: Bool,
+        vaultPassword: String,
+        chain: String,
+        isMldsa: Bool
+    ) async throws {
+        calls.append(Call(name: "wake"))
+        wakeMessages = keysignMessages
+        wakeChain = chain
+        wakeVaultPassword = vaultPassword
+        wakeIsECDSA = isECDSA
+        wakeIsMldsa = isMldsa
+    }
+
+    func awaitFastVaultPeer(
+        discovery _: ParticipantDiscovery,
+        session _: KeysignSessionInfo,
+        timeout _: TimeInterval
+    ) async throws -> [String] {
+        calls.append(Call(name: "awaitPeer"))
+        if let awaitError { throw awaitError }
+        return participants
+    }
+
+    func kickoffCommittee(session _: KeysignSessionInfo, participants: [String]) async throws {
+        calls.append(Call(name: "kickoff"))
+        kickoffParticipants = participants
+    }
+}
+
+// swiftlint:enable async_without_await


### PR DESCRIPTION
## Description

For a **fast (server-assisted) vault**, a transaction used to mount the keysign pairing screen (`PairScreen` → `KeysignDiscoveryView`) purely to auto-sign — a throwaway UX step, since there is no other device to pair with. This PR makes fast vaults route **Verify → Keysign directly**, with the pairing screen never entering the nav stack, unified across **Send / Swap / Function-call / Custom-message**. Secure (multi-device) vaults are unchanged — they still show the pairing/QR screen.

Generalizes the pattern QBTC already uses: a fast vault's `KeysignInput` can't be built up front (`keysignCommittee` only materializes once the Vultiserver joins the relay session), so instead of routing into `.keysign(input:)` we route into a keysign screen that runs the wake → await → kickoff bootstrap in its own `.task`, showing the signing animation during the wait.

Fixes #4766

### What changed

- **`FastVaultKeysignBootstrap`** (new) — shared off-screen helper on the existing view-free `KeysignSessionService`. Runs `newSession → build messages → registerAsParticipant → wakeFastVaultServer → awaitFastVaultPeer → kickoffCommittee` (the QBTC-proven order) and assembles the finished `KeysignInput`. Consolidates what were three copies of the fast relay-bootstrap (Send/Swap/FunctionCall's inline `KeysignDiscoveryViewModel.setData`, and QBTC's round runner). Preserves the Solana blockhash refresh so both signers share the same fresh hash. Unit-tested via a `FastVaultKeysignSessionProviding` seam + mock.
- **`FastKeysignBootstrapView`** (new) — thin shared wait wrapper: runs the bootstrap in `.task` (showing `KeysignAnimationView` while Vultiserver joins), then drives the standard `KeysignView`. Bootstrap failures surface through the existing keysign error surface (`SendCryptoKeysignView`) with a retry that re-runs the bootstrap — no new error UI or user-facing strings.
- **Per-flow routing** — each verify screen branches on the fast-sign password: a present password routes to a new dedicated fast route (`SendRoute.fastKeysign`, `FunctionCallRoute.fastKeysign`, `SwapRoute.fastKeysign`, or the custom-message keysign state), skipping the pairing route entirely. An empty password (paired-sign) and secure vaults keep the existing pairing route untouched.
  - **Send** → `SendFastKeysignScreen`
  - **FunctionCall** → reuses `SendFastKeysignScreen` (like the paired path reuses `SendKeysignScreen`)
  - **Swap** → `SwapFastKeysignScreen`
  - **Custom-message** → advances its ZStack state machine straight to the keysign state and renders `FastKeysignBootstrapView`
- **Retry-pop fix (Send + FunctionCall)** — `SendKeysignScreen`'s hardcoded `removeLast(min(2, …))` assumed the pairing screen was on the stack; on the pair-less fast stack that would wrongly pop verify+keysign. Replaced with predicate-based `navigateBackToKeysignVerify()` that pops back to the verify screen and is correct for both the paired stack (`verify → pairing → keysign`) and the fast stack (`verify → keysign`), for both `SendRoute` and `FunctionCallRoute` (FunctionCall reuses these screens). Swap already used predicate-based back-nav and is unchanged.

### QBTC decision

Left QBTC **as-is**. QBTC drives DKLS + its proof service directly via `QBTCClaimOrchestrator` (not `KeysignView`), signs a UTXO/hash payload (`isQbtcClaim`, no `KeysignPayload`), and runs a post-sign `/prove` broadcast step — none of which fit the `KeysignInput`/`KeysignView` shape `FastVaultKeysignBootstrap` produces. Both already share the underlying `KeysignSessionService`, so there is **no duplicated relay-bootstrap copy left behind** — the engine is consolidated. Folding QBTC's view layer onto the shared wrapper would destabilize a working claim flow for no dedup gain.

## Which feature is affected?
- [x] Sending
- [x] Swap
- [x] New Chain / Chain related feature — Function-call/DeFi + Custom-message signing (fast-vault routing)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (SwiftLint clean on all touched files)
- [x] I have added tests that prove my fix is effective (`FastVaultKeysignBootstrapTests`)

## Test / review notes

- **Cross-model review loop (Codex, gpt-5.5 high, read-only):** each step gated by a Codex review before the next. Findings triaged: Step 1 — 1 MAJOR fixed (`keysignType` was forced `.ECDSA` for custom-message chains → now derived from the resolved `coin.chain.signingKeyType`); Steps 2+3 — 1 MINOR fixed (fast done-nav now shows the bootstrap-resolved/signed payload, matching the paired path); Steps 4+5+6 and the whole-branch pass — no findings.
- **Gate:** `make test` (iPhone 16 sim, region forced en_US to avoid the known en_AR decimal-comma flake) — **Executed 2524 tests, 1 skipped, 0 failures**. SwiftLint clean.
- **MPC byte-parity:** this is a routing relocation only — no change to the signing ceremony / DKLS. Same session bootstrap, just moved off the pair screen.

### Pending manual verification (couldn't be exercised in this environment)
- [ ] Fast-vault on-device sign for Send / Swap / Function-call / Custom-message — confirm Verify → Keysign with **no** pairing screen and a successful broadcast.
- [ ] Secure (2-device paired) regression for all four flows — confirm the QR/pairing screen and signing still work unchanged.

## Agent Metadata
- **Agent**: Claude Code
- **Issue**: #4766
- **Confidence**: high
- **Needs human review for**: fast on-device + 2-device paired signing regression (MPC ceremony untouched, but not runtime-tested here)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster signing path that can skip the pairing step when a fast vault password is available.
  * Expanded fast-signing support across Send, Swap, Function Call, and Custom Message flows.
  * Introduced an off-screen bootstrap step that prepares signing before showing the standard signing screen.

* **Bug Fixes**
  * Improved retry navigation so users return to the correct verification screen after a signing interruption.
  * Made fast-signing navigation and completion handling more consistent across flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->