### PR TITLE
fix: restore peer discovery info description

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -809,6 +809,7 @@
 "passwordIsRequired" = "Passwort ist erforderlich.";
 "passwordMismatch" = "Passwort stimmt nicht überein";
 "paste" = "Einfügen";
+"peerDiscoveryInfoDescription" = "Öffnen Sie auf Ihrem anderen Gerät die App und tippen Sie auf \"QR scannen\", um es zu verbinden.";
 "peerDiscoveryInfoTitle" = "Scannen Sie den QR auf Ihren anderen Geräten";
 "peerDiscoveryScanDeviceDisclaimer" = "Scanne den QR-Code mit einem anderen Gerät. 3-Geräte-Setup empfohlen, 2 sind ausreichend.";
 "pendingRewards" = "Ausstehende Belohnungen";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -807,6 +807,7 @@
 "passwordIsRequired" = "Password is required.";
 "passwordMismatch" = "Password Mismatch";
 "paste" = "Paste";
+"peerDiscoveryInfoDescription" = "On your other device, open the app and tap \"Scan QR\" to connect it.";
 "peerDiscoveryInfoTitle" = "Scan the QR on your other devices";
 "peerDiscoveryScanDeviceDisclaimer" = "Scan QR with other device. 3-device setup recommended, 2 is sufficient.";
 "pendingRewards" = "Pending Rewards";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -809,6 +809,7 @@
 "passwordIsRequired" = "Se requiere contraseña.";
 "passwordMismatch" = "Las contraseñas no coinciden";
 "paste" = "Pegar";
+"peerDiscoveryInfoDescription" = "En tu otro dispositivo, abre la app y toca \"Escanear QR\" para conectarlo.";
 "peerDiscoveryInfoTitle" = "Escanea el QR en tus otros dispositivos";
 "peerDiscoveryScanDeviceDisclaimer" = "Escanea el QR con otro dispositivo. Se recomienda una configuración de 3 dispositivos, 2 son suficientes.";
 "pendingRewards" = "Recompensas pendientes";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -809,6 +809,7 @@
 "passwordIsRequired" = "Potrebna je lozinka.";
 "passwordMismatch" = "Lozinke se ne podudaraju";
 "paste" = "Zalijepi";
+"peerDiscoveryInfoDescription" = "Na drugom uređaju otvorite aplikaciju i dodirnite \"Skeniraj QR\" za povezivanje.";
 "peerDiscoveryInfoTitle" = "Skenirajte QR na svojim drugim uređajima";
 "peerDiscoveryScanDeviceDisclaimer" = "Skenirajte QR kod s drugim uređajem. Preporučena je konfiguracija s 3 uređaja, 2 su dovoljna.";
 "pendingRewards" = "Nagrade na čekanju";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -809,6 +809,7 @@
 "passwordIsRequired" = "È richiesta la password.";
 "passwordMismatch" = "Le password non corrispondono";
 "paste" = "Incolla";
+"peerDiscoveryInfoDescription" = "Sull'altro dispositivo, apri l'app e tocca \"Scansiona QR\" per connetterlo.";
 "peerDiscoveryInfoTitle" = "Scansiona il QR sugli altri dispositivi";
 "peerDiscoveryScanDeviceDisclaimer" = "Scansiona il QR con un altro dispositivo. Si consiglia un setup con 3 dispositivi, 2 sono sufficienti.";
 "pendingRewards" = "Premio in sospeso";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -807,6 +807,7 @@
 "passwordIsRequired" = "비밀번호가 필요합니다.";
 "passwordMismatch" = "비밀번호 불일치";
 "paste" = "붙여넣기";
+"peerDiscoveryInfoDescription" = "다른 기기에서 앱을 열고 \"QR 스캔\"을 탭하여 연결하세요.";
 "peerDiscoveryInfoTitle" = "다른 기기의 QR을 스캔하세요";
 "peerDiscoveryScanDeviceDisclaimer" = "다른 기기로 QR을 스캔하세요. 3기기 설정 권장, 2개로도 충분합니다.";
 "pendingRewards" = "대기 중인 보상";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -809,6 +809,7 @@
 "passwordIsRequired" = "A senha é necessária.";
 "passwordMismatch" = "Senhas não coincidem";
 "paste" = "Colar";
+"peerDiscoveryInfoDescription" = "No seu outro dispositivo, abra o app e toque em \"Escanear QR\" para conectá-lo.";
 "peerDiscoveryInfoTitle" = "Escaneie o QR nos seus outros dispositivos";
 "peerDiscoveryScanDeviceDisclaimer" = "Escaneie o QR com outro dispositivo. Configuração com 3 dispositivos recomendada, 2 são suficientes.";
 "pendingRewards" = "Recompensas pendentes";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -809,6 +809,7 @@
 "passwordIsRequired" = "密码是必需的";
 "passwordMismatch" = "密码不匹配";
 "paste" = "粘贴";
+"peerDiscoveryInfoDescription" = "在您的其他设备上打开应用，点击\"扫描二维码\"进行连接。";
 "peerDiscoveryInfoTitle" = "在其他设备上扫描二维码";
 "peerDiscoveryScanDeviceDisclaimer" = "使用其他设备扫描二维码。建议使用 3 个设备设置，2 个也足够";
 "pendingRewards" = "待领取奖励";


### PR DESCRIPTION
## Summary
- restore the missing peerDiscoveryInfoDescription localization used by the keygen peer-discovery banner
- add the established guidance to all 8 supported locales, including Korean
- preserve the existing Swift UI behavior while preventing the raw localization key from appearing

## Issue
Closes #4805

## Test Plan
- [x] Confirmed the key exists exactly once in all 8 locale files
- [x] Ran plutil validation for every Localizable.strings file
- [x] Ran the localization sort script successfully
- [x] SwiftLint completed with no serious violations; 43 pre-existing warnings remain on main
- [x] make build-check succeeded

Co-Authored-By: Codex <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for connecting another device by opening the app and selecting the QR scanning option.
  * Added translations for this guidance in German, English, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->