### PR TITLE
[Fix] Solana SPL ATA: fall back to derivation on a transient token-account lookup error

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -295,14 +295,23 @@ class SolanaService {
     }
 
     func fetchTokenAssociatedAccountByOwner(for ownerAddress: String, mintAddress: String) async throws -> (String, Bool) {
-        // First try getTokenAccountsByOwner
-        let (tokenAccounts, isToken2022) = try await getTokenAccountsByOwner(walletAddress: ownerAddress, mintAddress: mintAddress)
+        // First try getTokenAccountsByOwner. A transient RPC/node error is treated
+        // like an empty result: the account index can lag right after an ATA is
+        // created, or the node may momentarily fail, yet the ATA is still
+        // deterministically derivable. Falling through to the derivation probe
+        // instead of propagating keeps the send from failing when the account
+        // actually exists. A successful lookup keeps today's behavior exactly.
+        do {
+            let (tokenAccounts, isToken2022) = try await getTokenAccountsByOwner(walletAddress: ownerAddress, mintAddress: mintAddress)
 
-        if !tokenAccounts.isEmpty {
-            return (tokenAccounts, isToken2022)
+            if !tokenAccounts.isEmpty {
+                return (tokenAccounts, isToken2022)
+            }
+        } catch {
+            logger.warning("getTokenAccountsByOwner lookup failed; falling back to ATA derivation: \(error.localizedDescription, privacy: .public)")
         }
 
-        // If getTokenAccountsByOwner returns empty, probe the deterministic ATAs directly
+        // If getTokenAccountsByOwner returns empty (or errored), probe the deterministic ATAs directly
         guard let walletCoreAddress = WalletCore.SolanaAddress(string: ownerAddress) else {
             return ("", false)
         }

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaServiceAtaFallbackTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaServiceAtaFallbackTests.swift
@@ -1,0 +1,249 @@
+//
+//  SolanaServiceAtaFallbackTests.swift
+//  VultisigAppTests
+//
+//  Covers `SolanaService.fetchTokenAssociatedAccountByOwner` recovering from a
+//  transient `getTokenAccountsByOwner` failure. When the primary indexer lookup
+//  THROWS (a momentary RPC/node error, not an empty index) the method now falls
+//  through to the same deterministic ATA derivation + `getAccountInfo` existence
+//  probe used for the empty-result case, so a derivable/existing account still
+//  resolves and the send does not fail. A genuinely-missing account still yields
+//  the not-found result, and a successful primary lookup is unchanged.
+//
+
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+final class SolanaServiceAtaFallbackTests: XCTestCase {
+
+    /// Classic SPL token program — the owner reported for a standard ATA.
+    private let tokenProgramId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    /// Token-2022 program id (mirrors `SolanaService.TOKEN_PROGRAM_ID_2022`).
+    private let token2022ProgramId = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+
+    private let ownerAddress = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3"
+    private let mintAddress = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+    private func makeService(_ stub: SolanaAtaStubHTTPClient) -> SolanaService {
+        SolanaService(
+            resolver: NoOverrideResolver(),
+            httpClient: stub,
+            broadcastRetryBackoff: .zero
+        )
+    }
+
+    /// The classic-SPL ATA the fallback derives for our owner/mint pair.
+    private func derivedDefaultAta() throws -> String {
+        let address = try XCTUnwrap(WalletCore.SolanaAddress(string: ownerAddress))
+        return try XCTUnwrap(address.defaultTokenAddress(tokenMintAddress: mintAddress))
+    }
+
+    /// The Token-2022 ATA the fallback derives for our owner/mint pair.
+    private func derivedToken2022Ata() throws -> String {
+        let address = try XCTUnwrap(WalletCore.SolanaAddress(string: ownerAddress))
+        return try XCTUnwrap(address.token2022Address(tokenMintAddress: mintAddress))
+    }
+
+    // (a) Primary lookup throws, but the derived classic-SPL ATA exists on-chain:
+    //     the fallback probe finds it and returns it instead of failing the send.
+    func testThrowingPrimaryLookupReturnsDerivedExistingAta() async throws {
+        let defaultAta = try derivedDefaultAta()
+        let stub = SolanaAtaStubHTTPClient(
+            primaryOutcome: .failure,
+            existingAccounts: [defaultAta: tokenProgramId]
+        )
+        let service = makeService(stub)
+
+        let (account, isToken2022) = try await service.fetchTokenAssociatedAccountByOwner(
+            for: ownerAddress,
+            mintAddress: mintAddress
+        )
+
+        XCTAssertEqual(account, defaultAta)
+        XCTAssertFalse(isToken2022)
+        XCTAssertEqual(stub.tokenAccountsByOwnerCallCount, 1)
+        // Only the classic-SPL probe is needed; it exists, so we stop there.
+        XCTAssertEqual(stub.accountInfoCallCount, 1)
+    }
+
+    // (a') Primary lookup throws and only the Token-2022 ATA exists: the fallback
+    //      probes both derivations and returns the Token-2022 account.
+    func testThrowingPrimaryLookupReturnsDerivedToken2022Ata() async throws {
+        let token2022Ata = try derivedToken2022Ata()
+        let stub = SolanaAtaStubHTTPClient(
+            primaryOutcome: .failure,
+            existingAccounts: [token2022Ata: token2022ProgramId]
+        )
+        let service = makeService(stub)
+
+        let (account, isToken2022) = try await service.fetchTokenAssociatedAccountByOwner(
+            for: ownerAddress,
+            mintAddress: mintAddress
+        )
+
+        XCTAssertEqual(account, token2022Ata)
+        XCTAssertTrue(isToken2022)
+        XCTAssertEqual(stub.tokenAccountsByOwnerCallCount, 1)
+        // Classic-SPL probe misses, Token-2022 probe hits: two existence checks.
+        XCTAssertEqual(stub.accountInfoCallCount, 2)
+    }
+
+    // (b) Primary lookup throws and neither derived ATA exists: the account is
+    //     genuinely missing, so the not-found result is returned (not an error).
+    func testThrowingPrimaryLookupWithNoExistingAtaReturnsNotFound() async throws {
+        let stub = SolanaAtaStubHTTPClient(primaryOutcome: .failure)
+        let service = makeService(stub)
+
+        let (account, isToken2022) = try await service.fetchTokenAssociatedAccountByOwner(
+            for: ownerAddress,
+            mintAddress: mintAddress
+        )
+
+        XCTAssertEqual(account, "")
+        XCTAssertFalse(isToken2022)
+        XCTAssertEqual(stub.tokenAccountsByOwnerCallCount, 1)
+        // Both derivations are probed and both miss.
+        XCTAssertEqual(stub.accountInfoCallCount, 2)
+    }
+
+    // Success path unchanged: a non-empty primary lookup returns that account
+    // immediately, without probing the derived ATAs.
+    func testSuccessfulPrimaryLookupReturnsAccountWithoutProbing() async throws {
+        let indexedPubkey = "9gANMngbGUmAaLXL1RC3JdiaLjRowJXNbzCTh53ht7mq"
+        let stub = SolanaAtaStubHTTPClient(
+            primaryOutcome: .account(pubkey: indexedPubkey, ownerProgram: tokenProgramId)
+        )
+        let service = makeService(stub)
+
+        let (account, isToken2022) = try await service.fetchTokenAssociatedAccountByOwner(
+            for: ownerAddress,
+            mintAddress: mintAddress
+        )
+
+        XCTAssertEqual(account, indexedPubkey)
+        XCTAssertFalse(isToken2022)
+        XCTAssertEqual(stub.tokenAccountsByOwnerCallCount, 1)
+        // No fallback: the derived-ATA existence probe must not run.
+        XCTAssertEqual(stub.accountInfoCallCount, 0)
+    }
+}
+
+// MARK: - Test doubles
+
+private struct NoOverrideResolver: RPCEndpointResolving {
+    // swiftlint:disable:next unused_parameter
+    func url(for chain: Chain) -> String? { nil }
+}
+
+/// Routes Solana JSON-RPC calls by method so the ATA fallback can be exercised
+/// deterministically: the primary `getTokenAccountsByOwner` returns a scripted
+/// outcome (throw / empty / a matching account), and `getAccountInfo` reports an
+/// address as existing only when it is in `existingAccounts`.
+private final class SolanaAtaStubHTTPClient: HTTPClientProtocol {
+
+    enum PrimaryOutcome {
+        /// Transient RPC/node failure — the request itself throws.
+        case failure
+        /// Indexer returns no matching token account.
+        case empty
+        /// Indexer returns a matching token account.
+        case account(pubkey: String, ownerProgram: String)
+    }
+
+    private let primaryOutcome: PrimaryOutcome
+    /// getAccountInfo existence probe: address -> owning token-program id.
+    private let existingAccounts: [String: String]
+
+    private(set) var tokenAccountsByOwnerCallCount = 0
+    private(set) var accountInfoCallCount = 0
+
+    init(primaryOutcome: PrimaryOutcome, existingAccounts: [String: String] = [:]) {
+        self.primaryOutcome = primaryOutcome
+        self.existingAccounts = existingAccounts
+    }
+
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        guard let api = target as? SolanaAPI else {
+            XCTFail("unexpected non-Solana target in ATA fallback test")
+            throw HTTPError.invalidResponse
+        }
+
+        let json: String
+        switch api.rpcMethod {
+        case .getTokenAccountsByOwner:
+            tokenAccountsByOwnerCallCount += 1
+            switch primaryOutcome {
+            case .failure:
+                throw URLError(.timedOut)
+            case .empty:
+                json = Self.tokenAccountsEnvelope(valueJSON: "[]")
+            case let .account(pubkey, ownerProgram):
+                json = Self.tokenAccountsEnvelope(
+                    valueJSON: "[\(Self.tokenAccountJSON(pubkey: pubkey, ownerProgram: ownerProgram))]"
+                )
+            }
+        case let .getAccountInfo(address):
+            accountInfoCallCount += 1
+            if let owner = existingAccounts[address] {
+                json = #"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":{"owner":"\#(owner)"}}}"#
+            } else {
+                json = #"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":null}}"#
+            }
+        default:
+            XCTFail("unexpected RPC method in ATA fallback test")
+            throw HTTPError.invalidResponse
+        }
+
+        return Self.httpResponse(json: json)
+    }
+
+    private static func tokenAccountsEnvelope(valueJSON: String) -> String {
+        #"{"jsonrpc":"2.0","id":1,"result":{"context":{"apiVersion":"2.0.0","slot":1},"value":\#(valueJSON)}}"#
+    }
+
+    private static func tokenAccountJSON(pubkey: String, ownerProgram: String) -> String {
+        """
+        {
+          "pubkey": "\(pubkey)",
+          "account": {
+            "data": {
+              "parsed": {
+                "info": {
+                  "isNative": false,
+                  "mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                  "owner": "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3",
+                  "state": "initialized",
+                  "tokenAmount": {
+                    "amount": "0",
+                    "decimals": 6,
+                    "uiAmount": 0,
+                    "uiAmountString": "0"
+                  }
+                },
+                "type": "account"
+              },
+              "program": "spl-token",
+              "space": 165
+            },
+            "executable": false,
+            "lamports": 2039280,
+            "owner": "\(ownerProgram)",
+            "rentEpoch": 18446744073709551615,
+            "space": 165
+          }
+        }
+        """
+    }
+
+    private static func httpResponse(json: String) -> HTTPResponse<Data> {
+        let response = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: Data(json.utf8), response: response)
+    }
+}


