### PR TITLE
fix(limit-swap): honor the entered source chain + put asset selection before the execution condition

### DIFF
--- a/VultisigApp/VultisigApp/Features/LimitSwap/Logic/LimitMath.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Logic/LimitMath.swift
@@ -147,13 +147,21 @@ func marketProbeAmount(
     return probe
 }
 
-/// Preferred default SOURCE chain for the **limit-swap entry only**. The shared
-/// market default sorts alphabetically (`SwapCoinsResolver` picks the first held
-/// coin), which lands on a cheap source like RUNE and presents an
-/// untradeable-looking RUNE→BTC default. Prefer a high-value, liquid,
-/// THORChain-routable native source the vault actually holds — BTC, then ETH —
-/// skipping any candidate that collides with the target chain (which would be a
-/// self-pair).
+/// Preferred default SOURCE chain for the **limit-swap entry only**.
+///
+/// Two different situations arrive here as the same `marketDefaultChain`, and
+/// `isSourceExplicit` is what tells them apart:
+///
+/// - **No intent** (`false`) — the shared market default sorts alphabetically
+///   (`SwapCoinsResolver` picks the first held coin), which lands on a cheap
+///   source like RUNE and presents an untradeable-looking RUNE→BTC default. Here
+///   we prefer a high-value, liquid, THORChain-routable native source the vault
+///   actually holds — BTC, then ETH — skipping any candidate that collides with
+///   the target chain (which would be a self-pair).
+/// - **Explicit intent** (`true`) — the user entered the swap from a specific
+///   chain/coin, so that source is a real choice, not an alphabetical accident.
+///   Honor it whenever it is usable, and only fall back to the preference above
+///   when it isn't (unroutable, or a self-pair with the target).
 ///
 /// **Never returns `targetChain` while any held, THORChain-routable alternative
 /// native source exists** (a same-chain source→target is not THORChain-routable).
