### PR TITLE
fix(swap): map the node's price-limit rejection to an actionable slippage error

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapError.swift
@@ -17,6 +17,10 @@ enum SwapError: Error, LocalizedError, Equatable {
     case noLiquidityPool
     case tradingHalted
     case swapAmountTooSmall
+    /// The node refused the quote because its simulated output fell below the
+    /// minimum-output floor derived from the requested slippage tolerance.
+    /// Actionable by the user: raise the slippage setting or reduce the amount.
+    case slippageToleranceTooTight
     case lessThenMinSwapAmount(amount: String)
     case serverError(message: String)
 
@@ -34,6 +38,8 @@ enum SwapError: Error, LocalizedError, Equatable {
             return "swapTradingHalted".localized
         case .swapAmountTooSmall:
             return "swapAmountTooSmall".localized
+        case .slippageToleranceTooTight:
+            return "swapSlippageToleranceTooTight".localized
         case .lessThenMinSwapAmount(let amount):
             return String(format: "swapAmountTooSmallRecommended".localized, amount)
         case .serverError(let msg):

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -726,6 +726,13 @@ extension SwapService {
             // This typically means no liquidity pool exists for this token pair.
             return .noLiquidityPool
         }
+        if message.localizedCaseInsensitiveContains("less than price limit") {
+            // The node simulated the swap and its output landed under the `LIM`
+            // floor derived from the slippage tolerance we sent. Raw, this reads
+            // as "emit asset N less than price limit M" — meaningless to a user.
+            // Surface it as the actionable slippage message instead.
+            return .slippageToleranceTooTight
+        }
         return nil
     }
 

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1266,6 +1266,7 @@
 "swaps" = "Swaps";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "Ziel des Secured-Asset-Swaps ist keine gültige %1$@-Adresse (%2$@).";
+"swapSlippageToleranceTooTight" = "Der Preis hat deine Slippage-Toleranz überschritten. Erhöhe die Slippage-Einstellung in den Swap-Einstellungen oder versuche einen kleineren Betrag.";
 "swapTrackingLink" = "Tauschverfolgungslink";
 "swapTradingHalted" = "Der Handel für diesen Vermögenswert ist vorübergehend ausgesetzt. Bitte versuche es später erneut.";
 "swapTXHash" = "Tausch-Tx-Hash";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1264,6 +1264,7 @@
 "swaps" = "Swaps";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "Secured-asset swap destination is not a valid %1$@ address (%2$@).";
+"swapSlippageToleranceTooTight" = "Price moved beyond your slippage tolerance. Increase the slippage setting in swap settings, or try a smaller amount.";
 "swapTrackingLink" = "Swap tracking link";
 "swapTradingHalted" = "Trading for this asset is temporarily halted. Please try again later.";
 "swapTXHash" = "Swap Tx Hash";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1266,6 +1266,7 @@
 "swaps" = "Intercambios";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "El destino del swap de activo asegurado no es una dirección %1$@ válida (%2$@).";
+"swapSlippageToleranceTooTight" = "El precio superó tu tolerancia de slippage. Aumenta el ajuste de slippage en la configuración de intercambio o prueba con una cantidad menor.";
 "swapTrackingLink" = "Enlace de seguimiento del intercambio";
 "swapTradingHalted" = "La negociación de este activo está suspendida temporalmente. Inténtalo de nuevo más tarde.";
 "swapTXHash" = "Hash de la transacción de intercambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1266,6 +1266,7 @@
 "swaps" = "Zamjene";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "Odredište zamjene osiguranog sredstva nije valjana %1$@ adresa (%2$@).";
+"swapSlippageToleranceTooTight" = "Cijena je premašila vašu toleranciju klizanja. Povećajte postavku klizanja u postavkama zamjene ili pokušajte s manjim iznosom.";
 "swapTrackingLink" = "Poveznica za praćenje zamjene";
 "swapTradingHalted" = "Trgovanje ovom imovinom privremeno je zaustavljeno. Pokušajte ponovno kasnije.";
 "swapTXHash" = "Zamjenski Tx hash";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1266,6 +1266,7 @@
 "swaps" = "Scambi";
 "swapSecuredAssetBadge" = "Garantito";
 "swapSecuredAssetInvalidDestination" = "La destinazione dello swap dell'asset protetto non è un indirizzo %1$@ valido (%2$@).";
+"swapSlippageToleranceTooTight" = "Il prezzo ha superato la tua tolleranza di slippage. Aumenta l'impostazione dello slippage nelle impostazioni di scambio oppure prova con un importo inferiore.";
 "swapTrackingLink" = "Link di tracciamento dello scambio";
 "swapTradingHalted" = "La negoziazione di questo asset è temporaneamente sospesa. Riprova più tardi.";
 "swapTXHash" = "Hash Tx dello scambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1227,6 +1227,7 @@
 "swapRouteNotAvailable" = "스왑 경로를 사용할 수 없습니다";
 "swaps" = "스왑";
 "swapSecuredAssetInvalidDestination" = "보안 자산 스왑 대상이 유효한 %1$@ 주소가 아닙니다 (%2$@).";
+"swapSlippageToleranceTooTight" = "가격이 허용 슬리피지를 초과했습니다. 스왑 설정에서 슬리피지를 높이거나 더 적은 금액으로 시도해 주세요.";
 "swapTrackingLink" = "스왑 추적 링크";
 "swapTradingHalted" = "이 자산의 거래가 일시적으로 중단되었습니다. 나중에 다시 시도해 주세요.";
 "swapTXHash" = "스왑 Tx 해시";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1266,6 +1266,7 @@
 "swaps" = "Trocas";
 "swapSecuredAssetBadge" = "Secured";
 "swapSecuredAssetInvalidDestination" = "O destino do swap de ativo protegido não é um endereço %1$@ válido (%2$@).";
+"swapSlippageToleranceTooTight" = "O preço ultrapassou a sua tolerância de slippage. Aumente a definição de slippage nas definições de troca ou tente um valor menor.";
 "swapTrackingLink" = "Link de rastreamento da troca";
 "swapTradingHalted" = "A negociação deste ativo está temporariamente suspensa. Tente novamente mais tarde.";
 "swapTXHash" = "Hash da Tx da troca";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1266,6 +1266,7 @@
 "swaps" = "兑换";
 "swapSecuredAssetBadge" = "担保";
 "swapSecuredAssetInvalidDestination" = "受保护资产兑换的目标地址不是有效的 %1$@ 地址（%2$@）。";
+"swapSlippageToleranceTooTight" = "价格波动超出了您的滑点容忍度。请在交换设置中调高滑点，或尝试更小的金额。";
 "swapTrackingLink" = "交换跟踪链接";
 "swapTradingHalted" = "该资产的交易已暂时停止，请稍后再试。";
 "swapTXHash" = "交换交易哈希";

--- a/VultisigApp/VultisigAppTests/Swap/SwapErrorMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapErrorMappingTests.swift
@@ -109,4 +109,57 @@ final class SwapErrorMappingTests: XCTestCase {
         let error = MayachainSwapError(code: 3, error: "pool does not exist")
         XCTAssertEqual(SwapService.mapMayachainSwapError(error).errorDescription, "noLiquidityPool".localized)
     }
+
+    // MARK: - Price-limit rejection → actionable slippage message
+
+    func testThorchainPriceLimitRejectionMapsToSlippageTooTight() {
+        // Verbatim THORNode body captured from a live /quote/swap rejection.
+        let error = ThorchainSwapError(
+            code: 3,
+            message: "failed to simulate swap: failed to simulate handler: emit asset 42579895573 less than price limit 340083366993: invalid request"
+        )
+        XCTAssertEqual(
+            SwapService.mapThorchainSwapError(error).errorDescription,
+            "swapSlippageToleranceTooTight".localized
+        )
+    }
+
+    func testMayachainPriceLimitRejectionMapsToSlippageTooTight() {
+        // Verbatim Mayanode body — a shorter shape than THORChain's, which is why
+        // the classifier matches the common "less than price limit" substring.
+        let error = MayachainSwapError(
+            code: 3,
+            error: "failed to simulate swap: emit asset 336029740 less than price limit 340582434"
+        )
+        XCTAssertEqual(
+            SwapService.mapMayachainSwapError(error).errorDescription,
+            "swapSlippageToleranceTooTight".localized
+        )
+    }
+
+    func testPriceLimitRejectionIsCaseInsensitive() {
+        let error = ThorchainSwapError(code: 3, message: "Emit asset 1 LESS THAN PRICE LIMIT 2")
+        XCTAssertEqual(
+            SwapService.mapThorchainSwapError(error).errorDescription,
+            "swapSlippageToleranceTooTight".localized
+        )
+    }
+
+    func testPriceLimitRejectionNoLongerLeaksRawNodeString() {
+        // Regression guard: this body used to fall through to `.serverError`,
+        // showing the untranslated node text verbatim.
+        let raw = "failed to simulate swap: emit asset 336029740 less than price limit 340582434"
+        let error = MayachainSwapError(code: 3, error: raw)
+        XCTAssertNotEqual(SwapService.mapMayachainSwapError(error).errorDescription, raw)
+    }
+
+    func testHaltOutranksPriceLimit() {
+        // A halted pool that also trips the price-limit check must still surface
+        // as the retryable halt message — the halt check runs first.
+        let error = ThorchainSwapError(
+            code: 3,
+            message: "trading is halted: emit asset 1 less than price limit 2"
+        )
+        XCTAssertEqual(SwapService.mapThorchainSwapError(error).errorDescription, "swapTradingHalted".localized)
+    }
 }


