### PR TITLE
perf(swap): fix chain-picker jank on rapid back-and-forth switching

### DIFF
--- a/VultisigApp/VultisigApp/Components/Picker/FlatPicker.swift
+++ b/VultisigApp/VultisigApp/Components/Picker/FlatPicker.swift
@@ -32,6 +32,20 @@ struct FlatPicker<ItemView: View, Item: Equatable & Hashable>: View {
     @State private var currentVisibleIndex: Int = 0
     @State private var scrollViewProxy: ScrollViewProxy?
     @State private var scrollCheckWorkItem: DispatchWorkItem?
+    /// True while a programmatic scroll (external selection change / onLoad) is
+    /// animating. The offset churn such a scroll produces must NOT be mistaken
+    /// for a user drag: while set, the settle handler skips the `selectedItem`
+    /// write-back and the per-frame haptic. User drag-to-select stays intact —
+    /// the flag is only set for programmatic scrolls, so a physical drag still
+    /// writes back and still buzzes.
+    @State private var isProgrammaticScroll: Bool = false
+    @State private var programmaticScrollResetWorkItem: DispatchWorkItem?
+    /// True for the window between this picker writing `selectedItem` from a
+    /// drag settle and the resulting `onChange(of: selectedItem)`. It lets that
+    /// re-center distinguish its OWN drag-driven change (which must NOT arm the
+    /// programmatic-scroll suppression, or a rapid follow-up drag would be
+    /// swallowed) from an EXTERNAL selection change such as a chain-button tap.
+    @State private var isSelfSelectionUpdate: Bool = false
 #if os(iOS)
     private let impactGenerator = UIImpactFeedbackGenerator(style: .light)
 #endif
@@ -53,10 +67,14 @@ struct FlatPicker<ItemView: View, Item: Equatable & Hashable>: View {
                         // Calculate current visible index for haptic feedback
                         let newIndex = calculateIndex(newOffset: newOffset, containerSize: containerSize)
 
-                        // Trigger haptic feedback when passing through a new item
+                        // Trigger haptic feedback when passing through a new item.
+                        // Suppressed during a programmatic scroll so an external
+                        // selection's sweep doesn't machine-gun the haptic.
                         if newIndex != currentVisibleIndex {
                             #if os(iOS)
+                            if !isProgrammaticScroll {
                                 impactGenerator.impactOccurred()
+                            }
                             #endif
                             currentVisibleIndex = newIndex
                         }
@@ -72,9 +90,30 @@ struct FlatPicker<ItemView: View, Item: Equatable & Hashable>: View {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: workItem)
                     }
                     .onChange(of: lastOffset) { _, lastOffset in
+                        // A programmatic scroll (external selection / onLoad) is
+                        // in flight: its offset churn must not be written back as
+                        // a selection or it would fight the selection that
+                        // started it during rapid switching.
+                        if isProgrammaticScroll {
+                            // This settle IS the programmatic scroll landing:
+                            // consume it (no write-back, no re-snap) and disarm
+                            // now that it has settled, so a following user drag is
+                            // honored immediately. Disarming on the settle itself
+                            // (rather than a fixed timer) closes the gap between
+                            // the timer and the debounced settle. User drags never
+                            // arm the flag, so drag-to-select falls through below.
+                            programmaticScrollResetWorkItem?.cancel()
+                            isProgrammaticScroll = false
+                            return
+                        }
+
                         let newItemIndex = calculateIndex(newOffset: lastOffset, containerSize: containerSize)
 
                         if selectedItem != items[newItemIndex] {
+                            // Mark our own drag-driven write so the ensuing
+                            // onChange(of: selectedItem) re-centers WITHOUT arming
+                            // suppression — a rapid follow-up drag must still land.
+                            isSelfSelectionUpdate = true
                             selectedItem = items[newItemIndex]
                         }
 
@@ -82,11 +121,17 @@ struct FlatPicker<ItemView: View, Item: Equatable & Hashable>: View {
                     }
                     .onLoad {
                         scrollViewProxy = proxy
-                        // Initialize current visible index
-                        updateCurrentVisibilityIndex(animated: false)
+                        // Initialize current visible index (external-style: arm
+                        // suppression so the initial scroll isn't written back).
+                        updateCurrentVisibilityIndex(animated: false, suppressFeedback: true)
                     }
                     .onChange(of: selectedItem) { _, _ in
-                        updateCurrentVisibilityIndex(animated: true)
+                        // Only an EXTERNAL change (parent set it, e.g. a chain
+                        // button tap) arms suppression; a change from this
+                        // picker's own drag settle does not.
+                        let external = !isSelfSelectionUpdate
+                        isSelfSelectionUpdate = false
+                        updateCurrentVisibilityIndex(animated: true, suppressFeedback: external)
                     }
                 }
                 overlayingGradientsView
@@ -104,13 +149,37 @@ private extension FlatPicker {
         return clampedIndex
     }
 
-    func updateCurrentVisibilityIndex(animated: Bool) {
+    func updateCurrentVisibilityIndex(animated: Bool, suppressFeedback: Bool) {
         guard let selectedItem else { return }
         if let initialIndex = items.firstIndex(of: selectedItem) {
             currentVisibleIndex = initialIndex
         }
+        // Arm suppression only for externally-driven scrolls (chain-button tap /
+        // onLoad): their scrollTo animation drives offset churn that must not be
+        // written back as a competing selection. A re-center that followed this
+        // picker's own drag settle passes `suppressFeedback: false`, so a rapid
+        // follow-up user drag is still honored.
+        if suppressFeedback {
+            beginProgrammaticScroll()
+        }
         // Scroll to selected item on load
         updateSelectedItem(animated: animated)
+    }
+
+    /// Arms programmatic-scroll suppression. The flag is normally cleared when
+    /// the scroll's settle lands (see the `lastOffset` handler); this timer is a
+    /// safety net that disarms if no settle ever fires (e.g. a scrollTo that
+    /// produces no offset change because the target is already centered). It is
+    /// set well past the 0.2s scrollTo animation plus the 0.15s settle debounce
+    /// (with margin for janky frames) so a real settle always disarms first and
+    /// the timer only fires for the no-offset-change case. Overlapping
+    /// programmatic scrolls (rapid external switching) cancel and reschedule it.
+    func beginProgrammaticScroll() {
+        isProgrammaticScroll = true
+        programmaticScrollResetWorkItem?.cancel()
+        let workItem = DispatchWorkItem { isProgrammaticScroll = false }
+        programmaticScrollResetWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: workItem)
     }
 
     func updateSelectedItem(animated: Bool) {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -306,7 +306,14 @@ struct SwapCoinSelectionLogic {
         let merged = Self.mergeExternal(base: baseUnique, externals: externalBuckets)
         let withVault = Self.merge(base: merged, extra: vaultTokens)
         let deduped = Self.collapseToSingleNative(withVault)
-        let sorted = await MainActor.run { sort(tokens: deduped) }
+
+        // Precompute the vault balances on the MainActor (the only place the
+        // @Model reads are legal), then run the comparison off the MainActor
+        // against the value snapshot. The sort itself no longer calls the O(m)
+        // `vault.coin(for:)` linear scan twice per comparison on the main
+        // thread — the dominant per-switch cost.
+        let snapshot = await makeSortSnapshot(tokens: deduped)
+        let sorted = Self.sort(tokens: deduped, snapshot: snapshot)
 
         return SwapCoinSelectionResult(tokens: sorted)
     }
@@ -354,7 +361,44 @@ struct SwapCoinSelectionLogic {
         return result
     }
 
-    func sort(tokens: [CoinMeta]) -> [CoinMeta] {
+    /// Value snapshot of the MainActor-only inputs `sort` needs, so the
+    /// comparison can run off the MainActor without touching any SwiftData
+    /// `@Model`. `balancesByUniqueId` maps each token's `uniqueId` to its vault
+    /// fiat balance (resolved once per token via `Vault.coin(for:)` on the
+    /// MainActor); the `selected*` fields mirror the `selectedCoin` reads the
+    /// selected-first reordering used to make inline.
+    struct SortSnapshot: Sendable {
+        let balancesByUniqueId: [String: Decimal]
+        let selectedChain: Chain
+        let selectedTicker: String
+        let selectedCoinMeta: CoinMeta
+    }
+
+    /// Builds a `SortSnapshot` on the MainActor. `Vault.coin(for:)` is an O(m)
+    /// linear scan; the previous sort called it twice per comparison
+    /// (O(n·log n·m)). Here it runs exactly once per token (O(n·m)) and the
+    /// off-actor sort does O(1) dictionary lookups against the result. The
+    /// mapping mirrors `coin(for:)`'s own prefer-contract-else-ticker rule
+    /// because the key is the token's `uniqueId`, resolved by that same method.
+    @MainActor
+    func makeSortSnapshot(tokens: [CoinMeta]) -> SortSnapshot {
+        var balances = [String: Decimal](minimumCapacity: tokens.count)
+        for token in tokens {
+            balances[token.uniqueId] = vault.coin(for: token)?.balanceInFiatDecimal ?? 0
+        }
+        return SortSnapshot(
+            balancesByUniqueId: balances,
+            selectedChain: selectedCoin.chain,
+            selectedTicker: selectedCoin.ticker,
+            selectedCoinMeta: selectedCoin.toCoinMeta()
+        )
+    }
+
+    /// Sorts the picker list off the MainActor using only the value snapshot:
+    /// native token first, then descending vault fiat balance, then the
+    /// selected coin pinned first. Semantics are identical to the previous
+    /// MainActor sort — only the balance reads are pre-resolved into `snapshot`.
+    static func sort(tokens: [CoinMeta], snapshot: SortSnapshot) -> [CoinMeta] {
         // Sort coins: native token first, then by USD balance in descending order
         var sortedCoins = tokens.sorted { first, second in
             if first.isNativeToken && !second.isNativeToken {
@@ -365,17 +409,17 @@ struct SwapCoinSelectionLogic {
                 return false
             }
 
-            let firstCoin = vault.coin(for: first)
-            let secondCoin = vault.coin(for: second)
-
             // If both are native or both are not native, sort by USD balance
-            return firstCoin?.balanceInFiatDecimal ?? 0 > secondCoin?.balanceInFiatDecimal ?? 0
+            let firstBalance = snapshot.balancesByUniqueId[first.uniqueId] ?? 0
+            let secondBalance = snapshot.balancesByUniqueId[second.uniqueId] ?? 0
+            return firstBalance > secondBalance
         }
 
         // Show selected first
-        if selectedCoin.chain == sortedCoins.first?.chain, let index = sortedCoins.firstIndex(where: { $0.ticker.localizedCaseInsensitiveContains(selectedCoin.ticker)}) {
+        if snapshot.selectedChain == sortedCoins.first?.chain,
+           let index = sortedCoins.firstIndex(where: { $0.ticker.localizedCaseInsensitiveContains(snapshot.selectedTicker) }) {
             sortedCoins.remove(at: index)
-            sortedCoins = [selectedCoin.toCoinMeta()] + sortedCoins
+            sortedCoins = [snapshot.selectedCoinMeta] + sortedCoins
         }
 
         return sortedCoins

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -79,6 +79,10 @@ class SwapCoinSelectionViewModel: ObservableObject {
             // cached result in a single publish and skip the whole merge+sort.
             // `filteredTokens` is recomputed from the cached list against the
             // current search text inside `publish`.
+            // Bail if a newer chain switch superseded this task — the memoized
+            // fast-path skips the cold path's checkCancellation, so without this
+            // it could publish the previous chain's list mid-burst.
+            guard !Task.isCancelled else { return }
             await MainActor.run { error = nil }
             await publish(memoized)
             return

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -28,6 +28,15 @@ class SwapCoinSelectionViewModel: ObservableObject {
     private let logic: SwapCoinSelectionLogic
     private var cancellable: AnyCancellable?
 
+    /// Per-chain cache of the fully-assembled + sorted picker list for the
+    /// current picker session. Re-selecting a chain already assembled this
+    /// session republishes the cached result in one publish and skips the
+    /// whole merge+sort — the dominant cost on rapid back-and-forth switching.
+    /// Cleared on `forceRefresh` (first open per presentation), so live balance
+    /// changes are picked up on the next forced load. MainActor-isolated: only
+    /// touched from `MainActor.run` bodies.
+    @MainActor private var memo: [Chain: SwapCoinSelectionResult] = [:]
+
     @MainActor
     init(
         vault: Vault,
@@ -61,6 +70,20 @@ class SwapCoinSelectionViewModel: ObservableObject {
     /// `SwapTokenListCache` freshness logic — only the destination-registry
     /// catalog is forced.
     func fetchCoins(chain: Chain, forceRefresh: Bool = false) async {
+        if forceRefresh {
+            // First open per presentation: drop any memoized results so a stale
+            // assembled list can't shadow the forced re-fetch.
+            await MainActor.run { memo.removeAll() }
+        } else if let memoized = await MainActor.run(body: { memo[chain] }) {
+            // Re-selecting a chain already assembled this session: republish the
+            // cached result in a single publish and skip the whole merge+sort.
+            // `filteredTokens` is recomputed from the cached list against the
+            // current search text inside `publish`.
+            await MainActor.run { error = nil }
+            await publish(memoized)
+            return
+        }
+
         // Sync peek on the MainActor: when the chain's vault-independent token
         // list is already cached, do the cheap local merge and publish — the
         // first publish clears `isLoading`, so any spinner (initial state, or
@@ -106,7 +129,7 @@ class SwapCoinSelectionViewModel: ObservableObject {
             }
             let result = try await logic.fetchCoins(chain: chain, forceRefresh: forceRefresh)
             try Task.checkCancellation()
-            await publish(result)
+            await publish(result, memoizeFor: chain)
         } catch is CancellationError {
             // Superseded by a faster chain-switch — leave state for the winner.
         } catch {
@@ -125,6 +148,7 @@ class SwapCoinSelectionViewModel: ObservableObject {
             let result = try await logic.fetchCoins(chain: chain)
             try Task.checkCancellation()
             await MainActor.run {
+                self.memo[chain] = result
                 self.tokens = result.tokens
                 self.filteredTokens = self.logic.filterTokens(searchText: self.searchText, tokens: result.tokens)
             }
@@ -151,7 +175,7 @@ class SwapCoinSelectionViewModel: ObservableObject {
             }
             let result = try await logic.merge(externalTokens: externalTokens, chain: chain, forceRefresh: forceRefresh)
             try Task.checkCancellation()
-            await publish(result)
+            await publish(result, memoizeFor: chain)
         } catch {
             guard !Task.isCancelled else { return }
             await MainActor.run {
@@ -164,8 +188,17 @@ class SwapCoinSelectionViewModel: ObservableObject {
         }
     }
 
-    private func publish(_ result: SwapCoinSelectionResult) async {
+    /// Publishes a result to the view. Pass `memoizeFor:` with the chain when
+    /// the result is the fully-assembled final list so a later re-select can be
+    /// served from the memo — the partial `local` first-paint publishes omit it
+    /// (they're intentionally incomplete and must not be cached). `nil` chain
+    /// means "publish but don't memoize" (used for the memo-hit republish and
+    /// the destination first-paint).
+    private func publish(_ result: SwapCoinSelectionResult, memoizeFor chain: Chain? = nil) async {
         await MainActor.run {
+            if let chain {
+                self.memo[chain] = result
+            }
             self.tokens = result.tokens
             self.filteredTokens = self.logic.filterTokens(searchText: self.searchText, tokens: result.tokens)
             self.isLoading = false

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -234,6 +234,14 @@ struct SwapCoinPickerView: View {
         // fetch can't publish results for the wrong chain.
         reloadTask?.cancel()
         reloadTask = Task {
+            // Debounce a burst of back-and-forth chain switches: the cancel
+            // above coalesces the burst so only the last selection's task
+            // survives the sleep and actually fetches. First open
+            // (forceRefresh) skips the delay to stay snappy.
+            if !forceRefresh {
+                try? await Task.sleep(nanoseconds: 150_000_000)
+                guard !Task.isCancelled else { return }
+            }
             guard let selectedChain else { return }
             await viewModel.fetchCoins(chain: selectedChain, forceRefresh: forceRefresh)
         }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -240,8 +240,10 @@ struct SwapCoinPickerView: View {
             // (forceRefresh) skips the delay to stay snappy.
             if !forceRefresh {
                 try? await Task.sleep(nanoseconds: 150_000_000)
-                guard !Task.isCancelled else { return }
             }
+            // Applies to both the debounced and the forced path: a task the
+            // cancel above superseded must not go on to fetch/publish.
+            guard !Task.isCancelled else { return }
             guard let selectedChain else { return }
             await viewModel.fetchCoins(chain: selectedChain, forceRefresh: forceRefresh)
         }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -240,8 +240,10 @@ struct SwapCoinPickerView: View {
     }
 
     private func onSelect(chain: Chain) {
+        // Only mutate the selection; the single `.onChange(of: selectedChain)`
+        // owns the reload. Calling `reloadCoins()` here too fired two loads per
+        // tap, doubling the merge+sort work during rapid chain switching.
         selectedChain = chain
-        reloadCoins()
     }
 
     private func onSelect(coin: CoinMeta) {


### PR DESCRIPTION
## Summary

Fixes the swap asset/chain picker jank when the chain is toggled **back and forth rapidly** (slow switching was already fine). Purely a performance/behavior change — the set of tokens shown, their sort order, and all user-facing strings are unchanged.

Closes #4806

## Root cause

Static analysis (`origin/main` @ `c74e59ec1`) found one dominant cost the original write-up under-weighted, plus multipliers:

- **Unmemoized `assemble`+`sort` on the MainActor, × double-reload × double-publish.** `SwapCoinSelectionLogic.sort` called `Vault.coin(for:)` — an O(m) linear scan that lowercases ticker+contract per vault coin — **twice per comparison** inside `sorted { }`, i.e. O(n·log n·m) with heavy string allocation, on the **MainActor**, re-run on **every publish**. The destination picker publishes twice per fetch, and `reloadCoins` fired **twice per tap** (`onSelect(chain:)` set `selectedChain` *and* called `reloadCoins()`, while `.onChange(of: selectedChain)` also did). Only the raw external token list was cached — not the assembled+sorted result — so A↔B re-ran the whole merge+sort each time for identical output.
- **FlatPicker write-back feedback loop.** A programmatic `scrollTo` (from external selection) drives per-frame offset churn; the settle path writes `selectedItem` back into `selectedChain`. Mid-flight during a burst it resolves to a stale index and fights the latest selection — the oscillation that builds during a burst and settles on stop — while the haptic machine-guns across swept items.

## The 5 fixes (one commit each)

1. **Stop the double `reloadCoins` per tap** — `onSelect(chain:)` only sets `selectedChain`; the single `.onChange(of: selectedChain)` owns the reload.
2. **Memoize the assembled+sorted result per chain** — a MainActor `[Chain: SwapCoinSelectionResult]` memo; a non-forced fetch for an already-assembled chain republishes the cached list in one publish and skips merge+sort. `forceRefresh` (first open) clears the memo so live balance changes are picked up; `filteredTokens` is recomputed from the cached list against the current search text.
3. **O(1) balance lookup + off-MainActor sort** — snapshot the sort inputs into value types on the MainActor (a `[String: Decimal]` balance map keyed by `CoinMeta.uniqueId`, resolving `Vault.coin(for:)?.balanceInFiatDecimal` once per token, plus the selected coin's chain/ticker/`CoinMeta`), then run the comparison off the MainActor as a static pure function doing O(1) lookups. No SwiftData `@Model` is read off the MainActor. Sort semantics (native first → descending fiat balance → selected-first) are byte-identical.
4. **Debounce `reloadCoins` ~150 ms** — the reload Task sleeps 150 ms before fetching (skipped on `forceRefresh`), so the existing `reloadTask?.cancel()` coalesces a burst to the last selection.
5. **Suppress FlatPicker's programmatic-scroll write-back** — a flag armed only for external selection changes / onLoad (never for the picker's own drag-settle write-backs, via an `isSelfSelectionUpdate` marker) makes the settle skip the write-back + haptic. It's disarmed on the settle event itself (with a 0.6 s fallback for a scrollTo that produces no offset change), so it covers the animation + settle-debounce window without a timer racing the settle. **User drag-to-select is fully preserved** — consecutive drags never arm the flag.

## Correctness notes / deviations

- Fix 3 keeps the *balance resolution* on the MainActor by necessity (`balanceInFiatDecimal` reads the `Coin` `@Model`); only the comparison loop moved off it.
- Fix 5 has one narrow, deliberate residual: a user drag that *starts within the suppression window immediately after tapping a chain button* has its first settle consumed. This is inherent to a flag-based approach without a real touch signal from the scroll view (adding a `DragGesture` to a generic reusable component was judged too risky for a perf fix). Consecutive user drags — the normal drag-to-select flow — are never affected.

## Verification

- Cross-model review loop: codex read-only review gated each commit + a whole-branch pass; findings triaged (the whole-branch pass caught a user-drag-preservation gap in fix 5, which was fixed).
- `make generate` — OK.
- `make test` (full suite) — **`** TEST SUCCEEDED **`, Executed 2731 tests, 0 failures, 1 skipped.**
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 0 new warnings in the changed files (43 pre-existing baseline violations, unrelated).
- On-device Time Profiler confirmation (destination-vs-source asymmetry, #1 vs #2 dominance) is still the recommended follow-up; this PR is static-analysis + gate verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved coin picker behavior during chain switching by preventing duplicate reloads.
  * Faster coin list updates via per-session caching.
  * More stable selection positioning and smoother sorting for better perceived performance.
  * Refined picker scroll feedback to reduce unintended selection changes and excess haptics.
  * Enhanced handling of programmatic scrolling to keep selection consistent while scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->