### PR TITLE
chore(make): add `make open` to regenerate + open the project in Xcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -eo pipefail -c
 
-.PHONY: help bootstrap generate build-check test ui_test
+.PHONY: help bootstrap generate open build-check test ui_test
 
 # Paths
 VULTISIG_APP_DIR := VultisigApp
@@ -41,6 +41,7 @@ help: ## List all targets
 	@echo "Available targets:"
 	@echo "  make bootstrap   — install XcodeGen + SwiftLint (via Homebrew) and generate the Xcode project"
 	@echo "  make generate    — regenerate VultisigApp.xcodeproj from VultisigApp/project.yml"
+	@echo "  make open        — regenerate the project and open it in Xcode"
 	@echo "  make build-check — compile-only build check (for automation; tails 20 lines of output)"
 	@echo "  make test        — run unit tests on iOS simulator ($(APP_SCHEME) scheme)"
 	@echo "  make ui_test     — run UI tests on iOS simulator ($(UI_SCHEME) scheme)"
@@ -71,6 +72,9 @@ generate: ## Regenerate the Xcode project from project.yml
 		exit 1; \
 	fi
 	@cd $(VULTISIG_APP_DIR) && xcodegen generate --spec project.yml
+
+open: generate ## Regenerate the project and open it in Xcode
+	@cd $(VULTISIG_APP_DIR) && open $(PROJECT)
 
 build-check: generate ## Compile-only build check (no tests). Used by automation skills.
 	@cd $(VULTISIG_APP_DIR) && xcodebuild build \


### PR DESCRIPTION
## Description

Adds a `make open` target that regenerates `VultisigApp.xcodeproj` and opens it in Xcode in one step.

The `.xcodeproj` is **gitignored and generated** from `VultisigApp/project.yml` via XcodeGen, so opening it directly (double-click / `xed`) risks a stale project — or none at all on a fresh clone. `make open` makes the right thing the easy thing: it depends on `generate`, so the project is always current before Xcode opens it. Handy for newcomers and after any `project.yml` change.

```makefile
open: generate ## Regenerate the project and open it in Xcode
	@cd $(VULTISIG_APP_DIR) && open $(PROJECT)
```

Also wired into `.PHONY` and the `make help` listing.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

Tooling only — no app code touched.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (Makefile target; verified via `make -n open` that it resolves `generate` → `open VultisigApp.xcodeproj`)

## Additional context

Verified with `make -n open` (dry run):
```
cd VultisigApp && xcodegen generate --spec project.yml
cd VultisigApp && open VultisigApp.xcodeproj
```

## Agent Metadata
- **Agent**: Claude Code
- **Confidence**: high — one additive Makefile target, no app code
- **Needs human review for**: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a streamlined command to regenerate the Xcode project and open it directly in Xcode.
  * Documented the new command in the available build and development commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->