### PR TITLE
fix(thorchain): stop transient Midgard errors from becoming terminal FAILED

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/THORChainTransactionStatusProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/Providers/THORChainTransactionStatusProvider.swift
@@ -51,7 +51,7 @@ struct THORChainTransactionStatusProvider: TransactionStatusProvider {
             return mapActionToStatus(action: action, blockNumber: blockNum)
 
         } catch let error as HTTPError {
-            return handleHTTPError(error)
+            return try handleHTTPError(error)
         }
     }
 
@@ -118,11 +118,15 @@ struct THORChainTransactionStatusProvider: TransactionStatusProvider {
         return parts.joined(separator: ", ")
     }
 
-    private func handleHTTPError(_ error: HTTPError) -> TransactionStatusResult {
-        switch error {
-        case .statusCode(let code, _):
+    /// Maps HTTP failures to a status.
+    /// - 404: Midgard has no action for this txid yet → `.notFound` (keep polling).
+    /// - 429 / 5xx: marked `.failed` so the error surfaces to the user.
+    /// - timeout / network / other: transport-level, not an on-chain result, so
+    ///   thrown — the poller keeps polling and the duplicate-broadcast check keeps
+    ///   retrying instead of marking a live tx permanently FAILED.
+    private func handleHTTPError(_ error: HTTPError) throws -> TransactionStatusResult {
+        if case .statusCode(let code, _) = error {
             if code == 404 {
-                // Transaction not found in Midgard
                 return TransactionStatusResult(
                     status: .notFound,
                     blockNumber: nil,
@@ -131,7 +135,6 @@ struct THORChainTransactionStatusProvider: TransactionStatusProvider {
             }
 
             if code == 429 {
-                // Rate limited
                 return TransactionStatusResult(
                     status: .failed(reason: "Rate limited - too many requests"),
                     blockNumber: nil,
@@ -140,43 +143,14 @@ struct THORChainTransactionStatusProvider: TransactionStatusProvider {
             }
 
             if code >= 500 {
-                // Server error (retryable)
                 return TransactionStatusResult(
-                    status: .failed(reason: "Server error (retryable): \(code)"),
+                    status: .failed(reason: "Server error: \(code)"),
                     blockNumber: nil,
                     confirmations: nil
                 )
             }
-
-            // Other HTTP errors
-            return TransactionStatusResult(
-                status: .failed(reason: "HTTP error: \(code)"),
-                blockNumber: nil,
-                confirmations: nil
-            )
-
-        case .timeout:
-            // Network timeout (retryable)
-            return TransactionStatusResult(
-                status: .failed(reason: "Request timeout (retryable)"),
-                blockNumber: nil,
-                confirmations: nil
-            )
-
-        case .networkError:
-            // Network error (retryable)
-            return TransactionStatusResult(
-                status: .failed(reason: "Network error (retryable)"),
-                blockNumber: nil,
-                confirmations: nil
-            )
-
-        default:
-            return TransactionStatusResult(
-                status: .failed(reason: "Unknown error"),
-                blockNumber: nil,
-                confirmations: nil
-            )
         }
+
+        throw error
     }
 }


### PR DESCRIPTION
## Summary
- `THORChainTransactionStatusProvider.handleHTTPError` returned transient transport failures as `.failed`, which the status poller treats as terminal and `isAlreadyOnChain` treats as conclusive negative evidence.
- A single network/timeout blip could permanently mark a live THORChain/Maya tx as FAILED in tx history and on the done screen, and stop polling. It also poisoned the duplicate-broadcast safety net (peer wins the race + lookup blip → "Failed to broadcast" for an on-chain tx).
- Now: timeout / network / other errors **throw** so the poller keeps polling and the duplicate-broadcast check keeps retrying. `404` → `.notFound`. Per request, `429` and `5xx` still map to `.failed` to surface the error to the user.
- Covers Maya too — both chains route through this provider (only the Midgard endpoint differs).

## Issue
Closes #4787

## Test Plan
- [ ] Simulate a Midgard timeout/network error during THORChain status polling → poller keeps polling instead of marking FAILED
- [ ] Simulate a peer-broadcast race with a lookup timeout → `isAlreadyOnChain` retries and resolves on-chain instead of "Failed to broadcast"
- [ ] 429/5xx still surface as failed
- [x] SwiftLint passes
- [ ] xcodebuild build succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction status handling for HTTP errors.
  * Transactions now correctly report “not found” for 404 responses and server errors for 5xx responses.
  * Other network and HTTP errors are preserved for more accurate error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->