### PR TITLE
fix(swap): size percentage presets by the asset's own precision

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/Cardano.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/Cardano.swift
@@ -57,6 +57,12 @@ class CardanoHelper {
     /// note in the wiki spec.
     static let minLovelaceOnTokenOutput: UInt64 = 1_500_000
 
+    /// Decimal places used when a validation message quotes a suggested
+    /// "Send Max" amount. ADA carries 6 decimals and `Coin.getMaxValue` fills
+    /// the full precision, so the suggestion must quote all 6 — quoting fewer
+    /// would advertise a smaller amount than Max actually sends.
+    private static let adaDisplayDecimals = 6
+
     /// Validate Cardano transaction meets UTXO requirements for both send amount and remaining balance
     /// 
     /// Cardano UTXO Validation Rules:
@@ -98,10 +104,10 @@ class CardanoHelper {
         // 2. Check sufficient balance
         let totalNeeded = sendAmount + estimatedFee
         if totalBalance < totalNeeded {
-            // For MAX amount display, truncate to 5 decimal places to match getMaxValue behavior
+            // Quote the suggested MAX at ADA's full precision, matching getMaxValue.
             let totalBalanceDecimal = totalBalance.toADA
-            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: 5) // ADA has 6 decimals, so decimals - 1 = 5
-            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: 5)
+            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: adaDisplayDecimals)
+            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: adaDisplayDecimals)
 
             // Recommend Send Max for insufficient balance
             if totalBalance > estimatedFee && totalBalance > 0 {
@@ -115,10 +121,10 @@ class CardanoHelper {
         // 3. Check remaining balance (change) meets minimum UTXO requirement
         let remainingBalance = totalBalance - sendAmount - estimatedFee
         if remainingBalance > 0 && remainingBalance < minUTXOValue {
-            // For MAX amount display, truncate to 5 decimal places to match getMaxValue behavior
+            // Quote the suggested MAX at ADA's full precision, matching getMaxValue.
             let totalBalanceDecimal = totalBalance.toADA
-            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: 5) // ADA has 6 decimals, so decimals - 1 = 5
-            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: 5)
+            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: adaDisplayDecimals)
+            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: adaDisplayDecimals)
 
             // Always recommend Send Max for change issues - simplest solution
             return (false, "This amount would leave too little change. 💡 Try 'Send Max' (\(totalBalanceADA) ADA) to avoid this issue.")
@@ -139,10 +145,10 @@ class CardanoHelper {
         let lowBalanceThreshold: BigInt = 3_500_000 // 3.5 ADA in lovelaces
 
         if totalBalance <= lowBalanceThreshold && totalBalance > estimatedFee {
-            // For MAX amount display, truncate to 5 decimal places to match getMaxValue behavior
+            // Quote the suggested MAX at ADA's full precision, matching getMaxValue.
             let totalBalanceDecimal = totalBalance.toADA
-            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: 5) // ADA has 6 decimals, so decimals - 1 = 5
-            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: 5)
+            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: adaDisplayDecimals)
+            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: adaDisplayDecimals)
 
             return (true, "💡 Low balance detected. Consider 'Send Max' (\(totalBalanceADA) ADA) to avoid change issues.")
         }

