### PR TITLE
fix(defi): render cached Tron details immediately

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronConstants.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronConstants.swift
@@ -16,11 +16,7 @@ struct TronConstants {
         static let verticalSpacing: CGFloat = 16
         static let cornerRadius: CGFloat = 16
 
-        #if os(macOS)
-        static let mainViewTopPadding: CGFloat = 60
-        #else
         static let mainViewTopPadding: CGFloat = 16
-        #endif
 
         static let mainViewBottomPadding: CGFloat = 32
     }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronConstants.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronConstants.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct TronConstants {
 
     struct Design {
-        static let horizontalPadding: CGFloat = 20
+        static let horizontalPadding: CGFloat = 16
         static let cardPadding: CGFloat = 24
         static let verticalSpacing: CGFloat = 16
         static let cornerRadius: CGFloat = 16

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronScreen.swift
@@ -18,8 +18,8 @@ struct TronScreen: View {
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
-            .onAppear {
-                Task { await loadData() }
+            .task {
+                await loadData()
             }
     }
 
@@ -63,12 +63,15 @@ struct TronScreen: View {
             model.isLoading = cachedAccount == nil || cachedResource == nil
             model.isLoadingBalance = cachedAccount == nil
             model.isLoadingResources = cachedResource == nil
-        }
 
-        // Persist the frozen/unfreezing balance into `Coin.stakedBalance` so the
-        // DeFi portfolio main screen (which reads the persisted value) stays in
-        // sync with this live detail view instead of diverging.
-        await BalanceService.shared.updateBalance(for: trxCoin)
+            if let cachedAccount {
+                model.apply(account: cachedAccount)
+            }
+
+            if let cachedResource {
+                model.apply(resource: cachedResource)
+            }
+        }
 
         // Use structured concurrency for proper cancellation handling
         await withTaskGroup(of: Void.self) { group in
@@ -76,30 +79,7 @@ struct TronScreen: View {
             group.addTask {
                 do {
                     let account = try await tronService.getAccount(address: address, forceRefresh: forceRefresh)
-                    await MainActor.run {
-                        // Calculate available balance (in TRX, not SUN)
-                        let balanceSun = account.balance ?? 0
-                        self.model.availableBalance = Decimal(balanceSun) / Decimal(1_000_000)
-
-                        // Parse frozen balances from frozenV2 array (Stake 2.0)
-                        self.model.frozenBandwidthBalance = Decimal(account.frozenBandwidthSun) / Decimal(1_000_000)
-                        self.model.frozenEnergyBalance = Decimal(account.frozenEnergySun) / Decimal(1_000_000)
-
-                        // Parse unfreezing balance
-                        self.model.unfreezingBalance = Decimal(account.unfreezingTotalSun) / Decimal(1_000_000)
-
-                        // Parse pending withdrawals
-                        self.model.pendingWithdrawals = (account.unfrozenV2 ?? []).compactMap { entry in
-                            guard let amountSun = entry.unfreeze_amount, let expireTime = entry.unfreeze_expire_time else {
-                                return nil
-                            }
-                            let amountTrx = Decimal(amountSun) / Decimal(1_000_000)
-                            let expirationDate = Date(timeIntervalSince1970: TimeInterval(expireTime / 1000))
-                            return TronPendingWithdrawal(amount: amountTrx, expirationDate: expirationDate)
-                        }.sorted { $0.expirationDate < $1.expirationDate }
-
-                        self.model.isLoadingBalance = false
-                    }
+                    await self.model.apply(account: account)
                 } catch {
                     if !(error is CancellationError) {
                         await MainActor.run {
@@ -114,13 +94,7 @@ struct TronScreen: View {
             group.addTask {
                 do {
                     let resource = try await tronService.getAccountResource(address: address, forceRefresh: forceRefresh)
-                    await MainActor.run {
-                        self.model.availableBandwidth = resource.calculateAvailableBandwidth()
-                        self.model.totalBandwidth = resource.freeNetLimit + resource.NetLimit
-                        self.model.availableEnergy = resource.EnergyLimit - resource.EnergyUsed
-                        self.model.totalEnergy = resource.EnergyLimit
-                        self.model.isLoadingResources = false
-                    }
+                    await self.model.apply(resource: resource)
                 } catch {
                     if !(error is CancellationError) {
                         await MainActor.run {
@@ -134,5 +108,12 @@ struct TronScreen: View {
 
         // Clear global loading state after task group completes
         await MainActor.run { model.isLoading = false }
+        guard !Task.isCancelled else { return }
+
+        // Persist the frozen/unfreezing balance into `Coin.stakedBalance` so the
+        // DeFi portfolio main screen (which reads the persisted value) stays in
+        // sync with this live detail view instead of diverging. Run this only
+        // after the detail data is populated so its network calls never gate cards.
+        await BalanceService.shared.updateBalance(for: trxCoin)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronScreen.swift
@@ -33,6 +33,7 @@ struct TronScreen: View {
                 TronDashboardView(vault: vault, model: model, onRefresh: { await loadData(forceRefresh: true) })
             }
             .screenTitle("tronTitle".localized)
+            .screenEdgeInsets(.init(leading: 0, trailing: 0))
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronScreen.swift
@@ -33,7 +33,7 @@ struct TronScreen: View {
                 TronDashboardView(vault: vault, model: model, onRefresh: { await loadData(forceRefresh: true) })
             }
             .screenTitle("tronTitle".localized)
-            .screenEdgeInsets(.init(leading: 0, trailing: 0))
+            .screenEdgeInsets(.init(top: 0, leading: 0, trailing: 0))
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronViewModel.swift
@@ -115,4 +115,36 @@ final class TronViewModel: ObservableObject, Hashable, Equatable {
     var hasPendingWithdrawals: Bool {
         !pendingWithdrawals.isEmpty
     }
+
+    @MainActor
+    func apply(account: TronAccountResponse) {
+        let balanceSun = account.balance ?? 0
+        availableBalance = Decimal(balanceSun) / Decimal(1_000_000)
+
+        frozenBandwidthBalance = Decimal(account.frozenBandwidthSun) / Decimal(1_000_000)
+        frozenEnergyBalance = Decimal(account.frozenEnergySun) / Decimal(1_000_000)
+        unfreezingBalance = Decimal(account.unfreezingTotalSun) / Decimal(1_000_000)
+
+        pendingWithdrawals = (account.unfrozenV2 ?? []).compactMap { entry in
+            guard let amountSun = entry.unfreeze_amount,
+                  let expireTime = entry.unfreeze_expire_time else {
+                return nil
+            }
+
+            let amountTrx = Decimal(amountSun) / Decimal(1_000_000)
+            let expirationDate = Date(timeIntervalSince1970: TimeInterval(expireTime / 1_000))
+            return TronPendingWithdrawal(amount: amountTrx, expirationDate: expirationDate)
+        }.sorted { $0.expirationDate < $1.expirationDate }
+
+        isLoadingBalance = false
+    }
+
+    @MainActor
+    func apply(resource: TronAccountResourceResponse) {
+        availableBandwidth = resource.calculateAvailableBandwidth()
+        totalBandwidth = resource.freeNetLimit + resource.NetLimit
+        availableEnergy = resource.EnergyLimit - resource.EnergyUsed
+        totalEnergy = resource.EnergyLimit
+        isLoadingResources = false
+    }
 }

--- a/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/TronViewModelTests.swift
@@ -1,0 +1,111 @@
+//
+//  TronViewModelTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class TronViewModelTests: XCTestCase {
+
+    func testApplyAccountMapsBalancesAndValidPendingWithdrawals() throws {
+        let account = try decode(
+            TronAccountResponse.self,
+            from: """
+            {
+              "address": "TTestAddress",
+              "balance": 12345678,
+              "frozenV2": [
+                { "amount": 1000000 },
+                { "type": "BANDWIDTH", "amount": 2250000 },
+                { "type": "ENERGY", "amount": 3500000 },
+                { "type": "ENERGY" }
+              ],
+              "unfrozenV2": [
+                { "unfreeze_amount": 1500000, "unfreeze_expire_time": 1735689600000 },
+                { "unfreeze_amount": 750000, "unfreeze_expire_time": 1704067200000 },
+                { "unfreeze_amount": 999999 },
+                { "unfreeze_expire_time": 1767225600000 }
+              ]
+            }
+            """
+        )
+        let sut = TronViewModel()
+        sut.isLoadingBalance = true
+
+        sut.apply(account: account)
+
+        XCTAssertEqual(sut.availableBalance, try decimal("12.345678"))
+        XCTAssertEqual(sut.frozenBandwidthBalance, try decimal("3.25"))
+        XCTAssertEqual(sut.frozenEnergyBalance, try decimal("3.5"))
+        XCTAssertEqual(sut.unfreezingBalance, try decimal("3.249999"))
+        XCTAssertEqual(sut.totalFrozenBalance, try decimal("9.999999"))
+        XCTAssertEqual(sut.pendingWithdrawals.count, 2)
+        XCTAssertEqual(sut.pendingWithdrawals.map(\.amount), [try decimal("0.75"), try decimal("1.5")])
+        XCTAssertEqual(
+            sut.pendingWithdrawals.map(\.expirationDate),
+            [
+                Date(timeIntervalSince1970: 1_704_067_200),
+                Date(timeIntervalSince1970: 1_735_689_600)
+            ]
+        )
+        XCTAssertFalse(sut.isLoadingBalance)
+    }
+
+    func testApplyAccountWithMissingOptionalFieldsResetsDisplayedValues() throws {
+        let account = try decode(TronAccountResponse.self, from: #"{ "address": "TEmpty" }"#)
+        let sut = TronViewModel()
+        sut.availableBalance = 1
+        sut.frozenBandwidthBalance = 2
+        sut.frozenEnergyBalance = 3
+        sut.unfreezingBalance = 4
+        sut.pendingWithdrawals = [
+            TronPendingWithdrawal(amount: 5, expirationDate: Date(timeIntervalSince1970: 1))
+        ]
+        sut.isLoadingBalance = true
+
+        sut.apply(account: account)
+
+        XCTAssertEqual(sut.availableBalance, .zero)
+        XCTAssertEqual(sut.frozenBandwidthBalance, .zero)
+        XCTAssertEqual(sut.frozenEnergyBalance, .zero)
+        XCTAssertEqual(sut.unfreezingBalance, .zero)
+        XCTAssertTrue(sut.pendingWithdrawals.isEmpty)
+        XCTAssertFalse(sut.isLoadingBalance)
+    }
+
+    func testApplyResourceMapsAvailableAndTotalResources() throws {
+        let resource = try decode(
+            TronAccountResourceResponse.self,
+            from: """
+            {
+              "freeNetUsed": 100,
+              "freeNetLimit": 600,
+              "NetUsed": 1250,
+              "NetLimit": 10000,
+              "EnergyUsed": 275000,
+              "EnergyLimit": 1000000
+            }
+            """
+        )
+        let sut = TronViewModel()
+        sut.isLoadingResources = true
+
+        sut.apply(resource: resource)
+
+        XCTAssertEqual(sut.availableBandwidth, 9_250)
+        XCTAssertEqual(sut.totalBandwidth, 10_600)
+        XCTAssertEqual(sut.availableEnergy, 725_000)
+        XCTAssertEqual(sut.totalEnergy, 1_000_000)
+        XCTAssertFalse(sut.isLoadingResources)
+    }
+
+    private func decode<Value: Decodable>(_ type: Value.Type, from json: String) throws -> Value {
+        try JSONDecoder().decode(type, from: Data(json.utf8))
+    }
+
+    private func decimal(_ value: String) throws -> Decimal {
+        try XCTUnwrap(Decimal(string: value))
+    }
+}


### PR DESCRIPTION
## Summary
- hydrate the TRON DeFi dashboard from fresh cached account and resource responses before clearing skeleton states
- move the portfolio balance refresh behind detail population and bind loading to SwiftUI task cancellation
- centralize and test TRON account/resource response mapping
- align the TRON staking dashboard with the 16-point THORChain content insets horizontally and vertically

## Test Plan
- [x] Targeted SwiftLint passes with 0 violations
- [x] make test: 2,734 tests passed, 1 skipped, 0 failures
- [x] make build-check succeeds after the layout adjustments

## Related
Closes #4802

Co-Authored-By: Codex <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * TRON screen now loads using a SwiftUI async task and applies cached account/resource details immediately.
  * Bandwidth, energy, balances, frozen/unfreezing totals, and pending withdrawals are updated consistently from fetched data.
  * Updated TRON UI spacing (including fixed top padding and edge insets) for freeze/unfreeze presentation.
* **Bug Fixes**
  * Cancelled refreshes no longer risk persisting incomplete balance details; balance updates occur only after detail data is populated.
* **Tests**
  * Added unit tests for TRON balance, resources, pending withdrawals, expiration parsing, and empty/partial responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->