### PR DESCRIPTION
Part of #4838.

## What this does

Maps THORChain/Maya's price-limit quote rejection to a new localized `SwapError.slippageToleranceTooTight`, instead of leaking the raw node string to the user.

When the node simulates a swap whose output lands under the `LIM` floor derived from the slippage tolerance, it rejects the quote. That body fell through the classifier to `.serverError(message:)`, so the untranslated node text was shown verbatim — with no hint that the slippage setting is the knob to turn.

## Split out of #4849

This is **commit 2 of #4849, lifted onto `main` on its own**.

#4849 bundles this UX fix with a contested change: switching quotes to `liquidity_tolerance_bps` with a 100 bps default, which re-introduces an on-chain minimum-output floor in the same territory as the previously-reverted #4556. That one needs a cross-client product decision and an Android plan before it can land.

This error mapping is a **pure UX fix that is correct regardless of how the floor decision goes** — the node can reject on a price limit whenever a user sets a tight slippage, floor default or not. There's no reason to hold it behind that decision, so it ships separately. #4849 now contains only the floor change.

This branch contains **no** tolerance-related changes: no `liquidity_tolerance_bps`, no constant rename, no parameter switch.

## Real captured node strings

Both mapped, verbatim from live rejections:

- **THORChain:** `failed to simulate swap: failed to simulate handler: emit asset 42579895573 less than price limit 340083366993: invalid request`
- **Maya:** `failed to simulate swap: emit asset 336029740 less than price limit 340582434`