--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/Cardano.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/Cardano.swift
@@ -63,6 +63,16 @@ class CardanoHelper {
     /// would advertise a smaller amount than Max actually sends.
     private static let adaDisplayDecimals = 6
 
+    /// What "Send Max" would actually send: balance minus fee, matching
+    /// `SendCryptoLogic.computeMaxAmount`. Quoting the raw balance instead
+    /// advertises more ADA than Max can deliver — on a 10 ADA balance with a
+    /// 0.5 ADA fee it would promise 10 where Max sends 9.5.
+    private static func sendMaxSuggestionADA(totalBalance: BigInt, estimatedFee: BigInt) -> String {
+        let maxLovelaces = Swift.max(BigInt(0), totalBalance - estimatedFee)
+        let truncated = maxLovelaces.toADA.truncated(toPlaces: adaDisplayDecimals)
+        return truncated.formatToDecimal(digits: adaDisplayDecimals)
+    }
+
     /// Validate Cardano transaction meets UTXO requirements for both send amount and remaining balance
     /// 
     /// Cardano UTXO Validation Rules:
@@ -104,14 +114,11 @@ class CardanoHelper {
         // 2. Check sufficient balance
         let totalNeeded = sendAmount + estimatedFee
         if totalBalance < totalNeeded {
-            // Quote the suggested MAX at ADA's full precision, matching getMaxValue.
-            let totalBalanceDecimal = totalBalance.toADA
-            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: adaDisplayDecimals)
-            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: adaDisplayDecimals)
+            let sendMaxADA = sendMaxSuggestionADA(totalBalance: totalBalance, estimatedFee: estimatedFee)
 
             // Recommend Send Max for insufficient balance
             if totalBalance > estimatedFee && totalBalance > 0 {
-                return (false, "Insufficient balance. 💡 Try 'Send Max' to send \(totalBalanceADA) ADA instead.")
+                return (false, "Insufficient balance. 💡 Try 'Send Max' to send \(sendMaxADA) ADA instead.")
             } else {
                 let availableADA = totalBalance.toADAString
                 return (false, "Insufficient balance (\(availableADA) ADA). You need more ADA to complete this transaction.")
@@ -121,13 +128,10 @@ class CardanoHelper {
         // 3. Check remaining balance (change) meets minimum UTXO requirement
         let remainingBalance = totalBalance - sendAmount - estimatedFee
         if remainingBalance > 0 && remainingBalance < minUTXOValue {
-            // Quote the suggested MAX at ADA's full precision, matching getMaxValue.
-            let totalBalanceDecimal = totalBalance.toADA
-            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: adaDisplayDecimals)
-            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: adaDisplayDecimals)
+            let sendMaxADA = sendMaxSuggestionADA(totalBalance: totalBalance, estimatedFee: estimatedFee)
 
             // Always recommend Send Max for change issues - simplest solution
-            return (false, "This amount would leave too little change. 💡 Try 'Send Max' (\(totalBalanceADA) ADA) to avoid this issue.")
+            return (false, "This amount would leave too little change. 💡 Try 'Send Max' (\(sendMaxADA) ADA) to avoid this issue.")
         }
 
         return (true, nil)
@@ -145,12 +149,9 @@ class CardanoHelper {
         let lowBalanceThreshold: BigInt = 3_500_000 // 3.5 ADA in lovelaces
 
         if totalBalance <= lowBalanceThreshold && totalBalance > estimatedFee {
-            // Quote the suggested MAX at ADA's full precision, matching getMaxValue.
-            let totalBalanceDecimal = totalBalance.toADA
-            let truncatedBalance = totalBalanceDecimal.truncated(toPlaces: adaDisplayDecimals)
-            let totalBalanceADA = truncatedBalance.formatToDecimal(digits: adaDisplayDecimals)
+            let sendMaxADA = sendMaxSuggestionADA(totalBalance: totalBalance, estimatedFee: estimatedFee)
 
-            return (true, "💡 Low balance detected. Consider 'Send Max' (\(totalBalanceADA) ADA) to avoid change issues.")
+            return (true, "💡 Low balance detected. Consider 'Send Max' (\(sendMaxADA) ADA) to avoid change issues.")
         }
 
         return (false, nil)

--- a/VultisigApp/VultisigApp/Core/Utils/PercentageAmountLogic.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/PercentageAmountLogic.swift
@@ -1,0 +1,72 @@
+//
+//  PercentageAmountLogic.swift
+//  VultisigApp
+//
+//  Shared math behind the "25 / 50 / 75 / 100%" amount presets. Send, Swap and
+//  Limit Swap all funnel through here so the three flows cannot drift apart on
+//  how much precision a preset amount is allowed to carry.
+//
+
+import BigInt
+import Foundation
+
+enum PercentageAmountLogic {
+
+    /// Decimal places a fractional preset amount may carry.
+    ///
+    /// Capped at 8 — the widest precision the amount inputs render — and never
+    /// above what the asset itself can represent, so a preset never fills the
+    /// field with digits the chain would have to drop.
+    static func decimalPlaces(coinDecimals: Int) -> Int {
+        min(8, max(0, coinDecimals))
+    }
+
+    /// Amount string for `percentage`% of `rawBalance` (base units).
+    ///
+    /// 100% converts the raw balance at the asset's own precision, so the
+    /// preset strands nothing; the fractional presets truncate to
+    /// `decimalPlaces(coinDecimals:)`. Truncating rather than rounding keeps
+    /// every result at or below the balance.
+    ///
+    /// Callers that must reserve a network fee (a native 100% / Max) subtract
+    /// it from `rawBalance` before calling — this function only divides.
+    static func amountText(percentage: Int, rawBalance: BigInt, coinDecimals: Int) -> String {
+        let percentage = min(max(percentage, 0), 100)
+        let decimals = max(0, coinDecimals)
+        guard rawBalance > 0 else { return "0" }
+
+        guard percentage < 100 else {
+            return exactAmountText(rawBalance: rawBalance, decimals: decimals)
+        }
+
+        let balance = (Decimal(string: rawBalance.description) ?? .zero) / pow(10, decimals)
+        let digits = decimalPlaces(coinDecimals: decimals)
+        let amount = (balance * Decimal(percentage) / 100).truncated(toPlaces: digits)
+        return amount.formatToDecimal(digits: digits)
+    }
+
+    /// Exact base-units → decimal-string conversion, by string surgery.
+    ///
+    /// `Decimal.formatToDecimal` renders through `NumberFormatter`, which is
+    /// Double-backed and silently rounds past ~16 significant digits — enough
+    /// to round an 18-decimal balance *up*, above what the wallet actually
+    /// holds. The 100% preset has to show the balance itself, so it is built
+    /// from the digits directly. `rawBalance` is > 0 by the caller's guard.
+    private static func exactAmountText(rawBalance: BigInt, decimals: Int) -> String {
+        let digits = String(rawBalance)
+        guard decimals > 0 else { return digits }
+
+        // Left-pad so there is at least one whole digit before the point.
+        let padded = digits.count > decimals
+            ? digits
+            : String(repeating: "0", count: decimals - digits.count + 1) + digits
+
+        let split = padded.index(padded.endIndex, offsetBy: -decimals)
+        let whole = String(padded[..<split])
+        var fraction = String(padded[split...])
+        while fraction.last == "0" { fraction.removeLast() }
+
+        guard !fraction.isEmpty else { return whole }
+        return whole + (Locale.current.decimalSeparator ?? ".") + fraction
+    }
+}

--- a/VultisigApp/VultisigApp/Features/LimitSwap/ViewModel/LimitSwapFormViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/ViewModel/LimitSwapFormViewModel.swift
@@ -190,18 +190,19 @@ final class LimitSwapFormViewModel {
     }
 
     /// Formatted amount text for `pct`% of the source coin's balance, mirroring
-    /// the market swap's percentage buttons (same `balance × pct/100`,
-    /// truncated to 4 places). The view assigns this to the source-amount field,
-    /// whose `onChange` funnels it back into `draft.sourceAmount`.
+    /// the market swap's percentage buttons — both go through
+    /// `PercentageAmountLogic`, so the two flows share one precision rule.
     ///
     /// Phase-1 limit sources are native, and — matching the market
     /// (`show100 = !isNativeToken`) — native sources only expose 25/50/75, never
     /// a 100/Max button, so no gas headroom is reserved at input time; the
     /// deposit fee is applied later in the shared verify/keysign path.
     func sourceAmountText(forPercentage pct: Int, of coin: Coin) -> String {
-        let fraction = Decimal(min(max(pct, 0), 100)) / 100
-        let amount = (coin.balanceDecimal * fraction).truncated(toPlaces: 4)
-        return amount.formatToDecimal(digits: 4)
+        PercentageAmountLogic.amountText(
+            percentage: pct,
+            rawBalance: coin.rawBalance.toBigInt(),
+            coinDecimals: coin.decimals
+        )
     }
 
     func targetPriceChanged(_ price: Decimal) {

--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -198,10 +198,15 @@ enum SendCryptoLogic {
 
     /// Apply a percentage (0–100) to a max amount string. Used by the
     /// "25% / 50% / 75%" preset buttons in the Details screen.
+    ///
+    /// Send starts from a fee-adjusted max *amount* rather than a raw balance,
+    /// so it can't reuse `PercentageAmountLogic.amountText` wholesale — but the
+    /// precision rule is shared, so Send, Swap and Limit Swap all round a preset
+    /// to the same number of places.
     static func applyPercentage(maxAmount: String, percentage: Double, coinDecimals: Int) -> String {
         let multiplier = Decimal(percentage) / 100
         let target = maxAmount.toDecimal() * multiplier
-        let digits = coinDecimals > 8 ? 8 : coinDecimals
+        let digits = PercentageAmountLogic.decimalPlaces(coinDecimals: coinDecimals)
         return formatAmountInput(target, digits: digits)
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -191,7 +191,9 @@ enum SendCryptoLogic {
         let maxRaw = spendable / divisor
 
         let scaled = maxRaw / pow(10, coin.decimals)
-        return scaled < .zero ? 0 : scaled.truncated(toPlaces: coin.decimals - 1)
+        // Full precision, matching `Coin.getMaxValue`: the fixed-point solve
+        // already funds the burn tax, so there is nothing left to pad against.
+        return scaled < .zero ? 0 : scaled.truncated(toPlaces: coin.decimals)
     }
 
     /// Apply a percentage (0–100) to a max amount string. Used by the

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -63,7 +63,47 @@ enum SwapCryptoLogic {
     }
 
     static func amountInCoinDecimal(fromAmount: String, fromCoin: Coin) -> BigInt {
-        fromCoin.raw(for: fromAmount.toDecimal())
+        let amount = fromAmount.toDecimal()
+        let raw = fromCoin.raw(for: amount)
+
+        // `raw(for:)` rounds UP, and the amount text round-trips through
+        // `NumberFormatter`, which keeps only ~16 significant digits and rounds
+        // half-up. A 100% preset on an 18-decimal asset therefore parses back a
+        // hair ABOVE the balance and would broadcast more base units than the
+        // wallet holds — a transaction the chain rejects.
+        //
+        // This is the broadcast amount, so the invariant is simply that it can
+        // never exceed the balance. Over-spends are caught elsewhere, on a
+        // separate `Decimal` path (`balanceError` compares `fromAmount` against
+        // `balanceDecimal` and never calls this), so capping here hides nothing
+        // from the insufficient-funds check.
+        //
+        // A zero `rawBalance` means the balance hasn't loaded yet rather than
+        // an empty wallet; capping to it would zero out a valid amount.
+        let rawBalance = fromCoin.rawBalance.toBigInt()
+        guard rawBalance > 0 else { return raw }
+        return min(raw, rawBalance)
+    }
+
+    /// Amount string for a "25 / 50 / 75 / 100%" preset on the swap source
+    /// coin, or `nil` for a percentage the buttons don't offer.
+    ///
+    /// A native 100% has to leave the network fee behind; every other preset is
+    /// a straight fraction of the balance. Lives here rather than in the view
+    /// so the math is testable on its own.
+    static func percentageAmountText(percentage: Int, fromCoin: Coin, fee: BigInt) -> String? {
+        guard [25, 50, 75, 100].contains(percentage) else { return nil }
+
+        let rawBalance = fromCoin.rawBalance.toBigInt()
+        let spendable = percentage == 100 && fromCoin.isNativeToken
+            ? max(rawBalance - fee, .zero)
+            : rawBalance
+
+        return PercentageAmountLogic.amountText(
+            percentage: percentage,
+            rawBalance: spendable,
+            coinDecimals: fromCoin.decimals
+        )
     }
 
     // MARK: - Quote-derived

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -78,8 +78,13 @@ enum SwapCryptoLogic {
         // `balanceDecimal` and never calls this), so capping here hides nothing
         // from the insufficient-funds check.
         //
-        // A zero `rawBalance` means the balance hasn't loaded yet rather than
-        // an empty wallet; capping to it would zero out a valid amount.
+        // Skip the cap at zero. `Coin.init` seeds `rawBalance` to `String.zero`
+        // ("0"), so a coin whose balance hasn't loaded is indistinguishable
+        // from a genuinely empty wallet — there is no separate unloaded
+        // sentinel to branch on. Capping on zero would therefore zero out a
+        // valid amount every time the swap form renders before balances land,
+        // which is the far worse failure: an empty wallet is already rejected
+        // by `balanceError` on the `Decimal` path above.
         let rawBalance = fromCoin.rawBalance.toBigInt()
         guard rawBalance > 0 else { return raw }
         return min(raw, rawBalance)

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -459,37 +459,15 @@ struct SwapDetailsScreen: View {
 extension SwapDetailsScreen {
     func handlePercentageSelection(_ percentage: Int) {
         detailsViewModel.showAllPercentageButtons = false
-        let decimalsToUse: Int = 4
 
-        switch percentage {
-        case 25:
-            let amount = (detailsViewModel.fromCoin.balanceDecimal / 4).truncated(toPlaces: decimalsToUse)
-            detailsViewModel.fromAmount = amount.formatToDecimal(digits: decimalsToUse)
-            detailsViewModel.updateFromAmount(vault: vault, referredCode: referredViewModel.savedReferredCode, immediate: true)
-        case 50:
-            let amount = (detailsViewModel.fromCoin.balanceDecimal / 2).truncated(toPlaces: decimalsToUse)
-            detailsViewModel.fromAmount = amount.formatToDecimal(digits: decimalsToUse)
-            detailsViewModel.updateFromAmount(vault: vault, referredCode: referredViewModel.savedReferredCode, immediate: true)
-        case 75:
-            let amount = (detailsViewModel.fromCoin.balanceDecimal * 3 / 4).truncated(toPlaces: decimalsToUse)
-            detailsViewModel.fromAmount = amount.formatToDecimal(digits: decimalsToUse)
-            detailsViewModel.updateFromAmount(vault: vault, referredCode: referredViewModel.savedReferredCode, immediate: true)
-        case 100:
-            let fromCoin = detailsViewModel.fromCoin
-            if fromCoin.isNativeToken {
-                let fee = detailsViewModel.fee
-                let amountLessFee = fromCoin.rawBalance.toBigInt() - fee
-                let amountLessFeeDecimal = amountLessFee.toDecimal(decimals: fromCoin.decimals) / pow(10, fromCoin.decimals)
-                let amount = amountLessFeeDecimal.truncated(toPlaces: decimalsToUse)
-                detailsViewModel.fromAmount = amount.formatToDecimal(digits: decimalsToUse)
-            } else {
-                let amount = fromCoin.balanceDecimal.truncated(toPlaces: decimalsToUse)
-                detailsViewModel.fromAmount = amount.formatToDecimal(digits: decimalsToUse)
-            }
-            detailsViewModel.updateFromAmount(vault: vault, referredCode: referredViewModel.savedReferredCode, immediate: true)
-        default:
-            break
-        }
+        guard let amount = SwapCryptoLogic.percentageAmountText(
+            percentage: percentage,
+            fromCoin: detailsViewModel.fromCoin,
+            fee: detailsViewModel.fee
+        ) else { return }
+
+        detailsViewModel.fromAmount = amount
+        detailsViewModel.updateFromAmount(vault: vault, referredCode: referredViewModel.savedReferredCode, immediate: true)
     }
 
     // MARK: - Market / Limit tabs

--- a/VultisigApp/VultisigApp/Model/Coin.swift
+++ b/VultisigApp/VultisigApp/Model/Coin.swift
@@ -326,7 +326,12 @@ class Coin: ObservableObject, Codable, Hashable {
         let tokenDecimals = decimals
         let maxValueCalculated = maxValueDecimal / pow(10, tokenDecimals)
 
-        return maxValueCalculated < .zero ? 0 : maxValueCalculated.truncated(toPlaces: decimals - 1)
+        // Truncate to the coin's full precision. Shaving a digit off here used
+        // to strand up to one unit-of-last-place of dust on every Max send.
+        // No anti-overshoot margin is needed: `rawBalance - fee` is exact BigInt
+        // arithmetic and cannot overshoot, and the native Max is independently
+        // re-derived against a fresh balance + fee on the Verify screen.
+        return maxValueCalculated < .zero ? 0 : maxValueCalculated.truncated(toPlaces: decimals)
     }
 
     var balanceInFiatDecimal: Decimal {

--- a/VultisigApp/VultisigAppTests/Blockchain/Cardano/CardanoSendMaxSuggestionTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Cardano/CardanoSendMaxSuggestionTests.swift
@@ -1,0 +1,128 @@
+//
+//  CardanoSendMaxSuggestionTests.swift
+//  VultisigAppTests
+//
+//  Pins the ADA amount quoted by the three validation messages that suggest
+//  "Send Max". They must quote what Max would ACTUALLY send — balance minus
+//  fee, matching `SendCryptoLogic.computeMaxAmount` — not the raw balance.
+//  Quoting the balance advertises more ADA than Max can deliver, which is a
+//  promise the very next tap breaks.
+//
+//  Also pins ADA's full 6-decimal precision: an earlier `decimals - 1` shave
+//  quoted less than Max sends, the mirror-image lie.
+//
+//  Expected strings are built through the same `formatToDecimal` the production
+//  code uses, so these assertions hold on comma-decimal locales too.
+//
+
+@testable import VultisigApp
+import BigInt
+import XCTest
+
+final class CardanoSendMaxSuggestionTests: XCTestCase {
+
+    private let oneADA = BigInt(1_000_000)
+
+    /// Renders lovelaces the way the validation messages do.
+    private func ada(_ lovelaces: BigInt) -> String {
+        lovelaces.toADA.formatToDecimal(digits: 6)
+    }
+
+    // MARK: - Insufficient-balance path
+
+    func testInsufficientBalanceQuotesMaxNetOfFee() throws {
+        // 10 ADA balance, 0.5 ADA fee → Max sends 9.5, not 10.
+        let balance = oneADA * 10
+        let fee = BigInt(500_000)
+        let result = CardanoHelper.validateUTXORequirements(
+            sendAmount: BigInt(9_900_000),
+            totalBalance: balance,
+            estimatedFee: fee
+        )
+
+        XCTAssertFalse(result.isValid)
+        let message = try XCTUnwrap(result.errorMessage)
+        XCTAssertTrue(
+            message.contains(ada(balance - fee)),
+            "expected fee-adjusted \(ada(balance - fee)), got: \(message)"
+        )
+        XCTAssertFalse(
+            message.contains("\(ada(balance)) ADA"),
+            "must not advertise the raw balance \(ada(balance)): \(message)"
+        )
+    }
+
+    // MARK: - Change-too-small path
+
+    func testTooLittleChangeQuotesMaxNetOfFee() throws {
+        // 5 ADA balance, 0.17 ADA fee, sending 3.9 → change 0.93 (< 1.4 minUTXO).
+        let balance = oneADA * 5
+        let fee = BigInt(170_000)
+        let result = CardanoHelper.validateUTXORequirements(
+            sendAmount: BigInt(3_900_000),
+            totalBalance: balance,
+            estimatedFee: fee
+        )
+
+        XCTAssertFalse(result.isValid)
+        let message = try XCTUnwrap(result.errorMessage)
+        XCTAssertTrue(
+            message.contains(ada(balance - fee)),
+            "expected \(ada(balance - fee)), got: \(message)"
+        )
+    }
+
+    // MARK: - Low-balance recommendation
+
+    func testLowBalanceRecommendationQuotesMaxNetOfFee() throws {
+        // 3 ADA balance (under the 3.5 threshold), 0.17 ADA fee → 2.83.
+        let balance = oneADA * 3
+        let fee = BigInt(170_000)
+        let result = CardanoHelper.shouldRecommendSendMax(
+            totalBalance: balance,
+            estimatedFee: fee
+        )
+
+        XCTAssertTrue(result.shouldRecommend)
+        let message = try XCTUnwrap(result.message)
+        XCTAssertTrue(
+            message.contains(ada(balance - fee)),
+            "expected \(ada(balance - fee)), got: \(message)"
+        )
+    }
+
+    // MARK: - Precision
+
+    func testSuggestionKeepsAllSixAdaDecimals() throws {
+        // 3.123456 balance, 1 lovelace fee → 3.123455, exercising the 6th
+        // decimal. A `decimals - 1` shave would quote 3.12345 and strand a digit.
+        let balance = BigInt(3_123_456)
+        let fee = BigInt(1)
+        let result = CardanoHelper.shouldRecommendSendMax(
+            totalBalance: balance,
+            estimatedFee: fee
+        )
+
+        XCTAssertTrue(result.shouldRecommend)
+        let message = try XCTUnwrap(result.message)
+        // A shaved quote (3.12345) cannot contain the full 6-decimal string,
+        // so the positive assertion alone pins the precision. Asserting the
+        // absence of "3.12345" would not work — it is a prefix of "3.123455".
+        let expected = ada(balance - fee)
+        XCTAssertTrue(message.contains(expected), "expected full-precision \(expected), got: \(message)")
+    }
+
+    // MARK: - Guards
+
+    func testFeeExceedingBalanceDoesNotRecommendSendMax() {
+        // Below the fee there is nothing to suggest; the suggestion path must
+        // not be reached with a negative max.
+        let result = CardanoHelper.shouldRecommendSendMax(
+            totalBalance: BigInt(100_000),
+            estimatedFee: BigInt(170_000)
+        )
+
+        XCTAssertFalse(result.shouldRecommend)
+        XCTAssertNil(result.message)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Send/SendMaxAmountTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendMaxAmountTests.swift
@@ -65,6 +65,70 @@ final class SendMaxAmountTests: XCTestCase {
         XCTAssertEqual(amount.toDecimal(), Decimal(string: "9.5"))
     }
 
+    // MARK: - Full-precision max (no unit-of-last-place dust left behind)
+
+    func testTokenMaxFillsFullBalance() {
+        // USDT/USDC carry 6 decimals. Max must fill every one of them —
+        // truncating to 5 stranded the last digit (100.12345) on every send.
+        let usdt = makeCoin(.ethereum, ticker: "USDT", decimals: 6, isNative: false,
+                            rawBalance: "100123456") // 100.123456 USDT
+        let amount = SendCryptoLogic.computeMaxAmount(coin: usdt, fee: .zero)
+        XCTAssertEqual(amount.toDecimal(), Decimal(string: "100.123456"))
+    }
+
+    func testCardanoMaxFillsFullBalance() {
+        let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
+                           rawBalance: "10123456") // 10.123456 ADA
+        let amount = SendCryptoLogic.computeMaxAmount(coin: ada, fee: .zero)
+        XCTAssertEqual(amount.toDecimal(), Decimal(string: "10.123456"))
+    }
+
+    func testBitcoinMaxFillsFullBalanceToEightDecimals() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true,
+                           rawBalance: "12345678") // 0.12345678 BTC
+        let amount = SendCryptoLogic.computeMaxAmount(coin: btc, fee: .zero)
+        XCTAssertEqual(amount.toDecimal(), Decimal(string: "0.12345678"))
+    }
+
+    func testNativeMaxWithFeeEqualsBalanceMinusFeeExactly() {
+        let atom = makeCoin(.gaiaChain, ticker: "ATOM", decimals: 6, isNative: true,
+                            rawBalance: "10123456") // 10.123456 ATOM
+        let fee = BigInt(5_000) // 0.005 ATOM in uatom
+        let amount = SendCryptoLogic.computeMaxAmount(coin: atom, fee: fee)
+        // balance − fee, to the last unit: 10123456 − 5000 = 10118456 uatom.
+        XCTAssertEqual(amount.toDecimal(), Decimal(string: "10.118456"))
+    }
+
+    func testTerraClassicMaxFillsFullPrecisionAfterBurnTax() {
+        // Terra Classic bypasses getMaxValue for the burn-tax fixed point:
+        // max = (balance − baseGasFee) / (1 + rate), rate = 0.5%.
+        // 100 LUNC / 1.005 = 99.5024875621… → 99.502487 at full 6-dp precision.
+        let lunc = makeCoin(.terraClassic, ticker: "LUNC", decimals: 6, isNative: true,
+                            rawBalance: "100000000") // 100 LUNC
+        let amount = SendCryptoLogic.computeMaxAmount(coin: lunc, fee: .zero)
+        XCTAssertEqual(amount.toDecimal(), Decimal(string: "99.502487"))
+    }
+
+    func testComputeMaxAmountCapsDisplayAtEightDecimals() {
+        // Deliberate and pre-existing: the amount written into the input field
+        // is formatted at min(8, decimals), so an 18-decimal chain shows 8 dp
+        // rather than rendering a wei-precision string in the UI. The residue
+        // is sub-1e-8; the full precision is still available at the Coin level
+        // (see the test below). Pinned so the cap reads as intentional.
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1234567891234567890") // 1.23456789123456789 ETH
+        let amount = SendCryptoLogic.computeMaxAmount(coin: eth, fee: .zero)
+        XCTAssertEqual(amount.toDecimal(), Decimal(string: "1.23456789"))
+    }
+
+    func testGetMaxValueKeepsPrecisionBeyondDisplayCap() {
+        // computeMaxAmount formats at min(8, decimals), so an 18-decimal chain
+        // can only be observed at the Coin level. Pin full precision there.
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000123456") // 1.000000000000123456 ETH
+        XCTAssertEqual(eth.getMaxValue(.zero), Decimal(string: "1.000000000000123456"))
+    }
+
     // MARK: - applyPercentage
 
     func testApplyPercentageScalesAmountLinearly() {

--- a/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
@@ -234,7 +234,7 @@ final class SendValidationTests: XCTestCase {
         // Acceptance: the MAX-send reserve equals the balance-calc reserve.
         // Fixture models an OwnerCount > 0 account — total 12 XRP with a
         // 1 + 5 × 0.2 = 2 XRP reserve nets rawBalance 8.6 XRP (drops are
-        // 6-decimals; getMaxValue truncates to 5 dp). With the reserve-net
+        // 6-decimals; getMaxValue truncates to the coin's full 6 dp). With the reserve-net
         // balance R and fee f, MAX == R − f exactly — no second static 1 XRP.
         let xrp = makeCoin(.ripple, ticker: Chain.ripple.ticker, decimals: 6, isNative: true,
                            rawBalance: "8600000")

--- a/VultisigApp/VultisigAppTests/Services/SwapPercentageTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapPercentageTests.swift
@@ -186,6 +186,30 @@ final class SwapPercentageTests: XCTestCase {
         )
     }
 
+    /// "0" is the unloaded state, not a distinguishable empty wallet, so it
+    /// must NOT cap. `Coin.init` seeds `rawBalance` to `String.zero`, so every
+    /// coin reads "0" until a balance lands; capping there would zero out a
+    /// valid amount whenever the form renders before balances arrive.
+    func testZeroRawBalanceDoesNotCapTheAmount() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "0")
+        XCTAssertEqual(
+            SwapCryptoLogic.amountInCoinDecimal(fromAmount: "1.5", fromCoin: btc),
+            BigInt(150_000_000)
+        )
+    }
+
+    /// Pins the premise of the guard above: a freshly built coin carries "0",
+    /// not "". If `Coin.init` ever gains a distinct unloaded sentinel, this
+    /// fails and the cap can then tell the two states apart.
+    func testFreshCoinSeedsRawBalanceToZeroString() {
+        let coin = Coin(
+            asset: CoinMeta.make(chain: .bitcoin, ticker: "BTC", decimals: 8, isNativeToken: true),
+            address: "test-address-BTC",
+            hexPublicKey: ""
+        )
+        XCTAssertEqual(coin.rawBalance, "0")
+    }
+
     // MARK: - Helpers
 
     private func text(_ percentage: Int, _ coin: Coin, fee: BigInt = 0) -> String? {

--- a/VultisigApp/VultisigAppTests/Services/SwapPercentageTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapPercentageTests.swift
@@ -1,175 +1,210 @@
-import XCTest
+//
+//  SwapPercentageTests.swift
+//  VultisigAppTests
+//
+//  Coverage for the "25 / 50 / 75 / 100%" swap presets. Exercises the
+//  production helpers — `PercentageAmountLogic` and
+//  `SwapCryptoLogic.percentageAmountText` — rather than re-deriving the math,
+//  so a regression in the rule fails here.
+//
+
 import BigInt
+import XCTest
 @testable import VultisigApp
 
-// `formatToDecimal` uses `Locale.current`, so hardcoded `.`-separated
-// expected strings fail on simulators in comma-decimal locales (e.g. de_DE).
+// The amount text carries the current locale's decimal separator, so hardcoded
+// `.`-separated expectations fail on comma-decimal simulators (e.g. de_DE).
 // `.localeDecimal` rewrites the expected value with the current separator.
 private extension String {
     var localeDecimal: String {
-        let sep = Locale.current.decimalSeparator ?? "."
-        return replacingOccurrences(of: ".", with: sep)
+        let separator = Locale.current.decimalSeparator ?? "."
+        return replacingOccurrences(of: ".", with: separator)
     }
 }
 
-/// Tests the pure `Decimal` math + `formatToDecimal` formatting used when a
-/// user selects a 25/50/75/100% amount for a swap. This file validates the
-/// *intended* rule (`max(4, coin.decimals)`, capped at 9 for EVM chains).
-///
-/// Note: `SwapDetailsScreen.handlePercentageSelection` currently hardcodes
-/// `decimalsToUse: Int = 4` for every coin, so BTC/ETH amounts are truncated
-/// to 4 decimals in the UI today. Aligning the UI with this rule is tracked
-/// in the Swap flow rewrite (docs/refactors/10-swap-rewrite.md). Until then
-/// these tests verify the formatter+math primitives in isolation; they do
-/// not exercise the live UI behavior.
-class SwapPercentageTests: XCTestCase {
+@MainActor
+final class SwapPercentageTests: XCTestCase {
 
-    func testBTCPercentageCalculation() {
-        // Create a mock Bitcoin coin with 8 decimals
-        let btcMeta = CoinMeta(
-            chain: .bitcoin,
-            ticker: "BTC",
-            logo: "btc",
-            decimals: 8,
-            priceProviderId: "bitcoin",
-            contractAddress: "",
-            isNativeToken: true
-        )
+    // MARK: - Precision rule
 
-        let btcCoin = Coin(asset: btcMeta, address: "test", hexPublicKey: "test")
-
-        // Set a small balance: 0.00021322 BTC (21322 satoshis)
-        btcCoin.rawBalance = "21322"
-
-        // Test 25% calculation
-        let balance = btcCoin.balanceDecimal
-        let twentyFivePercent = balance * 0.25
-        let formattedAmount = twentyFivePercent.formatToDecimal(digits: 8)
-
-        // Should be 0.00005330 BTC, not 0.0001
-        XCTAssertEqual(formattedAmount, "0.0000533".localeDecimal, "25% of 0.00021322 BTC should be 0.00005330")
-
-        // Test with the actual implementation's logic (using max(4, decimals))
-        let decimalsToUse = max(4, btcCoin.decimals)
-        XCTAssertEqual(decimalsToUse, 8, "For BTC, should use 8 decimals")
-
-        // Test all percentages
-        let testCases: [(percentage: Double, expected: String)] = [
-            (0.25, "0.0000533"),
-            (0.50, "0.00010661"),
-            (0.75, "0.00015991"),
-            (1.00, "0.00021322")
-        ]
-
-        for testCase in testCases {
-            let calculatedAmount = (balance * Decimal(testCase.percentage)).formatToDecimal(digits: decimalsToUse)
-            XCTAssertEqual(
-                calculatedAmount,
-                testCase.expected.localeDecimal,
-                "\(Int(testCase.percentage * 100))% of 0.00021322 BTC should be \(testCase.expected)"
-            )
-        }
+    func testDecimalPlacesCapsAtEightAndNeverExceedsTheAsset() {
+        XCTAssertEqual(PercentageAmountLogic.decimalPlaces(coinDecimals: 0), 0)
+        XCTAssertEqual(PercentageAmountLogic.decimalPlaces(coinDecimals: 2), 2)
+        XCTAssertEqual(PercentageAmountLogic.decimalPlaces(coinDecimals: 6), 6)
+        XCTAssertEqual(PercentageAmountLogic.decimalPlaces(coinDecimals: 8), 8)
+        XCTAssertEqual(PercentageAmountLogic.decimalPlaces(coinDecimals: 9), 8)
+        XCTAssertEqual(PercentageAmountLogic.decimalPlaces(coinDecimals: 18), 8)
     }
 
-    func testETHPercentageCalculation() {
-        // Create a mock Ethereum coin with 18 decimals
-        let ethMeta = CoinMeta(
-            chain: .ethereum,
-            ticker: "ETH",
-            logo: "eth",
-            decimals: 18,
-            priceProviderId: "ethereum",
-            contractAddress: "",
-            isNativeToken: true
-        )
+    // MARK: - BTC: the reported bug
 
-        let ethCoin = Coin(asset: ethMeta, address: "test", hexPublicKey: "test")
+    /// 25% of 0.00021322 BTC is 0.000053305 — below the old hardcoded 4-decimal
+    /// floor, so the button used to produce a zero-value swap.
+    func testBtcSmallBalancePercentagesAreNonZero() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "21322")
 
-        // Set balance: 0.00894077 ETH
-        ethCoin.rawBalance = "8940770000000000" // in wei
+        XCTAssertEqual(text(25, btc), "0.0000533".localeDecimal)
+        XCTAssertEqual(text(50, btc), "0.00010661".localeDecimal)
+        XCTAssertEqual(text(75, btc), "0.00015991".localeDecimal)
+        XCTAssertEqual(text(100, btc), "0.00021322".localeDecimal)
 
-        let balance = ethCoin.balanceDecimal
-
-        // For EVM chains with 18 decimals, should cap at 9
-        let decimalsToUse: Int
-        if ethCoin.chainType == .EVM {
-            decimalsToUse = min(9, max(4, ethCoin.decimals))
-        } else {
-            decimalsToUse = max(4, ethCoin.decimals)
-        }
-
-        XCTAssertEqual(decimalsToUse, 9, "For ETH (EVM), should cap at 9 decimals")
-
-        // Test 25% calculation with capped decimals
-        let twentyFivePercent = (balance * 0.25).formatToDecimal(digits: decimalsToUse)
-        XCTAssertEqual(twentyFivePercent, "0.002235192".localeDecimal, "25% calculation should be capped at 9 decimals")
+        XCTAssertNotEqual(text(25, btc), "0", "25% must not truncate away to a zero-value swap")
     }
 
-    func testEVMDecimalCapping() {
-        // Test various EVM tokens with different decimals
-
-        // USDC - 6 decimals (should use 6)
-        let usdcMeta = CoinMeta(
-            chain: .ethereum,
-            ticker: "USDC",
-            logo: "usdc",
-            decimals: 6,
-            priceProviderId: "usd-coin",
-            contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-            isNativeToken: false
-        )
-
-        let usdcCoin = Coin(asset: usdcMeta, address: "test", hexPublicKey: "test")
-        let usdcDecimalsToUse = min(9, max(4, usdcCoin.decimals))
-        XCTAssertEqual(usdcDecimalsToUse, 6, "USDC should use 6 decimals")
-
-        // WBTC on Ethereum - 8 decimals (should use 8)
-        let wbtcMeta = CoinMeta(
-            chain: .ethereum,
-            ticker: "WBTC",
-            logo: "wbtc",
-            decimals: 8,
-            priceProviderId: "wrapped-bitcoin",
-            contractAddress: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
-            isNativeToken: false
-        )
-
-        let wbtcCoin = Coin(asset: wbtcMeta, address: "test", hexPublicKey: "test")
-        let wbtcDecimalsToUse = min(9, max(4, wbtcCoin.decimals))
-        XCTAssertEqual(wbtcDecimalsToUse, 8, "WBTC should use 8 decimals")
-
-        // DAI - 18 decimals (should cap at 9)
-        let daiMeta = CoinMeta(
-            chain: .ethereum,
-            ticker: "DAI",
-            logo: "dai",
-            decimals: 18,
-            priceProviderId: "dai",
-            contractAddress: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-            isNativeToken: false
-        )
-
-        let daiCoin = Coin(asset: daiMeta, address: "test", hexPublicKey: "test")
-        let daiDecimalsToUse = min(9, max(4, daiCoin.decimals))
-        XCTAssertEqual(daiDecimalsToUse, 9, "DAI should cap at 9 decimals")
+    func testBtcNativeHundredPercentReservesTheNetworkFee() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "21322")
+        XCTAssertEqual(text(100, btc, fee: BigInt(1_000)), "0.00020322".localeDecimal)
     }
 
-    func testNonEVMCoins() {
-        // Test that non-EVM coins are not capped
+    func testNativeHundredPercentFloorsAtZeroWhenFeeExceedsBalance() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "21322")
+        XCTAssertEqual(text(100, btc, fee: BigInt(50_000)), "0")
+    }
 
-        // Solana - 9 decimals
-        let solMeta = CoinMeta(
-            chain: .solana,
-            ticker: "SOL",
-            logo: "sol",
-            decimals: 9,
-            priceProviderId: "solana",
-            contractAddress: "",
-            isNativeToken: true
+    // MARK: - 100% strands nothing
+
+    func testNonNativeHundredPercentReturnsTheExactFullBalance() {
+        let wbtc = makeCoin(.ethereum, ticker: "WBTC", decimals: 8, isNative: false, rawBalance: "21322")
+        XCTAssertEqual(text(100, wbtc, fee: BigInt(1_000)), "0.00021322".localeDecimal)
+    }
+
+    /// The old 4-decimal truncation stranded up to 9_999 base units of an
+    /// 8-decimal token on every Max.
+    func testNonNativeHundredPercentDoesNotStrandSubUnitDust() {
+        let wbtc = makeCoin(.ethereum, ticker: "WBTC", decimals: 8, isNative: false, rawBalance: "123459999")
+        XCTAssertEqual(text(100, wbtc), "1.23459999".localeDecimal)
+    }
+
+    // MARK: - Other precisions
+
+    func testUsdcSixDecimals() {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, rawBalance: "1234567")
+
+        XCTAssertEqual(text(25, usdc), "0.308641".localeDecimal)
+        XCTAssertEqual(text(50, usdc), "0.617283".localeDecimal)
+        XCTAssertEqual(text(100, usdc), "1.234567".localeDecimal)
+    }
+
+    /// 18-decimal assets: fractional presets stop at the 8-place cap, while
+    /// 100% still hands back every last wei.
+    func testEighteenDecimalTokenCapsFractionsAtEightPlacesButNotHundredPercent() {
+        let dai = makeCoin(.ethereum, ticker: "DAI", decimals: 18, isNative: false, rawBalance: "1234567890123456789")
+
+        XCTAssertEqual(text(25, dai), "0.30864197".localeDecimal)
+        XCTAssertEqual(text(75, dai), "0.92592591".localeDecimal)
+        XCTAssertEqual(text(100, dai), "1.234567890123456789".localeDecimal)
+    }
+
+    /// The case that rules out a `max(4, decimals)` floor: a 2-decimal asset
+    /// cannot represent 4 places, so a preset must never claim them.
+    func testSubFourDecimalAssetIsNotPaddedBeyondItsPrecision() {
+        let coin = makeCoin(.ethereum, ticker: "LOWDP", decimals: 2, isNative: false, rawBalance: "12345")
+
+        XCTAssertEqual(text(25, coin), "30.86".localeDecimal)
+        XCTAssertEqual(text(50, coin), "61.72".localeDecimal)
+        XCTAssertEqual(text(100, coin), "123.45".localeDecimal)
+    }
+
+    func testZeroDecimalAssetHasNoFractionalPart() {
+        let coin = makeCoin(.ethereum, ticker: "ZERODP", decimals: 0, isNative: false, rawBalance: "12345")
+        XCTAssertEqual(text(100, coin), "12345")
+    }
+
+    // MARK: - Unsupported input
+
+    func testUnsupportedPercentageReturnsNil() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "21322")
+        XCTAssertNil(SwapCryptoLogic.percentageAmountText(percentage: 33, fromCoin: btc, fee: 0))
+        XCTAssertNil(SwapCryptoLogic.percentageAmountText(percentage: 0, fromCoin: btc, fee: 0))
+    }
+
+    func testZeroBalanceReturnsZero() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "0")
+        XCTAssertEqual(text(50, btc), "0")
+    }
+
+    // MARK: - Raw conversion clamp
+
+    /// `Coin.raw(for:)` rounds UP and the amount field round-trips through a
+    /// Double-backed `NumberFormatter`, so a full-precision 18-decimal balance
+    /// parses back slightly high. Unclamped that converts to more base units
+    /// than the wallet holds and the swap fails on chain.
+    func testHundredPercentOfEighteenDecimalBalanceConvertsToExactlyRawBalance() throws {
+        let rawBalance = "1234567890123456789"
+        let dai = makeCoin(.ethereum, ticker: "DAI", decimals: 18, isNative: false, rawBalance: rawBalance)
+        let expected = BigInt(rawBalance) ?? .zero
+        let amount = try XCTUnwrap(text(100, dai))
+
+        XCTAssertGreaterThan(
+            dai.raw(for: amount.toDecimal()),
+            expected,
+            "precondition: the unclamped conversion overshoots the balance"
         )
+        XCTAssertEqual(
+            SwapCryptoLogic.amountInCoinDecimal(fromAmount: amount, fromCoin: dai),
+            expected
+        )
+    }
 
-        let solCoin = Coin(asset: solMeta, address: "test", hexPublicKey: "test")
-        let solDecimalsToUse = max(4, solCoin.decimals)
-        XCTAssertEqual(solDecimalsToUse, 9, "SOL should use full 9 decimals without capping")
+    func testHundredPercentOfEightDecimalBalanceConvertsToExactlyRawBalance() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "21322")
+        XCTAssertEqual(
+            SwapCryptoLogic.amountInCoinDecimal(fromAmount: text(100, btc) ?? "", fromCoin: btc),
+            BigInt(21_322)
+        )
+    }
+
+    /// The broadcast amount is capped at the balance in every case, not just
+    /// for the presets — the chain rejects anything larger.
+    func testAmountAboveBalanceNeverBroadcastsMoreThanTheBalance() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "21322")
+        XCTAssertEqual(
+            SwapCryptoLogic.amountInCoinDecimal(fromAmount: "0.001", fromCoin: btc),
+            BigInt(21_322)
+        )
+    }
+
+    /// Capping the broadcast amount must not hide an over-spend: the
+    /// insufficient-funds check runs on a separate `Decimal` path and still
+    /// rejects the same input.
+    func testCappingDoesNotHideOverSpendFromTheBalanceCheck() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "21322")
+        XCTAssertEqual(
+            SwapCryptoLogic.balanceError(fromCoin: btc, feeCoin: btc, fromAmount: "0.001", fee: 0),
+            .insufficientFunds
+        )
+    }
+
+    /// A balance that hasn't loaded yet must not cap a legitimate amount to
+    /// zero — this is also what `SwapCryptoLogicTests` pins for an unset
+    /// balance.
+    func testUnloadedBalanceDoesNotCapTheAmount() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true, rawBalance: "")
+        XCTAssertEqual(
+            SwapCryptoLogic.amountInCoinDecimal(fromAmount: "1.5", fromCoin: btc),
+            BigInt(150_000_000)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func text(_ percentage: Int, _ coin: Coin, fee: BigInt = 0) -> String? {
+        SwapCryptoLogic.percentageAmountText(percentage: percentage, fromCoin: coin, fee: fee)
+    }
+
+    private func makeCoin(
+        _ chain: Chain,
+        ticker: String,
+        decimals: Int,
+        isNative: Bool,
+        rawBalance: String
+    ) -> Coin {
+        let coin = Coin(
+            asset: CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: isNative),
+            address: "test-address-\(ticker)",
+            hexPublicKey: ""
+        )
+        coin.rawBalance = rawBalance
+        return coin
     }
 }


