### PR TITLE
fix(send): switch into the right chain family for ambiguous Terra and EVM addresses

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/AddressService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/AddressService.swift
@@ -24,7 +24,7 @@ struct AddressService {
             return vault.coins.contains(where: { $0.chain == .mayaChain && $0.isNativeToken }) ? .mayaChain : nil
         }
 
-        // Special handling for ThorChain Stagenet
+        // Special handling for ThorChain Chainnet
         if AnyAddress.isValidBech32(string: address, coin: .thorchain, hrp: "cthor") {
             return vault.coins.contains(where: { $0.chain == .thorChainChainnet && $0.isNativeToken }) ? .thorChainChainnet : nil
         }
@@ -37,6 +37,13 @@ struct AddressService {
         // Special handling for qBTC
         if AnyAddress.isValidBech32(string: address, coin: .cosmos, hrp: "qbtc") {
             return vault.coins.contains(where: { $0.chain == .qbtc && $0.isNativeToken }) ? .qbtc : nil
+        }
+
+        // Terra and Terra Classic share the bech32 HRP `terra`, so an address
+        // cannot identify which network it belongs to. Don't auto-switch —
+        // same policy as EVM below.
+        if AnyAddress.isValidBech32(string: address, coin: .terraV2, hrp: "terra") {
+            return nil
         }
 
         // Special handling for Bittensor (SS58 prefix 42)
@@ -52,13 +59,15 @@ struct AddressService {
 
         // Iterate through all WalletCore CoinTypes to find matching address
         for coinType in CoinType.allCases {
-            if coinType.validate(address: address) {
-                // Map CoinType to Vultisig Chain
-                if let chain = Chain.allCases.first(where: { $0.coinType == coinType }) {
-                    // Only return if chain exists in vault with native token
-                    return vault.coins.contains(where: { $0.chain == chain && $0.isNativeToken }) ? chain : nil
-                }
+            guard coinType.validate(address: address) else { continue }
+            // Map CoinType to Vultisig Chain
+            guard let chain = Chain.allCases.first(where: { $0.coinType == coinType }) else { continue }
+            // Only return if chain exists in vault with native token
+            if vault.coins.contains(where: { $0.chain == chain && $0.isNativeToken }) {
+                return chain
             }
+            // Mapped chain isn't in the vault — keep looking rather than giving up,
+            // in case another CoinType also validates this address.
         }
 
         return nil

--- a/VultisigApp/VultisigApp/Core/Services/AddressService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/AddressService.swift
@@ -39,11 +39,16 @@ struct AddressService {
             return vault.coins.contains(where: { $0.chain == .qbtc && $0.isNativeToken }) ? .qbtc : nil
         }
 
-        // Terra and Terra Classic share the bech32 HRP `terra`, so an address
-        // cannot identify which network it belongs to. Don't auto-switch —
-        // same policy as EVM below.
+        // Terra and Terra Classic share the bech32 HRP `terra` and derive
+        // identical addresses from the same key, so the address cannot say
+        // which network it belongs to. The current-chain check above already
+        // leaves the form alone when the user is on either Terra chain, so
+        // reaching here means the selected chain cannot hold this address at
+        // all — landing in the Terra family beats leaving the form somewhere
+        // the address is outright invalid. Which of the two is a guess, broken
+        // by vault order.
         if AnyAddress.isValidBech32(string: address, coin: .terraV2, hrp: "terra") {
-            return nil
+            return firstHeldChain(in: vault) { $0 == .terra || $0 == .terraClassic }
         }
 
         // Special handling for Bittensor (SS58 prefix 42)
@@ -51,10 +56,13 @@ struct AddressService {
             return vault.coins.contains(where: { $0.chain == .bittensor && $0.isNativeToken }) ? .bittensor : nil
         }
 
-        // Check if it's an EVM address - don't auto-switch for safety
+        // Every EVM chain accepts every 0x address, so which one is a guess.
+        // The current-chain check above already leaves the form alone when the
+        // user is on any EVM chain — so reaching here means they are not, and
+        // switching into the family is a move between families, not between
+        // EVM chains. Which one is broken by vault order.
         if isEVMAddress(address) {
-            // Don't auto-switch between EVM chains for safety
-            return nil
+            return firstHeldChain(in: vault) { $0.chainType == .EVM }
         }
 
         // Iterate through all WalletCore CoinTypes to find matching address
@@ -71,6 +79,15 @@ struct AddressService {
         }
 
         return nil
+    }
+
+    /// First chain the vault actually holds a native coin on that satisfies
+    /// `matches`, in vault order. Used to break ties for address families whose
+    /// members are indistinguishable from the address itself (EVM, Terra):
+    /// vault order is not a real signal about the address, only a stable and
+    /// predictable way to pick a member the user can actually spend from.
+    private static func firstHeldChain(in vault: Vault, where matches: (Chain) -> Bool) -> Chain? {
+        vault.coins.first { $0.isNativeToken && matches($0.chain) }?.chain
     }
 
     /// Checks if an address is an EVM address (0x followed by 40 hex characters)

--- a/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
@@ -1,0 +1,175 @@
+//
+//  AddressServiceTests.swift
+//  VultisigAppTests
+//
+//  Covers `AddressService.detectChain`, the resolver behind the paste / QR /
+//  address-book "did the user mean another chain?" auto-switch.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class AddressServiceTests: XCTestCase {
+
+    // MARK: - Address fixtures
+
+    /// Valid bech32 addresses. Terra and Terra Classic share the `terra` HRP, so
+    /// this one address decodes cleanly on both networks — that ambiguity is the
+    /// reason `detectChain` must refuse to pick one.
+    private let terraAddress = "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+    private let mayaAddress = "maya18altpx2gwt4c4ejr5uzda4kyzsudyn9q5dhl9c"
+    private let chainnetThorAddress = "cthor1prxy0sufdqfve6ygkwu9gswe60cle8gyr664qj"
+    private let stagenetThorAddress = "sthor1prxy0sufdqfve6ygkwu9gswe60cle8gymn9sus"
+    private let qbtcAddress = "qbtc10d07y265gmmuvt4z0w9aw880jnsr700j89jqe8"
+    /// Generic Substrate SS58 address (prefix 42), which is what Bittensor uses.
+    private let bittensorAddress = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    private let evmAddress = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+
+    // MARK: - Coin builders
+
+    private func makeLUNA() -> Coin {
+        SendFormFixture.makeCoin(.terra, ticker: "LUNA", decimals: 6, isNative: true)
+    }
+
+    private func makeLUNC() -> Coin {
+        SendFormFixture.makeCoin(.terraClassic, ticker: "LUNC", decimals: 6, isNative: true)
+    }
+
+    // MARK: - Terra vs Terra Classic
+
+    func testTerraAddressDoesNotAutoSwitchWhenVaultHoldsBothChains() {
+        let vault = SendFormFixture.makeVault(coins: [makeLUNA(), makeLUNC()])
+
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertNil(detected)
+    }
+
+    func testTerraAddressDoesNotAutoSwitchWhenVaultHoldsOnlyTerraClassic() {
+        let vault = SendFormFixture.makeVault(coins: [makeLUNC()])
+
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertNil(detected)
+    }
+
+    func testTerraAddressDoesNotAutoSwitchWhenVaultHoldsOnlyTerra() {
+        let vault = SendFormFixture.makeVault(coins: [makeLUNA()])
+
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertNil(detected)
+    }
+
+    /// Precondition for everything above: the fixture really is ambiguous, and
+    /// validates on both networks. Without this the `XCTAssertNil` assertions
+    /// would also pass on an address that simply failed every validator.
+    func testTerraFixtureValidatesOnBothTerraChains() {
+        XCTAssertTrue(AddressService.validateAddress(address: terraAddress, chain: .terra))
+        XCTAssertTrue(AddressService.validateAddress(address: terraAddress, chain: .terraClassic))
+    }
+
+    // MARK: - Bech32 special cases
+
+    func testMayaAddressDetectsMayaChain() {
+        let cacao = SendFormFixture.makeCoin(.mayaChain, ticker: "CACAO", decimals: 10, isNative: true)
+        let vault = SendFormFixture.makeVault(coins: [cacao])
+
+        let detected = AddressService.detectChain(from: mayaAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertEqual(detected, .mayaChain)
+    }
+
+    func testMayaAddressReturnsNilWhenChainMissingFromVault() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeBTC()])
+
+        let detected = AddressService.detectChain(from: mayaAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertNil(detected)
+    }
+
+    func testChainnetThorAddressDetectsThorChainChainnet() {
+        let rune = SendFormFixture.makeCoin(.thorChainChainnet, ticker: "RUNE", decimals: 8, isNative: true)
+        let vault = SendFormFixture.makeVault(coins: [rune])
+
+        let detected = AddressService.detectChain(from: chainnetThorAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertEqual(detected, .thorChainChainnet)
+    }
+
+    func testStagenetThorAddressDetectsThorChainStagenet() {
+        let rune = SendFormFixture.makeCoin(.thorChainStagenet, ticker: "RUNE", decimals: 8, isNative: true)
+        let vault = SendFormFixture.makeVault(coins: [rune])
+
+        let detected = AddressService.detectChain(from: stagenetThorAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertEqual(detected, .thorChainStagenet)
+    }
+
+    func testQbtcAddressDetectsQbtc() {
+        let qbtc = SendFormFixture.makeCoin(.qbtc, ticker: "QBTC", decimals: 8, isNative: true)
+        let vault = SendFormFixture.makeVault(coins: [qbtc])
+
+        let detected = AddressService.detectChain(from: qbtcAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertEqual(detected, .qbtc)
+    }
+
+    func testQbtcAddressReturnsNilWhenChainMissingFromVault() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeBTC()])
+
+        let detected = AddressService.detectChain(from: qbtcAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertNil(detected)
+    }
+
+    // MARK: - Bittensor (SS58)
+
+    func testBittensorAddressDetectsBittensor() {
+        let tao = SendFormFixture.makeCoin(.bittensor, ticker: "TAO", decimals: 9, isNative: true)
+        let vault = SendFormFixture.makeVault(coins: [tao])
+
+        let detected = AddressService.detectChain(from: bittensorAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertEqual(detected, .bittensor)
+    }
+
+    func testBittensorAddressReturnsNilWhenChainMissingFromVault() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeBTC()])
+
+        let detected = AddressService.detectChain(from: bittensorAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertNil(detected)
+    }
+
+    // MARK: - EVM
+
+    func testEvmAddressNeverAutoSwitches() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeETH(), SendFormFixture.makeBTC()])
+
+        let detected = AddressService.detectChain(from: evmAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertNil(detected)
+    }
+
+    // MARK: - Loop path
+
+    func testBitcoinAddressDetectsBitcoin() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeBTC()])
+        let btcAddress = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+
+        let detected = AddressService.detectChain(from: btcAddress, vault: vault, currentChain: .litecoin)
+
+        XCTAssertEqual(detected, .bitcoin)
+    }
+
+    func testUnknownChainForVaultReturnsNil() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeETH()])
+        let btcAddress = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+
+        let detected = AddressService.detectChain(from: btcAddress, vault: vault, currentChain: .litecoin)
+
+        XCTAssertNil(detected)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/AddressServiceTests.swift
@@ -38,33 +38,75 @@ final class AddressServiceTests: XCTestCase {
 
     // MARK: - Terra vs Terra Classic
 
-    func testTerraAddressDoesNotAutoSwitchWhenVaultHoldsBothChains() {
+    /// From a chain that cannot hold the address at all, land in the Terra
+    /// family rather than sitting still. Which of the two is unknowable from
+    /// the address, so vault order breaks the tie.
+    func testTerraAddressSwitchesToFirstHeldTerraChain() {
         let vault = SendFormFixture.makeVault(coins: [makeLUNA(), makeLUNC()])
 
-        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .bitcoin)
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .thorChain)
 
-        XCTAssertNil(detected)
+        XCTAssertEqual(detected, .terra)
     }
 
