### PR TITLE
[Fix] Harden BlockChainSpecific decoding of untrusted keysign payload numeric fields

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -420,11 +420,16 @@ extension BlockChainSpecific {
                 ttl: value.ttl
             )
         case .ethereumSpecific(let value):
+            // Peer-supplied numeric strings: parse with the failable initializer
+            // so a malformed field decodes to 0 instead of trapping. A garbled
+            // value makes this device build a different tx than the initiator,
+            // so the MPC ceremony fails safe on a signature mismatch rather than
+            // crashing the app.
             self = .Ethereum(
-                maxFeePerGasWei: BigInt(stringLiteral: value.maxFeePerGasWei),
-                priorityFeeWei: BigInt(stringLiteral: value.priorityFee),
+                maxFeePerGasWei: BigInt(value.maxFeePerGasWei) ?? 0,
+                priorityFeeWei: BigInt(value.priorityFee) ?? 0,
                 nonce: value.nonce,
-                gasLimit: BigInt(stringLiteral: value.gasLimit)
+                gasLimit: BigInt(value.gasLimit) ?? 0
             )
         case .thorchainSpecific(let value):
             self = .THORChain(
@@ -450,19 +455,29 @@ extension BlockChainSpecific {
                 gasLimit: value.hasGasLimit ? value.gasLimit : nil
             )
         case .solanaSpecific(let value):
+            // Peer-supplied numeric strings: parse with the failable initializer
+            // so a malformed field decodes to 0 instead of trapping. The signer
+            // substitutes its defaults for non-positive values (see
+            // SolanaHelper.getPreSignedInputData), so 0 == "use default" ==
+            // absent field — the same behavior an old device shows.
             self = .Solana(
                 recentBlockHash: value.recentBlockHash,
-                priorityFee: BigInt(stringLiteral: value.priorityFee),
-                priorityLimit: value.hasComputeLimit ? BigInt(stringLiteral: value.computeLimit) : BigInt(0),
+                priorityFee: BigInt(value.priorityFee) ?? 0,
+                priorityLimit: value.hasComputeLimit ? (BigInt(value.computeLimit) ?? 0) : BigInt(0),
                 fromAddressPubKey: value.fromTokenAssociatedAddress.isEmpty ? nil : value.fromTokenAssociatedAddress,
                 toAddressPubKey: value.toTokenAssociatedAddress.isEmpty ? nil : value.toTokenAssociatedAddress,
                 hasProgramId: value.programID
             )
         case .polkadotSpecific(let value):
+            // Peer-supplied numeric string: parse with the failable initializer
+            // so a malformed field decodes to 0 instead of trapping. A garbled
+            // value makes this device build a different tx than the initiator,
+            // so the MPC ceremony fails safe on a signature mismatch rather than
+            // crashing the app.
             self = .Polkadot(
                 recentBlockHash: value.recentBlockHash,
                 nonce: value.nonce,
-                currentBlockNumber: BigInt(stringLiteral: value.currentBlockNumber),
+                currentBlockNumber: BigInt(value.currentBlockNumber) ?? 0,
                 specVersion: value.specVersion,
                 transactionVersion: value.transactionVersion,
                 genesisHash: value.genesisHash,

--- a/VultisigApp/VultisigAppTests/Keysign/KeysignPayloadMalformedChainSpecificTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/KeysignPayloadMalformedChainSpecificTests.swift
@@ -1,0 +1,174 @@
+//
+//  KeysignPayloadMalformedChainSpecificTests.swift
+//  VultisigAppTests
+//
+//  A keysign payload is untrusted data deserialized from a co-signer at the
+//  start of a ceremony. Decoding its chain-specific numeric fields with the
+//  trapping `BigInt(stringLiteral:)` initializer hard-crashes the receiving
+//  device when a peer sends a malformed/empty string. These tests pin the
+//  crash-hardened contract: malformed/empty/absent numeric fields fall back to
+//  0 (mirroring an absent field), while every well-formed value — including an
+//  explicit "0" — still maps through verbatim so the signed tx is unchanged.
+//
+
+import BigInt
+import XCTest
+import VultisigCommonData
+@testable import VultisigApp
+
+final class KeysignPayloadMalformedChainSpecificTests: XCTestCase {
+
+    // Base58 of 32 zero bytes — a structurally valid recent blockhash.
+    private let recentBlockHash = "11111111111111111111111111111111"
+
+    // MARK: - Solana priority_fee
+
+    func testSolanaMalformedPriorityFeeFallsBackToZero() throws {
+        let specific = try decodeSolana(priorityFee: "abc", computeLimit: nil)
+        guard case .Solana(_, let priorityFee, _, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityFee, 0, "malformed priority_fee must decode to 0, not crash")
+    }
+
+    func testSolanaEmptyPriorityFeeFallsBackToZero() throws {
+        let specific = try decodeSolana(priorityFee: "", computeLimit: nil)
+        guard case .Solana(_, let priorityFee, _, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityFee, 0, "empty priority_fee must decode to 0, not crash")
+    }
+
+    func testSolanaWellFormedPriorityFeeMapsVerbatim() throws {
+        let specific = try decodeSolana(priorityFee: "1000000", computeLimit: nil)
+        guard case .Solana(_, let priorityFee, _, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityFee, BigInt(1_000_000), "well-formed priority_fee must map through unchanged")
+    }
+
+    func testSolanaExplicitZeroPriorityFeeMapsToZero() throws {
+        let specific = try decodeSolana(priorityFee: "0", computeLimit: nil)
+        guard case .Solana(_, let priorityFee, _, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityFee, 0, "a valid explicit \"0\" must still map to 0")
+    }
+
+    // MARK: - Solana compute_limit
+
+    func testSolanaMalformedComputeLimitFallsBackToZero() throws {
+        let specific = try decodeSolana(priorityFee: "0", computeLimit: "abc")
+        guard case .Solana(_, _, let priorityLimit, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityLimit, 0, "malformed compute_limit must decode to 0, not crash")
+    }
+
+    func testSolanaEmptyComputeLimitFallsBackToZero() throws {
+        let specific = try decodeSolana(priorityFee: "0", computeLimit: "")
+        guard case .Solana(_, _, let priorityLimit, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityLimit, 0, "empty compute_limit must decode to 0, not crash")
+    }
+
+    func testSolanaAbsentComputeLimitIsZero() throws {
+        let specific = try decodeSolana(priorityFee: "0", computeLimit: nil)
+        guard case .Solana(_, _, let priorityLimit, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityLimit, 0, "absent compute_limit must decode to 0 (use-default sentinel)")
+    }
+
+    func testSolanaWellFormedComputeLimitMapsVerbatim() throws {
+        let specific = try decodeSolana(priorityFee: "0", computeLimit: "100000")
+        guard case .Solana(_, _, let priorityLimit, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityLimit, BigInt(100_000), "well-formed compute_limit must map through unchanged")
+    }
+
+    func testSolanaExplicitZeroComputeLimitMapsToZero() throws {
+        let specific = try decodeSolana(priorityFee: "0", computeLimit: "0")
+        guard case .Solana(_, _, let priorityLimit, _, _, _) = specific else {
+            return XCTFail("expected Solana case")
+        }
+        XCTAssertEqual(priorityLimit, 0, "a valid explicit \"0\" compute_limit must still map to 0")
+    }
+
+    // MARK: - EVM / Ethereum
+
+    func testEthereumMalformedNumericFieldsFallBackToZero() throws {
+        let specific = try decodeEthereum(maxFeePerGasWei: "abc", priorityFee: "", gasLimit: "xyz")
+        guard case .Ethereum(let maxFeePerGasWei, let priorityFeeWei, let nonce, let gasLimit) = specific else {
+            return XCTFail("expected Ethereum case")
+        }
+        XCTAssertEqual(maxFeePerGasWei, 0, "malformed max_fee_per_gas_wei must decode to 0, not crash")
+        XCTAssertEqual(priorityFeeWei, 0, "empty priority_fee must decode to 0, not crash")
+        XCTAssertEqual(gasLimit, 0, "malformed gas_limit must decode to 0, not crash")
+        XCTAssertEqual(nonce, 7, "the non-numeric-string fields are untouched")
+    }
+
+    func testEthereumWellFormedNumericFieldsMapVerbatim() throws {
+        let specific = try decodeEthereum(maxFeePerGasWei: "50000000000", priorityFee: "1500000000", gasLimit: "21000")
+        guard case .Ethereum(let maxFeePerGasWei, let priorityFeeWei, _, let gasLimit) = specific else {
+            return XCTFail("expected Ethereum case")
+        }
+        XCTAssertEqual(maxFeePerGasWei, BigInt(50_000_000_000), "well-formed max_fee_per_gas_wei must map through unchanged")
+        XCTAssertEqual(priorityFeeWei, BigInt(1_500_000_000), "well-formed priority_fee must map through unchanged")
+        XCTAssertEqual(gasLimit, BigInt(21_000), "well-formed gas_limit must map through unchanged")
+    }
+
+    // MARK: - Polkadot
+
+    func testPolkadotMalformedCurrentBlockNumberFallsBackToZero() throws {
+        let specific = try decodePolkadot(currentBlockNumber: "not-a-number")
+        guard case .Polkadot(_, _, let currentBlockNumber, _, _, _, _) = specific else {
+            return XCTFail("expected Polkadot case")
+        }
+        XCTAssertEqual(currentBlockNumber, 0, "malformed current_block_number must decode to 0, not crash")
+    }
+
+    func testPolkadotWellFormedCurrentBlockNumberMapsVerbatim() throws {
+        let specific = try decodePolkadot(currentBlockNumber: "24680123")
+        guard case .Polkadot(_, _, let currentBlockNumber, _, _, _, _) = specific else {
+            return XCTFail("expected Polkadot case")
+        }
+        XCTAssertEqual(currentBlockNumber, BigInt(24_680_123), "well-formed current_block_number must map through unchanged")
+    }
+
+    // MARK: - Helpers
+
+    /// Decodes a Solana chain-specific proto through the untrusted-payload path.
+    /// A nil `computeLimit` leaves the field unset (absent on the wire).
+    private func decodeSolana(priorityFee: String, computeLimit: String?) throws -> BlockChainSpecific {
+        var proto = VSSolanaSpecific()
+        proto.recentBlockHash = recentBlockHash
+        proto.priorityFee = priorityFee
+        if let computeLimit {
+            proto.computeLimit = computeLimit
+        }
+        return try BlockChainSpecific(proto: .solanaSpecific(proto))
+    }
+
+    private func decodeEthereum(maxFeePerGasWei: String, priorityFee: String, gasLimit: String) throws -> BlockChainSpecific {
+        var proto = VSEthereumSpecific()
+        proto.maxFeePerGasWei = maxFeePerGasWei
+        proto.priorityFee = priorityFee
+        proto.nonce = 7
+        proto.gasLimit = gasLimit
+        return try BlockChainSpecific(proto: .ethereumSpecific(proto))
+    }
+
+    private func decodePolkadot(currentBlockNumber: String) throws -> BlockChainSpecific {
+        var proto = VSPolkadotSpecific()
+        proto.recentBlockHash = recentBlockHash
+        proto.nonce = 1
+        proto.currentBlockNumber = currentBlockNumber
+        proto.specVersion = 1
+        proto.transactionVersion = 1
+        proto.genesisHash = recentBlockHash
+        return try BlockChainSpecific(proto: .polkadotSpecific(proto))
+    }
+}


### PR DESCRIPTION
## Summary

`BlockChainSpecific(from:)` decoded chain-specific numeric string fields from an inbound keysign payload with the **trapping** `BigInt(stringLiteral:)` initializer, which crashes on any non-numeric or empty string. A keysign payload is untrusted data deserialized from a co-signer at the start of a ceremony, so a buggy or malicious peer sending a garbled `compute_limit`/`priority_fee` (Solana), `max_fee_per_gas_wei`/`priority_fee`/`gas_limit` (EVM) or `current_block_number` (Polkadot) could hard-crash the **receiving** device while decoding the payload.

This replaces the trapping initializer with the failable `BigInt(_:) ?? 0` for the peer-supplied numeric fields, mirroring the existing Sui precedent in the same function. Android shipped the equivalent fix in [vultisig-android#5244](https://github.com/vultisig/vultisig-android/pull/5244).

`closes #4782`

## Why `?? 0` is safe

- **Solana:** the downstream signer substitutes defaults for non-positive values — `SolanaHelper.getPreSignedInputData` uses `priorityFee > 0 ? … : defaultPriorityFeePrice` and `priorityLimit > 0 ? … : priorityFeeLimit` (= 100_000). So `0` == "use default" == absent field, matching Android's "fall back to default."
- **EVM / Polkadot:** pure crash-hardening. If a peer sends a garbled numeric field, decoding to `0` makes this device build a different tx than the initiator, so the MPC ceremony **fails safe** on a signature mismatch (no fund loss) instead of crashing the app. The intent here is crash-avoidance, not semantic recovery.

Every well-formed value — including an explicit `"0"` — still maps through **verbatim**, so the signed transaction is unchanged for valid payloads. The signing path, default constants, and amount fields (`toAmount`/`amount`/`fromAmount`) are untouched.

## Changes

- `Features/Keysign/Services/KeysignMessage+ProtoMappable.swift` — Solana (`priorityFee`, `priorityLimit`), EVM (`maxFeePerGasWei`, `priorityFeeWei`, `gasLimit`), and Polkadot (`currentBlockNumber`) cases now parse with the failable `BigInt(_:) ?? 0`.
- New `VultisigAppTests/Keysign/KeysignPayloadMalformedChainSpecificTests.swift`.

## Test coverage

13 focused unit tests decoding a proto directly through `BlockChainSpecific(proto:)`:
- Solana `priority_fee` and `compute_limit`: malformed (`"abc"`), empty (`""`), absent, well-formed, and explicit `"0"` — asserting no crash, malformed/empty falls back to `0`, and well-formed (incl. `"0"`) maps verbatim.
- EVM: malformed `max_fee_per_gas_wei`/`priority_fee`/`gas_limit` fall back to `0` (no crash), well-formed map verbatim.
- Polkadot: malformed `current_block_number` falls back to `0` (no crash), well-formed maps verbatim.

## Gate

- `make test` (iPhone 16 Pro): **`** TEST SUCCEEDED **`** — Executed **2669 tests, 1 skipped, 0 failures**. All 13 new tests pass.
- `swiftlint` clean on both changed files (0 violations).
- Codex read-only review of the branch diff vs `origin/main`: **0 findings** — confirmed well-formed values map unchanged, malformed/empty decode to `0`, and the signing path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when processing malformed or missing numeric transaction data.
  * Prevented invalid chain-specific values from causing key-signing failures or crashes.
  * Invalid values now safely default to zero while valid values remain unchanged.

* **Tests**
  * Added coverage for malformed, missing, zero, and valid numeric values across Ethereum, Solana, and Polkadot transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->