### PR TITLE
fix(solana): re-read stake accounts via getAccountInfo to stop flipping Defi state

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -577,26 +577,22 @@ class SolanaService {
     /// Not cached — must reflect a just-submitted stake/unstake and freshly
     /// accrued rewards; the UI refreshes on appear.
     func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] {
-        // Discover the owner's stake accounts via getProgramAccounts. We prefer to
-        // re-read each account's live state with getAccountInfo below: many RPC
-        // providers serve getProgramAccounts from a lagging secondary index, so its
-        // parsed delegation/deactivation fields flip between refreshes right after a
-        // stake/unstake (observed on the Defi screen). getAccountInfo is a direct
-        // bank read with no index lag.
-        //
-        // But we KEEP the discovery row as a fallback: a just-created stake account
-        // may not be visible to getAccountInfo yet (it hasn't propagated to the node
-        // the follow-up read hits), and must not drop off the list in that window.
+        // Discover the owner's stake-account pubkeys via getProgramAccounts, but
+        // take ONLY the addresses from it. Many RPC providers serve
+        // getProgramAccounts from a lagging secondary index, so its parsed
+        // delegation/deactivation fields flip between refreshes right after a
+        // stake/unstake (observed on the Defi screen). Each account's live state is
+        // re-read below with getAccountInfo — a direct bank read with no index lag.
         let discovery = try await httpClient.request(
             api(.getStakeAccountsByOwner(staker: owner, pubkeyOnly: false)),
             responseType: SolanaGetProgramAccountsResponse.self
         )
-        let discovered = discovery.data.result.compactMap { SolanaStakeAccount(programAccount: $0) }
-        guard !discovered.isEmpty else { return [] }
+        let pubkeys = discovery.data.result.map(\.pubkey)
+        guard !pubkeys.isEmpty else { return [] }
 
-        let fresh = try await withThrowingTaskGroup(of: (String, SolanaStakeAccount?).self) { group in
-            for account in discovered {
-                group.addTask { [self] in (account.pubkey, try await fetchSolanaStakeAccount(address: account.pubkey)) }
+        let resolved = try await withThrowingTaskGroup(of: (String, SolanaStakeAccount?).self) { group in
+            for pubkey in pubkeys {
+                group.addTask { [self] in (pubkey, try await fetchSolanaStakeAccount(address: pubkey)) }
             }
             var byPubkey: [String: SolanaStakeAccount] = [:]
             for try await (pubkey, account) in group {
@@ -604,10 +600,9 @@ class SolanaService {
             }
             return byPubkey
         }
-        // Prefer the fresh getAccountInfo read; fall back to the discovery row when
-        // getAccountInfo hasn't caught up yet (e.g. a just-staked account). Preserve
-        // discovery order.
-        return discovered.map { fresh[$0.pubkey] ?? $0 }
+        // Preserve discovery order; drop any that stopped resolving (e.g. closed
+        // between discovery and the follow-up read).
+        return pubkeys.compactMap { resolved[$0] }
     }
 
     /// Full parsed info for a single stake account.

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -577,11 +577,32 @@ class SolanaService {
     /// Not cached — must reflect a just-submitted stake/unstake and freshly
     /// accrued rewards; the UI refreshes on appear.
     func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] {
-        let response = try await httpClient.request(
+        // Discover the owner's stake-account pubkeys via getProgramAccounts, but
+        // take ONLY the addresses from it. Many RPC providers serve
+        // getProgramAccounts from a lagging secondary index, so its parsed
+        // delegation/deactivation fields flip between refreshes right after a
+        // stake/unstake (observed on the Defi screen). Each account's live state is
+        // re-read below with getAccountInfo — a direct bank read with no index lag.
+        let discovery = try await httpClient.request(
             api(.getStakeAccountsByOwner(staker: owner, pubkeyOnly: false)),
             responseType: SolanaGetProgramAccountsResponse.self
         )
-        return response.data.result.compactMap { SolanaStakeAccount(programAccount: $0) }
+        let pubkeys = discovery.data.result.map(\.pubkey)
+        guard !pubkeys.isEmpty else { return [] }
+
+        let resolved = try await withThrowingTaskGroup(of: (String, SolanaStakeAccount?).self) { group in
+            for pubkey in pubkeys {
+                group.addTask { [self] in (pubkey, try await fetchSolanaStakeAccount(address: pubkey)) }
+            }
+            var byPubkey: [String: SolanaStakeAccount] = [:]
+            for try await (pubkey, account) in group {
+                byPubkey[pubkey] = account
+            }
+            return byPubkey
+        }
+        // Preserve discovery order; drop any that stopped resolving (e.g. closed
+        // between discovery and the follow-up read).
+        return pubkeys.compactMap { resolved[$0] }
     }
 
     /// Full parsed info for a single stake account.

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -577,22 +577,26 @@ class SolanaService {
     /// Not cached — must reflect a just-submitted stake/unstake and freshly
     /// accrued rewards; the UI refreshes on appear.
     func fetchSolanaStakeAccounts(owner: String) async throws -> [SolanaStakeAccount] {
-        // Discover the owner's stake-account pubkeys via getProgramAccounts, but
-        // take ONLY the addresses from it. Many RPC providers serve
-        // getProgramAccounts from a lagging secondary index, so its parsed
-        // delegation/deactivation fields flip between refreshes right after a
-        // stake/unstake (observed on the Defi screen). Each account's live state is
-        // re-read below with getAccountInfo — a direct bank read with no index lag.
+        // Discover the owner's stake accounts via getProgramAccounts. We prefer to
+        // re-read each account's live state with getAccountInfo below: many RPC
+        // providers serve getProgramAccounts from a lagging secondary index, so its
+        // parsed delegation/deactivation fields flip between refreshes right after a
+        // stake/unstake (observed on the Defi screen). getAccountInfo is a direct
+        // bank read with no index lag.
+        //
+        // But we KEEP the discovery row as a fallback: a just-created stake account
+        // may not be visible to getAccountInfo yet (it hasn't propagated to the node
+        // the follow-up read hits), and must not drop off the list in that window.
         let discovery = try await httpClient.request(
             api(.getStakeAccountsByOwner(staker: owner, pubkeyOnly: false)),
             responseType: SolanaGetProgramAccountsResponse.self
         )
-        let pubkeys = discovery.data.result.map(\.pubkey)
-        guard !pubkeys.isEmpty else { return [] }
+        let discovered = discovery.data.result.compactMap { SolanaStakeAccount(programAccount: $0) }
+        guard !discovered.isEmpty else { return [] }
 
-        let resolved = try await withThrowingTaskGroup(of: (String, SolanaStakeAccount?).self) { group in
-            for pubkey in pubkeys {
-                group.addTask { [self] in (pubkey, try await fetchSolanaStakeAccount(address: pubkey)) }
+        let fresh = try await withThrowingTaskGroup(of: (String, SolanaStakeAccount?).self) { group in
+            for account in discovered {
+                group.addTask { [self] in (account.pubkey, try await fetchSolanaStakeAccount(address: account.pubkey)) }
             }
             var byPubkey: [String: SolanaStakeAccount] = [:]
             for try await (pubkey, account) in group {
@@ -600,9 +604,10 @@ class SolanaService {
             }
             return byPubkey
         }
-        // Preserve discovery order; drop any that stopped resolving (e.g. closed
-        // between discovery and the follow-up read).
-        return pubkeys.compactMap { resolved[$0] }
+        // Prefer the fresh getAccountInfo read; fall back to the discovery row when
+        // getAccountInfo hasn't caught up yet (e.g. a just-staked account). Preserve
+        // discovery order.
+        return discovered.map { fresh[$0.pubkey] ?? $0 }
     }
 
     /// Full parsed info for a single stake account.


### PR DESCRIPTION
## Issue
Closes #4822

## Summary
The Solana Defi staked list (`SolanaStakeDefiViewModel` → `SolanaStakingService.fetchStakeAccounts` → `SolanaService.fetchSolanaStakeAccounts`) fetched stake accounts with a single `getProgramAccounts` (jsonParsed) call and bound its parsed state directly to the UI.

Many RPC providers serve `getProgramAccounts` from a **lagging secondary index**, so its `delegation`/`deactivationEpoch` fields flip between refreshes right after a stake/unstake — the staked list showed unstable/stale state (reproduced in testing).

This change uses `getProgramAccounts` only to **discover** the owner's stake-account pubkeys, then re-reads each account's **live** state via `getAccountInfo` — a direct bank read with no index lag:

- Discovery call unchanged (existing jsonParsed decoding); only the `pubkey` of each row is taken.
- Each account re-read concurrently via the existing `fetchSolanaStakeAccount(address:)` (`getAccountInfo`).
- Results returned in **discovery order** for a stable list across refreshes.

`getAccountInfo` is a known-address, direct read — the same fix pattern that resolves the flip-flop when querying a single stake account manually.

## Notes
- Cost goes from 1 → 1 + N requests (N = stake accounts held); the re-reads run in parallel. Fine for the handful a vault typically holds.
- The unused `getStakeAccountsByOwner(pubkeyOnly: true)` branch was left untouched — its base64 `data` array can't decode into `SolanaStakeAccountData` (expects an object), so it's dead as-is. Out of scope here; can be removed/fixed separately.

## Test Plan
- [x] Open the Solana Defi screen with an active stake account; refresh repeatedly — state (active/deactivating/inactive) stays stable.
- [x] Stake, then verify the new account appears with correct state.
- [x] Deactivate, then verify the row reflects deactivating/cooldown correctly across refreshes.
- [x] Vault with no stake accounts returns an empty list (no error).
- [x] SwiftLint passes (0 violations on changed file)
- [x] xcodebuild build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Summary of changes

* **Bug Fixes**
  * Improved Solana stake account retrieval by first discovering stake account addresses, then fetching each account’s latest live state for more accurate details.
  * Preserves the original discovery order in the returned results.
  * Returns an empty list when no stake accounts are found, and avoids failing when individual accounts can’t be refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->