### PR DESCRIPTION
Fixes #4835.

> **Stacked on `fix/send-max-precision-4836`.** This branch is cut from that
> branch, so the diff against `main` will show #4836's commit until it merges.
> Merge #4836 first; this PR's own change is the single commit on top.

## The bug

`handlePercentageSelection` hardcoded `let decimalsToUse: Int = 4` and applied it
to all five branches (25 / 50 / 75 / 100% native / 100% non-native):

- A BTC balance of `0.00021322` gave 25% = `0.000053305`, truncated to 4 places →
  **`"0"`**. The button produced a zero-value swap for any coin whose 25% share
  fell below `0.0001`.
- 100% non-native truncated to 4 places, stranding dust — an 8-decimal WBTC
  balance lost up to ~9 999 sats on every Max.

## The fix

One shared rule, `min(8, coin.decimals)`, in a new `PercentageAmountLogic`
(`Core/Utils/`), used by all three flows that had drifted apart:

| Call site | Before | Now |
|---|---|---|
| `SwapDetailsScreen.handlePercentageSelection` | hardcoded `4` | `SwapCryptoLogic.percentageAmountText` → shared helper |
| `LimitSwapFormViewModel.sourceAmountText` | hardcoded `4` (with a comment saying it deliberately matched the market buttons) | shared helper |
| `SendCryptoLogic.applyPercentage` | its own `coinDecimals > 8 ? 8 : coinDecimals` | shared helper (behavior unchanged) |

