### PR TITLE
Enable KyberSwap on Base

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/Actions/Coin+Swaps.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Actions/Coin+Swaps.swift
@@ -106,7 +106,7 @@ extension Coin {
         case .arbitrum:
             return [.mayachain, .oneinch(chain), .lifi, .kyberswap(chain), .swapkit]
         case .base:
-            return [.thorchain, .oneinch(chain), .lifi, .swapkit] // KyberSwap not supported
+            return [.thorchain, .oneinch(chain), .lifi, .kyberswap(chain), .swapkit]
         case .optimism, .polygon, .polygonV2:
             return [.lifi, .oneinch(chain), .kyberswap(chain), .swapkit] // KyberSwap supported
         case .mantle:


### PR DESCRIPTION
## Summary
- Add `.kyberswap(chain)` to the `.base` arm in `naturalSwapProviders` (`Coin+Swaps.swift`).
- Base was excluded since KyberSwap's introduction with no documented Base-specific reason — conservative-at-introduction, never revisited.
- The SDK live-confirmed Kyber on Base, and iOS's `KyberSwapService` already maps `.base -> "base"` (`KyberSwapService.swift:219-220`), so this is a registry-only change, not an integration.
- zkSync/Blast remain excluded intentionally (Kyber's API 404s on both).

## Issue
Closes #4793

## Test Plan
- [ ] Sanity-check one live Base Kyber quote (e.g. USDC→WETH) before merge
- [x] SwiftLint passes
- [ ] xcodebuild build succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KyberSwap as an available swap provider for the supported chain.
  * Users can now access KyberSwap when exchanging assets on that chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->