@@ -163,9 +171,17 @@ func marketProbeAmount(
 /// vault `Coin`. Does NOT change the shared market default.
 func preferredLimitSourceChain(
     marketDefaultChain: Chain,
+    isSourceExplicit: Bool,
     targetChain: Chain,
     availableNativeChains: Set<Chain>
 ) -> Chain {
+    // 0. An explicitly chosen source is real user intent — keep it when it's
+    //    usable (THORChain-routable and not a self-pair). Same rule as step 2;
+    //    intent is what promotes it above the BTC/ETH preference. An unusable
+    //    explicit source falls through rather than seeding an unplaceable order.
+    if isSourceExplicit, marketDefaultChain != targetChain, isThorchainRoutable(chain: marketDefaultChain) {
+        return marketDefaultChain
+    }
     // 1. High-value routable sources the vault holds (BTC → ETH), excluding a
     //    self-pair with the target. (BTC/ETH are always THORChain-routable.)
     for candidate in [Chain.bitcoin, .ethereum]
@@ -198,10 +214,20 @@ func preferredLimitSourceChain(
 /// back to the market default when the preferred chain isn't held (or already is
 /// the market default). Pure so the "held + non-colliding with target" guarantee
 /// is directly testable. Does NOT change the shared market default.
-func limitDefaultSourceCoin(marketDefault: Coin, targetCoin: Coin, vaultCoins: [Coin]) -> Coin {
+///
+/// `isSourceExplicit` marks `marketDefault` as a source the user actually chose
+/// (entered the swap from) rather than an alphabetical fallback — see
+/// `preferredLimitSourceChain`.
+func limitDefaultSourceCoin(
+    marketDefault: Coin,
+    isSourceExplicit: Bool,
+    targetCoin: Coin,
+    vaultCoins: [Coin]
+) -> Coin {
     let availableNativeChains = Set(vaultCoins.filter { $0.isNativeToken }.map(\.chain))
     let chain = preferredLimitSourceChain(
         marketDefaultChain: marketDefault.chain,
+        isSourceExplicit: isSourceExplicit,
         targetChain: targetCoin.chain,
         availableNativeChains: availableNativeChains
     )

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyView.swift
@@ -42,12 +42,13 @@ private enum LimitFocusField: Hashable {
 }
 
 /// Limit-swap body content — renders inside `SwapCryptoView` when the
-/// SegmentedControl is set to Limit. **Uniswap-style flat layout**: the price
-/// card ("When 1 <sell> is worth <price> <buy>" + Market/+1%/+5%/+10% pills) on
-/// top, the asset swap form (Sell + swap button + Buy) below it, then the expiry
-/// card, then the inline notices, with the Place-Order CTA pinned to the bottom.
-/// No collapse/expand — every input is visible at once, so the price and the
-/// amount it applies to are never hidden behind a chevron.
+/// SegmentedControl is set to Limit. **Uniswap-style flat layout**: the asset
+/// swap form (Sell + swap button + Buy) on top, the price card ("When 1 <sell>
+/// is worth <price> <buy>" + Market/+1%/+5%/+10% pills) below it, then the
+/// expiry card, then the inline notices, with the Place-Order CTA pinned to the
+/// bottom — the user picks what they're trading before stating the condition it
+/// executes under. No collapse/expand — every input is visible at once, so the
+/// price and the amount it applies to are never hidden behind a chevron.
 ///
 /// All business logic lives in `LimitSwapFormViewModel`; this view is
 /// declarative. The price field always edits `draft.targetPrice` in the target
@@ -87,15 +88,12 @@ struct LimitSwapBodyView: View {
         VStack(spacing: 12) {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 12) {
-                    LimitPriceCard(
-                        vm: vm,
-                        priceText: $priceText,
-                        usdText: $usdText,
-                        focusedField: $focusedField,
-                        onPickFromAsset: onPickFromAsset,
-                        onPickToAsset: onPickToAsset
-                    )
-
+                    // Asset selection comes first: the user picks what they're
+                    // trading before stating the condition it executes under.
+                    // The price card still names both assets ("When 1 BTC is
+                    // worth X ETH") because that sentence IS the condition —
+                    // its chips label the price's units and double as shortcuts
+                    // to the same pickers.
                     LimitAssetSwapForm(
                         vm: vm,
                         fromCoin: fromCoin,
@@ -105,6 +103,15 @@ struct LimitSwapBodyView: View {
                         onPickFromAsset: onPickFromAsset,
                         onPickToAsset: onPickToAsset,
                         onSwapAssets: onSwapAssets
+                    )
+
+                    LimitPriceCard(
+                        vm: vm,
+                        priceText: $priceText,
+                        usdText: $usdText,
+                        focusedField: $focusedField,
+                        onPickFromAsset: onPickFromAsset,
+                        onPickToAsset: onPickToAsset
                     )
 
                     LimitExpiryCard(vm: vm)

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -318,14 +318,19 @@ struct SwapDetailsScreen: View {
         }
     }
 
-    /// Source coin the **limit** entry seeds with. The shared market default
-    /// sorts alphabetically (lands on RUNE), which reads as an untradeable
-    /// RUNE→BTC default; prefer a high-value routable native source the vault
-    /// holds (BTC → ETH) that doesn't collide with the target. Limit-entry only
-    /// — the shared market `detailsViewModel.fromCoin` is unchanged.
+    /// Source coin the **limit** entry seeds with. Limit-entry only — the shared
+    /// market `detailsViewModel.fromCoin` is unchanged.
+    ///
+    /// A non-nil `fromCoin` means the user entered the swap from a specific
+    /// chain/coin, so the source is an explicit choice to honor. When it's nil the
+    /// source is `SwapCoinsResolver`'s alphabetical fallback (lands on RUNE, which
+    /// reads as an untradeable RUNE→BTC default), so prefer a high-value routable
+    /// native source the vault holds (BTC → ETH) instead. `detailsViewModel`
+    /// resolves the same optional the same way (`initialFromCoin ?? defaultFromCoin`).
     private var limitInitialFromCoin: Coin {
         limitDefaultSourceCoin(
             marketDefault: detailsViewModel.fromCoin,
+            isSourceExplicit: fromCoin != nil,
             targetCoin: detailsViewModel.toCoin,
             vaultCoins: vault.coins
         )

--- a/VultisigApp/VultisigAppTests/LimitSwap/Logic/LimitMathTests.swift
+++ b/VultisigApp/VultisigAppTests/LimitSwap/Logic/LimitMathTests.swift
@@ -293,10 +293,15 @@ final class LimitMathTests: XCTestCase {
 
     // MARK: - preferredLimitSourceChain (limit-entry default source)
 
+    // The BTC/ETH preference below applies to the NO-INTENT default only — an
+    // inherited alphabetical market default (`isSourceExplicit: false`). The
+    // explicit-intent contract is covered in the section after this one.
+
     func testPreferredLimitSourcePrefersBTCWhenHeld() {
         // Market default lands on RUNE; BTC is held and isn't the target → BTC.
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .thorChain,
+            isSourceExplicit: false,
             targetChain: .ethereum,
             availableNativeChains: [.bitcoin, .thorChain]
         )
@@ -307,6 +312,7 @@ final class LimitMathTests: XCTestCase {
         // Default RUNE→BTC: BTC is the target, so skip it and pick ETH → ETH→BTC.
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .thorChain,
+            isSourceExplicit: false,
             targetChain: .bitcoin,
             availableNativeChains: [.bitcoin, .ethereum, .thorChain]
         )
@@ -316,6 +322,7 @@ final class LimitMathTests: XCTestCase {
     func testPreferredLimitSourcePrefersBTCOverETHWhenBothHeld() {
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .thorChain,
+            isSourceExplicit: false,
             targetChain: .thorChain,
             availableNativeChains: [.bitcoin, .ethereum]
         )
@@ -327,6 +334,7 @@ final class LimitMathTests: XCTestCase {
         // keep the market default rather than inventing an unheld source.
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .litecoin,
+            isSourceExplicit: false,
             targetChain: .bitcoin,
             availableNativeChains: [.litecoin, .thorChain]
         )
@@ -336,6 +344,7 @@ final class LimitMathTests: XCTestCase {
     func testPreferredLimitSourceKeepsMarketDefaultWhenItIsAlreadyBTC() {
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .bitcoin,
+            isSourceExplicit: false,
             targetChain: .ethereum,
             availableNativeChains: [.bitcoin]
         )
@@ -348,6 +357,7 @@ final class LimitMathTests: XCTestCase {
         // self-pair — pick another held native chain instead.
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .ethereum,
+            isSourceExplicit: false,
             targetChain: .ethereum,
             availableNativeChains: [.ethereum, .thorChain]
         )
@@ -360,6 +370,7 @@ final class LimitMathTests: XCTestCase {
         // unavoidable — return the market default rather than an unheld chain.
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .ethereum,
+            isSourceExplicit: false,
             targetChain: .ethereum,
             availableNativeChains: [.ethereum]
         )
@@ -372,6 +383,7 @@ final class LimitMathTests: XCTestCase {
         // it) — fall back to the market default instead.
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .ethereum,
+            isSourceExplicit: false,
             targetChain: .ethereum,
             availableNativeChains: [.ethereum, .solana]
         )
@@ -383,10 +395,88 @@ final class LimitMathTests: XCTestCase {
         // must pick the routable alternate rather than seed the unroutable default.
         let chain = preferredLimitSourceChain(
             marketDefaultChain: .solana,
+            isSourceExplicit: false,
             targetChain: .ethereum,
             availableNativeChains: [.solana, .litecoin]
         )
         XCTAssertEqual(chain, .litecoin)
+    }
+
+    // MARK: - preferredLimitSourceChain (explicit user intent)
+
+    func testPreferredLimitSourceHonorsExplicitThorchainSource() {
+        // Entering the swap from THORChain chain detail is real user intent: the
+        // Limit tab must keep RUNE as the source instead of silently switching to
+        // BTC, even though BTC is held and would win the no-intent preference.
+        let chain = preferredLimitSourceChain(
+            marketDefaultChain: .thorChain,
+            isSourceExplicit: true,
+            targetChain: .bitcoin,
+            availableNativeChains: [.bitcoin, .ethereum, .thorChain]
+        )
+        XCTAssertEqual(chain, .thorChain)
+    }
+
+    func testPreferredLimitSourceHonorsExplicitNonPreferredSource() {
+        // Any explicitly chosen routable source is honored, not just THORChain —
+        // the BTC/ETH preference must not override an intentional LTC entry.
+        let chain = preferredLimitSourceChain(
+            marketDefaultChain: .litecoin,
+            isSourceExplicit: true,
+            targetChain: .ethereum,
+            availableNativeChains: [.bitcoin, .ethereum, .litecoin]
+        )
+        XCTAssertEqual(chain, .litecoin)
+    }
+
+    func testPreferredLimitSourceFallsBackWhenExplicitSourceIsUnroutable() {
+        // Explicit but NOT THORChain-routable (SOL): honoring it would seed an
+        // unplaceable order, so fall back to the BTC/ETH preference.
+        let chain = preferredLimitSourceChain(
+            marketDefaultChain: .solana,
+            isSourceExplicit: true,
+            targetChain: .ethereum,
+            availableNativeChains: [.bitcoin, .ethereum, .solana]
+        )
+        XCTAssertEqual(chain, .bitcoin)
+    }
+
+    func testPreferredLimitSourceFallsBackWhenExplicitSourceIsUnroutableTON() {
+        // Same rule for a second unroutable chain, with no BTC/ETH held → the
+        // routable alternate (LTC) wins over the unplaceable explicit source.
+        let chain = preferredLimitSourceChain(
+            marketDefaultChain: .ton,
+            isSourceExplicit: true,
+            targetChain: .ethereum,
+            availableNativeChains: [.ton, .litecoin]
+        )
+        XCTAssertEqual(chain, .litecoin)
+    }
+
+    func testPreferredLimitSourceAvoidsSelfPairWhenExplicitSourceEqualsTarget() {
+        // Explicit ETH source with an Ethereum target (e.g. the buy-VULT entry:
+        // explicit ETH → VULT on Ethereum) is a self-pair — intent can't make it
+        // routable, so fall through to a held routable source instead.
+        let chain = preferredLimitSourceChain(
+            marketDefaultChain: .ethereum,
+            isSourceExplicit: true,
+            targetChain: .ethereum,
+            availableNativeChains: [.bitcoin, .ethereum]
+        )
+        XCTAssertNotEqual(chain, .ethereum)
+        XCTAssertEqual(chain, .bitcoin)
+    }
+
+    func testPreferredLimitSourceExplicitSelfPairFallsBackToMarketDefaultWhenNothingElseHeld() {
+        // Degenerate: explicit source == target and no other routable native is
+        // held — a self-pair is unavoidable, so keep the concrete market default.
+        let chain = preferredLimitSourceChain(
+            marketDefaultChain: .ethereum,
+            isSourceExplicit: true,
+            targetChain: .ethereum,
+            availableNativeChains: [.ethereum]
+        )
+        XCTAssertEqual(chain, .ethereum)
     }
 
     // MARK: - isUserUsdPriceEdit (USD field feedback suppression)

--- a/VultisigApp/VultisigAppTests/LimitSwap/Logic/LimitSwapPayloadGasTests.swift
+++ b/VultisigApp/VultisigAppTests/LimitSwap/Logic/LimitSwapPayloadGasTests.swift
@@ -101,10 +101,46 @@ final class LimitSwapPayloadGasTests: XCTestCase {
         let rune = nativeCoin(chain: .thorChain, ticker: "RUNE", decimals: 8)
         let eth = nativeCoin(chain: .ethereum, ticker: "ETH", decimals: 18)
         let btc = nativeCoin(chain: .bitcoin, ticker: "BTC", decimals: 8)
-        // Market default RUNE→ETH; BTC held and != target → BTC preferred.
-        let resolved = limitDefaultSourceCoin(marketDefault: rune, targetCoin: eth, vaultCoins: [rune, eth, btc])
+        // Inherited alphabetical default RUNE→ETH; BTC held and != target → BTC preferred.
+        let resolved = limitDefaultSourceCoin(
+            marketDefault: rune,
+            isSourceExplicit: false,
+            targetCoin: eth,
+            vaultCoins: [rune, eth, btc]
+        )
         XCTAssertEqual(resolved.chain, .bitcoin)
         XCTAssertEqual(resolved.ticker, "BTC")
+    }
+
+    func testLimitDefaultSourceHonorsExplicitRuneSourceOverBTCPreference() {
+        // Entered the swap from THORChain: RUNE is an explicit choice, so the
+        // limit entry keeps it instead of silently switching the source to BTC.
+        let rune = nativeCoin(chain: .thorChain, ticker: "RUNE", decimals: 8)
+        let eth = nativeCoin(chain: .ethereum, ticker: "ETH", decimals: 18)
+        let btc = nativeCoin(chain: .bitcoin, ticker: "BTC", decimals: 8)
+        let resolved = limitDefaultSourceCoin(
+            marketDefault: rune,
+            isSourceExplicit: true,
+            targetCoin: eth,
+            vaultCoins: [rune, eth, btc]
+        )
+        XCTAssertEqual(resolved.chain, .thorChain)
+        XCTAssertEqual(resolved.ticker, "RUNE")
+    }
+
+    func testLimitDefaultSourceFallsBackWhenExplicitSourceIsUnroutable() {
+        // Explicit SOL source can't be encoded into a THORChain memo — fall back
+        // to the BTC preference rather than seeding an unplaceable order.
+        let sol = nativeCoin(chain: .solana, ticker: "SOL", decimals: 9)
+        let eth = nativeCoin(chain: .ethereum, ticker: "ETH", decimals: 18)
+        let btc = nativeCoin(chain: .bitcoin, ticker: "BTC", decimals: 8)
+        let resolved = limitDefaultSourceCoin(
+            marketDefault: sol,
+            isSourceExplicit: true,
+            targetCoin: eth,
+            vaultCoins: [sol, eth, btc]
+        )
+        XCTAssertEqual(resolved.chain, .bitcoin)
     }
 
     func testLimitDefaultSourceAvoidsSameChainSelfPair() {
@@ -113,7 +149,28 @@ final class LimitSwapPayloadGasTests: XCTestCase {
         let eth = nativeCoin(chain: .ethereum, ticker: "ETH", decimals: 18)
         let usdc = tokenCoin(chain: .ethereum, ticker: "USDC", decimals: 6)
         let btc = nativeCoin(chain: .bitcoin, ticker: "BTC", decimals: 8)
-        let resolved = limitDefaultSourceCoin(marketDefault: eth, targetCoin: usdc, vaultCoins: [eth, usdc, btc])
+        let resolved = limitDefaultSourceCoin(
+            marketDefault: eth,
+            isSourceExplicit: false,
+            targetCoin: usdc,
+            vaultCoins: [eth, usdc, btc]
+        )
+        XCTAssertEqual(resolved.chain, .bitcoin)
+    }
+
+    func testLimitDefaultSourceAvoidsSelfPairEvenWhenSourceIsExplicit() {
+        // The buy-VULT entry passes an explicit ETH source with an Ethereum-side
+        // target: intent can't make a same-chain pair routable, so it still
+        // resolves to a held routable source (BTC).
+        let eth = nativeCoin(chain: .ethereum, ticker: "ETH", decimals: 18)
+        let vult = tokenCoin(chain: .ethereum, ticker: "VULT", decimals: 18)
+        let btc = nativeCoin(chain: .bitcoin, ticker: "BTC", decimals: 8)
+        let resolved = limitDefaultSourceCoin(
+            marketDefault: eth,
+            isSourceExplicit: true,
+            targetCoin: vult,
+            vaultCoins: [eth, vult, btc]
+        )
         XCTAssertEqual(resolved.chain, .bitcoin)
     }
 
@@ -122,7 +179,12 @@ final class LimitSwapPayloadGasTests: XCTestCase {
         // keep the market default rather than inventing an unheld source.
         let eth = nativeCoin(chain: .ethereum, ticker: "ETH", decimals: 18)
         let usdc = tokenCoin(chain: .ethereum, ticker: "USDC", decimals: 6)
-        let resolved = limitDefaultSourceCoin(marketDefault: eth, targetCoin: usdc, vaultCoins: [eth, usdc])
+        let resolved = limitDefaultSourceCoin(
+            marketDefault: eth,
+            isSourceExplicit: false,
+            targetCoin: usdc,
+            vaultCoins: [eth, usdc]
+        )
         XCTAssertEqual(resolved.chain, .ethereum)
         XCTAssertEqual(resolved.ticker, "ETH")
     }
@@ -131,7 +193,12 @@ final class LimitSwapPayloadGasTests: XCTestCase {
         // Neither BTC nor ETH held; market default (LTC) isn't the target → keep it.
         let ltc = nativeCoin(chain: .litecoin, ticker: "LTC", decimals: 8)
         let btc = nativeCoin(chain: .bitcoin, ticker: "BTC", decimals: 8)
-        let resolved = limitDefaultSourceCoin(marketDefault: ltc, targetCoin: btc, vaultCoins: [ltc])
+        let resolved = limitDefaultSourceCoin(
+            marketDefault: ltc,
+            isSourceExplicit: false,
+            targetCoin: btc,
+            vaultCoins: [ltc]
+        )
         XCTAssertEqual(resolved.chain, .litecoin)
     }
 


### PR DESCRIPTION
Two reviewer suggestions on the THORChain limit-swap Place flow.

## 1. The Limit tab ignored the source chain you entered with

**Repro:** THORChain chain detail → "Swap" → the Market tab correctly preselects THORChain. Switching to "Limit" silently switched the source to **BTC**.

### Why the override existed (the heuristic is NOT deleted)

`preferredLimitSourceChain` deliberately prefers a high-value, THORChain-routable source (BTC, then ETH). The shared market default sorts alphabetically (`SwapCoinsResolver` picks the first held coin), which lands on a cheap source like RUNE and presents an untradeable-looking `RUNE→BTC` default — the preference exists to fix exactly that.

The bug is ordering. Step 2 of the function already said *"keep the market default when it's THORChain-routable and not a self-pair"* — which would have honored THORChain — but the BTC/ETH preference ran **first**, so for any vault holding BTC an explicitly-chosen THORChain source was **always** overridden.

The root defect: the heuristic couldn't distinguish two situations that arrive as the same non-optional `marketDefault`:
- **(a)** an arbitrary alphabetical fallback — no user intent — where the BTC/ETH preference is genuinely wanted;
- **(b)** an **explicit user selection** (arriving from chain detail via Swap) — real intent that must be honored.

### The fix: teach it the difference, keep the preference

`SwapDetailsScreen.fromCoin` is `Coin?` and is non-nil exactly when the user entered from a specific chain/coin. That optional is already the intent signal — `SwapDetailsViewModel.load` resolves it as `initialFromCoin ?? defaultFromCoin` ("explicit, else alphabetical"). `limitInitialFromCoin` was throwing that signal away by passing the already-resolved non-optional coin.

It's now threaded through as `isSourceExplicit`, and step 2's existing rule simply runs **first** when intent is real. **The BTC/ETH preference is unchanged and still governs the no-intent path.**

Edge cases fall out of the same gate rather than needing special-casing — an explicit source is honored **only** when THORChain-routable and not a self-pair:
- **explicit but unroutable** (SOL/TON) → falls through to the preference, so it can never seed an unplaceable order;
- **explicit source == target** (self-pair) → falls through. This preserves the **buy-VULT** entry (explicit ETH source + VULT-on-Ethereum target is same-chain), which still resolves to BTC exactly as before.

Pure functions stay pure; resolution stays in the view — extending the existing design rather than restructuring it.

## 2. Asset selection now precedes the execution condition

`LimitAssetSwapForm` (Sell / swap / Buy) now renders **above** `LimitPriceCard` (target price / "Execute When"); expiry stays last. The user picks what they're trading before stating the condition it executes under.

Verified couplings, not just the two lines:
- **Keyboard accessory:** the single `focusedField`-driven `.keyboard` toolbar is attached to the **outer VStack**, not to the cards, so the previously-fixed merged-accessory bug cannot resurrect from a sibling reorder.
- **Price-card chips:** kept. "When 1 BTC is worth X ETH" *is* the condition sentence, so it has to name both assets — the chips label the price's units and double as picker shortcuts; they don't duplicate the Sell/Buy controls.
- **Focus order** is tap-driven and follows the new visual order.

## Before / after (item 2 + item 1 in one shot)

| Before | After |
|---|---|
| Price card first; **Sell = Bitcoin** despite entering from THORChain | Sell = **THORChain / RUNE** first, then the condition |

## Verification

- **Runtime, iOS simulator** — drove the actual repro (THORChain chain detail → Swap → Limit) on a dedicated en_US sim, before **and** after:
  - **before:** source seeded **BTC**, price card above the asset form;
  - **after:** source stays **RUNE**, asset form above the price card.
- **Gate:** `** TEST SUCCEEDED **` — Executed **3065 tests, 1 skipped, 0 failures**.
- **macOS:** `** BUILD SUCCEEDED **` with the change. ⚠️ A macOS **runtime** UI pass was **not** completed — the UI-test target doesn't compile for macOS on `main` (pre-existing: `XCUIElement+Helpers.swift`), and it also lacks `AccessibilityID` in its sources. Item 1 is platform-independent pure logic, and the only platform-conditional code near item 2 (the `#if os(iOS)` keyboard toolbar) is untouched — but a manual macOS look at the Limit form is still worth doing before merge.
- **Tests:** `preferredLimitSourceChain`'s contract changed, so existing coverage was updated and new cases added for both paths — explicit THORChain honored, explicit non-preferred (LTC) honored, no-intent still prefers BTC/ETH, explicit-but-unroutable (SOL/TON) falls back, explicit self-pair avoided. Also updated `LimitSwapPayloadGasTests`, which covers `limitDefaultSourceCoin` over real coins.
- Cross-model reviewed (per-commit + whole-branch); no blocking findings.

## Notes for the reviewer

- Honoring intent deliberately restores `RUNE→BTC` **for an explicit THORChain entry** — that's the requested behavior. The no-intent default still prefers BTC/ETH, so the original fix is preserved where it applies.
- **Known limitation (deliberate, out of scope):** the signal is *entry* intent. A user who arrives with no intent and then manually changes the source in the Market tab still gets the heuristic on the Limit tab — the picker binds `$vm.fromCoin` directly, so capturing "user touched the source" needs a market-form binding change. Same defect class, much rarer; left out to keep this diff clear of PR #4816's conflict surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Limit swaps now preserve an explicitly selected source asset when it is routable.
  * Improved fallback selection chooses a suitable native asset when the selected source cannot be used.
  * Reordered the limit-swap layout to show asset selection before the price card.

* **Bug Fixes**
  * Prevented self-pair swaps and unsupported source assets from producing invalid limit-swap entries.

* **Tests**
  * Expanded coverage for explicit source selection, routing fallbacks, and source-asset resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->