### PR TITLE
feat(keysign): co-sign XRPL custom messages with SHA-512-half digest

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/Services/CustomMessagePayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/CustomMessagePayload.swift
@@ -36,6 +36,19 @@ struct CustomMessagePayload: Codable, Hashable {
             // misrouted method (e.g. eth_signTypedData_v4) must not flip us
             // into the EIP-712 path for a Cardano payload.
             return [data.hexString]
+        } else if chain.lowercased() == "ripple" {
+            // XRPL off-chain message signing (GemWallet signMessage /
+            // ripple-keypairs): the signed digest is SHA-512-half — the first
+            // 32 bytes of SHA-512 — of the message bytes. Mirrors the `ripple`
+            // branch of getCustomMessageHex.ts in vultisig-windows
+            // (`sha512(bytes).slice(0, 32)`), rendered as lowercase hex with no
+            // 0x prefix. Note this is the bare SHA-512-half of the message: the
+            // `TXN\0` prefix + uppercasing that Ripple.swift applies belong to
+            // the transaction-ID path, not here. Placed before the method
+            // branches, like Cardano, so a misrouted method can't pull an XRPL
+            // payload into the keccak/EIP-712 path.
+            let digest = Data(Hash.sha512(data: data).prefix(32))
+            return [digest.hexString]
         } else if method == "eth_signTypedData_v4" {
             // Handle eth_signTypedData_v4 (EIP-712)
             return keysignMessagesForTypedData()

--- a/VultisigApp/VultisigAppTests/Chains/RippleCustomMessageTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/RippleCustomMessageTests.swift
@@ -1,0 +1,95 @@
+//
+//  RippleCustomMessageTests.swift
+//  VultisigApp
+//
+
+@testable import VultisigApp
+import XCTest
+
+/// XRPL (Ripple) off-chain message co-signing path. The browser extension
+/// (vultisig-windows#4399) added GemWallet `signMessage()` over the shared MPC
+/// custom-message keysign, and the initiator hashes the message with
+/// SHA-512-half (the first 32 bytes of SHA-512). A Secure Vault iPhone acting
+/// as co-signer must reproduce the identical digest, or the message-ID derived
+/// from it diverges and the ceremony can never locate the setup message.
+///
+/// The expected digests below are computed OUTSIDE Swift (SHA-512 is
+/// standardised, so `hashlib.sha512(bytes)[:32]` equals the extension's
+/// `sha512(bytes).slice(0, 32)`), so these tests pin cross-platform byte
+/// identity rather than merely re-deriving iOS's own output.
+final class RippleCustomMessageTests: XCTestCase {
+
+    private func makePayload(method: String, message: String, chain: String = "Ripple") -> CustomMessagePayload {
+        CustomMessagePayload(
+            method: method,
+            message: message,
+            vaultPublicKeyECDSA: "",
+            vaultLocalPartyID: "",
+            chain: chain
+        )
+    }
+
+    func testUtf8MessageHashesToSha512Half() {
+        // "Hello, XRPL!" → hashlib.sha512(bytes)[:32].hex()
+        let payload = makePayload(method: "sign_message", message: "Hello, XRPL!")
+        XCTAssertEqual(
+            payload.keysignMessages,
+            ["f6805caef386076db074419d22a349341b0fa09c17838a2bdee43b2dc73cb988"]
+        )
+    }
+
+    func testHexMessageIsDecodedBeforeHashing() {
+        // 0xdeadbeef → sha512(<deadbeef bytes>)[:32], NOT sha512("0xdeadbeef" utf8).
+        // The shared 0x-decode must run before the digest, matching the
+        // extension's `Buffer.from(stripHexPrefix(message), 'hex')`.
+        let payload = makePayload(method: "sign_message", message: "0xdeadbeef")
+        XCTAssertEqual(
+            payload.keysignMessages,
+            ["1284b2d521535196f22175d5f558104220a6ad7680e78b49fa6f20e57ea7b185"]
+        )
+    }
+
+    func testDigestIsLowercaseSha512HalfShape() {
+        // 32 bytes = 64 lowercase hex chars, no 0x prefix — the extension emits
+        // Buffer.toString('hex') (lowercase). The TXN\0 prefix + uppercasing in
+        // Ripple.swift's transaction-ID path must NOT leak in here.
+        let digest = makePayload(method: "sign_message", message: "abc").keysignMessages[0]
+        XCTAssertEqual(digest.count, 64)
+        XCTAssertFalse(digest.hasPrefix("0x"))
+        XCTAssertEqual(digest, digest.lowercased())
+    }
+
+    func testRippleCaseAcceptsLowercaseAndMixedCase() {
+        for chain in ["ripple", "Ripple", "RIPPLE"] {
+            let payload = makePayload(method: "sign_message", message: "Hello, XRPL!", chain: chain)
+            XCTAssertEqual(
+                payload.keysignMessages,
+                ["f6805caef386076db074419d22a349341b0fa09c17838a2bdee43b2dc73cb988"],
+                "chain string \"\(chain)\" should match the Ripple branch"
+            )
+        }
+    }
+
+    func testRippleBranchTakesPrecedenceOverSolanaRawFallthrough() {
+        // Without the Ripple branch, method "sign_message" + chain "ripple"
+        // would miss every method branch and fall through to the raw-bytes
+        // path (return [data.hexString]) — the extension'd sign the plaintext,
+        // not its digest. Assert we hash instead of passing through.
+        let payload = makePayload(method: "sign_message", message: "Hello, XRPL!")
+        XCTAssertNotEqual(
+            payload.keysignMessages,
+            [Data("Hello, XRPL!".utf8).hexString],
+            "raw message bytes slipped through — the Ripple digest branch didn't run"
+        )
+    }
+
+    func testRippleBranchTakesPrecedenceOverEthSignTypedDataV4() {
+        // The branch must run independent of `method`, like Cardano. A misrouted
+        // eth_signTypedData_v4 on a Ripple payload must not hit the EIP-712 path.
+        let payload = makePayload(method: "eth_signTypedData_v4", message: "Hello, XRPL!")
+        XCTAssertEqual(
+            payload.keysignMessages,
+            ["f6805caef386076db074419d22a349341b0fa09c17838a2bdee43b2dc73cb988"]
+        )
+    }
+}


### PR DESCRIPTION
Closes #4844

## Problem

The browser extension added XRPL off-chain message signing for dApps — GemWallet `signMessage()` — in vultisig/vultisig-windows#4399. That flow reuses the shared MPC **custom-message** keysign, so for a **Secure (multi-device) Vault** an iOS device acting as co-signer must reproduce the exact digest the extension initiator signs.

`CustomMessagePayload.keysignMessages` had **no XRPL branch**: a `chain: Ripple` custom message missed every method branch and fell through to the raw-bytes path (`return [data.hexString]`), while the extension signs **SHA-512-half**. The digests — and the message-ID derived from them — diverge, so the co-sign ceremony can never locate the setup message and hangs / 404s.

Only affects **Secure Vaults** (extension + iPhone co-signing). Fast Vaults co-sign with VultiServer, so iOS is never invoked here.

## Alignment with windows/sdk

The digest must be byte-identical to the extension's. **The reference was verified against the actually-merged windows source, not the issue's paraphrase** — the local checkout predated #4399. Merged `core/ui/mpc/keysign/customMessage/getCustomMessageHex.ts` at merge commit `18a9cccc`:

```ts
ripple: () => Buffer.from(sha512(bytes).slice(0, 32)).toString('hex'),
```

where `bytes = message.startsWith('0x') ? hexDecode(stripHexPrefix(message)) : utf8(message)`, and the on-wire `chain` string is `OtherChain.Ripple = 'Ripple'`, `method: 'sign_message'`.

Three alignment details that the issue's summary understates and this PR gets right:

| aspect | windows contract | this branch |
|---|---|---|
| hash | `sha512(bytes)` | `Hash.sha512(data: data)` |
| truncation | `.slice(0, 32)` | `.prefix(32)` (SHA-512-half) |
| hex casing | `Buffer.toString('hex')` → **lowercase** | `.hexString` (lowercase) |
| prefix | none | **no** `0x`, **no** `TXN\0` |
| byte decode | `0x`→hex else UTF-8 | already shared at the top of `keysignMessages` |

The `TXN\0` prefix + `.uppercased()` in `Ripple.swift`'s `signedTransactionHash` belong to the XRPL **transaction-ID** path and are deliberately **not** used here — only the bare SHA-512-half of the message.

## The change

```swift
} else if chain.lowercased() == "ripple" {
    let digest = Data(Hash.sha512(data: data).prefix(32))
    return [digest.hexString]
}
```

Placed **before** the method-based branches (mirroring the Cardano branch) so a misrouted `method` — e.g. `eth_signTypedData_v4` — can't pull an XRPL payload into the keccak/EIP-712 path. Only the digest is the co-signer's concern; DER encoding + uppercasing stay the initiator's responsibility, so no signature-format change.

## Tests

New `VultisigAppTests/Chains/RippleCustomMessageTests.swift` (6 tests), mirroring `CardanoCustomMessageTests`. The expected digests are computed **outside Swift** (`hashlib.sha512(bytes)[:32]`, byte-identical to `@noble/hashes` since SHA-512 is standardised), so they pin **cross-platform byte identity** rather than merely re-deriving iOS's own output:

- `testUtf8MessageHashesToSha512Half` — `"Hello, XRPL!"` → `f6805cae…73cb988`
- `testHexMessageIsDecodedBeforeHashing` — `0xdeadbeef` decodes to bytes first → `1284b2d5…ea7b185` (not the digest of the literal string)
- `testDigestIsLowercaseSha512HalfShape` — 64 lowercase hex chars, no `0x` (guards against the tx-ID uppercasing/prefix leaking in)
- `testRippleCaseAcceptsLowercaseAndMixedCase` — `ripple` / `Ripple` / `RIPPLE`
- `testRippleBranchTakesPrecedenceOverSolanaRawFallthrough` — proves it hashes instead of passing raw bytes through (the pre-fix behaviour)
- `testRippleBranchTakesPrecedenceOverEthSignTypedDataV4` — method-independence

## Gate

`make test` on iPhone 16 Pro: **`** TEST SUCCEEDED **` — 3127 executed, 0 failures, 1 skipped**. All 6 new tests pass; Cardano's 4 remain green (no regression to other chains). SwiftLint clean.

Reviewed with a read-only cross-model (Codex) pass focused on the digest contract: no correctness issues — it independently re-derived both test vectors, and confirmed the digest matches the windows contract, the branch can't be bypassed by a misrouted method, and no `TXN\0`/uppercase leak from the tx-ID path.

## Out of scope (per the issue)

- Originating XRPL `signMessage` requests on iOS — the extension is the originator; iOS participates only as co-signer.
- XRPL dApp **transaction** co-signing — already shipped (`SignRipple` / `RippleHelper.dappSigningInput`).
- A Ripple-specific `CustomMessageDecoder` for nicer confirmation-screen display — nice-to-have, not required for signing correctness.

## Acceptance

- [x] Ripple branch returns SHA-512-half of the message bytes as hex, placed before the method branches
- [x] Digest byte-identical to `getCustomMessageHex.ts` for both UTF-8 and `0x`-hex messages (pinned by out-of-Swift vectors)
- [ ] End-to-end: a Secure Vault pairing the extension + an iPhone co-signs an XRPL dApp `signMessage`, dApp verifies the signature against the vault's XRP public key — **needs a two-device manual pass** (cannot be exercised in unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ripple/XRPL custom message signing using SHA-512-half hashing.
  * Ripple messages now produce lowercase, 64-character hexadecimal digests without a `0x` prefix.
  * Supports case-insensitive Ripple chain identifiers and correctly handles hexadecimal message inputs.

* **Bug Fixes**
  * Prevented Ripple messages from being processed through incompatible signing formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->