### PR TITLE
fix(solana): gate signAllTransactions N>1 before the keysign ceremony (#4796)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
@@ -306,10 +306,12 @@ enum SolanaHelper {
     static func getPreSignedImageHash(keysignPayload: KeysignPayload) throws -> [String] {
         // Handle SignSolana (raw transactions)
         if let signSolana = keysignPayload.signSolana {
-            // Reject a multi-transaction batch (signAllTransactions, N>1) here —
-            // the single pre-ceremony chokepoint reached on BOTH the initiator
-            // and the co-signer before peer discovery. getSignedTransaction only
-            // supports a single raw transaction, so without this the user would
+            // Reject a multi-transaction batch (signAllTransactions, N>1) here.
+            // This runs while keysign messages are built, before peer discovery.
+            // A relayed N>1 batch reaches this device only as a co-signer (the
+            // sole in-app signSolana producers are single-tx staking and the
+            // proto-ingress joiner path), and getSignedTransaction supports just
+            // one raw transaction — so without this the co-signer would
             // physically approve the full multi-device keysign and only then hit
             // an opaque post-ceremony failure. Fail fast with a clear message.
             guard signSolana.rawTransactions.count <= 1 else {

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
@@ -306,6 +306,15 @@ enum SolanaHelper {
     static func getPreSignedImageHash(keysignPayload: KeysignPayload) throws -> [String] {
         // Handle SignSolana (raw transactions)
         if let signSolana = keysignPayload.signSolana {
+            // Reject a multi-transaction batch (signAllTransactions, N>1) here —
+            // the single pre-ceremony chokepoint reached on BOTH the initiator
+            // and the co-signer before peer discovery. getSignedTransaction only
+            // supports a single raw transaction, so without this the user would
+            // physically approve the full multi-device keysign and only then hit
+            // an opaque post-ceremony failure. Fail fast with a clear message.
+            guard signSolana.rawTransactions.count <= 1 else {
+                throw HelperError.runtimeError("solanaBatchSigningNotSupported".localized)
+            }
             var allHashes: [String] = []
             for base64Tx in signSolana.rawTransactions {
                 let hashes = try getPreSignedImageHashForRaw(base64Transaction: base64Tx)

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1079,6 +1079,7 @@
 "slippageHelperText" = "Begrenzt, wie stark sich der Preis ändern darf, bevor die Ausführung abgebrochen wird.";
 "slippageMaxNote" = "Slippage ist auf %@ begrenzt.";
 "slippageTolerance" = "Slippage-Toleranz";
+"solanaBatchSigningNotSupported" = "Das Signieren mehrerer Solana-Transaktionen auf einmal wird noch nicht unterstützt.";
 "solanaStakingActionDelegate" = "Einsatz";
 "solanaStakingActionUnstake" = "Entstaken";
 "solanaStakingActionWithdraw" = "Abheben";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1077,6 +1077,7 @@
 "slippageHelperText" = "Limits how much the price can change before execution is canceled.";
 "slippageMaxNote" = "Slippage is capped at %@.";
 "slippageTolerance" = "Slippage Tolerance";
+"solanaBatchSigningNotSupported" = "Signing multiple Solana transactions at once isn't supported yet.";
 "solanaStakingActionDelegate" = "Stake";
 "solanaStakingActionUnstake" = "Unstake";
 "solanaStakingActionWithdraw" = "Withdraw";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1079,6 +1079,7 @@
 "slippageHelperText" = "Limita cuánto puede cambiar el precio antes de cancelar la ejecución.";
 "slippageMaxNote" = "El deslizamiento está limitado a %@.";
 "slippageTolerance" = "Tolerancia de deslizamiento";
+"solanaBatchSigningNotSupported" = "Aún no se admite firmar varias transacciones de Solana a la vez.";
 "solanaStakingActionDelegate" = "Apostar";
 "solanaStakingActionUnstake" = "Cancelar staking";
 "solanaStakingActionWithdraw" = "Retirar";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1079,6 +1079,7 @@
 "slippageHelperText" = "Ograničava koliko se cijena može promijeniti prije nego se izvršenje otkaže.";
 "slippageMaxNote" = "Klizanje je ograničeno na %@.";
 "slippageTolerance" = "Tolerancija klizanja";
+"solanaBatchSigningNotSupported" = "Potpisivanje više Solana transakcija odjednom još nije podržano.";
 "solanaStakingActionDelegate" = "Ulog";
 "solanaStakingActionUnstake" = "Skidanje stake-a";
 "solanaStakingActionWithdraw" = "Povuci";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1079,6 +1079,7 @@
 "slippageHelperText" = "Limita quanto il prezzo può cambiare prima che l'esecuzione venga annullata.";
 "slippageMaxNote" = "Lo slippage è limitato a %@.";
 "slippageTolerance" = "Tolleranza di slippage";
+"solanaBatchSigningNotSupported" = "La firma di più transazioni Solana contemporaneamente non è ancora supportata.";
 "solanaStakingActionDelegate" = "Palo";
 "solanaStakingActionUnstake" = "Ritira stake";
 "solanaStakingActionWithdraw" = "Preleva";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1079,6 +1079,7 @@
 "slippageHelperText" = "Limita quanto o preço pode mudar antes que a execução seja cancelada.";
 "slippageMaxNote" = "O slippage é limitado a %@.";
 "slippageTolerance" = "Tolerância de slippage";
+"solanaBatchSigningNotSupported" = "Assinar várias transações Solana de uma vez ainda não é suportado.";
 "solanaStakingActionDelegate" = "Estaca";
 "solanaStakingActionUnstake" = "Cancelar stake";
 "solanaStakingActionWithdraw" = "Sacar";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1079,6 +1079,7 @@
 "slippageHelperText" = "限制价格在执行被取消前可以变动的幅度。";
 "slippageMaxNote" = "滑点上限为 %@。";
 "slippageTolerance" = "滑点容差";
+"solanaBatchSigningNotSupported" = "暂不支持一次性签署多笔 Solana 交易。";
 "solanaStakingActionDelegate" = "质押";
 "solanaStakingActionUnstake" = "取消质押";
 "solanaStakingActionWithdraw" = "提取";

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -377,6 +377,14 @@ class JoinKeysignViewModel: ObservableObject {
         if status == .QBTCClaim {
             return
         }
+        // If preparing the keysign messages already failed (e.g. an unsupported
+        // multi-transaction Solana batch rejected in `prepareKeysignMessages`),
+        // keep the failure state. Otherwise the relay/discovery transition below
+        // would clobber it and let this co-signer walk into the confirm screen
+        // and start the ceremony with no messages to sign.
+        if status == .FailedToStart {
+            return
+        }
         if let keysignPayload {
             if vault.pubKeyECDSA != keysignPayload.vaultPubKeyECDSA {
                 self.status = .VaultMismatch

--- a/VultisigApp/VultisigAppTests/Chains/SolanaHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/SolanaHelperTests.swift
@@ -204,6 +204,76 @@ final class SolanaHelperTests: XCTestCase {
         XCTAssertEqual(result.transactionHash, Base58.encodeNoCheck(data: expectedSignature))
     }
 
+    // MARK: - signAllTransactions batch guard
+
+    /// Builds a minimal but structurally valid Solana raw-tx envelope —
+    /// `[shortvec(1)][64-byte sig slot][32-byte message]`, base64-encoded —
+    /// the same shape the dApp raw-signing path (SignSolana.rawTransactions)
+    /// consumes.
+    private func makeRawSolanaTransactionBase64(messageFill: UInt8) -> String {
+        var tx = Data([0x01])
+        tx.append(Data(repeating: 0x00, count: 64))
+        tx.append(Data(repeating: messageFill, count: 32))
+        return tx.base64EncodedString()
+    }
+
+    private func makeSignSolanaPayload(rawTransactions: [String]) throws -> KeysignPayload {
+        KeysignPayload(
+            coin: makeCoin(privateKey: try makeSignerKey()),
+            toAddress: try makeRecipientAddress(),
+            toAmount: 0,
+            chainSpecific: .Solana(
+                recentBlockHash: recentBlockHash,
+                priorityFee: 0,
+                priorityLimit: 0,
+                fromAddressPubKey: nil,
+                toAddressPubKey: nil,
+                hasProgramId: false
+            ),
+            utxos: [],
+            memo: nil,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            vaultLocalPartyID: "localPartyID",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: .signSolana(SignSolana(proto: .with { $0.rawTransactions = rawTransactions }))
+        )
+    }
+
+    /// A multi-transaction Solana batch (signAllTransactions, N>1) must be
+    /// rejected here — the single pre-ceremony chokepoint reached on BOTH the
+    /// initiator and the co-signer before peer discovery. getSignedTransaction
+    /// only supports one raw transaction, so without this fail-fast guard the
+    /// user would physically approve the entire multi-device keysign ceremony
+    /// and only then hit an opaque post-ceremony failure.
+    func testGetPreSignedImageHashRejectsMultipleRawTransactions() throws {
+        let tx1 = makeRawSolanaTransactionBase64(messageFill: 0x07)
+        let tx2 = makeRawSolanaTransactionBase64(messageFill: 0x09)
+        let payload = try makeSignSolanaPayload(rawTransactions: [tx1, tx2])
+
+        XCTAssertThrowsError(try SolanaHelper.getPreSignedImageHash(keysignPayload: payload))
+    }
+
+    /// Regression: the single raw-transaction path is untouched and still
+    /// yields exactly one non-empty pre-image hash.
+    func testGetPreSignedImageHashAllowsSingleRawTransaction() throws {
+        let tx = makeRawSolanaTransactionBase64(messageFill: 0x07)
+        let payload = try makeSignSolanaPayload(rawTransactions: [tx])
+
+        let hashes = try SolanaHelper.getPreSignedImageHash(keysignPayload: payload)
+
+        XCTAssertEqual(hashes.count, 1)
+        XCTAssertFalse(try XCTUnwrap(hashes.first).isEmpty)
+    }
+
     // MARK: - RPC request shape
 
     func testSendTransactionRequestPinsBase64Encoding() throws {

--- a/VultisigApp/VultisigAppTests/Keysign/JoinKeysignFailedStateGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/JoinKeysignFailedStateGuardTests.swift
@@ -1,0 +1,46 @@
+//
+//  JoinKeysignFailedStateGuardTests.swift
+//  VultisigAppTests
+//
+//  Pins that a co-signer whose keysign messages failed to prepare stays on the
+//  failure screen. `prepareKeysignMessages` rejects an unsupported payload —
+//  e.g. a multi-transaction Solana `signAllTransactions` batch (N>1) — by
+//  setting `.FailedToStart`, but the deeplink handler then runs
+//  `manageQrCodeStates()`. Without the guard that method unconditionally moves
+//  a relay payload to `.JoinKeysign`, clobbering the failure and letting the
+//  co-signer tap "Join" into the ceremony with no messages to sign. This test
+//  fails before the ceremony can be entered.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class JoinKeysignFailedStateGuardTests: XCTestCase {
+
+    func testManageQrCodeStatesKeepsFailedToStart() {
+        let viewModel = JoinKeysignViewModel()
+        // The relay path is the one that would otherwise transition to
+        // `.JoinKeysign`; prove the failure survives it.
+        viewModel.useVultisigRelay = true
+        viewModel.status = .FailedToStart
+
+        viewModel.manageQrCodeStates()
+
+        XCTAssertEqual(
+            viewModel.status,
+            .FailedToStart,
+            "A payload that failed to prepare must not be advanced into the join/ceremony flow"
+        )
+    }
+
+    func testManageQrCodeStatesStillAdvancesHealthyRelayPayload() {
+        let viewModel = JoinKeysignViewModel()
+        viewModel.useVultisigRelay = true
+        // Default status (.DiscoverSigningMsg) with no blocking payload: the
+        // regression guard must not interfere with the normal relay transition.
+        viewModel.manageQrCodeStates()
+
+        XCTAssertEqual(viewModel.status, .JoinKeysign)
+    }
+}


### PR DESCRIPTION
## Problem

`SolanaHelper.getPreSignedImageHash` looped over **all** `signSolana.rawTransactions`, so a multi-transaction Solana `signAllTransactions` batch (N>1) relayed to an iOS **co-signer** ran the FULL multi-device keysign ceremony — including the user's physical approval on the paired phone — before `getSignedTransaction` rejected N>1 (`rawTransactions.count == 1`) with an opaque post-ceremony error. Sibling of android#5238.

This does **not** implement batch support; it fails fast, before the ceremony, with a clear localized message. The single-transaction path is unchanged; the existing post-ceremony guard stays as defense-in-depth.

## Fix

1. **Pre-ceremony reject** — `VultisigApp/Blockchain/Solana/Signing/Solana.swift:317` — guard `signSolana.rawTransactions.count <= 1` at the top of `getPreSignedImageHash`, throwing `HelperError.runtimeError("solanaBatchSigningNotSupported".localized)`. This runs while keysign messages are built (`KeysignMessageFactory.getKeysignMessages()`), before peer discovery.

2. **Surface the failure on the co-signer** — `VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift:385` — the guard makes `prepareKeysignMessages` set `.FailedToStart`, but the joiner deeplink handler then always ran `manageQrCodeStates()`, which unconditionally advanced a relay payload to `.JoinKeysign` — clobbering the failure and letting the co-signer tap "Join transaction signing" into the ceremony with **no messages to sign**. `manageQrCodeStates()` now preserves an already-set `.FailedToStart`, so the error screen shows and the ceremony can't be entered. (This also correctly fixes every other `prepareKeysignMessages` failure the transition previously masked.)

### Why the initiator path needs no change
A cross-model review flagged that the initiator's `refreshSolanaBlockhash` strips `signData` (only staking is preserved), so the guard can't see an N>1 batch there. Verified this is a non-issue: iOS **never initiates** a non-staking / N>1 `signSolana` payload — the only in-app `.signSolana` producers are single-transaction staking (`BlockChainService`/`SolanaStakingSignDataResolver`) and the proto-ingress joiner deserialize path (`Cosmos+ProtoMappable`). An N>1 batch only ever arrives as a co-signer.

## Localization
Added `solanaBatchSigningNotSupported` (EN: "Signing multiple Solana transactions at once isn't supported yet.") to all 7 maintained locales (en, de, es, hr, it, pt, zh-Hans), alphabetically sorted via `sort_localizable.py`.

## Tests
- `SolanaHelperTests.testGetPreSignedImageHashRejectsMultipleRawTransactions` — asserts N>1 throws.
- `SolanaHelperTests.testGetPreSignedImageHashAllowsSingleRawTransaction` — regression: single-tx path still returns one non-empty hash.
- `JoinKeysignFailedStateGuardTests.testManageQrCodeStatesKeepsFailedToStart` — co-signer stays on the failure screen (can't enter the ceremony).
- `JoinKeysignFailedStateGuardTests.testManageQrCodeStatesStillAdvancesHealthyRelayPayload` — healthy relay payload still transitions to `.JoinKeysign`.

## Gate receipts
- **Full `make test`** on sim `vk-4796` (iPhone 17 Pro Max, iOS 26.5): **2677 tests, 1 skipped, 1 failure** — the sole failure is the known pre-existing decimal-comma locale flake (`StakingValidatorProjectionTests.testCosmosEmptyMonikerFallsBackToTruncatedAddress`, "12,3%" vs "12.3%"), unrelated to this change. All 4 new tests pass.
- **SwiftLint**: clean on all changed files (0 violations).
- **Cross-model review (Codex, read-only)**: round 1 raised the joiner-state overwrite (fixed here) + the initiator concern (verified non-exploitable); round 2 = "No functional findings".

## Cross-platform
- android#5238 (sibling fail-fast guard) still open.
- sdk#1205 closed as already-fixed via full batch support on main.

## Pending manual check
- [ ] On-device 2-device Solana `signAllTransactions` (N>1) batch is rejected before the ceremony with the localized message (no physical approval prompt on the paired phone).

Closes #4796

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Solana signing now clearly rejects attempts to sign multiple transactions at once.
  * Prevented failed key-signing sessions from incorrectly progressing toward confirmation.
  * Preserved the normal key-signing flow for valid relay sessions.

* **Localization**
  * Added messages explaining that Solana batch signing is unavailable in English, German, Spanish, Croatian, Italian, Portuguese, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->