### PR TITLE
fix(substrate): surface RPC error details

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Bittensor/Service/BittensorService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Bittensor/Service/BittensorService.swift
@@ -140,20 +140,8 @@ class BittensorService: RpcService {
 
     func broadcastTransaction(hex: String) async throws -> String {
         let hexWithPrefix = hex.hasPrefix("0x") ? hex : "0x\(hex)"
-        do {
-            let result = try await strRpcCall(method: "author_submitExtrinsic", params: [hexWithPrefix], endpoint: resolvedEndpoint)
-            return try SubstrateBroadcast.validatedHash(result)
-        } catch {
-            // Suppress "Already Imported" errors (multi-device signing, second device gets this)
-            let errorMessage = error.localizedDescription.lowercased()
-            if errorMessage.contains("already imported") {
-                // Return the hash from the hex data itself
-                let extrinsicData = Data(hexString: hex.stripHexPrefix()) ?? Data()
-                let txHash = Hash.blake2b(data: extrinsicData, size: 32).toHexString()
-                return "0x\(txHash)"
-            }
-            throw error
-        }
+        let result = try await strRpcCall(method: "author_submitExtrinsic", params: [hexWithPrefix], endpoint: resolvedEndpoint)
+        return try SubstrateBroadcast.validatedHash(result)
     }
 
     // MARK: - Public API

--- a/VultisigApp/VultisigApp/Core/Services/RpcService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/RpcService.swift
@@ -51,6 +51,11 @@ enum SubstrateBroadcast {
 /// message means the tx may never have been submitted, and a bare `"already"`
 /// matched almost anything. Those are excluded on purpose.
 enum BroadcastErrorClassifier {
+    /// RPC methods that submit a signed transaction. Only these may recover a
+    /// duplicate error as success — a duplicate-looking error from a read call
+    /// (e.g. `state_getStorage`) must throw, not return the sentinel.
+    static let broadcastMethods: Set<String> = ["author_submitExtrinsic", "eth_sendRawTransaction"]
+
     static func isDuplicateBroadcast(_ message: String) -> Bool {
         let message = message.lowercased()
         return message.contains("already known")
@@ -116,7 +121,8 @@ class RpcService {
             let dataMessage = error["data"] as? String
             let detail = dataMessage.flatMap { $0.isEmpty ? nil : $0 } ?? message
 
-            if BroadcastErrorClassifier.isDuplicateBroadcast(message)
+            if BroadcastErrorClassifier.broadcastMethods.contains(method),
+               BroadcastErrorClassifier.isDuplicateBroadcast(message)
                 || BroadcastErrorClassifier.isDuplicateBroadcast(detail) {
                 return try decode(SubstrateBroadcast.alreadyBroadcastedSentinel)
             }

--- a/VultisigApp/VultisigApp/Core/Services/RpcService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/RpcService.swift
@@ -17,12 +17,10 @@ enum RpcServiceError: LocalizedError {
 
 /// Validation for substrate `author_submitExtrinsic` broadcast results.
 ///
-/// `RpcService.sendRPCRequest` returns a non-matched RPC `error.message` as a
-/// plain string (so the base client can surface duplicate-broadcast sentinels
-/// without throwing). For broadcasts that means a rejection like
-/// `"Invalid extrinsic"` arrives where a hash is expected. Polkadot and
-/// Bittensor route their result through this validator so an error string
-/// throws instead of being persisted and polled as a fake txid.
+/// `RpcService.sendRPCRequest` returns a sentinel for duplicate broadcasts so
+/// callers can recover the locally computed transaction hash. Polkadot and
+/// Bittensor route successful results through this validator to ensure only a
+/// real extrinsic hash or that sentinel is persisted and polled as a txid.
 enum SubstrateBroadcast {
     /// Sentinel `RpcService.sendRPCRequest` returns when an extrinsic is
     /// rejected as a duplicate (already known / already imported). Callers
@@ -30,8 +28,7 @@ enum SubstrateBroadcast {
     static let alreadyBroadcastedSentinel = "Transaction already broadcasted."
 
     /// Returns `result` when it is an accepted broadcast — the 32-byte extrinsic
-    /// hash (`0x` + 64 hex) or the duplicate sentinel — otherwise throws, since
-    /// any other value is an error message the node returned in place of a hash.
+    /// hash (`0x` + 64 hex) or the duplicate sentinel — otherwise throws.
     static func validatedHash(_ result: String) throws -> String {
         if result == alreadyBroadcastedSentinel {
             return result
@@ -44,8 +41,9 @@ enum SubstrateBroadcast {
     }
 }
 
-/// Classifies a JSON-RPC broadcast `error.message` as a *true* duplicate — the
-/// signed tx is already in the mempool or on-chain — versus a genuine rejection.
+/// Classifies a JSON-RPC broadcast error message or detail as a *true*
+/// duplicate — the signed tx is already in the mempool or on-chain — versus a
+/// genuine rejection.
 ///
 /// Only exact duplicate signals count. Substrings that used to match here caused
 /// rejections to be reported as success: `"known"` matched every `"unknown …"`
@@ -107,33 +105,31 @@ class RpcService {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-        do {
-            // swiftlint:disable:next no_raw_urlsession
-            let (data, _) = try await URLSession.shared.data(for: request)
+        // swiftlint:disable:next no_raw_urlsession
+        let (data, _) = try await URLSession.shared.data(for: request)
 
-            guard let response = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                let responsePreview = String(data: data.prefix(200), encoding: .utf8) ?? "Unable to decode as string"
-                throw RpcServiceError.rpcError(code: 500, message: "Error to decode the JSON response. Preview: \(responsePreview)")
-            }
-
-            if let error = response["error"] as? [String: Any], let message = error["message"] as? String {
-                if BroadcastErrorClassifier.isDuplicateBroadcast(message) {
-                    return try decode(SubstrateBroadcast.alreadyBroadcastedSentinel)
-                }
-
-                return try decode(message)
-
-            } else if let result = response["result"] {
-                return try decode(result)
-            } else {
-                throw RpcServiceError.rpcError(code: 500, message: "Unknown error")
-            }
-        } catch {
-            print(payload)
-            print(error.localizedDescription)
-            throw error
+        guard let response = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            let responsePreview = String(data: data.prefix(200), encoding: .utf8) ?? "Unable to decode as string"
+            throw RpcServiceError.rpcError(code: 500, message: "Error to decode the JSON response. Preview: \(responsePreview)")
         }
 
+        if let error = response["error"] as? [String: Any] {
+            let code = error["code"] as? Int ?? -1
+            let message = error["message"] as? String ?? "Unknown RPC error"
+            let dataMessage = error["data"] as? String
+            let detail = dataMessage.flatMap { $0.isEmpty ? nil : $0 } ?? message
+
+            if BroadcastErrorClassifier.isDuplicateBroadcast(message)
+                || BroadcastErrorClassifier.isDuplicateBroadcast(detail) {
+                return try decode(SubstrateBroadcast.alreadyBroadcastedSentinel)
+            }
+
+            throw RpcServiceError.rpcError(code: code, message: detail)
+        } else if let result = response["result"] {
+            return try decode(result)
+        } else {
+            throw RpcServiceError.rpcError(code: 500, message: "Unknown error")
+        }
     }
 
     func intRpcCall(method: String, params: [Any], endpoint: String? = nil) async throws -> BigInt {
@@ -154,9 +150,6 @@ class RpcService {
 
     func strRpcCall(method: String, params: [Any], endpoint: String? = nil) async throws -> String {
         return try await sendRPCRequest(method: method, params: params, endpoint: endpoint) { result in
-
-            print(result)
-
             guard let resultString = result as? String else {
                 throw RpcServiceError.rpcError(code: 500, message: "Error to convert the RPC result to String")
             }

--- a/VultisigApp/VultisigApp/Core/Services/RpcService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/RpcService.swift
@@ -64,9 +64,6 @@ enum BroadcastErrorClassifier {
 }
 
 class RpcService {
-    // swiftlint:disable:next no_raw_urlsession
-    private let session = URLSession.shared
-
     internal let rpcEndpoint: String // Modificado para `internal` para permitir acesso pela subclass
 
     init(_ rpcEndpoint: String) {

--- a/VultisigApp/VultisigApp/Core/Services/RpcServiceStruct.swift
+++ b/VultisigApp/VultisigApp/Core/Services/RpcServiceStruct.swift
@@ -45,14 +45,17 @@ struct RpcServiceStruct {
             if let error = response["error"] as? [String: Any] {
                 let code = error["code"] as? Int ?? -1
                 let message = error["message"] as? String ?? "Unknown RPC error"
+                let dataMessage = error["data"] as? String
+                let detail = dataMessage.flatMap { $0.isEmpty ? nil : $0 } ?? message
 
                 // Special handling for transaction broadcast errors
-                if BroadcastErrorClassifier.isDuplicateBroadcast(message) {
+                if BroadcastErrorClassifier.isDuplicateBroadcast(message)
+                    || BroadcastErrorClassifier.isDuplicateBroadcast(detail) {
                     return try decode(SubstrateBroadcast.alreadyBroadcastedSentinel)
                 }
 
                 // For other errors, throw an exception instead of trying to decode the error message
-                throw RpcServiceError.rpcError(code: code, message: message)
+                throw RpcServiceError.rpcError(code: code, message: detail)
 
             } else if let result = response["result"] {
                 return try decode(result)

--- a/VultisigApp/VultisigApp/Core/Services/RpcServiceStruct.swift
+++ b/VultisigApp/VultisigApp/Core/Services/RpcServiceStruct.swift
@@ -49,7 +49,8 @@ struct RpcServiceStruct {
                 let detail = dataMessage.flatMap { $0.isEmpty ? nil : $0 } ?? message
 
                 // Special handling for transaction broadcast errors
-                if BroadcastErrorClassifier.isDuplicateBroadcast(message)
+                if BroadcastErrorClassifier.broadcastMethods.contains(method),
+                   BroadcastErrorClassifier.isDuplicateBroadcast(message)
                     || BroadcastErrorClassifier.isDuplicateBroadcast(detail) {
                     return try decode(SubstrateBroadcast.alreadyBroadcastedSentinel)
                 }

--- a/VultisigApp/VultisigAppTests/Services/RpcServiceErrorTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/RpcServiceErrorTests.swift
@@ -1,0 +1,91 @@
+//
+//  RpcServiceErrorTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class RpcServiceErrorTests: XCTestCase {
+    private static let stubHost = "rpc-service-error-stub.local"
+
+    override func setUp() {
+        super.setUp()
+        RpcServiceErrorStubProtocol.responseData = Data()
+        URLProtocol.registerClass(RpcServiceErrorStubProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(RpcServiceErrorStubProtocol.self)
+        RpcServiceErrorStubProtocol.responseData = Data()
+        super.tearDown()
+    }
+
+    func testCode1010ErrorSurfacesSpecificDataReason() async {
+        RpcServiceErrorStubProtocol.responseData = Data(
+            #"{"jsonrpc":"2.0","id":1,"error":{"code":1010,"message":"Invalid Transaction","data":"Transaction has a bad signature"}}"#.utf8
+        )
+
+        await assertRPCError(
+            expectedCode: 1010,
+            expectedMessage: "Transaction has a bad signature"
+        )
+    }
+
+    func testRPCErrorFallsBackToMessageWhenDataIsMissing() async {
+        RpcServiceErrorStubProtocol.responseData = Data(
+            #"{"jsonrpc":"2.0","id":1,"error":{"code":1010,"message":"Invalid Transaction"}}"#.utf8
+        )
+
+        await assertRPCError(
+            expectedCode: 1010,
+            expectedMessage: "Invalid Transaction"
+        )
+    }
+
+    private func assertRPCError(expectedCode: Int, expectedMessage: String) async {
+        let service = RpcService("https://\(Self.stubHost)/rpc")
+
+        do {
+            let result = try await service.strRpcCall(method: "author_submitExtrinsic", params: ["0x00"])
+            XCTFail("Expected RPC error, got \(result)")
+        } catch let RpcServiceError.rpcError(code, message) {
+            XCTAssertEqual(code, expectedCode)
+            XCTAssertEqual(message, expectedMessage)
+            XCTAssertEqual(
+                RpcServiceError.rpcError(code: code, message: message).localizedDescription,
+                "RPC Error \(expectedCode): \(expectedMessage)"
+            )
+        } catch {
+            XCTFail("Expected RpcServiceError.rpcError, got \(error)")
+        }
+    }
+}
+
+private final class RpcServiceErrorStubProtocol: URLProtocol {
+    static var responseData = Data()
+
+    // These are required `URLProtocol` class-method overrides; they cannot be `static`.
+    // swiftlint:disable static_over_final_class
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "rpc-service-error-stub.local"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    // swiftlint:enable static_over_final_class
+
+    override func startLoading() {
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        )!
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/VultisigApp/VultisigAppTests/Services/RpcServiceErrorTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/RpcServiceErrorTests.swift
@@ -43,6 +43,25 @@ final class RpcServiceErrorTests: XCTestCase {
         )
     }
 
+    func testNonBroadcastMethodDoesNotRecoverDuplicateError() async {
+        // A duplicate-looking error from a read call must throw, not return the
+        // broadcast sentinel (which a caller could misread as a valid result).
+        RpcServiceErrorStubProtocol.responseData = Data(
+            #"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"already imported"}}"#.utf8
+        )
+
+        let service = RpcService("https://\(Self.stubHost)/rpc")
+
+        do {
+            let result = try await service.strRpcCall(method: "state_getStorage", params: ["0x00"])
+            XCTFail("Expected RPC error, got \(result)")
+        } catch let RpcServiceError.rpcError(_, message) {
+            XCTAssertEqual(message, "already imported")
+        } catch {
+            XCTFail("Expected RpcServiceError.rpcError, got \(error)")
+        }
+    }
+
     private func assertRPCError(expectedCode: Int, expectedMessage: String) async {
         let service = RpcService("https://\(Self.stubHost)/rpc")
 


### PR DESCRIPTION
Preserve JSON-RPC error codes and prefer specific data reasons while retaining duplicate broadcast recovery. Remove the unreachable Bittensor catch and cover code 1010 plus message fallback.

## Description

Please include a summary of the change and which issue is fixed. 

Fixes #4840 

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

## Additional context

<!-- Agent-authored PRs: fill in the section below -->
<!-- Human-authored PRs: delete this section -->

## Agent Metadata (if applicable)
- **Agent**: <!-- e.g. Claude Code, OpenClaw -->
- **Issue**: <!-- #number -->
- **Confidence**: <!-- high / medium / low -->
- **Needs human review for**: <!-- e.g. "TSS logic", "migration", "none" -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined transaction broadcast error handling: duplicate/“already imported” cases are no longer blindly suppressed, and other submission failures now surface as clear errors.
  - Improved JSON-RPC error parsing by preferring available extra error detail and applying duplicate-broadcast handling only for appropriate broadcast methods.
  - Removed unintended debug output during RPC processing.
- **Tests**
  - Added coverage to ensure duplicate-style RPC errors are not recovered for non-broadcast requests, and to verify correct error code/message selection with and without extra error detail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->