-    func testTerraAddressDoesNotAutoSwitchWhenVaultHoldsOnlyTerraClassic() {
+    /// Same holdings, opposite vault order. Pins that the tie-break is vault
+    /// order and NOT `CoinType.allCases` order — WalletCore declares `terra`
+    /// before `terraV2`, so an enum-order implementation would answer
+    /// `.terraClassic` for this case *and* the one above.
+    func testTerraAddressTieBreakFollowsVaultOrderNotCoinTypeOrder() {
+        let vault = SendFormFixture.makeVault(coins: [makeLUNC(), makeLUNA()])
+
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .thorChain)
+
+        XCTAssertEqual(detected, .terraClassic)
+    }
+
+    func testTerraAddressSwitchesToTerraClassicWhenItIsTheOnlyOneHeld() {
         let vault = SendFormFixture.makeVault(coins: [makeLUNC()])
 
-        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .bitcoin)
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .thorChain)
 
-        XCTAssertNil(detected)
+        XCTAssertEqual(detected, .terraClassic)
     }
 
-    func testTerraAddressDoesNotAutoSwitchWhenVaultHoldsOnlyTerra() {
+    func testTerraAddressSwitchesToTerraWhenItIsTheOnlyOneHeld() {
         let vault = SendFormFixture.makeVault(coins: [makeLUNA()])
 
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .thorChain)
+
+        XCTAssertEqual(detected, .terra)
+    }
+
+    /// Already inside the family: the current-chain check keeps the form put,
+    /// so a Terra Classic user pasting a `terra1…` address is never flipped to
+    /// Terra V2 — the case where a silent guess would cost real money.
+    func testTerraAddressDoesNotSwitchWhenAlreadyOnTerraClassic() {
+        let vault = SendFormFixture.makeVault(coins: [makeLUNA(), makeLUNC()])
+
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .terraClassic)
+
+        XCTAssertNil(detected)
+    }
+
+    func testTerraAddressDoesNotSwitchWhenAlreadyOnTerra() {
+        let vault = SendFormFixture.makeVault(coins: [makeLUNA(), makeLUNC()])
+
+        let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .terra)
+
+        XCTAssertNil(detected)
+    }
+
+    func testTerraAddressReturnsNilWhenNoTerraChainIsHeld() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeBTC()])
+
         let detected = AddressService.detectChain(from: terraAddress, vault: vault, currentChain: .bitcoin)
 
         XCTAssertNil(detected)
     }
 
