### PR TITLE
spike(limit-swap): all 4 UX variants behind a runtime picker — NOT FOR MERGE

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "limitSwap.error.title" = "Order konnte nicht platziert werden";
 "limitSwap.error.unsupportedAsset" = "Dieses Asset wird für Limit-Orders nicht unterstützt. Wähle ein anderes Asset.";
 "limitSwap.executeWhen" = "Ausführen wenn";
+"limitSwap.executeWhen.headerIsWorth" = "wert ist";
+"limitSwap.executeWhen.headerWhenOne" = "Wenn 1";
 "limitSwap.executeWhen.marketReference" = "Markt %@";
 "limitSwap.executeWhen.oneUnit" = "1 %@";
 "limitSwap.expiry" = "Ablauf";
@@ -677,6 +679,7 @@
 "limitSwap.verify.title" = "Du platzierst eine Limit-Order";
 "limitSwap.warning.priceAtOrBelowMarket" = "Kurs bereits verfügbar, erwäge einen Markt-Swap";
 "limitSwap.warning.priceFarAboveMarket" = "Wird möglicherweise nicht vor Ablauf ausgeführt";
+"limitSwap.youReceiveAtLeast" = "Du erhältst mindestens";
 "limitSwapToggle" = "Limit-Swap";
 "liquidityPools" = "Liquiditätspools";
 "loading" = "Loading...";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -659,6 +659,8 @@
 "limitSwap.error.title" = "Couldn't place order";
 "limitSwap.error.unsupportedAsset" = "This asset isn't supported for limit orders. Pick a different asset.";
 "limitSwap.executeWhen" = "Execute when";
+"limitSwap.executeWhen.headerIsWorth" = "is worth";
+"limitSwap.executeWhen.headerWhenOne" = "When 1";
 "limitSwap.executeWhen.marketReference" = "Market %@";
 "limitSwap.executeWhen.oneUnit" = "1 %@";
 "limitSwap.expiry" = "Expiry";
@@ -675,6 +677,7 @@
 "limitSwap.verify.title" = "You're placing a limit order";
 "limitSwap.warning.priceAtOrBelowMarket" = "Price already available, consider market swap";
 "limitSwap.warning.priceFarAboveMarket" = "May not fill within expiry";
+"limitSwap.youReceiveAtLeast" = "You receive at least";
 "limitSwapToggle" = "Limit Swap";
 "liquidityPools" = "Liquidity Pools";
 "loading" = "Loading...";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "limitSwap.error.title" = "No se pudo colocar la orden";
 "limitSwap.error.unsupportedAsset" = "Este activo no es compatible con las órdenes límite. Elige otro activo.";
 "limitSwap.executeWhen" = "Ejecutar cuando";
+"limitSwap.executeWhen.headerIsWorth" = "valga";
+"limitSwap.executeWhen.headerWhenOne" = "Cuando 1";
 "limitSwap.executeWhen.marketReference" = "Mercado %@";
 "limitSwap.executeWhen.oneUnit" = "1 %@";
 "limitSwap.expiry" = "Vencimiento";
@@ -677,6 +679,7 @@
 "limitSwap.verify.title" = "Estás colocando una orden límite";
 "limitSwap.warning.priceAtOrBelowMarket" = "Precio ya disponible, considera un swap de mercado";
 "limitSwap.warning.priceFarAboveMarket" = "Puede no ejecutarse antes del vencimiento";
+"limitSwap.youReceiveAtLeast" = "Recibes al menos";
 "limitSwapToggle" = "Swap límite";
 "liquidityPools" = "Pools de liquidez";
 "loading" = "Loading...";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "limitSwap.error.title" = "Nije moguće postaviti nalog";
 "limitSwap.error.unsupportedAsset" = "Ova imovina nije podržana za limit naloge. Odaberite drugu imovinu.";
 "limitSwap.executeWhen" = "Izvrši kada";
+"limitSwap.executeWhen.headerIsWorth" = "vrijedi";
+"limitSwap.executeWhen.headerWhenOne" = "Kada 1";
 "limitSwap.executeWhen.marketReference" = "Tržište %@";
 "limitSwap.executeWhen.oneUnit" = "1 %@";
 "limitSwap.expiry" = "Istek";
@@ -677,6 +679,7 @@
 "limitSwap.verify.title" = "Postavljaš limit nalog";
 "limitSwap.warning.priceAtOrBelowMarket" = "Cijena već dostupna, razmotri tržišnu zamjenu";
 "limitSwap.warning.priceFarAboveMarket" = "Možda se neće izvršiti prije isteka";
+"limitSwap.youReceiveAtLeast" = "Primaš najmanje";
 "limitSwapToggle" = "Limit zamjena";
 "liquidityPools" = "Bazeni likvidnosti";
 "loading" = "Učitavanje...";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "limitSwap.error.title" = "Impossibile inserire l'ordine";
 "limitSwap.error.unsupportedAsset" = "Questo asset non è supportato per gli ordini limite. Scegli un altro asset.";
 "limitSwap.executeWhen" = "Esegui quando";
+"limitSwap.executeWhen.headerIsWorth" = "vale";
+"limitSwap.executeWhen.headerWhenOne" = "Quando 1";
 "limitSwap.executeWhen.marketReference" = "Mercato %@";
 "limitSwap.executeWhen.oneUnit" = "1 %@";
 "limitSwap.expiry" = "Scadenza";
@@ -677,6 +679,7 @@
 "limitSwap.verify.title" = "Stai inserendo un ordine limite";
 "limitSwap.warning.priceAtOrBelowMarket" = "Prezzo già disponibile, valuta uno swap di mercato";
 "limitSwap.warning.priceFarAboveMarket" = "Potrebbe non eseguirsi entro la scadenza";
+"limitSwap.youReceiveAtLeast" = "Ricevi almeno";
 "limitSwapToggle" = "Swap limite";
 "liquidityPools" = "Pool di liquidità";
 "loading" = "Caricamento...";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -659,6 +659,8 @@
 "limitSwap.error.title" = "주문을 넣을 수 없습니다";
 "limitSwap.error.unsupportedAsset" = "이 자산은 지정가 주문을 지원하지 않습니다. 다른 자산을 선택하세요.";
 "limitSwap.executeWhen" = "실행 조건";
+"limitSwap.executeWhen.headerIsWorth" = "의 가치가";
+"limitSwap.executeWhen.headerWhenOne" = "1";
 "limitSwap.executeWhen.marketReference" = "시장 %@";
 "limitSwap.executeWhen.oneUnit" = "1 %@";
 "limitSwap.expiry" = "만료";
@@ -675,6 +677,7 @@
 "limitSwap.verify.title" = "지정가 주문을 넣고 있습니다";
 "limitSwap.warning.priceAtOrBelowMarket" = "이미 가능한 가격입니다. 시장가 스왑을 고려하세요";
 "limitSwap.warning.priceFarAboveMarket" = "만료 전에 체결되지 않을 수 있습니다";
+"limitSwap.youReceiveAtLeast" = "최소 수령 수량";
 "limitSwapToggle" = "지정가 스왑";
 "liquidityPools" = "유동성 풀";
 "loading" = "로딩 중...";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "limitSwap.error.title" = "Não foi possível colocar a ordem";
 "limitSwap.error.unsupportedAsset" = "Este ativo não é compatível com ordens limite. Escolha outro ativo.";
 "limitSwap.executeWhen" = "Executar quando";
+"limitSwap.executeWhen.headerIsWorth" = "valer";
+"limitSwap.executeWhen.headerWhenOne" = "Quando 1";
 "limitSwap.executeWhen.marketReference" = "Mercado %@";
 "limitSwap.executeWhen.oneUnit" = "1 %@";
 "limitSwap.expiry" = "Validade";
@@ -677,6 +679,7 @@
 "limitSwap.verify.title" = "Você está colocando uma ordem limite";
 "limitSwap.warning.priceAtOrBelowMarket" = "Preço já disponível, considere um swap de mercado";
 "limitSwap.warning.priceFarAboveMarket" = "Pode não ser executada antes da validade";
+"limitSwap.youReceiveAtLeast" = "Você recebe pelo menos";
 "limitSwapToggle" = "Swap limite";
 "liquidityPools" = "Pools de liquidez";
 "loading" = "Loading...";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -661,6 +661,8 @@
 "limitSwap.error.title" = "无法下单";
 "limitSwap.error.unsupportedAsset" = "该资产不支持限价单。请选择其他资产。";
 "limitSwap.executeWhen" = "执行条件";
+"limitSwap.executeWhen.headerIsWorth" = "价值达到";
+"limitSwap.executeWhen.headerWhenOne" = "当 1";
 "limitSwap.executeWhen.marketReference" = "市场 %@";
 "limitSwap.executeWhen.oneUnit" = "1 %@";
 "limitSwap.expiry" = "到期";
@@ -677,6 +679,7 @@
 "limitSwap.verify.title" = "您正在下达限价单";
 "limitSwap.warning.priceAtOrBelowMarket" = "价格已可用，建议使用市价兑换";
 "limitSwap.warning.priceFarAboveMarket" = "可能在到期前无法成交";
+"limitSwap.youReceiveAtLeast" = "至少获得";
 "limitSwapToggle" = "限价兑换";
 "liquidityPools" = "流动性池";
 "loading" = "加载中...";

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitLayoutVariant.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitLayoutVariant.swift
@@ -51,4 +51,29 @@ enum LimitLayoutVariant: String, CaseIterable, Identifiable {
             return "Three sections"
         }
     }
