### PR TITLE
fix(solana): preflight stake withdrawals

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
@@ -36,6 +36,10 @@ struct SolanaAPI: TargetType {
 
     enum Method {
         case sendTransaction(encodedTransaction: String)
+        /// Simulates an unsigned, base64-encoded transaction against current
+        /// bank state. Used as the authoritative pre-keysign cooldown gate for
+        /// stake withdrawals.
+        case simulateTransaction(encodedTransaction: String)
         case getBalance(address: String)
         case getRecentPrioritizationFees
         case getLatestBlockhash
@@ -104,6 +108,22 @@ struct SolanaAPI: TargetType {
                 rpcEnvelope(
                     method: "sendTransaction",
                     params: [encodedTransaction, ["encoding": "base64", "preflightCommitment": "confirmed"]]
+                ),
+                .jsonEncoding
+            )
+        case .simulateTransaction(let encodedTransaction):
+            return .requestParameters(
+                rpcEnvelope(
+                    method: "simulateTransaction",
+                    params: [
+                        encodedTransaction,
+                        [
+                            "encoding": "base64",
+                            "commitment": "confirmed",
+                            "sigVerify": false,
+                            "replaceRecentBlockhash": true
+                        ] as [String: Any]
+                    ]
                 ),
                 .jsonEncoding
             )
@@ -227,6 +247,20 @@ struct SolanaSendTransactionResponse: Decodable {
                 let container = try decoder.singleValueContainer()
                 stringValue = try? container.decode(String.self)
             }
+        }
+    }
+}
+
+struct SolanaSimulateTransactionResponse: Decodable {
+    let result: Result?
+    let error: SolanaSendTransactionResponse.Error?
+
+    struct Result: Decodable {
+        let value: Value
+
+        struct Value: Decodable {
+            let err: SolanaSendTransactionResponse.Error.AnyCodableErr?
+            let logs: [String]?
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -32,6 +32,14 @@ enum SolanaRetryableError: Error, LocalizedError, RetryableBroadcastError {
     }
 }
 
+enum SolanaWithdrawPreflightError: Error, LocalizedError {
+    case stakeNotReady
+
+    var errorDescription: String? {
+        "solanaStakingErrorWithdrawNotReady".localized
+    }
+}
+
 class SolanaService {
     static let shared = SolanaService()
 
@@ -144,6 +152,43 @@ class SolanaService {
         // Unreachable: the loop either returns a result or throws on the final
         // attempt. Present to satisfy the non-optional control-flow analysis.
         return nil
+    }
+
+    /// Simulates the exact unsigned withdrawal before an MPC keysign starts.
+    /// Solana cooldown is stake-history dependent and can span multiple epochs,
+    /// so comparing only `currentEpoch` with `deactivationEpoch` is not an
+    /// authoritative readiness check. The Stake program is: if it still reports
+    /// insufficient funds while the account is cooling, fail before users spend
+    /// time approving a transaction the chain cannot accept yet.
+    func validateSolanaWithdraw(encodedTransaction: String) async throws {
+        let response = try await httpClient.request(
+            api(.simulateTransaction(encodedTransaction: encodedTransaction)),
+            responseType: SolanaSimulateTransactionResponse.self
+        )
+
+        if let error = response.data.error {
+            throw SolanaServiceError.rpcError(message: error.message, code: error.code)
+        }
+        guard let result = response.data.result else {
+            throw SolanaServiceError.rpcError(message: "Missing simulation result", code: -1)
+        }
+        guard result.value.err != nil else { return }
+
+        let logs = result.value.logs ?? []
+        let loweredLogs = logs.joined(separator: " ").lowercased()
+        logger.warning(
+            "Solana withdraw preflight rejected the transaction:\n\(logs.joined(separator: "\n"), privacy: .public)"
+        )
+
+        if loweredLogs.contains("insufficient funds")
+            || loweredLogs.contains("balance was too small") {
+            throw SolanaWithdrawPreflightError.stakeNotReady
+        }
+
+        let detail = logs.isEmpty
+            ? "Transaction simulation failed"
+            : logs.suffix(4).joined(separator: "\n")
+        throw SolanaServiceError.rpcError(message: detail, code: -32002)
     }
 
     func getSolanaBalance(coin: Coin) async throws -> String {

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaEpochCooldownGate.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaEpochCooldownGate.swift
@@ -7,7 +7,10 @@
 //  withdrawable only once the network epoch has advanced PAST the account's
 //  `deactivationEpoch`. Evaluating this before a (future) withdraw keysign
 //  avoids surprising the user with a transaction the Stake program would
-//  reject. Analog: `CosmosRedelegationCooldownGate`.
+//  reject. This epoch check drives the optimistic row state only; Solana's
+//  actual cooldown is stake-history dependent and can span multiple epochs, so
+//  the exact unsigned withdraw is also simulated before keysign. Analog:
+//  `CosmosRedelegationCooldownGate`.
 //
 
 import Foundation
@@ -23,7 +26,9 @@ enum SolanaEpochCooldownState: Equatable {
 enum SolanaEpochCooldownGate {
     /// Evaluates whether `stakeAccount`'s deactivated stake can be withdrawn at
     /// `currentEpoch`. Pure function over the parsed delegation + the live
-    /// epoch so the unit tests can pin the boundary deterministically.
+    /// epoch so the unit tests can pin the optimistic UI boundary
+    /// deterministically. `SolanaWithdrawPreflightChecking` remains the
+    /// authoritative gate before keysign.
     ///
     /// - A non-deactivating account (sentinel `deactivationEpoch`) is `available`
     ///   — there is nothing cooling down. (Whether it's still *delegated* is a

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingService.swift
@@ -21,6 +21,7 @@ import OSLog
 protocol SolanaStakingServiceProtocol: Sendable {
     func fetchValidators() async throws -> [SolanaValidator]
     func fetchStakeAccounts(owner: String) async throws -> [SolanaStakeAccount]
+    func fetchStakeAccount(address: String) async throws -> SolanaStakeAccount?
     func fetchEpochInfo() async throws -> SolanaEpochInfo
     func fetchRentReserve() async throws -> UInt64
     func fetchMinDelegation() async throws -> UInt64
@@ -33,6 +34,7 @@ protocol SolanaStakingServiceProtocol: Sendable {
 protocol SolanaStakingReading {
     func fetchSolanaValidators() async throws -> [SolanaValidator]
     func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount]
+    func fetchSolanaStakeAccount(address: String) async throws -> SolanaStakeAccount?
     func fetchSolanaEpochInfo() async throws -> SolanaEpochInfo
     func fetchSolanaRentReserve() async throws -> UInt64
     func fetchSolanaMinDelegation() async throws -> UInt64
@@ -92,6 +94,12 @@ actor SolanaStakingService: SolanaStakingServiceProtocol {
         // Intentionally uncached — stake accounts must reflect a just-submitted
         // stake/unstake and newly accrued (auto-compounded) rewards.
         try await solanaService.fetchSolanaStakeAccounts(owner: owner)
+    }
+
+    func fetchStakeAccount(address: String) async throws -> SolanaStakeAccount? {
+        // Intentionally uncached — Verify uses this to replace the DeFi row's
+        // snapshot with the exact balance that will be withdrawn.
+        try await solanaService.fetchSolanaStakeAccount(address: address)
     }
 
     func fetchEpochInfo() async throws -> SolanaEpochInfo {

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingSignDataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingSignDataResolver.swift
@@ -148,9 +148,10 @@ enum SolanaStakingSignDataResolver {
     }
 
     /// Resolves the `SignSolana` artefact for a withdraw payload. The withdraw
-    /// CTA is gated upstream by `SolanaEpochCooldownGate` (full inactivity), so
-    /// no cooldown check is repeated here — only the field/shape validation and
-    /// the byte-parity build. Carries the stake account + the withdrawal amount.
+    /// CTA has an optimistic epoch gate upstream. The exact transaction is
+    /// simulated by `SolanaStakingVerifyResolver` after this byte-parity build,
+    /// before keysign, because real cooldown is stake-history dependent. Carries
+    /// the stake account + the withdrawal amount.
     static func resolveWithdraw(basePayload: KeysignPayload) throws -> SignSolana {
         guard let payload = basePayload.solanaStakingPayload else {
             throw Errors.missingPayload

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingVerifyResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingVerifyResolver.swift
@@ -5,7 +5,8 @@
 //  Shared Verify → KeysignPayload bridge for Solana native staking. Dispatches
 //  a `SolanaStakingPayload` to the right `SolanaStakingSignDataResolver` branch
 //  and fetches the per-op live inputs (delegate needs rent reserve + validator
-//  set; deactivate/withdraw operate on an existing account and need neither).
+//  set; withdraw re-checks its exact account balance and simulates the unsigned
+//  transaction; deactivate needs neither).
 //
 //  Lives once here so both entry points — `SendCryptoVerifyLogic` and
 //  `FunctionCallVerifyViewModel` — share identical resolution rather than each
@@ -13,6 +14,12 @@
 //
 
 import Foundation
+
+protocol SolanaWithdrawPreflightChecking {
+    func validateSolanaWithdraw(encodedTransaction: String) async throws
+}
+
+extension SolanaService: SolanaWithdrawPreflightChecking {}
 
 enum SolanaStakingVerifyResolver {
 
@@ -22,7 +29,8 @@ enum SolanaStakingVerifyResolver {
         payload: SolanaStakingPayload,
         basePayload: KeysignPayload,
         coin: Coin,
-        stakingService: SolanaStakingServiceProtocol = SolanaStakingService.shared
+        stakingService: SolanaStakingServiceProtocol = SolanaStakingService.shared,
+        withdrawPreflight: SolanaWithdrawPreflightChecking = SolanaService.shared
     ) async throws -> SignSolana {
         switch payload.opType {
         case .delegate:
@@ -45,7 +53,19 @@ enum SolanaStakingVerifyResolver {
         case .unstake:
             return try SolanaStakingSignDataResolver.resolveDeactivate(basePayload: basePayload)
         case .withdraw:
-            return try SolanaStakingSignDataResolver.resolveWithdraw(basePayload: basePayload)
+            guard let stakeAccountAddress = payload.stakeAccount else {
+                throw SolanaStakingSignDataResolver.Errors.missingPayloadField("stakeAccount")
+            }
+            guard let liveAccount = try await stakingService.fetchStakeAccount(address: stakeAccountAddress),
+                  liveAccount.lamports == payload.lamports else {
+                throw SolanaWithdrawPreflightError.stakeNotReady
+            }
+            let signSolana = try SolanaStakingSignDataResolver.resolveWithdraw(basePayload: basePayload)
+            guard let rawTransaction = signSolana.rawTransactions.first else {
+                throw SolanaStakingSignDataResolver.Errors.missingPayloadField("rawTransaction")
+            }
+            try await withdrawPreflight.validateSolanaWithdraw(encodedTransaction: rawTransaction)
+            return signSolana
         }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1105,6 +1105,7 @@
 "solanaStakingErrorMissingPayload" = "Solana-Staking-Payload fehlt.";
 "solanaStakingErrorMissingPayloadField" = "Solana-Staking-Payload fehlt erforderliches Feld: %@";
 "solanaStakingErrorValidatorPreflightFailed" = "Validator-Prüfung fehlgeschlagen: %@";
+"solanaStakingErrorWithdrawNotReady" = "Dieses Stake-Konto ist noch nicht zur Auszahlung bereit. Aktualisiere die Ansicht und versuche es später erneut.";
 "solanaStakingErrorWrongOpType" = "Nicht unterstützte Solana-Staking-Operation.";
 "solanaStakingInactiveNotice" = "Inaktiv — abgekühlt und bereit zum Abheben.";
 "solanaStakingMinimumDelegation" = "Mindest-Stake beträgt %@ SOL";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1103,6 +1103,7 @@
 "solanaStakingErrorMissingPayload" = "Solana staking payload is missing.";
 "solanaStakingErrorMissingPayloadField" = "Solana staking payload missing required field: %@";
 "solanaStakingErrorValidatorPreflightFailed" = "Validator validation failed: %@";
+"solanaStakingErrorWithdrawNotReady" = "This stake account is not ready to withdraw. Refresh and try again later.";
 "solanaStakingErrorWrongOpType" = "Unsupported Solana staking operation.";
 "solanaStakingInactiveNotice" = "Inactive — cooled down and ready to withdraw.";
 "solanaStakingMinimumDelegation" = "Minimum stake is %@ SOL";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1105,6 +1105,7 @@
 "solanaStakingErrorMissingPayload" = "Falta el payload de staking de Solana.";
 "solanaStakingErrorMissingPayloadField" = "Al payload de staking de Solana le falta un campo requerido: %@";
 "solanaStakingErrorValidatorPreflightFailed" = "Falló la validación del validador: %@";
+"solanaStakingErrorWithdrawNotReady" = "Esta cuenta de staking aún no está lista para retirar. Actualiza e inténtalo de nuevo más tarde.";
 "solanaStakingErrorWrongOpType" = "Operación de staking de Solana no soportada.";
 "solanaStakingInactiveNotice" = "Inactivo — enfriado y listo para retirar.";
 "solanaStakingMinimumDelegation" = "El staking mínimo es %@ SOL";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1105,6 +1105,7 @@
 "solanaStakingErrorMissingPayload" = "Nedostaje Solana staking payload.";
 "solanaStakingErrorMissingPayloadField" = "Solana staking payload nedostaje obavezno polje: %@";
 "solanaStakingErrorValidatorPreflightFailed" = "Provjera validatora nije uspjela: %@";
+"solanaStakingErrorWithdrawNotReady" = "Ovaj staking račun još nije spreman za povlačenje. Osvježite i pokušajte ponovno kasnije.";
 "solanaStakingErrorWrongOpType" = "Nepodržana Solana staking operacija.";
 "solanaStakingInactiveNotice" = "Neaktivno — ohlađeno i spremno za povlačenje.";
 "solanaStakingMinimumDelegation" = "Minimalni ulog je %@ SOL";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1105,6 +1105,7 @@
 "solanaStakingErrorMissingPayload" = "Payload di staking Solana mancante.";
 "solanaStakingErrorMissingPayloadField" = "Al payload di staking Solana manca un campo obbligatorio: %@";
 "solanaStakingErrorValidatorPreflightFailed" = "Validazione del validatore non riuscita: %@";
+"solanaStakingErrorWithdrawNotReady" = "Questo account di staking non è ancora pronto per il prelievo. Aggiorna e riprova più tardi.";
 "solanaStakingErrorWrongOpType" = "Operazione di staking Solana non supportata.";
 "solanaStakingInactiveNotice" = "Inattivo — raffreddato e pronto per il prelievo.";
 "solanaStakingMinimumDelegation" = "Lo stake minimo è %@ SOL";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1105,6 +1105,7 @@
 "solanaStakingErrorMissingPayload" = "Payload de staking da Solana ausente.";
 "solanaStakingErrorMissingPayloadField" = "Falta um campo obrigatório no payload de staking da Solana: %@";
 "solanaStakingErrorValidatorPreflightFailed" = "Falha na validação do validador: %@";
+"solanaStakingErrorWithdrawNotReady" = "Esta conta de staking ainda não está pronta para saque. Atualize e tente novamente mais tarde.";
 "solanaStakingErrorWrongOpType" = "Operação de staking da Solana não suportada.";
 "solanaStakingInactiveNotice" = "Inativo — esfriado e pronto para sacar.";
 "solanaStakingMinimumDelegation" = "O staking mínimo é %@ SOL";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1105,6 +1105,7 @@
 "solanaStakingErrorMissingPayload" = "缺少 Solana 质押载荷。";
 "solanaStakingErrorMissingPayloadField" = "Solana 质押载荷缺少必填字段：%@";
 "solanaStakingErrorValidatorPreflightFailed" = "验证者校验失败：%@";
+"solanaStakingErrorWithdrawNotReady" = "此质押账户尚未准备好提取。请刷新并稍后重试。";
 "solanaStakingErrorWrongOpType" = "不支持的 Solana 质押操作。";
 "solanaStakingInactiveNotice" = "未激活 — 已冷却，可提取。";
 "solanaStakingMinimumDelegation" = "最低质押为 %@ SOL";

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -313,19 +313,25 @@ struct DefiChainMainScreen: View {
                 ))
             },
             onWithdraw: { row in
-                // The row gates Withdraw on a fully-inactive (cooled-down)
-                // account — `canWithdraw` IS the cooldown guard, so a still-
-                // cooling account never reaches here. A full withdraw has no
-                // editable field, so skip the confirm screen: build from the
-                // live account's whole balance and go straight to Verify.
+                // Refresh the individual account BEFORE constructing Verify so
+                // the displayed full-withdraw amount includes the latest rewards
+                // and matches the bytes that will be signed. Verify re-checks
+                // that this balance has not changed, then simulates the exact tx.
                 guard let stakeAccount = row.stakeAccount, row.canWithdraw else { return }
-                let divisor = pow(Decimal(10), coin.decimals)
-                let withdrawableAmount = Decimal(stakeAccount.lamports) / divisor
-                presentVerify(for: SolanaWithdrawTransactionBuilder(
-                    coin: coin,
-                    stakeAccount: stakeAccount.pubkey,
-                    amount: withdrawableAmount.formatToDecimal(digits: coin.decimals)
-                ))
+                presentVerify(preparing: {
+                    guard let liveAccount = try await solanaStakeViewModel.fetchStakeAccount(
+                        address: stakeAccount.pubkey
+                    ) else {
+                        throw SolanaWithdrawPreflightError.stakeNotReady
+                    }
+                    let divisor = pow(Decimal(10), coin.decimals)
+                    let withdrawableAmount = Decimal(liveAccount.lamports) / divisor
+                    return SolanaWithdrawTransactionBuilder(
+                        coin: coin,
+                        stakeAccount: liveAccount.pubkey,
+                        amount: withdrawableAmount.formatToDecimal(digits: coin.decimals)
+                    )
+                })
             },
             emptyStateView: { emptyStateView }
         )
@@ -496,17 +502,31 @@ struct DefiChainMainScreen: View {
     /// Verify shows the fee immediately; it is re-fetched there anyway, so a
     /// failure here is non-fatal.
     func presentVerify(for builder: TransactionBuilder) {
+        presentVerify(preparing: { builder })
+    }
+
+    /// Resolves any required live inputs before constructing the transaction the
+    /// user reviews. Builder-preparation failures are surfaced here rather than
+    /// navigating to a Verify screen with stale data.
+    func presentVerify(
+        preparing builderProvider: @escaping @MainActor () async throws -> TransactionBuilder
+    ) {
         Task { @MainActor in
             isLoading = true
             defer { isLoading = false }
-            var sendTx = builder.buildSendTransaction(vault: vault)
             do {
-                let chainSpecific = try await BlockChainService.shared.fetchSpecific(tx: sendTx)
-                sendTx = sendTx.copy(gas: chainSpecific.gas)
+                let builder = try await builderProvider()
+                var sendTx = builder.buildSendTransaction(vault: vault)
+                do {
+                    let chainSpecific = try await BlockChainService.shared.fetchSpecific(tx: sendTx)
+                    sendTx = sendTx.copy(gas: chainSpecific.gas)
+                } catch {
+                    // Non-fatal: gas is re-fetched during Verify.
+                }
+                router.navigate(to: FunctionCallRoute.verify(tx: sendTx, vault: vault))
             } catch {
-                // Non-fatal: gas is re-fetched during Verify.
+                self.error = HelperError.runtimeError(error.localizedDescription)
             }
-            router.navigate(to: FunctionCallRoute.verify(tx: sendTx, vault: vault))
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/SolanaStakeDefiViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/SolanaStakeDefiViewModel.swift
@@ -199,6 +199,13 @@ final class SolanaStakeDefiViewModel: ObservableObject {
         await refresh(owner: owner, decimals: decimals)
     }
 
+    /// Uncached single-account read used when Withdraw is tapped, before the
+    /// Verify screen is built. This makes the amount the user reviews the exact
+    /// current account balance rather than the earlier list snapshot.
+    func fetchStakeAccount(address: String) async throws -> SolanaStakeAccount? {
+        try await stakingService.fetchStakeAccount(address: address)
+    }
+
     /// Best-effort background prime of the FULL validator set + its metadata so
     /// the validator picker opens warm. Both reads hit the process-wide shared
     /// service/provider caches, so this is safe to call on every Solana DeFi tab

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaDeactivateWithdrawResolverTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaDeactivateWithdrawResolverTests.swift
@@ -13,6 +13,49 @@ import BigInt
 import WalletCore
 import XCTest
 
+private enum WithdrawPreflightTestError: Error {
+    case rejected
+}
+
+private actor FakeWithdrawPreflight: SolanaWithdrawPreflightChecking {
+    private(set) var encodedTransaction: String?
+    private let shouldReject: Bool
+
+    init(shouldReject: Bool = false) {
+        self.shouldReject = shouldReject
+    }
+
+    // Protocol conformance requires async; this deterministic fake does no work
+    // that can suspend.
+    // swiftlint:disable:next async_without_await
+    func validateSolanaWithdraw(encodedTransaction: String) async throws {
+        self.encodedTransaction = encodedTransaction
+        if shouldReject { throw WithdrawPreflightTestError.rejected }
+    }
+}
+
+// Protocol conformance requires async reads; this deterministic fake never
+// suspends.
+// swiftlint:disable async_without_await unused_parameter
+private final class RefreshingWithdrawStakingService: SolanaStakingServiceProtocol, @unchecked Sendable {
+    let account: SolanaStakeAccount?
+
+    init(account: SolanaStakeAccount?) {
+        self.account = account
+    }
+
+    func fetchValidators() async throws -> [SolanaValidator] { [] }
+    func fetchStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] { [] }
+    func fetchStakeAccount(address: String) async throws -> SolanaStakeAccount? { account }
+    func fetchEpochInfo() async throws -> SolanaEpochInfo {
+        SolanaEpochInfo(epoch: 1_002, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
+    }
+    func fetchRentReserve() async throws -> UInt64 { 2_282_880 }
+    func fetchMinDelegation() async throws -> UInt64 { 1_000_000_000 }
+    func fetchInflationRate() async throws -> Double { 0.07 }
+}
+// swiftlint:enable async_without_await unused_parameter
+
 final class SolanaDeactivateWithdrawResolverTests: XCTestCase {
 
     private let recentBlockHash = "11111111111111111111111111111111"
@@ -59,6 +102,17 @@ final class SolanaDeactivateWithdrawResolverTests: XCTestCase {
             qbtcClaimPayload: nil, isQbtcClaim: false,
             solanaStakingPayload: stakingPayload,
             skipBroadcast: false, signData: nil
+        )
+    }
+
+    private func liveAccount(address: String, lamports: UInt64) -> SolanaStakeAccount {
+        SolanaStakeAccount(
+            pubkey: address,
+            lamports: lamports,
+            rentExemptReserve: 2_282_880,
+            staker: "Owner",
+            withdrawer: "Owner",
+            delegation: nil
         )
     }
 
@@ -113,6 +167,99 @@ final class SolanaDeactivateWithdrawResolverTests: XCTestCase {
         )
         let rebuildHashes = try SolanaHelper.getPreSignedImageHash(keysignPayload: payload)
         XCTAssertEqual(relayedHashes, rebuildHashes)
+    }
+
+    func testWithdrawVerifyPreflightsExactRelayedTransaction() async throws {
+        let privateKey = try makeSignerKey()
+        let stakeAccount = try stakeAccountAddress()
+        let liveLamports: UInt64 = 1_003_200_626
+        let stakingPayload = SolanaStakingPayload.withdraw(
+            stakeAccount: stakeAccount,
+            lamports: liveLamports
+        )
+        let payload = makePayload(privateKey: privateKey, stakingPayload: stakingPayload)
+        let preflight = FakeWithdrawPreflight()
+        let stakingService = RefreshingWithdrawStakingService(
+            account: liveAccount(address: stakeAccount, lamports: liveLamports)
+        )
+
+        let signSolana = try await SolanaStakingVerifyResolver.resolve(
+            payload: stakingPayload,
+            basePayload: payload,
+            coin: payload.coin,
+            stakingService: stakingService,
+            withdrawPreflight: preflight
+        )
+
+        let preflightTransaction = await preflight.encodedTransaction
+        XCTAssertEqual(preflightTransaction, signSolana.rawTransactions.first)
+
+        let expected = try SolanaStakingSignDataResolver.resolveWithdraw(basePayload: payload)
+        XCTAssertEqual(signSolana.rawTransactions, expected.rawTransactions)
+    }
+
+    func testWithdrawVerifyStopsWhenBalanceChangedAfterConfirmation() async throws {
+        let privateKey = try makeSignerKey()
+        let stakeAccount = try stakeAccountAddress()
+        let displayedLamports: UInt64 = 1_002_893_292
+        let stakingPayload = SolanaStakingPayload.withdraw(
+            stakeAccount: stakeAccount,
+            lamports: displayedLamports
+        )
+        let payload = makePayload(privateKey: privateKey, stakingPayload: stakingPayload)
+        let preflight = FakeWithdrawPreflight()
+        let stakingService = RefreshingWithdrawStakingService(
+            account: liveAccount(address: stakeAccount, lamports: 1_003_200_626)
+        )
+
+        do {
+            _ = try await SolanaStakingVerifyResolver.resolve(
+                payload: stakingPayload,
+                basePayload: payload,
+                coin: payload.coin,
+                stakingService: stakingService,
+                withdrawPreflight: preflight
+            )
+            XCTFail("expected a changed live balance to stop keysign resolution")
+        } catch let error as SolanaWithdrawPreflightError {
+            guard case .stakeNotReady = error else {
+                return XCTFail("unexpected preflight error: \(error)")
+            }
+            let preflightTransaction = await preflight.encodedTransaction
+            XCTAssertNil(preflightTransaction)
+        } catch {
+            XCTFail("expected SolanaWithdrawPreflightError.stakeNotReady, got \(error)")
+        }
+    }
+
+    func testWithdrawVerifyStopsWhenStakeProgramPreflightRejectsCooldown() async throws {
+        let privateKey = try makeSignerKey()
+        let stakeAccount = try stakeAccountAddress()
+        let stakingPayload = SolanaStakingPayload.withdraw(
+            stakeAccount: stakeAccount,
+            lamports: 1_002_893_292
+        )
+        let payload = makePayload(privateKey: privateKey, stakingPayload: stakingPayload)
+        let preflight = FakeWithdrawPreflight(shouldReject: true)
+        let stakingService = RefreshingWithdrawStakingService(
+            account: liveAccount(address: stakeAccount, lamports: 1_002_893_292)
+        )
+
+        do {
+            _ = try await SolanaStakingVerifyResolver.resolve(
+                payload: stakingPayload,
+                basePayload: payload,
+                coin: payload.coin,
+                stakingService: stakingService,
+                withdrawPreflight: preflight
+            )
+            XCTFail("expected the rejected cooldown preflight to stop verify resolution")
+        } catch WithdrawPreflightTestError.rejected {
+            let preflightTransaction = await preflight.encodedTransaction
+            XCTAssertNotNil(preflightTransaction)
+        } catch {
+            XCTFail("expected WithdrawPreflightTestError.rejected, got \(error)")
+        }
     }
 
     func testWithdrawRejectsDeactivatePayload() throws {

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaDelegateTransactionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaDelegateTransactionViewModelTests.swift
@@ -21,6 +21,7 @@ private final class FakeDelegateStakingService: SolanaStakingServiceProtocol, @u
 
     func fetchValidators() async throws -> [SolanaValidator] { [] }
     func fetchStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] { [] }
+    func fetchStakeAccount(address: String) async throws -> SolanaStakeAccount? { nil }
     func fetchEpochInfo() async throws -> SolanaEpochInfo {
         SolanaEpochInfo(epoch: 800, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
     }

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakeDefiViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakeDefiViewModelTests.swift
@@ -57,6 +57,10 @@ private final class FakeStakingService: SolanaStakingServiceProtocol, @unchecked
         return accounts
     }
 
+    func fetchStakeAccount(address: String) async throws -> SolanaStakeAccount? {
+        accounts.first { $0.pubkey == address }
+    }
+
     func fetchEpochInfo() async throws -> SolanaEpochInfo { epoch }
     func fetchRentReserve() async throws -> UInt64 { rentReserve }
     func fetchMinDelegation() async throws -> UInt64 { 1_000_000_000 }
@@ -78,6 +82,7 @@ private final class CountingReader: SolanaStakingReading, @unchecked Sendable {
     }
 
     func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] { [] }
+    func fetchSolanaStakeAccount(address: String) async throws -> SolanaStakeAccount? { nil }
     func fetchSolanaEpochInfo() async throws -> SolanaEpochInfo {
         SolanaEpochInfo(epoch: 800, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
     }
@@ -254,6 +259,22 @@ final class SolanaStakeDefiViewModelTests: XCTestCase {
         // cache-invalidation hook fired exactly once on the post-keysign refresh.
         XCTAssertEqual(service.stakeAccountCalls, 2)
         XCTAssertEqual(invalidated, 1)
+    }
+
+    func testWithdrawPreparationFetchesIndividualLiveAccount() async throws {
+        let expected = account(
+            pubkey: "StakeLive",
+            vote: "V1",
+            stake: 1_000_610_412,
+            activationEpoch: 998,
+            deactivationEpoch: 1_001
+        )
+        let service = FakeStakingService(accounts: [expected])
+        let vm = makeViewModel(service: service)
+
+        let fetched = try await vm.fetchStakeAccount(address: expected.pubkey)
+
+        XCTAssertEqual(fetched, expected)
     }
 
     // MARK: - Cache-first paint

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingAPITests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingAPITests.swift
@@ -86,6 +86,20 @@ final class SolanaStakingAPITests: XCTestCase {
         XCTAssertTrue(rpcParams.isEmpty)
     }
 
+    func testWithdrawSimulationUsesUnsignedBase64AndReplacesBlockhash() throws {
+        let encodedTransaction = "dGVzdC10cmFuc2FjdGlvbg=="
+        let envelope = try params(for: .simulateTransaction(encodedTransaction: encodedTransaction))
+
+        XCTAssertEqual(envelope["method"] as? String, "simulateTransaction")
+        let rpcParams = try XCTUnwrap(envelope["params"] as? [Any])
+        XCTAssertEqual(rpcParams.first as? String, encodedTransaction)
+        let config = try XCTUnwrap(rpcParams[1] as? [String: Any])
+        XCTAssertEqual(config["encoding"] as? String, "base64")
+        XCTAssertEqual(config["commitment"] as? String, "confirmed")
+        XCTAssertEqual(config["sigVerify"] as? Bool, false)
+        XCTAssertEqual(config["replaceRecentBlockhash"] as? Bool, true)
+    }
+
     func testMinDelegationPublicHostsDropTheProxyPath() {
         // The public endpoints are complete JSON-RPC URLs, so the `/solana/`
         // proxy path must not be appended.
@@ -124,6 +138,17 @@ final class SolanaStakingAPITests: XCTestCase {
             from: Data(json.utf8)
         )
         XCTAssertEqual(response.result.value, 1_000_000_000)
+    }
+
+    func testWithdrawSimulationResponseDecodesStakeProgramFailure() throws {
+        let json = #"{"jsonrpc":"2.0","result":{"value":{"err":{"InstructionError":[2,"InsufficientFunds"]},"logs":["Program log: ERROR: An account's balance was too small to complete the instruction"]}},"id":1}"#
+        let response = try JSONDecoder().decode(
+            SolanaSimulateTransactionResponse.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertNotNil(response.result?.value.err)
+        XCTAssertEqual(response.result?.value.logs?.count, 1)
     }
 
     func testVoteAccountsResponseDecodesAndTagsDelinquency() throws {

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingServiceCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaStakingServiceCacheTests.swift
@@ -44,6 +44,8 @@ private final class CountingReader: SolanaStakingReading, @unchecked Sendable {
         return []
     }
 
+    func fetchSolanaStakeAccount(address: String) async throws -> SolanaStakeAccount? { nil }
+
     func fetchSolanaEpochInfo() async throws -> SolanaEpochInfo {
         SolanaEpochInfo(epoch: 993, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
     }

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaWithdrawTransactionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/Staking/SolanaWithdrawTransactionViewModelTests.swift
@@ -20,6 +20,7 @@ import XCTest
 private final class FakeWithdrawStakingService: SolanaStakingServiceProtocol, @unchecked Sendable {
     func fetchValidators() async throws -> [SolanaValidator] { [] }
     func fetchStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] { [] }
+    func fetchStakeAccount(address: String) async throws -> SolanaStakeAccount? { nil }
     func fetchEpochInfo() async throws -> SolanaEpochInfo {
         SolanaEpochInfo(epoch: 800, slotIndex: 1, slotsInEpoch: 432_000, absoluteSlot: 1)
     }

--- a/VultisigApp/VultisigAppTests/Chains/SolanaServiceBroadcastTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/SolanaServiceBroadcastTests.swift
@@ -23,6 +23,14 @@ final class SolanaServiceBroadcastTests: XCTestCase {
         )
     }
 
+    private func makePreflightService(_ json: String) -> SolanaService {
+        SolanaService(
+            resolver: NoOverrideResolver(),
+            httpClient: SolanaPreflightStubHTTPClient(json: json),
+            broadcastRetryBackoff: .zero
+        )
+    }
+
     func test_send_returnsSignature_onFirstAttempt() async throws {
         let stub = SolanaStubHTTPClient(results: [.success("sig123")])
         let service = makeService(stub)
@@ -107,6 +115,65 @@ final class SolanaServiceBroadcastTests: XCTestCase {
         }
         XCTAssertEqual(stub.callCount, 1)
     }
+
+    func test_withdrawPreflight_allowsSuccessfulSimulation() async throws {
+        let service = makePreflightService(
+            #"{"jsonrpc":"2.0","id":1,"result":{"value":{"err":null,"logs":[]}}}"#
+        )
+
+        try await service.validateSolanaWithdraw(encodedTransaction: "dGVzdA==")
+    }
+
+    func test_withdrawPreflight_mapsReportedInsufficientFundsToNotReady() async {
+        let json = #"{"jsonrpc":"2.0","id":1,"result":{"value":{"err":{"InstructionError":[2,"InsufficientFunds"]},"logs":["Program log: ERROR: An account's balance was too small to complete the instruction","Program Stake11111111111111111111111111111111111111 failed: insufficient funds for instruction"]}}}"#
+        let service = makePreflightService(json)
+
+        do {
+            try await service.validateSolanaWithdraw(encodedTransaction: "dGVzdA==")
+            XCTFail("expected stakeNotReady")
+        } catch let error as SolanaWithdrawPreflightError {
+            guard case .stakeNotReady = error else {
+                return XCTFail("unexpected preflight error: \(error)")
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_withdrawPreflight_preservesOtherSimulationFailure() async {
+        let json = #"{"jsonrpc":"2.0","id":1,"result":{"value":{"err":{"InstructionError":[2,"InvalidAccountData"]},"logs":["Program failed: invalid account data"]}}}"#
+        let service = makePreflightService(json)
+
+        do {
+            try await service.validateSolanaWithdraw(encodedTransaction: "dGVzdA==")
+            XCTFail("expected rpcError")
+        } catch let error as SolanaServiceError {
+            guard case .rpcError(_, let code) = error else {
+                return XCTFail("unexpected service error: \(error)")
+            }
+            XCTAssertEqual(code, -32002)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func test_withdrawPreflight_preservesTopLevelRpcError() async {
+        let service = makePreflightService(
+            #"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}"#
+        )
+
+        do {
+            try await service.validateSolanaWithdraw(encodedTransaction: "dGVzdA==")
+            XCTFail("expected rpcError")
+        } catch let error as SolanaServiceError {
+            guard case .rpcError(_, let code) = error else {
+                return XCTFail("unexpected service error: \(error)")
+            }
+            XCTAssertEqual(code, -32601)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
 }
 
 // MARK: - Test doubles
@@ -149,6 +216,31 @@ private final class SolanaStubHTTPClient: HTTPClientProtocol {
             json = #"{"jsonrpc":"2.0","id":1,"error":{"code":\#(code),"message":"\#(message)"}}"#
         }
 
+        let response = HTTPURLResponse(
+            url: URL(string: "https://test.local")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return HTTPResponse(data: Data(json.utf8), response: response)
+    }
+}
+
+private final class SolanaPreflightStubHTTPClient: HTTPClientProtocol {
+    private let json: String
+
+    init(json: String) {
+        self.json = json
+    }
+
+    // Protocol requires `async`; the body is sync. Silence the lint here.
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        guard let api = target as? SolanaAPI,
+              case .simulateTransaction = api.rpcMethod else {
+            XCTFail("expected simulateTransaction")
+            throw HTTPError.invalidResponse
+        }
         let response = HTTPURLResponse(
             url: URL(string: "https://test.local")!,
             statusCode: 200,


### PR DESCRIPTION
## Summary
- refresh the individual Solana stake account before constructing Verify so the reviewed full-withdraw amount uses the latest live `lamports`
- re-check that balance immediately before keysign and fail closed if it changed
- simulate the exact unsigned withdrawal before MPC so stake-history-dependent cooldown failures are surfaced early
- keep full-close semantics: the total account balance already includes the refundable rent-exempt reserve, so it is never added twice

## Root cause
The submitted transaction withdrew `1,002,893,292` lamports while the source account held more than that, but the Stake program still returned `InstructionError[2, "InsufficientFunds"]`. The account had advanced past its recorded deactivation epoch but still had effective stake cooling down. The previous one-epoch UI heuristic was therefore not authoritative.

## Test plan
- [x] Focused SwiftLint: 0 violations in changed Swift files
- [x] 42 focused Solana resolver, RPC, service, and DeFi view-model tests pass
- [x] Isolated iOS simulator build succeeds
- [x] Full SwiftLint remains at the existing baseline of 43 unrelated warnings, with no new warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preflight validation for Solana staking withdrawals before signing.
  * Withdrawals now use the latest on-chain stake balance and simulated transaction status.
  * Added clearer handling when staking is not yet ready for withdrawal.
* **Bug Fixes**
  * Prevented withdrawals based on stale stake balances.
  * Improved transaction simulation and error reporting.
* **Documentation**
  * Clarified Solana staking cooldown and withdrawal validation behavior.
* **Localization**
  * Added “withdrawal not ready” messaging in supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->