### PR TITLE
fix(swap): derive toAmountLimit from the signed memo, not expected output

### DIFF
--- a/VultisigApp/VultisigApp/Features/LimitSwap/Logic/LimitSwapPayloadAssembler.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Logic/LimitSwapPayloadAssembler.swift
@@ -267,10 +267,11 @@ func buildLimitSwapKeysignPayload(
 /// only cross-device SWAP display — the co-signer's "you receive" row — so a
 /// resting limit order shows its LIM floor rather than 0. Signing and every
 /// fund-safety gate ignore it (they read `transaction` / `toCoin.address`), so
-/// its exact value can never affect what is signed. `toAmountLimit` stays "0":
-/// it drives only the WalletCore native-RUNE `THORChainSwap.build` min-output
-/// arg, which an ERC20 `depositWithExpiry` never reaches, and nothing displays
-/// it.
+/// its exact value can never affect what is signed. `toAmountLimit` and the two
+/// streaming fields stay "0": nothing on this device reads them and no signer
+/// consumes them — they exist only to travel in the cross-device proto. For a
+/// resting limit order that is also the honest value, since the order's floor
+/// lives in the `=<` memo on `KeysignPayload.memo`, not here.
 ///
 /// `expirationTime` is the router's ON-CHAIN tx-execution deadline
 /// (`require(block.timestamp < expiry)` inside `depositWithExpiry`) — a guard

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -78,32 +78,106 @@ extension SwapCryptoLogic {
         return ERC20ApprovePayload(amount: amount, spender: spender)
     }
 
+    /// The `LIM/INTERVAL/QUANTITY` triple a THORChain/MayaChain swap memo
+    /// carries. Every field is a decimal string in the node's own units and
+    /// semantics; `"0"` is meaningful in all three positions (no output floor,
+    /// no streaming, protocol-chosen sub-swap count) rather than a sentinel.
+    struct ThorchainMemoSwapTerms: Equatable {
+        /// Minimum acceptable output, in the node's base units (THORChain 1e8 —
+        /// the same units as `expected_amount_out`). `"0"` = no floor asserted.
+        let limit: String
+        /// Streaming-swap block interval. `"0"` = a single (rapid) swap.
+        let streamingInterval: String
+        /// Streaming-swap sub-swap count. `"0"` = the protocol picks it.
+        let streamingQuantity: String
+
+        /// What an absent, truncated, or unparseable memo yields: a swap that
+        /// asserts nothing. Every field claims the weakest thing it can.
+        static let unspecified = ThorchainMemoSwapTerms(
+            limit: "0",
+            streamingInterval: "0",
+            streamingQuantity: "0"
+        )
+    }
+
+    /// Read the `LIM/INTERVAL/QUANTITY` triple out of a node-returned
+    /// THORChain/MayaChain swap memo.
+    ///
+    /// Memo grammar: `SWAP:ASSET:DESTADDR:LIM/INTERVAL/QUANTITY[:AFFILIATE:FEE]`,
+    /// with `SWAP` abbreviating to `=` or `s` (e.g. `=:e:0x742d…:0/1/0`). Neither
+    /// ASSET nor DESTADDR can contain a colon, so the triple is always the 4th
+    /// colon-delimited field and optional trailing affiliate/fee fields never
+    /// shift it. A rapid swap may stop after `LIM`; the omitted trailing terms
+    /// then read as `"0"`, matching the node's own reading of a short memo.
+    ///
+    /// Parsing is all-or-nothing: an action that isn't a swap, a triple with a
+    /// term we can't read as a bare decimal integer, or more than three terms
+    /// all yield `.unspecified`. Every one of those means the memo is not the
+    /// grammar we think it is, and a LIM salvaged from a memo we failed to
+    /// understand is exactly the false floor this parser exists to avoid. No
+    /// whitespace is trimmed either — the memo is signed byte-for-byte, so a
+    /// term that isn't already canonical is a term we should not vouch for.
+    static func thorchainMemoSwapTerms(from memo: String) -> ThorchainMemoSwapTerms {
+        let fields = memo.split(separator: ":", omittingEmptySubsequences: false)
+        guard fields.count >= 4, isThorchainSwapAction(fields[0]) else { return .unspecified }
+
+        let terms = fields[3].split(separator: "/", omittingEmptySubsequences: false)
+        guard !terms.isEmpty, terms.count <= 3 else { return .unspecified }
+
+        var parsed = ["0", "0", "0"]
+        for (index, term) in terms.enumerated() {
+            // ASCII digits only — `Character.isNumber` alone also accepts
+            // non-ASCII numerals and fractions, which would sail through here
+            // and land in the proto as an uninterpretable string.
+            guard !term.isEmpty, term.allSatisfy({ $0.isASCII && $0.isNumber }) else {
+                return .unspecified
+            }
+            parsed[index] = String(term)
+        }
+
+        return ThorchainMemoSwapTerms(
+            limit: parsed[0],
+            streamingInterval: parsed[1],
+            streamingQuantity: parsed[2]
+        )
+    }
+
+    /// THORChain and MayaChain both spell the swap action `SWAP`, `=` or `s`,
+    /// case-insensitively. Every other action (`ADD`, `WITHDRAW`, `DONATE`,
+    /// `LOAN+`, …) lays its fields out differently, so its 4th field is not a
+    /// `LIM/INTERVAL/QUANTITY` triple and must not be read as one.
+    private static func isThorchainSwapAction(_ field: Substring) -> Bool {
+        switch field.lowercased() {
+        case "swap", "=", "s":
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Build the THORChain/MayaChain swap payload from primitives + selected quote.
     /// `now` parameterised so tests can pin the 15-minute expiration deterministically.
     ///
-    /// The on-chain minimum-output floor is enforced by the `LIM` field inside
-    /// the node-returned `quote.memo` (driven by the `tolerance_bps` we send on
-    /// the quote request); that memo is what gets signed verbatim. The
-    /// `toAmountLimit` / `streamingQuantity` fields here travel in the proto
-    /// payload for cross-device display — we mirror the node's derivation so
-    /// they stay consistent with the signed memo instead of reading `0`.
+    /// `toAmountLimit`, `streamingInterval` and `streamingQuantity` are read
+    /// straight out of `quote.memo`. That memo is signed and broadcast verbatim,
+    /// so its `LIM/INTERVAL/QUANTITY` triple is the only authoritative statement
+    /// of the output floor and streaming plan — neither is derivable from the
+    /// quote's other fields, because the node applies its tolerance parameter to
+    /// a feeless price we never see and bakes its own streaming choice into the
+    /// memo. All three are inert on this device (nothing renders them, no signer
+    /// reads them); they ride the proto so the co-signer sees exactly what the
+    /// memo commits to.
     static func buildThorchainSwapPayload(
         fromCoin: Coin,
         toCoin: Coin,
         fromAmountInCoin: BigInt,
         toAmountDecimal: Decimal,
         quote: ThorchainSwapQuote,
-        provider: SwapProvider,
-        toleranceBps: Int = SwapService.defaultThorchainToleranceBps,
         now: Date = Date()
     ) -> THORChainSwapPayload {
         let vaultAddress = quote.inboundAddress ?? fromCoin.address
         let expirationTime = now.addingTimeInterval(60 * 15)
-        let toAmountLimit = thorchainToAmountLimit(
-            expectedAmountOut: quote.expectedAmountOut,
-            toleranceBps: toleranceBps
-        )
-        let streamingQuantity = quote.maxStreamingQuantity.map(String.init) ?? "0"
+        let memoTerms = thorchainMemoSwapTerms(from: quote.memo)
         return THORChainSwapPayload(
             fromAddress: fromCoin.address,
             fromCoin: fromCoin,
@@ -112,26 +186,12 @@ extension SwapCryptoLogic {
             routerAddress: quote.router,
             fromAmount: fromAmountInCoin,
             toAmountDecimal: toAmountDecimal,
-            toAmountLimit: toAmountLimit,
-            streamingInterval: String(provider.streamingInterval),
-            streamingQuantity: streamingQuantity,
+            toAmountLimit: memoTerms.limit,
+            streamingInterval: memoTerms.streamingInterval,
+            streamingQuantity: memoTerms.streamingQuantity,
             expirationTime: UInt64(expirationTime.timeIntervalSince1970),
             isAffiliate: SwapCryptoLogic.isAffiliate
         )
-    }
-
-    /// Minimum acceptable output, mirroring the node's `LIM` derivation:
-    /// `floor(expectedAmountOut × (10_000 − toleranceBps) / 10_000)`.
-    /// `expectedAmountOut` is the quote's raw integer output (THORChain 1e8
-    /// units). Returns `"0"` when the input can't be parsed or tolerance is out
-    /// of range — the node-side memo `LIM` remains the authoritative floor.
-    static func thorchainToAmountLimit(expectedAmountOut: String, toleranceBps: Int) -> String {
-        guard toleranceBps >= 0, toleranceBps < 10_000,
-              let expected = BigInt(expectedAmountOut), expected > 0 else {
-            return "0"
-        }
-        let limit = expected * BigInt(10_000 - toleranceBps) / BigInt(10_000)
-        return String(limit)
     }
 
     /// Assemble the final `KeysignPayload` for a swap given a finalised
@@ -174,7 +234,6 @@ extension SwapCryptoLogic {
                     fromAmountInCoin: amountInCoin,
                     toAmountDecimal: toDecimal,
                     quote: quote,
-                    provider: .mayachain,
                     now: now
                 )),
                 approvePayload: approvePayload,
@@ -195,7 +254,6 @@ extension SwapCryptoLogic {
                     fromAmountInCoin: amountInCoin,
                     toAmountDecimal: toDecimal,
                     quote: quote,
-                    provider: .thorchain,
                     now: now
                 )),
                 approvePayload: approvePayload,
@@ -216,7 +274,6 @@ extension SwapCryptoLogic {
                     fromAmountInCoin: amountInCoin,
                     toAmountDecimal: toDecimal,
                     quote: quote,
-                    provider: .thorchainChainnet,
                     now: now
                 )),
                 approvePayload: approvePayload,
@@ -237,7 +294,6 @@ extension SwapCryptoLogic {
                     fromAmountInCoin: amountInCoin,
                     toAmountDecimal: toDecimal,
                     quote: quote,
-                    provider: .thorchainStagenet,
                     now: now
                 )),
                 approvePayload: approvePayload,

