### PR TITLE
Fix TerraClassic IBC token display: resolve to symbol/icon/fiat, truncate unknown vouchers

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosAPI.swift
@@ -24,6 +24,7 @@ struct CosmosAPI: TargetType {
         case wasmTokenBalance(contractAddress: String, base64Payload: String)
         case wasmTokenInfo(contractAddress: String)
         case ibcDenomTrace(hash: String)
+        case ibcDenom(hash: String)
         case denomMetadata(denom: String)
         case allDenomsMetadata
         case latestBlock
@@ -51,6 +52,12 @@ struct CosmosAPI: TargetType {
             return Self.wasmSmartQueryPath(contractAddress: contractAddress, base64Payload: base64Payload)
         case .ibcDenomTrace(let hash):
             return "/ibc/apps/transfer/v1/denom_traces/\(hash)"
+        case .ibcDenom(let hash):
+            // Modern ibc-go path. Unlike the deprecated `denom_traces/{hash}`
+            // endpoint (which Terra Classic LCDs answer with `code 12 Not
+            // Implemented`), Terra Classic implements this one — it returns the
+            // base denom + hop trace for a hashed IBC voucher.
+            return "/ibc/apps/transfer/v1/denoms/\(hash)"
         case .denomMetadata(let denom):
             // Denom strings can contain `/` (factory/..., ibc/HASH) which the
             // URL parser would otherwise treat as path separators. Percent-
@@ -143,6 +150,32 @@ struct CosmosCw20TokenInfoResponse: Decodable {
         let name: String?
         let symbol: String?
         let decimals: Int?
+    }
+}
+
+/// Response for the modern `/ibc/apps/transfer/v1/denoms/{hash}` endpoint.
+///
+/// A resolved voucher answers `{"denom":{"base":"uusdc","trace":[{...}]}}`;
+/// the base denom is what the wallet derives a ticker + decimals from. Every
+/// field is optional so the gRPC-gateway NotFound shape (`{"code":5,
+/// "message":"...not found..."}`) decodes to a `nil` base — treated as
+/// unresolved — instead of throwing a decode error.
+struct CosmosIbcDenom: Decodable {
+    let denom: Denom?
+
+    struct Denom: Decodable {
+        let base: String?
+        let trace: [Hop]?
+
+        struct Hop: Decodable {
+            let portId: String?
+            let channelId: String?
+
+            enum CodingKeys: String, CodingKey {
+                case portId = "port_id"
+                case channelId = "channel_id"
+            }
+        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosCoinFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosCoinFinder.swift
@@ -168,7 +168,11 @@ actor CosmosCoinFinder {
                 let baseMeta = await metadataResolver.denomMetadata(chain: chain, denom: baseDenom)
                 let decimals = baseMeta.flatMap(CosmosTokenMetadataResolver.decimalsFromMeta)
                     ?? feeDecimals(for: chain)
+                // An opaque base (EVM `0x…` address, namespaced/over-long denom)
+                // has no readable symbol, so degrade the voucher to its short
+                // `IBC-<6hex>` label rather than showing the raw base string.
                 let ticker = CosmosTokenMetadataResolver.ibcTicker(baseDenom: baseDenom)
+                    ?? CosmosTokenMetadataResolver.deriveTicker(denom: denom, meta: nil)
                 return makeDiscovered(
                     chain: chain,
                     denom: denom,

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosCoinFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosCoinFinder.swift
@@ -45,6 +45,15 @@ actor CosmosCoinFinder {
     /// implement IBC trace lookups for any chain.
     static let ibcTraceCapableChains: Set<Chain> = [.terra]
 
+    /// Chains whose LCD nodes implement the modern ibc-go
+    /// `GET /ibc/apps/transfer/v1/denoms/{hash}` endpoint. Terra Classic
+    /// serves this (publicnode) even though it rejects the deprecated
+    /// `denom_traces/{hash}` path with `code 12 Not Implemented`, so it's the
+    /// resolution path we use to turn a held `ibc/<hash>` voucher into a real
+    /// base denom there. Phoenix-1 (`.terra`) stays on its existing working
+    /// `denom_traces` path to avoid regressing it.
+    static let ibcModernDenomChains: Set<Chain> = [.terraClassic]
+
     init(
         httpClient: HTTPClientProtocol = HTTPClient(),
         metadataResolver: CosmosTokenMetadataResolver = CosmosTokenMetadataResolver.shared
@@ -143,6 +152,33 @@ actor CosmosCoinFinder {
                 decimals: decimals,
                 isHidden: false
             )
+        }
+
+        // Tier 2b: modern IBC resolution. Terra Classic LCDs implement the
+        // ibc-go `/denoms/{hash}` endpoint (but reject the deprecated
+        // `denom_traces/{hash}` path used by Tier 3), so for an `ibc/<HASH>`
+        // voucher on such a chain we resolve the base denom here, derive a
+        // ticker from it (`uusdc` -> `USDC`), and take decimals from the base
+        // denom's metadata when present, else the chain fee-coin fallback.
+        // `isHidden = true` mirrors the SDK's semantics for a discovered IBC
+        // voucher; `makeDiscovered` still backfills a curated logo /
+        // priceProviderId when the derived ticker matches a bundled entry.
+        if denom.hasPrefix("ibc/"), Self.ibcModernDenomChains.contains(chain) {
+            if let baseDenom = await metadataResolver.ibcDenom(chain: chain, denom: denom) {
+                let baseMeta = await metadataResolver.denomMetadata(chain: chain, denom: baseDenom)
+                let decimals = baseMeta.flatMap(CosmosTokenMetadataResolver.decimalsFromMeta)
+                    ?? feeDecimals(for: chain)
+                let ticker = CosmosTokenMetadataResolver.ibcTicker(baseDenom: baseDenom)
+                return makeDiscovered(
+                    chain: chain,
+                    denom: denom,
+                    ticker: ticker,
+                    decimals: decimals,
+                    isHidden: true
+                )
+            }
+            // Voucher unknown to the modern endpoint — fall through to the
+            // hidden tier, which now yields `IBC-<6hex>` via deriveTicker.
         }
 
         // Tier 3: IBC trace recursion. Only applies to `ibc/<HASH>` denoms;

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosCoinFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosCoinFinder.swift
@@ -210,10 +210,13 @@ actor CosmosCoinFinder {
                         isHidden: true
                     )
                 }
-                // Trace returned but no base metadata — fall through to
-                // the hidden-with-derived-ticker tier using the base denom
-                // string for ticker derivation.
-                let ticker = CosmosTokenMetadataResolver.deriveTicker(denom: baseDenom, meta: nil)
+                // Trace returned but no base metadata — derive a ticker from
+                // the base denom, degrading to the voucher's `IBC-<6hex>` when
+                // the base is opaque (EVM `0x…`, namespaced, over-long) so it
+                // never renders as a raw address. Same handling as the modern
+                // `/denoms` tier above.
+                let ticker = CosmosTokenMetadataResolver.ibcTicker(baseDenom: baseDenom)
+                    ?? CosmosTokenMetadataResolver.deriveTicker(denom: denom, meta: nil)
                 return makeDiscovered(
                     chain: chain,
                     denom: denom,

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
@@ -308,24 +308,59 @@ actor CosmosTokenMetadataResolver {
                 return "IBC-" + hash.prefix(6).uppercased()
             }
         }
-        return denom
+        // Plain bank denom: strip a leading `u`/`a` micro-unit prefix and
+        // uppercase, so Terra fiat micro-denoms read as symbols
+        // (`ucny` -> `CNY`, `uluna` -> `LUNA`) instead of the raw `ucny`. This
+        // tier only runs for the Cosmos discovery path (`CosmosCoinFinder`,
+        // allowlisted to Terra / TerraClassic), so the strip is Terra-scoped.
+        return stripMicroUnitPrefix(denom).uppercased()
     }
 
-    /// Derive a display ticker from an IBC voucher's resolved base denom by
-    /// stripping a single leading micro-unit prefix (`u`/`a`) and uppercasing
-    /// — `uusdc` -> `USDC`, `uatom` -> `ATOM`. Mirrors the SDK
-    /// `deriveIbcTraceTicker` and Android `stripDenomUnitPrefix` (which strips
-    /// only when the second character is a letter, so `u123`-style denoms are
-    /// left untouched).
-    static func ibcTicker(baseDenom: String) -> String {
+    /// Strip a single leading micro-unit prefix (`u`/`a`) from a denom, but
+    /// only when the second character is a letter — so genuine micro-denoms
+    /// (`uatom`, `aevmos`) are stripped while `u123`-style ids are left
+    /// intact. Does NOT uppercase. Mirrors Android `stripDenomUnitPrefix`.
+    private static func stripMicroUnitPrefix(_ denom: String) -> String {
         let unitPrefixes: Set<Character> = ["u", "a"]
-        guard baseDenom.count > 1,
-              let first = baseDenom.first,
+        guard denom.count > 1,
+              let first = denom.first,
               unitPrefixes.contains(first),
-              baseDenom[baseDenom.index(after: baseDenom.startIndex)].isLetter else {
+              denom[denom.index(after: denom.startIndex)].isLetter else {
+            return denom
+        }
+        return String(denom.dropFirst())
+    }
+
+    /// Derive a display ticker from an IBC voucher's resolved base denom, or
+    /// `nil` when the base is opaque (an EVM `0x…` address, a namespaced denom,
+    /// or too long to read as a symbol) — the caller then degrades the voucher
+    /// to a short `IBC-<6hex>` label. Mirrors the SDK / Android IBC-ticker
+    /// conventions:
+    ///   - `factory/<minter>/<sub>` -> `<sub>` (single leading `u` stripped),
+    ///     uppercased (`…/alloyed/allBTC` -> `ALLBTC`).
+    ///   - a leading `u`/`a` micro-unit prefix -> stripped + uppercased
+    ///     (`uusdc` -> `USDC`, `uatom` -> `ATOM`).
+    ///   - an already-clean short symbol (`[A-Za-z0-9-]{1,12}`, not `0x…`)
+    ///     -> uppercased (`wbnb-wei` -> `WBNB-WEI`).
+    ///   - anything else (EVM address, contains `/`, too long) -> `nil`.
+    static func ibcTicker(baseDenom: String) -> String? {
+        if baseDenom.hasPrefix("factory/") {
+            let sub = baseDenom.split(separator: "/").last.map(String.init) ?? baseDenom
+            let stripped = sub.hasPrefix("u") ? String(sub.dropFirst()) : sub
+            return stripped.uppercased()
+        }
+
+        let microStripped = stripMicroUnitPrefix(baseDenom)
+        if microStripped != baseDenom {
+            return microStripped.uppercased()
+        }
+
+        if !baseDenom.lowercased().hasPrefix("0x"),
+           baseDenom.range(of: "^[A-Za-z0-9-]{1,12}$", options: .regularExpression) != nil {
             return baseDenom.uppercased()
         }
-        return String(baseDenom.dropFirst()).uppercased()
+
+        return nil
     }
 
     // MARK: - Private fetch implementations

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
@@ -52,6 +52,7 @@ actor CosmosTokenMetadataResolver {
 
     private var metadataCache: [String: CachedTask<CosmosDenomMetadata>] = [:]
     private var traceCache: [String: CachedTask<CosmosIbcDenomTraceDenomTrace>] = [:]
+    private var ibcDenomCache: [String: CachedTask<String>] = [:]
     private var cw20Cache: [String: CachedTask<CosmosCw20TokenInfo>] = [:]
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
@@ -149,6 +150,56 @@ actor CosmosTokenMetadataResolver {
         }
     }
 
+    /// Resolve the base denom behind an `ibc/<HASH>` voucher via the modern
+    /// ibc-go `/ibc/apps/transfer/v1/denoms/{hash}` endpoint. Unlike the
+    /// deprecated `denom_traces/{hash}` path (which Terra Classic LCDs answer
+    /// with `code 12 Not Implemented`), this endpoint is implemented on Terra
+    /// Classic, so it's the resolution path the caller uses there.
+    ///
+    /// Returns `nil` for non-IBC denoms WITHOUT a network call (same prefix
+    /// guard as `ibcDenomTrace`), and `nil` when the voucher is unknown
+    /// (NotFound decodes to a nil base). Cache-coalesced exactly like
+    /// `ibcDenomTrace`: concurrent callers share one in-flight round-trip and
+    /// a `nil`/error result is evicted so the next call retries.
+    func ibcDenom(chain: Chain, denom: String) async -> String? {
+        guard denom.hasPrefix("ibc/") else { return nil }
+        let hash = String(denom.dropFirst("ibc/".count))
+        guard !hash.isEmpty else { return nil }
+
+        let key = cacheKey(chain: chain, value: denom)
+
+        if let cached = ibcDenomCache[key], !isExpired(storedAt: cached.storedAt) {
+            do {
+                if let value = try await cached.task.value {
+                    return value
+                }
+                ibcDenomCache.removeValue(forKey: key)
+                return nil
+            } catch {
+                ibcDenomCache.removeValue(forKey: key)
+                return nil
+            }
+        }
+
+        let httpClient = self.httpClient
+        let task = Task<String?, Error> {
+            try await Self.fetchIbcDenomBase(httpClient: httpClient, chain: chain, hash: hash)
+        }
+        ibcDenomCache[key] = CachedTask(task: task, storedAt: Date())
+
+        do {
+            if let value = try await task.value {
+                return value
+            }
+            ibcDenomCache.removeValue(forKey: key)
+            return nil
+        } catch {
+            logger.warning("IBC denom lookup failed for \(denom, privacy: .public) on \(chain.rawValue, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            ibcDenomCache.removeValue(forKey: key)
+            return nil
+        }
+    }
+
     /// Resolve CW20 token metadata (`name`, `symbol`, `decimals`) for a wasm
     /// contract via the `{"token_info":{}}` smart query — the same lookup the
     /// SDK's `getCw20MetaFromLCD` performs.
@@ -201,6 +252,7 @@ actor CosmosTokenMetadataResolver {
     func clearCacheForTests() {
         metadataCache.removeAll()
         traceCache.removeAll()
+        ibcDenomCache.removeAll()
         cw20Cache.removeAll()
     }
 
@@ -246,7 +298,34 @@ actor CosmosTokenMetadataResolver {
             let sub = denom.split(separator: "/").last.map(String.init) ?? denom
             return sub.hasPrefix("u") ? String(sub.dropFirst()) : sub
         }
+        if denom.hasPrefix("ibc/") {
+            // Guaranteed layout fallback for an unresolved voucher: a short
+            // `IBC-<6 hex>` label instead of the raw 64-char hash. Mirrors
+            // Android `String.toCosmosTicker` (`IBC-` + 6-char uppercase
+            // preview) so the three clients degrade to the same label.
+            let hash = denom.dropFirst("ibc/".count)
+            if !hash.isEmpty {
+                return "IBC-" + hash.prefix(6).uppercased()
+            }
+        }
         return denom
+    }
+
+    /// Derive a display ticker from an IBC voucher's resolved base denom by
+    /// stripping a single leading micro-unit prefix (`u`/`a`) and uppercasing
+    /// — `uusdc` -> `USDC`, `uatom` -> `ATOM`. Mirrors the SDK
+    /// `deriveIbcTraceTicker` and Android `stripDenomUnitPrefix` (which strips
+    /// only when the second character is a letter, so `u123`-style denoms are
+    /// left untouched).
+    static func ibcTicker(baseDenom: String) -> String {
+        let unitPrefixes: Set<Character> = ["u", "a"]
+        guard baseDenom.count > 1,
+              let first = baseDenom.first,
+              unitPrefixes.contains(first),
+              baseDenom[baseDenom.index(after: baseDenom.startIndex)].isLetter else {
+            return baseDenom.uppercased()
+        }
+        return String(baseDenom.dropFirst()).uppercased()
     }
 
     // MARK: - Private fetch implementations
@@ -360,6 +439,44 @@ actor CosmosTokenMetadataResolver {
             responseType: CosmosIbcDenomTrace.self
         )
         return response.data.denomTrace
+    }
+
+    private static func fetchIbcDenomBase(
+        httpClient: HTTPClientProtocol,
+        chain: Chain,
+        hash: String
+    ) async throws -> String? {
+        guard let config = try? CosmosServiceConfig.getConfig(forChain: chain),
+              let baseURL = config.baseURL else {
+            return nil
+        }
+
+        let response: HTTPResponse<CosmosIbcDenom>
+        do {
+            response = try await httpClient.request(
+                CosmosAPI(baseURL: baseURL, endpoint: .ibcDenom(hash: hash)),
+                responseType: CosmosIbcDenom.self
+            )
+        } catch HTTPError.statusCode(let code, let data) {
+            // A NotFound voucher answers with gRPC NOT_FOUND (HTTP 404, body
+            // `{"code":5,"message":"...not found..."}`). Treat any non-transient
+            // status as "voucher unknown" -> nil so the caller degrades to the
+            // truncated-ticker fallback. Transient gateway/overload statuses
+            // rethrow so the resolver's cache eviction retries them. Same
+            // discipline as `fetchCw20TokenInfo`.
+            guard !transientHTTPStatuses.contains(code) else {
+                throw HTTPError.statusCode(code, data)
+            }
+            return nil
+        } catch HTTPError.decodingFailed {
+            return nil
+        }
+
+        // A resolved voucher with an empty/absent base is also unresolved.
+        guard let base = response.data.denom?.base, !base.isEmpty else {
+            return nil
+        }
+        return base
     }
 
     // MARK: - Helpers

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
@@ -344,23 +344,25 @@ actor CosmosTokenMetadataResolver {
     ///     -> uppercased (`wbnb-wei` -> `WBNB-WEI`).
     ///   - anything else (EVM address, contains `/`, too long) -> `nil`.
     static func ibcTicker(baseDenom: String) -> String? {
+        // Reduce the base to a candidate symbol: a `factory/<minter>/<sub>`
+        // base uses its last path segment (single leading `u` stripped), a
+        // `u`/`a` micro-denom is stripped, otherwise the base stands as-is.
+        let candidate: String
         if baseDenom.hasPrefix("factory/") {
             let sub = baseDenom.split(separator: "/").last.map(String.init) ?? baseDenom
-            let stripped = sub.hasPrefix("u") ? String(sub.dropFirst()) : sub
-            return stripped.uppercased()
+            candidate = sub.hasPrefix("u") ? String(sub.dropFirst()) : sub
+        } else {
+            candidate = stripMicroUnitPrefix(baseDenom)
         }
 
-        let microStripped = stripMicroUnitPrefix(baseDenom)
-        if microStripped != baseDenom {
-            return microStripped.uppercased()
+        // Accept only a clean short symbol; reject opaque values (EVM `0x…`
+        // addresses, anything containing `/`, over-long tails) so the caller
+        // degrades the voucher to a short `IBC-<6hex>` label instead.
+        guard !candidate.lowercased().hasPrefix("0x"),
+              candidate.range(of: "^[A-Za-z0-9-]{1,12}$", options: .regularExpression) != nil else {
+            return nil
         }
-
-        if !baseDenom.lowercased().hasPrefix("0x"),
-           baseDenom.range(of: "^[A-Za-z0-9-]{1,12}$", options: .regularExpression) != nil {
-            return baseDenom.uppercased()
-        }
-
-        return nil
+        return candidate.uppercased()
     }
 
     // MARK: - Private fetch implementations

--- a/VultisigApp/VultisigApp/Core/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/TokensStore.swift
@@ -1900,6 +1900,15 @@ class TokensStore {
             contractAddress: "uusd",
             isNativeToken: false
         ),
+        CoinMeta(
+            chain: .terraClassic,
+            ticker: "USDC",
+            logo: "usdc",
+            decimals: 6,
+            priceProviderId: "usd-coin",
+            contractAddress: "ibc/0BB9D8513E8E8E9AE6A9D211D9136E6DA42288DDE6CFAA453A150A4566054DC5",
+            isNativeToken: false
+        ),
         rune,
         CoinMeta(
             chain: .thorChainChainnet,

--- a/VultisigApp/VultisigAppTests/Chains/CosmosCoinFinderTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CosmosCoinFinderTests.swift
@@ -180,9 +180,23 @@ final class CosmosCoinFinderTests: XCTestCase {
         XCTAssertEqual(ticker, "ruji")
     }
 
-    func testDeriveTickerFallsThroughToFullDenomWhenNoRuleMatches() {
-        let ticker = CosmosTokenMetadataResolver.deriveTicker(denom: "uatom", meta: nil)
-        XCTAssertEqual(ticker, "uatom")
+    func testDeriveTickerPlainMicroDenomStripsPrefixAndUppercases() {
+        // Final plain-denom fallback: a leading `u`/`a` micro-unit prefix is
+        // stripped and the result uppercased, so native Terra fiat
+        // micro-denoms read as symbols instead of the raw `ucny`.
+        XCTAssertEqual(CosmosTokenMetadataResolver.deriveTicker(denom: "ucny", meta: nil), "CNY")
+        XCTAssertEqual(CosmosTokenMetadataResolver.deriveTicker(denom: "uhkd", meta: nil), "HKD")
+        XCTAssertEqual(CosmosTokenMetadataResolver.deriveTicker(denom: "uluna", meta: nil), "LUNA")
+        XCTAssertEqual(CosmosTokenMetadataResolver.deriveTicker(denom: "uatom", meta: nil), "ATOM")
+    }
+
+    func testDeriveTickerPlainDenomKeepsNonMicroPrefix() {
+        // Guard: strip only when the 2nd char is a letter, so `u123`-style
+        // denoms keep their leading char (just uppercased); short/edge denoms
+        // must not crash.
+        XCTAssertEqual(CosmosTokenMetadataResolver.deriveTicker(denom: "u1", meta: nil), "U1")
+        XCTAssertEqual(CosmosTokenMetadataResolver.deriveTicker(denom: "u123", meta: nil), "U123")
+        XCTAssertEqual(CosmosTokenMetadataResolver.deriveTicker(denom: "u", meta: nil), "U")
     }
 
     func testDeriveTickerIbcDenomTruncatesToShortHash() {
@@ -198,9 +212,10 @@ final class CosmosCoinFinderTests: XCTestCase {
 
     func testDeriveTickerIbcDenomWithEmptyHashFallsThrough() {
         // A malformed `ibc/` with no hash must not produce a bare `IBC-`
-        // label — it falls through to the raw-denom return.
+        // label — it falls through to the plain-denom fallback (which now
+        // uppercases): `ibc/` -> `IBC/`.
         let ticker = CosmosTokenMetadataResolver.deriveTicker(denom: "ibc/", meta: nil)
-        XCTAssertEqual(ticker, "ibc/")
+        XCTAssertEqual(ticker, "IBC/")
     }
 
     // MARK: - IBC ticker derivation (pure)
@@ -233,6 +248,33 @@ final class CosmosCoinFinderTests: XCTestCase {
         // leading char — they are not micro-denominated units.
         XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "u123"), "U123")
         XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "a0x"), "A0X")
+    }
+
+    func testIbcTickerFactoryBaseUsesLastSegment() {
+        // A factory base (e.g. an Osmosis alloyed asset) uses its last path
+        // segment, uppercased — never the full namespaced string.
+        XCTAssertEqual(
+            CosmosTokenMetadataResolver.ibcTicker(baseDenom: "factory/osmo1z6r6/alloyed/allBTC"),
+            "ALLBTC"
+        )
+        XCTAssertEqual(
+            CosmosTokenMetadataResolver.ibcTicker(baseDenom: "factory/osmo1q77/slayer"),
+            "SLAYER"
+        )
+    }
+
+    func testIbcTickerAcceptsCleanShortTicker() {
+        // An already-clean short symbol (<= 12 chars, `[A-Za-z0-9-]`, not a
+        // `0x…` address) is accepted and uppercased.
+        XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "wbnb-wei"), "WBNB-WEI")
+    }
+
+    func testIbcTickerReturnsNilForOpaqueEvmAddress() {
+        // An EVM `0x…` address is opaque — return nil so the caller degrades
+        // the voucher to `IBC-<6hex>` instead of showing the raw address.
+        XCTAssertNil(
+            CosmosTokenMetadataResolver.ibcTicker(baseDenom: "0x45804880de22913dafe09f4980848ece6ecbaf78")
+        )
     }
 
     // MARK: - Fee-denom + fee-decimals table
@@ -497,6 +539,103 @@ final class CosmosCoinFinderTests: XCTestCase {
             0,
             "Terra Classic must NOT hit the deprecated denom_traces endpoint"
         )
+    }
+
+    func testTerraClassicIbcVoucherWithOpaqueEvmBaseFallsBackToTruncatedTicker() async throws {
+        // The voucher resolves, but its base denom is an opaque EVM `0x…`
+        // address with no readable symbol. The ticker must degrade to the
+        // voucher's short IBC-<6hex>, never the raw 0x address.
+        let ibcHash = "AF91F7ABCDEF"
+        let ibcDenom = "ibc/\(ibcHash)"
+        let stub = ScriptedHTTPClient()
+        stub.balances = [
+            ("uluna", "1000"),
+            (ibcDenom, "1000000000000000000")
+        ]
+        stub.ibcDenomPayloads[ibcHash] = "0x45804880de22913dafe09f4980848ece6ecbaf78"
+
+        let finder = CosmosCoinFinder(
+            httpClient: stub,
+            metadataResolver: makeIsolatedResolver(client: stub)
+        )
+        let result = try await finder.discoverBankDenoms(
+            chain: .terraClassic,
+            address: "terra1classic"
+        )
+
+        XCTAssertEqual(result.count, 1)
+        let voucher = try XCTUnwrap(result.first)
+        XCTAssertEqual(voucher.denom, ibcDenom)
+        XCTAssertEqual(
+            voucher.ticker,
+            "IBC-AF91F7",
+            "Opaque EVM base -> voucher IBC-<6hex>, never the raw 0x address"
+        )
+        XCTAssertTrue(voucher.isHidden)
+        XCTAssertEqual(stub.ibcDenomCallCount, 1, "Must resolve the base via the modern /denoms endpoint")
+        // Prove the resolved 0x base was actually consumed (its metadata was
+        // looked up for decimals) — not that we merely fell through to Tier 4,
+        // which would coincidentally yield the same IBC-<6hex> label.
+        XCTAssertEqual(
+            stub.denomMetadataCallCount(for: "0x45804880de22913dafe09f4980848ece6ecbaf78"),
+            1,
+            "The modern tier must resolve the base denom's metadata before degrading the ticker"
+        )
+    }
+
+    func testTerraClassicIbcVoucherWithFactoryBaseUsesLastSegment() async throws {
+        // A voucher whose base is a factory alloyed asset resolves to the
+        // last path segment (uppercased), not the full namespaced string.
+        let ibcHash = "FACTORYVOUCHERHASH"
+        let ibcDenom = "ibc/\(ibcHash)"
+        let stub = ScriptedHTTPClient()
+        stub.balances = [
+            ("uluna", "1000"),
+            (ibcDenom, "1000000")
+        ]
+        stub.ibcDenomPayloads[ibcHash] = "factory/osmo1z6r6/alloyed/allBTC"
+
+        let finder = CosmosCoinFinder(
+            httpClient: stub,
+            metadataResolver: makeIsolatedResolver(client: stub)
+        )
+        let result = try await finder.discoverBankDenoms(
+            chain: .terraClassic,
+            address: "terra1classic"
+        )
+
+        XCTAssertEqual(result.count, 1)
+        let voucher = try XCTUnwrap(result.first)
+        XCTAssertEqual(voucher.ticker, "ALLBTC")
+        XCTAssertTrue(voucher.isHidden)
+    }
+
+    func testTerraClassicNativeFiatMicroDenomResolvesToUppercaseSymbol() async throws {
+        // A non-IBC native fiat micro-denom (`ucny`) has no curated entry and
+        // no metadata, so it reaches the hidden Tier-4 fallback — which now
+        // renders it as the uppercase symbol `CNY` instead of the raw `ucny`.
+        let stub = ScriptedHTTPClient()
+        stub.balances = [
+            ("uluna", "1000"),
+            ("ucny", "5000")
+        ]
+
+        let finder = CosmosCoinFinder(
+            httpClient: stub,
+            metadataResolver: makeIsolatedResolver(client: stub)
+        )
+        let result = try await finder.discoverBankDenoms(
+            chain: .terraClassic,
+            address: "terra1classic"
+        )
+
+        XCTAssertEqual(result.count, 1)
+        let cny = try XCTUnwrap(result.first)
+        XCTAssertEqual(cny.denom, "ucny")
+        XCTAssertEqual(cny.ticker, "CNY", "Native fiat micro-denom must render as its uppercase symbol")
+        XCTAssertEqual(cny.decimals, 6)
+        XCTAssertTrue(cny.isHidden)
+        XCTAssertEqual(stub.ibcDenomCallCount, 0, "A non-IBC denom must not hit the /denoms endpoint")
     }
 
     func testTerraPhoenix1IbcDenomStillUsesTraceEndpoint() async throws {

--- a/VultisigApp/VultisigAppTests/Chains/CosmosCoinFinderTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CosmosCoinFinderTests.swift
@@ -277,6 +277,14 @@ final class CosmosCoinFinderTests: XCTestCase {
         )
     }
 
+    func testIbcTickerReturnsNilForOpaqueFactoryTail() {
+        // A factory base whose last segment is itself opaque (an EVM `0x…`
+        // address or an over-long tail) must NOT render raw — it goes through
+        // the same clean-short-symbol gate and returns nil.
+        XCTAssertNil(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "factory/osmo1abc/0xdeadbeefcafebabe"))
+        XCTAssertNil(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "factory/osmo1abc/thisnameiswaytoolong"))
+    }
+
     // MARK: - Fee-denom + fee-decimals table
 
     func testFeeDenomForTerraIsUluna() {
@@ -636,6 +644,38 @@ final class CosmosCoinFinderTests: XCTestCase {
         XCTAssertEqual(cny.decimals, 6)
         XCTAssertTrue(cny.isHidden)
         XCTAssertEqual(stub.ibcDenomCallCount, 0, "A non-IBC denom must not hit the /denoms endpoint")
+    }
+
+    func testTerraPhoenix1IbcVoucherWithOpaqueTraceBaseFallsBackToTruncatedTicker() async throws {
+        // On phoenix-1 the trace resolves a base denom with no metadata; when
+        // that base is opaque (an EVM `0x…` address) the ticker must degrade
+        // to the voucher's IBC-<6hex>, never the raw address.
+        let ibcHash = "BEEF12ABCDEF"
+        let ibcDenom = "ibc/\(ibcHash)"
+        let stub = ScriptedHTTPClient()
+        stub.balances = [(ibcDenom, "1000000000000000000")]
+        stub.ibcTracePayloads[ibcHash] = ScriptedHTTPClient.TracePayload(
+            path: "transfer/channel-0",
+            baseDenom: "0x45804880de22913dafe09f4980848ece6ecbaf78"
+        )
+        // No metadata payload for the base -> the meta-missing fallback path.
+
+        let finder = CosmosCoinFinder(
+            httpClient: stub,
+            metadataResolver: makeIsolatedResolver(client: stub)
+        )
+        let result = try await finder.discoverBankDenoms(chain: .terra, address: "terra1abc")
+
+        XCTAssertEqual(result.count, 1)
+        let voucher = try XCTUnwrap(result.first)
+        XCTAssertEqual(voucher.denom, ibcDenom)
+        XCTAssertEqual(
+            voucher.ticker,
+            "IBC-BEEF12",
+            "Opaque trace base -> voucher IBC-<6hex>, never the raw 0x address"
+        )
+        XCTAssertTrue(voucher.isHidden)
+        XCTAssertEqual(stub.ibcTraceCallCount, 1, "Phoenix-1 resolves via the trace endpoint")
     }
 
     func testTerraPhoenix1IbcDenomStillUsesTraceEndpoint() async throws {

--- a/VultisigApp/VultisigAppTests/Chains/CosmosCoinFinderTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/CosmosCoinFinderTests.swift
@@ -185,6 +185,56 @@ final class CosmosCoinFinderTests: XCTestCase {
         XCTAssertEqual(ticker, "uatom")
     }
 
+    func testDeriveTickerIbcDenomTruncatesToShortHash() {
+        // Unresolved voucher -> IBC-<6hex uppercase>, never the raw 64-char
+        // hash. Mirrors Android `String.toCosmosTicker`. Uses a lowercase
+        // hash so the uppercasing is actually exercised.
+        let ticker = CosmosTokenMetadataResolver.deriveTicker(
+            denom: "ibc/0bb9d8513e8e8e9ae6a9d211d9136e6da42288dde6cfaa453a150a4566054dc5",
+            meta: nil
+        )
+        XCTAssertEqual(ticker, "IBC-0BB9D8")
+    }
+
+    func testDeriveTickerIbcDenomWithEmptyHashFallsThrough() {
+        // A malformed `ibc/` with no hash must not produce a bare `IBC-`
+        // label — it falls through to the raw-denom return.
+        let ticker = CosmosTokenMetadataResolver.deriveTicker(denom: "ibc/", meta: nil)
+        XCTAssertEqual(ticker, "ibc/")
+    }
+
+    // MARK: - IBC ticker derivation (pure)
+
+    func testIbcTickerStripsMicroPrefixAndUppercases() {
+        // Standard micro-denoms: strip the leading `u`, uppercase.
+        XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "uusdc"), "USDC")
+        XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "uatom"), "ATOM")
+    }
+
+    func testIbcTickerStripsAttoPrefix() {
+        // `a` (atto) is a valid micro-unit prefix on EVM-on-Cosmos chains.
+        XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "aevmos"), "EVMOS")
+    }
+
+    func testIbcTickerLeavesNonPrefixedDenomUppercased() {
+        // No leading u/a micro prefix -> just uppercase, no strip.
+        XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "gravity0x123"), "GRAVITY0X123")
+    }
+
+    func testIbcTickerLeavesSingleCharDenomUntouched() {
+        // Guard: length must exceed 1 before stripping, so a lone `u`/`a`
+        // survives (just uppercased).
+        XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "u"), "U")
+    }
+
+    func testIbcTickerDoesNotStripWhenSecondCharIsNotLetter() {
+        // The prefix is stripped only when the second character is a letter
+        // (Android `stripDenomUnitPrefix` guard), so `u123` / `a0x` keep their
+        // leading char — they are not micro-denominated units.
+        XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "u123"), "U123")
+        XCTAssertEqual(CosmosTokenMetadataResolver.ibcTicker(baseDenom: "a0x"), "A0X")
+    }
+
     // MARK: - Fee-denom + fee-decimals table
 
     func testFeeDenomForTerraIsUluna() {
@@ -324,27 +374,18 @@ final class CosmosCoinFinderTests: XCTestCase {
         XCTAssertTrue(atom.isHidden, "IBC trace path always sets isHidden = true")
     }
 
-    // MARK: - Terra Classic IBC trace gap
+    // MARK: - Terra Classic modern IBC resolution (#4761)
 
-    func testTerraClassicIbcDenomSkipsTraceEndpointAndLandsHidden() async throws {
-        // Terra Classic LCDs (publicnode, hexxagon, binodes) all return
-        // `code 12 Not Implemented` for /ibc/apps/transfer/v1/denom_traces.
-        // Mirroring the SDK (which has no IBC trace lookup for any chain),
-        // we skip the trace endpoint on Classic and fall through to the
-        // hidden tier with a derived ticker.
-        let ibcHash = "CLASSICHASH"
-        let ibcDenom = "ibc/\(ibcHash)"
+    func testTerraClassicReportedIbcTokenResolvesToUsdcViaTokensStore() async throws {
+        // The token in the bug report is Axelar USDC. A curated TokensStore
+        // entry keyed by the full ibc/<hash> contract resolves it at Tier 0
+        // -> symbol + logo + fiat, with no LCD metadata round-trip.
+        let reportedDenom = "ibc/0BB9D8513E8E8E9AE6A9D211D9136E6DA42288DDE6CFAA453A150A4566054DC5"
         let stub = ScriptedHTTPClient()
         stub.balances = [
             ("uluna", "1000"),
-            (ibcDenom, "999")
+            (reportedDenom, "5000000")
         ]
-        // Configure trace payload that would resolve to ATOM if the trace
-        // endpoint were called — the test asserts we DON'T call it.
-        stub.ibcTracePayloads[ibcHash] = ScriptedHTTPClient.TracePayload(
-            path: "transfer/channel-0",
-            baseDenom: "uatom"
-        )
 
         let finder = CosmosCoinFinder(
             httpClient: stub,
@@ -356,14 +397,105 @@ final class CosmosCoinFinderTests: XCTestCase {
         )
 
         XCTAssertEqual(result.count, 1)
-        let hidden = try XCTUnwrap(result.first)
-        XCTAssertEqual(hidden.denom, ibcDenom)
-        XCTAssertTrue(hidden.isHidden)
-        XCTAssertEqual(hidden.decimals, 6, "Hidden tier uses chain fee-coin decimals")
+        let usdc = try XCTUnwrap(result.first)
+        XCTAssertEqual(usdc.denom, reportedDenom)
+        XCTAssertEqual(usdc.ticker, "USDC")
+        XCTAssertEqual(usdc.decimals, 6)
+        XCTAssertEqual(usdc.priceProviderId, "usd-coin")
+        XCTAssertFalse(usdc.logo.isEmpty, "Curated entry must supply the USDC logo")
+        XCTAssertFalse(usdc.isHidden)
+        XCTAssertEqual(
+            stub.ibcDenomCallCount,
+            0,
+            "Curated Tier 0 must short-circuit before the /denoms endpoint"
+        )
+        XCTAssertEqual(stub.ibcTraceCallCount, 0)
+        XCTAssertEqual(
+            stub.totalCallCount,
+            1,
+            "Only the balance fetch — curated Tier 0 must not hit any metadata/denoms LCD call"
+        )
+    }
+
+    func testTerraClassicIbcDenomResolvesViaModernDenomsEndpoint() async throws {
+        // A non-curated ibc voucher on Terra Classic resolves through the
+        // modern /denoms endpoint: base `uusdc` -> ticker `USDC`. Terra
+        // Classic implements /denoms even though it rejects the deprecated
+        // denom_traces path, so the trace endpoint must NOT be hit. Decimals
+        // fall back to the chain fee-coin (6) because the base denom has no
+        // bank metadata, and the derived USDC ticker backfills the curated
+        // logo / priceProviderId.
+        let ibcHash = "AXLUSDCUNKNOWNHASH"
+        let ibcDenom = "ibc/\(ibcHash)"
+        let stub = ScriptedHTTPClient()
+        stub.balances = [
+            ("uluna", "1000"),
+            (ibcDenom, "5000000")
+        ]
+        stub.ibcDenomPayloads[ibcHash] = "uusdc"
+
+        let finder = CosmosCoinFinder(
+            httpClient: stub,
+            metadataResolver: makeIsolatedResolver(client: stub)
+        )
+        let result = try await finder.discoverBankDenoms(
+            chain: .terraClassic,
+            address: "terra1classic"
+        )
+
+        XCTAssertEqual(result.count, 1)
+        let usdc = try XCTUnwrap(result.first)
+        XCTAssertEqual(usdc.denom, ibcDenom, "Discovered denom must be the on-chain ibc/<hash> id")
+        XCTAssertEqual(usdc.ticker, "USDC")
+        XCTAssertEqual(usdc.decimals, 6, "No base-denom metadata -> chain fee-coin decimals")
+        XCTAssertTrue(usdc.isHidden, "Discovered IBC voucher stays hidden per SDK semantics")
+        XCTAssertFalse(usdc.logo.isEmpty, "Derived USDC ticker backfills the curated logo")
+        XCTAssertEqual(stub.ibcDenomCallCount, 1, "Terra Classic must hit the modern /denoms endpoint")
         XCTAssertEqual(
             stub.ibcTraceCallCount,
             0,
-            "Terra Classic must NOT hit /ibc/apps/transfer/v1/denom_traces"
+            "Terra Classic must NOT hit the deprecated denom_traces endpoint"
+        )
+    }
+
+    func testTerraClassicIbcDenomFallsBackToTruncatedTickerWhenDenomsNotFound() async throws {
+        // When /denoms returns NotFound for an unknown voucher, the finder
+        // degrades to a short IBC-<6hex> label (Android parity) instead of
+        // the raw 64-char hash, and marks it hidden — never dropped.
+        let ibcHash = "0BB9D8FFEEDDCCBBAA"
+        let ibcDenom = "ibc/\(ibcHash)"
+        let stub = ScriptedHTTPClient()
+        stub.balances = [
+            ("uluna", "1000"),
+            (ibcDenom, "999")
+        ]
+        // No ibcDenomPayloads entry -> the stub answers 404 (gRPC NOT_FOUND).
+
+        let finder = CosmosCoinFinder(
+            httpClient: stub,
+            metadataResolver: makeIsolatedResolver(client: stub)
+        )
+        let result = try await finder.discoverBankDenoms(
+            chain: .terraClassic,
+            address: "terra1classic"
+        )
+
+        XCTAssertEqual(result.count, 1, "Unresolved vouchers are surfaced hidden, not dropped")
+        let hidden = try XCTUnwrap(result.first)
+        XCTAssertEqual(hidden.denom, ibcDenom)
+        XCTAssertEqual(
+            hidden.ticker,
+            "IBC-0BB9D8",
+            "Fallback truncates to IBC-<6hex uppercase>, never the raw hash"
+        )
+        XCTAssertNotEqual(hidden.ticker, ibcDenom, "The raw ibc/<hash> denom must never become the ticker")
+        XCTAssertEqual(hidden.decimals, 6, "Hidden tier uses chain fee-coin decimals")
+        XCTAssertTrue(hidden.isHidden)
+        XCTAssertEqual(stub.ibcDenomCallCount, 1, "Must attempt the modern /denoms endpoint")
+        XCTAssertEqual(
+            stub.ibcTraceCallCount,
+            0,
+            "Terra Classic must NOT hit the deprecated denom_traces endpoint"
         )
     }
 
@@ -519,6 +651,72 @@ final class CosmosCoinFinderTests: XCTestCase {
         )
     }
 
+    // MARK: - Modern IBC denom resolution cache
+
+    func testIbcDenomShortCircuitsForNonIbcDenom() async {
+        // Same prefix guard as ibcDenomTrace: `uluna` must return nil WITHOUT
+        // a /denoms round-trip.
+        let stub = ScriptedHTTPClient()
+        let resolver = makeIsolatedResolver(client: stub)
+
+        let result = await resolver.ibcDenom(chain: .terraClassic, denom: "uluna")
+        XCTAssertNil(result)
+        XCTAssertEqual(stub.ibcDenomCallCount, 0, "Non-IBC denoms must not trigger a /denoms lookup")
+    }
+
+    func testIbcDenomCacheCoalescesConcurrentLookups() async {
+        // Two concurrent lookups for the same voucher share one /denoms
+        // round-trip — same Task-cell coalescing as the metadata/trace caches.
+        let stub = ScriptedHTTPClient()
+        let ibcHash = "DEADBEEF"
+        let ibcDenom = "ibc/\(ibcHash)"
+        stub.ibcDenomPayloads[ibcHash] = "uusdc"
+        let resolver = makeIsolatedResolver(client: stub)
+
+        async let first = resolver.ibcDenom(chain: .terraClassic, denom: ibcDenom)
+        async let second = resolver.ibcDenom(chain: .terraClassic, denom: ibcDenom)
+        let (a, b) = await (first, second)
+
+        XCTAssertEqual(a, "uusdc")
+        XCTAssertEqual(b, "uusdc")
+        XCTAssertEqual(
+            stub.ibcDenomCallCount,
+            1,
+            "Concurrent in-flight /denoms lookups must share one round-trip"
+        )
+    }
+
+    func testIbcDenomReturnsNilForUnknownVoucher() async {
+        // The modern endpoint answers 404 (gRPC NOT_FOUND) for an unknown
+        // voucher; the resolver must surface that as nil, not throw.
+        let stub = ScriptedHTTPClient()
+        let ibcDenom = "ibc/UNKNOWNVOUCHER"
+        let resolver = makeIsolatedResolver(client: stub)
+
+        let result = await resolver.ibcDenom(chain: .terraClassic, denom: ibcDenom)
+        XCTAssertNil(result)
+        XCTAssertEqual(stub.ibcDenomCallCount, 1)
+    }
+
+    // MARK: - CosmosIbcDenom decoding
+
+    func testCosmosIbcDenomDecodesResolvedShape() throws {
+        let json = Data(#"{"denom":{"base":"uusdc","trace":[{"port_id":"transfer","channel_id":"channel-113"}]}}"#.utf8)
+        let decoded = try JSONDecoder().decode(CosmosIbcDenom.self, from: json)
+        XCTAssertEqual(decoded.denom?.base, "uusdc")
+        XCTAssertEqual(decoded.denom?.trace?.first?.channelId, "channel-113")
+        XCTAssertEqual(decoded.denom?.trace?.first?.portId, "transfer")
+    }
+
+    func testCosmosIbcDenomDecodesNotFoundShapeToNilBase() throws {
+        // gRPC NOT_FOUND body must decode to a nil denom (unresolved) rather
+        // than throwing a decode error.
+        let json = Data(#"{"code":5,"message":"denomination trace not found"}"#.utf8)
+        let decoded = try JSONDecoder().decode(CosmosIbcDenom.self, from: json)
+        XCTAssertNil(decoded.denom)
+        XCTAssertNil(decoded.denom?.base)
+    }
+
     // MARK: - Test helpers
 
     private func makeIsolatedResolver(client: HTTPClientProtocol) -> CosmosTokenMetadataResolver {
@@ -553,11 +751,16 @@ private final class ScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable 
     var balances: [(denom: String, amount: String)] = []
     var denomMetadataPayloads: [String: MetaPayload] = [:]
     var ibcTracePayloads: [String: TracePayload] = [:]
+    /// Modern `/denoms/{hash}` responses: hash -> resolved base denom. A hash
+    /// with no entry answers HTTP 404 (gRPC NOT_FOUND), matching the modern
+    /// endpoint's reply for an unknown voucher.
+    var ibcDenomPayloads: [String: String] = [:]
     var shouldFailAllRequests = false
 
     private let queue = DispatchQueue(label: "ScriptedHTTPClient.queue")
     private var _denomMetadataCalls: [String: Int] = [:]
     private var _ibcTraceCalls = 0
+    private var _ibcDenomCalls = 0
     private var _totalCalls = 0
 
     func denomMetadataCallCount(for denom: String) -> Int {
@@ -566,6 +769,10 @@ private final class ScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable 
 
     var ibcTraceCallCount: Int {
         queue.sync { _ibcTraceCalls }
+    }
+
+    var ibcDenomCallCount: Int {
+        queue.sync { _ibcDenomCalls }
     }
 
     var totalCallCount: Int {
@@ -645,6 +852,23 @@ private final class ScriptedHTTPClient: HTTPClientProtocol, @unchecked Sendable 
             } else {
                 envelope = [:]
             }
+            let data = try JSONSerialization.data(withJSONObject: envelope)
+            let decoded = try JSONDecoder().decode(T.self, from: data)
+            return HTTPResponse(data: decoded, response: stubUrl)
+
+        case .ibcDenom(let hash):
+            queue.sync { _ibcDenomCalls += 1 }
+            guard let baseDenom = ibcDenomPayloads[hash] else {
+                // Unknown voucher: the modern endpoint answers gRPC NOT_FOUND
+                // (HTTP 404). The resolver must treat this as unresolved (nil).
+                throw HTTPError.statusCode(404, nil)
+            }
+            let envelope: [String: Any] = [
+                "denom": [
+                    "base": baseDenom,
+                    "trace": [["port_id": "transfer", "channel_id": "channel-113"]]
+                ]
+            ]
             let data = try JSONSerialization.data(withJSONObject: envelope)
             let decoded = try JSONDecoder().decode(T.self, from: data)
             return HTTPResponse(data: decoded, response: stubUrl)


### PR DESCRIPTION
closes #4761

## Problem

On **TerraClassic**, a held `ibc/<hash>` token rendered with the raw 64-char denom as its name — a long wrapping string, no symbol, no icon, and no fiat value (`—` / $0.00). iOS was the only client showing the raw hash; Android and Windows/SDK both degrade gracefully.

## Root cause

A held `ibc/<hash>` denom flows through `CosmosCoinFinder.resolve`'s tiers and lands on the last one:

1. **Curated `TokensStore`** — no TerraClassic `ibc/` entries → miss.
2. **`denoms_metadata`** — TerraClassic returns a malformed record (`decimalsFromMeta` → nil) → rejected.
3. **IBC trace recursion** — gated to `.terra` via `ibcTraceCapableChains`, skipped for TerraClassic because the deprecated `/denom_traces/{hash}` endpoint returns `code 12 Not Implemented` there.
4. **Fallback `deriveTicker(denom:meta:nil)`** — had **no `ibc/` branch**, so it hit `return denom` → the raw `ibc/<hash>` became `Coin.ticker`.

That single ticker value drove all four symptoms: the name, the repeated balance-column suffix, and (via empty `logo`/`priceProviderId`) the missing icon and fiat.

## Key finding: the modern ibc-go endpoint works on TerraClassic

The deprecated `/ibc/apps/transfer/v1/denom_traces/{hash}` is genuinely dead on TerraClassic (publicnode `-32701`, hexxagon `code 12`) — the existing code correctly avoids it. But the **modern** ibc-go path is implemented:

```
GET /ibc/apps/transfer/v1/denoms/{hash}
→ {"denom":{"base":"uusdc","trace":[{"port_id":"transfer","channel_id":"channel-113"}]}}
```

So the reported token is **Axelar USDC** (base `uusdc`, 6 decimals). Neither Android nor Windows/SDK uses this endpoint yet — iOS exceeds parity here.

## The fix (layered — highest fidelity first, guaranteed-safe fallback last)

1. **`CosmosAPI`** — new `.ibcDenom(hash:)` endpoint + a `CosmosIbcDenom` model whose fields are optional so the gRPC-gateway NotFound shape (`{code,message}`) decodes to a nil base rather than throwing.
2. **`CosmosTokenMetadataResolver`** —
   - `ibcDenom(chain:denom:)` resolves the base denom via `/denoms`, cache-coalesced exactly like `ibcDenomTrace`;
   - `ibcTicker(baseDenom:)` strips a single leading `u`/`a` micro-unit prefix and uppercases (`uusdc` → `USDC`), mirroring the SDK `deriveIbcTraceTicker` / Android `stripDenomUnitPrefix`;
   - a new `ibc/` branch in `deriveTicker` returns **`IBC-<6hex>`** (e.g. `IBC-0BB9D8`) — the guaranteed layout fix even with zero network, matching Android's `String.toCosmosTicker`.
3. **`CosmosCoinFinder`** — `ibcModernDenomChains = [.terraClassic]` plus a new resolution tier between direct-metadata and the `.terra`-only trace recursion: an `ibc/<hash>` on a modern-endpoint chain resolves its base denom → derived ticker + metadata/fee-coin decimals, `isHidden = true` (SDK semantics), with curated logo/`priceProviderId` backfilled by ticker. `.terra`/phoenix-1 stays on its working `denom_traces` path (no regression).
4. **`TokensStore`** — one curated `.terraClassic` Axelar-USDC entry keyed by the full `ibc/0BB9…4DC5` contract (`USDC`, 6 decimals, `usd-coin`, `usdc` logo), so the reported token resolves at Tier 0 → symbol + icon + fiat with **no network call**.

The display layer (`TokenCellView`) and models (`Coin`/`CoinMeta`) are unchanged — they already render `ticker`.

### Follow-up hardening (from on-device testing against a TerraClassic address holding many vouchers)

The `u`-based IBC bases resolved cleanly (ATOM, DGN, USDT, SCRT, WHALE, USDC). Two more display gaps were then closed:

- **IBC vouchers whose resolved base is not a `u`/`a` micro-denom.** `ibcTicker(baseDenom:)` now returns `String?`: `factory/<minter>/<sub>` bases use the last path segment (`…/alloyed/allBTC` → `ALLBTC`), an already-clean short ticker uppercases (`wbnb-wei` → `WBNB-WEI`), and an opaque base (an EVM `0x…` address, namespaced, or over-long) returns `nil`. At the modern-IBC tier the call site then falls back to the voucher's `IBC-<6hex>` (`0x4580…` base → `IBC-AF91F7`), so a raw address never reaches the UI.
- **Native Terra fiat micro-denoms.** Non-IBC denoms like `ucny`/`uhkd`/`ukrw` reached the plain-denom Tier-4 fallback and rendered as raw `ucny`. `deriveTicker`'s final fallback now strips a leading `u`/`a` micro-unit prefix (only when the 2nd char is a letter, so `u123`-style ids are untouched) and uppercases → `CNY`. This tier only runs for the Cosmos discovery path (`CosmosCoinFinder`, allowlisted to Terra/TerraClassic), so the change is Terra-scoped. The `u`/`a` strip is factored into a shared `stripMicroUnitPrefix` helper reused by `ibcTicker` and `deriveTicker`.

## Tests

`CosmosCoinFinderTests` gains: the reported token resolving via curated Tier 0 (no LCD call); a non-curated voucher resolving via `/denoms` (`uusdc` → `USDC`, trace endpoint untouched); an unknown voucher degrading to `IBC-0BB9D8` instead of the raw hash; `deriveTicker` `ibc/` + `ibcTicker` `u`/`a`-strip edge cases (incl. the "second char must be a letter" guard); `ibcDenom` cache short-circuit/coalesce/NotFound; and `CosmosIbcDenom` decode for the resolved + NotFound shapes.

## On-device status

Tested on-device against a TerraClassic address holding many vouchers: `u`-based bases resolve to symbols (ATOM, DGN, USDT, SCRT, WHALE, USDC); factory/alloyed, EVM `0x…`, and native fiat micro-denoms are handled by the follow-up above. Remaining manual check: confirm the curated Axelar-USDC token shows `USDC` + icon + fiat, and an unknown voucher shows `IBC-<6hex>`.

## Known limitations / recommended follow-ups

These are pre-existing behaviors this display fix does not change; both surfaced during cross-model review and are deliberately out of scope here (they touch persisted `@Model` state the plan excluded):

- **Already-affected vaults are not auto-refreshed.** A vault that auto-added this token *before* this fix keeps the raw-hash ticker/empty logo, because `CoinService.insertVisibleDiscoveredToken` skips existing coins (`vault.coin(for:)` matches by contract) without refreshing them. New discoveries and re-added tokens display correctly. A safe refresh must also update the persisted `Coin.id` (it embeds the ticker and is the balance-cache key, the `Coin` equality key, and keysign identity) — a migration worth its own change. **Workaround for the reporter:** remove and re-add the token.
- **Hidden-token ticker match.** A user who explicitly hid the raw-ticker token could see it reappear (correctly labeled) once the ticker resolves, because `HiddenToken.matches` requires a ticker match. A fix would broaden hidden-token matching to chain+contract for non-native tokens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added modern IBC voucher denomination resolution for Terra Classic (via the modern denom endpoint).
  * Added a built-in Terra Classic USDC token entry.
  * Improved ticker derivation for unresolved IBC assets using deterministic `IBC-` labels.

* **Bug Fixes**
  * Unknown/unresolvable IBC vouchers now decode/fail gracefully and produce hidden-token fallbacks (no crashes).
  * Improved concurrent IBC denom resolution with request coalescing and safer cache retry behavior.
  * Refined ticker derivation to prefer resolved base-denom metadata when available.

* **Tests**
  * Expanded coverage for modern IBC resolution, caching behavior, and ticker/metadata fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->