### PR TITLE
fix(balances): stop a partial Multicall3 failure silently zeroing an EVM balance

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/EVM/Multicall3.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Multicall3.swift
@@ -87,8 +87,12 @@ enum Multicall3 {
     /// Decodes the `(bool success, bytes returnData)[]` returned by `aggregate3`,
     /// in the same order the calls were built. Each entry is the `uint256` parsed
     /// from `returnData`, or `nil` when the sub-call failed or returned fewer than
-    /// 32 bytes — the caller maps `nil` to a `0` balance, reproducing today's
-    /// per-call "balance check failed → 0" fallback.
+    /// 32 bytes.
+    ///
+    /// `nil` means "this read failed", NOT "the wallet holds zero" — the two must
+    /// stay distinguishable all the way to the write. A failed read has to preserve
+    /// the last known balance (what the per-coin path does), whereas a genuine zero
+    /// is a legitimate balance to persist. See `mapBalances`.
     static func decodeAggregate3Results(hex: String) -> [BigInt?] {
         guard let data = Data(hexString: hex.stripHexPrefix()) else { return [] }
         let bytes = [UInt8](data)
@@ -152,6 +156,46 @@ enum Multicall3 {
         }
 
         return results
+    }
+
+    // MARK: - Result mapping
+
+    /// Maps `decodeAggregate3Results` output back onto the inputs that produced it,
+    /// in the order `fetchERC20Balances` builds the calls: the optional native
+    /// `getEthBalance` first, then one `balanceOf` per contract address.
+    ///
+    /// Preserves the success/failure distinction the decoder encodes as `nil`: a
+    /// failed sub-call is **omitted** from `balances` (and leaves `native` nil)
+    /// rather than being recorded as `0`, so the caller can retry just that coin
+    /// instead of persisting a bogus zero over a funded one. A sub-call that
+    /// genuinely returned `0` **is** recorded — an empty wallet is a real balance.
+    ///
+    /// Returns `nil` when `decoded` doesn't match the call plan, which the caller
+    /// treats as a whole-batch failure.
+    static func mapBalances(
+        decoded: [BigInt?],
+        includeNative: Bool,
+        contractAddresses: [String]
+    ) -> (native: BigInt?, balances: [String: BigInt])? {
+        let expectedCount = (includeNative ? 1 : 0) + contractAddresses.count
+        guard decoded.count == expectedCount else { return nil }
+
+        var index = 0
+        var native: BigInt?
+        if includeNative {
+            native = decoded[index]
+            index += 1
+        }
+
+        var balances: [String: BigInt] = [:]
+        for contractAddress in contractAddresses {
+            if let value = decoded[index] {
+                balances[contractAddress] = value
+            }
+            index += 1
+        }
+
+        return (native, balances)
     }
 
     // MARK: - Hex helpers

--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceStruct.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceStruct.swift
@@ -218,8 +218,14 @@ struct EvmServiceStruct {
     /// to Multicall3 `aggregate3`. When `includeNative` is set, a `getEthBalance`
     /// call is prepended so the native balance comes back in the same round-trip.
     /// Every sub-call uses `allowFailure = true`, so a reverting/garbage contract
-    /// maps to `0` instead of failing its siblings (mirrors today's per-call
-    /// fallback). Order is the contract for mapping results back to inputs.
+    /// fails on its own without taking its siblings down. Order is the contract for
+    /// mapping results back to inputs.
+    ///
+    /// A failed sub-call is **absent** from `balances` (and leaves `native` nil)
+    /// rather than reported as `0`: `aggregate3` returns success at the top level
+    /// even when an individual sub-call fails, so this is the only signal the
+    /// caller gets, and collapsing it to `0` would persist an empty balance over a
+    /// funded coin. Callers must retry an absent entry per-coin.
     func fetchERC20Balances(
         contractAddresses: [String],
         walletAddress: String,
@@ -242,26 +248,17 @@ struct EvmServiceStruct {
         let resultHex = try await rpcService.strRpcCall(method: "eth_call", params: params)
         let decoded = Multicall3.decodeAggregate3Results(hex: resultHex)
 
-        // A short/garbage decode would silently zero balances; treat it as a batch
+        // A short/garbage decode would silently drop balances; treat it as a batch
         // failure so the caller falls back to the per-token path.
-        guard decoded.count == calls.count else {
+        guard let mapped = Multicall3.mapBalances(
+            decoded: decoded,
+            includeNative: includeNative,
+            contractAddresses: contractAddresses
+        ) else {
             throw RpcEvmServiceError.rpcError(code: -1, message: "Unexpected Multicall3 result count")
         }
 
-        var index = 0
-        var native: BigInt?
-        if includeNative {
-            native = decoded[index] ?? 0
-            index += 1
-        }
-
-        var balances: [String: BigInt] = [:]
-        for contractAddress in contractAddresses {
-            balances[contractAddress] = decoded[index] ?? 0
-            index += 1
-        }
-
-        return (native, balances)
+        return mapped
     }
 
     func fetchAllowance(contractAddress: String, owner: String, spender: String) async throws -> BigInt {

--- a/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
@@ -48,7 +48,7 @@ class BalanceService {
 
     /// Value type to identify a coin for balance fetching without holding SwiftData model references
     /// Reuses CoinMeta and adds only the minimal additional fields needed for balance operations
-    private struct CoinIdentifier: Hashable {
+    struct CoinIdentifier: Hashable {
         let coinId: String
         let coinMeta: CoinMeta
         let address: String
@@ -66,7 +66,7 @@ class BalanceService {
     }
 
     /// Value type containing balance update data for a specific coin
-    private struct CoinBalanceUpdate {
+    struct CoinBalanceUpdate {
         let coinId: String
         let rawBalance: String?
         let stakedBalance: String?
@@ -198,6 +198,13 @@ class BalanceService {
     /// Multicall3 call. On any thrown error (network blip, unexpected decode, or
     /// a failed runtime gate) the whole group degrades to the per-coin path, so a
     /// batch failure never zeroes balances — it just reverts to today's behaviour.
+    ///
+    /// A **partial** failure doesn't throw: `aggregate3` reports success at the top
+    /// level while an individual sub-call reports `success = false`, so the thrown
+    /// path above never fires and only the per-coin retry below saves the affected
+    /// coin from a bogus `0`. Coins whose sub-call failed are re-fetched
+    /// individually; that path preserves the last known balance if it fails too.
+    ///
     /// EVM chains carry no staked/bonded balances, so the batch produces only
     /// `rawBalance`, identical to the per-coin path.
     private func fetchEvmBatchBalances(chain: Chain, address: String, coins: [CoinIdentifier]) async -> [CoinBalanceUpdate] {
@@ -223,23 +230,64 @@ class BalanceService {
                 includeNative: !nativeCoins.isEmpty
             )
 
-            var updates: [CoinBalanceUpdate] = []
-            updates.reserveCapacity(coins.count)
+            let (updates, failed) = Self.partitionBatchResult(
+                native: result.native,
+                balances: result.balances,
+                nativeCoins: nativeCoins,
+                tokenCoins: tokenCoins
+            )
 
-            for coin in nativeCoins {
-                let value = result.native ?? 0
-                updates.append(CoinBalanceUpdate(coinId: coin.coinId, rawBalance: String(value), stakedBalance: nil, bondedNodes: nil, error: nil))
-            }
-            for coin in tokenCoins {
-                let value = result.balances[coin.coinMeta.contractAddress] ?? 0
-                updates.append(CoinBalanceUpdate(coinId: coin.coinId, rawBalance: String(value), stakedBalance: nil, bondedNodes: nil, error: nil))
-            }
+            guard !failed.isEmpty else { return updates }
 
-            return updates
+            // Silence here is what let a zeroed balance ship unnoticed — say so.
+            logger.warning("Multicall3 sub-call failed for \(failed.map { $0.ticker }.joined(separator: ", ")) on \(chain.name); retrying per-coin")
+            return updates + (await fallbackPerCoin(failed))
         } catch {
             logger.warning("Multicall3 batch failed for \(chain.name); falling back to per-coin: \(error.localizedDescription)")
             return await fallbackPerCoin(coins)
         }
+    }
+
+    /// Splits a Multicall3 batch result into balance updates that are ready to
+    /// write and the coins whose sub-call failed and must be retried per-coin.
+    ///
+    /// The distinction this preserves is the whole point: a coin absent from
+    /// `balances` (or a nil `native`) had its read fail and yields **no update**,
+    /// so `applyBalanceUpdates` skips it and its last known balance survives. A
+    /// coin that genuinely returned `0` yields a real `0` update — an empty wallet
+    /// must still render as empty.
+    static func partitionBatchResult(
+        native: BigInt?,
+        balances: [String: BigInt],
+        nativeCoins: [CoinIdentifier],
+        tokenCoins: [CoinIdentifier]
+    ) -> (updates: [CoinBalanceUpdate], failed: [CoinIdentifier]) {
+        var updates: [CoinBalanceUpdate] = []
+        updates.reserveCapacity(nativeCoins.count + tokenCoins.count)
+        var failed: [CoinIdentifier] = []
+
+        func resolve(_ coin: CoinIdentifier, _ value: BigInt?) {
+            guard let value else {
+                failed.append(coin)
+                return
+            }
+            updates.append(CoinBalanceUpdate(
+                coinId: coin.coinId,
+                rawBalance: String(value),
+                stakedBalance: nil,
+                bondedNodes: nil,
+                error: nil
+            ))
+        }
+
+        for coin in nativeCoins {
+            resolve(coin, native)
+        }
+        for coin in tokenCoins {
+            resolve(coin, balances[coin.coinMeta.contractAddress])
+        }
+
+        return (updates, failed)
     }
 
     /// Per-coin path used when a Multicall3 batch is unavailable or fails. Fans

--- a/VultisigApp/VultisigAppTests/Blockchain/Multicall3Tests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Multicall3Tests.swift
@@ -120,4 +120,104 @@ final class Multicall3Tests: XCTestCase {
         XCTAssertTrue(Multicall3.decodeAggregate3Results(hex: "0x").isEmpty)
         XCTAssertTrue(Multicall3.decodeAggregate3Results(hex: "not-hex").isEmpty)
     }
+
+    // MARK: - mapBalances
+    //
+    // `aggregate3` returns success at the top level even when a sub-call fails, so
+    // this mapping is the only place a partial failure can be told apart from a
+    // genuine zero. Collapsing the two here persists an empty balance over a
+    // funded coin, with no throw and no fallback to catch it.
+
+    func testMapBalancesOmitsFailedSubCallRatherThanZeroingIt() {
+        // USDC's sub-call failed (nil). It must be ABSENT — not present-as-zero —
+        // so the caller retries it instead of writing 0 over a funded coin.
+        let mapped = Multicall3.mapBalances(
+            decoded: [BigInt(500), nil, BigInt(200)],
+            includeNative: false,
+            contractAddresses: ["0xDAI", "0xUSDC", "0xWBTC"]
+        )
+
+        XCTAssertNil(mapped?.balances["0xUSDC"], "a failed sub-call must not be recorded at all")
+        XCTAssertFalse(mapped?.balances.keys.contains("0xUSDC") ?? true, "absent, not zero")
+        XCTAssertEqual(mapped?.balances["0xDAI"], BigInt(500), "siblings still resolve")
+        XCTAssertEqual(mapped?.balances["0xWBTC"], BigInt(200), "siblings still resolve")
+    }
+
+    func testMapBalancesKeepsGenuineZeroBalance() {
+        // An empty wallet is a real balance and must survive as 0 — the fix must
+        // not "preserve" its way into never writing zeroes.
+        let mapped = Multicall3.mapBalances(
+            decoded: [BigInt(0), nil],
+            includeNative: false,
+            contractAddresses: ["0xEMPTY", "0xFAILED"]
+        )
+
+        XCTAssertEqual(mapped?.balances["0xEMPTY"], BigInt(0), "a genuine zero is a real balance")
+        XCTAssertTrue(mapped?.balances.keys.contains("0xEMPTY") ?? false)
+        XCTAssertFalse(mapped?.balances.keys.contains("0xFAILED") ?? true)
+    }
+
+    func testMapBalancesFailedNativeCallIsNilWhileTokensResolve() {
+        let mapped = Multicall3.mapBalances(
+            decoded: [nil, BigInt(42)],
+            includeNative: true,
+            contractAddresses: ["0xDAI"]
+        )
+
+        XCTAssertNil(mapped?.native, "a failed native read must not become a 0 balance")
+        XCTAssertEqual(mapped?.balances["0xDAI"], BigInt(42))
+    }
+
+    func testMapBalancesNativeZeroIsDistinctFromNativeFailure() {
+        let zero = Multicall3.mapBalances(decoded: [BigInt(0)], includeNative: true, contractAddresses: [])
+        let failed = Multicall3.mapBalances(decoded: [nil], includeNative: true, contractAddresses: [])
+
+        XCTAssertEqual(zero?.native, BigInt(0))
+        XCTAssertNil(failed?.native)
+    }
+
+    func testMapBalancesAssignsResultsInCallOrderWithNativeFirst() {
+        // Order is the contract: native getEthBalance first, then one balanceOf per
+        // contract in the order given. A drift here silently swaps balances between
+        // tokens.
+        let mapped = Multicall3.mapBalances(
+            decoded: [BigInt(1), BigInt(2), BigInt(3)],
+            includeNative: true,
+            contractAddresses: ["0xA", "0xB"]
+        )
+
+        XCTAssertEqual(mapped?.native, BigInt(1))
+        XCTAssertEqual(mapped?.balances["0xA"], BigInt(2))
+        XCTAssertEqual(mapped?.balances["0xB"], BigInt(3))
+    }
+
+    func testMapBalancesCountMismatchReturnsNilSoCallerFallsBack() {
+        // A short decode must read as a whole-batch failure, never as a partial
+        // success that zeroes the missing tail.
+        XCTAssertNil(Multicall3.mapBalances(decoded: [], includeNative: false, contractAddresses: ["0xA"]))
+        XCTAssertNil(Multicall3.mapBalances(decoded: [BigInt(1)], includeNative: true, contractAddresses: ["0xA"]))
+        XCTAssertNil(Multicall3.mapBalances(decoded: [BigInt(1), BigInt(2)], includeNative: false, contractAddresses: ["0xA"]))
+    }
+
+    func testMapBalancesDecodedFailureRoundTripsFromRealAggregate3Response() {
+        // End-to-end over the pure pair: the mixed success/failure/success fixture
+        // decoded above must land as "middle token absent", not "middle token 0".
+        let response = "0x"
+            + w(0x20) + w(3)
+            + w(0x60) + w(0xe0) + w(0x140)
+            + w(1) + w(0x40) + w(0x20) + w(100)   // success 100
+            + w(0) + w(0x40) + w(0)               // failure
+            + w(1) + w(0x40) + w(0x20) + w(200)   // success 200
+
+        let decoded = Multicall3.decodeAggregate3Results(hex: response)
+        let mapped = Multicall3.mapBalances(
+            decoded: decoded,
+            includeNative: false,
+            contractAddresses: ["0xA", "0xB", "0xC"]
+        )
+
+        XCTAssertEqual(mapped?.balances["0xA"], BigInt(100))
+        XCTAssertFalse(mapped?.balances.keys.contains("0xB") ?? true, "the failed sub-call must not surface as 0")
+        XCTAssertEqual(mapped?.balances["0xC"], BigInt(200))
+    }
 }

--- a/VultisigApp/VultisigAppTests/Services/BalanceServiceMulticallPartitionTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BalanceServiceMulticallPartitionTests.swift
@@ -132,11 +132,15 @@ final class BalanceServiceMulticallPartitionTests: XCTestCase {
 
     // MARK: - The preservation mechanism itself
 
-    func testUpdateWithoutRawBalanceIsSkippedByTheWritePath() {
-        // `applyBalanceUpdates` filters on `hasUpdates` and additionally guards the
-        // write with `if let rawBalance`. This is what makes "no update" mean "keep
-        // the last known balance" — and what the per-coin retry falls back on when
-        // it fails too.
+    func testUpdateWithoutRawBalanceReportsNothingToWrite() {
+        // `hasUpdates` is the predicate `applyBalanceUpdates` filters on
+        // (`for update in updates where update.hasUpdates`), so a nil rawBalance
+        // reporting `false` here is what makes "no update" mean "keep the last
+        // known balance". This asserts the predicate only — the end-to-end
+        // fetchEvmBatchBalances -> fallbackPerCoin -> applyBalanceUpdates
+        // integration is not unit-testable (EvmService is a non-injectable enum
+        // factory) and was verified at runtime instead, against a live batch with
+        // a deliberately reverting sub-call.
         let update = BalanceService.CoinBalanceUpdate(
             coinId: "eth-coin",
             rawBalance: nil,

--- a/VultisigApp/VultisigAppTests/Services/BalanceServiceMulticallPartitionTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/BalanceServiceMulticallPartitionTests.swift
@@ -1,0 +1,167 @@
+//
+//  BalanceServiceMulticallPartitionTests.swift
+//  VultisigAppTests
+//
+//  Covers the write-side of the Multicall3 batch: which coins get a balance
+//  written and which are held back for a per-coin retry.
+//
+//  The bug this pins: a PARTIAL batch failure doesn't throw. `aggregate3` reports
+//  success at the top level while an individual sub-call reports success = false,
+//  so the batch-level "fall back to per-coin" path never fires. Mapping that
+//  sub-call to `0` therefore persisted an empty balance over a funded coin with no
+//  throw, no fallback and no log. A failed read and an empty wallet must stay
+//  distinguishable all the way to the write.
+//
+
+@testable import VultisigApp
+import BigInt
+import XCTest
+
+@MainActor
+final class BalanceServiceMulticallPartitionTests: XCTestCase {
+
+    private func identifier(ticker: String, isNativeToken: Bool) -> BalanceService.CoinIdentifier {
+        let coin = Coin(
+            asset: CoinMeta.make(chain: .ethereum, ticker: ticker, decimals: 18, isNativeToken: isNativeToken),
+            address: "0xwallet",
+            hexPublicKey: ""
+        )
+        return BalanceService.CoinIdentifier(from: coin)
+    }
+
+    /// `CoinMeta.make` derives the contract address from the ticker.
+    private func contract(_ ticker: String) -> String { "\(ticker)-contract" }
+
+    // MARK: - A failed sub-call must never be written as a balance
+
+    func testFailedTokenSubCallProducesNoUpdateSoBalanceIsPreserved() {
+        // USDC is absent from `balances` (its sub-call failed). It must yield NO
+        // update — `applyBalanceUpdates` only writes coins that carry one, so no
+        // update is what preserves the funded coin's last known balance.
+        let usdc = identifier(ticker: "USDC", isNativeToken: false)
+
+        let (updates, failed) = BalanceService.partitionBatchResult(
+            native: nil,
+            balances: [:],
+            nativeCoins: [],
+            tokenCoins: [usdc]
+        )
+
+        XCTAssertTrue(updates.isEmpty, "a failed sub-call must not produce a balance write")
+        XCTAssertEqual(failed.map { $0.ticker }, ["USDC"], "it must be handed to the per-coin retry")
+    }
+
+    func testFailedSubCallDoesNotZeroFundedCoinWhileSiblingsStillUpdate() {
+        // The core regression: one reverting token in a multi-token batch must not
+        // zero itself, and must not hold its siblings back either.
+        let dai = identifier(ticker: "DAI", isNativeToken: false)
+        let usdc = identifier(ticker: "USDC", isNativeToken: false)
+        let wbtc = identifier(ticker: "WBTC", isNativeToken: false)
+
+        let (updates, failed) = BalanceService.partitionBatchResult(
+            native: nil,
+            balances: [contract("DAI"): BigInt(500), contract("WBTC"): BigInt(200)],
+            nativeCoins: [],
+            tokenCoins: [dai, usdc, wbtc]
+        )
+
+        XCTAssertEqual(failed.map { $0.ticker }, ["USDC"])
+
+        let byId = Dictionary(uniqueKeysWithValues: updates.map { ($0.coinId, $0) })
+        XCTAssertNil(byId[usdc.coinId], "the failed coin must have no update to write")
+        XCTAssertEqual(byId[dai.coinId]?.rawBalance, "500", "siblings still update")
+        XCTAssertEqual(byId[wbtc.coinId]?.rawBalance, "200", "siblings still update")
+    }
+
+    func testFailedNativeSubCallProducesNoUpdateWhileTokensUpdate() {
+        let eth = identifier(ticker: "ETH", isNativeToken: true)
+        let dai = identifier(ticker: "DAI", isNativeToken: false)
+
+        let (updates, failed) = BalanceService.partitionBatchResult(
+            native: nil,
+            balances: [contract("DAI"): BigInt(7)],
+            nativeCoins: [eth],
+            tokenCoins: [dai]
+        )
+
+        XCTAssertEqual(failed.map { $0.ticker }, ["ETH"])
+        XCTAssertEqual(updates.count, 1)
+        XCTAssertEqual(updates.first?.coinId, dai.coinId)
+    }
+
+    // MARK: - A genuine zero is still a real balance
+
+    func testGenuineZeroBalanceStillWritesZero() {
+        // An empty wallet must render as empty. "Preserve on failure" must not turn
+        // into "never write zero" — that would strand a coin the user just drained.
+        let dai = identifier(ticker: "DAI", isNativeToken: false)
+        let eth = identifier(ticker: "ETH", isNativeToken: true)
+
+        let (updates, failed) = BalanceService.partitionBatchResult(
+            native: BigInt(0),
+            balances: [contract("DAI"): BigInt(0)],
+            nativeCoins: [eth],
+            tokenCoins: [dai]
+        )
+
+        XCTAssertTrue(failed.isEmpty, "a genuine zero is a successful read, not a failure")
+        XCTAssertEqual(updates.count, 2)
+        for update in updates {
+            XCTAssertEqual(update.rawBalance, "0")
+            XCTAssertTrue(update.hasUpdates, "a zero balance must still reach the write")
+        }
+    }
+
+    func testZeroAndFailureAreDistinguishableInTheSameBatch() {
+        // The whole point of the fix, in one assertion pair: same batch, one token
+        // genuinely at zero, one token failed — they must not come out the same.
+        let empty = identifier(ticker: "EMPTY", isNativeToken: false)
+        let broken = identifier(ticker: "BROKEN", isNativeToken: false)
+
+        let (updates, failed) = BalanceService.partitionBatchResult(
+            native: nil,
+            balances: [contract("EMPTY"): BigInt(0)],
+            nativeCoins: [],
+            tokenCoins: [empty, broken]
+        )
+
+        XCTAssertEqual(updates.map { $0.coinId }, [empty.coinId])
+        XCTAssertEqual(updates.first?.rawBalance, "0", "genuine zero → written as 0")
+        XCTAssertEqual(failed.map { $0.coinId }, [broken.coinId], "failed → retried, not written")
+    }
+
+    // MARK: - The preservation mechanism itself
+
+    func testUpdateWithoutRawBalanceIsSkippedByTheWritePath() {
+        // `applyBalanceUpdates` filters on `hasUpdates` and additionally guards the
+        // write with `if let rawBalance`. This is what makes "no update" mean "keep
+        // the last known balance" — and what the per-coin retry falls back on when
+        // it fails too.
+        let update = BalanceService.CoinBalanceUpdate(
+            coinId: "eth-coin",
+            rawBalance: nil,
+            stakedBalance: nil,
+            bondedNodes: nil,
+            error: nil
+        )
+
+        XCTAssertFalse(update.hasUpdates, "a nil rawBalance must not reach the coin")
+    }
+
+    func testFullySuccessfulBatchNeedsNoPerCoinRetry() {
+        let eth = identifier(ticker: "ETH", isNativeToken: true)
+        let dai = identifier(ticker: "DAI", isNativeToken: false)
+
+        let (updates, failed) = BalanceService.partitionBatchResult(
+            native: BigInt(11),
+            balances: [contract("DAI"): BigInt(22)],
+            nativeCoins: [eth],
+            tokenCoins: [dai]
+        )
+
+        XCTAssertTrue(failed.isEmpty)
+        XCTAssertEqual(updates.count, 2)
+        XCTAssertEqual(updates.first(where: { $0.coinId == eth.coinId })?.rawBalance, "11")
+        XCTAssertEqual(updates.first(where: { $0.coinId == dai.coinId })?.rawBalance, "22")
+    }
+}


### PR DESCRIPTION
## Problem

A **partial** Multicall3 failure silently persisted a `0` balance over a coin that has funds.

`aggregate3` is called with `allowFailure = true`. When an individual sub-call reverts, the batch **still succeeds at the top level** — the sub-call just comes back with `success = false`. `decodeAggregate3Results` correctly maps that to `nil`, and then the callers collapsed it with `?? 0`:

- `EvmServiceStruct.swift:254` — `native = decoded[index] ?? 0`
- `EvmServiceStruct.swift:260` — `balances[contractAddress] = decoded[index] ?? 0`
- `BalanceService.swift:230` — `let value = result.native ?? 0`
- `BalanceService.swift:234` — `let value = result.balances[coin.coinMeta.contractAddress] ?? 0`

A reverting or erroring token contract therefore wrote a real `0` to a funded coin. No throw, no fallback, no log.

Introduced by `30fb07391` (#4693), first shipped in **v1.41.64**.

## The non-obvious part: a partial failure is not a thrown failure

`BalanceService` already documents that a batch failure "never zeroes balances — it just reverts to today's behaviour", and that is **true for a _thrown_ error**: a network blip, an unexpected decode, or a failed runtime gate degrades the whole group to the per-coin path. That comment is why this area reads as if the case were already handled.

But a **partial** failure never throws. The top-level `eth_call` succeeded, so the `catch` never fires and the per-coin fallback never runs. The existing guard covers the case that *does* throw — which reads as complete coverage right up until the case that doesn't.

## The doc comment that justified it was wrong

`Multicall3.swift:87-91` justified the `nil → 0` mapping:

> …or `nil` when the sub-call failed or returned fewer than 32 bytes — the caller maps `nil` to a `0` balance, **reproducing today's per-call "balance check failed → 0" fallback**.

**There is no such fallback.** The per-coin path preserves the last known balance:

1. `EvmServiceStruct.getBalance` → `RpcServiceStruct.intRpcCall` **throws** on a JSON-RPC error. It does not substitute zero.
2. `fetchBalanceUpdate` catches it and leaves `rawBalance == nil`.
3. `CoinBalanceUpdate.hasUpdates` goes `false` (EVM carries no staked/bonded balance).
4. `applyBalanceUpdates`' `for update in updates where update.hasUpdates` **skips the coin entirely** — the stored balance survives. The write is additionally guarded by `if let rawBalance`.

So the `?? 0` was a **regression**, not parity. The comment is corrected here.

The phrase does exist in the codebase — `EvmServiceStruct.getTokensFallback` carries *"If balance check fails, assume zero balance"* — but that is the **token-discovery** walk, which merely omits a token from the discovered list. It never persists a balance. The phrase exists; the behaviour does not.

## Fix

Preserve the `nil` all the way to the write. The plumbing already existed — only the callers threw it away.

- **`Multicall3.mapBalances`** (new, pure) — maps results back onto the call plan while keeping the distinction: a failed sub-call is **omitted**; a sub-call that genuinely returned `0` **is recorded**. Returns `nil` on a count mismatch (whole-batch failure). Extracted so the mapping has a unit-testable seam — `fetchERC20Balances` does I/O and `EvmService` is a non-injectable enum factory, so there was nowhere to test this before.
- **`EvmServiceStruct.fetchERC20Balances`** — delegates; both `?? 0` gone.
- **`BalanceService.fetchEvmBatchBalances`** — partitions into ready updates and failed coins; failed coins go through the **existing** `fallbackPerCoin`, and the failure is now **logged**. If the retry fails too, the per-coin path's own `nil` preservation keeps the last known value.

The batch path is not restructured — the I/O flow is untouched. A permanently reverting token now costs one extra per-coin `eth_call` per refresh, which is exactly its pre-#4693 cost.

### A genuine zero is still written

An empty wallet is a legitimate `0` and must still render as `0` — the whole point is that "failed" and "actually zero" stop being the same value. `testGenuineZeroBalanceStillWritesZero` and `testZeroAndFailureAreDistinguishableInTheSameBatch` pin both halves in a single batch.

## Verification

**Runtime — proven against live Ethereum mainnet.** A temporary probe drove the real production path end-to-end (`updateBalances` → `encodeAggregate3` → real `eth_call` → `decodeAggregate3Results` → `mapBalances` → `partitionBatchResult` → `fallbackPerCoin` → `applyBalanceUpdates` → SwiftData write) against a real funded mainnet address, with a **reverting contract injected into the batch** as the failing sub-call (`balanceOf` on the Multicall3 contract itself reverts → `success = false` for that entry only, while the batch still succeeds at the top level — exactly the partial failure that never throws).

```
PROBE ---- BEFORE ---- ETH=0 USDC=0 BOGUS=123456789
PROBE ---- AFTER  ---- ETH=226351975215885383039011 USDC=49052076175 BOGUS=123456789
PROBE ---- VERDICT ---- BOGUS preserved: true | BOGUS zeroed: false
** TEST SUCCEEDED **
```

The affected token's balance is **preserved**, while its siblings update with real mainnet values. The run also emitted `Multicall3 sub-call failed for BOGUS on Ethereum; retrying per-coin`, which confirms the partial-failure path genuinely executed — so the pass is not vacuous. The probe was removed before commit; only the intentional failure log ships.

**Honest gap — the pre-fix A/B control could not be captured.** I attempted 7 runs of the same harness against the pre-fix code to show `BOGUS → 0`; every one timed out at exactly 60s (URLSession timeout) with the whole batch failing, which exercises the *thrown* path, not the partial one. This is **environmental, not behavioural**: the identical post-fix build that succeeded above also began timing out the same way once the endpoint started throttling repeated runs, and the two builds issue byte-identical network calls (only the result *mapping* differs). So the pre-fix zeroing rests on the static trace — `decoded[index] ?? 0` → `String(BigInt(0))` → `"0"` → `hasUpdates == true` → written — which Codex independently confirmed, rather than on an observed run.

**Gate.** `** TEST SUCCEEDED **` — `Executed 3070 tests, with 1 test skipped and 0 failures (0 unexpected)`. SwiftLint clean. No `Package.resolved` churn.

## Interaction with the `—` placeholder follow-up (noted, not fixed)

This fix makes "never successfully fetched" a *distinguishable* state for the first time: a coin whose sub-call fails on its very first refresh now keeps `rawBalance` unset rather than being written to `0`. What the chain rows should **display** for a never-fetched balance is the separate placeholder question raised in the sibling investigation (chain rows never adopted #4693's `String.fiatPlaceholder`, so token cells show `—` while chain rows show `$0.00`). Left for a human decision.

## Scope

Deliberately independent of #4824 (per-chain fiat staleness) — disjoint file sets, no overlap.

Out of scope: `—` placeholder adoption in chain rows; cancelled refresh cycles not cancelling in-flight requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed EVM balance reads are no longer reported as zero balances.
  * Failed token reads are omitted and retried individually, preserving existing balances.
  * Genuine zero balances continue to display correctly.
  * Unexpected batch results now trigger an error instead of producing incorrect data.

* **Tests**
  * Added coverage for mixed success and failure scenarios, native balances, token balances, retries, and result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->