The two node shapes differ, so the match is on the **shared `less than price limit` substring**, placed inside `classifyNativeQuoteError` — the helper both `mapThorchainSwapError` and `mapMayachainSwapError` run through. One match therefore covers both nodes.

It sits **after** the trading-halt check, so a halted pool still surfaces the retryable halt message rather than the slippage one. `testHaltOutranksPriceLimit` pins that ordering.

Localized in all 8 locales (de, en, es, hr, it, ko, pt, zh-Hans).

## Gate

`make test` on iOS Simulator: `** TEST SUCCEEDED **` — **3126 tests, 1 skipped, 0 failures**. No `BUILD FAILED` / `TEST FAILED` markers in the log.

New tests (5), all passing:
- `testThorchainPriceLimitRejectionMapsToSlippageTooTight`
- `testMayachainPriceLimitRejectionMapsToSlippageTooTight`
- `testPriceLimitRejectionIsCaseInsensitive`
- `testPriceLimitRejectionNoLongerLeaksRawNodeString`
- `testHaltOutranksPriceLimit`

## Diff

11 files, +74/-0 — `SwapError.swift` (new case), `SwapService.swift` (one classifier branch), 8 locale files, `SwapErrorMappingTests.swift`.

Draft pending review of the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clear swap error when the price exceeds the configured slippage tolerance.
  - Users are advised to increase slippage or try a smaller swap amount.
- **Bug Fixes**
  - Price-limit rejections now display a helpful localized message instead of raw node error text.
  - Existing trading-halted errors continue to take precedence when applicable.
- **Localization**
  - Added translations for the new error message across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->