--- a/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
@@ -66,62 +66,192 @@ final class SwapPayloadBuilderTests: XCTestCase {
         XCTAssertEqual(payload.toAddress, "thor-router")
     }
 
-    // MARK: - Minimum-output limit (toAmountLimit) derivation
+    // MARK: - Memo LIM/INTERVAL/QUANTITY parsing
 
-    func testThorchainToAmountLimitAppliesTolerance() {
-        // 1% (100 bps) tolerance off 100_000_000 → 99_000_000.
-        let limit = SwapCryptoLogic.thorchainToAmountLimit(
-            expectedAmountOut: "100000000",
-            toleranceBps: 100
+    func testMemoTermsAutoSlippageMemoAssertsNoFloor() {
+        // Real mainnet memo captured from thornode with no tolerance param:
+        // the node emits LIM 0, i.e. "no minimum output guaranteed".
+        let terms = SwapCryptoLogic.thorchainMemoSwapTerms(
+            from: "=:e:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:0/1/0"
         )
-        XCTAssertEqual(limit, "99000000")
+        XCTAssertEqual(terms.limit, "0", "Auto slippage carries no LIM — the payload must not claim one")
+        XCTAssertEqual(terms.streamingInterval, "1")
+        XCTAssertEqual(terms.streamingQuantity, "0")
     }
 
-    func testThorchainToAmountLimitFloorsFractionalResult() {
-        // 100 bps off 12_345 = 12_221.55 → floored to 12_221.
-        let limit = SwapCryptoLogic.thorchainToAmountLimit(
-            expectedAmountOut: "12345",
-            toleranceBps: 100
+    func testMemoTermsCustomSlippageParsesNodeLimitExactly() {
+        // The node's own floor for tolerance_bps=100 at 0.1 BTC. It is NOT
+        // expected_amount_out × 0.99 (that would be 338179686) — which is why
+        // this value can only come from the memo.
+        let terms = SwapCryptoLogic.thorchainMemoSwapTerms(
+            from: "=:e:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:340077095/1/3"
         )
-        XCTAssertEqual(limit, "12221")
+        XCTAssertEqual(terms.limit, "340077095")
+        XCTAssertEqual(terms.streamingInterval, "1")
+        XCTAssertEqual(terms.streamingQuantity, "3")
     }
 
-    func testThorchainToAmountLimitZeroToleranceKeepsFullAmount() {
-        let limit = SwapCryptoLogic.thorchainToAmountLimit(
-            expectedAmountOut: "500",
-            toleranceBps: 0
+    func testMemoTermsIgnoreTrailingAffiliateAndFeeFields() {
+        // Affiliate + fee fields sit AFTER the triple, so they must not shift it.
+        let terms = SwapCryptoLogic.thorchainMemoSwapTerms(
+            from: "=:BTC.BTC:bc1qexampleaddress:12345/2/4:va:50"
         )
-        XCTAssertEqual(limit, "500")
+        XCTAssertEqual(terms.limit, "12345")
+        XCTAssertEqual(terms.streamingInterval, "2")
+        XCTAssertEqual(terms.streamingQuantity, "4")
     }
 
-    func testThorchainToAmountLimitFallsBackToZeroOnBadInput() {
+    func testMemoTermsUnabbreviatedSwapPrefixAndMissingStreamingFields() {
+        // Full `SWAP:` prefix, rapid swap: LIM present, no `/INTERVAL/QUANTITY`.
+        let terms = SwapCryptoLogic.thorchainMemoSwapTerms(
+            from: "SWAP:ETH.ETH:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:98765"
+        )
+        XCTAssertEqual(terms.limit, "98765")
+        XCTAssertEqual(terms.streamingInterval, "0", "A memo with no streaming spec is a single swap")
+        XCTAssertEqual(terms.streamingQuantity, "0")
+    }
+
+    func testMemoTermsSecuredAssetMemoParsesLimit() {
+        // Secured-asset notation uses `-` inside the asset field, never `:`,
+        // so the triple stays in the 4th field.
+        let terms = SwapCryptoLogic.thorchainMemoSwapTerms(
+            from: "=:BTC-BTC:thor1exampledestination:777/1/0"
+        )
+        XCTAssertEqual(terms.limit, "777")
+        XCTAssertEqual(terms.streamingInterval, "1")
+        XCTAssertEqual(terms.streamingQuantity, "0")
+    }
+
+    func testMemoTermsMayaMemoParsesLimit() {
+        // Maya memos share the THORChain grammar (CACAO uses 1e10 units, but
+        // the parser is unit-agnostic — it mirrors whatever the memo says).
+        let terms = SwapCryptoLogic.thorchainMemoSwapTerms(
+            from: "=:MAYA.CACAO:maya1exampledestination:338900185/3/0"
+        )
+        XCTAssertEqual(terms.limit, "338900185")
+        XCTAssertEqual(terms.streamingInterval, "3")
+        XCTAssertEqual(terms.streamingQuantity, "0")
+    }
+
+    func testMemoTermsFallBackToUnspecifiedOnUnusableMemo() {
+        // Never fall back to expected_amount_out: "0" honestly says "no floor
+        // asserted", a derived number would claim one the memo doesn't carry.
+        for memo in [
+            "",                                       // no memo at all
+            "=:BTC.BTC",                              // truncated before DESTADDR
+            "=:BTC.BTC:bc1qexampleaddress",           // no LIM field
+            "=:BTC.BTC:bc1qexampleaddress:",          // empty LIM field
+            "=:BTC.BTC:bc1qexampleaddress:abc/1/0",   // non-numeric LIM
+            "=:BTC.BTC:bc1qexampleaddress:-5/1/0",    // signed LIM
+            "=:BTC.BTC:bc1qexampleaddress:1.5/1/0",   // fractional LIM
+            "=:BTC.BTC:bc1qexampleaddress: 500/1/0",  // padded LIM is not canonical
+            "=:BTC.BTC:bc1qexampleaddress:١٢٣/1/0",   // non-ASCII numerals
+            "=:BTC.BTC:bc1qexampleaddress:5/1/0/9"    // more terms than the grammar has
+        ] {
+            XCTAssertEqual(
+                SwapCryptoLogic.thorchainMemoSwapTerms(from: memo), .unspecified,
+                "Unusable memo \"\(memo)\" must assert nothing"
+            )
+        }
+    }
+
+    func testMemoTermsRejectNonSwapActions() {
+        // Other THORChain actions lay their fields out differently, so their
+        // 4th field is not a LIM triple even when it happens to be numeric.
+        for memo in [
+            "DONATE:BTC.BTC:bc1qexampleaddress:500",
+            "ADD:BTC.BTC:bc1qexampleaddress:500/1/0",
+            "LOAN+:BTC.BTC:bc1qexampleaddress:500/1/0"
+        ] {
+            XCTAssertEqual(
+                SwapCryptoLogic.thorchainMemoSwapTerms(from: memo), .unspecified,
+                "Non-swap memo \"\(memo)\" must not be read as a swap"
+            )
+        }
+    }
+
+    func testMemoTermsAcceptEverySwapActionSpelling() {
+        // THORChain spells the swap action `SWAP`, `=` or `s`, case-insensitively.
+        for action in ["SWAP", "swap", "=", "s", "S"] {
+            XCTAssertEqual(
+                SwapCryptoLogic.thorchainMemoSwapTerms(
+                    from: "\(action):BTC.BTC:bc1qexampleaddress:500/1/0"
+                ).limit,
+                "500",
+                "\"\(action)\" is a valid swap action spelling"
+            )
+        }
+    }
+
+    func testMemoTermsRejectWholeTripleWhenAnyTermIsUnreadable() {
+        // All-or-nothing: a LIM salvaged from a memo whose grammar we failed to
+        // parse is exactly the false floor this parser exists to avoid.
         XCTAssertEqual(
-            SwapCryptoLogic.thorchainToAmountLimit(expectedAmountOut: "not-a-number", toleranceBps: 100),
-            "0"
-        )
-        XCTAssertEqual(
-            SwapCryptoLogic.thorchainToAmountLimit(expectedAmountOut: "0", toleranceBps: 100),
-            "0"
-        )
-        XCTAssertEqual(
-            SwapCryptoLogic.thorchainToAmountLimit(expectedAmountOut: "1000", toleranceBps: 10_000),
-            "0",
-            "100% tolerance is out of range and must not zero the floor silently to a wrong value"
+            SwapCryptoLogic.thorchainMemoSwapTerms(from: "=:BTC.BTC:bc1qexampleaddress:500/x/7"),
+            .unspecified
         )
     }
 
-    func testBuildThorchainSwapPayloadSetsNonZeroLimit() {
+    // MARK: - Payload wiring of the memo terms
+
+    func testBuildThorchainSwapPayloadTakesLimitAndStreamingFromMemo() {
         let payload = SwapCryptoLogic.buildThorchainSwapPayload(
             fromCoin: makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true),
-            toCoin: makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true),
+            toCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
             fromAmountInCoin: BigInt(100_000_000),
             toAmountDecimal: 1,
-            quote: makeThorQuote(inboundAddress: "thor-vault", router: nil),
-            provider: .thorchain,
-            toleranceBps: 100,
+            quote: makeThorQuote(
+                inboundAddress: "thor-vault",
+                router: nil,
+                memo: "=:e:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:340077095/1/3"
+            ),
             now: fixedNow
         )
-        XCTAssertNotEqual(payload.toAmountLimit, "0", "Payload must carry a real minimum-output limit, not 0")
+        XCTAssertEqual(payload.toAmountLimit, "340077095")
+        XCTAssertEqual(payload.streamingInterval, "1")
+        XCTAssertEqual(payload.streamingQuantity, "3")
+    }
+
+    func testBuildThorchainSwapPayloadReportsNoFloorForAutoSlippage() {
+        // The regression this fixes: the old derivation reported 100% of
+        // expected_amount_out as a guaranteed floor on every Auto swap.
+        let quote = makeThorQuote(
+            inboundAddress: "thor-vault",
+            router: nil,
+            memo: "=:e:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:0/1/0"
+        )
+        let payload = SwapCryptoLogic.buildThorchainSwapPayload(
+            fromCoin: makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true),
+            toCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            fromAmountInCoin: BigInt(100_000_000),
+            toAmountDecimal: 1,
+            quote: quote,
+            now: fixedNow
+        )
+        XCTAssertEqual(payload.toAmountLimit, "0")
+        XCTAssertNotEqual(
+            payload.toAmountLimit, quote.expectedAmountOut,
+            "A memo with LIM 0 must never report the full expected output as a floor"
+        )
+    }
+
+    func testBuildThorchainSwapPayloadIgnoresMaxStreamingQuantityCeiling() {
+        // `max_streaming_quantity` is the node's capacity ceiling, not the
+        // quantity it baked into the memo — the payload must report the memo's.
+        let payload = SwapCryptoLogic.buildThorchainSwapPayload(
+            fromCoin: makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true),
+            toCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            fromAmountInCoin: BigInt(100_000_000),
+            toAmountDecimal: 1,
+            quote: makeThorQuote(
+                inboundAddress: "thor-vault",
+                router: nil,
+                memo: "=:e:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:0/1/0",
+                maxStreamingQuantity: 42
+            ),
+            now: fixedNow
+        )
+        XCTAssertEqual(payload.streamingQuantity, "0")
     }
 
     // MARK: - MayaChain
@@ -513,7 +643,9 @@ final class SwapPayloadBuilderTests: XCTestCase {
 
     private func makeThorQuote(
         inboundAddress: String?,
-        router: String?
+        router: String?,
+        memo: String = "thor-memo",
+        maxStreamingQuantity: Int? = nil
     ) -> ThorchainSwapQuote {
         ThorchainSwapQuote(
             dustThreshold: nil,
@@ -523,7 +655,7 @@ final class SwapPayloadBuilderTests: XCTestCase {
             inboundAddress: inboundAddress,
             inboundConfirmationBlocks: nil,
             inboundConfirmationSeconds: nil,
-            memo: "thor-memo",
+            memo: memo,
             notes: "",
             outboundDelayBlocks: 0,
             outboundDelaySeconds: 0,
@@ -532,7 +664,7 @@ final class SwapPayloadBuilderTests: XCTestCase {
             totalSwapSeconds: nil,
             warning: "",
             router: router,
-            maxStreamingQuantity: nil
+            maxStreamingQuantity: maxStreamingQuantity
         )
     }
 


### PR DESCRIPTION
Fixes #4841.

## The bug

`SwapCryptoLogic.buildThorchainSwapPayload` derived the payload's minimum-output floor as:

```swift
let limit = expected * BigInt(10_000 - toleranceBps) / BigInt(10_000)
```

`toleranceBps` defaulted to `SwapService.defaultThorchainToleranceBps`, which is `0`, and **no production caller ever passed it** — all four call sites (maya / thorchain / chainnet / stagenet) omitted the argument. So `toAmountLimit == quote.expectedAmountOut` verbatim: every THORChain and MayaChain swap payload claimed a guaranteed floor of 100% of the expected output.

Only one test passed a nonzero tolerance, exercising a path production never took. That is what kept this invisible.

## Why not just thread the real `slippageBps` through

That was the obvious fix, and live measurement against thornode rules it out. At 0.1 BTC with `tolerance_bps=100`:

| | value |
|---|---|
| real memo `LIM` | `340077095` |
| what the formula gives | `338179686` |

The formula matches **`liquidity_tolerance_bps`** semantics exactly, but `tolerance_bps` is what iOS actually sends — so threading the real slippage through would still report a wrong floor on the custom-slippage path. And on Auto the memo carries no `LIM` at all while the formula keeps returning 100%. Full measurements: https://github.com/vultisig/vultisig-ios/issues/4838#issuecomment-5021569752

## The fix — parse `LIM` out of `quote.memo`

The memo is signed and broadcast verbatim, which makes its `LIM/INTERVAL/QUANTITY` triple the only authoritative statement of the floor and the streaming plan. Parsing it is correct by construction on Auto (`LIM` `0`), on custom slippage (the node's exact number), and under either tolerance parameter — so it also survives whatever #4838 settles on, with no rework.

Parsing is deliberately **all-or-nothing**. A non-swap action, a term that isn't a canonical bare decimal integer, or more terms than the grammar has all yield `"0"` across the board. `"0"` honestly means *no floor asserted*; salvaging a number out of a memo we failed to parse is the same class of false claim this change exists to remove. Legitimately absent trailing terms still read `"0"` — a rapid-swap memo may stop after `LIM`, which is valid grammar rather than a parse failure.

`thorchainToAmountLimit` and its five tests are deleted (four covered the path no production caller took).

## `streamingQuantity` and `streamingInterval` had the same bug

Both are fixed here, from the same parse:

- `streamingQuantity` reported `max_streaming_quantity` — the node's *capacity ceiling*, not the quantity it baked into the memo. `SwapService` already notes that "the chosen quantity is baked into the returned memo".
- `streamingInterval` reported a static per-provider constant. It diverges whenever the anti-rekt path refetches at `interval: 1` and picks the streaming quote: memo says `1`, payload said `0`.

Fixing quantity from the memo while leaving interval on a provider constant would have left the two halves of one memo field disagreeing, so both now come from the same source. This made the `provider` parameter dead, so it is removed from `buildThorchainSwapPayload`.

## Scope note — these fields are inert on iOS today

Nothing renders `toAmountLimit` and no signer reads it; it only travels in the keysign proto to the co-signer. So this is a correctness fix for the cross-device payload and for any future "minimum received" display, not a user-visible change. **Tests are the only verification surface — no runtime verification was performed, and none is possible without a display.**

Two false doc comments are corrected: `SwapPayloadBuilder` claimed these fields "mirror the node's derivation", and `LimitSwapPayloadAssembler` claimed `toAmountLimit` drives the WalletCore native-RUNE min-output arg (it does not, at HEAD).

## Tests

13 tests replace the 5 deleted ones. Parser: Auto memo (`LIM` `0`), custom slippage parsed exactly, trailing affiliate/fee fields, unabbreviated `SWAP:` prefix with no streaming spec, secured-asset memo, Maya memo, every swap-action spelling (`SWAP`/`swap`/`=`/`s`/`S`), non-swap actions rejected, whole-triple rejection on an unreadable term, and a table of unusable memos (empty, truncated, non-numeric, signed, fractional, padded, non-ASCII numerals, too many terms). Payload wiring: limit + streaming read from the memo, Auto reports no floor, `max_streaming_quantity` ceiling ignored.

The real mainnet memo `=:e:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:0/1/0` is used as a fixture.

## Gate

`make generate && make test` on iPhone 16e — `** TEST SUCCEEDED **`, **3126 tests executed, 1 skipped, 0 failures**.

Reviewed across two `codex exec --sandbox read-only` rounds: round 1 raised one MINOR finding on parser leniency (three parts — non-swap actions, whitespace normalization, per-field vs whole-triple rejection), all three accepted and fixed; round 2 on the amended commit returned no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * THORChain and MayaChain swaps now use limit and streaming settings directly from the swap memo.
  * Improved handling of auto-slippage, custom minimum outputs, and incomplete or invalid memo terms.
  * Limit-swap documentation now clarifies how minimum-output limits are represented.

* **Tests**
  * Added coverage for memo parsing, streaming parameters, secured assets, MayaChain swaps, and invalid memo formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->