### PR TITLE
DoneScreen staged reveal — centered hero → settle-up + details

### DIFF
--- a/VultisigApp/VultisigApp/Components/TransactionDone/DoneScreen.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/DoneScreen.swift
@@ -45,6 +45,23 @@ struct DoneScreen<
 
     @State private var showAlert = false
 
+    /// Two-phase arrival. `.hero` shows only the status animation + title,
+    /// vertically centered (continuing the full-bleed keysign animation that
+    /// crossfades in). After `revealDelay` the header settles to the top and
+    /// the card / details / bottom bar reveal beneath it (`.expanded`).
+    /// Reduce Motion seeds `.expanded` so there's no staged beat.
+    @State private var revealPhase: RevealPhase = .hero
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private enum RevealPhase { case hero, expanded }
+    private var isExpanded: Bool { revealPhase == .expanded }
+
+    /// Hold the centered hero before settling up. Sized so the #4777
+    /// keysign→overview crossfade (0.35s opacity fade-in) finishes first,
+    /// then the hero holds ~0.8s — so the crossfade and the settle-up read
+    /// as two sequential beats instead of overlapping into one blur.
+    private let revealDelay: UInt64 = 1_150_000_000 // ≈ 0.35s crossfade + 0.8s hold
+
     /// Construct via `DoneStatusServiceFactory`. The
     /// `statusService` autoclosure is evaluated lazily by `@StateObject`
     /// the first time the view appears — subsequent re-renders re-call
@@ -78,26 +95,57 @@ struct DoneScreen<
 
     private var content: some View {
         VStack(spacing: 0) {
-            ScrollView {
-                VStack(spacing: 8) {
-                    TransactionStatusHeaderView(status: statusService.status, verb: input.verb)
-                        .frame(minHeight: 150, maxHeight: 200)
-                        .padding(.bottom, 36)
+            // Top spacer — present only in the hero phase; collapses to 0 on
+            // expand so the header rises from center to top.
+            Spacer(minLength: 0)
+                .frame(maxHeight: isExpanded ? 0 : .infinity)
 
-                    tokenContent()
+            TransactionStatusHeaderView(status: statusService.status, verb: input.verb)
+                .frame(minHeight: 150, maxHeight: 200)
+                .padding(.bottom, isExpanded ? 36 : 0)
 
-                    detailContent()
+            // Body — laid out only once expanded; fades + slides up.
+            if isExpanded {
+                ScrollView {
+                    VStack(spacing: 8) {
+                        tokenContent()
+
+                        detailContent()
+                    }
                 }
-            }
-            .scrollIndicators(.hidden)
+                .scrollIndicators(.hidden)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
 
-            bottomBarContent()
+                bottomBarContent()
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
+            // Bottom spacer — mirrors the top spacer to center the hero.
+            Spacer(minLength: 0)
+                .frame(maxHeight: isExpanded ? 0 : .infinity)
         }
         .onAppear {
             statusService.start()
             TransactionHistoryRecording.record(payload: input)
         }
         .onDisappear { statusService.stop() }
+        .task { await revealAfterHold() }
+    }
+
+    /// Holds the centered hero for `revealDelay`, then springs to the
+    /// expanded layout. Reduce Motion skips the hold and the animation.
+    private func revealAfterHold() async {
+        guard !reduceMotion else {
+            revealPhase = .expanded
+            return
+        }
+        try? await Task.sleep(nanoseconds: revealDelay)
+        // Respect `.task` cancellation on disappear — don't flip state /
+        // animate a view that's already gone (e.g. after `restart()`).
+        guard !Task.isCancelled else { return }
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.85)) {
+            revealPhase = .expanded
+        }
     }
 }
 
@@ -264,3 +312,52 @@ extension EnvironmentValues {
         set { self[NotifyHashCopiedKey.self] = newValue }
     }
 }