+
+    /// Ultra-compact tag for the collapsed picker label. The picker shares a row
+    /// with the Market/Limit segmented control, so the label has to stay narrow
+    /// enough that it can't crowd the tabs on the smallest screen — a full
+    /// "Accordion (current)" there would. These letters are the vocabulary the
+    /// spike already uses for the variants (A/B/C/D), and `menuLabel` spells the
+    /// mapping out one tap away, so the shortening costs no clarity.
+    var shortName: String {
+        switch self {
+        case .accordion:
+            return "A"
+        case .assetsFirst:
+            return "B"
+        case .uniswapFlat:
+            return "C"
+        case .threeSection:
+            return "D"
+        }
+    }
+
+    /// Expanded menu row — letter + full name, so opening the picker teaches the
+    /// letter that the collapsed label shows.
+    var menuLabel: String {
+        "\(shortName) — \(displayName)"
+    }
 }

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitLayoutVariant.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitLayoutVariant.swift
@@ -1,0 +1,54 @@
+//
+//  LimitLayoutVariant.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// The four candidate layouts for the limit-swap form, carried side-by-side on
+/// this **design-review branch** so they can be compared live in one build
+/// instead of by rebuilding four branches.
+///
+/// Every case renders the SAME `LimitSwapFormViewModel`, memo math, validation,
+/// routability gate and place-order flow — they differ in presentation only, so
+/// a comparison between them is a comparison of layout and nothing else.
+///
+/// `String`-backed (not `Int`) so the dev's choice persists legibly through
+/// `@AppStorage` and survives a relaunch; `@AppStorage`'s `RawRepresentable`
+/// overload falls back to the declared default if the stored raw value no
+/// longer maps to a case, so removing a variant can't wedge the screen.
+enum LimitLayoutVariant: String, CaseIterable, Identifiable {
+
+    /// Two-section accordion — Execute-when first, Asset second.
+    case accordion
+
+    /// Two-section accordion — Asset first, Execute-when second.
+    case assetsFirst
+
+    /// Flat: no accordion, every input visible at once.
+    case uniswapFlat
+
+    /// Three-section accordion — Asset → Execute when → Amount, the last
+    /// carrying the reflected output.
+    case threeSection
+
+    var id: String { rawValue }
+
+    /// Dev-facing label for the review picker. Deliberately NOT localized: this
+    /// picker exists only on this never-merging review branch, behind the
+    /// default-off `limitSwapEnabled` advanced setting, and is read by the devs
+    /// and designers comparing the layouts — never by a shipping user. Adding
+    /// four throwaway keys to eight locale files would be pure churn.
+    var displayName: String {
+        switch self {
+        case .accordion:
+            return "Accordion (current)"
+        case .assetsFirst:
+            return "Assets first"
+        case .uniswapFlat:
+            return "Uniswap flat"
+        case .threeSection:
+            return "Three sections"
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyAssetsFirstView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyAssetsFirstView.swift
@@ -1,0 +1,1159 @@
+//
+//  LimitSwapBodyAssetsFirstView.swift
+//  VultisigApp
+//
+
+import BigInt
+import SwiftUI
+
+/// Limit-swap body content — renders inside `SwapCryptoView` when the
+/// SegmentedControl is set to Limit. Matches Figma `74341-118736`: a two-section
+/// **accordion** (Asset / Execute when, one open at a time) with the Place-Order
+/// CTA pinned to the bottom.
+///
+/// All business logic lives in `LimitSwapFormViewModel`; this view is
+/// declarative. The price field always edits `draft.targetPrice` in the target
+/// asset's terms (the value the signed memo's LIM is derived from) — the $/asset
+/// toggle only changes which representation is emphasized, never how the price is
+/// stored, so the memo math is never at risk.
+struct LimitSwapBodyAssetsFirstView: View {
+
+    enum FocusedSection: Hashable {
+        case executeWhen
+        case asset
+    }
+
+    @Bindable var vm: LimitSwapFormViewModel
+    let fromCoin: Coin
+    let toCoin: Coin
+
+    /// Which section is open on first launch. Defaults to Asset — the pair and
+    /// sell amount are what the price is *expressed in*, so picking them first
+    /// means the Execute-when card opens already denominated in the right
+    /// ticker; tapping "Execute when" collapses Asset into its compact summary
+    /// and expands the price card. The section is actually opened by `.onLoad`
+    /// committing this into `focusedSection` (see below).
+    var initialFocusedSection: FocusedSection = .asset
+
+    /// `nil` on frame 0, then seeded from `initialFocusedSection` in `.onLoad`.
+    /// Starting at `nil` (rather than a fixed section) is what lets each
+    /// `FormExpandableSection`'s `onChange(of: focusedField)` observe the
+    /// transition and drive its open animation — the same nil→onLoad focus
+    /// pattern the Send/Bond expandable forms use.
+    @State private var focusedSection: FocusedSection?
+    @State private var sourceAmountText: String = ""
+    @State private var priceText: String = ""
+    /// USD-mode mirror of `priceText`. Editable in USD mode; kept in sync with
+    /// `draft.targetPrice` (× the target USD rate) so switching modes shows the
+    /// right value. The canonical price stays `draft.targetPrice` (asset terms).
+    @State private var usdText: String = ""
+    /// The last value written to `usdText` PROGRAMMATICALLY (by `syncUsdText`).
+    /// `onChange(usdText)` absorbs this one echo so a preset/rate/mode redraw of
+    /// the USD field can't round-trip through the 2-dp USD display and mutate the
+    /// canonical asset-terms price. `nil` once absorbed → the next change is a
+    /// genuine user edit.
+    @State private var lastSyncedUsdText: String?
+    /// Mirrors the market swap: reset to `true` on a manual amount edit so the
+    /// shared `SwapPercentageButtons` clears its selected-pill highlight.
+    @State private var showAllPercentageButtons = true
+
+    let onPickFromAsset: () -> Void
+    let onPickToAsset: () -> Void
+    let onSwapAssets: () -> Void
+    let onPlaceOrder: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 8) {
+                    // Asset first — the pair defines the units the target price is
+                    // quoted in, so the user picks Sell/Buy before naming a price.
+                    FormExpandableSection(
+                        title: "limitSwap.asset".localized,
+                        isValid: bothAssetsPicked,
+                        showValue: focusedSection != .asset,
+                        focusedField: $focusedSection,
+                        focusedFieldEquals: .asset,
+                        cornerRadius: 24,
+                        plainSeparator: true,
+                        onExpand: { isExpanded in
+                            focusedSection = isExpanded ? .asset : nil
+                        },
+                        content: {
+                            LimitAssetSwapForm(
+                                vm: vm,
+                                fromCoin: fromCoin,
+                                toCoin: toCoin,
+                                sourceAmountText: $sourceAmountText,
+                                showAllPercentageButtons: $showAllPercentageButtons,
+                                onPickFromAsset: onPickFromAsset,
+                                onPickToAsset: onPickToAsset,
+                                onSwapAssets: onSwapAssets
+                            )
+                        },
+                        valueView: {
+                            LimitAssetCompactValue(
+                                fromAsset: vm.draft.fromAsset,
+                                toAsset: vm.draft.toAsset
+                            )
+                        }
+                    )
+
+                    // Execute-when is now the SECOND (collapsed-on-load) section, so
+                    // it carries a compact summary the way Asset always has —
+                    // otherwise the landing screen's only other section would render
+                    // as a bare, inert-looking title. `isValid` gates the
+                    // checkmark/pencil affordance AND (via FormSectionHeader) whether
+                    // the value is rendered at all, so both track a set price.
+                    FormExpandableSection(
+                        title: "limitSwap.executeWhen".localized,
+                        isValid: vm.draft.targetPrice > 0,
+                        value: targetPriceSummary,
+                        showValue: focusedSection != .executeWhen,
+                        focusedField: $focusedSection,
+                        focusedFieldEquals: .executeWhen,
+                        cornerRadius: 24,
+                        plainSeparator: true,
+                        onExpand: { isExpanded in
+                            focusedSection = isExpanded ? .executeWhen : nil
+                        },
+                        content: {
+                            LimitExecuteWhenContent(
+                                vm: vm,
+                                priceText: $priceText,
+                                usdText: $usdText,
+                                onPickFromAsset: onPickFromAsset
+                            )
+                        }
+                    )
+
+                    if vm.advancedSwapQueueEnabled == false {
+                        LimitUnavailableRow()
+                    }
+
+                    if let unroutable = vm.pairUnroutableReason {
+                        LimitNoticeRow(message: unroutable.message)
+                    }
+
+                    if let warning = vm.displayedWarning {
+                        LimitWarningRow(warning: warning)
+                    }
+                }
+            }
+
+            PrimaryButton(
+                title: "limitSwap.placeOrder".localized,
+                action: onPlaceOrder
+            )
+            .disabled(!vm.canPlaceOrder)
+            .padding(.bottom, 16)
+        }
+        .onLoad {
+            // Commit the initial focus so each FormExpandableSection's onChange
+            // fires and animates the default section open (both start collapsed
+            // on frame 0).
+            if focusedSection == nil {
+                focusedSection = initialFocusedSection
+            }
+            // Reflect an already-populated draft in the editable fields on first
+            // appear — otherwise they only sync via onChange and read empty
+            // until the user edits them.
+            if priceText.isEmpty, vm.draft.targetPrice > 0 {
+                priceText = formatPrice(vm.draft.targetPrice)
+            }
+            if usdText.isEmpty, vm.draft.targetPrice > 0, vm.targetUsdPricePerUnit > 0 {
+                let text = formatUsdValue(vm.draft.targetPrice * vm.targetUsdPricePerUnit)
+                lastSyncedUsdText = text
+                usdText = text
+            }
+            if sourceAmountText.isEmpty, vm.draft.sourceAmount > 0 {
+                sourceAmountText = formatPrice(fromCoin.decimal(for: vm.draft.sourceAmount))
+            }
+        }
+        .onChange(of: sourceAmountText) { _, newText in
+            vm.amountChanged(parseLimitAmount(newText, decimals: vm.draft.fromAsset.decimals))
+            // A manual edit clears the selected-percentage highlight (market parity).
+            showAllPercentageButtons = true
+        }
+        .onChange(of: priceText) { _, newText in
+            let parsed = parseLimitPrice(newText)
+            if parsed != vm.draft.targetPrice {
+                vm.targetPriceChanged(parsed)
+            }
+        }
+        .onChange(of: usdText) { _, newText in
+            // Convert USD → canonical asset-terms price only while USD is the
+            // ACTIVE (editable) representation. In asset mode `usdText` is synced
+            // in the background; gating on the mode stops that from feeding back.
+            guard vm.draft.displayUnit == .usd else { return }
+            // Absorb the one echo of a programmatic sync so a preset/rate/mode
+            // redraw of the USD field can't round the canonical price through the
+            // 2-dp USD display (or silently clear the active preset).
+            let synced = lastSyncedUsdText
+            lastSyncedUsdText = nil
+            guard isUserUsdPriceEdit(newText: newText, lastSyncedText: synced) else { return }
+            vm.targetPriceChangedFromUsd(parseLimitPrice(newText))
+        }
+        .onChange(of: vm.draft.targetPrice) { _, newPrice in
+            // Sync vm → text only when the local text doesn't already parse to the
+            // same Decimal. Preserves a trailing "." while typing and reflects
+            // preset-pill taps that mutate vm.
+            if parseLimitPrice(priceText) != newPrice {
+                priceText = newPrice == 0 ? "" : formatPrice(newPrice)
+            }
+            syncUsdText(for: newPrice)
+        }
+        .onChange(of: vm.targetUsdPricePerUnit) { _, _ in
+            // The target asset (and thus its USD rate) changed — re-derive the USD
+            // field from the unchanged canonical price.
+            syncUsdText(for: vm.draft.targetPrice)
+        }
+        .onChange(of: fromCoin) { _, newCoin in
+            // The source coin's decimals changed. `sourceAmountText`'s onChange
+            // only fires on TEXT edits, so without this the visible amount ("1")
+            // would keep the OLD coin's raw `draft.sourceAmount` (e.g. 1 BTC's
+            // 1e8 read as 1e-10 ETH). Reparse the visible text with the new coin's
+            // decimals so text ↔ draft stays consistent.
+            vm.amountChanged(parseLimitAmount(sourceAmountText, decimals: newCoin.decimals))
+        }
+    }
+
+    /// Asset section shows the collapsed summary + checkmark/pencil once the user
+    /// has a non-empty pair — true on launch since we seed from the host's coins.
+    private var bothAssetsPicked: Bool {
+        !vm.draft.fromAsset.ticker.isEmpty && !vm.draft.toAsset.ticker.isEmpty
+    }
+
+    /// Collapsed Execute-when summary, echoing the expanded card's own phrasing
+    /// ("1 <sell>" chip + the price in the buy asset's terms) so collapsing the
+    /// section doesn't change what the number means. Always quoted in ASSET terms
+    /// — that is the canonical `draft.targetPrice` the memo's LIM derives from,
+    /// and unlike the USD mirror it is available even when no USD rate resolved.
+    /// Reuses the card's `oneUnit` key, so no new localized string is needed.
+    private var targetPriceSummary: String {
+        guard vm.draft.targetPrice > 0 else { return "" }
+        let unit = String(format: "limitSwap.executeWhen.oneUnit".localized, vm.draft.fromAsset.ticker)
+        return "\(unit) = \(formatPrice(vm.draft.targetPrice)) \(vm.draft.toAsset.ticker)"
+    }
+
+    private func formatPrice(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 8
+        formatter.usesGroupingSeparator = false
+        return formatter.string(from: NSDecimalNumber(decimal: value))
+            ?? NSDecimalNumber(decimal: value).stringValue
+    }
+
+    /// USD amount formatted for the editable USD field (no grouping separators
+    /// so it round-trips through `parseLimitPrice`).
+    private func formatUsdValue(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.usesGroupingSeparator = false
+        return formatter.string(from: NSDecimalNumber(decimal: value))
+            ?? NSDecimalNumber(decimal: value).stringValue
+    }
+
+    /// Re-derive `usdText` from the canonical target price, skipping the rewrite
+    /// when the current text already maps to `targetPrice` (so active USD typing
+    /// isn't clobbered — the mapping is exact because both sides divide the typed
+    /// USD by the same rate). Records the written value in `lastSyncedUsdText` so
+    /// the resulting `onChange(usdText)` is absorbed instead of feeding back.
+    private func syncUsdText(for targetPrice: Decimal) {
+        let newText: String
+        if vm.targetUsdPricePerUnit > 0 {
+            let mappedAsset = parseLimitPrice(usdText) / vm.targetUsdPricePerUnit
+            guard mappedAsset != targetPrice else { return }
+            let usd = targetPrice * vm.targetUsdPricePerUnit
+            newText = usd == 0 ? "" : formatUsdValue(usd)
+        } else {
+            guard !usdText.isEmpty else { return }
+            newText = ""
+        }
+        lastSyncedUsdText = newText
+        usdText = newText
+    }
+}
+
+// MARK: - Keyboard accessory
+//
+// The limit form's decimal-pad fields (Sell amount, target price) have no
+// return key, so they need a Done accessory to dismiss — the same mechanism the
+// market swap uses (`SwapPercentageButtons` + `hideKeyboard()`). The Sell field
+// passes the shared percentage buttons as leading content; the price field
+// passes none (Done only).
+
+private extension View {
+    @ViewBuilder
+    func limitKeyboardAccessory<Leading: View>(
+        @ViewBuilder leading: @escaping () -> Leading
+    ) -> some View {
+        #if os(iOS)
+        toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                leading()
+                Spacer()
+                Button {
+                    hideKeyboard()
+                } label: {
+                    Text("done".localized)
+                }
+            }
+        }
+        #else
+        self
+        #endif
+    }
+}
+
+// MARK: - Execute-when content (price display + toggle + presets + expiry)
+
+private struct LimitExecuteWhenContent: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    @Binding var priceText: String
+    @Binding var usdText: String
+    let onPickFromAsset: () -> Void
+
+    var body: some View {
+        VStack(spacing: 6) {
+            // Price + presets sit together (Figma gap-10) with the price box's
+            // 12pt bottom padding; the expiry sub-box follows with the 6pt
+            // content gap (→ ~18pt between the presets row and the expiry box).
+            VStack(spacing: 10) {
+                ZStack(alignment: .trailing) {
+                    LimitPriceDisplay(vm: vm, priceText: $priceText, usdText: $usdText, onPickFromAsset: onPickFromAsset)
+                    LimitPriceToggle(vm: vm)
+                        .padding(.trailing, 4)
+                }
+
+                LimitPresetPills(vm: vm)
+            }
+            .padding(.bottom, 12)
+
+            LimitExpiryRow(vm: vm)
+        }
+    }
+}
+
+// MARK: - Centered price display
+//
+// Market-reference line + "1 <fromTicker>" unit chip + the editable target price
+// with its USD equivalent. The editable field is ALWAYS bound to the target
+// price in the target asset's terms (the memo's LIM source) — the $/asset toggle
+// only swaps which representation is emphasized (large vs subtitle).
+//
+// NOTE (maintainer): Figma expresses the price as "1 <buyAsset> = $<usd>", which
+// inverts this per-unit-rate convention. Reconciling which representation is
+// canonical is a fund-safety-sensitive VM change that needs designer sign-off; it
+// is intentionally NOT guessed at here (a wrong inversion would place orders at
+// the reciprocal price).
+
+private struct LimitPriceDisplay: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    @Binding var priceText: String
+    @Binding var usdText: String
+    let onPickFromAsset: () -> Void
+
+    /// USD-mode editing is only offered when a USD rate for the target is known;
+    /// otherwise the USD value stays a read-only reflection.
+    private var usdEditable: Bool { vm.targetUsdPricePerUnit > 0 }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            marketReference
+
+            unitChip
+
+            // The primary/secondary representations swap on toggle; a new identity
+            // per unit + an opacity transition crossfades them (the toggle wraps
+            // the mutation in withAnimation). Storage of draft.targetPrice is
+            // unchanged — only which representation is emphasised.
+            priceValues
+                .id(vm.draft.displayUnit)
+                .transition(.opacity)
+        }
+        .frame(maxWidth: .infinity, minHeight: 180)
+        .padding(.vertical, 8)
+        // Done-only keyboard accessory for the decimal-pad target-price field
+        // (no percentages — the target price isn't balance-derived).
+        .limitKeyboardAccessory { EmptyView() }
+    }
+
+    @ViewBuilder
+    private var priceValues: some View {
+        VStack(spacing: 6) {
+            if vm.draft.displayUnit == .usd {
+                // USD mode: the emphasized value is the editable USD field (when a
+                // rate is known); the secondary is a read-only asset reflection.
+                if usdEditable {
+                    usdPriceField(font: Theme.fonts.priceTitle1, color: Theme.colors.textPrimary)
+                } else {
+                    Text(usdString)
+                        .font(Theme.fonts.priceTitle1)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                }
+                assetReflection(font: Theme.fonts.bodySMedium, color: Theme.colors.textTertiary)
+            } else {
+                // Asset mode: the emphasized value is the editable asset field; the
+                // secondary is the read-only USD reflection.
+                assetPriceField(font: Theme.fonts.priceTitle1, color: Theme.colors.textPrimary)
+                Text(usdString)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    /// Editable USD-denominated price field. Edits flow to the canonical
+    /// asset-terms `draft.targetPrice` via the parent's `usdText` sync + the VM's
+    /// `targetPriceChangedFromUsd` — the USD number is NEVER stored as the price.
+    private func usdPriceField(font: Font, color: Color) -> some View {
+        HStack(spacing: 2) {
+            Text("$")
+                .font(font)
+                .foregroundStyle(color)
+            TextField("0", text: $usdText.decimalOnly())
+                // `.plain` strips macOS's default bordered chrome (the dark bezel
+                // box); iOS is unaffected. Matches the market amount field, which
+                // uses PlainTextFieldStyle via `.borderlessTextFieldStyle()`.
+                .textFieldStyle(.plain)
+                .font(font)
+                .foregroundStyle(color)
+                .multilineTextAlignment(.center)
+                // `.fixedSize()` on BOTH axes so the field's frame collapses to its
+                // text — otherwise macOS keeps the field at its taller intrinsic
+                // height, so the caret/placeholder sit off the `$` baseline.
+                .fixedSize()
+                .lineLimit(1)
+                #if os(iOS)
+                .keyboardType(.decimalPad)
+                #endif
+        }
+    }
+
+    /// Read-only reflection of the canonical asset-terms price, shown as the
+    /// secondary value in USD mode (mirrors `priceText`, which the parent keeps in
+    /// sync with `draft.targetPrice`).
+    private func assetReflection(font: Font, color: Color) -> some View {
+        Text("\(priceText.isEmpty ? "0" : priceText) \(vm.draft.toAsset.ticker)")
+            .font(font)
+            .foregroundStyle(color)
+            .lineLimit(1)
+    }
+
+    @ViewBuilder
+    private var marketReference: some View {
+        if let market = vm.marketPriceRef, market > 0 {
+            Text(String(format: "limitSwap.executeWhen.marketReference".localized, marketString(market)))
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+        }
+    }
+
+    private var unitChip: some View {
+        // The "1 <sell>" chip: icon + tap target are the SELL (from) asset —
+        // the price is expressed as "1 <from> is worth <price> <to>", so the
+        // editable side here is the source. Tapping opens the from-asset picker.
+        Button(action: onPickFromAsset) {
+            HStack(spacing: 8) {
+                if !vm.draft.fromAsset.logo.isEmpty {
+                    AsyncImageView(
+                        logo: vm.draft.fromAsset.logo,
+                        size: CGSize(width: 24, height: 24),
+                        ticker: vm.draft.fromAsset.ticker,
+                        tokenChainLogo: vm.draft.fromAsset.chainLogo
+                    )
+                }
+                Text(String(format: "limitSwap.executeWhen.oneUnit".localized, vm.draft.fromAsset.ticker))
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textSecondary)
+            }
+            .padding(.leading, 6)
+            .padding(.trailing, 12)
+            .padding(.vertical, 6)
+            .overlay(
+                RoundedRectangle(cornerRadius: 99)
+                    .stroke(Theme.colors.borderLight, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func assetPriceField(font: Font, color: Color) -> some View {
+        HStack(spacing: 6) {
+            TextField("0", text: $priceText.decimalOnly())
+                // `.plain` strips macOS's default bordered chrome (the dark bezel
+                // box); iOS is unaffected. Matches the market amount field.
+                .textFieldStyle(.plain)
+                .font(font)
+                .foregroundStyle(color)
+                .multilineTextAlignment(.center)
+                // `.fixedSize()` on BOTH axes so the field's frame collapses to its
+                // text — otherwise macOS keeps the field at its taller intrinsic
+                // height, so the caret/placeholder sit off the ticker's baseline.
+                .fixedSize()
+                .lineLimit(1)
+                #if os(iOS)
+                .keyboardType(.decimalPad)
+                #endif
+            Text(vm.draft.toAsset.ticker)
+                .font(font)
+                .foregroundStyle(color)
+        }
+    }
+
+    /// USD equivalent of the target price (per the design-flags decision:
+    /// `targetPrice × targetUsdPricePerUnit`). Falls back to the asset-terms
+    /// value when no USD rate is available.
+    private var usdString: String {
+        guard vm.targetUsdPricePerUnit > 0, vm.draft.targetPrice > 0 else {
+            return "$0.00"
+        }
+        let usd = vm.draft.targetPrice * vm.targetUsdPricePerUnit
+        return "$\(formatUsd(usd))"
+    }
+
+    private func marketString(_ market: Decimal) -> String {
+        if vm.targetUsdPricePerUnit > 0 {
+            return "$\(formatUsd(market * vm.targetUsdPricePerUnit))"
+        }
+        return "\(market.formatForDisplay()) \(vm.draft.toAsset.ticker)"
+    }
+
+    private func formatUsd(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        formatter.groupingSeparator = ","
+        return formatter.string(from: NSDecimalNumber(decimal: value)) ?? "0.00"
+    }
+}
+
+// MARK: - $/asset toggle (two stacked circular buttons)
+
+private struct LimitPriceToggle: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    @Namespace private var thumb
+
+    var body: some View {
+        VStack(spacing: 2) {
+            // Top: the asset-terms view (Figma "circles" glyph — two interlocking
+            // rings). Bottom: the USD toggle ($, blue-filled when active).
+            toggleButton(unit: .asset, systemImage: "circlebadge.2")
+            toggleButton(unit: .usd, systemImage: "dollarsign.circle")
+        }
+        .padding(3)
+        .background(Theme.colors.bgSurface1)
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+    }
+
+    private func toggleButton(unit: PriceDisplayUnit, systemImage: String) -> some View {
+        let isActive = vm.draft.displayUnit == unit
+        return Button {
+            guard vm.draft.displayUnit != unit else { return }
+            // Animate the crossfade (price block) + the thumb slide together.
+            // Storage of draft.targetPrice is untouched — behaviour identical.
+            withAnimation(.easeInOut(duration: 0.2)) {
+                vm.toggleDisplayUnit()
+            }
+        } label: {
+            Image(systemName: systemImage)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(isActive ? Theme.colors.textPrimary : Theme.colors.textSecondary)
+                .frame(width: 32, height: 32)
+                .background {
+                    // The selected indicator is a single matched-geometry thumb, so
+                    // it slides between the two chips instead of hard-switching.
+                    if isActive {
+                        RoundedRectangle(cornerRadius: 18)
+                            .fill(Theme.colors.primaryAccent3)
+                            .matchedGeometryEffect(id: "thumb", in: thumb)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Expiry row (inside the Execute-when card)
+
+private struct LimitExpiryRow: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+
+    var body: some View {
+        HStack {
+            Text("limitSwap.expiry".localized)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+
+            Spacer()
+
+            HStack(spacing: 6) {
+                pill(titleKey: "limitSwap.expiry.12h", hours: 12)
+                pill(titleKey: "limitSwap.expiry.24h", hours: 24)
+                pill(titleKey: "limitSwap.expiry.3d", hours: 72)
+            }
+        }
+        .padding(14)
+        // Figma "backgrounds/disabled" (#0b1a3a80) — the design-system token
+        // with that exact base hex is bgButtonDisabled (#0b1a3a), at 50%.
+        .background(Theme.colors.bgButtonDisabled.opacity(0.5))
+        .clipShape(UnevenRoundedRectangle(cornerRadii: Self.corners))
+        .overlay(
+            UnevenRoundedRectangle(cornerRadii: Self.corners)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+    }
+
+    // Nests under the price area: small top corners, larger bottom corners that
+    // echo the enclosing card (Figma top-12 / bottom-16).
+    private static let corners = RectangleCornerRadii(
+        topLeading: 12, bottomLeading: 16, bottomTrailing: 16, topTrailing: 12
+    )
+
+    private func pill(titleKey: String, hours: Int) -> some View {
+        let isSelected = vm.draft.expiryHours == hours
+        return Button {
+            vm.selectExpiryHours(hours)
+        } label: {
+            Text(titleKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(isSelected ? Theme.colors.bgSurface2 : Color.clear)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 100)
+                        .stroke(Theme.colors.border, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 100))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Collapsed Asset summary (Sell <ticker> · Buy <ticker>)
+//
+// Rendered by FormExpandableSection as the section's value view when the Asset
+// section is collapsed. The checkmark + pencil affordances are supplied by
+// FormExpandableSection itself.
+
+private struct LimitAssetCompactValue: View {
+
+    let fromAsset: LimitSwapAsset
+    let toAsset: LimitSwapAsset
+
+    var body: some View {
+        HStack(spacing: 12) {
+            chip(labelKey: "limitSwap.sell", asset: fromAsset)
+            chip(labelKey: "limitSwap.buy", asset: toAsset)
+        }
+    }
+
+    private func chip(labelKey: String, asset: LimitSwapAsset) -> some View {
+        HStack(spacing: 4) {
+            Text(labelKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+            if !asset.logo.isEmpty {
+                AsyncImageView(
+                    logo: asset.logo,
+                    size: CGSize(width: 16, height: 16),
+                    ticker: asset.ticker,
+                    tokenChainLogo: asset.chainLogo
+                )
+            }
+            Text(asset.ticker)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+        }
+    }
+}
+
+// MARK: - Asset swap form (Sell + middle swap button + Buy)
+//
+// Inner content of the Asset FormExpandableSection's expanded state.
+
+private struct LimitAssetSwapForm: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    let fromCoin: Coin
+    let toCoin: Coin
+    @Binding var sourceAmountText: String
+    @Binding var showAllPercentageButtons: Bool
+    let onPickFromAsset: () -> Void
+    let onPickToAsset: () -> Void
+    let onSwapAssets: () -> Void
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 8) {
+                LimitAssetRow(
+                    kind: .sell,
+                    coin: fromCoin,
+                    asset: vm.draft.fromAsset,
+                    amountText: $sourceAmountText,
+                    amountIsEditable: true,
+                    computedAmount: nil,
+                    usdPricePerUnit: Decimal(fromCoin.price),
+                    onPickAsset: onPickFromAsset
+                )
+                // Reuse the market swap's percentage buttons + Done accessory on
+                // the Sell amount keyboard. Attached to the row (an ancestor of
+                // the field) so it scopes to the sell amount's editing session.
+                .limitKeyboardAccessory {
+                    SwapPercentageButtons(
+                        show100: !fromCoin.isNativeToken,
+                        showAllPercentageButtons: $showAllPercentageButtons,
+                        onTap: handleSellPercentage
+                    )
+                }
+
+                LimitAssetRow(
+                    kind: .buy,
+                    coin: toCoin,
+                    asset: vm.draft.toAsset,
+                    amountText: .constant(formattedBuyAmount),
+                    amountIsEditable: false,
+                    computedAmount: buyAmountDecimal,
+                    usdPricePerUnit: vm.targetUsdPricePerUnit,
+                    onPickAsset: onPickToAsset
+                )
+            }
+
+            // Shared with the market swap form: same visual + spring flip.
+            SwapAssetsButton {
+                onSwapAssets()
+            }
+        }
+    }
+
+    /// Sets the Sell amount to `pct`% of the source balance. Assigns the field
+    /// text (its `onChange` funnels the value into `draft.sourceAmount`); the
+    /// balance math + formatting live in the VM (market parity).
+    private func handleSellPercentage(_ pct: Int) {
+        showAllPercentageButtons = false
+        sourceAmountText = vm.sourceAmountText(forPercentage: pct, of: fromCoin)
+    }
+
+    /// Buy amount preview — the VM derives it from the signed `computeLim`
+    /// path so it can't diverge from the memo's truncated LIM. `nil` when not
+    /// yet computable (row shows "0").
+    private var buyAmountDecimal: Decimal? {
+        let amount = vm.expectedBuyAmount
+        return amount > 0 ? amount : nil
+    }
+
+    private var formattedBuyAmount: String {
+        guard let amount = buyAmountDecimal else { return "0" }
+        return NSDecimalNumber(decimal: amount).stringValue
+    }
+}
+
+// MARK: - Single asset row (chain header + coin pill + amount field)
+
+private enum LimitAssetRowKind {
+    case sell
+    case buy
+
+    var labelKey: String {
+        self == .sell ? "limitSwap.sell" : "limitSwap.buy"
+    }
+
+    var cornerRadii: RectangleCornerRadii {
+        // Mirrors the Figma — Sell rounded top-heavy, Buy bottom-heavy.
+        switch self {
+        case .sell:
+            return .init(topLeading: 24, bottomLeading: 12, bottomTrailing: 12, topTrailing: 24)
+        case .buy:
+            return .init(topLeading: 12, bottomLeading: 24, bottomTrailing: 24, topTrailing: 12)
+        }
+    }
+}
+
+private struct LimitAssetRow: View {
+
+    let kind: LimitAssetRowKind
+    let coin: Coin
+    let asset: LimitSwapAsset
+    @Binding var amountText: String
+    let amountIsEditable: Bool
+    let computedAmount: Decimal?
+    let usdPricePerUnit: Decimal
+    let onPickAsset: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                HStack(spacing: 6) {
+                    Text(kind.labelKey.localized)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+
+                    Button(action: onPickAsset) {
+                        HStack(spacing: 4) {
+                            if !asset.chainLogo.isEmpty {
+                                AsyncImageView(
+                                    logo: asset.chainLogo,
+                                    size: CGSize(width: 16, height: 16),
+                                    ticker: asset.chain.ticker,
+                                    tokenChainLogo: nil
+                                )
+                            }
+                            Text(asset.chain.name)
+                                .font(Theme.fonts.caption12)
+                                .foregroundStyle(Theme.colors.textPrimary)
+                            Image(systemName: "chevron.down")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundStyle(Theme.colors.textTertiary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
+
+                if kind == .sell {
+                    Text("\(coin.balanceString) \(coin.ticker)")
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            HStack(alignment: .center) {
+                Button(action: onPickAsset) {
+                    HStack(spacing: 8) {
+                        if !asset.logo.isEmpty {
+                            AsyncImageView(
+                                logo: asset.logo,
+                                size: CGSize(width: 36, height: 36),
+                                ticker: asset.ticker,
+                                tokenChainLogo: asset.chainLogo
+                            )
+                        }
+                        Text(asset.ticker)
+                            .font(Theme.fonts.caption12)
+                            .foregroundStyle(Theme.colors.textPrimary)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(Theme.colors.textTertiary)
+                    }
+                    .padding(.leading, 6)
+                    .padding(.trailing, 12)
+                    .padding(.vertical, 6)
+                    .background(Theme.colors.bgSurface2)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+
+                Spacer(minLength: 12)
+
+                VStack(alignment: .trailing, spacing: 6) {
+                    if amountIsEditable {
+                        TextField("0", text: $amountText.decimalOnly())
+                            // `.plain` strips macOS's default bordered chrome (the
+                            // dark bezel box); iOS is unaffected. Matches the market
+                            // amount field.
+                            .textFieldStyle(.plain)
+                            .font(Theme.fonts.title2)
+                            .foregroundStyle(Theme.colors.textPrimary)
+                            .multilineTextAlignment(.trailing)
+                            .lineLimit(1)
+                            #if os(iOS)
+                            .keyboardType(.decimalPad)
+                            #endif
+                    } else {
+                        Text(amountText)
+                            .font(Theme.fonts.title2)
+                            .foregroundStyle(Theme.colors.textPrimary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.6)
+                    }
+
+                    Text(fiatLine)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            UnevenRoundedRectangle(cornerRadii: kind.cornerRadii)
+                .fill(Color.clear)
+                .overlay(
+                    UnevenRoundedRectangle(cornerRadii: kind.cornerRadii)
+                        .stroke(Theme.colors.borderLight, lineWidth: 1)
+                )
+        )
+    }
+
+    private var fiatLine: String {
+        let amount = effectiveAmount
+        guard usdPricePerUnit > 0, amount > 0 else { return "$0.00" }
+        let usd = amount * usdPricePerUnit
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        formatter.groupingSeparator = ","
+        let value = formatter.string(from: NSDecimalNumber(decimal: usd)) ?? "0.00"
+        return "$\(value)"
+    }
+
+    private var effectiveAmount: Decimal {
+        if let computedAmount {
+            return computedAmount
+        }
+        // Locale-aware so the fiat sub-line doesn't mis-read a pasted grouped
+        // number (shares the parser the amount field itself uses).
+        return parseLimitDecimal(amountText)
+    }
+}
+
+// MARK: - Preset pills
+//
+// The +1% / +5% / +10% pills are always static. The Market pill is dynamic but
+// only after a *manual* edit — while any preset is the live source it stays
+// static "Market". Uses `LimitPillFlow` so it wraps to a second row when the
+// dynamic Market pill's content grows.
+
+private struct LimitPresetPills: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+
+    var body: some View {
+        // Figma lays the four presets out as equal-width pills filling the row.
+        HStack(spacing: 6) {
+            marketPill
+            staticPill(titleKey: "limitSwap.preset.plus1", pct: 1)
+            staticPill(titleKey: "limitSwap.preset.plus5", pct: 5)
+            staticPill(titleKey: "limitSwap.preset.plus10", pct: 10)
+        }
+    }
+
+    @ViewBuilder
+    private var marketPill: some View {
+        let rounded = roundedPctFromMarket
+        let renderStatic = vm.lastPresetPct != nil || rounded == 0
+        Button {
+            dismissKeyboard()
+            vm.selectPresetPct(0)
+        } label: {
+            HStack(spacing: 4) {
+                if renderStatic {
+                    Text("limitSwap.preset.market".localized)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textSecondary)
+                } else {
+                    Text(formatRoundedPct(rounded))
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textSecondary)
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Theme.colors.textTertiary)
+                }
+            }
+            .lineLimit(1)
+            .minimumScaleFactor(0.85)
+            .pillShape()
+        }
+        .buttonStyle(.plain)
+        .disabled(vm.marketPriceRef == nil)
+    }
+
+    private func staticPill(titleKey: String, pct: Int) -> some View {
+        Button {
+            dismissKeyboard()
+            vm.selectPresetPct(pct)
+        } label: {
+            Text(titleKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+                .pillShape()
+        }
+        .buttonStyle(.plain)
+        .disabled(vm.marketPriceRef == nil)
+    }
+
+    private var roundedPctFromMarket: Decimal {
+        guard vm.marketPriceRef != nil, vm.draft.targetPrice > 0 else { return 0 }
+        var doubled = vm.pctFromMarket * 2
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &doubled, 0, .plain)
+        return rounded / 2
+    }
+
+    private func formatRoundedPct(_ pct: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 1
+        formatter.maximumFractionDigits = 1
+        formatter.positivePrefix = "+"
+        let value = formatter.string(from: NSDecimalNumber(decimal: pct)) ?? "0"
+        return "\(value)%"
+    }
+
+    private func dismissKeyboard() {
+        #if os(iOS)
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+        #endif
+    }
+}
+
+// MARK: - Preset pill shape
+//
+// Equal-width rounded outline used by every Execute-when preset pill so the row
+// distributes them evenly (Figma lays them out flex-1).
+
+private extension View {
+    func pillShape() -> some View {
+        self
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity)
+            .overlay(
+                RoundedRectangle(cornerRadius: 100)
+                    .stroke(Theme.colors.borderLight, lineWidth: 1)
+            )
+    }
+}
+
+// MARK: - Advanced Swap Queue unavailable row
+//
+// Shown when the `EnableAdvSwapQueue` mimir is resolved-disabled: THORChain
+// isn't accepting resting `=<` limit orders right now, so placement is blocked
+// (fail-closed).
+
+private struct LimitUnavailableRow: View {
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.octagon.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text("limitSwap.error.advancedSwapQueueDisabled".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Generic blocking-notice row
+//
+// A message-driven sibling of `LimitUnavailableRow`, used for the pair-not-
+// routable / unsupported-asset gate: the coin picker filters by CHAIN
+// routability only, so a poolless pair (e.g. RUNE→VULT) slips through — the
+// market-price probe's failure surfaces here (previously `marketPriceError` was
+// never rendered) and the Place CTA is disabled while it shows.
+
+private struct LimitNoticeRow: View {
+
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.octagon.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text(message)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Warning row
+
+private struct LimitWarningRow: View {
+
+    let warning: LimitSwapWarning
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text(messageKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var messageKey: String {
+        switch warning {
+        case .priceAtOrBelowMarket:
+            return "limitSwap.warning.priceAtOrBelowMarket"
+        case .priceFarAboveMarket:
+            return "limitSwap.warning.priceFarAboveMarket"
+        }
+    }
+}
+
+private extension Binding where Value == String {
+    /// Wrap a text binding so an edit is accepted only when it is a valid numeric
+    /// input (`isDecimalInput`). The price/amount fields then reject any letter or
+    /// symbol — whether typed or pasted — instead of silently keeping its digits,
+    /// which matches what the iOS `.decimalPad` enforces for free (macOS has no
+    /// such keypad). A rejected edit leaves the prior value untouched.
+    func decimalOnly() -> Binding<String> {
+        Binding<String>(
+            get: { wrappedValue },
+            set: { newValue in
+                if newValue.isDecimalInput() { wrappedValue = newValue }
+            }
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyThreeSectionView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyThreeSectionView.swift
@@ -1,0 +1,1414 @@
+//
+//  LimitSwapBodyThreeSectionView.swift
+//  VultisigApp
+//
+
+import BigInt
+import SwiftUI
+
+/// Limit-swap body content — renders inside `SwapCryptoView` when the
+/// SegmentedControl is set to Limit. A **three-section accordion** (Asset /
+/// Execute when / Amount, one open at a time) with the Place-Order CTA pinned to
+/// the bottom.
+///
+/// The three sections split the order into the three decisions it actually is,
+/// in the order they depend on each other:
+///
+/// 1. **Asset** — *what* pair. Everything downstream is denominated in it.
+/// 2. **Execute when** — *at what price* (and for how long) it should fill.
+/// 3. **Amount** — *how much* to sell, and the output that price+amount implies.
+///
+/// The Amount section is last because it is the only one whose displayed result
+/// depends on both of the others: the reflected output is a function of the
+/// pair, the target price, and the sell amount. Putting it after them means the
+/// user never sees the reflection change for a reason that is scrolled off
+/// screen.
+///
+/// All business logic lives in `LimitSwapFormViewModel`; this view is
+/// declarative. The price field always edits `draft.targetPrice` in the target
+/// asset's terms (the value the signed memo's LIM is derived from) — the $/asset
+/// toggle only changes which representation is emphasized, never how the price is
+/// stored, so the memo math is never at risk.
+struct LimitSwapBodyThreeSectionView: View {
+
+    enum FocusedSection: Hashable {
+        case asset
+        case executeWhen
+        case amount
+    }
+
+    @Bindable var vm: LimitSwapFormViewModel
+    /// The SOURCE coin. Only the source is needed as a `Coin`: it supplies the
+    /// spendable balance, the decimals the amount field parses against, and the
+    /// source USD rate. The target's rate reaches the form through the VM
+    /// (`targetUsdPricePerUnit`), and everything else about the pair comes from
+    /// `vm.draft`, so a `toCoin` would be unused.
+    let fromCoin: Coin
+
+    /// Which section is open on first launch. Defaults to Execute-when (the
+    /// price card): the pair is pre-seeded from the host's coins and the target
+    /// price is auto-seeded to Market, so the price is the one input that lands
+    /// holding a *placeholder* the user very likely wants to change — that is
+    /// what makes it more urgent than the (empty, but obviously-required) Amount.
+    /// It is also the reason the user chose Limit over Market at all. Both
+    /// neighbours are one tap away. The section is actually opened by `.onLoad`
+    /// committing this into `focusedSection` (see below).
+    var initialFocusedSection: FocusedSection = .executeWhen
+
+    /// `nil` on frame 0, then seeded from `initialFocusedSection` in `.onLoad`.
+    /// Starting at `nil` (rather than a fixed section) is what lets each
+    /// `FormExpandableSection`'s `onChange(of: focusedField)` observe the
+    /// transition and drive its open animation — the same nil→onLoad focus
+    /// pattern the Send/Bond expandable forms use.
+    @State private var focusedSection: FocusedSection?
+    @State private var sourceAmountText: String = ""
+    @State private var priceText: String = ""
+    /// USD-mode mirror of `priceText`. Editable in USD mode; kept in sync with
+    /// `draft.targetPrice` (× the target USD rate) so switching modes shows the
+    /// right value. The canonical price stays `draft.targetPrice` (asset terms).
+    @State private var usdText: String = ""
+    /// The last value written to `usdText` PROGRAMMATICALLY (by `syncUsdText`).
+    /// `onChange(usdText)` absorbs this one echo so a preset/rate/mode redraw of
+    /// the USD field can't round-trip through the 2-dp USD display and mutate the
+    /// canonical asset-terms price. `nil` once absorbed → the next change is a
+    /// genuine user edit.
+    @State private var lastSyncedUsdText: String?
+    /// Mirrors the market swap: reset to `true` on a manual amount edit so the
+    /// shared `SwapPercentageButtons` clears its selected-pill highlight.
+    @State private var showAllPercentageButtons = true
+
+    let onPickFromAsset: () -> Void
+    let onPickToAsset: () -> Void
+    let onSwapAssets: () -> Void
+    let onPlaceOrder: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 8) {
+                    assetSection
+                    executeWhenSection
+                    amountSection
+
+                    if vm.advancedSwapQueueEnabled == false {
+                        LimitUnavailableRow()
+                    }
+
+                    if let unroutable = vm.pairUnroutableReason {
+                        LimitNoticeRow(message: unroutable.message)
+                    }
+
+                    if let warning = vm.displayedWarning {
+                        LimitWarningRow(warning: warning)
+                    }
+                }
+            }
+
+            PrimaryButton(
+                title: "limitSwap.placeOrder".localized,
+                action: onPlaceOrder
+            )
+            .disabled(!vm.canPlaceOrder)
+            .padding(.bottom, 16)
+        }
+        .onLoad {
+            // Commit the initial focus so each FormExpandableSection's onChange
+            // fires and animates the default section open (all start collapsed
+            // on frame 0).
+            if focusedSection == nil {
+                focusedSection = initialFocusedSection
+            }
+            // Reflect an already-populated draft in the editable fields on first
+            // appear — otherwise they only sync via onChange and read empty
+            // until the user edits them.
+            if priceText.isEmpty, vm.draft.targetPrice > 0 {
+                priceText = formatPrice(vm.draft.targetPrice)
+            }
+            if usdText.isEmpty, vm.draft.targetPrice > 0, vm.targetUsdPricePerUnit > 0 {
+                let text = formatUsdValue(vm.draft.targetPrice * vm.targetUsdPricePerUnit)
+                lastSyncedUsdText = text
+                usdText = text
+            }
+            if sourceAmountText.isEmpty, vm.draft.sourceAmount > 0 {
+                sourceAmountText = formatPrice(fromCoin.decimal(for: vm.draft.sourceAmount))
+            }
+        }
+        .onChange(of: sourceAmountText) { _, newText in
+            vm.amountChanged(parseLimitAmount(newText, decimals: vm.draft.fromAsset.decimals))
+            // A manual edit clears the selected-percentage highlight (market parity).
+            showAllPercentageButtons = true
+        }
+        .onChange(of: priceText) { _, newText in
+            let parsed = parseLimitPrice(newText)
+            if parsed != vm.draft.targetPrice {
+                vm.targetPriceChanged(parsed)
+            }
+        }
+        .onChange(of: usdText) { _, newText in
+            // Convert USD → canonical asset-terms price only while USD is the
+            // ACTIVE (editable) representation. In asset mode `usdText` is synced
+            // in the background; gating on the mode stops that from feeding back.
+            guard vm.draft.displayUnit == .usd else { return }
+            // Absorb the one echo of a programmatic sync so a preset/rate/mode
+            // redraw of the USD field can't round the canonical price through the
+            // 2-dp USD display (or silently clear the active preset).
+            let synced = lastSyncedUsdText
+            lastSyncedUsdText = nil
+            guard isUserUsdPriceEdit(newText: newText, lastSyncedText: synced) else { return }
+            vm.targetPriceChangedFromUsd(parseLimitPrice(newText))
+        }
+        .onChange(of: vm.draft.targetPrice) { _, newPrice in
+            // Sync vm → text only when the local text doesn't already parse to the
+            // same Decimal. Preserves a trailing "." while typing and reflects
+            // preset-pill taps that mutate vm.
+            if parseLimitPrice(priceText) != newPrice {
+                priceText = newPrice == 0 ? "" : formatPrice(newPrice)
+            }
+            syncUsdText(for: newPrice)
+        }
+        .onChange(of: vm.targetUsdPricePerUnit) { _, _ in
+            // The target asset (and thus its USD rate) changed — re-derive the USD
+            // field from the unchanged canonical price.
+            syncUsdText(for: vm.draft.targetPrice)
+        }
+        .onChange(of: fromCoin) { _, newCoin in
+            // The source coin's decimals changed. `sourceAmountText`'s onChange
+            // only fires on TEXT edits, so without this the visible amount ("1")
+            // would keep the OLD coin's raw `draft.sourceAmount` (e.g. 1 BTC's
+            // 1e8 read as 1e-10 ETH). Reparse the visible text with the new coin's
+            // decimals so text ↔ draft stays consistent.
+            vm.amountChanged(parseLimitAmount(sourceAmountText, decimals: newCoin.decimals))
+        }
+    }
+
+    // MARK: - Sections
+
+    /// 1 — the pair. Collapsed summary: `Sell BTC · Buy ETH` (the pair is the
+    /// whole content of this section, so the summary is lossless).
+    private var assetSection: some View {
+        FormExpandableSection(
+            title: "limitSwap.asset".localized,
+            isValid: bothAssetsPicked,
+            showValue: focusedSection != .asset,
+            focusedField: $focusedSection,
+            focusedFieldEquals: .asset,
+            cornerRadius: 24,
+            plainSeparator: true,
+            onExpand: { isExpanded in
+                focusedSection = isExpanded ? .asset : nil
+            },
+            content: {
+                LimitAssetPickerForm(
+                    vm: vm,
+                    fromCoin: fromCoin,
+                    onPickFromAsset: onPickFromAsset,
+                    onPickToAsset: onPickToAsset,
+                    onSwapAssets: onSwapAssets
+                )
+            },
+            valueView: {
+                LimitAssetCompactValue(
+                    fromAsset: vm.draft.fromAsset,
+                    toAsset: vm.draft.toAsset
+                )
+            }
+        )
+    }
+
+    /// 2 — the trigger condition: target price + expiry. Expiry stays here (it
+    /// did not move to Amount) because both inputs answer the section's literal
+    /// question: a limit order executes when the price is met AND before the
+    /// expiry elapses. They are one condition with two clauses; the amount is a
+    /// separate concern.
+    ///
+    /// Collapsed summary: `$2,650.00 · 24h` — price in the unit the user is
+    /// currently editing in, plus the expiry the section also owns.
+    private var executeWhenSection: some View {
+        FormExpandableSection(
+            title: "limitSwap.executeWhen".localized,
+            isValid: vm.draft.targetPrice > 0,
+            showValue: focusedSection != .executeWhen && vm.draft.targetPrice > 0,
+            focusedField: $focusedSection,
+            focusedFieldEquals: .executeWhen,
+            cornerRadius: 24,
+            plainSeparator: true,
+            onExpand: { isExpanded in
+                focusedSection = isExpanded ? .executeWhen : nil
+            },
+            content: {
+                LimitExecuteWhenContent(
+                    vm: vm,
+                    priceText: $priceText,
+                    usdText: $usdText,
+                    onPickFromAsset: onPickFromAsset
+                )
+            },
+            valueView: {
+                LimitExecuteWhenCompactValue(
+                    targetPrice: vm.draft.targetPrice,
+                    displayUnit: vm.draft.displayUnit,
+                    toTicker: vm.draft.toAsset.ticker,
+                    targetUsdPricePerUnit: vm.targetUsdPricePerUnit,
+                    expiryHours: vm.draft.expiryHours
+                )
+            }
+        )
+    }
+
+    /// 3 — how much, and what that buys. Collapsed summary: `0.5 BTC → 12.75 ETH`
+    /// — the input and the reflected output together, because the pair of them is
+    /// the section's actual result (either alone is only half an answer).
+    private var amountSection: some View {
+        FormExpandableSection(
+            // Reuses the app-wide "amount" key rather than minting a
+            // limit-specific duplicate — it is already the established term for
+            // an amount field in every locale.
+            title: "amount".localized,
+            isValid: vm.draft.sourceAmount > 0,
+            showValue: focusedSection != .amount && vm.draft.sourceAmount > 0,
+            focusedField: $focusedSection,
+            focusedFieldEquals: .amount,
+            cornerRadius: 24,
+            plainSeparator: true,
+            onExpand: { isExpanded in
+                focusedSection = isExpanded ? .amount : nil
+            },
+            content: {
+                LimitAmountContent(
+                    vm: vm,
+                    fromCoin: fromCoin,
+                    sourceAmountText: $sourceAmountText,
+                    showAllPercentageButtons: $showAllPercentageButtons
+                )
+            },
+            valueView: {
+                LimitAmountCompactValue(
+                    sellAmount: fromCoin.decimal(for: vm.draft.sourceAmount),
+                    sellTicker: vm.draft.fromAsset.ticker,
+                    buyAmount: vm.expectedBuyAmount,
+                    buyTicker: vm.draft.toAsset.ticker
+                )
+            }
+        )
+    }
+
+    /// Asset section shows the collapsed summary + checkmark/pencil once the user
+    /// has a non-empty pair — true on launch since we seed from the host's coins.
+    private var bothAssetsPicked: Bool {
+        !vm.draft.fromAsset.ticker.isEmpty && !vm.draft.toAsset.ticker.isEmpty
+    }
+
+    private func formatPrice(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 8
+        formatter.usesGroupingSeparator = false
+        return formatter.string(from: NSDecimalNumber(decimal: value))
+            ?? NSDecimalNumber(decimal: value).stringValue
+    }
+
+    /// USD amount formatted for the editable USD field (no grouping separators
+    /// so it round-trips through `parseLimitPrice`).
+    private func formatUsdValue(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.usesGroupingSeparator = false
+        return formatter.string(from: NSDecimalNumber(decimal: value))
+            ?? NSDecimalNumber(decimal: value).stringValue
+    }
+
+    /// Re-derive `usdText` from the canonical target price, skipping the rewrite
+    /// when the current text already maps to `targetPrice` (so active USD typing
+    /// isn't clobbered — the mapping is exact because both sides divide the typed
+    /// USD by the same rate). Records the written value in `lastSyncedUsdText` so
+    /// the resulting `onChange(usdText)` is absorbed instead of feeding back.
+    private func syncUsdText(for targetPrice: Decimal) {
+        let newText: String
+        if vm.targetUsdPricePerUnit > 0 {
+            let mappedAsset = parseLimitPrice(usdText) / vm.targetUsdPricePerUnit
+            guard mappedAsset != targetPrice else { return }
+            let usd = targetPrice * vm.targetUsdPricePerUnit
+            newText = usd == 0 ? "" : formatUsdValue(usd)
+        } else {
+            guard !usdText.isEmpty else { return }
+            newText = ""
+        }
+        lastSyncedUsdText = newText
+        usdText = newText
+    }
+}
+
+// MARK: - Shared display formatting
+
+/// Fiat formatting for a read-only USD reflection (2 dp, grouped). Shared by the
+/// price display and the amount rows so the form has ONE fiat rendering.
+private func formatLimitUsd(_ value: Decimal) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.minimumFractionDigits = 2
+    formatter.maximumFractionDigits = 2
+    formatter.groupingSeparator = ","
+    return formatter.string(from: NSDecimalNumber(decimal: value)) ?? "0.00"
+}
+
+/// Display formatting for a read-only asset amount.
+///
+/// Capped at 8 fraction digits, which is EXACT rather than lossy for the value
+/// this renders most: a THORChain LIM is 1e8 fixed-point, so
+/// `vm.expectedBuyAmount` never carries more than 8 decimal places and no
+/// rounding occurs. That matters — this figure is a guaranteed MINIMUM, and a
+/// formatter that rounded the last place up would display a number the order
+/// does not actually guarantee.
+private func formatLimitAmount(_ value: Decimal) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.minimumFractionDigits = 0
+    formatter.maximumFractionDigits = 8
+    formatter.groupingSeparator = ","
+    return formatter.string(from: NSDecimalNumber(decimal: value))
+        ?? NSDecimalNumber(decimal: value).stringValue
+}
+
+// MARK: - Sell / Buy side
+
+/// Which side of the pair a row represents. Shared by the Asset section's picker
+/// rows and the Amount section's value rows so both stacked pairs get the same
+/// grouped-card geometry.
+private enum LimitSide {
+    case sell
+    case buy
+
+    var labelKey: String {
+        self == .sell ? "limitSwap.sell" : "limitSwap.buy"
+    }
+
+    var cornerRadii: RectangleCornerRadii {
+        // The top row of a stacked pair is rounded top-heavy and the bottom row
+        // bottom-heavy, so the two read as one grouped control.
+        switch self {
+        case .sell:
+            return .init(topLeading: 24, bottomLeading: 12, bottomTrailing: 12, topTrailing: 24)
+        case .buy:
+            return .init(topLeading: 12, bottomLeading: 24, bottomTrailing: 24, topTrailing: 12)
+        }
+    }
+}
+
+/// The bordered card both row kinds sit in.
+private extension View {
+    func limitRowCard(side: LimitSide) -> some View {
+        self
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                UnevenRoundedRectangle(cornerRadii: side.cornerRadii)
+                    .fill(Color.clear)
+                    .overlay(
+                        UnevenRoundedRectangle(cornerRadii: side.cornerRadii)
+                            .stroke(Theme.colors.borderLight, lineWidth: 1)
+                    )
+            )
+    }
+}
+
+// MARK: - Keyboard accessory
+//
+// The limit form's decimal-pad fields (Sell amount, target price) have no
+// return key, so they need a Done accessory to dismiss — the same mechanism the
+// market swap uses (`SwapPercentageButtons` + `hideKeyboard()`). The Sell field
+// passes the shared percentage buttons as leading content; the price field
+// passes none (Done only).
+
+private extension View {
+    @ViewBuilder
+    func limitKeyboardAccessory<Leading: View>(
+        @ViewBuilder leading: @escaping () -> Leading
+    ) -> some View {
+        #if os(iOS)
+        toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                leading()
+                Spacer()
+                Button {
+                    hideKeyboard()
+                } label: {
+                    Text("done".localized)
+                }
+            }
+        }
+        #else
+        self
+        #endif
+    }
+}
+
+// MARK: - Execute-when content (price display + toggle + presets + expiry)
+
+private struct LimitExecuteWhenContent: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    @Binding var priceText: String
+    @Binding var usdText: String
+    let onPickFromAsset: () -> Void
+
+    var body: some View {
+        VStack(spacing: 6) {
+            // Price + presets sit together (Figma gap-10) with the price box's
+            // 12pt bottom padding; the expiry sub-box follows with the 6pt
+            // content gap (→ ~18pt between the presets row and the expiry box).
+            VStack(spacing: 10) {
+                ZStack(alignment: .trailing) {
+                    LimitPriceDisplay(vm: vm, priceText: $priceText, usdText: $usdText, onPickFromAsset: onPickFromAsset)
+                    LimitPriceToggle(vm: vm)
+                        .padding(.trailing, 4)
+                }
+
+                LimitPresetPills(vm: vm)
+            }
+            .padding(.bottom, 12)
+
+            LimitExpiryRow(vm: vm)
+        }
+    }
+}
+
+// MARK: - Centered price display
+//
+// Market-reference line + "1 <fromTicker>" unit chip + the editable target price
+// with its USD equivalent. The editable field is ALWAYS bound to the target
+// price in the target asset's terms (the memo's LIM source) — the $/asset toggle
+// only swaps which representation is emphasized (large vs subtitle).
+//
+// NOTE (maintainer): Figma expresses the price as "1 <buyAsset> = $<usd>", which
+// inverts this per-unit-rate convention. Reconciling which representation is
+// canonical is a fund-safety-sensitive VM change that needs designer sign-off; it
+// is intentionally NOT guessed at here (a wrong inversion would place orders at
+// the reciprocal price).
+
+private struct LimitPriceDisplay: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    @Binding var priceText: String
+    @Binding var usdText: String
+    let onPickFromAsset: () -> Void
+
+    /// USD-mode editing is only offered when a USD rate for the target is known;
+    /// otherwise the USD value stays a read-only reflection.
+    private var usdEditable: Bool { vm.targetUsdPricePerUnit > 0 }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            marketReference
+
+            unitChip
+
+            // The primary/secondary representations swap on toggle; a new identity
+            // per unit + an opacity transition crossfades them (the toggle wraps
+            // the mutation in withAnimation). Storage of draft.targetPrice is
+            // unchanged — only which representation is emphasised.
+            priceValues
+                .id(vm.draft.displayUnit)
+                .transition(.opacity)
+        }
+        .frame(maxWidth: .infinity, minHeight: 180)
+        .padding(.vertical, 8)
+        // Done-only keyboard accessory for the decimal-pad target-price field
+        // (no percentages — the target price isn't balance-derived).
+        .limitKeyboardAccessory { EmptyView() }
+    }
+
+    @ViewBuilder
+    private var priceValues: some View {
+        VStack(spacing: 6) {
+            if vm.draft.displayUnit == .usd {
+                // USD mode: the emphasized value is the editable USD field (when a
+                // rate is known); the secondary is a read-only asset reflection.
+                if usdEditable {
+                    usdPriceField(font: Theme.fonts.priceTitle1, color: Theme.colors.textPrimary)
+                } else {
+                    Text(usdString)
+                        .font(Theme.fonts.priceTitle1)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                }
+                assetReflection(font: Theme.fonts.bodySMedium, color: Theme.colors.textTertiary)
+            } else {
+                // Asset mode: the emphasized value is the editable asset field; the
+                // secondary is the read-only USD reflection.
+                assetPriceField(font: Theme.fonts.priceTitle1, color: Theme.colors.textPrimary)
+                Text(usdString)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    /// Editable USD-denominated price field. Edits flow to the canonical
+    /// asset-terms `draft.targetPrice` via the parent's `usdText` sync + the VM's
+    /// `targetPriceChangedFromUsd` — the USD number is NEVER stored as the price.
+    private func usdPriceField(font: Font, color: Color) -> some View {
+        HStack(spacing: 2) {
+            Text("$")
+                .font(font)
+                .foregroundStyle(color)
+            TextField("0", text: $usdText.decimalOnly())
+                // `.plain` strips macOS's default bordered chrome (the dark bezel
+                // box); iOS is unaffected. Matches the market amount field, which
+                // uses PlainTextFieldStyle via `.borderlessTextFieldStyle()`.
+                .textFieldStyle(.plain)
+                .font(font)
+                .foregroundStyle(color)
+                .multilineTextAlignment(.center)
+                // `.fixedSize()` on BOTH axes so the field's frame collapses to its
+                // text — otherwise macOS keeps the field at its taller intrinsic
+                // height, so the caret/placeholder sit off the `$` baseline.
+                .fixedSize()
+                .lineLimit(1)
+                #if os(iOS)
+                .keyboardType(.decimalPad)
+                #endif
+        }
+    }
+
+    /// Read-only reflection of the canonical asset-terms price, shown as the
+    /// secondary value in USD mode (mirrors `priceText`, which the parent keeps in
+    /// sync with `draft.targetPrice`).
+    private func assetReflection(font: Font, color: Color) -> some View {
+        Text("\(priceText.isEmpty ? "0" : priceText) \(vm.draft.toAsset.ticker)")
+            .font(font)
+            .foregroundStyle(color)
+            .lineLimit(1)
+    }
+
+    @ViewBuilder
+    private var marketReference: some View {
+        if let market = vm.marketPriceRef, market > 0 {
+            Text(String(format: "limitSwap.executeWhen.marketReference".localized, marketString(market)))
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+        }
+    }
+
+    private var unitChip: some View {
+        // The "1 <sell>" chip: icon + tap target are the SELL (from) asset —
+        // the price is expressed as "1 <from> is worth <price> <to>", so the
+        // editable side here is the source. Tapping opens the from-asset picker.
+        Button(action: onPickFromAsset) {
+            HStack(spacing: 8) {
+                if !vm.draft.fromAsset.logo.isEmpty {
+                    AsyncImageView(
+                        logo: vm.draft.fromAsset.logo,
+                        size: CGSize(width: 24, height: 24),
+                        ticker: vm.draft.fromAsset.ticker,
+                        tokenChainLogo: vm.draft.fromAsset.chainLogo
+                    )
+                }
+                Text(String(format: "limitSwap.executeWhen.oneUnit".localized, vm.draft.fromAsset.ticker))
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textSecondary)
+            }
+            .padding(.leading, 6)
+            .padding(.trailing, 12)
+            .padding(.vertical, 6)
+            .overlay(
+                RoundedRectangle(cornerRadius: 99)
+                    .stroke(Theme.colors.borderLight, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func assetPriceField(font: Font, color: Color) -> some View {
+        HStack(spacing: 6) {
+            TextField("0", text: $priceText.decimalOnly())
+                // `.plain` strips macOS's default bordered chrome (the dark bezel
+                // box); iOS is unaffected. Matches the market amount field.
+                .textFieldStyle(.plain)
+                .font(font)
+                .foregroundStyle(color)
+                .multilineTextAlignment(.center)
+                // `.fixedSize()` on BOTH axes so the field's frame collapses to its
+                // text — otherwise macOS keeps the field at its taller intrinsic
+                // height, so the caret/placeholder sit off the ticker's baseline.
+                .fixedSize()
+                .lineLimit(1)
+                #if os(iOS)
+                .keyboardType(.decimalPad)
+                #endif
+            Text(vm.draft.toAsset.ticker)
+                .font(font)
+                .foregroundStyle(color)
+        }
+    }
+
+    /// USD equivalent of the target price (per the design-flags decision:
+    /// `targetPrice × targetUsdPricePerUnit`). Falls back to the asset-terms
+    /// value when no USD rate is available.
+    private var usdString: String {
+        guard vm.targetUsdPricePerUnit > 0, vm.draft.targetPrice > 0 else {
+            return "$0.00"
+        }
+        let usd = vm.draft.targetPrice * vm.targetUsdPricePerUnit
+        return "$\(formatLimitUsd(usd))"
+    }
+
+    private func marketString(_ market: Decimal) -> String {
+        if vm.targetUsdPricePerUnit > 0 {
+            return "$\(formatLimitUsd(market * vm.targetUsdPricePerUnit))"
+        }
+        return "\(market.formatForDisplay()) \(vm.draft.toAsset.ticker)"
+    }
+}
+
+// MARK: - $/asset toggle (two stacked circular buttons)
+
+private struct LimitPriceToggle: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    @Namespace private var thumb
+
+    var body: some View {
+        VStack(spacing: 2) {
+            // Top: the asset-terms view (Figma "circles" glyph — two interlocking
+            // rings). Bottom: the USD toggle ($, blue-filled when active).
+            toggleButton(unit: .asset, systemImage: "circlebadge.2")
+            toggleButton(unit: .usd, systemImage: "dollarsign.circle")
+        }
+        .padding(3)
+        .background(Theme.colors.bgSurface1)
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+    }
+
+    private func toggleButton(unit: PriceDisplayUnit, systemImage: String) -> some View {
+        let isActive = vm.draft.displayUnit == unit
+        return Button {
+            guard vm.draft.displayUnit != unit else { return }
+            // Animate the crossfade (price block) + the thumb slide together.
+            // Storage of draft.targetPrice is untouched — behaviour identical.
+            withAnimation(.easeInOut(duration: 0.2)) {
+                vm.toggleDisplayUnit()
+            }
+        } label: {
+            Image(systemName: systemImage)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(isActive ? Theme.colors.textPrimary : Theme.colors.textSecondary)
+                .frame(width: 32, height: 32)
+                .background {
+                    // The selected indicator is a single matched-geometry thumb, so
+                    // it slides between the two chips instead of hard-switching.
+                    if isActive {
+                        RoundedRectangle(cornerRadius: 18)
+                            .fill(Theme.colors.primaryAccent3)
+                            .matchedGeometryEffect(id: "thumb", in: thumb)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Expiry row (inside the Execute-when card)
+
+private struct LimitExpiryRow: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+
+    var body: some View {
+        HStack {
+            Text("limitSwap.expiry".localized)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+
+            Spacer()
+
+            HStack(spacing: 6) {
+                pill(titleKey: "limitSwap.expiry.12h", hours: 12)
+                pill(titleKey: "limitSwap.expiry.24h", hours: 24)
+                pill(titleKey: "limitSwap.expiry.3d", hours: 72)
+            }
+        }
+        .padding(14)
+        // Figma "backgrounds/disabled" (#0b1a3a80) — the design-system token
+        // with that exact base hex is bgButtonDisabled (#0b1a3a), at 50%.
+        .background(Theme.colors.bgButtonDisabled.opacity(0.5))
+        .clipShape(UnevenRoundedRectangle(cornerRadii: Self.corners))
+        .overlay(
+            UnevenRoundedRectangle(cornerRadii: Self.corners)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+    }
+
+    // Nests under the price area: small top corners, larger bottom corners that
+    // echo the enclosing card (Figma top-12 / bottom-16).
+    private static let corners = RectangleCornerRadii(
+        topLeading: 12, bottomLeading: 16, bottomTrailing: 16, topTrailing: 12
+    )
+
+    private func pill(titleKey: String, hours: Int) -> some View {
+        let isSelected = vm.draft.expiryHours == hours
+        return Button {
+            vm.selectExpiryHours(hours)
+        } label: {
+            Text(titleKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(isSelected ? Theme.colors.bgSurface2 : Color.clear)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 100)
+                        .stroke(Theme.colors.border, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 100))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Collapsed section summaries
+//
+// Rendered by FormExpandableSection as a section's value view while it is
+// collapsed. The checkmark / pencil affordances are supplied by
+// FormExpandableSection itself.
+
+/// Asset — `Sell <ticker> · Buy <ticker>`.
+private struct LimitAssetCompactValue: View {
+
+    let fromAsset: LimitSwapAsset
+    let toAsset: LimitSwapAsset
+
+    var body: some View {
+        HStack(spacing: 12) {
+            chip(labelKey: "limitSwap.sell", asset: fromAsset)
+            chip(labelKey: "limitSwap.buy", asset: toAsset)
+        }
+    }
+
+    private func chip(labelKey: String, asset: LimitSwapAsset) -> some View {
+        HStack(spacing: 4) {
+            Text(labelKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+            if !asset.logo.isEmpty {
+                AsyncImageView(
+                    logo: asset.logo,
+                    size: CGSize(width: 16, height: 16),
+                    ticker: asset.ticker,
+                    tokenChainLogo: asset.chainLogo
+                )
+            }
+            Text(asset.ticker)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+        }
+    }
+}
+
+/// Execute-when — `<price> · <expiry>`.
+///
+/// The price renders in whichever unit the user is currently editing in, so the
+/// collapsed value matches what they just typed. The pair context ("1 BTC =") is
+/// deliberately dropped: the Asset summary one row above already names the pair,
+/// and the section title frames this as the trigger — so omitting it keeps the
+/// value on one caption line instead of truncating.
+private struct LimitExecuteWhenCompactValue: View {
+
+    let targetPrice: Decimal
+    let displayUnit: PriceDisplayUnit
+    let toTicker: String
+    let targetUsdPricePerUnit: Decimal
+    let expiryHours: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(priceString)
+                .font(Theme.fonts.priceCaption)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            if let expiryKey {
+                Text(verbatim: "·")
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textTertiary)
+
+                Text(expiryKey.localized)
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textTertiary)
+            }
+        }
+    }
+
+    private var priceString: String {
+        if displayUnit == .usd, targetUsdPricePerUnit > 0 {
+            return "$\(formatLimitUsd(targetPrice * targetUsdPricePerUnit))"
+        }
+        return "\(formatLimitAmount(targetPrice)) \(toTicker)"
+    }
+
+    /// The expiry pills are the only writer of `expiryHours`, so these three
+    /// cases are exhaustive in practice; an unrecognized value drops the chip
+    /// rather than mislabel the order's lifetime.
+    private var expiryKey: String? {
+        switch expiryHours {
+        case 12: return "limitSwap.expiry.12h"
+        case 24: return "limitSwap.expiry.24h"
+        case 72: return "limitSwap.expiry.3d"
+        default: return nil
+        }
+    }
+}
+
+/// Amount — `<sell> <ticker> → <min buy> <ticker>`.
+private struct LimitAmountCompactValue: View {
+
+    let sellAmount: Decimal
+    let sellTicker: String
+    let buyAmount: Decimal
+    let buyTicker: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text("\(formatLimitAmount(sellAmount)) \(sellTicker)")
+                .font(Theme.fonts.priceCaption)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Image(systemName: "arrow.right")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            Text("\(formatLimitAmount(buyAmount)) \(buyTicker)")
+                .font(Theme.fonts.priceCaption)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+}
+
+// MARK: - Asset section content (Sell picker + swap button + Buy picker)
+//
+// Picker-only: this section's single job is choosing the pair, so the rows carry
+// no amounts. The WHOLE row is the tap target — the old layout had a chain chip
+// and a coin pill side by side that both opened the same picker, so collapsing
+// them into one control removes a redundant affordance rather than adding one.
+
+private struct LimitAssetPickerForm: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    let fromCoin: Coin
+    let onPickFromAsset: () -> Void
+    let onPickToAsset: () -> Void
+    let onSwapAssets: () -> Void
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 8) {
+                LimitAssetPickerRow(
+                    side: .sell,
+                    asset: vm.draft.fromAsset,
+                    balanceText: "\(fromCoin.balanceString) \(fromCoin.ticker)",
+                    onPickAsset: onPickFromAsset
+                )
+
+                LimitAssetPickerRow(
+                    side: .buy,
+                    asset: vm.draft.toAsset,
+                    balanceText: nil,
+                    onPickAsset: onPickToAsset
+                )
+            }
+
+            // Shared with the market swap form: same visual + spring flip. Drawn
+            // last so it wins hit-testing over the full-row picker buttons.
+            SwapAssetsButton {
+                onSwapAssets()
+            }
+        }
+    }
+}
+
+private struct LimitAssetPickerRow: View {
+
+    let side: LimitSide
+    let asset: LimitSwapAsset
+    /// Sell side only — the balance is decision-relevant when choosing what to
+    /// sell. `nil` on the buy side (holding the target asset is irrelevant).
+    let balanceText: String?
+    let onPickAsset: () -> Void
+
+    var body: some View {
+        Button(action: onPickAsset) {
+            HStack(spacing: 12) {
+                if !asset.logo.isEmpty {
+                    AsyncImageView(
+                        logo: asset.logo,
+                        size: CGSize(width: 36, height: 36),
+                        ticker: asset.ticker,
+                        tokenChainLogo: asset.chainLogo
+                    )
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(asset.ticker)
+                        .font(Theme.fonts.bodyMMedium)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                        .lineLimit(1)
+
+                    Text(asset.chain.name)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 12)
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(side.labelKey.localized)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+
+                    if let balanceText {
+                        Text(balanceText)
+                            .font(Theme.fonts.priceCaption)
+                            .foregroundStyle(Theme.colors.textSecondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Theme.colors.textTertiary)
+            }
+            .limitRowCard(side: side)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Amount section content (Sell amount + reflected minimum output)
+
+private struct LimitAmountContent: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    let fromCoin: Coin
+    @Binding var sourceAmountText: String
+    @Binding var showAllPercentageButtons: Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            LimitAmountRow(
+                side: .sell,
+                labelKey: "limitSwap.sell",
+                asset: vm.draft.fromAsset,
+                amountText: $sourceAmountText,
+                amountIsEditable: true,
+                computedAmount: nil,
+                usdPricePerUnit: Decimal(fromCoin.price),
+                balanceText: "\(fromCoin.balanceString) \(fromCoin.ticker)"
+            )
+            // Reuse the market swap's percentage buttons + Done accessory on
+            // the Sell amount keyboard. Attached to the row (an ancestor of
+            // the field) so it scopes to the sell amount's editing session.
+            .limitKeyboardAccessory {
+                SwapPercentageButtons(
+                    show100: !fromCoin.isNativeToken,
+                    showAllPercentageButtons: $showAllPercentageButtons,
+                    onTap: handleSellPercentage
+                )
+            }
+
+            LimitAmountRow(
+                side: .buy,
+                labelKey: "limitSwap.youReceiveAtLeast",
+                asset: vm.draft.toAsset,
+                amountText: .constant(formattedBuyAmount),
+                amountIsEditable: false,
+                computedAmount: buyAmountDecimal,
+                usdPricePerUnit: vm.targetUsdPricePerUnit,
+                balanceText: nil
+            )
+        }
+    }
+
+    /// Sets the Sell amount to `pct`% of the source balance. Assigns the field
+    /// text (its `onChange` funnels the value into `draft.sourceAmount`); the
+    /// balance math + formatting live in the VM (market parity).
+    private func handleSellPercentage(_ pct: Int) {
+        showAllPercentageButtons = false
+        sourceAmountText = vm.sourceAmountText(forPercentage: pct, of: fromCoin)
+    }
+
+    /// The reflected output — the VM derives it from the signed `computeLim`
+    /// path, so it is the exact minimum the order guarantees and can never read
+    /// higher than what the memo encodes. `nil` when not yet computable (row
+    /// shows "0"). No math happens in this view.
+    private var buyAmountDecimal: Decimal? {
+        let amount = vm.expectedBuyAmount
+        return amount > 0 ? amount : nil
+    }
+
+    private var formattedBuyAmount: String {
+        guard let amount = buyAmountDecimal else { return "0" }
+        return formatLimitAmount(amount)
+    }
+}
+
+/// One amount row: an identity chip on the left, the number + its fiat value on
+/// the right. Used for both the editable Sell amount and the read-only reflected
+/// output, which are deliberately given the SAME visual weight — "you sell this,
+/// you get at least that" is the section's whole message, and demoting the
+/// reflection would bury the half of it the user can't control.
+private struct LimitAmountRow: View {
+
+    let side: LimitSide
+    let labelKey: String
+    let asset: LimitSwapAsset
+    @Binding var amountText: String
+    let amountIsEditable: Bool
+    /// Pre-derived amount for a read-only row, used for the fiat sub-line so it
+    /// doesn't re-parse the formatted (grouped) display text. `nil` on an
+    /// editable row, whose fiat line parses the field itself.
+    let computedAmount: Decimal?
+    let usdPricePerUnit: Decimal
+    let balanceText: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(labelKey.localized)
+                    .font(Theme.fonts.caption12)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 8)
+
+                if let balanceText {
+                    Text(balanceText)
+                        .font(Theme.fonts.priceCaption)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            HStack(alignment: .center, spacing: 12) {
+                assetChip
+
+                Spacer(minLength: 12)
+
+                VStack(alignment: .trailing, spacing: 4) {
+                    amountValue
+
+                    Text(fiatLine)
+                        .font(Theme.fonts.priceCaption)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .limitRowCard(side: side)
+    }
+
+    /// Non-interactive: picking the pair is the Asset section's job. Here the
+    /// coin is a label that tells you what the number is denominated in, not a
+    /// control.
+    private var assetChip: some View {
+        HStack(spacing: 8) {
+            if !asset.logo.isEmpty {
+                AsyncImageView(
+                    logo: asset.logo,
+                    size: CGSize(width: 28, height: 28),
+                    ticker: asset.ticker,
+                    tokenChainLogo: asset.chainLogo
+                )
+            }
+            Text(asset.ticker)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+                .lineLimit(1)
+        }
+        .padding(.leading, 6)
+        .padding(.trailing, 12)
+        .padding(.vertical, 6)
+        .background(Theme.colors.bgSurface2)
+        .clipShape(Capsule())
+    }
+
+    @ViewBuilder
+    private var amountValue: some View {
+        if amountIsEditable {
+            TextField("0", text: $amountText.decimalOnly())
+                // `.plain` strips macOS's default bordered chrome (the dark bezel
+                // box); iOS is unaffected. Matches the market amount field.
+                .textFieldStyle(.plain)
+                .font(Theme.fonts.priceTitle1)
+                .foregroundStyle(Theme.colors.textPrimary)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(1)
+                #if os(iOS)
+                .keyboardType(.decimalPad)
+                #endif
+        } else {
+            Text(amountText)
+                .font(Theme.fonts.priceTitle1)
+                .foregroundStyle(Theme.colors.textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+        }
+    }
+
+    private var fiatLine: String {
+        let amount = effectiveAmount
+        guard usdPricePerUnit > 0, amount > 0 else { return "$0.00" }
+        return "$\(formatLimitUsd(amount * usdPricePerUnit))"
+    }
+
+    private var effectiveAmount: Decimal {
+        if let computedAmount {
+            return computedAmount
+        }
+        // Locale-aware so the fiat sub-line doesn't mis-read a pasted grouped
+        // number (shares the parser the amount field itself uses).
+        return parseLimitDecimal(amountText)
+    }
+}
+
+// MARK: - Preset pills
+//
+// The +1% / +5% / +10% pills are always static. The Market pill is dynamic but
+// only after a *manual* edit — while any preset is the live source it stays
+// static "Market". Uses `LimitPillFlow` so it wraps to a second row when the
+// dynamic Market pill's content grows.
+
+private struct LimitPresetPills: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+
+    var body: some View {
+        // Figma lays the four presets out as equal-width pills filling the row.
+        HStack(spacing: 6) {
+            marketPill
+            staticPill(titleKey: "limitSwap.preset.plus1", pct: 1)
+            staticPill(titleKey: "limitSwap.preset.plus5", pct: 5)
+            staticPill(titleKey: "limitSwap.preset.plus10", pct: 10)
+        }
+    }
+
+    @ViewBuilder
+    private var marketPill: some View {
+        let rounded = roundedPctFromMarket
+        let renderStatic = vm.lastPresetPct != nil || rounded == 0
+        Button {
+            dismissKeyboard()
+            vm.selectPresetPct(0)
+        } label: {
+            HStack(spacing: 4) {
+                if renderStatic {
+                    Text("limitSwap.preset.market".localized)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textSecondary)
+                } else {
+                    Text(formatRoundedPct(rounded))
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textSecondary)
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Theme.colors.textTertiary)
+                }
+            }
+            .lineLimit(1)
+            .minimumScaleFactor(0.85)
+            .pillShape()
+        }
+        .buttonStyle(.plain)
+        .disabled(vm.marketPriceRef == nil)
+    }
+
+    private func staticPill(titleKey: String, pct: Int) -> some View {
+        Button {
+            dismissKeyboard()
+            vm.selectPresetPct(pct)
+        } label: {
+            Text(titleKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+                .pillShape()
+        }
+        .buttonStyle(.plain)
+        .disabled(vm.marketPriceRef == nil)
+    }
+
+    private var roundedPctFromMarket: Decimal {
+        guard vm.marketPriceRef != nil, vm.draft.targetPrice > 0 else { return 0 }
+        var doubled = vm.pctFromMarket * 2
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &doubled, 0, .plain)
+        return rounded / 2
+    }
+
+    private func formatRoundedPct(_ pct: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 1
+        formatter.maximumFractionDigits = 1
+        formatter.positivePrefix = "+"
+        let value = formatter.string(from: NSDecimalNumber(decimal: pct)) ?? "0"
+        return "\(value)%"
+    }
+
+    private func dismissKeyboard() {
+        #if os(iOS)
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+        #endif
+    }
+}
+
+// MARK: - Preset pill shape
+//
+// Equal-width rounded outline used by every Execute-when preset pill so the row
+// distributes them evenly (Figma lays them out flex-1).
+
+private extension View {
+    func pillShape() -> some View {
+        self
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity)
+            .overlay(
+                RoundedRectangle(cornerRadius: 100)
+                    .stroke(Theme.colors.borderLight, lineWidth: 1)
+            )
+    }
+}
+
+// MARK: - Advanced Swap Queue unavailable row
+//
+// Shown when the `EnableAdvSwapQueue` mimir is resolved-disabled: THORChain
+// isn't accepting resting `=<` limit orders right now, so placement is blocked
+// (fail-closed).
+
+private struct LimitUnavailableRow: View {
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.octagon.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text("limitSwap.error.advancedSwapQueueDisabled".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Generic blocking-notice row
+//
+// A message-driven sibling of `LimitUnavailableRow`, used for the pair-not-
+// routable / unsupported-asset gate: the coin picker filters by CHAIN
+// routability only, so a poolless pair (e.g. RUNE→VULT) slips through — the
+// market-price probe's failure surfaces here (previously `marketPriceError` was
+// never rendered) and the Place CTA is disabled while it shows.
+
+private struct LimitNoticeRow: View {
+
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.octagon.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text(message)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Warning row
+
+private struct LimitWarningRow: View {
+
+    let warning: LimitSwapWarning
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text(messageKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var messageKey: String {
+        switch warning {
+        case .priceAtOrBelowMarket:
+            return "limitSwap.warning.priceAtOrBelowMarket"
+        case .priceFarAboveMarket:
+            return "limitSwap.warning.priceFarAboveMarket"
+        }
+    }
+}
+
+private extension Binding where Value == String {
+    /// Wrap a text binding so an edit is accepted only when it is a valid numeric
+    /// input (`isDecimalInput`). The price/amount fields then reject any letter or
+    /// symbol — whether typed or pasted — instead of silently keeping its digits,
+    /// which matches what the iOS `.decimalPad` enforces for free (macOS has no
+    /// such keypad). A rejected edit leaves the prior value untouched.
+    func decimalOnly() -> Binding<String> {
+        Binding<String>(
+            get: { wrappedValue },
+            set: { newValue in
+                if newValue.isDecimalInput() { wrappedValue = newValue }
+            }
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyUniswapView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyUniswapView.swift
@@ -1,0 +1,1168 @@
+//
+//  LimitSwapBodyUniswapView.swift
+//  VultisigApp
+//
+
+import BigInt
+import SwiftUI
+
+/// Corner radius for the limit form's standalone peer sections (price card,
+/// expiry card). This is the OUTER radius of the market swap's reusable section
+/// (`SwapFromToField`), so the limit form speaks the same radius language as the
+/// rest of swap. `SwapFromToField`'s uneven 24/12 shape exists only because its
+/// from/to fields are a stacked PAIR that must read as one unit (24 outside, 12
+/// where they meet) — a standalone card has no neighbour to meet, so it takes the
+/// outer 24 on all corners. The paired Sell/Buy rows below keep the uneven
+/// pairing shape (see `LimitAssetRowKind.cornerRadii`).
+private let limitSectionCornerRadius: CGFloat = 24
+
+/// Corner radius for the inline notice/warning rows. Deliberately NOT the section
+/// radius: these rows are single-line annotations (~39pt tall), and a 24pt radius
+/// exceeds half their height, degenerating the shape into a capsule and making
+/// them read as pills rather than as messages.
+private let limitNoticeCornerRadius: CGFloat = 12
+
+/// Limit-swap body content — renders inside `SwapCryptoView` when the
+/// SegmentedControl is set to Limit. **Uniswap-style flat layout**: the price
+/// card ("When 1 <sell> is worth <price> <buy>" + Market/+1%/+5%/+10% pills) on
+/// top, the asset swap form (Sell + swap button + Buy) below it, then the expiry
+/// card, then the inline notices, with the Place-Order CTA pinned to the bottom.
+/// No collapse/expand — every input is visible at once, so the price and the
+/// amount it applies to are never hidden behind a chevron.
+///
+/// All business logic lives in `LimitSwapFormViewModel`; this view is
+/// declarative. The price field always edits `draft.targetPrice` in the target
+/// asset's terms (the value the signed memo's LIM is derived from) — the $/asset
+/// toggle only changes which representation is emphasized, never how the price is
+/// stored, so the memo math is never at risk.
+struct LimitSwapBodyUniswapView: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    let fromCoin: Coin
+    let toCoin: Coin
+
+    @State private var sourceAmountText: String = ""
+    @State private var priceText: String = ""
+    /// USD-mode mirror of `priceText`. Editable in USD mode; kept in sync with
+    /// `draft.targetPrice` (× the target USD rate) so switching modes shows the
+    /// right value. The canonical price stays `draft.targetPrice` (asset terms).
+    @State private var usdText: String = ""
+    /// The last value written to `usdText` PROGRAMMATICALLY (by `syncUsdText`).
+    /// `onChange(usdText)` absorbs this one echo so a preset/rate/mode redraw of
+    /// the USD field can't round-trip through the 2-dp USD display and mutate the
+    /// canonical asset-terms price. `nil` once absorbed → the next change is a
+    /// genuine user edit.
+    @State private var lastSyncedUsdText: String?
+    /// Mirrors the market swap: reset to `true` on a manual amount edit so the
+    /// shared `SwapPercentageButtons` clears its selected-pill highlight.
+    @State private var showAllPercentageButtons = true
+
+    let onPickFromAsset: () -> Void
+    let onPickToAsset: () -> Void
+    let onSwapAssets: () -> Void
+    let onPlaceOrder: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 12) {
+                    LimitPriceCard(
+                        vm: vm,
+                        priceText: $priceText,
+                        usdText: $usdText,
+                        onPickFromAsset: onPickFromAsset,
+                        onPickToAsset: onPickToAsset
+                    )
+
+                    LimitAssetSwapForm(
+                        vm: vm,
+                        fromCoin: fromCoin,
+                        toCoin: toCoin,
+                        sourceAmountText: $sourceAmountText,
+                        showAllPercentageButtons: $showAllPercentageButtons,
+                        onPickFromAsset: onPickFromAsset,
+                        onPickToAsset: onPickToAsset,
+                        onSwapAssets: onSwapAssets
+                    )
+
+                    LimitExpiryCard(vm: vm)
+
+                    if vm.advancedSwapQueueEnabled == false {
+                        LimitUnavailableRow()
+                    }
+
+                    if let unroutable = vm.pairUnroutableReason {
+                        LimitNoticeRow(message: unroutable.message)
+                    }
+
+                    if let warning = vm.displayedWarning {
+                        LimitWarningRow(warning: warning)
+                    }
+                }
+            }
+
+            PrimaryButton(
+                title: "limitSwap.placeOrder".localized,
+                action: onPlaceOrder
+            )
+            .disabled(!vm.canPlaceOrder)
+            .padding(.bottom, 16)
+        }
+        .onLoad {
+            // Reflect an already-populated draft in the editable fields on first
+            // appear — otherwise they only sync via onChange and read empty
+            // until the user edits them.
+            if priceText.isEmpty, vm.draft.targetPrice > 0 {
+                priceText = formatPrice(vm.draft.targetPrice)
+            }
+            if usdText.isEmpty, vm.draft.targetPrice > 0, vm.targetUsdPricePerUnit > 0 {
+                let text = formatUsdValue(vm.draft.targetPrice * vm.targetUsdPricePerUnit)
+                lastSyncedUsdText = text
+                usdText = text
+            }
+            if sourceAmountText.isEmpty, vm.draft.sourceAmount > 0 {
+                sourceAmountText = formatPrice(fromCoin.decimal(for: vm.draft.sourceAmount))
+            }
+        }
+        .onChange(of: sourceAmountText) { _, newText in
+            vm.amountChanged(parseLimitAmount(newText, decimals: vm.draft.fromAsset.decimals))
+            // A manual edit clears the selected-percentage highlight (market parity).
+            showAllPercentageButtons = true
+        }
+        .onChange(of: priceText) { _, newText in
+            let parsed = parseLimitPrice(newText)
+            if parsed != vm.draft.targetPrice {
+                vm.targetPriceChanged(parsed)
+            }
+        }
+        .onChange(of: usdText) { _, newText in
+            // Convert USD → canonical asset-terms price only while USD is the
+            // ACTIVE (editable) representation. In asset mode `usdText` is synced
+            // in the background; gating on the mode stops that from feeding back.
+            guard vm.draft.displayUnit == .usd else { return }
+            // Absorb the one echo of a programmatic sync so a preset/rate/mode
+            // redraw of the USD field can't round the canonical price through the
+            // 2-dp USD display (or silently clear the active preset).
+            let synced = lastSyncedUsdText
+            lastSyncedUsdText = nil
+            guard isUserUsdPriceEdit(newText: newText, lastSyncedText: synced) else { return }
+            vm.targetPriceChangedFromUsd(parseLimitPrice(newText))
+        }
+        .onChange(of: vm.draft.targetPrice) { _, newPrice in
+            // Sync vm → text only when the local text doesn't already parse to the
+            // same Decimal. Preserves a trailing "." while typing and reflects
+            // preset-pill taps that mutate vm.
+            if parseLimitPrice(priceText) != newPrice {
+                priceText = newPrice == 0 ? "" : formatPrice(newPrice)
+            }
+            syncUsdText(for: newPrice)
+        }
+        .onChange(of: vm.targetUsdPricePerUnit) { _, _ in
+            // The target asset (and thus its USD rate) changed — re-derive the USD
+            // field from the unchanged canonical price.
+            syncUsdText(for: vm.draft.targetPrice)
+        }
+        .onChange(of: fromCoin) { _, newCoin in
+            // The source coin's decimals changed. `sourceAmountText`'s onChange
+            // only fires on TEXT edits, so without this the visible amount ("1")
+            // would keep the OLD coin's raw `draft.sourceAmount` (e.g. 1 BTC's
+            // 1e8 read as 1e-10 ETH). Reparse the visible text with the new coin's
+            // decimals so text ↔ draft stays consistent.
+            vm.amountChanged(parseLimitAmount(sourceAmountText, decimals: newCoin.decimals))
+        }
+    }
+
+    private func formatPrice(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 8
+        formatter.usesGroupingSeparator = false
+        return formatter.string(from: NSDecimalNumber(decimal: value))
+            ?? NSDecimalNumber(decimal: value).stringValue
+    }
+
+    /// USD amount formatted for the editable USD field (no grouping separators
+    /// so it round-trips through `parseLimitPrice`).
+    private func formatUsdValue(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.usesGroupingSeparator = false
+        return formatter.string(from: NSDecimalNumber(decimal: value))
+            ?? NSDecimalNumber(decimal: value).stringValue
+    }
+
+    /// Re-derive `usdText` from the canonical target price, skipping the rewrite
+    /// when the current text already maps to `targetPrice` (so active USD typing
+    /// isn't clobbered — the mapping is exact because both sides divide the typed
+    /// USD by the same rate). Records the written value in `lastSyncedUsdText` so
+    /// the resulting `onChange(usdText)` is absorbed instead of feeding back.
+    private func syncUsdText(for targetPrice: Decimal) {
+        let newText: String
+        if vm.targetUsdPricePerUnit > 0 {
+            let mappedAsset = parseLimitPrice(usdText) / vm.targetUsdPricePerUnit
+            guard mappedAsset != targetPrice else { return }
+            let usd = targetPrice * vm.targetUsdPricePerUnit
+            newText = usd == 0 ? "" : formatUsdValue(usd)
+        } else {
+            guard !usdText.isEmpty else { return }
+            newText = ""
+        }
+        lastSyncedUsdText = newText
+        usdText = newText
+    }
+}
+
+// MARK: - Keyboard accessory
+//
+// The limit form's decimal-pad fields (Sell amount, target price) have no
+// return key, so they need a Done accessory to dismiss — the same mechanism the
+// market swap uses (`SwapPercentageButtons` + `hideKeyboard()`). The Sell field
+// passes the shared percentage buttons as leading content; the price field
+// passes none (Done only).
+
+private extension View {
+    @ViewBuilder
+    func limitKeyboardAccessory<Leading: View>(
+        @ViewBuilder leading: @escaping () -> Leading
+    ) -> some View {
+        #if os(iOS)
+        toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                leading()
+                Spacer()
+                Button {
+                    hideKeyboard()
+                } label: {
+                    Text("done".localized)
+                }
+            }
+        }
+        #else
+        self
+        #endif
+    }
+}
+
+// MARK: - Limit price card (Uniswap-style, flat)
+//
+// Header: "When 1 [icon] <TICKER> is worth" (LimitExecuteWhenTitle) — the icon +
+// ticker are tappable and open the from-asset picker; the $/asset toggle sits at
+// the trailing edge of the same row. Body: the large editable price on the left,
+// the target [icon] TICKER button on the right (tappable → to-asset picker), with
+// the secondary representation beneath it. Then the market reference line, then
+// the preset pills (the Market pill is dynamic — see LimitPresetPills).
+//
+// The editable field is ALWAYS bound to the target price in the target asset's
+// terms (the memo's LIM source) — the $/asset toggle only swaps which
+// representation is emphasized (large vs subtitle).
+//
+// NOTE (maintainer): Figma expresses the price as "1 <buyAsset> = $<usd>", which
+// inverts this per-unit-rate convention. Reconciling which representation is
+// canonical is a fund-safety-sensitive VM change that needs designer sign-off; it
+// is intentionally NOT guessed at here (a wrong inversion would place orders at
+// the reciprocal price).
+
+private struct LimitPriceCard: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    @Binding var priceText: String
+    @Binding var usdText: String
+    let onPickFromAsset: () -> Void
+    let onPickToAsset: () -> Void
+
+    /// USD-mode editing is only offered when a USD rate for the target is known;
+    /// otherwise the USD value stays a read-only reflection.
+    private var usdEditable: Bool { vm.targetUsdPricePerUnit > 0 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center) {
+                LimitExecuteWhenTitle(
+                    asset: vm.draft.fromAsset,
+                    onTapAsset: onPickFromAsset
+                )
+
+                Spacer(minLength: 8)
+
+                LimitPriceToggle(vm: vm)
+            }
+
+            HStack(alignment: .center) {
+                // The primary/secondary representations swap on toggle; a new
+                // identity per unit + an opacity transition crossfades them (the
+                // toggle wraps the mutation in withAnimation). Storage of
+                // draft.targetPrice is unchanged — only which representation is
+                // emphasised.
+                priceValues
+                    .id(vm.draft.displayUnit)
+                    .transition(.opacity)
+
+                Spacer(minLength: 8)
+
+                // The trailing chip names the unit the price is quoted in AND
+                // opens the to-asset picker — the flat layout's stand-in for the
+                // accordion's inline ticker label.
+                LimitAssetChip(
+                    asset: vm.draft.toAsset,
+                    iconSize: 20,
+                    font: Theme.fonts.priceBodyL,
+                    action: onPickToAsset
+                )
+            }
+
+            LimitPresetPills(vm: vm)
+        }
+        .padding(16)
+        .overlay(
+            RoundedRectangle(cornerRadius: limitSectionCornerRadius)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: limitSectionCornerRadius))
+        // Done-only keyboard accessory for the decimal-pad target-price field
+        // (no percentages — the target price isn't balance-derived).
+        .limitKeyboardAccessory { EmptyView() }
+    }
+
+    @ViewBuilder
+    private var priceValues: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if vm.draft.displayUnit == .usd {
+                // USD mode: the emphasized value is the editable USD field (when a
+                // rate is known); the secondary is a read-only asset reflection.
+                if usdEditable {
+                    usdPriceField(font: Theme.fonts.priceTitle1, color: Theme.colors.textPrimary)
+                } else {
+                    Text(usdString)
+                        .font(Theme.fonts.priceTitle1)
+                        .foregroundStyle(Theme.colors.textPrimary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                }
+                assetReflection(font: Theme.fonts.bodySMedium, color: Theme.colors.textTertiary)
+            } else {
+                // Asset mode: the emphasized value is the editable asset field; the
+                // secondary is the read-only USD reflection.
+                assetPriceField(font: Theme.fonts.priceTitle1, color: Theme.colors.textPrimary)
+                Text(usdString)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    /// Editable USD-denominated price field. Edits flow to the canonical
+    /// asset-terms `draft.targetPrice` via the parent's `usdText` sync + the VM's
+    /// `targetPriceChangedFromUsd` — the USD number is NEVER stored as the price.
+    private func usdPriceField(font: Font, color: Color) -> some View {
+        HStack(spacing: 2) {
+            Text("$")
+                .font(font)
+                .foregroundStyle(color)
+            TextField("0", text: $usdText.decimalOnly())
+                // `.plain` strips macOS's default bordered chrome (the dark bezel
+                // box); iOS is unaffected. Matches the market amount field, which
+                // uses PlainTextFieldStyle via `.borderlessTextFieldStyle()`.
+                .textFieldStyle(.plain)
+                .font(font)
+                .foregroundStyle(color)
+                .multilineTextAlignment(.leading)
+                // `.fixedSize()` on BOTH axes so the field's frame collapses to its
+                // text — otherwise macOS keeps the field at its taller intrinsic
+                // height, so the caret/placeholder sit off the `$` baseline.
+                .fixedSize()
+                .lineLimit(1)
+                #if os(iOS)
+                .keyboardType(.decimalPad)
+                #endif
+        }
+    }
+
+    /// Editable asset-terms price field — the canonical `draft.targetPrice`. The
+    /// unit it is quoted in is named by the adjacent `targetAssetButton`.
+    private func assetPriceField(font: Font, color: Color) -> some View {
+        TextField("0", text: $priceText.decimalOnly())
+            // `.plain` strips macOS's default bordered chrome (the dark bezel box);
+            // iOS is unaffected. Matches the market amount field.
+            .textFieldStyle(.plain)
+            .font(font)
+            .foregroundStyle(color)
+            .multilineTextAlignment(.leading)
+            // `.fixedSize()` on BOTH axes so the field's frame collapses to its
+            // text — otherwise macOS keeps the field at its taller intrinsic
+            // height, so the caret/placeholder sit off the target-asset button's
+            // baseline.
+            .fixedSize()
+            .lineLimit(1)
+            #if os(iOS)
+            .keyboardType(.decimalPad)
+            #endif
+    }
+
+    /// Read-only reflection of the canonical asset-terms price, shown as the
+    /// secondary value in USD mode (mirrors `priceText`, which the parent keeps in
+    /// sync with `draft.targetPrice`).
+    private func assetReflection(font: Font, color: Color) -> some View {
+        Text("\(priceText.isEmpty ? "0" : priceText) \(vm.draft.toAsset.ticker)")
+            .font(font)
+            .foregroundStyle(color)
+            .lineLimit(1)
+    }
+
+    /// USD equivalent of the target price (per the design-flags decision:
+    /// `targetPrice × targetUsdPricePerUnit`). Falls back to the asset-terms
+    /// value when no USD rate is available.
+    private var usdString: String {
+        guard vm.targetUsdPricePerUnit > 0, vm.draft.targetPrice > 0 else {
+            return "$0.00"
+        }
+        let usd = vm.draft.targetPrice * vm.targetUsdPricePerUnit
+        return "$\(formatUsd(usd))"
+    }
+
+    private func formatUsd(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        formatter.groupingSeparator = ","
+        return formatter.string(from: NSDecimalNumber(decimal: value)) ?? "0.00"
+    }
+}
+
+// MARK: - Tappable asset chip
+//
+// The shared construction behind BOTH asset-picker chips in the price card (the
+// "When 1 [chip] is worth" source chip and the trailing target chip), so the two
+// stay symmetric with each other. Matches the established asset-pill style used by
+// `LimitAssetRow` — filled `bgSurface2` capsule with the 6/12/6 padding — so the
+// fill (not just a border) is what signals "tappable". Only the icon size + font
+// vary, tied to the type scale of the row each chip sits in.
+
+private struct LimitAssetChip: View {
+
+    let asset: LimitSwapAsset
+    let iconSize: CGFloat
+    let font: Font
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if !asset.logo.isEmpty {
+                    AsyncImageView(
+                        logo: asset.logo,
+                        size: CGSize(width: iconSize, height: iconSize),
+                        ticker: asset.ticker,
+                        tokenChainLogo: asset.chainLogo
+                    )
+                }
+                Text(asset.ticker)
+                    .font(font)
+                    .foregroundStyle(Theme.colors.textPrimary)
+            }
+            .padding(.leading, 6)
+            .padding(.trailing, 12)
+            .padding(.vertical, 6)
+            .background(Theme.colors.bgSurface2)
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Execute When card title
+//
+// "When 1 [icon] <TICKER> is worth" — the icon + ticker reference the source
+// asset (the thing being sold) and are tappable as a single chip that opens the
+// from-asset picker.
+
+private struct LimitExecuteWhenTitle: View {
+
+    let asset: LimitSwapAsset
+    let onTapAsset: () -> Void
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text("limitSwap.executeWhen.headerWhenOne".localized)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+
+            LimitAssetChip(
+                asset: asset,
+                iconSize: 16,
+                font: Theme.fonts.bodySMedium,
+                action: onTapAsset
+            )
+
+            Text("limitSwap.executeWhen.headerIsWorth".localized)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+        }
+        .lineLimit(1)
+    }
+}
+
+// MARK: - $/asset toggle (two side-by-side circular buttons)
+//
+// Laid out horizontally so the price card spends its vertical budget on the price
+// itself — the flat layout stacks every section, so vertical space is the scarce
+// axis. The matched-geometry thumb is layout-agnostic: it interpolates the
+// selected indicator's frame between the two chips, so it now slides on the X axis
+// instead of Y with no change to the animation itself.
+
+private struct LimitPriceToggle: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    @Namespace private var thumb
+
+    var body: some View {
+        HStack(spacing: 2) {
+            // Leading: the asset-terms view (Figma "circles" glyph — two
+            // interlocking rings). Trailing: the USD toggle ($, blue-filled when
+            // active).
+            toggleButton(unit: .asset, systemImage: "circlebadge.2")
+            toggleButton(unit: .usd, systemImage: "dollarsign.circle")
+        }
+        .padding(3)
+        .background(Theme.colors.bgSurface1)
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+    }
+
+    private func toggleButton(unit: PriceDisplayUnit, systemImage: String) -> some View {
+        let isActive = vm.draft.displayUnit == unit
+        return Button {
+            guard vm.draft.displayUnit != unit else { return }
+            // Animate the crossfade (price block) + the thumb slide together.
+            // Storage of draft.targetPrice is untouched — behaviour identical.
+            withAnimation(.easeInOut(duration: 0.2)) {
+                vm.toggleDisplayUnit()
+            }
+        } label: {
+            Image(systemName: systemImage)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(isActive ? Theme.colors.textPrimary : Theme.colors.textSecondary)
+                .frame(width: 32, height: 32)
+                .background {
+                    // The selected indicator is a single matched-geometry thumb, so
+                    // it slides between the two chips instead of hard-switching.
+                    if isActive {
+                        RoundedRectangle(cornerRadius: 18)
+                            .fill(Theme.colors.primaryAccent3)
+                            .matchedGeometryEffect(id: "thumb", in: thumb)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Expiry card
+//
+// Its own flat card in the Uniswap layout (rather than a sub-box nested inside
+// the price card), so the expiry choice reads as a peer of the price and the
+// asset rather than a detail of the price.
+
+private struct LimitExpiryCard: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+
+    var body: some View {
+        HStack {
+            Text("limitSwap.expiry".localized)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+
+            Spacer()
+
+            HStack(spacing: 6) {
+                pill(titleKey: "limitSwap.expiry.12h", hours: 12)
+                pill(titleKey: "limitSwap.expiry.24h", hours: 24)
+                pill(titleKey: "limitSwap.expiry.3d", hours: 72)
+            }
+        }
+        .padding(14)
+        .overlay(
+            RoundedRectangle(cornerRadius: limitSectionCornerRadius)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: limitSectionCornerRadius))
+    }
+
+    private func pill(titleKey: String, hours: Int) -> some View {
+        let isSelected = vm.draft.expiryHours == hours
+        return Button {
+            vm.selectExpiryHours(hours)
+        } label: {
+            Text(titleKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(isSelected ? Theme.colors.bgSurface2 : Color.clear)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 100)
+                        .stroke(Theme.colors.border, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 100))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Asset swap form (Sell + middle swap button + Buy)
+//
+// A flat card in the Uniswap layout — always visible alongside the price, so the
+// amount the target price applies to is never hidden.
+
+private struct LimitAssetSwapForm: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+    let fromCoin: Coin
+    let toCoin: Coin
+    @Binding var sourceAmountText: String
+    @Binding var showAllPercentageButtons: Bool
+    let onPickFromAsset: () -> Void
+    let onPickToAsset: () -> Void
+    let onSwapAssets: () -> Void
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 8) {
+                LimitAssetRow(
+                    kind: .sell,
+                    coin: fromCoin,
+                    asset: vm.draft.fromAsset,
+                    amountText: $sourceAmountText,
+                    amountIsEditable: true,
+                    computedAmount: nil,
+                    usdPricePerUnit: Decimal(fromCoin.price),
+                    onPickAsset: onPickFromAsset
+                )
+                // Reuse the market swap's percentage buttons + Done accessory on
+                // the Sell amount keyboard. Attached to the row (an ancestor of
+                // the field) so it scopes to the sell amount's editing session.
+                .limitKeyboardAccessory {
+                    SwapPercentageButtons(
+                        show100: !fromCoin.isNativeToken,
+                        showAllPercentageButtons: $showAllPercentageButtons,
+                        onTap: handleSellPercentage
+                    )
+                }
+
+                LimitAssetRow(
+                    kind: .buy,
+                    coin: toCoin,
+                    asset: vm.draft.toAsset,
+                    amountText: .constant(formattedBuyAmount),
+                    amountIsEditable: false,
+                    computedAmount: buyAmountDecimal,
+                    usdPricePerUnit: vm.targetUsdPricePerUnit,
+                    onPickAsset: onPickToAsset
+                )
+            }
+
+            // Shared with the market swap form: same visual + spring flip.
+            SwapAssetsButton {
+                onSwapAssets()
+            }
+        }
+    }
+
+    /// Sets the Sell amount to `pct`% of the source balance. Assigns the field
+    /// text (its `onChange` funnels the value into `draft.sourceAmount`); the
+    /// balance math + formatting live in the VM (market parity).
+    private func handleSellPercentage(_ pct: Int) {
+        showAllPercentageButtons = false
+        sourceAmountText = vm.sourceAmountText(forPercentage: pct, of: fromCoin)
+    }
+
+    /// Buy amount preview — the VM derives it from the signed `computeLim`
+    /// path so it can't diverge from the memo's truncated LIM. `nil` when not
+    /// yet computable (row shows "0").
+    private var buyAmountDecimal: Decimal? {
+        let amount = vm.expectedBuyAmount
+        return amount > 0 ? amount : nil
+    }
+
+    private var formattedBuyAmount: String {
+        guard let amount = buyAmountDecimal else { return "0" }
+        return NSDecimalNumber(decimal: amount).stringValue
+    }
+}
+
+// MARK: - Single asset row (chain header + coin pill + amount field)
+
+private enum LimitAssetRowKind {
+    case sell
+    case buy
+
+    var labelKey: String {
+        self == .sell ? "limitSwap.sell" : "limitSwap.buy"
+    }
+
+    var cornerRadii: RectangleCornerRadii {
+        // Mirrors the Figma — Sell rounded top-heavy, Buy bottom-heavy.
+        switch self {
+        case .sell:
+            return .init(topLeading: 24, bottomLeading: 12, bottomTrailing: 12, topTrailing: 24)
+        case .buy:
+            return .init(topLeading: 12, bottomLeading: 24, bottomTrailing: 24, topTrailing: 12)
+        }
+    }
+}
+
+private struct LimitAssetRow: View {
+
+    let kind: LimitAssetRowKind
+    let coin: Coin
+    let asset: LimitSwapAsset
+    @Binding var amountText: String
+    let amountIsEditable: Bool
+    let computedAmount: Decimal?
+    let usdPricePerUnit: Decimal
+    let onPickAsset: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                HStack(spacing: 6) {
+                    Text(kind.labelKey.localized)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+
+                    Button(action: onPickAsset) {
+                        HStack(spacing: 4) {
+                            if !asset.chainLogo.isEmpty {
+                                AsyncImageView(
+                                    logo: asset.chainLogo,
+                                    size: CGSize(width: 16, height: 16),
+                                    ticker: asset.chain.ticker,
+                                    tokenChainLogo: nil
+                                )
+                            }
+                            Text(asset.chain.name)
+                                .font(Theme.fonts.caption12)
+                                .foregroundStyle(Theme.colors.textPrimary)
+                            Image(systemName: "chevron.down")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundStyle(Theme.colors.textTertiary)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
+
+                if kind == .sell {
+                    Text("\(coin.balanceString) \(coin.ticker)")
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            HStack(alignment: .center) {
+                Button(action: onPickAsset) {
+                    HStack(spacing: 8) {
+                        if !asset.logo.isEmpty {
+                            AsyncImageView(
+                                logo: asset.logo,
+                                size: CGSize(width: 36, height: 36),
+                                ticker: asset.ticker,
+                                tokenChainLogo: asset.chainLogo
+                            )
+                        }
+                        Text(asset.ticker)
+                            .font(Theme.fonts.caption12)
+                            .foregroundStyle(Theme.colors.textPrimary)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(Theme.colors.textTertiary)
+                    }
+                    .padding(.leading, 6)
+                    .padding(.trailing, 12)
+                    .padding(.vertical, 6)
+                    .background(Theme.colors.bgSurface2)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+
+                Spacer(minLength: 12)
+
+                VStack(alignment: .trailing, spacing: 6) {
+                    if amountIsEditable {
+                        TextField("0", text: $amountText.decimalOnly())
+                            // `.plain` strips macOS's default bordered chrome (the
+                            // dark bezel box); iOS is unaffected. Matches the market
+                            // amount field.
+                            .textFieldStyle(.plain)
+                            .font(Theme.fonts.title2)
+                            .foregroundStyle(Theme.colors.textPrimary)
+                            .multilineTextAlignment(.trailing)
+                            .lineLimit(1)
+                            #if os(iOS)
+                            .keyboardType(.decimalPad)
+                            #endif
+                    } else {
+                        Text(amountText)
+                            .font(Theme.fonts.title2)
+                            .foregroundStyle(Theme.colors.textPrimary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.6)
+                    }
+
+                    Text(fiatLine)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            UnevenRoundedRectangle(cornerRadii: kind.cornerRadii)
+                .fill(Color.clear)
+                .overlay(
+                    UnevenRoundedRectangle(cornerRadii: kind.cornerRadii)
+                        .stroke(Theme.colors.borderLight, lineWidth: 1)
+                )
+        )
+    }
+
+    private var fiatLine: String {
+        let amount = effectiveAmount
+        guard usdPricePerUnit > 0, amount > 0 else { return "$0.00" }
+        let usd = amount * usdPricePerUnit
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        formatter.groupingSeparator = ","
+        let value = formatter.string(from: NSDecimalNumber(decimal: usd)) ?? "0.00"
+        return "$\(value)"
+    }
+
+    private var effectiveAmount: Decimal {
+        if let computedAmount {
+            return computedAmount
+        }
+        // Locale-aware so the fiat sub-line doesn't mis-read a pasted grouped
+        // number (shares the parser the amount field itself uses).
+        return parseLimitDecimal(amountText)
+    }
+}
+
+// MARK: - Preset pills
+//
+// Layout uses a custom `LimitPillFlow` so pills wrap to a second row when the
+// dynamic Market pill's content (e.g. "+12.5% ✕") is too wide for one row. The
+// +1% / +5% / +10% pills are always static and just call `selectPresetPct(pct)`.
+// The Market pill is dynamic but only after a *manual* edit — when any preset is
+// the live source (`vm.lastPresetPct != nil`), it stays static "Market". Tapping
+// any pill dismisses the keyboard so it doesn't linger after a selection.
+
+private struct LimitPresetPills: View {
+
+    @Bindable var vm: LimitSwapFormViewModel
+
+    var body: some View {
+        LimitPillFlow(spacing: 6) {
+            marketPill
+            staticPill(titleKey: "limitSwap.preset.plus1", pct: 1)
+            staticPill(titleKey: "limitSwap.preset.plus5", pct: 5)
+            staticPill(titleKey: "limitSwap.preset.plus10", pct: 10)
+        }
+    }
+
+    @ViewBuilder
+    private var marketPill: some View {
+        let rounded = roundedPctFromMarket
+        // Render statically when *any* preset is the live source (including the
+        // Market preset) OR when there's effectively no delta from market. The
+        // dynamic state only kicks in after the user manually edits the price
+        // (which sets `vm.lastPresetPct = nil`).
+        let renderStatic = vm.lastPresetPct != nil || rounded == 0
+        Button {
+            dismissKeyboard()
+            vm.selectPresetPct(0)
+        } label: {
+            HStack(spacing: 4) {
+                if renderStatic {
+                    Text("limitSwap.preset.market".localized)
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textSecondary)
+                } else {
+                    Text(formatRoundedPct(rounded))
+                        .font(Theme.fonts.caption12)
+                        .foregroundStyle(Theme.colors.textSecondary)
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Theme.colors.textTertiary)
+                }
+            }
+            .lineLimit(1)
+            .pillShape()
+        }
+        .buttonStyle(.plain)
+        .disabled(vm.marketPriceRef == nil)
+    }
+
+    private func staticPill(titleKey: String, pct: Int) -> some View {
+        Button {
+            dismissKeyboard()
+            vm.selectPresetPct(pct)
+        } label: {
+            Text(titleKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+                .pillShape()
+        }
+        .buttonStyle(.plain)
+        .disabled(vm.marketPriceRef == nil)
+    }
+
+    /// Rounds `vm.pctFromMarket` to the nearest 0.5%. Returns 0 when no market
+    /// reference is loaded yet, when target price is 0, or when the actual pct
+    /// rounds to 0 (i.e. |pct| < 0.25%).
+    private var roundedPctFromMarket: Decimal {
+        guard vm.marketPriceRef != nil, vm.draft.targetPrice > 0 else { return 0 }
+        var doubled = vm.pctFromMarket * 2
+        var rounded = Decimal()
+        NSDecimalRound(&rounded, &doubled, 0, .plain)
+        return rounded / 2
+    }
+
+    private func formatRoundedPct(_ pct: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 1
+        formatter.maximumFractionDigits = 1
+        formatter.positivePrefix = "+"
+        let value = formatter.string(from: NSDecimalNumber(decimal: pct)) ?? "0"
+        return "\(value)%"
+    }
+
+    private func dismissKeyboard() {
+        #if os(iOS)
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+        #endif
+    }
+}
+
+// MARK: - Preset pill shape
+//
+// Intrinsically-sized rounded outline: each pill hugs its own content so
+// `LimitPillFlow` can wrap a grown Market pill to its own row instead of
+// cropping it.
+
+private extension View {
+    func pillShape() -> some View {
+        self
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .overlay(
+                RoundedRectangle(cornerRadius: 100)
+                    .stroke(Theme.colors.borderLight, lineWidth: 1)
+            )
+    }
+}
+
+// MARK: - Pill flow layout
+//
+// Wraps subviews to a second row when content overflows the available width.
+// Each child is sized by its own intrinsic content (so the dynamic Market pill
+// grows when its label becomes "+12.5% ✕"); other pills can drop to the next line
+// instead of getting cropped.
+
+private struct LimitPillFlow: Layout {
+
+    let spacing: CGFloat
+
+    init(spacing: CGFloat = 6) {
+        self.spacing = spacing
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+        let width = proposal.width ?? .infinity
+        let lines = arrange(subviews: subviews, in: width)
+        let totalHeight = lines.map(\.height).reduce(0, +)
+            + CGFloat(max(0, lines.count - 1)) * spacing
+        let widestLine = lines.map(\.width).max() ?? 0
+        return CGSize(width: widestLine, height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        let lines = arrange(subviews: subviews, in: bounds.width)
+        var y = bounds.minY
+        for line in lines {
+            var x = bounds.minX
+            for index in line.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + spacing
+            }
+            y += line.height + spacing
+        }
+    }
+
+    private struct Line {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func arrange(subviews: Subviews, in maxWidth: CGFloat) -> [Line] {
+        var lines: [Line] = [Line()]
+        for (i, sub) in subviews.enumerated() {
+            let size = sub.sizeThatFits(.unspecified)
+            let extraSpacing: CGFloat = lines[lines.count - 1].indices.isEmpty ? 0 : spacing
+            let prospectiveWidth = lines[lines.count - 1].width + extraSpacing + size.width
+            if prospectiveWidth > maxWidth, !lines[lines.count - 1].indices.isEmpty {
+                var newLine = Line()
+                newLine.indices = [i]
+                newLine.width = size.width
+                newLine.height = size.height
+                lines.append(newLine)
+            } else {
+                lines[lines.count - 1].indices.append(i)
+                lines[lines.count - 1].width = prospectiveWidth
+                lines[lines.count - 1].height = max(lines[lines.count - 1].height, size.height)
+            }
+        }
+        return lines
+    }
+}
+
+// MARK: - Advanced Swap Queue unavailable row
+//
+// Shown when the `EnableAdvSwapQueue` mimir is resolved-disabled: THORChain
+// isn't accepting resting `=<` limit orders right now, so placement is blocked
+// (fail-closed).
+
+private struct LimitUnavailableRow: View {
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.octagon.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text("limitSwap.error.advancedSwapQueueDisabled".localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: limitNoticeCornerRadius)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: limitNoticeCornerRadius))
+    }
+}
+
+// MARK: - Generic blocking-notice row
+//
+// A message-driven sibling of `LimitUnavailableRow`, used for the pair-not-
+// routable / unsupported-asset gate: the coin picker filters by CHAIN
+// routability only, so a poolless pair (e.g. RUNE→VULT) slips through — the
+// market-price probe's failure surfaces here and the Place CTA is disabled while
+// it shows.
+
+private struct LimitNoticeRow: View {
+
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.octagon.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text(message)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: limitNoticeCornerRadius)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: limitNoticeCornerRadius))
+    }
+}
+
+// MARK: - Warning row
+
+private struct LimitWarningRow: View {
+
+    let warning: LimitSwapWarning
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.colors.alertWarning)
+
+            Text(messageKey.localized)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .background(Theme.colors.bgSurface1)
+        .overlay(
+            RoundedRectangle(cornerRadius: limitNoticeCornerRadius)
+                .stroke(Theme.colors.borderLight, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: limitNoticeCornerRadius))
+    }
+
+    private var messageKey: String {
+        switch warning {
+        case .priceAtOrBelowMarket:
+            return "limitSwap.warning.priceAtOrBelowMarket"
+        case .priceFarAboveMarket:
+            return "limitSwap.warning.priceFarAboveMarket"
+        }
+    }
+}
+
+private extension Binding where Value == String {
+    /// Wrap a text binding so an edit is accepted only when it is a valid numeric
+    /// input (`isDecimalInput`). The price/amount fields then reject any letter or
+    /// symbol — whether typed or pasted — instead of silently keeping its digits,
+    /// which matches what the iOS `.decimalPad` enforces for free (macOS has no
+    /// such keypad). A rejected edit leaves the prior value untouched.
+    func decimalOnly() -> Binding<String> {
+        Binding<String>(
+            get: { wrappedValue },
+            set: { newValue in
+                if newValue.isDecimalInput() { wrappedValue = newValue }
+            }
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapEntryView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapEntryView.swift
@@ -44,9 +44,13 @@ struct LimitSwapEntryView: View {
     @State private var showFromCoinPicker: Bool = false
     @State private var showToCoinPicker: Bool = false
 
-    /// Which candidate layout to render. `@AppStorage` so a reviewer's choice
-    /// survives relaunch — comparing layouts means backgrounding the app, and
-    /// re-picking the variant on every cold start would make that unusable.
+    /// Which candidate layout to render. The picker that WRITES this lives in
+    /// `SwapDetailsScreen`, inline with the Market/Limit segmented control; this
+    /// is the read side. No binding is threaded down: `@AppStorage` instances
+    /// sharing a key observe the same `UserDefaults`, so the write there redraws
+    /// here. It also means the choice survives relaunch — comparing layouts
+    /// means backgrounding the app, and re-picking on every cold start would
+    /// make that tedious.
     @AppStorage("limitLayoutVariant") private var layoutVariant: LimitLayoutVariant = .accordion
 
     /// `SwapCoinPickerView` declares an `@EnvironmentObject` for this VM and
@@ -81,8 +85,14 @@ struct LimitSwapEntryView: View {
     }
 
     var body: some View {
+        // The container is load-bearing despite its single child: it gives the
+        // modifiers below a STABLE identity. Hung directly off `selectedBody`
+        // they would belong to a `_ConditionalContent` that changes type when
+        // the variant switches, so `.task` would re-run and its
+        // `selectPresetPct(0)` would silently reset the reviewer's amount on
+        // every flip — destroying the like-for-like comparison the picker is
+        // for. Anchored here, the VM and the entered order survive the switch.
         VStack(spacing: 0) {
-            variantPicker
             selectedBody
         }
         .task {
@@ -193,47 +203,6 @@ struct LimitSwapEntryView: View {
                 onPlaceOrder: handlePlaceOrder
             )
         }
-    }
-
-    /// Compact dev-facing layout switcher. Mirrors the `Menu { Picker }` shape
-    /// the repo already uses for its debug `forcedSwapProvider` picker
-    /// (`SettingPickerCell`), which is also unlocalized and also ungated.
-    ///
-    /// Not `#if DEBUG`-gated on purpose: the point of this branch is to hand ONE
-    /// build to devs and designers and let them flip between the four layouts,
-    /// and those builds are frequently Release/TestFlight — a DEBUG gate would
-    /// delete the picker from exactly the builds it exists for. It is already
-    /// unreachable for normal users behind the default-off `limitSwapEnabled`
-    /// advanced setting, and this branch is not intended to merge, so the gate
-    /// would buy no safety it doesn't already have.
-    private var variantPicker: some View {
-        Menu {
-            Picker("", selection: $layoutVariant) {
-                ForEach(LimitLayoutVariant.allCases) { variant in
-                    Text(variant.displayName).tag(variant)
-                }
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Text(layoutVariant.displayName)
-                Image(systemName: "chevron.up.chevron.down")
-            }
-            .font(Theme.fonts.caption12)
-            .foregroundStyle(Theme.colors.textSecondary)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Theme.colors.bgSurface1)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Theme.colors.border, lineWidth: 1)
-                    )
-            )
-        }
-        .fixedSize()
-        .frame(maxWidth: .infinity, alignment: .trailing)
-        .padding(.bottom, 8)
     }
 
     // MARK: - Picker bindings (swap-on-collision)

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapEntryView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapEntryView.swift
@@ -15,6 +15,12 @@ import SwiftUI
 /// `SwapTransaction` carrying `limitContext`. From there the standard
 /// Swap pipeline (Verify → Pair → Keysign → Done) handles the rest —
 /// each screen surfaces limit-specific UI when `transaction.isLimit`.