### PR DESCRIPTION
## Summary
`SolanaService.fetchTokenAssociatedAccountByOwner` already derives the classic-SPL and Token-2022 ATAs and confirms them via `getAccountInfo` when `getTokenAccountsByOwner` returns an **empty** result (the common indexer-lag case right after an ATA is created). But when the primary `getTokenAccountsByOwner` call **threw** (a transient RPC/node error rather than an empty index), the error propagated and the derivation fallback was skipped — failing the send even though the ATA is deterministically derivable/exists.

This wraps the primary lookup in `do/catch` so a thrown error flows into the **same existing** ATA-derivation + `checkAccountExists` probe as the empty branch, logging the error via OSLog first (never swallowed). The success path and caching are unchanged; the final not-found result `("", false)` is kept when neither derived ATA exists.

Brings iOS to parity with Android's error-path handling ([vultisig-android#5245](https://github.com/vultisig/vultisig-android/pull/5245)).

`closes #4783`

## Changes
- `Blockchain/Solana/Service/SolanaService.swift` (+19/−5) — `do/catch` around the primary lookup; OSLog warning on the error path before falling through to the existing derivation probe.
- `VultisigAppTests/Blockchain/Solana/SolanaServiceAtaFallbackTests.swift` (new, 4 tests).

## Tests
New `SolanaServiceAtaFallbackTests` (all pass):
- `testSuccessfulPrimaryLookupReturnsAccountWithoutProbing` — success path unchanged.
- `testThrowingPrimaryLookupReturnsDerivedExistingAta` — a thrown lookup still returns the derivable classic-SPL ATA.
- `testThrowingPrimaryLookupReturnsDerivedToken2022Ata` — same for a Token-2022 ATA.
- `testThrowingPrimaryLookupWithNoExistingAtaReturnsNotFound` — a genuinely-missing account still yields not-found.

## Gate
- Full suite (`make test`, iPhone 16 Plus, sim pinned to en_US): **`** TEST SUCCEEDED **` — Executed 2660 tests, 1 skipped, 0 failures.**
- SwiftLint: clean on the changed files (0 new warnings).
- Codex read-only review (whole-branch, single commit): **0 findings** — confirmed the success path and caching are unchanged and the error is logged, not swallowed.

## Notes
Out of scope: no change to the empty-result path, the success path, or caching. This only adds the error → derivation fallback (previously the error propagated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana token account lookup reliability when the primary account service is unavailable.
  * Automatically checks standard and Token-2022 associated accounts as a fallback.
  * Returns a clear not-found result when no associated account exists.

* **Tests**
  * Added coverage for fallback discovery, Token-2022 accounts, missing accounts, and successful primary lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->