### PR TITLE
fix(wallet): refresh per-chain fiat when rates land, not only after a balance refresh

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
@@ -27,6 +27,15 @@ final class RateProvider {
 
     static let shared = RateProvider()
 
+    /// Fires on the main actor whenever the cached rate set changes — the initial
+    /// load of persisted rates and every `save(rates:)`.
+    ///
+    /// Rates are an otherwise silent cache: callers that render a *precomputed*
+    /// fiat value (rather than reading `rate(for:)` inside `body`) have no way to
+    /// learn that a rate arrived, so their fiat stays frozen at whatever was
+    /// cached when they last recomputed. This signal is that missing link.
+    let ratesDidChange = PassthroughSubject<Void, Never>()
+
     static func cryptoId(for coin: CoinMeta) -> CryptoId {
         switch coin.chain.chainType {
         case .EVM, .Solana, .Sui, .THORChain:
@@ -66,6 +75,10 @@ final class RateProvider {
             do {
                 let objects = try Storage.shared.modelContext.fetch(descriptor)
                 self.rates = Set(objects.map { Rate(object: $0) })
+                // Persisted rates make fiat renderable immediately on a warm
+                // start; announce them so views that cached a pre-load fiat
+                // value recompute instead of waiting on a network refresh.
+                self.ratesDidChange.send()
             } catch {
                 print("Failed to load rates: \(error.localizedDescription)")
             }
@@ -155,5 +168,6 @@ final class RateProvider {
         }
 
         try Storage.shared.modelContext.save()
+        ratesDidChange.send()
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
@@ -149,6 +149,12 @@ final class RateProvider {
         let newRateIds = Set(newRates.map { $0.id })
         rates = rates.filter { !newRateIds.contains($0.id) }.union(newRates)
 
+        // The in-memory cache is what rendering reads, and it has already
+        // changed — announce it even if the persistence below throws, or a
+        // failed write would leave the UI showing fiat that contradicts the
+        // cache until the next refresh.
+        defer { ratesDidChange.send() }
+
         // Update existing or insert new rates
         for rate in newRates {
             let rateId = rate.id // Capture the value outside the predicate
@@ -168,6 +174,5 @@ final class RateProvider {
         }
 
         try Storage.shared.modelContext.save()
-        ratesDidChange.send()
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -56,13 +56,23 @@ class VaultDetailViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
-    /// Recomputes the projection against the currently cached rates. No-ops when
-    /// nothing changed, so the repeated `save(rates:)` calls of a single refresh
-    /// collapse into at most one publish.
+    /// Recomputes the projection's fiat against the currently cached rates,
+    /// **keeping the current row order**.
+    ///
+    /// `chainRows(vault:)` orders by fiat descending, and rates land once per
+    /// chain group, so re-sorting here would reshuffle the list under the user
+    /// several times per refresh. A rate arriving should refresh the values, not
+    /// reorder — the authoritative fiat-desc re-sort stays on `updateBalance`'s
+    /// tail, which keeps the deliberate "no stale-then-fresh double reorder"
+    /// behaviour intact. No-ops when nothing changed.
     private func rebuildRowsForRateChange() {
-        guard let vault = rowsVault, !chains.isEmpty else { return }
-        let rebuilt = logic.chainRows(vault: vault)
-        guard rebuilt != rows else { return }
+        guard let vault = rowsVault, !rows.isEmpty else { return }
+        let byChain = Dictionary(
+            logic.chainRows(vault: vault).map { ($0.chain, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        let rebuilt = rows.compactMap { byChain[$0.chain] }
+        guard rebuilt.count == rows.count, rebuilt != rows else { return }
         rows = rebuilt
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Amol Kumar on 2024-03-09.
 //
 
+import Combine
 import Foundation
 import SwiftUI
 
@@ -32,8 +33,37 @@ class VaultDetailViewModel: ObservableObject {
 
     private let bannerStore: PromoBannerDismissalStoring
 
-    init(bannerStore: PromoBannerDismissalStoring = PromoBannerDismissalStore.shared) {
+    /// The vault `rows` currently projects. Held so a rate arrival can rebuild the
+    /// projection without waiting for the next `updateBalance(vault:)` call.
+    private weak var rowsVault: Vault?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        bannerStore: PromoBannerDismissalStoring = PromoBannerDismissalStore.shared,
+        rateProvider: RateProvider = .shared
+    ) {
         self.bannerStore = bannerStore
+
+        // `rows` bakes fiat into a formatted string, so it is inert to a rate
+        // landing afterwards. Without this subscription the only rebuild happens
+        // at the tail of `updateBalance`'s network refresh, so the per-chain fiat
+        // stays at "$0.00" for the whole balance round trip — and never updates at
+        // all when that task is cancelled by a re-entrant refresh. Rebuilding here
+        // is pure and network-free.
+        rateProvider.ratesDidChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.rebuildRowsForRateChange() }
+            .store(in: &cancellables)
+    }
+
+    /// Recomputes the projection against the currently cached rates. No-ops when
+    /// nothing changed, so the repeated `save(rates:)` calls of a single refresh
+    /// collapse into at most one publish.
+    private func rebuildRowsForRateChange() {
+        guard let vault = rowsVault, !chains.isEmpty else { return }
+        let rebuilt = logic.chainRows(vault: vault)
+        guard rebuilt != rows else { return }
+        rows = rebuilt
     }
 
     func filteredChains(in vault: Vault) -> [Chain] {
@@ -65,6 +95,7 @@ class VaultDetailViewModel: ObservableObject {
         // auto-discovery adds non-native coins to existing chains, so the
         // chain set is unchanged and the list does not reshuffle.
         let membershipChanged = Set(vault.chainsWithCoins) != Set(chains)
+        rowsVault = vault
         if chains.isEmpty || chainsVaultPubKeyECDSA != vault.pubKeyECDSA || membershipChanged {
             chains = logic.sortedChains(vault: vault)
             rows = logic.chainRows(vault: vault)
@@ -93,6 +124,7 @@ class VaultDetailViewModel: ObservableObject {
     }
 
     func groupChains(vault: Vault) {
+        rowsVault = vault
         chains = logic.sortedChains(vault: vault)
         rows = logic.chainRows(vault: vault)
         chainsVaultPubKeyECDSA = vault.pubKeyECDSA

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -111,6 +111,38 @@ final class VaultDetailViewModelTests: XCTestCase {
         await fulfillment(of: [rebuilt], timeout: 2)
     }
 
+    /// Rates land once per chain group, and `chainRows` orders by fiat desc, so a
+    /// rate-driven rebuild that re-sorted would reshuffle the list under the user
+    /// mid-refresh. The rate rebuild must refresh values in place and leave
+    /// ordering to `updateBalance`'s tail.
+    func testRateArrivalRefreshesFiatWithoutReorderingRows() async throws {
+        let btcId = "order-btc-\(UUID().uuidString)"
+        let ethId = "order-eth-\(UUID().uuidString)"
+        let vault = makeVault(pubKey: "vault-order", chains: [])
+        vault.coins = [
+            makePricedCoin(chain: .bitcoin, ticker: "BTC", providerId: btcId, rawBalance: "100000000"),
+            makePricedCoin(chain: .ethereum, ticker: "ETH", providerId: ethId, rawBalance: "1000000000000000000")
+        ]
+
+        let vm = VaultDetailViewModel()
+        vm.groupChains(vault: vault)
+        let orderBefore = vm.rows.map(\.chain)
+
+        // Price ETH far above BTC. A re-sorting rebuild would flip the order.
+        let rebuilt = expectation(description: "fiat refreshed")
+        rateCancellable = vm.$rows.dropFirst().sink { rows in
+            if rows.contains(where: { $0.fiatBalance != Decimal.zero.formatToFiat(includeCurrencySymbol: true) }) {
+                rebuilt.fulfill()
+            }
+        }
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: ethId, value: 900_000)
+        ])
+        await fulfillment(of: [rebuilt], timeout: 2)
+
+        XCTAssertEqual(vm.rows.map(\.chain), orderBefore, "a rate arrival must not reorder the list")
+    }
+
     /// A rate for a coin this vault does not hold must not republish `rows` —
     /// `save(rates:)` fires once per chain group, so an unguarded rebuild would
     /// churn the list several times per refresh.

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -27,12 +27,108 @@
 //       equal inputs are `==` (Equatable rows).
 //
 
+import Combine
 import Foundation
 import XCTest
 @testable import VultisigApp
 
 @MainActor
 final class VaultDetailViewModelTests: XCTestCase {
+
+    private var rateCancellable: AnyCancellable?
+
+    // MARK: - Rate arrival refreshes the row projection
+
+    /// `ChainRowModel.fiatBalance` is a *formatted string* baked at projection
+    /// time, so a rate landing afterwards is invisible to it. The only rebuild
+    /// used to be the tail of `updateBalance`'s network refresh, which meant the
+    /// per-chain fiat sat at "$0.00" for the whole balance round trip (observed:
+    /// 60s on a flaky network, with the correct rates cached in memory the entire
+    /// time) — and never refreshed at all when that task lost its cancellation
+    /// race. A rate arriving must rebuild the projection on its own, with no
+    /// balance fetch involved.
+    func testRowsRefreshWhenRateLandsAfterProjectionWasBuilt() async throws {
+        let providerId = "vaultmain-rate-\(UUID().uuidString)"
+        let vault = makeVault(pubKey: "vault-rate", chains: [])
+        vault.coins = [makePricedCoin(chain: .bitcoin, ticker: "BTC", providerId: providerId, rawBalance: "100000000")]
+
+        let vm = VaultDetailViewModel()
+        vm.groupChains(vault: vault)
+
+        let fiatBefore = try XCTUnwrap(vm.rows.first(where: { $0.chain == .bitcoin })?.fiatBalance)
+        XCTAssertEqual(
+            fiatBefore,
+            Decimal.zero.formatToFiat(includeCurrencySymbol: true),
+            "precondition: no rate cached, so the projection bakes a zero fiat"
+        )
+
+        let rebuilt = expectation(description: "rows rebuilt on rate arrival")
+        rateCancellable = vm.$rows
+            .dropFirst()
+            .sink { rows in
+                if rows.first(where: { $0.chain == .bitcoin })?.fiatBalance != fiatBefore {
+                    rebuilt.fulfill()
+                }
+            }
+
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: providerId, value: 50_000)
+        ])
+
+        await fulfillment(of: [rebuilt], timeout: 2)
+        XCTAssertNotEqual(
+            vm.rows.first(where: { $0.chain == .bitcoin })?.fiatBalance,
+            fiatBefore,
+            "a cached rate must reach the row without a balance refresh"
+        )
+    }
+
+    /// The rebuild must be driven by the rate cache, not by `updateBalance` — a
+    /// view model that never ran a network refresh still has to pick up a rate.
+    /// Guards against "fixing" this by re-coupling the rebuild to balances.
+    func testRowsRefreshOnRateArrivalWithoutAnyBalanceRefresh() async throws {
+        let providerId = "vaultmain-norefresh-\(UUID().uuidString)"
+        let vault = makeVault(pubKey: "vault-norefresh", chains: [])
+        vault.coins = [makePricedCoin(chain: .ethereum, ticker: "ETH", providerId: providerId, rawBalance: "1000000000000000000")]
+
+        let vm = VaultDetailViewModel()
+        vm.groupChains(vault: vault)
+        let fiatBefore = try XCTUnwrap(vm.rows.first(where: { $0.chain == .ethereum })?.fiatBalance)
+
+        let rebuilt = expectation(description: "rows rebuilt without updateBalance")
+        rateCancellable = vm.$rows
+            .dropFirst()
+            .sink { rows in
+                if rows.first(where: { $0.chain == .ethereum })?.fiatBalance != fiatBefore {
+                    rebuilt.fulfill()
+                }
+            }
+
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: providerId, value: 2_000)
+        ])
+
+        await fulfillment(of: [rebuilt], timeout: 2)
+    }
+
+    /// A rate for a coin this vault does not hold must not republish `rows` —
+    /// `save(rates:)` fires once per chain group, so an unguarded rebuild would
+    /// churn the list several times per refresh.
+    func testUnrelatedRateDoesNotRepublishRows() async throws {
+        let vault = makeVault(pubKey: "vault-unrelated", chains: [.bitcoin])
+        let vm = VaultDetailViewModel()
+        vm.groupChains(vault: vault)
+
+        let noPublish = expectation(description: "rows must not republish")
+        noPublish.isInverted = true
+        rateCancellable = vm.$rows.dropFirst().sink { _ in noPublish.fulfill() }
+
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: "unrelated-\(UUID().uuidString)", value: 42)
+        ])
+
+        await fulfillment(of: [noPublish], timeout: 0.5)
+    }
 
     func testUpdateBalance_firstCall_seedsChainsSynchronously() {
         let vault = makeVault(pubKey: "vault-a", chains: [.bitcoin, .ethereum])
@@ -432,5 +528,23 @@ final class VaultDetailViewModelTests: XCTestCase {
             isNativeToken: true
         )
         return Coin(asset: meta, address: "addr-\(pubKey)-\(chain.name)", hexPublicKey: "")
+    }
+
+    /// Native coin with a unique `priceProviderId` and a non-zero balance, so a
+    /// rate saved under that id changes the projected fiat. The unique id keeps
+    /// the `RateProvider` singleton's cache from leaking across tests.
+    private func makePricedCoin(chain: Chain, ticker: String, providerId: String, rawBalance: String) -> Coin {
+        let meta = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: "",
+            decimals: chain == .ethereum ? 18 : 8,
+            priceProviderId: providerId,
+            contractAddress: "",
+            isNativeToken: true
+        )
+        let coin = Coin(asset: meta, address: "addr-\(providerId)", hexPublicKey: "")
+        coin.rawBalance = rawBalance
+        return coin
     }
 }


### PR DESCRIPTION
Closes #4830

## Problem

The **per-chain fiat total** on the wallet main screen takes far too long to appear, or never appears at all. The vault header total updates fine — only the per-chain rows are stuck.

## Root cause (proven at runtime, not inferred)

`VaultMainChainListView` renders `ChainRowModel.fiatBalance`, a **preformatted `String`** baked when `VaultDetailViewModel.rows` is assigned. `VaultChainCellView` holds `vault` as a plain `let`, so nothing about a rate landing can repaint it.

Three facts combine:

1. **`RateProvider` is a silent cache** — no `ObservableObject`, no `@Published`, no subject. A rate landing is unobservable by design.
2. **`BalanceService.refreshFiat`'s `objectWillChange.send()` is useless for the rows.** It repaints the views, but the rows' *data* is still the stale snapshot. It does work for the header total, which reads `vault.coins` live via `@ObservedObject var vault` — hence the asymmetry.
3. **The only rebuild is the tail of `updateBalance`'s network refresh**, behind a 250 ms debounce, the full balance+price round trip, and `if !Task.isCancelled`.

So the per-chain fiat can only change when a *full, uncancelled, vault-wide network refresh* completes — even though the rates it needs are normally already cached.

### Log timeline

Instrumented `origin/main`, real 21-coin vault (Ethereum + TerraClassic), dedicated en_US sim. Cold launch:

```
t=  0.001  chainRows() BUILD: RateProvider has rates for 0/21 coins
t=  0.003  VM.SEED rows -> Ethereum=$0.00, TerraClassic=$0.00
t=  0.003  VM.TASK aborted during 250ms debounce (cancelled) -> rows NEVER rebuilt this cycle
t=  0.066  RateProvider.WARMUP loaded 34 PERSISTED rates from SwiftData -- fiat renderable from here on
t=  0.258  BalanceService.updateBalances ENTER coins=21
t= 60.632  BalanceService.BALANCES fetched (21 updates)
t= 60.632  fetchRatesSafely THREW after 60.37s: timeout -- REMAINING RATES NEVER FETCHED
t= 60.655  chainRows() BUILD: RateProvider has rates for 15/21 coins
t= 60.657  VM.ROWS REBUILT -> TerraClassic=$44.32, Ethereum=$27.00
```

The decisive detail: **the price fetch threw** — zero new rates were saved that cycle. The correct fiat shown at t=60.657 came entirely from rates cached at **t=0.066**. The list sat at `$0.00` for **60.6 seconds with the right answer already in RAM**.

On a healthy network the same gap is ~1.7 s (rates t=2.345, rows t=4.071) — which is why this reads as intermittent rather than always-broken.

### "Slow" and "never" are one bug, two triggers

- **Slow** — rows wait for the slowest balance RPC in the entire vault (`withTaskGroup` waits for all) plus `await pricesDone`. One dead chain gates every chain's fiat.
- **Never** — `refresh()` fires from ~6 entry points, each cancelling the previous task. A cycle cancelled after `updateBalances` returns skips the rebuild entirely (the `t=0.003` line above is that path firing). Nothing retries until the next appear/pull, so it can stay `$0.00` indefinitely.

**Affects all chains equally** — a view-model binding defect, not chain-specific, and not the Multicall3/EVM path. All entry paths (cold launch, revisit, pull-to-refresh, currency change) share the same tail rebuild.

## Which commit

**`2dee43844`** ("reactive + cheap vault chain list via value-type row projection", #4500, first in `v1.39.60`) — it replaced a live-computed `fiatBalance` (recomputed on every `vault.objectWillChange`) with the baked snapshot.

The defect is **latent and network-dependent** (~1.7 s good network, 60 s+/never on a bad one), so it surfaces intermittently rather than at a clean release boundary.

### `30fb07391` (#4693, price/balance decoupling) is innocent

It was the prime suspect. Cleared two ways:

1. **Static** — `VaultDetailViewModel.updateBalance` is *byte-identical* between `v1.40.63` (last good) and `origin/main`. The row-rebuild trigger never changed.
2. **A/B experiment** — one binary, env-gated ordering, same vault/sim:

   | Run | Ordering | Rates in RAM | Rows correct |
   |---|---|---|---|
   | A | POST-#4693 (concurrent) | t=0.065 | **t=60.657** |
   | B | PRE-#4693 (prices-first, as v1.40.63) | t=0.065 | **t=60.656** |

   Identical to within 1 ms. If anything #4693 *improves* the worst case: rows land at `max(T_price, T_balance)` instead of `T_price + T_balance`.

## Fix

Fix the broken binding, not the timing — no timers, no forced refresh, no re-coupling:

1. **`RateProvider.ratesDidChange`** — a `PassthroughSubject` fired on the persisted-rate warmup and every `save(rates:)`. The missing reactive link.
2. **`VaultDetailViewModel`** subscribes and rebuilds its projection's fiat **in place, preserving row order**. Pure, network-free, no-ops when unchanged.
3. **Send from a `defer`** right after the cache mutation in `save`, so a throwing persist still announces the already-changed cache.

Balance/price fetching is untouched — #4693's Multicall3 batching and decoupling keep their wins.

**Why order-preserving:** `chainRows(vault:)` sorts by fiat descending and rates land once per chain group, so a re-sorting rebuild would reshuffle the list several times per refresh — the "stale-then-fresh double reorder" this view model deliberately avoids. The rate rebuild refreshes values only; the authoritative re-sort stays on `updateBalance`'s tail.

## Tests

`BalancePriceDecouplingTests` passes while the UI is broken because it tests the wrong seam: it mocks `CryptoPriceService` and asserts on `Coin.balanceInFiatForDisplay` — the **per-coin lazy** path used by `TokenCellView`/`CoinDetailHeaderView`, which the chain list does not use. It never touches `VaultDetailViewModel`, `ChainRowModel`, or the projection.

New tests pin the seam that actually failed:
- `testRowsRefreshWhenRateLandsAfterProjectionWasBuilt`
- `testRowsRefreshOnRateArrivalWithoutAnyBalanceRefresh` — guards against "fixing" this by re-coupling to balances
- `testRateArrivalRefreshesFiatWithoutReorderingRows`
- `testUnrelatedRateDoesNotRepublishRows`

## Follow-ups (not in this PR)

- **`$0.00` vs `—` inconsistency.** #4693 added `String.fiatPlaceholder` + `Coin.balanceInFiatForDisplay` for the cold-start "misleading $0.00 frame", but chain rows use `totalBalanceInFiatDecimal` and never adopted it — token cells show `—`, chain rows show `$0.00`. Adopting it for rows is a behaviour change beyond restoring refresh semantics, so it's left for a decision. Largely moot once rates render at t≈0.066.
- **Multicall3 zeroes on sub-call failure.** `decodeAggregate3Results` maps a failed sub-call to `nil` → `?? 0` → balance persisted as 0, whereas the per-coin path returns `nil` and *preserves* the last known balance.
- **Cancelled cycles keep their network work** (ETH ×6, LUNC ×3 duplicate fetches observed in one cycle).
- **`VaultDetailViewModel` actor isolation is implicit** — touches SwiftData `@Model`s from non-isolated methods, relying on `.receive(on: .main)`/call-site discipline rather than `@MainActor`. Pre-existing across the whole VM; annotating it is a separate refactor.

## Verification

- Gate: `make test` — see comment below for the literal marker + counts.
- Codex read-only review, per-commit + whole-branch: 1 Low + 1 Minor fixed (order preservation, `defer` send); 1 Medium deferred with reason (VM-wide `@MainActor` = separate refactor). Codex independently confirmed the first three new tests fail without the fix.
- Diagnostic logging stripped before commit.

**Pending on-device:** cold launch on a real multi-chain vault under a degraded network — per-chain fiat should render from cache within ~100 ms instead of waiting on the balance round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet details now update fiat values and projections automatically when exchange rates become available or change.
  * Existing chain rows retain their order while refreshed rate information is applied.

* **Bug Fixes**
  * Improved wallet balance displays when rates load after the initial screen render.

* **Tests**
  * Added coverage for rate-driven updates, projected fiat values, row ordering, and unrelated rate changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