+
+// MARK: - Previews
+
+#if DEBUG
+/// Preview-only status backend — surfaces a fixed status and never polls,
+/// so the staged reveal can be exercised in the canvas without a live tx.
+private struct PreviewDoneStatusPoller: DoneStatusPoller {
+    let initialStatus: TransactionStatus
+    func start(onStatus _: @escaping (TransactionStatus) -> Void) { }
+    func stop() { }
+}
+
+private func previewDonePayload() -> TransactionDonePayload {
+    TransactionDonePayload(
+        coin: .example,
+        amountCrypto: "0.5 ETH",
+        amountFiat: "1234.56",
+        hash: "0x8f3ac1b29e7d5640",
+        explorerLink: "",
+        memo: "",
+        isSend: true,
+        fromAddress: "0x1A2b3C4d5E6f7089",
+        toAddress: "0x90aB81cD72eF6350",
+        fee: FeeDisplay(crypto: "0.00021 ETH", fiat: "$0.62"),
+        keysignPayload: nil,
+        pubKeyECDSA: ""
+    )
+}
+
+@MainActor
+private func previewDoneScreen(_ status: TransactionStatus) -> some View {
+    DoneScreen(
+        input: previewDonePayload(),
+        statusService: DoneStatusService(poller: PreviewDoneStatusPoller(initialStatus: status)),
+        navigationTitle: "overview".localized
+    )
+    .environmentObject(AppViewModel())
+}
+
+// Re-run the preview (⌘-Option-P / the refresh button) to replay the
+// hero → settle-up reveal.
+#Preview("Staged reveal · broadcasted") {
+    previewDoneScreen(.broadcasted(estimatedTime: "~5 sec"))
+}
+
+#Preview("Staged reveal · confirmed") {
+    previewDoneScreen(.confirmed)
+}
+#endif


### PR DESCRIPTION
Follow-up polish on the keysign → overview flow (builds on #4777 / #4768). **Stacked on `feat/keysign-overview-container-4768`** — this PR's base is the #4777 branch, so its diff is just the one commit below; retarget to `main` once #4777 merges.

## What & why

Today the whole overview appears at once. This stages the *arrival* on the Done surface into two beats so it reads as a deliberate completion instead of a pop-in:

1. **Hero** — on appear, only the status animation + title ("Transaction broadcasted") show, **vertically centered**.
2. **Settle-up** — after a brief hold the header **springs to the top** and the token card + details + bottom bar **fade + slide up** beneath it.

Because #4777 crossfades the full-bleed keysign animation into `DoneScreen`, and the hero holds the status animation centered at ≈ the same screen position, the two transitions chain into one continuous motion: keysign animation → (0.35s crossfade) → centered status hero → settle-up. The hold is sized (`~1.15s = 0.35s crossfade + 0.8s hold`) so the crossfade finishes before the settle-up starts, rather than overlapping into one blur.

## Scope

Built into `DoneScreen` itself, so **every** done surface gets it — Send, Swap, cosigner (`JoinKeysignDoneView`), QBTC, signed-message. **Reduce Motion → immediate** (seeds `.expanded`, no staged beat).

## What changed

- **`DoneScreen.swift`** — `@State revealPhase (.hero/.expanded)`; the header is **hoisted out of the `ScrollView`** as a stable-identity element so it interpolates center→top (via top/bottom spacers that collapse on expand); the body reveals with `.opacity + .move(edge: .bottom)`. Trigger: `.task { … Task.sleep(revealDelay); withAnimation(.spring) { revealPhase = .expanded } }`, gated by `Task.isCancelled` so it never mutates a torn-down view.
- DEBUG-only `#Preview` (broadcasted + confirmed) with a no-network mock poller, to iterate the feel without a live tx.

## Parity preserved

- `DoneStatusService.start()` + `TransactionHistoryRecording.record()` still fire **exactly once, on appear**, phase-independent — the reveal is purely visual. No polling / payload / recording / status-handling change.
- Immediate (Reduce Motion) path reproduces today's layout.
- macOS parity (no iOS-only API).

## Cross-model review (Codex, read-only)

| Step | Commit | Findings | Disposition |
|------|--------|----------|-------------|
| 1 — Staged reveal + preview | 8fb814218 | 1 BLOCKER — `Task.sleep` swallowed `.task` cancellation → `revealPhase` could flip post-disappear | Fixed (`guard !Task.isCancelled`) |

## Verification

- **`make test`** (full suite, iPhone 17 Pro Max sim, en_US): **2651 tests, 1 skipped, 0 failures — TEST SUCCEEDED**.
- **SwiftLint**: 0 violations on the changed file.

### Pending on-device checklist (motion needs a simulator/device pass)

- [ ] Send/Swap: keysign animation → crossfade → **centered hero** → header glides to top, card/details/Done reveal (no snap).
- [ ] Hold timing feels right after the crossfade (not overlapping, not too long).
- [ ] Cosigner / QBTC / signed-message (reached via push, no crossfade): hero-then-expand still reads well.
- [ ] Reduce Motion: no staged beat — everything present immediately.
- [ ] Failure state: red hero centered → settles with single **Try again**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)