-    /// Precondition for everything above: the fixture really is ambiguous, and
-    /// validates on both networks. Without this the `XCTAssertNil` assertions
-    /// would also pass on an address that simply failed every validator.
+    /// Precondition for the family tests: the fixture really is ambiguous and
+    /// validates on both networks. Without this, a merely-invalid address
+    /// would satisfy the same assertions for the wrong reason.
     func testTerraFixtureValidatesOnBothTerraChains() {
         XCTAssertTrue(AddressService.validateAddress(address: terraAddress, chain: .terra))
         XCTAssertTrue(AddressService.validateAddress(address: terraAddress, chain: .terraClassic))
@@ -145,8 +187,29 @@ final class AddressServiceTests: XCTestCase {
 
     // MARK: - EVM
 
-    func testEvmAddressNeverAutoSwitches() {
+    /// From a non-EVM chain, land in the EVM family rather than leaving the
+    /// form on a chain that cannot hold a `0x…` address.
+    func testEvmAddressSwitchesToFirstHeldEvmChainFromANonEvmChain() {
         let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeETH(), SendFormFixture.makeBTC()])
+
+        let detected = AddressService.detectChain(from: evmAddress, vault: vault, currentChain: .bitcoin)
+
+        XCTAssertEqual(detected, .ethereum)
+    }
+
+    /// Still never switches *between* EVM chains: every EVM chain accepts every
+    /// `0x…` address, so the current-chain check returns nil before the family
+    /// guard is reached. Arbitrum stays Arbitrum even though the vault holds ETH.
+    func testEvmAddressDoesNotSwitchWhenAlreadyOnAnEvmChain() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeETH(), SendFormFixture.makeBTC()])
+
+        let detected = AddressService.detectChain(from: evmAddress, vault: vault, currentChain: .arbitrum)
+
+        XCTAssertNil(detected)
+    }
+
+    func testEvmAddressReturnsNilWhenNoEvmChainIsHeld() {
+        let vault = SendFormFixture.makeVault(coins: [SendFormFixture.makeBTC()])
 
         let detected = AddressService.detectChain(from: evmAddress, vault: vault, currentChain: .bitcoin)
 


### PR DESCRIPTION
Fixes #4843

## Problem

Terra and Terra Classic both use the bech32 HRP `terra`, so a `terra1…` address decodes cleanly on **both** networks and carries no information about which one it belongs to.

`AddressService.detectChain` resolved a scanned/pasted address by iterating `CoinType.allCases` and taking the first CoinType that validated it. `Chain.terra → CoinType.terraV2` and `Chain.terraClassic → CoinType.terra`, and WalletCore declares `terra` before `terraV2` — so **Terra Classic won**. A user holding both LUNA and LUNC who scanned a Terra V2 address was silently switched to Terra Classic and could send LUNC to a LUNA address. Separate networks, no recovery path.

Which chain wins was decided by WalletCore's enum ordering, not by anything about the address, so the direction could also flip on a WalletCore bump with no change on our side.

The sink is wider than the QR scanner: `SendDetailsAddressFields.handle(addressResult:)` feeds `detectAndSwitchChain` from paste, camera QR, photo QR, drag-drop image, the macOS scanner **and** the address book — and it suppresses the address alert and auto-advances to the Amount tab, so the switch is easy to miss.

## Why the address can't decide this

Settled before designing the fix. `wallet-core/registry.json` gives `terra` (LUNC) and `terrav2` (LUNA) **identical** derivation path (`m/44'/330'/0'/0/0`), curve, publicKeyType, `sha256ripemd` hasher and `terra` HRP. Only `coinId`/`name`/`symbol` differ, none of which affect derivation — **one key produces a byte-identical address on both networks**, so a vault's own LUNA and LUNC receive addresses are the same string.

Confirmed independently:
- Terra's [Migration FAQ](https://docs.terra.money/migration/exchange-faq/): *"the address format is the same. The same address will be generated from the same seed on both chains."*
- [Ledger's Terra 2.0 docs](https://support.ledger.com/article/4729005570205-zd) confirm Terra 2.0 kept coin type 330 rather than moving to the Cosmos default 118.

The QR payload doesn't help either — `Utils.parseCryptoURI` special-cases only `ton://` and otherwise keeps just address/amount/memo, and both Terra wallets emit `terra:` regardless.

This is not a WalletCore limitation. There is no bit to detect, so no API could expose one.

## The fix

**Which member of the family is unknowable. Which family is not.**

An earlier revision returned `nil` for every ambiguous address. That removed the wrong-chain risk but left the form on a chain the address cannot belong to — paste a `terra1…` while THORChain is selected and *nothing happened at all*, which is wrong for every Terra user rather than just the ambiguous minority.

So switch into the family, and break the tie by vault order:

```swift
// Terra
return firstHeldChain(in: vault) { $0 == .terra || $0 == .terraClassic }

// EVM
return firstHeldChain(in: vault) { $0.chainType == .EVM }
```

### Why this is safe at exactly these two guards

Reaching either guard already **proves** the selected chain cannot hold the address, because `detectChain` opens with:

```swift
if validateAddress(address: address, chain: currentChain) { return nil }  // Already on correct chain
```

Every EVM chain accepts every `0x…`, and both Terra chains accept every `terra1…`. So that check returns `nil` whenever the user is already inside the relevant family, and these guards only ever move **between** families, never **within** one.

**The EVM safety property is unchanged** — we still never auto-switch between EVM chains. It is now enforced by the current-chain check rather than by refusing to switch at all: Arbitrum stays Arbitrum, while Bitcoin moves into the family.

### Why not compare `ChainType`

That was the obvious implementation and it is wrong. `ChainType.Cosmos` covers `gaiaChain, kujira, dydx, osmosis, terra, terraClassic, noble, akash, qbtc` — so "Osmosis selected, paste `terra1…`" would compare equal and keep Osmosis, even though `terra1…` is invalid there (hrp `osmo`). That is the same defect this PR fixes, relocated to another chain.

Address validity is the more precise predicate, and `detectChain` already had it.

### Behaviour

| current chain | pasted | before | after |
|---|---|---|---|
| THORChain / Osmosis / any non-Terra | `terra1…` | ❌ silently switched to Terra Classic | → first held Terra chain |
| Terra / Terra Classic | `terra1…` | ✅ stays | unchanged |
| Bitcoin / any non-EVM | `0x…` | ❌ nothing | → first held EVM chain |
| Arbitrum / any EVM | `0x…` | ✅ stays | unchanged |
| any | family not held | ❌ nothing | unchanged (`nil`) |

## Hardening / cleanup (no user-facing behaviour change)

**The fallback loop's `return`** was nested inside `if let chain`, so a CoinType whose mapped chain wasn't in the vault aborted the whole function instead of continuing. Rewritten to fall through and keep looking.

This is **behaviourally inert today** — every HRP collision we ship is guarded ahead of the loop — and is deliberate future-proofing, not a fix for an observed bug. The latent hazard is tracked in #4853.

Deliberately **not** done: iterating every `Chain` that maps to a CoinType. `CoinType.thorchain` maps to four chains (`thorChain`, `thorChainChainnet`, `thorChainStagenet`, `mayaChain`), so that version would resolve a `thor1…` address to MayaChain for a vault holding CACAO but not RUNE — a new wrong-chain bug of exactly the kind this PR removes. `.first` stays.

**The `cthor` branch** was commented "ThorChain Stagenet" but returns `.thorChainChainnet`. Copy-paste from the `sthor` branch below it.

## Tests

`detectChain` had **zero** coverage and this PR rewrites its control flow, so `VultisigAppTests/Services/AddressServiceTests.swift` is the real deliverable.

The load-bearing one is `testTerraAddressTieBreakFollowsVaultOrderNotCoinTypeOrder`: it builds the same two coins in the **opposite** vault order and asserts the opposite result. WalletCore declares `terra` before `terraV2`, so any implementation resolving by enum order would answer `.terraClassic` for both orderings and fail one of them. Paired with `testTerraAddressSwitchesToFirstHeldTerraChain`, that pins the tie-break to vault order specifically — and satisfies the issue's acceptance criterion that the result must not depend on `CoinType.allCases` ordering.

Also covered:
- switching to Terra / Terra Classic when it is the only one held, and `nil` when neither is
- **not** switching when already on Terra or Terra Classic (the case where a silent guess would cost real money)
- EVM: switches from a non-EVM chain, does **not** switch when already on Arbitrum, `nil` when no EVM chain is held
- `testTerraFixtureValidatesOnBothTerraChains` — asserts the fixture genuinely validates under both networks, so the family assertions can't pass on a merely-invalid address
- regression coverage for every pre-loop guard the change reorders around (maya, cthor, sthor, qbtc, Bittensor SS58), each for both the in-vault and not-in-vault case
- loop path: a bech32 BTC address resolves to `.bitcoin`, and `nil` when the vault lacks it

Every address fixture is a real, checksum-valid address — taken from existing repo fixtures/production code, or derived by re-encoding a known-good payload under the target HRP with a recomputed checksum. The positive-detection tests can only pass if the fixture genuinely validates.

## Known tradeoff — deliberate, and the remaining gap

**Vault order is a stable tie-break, not information about the address.** A vault holding both Terra chains still gets LUNA-or-LUNC decided for it, and the caller auto-advances to the Amount tab on any successful detection — so that guess skips the screen showing which chain was picked.

Accepted here because the alternative, doing nothing at all, is the bug being fixed and affects every Terra user rather than only those holding both. But it is a real residual risk and should be read as such, not as a solved problem.

**A chain picker for the ambiguous case is the proper close**, and is Terra's own recommended mitigation for integrators who cannot separate the addresses ([exchange migration guide](https://docs.terra.money/migration/exchange-migration/): *"include a warning to users to make sure they are transacting on the correct chain"*). Not attempted here — it is new UI in a flow that currently has none.

## Gate

`make test` on iPhone 16 Pro: **`** TEST SUCCEEDED **` — 3139 executed, 0 failures, 1 skipped**. SwiftLint clean on the changed files.

Reviewed with a read-only cross-model pass. One MINOR finding — a Terra test that exited through the "already on correct chain" early return and so couldn't verify what its comment claimed — was valid and fixed: that vacuous test was replaced with the fixture-validity assertion above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
