### PR TITLE
fix(broadcast): stop dup-sentinel over-matching rejections as success

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/RpcService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/RpcService.swift
@@ -44,6 +44,27 @@ enum SubstrateBroadcast {
     }
 }
 
+/// Classifies a JSON-RPC broadcast `error.message` as a *true* duplicate — the
+/// signed tx is already in the mempool or on-chain — versus a genuine rejection.
+///
+/// Only exact duplicate signals count. Substrings that used to match here caused
+/// rejections to be reported as success: `"known"` matched every `"unknown …"`
+/// message, `"nonce too high"` is a nonce gap (tx NOT accepted), the rate-limit
+/// message means the tx may never have been submitted, and a bare `"already"`
+/// matched almost anything. Those are excluded on purpose.
+enum BroadcastErrorClassifier {
+    static func isDuplicateBroadcast(_ message: String) -> Bool {
+        let message = message.lowercased()
+        return message.contains("already known")
+            || message.contains("already exists")
+            || message.contains("already_exists")
+            || message.contains("already imported")
+            || message.contains("already mined")
+            || message.contains("transaction is temporarily banned")
+            || message.contains("nonce too low")
+    }
+}
+
 class RpcService {
     // swiftlint:disable:next no_raw_urlsession
     private let session = URLSession.shared
@@ -96,16 +117,8 @@ class RpcService {
             }
 
             if let error = response["error"] as? [String: Any], let message = error["message"] as? String {
-                if message.lowercased().contains("known".lowercased())
-                    || message.lowercased().contains("already known".lowercased())
-                    || message.lowercased().contains("Transaction is temporarily banned".lowercased())
-                    || message.lowercased().contains("nonce too low".lowercased())
-                    || message.lowercased().contains("nonce too high".lowercased())
-                    || message.lowercased().contains("transaction already exists".lowercased())
-                    || message.lowercased().contains("many requests for a specific RPC call".lowercased())
-                    || message.lowercased().contains("already".lowercased())
-                    || message.lowercased().contains("already mined".lowercased()) {
-                    return try decode("Transaction already broadcasted.")
+                if BroadcastErrorClassifier.isDuplicateBroadcast(message) {
+                    return try decode(SubstrateBroadcast.alreadyBroadcastedSentinel)
                 }
 
                 return try decode(message)

--- a/VultisigApp/VultisigApp/Core/Services/RpcServiceStruct.swift
+++ b/VultisigApp/VultisigApp/Core/Services/RpcServiceStruct.swift
@@ -47,16 +47,8 @@ struct RpcServiceStruct {
                 let message = error["message"] as? String ?? "Unknown RPC error"
 
                 // Special handling for transaction broadcast errors
-                if message.lowercased().contains("known".lowercased())
-                    || message.lowercased().contains("already known".lowercased())
-                    || message.lowercased().contains("Transaction is temporarily banned".lowercased())
-                    || message.lowercased().contains("nonce too low".lowercased())
-                    || message.lowercased().contains("nonce too high".lowercased())
-                    || message.lowercased().contains("transaction already exists".lowercased())
-                    || message.lowercased().contains("many requests for a specific RPC call".lowercased())
-                    || message.lowercased().contains("already".lowercased())
-                    || message.lowercased().contains("already mined".lowercased()) {
-                    return try decode("Transaction already broadcasted.")
+                if BroadcastErrorClassifier.isDuplicateBroadcast(message) {
+                    return try decode(SubstrateBroadcast.alreadyBroadcastedSentinel)
                 }
 
                 // For other errors, throw an exception instead of trying to decode the error message

--- a/VultisigApp/VultisigAppTests/Services/BroadcastErrorClassifierTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BroadcastErrorClassifierTests.swift
@@ -1,0 +1,44 @@
+//
+//  BroadcastErrorClassifierTests.swift
+//  VultisigAppTests
+//
+//  Guards the broadcast dup-sentinel classifier shared by the EVM
+//  (`RpcServiceStruct`) and substrate (`RpcService`, backing Polkadot and
+//  Bittensor) broadcast paths. The old substring match reported real rejections
+//  — a nonce gap, a rate-limited RPC, any "unknown …" message — as a duplicate,
+//  which downstream converts to a fake success hash. These tests lock in which
+//  messages are true duplicates and which must stay rejections.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class BroadcastErrorClassifierTests: XCTestCase {
+
+    func testTrueDuplicatesAreClassified() {
+        for message in [
+            "already known",
+            "ALREADY_EXISTS",
+            "transaction already exists",
+            "Transaction already imported.",
+            "already mined",
+            "Transaction is temporarily banned",
+            "nonce too low"
+        ] {
+            XCTAssertTrue(BroadcastErrorClassifier.isDuplicateBroadcast(message), "\(message) should be a duplicate")
+        }
+    }
+
+    func testRejectionsAreNotClassifiedAsDuplicates() {
+        for message in [
+            "nonce too high",
+            "unknown block",
+            "unknown method eth_foo",
+            "many requests for a specific RPC call",
+            "insufficient funds for gas",
+            "invalid extrinsic"
+        ] {
+            XCTAssertFalse(BroadcastErrorClassifier.isDuplicateBroadcast(message), "\(message) should NOT be a duplicate")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- The broadcast error classifier mapped several **non-duplicate** rejections to the `"Transaction already broadcasted."` sentinel, which `KeysignViewModel` then converts to a locally computed hash and reports as **success** — showing a success screen with a hash that will never exist.
- Root cause: an identical over-broad substring list was copy-pasted into `RpcServiceStruct` (EVM) and `RpcService` (substrate, backing Polkadot + Bittensor). Both now route through a single shared `BroadcastErrorClassifier`.
- Dropped false positives: bare `"known"` (matched every `"unknown …"`), `"nonce too high"` (a nonce gap → tx **not** accepted), `"many requests…"` (rate limit), and a bare `"already"`.
- Kept the true duplicate signals: `already known`, `already exists`/`already_exists` (EVM `ALREADY_EXISTS`), `already imported`, `already mined`, `temporarily banned`, `nonce too low`.

## Issue
Closes #4786

## Notes
- Scoped to the reported root cause (the over-match), which eliminates every scenario in the title.
- Deferred the report's defense-in-depth extras — gating the sentinel→success conversion behind `isAlreadyOnChain`, and Polkadot `.pending`→`.notFound` — both trade a fixed false-success for a possible false-*failure* on a slow indexer.

## Test Plan
- [x] New `BroadcastErrorClassifierTests` locks in duplicates vs rejections (caught that `ALREADY_EXISTS` lowercases with an underscore) — passing
- [x] SwiftLint passes on changed files (no new violations)
- [x] xcodebuild build succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transaction broadcast errors by distinguishing genuine duplicate broadcasts from other rejection messages.
  * Preserved accurate error reporting for nonce, method, rate-limit, and other non-duplicate failures.

* **Tests**
  * Added coverage for duplicate broadcast detection and rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->