### PR TITLE
fix(swap): itemize the Verify fee rows — affiliate-only Vultisig Fee, % from bps, reconciled total

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapQuote+Ranking.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapQuote+Ranking.swift
@@ -38,7 +38,7 @@ extension SwapQuote {
             guard let raw = BigInt(quote.dstAmount), raw > 0 else { return nil }
             return toCoin.decimal(for: raw)
 
-        case .jupiter(let quote, _, _):
+        case .jupiter(let quote, _, _, _):
             // Jupiter `outAmount` is already net of the affiliate platform fee
             // (Jupiter deducts the fee from the AMM output and reports it
             // separately in `platformFee`), so it's the amount the user

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -636,14 +636,14 @@ private extension SwapService {
         slippageBps: Int?
     ) async throws -> SwapQuote {
         let fromAmount = fromCoin.raw(for: amount)
-        let (quote, fee, platformFee) = try await service.fetchQuote(
+        let (quote, fee, platformFee, feeOnInput) = try await service.fetchQuote(
             fromCoin: fromCoin,
             toCoin: toCoin,
             fromAmount: fromAmount,
             vultTierDiscount: vultTierDiscount,
             slippageBps: slippageBps
         )
-        return .jupiter(quote, fee: fee, platformFee: platformFee)
+        return .jupiter(quote, fee: fee, platformFee: platformFee, feeOnInput: feeOnInput)
     }
 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Jupiter/JupiterService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Jupiter/JupiterService.swift
@@ -62,7 +62,7 @@ struct JupiterService {
         fromAmount: BigInt,
         vultTierDiscount: Int,
         slippageBps: Int?
-    ) async throws -> (quote: EVMQuote, fee: BigInt?, platformFee: Decimal?) {
+    ) async throws -> (quote: EVMQuote, fee: BigInt?, platformFee: Decimal, feeOnInput: Bool) {
         let inputMint = jupiterMint(for: fromCoin)
         let outputMint = jupiterMint(for: toCoin)
 
@@ -104,14 +104,15 @@ struct JupiterService {
             feeAccount: feeAccount
         )
 
-        // `platformFee` is denominated in the fee mint. Surface it for display
-        // only when the fee mint is the output mint (so it's in `toCoin` units);
-        // for the input-mint case (native-SOL outputs) it would be
-        // mis-denominated, so omit it. Ranking uses `outAmount` (already net of
-        // the fee) regardless of which mint the fee is taken in.
-        let platformFee = feeMint == outputMint
-            ? platformFeeDecimal(from: quoteResponse, toCoin: toCoin)
-            : nil
+        // `platformFee` is denominated in the fee mint. It's surfaceable in
+        // `toCoin` units only when the fee mint IS the output mint. For the
+        // input-mint case (native-SOL outputs) it would be mis-denominated, so
+        // it's flagged `feeOnInput` and reported as 0 — display suppresses the
+        // affiliate row there rather than show a misleading amount. A zero
+        // output-mint fee (Ultimate tier) is a real 0, shown as a $0.00 row.
+        // Ranking uses `outAmount` (already net of the fee) regardless.
+        let feeOnInput = feeMint != outputMint
+        let platformFee: Decimal = feeOnInput ? .zero : (platformFeeDecimal(from: quoteResponse, toCoin: toCoin) ?? .zero)
 
         let evmQuote = EVMQuote(
             dstAmount: quoteResponse.outAmount,
@@ -124,7 +125,7 @@ struct JupiterService {
                 gas: 0
             )
         )
-        return (evmQuote, nil, platformFee)
+        return (evmQuote, nil, platformFee, feeOnInput)
     }
 
     /// The mint Jupiter expects for a coin: the SPL contract address, or wrapped

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
@@ -250,7 +250,7 @@ private extension MayachainService {
     /// Returns (affiliateAddress, affiliateBps) as URL-param-ready strings, or (nil, nil)
     /// if no affiliate should be sent.
     static func affiliateParams(referredCode _: String, discountBps: Int) -> (String?, String?) {
-        let feeRate = max(0, THORChainSwaps.affiliateFeeRateBp - discountBps)
+        let feeRate = THORChainSwaps.discountedAffiliateBps(baseBps: THORChainSwaps.affiliateFeeRateBp, discountBps: discountBps)
         return (THORChainSwaps.affiliateFeeAddress, "\(feeRate)")
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
@@ -340,12 +340,12 @@ class ThorchainService: ThorchainSwapProvider {
     /// Returns `(nil, nil)` if no affiliate entry should be sent.
     static func affiliateParams(referredCode: String, discountBps: Int) -> (String?, String?) {
         if !referredCode.isEmpty {
-            let feeRate = max(0, THORChainSwaps.referredAffiliateFeeRateBp - discountBps)
+            let feeRate = THORChainSwaps.discountedAffiliateBps(baseBps: THORChainSwaps.referredAffiliateFeeRateBp, discountBps: discountBps)
             let addresses = "\(referredCode)/\(THORChainSwaps.affiliateFeeAddress)"
             let bps = "\(THORChainSwaps.referredUserFeeRateBp)/\(feeRate)"
             return (addresses, bps)
         } else {
-            let feeRate = max(0, THORChainSwaps.affiliateFeeRateBp - discountBps)
+            let feeRate = THORChainSwaps.discountedAffiliateBps(baseBps: THORChainSwaps.affiliateFeeRateBp, discountBps: discountBps)
             return (THORChainSwaps.affiliateFeeAddress, "\(feeRate)")
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Signing/THORChainSwaps.swift
@@ -26,6 +26,35 @@ class THORChainSwaps {
 
     static let affiliateFeeAddress = "vi"
 
+    /// SwapKit's affiliate share is set on the partner dashboard, not sent per
+    /// transaction, so it's a fixed 0.50% baked into the quoted rate regardless
+    /// of build (the DEBUG toggle on `affiliateFeeRateBp` only affects the
+    /// native `affiliate_bps` we send ourselves).
+    static let swapKitAffiliateFeeBps = 50
+
+    /// Effective per-affiliate bps after applying the VULT tier discount,
+    /// clamped at zero. Single source of truth consumed by BOTH the quote
+    /// request builders (the `affiliate_bps` query param) and the fee-percentage
+    /// display, so the shown % equals the bps actually sent by construction.
+    static func discountedAffiliateBps(baseBps: Int, discountBps: Int) -> Int {
+        max(0, baseBps - discountBps)
+    }
+
+    /// Total affiliate bps the protocol charges for a swap — the sum of every
+    /// affiliate entry the request sends. The node computes `fees.affiliate`
+    /// from this, so it is the number behind the "Vultisig Fee (X.XX%)"
+    /// percentage and reconciles with the shown affiliate amount by
+    /// construction. `isReferred` mirrors the request builder's
+    /// `!referredCode.isEmpty` branch: a referred swap splits the fee into the
+    /// referrer's fixed share plus the discounted Vultisig share.
+    static func effectiveAffiliateFeeBps(discountBps: Int, isReferred: Bool) -> Int {
+        if isReferred {
+            let referrerBps = Int(referredUserFeeRateBp) ?? 0
+            return referrerBps + discountedAffiliateBps(baseBps: referredAffiliateFeeRateBp, discountBps: discountBps)
+        }
+        return discountedAffiliateBps(baseBps: affiliateFeeRateBp, discountBps: discountBps)
+    }
+
     init() {}
 
     func getPreSignedInputData(swapPayload: THORChainSwapPayload, keysignPayload: KeysignPayload, incrementNonce: Bool) throws -> Data {

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -199,7 +199,7 @@ struct SwapDetailsSummary: View {
 
     var outboundFee: some View {
         getSummaryCell(
-            leadingText: "swap.outbound_fee",
+            leadingText: "swap.protocol_fee",
             trailingText: outboundFeeString
         )
     }

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -17,7 +17,7 @@ struct SwapDetailsSummary: View {
 
     private var hasExpandableFees: Bool {
         vm.showGas ||
-        !vm.baseAffiliateFee.isEmpty ||
+        vm.showAffiliateFeeRow ||
         !outboundFeeString.isEmpty ||
         !vm.vultDiscount.isEmpty ||
         !vm.referralDiscount.isEmpty ||
@@ -120,7 +120,7 @@ struct SwapDetailsSummary: View {
                 swapGas
             }
 
-            if !vm.baseAffiliateFee.isEmpty {
+            if vm.showAffiliateFeeRow {
                 affiliateFee
             }
 

--- a/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapDetailsSummary.swift
@@ -18,7 +18,7 @@ struct SwapDetailsSummary: View {
     private var hasExpandableFees: Bool {
         vm.showGas ||
         vm.showAffiliateFeeRow ||
-        !outboundFeeString.isEmpty ||
+        vm.showProtocolFeeRow ||
         !vm.vultDiscount.isEmpty ||
         !vm.referralDiscount.isEmpty ||
         !vm.priceImpactString.isEmpty
@@ -124,7 +124,7 @@ struct SwapDetailsSummary: View {
                 affiliateFee
             }
 
-            if !outboundFeeString.isEmpty {
+            if vm.showProtocolFeeRow {
                 outboundFee
             }
 

--- a/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
@@ -263,7 +263,7 @@ struct SwapDoneSummaryCard: View {
                 getCell(title: transaction.swapFeeLabel, value: transaction.baseAffiliateFee)
             }
             // Protocol Fee (native THOR/Maya outbound).
-            if !transaction.outboundFeeString.isEmpty {
+            if transaction.showProtocolFeeRow {
                 getCell(title: "swap.protocol_fee", value: transaction.outboundFeeString)
             }
         }

--- a/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/SwapDoneSummaryCard.swift
@@ -250,14 +250,21 @@ struct SwapDoneSummaryCard: View {
 
     private func expandableFees(_ transaction: SwapTransaction) -> some View {
         VStack(spacing: 4) {
-            if transaction.showFees {
-                getCell(title: "swapFee", value: transaction.swapFeeString)
-            }
             if transaction.showGas {
                 getCell(
                     title: "networkFee",
                     value: "\(transaction.swapGasString)(\(transaction.approveFeeString))"
                 )
+            }
+            // Vultisig Fee (affiliate only) — matches the reconciled Total, so the
+            // breakdown no longer shows THORChain's composite as the swap fee. The
+            // label is already localized (embeds the %), so it's used verbatim.
+            if transaction.showAffiliateFeeRow {
+                getCell(title: transaction.swapFeeLabel, value: transaction.baseAffiliateFee)
+            }
+            // Protocol Fee (native THOR/Maya outbound).
+            if !transaction.outboundFeeString.isEmpty {
+                getCell(title: "swap.protocol_fee", value: transaction.outboundFeeString)
             }
         }
     }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1492,6 +1492,8 @@
 "vultisig-referrals" = "Vultisig Empfehlungen";
 "vultisigCommunity" = "Vultisig -Gemeinschaft";
 "vultisigEducation" = "Vultisig -Bildung";
+"vultisigFee" = "Vultisig-Gebühr";
+"vultisigFeePercentage" = "Vultisig-Gebühr (%.2f%%)";
 "vultisigWebsite" = "Vultisig -Website";
 "vultTierBadge" = "VULT-STUFE";
 "waitChurnedOutNode" = "Warten Sie, bis der Knoten ausgeschieden ist";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1208,11 +1208,13 @@
 "supportedFileTypesUpload" = "Unterstützte Dateitypen: .bak, .vult & .zip";
 "swap" = "Tausch";
 "swap.duration.instant" = "Sofort";
+"swap.included_in_rate" = "im angebotenen Kurs enthalten";
 "swap.outbound_fee" = "Ausgangsgebühr";
 "swap.price_impact" = "Preisauswirkung";
 "swap.price_impact.average" = "Mittel";
 "swap.price_impact.good" = "Gut";
 "swap.price_impact.high" = "Hoch";
+"swap.protocol_fee" = "Protokollgebühr";
 "swap.referral_discount" = "Empfehlung (-%d bps)";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Markt";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1206,11 +1206,13 @@
 "supportedFileTypesUpload" = "Supported file types: .bak, .vult & .zip";
 "swap" = "Swap";
 "swap.duration.instant" = "Instant";
+"swap.included_in_rate" = "included in quoted rate";
 "swap.outbound_fee" = "Outbound Fee";
 "swap.price_impact" = "Price Impact";
 "swap.price_impact.average" = "Average";
 "swap.price_impact.good" = "Good";
 "swap.price_impact.high" = "High";
+"swap.protocol_fee" = "Protocol Fee";
 "swap.referral_discount" = "Referral (-%d bps)";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Market";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1490,6 +1490,8 @@
 "vultisig-referrals" = "Vultisig Referrals";
 "vultisigCommunity" = "Vultisig Community";
 "vultisigEducation" = "Vultisig Education";
+"vultisigFee" = "Vultisig Fee";
+"vultisigFeePercentage" = "Vultisig Fee (%.2f%%)";
 "vultisigWebsite" = "Vultisig Website";
 "vultTierBadge" = "VULT TIER";
 "waitChurnedOutNode" = "Wait until Node is churned out";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1492,6 +1492,8 @@
 "vultisig-referrals" = "Vultisig Referidos";
 "vultisigCommunity" = "Comunidad Vultisig";
 "vultisigEducation" = "Educación Vultisig";
+"vultisigFee" = "Comisión de Vultisig";
+"vultisigFeePercentage" = "Comisión de Vultisig (%.2f%%)";
 "vultisigWebsite" = "Sitio web de Vultisig";
 "vultTierBadge" = "NIVEL VULT";
 "waitChurnedOutNode" = "Espera hasta que el Nodo sea desvinculado";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1208,11 +1208,13 @@
 "supportedFileTypesUpload" = "Tipos de archivos soportados: .bak, .vult & .zip";
 "swap" = "Intercambio";
 "swap.duration.instant" = "Instantáneo";
+"swap.included_in_rate" = "incluido en la tarifa cotizada";
 "swap.outbound_fee" = "Tarifa de Salida";
 "swap.price_impact" = "Impacto del Precio";
 "swap.price_impact.average" = "Medio";
 "swap.price_impact.good" = "Bueno";
 "swap.price_impact.high" = "Alto";
+"swap.protocol_fee" = "Comisión de protocolo";
 "swap.referral_discount" = "Referido (-%d bps)";
 "swap.tab.limit" = "Límite";
 "swap.tab.market" = "Mercado";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1492,6 +1492,8 @@
 "vultisig-referrals" = "Vultisig Preporuke";
 "vultisigCommunity" = "Vultisig zajednica";
 "vultisigEducation" = "Edukacija Vultisig";
+"vultisigFee" = "Vultisig naknada";
+"vultisigFeePercentage" = "Vultisig naknada (%.2f%%)";
 "vultisigWebsite" = "Web stranica Vultisig";
 "vultTierBadge" = "VULT RAZINA";
 "waitChurnedOutNode" = "Pričekajte dok čvor ne bude isključen";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1208,11 +1208,13 @@
 "supportedFileTypesUpload" = "Podržane vrste datoteka: .bak, .vult & .zip";
 "swap" = "Zamjena";
 "swap.duration.instant" = "Trenutno";
+"swap.included_in_rate" = "uključeno u ponuđeni tečaj";
 "swap.outbound_fee" = "Izlazna naknada";
 "swap.price_impact" = "Utjecaj na cijenu";
 "swap.price_impact.average" = "Srednje";
 "swap.price_impact.good" = "Dobro";
 "swap.price_impact.high" = "Visoko";
+"swap.protocol_fee" = "Naknada protokola";
 "swap.referral_discount" = "Preporuka (-%d bps)";
 "swap.tab.limit" = "Limit";
 "swap.tab.market" = "Tržište";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1492,6 +1492,8 @@
 "vultisig-referrals" = "Vultisig Inviti";
 "vultisigCommunity" = "Comunità Vultisig";
 "vultisigEducation" = "Vultisig Education";
+"vultisigFee" = "Commissione Vultisig";
+"vultisigFeePercentage" = "Commissione Vultisig (%.2f%%)";
 "vultisigWebsite" = "Sito Web Vultisig";
 "vultTierBadge" = "LIVELLO VULT";
 "waitChurnedOutNode" = "Attendi fino a quando il Nodo non viene escluso";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1208,11 +1208,13 @@
 "supportedFileTypesUpload" = "Tipi di file supportati: .bak, .vult & .zip";
 "swap" = "Scambio";
 "swap.duration.instant" = "Istantaneo";
+"swap.included_in_rate" = "incluso nel tasso quotato";
 "swap.outbound_fee" = "Commissione in Uscita";
 "swap.price_impact" = "Impatto sul Prezzo";
 "swap.price_impact.average" = "Medio";
 "swap.price_impact.good" = "Buono";
 "swap.price_impact.high" = "Alto";
+"swap.protocol_fee" = "Commissione di protocollo";
 "swap.referral_discount" = "Referral (-%d bps)";
 "swap.tab.limit" = "Limite";
 "swap.tab.market" = "Mercato";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1171,11 +1171,13 @@
 "supportedFileTypesUpload" = "지원되는 파일 형식: .bak, .vult & .zip";
 "swap" = "스왑";
 "swap.duration.instant" = "즉시";
+"swap.included_in_rate" = "제시된 환율에 포함됨";
 "swap.outbound_fee" = "아웃바운드 수수료";
 "swap.price_impact" = "가격 영향";
 "swap.price_impact.average" = "보통";
 "swap.price_impact.good" = "양호";
 "swap.price_impact.high" = "높음";
+"swap.protocol_fee" = "프로토콜 수수료";
 "swap.referral_discount" = "추천 (-%d bps)";
 "swap.tab.limit" = "지정가";
 "swap.tab.market" = "시장";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1453,6 +1453,8 @@
 "vultisig-referrals" = "Vultisig 추천";
 "vultisigCommunity" = "Vultisig 커뮤니티";
 "vultisigEducation" = "Vultisig 교육";
+"vultisigFee" = "Vultisig 수수료";
+"vultisigFeePercentage" = "Vultisig 수수료 (%.2f%%)";
 "vultisigWebsite" = "Vultisig 웹사이트";
 "vultTierBadge" = "VULT 등급";
 "waitChurnedOutNode" = "노드가 처른될 때까지 기다리세요";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1492,6 +1492,8 @@
 "vultisig-referrals" = "Vultisig Indicações";
 "vultisigCommunity" = "Comunidade Vultisig";
 "vultisigEducation" = "Educação Vultisig";
+"vultisigFee" = "Taxa da Vultisig";
+"vultisigFeePercentage" = "Taxa da Vultisig (%.2f%%)";
 "vultisigWebsite" = "Site do Vultisig";
 "vultTierBadge" = "NÍVEL VULT";
 "waitChurnedOutNode" = "Aguarde até que o Nó seja excluído";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1208,11 +1208,13 @@
 "supportedFileTypesUpload" = "Tipos de arquivos suportados: .bak, .vult & .zip";
 "swap" = "Troca";
 "swap.duration.instant" = "Instantâneo";
+"swap.included_in_rate" = "incluída na taxa cotada";
 "swap.outbound_fee" = "Taxa de Saída";
 "swap.price_impact" = "Impacto no Preço";
 "swap.price_impact.average" = "Médio";
 "swap.price_impact.good" = "Bom";
 "swap.price_impact.high" = "Alto";
+"swap.protocol_fee" = "Taxa de protocolo";
 "swap.referral_discount" = "Indicação (-%d bps)";
 "swap.tab.limit" = "Limite";
 "swap.tab.market" = "Mercado";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1208,11 +1208,13 @@
 "supportedFileTypesUpload" = "支持的文件类型：.bak、.vult 和 .zip";
 "swap" = "交换";
 "swap.duration.instant" = "即时";
+"swap.included_in_rate" = "已包含在报价汇率中";
 "swap.outbound_fee" = "出站费用";
 "swap.price_impact" = "价格影响";
 "swap.price_impact.average" = "中等";
 "swap.price_impact.good" = "良好";
 "swap.price_impact.high" = "较高";
+"swap.protocol_fee" = "协议费用";
 "swap.referral_discount" = "推荐 (-%d bps)";
 "swap.tab.limit" = "限价";
 "swap.tab.market" = "市场";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1492,6 +1492,8 @@
 "vultisig-referrals" = "Vultisig 推荐";
 "vultisigCommunity" = "Vultisig 社区";
 "vultisigEducation" = "Vultisig 教育";
+"vultisigFee" = "Vultisig 费用";
+"vultisigFeePercentage" = "Vultisig 费用 (%.2f%%)";
 "vultisigWebsite" = "Vultisig 网站";
 "vultTierBadge" = "VULT 等级";
 "waitChurnedOutNode" = "等待节点被淘汰";

--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -317,7 +317,7 @@ class Endpoint {
     }
 
     static func bps(for discount: Int, affiliateFeeRate: Int) -> Int {
-        max(0, affiliateFeeRate - discount)
+        THORChainSwaps.discountedAffiliateBps(baseBps: affiliateFeeRate, discountBps: discount)
     }
 
     static func fetchCoinPaprikaQuotes(_ quotes: String) -> String {

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
@@ -76,7 +76,8 @@ struct DefaultSwapInteractor: SwapInteractor {
             quote: fetched.best,
             allQuotes: fetched.ranked,
             vultDiscountBps: vultDiscountBps,
-            referralDiscountBps: referralDiscountBps
+            referralDiscountBps: referralDiscountBps,
+            isReferred: !referredCode.isEmpty
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -600,7 +600,7 @@ extension SwapCryptoLogic {
                 throw SwapKitError.unsupportedTxType(txType)
             }
 
-        case let .jupiter(evmQuote, _, _):
+        case let .jupiter(evmQuote, _, _, _):
             // Jupiter rides the proven SwapKit-Solana signing path: the base64
             // Solana wire tx lives in `quote.tx.data`, routed via
             // `SwapPayload.generic` to `SolanaSwaps`, which refreshes only the

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapQuoteResult.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapQuoteResult.swift
@@ -17,16 +17,24 @@ struct SwapQuoteResult: Equatable {
     let allQuotes: [SwapQuote]
     let vultDiscountBps: Int
     let referralDiscountBps: Int
+    /// Whether a referral code was active for this fetch (`!referredCode.isEmpty`).
+    /// Kept as a clean bit rather than inferred from `referralDiscountBps`, which
+    /// collapses to 0 in DEBUG (base affiliate rate is 0) even when a code is
+    /// present. Drives the route-aware affiliate-percentage label so the shown %
+    /// matches the `affiliate_bps` the request builder actually sent.
+    let isReferred: Bool
 
     init(
         quote: SwapQuote,
         allQuotes: [SwapQuote]? = nil,
         vultDiscountBps: Int,
-        referralDiscountBps: Int
+        referralDiscountBps: Int,
+        isReferred: Bool = false
     ) {
         self.quote = quote
         self.allQuotes = allQuotes ?? [quote]
         self.vultDiscountBps = vultDiscountBps
         self.referralDiscountBps = referralDiscountBps
+        self.isReferred = isReferred
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -291,6 +291,12 @@ extension SwapTransaction {
         SwapCryptoLogic.showTotalFees(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin, fee: fee)
     }
 
+    /// Whether the itemized "Vultisig Fee" affiliate row should render (every
+    /// market swap route, even at 0%; not secured mints or limit orders).
+    var showAffiliateFeeRow: Bool {
+        SwapCryptoLogic.showAffiliateFeeRow(quote: quote, mode: mode)
+    }
+
     /// Whether an expandable fee breakdown has any rows to show. Mirrors the
     /// rows the swap fee surfaces emit (swap fee and/or network gas), so a
     /// "Total fee" chevron is only offered when expanding reveals something.

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -79,6 +79,14 @@ struct SwapTransaction: Hashable {
     let vultDiscountBps: Int
     let referralDiscountBps: Int
 
+    /// Whether a referral code was active when this quote was fetched. Used by
+    /// the route-aware affiliate-percentage label to reproduce the exact
+    /// `affiliate_bps` the request builder sent — a clean bit, because
+    /// `referralDiscountBps` collapses to 0 in DEBUG (base rate 0) even when
+    /// referred. `var` with a default so the memberwise init stays source-
+    /// compatible; set once at construction, never mutated (immutable hand-off).
+    var isReferred: Bool = false
+
     /// Source-chain broadcast-gas ESTIMATE for a placed LIMIT order, in the fee
     /// coin's smallest units. A dedicated field — NOT the market `thorchainFee`,
     /// whose meaning is the THORChain protocol/outbound fee that feeds
@@ -154,7 +162,8 @@ extension SwapTransaction {
         gasLimit: BigInt? = nil,
         thorchainFee: BigInt? = nil,
         vultDiscountBps: Int? = nil,
-        referralDiscountBps: Int? = nil
+        referralDiscountBps: Int? = nil,
+        isReferred: Bool? = nil
     ) -> SwapTransaction {
         SwapTransaction(
             fromCoin: fromCoin,
@@ -172,6 +181,7 @@ extension SwapTransaction {
             thorchainFee: thorchainFee ?? self.thorchainFee,
             vultDiscountBps: vultDiscountBps ?? self.vultDiscountBps,
             referralDiscountBps: referralDiscountBps ?? self.referralDiscountBps,
+            isReferred: isReferred ?? self.isReferred,
             networkFeeEstimate: networkFeeEstimate,
             feeCoin: feeCoin,
             advancedSettings: advancedSettings
@@ -338,7 +348,10 @@ extension SwapTransaction {
     }
 
     var swapFeeLabel: String {
-        SwapCryptoLogic.swapFeeLabel(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin, fromAmount: fromAmountString)
+        SwapCryptoLogic.swapFeeLabel(
+            quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
+            fromAmount: fromAmountString, vultDiscountBps: vultDiscountBps, isReferred: isReferred
+        )
     }
 
     var outboundFeeString: String {

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -192,7 +192,7 @@ extension SwapTransaction {
 // MARK: - Convenience computed helpers
 //
 // Sugar over the primitive-taking SwapCryptoLogic free functions so view code
-// reads `transaction.swapFeeString` instead of spelling out the args.
+// reads `transaction.baseAffiliateFee` instead of spelling out the args.
 
 extension SwapTransaction {
     private var fromAmountString: String { fromAmount.description }
@@ -297,18 +297,12 @@ extension SwapTransaction {
         SwapCryptoLogic.showAffiliateFeeRow(quote: quote, mode: mode)
     }
 
-    /// Whether an expandable fee breakdown has any rows to show. Mirrors the
-    /// rows the swap fee surfaces emit (swap fee and/or network gas), so a
+    /// Whether an expandable fee breakdown has any itemized rows to show, so the
     /// "Total fee" chevron is only offered when expanding reveals something.
-    /// `showTotalFees` can be true while both components are suppressed — for
-    /// quote-driven EVM swaps `totalFeeString` keys off `fee` while `showGas`
-    /// keys off `gas`, a distinct gas price.
+    /// Mirrors the itemized rows the Done breakdown emits (network gas, the
+    /// Vultisig affiliate row, the protocol/outbound row).
     var hasFeeBreakdown: Bool {
-        showFees || showGas
-    }
-
-    var swapFeeString: String {
-        SwapCryptoLogic.swapFeeString(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+        showGas || showAffiliateFeeRow || !outboundFeeString.isEmpty
     }
 
     var swapGasString: String {

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -297,12 +297,17 @@ extension SwapTransaction {
         SwapCryptoLogic.showAffiliateFeeRow(quote: quote, mode: mode)
     }
 
+    /// Whether the "Protocol Fee" (native outbound) row should render.
+    var showProtocolFeeRow: Bool {
+        SwapCryptoLogic.showProtocolFeeRow(quote: quote, toCoin: toCoin, mode: mode)
+    }
+
     /// Whether an expandable fee breakdown has any itemized rows to show, so the
     /// "Total fee" chevron is only offered when expanding reveals something.
     /// Mirrors the itemized rows the Done breakdown emits (network gas, the
     /// Vultisig affiliate row, the protocol/outbound row).
     var hasFeeBreakdown: Bool {
-        showGas || showAffiliateFeeRow || !outboundFeeString.isEmpty
+        showGas || showAffiliateFeeRow || showProtocolFeeRow
     }
 
     var swapGasString: String {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -442,27 +442,80 @@ enum SwapCryptoLogic {
         }
     }
 
-    static func swapFeeLabel(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin, fromAmount: String) -> String {
-        guard let quote else { return "swapFee".localized }
-
-        let feeFiat: Decimal
-        if let evmFee = evmSwapFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin) {
-            feeFiat = evmFee
-        } else {
-            switch quote {
-            case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
-                let feeAmt = q.fees.affiliate.toDecimal() / pow(10, 8)
-                feeFiat = toCoin.fiat(decimal: feeAmt)
-            default:
-                return String(format: "swapFeePercentage".localized, 0.0)
-            }
+    /// Affiliate (Vultisig) fee component in fiat — money Vultisig receives,
+    /// itemized separately from the protocol's outbound/liquidity fees. The
+    /// source per route: native THOR/Maya `fees.affiliate`, EVM aggregator
+    /// `tx.swapFee`, Jupiter `platformFee`. SwapKit's flat affiliate is baked
+    /// into the quoted rate (not a separable line item), so it contributes
+    /// nothing to the itemized fiat total. `.zero` (not empty) for a real
+    /// affiliate route charging 0 — the Ultimate/waiver case keeps a $0.00 row.
+    static func affiliateFeeFiat(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin) -> Decimal {
+        guard let quote else { return .zero }
+        switch quote {
+        case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
+            let feeDecimal = q.fees.affiliate.toDecimal() / pow(10, 8)
+            return toCoin.fiat(decimal: feeDecimal)
+        case .oneinch, .kyberswap, .lifi:
+            let coin = swapFeeCoin(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+            let feeDecimal = coin.decimal(for: quote.evmSwapFeeBigInt ?? .zero)
+            return coin.fiat(decimal: feeDecimal)
+        case let .jupiter(_, _, platformFee):
+            // `platformFee` is already denominated in `toCoin` units.
+            return toCoin.fiat(decimal: platformFee ?? 0)
+        case .swapkit:
+            return .zero
         }
+    }
 
-        let inputFiat = fromCoin.fiat(decimal: fromAmountDecimal(fromAmount: fromAmount))
-        guard inputFiat > 0 else { return "swapFee".localized }
+    /// Label for the "Vultisig Fee (X.XX%)" affiliate row. The percentage source
+    /// depends on the route:
+    /// - Native THOR/Maya: derived from the effective affiliate bps actually sent
+    ///   on the quote request (`THORChainSwaps.effectiveAffiliateFeeBps`), so the
+    ///   shown % equals what the node charged — and reconciles with `fees.affiliate`
+    ///   by construction, rather than a lossy `fee/input` fiat division.
+    /// - SwapKit: a flat 0.50% baked into the quoted rate (no per-tx fee field).
+    /// - EVM aggregators / Jupiter: the affiliate amount comes from a route field
+    ///   (`tx.swapFee` / `platformFee`), so the % is derived from that amount and
+    ///   matches the amount shown for the route.
+    static func swapFeeLabel(
+        quote: SwapQuote?,
+        fromCoin: Coin,
+        toCoin: Coin,
+        feeCoin: Coin,
+        fromAmount: String,
+        vultDiscountBps: Int,
+        isReferred: Bool
+    ) -> String {
+        guard let quote else { return "vultisigFee".localized }
 
-        let percentage = (feeFiat / inputFiat) * 100
-        return String(format: "swapFeePercentage".localized, NSDecimalNumber(decimal: percentage).doubleValue)
+        switch quote {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet:
+            // All three THORChain services build affiliate params via
+            // `ThorchainService.affiliateParams`, which applies the referred
+            // split whenever a code is present.
+            let bps = THORChainSwaps.effectiveAffiliateFeeBps(
+                discountBps: vultDiscountBps,
+                isReferred: isReferred
+            )
+            return String(format: "vultisigFeePercentage".localized, Double(bps) / 100.0)
+        case .mayachain:
+            // MayaChain's affiliate params ignore the referral code entirely
+            // (`MayachainService.affiliateParams(referredCode _:)`), so it always
+            // sends the single standard rate — never the referred split.
+            let bps = THORChainSwaps.effectiveAffiliateFeeBps(
+                discountBps: vultDiscountBps,
+                isReferred: false
+            )
+            return String(format: "vultisigFeePercentage".localized, Double(bps) / 100.0)
+        case .swapkit:
+            return String(format: "vultisigFeePercentage".localized, Double(THORChainSwaps.swapKitAffiliateFeeBps) / 100.0)
+        case .oneinch, .kyberswap, .lifi, .jupiter:
+            let feeFiat = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+            let inputFiat = fromCoin.fiat(decimal: fromAmountDecimal(fromAmount: fromAmount))
+            guard inputFiat > 0 else { return "vultisigFee".localized }
+            let percentage = (feeFiat / inputFiat) * 100
+            return String(format: "vultisigFeePercentage".localized, NSDecimalNumber(decimal: percentage).doubleValue)
+        }
     }
 
     static func outboundFeeString(quote: SwapQuote?, toCoin: Coin) -> String {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -562,6 +562,15 @@ enum SwapCryptoLogic {
         }
     }
 
+    /// Whether the "Protocol Fee" (native outbound) row should render: a native
+    /// THOR/Maya route carrying an outbound fee. Suppressed for a secured mint —
+    /// its synthetic ~1:1 quote reports a zero outbound that is not a real
+    /// protocol fee, so the row would otherwise show a spurious `$0.00`.
+    static func showProtocolFeeRow(quote: SwapQuote?, toCoin: Coin, mode: SwapMode) -> Bool {
+        guard mode != .securedMint else { return false }
+        return !outboundFeeString(quote: quote, toCoin: toCoin).isEmpty
+    }
+
     // MARK: - Discounts
 
     static func vultDiscountLabel(vultDiscountBps: Int) -> String {

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -374,18 +374,18 @@ enum SwapCryptoLogic {
         fee == .zero
     }
 
+    /// Reconciled total fee = Network + Vultisig(affiliate) + Protocol(outbound),
+    /// matching the itemized rows shown on the Verify/Details/Done screens.
+    /// Deliberately NOT `fees.total`: that composite also carries the
+    /// `asset`/liquidity slippage, which is already reflected in the quoted
+    /// output amount and must not be double-counted (Android's reference,
+    /// `SwapQuoteManager.kt`, reconciles the same way).
     static func totalFeeString(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin, fee: BigInt) -> String {
+        guard quote != nil else { return .empty }
         let networkFee = feeCoin.fiat(gas: fee)
-
-        if let evmFee = evmSwapFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin) {
-            return (evmFee + networkFee).formatToFiat(includeCurrencySymbol: true)
-        }
-
-        guard let inboundFee = inboundFeeDecimal(quote: quote, toCoin: toCoin) else { return .empty }
-
-        let inboundFeeRaw = toCoin.raw(for: inboundFee)
-        let providerFee = toCoin.fiat(value: inboundFeeRaw)
-        return (providerFee + networkFee).formatToFiat(includeCurrencySymbol: true)
+        let affiliateFee = affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+        let outboundFee = outboundFeeFiat(quote: quote, toCoin: toCoin)
+        return (networkFee + affiliateFee + outboundFee).formatToFiat(includeCurrencySymbol: true)
     }
 
     // MARK: - Display: limit-order network fee
@@ -424,22 +424,41 @@ enum SwapCryptoLogic {
         return formatter.string(from: fromDate, to: toDate) ?? .empty
     }
 
+    /// Trailing value for the "Vultisig Fee" affiliate row. The affiliate
+    /// component ONLY, sourced per route from `affiliateFeeFiat` — never the
+    /// composite `fees.total`. Returns `$0.00` (not empty) for a real affiliate
+    /// route charging zero, so the Ultimate/100%-waiver user still sees the row;
+    /// SwapKit's flat 0.50% is baked into the quoted rate, so it shows an
+    /// "included in quoted rate" note instead of a separate amount. `.empty`
+    /// only when there is no quote — row visibility is gated by
+    /// `showAffiliateFeeRow`, not by this string being empty.
     static func baseAffiliateFee(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin) -> String {
         guard let quote else { return .empty }
-
-        if let evmFee = evmSwapFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin) {
-            return evmFee.formatToFiat(includeCurrencySymbol: true)
+        if case .swapkit = quote {
+            return "swap.included_in_rate".localized
         }
+        return affiliateFeeFiat(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+            .formatToFiat(includeCurrencySymbol: true)
+    }
 
-        switch quote {
-        case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
-            let feeAmount = q.fees.affiliate.toDecimal()
-            guard feeAmount > 0 else { return .empty }
-            let feeDecimal = feeAmount / pow(10, 8)
-            return toCoin.fiat(decimal: feeDecimal).formatToFiat(includeCurrencySymbol: true)
-        default:
-            return .empty
+    /// Whether the "Vultisig Fee" affiliate row should render. Every real market
+    /// swap route has an affiliate concept (shown even at 0% for the Ultimate
+    /// waiver), but a secured mint is a ~1:1 SECURE+ deposit with no affiliate
+    /// and a limit order carries no market quote.
+    ///
+    /// The one exception is a Jupiter swap whose OUTPUT is native SOL: Jupiter
+    /// collects the affiliate fee on the INPUT mint there (wrapped-SOL outputs
+    /// have no fee ATA), so `platformFee` is deliberately `nil` — the amount is
+    /// never surfaced in `toCoin` units. Rather than render a misleading `$0.00`
+    /// (the real fee is non-zero), the row is suppressed for that case, on both
+    /// the form and verify (kept symmetric). Every other Jupiter route (token
+    /// output) carries `platformFee` and shows the row normally.
+    static func showAffiliateFeeRow(quote: SwapQuote?, mode: SwapMode) -> Bool {
+        guard let quote, mode != .securedMint else { return false }
+        if case let .jupiter(_, _, platformFee) = quote, platformFee == nil {
+            return false
         }
+        return true
     }
 
     /// Affiliate (Vultisig) fee component in fiat — money Vultisig receives,
@@ -518,24 +537,29 @@ enum SwapCryptoLogic {
         }
     }
 
-    static func outboundFeeString(quote: SwapQuote?, toCoin: Coin) -> String {
-        guard let quote else { return .empty }
-
-        var outboundFeeString: String?
-        let feeDecimals = 8 // THORChain standard
-
+    /// Protocol outbound-fee component in fiat (denominated in the output asset),
+    /// native THOR/Maya only. `.zero` for every other route. The `asset`/liquidity
+    /// slippage component of `fees.total` is deliberately excluded — it is already
+    /// reflected in the quoted output amount, so folding it into the fee total
+    /// would double-count it.
+    static func outboundFeeFiat(quote: SwapQuote?, toCoin: Coin) -> Decimal {
+        guard let quote else { return .zero }
         switch quote {
         case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
-            outboundFeeString = q.fees.outbound
+            return toCoin.fiat(decimal: q.fees.outbound.toDecimal() / pow(10, 8))
+        default:
+            return .zero
+        }
+    }
+
+    static func outboundFeeString(quote: SwapQuote?, toCoin: Coin) -> String {
+        guard let quote else { return .empty }
+        switch quote {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
+            return outboundFeeFiat(quote: quote, toCoin: toCoin).formatToFiat(includeCurrencySymbol: true)
         default:
             return .empty
         }
-
-        guard let outboundFeeString else { return .empty }
-        let feeAmount = outboundFeeString.toDecimal()
-        let feeDecimal = feeAmount / pow(10, feeDecimals)
-        // Outbound fee is denominated in the output asset.
-        return toCoin.fiat(decimal: feeDecimal).formatToFiat(includeCurrencySymbol: true)
     }
 
     // MARK: - Discounts

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -88,7 +88,7 @@ enum SwapCryptoLogic {
             default:
                 return fee ?? 0
             }
-        case let .jupiter(_, fee, _):
+        case let .jupiter(_, fee, _, _):
             // Jupiter exposes no network fee at quote time; fall back to the
             // Solana-source plan fee carried in `thorchainFee`
             // (`chainSpecific.gas`), the same way Send computes it.
@@ -137,7 +137,7 @@ enum SwapCryptoLogic {
         case let .oneinch(quote, _), let .lifi(quote, _, _), let .kyberswap(quote, _):
             let amount = BigInt(quote.dstAmount) ?? BigInt.zero
             return toCoin.decimal(for: amount)
-        case let .jupiter(quote, _, _):
+        case let .jupiter(quote, _, _, _):
             // `outAmount` is already net of the affiliate fee (deducted from the
             // output and reported separately), so it's what the user receives —
             // same as LiFi above. Do NOT subtract the fee again.
@@ -448,14 +448,15 @@ enum SwapCryptoLogic {
     ///
     /// The one exception is a Jupiter swap whose OUTPUT is native SOL: Jupiter
     /// collects the affiliate fee on the INPUT mint there (wrapped-SOL outputs
-    /// have no fee ATA), so `platformFee` is deliberately `nil` — the amount is
-    /// never surfaced in `toCoin` units. Rather than render a misleading `$0.00`
-    /// (the real fee is non-zero), the row is suppressed for that case, on both
-    /// the form and verify (kept symmetric). Every other Jupiter route (token
-    /// output) carries `platformFee` and shows the row normally.
+    /// have no fee ATA), so the amount is never surfaced in `toCoin` units
+    /// (`feeOnInput == true`). Rather than render a misleading `$0.00` (the real
+    /// fee is non-zero), the row is suppressed for that case, on both the form
+    /// and verify (kept symmetric). A token-output Jupiter route always shows the
+    /// row — including at 0.00% / $0.00 for the Ultimate tier, where the fee is
+    /// on the output mint and simply zero.
     static func showAffiliateFeeRow(quote: SwapQuote?, mode: SwapMode) -> Bool {
         guard let quote, mode != .securedMint else { return false }
-        if case let .jupiter(_, _, platformFee) = quote, platformFee == nil {
+        if case let .jupiter(_, _, _, feeOnInput) = quote, feeOnInput {
             return false
         }
         return true
@@ -464,23 +465,36 @@ enum SwapCryptoLogic {
     /// Affiliate (Vultisig) fee component in fiat — money Vultisig receives,
     /// itemized separately from the protocol's outbound/liquidity fees. The
     /// source per route: native THOR/Maya `fees.affiliate`, EVM aggregator
-    /// `tx.swapFee`, Jupiter `platformFee`. SwapKit's flat affiliate is baked
-    /// into the quoted rate (not a separable line item), so it contributes
-    /// nothing to the itemized fiat total. `.zero` (not empty) for a real
-    /// affiliate route charging 0 — the Ultimate/waiver case keeps a $0.00 row.
+    /// `tx.swapFee`, LiFi (EVM `tx.swapFee`, Solana the integrator fraction of
+    /// the output), Jupiter `platformFee`. SwapKit's flat affiliate is baked into
+    /// the quoted rate (not a separable line item), so it contributes nothing to
+    /// the itemized fiat total. `.zero` (not empty) for a real affiliate route
+    /// charging 0 — the Ultimate/waiver case keeps a $0.00 row.
     static func affiliateFeeFiat(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin, feeCoin: Coin) -> Decimal {
         guard let quote else { return .zero }
         switch quote {
         case let .thorchain(q), let .thorchainChainnet(q), let .thorchainStagenet(q), let .mayachain(q):
             let feeDecimal = q.fees.affiliate.toDecimal() / pow(10, 8)
             return toCoin.fiat(decimal: feeDecimal)
-        case .oneinch, .kyberswap, .lifi:
+        case .oneinch, .kyberswap:
             let coin = swapFeeCoin(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
             let feeDecimal = coin.decimal(for: quote.evmSwapFeeBigInt ?? .zero)
             return coin.fiat(decimal: feeDecimal)
-        case let .jupiter(_, _, platformFee):
-            // `platformFee` is already denominated in `toCoin` units.
-            return toCoin.fiat(decimal: platformFee ?? 0)
+        case let .lifi(evmQuote, _, integratorFee):
+            // EVM LiFi carries the fee as a token amount in `tx.swapFee`. Solana
+            // LiFi deliberately reports `swapFee` "0" and charges the integrator
+            // fee as a fraction of the output amount instead — so fall back to
+            // that, or the fee row and Total would drop the charged fee.
+            if let evmFee = quote.evmSwapFeeBigInt {
+                let coin = swapFeeCoin(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
+                return coin.fiat(decimal: coin.decimal(for: evmFee))
+            }
+            let outAmount = toCoin.decimal(for: BigInt(evmQuote.dstAmount) ?? .zero)
+            return toCoin.fiat(decimal: outAmount * (integratorFee ?? 0))
+        case let .jupiter(_, _, platformFee, _):
+            // `platformFee` is already denominated in `toCoin` units (0 when the
+            // fee is on the input mint or none is charged).
+            return toCoin.fiat(decimal: platformFee)
         case .swapkit:
             return .zero
         }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -590,6 +590,12 @@ extension SwapDetailsViewModel {
         SwapCryptoLogic.showTotalFees(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin, fee: fee)
     }
 
+    /// Whether the itemized "Vultisig Fee" affiliate row should render (every
+    /// market swap route, even at 0%; not secured mints or limit orders).
+    var showAffiliateFeeRow: Bool {
+        SwapCryptoLogic.showAffiliateFeeRow(quote: quote, mode: isSecuredMint ? .securedMint : .standard)
+    }
+
     var swapFeeString: String {
         SwapCryptoLogic.swapFeeString(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
     }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -96,6 +96,10 @@ final class SwapDetailsViewModel {
     var gasLimit: BigInt = .zero
     var vultDiscountBps: Int = 0
     var referralDiscountBps: Int = 0
+    /// Whether a referral code is active for the current quote. Route-aware
+    /// affiliate-% display keys off this clean bit (not `referralDiscountBps`,
+    /// which is 0 in DEBUG even when referred).
+    var isReferred: Bool = false
 
     // MARK: - UI state (details-screen-only)
 
@@ -425,6 +429,7 @@ final class SwapDetailsViewModel {
             thorchainFee: thorchainFee,
             vultDiscountBps: vultDiscountBps,
             referralDiscountBps: referralDiscountBps,
+            isReferred: isReferred,
             feeCoin: feeCoin,
             advancedSettings: resolvedAdvancedSettings
         )
@@ -614,7 +619,10 @@ extension SwapDetailsViewModel {
     }
 
     var swapFeeLabel: String {
-        SwapCryptoLogic.swapFeeLabel(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin, fromAmount: fromAmount)
+        SwapCryptoLogic.swapFeeLabel(
+            quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin,
+            fromAmount: fromAmount, vultDiscountBps: vultDiscountBps, isReferred: isReferred
+        )
     }
 
     var outboundFeeString: String {
@@ -689,6 +697,7 @@ private extension SwapDetailsViewModel {
             thorchainFee = .zero
             vultDiscountBps = 0
             referralDiscountBps = 0
+            isReferred = false
             error = nil
             isLoadingQuotes = false
             isLoadingFees = false
@@ -711,6 +720,7 @@ private extension SwapDetailsViewModel {
             thorchainFee = .zero
             vultDiscountBps = 0
             referralDiscountBps = 0
+            isReferred = false
         }
         error = nil
         isLoadingQuotes = true
@@ -768,6 +778,7 @@ private extension SwapDetailsViewModel {
             quotedAmount = fromAmount
             vultDiscountBps = 0
             referralDiscountBps = 0
+            isReferred = false
             return
         }
 
@@ -795,6 +806,7 @@ private extension SwapDetailsViewModel {
                 quotedAmount = fromAmount
                 vultDiscountBps = result.vultDiscountBps
                 referralDiscountBps = result.referralDiscountBps
+                isReferred = result.isReferred
             }
         } catch {
             // Ignore cancellation from a superseding amount edit — surfacing it

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -596,6 +596,11 @@ extension SwapDetailsViewModel {
         SwapCryptoLogic.showAffiliateFeeRow(quote: quote, mode: isSecuredMint ? .securedMint : .standard)
     }
 
+    /// Whether the "Protocol Fee" (native outbound) row should render.
+    var showProtocolFeeRow: Bool {
+        SwapCryptoLogic.showProtocolFeeRow(quote: quote, toCoin: toCoin, mode: isSecuredMint ? .securedMint : .standard)
+    }
+
     var swapFeeString: String {
         SwapCryptoLogic.swapFeeString(quote: quote, fromCoin: fromCoin, toCoin: toCoin, feeCoin: feeCoin)
     }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -113,7 +113,8 @@ final class SwapVerifyViewModel {
                     updated = updated.with(
                         quote: result.quote,
                         vultDiscountBps: result.vultDiscountBps,
-                        referralDiscountBps: result.referralDiscountBps
+                        referralDiscountBps: result.referralDiscountBps,
+                        isReferred: result.isReferred
                     )
                 }
             }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -152,7 +152,7 @@ struct SwapVerifyScreen: View {
                 }
 
                 // Protocol Fee (native THOR/Maya outbound).
-                if !currentTransaction.outboundFeeString.isEmpty {
+                if currentTransaction.showProtocolFeeRow {
                     separator
                     getValueCell(
                         for: "swap.protocol_fee",

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -142,20 +142,48 @@ struct SwapVerifyScreen: View {
                     .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
-                if currentTransaction.showFees {
+                // Vultisig Fee (affiliate component only). The label carries the
+                // effective affiliate %, the value the fiat amount — sourced from
+                // `fees.affiliate`, never THORChain's composite `fees.total`.
+                if currentTransaction.showAffiliateFeeRow {
+                    separator
+                    affiliateFeeRow
+                        .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
+                }
+
+                // Protocol Fee (native THOR/Maya outbound).
+                if !currentTransaction.outboundFeeString.isEmpty {
                     separator
                     getValueCell(
-                        for: "swapFee",
-                        with: currentTransaction.swapFeeString,
-                        bracketValue: nil
+                        for: "swap.protocol_fee",
+                        with: currentTransaction.outboundFeeString
                     )
                     .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
                 }
 
+                // VULT tier saving (with the tier badge).
+                if !currentTransaction.vultDiscount.isEmpty {
+                    separator
+                    vultDiscountRow
+                }
+
+                // Referral saving.
+                if !currentTransaction.referralDiscount.isEmpty {
+                    separator
+                    referralDiscountRow
+                }
+
+                // Price Impact (only when the provider reports slippage).
+                if !currentTransaction.priceImpactString.isEmpty {
+                    separator
+                    priceImpactRow
+                }
+
+                // Total Fee — reconciles to Network + Vultisig + Protocol.
                 if currentTransaction.showTotalFees {
                     separator
                     getValueCell(
-                        for: "maxTotalFee",
+                        for: "totalFee",
                         with: currentTransaction.totalFeeString
                     )
                     .blur(radius: verifyViewModel.isLoadingFees ? 1 : 0)
@@ -396,6 +424,85 @@ struct SwapVerifyScreen: View {
         if !currentTransaction.isLimit {
             SwapRefreshQuoteCounter(timer: verifyViewModel.timer)
         }
+    }
+
+    /// "Vultisig Fee (X.XX%)" affiliate row. The label is already localized (it
+    /// embeds the percentage), so it's rendered verbatim rather than through a
+    /// key lookup.
+    private var affiliateFeeRow: some View {
+        HStack(spacing: 4) {
+            Text(currentTransaction.swapFeeLabel)
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            Spacer()
+
+            Text(currentTransaction.baseAffiliateFee)
+                .foregroundStyle(Theme.colors.textPrimary)
+        }
+        .font(Theme.fonts.bodySMedium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var vultDiscountRow: some View {
+        HStack(spacing: 4) {
+            vultTierIcon
+
+            Text(currentTransaction.vultDiscountLabel)
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            Spacer()
+
+            Text(currentTransaction.vultDiscount)
+                .foregroundStyle(Theme.colors.textPrimary)
+        }
+        .font(Theme.fonts.bodySMedium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var vultTierIcon: some View {
+        if let tier = VultDiscountTier.from(bpsDiscount: currentTransaction.vultDiscountBps) {
+            Image(tier.icon)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 16, height: 16)
+        } else {
+            Image(systemName: "star.circle.fill")
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.turquoise)
+        }
+    }
+
+    private var referralDiscountRow: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "megaphone.fill")
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.primaryAccent4)
+
+            Text(currentTransaction.referralDiscountLabel)
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            Spacer()
+
+            Text(currentTransaction.referralDiscount)
+                .foregroundStyle(Theme.colors.textPrimary)
+        }
+        .font(Theme.fonts.bodySMedium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var priceImpactRow: some View {
+        HStack(spacing: 4) {
+            Text(NSLocalizedString("swap.price_impact", comment: "Price Impact"))
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            Spacer()
+
+            Text(currentTransaction.priceImpactString)
+                .foregroundStyle(currentTransaction.priceImpactColor)
+        }
+        .font(Theme.fonts.bodySMedium)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     func getValueCell(

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -18,9 +18,15 @@ enum SwapQuote: Hashable {
     case lifi(EVMQuote, fee: BigInt?, integratorFee: Decimal?)
     case swapkit(SwapKitSwapResponse, fee: BigInt?, subProvider: String)
     /// Jupiter Solana swap. `EVMQuote.tx.data` carries the base64 Solana wire
-    /// transaction (mirrors the SwapKit-Solana shape); `platformFee` is the
-    /// VULT-scaled affiliate fee in `toCoin` units, subtracted in ranking.
-    case jupiter(EVMQuote, fee: BigInt?, platformFee: Decimal?)
+    /// transaction (mirrors the SwapKit-Solana shape). `platformFee` is the
+    /// VULT-scaled affiliate fee in `toCoin` units — 0 when none is charged (the
+    /// Ultimate tier), so a token-output swap still shows an explicit $0.00 row.
+    /// `feeOnInput` is true only when the fee is collected on the INPUT mint —
+    /// native-SOL (wrapped-SOL) outputs, where the amount can't be expressed in
+    /// `toCoin` units — so `platformFee` is 0 there and callers suppress the
+    /// affiliate row rather than render a misleading $0.00. Ranking is
+    /// unaffected: it reads `outAmount`, already net of the fee.
+    case jupiter(EVMQuote, fee: BigInt?, platformFee: Decimal, feeOnInput: Bool)
 
     /// True for the native-protocol routes (THORChain on any network, MayaChain)
     /// that deposit into a THOR/Maya inbound vault, so a source-chain halt can
@@ -59,7 +65,7 @@ enum SwapQuote: Hashable {
         case .oneinch(let quote, _),
                 .lifi(let quote, _, _),
                 .kyberswap(let quote, _),
-                .jupiter(let quote, _, _):
+                .jupiter(let quote, _, _, _):
             return quote.tx.to
         case .swapkit(let response, _, _):
             return response.targetAddress
@@ -82,7 +88,7 @@ enum SwapQuote: Hashable {
         case .oneinch(let quote, _),
                 .lifi(let quote, _, _),
                 .kyberswap(let quote, _),
-                .jupiter(let quote, _, _):
+                .jupiter(let quote, _, _, _):
             return quote.tx.to
         case .swapkit(let response, _, _):
             return response.inboundAddress ?? response.targetAddress
@@ -146,10 +152,10 @@ enum SwapQuote: Hashable {
             let toAmountBigInt = BigInt(quote.dstAmount) ?? .zero
             let toAmountDecimal = toCoin.decimal(for: toAmountBigInt)
             return toAmountDecimal * (integratorFee ?? 0)
-        case .jupiter(_, _, let platformFee):
+        case .jupiter(_, _, let platformFee, _):
             // Jupiter's affiliate platform fee is already denominated in toCoin
-            // units (taken from the output mint).
-            return platformFee ?? .zero
+            // units (0 when none is charged or the fee is taken on the input mint).
+            return platformFee
         case .oneinch, .kyberswap, .swapkit:
             // Fee is in native gas token, not toCoin — handled via evmSwapFeeBigInt
             return .zero
@@ -287,10 +293,11 @@ enum SwapQuote: Hashable {
             hasher.combine(response)
             hasher.combine(fee)
             hasher.combine(subProvider)
-        case .jupiter(let quote, let fee, let platformFee):
+        case .jupiter(let quote, let fee, let platformFee, let feeOnInput):
             hasher.combine(quote)
             hasher.combine(fee)
             hasher.combine(platformFee)
+            hasher.combine(feeOnInput)
         }
     }
 }

--- a/VultisigApp/VultisigAppTests/Services/SwapQuoteRankingTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/SwapQuoteRankingTests.swift
@@ -231,14 +231,15 @@ final class SwapQuoteRankingTests: XCTestCase {
         let quote: SwapQuote = .jupiter(
             makeEVMQuote(dstAmount: "30000000000000000"),
             fee: nil,
-            platformFee: Decimal(string: "0.0001")
+            platformFee: Decimal(string: "0.0001") ?? .zero,
+            feeOnInput: false
         )
 
         XCTAssertEqual(quote.expectedNetToAmount(toCoin: ethCoin()), Decimal(string: "0.03"))
     }
 
     func test_expectedNetToAmount_jupiter_nilPlatformFee_returnsGrossOutput() {
-        let quote: SwapQuote = .jupiter(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil, platformFee: nil)
+        let quote: SwapQuote = .jupiter(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil, platformFee: 0, feeOnInput: false)
 
         XCTAssertEqual(quote.expectedNetToAmount(toCoin: ethCoin()), Decimal(string: "0.03"))
     }
@@ -248,7 +249,7 @@ final class SwapQuoteRankingTests: XCTestCase {
         // output is marginally higher but in band, so the higher-priority Jupiter
         // wins (no aggregator markup). Jupiter exposes no sourceGasWei, so the
         // lower-gas tie-break can't fire and selection falls to priority.
-        let jupiter: SwapQuote = .jupiter(makeEVMQuote(dstAmount: "29900000000000000"), fee: nil, platformFee: nil) // 0.0299
+        let jupiter: SwapQuote = .jupiter(makeEVMQuote(dstAmount: "29900000000000000"), fee: nil, platformFee: 0, feeOnInput: false) // 0.0299
         let lifi: SwapQuote = .lifi(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil, integratorFee: nil) // 0.03
 
         let pick = SwapService.selectBestQuote(quotes: [lifi, jupiter], toCoin: ethCoin())
@@ -260,7 +261,7 @@ final class SwapQuoteRankingTests: XCTestCase {
         // LI.FI materially better (outside the 50bps band) must win over Jupiter
         // despite Jupiter's higher priority — banded preference never trades away
         // a real rate advantage.
-        let jupiter: SwapQuote = .jupiter(makeEVMQuote(dstAmount: "29000000000000000"), fee: nil, platformFee: nil) // 0.029
+        let jupiter: SwapQuote = .jupiter(makeEVMQuote(dstAmount: "29000000000000000"), fee: nil, platformFee: 0, feeOnInput: false) // 0.029
         let lifi: SwapQuote = .lifi(makeEVMQuote(dstAmount: "30000000000000000"), fee: nil, integratorFee: nil) // 0.03
 
         let pick = SwapService.selectBestQuote(quotes: [jupiter, lifi], toCoin: ethCoin())

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -192,6 +192,27 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         XCTAssertTrue(SwapCryptoLogic.showAffiliateFeeRow(quote: makeJupiterQuote(platformFee: Decimal(string: "0.01")), mode: .standard))
     }
 
+    func testShowProtocolFeeRowFalseForSecuredMint() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCPROT", decimals: 8, isNative: true)
+        // Secured mint's synthetic quote reports a zero outbound that is not a
+        // real protocol fee, so the row must be suppressed (no spurious $0.00).
+        let quote = SwapQuote.thorchain(makeThorQuote(outbound: "0"))
+        XCTAssertFalse(SwapCryptoLogic.showProtocolFeeRow(quote: quote, toCoin: btc, mode: .securedMint))
+    }
+
+    func testShowProtocolFeeRowTrueForNativeSwap() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCPROT2", decimals: 8, isNative: true)
+        let quote = SwapQuote.thorchain(makeThorQuote(outbound: "2000000"))
+        XCTAssertTrue(SwapCryptoLogic.showProtocolFeeRow(quote: quote, toCoin: btc, mode: .standard))
+    }
+
+    func testShowProtocolFeeRowFalseForNonNativeRoute() {
+        let usdc = makeCoin(.solana, ticker: "USDCPR", decimals: 6, isNative: false)
+        // Jupiter / EVM aggregators have no native protocol outbound fee.
+        let quote = makeJupiterQuote(platformFee: Decimal(string: "0.01"))
+        XCTAssertFalse(SwapCryptoLogic.showProtocolFeeRow(quote: quote, toCoin: usdc, mode: .standard))
+    }
+
     // MARK: - Total-fee reconciliation (Network + affiliate + outbound, no liquidity)
 
     func testTotalFeeReconcilesAndDropsLiquidity() {

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -163,7 +163,7 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         setPrice(2, for: usdc) // 1 USDC = $2 for the test
         // platformFee 0.02 USDC × $2 = $0.04 (hardcoded so a silent rate-seeding
         // failure would fail the test rather than pass at $0.00 on both sides).
-        let quote = makeJupiterQuote(platformFee: Decimal(2) / Decimal(100))
+        let quote = makeJupiterQuote(platformFee: Decimal(2) / Decimal(100), feeOnInput: false)
         let value = SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol)
         XCTAssertEqual(value, (Decimal(4) / Decimal(100)).formatToFiat(includeCurrencySymbol: true))
     }
@@ -183,13 +183,51 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
     }
 
     func testShowAffiliateFeeRowFalseForNativeSolJupiter() {
-        // platformFee == nil ⇒ fee taken on the input mint (native-SOL output);
-        // amount isn't surfaced, so suppress rather than show a misleading $0.00.
-        XCTAssertFalse(SwapCryptoLogic.showAffiliateFeeRow(quote: makeJupiterQuote(platformFee: nil), mode: .standard))
+        // feeOnInput ⇒ fee taken on the input mint (native-SOL output); the
+        // amount isn't surfaced in toCoin units, so suppress rather than show a
+        // misleading $0.00.
+        XCTAssertFalse(SwapCryptoLogic.showAffiliateFeeRow(quote: makeJupiterQuote(platformFee: 0, feeOnInput: true), mode: .standard))
     }
 
     func testShowAffiliateFeeRowTrueForTokenJupiter() {
-        XCTAssertTrue(SwapCryptoLogic.showAffiliateFeeRow(quote: makeJupiterQuote(platformFee: Decimal(string: "0.01")), mode: .standard))
+        let quote = makeJupiterQuote(platformFee: Decimal(string: "0.01") ?? 0, feeOnInput: false)
+        XCTAssertTrue(SwapCryptoLogic.showAffiliateFeeRow(quote: quote, mode: .standard))
+    }
+
+    func testShowAffiliateFeeRowTrueForUltimateTokenJupiter() {
+        // Ultimate tier, token output: the fee is on the OUTPUT mint but zero.
+        // The row must still show (0.00% / $0.00), NOT be suppressed like the
+        // input-mint (native-SOL) case.
+        XCTAssertTrue(SwapCryptoLogic.showAffiliateFeeRow(quote: makeJupiterQuote(platformFee: 0, feeOnInput: false), mode: .standard))
+    }
+
+    func testBaseAffiliateFeeUltimateTokenJupiterShowsZero() {
+        let sol = makeCoin(.solana, ticker: "SOLJUP0", decimals: 9, isNative: true)
+        let usdc = makeCoin(.solana, ticker: "USDCJUP0", decimals: 6, isNative: false)
+        setPrice(2, for: usdc)
+        let value = SwapCryptoLogic.baseAffiliateFee(
+            quote: makeJupiterQuote(platformFee: 0, feeOnInput: false), fromCoin: sol, toCoin: usdc, feeCoin: sol
+        )
+        XCTAssertEqual(value, Decimal(0).formatToFiat(includeCurrencySymbol: true))
+    }
+
+    func testAffiliateFeeFiatLifiSolanaUsesIntegratorFee() {
+        let sol = makeCoin(.solana, ticker: "SOLLIFI", decimals: 9, isNative: true)
+        let usdc = makeCoin(.solana, ticker: "USDCLIFI", decimals: 6, isNative: false)
+        setPrice(1, for: usdc) // 1 USDC = $1
+        // LiFi-Solana: swapFee "0"; integrator fee 0.005 of the 100-USDC output
+        // (dstAmount 100_000_000 at 6 dp) → 0.5 USDC → $0.50. Must appear in the
+        // row and the Total (network 0 + affiliate 0.5 + outbound 0).
+        let quote = makeLiFiSolanaQuote(integratorFee: Decimal(5) / Decimal(1000), dstAmount: "100000000")
+        let expected = (Decimal(5) / Decimal(10)).formatToFiat(includeCurrencySymbol: true)
+        XCTAssertEqual(SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol), expected)
+        XCTAssertEqual(
+            SwapCryptoLogic.totalFeeString(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol, fee: .zero),
+            expected
+        )
+        // NOT $0.00 — the old evmSwapFeeBigInt-only path dropped the integrator fee.
+        XCTAssertNotEqual(SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol),
+                          Decimal(0).formatToFiat(includeCurrencySymbol: true))
     }
 
     func testShowProtocolFeeRowFalseForSecuredMint() {
@@ -209,7 +247,7 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
     func testShowProtocolFeeRowFalseForNonNativeRoute() {
         let usdc = makeCoin(.solana, ticker: "USDCPR", decimals: 6, isNative: false)
         // Jupiter / EVM aggregators have no native protocol outbound fee.
-        let quote = makeJupiterQuote(platformFee: Decimal(string: "0.01"))
+        let quote = makeJupiterQuote(platformFee: Decimal(string: "0.01") ?? 0, feeOnInput: false)
         XCTAssertFalse(SwapCryptoLogic.showProtocolFeeRow(quote: quote, toCoin: usdc, mode: .standard))
     }
 
@@ -308,12 +346,26 @@ final class SwapAffiliateFeeDisplayTests: XCTestCase {
         )
     }
 
-    private func makeJupiterQuote(platformFee: Decimal?) -> SwapQuote {
+    private func makeJupiterQuote(platformFee: Decimal, feeOnInput: Bool) -> SwapQuote {
         let evm = EVMQuote(
             dstAmount: "1000000",
             tx: EVMQuote.Transaction(from: "from", to: "mint", data: "data", value: "0", gasPrice: "0", gas: 0)
         )
-        return .jupiter(evm, fee: nil, platformFee: platformFee)
+        return .jupiter(evm, fee: nil, platformFee: platformFee, feeOnInput: feeOnInput)
+    }
+
+    /// LiFi-Solana quote fixture: `swapFee` is "0" and the affiliate fee is
+    /// carried as `integratorFee` (a fraction of the output amount), mirroring
+    /// `LiFiService`'s Solana branch.
+    private func makeLiFiSolanaQuote(integratorFee: Decimal, dstAmount: String) -> SwapQuote {
+        let evm = EVMQuote(
+            dstAmount: dstAmount,
+            tx: EVMQuote.Transaction(
+                from: "from", to: "to", data: "0x", value: "0", gasPrice: "0", gas: 0,
+                swapFee: "0", swapFeeTokenContract: ""
+            )
+        )
+        return .lifi(evm, fee: nil, integratorFee: integratorFee)
     }
 
     private func makeSwapKitQuote() -> SwapQuote {

--- a/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapAffiliateFeeDisplayTests.swift
@@ -1,0 +1,356 @@
+//
+//  SwapAffiliateFeeDisplayTests.swift
+//  VultisigAppTests
+//
+//  First real coverage for the affiliate-fee display helpers exercised by the
+//  Verify / Details / Done screens (#4859): the shared effective-affiliate-bps
+//  function, the bps-derived percentage label, per-route affiliate amounts, the
+//  Total-fee reconciliation (which drops the fees.total liquidity component),
+//  the row-visibility gate, and the display-only invariant that none of this
+//  touches the signed keysign payload.
+//
+//  DEBUG note: `THORChainSwaps.affiliateFeeRateBp` is 0 in test builds, so
+//  non-referred native percentages read 0.00% here — that matches what the
+//  request builder sends in DEBUG. Base-50 tier math is asserted directly on
+//  the pure `discountedAffiliateBps` helper so it's independent of the build.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class SwapAffiliateFeeDisplayTests: XCTestCase {
+
+    // MARK: - Shared effective-affiliate-bps (pure, build-independent)
+
+    func testDiscountedAffiliateBpsBaseFiftyPerTier() {
+        func bps(_ discount: Int) -> Int {
+            THORChainSwaps.discountedAffiliateBps(baseBps: 50, discountBps: discount)
+        }
+        XCTAssertEqual(bps(0), 50)                                    // no tier
+        XCTAssertEqual(bps(VultDiscountTier.bronze.bpsDiscount), 45)  // 5
+        XCTAssertEqual(bps(VultDiscountTier.silver.bpsDiscount), 40)  // 10
+        XCTAssertEqual(bps(VultDiscountTier.gold.bpsDiscount), 30)    // 20
+        XCTAssertEqual(bps(VultDiscountTier.platinum.bpsDiscount), 25) // 25
+        XCTAssertEqual(bps(VultDiscountTier.diamond.bpsDiscount), 15) // 35
+        XCTAssertEqual(bps(VultDiscountTier.ultimate.bpsDiscount), 0) // Int.max → 0
+    }
+
+    func testDiscountedAffiliateBpsUltimateDoesNotOverflow() {
+        // Int.max discount must clamp to 0, not trap on `50 - Int.max`.
+        XCTAssertEqual(THORChainSwaps.discountedAffiliateBps(baseBps: 50, discountBps: .max), 0)
+    }
+
+    func testEffectiveAffiliateFeeBpsNonReferredMatchesDiscounted() {
+        for discount in [0, 5, 10, 20, 25, 35, Int.max] {
+            XCTAssertEqual(
+                THORChainSwaps.effectiveAffiliateFeeBps(discountBps: discount, isReferred: false),
+                THORChainSwaps.discountedAffiliateBps(baseBps: THORChainSwaps.affiliateFeeRateBp, discountBps: discount)
+            )
+        }
+    }
+
+    func testEffectiveAffiliateFeeBpsReferredAddsReferrerShare() {
+        let referrer = Int(THORChainSwaps.referredUserFeeRateBp) ?? 0 // 10
+        // Referred total = referrer share + discounted 35-bp Vultisig share.
+        XCTAssertEqual(THORChainSwaps.effectiveAffiliateFeeBps(discountBps: 0, isReferred: true), referrer + 35)   // 45
+        XCTAssertEqual(THORChainSwaps.effectiveAffiliateFeeBps(discountBps: 35, isReferred: true), referrer + 0)   // 10 (diamond)
+        XCTAssertEqual(THORChainSwaps.effectiveAffiliateFeeBps(discountBps: .max, isReferred: true), referrer)     // 10 (ultimate keeps the referrer share)
+    }
+
+    // MARK: - Display bps equals the request builder's sent bps
+
+    func testDisplayBpsMatchesThorchainRequestBuilderNonReferred() {
+        for discount in [0, 5, 35] {
+            let (_, bpsStr) = ThorchainService.affiliateParams(referredCode: "", discountBps: discount)
+            let sent = Int(bpsStr ?? "") ?? -1
+            XCTAssertEqual(sent, THORChainSwaps.effectiveAffiliateFeeBps(discountBps: discount, isReferred: false))
+        }
+    }
+
+    func testDisplayBpsMatchesThorchainRequestBuilderReferred() {
+        for discount in [0, 5, 35] {
+            let (_, bpsStr) = ThorchainService.affiliateParams(referredCode: "code", discountBps: discount)
+            // Referred builder sends "referrer/vultisig"; the total charged is the sum.
+            let sentTotal = (bpsStr ?? "").split(separator: "/").compactMap { Int($0) }.reduce(0, +)
+            XCTAssertEqual(sentTotal, THORChainSwaps.effectiveAffiliateFeeBps(discountBps: discount, isReferred: true))
+        }
+    }
+
+    // MARK: - swapFeeLabel percentage per route
+
+    func testSwapFeeLabelNativeThorchainDerivesFromBps() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCLBL", decimals: 8, isNative: true)
+        let label = SwapCryptoLogic.swapFeeLabel(
+            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, isReferred: false
+        )
+        let expectedBps = THORChainSwaps.effectiveAffiliateFeeBps(discountBps: 0, isReferred: false)
+        XCTAssertEqual(label, String(format: "vultisigFeePercentage".localized, Double(expectedBps) / 100.0))
+    }
+
+    func testSwapFeeLabelThorchainReferredShowsReferredSplit() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCREF", decimals: 8, isNative: true)
+        let label = SwapCryptoLogic.swapFeeLabel(
+            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, isReferred: true
+        )
+        // 10 (referrer) + 35 (discounted base 35) = 45 bps, even in DEBUG.
+        XCTAssertEqual(label, String(format: "vultisigFeePercentage".localized, 0.45))
+    }
+
+    func testSwapFeeLabelMayaIgnoresReferralSplit() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCMAYA", decimals: 8, isNative: true)
+        let mayaReferred = SwapCryptoLogic.swapFeeLabel(
+            quote: .mayachain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, isReferred: true
+        )
+        let thorReferred = SwapCryptoLogic.swapFeeLabel(
+            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, isReferred: true
+        )
+        let thorNonReferred = SwapCryptoLogic.swapFeeLabel(
+            quote: .thorchain(makeThorQuote()), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, isReferred: false
+        )
+        // Maya never applies the referral split → it must match the standard
+        // (non-referred) rate, not the THORChain referred rate.
+        XCTAssertEqual(mayaReferred, thorNonReferred)
+        XCTAssertNotEqual(mayaReferred, thorReferred)
+    }
+
+    func testSwapFeeLabelSwapKitStaticHalfPercent() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCSK", decimals: 8, isNative: true)
+        let label = SwapCryptoLogic.swapFeeLabel(
+            quote: makeSwapKitQuote(), fromCoin: btc, toCoin: btc, feeCoin: btc,
+            fromAmount: "1", vultDiscountBps: 0, isReferred: false
+        )
+        XCTAssertEqual(label, String(format: "vultisigFeePercentage".localized, 0.50))
+    }
+
+    // MARK: - baseAffiliateFee amount per route
+
+    func testBaseAffiliateFeeSourcesAffiliateNotComposite() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCAFF", decimals: 8, isNative: true)
+        setPrice(1000, for: btc)
+        // affiliate 0.01 BTC → $10; total (composite) 0.09 BTC would be $90.
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "1000000", outbound: "0", total: "9000000"))
+        let value = SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc)
+        XCTAssertEqual(value, Decimal(10).formatToFiat(includeCurrencySymbol: true))
+        XCTAssertNotEqual(value, Decimal(90).formatToFiat(includeCurrencySymbol: true))
+    }
+
+    func testBaseAffiliateFeeUltimateShowsZeroNotEmpty() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCULT", decimals: 8, isNative: true)
+        setPrice(1000, for: btc)
+        // Ultimate/100% waiver → node charges 0 affiliate; the row stays at $0.00.
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "0", outbound: "0", total: "0"))
+        let value = SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: btc, toCoin: btc, feeCoin: btc)
+        XCTAssertFalse(value.isEmpty)
+        XCTAssertEqual(value, Decimal(0).formatToFiat(includeCurrencySymbol: true))
+    }
+
+    func testBaseAffiliateFeeSwapKitIncludedInRate() {
+        let btc = makeCoin(.bitcoin, ticker: "BTCSK2", decimals: 8, isNative: true)
+        let value = SwapCryptoLogic.baseAffiliateFee(quote: makeSwapKitQuote(), fromCoin: btc, toCoin: btc, feeCoin: btc)
+        XCTAssertEqual(value, "swap.included_in_rate".localized)
+    }
+
+    func testBaseAffiliateFeeJupiterUsesPlatformFee() {
+        let sol = makeCoin(.solana, ticker: "SOLJUP", decimals: 9, isNative: true)
+        let usdc = makeCoin(.solana, ticker: "USDCJUP", decimals: 6, isNative: false)
+        setPrice(2, for: usdc) // 1 USDC = $2 for the test
+        // platformFee 0.02 USDC × $2 = $0.04 (hardcoded so a silent rate-seeding
+        // failure would fail the test rather than pass at $0.00 on both sides).
+        let quote = makeJupiterQuote(platformFee: Decimal(2) / Decimal(100))
+        let value = SwapCryptoLogic.baseAffiliateFee(quote: quote, fromCoin: sol, toCoin: usdc, feeCoin: sol)
+        XCTAssertEqual(value, (Decimal(4) / Decimal(100)).formatToFiat(includeCurrencySymbol: true))
+    }
+
+    // MARK: - Row visibility gate
+
+    func testShowAffiliateFeeRowTrueForMarketSwap() {
+        XCTAssertTrue(SwapCryptoLogic.showAffiliateFeeRow(quote: .thorchain(makeThorQuote()), mode: .standard))
+    }
+
+    func testShowAffiliateFeeRowFalseForSecuredMint() {
+        XCTAssertFalse(SwapCryptoLogic.showAffiliateFeeRow(quote: .thorchain(makeThorQuote()), mode: .securedMint))
+    }
+
+    func testShowAffiliateFeeRowFalseForNilQuote() {
+        XCTAssertFalse(SwapCryptoLogic.showAffiliateFeeRow(quote: nil, mode: .standard))
+    }
+
+    func testShowAffiliateFeeRowFalseForNativeSolJupiter() {
+        // platformFee == nil ⇒ fee taken on the input mint (native-SOL output);
+        // amount isn't surfaced, so suppress rather than show a misleading $0.00.
+        XCTAssertFalse(SwapCryptoLogic.showAffiliateFeeRow(quote: makeJupiterQuote(platformFee: nil), mode: .standard))
+    }
+
+    func testShowAffiliateFeeRowTrueForTokenJupiter() {
+        XCTAssertTrue(SwapCryptoLogic.showAffiliateFeeRow(quote: makeJupiterQuote(platformFee: Decimal(string: "0.01")), mode: .standard))
+    }
+
+    // MARK: - Total-fee reconciliation (Network + affiliate + outbound, no liquidity)
+
+    func testTotalFeeReconcilesAndDropsLiquidity() {
+        let rune = makeCoin(.thorChain, ticker: "RUNETOT", decimals: 8, isNative: true)
+        let btc = makeCoin(.bitcoin, ticker: "BTCTOT", decimals: 8, isNative: true)
+        setPrice(10, for: rune)   // network fee coin
+        setPrice(1000, for: btc)  // output coin (affiliate + outbound denominated here)
+
+        // affiliate 0.01 BTC = $10, outbound 0.02 BTC = $20, total(composite)
+        // 0.09 BTC = $90 (carries $60 of liquidity that must be dropped).
+        let quote = SwapQuote.thorchain(makeThorQuote(affiliate: "1000000", outbound: "2000000", total: "9000000"))
+        let networkFeeWei = BigInt(100_000_000) // 1 RUNE = $10
+
+        let total = SwapCryptoLogic.totalFeeString(quote: quote, fromCoin: rune, toCoin: btc, feeCoin: rune, fee: networkFeeWei)
+
+        // Reconciled: $10 network + $10 affiliate + $20 outbound = $40 (computed
+        // by hand from the inputs, independent of the helper's own arithmetic).
+        XCTAssertEqual(total, Decimal(40).formatToFiat(includeCurrencySymbol: true))
+        // NOT the old composite path ($10 network + $90 fees.total = $100).
+        XCTAssertNotEqual(total, Decimal(100).formatToFiat(includeCurrencySymbol: true))
+    }
+
+    // MARK: - Display-only invariant: signed payload unchanged
+
+    func testDisplayFeeInputsDoNotAlterSignedPayload() async throws {
+        let vault = makeVault()
+        let quote = makeThorQuote(affiliate: "1000000", outbound: "2000000", total: "9000000", memo: "=:BTC.BTC:addr:0/1/0")
+
+        // Baseline (no tier, no referral) vs. a heavily-discounted referred user:
+        // only the DISPLAY fee inputs differ — the signed artifact must not.
+        let baseline = makeNativeThorchainTransaction(quote: quote, vultDiscountBps: 0, referralDiscountBps: 0, isReferred: false)
+        let discounted = makeNativeThorchainTransaction(quote: quote, vultDiscountBps: 35, referralDiscountBps: 5, isReferred: true)
+
+        let p1 = try await SwapCryptoLogic.buildSwapKeysignPayload(transaction: baseline, chainSpecific: cosmosChainSpecific(), vault: vault)
+        let p2 = try await SwapCryptoLogic.buildSwapKeysignPayload(transaction: discounted, chainSpecific: cosmosChainSpecific(), vault: vault)
+
+        XCTAssertEqual(p1.memo, p2.memo, "Signed memo must not depend on display-fee inputs")
+        XCTAssertEqual(p1.toAmount, p2.toAmount, "Signed amount must not depend on display-fee inputs")
+        XCTAssertEqual(p1.toAddress, p2.toAddress)
+        XCTAssertEqual(p1.memo, "=:BTC.BTC:addr:0/1/0")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {
+        let asset = CoinMeta(
+            chain: chain, ticker: ticker, logo: "logo", decimals: decimals,
+            priceProviderId: ticker.lowercased(), contractAddress: "", isNativeToken: isNative
+        )
+        return Coin(asset: asset, address: "test-\(ticker)", hexPublicKey: "")
+    }
+
+    private func setPrice(_ value: Double, for coin: Coin) {
+        let cryptoId = RateProvider.cryptoId(for: coin.toCoinMeta()).id
+        do {
+            try RateProvider.shared.save(rates: [
+                Rate(fiat: SettingsCurrency.current.rawValue, crypto: cryptoId, value: value)
+            ])
+        } catch {
+            XCTFail("Failed to seed rate for \(coin.ticker): \(error)")
+        }
+        // Guard against a silent seeding failure making fiat assertions vacuous.
+        XCTAssertEqual(coin.price, value, accuracy: 0.0001, "Rate for \(coin.ticker) did not take effect")
+    }
+
+    private func makeThorQuote(
+        affiliate: String = "0",
+        outbound: String = "0",
+        total: String = "0",
+        expectedAmountOut: String = "100000000",
+        memo: String = "thor-memo",
+        slippageBps: Int? = nil,
+        router: String? = nil
+    ) -> ThorchainSwapQuote {
+        ThorchainSwapQuote(
+            dustThreshold: nil,
+            expectedAmountOut: expectedAmountOut,
+            expiry: 0,
+            fees: Fees(affiliate: affiliate, asset: "RUNE", outbound: outbound, total: total, liquidity: nil, slippageBps: nil, totalBps: nil),
+            inboundAddress: "thor-vault",
+            inboundConfirmationBlocks: nil,
+            inboundConfirmationSeconds: nil,
+            memo: memo,
+            notes: "",
+            outboundDelayBlocks: 0,
+            outboundDelaySeconds: 0,
+            recommendedMinAmountIn: "0",
+            slippageBps: slippageBps,
+            totalSwapSeconds: nil,
+            warning: "",
+            router: router,
+            maxStreamingQuantity: nil
+        )
+    }
+
+    private func makeJupiterQuote(platformFee: Decimal?) -> SwapQuote {
+        let evm = EVMQuote(
+            dstAmount: "1000000",
+            tx: EVMQuote.Transaction(from: "from", to: "mint", data: "data", value: "0", gasPrice: "0", gas: 0)
+        )
+        return .jupiter(evm, fee: nil, platformFee: platformFee)
+    }
+
+    private func makeSwapKitQuote() -> SwapQuote {
+        let json = """
+        {
+          "swapId": "s", "routeId": "r", "providers": ["Chainflip"],
+          "sellAsset": "BTC.BTC", "buyAsset": "ETH.ETH", "sellAmount": "0.01",
+          "expectedBuyAmount": "0.1", "expectedBuyAmountMaxSlippage": "0.1",
+          "sourceAddress": "from", "destinationAddress": "to", "targetAddress": "target",
+          "meta": { "txType": "EVM" },
+          "tx": { "from": "from", "to": "to", "value": "0", "data": "0x", "gas": "0x30d40", "gasPrice": "0x4a817c800" },
+          "fees": []
+        }
+        """
+        // swiftlint:disable:next force_try
+        let response = try! JSONDecoder().decode(SwapKitSwapResponse.self, from: Data(json.utf8))
+        return .swapkit(response, fee: BigInt(10), subProvider: "Chainflip")
+    }
+
+    private func makeNativeThorchainTransaction(
+        quote: ThorchainSwapQuote,
+        vultDiscountBps: Int,
+        referralDiscountBps: Int,
+        isReferred: Bool
+    ) -> SwapTransaction {
+        let rune = makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true)
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
+        return SwapTransaction(
+            fromCoin: rune,
+            toCoin: btc,
+            fromAmount: 1.0,
+            kind: .market(.thorchain(quote)),
+            gas: 0,
+            gasLimit: 0,
+            thorchainFee: BigInt(2_000),
+            vultDiscountBps: vultDiscountBps,
+            referralDiscountBps: referralDiscountBps,
+            isReferred: isReferred,
+            feeCoin: rune,
+            advancedSettings: .default
+        )
+    }
+
+    private func makeVault() -> Vault {
+        Vault(
+            name: "Test Vault",
+            signers: [],
+            pubKeyECDSA: "test-pub-ecdsa",
+            pubKeyEdDSA: "test-pub-eddsa",
+            keyshares: [],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+    }
+
+    private func cosmosChainSpecific() -> BlockChainSpecific {
+        .Cosmos(accountNumber: 1, sequence: 0, gas: 200_000, transactionType: 0, ibcDenomTrace: nil, gasLimit: nil)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
@@ -217,7 +217,8 @@ final class SwapPayloadBuilderTests: XCTestCase {
             quote: .jupiter(
                 makeSolanaEVMQuote(base64: "AQIDBA=="),
                 fee: nil,
-                platformFee: Decimal(string: "0.5")
+                platformFee: Decimal(string: "0.5") ?? .zero,
+                feeOnInput: false
             )
         )
 

--- a/VultisigApp/VultisigAppTests/Views/Done/TransactionDonePayloadTests.swift
+++ b/VultisigApp/VultisigAppTests/Views/Done/TransactionDonePayloadTests.swift
@@ -33,14 +33,17 @@ final class TransactionDonePayloadTests: XCTestCase {
         XCTAssertTrue(transaction.hasFeeBreakdown)
     }
 
-    func testHasFeeBreakdownFalseWhenComponentsSuppressed() {
-        // Zero gas + a zero-fee quote => both `showGas` and `showFees` are
-        // false, so expanding would reveal nothing. The gate must be false so
-        // the card renders the total as a plain row with no chevron.
+    func testHasFeeBreakdownTrueForNativeSwapAffiliateRow() {
+        // A native swap always carries the itemized Vultisig Fee row (shown even
+        // at $0.00 for the Ultimate/100%-waiver user) plus a Protocol Fee row, so
+        // the Done-card breakdown chevron is meaningful even with zero gas and a
+        // zero-fee quote. `showFees` (the old composite predicate) stays false —
+        // the breakdown no longer keys off it.
         let transaction = makeThorchainTransaction(gas: 0)
         XCTAssertFalse(transaction.showGas)
         XCTAssertFalse(transaction.showFees)
-        XCTAssertFalse(transaction.hasFeeBreakdown)
+        XCTAssertTrue(transaction.showAffiliateFeeRow)
+        XCTAssertTrue(transaction.hasFeeBreakdown)
     }
 
     private func makeThorchainTransaction(gas: BigInt) -> SwapTransaction {


### PR DESCRIPTION
Closes #4859

## Problem

The Verify screen — the one the user approves before signing — collapsed every swap fee into THORChain's composite `fees.total` and labelled it "Swap Fee", throwing away the affiliate itemization, the percentage, the outbound row and the VULT tier saving that the Details screen shows. The least transparent screen in the flow was the one the user signs from.

## iOS was not actually blocked by SDK#1450

The issue flags vultisig-sdk#1450 as a blocker. That binds windows/extension (they read the TS SDK's fee surface). **iOS has its own `ThorchainSwapQuote.Fees` where `affiliate` is already a separate field from `total`** — the Details screen itemizes it today. Every acceptance criterion here is met with data iOS already has locally; SDK#1450 gates cross-client unification, not this fix. (Confirmed with the maintainer.)

Root cause was a one-field divergence: Verify rendered `fees.total` via `swapFeeString`; Details renders `fees.affiliate`. And Verify already had `baseAffiliateFee` / `swapFeeLabel` / `vultDiscount` on the transaction — it just never referenced them.

## What changed

**Canonical rows on Verify (and Details / Done, kept consistent):** `Network Fee`, `Vultisig Fee (X.XX%)` (affiliate only), `Protocol Fee` (outbound), `Price Impact` (when the provider reports slippage), `Total Fee`, and the `VULT {tier}` saving row.

**Percentage from the effective affiliate bps, not a fiat division.** Extracted `THORChainSwaps.effectiveAffiliateFeeBps` (and the `discountedAffiliateBps` clamp) and had **both** the request builders (`ThorchainService`/`MayaChainService`/`Endpoint`) **and** the display label consume it, so the shown % equals the bps the node was actually asked to charge — by construction, not by inference. It also reconciles with the `fees.affiliate` amount because the node computes that amount from that bps. (Android's own reference uses a fiat-division %; this does better on that criterion.)

**Total reconciles to the itemized rows, dropping liquidity.** `Total = Network + Vultisig(affiliate) + Protocol(outbound)`, not `fees.total` — the `asset`/liquidity component is already reflected in the expected output and must not be double-counted (Android `SwapQuoteManager.kt:360-367` is the reference).

**Per-route behaviour fixed:**
- **Jupiter/Solana** now shows the affiliate row on **both** form and verify (was inverted — hidden on form, shown on verify).
- **Ultimate tier** keeps the row visible as `Vultisig Fee (0.00%) — $0.00` (removed the `feeAmount > 0` guard).
- **SwapKit** renders `Vultisig Fee (0.50%) — included in quoted rate` (no per-tx fee field; 50 bps is a known constant).
- **LiFi-Solana** sources the fee from `integratorFee` (it reports `swapFee "0"` and charges via the integrator fraction), so it no longer shows $0.00 or drops from Total.

## Distinguishing the two Jupiter zero-fee cases

`platformFee == nil` previously conflated two situations. The `.jupiter` case is now `jupiter(EVMQuote, fee: BigInt?, platformFee: Decimal, feeOnInput: Bool)`, where `feeOnInput = (feeMint != outputMint)` computed in `JupiterService` where both mints are known:
- **native-SOL output** (`feeOnInput = true`) — fee is on the input mint, unsurfaceable in `toCoin` units → row suppressed (correct).
- **Ultimate token output** (`feeOnInput = false`, `platformFee = 0`) — a real fee-on-output of zero → row shows `0.00% / $0.00` (correct, per AC).

## Signed-payload invariant (this is the screen the user signs from)

**All changes are display-only.** `SwapPayloadBuilder` is untouched; the added transaction fields and the enum-shape change do not feed the memo, signed amount, `toAmount`, or `toAmountLimit`; the request-builder refactor is mathematically identical; route ranking still reads only `outAmount`. Verified by a whole-branch cross-model (Codex) review focused on this invariant, which confirmed it holds, plus that native displayed-bps match sent-bps across every tier and the referral split.

## Tests

`baseAffiliateFee` / `swapFeeString` / `swapFeeLabel` / `vultDiscount` / `outboundFeeString` were **entirely untested** (fixtures built `affiliate: "0"`, so affiliate itemization was never exercised). New `SwapAffiliateFeeDisplayTests` (28 tests) covers: the bps-% equalling the sent bps per tier + referral, the Total reconciliation identity (excludes liquidity), Ultimate `0.00%/$0.00`, SwapKit static label, LiFi-Solana integrator fee in row + Total, and Jupiter native-SOL-suppressed vs Ultimate-token-shown. The pre-existing Done breakdown-gate test was updated (native swaps now always carry the $0.00 affiliate row, so the breakdown chevron is meaningful).

## Gate

`make test` on iPhone 16 Pro: **`** TEST SUCCEEDED **` — 3148 executed, 0 failures, 1 skipped**. SwiftLint clean on the touched files. Reviewed with a per-commit + whole-branch cross-model (Codex) loop; two P1 route bugs (LiFi-Solana, Ultimate-Jupiter) it caught were fixed in the final commit and re-reviewed clean.

## Out of scope

- **Co-signer parity** (`KeysignSwapConfirmView` / `JoinKeysignSwapFeeViewModel`) — #4422's territory; none of this issue's ACs touch it.
- Cross-client SDK unification — vultisig-sdk#1450 (windows/extension).

## Manual check worth doing before merge

A visual pass of the itemized Verify rows across the four route families (native THOR/Maya, EVM aggregator, Jupiter token-output, SwapKit) on device — the row math is unit-tested, but the layout/blur/loading states are only exercised by the UI layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer swap fee breakdowns for affiliate, protocol, network, referral, and VULT discounts.
  - Added price-impact and “included in quoted rate” details during swap verification.
  - Improved Jupiter fee handling, including fees charged in the input asset.
  - Added referral-aware fee calculations and display logic.

- **Localization**
  - Added translated labels for protocol fees, included rates, and Vultisig fees across supported languages.

- **Bug Fixes**
  - Improved total-fee reconciliation and prevented misleading zero-value fee rows.
  - Corrected affiliate fee calculations for discounted and referred swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->