### PR TITLE
fix(history): prevent completed card expansion leak

### DIFF
--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
@@ -8,13 +8,11 @@ import SwiftUI
 struct TransactionHistoryCardView: View {
     let transaction: TransactionHistoryData
 
-    @State private var isExpanded: Bool
     @State private var elapsedTime: TimeInterval = 0
     @State private var timer: Timer?
 
-    init(transaction: TransactionHistoryData) {
-        self.transaction = transaction
-        _isExpanded = State(initialValue: transaction.status == .inProgress && transaction.type != .approve)
+    private var isExpanded: Bool {
+        Self.shouldExpand(status: transaction.status, type: transaction.type)
     }
 
     var body: some View {
@@ -49,11 +47,12 @@ struct TransactionHistoryCardView: View {
         .onChange(of: transaction.status) { _, newStatus in
             if newStatus != .inProgress {
                 stopTimer()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    withAnimation { isExpanded = false }
-                }
             }
         }
+    }
+
+    static func shouldExpand(status: TransactionHistoryStatus, type: TransactionHistoryType) -> Bool {
+        status == .inProgress && type != .approve
     }
 
     // MARK: - Top Row

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryCardViewTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryCardViewTests.swift
@@ -1,0 +1,23 @@
+//
+//  TransactionHistoryCardViewTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TransactionHistoryCardViewTests: XCTestCase {
+    func testCompletedTransactionsNeverExpand() {
+        for status in [TransactionHistoryStatus.successful, .error] {
+            XCTAssertFalse(TransactionHistoryCardView.shouldExpand(status: status, type: .send))
+            XCTAssertFalse(TransactionHistoryCardView.shouldExpand(status: status, type: .swap))
+            XCTAssertFalse(TransactionHistoryCardView.shouldExpand(status: status, type: .approve))
+        }
+    }
+
+    func testInProgressTransactionExpandsUnlessItIsApproval() {
+        XCTAssertTrue(TransactionHistoryCardView.shouldExpand(status: .inProgress, type: .send))
+        XCTAssertTrue(TransactionHistoryCardView.shouldExpand(status: .inProgress, type: .swap))
+        XCTAssertFalse(TransactionHistoryCardView.shouldExpand(status: .inProgress, type: .approve))
+    }
+}


### PR DESCRIPTION
## Summary
- derive transaction-card expansion directly from the current status and transaction type
- remove stale local expansion state and its delayed collapse callback
- add regression coverage proving completed/error cards never render expanded and approvals stay collapsed

## Issue
Closes #4801

## Test Plan
- [x] `make test` — 2,725 tests passed, 1 skipped, 0 failures
- [x] focused SwiftLint — 0 violations in changed files
- [x] full SwiftLint — 43 pre-existing warnings, 0 serious (matches baseline)

Co-Authored-By: Codex <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction history expansion behavior by removing delayed collapse effects.
  * Transaction cards now expand and collapse consistently based on transaction status and type.
  * Preserved elapsed-time tracking for transactions in progress.

* **Tests**
  * Added coverage for expansion behavior across completed, in-progress, send, swap, and approval transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->