### PR TITLE
fix(swap): re-introduce the on-chain swap floor via liquidity_tolerance_bps

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -22,11 +22,21 @@ struct SwapService {
     /// and `vultisig-android` (`STREAMING_SLIPPAGE_THRESHOLD_BPS`).
     static let streamingSlippageThresholdBps = 100
 
-    /// `Auto` slippage default. 0 → `tolerance_bps` is omitted, so the node sets
-    /// no `LIM` and never rejects the quote. A nonzero default blocks legitimate
-    /// swaps: the node gates `tolerance_bps` on the single-swap emit, so any swap
-    /// whose price impact exceeds it is refused. A user-set slippage overrides this.
-    static let defaultThorchainToleranceBps = 0
+    /// `Auto` slippage default, sent as `liquidity_tolerance_bps`. 100 bps = 1%.
+    ///
+    /// The node bakes this into the returned memo as a `LIM` floor of exactly
+    /// `floor(expected_amount_out × (10_000 − bps) / 10_000)`, so an `Auto` swap
+    /// gets on-chain protection instead of settling at any price.
+    ///
+    /// This is *not* the same knob as `tolerance_bps` — the node rejects a
+    /// request carrying both. `tolerance_bps` is gated against the single-swap
+    /// emit while anchored to the feeless price, so it refuses any swap with
+    /// real price impact; `liquidity_tolerance_bps` is immune to price impact
+    /// and yields a clean 1% floor at every size on both THORChain and Maya.
+    ///
+    /// A user-set slippage overrides this, and a user-set 0 still omits the
+    /// parameter entirely (no floor).
+    static let defaultLiquidityToleranceBps = 100
 
     func fetchQuote(
         amount: Decimal,
@@ -428,10 +438,10 @@ private extension SwapService {
             // THORChain expects integer amounts - truncate any floating point residuals
             let truncatedAmount = normalizedAmount.truncated(toPlaces: 0)
 
-            // `Auto` (nil) keeps the conservative default tolerance; a custom
-            // slippage maps directly to `tolerance_bps`, which the node bakes
+            // `Auto` (nil) takes the default 1% tolerance; a custom slippage
+            // maps directly to `liquidity_tolerance_bps`, which the node bakes
             // into the returned memo's `LIM` floor.
-            let toleranceBps = slippageBps ?? Self.defaultThorchainToleranceBps
+            let liquidityToleranceBps = slippageBps ?? Self.defaultLiquidityToleranceBps
 
             // External recipient (when set) becomes the swap's `destination` — the
             // node encodes it into the returned memo, so the swapped funds land at
@@ -451,7 +461,7 @@ private extension SwapService {
                 toAsset: toCoin.swapAsset,
                 amount: truncatedAmount.description,
                 interval: provider.streamingInterval,
-                toleranceBps: toleranceBps,
+                liquidityToleranceBps: liquidityToleranceBps,
                 referredCode: referredCode,
                 vultTierDiscount: vultTierDiscount
             )
@@ -475,7 +485,7 @@ private extension SwapService {
                 amount: truncatedAmount.description,
                 referredCode: referredCode,
                 vultTierDiscount: vultTierDiscount,
-                toleranceBps: toleranceBps
+                liquidityToleranceBps: liquidityToleranceBps
             )
 
             switch service {
@@ -829,7 +839,7 @@ extension SwapService {
         amount: String,
         referredCode: String,
         vultTierDiscount: Int,
-        toleranceBps: Int = SwapService.defaultThorchainToleranceBps
+        liquidityToleranceBps: Int = SwapService.defaultLiquidityToleranceBps
     ) async -> ThorchainSwapQuote {
         guard Self.supportsStreamingFallback(provider) else {
             return rapid
@@ -856,7 +866,7 @@ extension SwapService {
                 amount: amount,
                 interval: 1,
                 streamingQuantity: streamingQuantity,
-                toleranceBps: toleranceBps,
+                liquidityToleranceBps: liquidityToleranceBps,
                 referredCode: referredCode,
                 vultTierDiscount: vultTierDiscount
             )

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainAPI.swift
@@ -29,7 +29,7 @@ struct MayaChainAPI: TargetType {
             streamingQuantity: String?,
             affiliate: String?,
             affiliateBps: String?,
-            toleranceBps: String?
+            liquidityToleranceBps: String?
         )
         case broadcast(body: Data)
         case pools
@@ -77,7 +77,7 @@ struct MayaChainAPI: TargetType {
         switch endpoint {
         case .balances, .accountNumber, .pools, .inboundAddresses:
             return .requestPlain
-        case .swapQuote(let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliate, let affiliateBps, let toleranceBps):
+        case .swapQuote(let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliate, let affiliateBps, let liquidityToleranceBps):
             var params: [String: Any] = [
                 "from_asset": from,
                 "to_asset": to,
@@ -88,7 +88,7 @@ struct MayaChainAPI: TargetType {
             if let streamingQuantity = streamingQuantity { params["streaming_quantity"] = streamingQuantity }
             if let affiliate = affiliate { params["affiliate"] = affiliate }
             if let affiliateBps = affiliateBps { params["affiliate_bps"] = affiliateBps }
-            if let toleranceBps = toleranceBps { params["tolerance_bps"] = toleranceBps }
+            if let liquidityToleranceBps = liquidityToleranceBps { params["liquidity_tolerance_bps"] = liquidityToleranceBps }
             return .requestParameters(params, .urlEncoding)
         case .broadcast(let body):
             return .requestData(body)

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
@@ -111,7 +111,7 @@ class MayachainService: ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
-        toleranceBps: Int,
+        liquidityToleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -130,7 +130,7 @@ class MayachainService: ThorchainSwapProvider {
             streamingQuantity: streamingQuantityParam,
             affiliate: affiliate,
             affiliateBps: affiliateBps,
-            toleranceBps: toleranceBps > 0 ? String(toleranceBps) : nil
+            liquidityToleranceBps: liquidityToleranceBps > 0 ? String(liquidityToleranceBps) : nil
         ))
 
         // Maya sometimes returns a structured swap error body with a

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainMainnetAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainMainnetAPI.swift
@@ -60,7 +60,7 @@ struct ThorchainMainnetAPI: TargetType {
             streamingQuantity: String?,
             affiliates: String?,
             affiliateBps: String?,
-            toleranceBps: String?
+            liquidityToleranceBps: String?
         )
         case tcyStaker(address: String)
         /// `/thorchain/queue/limit_swaps[?sender=<addr>]` — every limit (`=<`)
@@ -184,7 +184,7 @@ struct ThorchainMainnetAPI: TargetType {
         case .allDenomMetadata:
             return .requestParameters(["pagination.limit": "1000"], .urlEncoding)
 
-        case .swapQuote(let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliates, let affiliateBps, let toleranceBps):
+        case .swapQuote(let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliates, let affiliateBps, let liquidityToleranceBps):
             var params: [String: Any] = [
                 "from_asset": from,
                 "to_asset": to,
@@ -195,7 +195,7 @@ struct ThorchainMainnetAPI: TargetType {
             if let streamingQuantity = streamingQuantity { params["streaming_quantity"] = streamingQuantity }
             if let affiliates = affiliates { params["affiliate"] = affiliates }
             if let affiliateBps = affiliateBps { params["affiliate_bps"] = affiliateBps }
-            if let toleranceBps = toleranceBps { params["tolerance_bps"] = toleranceBps }
+            if let liquidityToleranceBps = liquidityToleranceBps { params["liquidity_tolerance_bps"] = liquidityToleranceBps }
             return .requestParameters(params, .urlEncoding)
 
         case .rujiGraphQL(let query):

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
@@ -158,7 +158,7 @@ class ThorchainService: ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
-        toleranceBps: Int,
+        liquidityToleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -176,7 +176,7 @@ class ThorchainService: ThorchainSwapProvider {
             streamingQuantity: streamingQuantity > 0 ? String(streamingQuantity) : nil,
             affiliates: affiliates,
             affiliateBps: affiliateBps,
-            toleranceBps: toleranceBps > 0 ? String(toleranceBps) : nil
+            liquidityToleranceBps: liquidityToleranceBps > 0 ? String(liquidityToleranceBps) : nil
         ))
 
         // THORChain returns a typed swap-error body (sometimes with HTTP 200,

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenet2Service.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenet2Service.swift
@@ -123,7 +123,7 @@ class ThorchainStagenetService: ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
-        toleranceBps: Int,
+        liquidityToleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -142,7 +142,7 @@ class ThorchainStagenetService: ThorchainSwapProvider {
             streamingQuantity: streamingQuantity > 0 ? String(streamingQuantity) : nil,
             affiliates: affiliates,
             affiliateBps: affiliateBps,
-            toleranceBps: toleranceBps > 0 ? String(toleranceBps) : nil
+            liquidityToleranceBps: liquidityToleranceBps > 0 ? String(liquidityToleranceBps) : nil
         )
 
         do {

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetAPI.swift
@@ -66,7 +66,7 @@ enum ThorchainStagenetAPI: TargetType {
         streamingQuantity: String?,
         affiliates: String?,
         affiliateBps: String?,
-        toleranceBps: String?
+        liquidityToleranceBps: String?
     )
     case broadcast(env: Environment, body: Data)
 
@@ -149,7 +149,7 @@ enum ThorchainStagenetAPI: TargetType {
         case .allDenomMetadata:
             return .requestParameters(["pagination.limit": "1000"], .urlEncoding)
 
-        case .swapQuote(_, let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliates, let affiliateBps, let toleranceBps):
+        case .swapQuote(_, let from, let to, let amount, let dest, let interval, let streamingQuantity, let affiliates, let affiliateBps, let liquidityToleranceBps):
             var params: [String: Any] = [
                 "from_asset": from,
                 "to_asset": to,
@@ -160,7 +160,7 @@ enum ThorchainStagenetAPI: TargetType {
             if let streamingQuantity = streamingQuantity { params["streaming_quantity"] = streamingQuantity }
             if let affiliates = affiliates { params["affiliate"] = affiliates }
             if let affiliateBps = affiliateBps { params["affiliate_bps"] = affiliateBps }
-            if let toleranceBps = toleranceBps { params["tolerance_bps"] = toleranceBps }
+            if let liquidityToleranceBps = liquidityToleranceBps { params["liquidity_tolerance_bps"] = liquidityToleranceBps }
             return .requestParameters(params, .urlEncoding)
 
         case .broadcast(_, let body):

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetService.swift
@@ -125,7 +125,7 @@ class ThorchainChainnetService: ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
-        toleranceBps: Int,
+        liquidityToleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -144,7 +144,7 @@ class ThorchainChainnetService: ThorchainSwapProvider {
             streamingQuantity: streamingQuantity > 0 ? String(streamingQuantity) : nil,
             affiliates: affiliates,
             affiliateBps: affiliateBps,
-            toleranceBps: toleranceBps > 0 ? String(toleranceBps) : nil
+            liquidityToleranceBps: liquidityToleranceBps > 0 ? String(liquidityToleranceBps) : nil
         )
 
         do {

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainSwapProvider.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainSwapProvider.swift
@@ -15,7 +15,7 @@ protocol ThorchainSwapProvider {
         amount: String,
         interval: Int,
         streamingQuantity: Int,
-        toleranceBps: Int,
+        liquidityToleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote
@@ -28,7 +28,7 @@ extension ThorchainSwapProvider {
         toAsset: String,
         amount: String,
         interval: Int,
-        toleranceBps: Int,
+        liquidityToleranceBps: Int,
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote {
@@ -39,7 +39,7 @@ extension ThorchainSwapProvider {
             amount: amount,
             interval: interval,
             streamingQuantity: 0,
-            toleranceBps: toleranceBps,
+            liquidityToleranceBps: liquidityToleranceBps,
             referredCode: referredCode,
             vultTierDiscount: vultTierDiscount
         )

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Services/ThorchainService+LimitSwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Services/ThorchainService+LimitSwapQuote.swift
@@ -38,7 +38,7 @@ extension ThorchainService: LimitSwapQuoteServiceProtocol {
             streamingQuantity: 0,
             // No minimum-output limit on the reference quote — this fetch only
             // derives the market price for the form, it never broadcasts.
-            toleranceBps: 0,
+            liquidityToleranceBps: 0,
             referredCode: "",
             vultTierDiscount: 0
         )

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -166,7 +166,10 @@ extension SwapCryptoLogic {
                 coin: fromCoin,
                 toAddress: toAddress ?? fromCoin.address,
                 amount: amountInCoin,
-                memo: quote.memo,
+                memo: ThorchainMemoLimit.compressed(
+                    quote.memo,
+                    maxBytes: ThorchainMemoLimit.memoByteLimit(for: fromCoin.chain)
+                ),
                 chainSpecific: chainSpecific,
                 swapPayload: .mayachain(buildThorchainSwapPayload(
                     fromCoin: fromCoin,
@@ -187,7 +190,10 @@ extension SwapCryptoLogic {
                 coin: fromCoin,
                 toAddress: toAddress,
                 amount: amountInCoin,
-                memo: quote.memo,
+                memo: ThorchainMemoLimit.compressed(
+                    quote.memo,
+                    maxBytes: ThorchainMemoLimit.memoByteLimit(for: fromCoin.chain)
+                ),
                 chainSpecific: chainSpecific,
                 swapPayload: .thorchain(buildThorchainSwapPayload(
                     fromCoin: fromCoin,
@@ -208,7 +214,10 @@ extension SwapCryptoLogic {
                 coin: fromCoin,
                 toAddress: toAddress,
                 amount: amountInCoin,
-                memo: quote.memo,
+                memo: ThorchainMemoLimit.compressed(
+                    quote.memo,
+                    maxBytes: ThorchainMemoLimit.memoByteLimit(for: fromCoin.chain)
+                ),
                 chainSpecific: chainSpecific,
                 swapPayload: .thorchainChainnet(buildThorchainSwapPayload(
                     fromCoin: fromCoin,
@@ -229,7 +238,10 @@ extension SwapCryptoLogic {
                 coin: fromCoin,
                 toAddress: toAddress,
                 amount: amountInCoin,
-                memo: quote.memo,
+                memo: ThorchainMemoLimit.compressed(
+                    quote.memo,
+                    maxBytes: ThorchainMemoLimit.memoByteLimit(for: fromCoin.chain)
+                ),
                 chainSpecific: chainSpecific,
                 swapPayload: .thorchainStagenet(buildThorchainSwapPayload(
                     fromCoin: fromCoin,

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -82,7 +82,7 @@ extension SwapCryptoLogic {
     /// `now` parameterised so tests can pin the 15-minute expiration deterministically.
     ///
     /// The on-chain minimum-output floor is enforced by the `LIM` field inside
-    /// the node-returned `quote.memo` (driven by the `tolerance_bps` we send on
+    /// the node-returned `quote.memo` (driven by the `liquidity_tolerance_bps` we send on
     /// the quote request); that memo is what gets signed verbatim. The
     /// `toAmountLimit` / `streamingQuantity` fields here travel in the proto
     /// payload for cross-device display — we mirror the node's derivation so
@@ -94,7 +94,7 @@ extension SwapCryptoLogic {
         toAmountDecimal: Decimal,
         quote: ThorchainSwapQuote,
         provider: SwapProvider,
-        toleranceBps: Int = SwapService.defaultThorchainToleranceBps,
+        toleranceBps: Int = SwapService.defaultLiquidityToleranceBps,
         now: Date = Date()
     ) -> THORChainSwapPayload {
         let vaultAddress = quote.inboundAddress ?? fromCoin.address

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
@@ -1,0 +1,116 @@
+//
+//  ThorchainMemoLimit.swift
+//  VultisigApp
+//
+//  Shrinks the minimum-output floor (`LIM`) inside a node-returned THORChain /
+//  Maya swap memo into scientific notation so a large UTXO swap's memo fits its
+//  source chain's `OP_RETURN` byte cap. THORChain and Maya both parse
+//  `<mantissa>e<exponent>` (mantissa followed by `exponent` trailing zeros) in
+//  the LIM field at execution, so rewriting the memo before signing keeps the
+//  floor on every route without changing what the chain reads.
+//
+//  Rounding is always DOWN. For a market swap a lower floor is strictly more
+//  permissive: it can never wrongfully reject a fillable swap, only accept one
+//  at a fractionally worse price. (This is the opposite direction from
+//  `LimitSwapMemoBuilder`, which rounds a limit order's LIM UP — there raising
+//  the floor is the safe direction because the user must never receive less
+//  than their resting target.)
+//
+
+import BigInt
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-memo-limit")
+
+enum ThorchainMemoLimit {
+
+    /// Never round the floor to fewer than this many significant digits. 5 sig
+    /// figs is a ~0.001% precision loss on the LIM — negligible against the 1%
+    /// liquidity tolerance the floor already carries.
+    private static let minSignificantDigits = 5
+
+    /// The UTF-8 byte budget a chain's THORChain / Maya swap memo must fit, or
+    /// `nil` when the source chain carries no such cap.
+    ///
+    /// UTXO sources embed the memo in an 80-byte `OP_RETURN` (Bitcoin's consensus
+    /// data cap, shared by LTC / BCH / DOGE / DASH / ZEC). Every other source
+    /// (EVM via a contract call, Cosmos / THORChain via `MsgDeposit`) has no
+    /// 80-byte constraint, so no compression is applied there.
+    static func memoByteLimit(for chain: Chain) -> Int? {
+        chain.chainType == .UTXO ? 80 : nil
+    }
+
+    /// Rewrites the LIM field of a THORChain / Maya swap memo into scientific
+    /// notation so the whole memo fits `maxBytes`, rounding the floor DOWN.
+    ///
+    /// Returns `memo` unchanged — byte-for-byte — when any of the following hold,
+    /// so a memo we don't fully understand or don't need to touch is never
+    /// corrupted:
+    /// - `maxBytes` is `nil` (source chain has no memo cap), or
+    /// - the memo already fits `maxBytes` (compress only on overflow), or
+    /// - the memo isn't a recognised swap shape (fewer than 4 `:`-fields), or
+    /// - the LIM isn't a canonical positive integer (no floor, or already
+    ///   scientific / signed / zero-padded), or
+    /// - even the 5-significant-digit floor still overflows `maxBytes`.
+    ///
+    /// Every non-LIM field (function, asset, destination, streaming interval and
+    /// quantity, affiliate, fee) is preserved verbatim.
+    static func compressed(_ memo: String, maxBytes: Int?) -> String {
+        guard let maxBytes else { return memo }
+        guard memo.utf8.count > maxBytes else { return memo }
+
+        // THORChain swap memo: `=:ASSET:DEST:LIM/INTERVAL/QUANTITY:AFFILIATE:FEE`.
+        // Keep empty subsequences so `joined(separator: ":")` round-trips the
+        // input exactly when we haven't touched a field.
+        var fields = memo.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        let limFieldIndex = 3
+        guard fields.count > limFieldIndex else { return memo }
+
+        // The LIM is the amount before the first `/` in the streaming triple
+        // `LIM/INTERVAL/QUANTITY`; the `/INTERVAL/QUANTITY` remainder (if any)
+        // travels untouched.
+        let limField = fields[limFieldIndex]
+        let limString: String
+        let limSuffix: String
+        if let slashIndex = limField.firstIndex(of: "/") {
+            limString = String(limField[..<slashIndex])
+            limSuffix = String(limField[slashIndex...])
+        } else {
+            limString = limField
+            limSuffix = ""
+        }
+
+        // Only compress a floor we can round exactly: a canonical positive
+        // integer. `String(limValue) == limString` rejects a sign, zero-padding,
+        // or an already-scientific mantissa; `limValue > 0` skips a "0" (no
+        // floor — nothing to compress).
+        guard let limValue = BigInt(limString), limValue > 0, String(limValue) == limString else {
+            return memo
+        }
+
+        let totalDigits = limString.count
+        guard totalDigits > minSignificantDigits else { return memo }
+
+        // Keep as many significant digits as still fit — a tighter floor is both
+        // safe (still ≤ the original) and more protective — down to the 5-digit
+        // floor. Memo length is non-decreasing in `keptDigits`, so the first fit
+        // scanning from most-precise is the largest that fits.
+        for keptDigits in stride(from: totalDigits - 1, through: minSignificantDigits, by: -1) {
+            let droppedDigits = totalDigits - keptDigits
+            let scale = BigInt(10).power(droppedDigits)
+            let truncated = limValue / scale // integer division rounds DOWN
+            fields[limFieldIndex] = "\(truncated)e\(droppedDigits)" + limSuffix
+            let candidate = fields.joined(separator: ":")
+            if candidate.utf8.count <= maxBytes {
+                return candidate
+            }
+        }
+
+        // Even the 5-significant-digit floor overflows `maxBytes` — not expected
+        // for a realistic base-1e8 LIM. Leave the memo for the caller rather than
+        // emit one we know is over the cap.
+        logger.debug("THORChain swap memo LIM could not be compressed within \(maxBytes) bytes; leaving memo unchanged")
+        return memo
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapSlippage.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapSlippage.swift
@@ -22,9 +22,9 @@ enum SwapSlippage: Equatable, Hashable {
 
     /// Upper bound on a custom slippage (basis points). Matches the downstream
     /// aggregator clamp (1inch/LI.FI cap at 5000 bps = 50%); THORChain/Maya pass
-    /// `tolerance_bps` raw and KyberSwap/SwapKit forward without an upper clamp, so
-    /// the cap is enforced here at the input layer to keep an absurd
-    /// `tolerance_bps` off the wire entirely.
+    /// `liquidity_tolerance_bps` raw and KyberSwap/SwapKit forward without an upper
+    /// clamp, so the cap is enforced here at the input layer to keep an absurd
+    /// `liquidity_tolerance_bps` off the wire entirely.
     static let maxCustomBps = 5000
 
     /// Clamp a custom slippage to `0...maxCustomBps`.

--- a/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
@@ -81,8 +81,12 @@ final class ThorchainAntiRektTests: XCTestCase {
         XCTAssertEqual(result.expectedAmountOut, streaming.expectedAmountOut)
         XCTAssertEqual(mock.callCount, 1, "Streaming must be fetched at 101 bps with a 1% threshold")
         XCTAssertEqual(
-            mock.lastToleranceBps, SwapService.defaultThorchainToleranceBps,
-            "Streaming quote carries the same tolerance_bps as rapid (Auto default = 0 → omitted; node imposes no LIM)"
+            mock.lastLiquidityToleranceBps, SwapService.defaultLiquidityToleranceBps,
+            "Streaming re-quote must carry the same liquidity_tolerance_bps as rapid, so the upgraded quote's memo LIM matches what the user was shown"
+        )
+        XCTAssertEqual(
+            SwapService.defaultLiquidityToleranceBps, 100,
+            "Auto slippage sends liquidity_tolerance_bps=100, so the node bakes a floor(expected × 0.99) LIM into the memo instead of leaving the swap unprotected"
         )
     }
 
@@ -263,7 +267,7 @@ private final class MockSwapProvider: ThorchainSwapProvider {
     private(set) var callCount = 0
     private(set) var lastInterval: Int?
     private(set) var lastStreamingQuantity: Int?
-    private(set) var lastToleranceBps: Int?
+    private(set) var lastLiquidityToleranceBps: Int?
 
     init(response: Result<ThorchainSwapQuote, Error>) {
         self.response = response
@@ -276,7 +280,7 @@ private final class MockSwapProvider: ThorchainSwapProvider {
         amount _: String,
         interval: Int,
         streamingQuantity: Int,
-        toleranceBps: Int,
+        liquidityToleranceBps: Int,
         referredCode _: String,
         vultTierDiscount _: Int
     ) async throws -> ThorchainSwapQuote {
@@ -284,7 +288,7 @@ private final class MockSwapProvider: ThorchainSwapProvider {
         callCount += 1
         lastInterval = interval
         lastStreamingQuantity = streamingQuantity
-        lastToleranceBps = toleranceBps
+        lastLiquidityToleranceBps = liquidityToleranceBps
         return try response.get()
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/ThorchainMemoLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/ThorchainMemoLimitTests.swift
@@ -1,0 +1,198 @@
+//
+//  ThorchainMemoLimitTests.swift
+//  VultisigAppTests
+//
+//  Coverage for `ThorchainMemoLimit.compressed(_:maxBytes:)` (round-DOWN LIM
+//  compression into scientific notation) and `memoByteLimit(for:)`. The
+//  load-bearing invariants: the compressed floor is always <= the original and
+//  > 0 (round-down), every non-LIM field is byte-identical, and no-op cases
+//  return the memo unchanged.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+final class ThorchainMemoLimitTests: XCTestCase {
+
+    // The real boundary example from the live thornode test: exactly 80 bytes,
+    // a 14-digit LIM. `=:ASSET:DEST:LIM/INTERVAL/QUANTITY:AFFILIATE:FEE`.
+    private let boundaryMemo = "=:ETH.USDC:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:65342292972125/0/224:vi:50"
+    // The ≥20 BTC overflow: same shape with a 15-digit LIM → 81 bytes → thornode
+    // rejects "generated memo too long for source chain" without compression.
+    private let overflowMemo = "=:ETH.USDC:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:653422929721250/0/224:vi:50"
+
+    // MARK: - Compression happens (round-down, fits, sci-notation)
+
+    func testCompressesOverflowingLimToScientificNotation() {
+        XCTAssertEqual(overflowMemo.utf8.count, 81, "Precondition: overflow memo is 81 bytes")
+        let result = ThorchainMemoLimit.compressed(overflowMemo, maxBytes: 80)
+
+        XCTAssertNotEqual(result, overflowMemo, "An overflowing memo must be compressed")
+        XCTAssertLessThanOrEqual(result.utf8.count, 80, "Compressed memo must fit the 80-byte cap")
+        XCTAssertTrue(limField(of: result).contains("e"), "LIM must be scientific notation")
+
+        let original = BigInt("653422929721250")
+        let compressed = decodedLim(from: result)
+        XCTAssertNotNil(compressed)
+        XCTAssertLessThan(compressed!, original, "Round-down: compressed floor is strictly lower")
+        XCTAssertGreaterThan(compressed!, 0, "Floor must stay positive")
+    }
+
+    // Honours the task's explicit 14-digit LIM value. The boundary memo is
+    // exactly 80 bytes, so it overflows only a tighter cap; at 79 the same
+    // `65342292972125` LIM compresses to sci-notation, rounding down.
+    func testCompressesFourteenDigitTaskLimWhenOverCap() {
+        let result = ThorchainMemoLimit.compressed(boundaryMemo, maxBytes: 79)
+
+        XCTAssertNotEqual(result, boundaryMemo)
+        XCTAssertLessThanOrEqual(result.utf8.count, 79)
+        XCTAssertTrue(limField(of: result).contains("e"))
+
+        let original = BigInt("65342292972125")
+        let compressed = decodedLim(from: result)!
+        XCTAssertLessThan(compressed, original, "Round-down invariant")
+        XCTAssertGreaterThan(compressed, 0)
+    }
+
+    // Task boundary example: exactly 80 bytes at an 80-byte cap → it fits, so it
+    // is a byte-identical no-op that stays a valid `=:…:<lim>/0/224:vi:50` shape.
+    func testBoundaryMemoAtEightyByteCapIsNoOp() {
+        XCTAssertEqual(boundaryMemo.utf8.count, 80, "Precondition: boundary memo is 80 bytes")
+        let result = ThorchainMemoLimit.compressed(boundaryMemo, maxBytes: 80)
+
+        XCTAssertEqual(result, boundaryMemo, "A memo that already fits is left untouched")
+        XCTAssertLessThanOrEqual(result.utf8.count, 80)
+        let fields = result.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        XCTAssertEqual(fields.first, "=")
+        XCTAssertTrue(fields[3].hasSuffix("/0/224"))
+        XCTAssertEqual(fields[4], "vi")
+        XCTAssertEqual(fields[5], "50")
+    }
+
+    // MARK: - No-ops
+
+    func testNoOpWhenMemoAlreadyFits() {
+        let memo = "=:ETH.USDC:0xAbCd:1000/0/0:vi:50"
+        XCTAssertLessThanOrEqual(memo.utf8.count, 80)
+        XCTAssertEqual(ThorchainMemoLimit.compressed(memo, maxBytes: 80), memo)
+    }
+
+    func testNoOpWhenLimIsZero() {
+        // No floor: even if forced past the cap, a "0" LIM has nothing to
+        // compress and must be returned untouched.
+        let memo = "=:ETH.USDC:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:0/0/224:vi:50"
+        XCTAssertEqual(ThorchainMemoLimit.compressed(memo, maxBytes: 10), memo)
+    }
+
+    func testNoOpWhenMaxBytesIsNil() {
+        XCTAssertEqual(ThorchainMemoLimit.compressed(overflowMemo, maxBytes: nil), overflowMemo)
+    }
+
+    // MARK: - Non-LIM fields are byte-identical
+
+    func testNonLimFieldsAreByteIdentical() {
+        let result = ThorchainMemoLimit.compressed(overflowMemo, maxBytes: 80)
+        let before = overflowMemo.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        let after = result.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+
+        XCTAssertEqual(before.count, after.count)
+        // Function, asset, destination, affiliate, fee: verbatim.
+        XCTAssertEqual(after[0], before[0])
+        XCTAssertEqual(after[1], before[1])
+        XCTAssertEqual(after[2], before[2])
+        XCTAssertEqual(after[4], before[4])
+        XCTAssertEqual(after[5], before[5])
+        // Only the LIM before the first `/` changed; the streaming suffix is kept.
+        XCTAssertTrue(before[3].hasSuffix("/0/224"))
+        XCTAssertTrue(after[3].hasSuffix("/0/224"))
+        XCTAssertNotEqual(limField(of: result), limField(of: overflowMemo))
+    }
+
+    // MARK: - Malformed / unexpected memos
+
+    func testMalformedMemosReturnedUnchanged() {
+        // Small cap forces each input past the fits-check so the shape/LIM
+        // guards are the reason it is returned unchanged.
+        let cases = [
+            "=:ETH.USDC:0xabc",                        // fewer than 4 fields
+            "=:ETH.USDC:0xabc:notanumber/0/0:vi:50",   // LIM not an integer
+            "=:ETH.USDC:0xabc:65342e9/0/0:vi:50",      // LIM already scientific
+            "=:ETH.USDC:0xabc:007/0/0:vi:50",          // zero-padded (non-canonical)
+            "=:ETH.USDC:0xabc:-5/0/0:vi:50"            // negative
+        ]
+        for memo in cases {
+            XCTAssertEqual(ThorchainMemoLimit.compressed(memo, maxBytes: 5), memo, "Unchanged for: \(memo)")
+        }
+    }
+
+    // MARK: - Maya
+
+    func testMayaFormatMemoCompressesSameWay() {
+        // Maya is a THORChain fork with the same memo grammar and also parses
+        // scientific notation. 83 bytes → must compress to fit 80.
+        let maya = "=:THOR.RUNE:maya1qz8p9dxq4l7wg2m4vtn5xq6r3jf0h8u2vk9c7d:653422929721250/0/224:vi:50"
+        XCTAssertEqual(maya.utf8.count, 83)
+        let result = ThorchainMemoLimit.compressed(maya, maxBytes: 80)
+
+        XCTAssertNotEqual(result, maya)
+        XCTAssertLessThanOrEqual(result.utf8.count, 80)
+        XCTAssertTrue(limField(of: result).contains("e"))
+        let compressed = decodedLim(from: result)!
+        XCTAssertLessThan(compressed, BigInt("653422929721250"))
+        XCTAssertGreaterThan(compressed, 0)
+        // Destination and affiliate untouched.
+        let fields = result.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        XCTAssertEqual(fields[2], "maya1qz8p9dxq4l7wg2m4vtn5xq6r3jf0h8u2vk9c7d")
+        XCTAssertEqual(fields[4], "vi")
+    }
+
+    // MARK: - Round-down invariant across magnitudes
+
+    func testRoundDownInvariantAcrossMagnitudes() {
+        let lims = ["100000007", "999999999999", "65342292972125", "653422929721250", "123456789012345678", "900000000000001"]
+        for lim in lims {
+            let memo = "=:ETH.USDC:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:\(lim)/0/224:vi:50"
+            // One byte under the exact length forces minimal compression.
+            let cap = memo.utf8.count - 1
+            let result = ThorchainMemoLimit.compressed(memo, maxBytes: cap)
+
+            XCTAssertLessThanOrEqual(result.utf8.count, cap, "Must fit cap for LIM \(lim)")
+            XCTAssertTrue(limField(of: result).contains("e"), "Must be sci-notation for LIM \(lim)")
+            let original = BigInt(lim)!
+            let compressed = decodedLim(from: result)!
+            XCTAssertLessThanOrEqual(compressed, original, "Round-down for LIM \(lim)")
+            XCTAssertGreaterThan(compressed, 0, "Positive floor for LIM \(lim)")
+        }
+    }
+
+    // MARK: - memoByteLimit
+
+    func testMemoByteLimitIsEightyForUtxoSourcesAndNilOtherwise() {
+        for chain in [Chain.bitcoin, .litecoin, .bitcoinCash, .dogecoin, .dash, .zcash] {
+            XCTAssertEqual(ThorchainMemoLimit.memoByteLimit(for: chain), 80, "\(chain) is a UTXO OP_RETURN source")
+        }
+        for chain in [Chain.ethereum, .thorChain, .gaiaChain, .mayaChain, .solana, .cardano] {
+            XCTAssertNil(ThorchainMemoLimit.memoByteLimit(for: chain), "\(chain) carries no 80-byte OP_RETURN cap")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// The LIM substring of field index 3 (before the first `/`).
+    private func limField(of memo: String) -> String {
+        let fields = memo.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        guard fields.count > 3 else { return "" }
+        return fields[3].split(separator: "/", omittingEmptySubsequences: false).first.map(String.init) ?? fields[3]
+    }
+
+    /// Decodes a plain or `<mantissa>e<exponent>` LIM into its integer value.
+    private func decodedLim(from memo: String) -> BigInt? {
+        let field = limField(of: memo)
+        guard let eIndex = field.firstIndex(of: "e") else { return BigInt(field) }
+        let mantissa = String(field[..<eIndex])
+        let exponent = String(field[field.index(after: eIndex)...])
+        guard let m = BigInt(mantissa), let e = Int(exponent), e >= 0 else { return nil }
+        return m * BigInt(10).power(e)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/ThorchainSwapQuoteRequestTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/ThorchainSwapQuoteRequestTests.swift
@@ -1,0 +1,93 @@
+//
+//  ThorchainSwapQuoteRequestTests.swift
+//  VultisigAppTests
+//
+//  Pins the on-wire slippage contract for THORChain / Maya swap quotes: the
+//  request must carry `liquidity_tolerance_bps` (movement-anchored, immune to
+//  price impact) and must NEVER carry `tolerance_bps` (feeless-anchored, gated
+//  against the single-swap emit — it rejects any swap with real price impact,
+//  which is why it was shipped and reverted once). Omitted when nil, so an
+//  explicit 0-bps selection sends no floor.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class ThorchainSwapQuoteRequestTests: XCTestCase {
+
+    private enum TaskShapeError: Error { case notRequestParameters }
+
+    private func params(from task: HTTPTask) throws -> [String: Any] {
+        guard case let .requestParameters(params, _) = task else {
+            XCTFail("swapQuote must build requestParameters")
+            throw TaskShapeError.notRequestParameters
+        }
+        return params
+    }
+
+    private func mainnetSwapQuoteParams(liquidityToleranceBps: String?) throws -> [String: Any] {
+        try params(from: ThorchainMainnetAPI(.swapQuote(
+            fromAsset: "BTC.BTC",
+            toAsset: "ETH.ETH",
+            amount: "10000000",
+            destination: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+            streamingInterval: "0",
+            streamingQuantity: nil,
+            affiliates: "vi",
+            affiliateBps: "50",
+            liquidityToleranceBps: liquidityToleranceBps
+        )).task)
+    }
+
+    private func mayaSwapQuoteParams(liquidityToleranceBps: String?) throws -> [String: Any] {
+        try params(from: MayaChainAPI(.swapQuote(
+            fromAsset: "BTC.BTC",
+            toAsset: "ETH.ETH",
+            amount: "10000000",
+            destination: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+            streamingInterval: "3",
+            streamingQuantity: nil,
+            affiliate: "vi",
+            affiliateBps: "50",
+            liquidityToleranceBps: liquidityToleranceBps
+        )).task)
+    }
+
+    // MARK: - THORChain mainnet
+
+    func testMainnetSwapQuoteSendsLiquidityToleranceBps() throws {
+        let params = try mainnetSwapQuoteParams(liquidityToleranceBps: "100")
+        XCTAssertEqual(params["liquidity_tolerance_bps"] as? String, "100")
+    }
+
+    func testMainnetSwapQuoteOmitsToleranceWhenNil() throws {
+        let params = try mainnetSwapQuoteParams(liquidityToleranceBps: nil)
+        XCTAssertNil(params["liquidity_tolerance_bps"],
+                     "nil (Auto→0, or explicit 0 bps) must omit the floor param, not send it")
+    }
+
+    func testMainnetSwapQuoteNeverSendsLegacyToleranceBps() throws {
+        // The regression this guards: reverting to `tolerance_bps` (the param
+        // that rejects price-impacted swaps) must fail loudly here.
+        let values: [String?] = ["100", nil]
+        for value in values {
+            let params = try mainnetSwapQuoteParams(liquidityToleranceBps: value)
+            XCTAssertNil(params["tolerance_bps"],
+                         "legacy `tolerance_bps` must never be on the wire (value=\(value ?? "nil"))")
+        }
+    }
+
+    // MARK: - Maya
+
+    func testMayaSwapQuoteSendsLiquidityToleranceBpsAndNeverLegacy() throws {
+        let params = try mayaSwapQuoteParams(liquidityToleranceBps: "100")
+        XCTAssertEqual(params["liquidity_tolerance_bps"] as? String, "100")
+        XCTAssertNil(params["tolerance_bps"], "Maya must not send legacy `tolerance_bps` either")
+    }
+
+    func testMayaSwapQuoteOmitsToleranceWhenNil() throws {
+        let params = try mayaSwapQuoteParams(liquidityToleranceBps: nil)
+        XCTAssertNil(params["liquidity_tolerance_bps"])
+        XCTAssertNil(params["tolerance_bps"])
+    }
+}


### PR DESCRIPTION
Part of #4838 (the cross-client unify issue — intentionally **not** `Closes`, since Android/Windows alignment is still open; see the decision thread linked below).

## What this does

Switch every THORChain/Maya quote request from `tolerance_bps` to `liquidity_tolerance_bps`, raise the shared Auto-slippage default from `0` to `100` bps, and compress the resulting memo `LIM` so it still fits a UTXO source's `OP_RETURN` (see [Memo-length](#the-memo-length-blocker-and-its-fix) below — that's what makes the floor shippable on all routes).

> **Note:** this PR originally carried a second commit — the friendly `less than price limit` error mapping. That pure UX fix was **split out into #4852** (merged) and is no longer here. This PR is purely the floor + its memo-length enabler.

## ⚠️ This re-introduces an on-chain floor that was previously reverted

An on-chain minimum-output floor was added on mobile in **#4556** and **reverted in `1071a2925`** because THORChain rejected real swaps. This re-introduces it **via a different, verified parameter** — not a revert-of-the-revert.

The two are genuinely different knobs, and the node enforces it: sending both returns `code:3 "must only include one of: tolerance_bps or liquidity_tolerance_bps"`. So the old param is **removed**, not supplemented.

`tolerance_bps` was the wrong knob — the node gates it against the **single-swap** emit while anchoring the limit to the **feeless** price; at size those diverge by an order of magnitude, so rejection is structurally guaranteed. `liquidity_tolerance_bps` is immune to price impact.

## Live thornode diff

`BTC.BTC → ETH.ETH`, app's own mainnet host. Memo `LIM` is the on-chain floor.

| size | param | HTTP | memo LIM | LIM / expected |
|---|---|---|---|---|
| 0.1 BTC | none | 200 | `0` | no floor |
| 0.1 BTC | `tolerance_bps=100` | 200 | 340077095 | 0.99555 |
| 0.1 BTC | `liquidity_tolerance_bps=100` | 200 | 338179686 | **0.99000** |
| 0.1 BTC | both | **400** | — | rejected |
| 100 BTC | `tolerance_bps=100` | **400** | — | **rejected** |
| 100 BTC | `liquidity_tolerance_bps=100` | 200 | 338931386217 | **0.99000** |
| 2000 BTC | `tolerance_bps=100` | **400** | — | **rejected** |
| 2000 BTC | `liquidity_tolerance_bps=100` | 200 | 6751363570084 | **0.99000** |

Maya rejects `tolerance_bps=100` **even at 0.1 BTC** — stricter than THORChain — while `liquidity_tolerance_bps=100` returns a clean floor. `liquidity_tolerance_bps` is exactly `floor(expected × (10000 − bps)/10000)`, verified at every size. Full findings: https://github.com/vultisig/vultisig-ios/issues/4838#issuecomment-5021569752

## The memo-length blocker, and its fix

A non-zero `LIM` lengthens the swap memo. For **UTXO → stablecoin** above ~10 BTC-equivalent, the 13–15-digit `LIM` pushes the memo past Bitcoin's **80-byte OP_RETURN** cap → thornode rejects `code:3 "generated memo too long for source chain"`. Measured, BTC→USDC with production affiliate params: OK at ~10 BTC (80 bytes, at the cap), **rejected at ≥20 BTC**. The driver is digit-count, not swap size — `BTC→ETH.ETH` (short output) is safe past 500 BTC.

**Fix (`ThorchainMemoLimit`):** rewrite the node-returned `LIM` into THORChain's documented [scientific-notation memo form](https://dev.thorchain.org/concepts/memo-length-reduction.html) (`65342292972125` → `65342e9`) **before signing** — the on-chain parser reads our compressed form at execution. Rounding is always **DOWN** (a lower floor is strictly more permissive — it can never wrongfully reject a fillable swap, only accept one at a fractionally worse price; ~0.001% at the 5-sig-fig floor, negligible vs the 1% tolerance). Applied **only** when the memo would overflow a memo-capped (UTXO) source; every other route and every non-LIM field is byte-identical. So the floor now stays on **all** routes, including large BTC→stablecoin.

Boundary: `…:653422929721250/0/224:vi:50` (81 bytes, rejected) → `…:653422929721e3/0/224:vi:50` (80 bytes, fills).

## Behaviour change

- **Auto slippage now gets a real 1% floor** (`SwapSlippage.auto.bps` is nil → falls back to the 100-bps default). An Auto swap that moves >1% between quote and execution now refunds on-chain rather than filling worse.
- **Explicit 0-bps still sends no floor** — the `> 0 ? … : nil` omission guard is kept.
- **Limit swaps untouched** — they carry their own floor via the limit price.

## Cross-client divergence — NOT closed by this PR

**vultisig-android still sends `tolerance_bps`** and remains divergent; **the SDK/Windows already ship `liquidity_tolerance_bps=100` but unconditionally, with no memo-length guard** (so desktop has likely been silently rejecting large UTXO→stablecoin swaps — see the decision thread). This PR narrows the gap but does not close it. → **Decision + per-platform asks tagging both teams: https://github.com/vultisig/vultisig-ios/issues/4838#issuecomment-5035507980**

## Status: HELD

Technically complete and gated green — held on the **cross-client product decision** above, not on any remaining iOS work. Draft on purpose; do not merge without team sign-off + an Android plan.

## Testing

**Automated (green):**
- `ThorchainMemoLimitTests` (11) — compression math, round-down invariant, byte-identical non-LIM fields, all no-op cases, Maya, the live boundary example.
- `ThorchainSwapQuoteRequestTests` (5) — the wire contract: the request carries `liquidity_tolerance_bps` (present when set, omitted when nil) and **never** the legacy `tolerance_bps`, on both THORChain and Maya.
- `ThorchainAntiRektTests` — default is 100, and the streaming re-quote retains it.
- Gate: `make test` on current `main`, `** TEST SUCCEEDED **` — **3386 tests, 1 skipped, 0 failures**. SwiftLint clean.

**⚠️ Manual QA required before ship** (can't be unit-tested): the compressed sci-notation `LIM` being honored **on-chain** needs one real swap to confirm. Cheapest: in a debug build temporarily lower `ThorchainMemoLimit.memoByteLimit` to ~40, do a small (~$20) BTC→USDC Auto swap so compression fires, broadcast, and confirm on a THORChain explorer that the memo shows the sci-notation LIM and the swap filled/refunded honoring it. Revert the debug limit before merge. (Alternatively a large BTC→stablecoin on THORChain **stagenet**.) Regression smoke: small BTC→ETH (no compression, floor present), EVM→X (no compression), explicit slippage honored, explicit 0 → no floor.

## Known deferred

- `SwapPayloadBuilder.thorchainToAmountLimit` display proto — **#4841**'s scope. Note: #4851's memo-`LIM` display parser does integer `BigInt(limField)`, which would render a compressed `65342e9` as "0"; when both land it must decode sci-notation (display-only, safe — signing is correct).

## Review

Cross-model Codex review: per-commit + whole-branch passes, no outstanding findings. This is a **cross-client product decision**, not just an iOS fix — same territory as the reverted #4556. Review with that framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated THORChain-family (THORChain and Maya) swap quote requests to use liquidity-tolerance parameters end-to-end (replacing legacy tolerance).
  * Set the default liquidity tolerance to **100 bps** and ensured it’s carried through rapid → streaming quote upgrades.
* **New Features**
  * Automatic THORChain-family memo “LIM” compression to better comply with UTXO memo size limits.
* **Tests**
  * Expanded coverage to verify liquidity-tolerance wiring and correct memo compression/parameter behavior across supported quote formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->