+///
+/// **Design-review branch:** this entry view additionally carries all four
+/// candidate limit layouts (see `LimitLayoutVariant`) behind a runtime picker.
+/// Only the body view swaps — the VM, the coin state, the pickers, the
+/// routability gate and the place-order flow below are shared verbatim by every
+/// variant, which is what makes the comparison honest.
 struct LimitSwapEntryView: View {
 
     let initialFromCoin: Coin
@@ -37,6 +43,11 @@ struct LimitSwapEntryView: View {
 
     @State private var showFromCoinPicker: Bool = false
     @State private var showToCoinPicker: Bool = false
+
+    /// Which candidate layout to render. `@AppStorage` so a reviewer's choice
+    /// survives relaunch — comparing layouts means backgrounding the app, and
+    /// re-picking the variant on every cold start would make that unusable.
+    @AppStorage("limitLayoutVariant") private var layoutVariant: LimitLayoutVariant = .accordion
 
     /// `SwapCoinPickerView` declares an `@EnvironmentObject` for this VM and
     /// will crash at runtime if the picker sheet renders without it. The
@@ -70,15 +81,10 @@ struct LimitSwapEntryView: View {
     }
 
     var body: some View {
-        LimitSwapBodyView(
-            vm: vm,
-            fromCoin: limitFromCoin,
-            toCoin: limitToCoin,
-            onPickFromAsset: { showFromCoinPicker = true },
-            onPickToAsset: { showToCoinPicker = true },
-            onSwapAssets: handleSwapAssets,
-            onPlaceOrder: handlePlaceOrder
-        )
+        VStack(spacing: 0) {
+            variantPicker
+            selectedBody
+        }
         .task {
             async let supportedChains: () = vm.refreshSupportedChains()
             async let marketPrice: () = vm.refreshMarketPrice()
@@ -136,6 +142,98 @@ struct LimitSwapEntryView: View {
         } message: { error in
             Text(error.message)
         }
+    }
+
+    // MARK: - Layout variants (design-review branch only)
+
+    /// Renders the selected candidate layout. Every case is handed the same VM,
+    /// the same coin state and the same callbacks — `.threeSection` takes no
+    /// `toCoin` because that layout reads the target's rate off the VM instead
+    /// (see `LimitSwapBodyThreeSectionView.fromCoin`); the other three need it.
+    @ViewBuilder
+    private var selectedBody: some View {
+        switch layoutVariant {
+        case .accordion:
+            LimitSwapBodyView(
+                vm: vm,
+                fromCoin: limitFromCoin,
+                toCoin: limitToCoin,
+                onPickFromAsset: { showFromCoinPicker = true },
+                onPickToAsset: { showToCoinPicker = true },
+                onSwapAssets: handleSwapAssets,
+                onPlaceOrder: handlePlaceOrder
+            )
+        case .assetsFirst:
+            LimitSwapBodyAssetsFirstView(
+                vm: vm,
+                fromCoin: limitFromCoin,
+                toCoin: limitToCoin,
+                onPickFromAsset: { showFromCoinPicker = true },
+                onPickToAsset: { showToCoinPicker = true },
+                onSwapAssets: handleSwapAssets,
+                onPlaceOrder: handlePlaceOrder
+            )
+        case .uniswapFlat:
+            LimitSwapBodyUniswapView(
+                vm: vm,
+                fromCoin: limitFromCoin,
+                toCoin: limitToCoin,
+                onPickFromAsset: { showFromCoinPicker = true },
+                onPickToAsset: { showToCoinPicker = true },
+                onSwapAssets: handleSwapAssets,
+                onPlaceOrder: handlePlaceOrder
+            )
+        case .threeSection:
+            LimitSwapBodyThreeSectionView(
+                vm: vm,
+                fromCoin: limitFromCoin,
+                onPickFromAsset: { showFromCoinPicker = true },
+                onPickToAsset: { showToCoinPicker = true },
+                onSwapAssets: handleSwapAssets,
+                onPlaceOrder: handlePlaceOrder
+            )
+        }
+    }
+
+    /// Compact dev-facing layout switcher. Mirrors the `Menu { Picker }` shape
+    /// the repo already uses for its debug `forcedSwapProvider` picker
+    /// (`SettingPickerCell`), which is also unlocalized and also ungated.
+    ///
+    /// Not `#if DEBUG`-gated on purpose: the point of this branch is to hand ONE
+    /// build to devs and designers and let them flip between the four layouts,
+    /// and those builds are frequently Release/TestFlight — a DEBUG gate would
+    /// delete the picker from exactly the builds it exists for. It is already
+    /// unreachable for normal users behind the default-off `limitSwapEnabled`
+    /// advanced setting, and this branch is not intended to merge, so the gate
+    /// would buy no safety it doesn't already have.
+    private var variantPicker: some View {
+        Menu {
+            Picker("", selection: $layoutVariant) {
+                ForEach(LimitLayoutVariant.allCases) { variant in
+                    Text(variant.displayName).tag(variant)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(layoutVariant.displayName)
+                Image(systemName: "chevron.up.chevron.down")
+            }
+            .font(Theme.fonts.caption12)
+            .foregroundStyle(Theme.colors.textSecondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Theme.colors.bgSurface1)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Theme.colors.border, lineWidth: 1)
+                    )
+            )
+        }
+        .fixedSize()
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.bottom, 8)
     }
 
     // MARK: - Picker bindings (swap-on-collision)

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -22,6 +22,13 @@ struct SwapDetailsScreen: View {
     @State private var selectedSwapMode: SwapMode = .market
     @State private var showAdvancedLockedSheet = false
 
+    /// Design-review branch only: which limit layout the tab-row picker selects.
+    /// `LimitSwapEntryView` declares the SAME key and does the actual body
+    /// switch — same-key `@AppStorage` instances share one `UserDefaults`
+    /// entry, so writing here redraws there without threading a binding through.
+    /// Read/written only from the Limit tab; Market never observes it.
+    @AppStorage("limitLayoutVariant") private var limitLayoutVariant: LimitLayoutVariant = .accordion
+
     private let tierService = VultTierService()
 
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
@@ -36,7 +43,12 @@ struct SwapDetailsScreen: View {
                     swapModeTabs
                         .fixedSize()
                     Spacer(minLength: 8)
+                    // Two mutually-exclusive occupants of the row's trailing
+                    // slot: the countdown renders only in Market, the variant
+                    // picker only in Limit. At most one is ever non-empty, so
+                    // they can share the slot without competing for width.
                     tabRowCountdown
+                    tabRowVariantPicker
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 8)
@@ -329,6 +341,54 @@ struct SwapDetailsScreen: View {
             targetCoin: detailsViewModel.toCoin,
             vaultCoins: vault.coins
         )
+    }
+
+    /// Limit-layout switcher for this **design-review branch**, sharing the tab
+    /// row's trailing slot with `tabRowCountdown` — which never renders in Limit
+    /// mode, leaving the slot free. Limit mode only, so Market's row is byte-for
+    /// -byte the layout it was: this returns an empty `@ViewBuilder` there, the
+    /// same way the countdown already does in Limit.
+    ///
+    /// The label collapses to `variant.shortName` (a single letter) because it
+    /// shares a row with a `.fixedSize()` segmented control and only a
+    /// `Spacer(minLength: 8)` separates them — a full "Accordion (current)"
+    /// would crowd the tabs on a narrow screen. The menu carries the full names.
+    ///
+    /// Not `#if DEBUG`-gated on purpose, matching the repo's existing debug
+    /// `forcedSwapProvider` picker: the row is already behind the default-off
+    /// `limitSwapEnabled` advanced setting, this branch never merges, and review
+    /// builds are often Release/TestFlight — a DEBUG gate would delete the
+    /// picker from exactly the builds it exists for.
+    @ViewBuilder
+    var tabRowVariantPicker: some View {
+        if selectedSwapMode == .limit {
+            Menu {
+                Picker("", selection: $limitLayoutVariant) {
+                    ForEach(LimitLayoutVariant.allCases) { variant in
+                        Text(variant.menuLabel).tag(variant)
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text(limitLayoutVariant.shortName)
+                    Image(systemName: "chevron.up.chevron.down")
+                }
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textSecondary)
+                .lineLimit(1)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Theme.colors.bgSurface1)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Theme.colors.border, lineWidth: 1)
+                        )
+                )
+            }
+            .fixedSize()
+        }
     }
 
     /// Quote-refresh countdown in the Market/Limit tab row. Market mode only —


