### PR TITLE
feat(tron): add USDC, USDD & stUSDT tokens (desktop parity)

### DIFF
--- a/VultisigApp/VultisigApp/Assets.xcassets/Crypto/stusdt.imageset/Contents.json
+++ b/VultisigApp/VultisigApp/Assets.xcassets/Crypto/stusdt.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "stusdt.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VultisigApp/VultisigApp/Assets.xcassets/Crypto/stusdt.imageset/stusdt.svg
+++ b/VultisigApp/VultisigApp/Assets.xcassets/Crypto/stusdt.imageset/stusdt.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="12" fill="#1EAF86"/>
+  <path d="M12 6V18" stroke="white" stroke-width="2.1" stroke-linecap="round"/>
+  <path d="M7.5 7.2H16.5" stroke="white" stroke-width="2.1" stroke-linecap="round"/>
+  <path d="M8.4 10.2C8.4 9.1 9.4 8.2 10.8 8.2H13.2C14.6 8.2 15.6 9.1 15.6 10.2C15.6 11.4 14.6 12 12 12C9.4 12 8.4 12.6 8.4 13.8C8.4 14.9 9.4 15.8 10.8 15.8H13.2C14.6 15.8 15.6 14.9 15.6 13.8" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M5.7 5.5L4.2 7M18.3 18.5L19.8 17" stroke="#CFF7EA" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/VultisigApp/VultisigApp/Assets.xcassets/Crypto/usdd.imageset/Contents.json
+++ b/VultisigApp/VultisigApp/Assets.xcassets/Crypto/usdd.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "usdd.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VultisigApp/VultisigApp/Assets.xcassets/Crypto/usdd.imageset/usdd.svg
+++ b/VultisigApp/VultisigApp/Assets.xcassets/Crypto/usdd.imageset/usdd.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="12" fill="#111111"/>
+  <circle cx="12" cy="12" r="9" fill="#F6C744"/>
+  <path d="M7.2 8.2H12C14.4 8.2 16.3 9.9 16.3 12C16.3 14.1 14.4 15.8 12 15.8H7.2V8.2ZM9.3 10V14H12C13.2 14 14.1 13.1 14.1 12C14.1 10.9 13.2 10 12 10H9.3Z" fill="#111111"/>
+  <path d="M5.8 6.4H18.2V8.2H5.8V6.4ZM5.8 15.8H18.2V17.6H5.8V15.8Z" fill="#111111"/>
+</svg>

--- a/VultisigApp/VultisigApp/Core/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/TokensStore.swift
@@ -2039,6 +2039,33 @@ class TokensStore {
             isNativeToken: false
         ),
         CoinMeta(
+            chain: .tron,
+            ticker: "USDC",
+            logo: "usdc",
+            decimals: 6,
+            priceProviderId: "usd-coin",
+            contractAddress: "TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8",
+            isNativeToken: false
+        ),
+        CoinMeta(
+            chain: .tron,
+            ticker: "USDD",
+            logo: "usdd",
+            decimals: 18,
+            priceProviderId: "usdd",
+            contractAddress: "TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz",
+            isNativeToken: false
+        ),
+        CoinMeta(
+            chain: .tron,
+            ticker: "stUSDT",
+            logo: "stusdt",
+            decimals: 18,
+            priceProviderId: "staked-usdt",
+            contractAddress: "TThzxNRLrW2Brp9DcTQU8i4Wd9udCWEdZ3",
+            isNativeToken: false
+        ),
+        CoinMeta(
             chain: .zksync,
             ticker: "ETH",
             logo: "zsync_era",


### PR DESCRIPTION
## Summary
Desktop / SDK enable **four** default TRC-20 tokens on Tron; iOS shipped only **two** (TRX native + USDT). This adds the missing three so users can enable them from Choose Tokens without adding each as a custom token.

## Tokens added
Verified against `vultisig-sdk` `packages/core/chain/coin/knownTokens/index.ts` `[Chain.Tron]` (not just the issue body):

| Token  | Contract                             | Decimals | priceProviderId |
|--------|--------------------------------------|----------|-----------------|
| USDC   | `TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8` | 6        | usd-coin        |
| USDD   | `TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz` | 18       | usdd            |
| stUSDT | `TThzxNRLrW2Brp9DcTQU8i4Wd9udCWEdZ3` | 18       | staked-usdt     |

- **USDC**: CoinGecko-canonical address (TronScan shows `USDCOLD` publicTag but `USDC` blueTag + 2.5M+ txns confirm Circle's USDC).
- **USDD**: canonical token — the deprecated `USDDOLD` migration source is intentionally not used.
- **stUSDT**: the JustLend liquid-staking receipt token (not the similarly-named Sunswap LP token).

## Assets
- `usdc` logo already existed.
- Added `usdd` + `stusdt` SVG imagesets, ported from the shared `vultisig-windows/core/ui/public/coins/` logos (iOS crypto logos are SVG imagesets, same format as `usdc`).

## Verification
- `make test`: **`** TEST SUCCEEDED **`** — 2731 tests, 0 failures (1 skipped), iPhone 16 Pro sim.
- SwiftLint clean; cross-model (codex) read-only review clean — contract/decimals/priceProviderId cross-checked against the SDK, no duplicate `.tron` tickers/contracts, imagesets valid.
- **Pending on-device**: enable each token on Tron, confirm balance + USD price resolve and the `usdd`/`stusdt` logos render.

Closes #4811

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying USDC, USDD, and stUSDT tokens on the Tron network.
  * Added token logos and metadata for the newly supported assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->