`min(9, max(4, decimals))` — the rule the old tests documented — was rejected:
the `max(4, …)` floor over-reports precision for assets with fewer than 4
decimals, producing amounts the asset cannot represent.

100% now converts the **raw balance** directly rather than a decimal-truncated
view, so it strands nothing. The native 100% still reserves the network fee.

The math was extracted out of the SwiftUI view into
`SwapCryptoLogic.percentageAmountText`, which is what makes it testable at all —
the view method is precisely why the old tests dodged it.

## Why the `raw(for:)` cap ships here

This is not unrelated hardening — **the precision fix arms a latent overflow**,
so the two cannot be separated.

`Coin.raw(for:)` rounds **UP**, and the amount field round-trips through
`String.toDecimal()`, which parses via a Double-backed `NumberFormatter` that
keeps only ~16 significant digits and rounds half-up. Verified:
`1.234567890123456789` parses back as `1.234567890123457`. So a 100% preset on an
18-decimal asset converted to **more base units than the wallet holds** and the
transaction would fail on chain. The old 4-decimal truncation masked this;
restoring full precision exposes it.

`SwapCryptoLogic.amountInCoinDecimal` therefore caps the result at `rawBalance`.
The cap is deliberately narrow and lives in the swap amount path, not inside
`raw(for:)` — that function is also used for UTXO/Cardano fee planning in
`SwapPayloadBuilder`, and the `.up` rounding mode is left untouched.

