### PR TITLE
fix(keysign): sha256-hash cosmos custom messages to match Android/Windows

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Services/CustomMessagePayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/CustomMessagePayload.swift
@@ -39,6 +39,14 @@ struct CustomMessagePayload: Codable, Hashable {
         } else if method == "eth_signTypedData_v4" {
             // Handle eth_signTypedData_v4 (EIP-712)
             return keysignMessagesForTypedData()
+        } else if isCosmosFamily {
+            // Cosmos-family chains (incl. THORChain/Maya) sign the sha256 of the
+            // message (Keplr ADR-36 signArbitrary over the StdSignDoc bytes).
+            // keccak256 here diverges from the md5 message-ID the initiator
+            // derives, so cross-platform co-signing 404s. Mirrors
+            // getCustomMessageHex.ts in vultisig-windows and vultisig-android.
+            let hash = data.sha256()
+            return [hash.hexString]
         } else if method == "sign_message" && chain.lowercased() == "tron" {
             // TRON: message has TIP-191/legacy header prefix from extension, hash with keccak256
             let hash = data.sha3(.keccak256)
@@ -51,6 +59,22 @@ struct CustomMessagePayload: Codable, Hashable {
         } else {
             // For Solana and other chains that don't use keccak256, use the message directly
             return [data.hexString]
+        }
+    }
+
+    /// Whether `chain` is a Cosmos-family chain (Cosmos SDK or THORChain/Maya),
+    /// which sign the sha256 of the custom message rather than keccak256.
+    private var isCosmosFamily: Bool {
+        guard let resolved = Chain.allCases.first(where: {
+            $0.name.caseInsensitiveCompare(chain) == .orderedSame
+        }) else {
+            return false
+        }
+        switch resolved.chainType {
+        case .Cosmos, .THORChain:
+            return true
+        default:
+            return false
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Chains/CosmosCustomMessageTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CosmosCustomMessageTests.swift
@@ -1,0 +1,71 @@
+//
+//  CosmosCustomMessageTests.swift
+//  VultisigApp
+//
+
+@testable import VultisigApp
+import Foundation
+import WalletCore
+import XCTest
+
+/// Cosmos-family dApp custom-message co-signing path. Cosmos SDK chains and
+/// THORChain/Maya sign the sha256 of the message (Keplr ADR-36 signArbitrary
+/// over the StdSignDoc bytes). keccak256 here — the EVM default in this code
+/// path — diverges from the md5 message-ID the initiator derives, so
+/// cross-platform co-signing 404s. Mirrors getCustomMessageHex.ts in
+/// vultisig-windows and the fix in vultisig-android#5240.
+final class CosmosCustomMessageTests: XCTestCase {
+
+    private func makePayload(method: String, message: String, chain: String) -> CustomMessagePayload {
+        CustomMessagePayload(
+            method: method,
+            message: message,
+            vaultPublicKeyECDSA: "",
+            vaultLocalPartyID: "",
+            chain: chain
+        )
+    }
+
+    func testThorChainHexMessageIsSha256Hashed() {
+        let hexMessage = "0xabcdef0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d"
+        let expected = Data(hex: hexMessage).sha256().hexString
+        let payload = makePayload(method: "sign", message: hexMessage, chain: "THORChain")
+
+        XCTAssertEqual(payload.keysignMessages, [expected])
+    }
+
+    func testNativeCosmosPlainTextMessageIsSha256Hashed() {
+        let message = "Hello Vultisig"
+        let expected = Data(message.utf8).sha256().hexString
+        let payload = makePayload(method: "sign", message: message, chain: "Cosmos")
+
+        XCTAssertEqual(payload.keysignMessages, [expected])
+    }
+
+    func testMayaChainMessageIsSha256Hashed() {
+        let message = "Hello Maya"
+        let expected = Data(message.utf8).sha256().hexString
+        let payload = makePayload(method: "sign", message: message, chain: "MayaChain")
+
+        XCTAssertEqual(payload.keysignMessages, [expected])
+    }
+
+    func testCosmosBranchAcceptsMixedCaseChainName() {
+        let message = "case insensitive"
+        let expected = Data(message.utf8).sha256().hexString
+        for chain in ["thorchain", "THORChain", "THORCHAIN"] {
+            let payload = makePayload(method: "sign", message: message, chain: chain)
+            XCTAssertEqual(payload.keysignMessages, [expected], "Failed for chain: \(chain)")
+        }
+    }
+
+    func testEvmMessageDoesNotTakeCosmosSha256Path() {
+        // Guard against the Cosmos branch swallowing EVM custom messages: an
+        // Ethereum personal_sign must NOT produce the sha256 digest.
+        let message = "not a cosmos message"
+        let sha256Digest = Data(message.utf8).sha256().hexString
+        let payload = makePayload(method: "personal_sign", message: message, chain: "Ethereum")
+
+        XCTAssertNotEqual(payload.keysignMessages, [sha256Digest])
+    }
+}


### PR DESCRIPTION
## Summary
Ports [vultisig-android#5240](https://github.com/vultisig/vultisig-android/pull/5240) to iOS/macOS.

Cosmos-family chains (Cosmos SDK, THORChain/Maya) sign the **sha256** of a custom message — Keplr ADR-36 `signArbitrary` over the `StdSignDoc` bytes — but `CustomMessagePayload.keysignMessages` fell through to the **keccak256** branch for them. The resulting digest (and the message-ID the relay derives from it) diverged from **Android**, **Windows/extension** (`getCustomMessageHex.ts`), and the **CLI initiator**, so an iOS device **could not co-sign a cosmos custom message cross-platform** — the keysign rounds 404'd and the session timed out.

Contrary to the Android PR's description, iOS was **not** already the correct reference; it had the same bug.

## Fix
Route the digest by chain kind, mirroring `getCustomMessageHex.ts` and the Android fix:

| chain kind | digest |
|---|---|
| cosmos-family (`.Cosmos`, `.THORChain` incl. Maya) | sha256 |
| EdDSA (Solana, TON, Cardano) | raw / precomputed |
| everything else (EVM, Tron) | keccak256 |

`isCosmosFamily` resolves the payload's `chain` name (case-insensitively) to a `Chain` and checks its `chainType`, the analog of Android's `TokenStandard.COSMOS || THORCHAIN`. The Cardano and EIP-712 special cases keep their precedence; EVM / EdDSA / Tron / typed-data behavior is unchanged — only cosmos-family custom messages change (keccak256 → sha256).

## Test Plan
- [x] New `CosmosCustomMessageTests` (THORChain/Cosmos/Maya → sha256, mixed-case chain name, EVM guard) — 5/5 pass
- [x] Existing `CardanoCustomMessageTests` still green (regression) — 5/5 pass
- [x] SwiftLint passes (0 violations)
- [x] Build succeeds (`test_sim` on iPhone 16 Pro)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message signing for Cosmos-family chains, ensuring the signed payload is now hashed consistently for supported networks.
  * Added case-insensitive chain handling so the same network name works regardless of capitalization.
  * Preserved existing behavior for non-Cosmos signing flows.

* **Tests**
  * Added coverage for supported chain signing results and capitalization variations.
  * Added a check to confirm Ethereum-style signing does not use the Cosmos-family hashing path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->