### PR DESCRIPTION
## Description

> ⚠️ **SPIKE — NOT FOR MERGE.** This branch exists only so the team can compare the four candidate limit-swap layouts in a single build. Once a direction is picked, the winner gets implemented properly on `feat/4232-thorchain-limit-swap-place-flow` (#4319) and this branch is closed and deleted.

Carries all four candidate UX layouts for the THORChain limit-swap form in one build, switchable at runtime.

Related: #4232 / #4319 (deliberately not `Fixes` — nothing to close).

### How to try it

Settings → Advanced → enable **Limit Swap** → Swap → **Limit** tab. The small **A** dropdown to the right of the Market/Limit tabs switches layouts (the menu spells out the full names); your choice persists across relaunch.

The VM is owned by the entry view and each body rehydrates from the draft on load, so **flipping variants preserves the order you typed** — you can compare like-for-like without re-entering an amount.

### The variants

|  | Variant | Source |
|---|---|---|
| **A** | **Accordion (current)** — Execute-when first, Asset second | the current #4319 layout, byte-identical |
| **B** | **Assets first** — Asset first, Execute-when second | `feat/4232-limit-ux-assets-first` |
| **C** | **Uniswap flat** — no accordion, horizontal unit toggle, chipped assets, unified radii | `feat/4232-limit-ux-uniswap` |
| **D** | **Three sections** — Asset → Execute-when → Amount with reflected output | `feat/4232-limit-ux-3section` |

### Notes for reviewers

- **Presentation only.** All four share the same `LimitSwapFormViewModel`, memo math, validation, routability gate and place-order flow. No behavior differs between them.
- **The duplication is deliberate — please don't factor it out.** Each variant is a self-contained file whose sub-views are file-private. Variant A is byte-identical to the base; B/C/D differ from their source commits by exactly the two rename lines. Keeping them unshared is what makes the comparison honest rather than homogenized.
- **Please don't "clean up" the single-child `VStack` in `LimitSwapEntryView`.** It anchors `.task`/`.onChange` to a stable identity. Attached directly to the variant switch they'd live on a `_ConditionalContent` whose type changes on every flip, so `.task` would re-run and reset the amount each time you switch — destroying the comparison. It's documented in-code.
- **Market mode is visually unchanged.** The picker renders only in Limit mode, in the slot the quote countdown already leaves free.

## Which feature is affected?
- [x] Swap — no tx link: this is a UI-comparison spike. Nothing is signed or broadcast here that isn't already covered by #4319.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings — SwiftLint 0 violations; macOS Debug `** BUILD SUCCEEDED **`
- [ ] I have added tests — **N/A by design**: throwaway spike, presentation-only, no logic changed. The full suite is green on the base (3018 tests, 0 failures) and this branch adds no behavior to test.

## Screenshots (if applicable)

Not attached on purpose — the whole point is to run it and flip between the four live.

## Additional context

Based on `feat/4232-thorchain-limit-swap-place-flow` rather than `main`, so the diff shows only the spike (~+3980/−9) instead of burying it under the entire limit-swap feature.

## Agent Metadata

- **Agent**: Claude Code
- **Issue**: #4232 / PR #4319 (design-review aid)
- **Confidence**: high — presentation-only; build + lint green; each variant verified byte-faithful to its source commit
- **Needs human review for**: nothing to merge. What's wanted here is **design feedback: which layout wins.**