It cannot hide an over-spend: the insufficient-funds check is
`SwapCryptoLogic.balanceError`, which compares `Decimal` values and never calls
`amountInCoinDecimal` — that helper feeds only `SwapPayloadBuilder`. A test pins
this. A zero `rawBalance` (balance not yet loaded) is excluded, so a valid amount
is never capped to zero; `SwapCryptoLogicTests`' `amountInCoinDecimal("1.5", btc)
== 150_000_000` assertion is unaffected.

## Tests

`SwapPercentageTests` was **rewritten**. The old version never invoked production
code — it asserted `min`/`max` on literals plus `formatToDecimal`, and its own
header admitted as much. It passed with the bug present and would have passed
unchanged after the fix.

17 tests now exercise the extracted helpers: the reported BTC case at 25/50/75/100%
(25% asserted non-zero), 100% returning the exact full balance, 6-decimal USDC,
an 18-decimal token (8-place cap on fractions, full precision on 100%), a
sub-4-decimal asset, the fee reservation, and the cap — including that a
full-precision 18-decimal balance converts to exactly `rawBalance` and not one
unit more.

## Gate

`make test` on iPhone 16 Pro Max — `** TEST SUCCEEDED **`, **3138 tests, 1 skipped,
0 failures**. SwiftLint clean on all changed files.

Reviewed with the cross-model loop; Codex's final whole-branch pass returned
no findings (it caught a real missing-brace blocker one round earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved max-send calculations to preserve full asset precision and avoid over-spending, including fee-adjusted caps and correct handling when balances are zero/unavailable.
  - Standardized percentage preset amount calculations across send and swap flows, with consistent truncation/rounding rules for low-decimal assets and fee scenarios.
  - Updated Cardano ADA validation/recommendation text to quote fee-adjusted “Send Max” with consistent 6-decimal precision.

- **Tests**
  - Expanded send-max, fee edge-case, locale-aware percentage, and Cardano “Send Max” suggestion/validation coverage to match the updated precision and formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->