### PR TITLE
fix(defi): surface RUJI's bonded and auto-compounding positions as separate cards

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -81,10 +81,28 @@ private extension THORChainStakingService {
             return .empty
         }
 
-        // 2. Parse staked amount
+        // 2. Parse the bonded amount — the position that accrues claimable USDC.
         let stakedAmount = BigInt(stake.bonded.amount) ?? .zero
         let stakedDecimal = Decimal(string: stakedAmount.description) ?? 0
         let stakedFinal = stakedDecimal / pow(10, 8) // RUJI has 8 decimals
+
+        // 2b. Parse the auto-compounding amount. `liquidSize` is the sRUJI receipt
+        // valued in RUJI at the pool's current share price, which is what the
+        // Rujira app shows; the raw on-chain receipt balance is a share count and
+        // would understate the position. Independent of `bonded` — an account can
+        // hold both — so this never falls back to it.
+        //
+        // The field is non-null in the Rujira schema and is the only source for the
+        // auto-compounding position, so a missing or unparseable value means a
+        // partial response, not an empty position. Fail closed like the guards
+        // above rather than report a zero that would erase a live position.
+        guard let liquidSize = stake.liquidSize,
+              let liquidSizeRaw = liquidSize.amount,
+              let liquidSizeAmount = BigInt(liquidSizeRaw),
+              let liquidSizeDecimal = Decimal(string: liquidSizeAmount.description) else {
+            throw StakingError.invalidResponse
+        }
+        let liquidSizeFinal = liquidSizeDecimal / pow(10, 8)
 
         // 3. Parse rewards
         let rewardsAmount = BigInt(stake.pendingRevenue?.amount ?? "0") ?? .zero
@@ -108,6 +126,7 @@ private extension THORChainStakingService {
 
         return StakingDetails(
             stakedAmount: stakedFinal,
+            autoCompoundAmount: liquidSizeFinal,
             apr: apr,
             estimatedReward: nil, // Not available for RUJI
             nextPayoutDate: nil, // Not available for RUJI
@@ -140,6 +159,7 @@ private extension THORChainStakingService {
 
         return StakingDetails(
             stakedAmount: stakedDecimal,
+            autoCompoundAmount: 0, // TCY's auto-compound side is read on-chain, not here
             apr: apr,
             estimatedReward: estimatedReward,
             nextPayoutDate: nextPayout,

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -70,11 +70,19 @@ class THORChainStakingService: THORChainStakingProviding {
 private extension THORChainStakingService {
     /// Fetch RUJI staking details from GraphQL API
     func fetchRujiStakingDetails(address: String) async throws -> StakingDetails {
-        // 1. Make GraphQL request using HTTPClient
         let target = THORChainStakingAPI.getRujiStaking(address: address)
         let response = try await httpClient.request(target, responseType: AccountRootData.self)
-        let decoded = response.data
+        return try Self.makeRujiStakingDetails(from: response.data)
+    }
+}
 
+extension THORChainStakingService {
+    /// Translates a Rujira account payload into `StakingDetails`, selecting the
+    /// RUJI pool and scaling every amount out of base units.
+    ///
+    /// Pure so the parse is unit-testable without the network round-trip, the
+    /// same way `ThorchainService.parseStakingReceiptAmount` is.
+    static func makeRujiStakingDetails(from decoded: AccountRootData) throws -> StakingDetails {
         // Distinguish "address has no RUJI stake" (genuine empty) from "response is missing /
         // partial" (don't trust it). Returning `.empty` for the latter caused persisted RUJI
         // positions to be silently overwritten with zero on stale GraphQL responses.
@@ -84,6 +92,8 @@ private extension THORChainStakingService {
         guard let stakingV2 = node.stakingV2 else {
             throw StakingError.invalidResponse
         }
+        // `stakingV2` carries an entry per Rujira staking pool the account touches,
+        // and the first is not guaranteed to be RUJI. Select by bond-asset symbol.
         guard let stake = stakingV2.first(where: {
             $0.bonded.asset.metadata?.symbol.uppercased() == "RUJI"
         }) else {
@@ -91,12 +101,16 @@ private extension THORChainStakingService {
             return .empty
         }
 
-        // 2. Parse the bonded amount — the position that accrues claimable USDC.
-        let stakedAmount = BigInt(stake.bonded.amount) ?? .zero
-        let stakedDecimal = Decimal(string: stakedAmount.description) ?? 0
+        // Parse the bonded amount — the position that accrues claimable USDC. An
+        // unparseable value is a partial response, not an empty position, and a
+        // spurious zero here is precisely what disables Unstake on a funded card.
+        guard let stakedAmount = BigInt(stake.bonded.amount),
+              let stakedDecimal = Decimal(string: stakedAmount.description) else {
+            throw StakingError.invalidResponse
+        }
         let stakedFinal = stakedDecimal / pow(10, 8) // RUJI has 8 decimals
 
-        // 2b. Parse the auto-compounding amount. `liquidSize` is the sRUJI receipt
+        // Parse the auto-compounding amount. `liquidSize` is the sRUJI receipt
         // valued in RUJI at the pool's current share price, which is what the
         // Rujira app shows; the raw on-chain receipt balance is a share count and
         // would understate the position. Independent of `bonded` — an account can
@@ -114,16 +128,18 @@ private extension THORChainStakingService {
         }
         let liquidSizeFinal = liquidSizeDecimal / pow(10, 8)
 
-        // 3. Parse rewards
+        // Parse the claimable revenue. Lenient on purpose, unlike the two amounts
+        // above: revenue is a CTA on an otherwise-complete card, so losing it must
+        // not take the position balances down with it.
         let rewardsAmount = BigInt(stake.pendingRevenue?.amount ?? "0") ?? .zero
         let rewardsDecimal = Decimal(string: rewardsAmount.description) ?? 0
         let rewardsFinal = rewardsDecimal / pow(10, 8) // THORChain normalizes all assets to 8 decimals
 
-        // 4. Parse APR. The fractional-rate conversion (12-decimal Bigint → e.g. 0.0116 for
+        // Parse APR. The fractional-rate conversion (12-decimal Bigint → e.g. 0.0116 for
         // 1.16%) lives on the model itself; see `AccountRootData...APR.fractionalRate`.
         let apr: Double? = stake.pool?.summary?.apr?.fractionalRate
 
-        // 5. Create USDC coin meta for rewards
+        // USDC coin meta for the claimable revenue
         let usdcCoin = CoinMeta(
             chain: .thorChain,
             ticker: "USDC",

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -9,8 +9,15 @@ import BigInt
 import Foundation
 import OSLog
 
+/// Read side of THORChain ecosystem staking, abstracted so callers can be driven
+/// without the network. `THORChainStakingService.shared` is the production
+/// implementation.
+protocol THORChainStakingProviding {
+    func fetchStakingDetails(coinMeta: CoinMeta, runeCoinMeta: CoinMeta, address: String) async throws -> StakingDetails
+}
+
 /// Service for fetching staking details for THORChain ecosystem coins (RUJI and TCY)
-class THORChainStakingService {
+class THORChainStakingService: THORChainStakingProviding {
     static let shared = THORChainStakingService()
 
     private let httpClient: HTTPClient
@@ -45,7 +52,10 @@ class THORChainStakingService {
     /// - Returns: StakingDetails with amount, APR, rewards, etc.
     func fetchStakingDetails(coinMeta: CoinMeta, runeCoinMeta: CoinMeta, address: String) async throws -> StakingDetails {
         switch coinMeta.ticker.uppercased() {
-        case "RUJI":
+        case "RUJI", "SRUJI":
+            // One pool, two positions: the bonded amount and the auto-compounding
+            // amount both come from the same account query, so the sRUJI receipt
+            // resolves against the RUJI pool rather than a pool of its own.
             return try await fetchRujiStakingDetails(address: address)
         case "TCY":
             return try await fetchTcyStakingDetails(coinMeta: coinMeta, runeCoinMeta: runeCoinMeta, address: address)

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/TargetType/THORChainStakingAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/TargetType/THORChainStakingAPI.swift
@@ -99,6 +99,9 @@ enum THORChainStakingAPI: TargetType {
                     }
                   }
                 }
+                liquidSize {
+                  amount
+                }
                 pendingRevenue {
                   amount
                   asset {

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+TCYStake.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+TCYStake.swift
@@ -107,10 +107,12 @@ extension ThorchainService {
         try await fetchStakingReceiptAmount(address: address, denom: TokensStore.ybrune.contractAddress)
     }
 
-    /// Fetches the user's `x/staking-x/ruji` (staked RUJI receipt) balance from THORNode.
+    /// Fetches the user's `x/staking-x/ruji` (sRUJI receipt) balance from THORNode.
     ///
-    /// The DeFi Staked RUJI card prefers this on-chain receipt balance over the Rujira
-    /// staking API's `bonded.amount`, which can report zero even while receipts are held.
+    /// This is a count of vault SHARES, not RUJI — the share price drifts above 1 RUJI
+    /// as the pool compounds — so it is not a display value. It sizes the funds of a
+    /// `liquid.unbond`, which spends receipt shares; the amount shown on the
+    /// auto-compounding card comes from the staking API's liquid size instead.
     /// Sibling of `fetchTcyAutoCompoundAmount` / `fetchBRuneAutoCompoundAmount`.
     func fetchRujiStakingReceiptAmount(address: String) async throws -> Decimal {
         try await fetchStakingReceiptAmount(address: address, denom: TokensStore.sruji.contractAddress)

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1535,6 +1535,7 @@
 "withdrawAmount" = "%@ abheben";
 "withdrawBelowOutboundFee" = "Betrag unter Ausgangsgebühr — mindestens %@ %@ abheben, um Netzwerkkosten zu decken";
 "withdrawPercentage" = "Abhebungsprozentsatz";
+"withdrawRewards" = "%@-Belohnungen abheben";
 "withdrawSecuredAssetError" = "To withdraw %@, you need to add the %@ coin to your vault first. Go to vault settings and add %@ to continue.";
 "wrongPassword" = "Falsches Passwort";
 "wrongVaultPassword" = "Falsches Gewölbekennwort. Bitte versuchen Sie es erneut.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1533,6 +1533,7 @@
 "withdrawAmount" = "Withdraw %@";
 "withdrawBelowOutboundFee" = "Amount below outbound fee — withdraw at least %@ %@ to cover network costs";
 "withdrawPercentage" = "Withdraw Percentage";
+"withdrawRewards" = "Withdraw %@ Rewards";
 "withdrawSecuredAssetError" = "To withdraw %@, you need to add the %@ coin to your vault first. Go to vault settings and add %@ to continue.";
 "wrongPassword" = "Wrong password";
 "wrongVaultPassword" = "Wrong vault password. Please, try again.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1535,6 +1535,7 @@
 "withdrawAmount" = "Retirar %@";
 "withdrawBelowOutboundFee" = "Monto por debajo de la tarifa de salida — retira al menos %@ %@ para cubrir los costos de red";
 "withdrawPercentage" = "Porcentaje de retiro";
+"withdrawRewards" = "Retirar recompensas de %@";
 "withdrawSecuredAssetError" = "To withdraw %@, you need to add the %@ coin to your vault first. Go to vault settings and add %@ to continue.";
 "wrongPassword" = "Contraseña incorrecta";
 "wrongVaultPassword" = "Contraseña de bóveda incorrecta. Por favor, intente de nuevo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1535,6 +1535,7 @@
 "withdrawAmount" = "Podignite %@";
 "withdrawBelowOutboundFee" = "Iznos ispod izlazne naknade — podignite barem %@ %@ za pokriće mrežnih troškova";
 "withdrawPercentage" = "Postotak povlačenja";
+"withdrawRewards" = "Povuci nagrade za %@";
 "withdrawSecuredAssetError" = "Za povlačenje %@, prvo morate dodati %@ kovanicu u svoj trezor. Idite u postavke trezora i dodajte %@ za nastavak.";
 "wrongPassword" = "Pogrešna lozinka";
 "wrongVaultPassword" = "Pogrešna lozinka trezora. Molim vas, pokušajte ponovo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1535,6 +1535,7 @@
 "withdrawAmount" = "Preleva %@";
 "withdrawBelowOutboundFee" = "Importo inferiore alla commissione in uscita — preleva almeno %@ %@ per coprire i costi di rete";
 "withdrawPercentage" = "Percentuale di prelievo";
+"withdrawRewards" = "Preleva ricompense di %@";
 "withdrawSecuredAssetError" = "Per prelevare %@, devi prima aggiungere la moneta %@ al tuo vault. Vai nelle impostazioni del vault e aggiungi %@ per continuare.";
 "wrongPassword" = "Password errata";
 "wrongVaultPassword" = "Password di Vault sbagliata. Per favore, riprova.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1496,6 +1496,7 @@
 "withdrawAmount" = "%@ 출금";
 "withdrawBelowOutboundFee" = "출금 금액이 출금 수수료보다 낮음 — 네트워크 비용을 충당하려면 최소 %@ %@을(를) 출금하세요";
 "withdrawPercentage" = "출금 비율";
+"withdrawRewards" = "%@ 보상 출금";
 "withdrawSecuredAssetError" = "%@을(를) 출금하려면 먼저 볼트에 %@ 코인을 추가해야 합니다. 볼트 설정으로 이동하여 %@을(를) 추가하고 계속하세요.";
 "wrongPassword" = "잘못된 비밀번호";
 "wrongVaultPassword" = "잘못된 볼트 비밀번호입니다. 다시 시도하세요.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1535,6 +1535,7 @@
 "withdrawAmount" = "Retirar %@";
 "withdrawBelowOutboundFee" = "Valor abaixo da taxa de saída — retire pelo menos %@ %@ para cobrir os custos da rede";
 "withdrawPercentage" = "Porcentagem de saque";
+"withdrawRewards" = "Sacar recompensas de %@";
 "withdrawSecuredAssetError" = "To withdraw %@, you need to add the %@ coin to your vault first. Go to vault settings and add %@ to continue.";
 "wrongPassword" = "Senha incorreta";
 "wrongVaultPassword" = "Senha do cofre errada. Por favor, tente novamente.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1535,6 +1535,7 @@
 "withdrawAmount" = "提取 %@";
 "withdrawBelowOutboundFee" = "金额低于出站费用 — 请至少提取 %@ %@ 以支付网络费用";
 "withdrawPercentage" = "提取百分比";
+"withdrawRewards" = "提取 %@ 奖励";
 "withdrawSecuredAssetError" = "要提取 %@，您需要先将 %@ 代币添加到您的保险库。请前往保险库设置并添加 %@ 以继续。";
 "wrongPassword" = "密码错误";
 "wrongVaultPassword" = "保险库密码错误。请重试";

--- a/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
@@ -76,7 +76,8 @@ struct AppMigrationService {
         return [
             THORChainDuplicateTokensMigration(),
             TonGramRebrandMigration(),
-            PromoBannerDismissalMigration()
+            PromoBannerDismissalMigration(),
+            RujiAutoCompoundPositionMigration()
         ]
     }
 }

--- a/VultisigApp/VultisigApp/Core/Migration/Migrations/RujiAutoCompoundPositionMigration.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/Migrations/RujiAutoCompoundPositionMigration.swift
@@ -12,9 +12,16 @@ import SwiftData
 /// keyed on two coins. Before the split, a vault holding the auto-compounding
 /// position saw it under the single "RUJI" toggle — without this, that card
 /// would silently vanish until the user found the new "sRUJI" entry in the
-/// position picker. Adding the coin is enough on its own: the card only
-/// materialises once the vault actually holds the receipt, because the
-/// interactor skips positions whose coin is absent from the vault.
+/// position picker.
+///
+/// Widening the position list is all this does; it deliberately does NOT insert
+/// the sRUJI coin into `vault.coins` the way the picker's save does. THORChain
+/// token discovery already adds `x/staking-x/ruji` for every vault that holds
+/// it — which is why the receipt shows in the wallet list today — so the card
+/// materialises on its own for exactly the vaults that have a position, and
+/// vaults that never auto-compounded gain nothing to render. Writing the coin
+/// in would instead put a zero-balance sRUJI row in the wallet list of every
+/// RUJI staker.
 ///
 /// Idempotency comes from `AppMigrationService` (Keychain-versioned, runs once)
 /// and is reinforced by the contains-check, so a user who deliberately turns

--- a/VultisigApp/VultisigApp/Core/Migration/Migrations/RujiAutoCompoundPositionMigration.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/Migrations/RujiAutoCompoundPositionMigration.swift
@@ -1,0 +1,57 @@
+//
+//  RujiAutoCompoundPositionMigration.swift
+//  VultisigApp
+//
+
+import SwiftData
+
+/// Opts every vault that already tracks the RUJI staking position into the sRUJI
+/// one as well.
+///
+/// RUJI staking has two independent positions, and they are now two DeFi cards
+/// keyed on two coins. Before the split, a vault holding the auto-compounding
+/// position saw it under the single "RUJI" toggle — without this, that card
+/// would silently vanish until the user found the new "sRUJI" entry in the
+/// position picker. Adding the coin is enough on its own: the card only
+/// materialises once the vault actually holds the receipt, because the
+/// interactor skips positions whose coin is absent from the vault.
+///
+/// Idempotency comes from `AppMigrationService` (Keychain-versioned, runs once)
+/// and is reinforced by the contains-check, so a user who deliberately turns
+/// sRUJI back off is not overridden.
+struct RujiAutoCompoundPositionMigration: @MainActor AppMigration {
+    /// Surfaced when the store cannot be read. Throwing leaves the migration
+    /// version un-bumped so `AppMigrationService` retries on the next launch
+    /// rather than marking the opt-in as done with no data.
+    private enum MigrationError: Error {
+        case missingModelContext
+    }
+
+    let version: Int = 3
+
+    let description: String = "Enabling the sRUJI staking position for vaults that track RUJI"
+
+    @MainActor
+    func migrate() throws {
+        guard let modelContext = Storage.shared.modelContext else {
+            throw MigrationError.missingModelContext
+        }
+
+        var descriptor = FetchDescriptor<Vault>()
+        descriptor.relationshipKeyPathsForPrefetching = [\.defiPositions]
+
+        for vault in try modelContext.fetch(descriptor) {
+            guard let positions = vault.defiPositions.first(where: { $0.chain == .thorChain }) else {
+                continue
+            }
+            // Match on ticker, not on the whole `CoinMeta`: a persisted entry can
+            // carry metadata (logo, price provider) that has since changed and
+            // would no longer compare equal.
+            let tickers = Set(positions.staking.map { $0.ticker.uppercased() })
+            guard tickers.contains("RUJI"), !tickers.contains("SRUJI") else { continue }
+            positions.staking.append(TokensStore.sruji)
+        }
+
+        try Storage.shared.save()
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Models/AccountRootData.swift
+++ b/VultisigApp/VultisigApp/Core/Models/AccountRootData.swift
@@ -42,6 +42,16 @@ struct AccountRootData: Decodable {
             struct StakingV2: Decodable {
                 let account: String
                 let bonded: Bonded
+                /// Value of the account's auto-compounding position, denominated in the
+                /// BOND token (RUJI) rather than in receipt shares. Rujira mints a liquid
+                /// receipt (sRUJI) whose share price drifts above 1 RUJI, so the raw
+                /// receipt balance is not a valid display amount — this is that balance
+                /// converted at the pool's current share price, and it is what the Rujira
+                /// app shows. Independent of `bonded`: one account can hold both.
+                ///
+                /// Non-null in the Rujira schema, but decoded as optional so a partial or
+                /// older response still decodes into the rest of the entry.
+                let liquidSize: LiquidSize?
                 let pendingRevenue: PendingRevenue?
                 let pool: Pool?
             }
@@ -75,6 +85,13 @@ struct AccountRootData: Decodable {
             struct Bonded: Decodable {
                 let amount: String
                 let asset: Asset
+            }
+
+            struct LiquidSize: Decodable {
+                /// Optional so an absent amount surfaces through the caller's
+                /// explicit partial-response guard rather than as a decode failure
+                /// that takes the whole account payload down with it.
+                let amount: String?
             }
 
             struct PendingRevenue: Decodable {

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
@@ -29,7 +29,11 @@ struct DefiPositionsService {
             [
                 TokensStore.tcy,
                 TokensStore.stcy,
+                // RUJI's two staking positions are independent and are selected
+                // independently: `ruji` is the bonded one (claimable USDC),
+                // `sruji` the auto-compounding one (the receipt it mints).
                 TokensStore.ruji,
+                TokensStore.sruji,
                 TokensStore.yrune,
                 TokensStore.ytcy,
                 // ybRUNE is the auto-compound (`.compound`) position; its card

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -403,6 +403,8 @@ struct DefiChainMainScreen: View {
             return TokensStore.tcy
         case "YBRUNE":
             return TokensStore.brune
+        case "SRUJI":
+            return TokensStore.ruji
         default:
             return compoundCoin
         }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
@@ -10,21 +10,14 @@ import OSLog
 private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-stake-interactor")
 
 struct THORChainStakeInteractor: StakeInteractor {
-    private let stakingService = THORChainStakingService.shared
+    private let stakingService: THORChainStakingProviding
+
+    init(stakingService: THORChainStakingProviding = THORChainStakingService.shared) {
+        self.stakingService = stakingService
+    }
 
     static func scaledAmount(rawAmount: Decimal, decimals: Int) -> Decimal {
         rawAmount / pow(10, decimals)
-    }
-
-    /// Resolves the Staked RUJI amount shown on the DeFi card.
-    ///
-    /// Prefers the on-chain `x/staking-x/ruji` receipt balance (`onChainRaw`, unscaled) —
-    /// the source of truth — over the Rujira staking API's already-scaled `bonded` amount,
-    /// which can report zero even while receipts are held. `onChainRaw == nil` means the
-    /// on-chain read failed, so fall back to `bonded`; a successful zero stays zero.
-    static func resolveRujiStakedAmount(onChainRaw: Decimal?, bonded: Decimal, decimals: Int) -> Decimal {
-        guard let onChainRaw else { return bonded }
-        return scaledAmount(rawAmount: onChainRaw, decimals: decimals)
     }
 
     func fetchStakePositions(vault: Vault) async -> [StakePositionData] {
@@ -35,9 +28,7 @@ struct THORChainStakeInteractor: StakeInteractor {
 
         var dtos: [StakePositionData] = []
         for snapshot in snapshots {
-            if let dto = await dto(for: snapshot, runeMeta: runeMeta) {
-                dtos.append(dto)
-            }
+            dtos.append(contentsOf: await positions(for: snapshot, runeMeta: runeMeta))
         }
         return dtos
     }
@@ -72,7 +63,10 @@ private extension THORChainStakeInteractor {
         }
     }
 
-    func dto(for snapshot: CoinSnapshot, runeMeta: CoinMeta) async -> StakePositionData? {
+    /// Positions contributed by one enabled coin. Returns an empty array when the
+    /// read failed or the value is not trustworthy yet — storage upserts only what
+    /// is returned, so the persisted row keeps its last good value.
+    func positions(for snapshot: CoinSnapshot, runeMeta: CoinMeta) async -> [StakePositionData] {
         let ticker = snapshot.meta.ticker.uppercased()
         let type = StakePositionType.defaultType(for: snapshot.meta)
 
@@ -84,7 +78,7 @@ private extension THORChainStakeInteractor {
                     runeCoinMeta: runeMeta,
                     address: snapshot.address
                 )
-                return StakePositionData(
+                return [StakePositionData(
                     coin: snapshot.meta,
                     type: type,
                     amount: details.stakedAmount,
@@ -93,77 +87,92 @@ private extension THORChainStakeInteractor {
                     nextPayout: details.nextPayoutDate,
                     rewards: details.rewards,
                     rewardCoin: details.rewardsCoin
-                )
+                )]
             } catch {
                 logger.error("Error fetching TCY staking details: \(error.localizedDescription, privacy: .private)")
-                return nil
+                return []
             }
 
         case "RUJI":
+            // The BONDED position — staked with `account.bond`, unstaked with
+            // `account.withdraw`, and the only one that accrues manually-claimable
+            // USDC. It is independent of the auto-compounding position below (an
+            // account can hold either, both or neither), so it reports the pool's
+            // `bonded` amount alone and never substitutes the sRUJI receipt for it.
+            // APR and pending revenue ride here because the auto-compounding side
+            // reinvests its revenue instead of making it claimable.
             do {
                 let details = try await stakingService.fetchStakingDetails(
                     coinMeta: snapshot.meta,
                     runeCoinMeta: runeMeta,
                     address: snapshot.address
                 )
-                // The Rujira staking API's `bonded.amount` (surfaced as `details.stakedAmount`)
-                // can report zero even while sRUJI receipts are held on-chain. Prefer the
-                // on-chain `x/staking-x/ruji` receipt balance as the source of truth; a
-                // successful read — including a genuine zero — wins. Fall back to the API
-                // amount only when the on-chain read fails (throws → nil via `try?`).
-                let onChainRaw = try? await ThorchainService.shared.fetchRujiStakingReceiptAmount(address: snapshot.address)
-                let amount = THORChainStakeInteractor.resolveRujiStakedAmount(
-                    onChainRaw: onChainRaw,
-                    bonded: details.stakedAmount,
-                    decimals: snapshot.meta.decimals
-                )
-                return StakePositionData(
+                return [StakePositionData(
                     coin: snapshot.meta,
                     type: type,
-                    amount: amount,
+                    amount: details.stakedAmount,
                     apr: details.apr,
                     estimatedReward: details.estimatedReward,
                     nextPayout: details.nextPayoutDate,
                     rewards: details.rewards,
                     rewardCoin: details.rewardsCoin
-                )
+                )]
             } catch {
                 logger.error("Error fetching RUJI staking details: \(error.localizedDescription, privacy: .private)")
-                return nil
+                return []
+            }
+
+        case "SRUJI":
+            // The AUTO-COMPOUNDING position — staked with `liquid.bond`, unstaked
+            // with `liquid.unbond`, and receipted by the sRUJI vault share. Its
+            // amount is the pool's liquid size, i.e. the receipt valued in RUJI at
+            // the current share price; the raw share count would understate the
+            // position by that factor. Stat-free like sTCY: revenue compounds into
+            // the amount rather than becoming claimable.
+            do {
+                let details = try await stakingService.fetchStakingDetails(
+                    coinMeta: snapshot.meta,
+                    runeCoinMeta: runeMeta,
+                    address: snapshot.address
+                )
+                return [StakePositionData(coin: snapshot.meta, type: type, amount: details.autoCompoundAmount)]
+            } catch {
+                logger.error("Error fetching sRUJI staking details: \(error.localizedDescription, privacy: .private)")
+                return []
             }
 
         case "STCY":
             do {
                 let rawAmount = try await ThorchainService.shared.fetchTcyAutoCompoundAmount(address: snapshot.address)
                 let amount = THORChainStakeInteractor.scaledAmount(rawAmount: rawAmount, decimals: snapshot.meta.decimals)
-                return StakePositionData(coin: snapshot.meta, type: type, amount: amount)
+                return [StakePositionData(coin: snapshot.meta, type: type, amount: amount)]
             } catch {
                 logger.error("Error fetching STCY auto-compound amount: \(error.localizedDescription, privacy: .private)")
-                return nil
+                return []
             }
 
         case "YBRUNE":
             do {
                 let rawAmount = try await ThorchainService.shared.fetchBRuneAutoCompoundAmount(address: snapshot.address)
                 let amount = THORChainStakeInteractor.scaledAmount(rawAmount: rawAmount, decimals: snapshot.meta.decimals)
-                return StakePositionData(coin: snapshot.meta, type: type, amount: amount)
+                return [StakePositionData(coin: snapshot.meta, type: type, amount: amount)]
             } catch {
                 logger.error("Error fetching ybRUNE auto-compound amount: \(error.localizedDescription, privacy: .private)")
-                return nil
+                return []
             }
 
         case "YRUNE", "YTCY":
             // Reads `coin.balanceDecimal` (kept up-to-date by `BalanceService`). Only update the
             // persisted row when balance is non-zero — `BalanceService` may briefly observe zero
             // mid-refresh, which would otherwise clobber a previously good amount.
-            guard snapshot.balance > 0 else { return nil }
-            return StakePositionData(coin: snapshot.meta, type: type, amount: snapshot.balance)
+            guard snapshot.balance > 0 else { return [] }
+            return [StakePositionData(coin: snapshot.meta, type: type, amount: snapshot.balance)]
 
         default:
             // Same rationale as YRUNE/YTCY — `coin.stakedBalanceDecimal` mirrors a chain read
             // that can transiently report zero.
-            guard snapshot.stakedBalance > 0 else { return nil }
-            return StakePositionData(coin: snapshot.meta, type: type, amount: snapshot.stakedBalance)
+            guard snapshot.stakedBalance > 0 else { return [] }
+            return [StakePositionData(coin: snapshot.meta, type: type, amount: snapshot.stakedBalance)]
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Model/Staking/StakePosition.swift
@@ -201,7 +201,7 @@ enum StakePositionType: String, Codable, Equatable {
 
     static func defaultType(for coin: CoinMeta) -> StakePositionType {
         switch coin.ticker.uppercased() {
-        case "STCY", "YBRUNE":
+        case "STCY", "YBRUNE", "SRUJI":
             return .compound
         case "YRUNE", "YTCY":
             return .index

--- a/VultisigApp/VultisigApp/Features/Defi/Models/StakingDetails.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Models/StakingDetails.swift
@@ -11,7 +11,13 @@ import Foundation
 /// This model is used by THORChainStakingService to return staking information
 /// Can be easily converted to StakePosition for the view layer
 struct StakingDetails {
+    /// Amount held in the plain (non auto-compounding) position. For RUJI this is
+    /// the bonded position — the one that accrues manually-claimable USDC.
     let stakedAmount: Decimal
+    /// Amount held in the auto-compounding position, denominated in the bond
+    /// token (not in receipt shares). `0` for coins whose staking has no
+    /// auto-compounding side reported by the same API call.
+    let autoCompoundAmount: Decimal
     let apr: Double?
     let estimatedReward: Decimal?
     let nextPayoutDate: TimeInterval?
@@ -20,6 +26,7 @@ struct StakingDetails {
 
     static let empty = StakingDetails(
         stakedAmount: 0,
+        autoCompoundAmount: 0,
         apr: nil,
         estimatedReward: nil,
         nextPayoutDate: nil,

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Stake/StakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Stake/StakeTransactionViewModel.swift
@@ -69,6 +69,18 @@ final class StakeTransactionViewModel: ObservableObject, Form {
                 sendMaxAmount: isMaxAmount
             )
         case "RUJI":
+            // Both RUJI positions bond `x/ruji`, so the message has to follow the
+            // card the user tapped: `liquid.bond` mints the sRUJI receipt into the
+            // auto-compounding position, `account.bond` deposits into the bonded
+            // one. Routing both to the same message would silently move funds into
+            // the position with the other rewards and the other unstake path.
+            if isAutocompound {
+                return RUJILiquidBondTransactionBuilder(
+                    coin: coin,
+                    amount: amountField.value,
+                    sendMaxAmount: isMaxAmount
+                )
+            }
             return RUJIStakeTransactionBuilder(
                 coin: coin,
                 amount: amountField.value,

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -46,10 +46,21 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
         if isAutocompound {
             Task { @MainActor in
                 await fetchAutocompoundBalance()
+                guard receiptBalanceIsAvailableAmount else { return }
                 self.availableAmount = autocompoundBalance
                 self.setupAmountField()
             }
         }
+    }
+
+    /// Whether the auto-compound receipt balance is also the amount shown to the
+    /// user. True for TCY and bRUNE, whose staked cards render receipt units
+    /// directly. RUJI's compounded card renders the RUJI-denominated value of the
+    /// receipt, so its ceiling stays the amount the card was showing and the
+    /// receipt balance is used only to size the redeemed shares — otherwise the
+    /// sheet would offer a smaller maximum than the card it was opened from.
+    private var receiptBalanceIsAvailableAmount: Bool {
+        coin.ticker.uppercased() != "RUJI"
     }
 
     var transactionBuilder: TransactionBuilder? {
@@ -73,6 +84,25 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
                 sendMaxAmount: isMaxAmount
             )
         case "RUJI":
+            // RUJI's two positions unstake through completely different messages:
+            // the auto-compounding one redeems sRUJI receipt shares with
+            // `liquid.unbond`, the bonded one withdraws RUJI with
+            // `account.withdraw`. Both arrive here on the RUJI coin because the
+            // compounded card maps sRUJI back to its bond coin.
+            if isAutocompound {
+                // The redemption spends receipt shares, and unlike TCY/bRUNE the
+                // share balance is not what bounds the amount field — so nothing
+                // else stops a zero here. A zero means the read is still in flight,
+                // failed, or the position is empty; all three would build a wasm
+                // execute carrying no funds.
+                guard autocompoundBalance > 0 else { return nil }
+                return RUJILiquidUnbondTransactionBuilder(
+                    coin: coin,
+                    percentage: Int(percentageSelected ?? percentageFromAmount),
+                    receiptShares: autocompoundBalance,
+                    sendMaxAmount: isMaxAmount
+                )
+            }
             return RUJIUnstakeTransactionBuilder(
                 coin: coin,
                 amount: amountField.value,
@@ -124,6 +154,18 @@ final class UnstakeTransactionViewModel: ObservableObject, Form {
                 amount = try await ThorchainService.shared.fetchBRuneAutoCompoundAmount(address: coin.address)
             } catch {
                 logger.error("Failed to fetch ybRUNE autocompound balance: \(error.localizedDescription, privacy: .private)")
+                amount = .zero
+            }
+            self.autocompoundBalance = coin.valueWithDecimals(value: amount)
+        case "RUJI":
+            // The sRUJI receipt share balance — what `liquid.unbond` spends. Not a
+            // display value: shares are worth more than 1 RUJI each and drift
+            // further apart as the pool compounds.
+            let amount: Decimal
+            do {
+                amount = try await ThorchainService.shared.fetchRujiStakingReceiptAmount(address: coin.address)
+            } catch {
+                logger.error("Failed to fetch sRUJI receipt balance: \(error.localizedDescription, privacy: .private)")
                 amount = .zero
             }
             self.autocompoundBalance = coin.valueWithDecimals(value: amount)

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidBondTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidBondTransactionBuilder.swift
@@ -1,0 +1,56 @@
+//
+//  RUJILiquidBondTransactionBuilder.swift
+//  VultisigApp
+//
+
+import Foundation
+import VultisigCommonData
+
+/// Stake builder for the AUTO-COMPOUNDING RUJI position: emits the
+/// `{"liquid":{"bond":{}}}` wasm execute against the RUJI staking contract,
+/// funded with `x/ruji`, and mints the sRUJI receipt in return. The bonded
+/// position is a different message and keeps using `RUJIStakeTransactionBuilder`.
+///
+/// Both actions bond RUJI, so routing them to the same message would silently
+/// move the user's funds into the other position — the one whose card they did
+/// not tap, with different rewards and a different unstake path.
+struct RUJILiquidBondTransactionBuilder: TransactionBuilder {
+    static let destinationAddress = RUJIStakingConstants.contract
+    let coin: Coin
+    let amount: String
+    let sendMaxAmount: Bool
+
+    /// Bonded amount in whole base units of `x/ruji`. Rounds DOWN: the amount
+    /// field does not cap to the coin's 8 dp, and `CosmosCoin.amount` must be an
+    /// integer base-unit string or the execute is malformed. Never round up —
+    /// funding more base units than held would fail on-chain.
+    var rawAmount: String {
+        String(coin.decimalToCrypto(value: amount.toDecimal()).toInt())
+    }
+
+    var memo: String { "" }
+
+    var memoFunctionDictionary: ThreadSafeDictionary<String, String> {
+        let dict = ThreadSafeDictionary<String, String>()
+        dict.set("memo", memo)
+        return dict
+    }
+
+    var transactionType: VSTransactionType { .genericContract }
+
+    var wasmContractPayload: WasmExecuteContractPayload? {
+        WasmExecuteContractPayload(
+            senderAddress: coin.address,
+            contractAddress: Self.destinationAddress,
+            executeMsg: """
+            { "liquid": { "bond": {} } }
+            """,
+            coins: [CosmosCoin(
+                amount: rawAmount,
+                denom: coin.contractAddress
+            )]
+        )
+    }
+
+    var toAddress: String { "" }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidBondTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidBondTransactionBuilder.swift
@@ -20,14 +20,6 @@ struct RUJILiquidBondTransactionBuilder: TransactionBuilder {
     let amount: String
     let sendMaxAmount: Bool
 
-    /// Bonded amount in whole base units of `x/ruji`. Rounds DOWN: the amount
-    /// field does not cap to the coin's 8 dp, and `CosmosCoin.amount` must be an
-    /// integer base-unit string or the execute is malformed. Never round up —
-    /// funding more base units than held would fail on-chain.
-    var rawAmount: String {
-        String(coin.decimalToCrypto(value: amount.toDecimal()).toInt())
-    }
-
     var memo: String { "" }
 
     var memoFunctionDictionary: ThreadSafeDictionary<String, String> {
@@ -39,14 +31,24 @@ struct RUJILiquidBondTransactionBuilder: TransactionBuilder {
     var transactionType: VSTransactionType { .genericContract }
 
     var wasmContractPayload: WasmExecuteContractPayload? {
-        WasmExecuteContractPayload(
+        // Rounds DOWN to whole base units of `x/ruji`: the amount field does not
+        // cap to the coin's 8 dp, and `CosmosCoin.amount` must be an integer
+        // base-unit string or the execute is malformed. Never round up — funding
+        // more base units than held would fail on-chain.
+        let units = coin.decimalToCrypto(value: amount.toDecimal()).toInt()
+        // Sub-base-unit dust truncates to zero, which the amount validator lets
+        // through (it only rejects an exact zero). Bonding zero funds is a no-op
+        // that still costs a fee, so refuse to build it. Mirrors the unbond side.
+        guard units >= 1 else { return nil }
+
+        return WasmExecuteContractPayload(
             senderAddress: coin.address,
             contractAddress: Self.destinationAddress,
             executeMsg: """
             { "liquid": { "bond": {} } }
             """,
             coins: [CosmosCoin(
-                amount: rawAmount,
+                amount: String(units),
                 denom: coin.contractAddress
             )]
         )

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJILiquidUnbondTransactionBuilder.swift
@@ -1,0 +1,65 @@
+//
+//  RUJILiquidUnbondTransactionBuilder.swift
+//  VultisigApp
+//
+
+import Foundation
+import VultisigCommonData
+
+/// Unstake builder for the AUTO-COMPOUNDING RUJI position: emits the
+/// `{"liquid":{"unbond":{}}}` wasm execute against the RUJI staking contract,
+/// funded with the `x/staking-x/ruji` receipt shares being redeemed. The message
+/// itself carries no amount — the funds do. The bonded position is a different
+/// message entirely and keeps using `RUJIUnstakeTransactionBuilder`.
+///
+/// `coin` is the RUJI bond coin (the compounded card maps sRUJI back to RUJI via
+/// `stakeCoin(for:)`); `receiptShares` is the human-readable on-chain
+/// `x/staking-x/ruji` balance. RUJI and sRUJI share 8 decimals, so scaling the
+/// redeemed fraction with the RUJI coin yields the right receipt base units.
+///
+/// Redeeming a share of the position is driven by the percentage rather than by
+/// a RUJI amount, which sidesteps the share-price conversion entirely: at 100%
+/// the exact held share balance is redeemed, so there is no rounding dust and it
+/// can never exceed what is held even if the share price moved since the sheet
+/// opened.
+struct RUJILiquidUnbondTransactionBuilder: TransactionBuilder {
+    static let destinationAddress = RUJIStakingConstants.contract
+    let coin: Coin
+    let percentage: Int
+    let receiptShares: Decimal
+    let sendMaxAmount: Bool
+
+    var amount: String { "0" }
+
+    var memo: String { "" }
+
+    var memoFunctionDictionary: ThreadSafeDictionary<String, String> {
+        let dict = ThreadSafeDictionary<String, String>()
+        dict.set("memo", memo)
+        return dict
+    }
+
+    var transactionType: VSTransactionType { .genericContract }
+
+    var wasmContractPayload: WasmExecuteContractPayload? {
+        let redeemed = (coin.decimalToCrypto(value: receiptShares) * Decimal(percentage)) / 100
+        // Rounds DOWN to whole base units: redeeming more shares than are held
+        // would fail on-chain, and a fractional `CosmosCoin.amount` is malformed.
+        let units = redeemed.toInt()
+        guard units >= 1 else { return nil }
+
+        return WasmExecuteContractPayload(
+            senderAddress: coin.address,
+            contractAddress: Self.destinationAddress,
+            executeMsg: """
+            { "liquid": { "unbond": {} } }
+            """,
+            coins: [CosmosCoin(
+                amount: String(units),
+                denom: TokensStore.sruji.contractAddress
+            )]
+        )
+    }
+
+    var toAddress: String { "" }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJIStakeTransactionBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/TransactionBuilder/Staking/RUJI/RUJIStakeTransactionBuilder.swift
@@ -14,8 +14,12 @@ struct RUJIStakeTransactionBuilder: TransactionBuilder {
     let amount: String
     let sendMaxAmount: Bool
 
+    /// Bonded amount in whole base units of `x/ruji`. Rounds DOWN: the amount
+    /// field does not cap to the coin's 8 dp, and `CosmosCoin.amount` must be an
+    /// integer base-unit string or the execute is malformed. Never round up —
+    /// funding more base units than held would fail on-chain.
     var rawAmount: String {
-        coin.decimalToCrypto(value: amount.toDecimal()).description
+        String(coin.decimalToCrypto(value: amount.toDecimal()).toInt())
     }
 
     var memo: String {
@@ -33,7 +37,12 @@ struct RUJIStakeTransactionBuilder: TransactionBuilder {
     }
 
     var wasmContractPayload: WasmExecuteContractPayload? {
-        WasmExecuteContractPayload(
+        // Sub-base-unit dust truncates to zero, which the amount validator lets
+        // through (it only rejects an exact zero). Bonding zero funds is a no-op
+        // that still costs a fee, so refuse to build it.
+        guard rawAmount != "0" else { return nil }
+
+        return WasmExecuteContractPayload(
             senderAddress: coin.address,
             contractAddress: Self.destinationAddress,
             executeMsg: """

--- a/VultisigApp/VultisigAppTests/Defi/RujiDualPositionWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/RujiDualPositionWiringTests.swift
@@ -1,0 +1,170 @@
+//
+//  RujiDualPositionWiringTests.swift
+//  VultisigAppTests
+//
+//  The three small hooks that turn `TokensStore.sruji` into RUJI's
+//  auto-compounding DeFi card. Each is a one-line mapping, and each one being
+//  wrong routes real money: without the `.compound` type the card's actions take
+//  the bonded path, and without the compound→bond mapping the transaction is
+//  built against the receipt denom instead of `x/ruji`.
+//
+
+@testable import VultisigApp
+import XCTest
+
+@MainActor
+final class RujiDualPositionWiringTests: XCTestCase {
+
+    func testSRujiIsSelectableAlongsideRujiOnTHORChain() {
+        let coins = DefiPositionsService().stakeCoins(for: .thorChain)
+        XCTAssertTrue(coins.contains(TokensStore.ruji), "the bonded position must stay selectable")
+        XCTAssertTrue(coins.contains(TokensStore.sruji), "the auto-compounding position must be selectable")
+    }
+
+    func testSRujiIsACompoundPosition() {
+        XCTAssertEqual(StakePositionType.defaultType(for: TokensStore.sruji), .compound)
+        XCTAssertEqual(StakePositionType.defaultType(for: TokensStore.ruji), .stake)
+    }
+
+    /// The compounded card's stake/unstake actions run against the BOND coin —
+    /// `liquid.bond` is funded with `x/ruji` and `liquid.unbond` is built from
+    /// the RUJI coin's decimals — so sRUJI has to map back to RUJI, like sTCY
+    /// and ybRUNE do.
+    func testCompoundedCardMapsBackToTheRujiBondCoin() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let screen = DefiChainMainScreen(vault: TestStore.makeVault(), chain: .thorChain)
+
+        XCTAssertEqual(screen.stakeCoin(for: TokensStore.sruji), TokensStore.ruji)
+        // Unchanged siblings.
+        XCTAssertEqual(screen.stakeCoin(for: TokensStore.stcy), TokensStore.tcy)
+        XCTAssertEqual(screen.stakeCoin(for: TokensStore.ybrune), TokensStore.brune)
+        // A non-compound coin maps to itself.
+        XCTAssertEqual(screen.stakeCoin(for: TokensStore.ruji), TokensStore.ruji)
+    }
+
+    /// The two cards are keyed on different denoms, which is what gives them
+    /// distinct persistent ids without a SwiftData migration.
+    func testTheTwoPositionsGetDistinctPersistentIds() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = TestStore.makeVault()
+
+        let bondedID = StakePosition.makeID(coin: TokensStore.ruji, vault: vault, stakeAccountPubkey: nil)
+        let compoundedID = StakePosition.makeID(coin: TokensStore.sruji, vault: vault, stakeAccountPubkey: nil)
+
+        XCTAssertNotEqual(bondedID, compoundedID)
+        XCTAssertTrue(bondedID.contains("x/ruji"))
+        XCTAssertTrue(compoundedID.contains("x/staking-x/ruji"))
+    }
+
+    // MARK: - Which message each card signs
+    //
+    // Both cards reach the shared stake/unstake view models on the RUJI coin, so
+    // `isAutocompound` is the ONLY thing separating two messages that move money
+    // into and out of different positions.
+
+    private func makeRujiCoin() -> Coin {
+        Coin(
+            asset: TokensStore.ruji,
+            address: "thor1fixturerujivaultaddress0000000000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+    }
+
+    private func executeMsg(_ builder: TransactionBuilder) throws -> [String: Any] {
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        return try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(payload.executeMsg.utf8)) as? [String: Any]
+        )
+    }
+
+    func testCompoundedUnstakeRedeemsTheReceiptWithLiquidUnbond() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeRujiCoin(),
+            vault: TestStore.makeVault(),
+            isAutocompound: true,
+            availableToUnstake: Decimal(string: "140.64866515")!
+        )
+        viewModel.autocompoundBalance = Decimal(string: "138.55943656")!
+        viewModel.validForm = true
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        XCTAssertNotNil(try executeMsg(builder)["liquid"])
+        let funds = try XCTUnwrap(try XCTUnwrap(builder.wasmContractPayload).coins.first)
+        XCTAssertEqual(funds.denom, "x/staking-x/ruji")
+        XCTAssertEqual(funds.amount, "13855943656")
+    }
+
+    func testBondedUnstakeWithdrawsWithAccountWithdraw() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeRujiCoin(),
+            vault: TestStore.makeVault(),
+            isAutocompound: false,
+            availableToUnstake: Decimal(string: "16382.3899")!
+        )
+        viewModel.amountField.value = "10"
+        viewModel.validForm = true
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        XCTAssertNotNil(try executeMsg(builder)["account"])
+        XCTAssertTrue(try XCTUnwrap(builder.wasmContractPayload).coins.isEmpty)
+    }
+
+    /// The compounded sheet's ceiling is the card's RUJI-denominated amount, not
+    /// the share balance, so nothing else stops a redemption being built before
+    /// the share balance has loaded (or after that read failed).
+    func testCompoundedUnstakeRefusesToBuildBeforeTheShareBalanceLoads() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = UnstakeTransactionViewModel(
+            coin: makeRujiCoin(),
+            vault: TestStore.makeVault(),
+            isAutocompound: true,
+            availableToUnstake: Decimal(string: "140.64866515")!
+        )
+        viewModel.validForm = true
+
+        XCTAssertNil(viewModel.transactionBuilder)
+    }
+
+    func testCompoundedStakeMintsTheReceiptWithLiquidBond() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = StakeTransactionViewModel(
+            coin: makeRujiCoin(),
+            vault: TestStore.makeVault(),
+            isAutocompound: true
+        )
+        viewModel.amountField.value = "10"
+        viewModel.validForm = true
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        let message = try executeMsg(builder)
+        XCTAssertNotNil(message["liquid"])
+        XCTAssertNil(message["account"])
+        let funds = try XCTUnwrap(try XCTUnwrap(builder.wasmContractPayload).coins.first)
+        XCTAssertEqual(funds.denom, "x/ruji")
+    }
+
+    func testBondedStakeDepositsWithAccountBond() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let viewModel = StakeTransactionViewModel(
+            coin: makeRujiCoin(),
+            vault: TestStore.makeVault(),
+            isAutocompound: false
+        )
+        viewModel.amountField.value = "10"
+        viewModel.validForm = true
+
+        let builder = try XCTUnwrap(viewModel.transactionBuilder)
+        let message = try executeMsg(builder)
+        XCTAssertNotNil(message["account"])
+        XCTAssertNil(message["liquid"])
+    }
+}

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/RUJIStakingTransactionBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/RUJIStakingTransactionBuilderTests.swift
@@ -87,6 +87,18 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
         XCTAssertFalse(funds.amount.contains("."), "funds amount must be an integer base-unit string")
     }
 
+    /// The amount validator only rejects an exact zero, so sub-base-unit dust
+    /// reaches the builder. Bonding zero funds is a no-op that still costs a
+    /// fee, so no payload is produced — mirroring the unbond side.
+    func testLiquidBondProducesNoPayloadBelowOneBaseUnit() {
+        let builder = RUJILiquidBondTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            amount: "0.000000009",
+            sendMaxAmount: false
+        )
+        XCTAssertNil(builder.wasmContractPayload)
+    }
+
     // MARK: - Auto-compounding unstake (liquid.unbond)
 
     func testLiquidUnbondEmitsLiquidUnbondMessage() throws {
@@ -164,6 +176,30 @@ final class RUJIStakingTransactionBuilderTests: XCTestCase {
         let funds = try XCTUnwrap(payload.coins.first)
         XCTAssertEqual(funds.denom, Self.bondDenom)
         XCTAssertEqual(funds.amount, "1000000000")
+    }
+
+    /// `CosmosCoin.amount` must be an integer base-unit string; a fractional one
+    /// is a malformed execute. The bonded builder used to stringify the raw
+    /// `Decimal`, so 9 dp produced `"112345678.9"`.
+    func testBondedStakeFundsWithAnIntegerBaseUnitString() throws {
+        let builder = RUJIStakeTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            amount: "1.123456789",
+            sendMaxAmount: false
+        )
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        let funds = try XCTUnwrap(payload.coins.first)
+        XCTAssertEqual(funds.amount, "112345678")
+        XCTAssertFalse(funds.amount.contains("."), "funds amount must be an integer base-unit string")
+    }
+
+    func testBondedStakeProducesNoPayloadBelowOneBaseUnit() {
+        let builder = RUJIStakeTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            amount: "0.000000009",
+            sendMaxAmount: false
+        )
+        XCTAssertNil(builder.wasmContractPayload)
     }
 
     /// The bonded position holds no receipt token, so its withdrawal names the

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/RUJIStakingTransactionBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/RUJIStakingTransactionBuilderTests.swift
@@ -1,0 +1,185 @@
+//
+//  RUJIStakingTransactionBuilderTests.swift
+//  VultisigAppTests
+//
+//  Pins the RUJI staking transaction builders. RUJI has TWO independent
+//  positions on one contract — bonded (`account.*`) and auto-compounding
+//  (`liquid.*`) — and they move money through different wasm executes against
+//  different denoms. A message crossing over would deposit into, or redeem from,
+//  the position the user did not choose, so the exact `executeMsg` JSON, the
+//  contract address and the funds are byte-pinned here.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class RUJIStakingTransactionBuilderTests: XCTestCase {
+
+    /// The `rujira-staking:x/ruji` contract, pinned literally so a constant
+    /// change has to be deliberate.
+    private static let stakingContract = "thor13g83nn5ef4qzqeafp0508dnvkvm0zqr3sj7eefcn5umu65gqluusrml5cr"
+    private static let receiptDenom = "x/staking-x/ruji"
+    private static let bondDenom = "x/ruji"
+
+    private static func makeRujiCoin() -> Coin {
+        let coin = Coin(
+            asset: TokensStore.ruji,
+            address: "thor1fixturerujivaultaddress0000000000000000",
+            hexPublicKey: "02" + String(repeating: "00", count: 32)
+        )
+        coin.rawBalance = "10000000000"
+        return coin
+    }
+
+    /// Parses `executeMsg` and asserts the `{ "<outer>": { "<inner>": {} } }`
+    /// shape (whitespace-independent) so the test survives formatting changes.
+    private func assertEmptyMessage(_ executeMsg: String, outer: String, inner: String) throws {
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(executeMsg.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(Array(json.keys), [outer], "executeMsg must have exactly one top-level key")
+        let branch = try XCTUnwrap(json[outer] as? [String: Any])
+        XCTAssertEqual(Array(branch.keys), [inner], "\(outer) must contain exactly \(inner)")
+        let action = try XCTUnwrap(branch[inner] as? [String: Any])
+        XCTAssertTrue(action.isEmpty, "\(inner) must be an empty object")
+    }
+
+    // MARK: - Contract pin
+
+    func testConstantMatchesTheDeployedStakingContract() {
+        XCTAssertEqual(RUJIStakingConstants.contract, Self.stakingContract)
+        XCTAssertEqual(TokensStore.ruji.contractAddress, Self.bondDenom)
+        XCTAssertEqual(TokensStore.sruji.contractAddress, Self.receiptDenom)
+    }
+
+    // MARK: - Auto-compounding stake (liquid.bond)
+
+    func testLiquidBondEmitsLiquidBondMessage() throws {
+        let builder = RUJILiquidBondTransactionBuilder(coin: Self.makeRujiCoin(), amount: "10", sendMaxAmount: false)
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        try assertEmptyMessage(payload.executeMsg, outer: "liquid", inner: "bond")
+        XCTAssertEqual(payload.contractAddress, Self.stakingContract)
+        XCTAssertEqual(payload.senderAddress, Self.makeRujiCoin().address)
+        XCTAssertEqual(builder.transactionType, .genericContract)
+    }
+
+    func testLiquidBondFundsWithTheBondDenom() throws {
+        let builder = RUJILiquidBondTransactionBuilder(coin: Self.makeRujiCoin(), amount: "10", sendMaxAmount: false)
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        XCTAssertEqual(payload.coins.count, 1)
+        let funds = try XCTUnwrap(payload.coins.first)
+        XCTAssertEqual(funds.denom, Self.bondDenom)
+        // 10 RUJI at 8 decimals → 1_000_000_000 base units.
+        XCTAssertEqual(funds.amount, "1000000000")
+    }
+
+    func testLiquidBondTruncatesSubBaseUnitPrecision() throws {
+        // 9 dp exceeds RUJI's 8 dp: 1.123456789 × 1e8 = 112345678.9, which must
+        // round DOWN to an integer base-unit string.
+        let builder = RUJILiquidBondTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            amount: "1.123456789",
+            sendMaxAmount: false
+        )
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        let funds = try XCTUnwrap(payload.coins.first)
+        XCTAssertEqual(funds.amount, "112345678")
+        XCTAssertFalse(funds.amount.contains("."), "funds amount must be an integer base-unit string")
+    }
+
+    // MARK: - Auto-compounding unstake (liquid.unbond)
+
+    func testLiquidUnbondEmitsLiquidUnbondMessage() throws {
+        let builder = RUJILiquidUnbondTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            percentage: 100,
+            receiptShares: Decimal(string: "138.55943656")!,
+            sendMaxAmount: true
+        )
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        try assertEmptyMessage(payload.executeMsg, outer: "liquid", inner: "unbond")
+        XCTAssertEqual(payload.contractAddress, Self.stakingContract)
+        XCTAssertEqual(builder.transactionType, .genericContract)
+    }
+
+    /// At 100% the EXACT held share balance is redeemed — no rounding dust, and
+    /// it can never exceed what is held even if the share price moved since the
+    /// sheet opened. This is what makes the percentage-driven redemption safe
+    /// without a share-price conversion.
+    func testLiquidUnbondRedeemsTheExactShareBalanceAtFullPercentage() throws {
+        let builder = RUJILiquidUnbondTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            percentage: 100,
+            receiptShares: Decimal(string: "138.55943656")!,
+            sendMaxAmount: true
+        )
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        XCTAssertEqual(payload.coins.count, 1)
+        let funds = try XCTUnwrap(payload.coins.first)
+        XCTAssertEqual(funds.denom, Self.receiptDenom)
+        XCTAssertEqual(funds.amount, "13855943656")
+    }
+
+    func testLiquidUnbondScalesSharesByPercentage() throws {
+        let builder = RUJILiquidUnbondTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            percentage: 50,
+            receiptShares: Decimal(string: "138.55943656")!,
+            sendMaxAmount: false
+        )
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        let funds = try XCTUnwrap(payload.coins.first)
+        XCTAssertEqual(funds.amount, "6927971828")
+    }
+
+    /// Redeeming zero shares is a no-op the contract would reject, so the
+    /// builder produces no payload rather than an empty unbond.
+    func testLiquidUnbondProducesNoPayloadBelowOneBaseUnit() {
+        let builder = RUJILiquidUnbondTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            percentage: 1,
+            receiptShares: Decimal(string: "0.00000001")!,
+            sendMaxAmount: false
+        )
+        XCTAssertNil(builder.wasmContractPayload)
+    }
+
+    func testLiquidUnbondProducesNoPayloadWithoutAShareBalance() {
+        let builder = RUJILiquidUnbondTransactionBuilder(
+            coin: Self.makeRujiCoin(),
+            percentage: 100,
+            receiptShares: 0,
+            sendMaxAmount: true
+        )
+        XCTAssertNil(builder.wasmContractPayload)
+    }
+
+    // MARK: - Bonded position stays on the account.* messages
+
+    func testBondedStakeStillEmitsAccountBondFundedWithRuji() throws {
+        let builder = RUJIStakeTransactionBuilder(coin: Self.makeRujiCoin(), amount: "10", sendMaxAmount: false)
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        try assertEmptyMessage(payload.executeMsg, outer: "account", inner: "bond")
+        XCTAssertEqual(payload.contractAddress, Self.stakingContract)
+        let funds = try XCTUnwrap(payload.coins.first)
+        XCTAssertEqual(funds.denom, Self.bondDenom)
+        XCTAssertEqual(funds.amount, "1000000000")
+    }
+
+    /// The bonded position holds no receipt token, so its withdrawal names the
+    /// amount in the message and sends no funds — the mirror image of
+    /// `liquid.unbond`.
+    func testBondedUnstakeStillEmitsAccountWithdrawWithNoFunds() throws {
+        let builder = RUJIUnstakeTransactionBuilder(coin: Self.makeRujiCoin(), amount: "10", sendMaxAmount: false)
+        let payload = try XCTUnwrap(builder.wasmContractPayload)
+        XCTAssertEqual(payload.contractAddress, Self.stakingContract)
+        XCTAssertTrue(payload.coins.isEmpty, "account.withdraw carries no funds")
+
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: Data(payload.executeMsg.utf8)) as? [String: Any]
+        )
+        let account = try XCTUnwrap(json["account"] as? [String: Any])
+        let withdraw = try XCTUnwrap(account["withdraw"] as? [String: Any])
+        XCTAssertEqual(withdraw["amount"] as? String, "1000000000")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Migration/RujiAutoCompoundPositionMigrationTests.swift
+++ b/VultisigApp/VultisigAppTests/Migration/RujiAutoCompoundPositionMigrationTests.swift
@@ -1,0 +1,208 @@
+//
+//  RujiAutoCompoundPositionMigrationTests.swift
+//  VultisigAppTests
+//
+//  RUJI's auto-compounding position used to live under the single "RUJI"
+//  toggle. Now that it is its own selectable position, a vault that was already
+//  auto-compounding would lose its card until the user discovered the new sRUJI
+//  entry — so the migration opts those vaults in. These pin that it opts in
+//  exactly once, and only where it should.
+//
+
+import SwiftData
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class RujiAutoCompoundPositionMigrationTests: XCTestCase {
+    private var token: TestContextToken?
+
+    override func setUpWithError() throws {
+        token = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDownWithError() throws {
+        TestStore.restore(token)
+        token = nil
+    }
+
+    /// Builds a vault with unique values for EVERY `@Attribute(.unique)` field.
+    /// `TestStore.makeVault` varies only `pubKeyECDSA`, so two of its vaults in
+    /// one test collapse into a single row via the unique `pubKeyEdDSA` — and
+    /// this migration has to be exercised across several vaults at once.
+    private func makeVault(staking: [CoinMeta], chain: Chain = .thorChain) throws -> Vault {
+        let id = UUID().uuidString
+        let vault = Vault(
+            name: "Test Vault \(id)",
+            signers: [],
+            pubKeyECDSA: "ecdsa-\(id)",
+            pubKeyEdDSA: "eddsa-\(id)",
+            keyshares: [],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        Storage.shared.modelContext.insert(vault)
+        vault.defiPositions.append(DefiPositions(chain: chain, bonds: [], staking: staking, lps: []))
+        try Storage.shared.save()
+        return vault
+    }
+
+    private func stakingTickers(_ vault: Vault, chain: Chain = .thorChain) -> [String] {
+        (vault.defiPositions.first { $0.chain == chain }?.staking ?? [])
+            .map { $0.ticker.uppercased() }
+            .sorted()
+    }
+
+    func testEnablesSRujiForVaultsTrackingRuji() throws {
+        let vault = try makeVault(staking: [TokensStore.ruji])
+
+        try RujiAutoCompoundPositionMigration().migrate()
+
+        XCTAssertEqual(stakingTickers(vault), ["RUJI", "SRUJI"])
+        XCTAssertTrue(
+            vault.defiPositions.first { $0.chain == .thorChain }?.staking
+                .contains { $0.contractAddress == "x/staking-x/ruji" } ?? false,
+            "sRUJI must be added under its real on-chain denom"
+        )
+    }
+
+    func testIsIdempotent() throws {
+        let vault = try makeVault(staking: [TokensStore.ruji])
+
+        try RujiAutoCompoundPositionMigration().migrate()
+        try RujiAutoCompoundPositionMigration().migrate()
+
+        XCTAssertEqual(stakingTickers(vault), ["RUJI", "SRUJI"])
+    }
+
+    /// The contains-check is what keeps a deliberate opt-out from being undone.
+    func testLeavesVaultsThatAlreadyTrackSRujiAlone() throws {
+        let vault = try makeVault(staking: [TokensStore.ruji, TokensStore.sruji])
+
+        try RujiAutoCompoundPositionMigration().migrate()
+
+        XCTAssertEqual(stakingTickers(vault), ["RUJI", "SRUJI"])
+    }
+
+    func testLeavesVaultsWithoutRujiAlone() throws {
+        let vault = try makeVault(staking: [TokensStore.tcy])
+
+        try RujiAutoCompoundPositionMigration().migrate()
+
+        XCTAssertEqual(stakingTickers(vault), ["TCY"])
+    }
+
+    func testLeavesVaultsWithoutAnyThorchainPositionsAlone() throws {
+        let vault = TestStore.makeVault()
+        try Storage.shared.save()
+
+        try RujiAutoCompoundPositionMigration().migrate()
+
+        XCTAssertTrue(vault.defiPositions.isEmpty)
+    }
+
+    func testMigratesEveryVaultIndependently() throws {
+        let withRuji = try makeVault(staking: [TokensStore.ruji])
+        let withoutRuji = try makeVault(staking: [TokensStore.tcy])
+
+        try RujiAutoCompoundPositionMigration().migrate()
+
+        XCTAssertEqual(stakingTickers(withRuji), ["RUJI", "SRUJI"])
+        XCTAssertEqual(stakingTickers(withoutRuji), ["TCY"])
+    }
+
+    /// The migration only widens the position list; it must not touch the other
+    /// chains' selections.
+    func testDoesNotTouchOtherChains() throws {
+        let vault = try makeVault(staking: [TokensStore.cacao], chain: .mayaChain)
+        vault.defiPositions.append(
+            DefiPositions(chain: .thorChain, bonds: [], staking: [TokensStore.ruji], lps: [])
+        )
+        try Storage.shared.save()
+
+        try RujiAutoCompoundPositionMigration().migrate()
+
+        XCTAssertEqual(stakingTickers(vault, chain: .mayaChain), ["CACAO"])
+        XCTAssertEqual(stakingTickers(vault), ["RUJI", "SRUJI"])
+    }
+
+    /// Registered with `AppMigrationService`, so it actually runs on launch —
+    /// driven through the real service with a seeded version so only migrations
+    /// newer than the shipped ones execute.
+    func testIsRunByTheMigrationService() throws {
+        let vault = try makeVault(staking: [TokensStore.ruji])
+        let keychain = MockKeychainService(lastMigratedVersion: PromoBannerDismissalMigration().version)
+
+        AppMigrationService(keychainService: keychain).performMigrationsIfNeeded()
+
+        XCTAssertEqual(stakingTickers(vault), ["RUJI", "SRUJI"])
+        XCTAssertEqual(
+            keychain.lastMigratedVersion,
+            RujiAutoCompoundPositionMigration().version,
+            "the migration version must ratchet forward so it does not re-run"
+        )
+    }
+
+    /// Already migrated ⇒ nothing runs, which is what stops a deliberate opt-out
+    /// being undone on every launch.
+    func testDoesNotRunAgainOnceTheVersionHasRatchetedForward() throws {
+        let vault = try makeVault(staking: [TokensStore.ruji])
+        let keychain = MockKeychainService(lastMigratedVersion: RujiAutoCompoundPositionMigration().version)
+
+        AppMigrationService(keychainService: keychain).performMigrationsIfNeeded()
+
+        XCTAssertEqual(stakingTickers(vault), ["RUJI"])
+    }
+
+    /// End to end: a vault that was auto-compounding under the old single-card
+    /// model gets its compounded card back from the very next refresh, without
+    /// the migration writing anything into `vault.coins` — THORChain discovery
+    /// has already added the receipt for any vault that holds one.
+    func testMigratedVaultThatHoldsTheReceiptEmitsTheCompoundedCard() async throws {
+        let vault = try makeVault(staking: [TokensStore.ruji])
+        let address = "thor1fixturevaultaddress00000000000000000000"
+        let hexPublicKey = "02" + String(repeating: "00", count: 32)
+        vault.coins.append(Coin(asset: TokensStore.rune, address: address, hexPublicKey: hexPublicKey))
+        vault.coins.append(Coin(asset: TokensStore.ruji, address: address, hexPublicKey: hexPublicKey))
+        // Added by THORChain token discovery because the vault holds the receipt.
+        vault.coins.append(Coin(asset: TokensStore.sruji, address: address, hexPublicKey: hexPublicKey))
+        try Storage.shared.save()
+
+        try RujiAutoCompoundPositionMigration().migrate()
+
+        let details = StakingDetails(
+            stakedAmount: 0,
+            autoCompoundAmount: Decimal(string: "14064.86651509")!,
+            apr: nil,
+            estimatedReward: nil,
+            nextPayoutDate: nil,
+            rewards: nil,
+            rewardsCoin: nil
+        )
+        let dtos = await THORChainStakeInteractor(stakingService: MockTHORChainStakingService(details: details))
+            .fetchStakePositions(vault: vault)
+
+        let compounded = try XCTUnwrap(dtos.first { $0.coin.ticker.uppercased() == "SRUJI" })
+        XCTAssertEqual(compounded.amount, Decimal(string: "14064.86651509"))
+        XCTAssertEqual(compounded.type, .compound)
+    }
+
+    /// Newer than every shipped migration, so registering it does not replay them.
+    func testVersionIsAheadOfTheShippedMigrations() {
+        XCTAssertEqual(RujiAutoCompoundPositionMigration().version, 3)
+        XCTAssertGreaterThan(
+            RujiAutoCompoundPositionMigration().version,
+            PromoBannerDismissalMigration().version
+        )
+        XCTAssertGreaterThan(
+            RujiAutoCompoundPositionMigration().version,
+            TonGramRebrandMigration().version
+        )
+        XCTAssertGreaterThan(
+            RujiAutoCompoundPositionMigration().version,
+            THORChainDuplicateTokensMigration().version
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -1,0 +1,42 @@
+//
+//  MockKeychainService.swift
+//  VultisigAppTests
+//
+
+import Foundation
+@testable import VultisigApp
+
+/// In-memory `KeychainService` so migration-ordering behaviour can be driven
+/// without touching the real Keychain (which persists across test runs and
+/// across app reinstalls).
+final class MockKeychainService: KeychainService {
+    var lastMigratedVersion: Int?
+
+    private var fastPasswords: [String: String] = [:]
+    private var fastHints: [String: String] = [:]
+    private var deviceToken: String?
+
+    init(lastMigratedVersion: Int? = nil) {
+        self.lastMigratedVersion = lastMigratedVersion
+    }
+
+    func getFastPassword(pubKeyECDSA: String) -> String? { fastPasswords[pubKeyECDSA] }
+
+    func setFastPassword(_ fastPassword: String?, pubKeyECDSA: String) {
+        fastPasswords[pubKeyECDSA] = fastPassword
+    }
+
+    func getFastHint(pubKeyECDSA: String) -> String? { fastHints[pubKeyECDSA] }
+
+    func setFastHint(_ fastHint: String?, pubKeyECDSA: String) {
+        fastHints[pubKeyECDSA] = fastHint
+    }
+
+    func getLastMigratedVersion() -> Int? { lastMigratedVersion }
+
+    func setLastMigratedVersion(_ version: Int?) { lastMigratedVersion = version }
+
+    func getDeviceToken() -> String? { deviceToken }
+
+    func setDeviceToken(_ token: String?) { deviceToken = token }
+}

--- a/VultisigApp/VultisigAppTests/Mocks/MockTHORChainStakingService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockTHORChainStakingService.swift
@@ -1,0 +1,29 @@
+//
+//  MockTHORChainStakingService.swift
+//  VultisigAppTests
+//
+
+import Foundation
+@testable import VultisigApp
+
+// swiftlint:disable unused_parameter async_without_await
+
+/// Returns a fixed staking snapshot so the THORChain staking branches can be
+/// driven without the network.
+struct MockTHORChainStakingService: THORChainStakingProviding {
+    let details: StakingDetails
+
+    func fetchStakingDetails(coinMeta: CoinMeta, runeCoinMeta: CoinMeta, address: String) async throws -> StakingDetails {
+        details
+    }
+}
+
+/// Fails every read, so callers can be checked for keeping the last known
+/// position rather than reporting a zero.
+struct FailingTHORChainStakingService: THORChainStakingProviding {
+    func fetchStakingDetails(coinMeta: CoinMeta, runeCoinMeta: CoinMeta, address: String) async throws -> StakingDetails {
+        throw StakingError.invalidResponse
+    }
+}
+
+// swiftlint:enable unused_parameter async_without_await

--- a/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
@@ -88,10 +88,11 @@ final class THORChainStakeInteractorTests: XCTestCase {
 
     // MARK: - fetchStakePositions early-return paths
     //
-    // Branching tests for TCY/RUJI/STCY/YRUNE/default require injecting
-    // `THORChainStakingService` and `ThorchainService` (currently global singletons).
-    // Tracked under [[projects/vultisig/defi-tab-fixes/architecture-review]] as the next
-    // testability win — extract a protocol for the staking service.
+    // The TCY/RUJI/SRUJI branches are driven through the injected
+    // `THORChainStakingProviding`. STCY/YBRUNE still read `ThorchainService`
+    // (a global singleton), so their branches remain uncovered — tracked under
+    // [[projects/vultisig/defi-tab-fixes/architecture-review]] as the next
+    // testability win.
 
     func testFetchStakePositionsReturnsEmptyWithoutRuneCoin() async throws {
         let token = try TestStore.installInMemoryContainer()
@@ -100,5 +101,361 @@ final class THORChainStakeInteractorTests: XCTestCase {
         // No RUNE coin in vault → guard short-circuits.
         let result = await THORChainStakeInteractor().fetchStakePositions(vault: vault)
         XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - RUJI's two independent positions
+    //
+    // A Rujira account can hold a bonded position (claimable USDC, `account.*`)
+    // and an auto-compounding one (sRUJI receipt, `liquid.*`) at the same time.
+    // The interactor must report each on its own card: collapsing them lets one
+    // side's zero hide the other side's balance, which is what disabled Unstake
+    // for bonded-only holders.
+
+    /// Live shape from the Rujira staking API for an account holding both sides.
+    private func makeRujiDetails(bonded: Decimal, liquidSize: Decimal) -> StakingDetails {
+        StakingDetails(
+            stakedAmount: bonded,
+            autoCompoundAmount: liquidSize,
+            apr: 0.039662357617,
+            estimatedReward: nil,
+            nextPayoutDate: nil,
+            rewards: Decimal(string: "31.12926996")!,
+            rewardsCoin: CoinMeta(
+                chain: .thorChain,
+                ticker: "USDC",
+                logo: "usdc",
+                decimals: 6,
+                priceProviderId: "usd-coin",
+                contractAddress: "USDC",
+                isNativeToken: false
+            )
+        )
+    }
+
+    private func makeRujiVault(staking: [CoinMeta], holding: [CoinMeta]) -> Vault {
+        let vault = TestStore.makeVault()
+        let address = "thor1fixturevaultaddress00000000000000000000"
+        let hexPublicKey = "02" + String(repeating: "00", count: 32)
+        vault.coins.append(Coin(asset: TokensStore.rune, address: address, hexPublicKey: hexPublicKey))
+        for meta in holding {
+            vault.coins.append(Coin(asset: meta, address: address, hexPublicKey: hexPublicKey))
+        }
+        vault.defiPositions.append(DefiPositions(chain: .thorChain, bonds: [], staking: staking, lps: []))
+        return vault
+    }
+
+    private func position(_ dtos: [StakePositionData], ticker: String) throws -> StakePositionData {
+        try XCTUnwrap(dtos.first { $0.coin.ticker.uppercased() == ticker.uppercased() })
+    }
+
+    func testVaultHoldingBothRujiPositionsGetsOneCardEach() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = makeRujiVault(
+            staking: [TokensStore.ruji, TokensStore.sruji],
+            holding: [TokensStore.ruji, TokensStore.sruji]
+        )
+        let details = makeRujiDetails(
+            bonded: Decimal(string: "16382.3899")!,
+            liquidSize: Decimal(string: "14064.86651509")!
+        )
+
+        let dtos = await THORChainStakeInteractor(stakingService: MockTHORChainStakingService(details: details))
+            .fetchStakePositions(vault: vault)
+
+        XCTAssertEqual(dtos.count, 2)
+        let bonded = try position(dtos, ticker: "RUJI")
+        let compounded = try position(dtos, ticker: "SRUJI")
+        XCTAssertEqual(bonded.amount, Decimal(string: "16382.3899"))
+        XCTAssertEqual(bonded.type, .stake)
+        XCTAssertEqual(compounded.amount, Decimal(string: "14064.86651509"))
+        XCTAssertEqual(compounded.type, .compound)
+    }
+
+    /// The regression this fix exists for: a bonded-only holder used to see a
+    /// zero card because the on-chain sRUJI receipt read (a genuine zero) won,
+    /// and `canUnstake` keys off the displayed amount.
+    func testBondedOnlyVaultKeepsAnUnstakableBondedCard() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = makeRujiVault(
+            staking: [TokensStore.ruji, TokensStore.sruji],
+            holding: [TokensStore.ruji, TokensStore.sruji]
+        )
+        let details = makeRujiDetails(bonded: Decimal(string: "16382.3899")!, liquidSize: 0)
+
+        let dtos = await THORChainStakeInteractor(stakingService: MockTHORChainStakingService(details: details))
+            .fetchStakePositions(vault: vault)
+
+        let bonded = try position(dtos, ticker: "RUJI")
+        XCTAssertEqual(bonded.amount, Decimal(string: "16382.3899"))
+        XCTAssertTrue(StakePosition(bonded, vault: vault).canUnstake)
+        XCTAssertEqual(try position(dtos, ticker: "SRUJI").amount, 0)
+    }
+
+    /// The mirror-image regression: an auto-compounding holder must see the
+    /// RUJI-denominated liquid size, and must be able to unstake it.
+    func testAutoCompoundOnlyVaultKeepsAnUnstakableCompoundedCard() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = makeRujiVault(
+            staking: [TokensStore.ruji, TokensStore.sruji],
+            holding: [TokensStore.ruji, TokensStore.sruji]
+        )
+        let details = makeRujiDetails(bonded: 0, liquidSize: Decimal(string: "14064.86651509")!)
+
+        let dtos = await THORChainStakeInteractor(stakingService: MockTHORChainStakingService(details: details))
+            .fetchStakePositions(vault: vault)
+
+        let compounded = try position(dtos, ticker: "SRUJI")
+        XCTAssertEqual(compounded.amount, Decimal(string: "14064.86651509"))
+        XCTAssertTrue(StakePosition(compounded, vault: vault).canUnstake)
+        XCTAssertEqual(try position(dtos, ticker: "RUJI").amount, 0)
+    }
+
+    /// Revenue on the auto-compounding side is reinvested rather than made
+    /// claimable, so the APR and the pending USDC belong to the bonded card only
+    /// — the compounded card is stat-free, like sTCY.
+    func testAprAndClaimableRevenueRideOnTheBondedCardOnly() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = makeRujiVault(
+            staking: [TokensStore.ruji, TokensStore.sruji],
+            holding: [TokensStore.ruji, TokensStore.sruji]
+        )
+        let details = makeRujiDetails(
+            bonded: Decimal(string: "16382.3899")!,
+            liquidSize: Decimal(string: "14064.86651509")!
+        )
+
+        let dtos = await THORChainStakeInteractor(stakingService: MockTHORChainStakingService(details: details))
+            .fetchStakePositions(vault: vault)
+
+        let bonded = try position(dtos, ticker: "RUJI")
+        XCTAssertEqual(try XCTUnwrap(bonded.apr), 0.039662357617, accuracy: 1e-12)
+        XCTAssertEqual(bonded.rewards, Decimal(string: "31.12926996"))
+        XCTAssertEqual(bonded.rewardCoin?.ticker, "USDC")
+
+        let compounded = try position(dtos, ticker: "SRUJI")
+        XCTAssertNil(compounded.apr)
+        XCTAssertNil(compounded.rewards)
+        XCTAssertNil(compounded.rewardCoin)
+    }
+
+    /// An empty vault still gets both cards at zero, so the persisted rows are
+    /// zeroed by the refresh rather than frozen at their last non-zero value
+    /// (`upsert(stake:for:)` has no delete-stale), and there is a card to stake
+    /// into.
+    func testEmptyVaultStillReportsBothPositionsAtZero() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = makeRujiVault(
+            staking: [TokensStore.ruji, TokensStore.sruji],
+            holding: [TokensStore.ruji, TokensStore.sruji]
+        )
+
+        let dtos = await THORChainStakeInteractor(stakingService: MockTHORChainStakingService(details: makeRujiDetails(bonded: 0, liquidSize: 0)))
+            .fetchStakePositions(vault: vault)
+
+        XCTAssertEqual(dtos.count, 2)
+        XCTAssertEqual(try position(dtos, ticker: "RUJI").amount, 0)
+        XCTAssertEqual(try position(dtos, ticker: "SRUJI").amount, 0)
+        XCTAssertFalse(StakePosition(try position(dtos, ticker: "SRUJI"), vault: vault).canUnstake)
+    }
+
+    func testOnlyEnabledPositionsAreReported() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = makeRujiVault(
+            staking: [TokensStore.ruji],
+            holding: [TokensStore.ruji, TokensStore.sruji]
+        )
+        let details = makeRujiDetails(
+            bonded: Decimal(string: "16382.3899")!,
+            liquidSize: Decimal(string: "14064.86651509")!
+        )
+
+        let dtos = await THORChainStakeInteractor(stakingService: MockTHORChainStakingService(details: details))
+            .fetchStakePositions(vault: vault)
+
+        XCTAssertEqual(dtos.map { $0.coin.ticker.uppercased() }, ["RUJI"])
+    }
+
+    /// The opt-in migration enables sRUJI for every vault tracking RUJI, so the
+    /// vaults that never held the receipt must stay one-card.
+    func testEnabledPositionIsNotReportedWhenTheVaultDoesNotHoldTheCoin() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = makeRujiVault(
+            staking: [TokensStore.ruji, TokensStore.sruji],
+            holding: [TokensStore.ruji]
+        )
+        let details = makeRujiDetails(
+            bonded: Decimal(string: "16382.3899")!,
+            liquidSize: Decimal(string: "14064.86651509")!
+        )
+
+        let dtos = await THORChainStakeInteractor(stakingService: MockTHORChainStakingService(details: details))
+            .fetchStakePositions(vault: vault)
+
+        XCTAssertEqual(dtos.map { $0.coin.ticker.uppercased() }, ["RUJI"])
+    }
+
+    /// A failed read reports nothing so the persisted rows keep their last good
+    /// amounts instead of flickering to zero.
+    func testFailedStakingReadReportsNoPositions() async throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let vault = makeRujiVault(
+            staking: [TokensStore.ruji, TokensStore.sruji],
+            holding: [TokensStore.ruji, TokensStore.sruji]
+        )
+
+        let dtos = await THORChainStakeInteractor(stakingService: FailingTHORChainStakingService())
+            .fetchStakePositions(vault: vault)
+
+        XCTAssertTrue(dtos.isEmpty)
+    }
+
+    // MARK: - liquidSize plumbing
+
+    /// The auto-compounding amount has no other source, so the query must ask
+    /// for it.
+    func testRujiStakingQueryRequestsLiquidSize() throws {
+        guard case .requestParameters(let body, _) = THORChainStakingAPI.getRujiStaking(address: "thor1abc").task else {
+            return XCTFail("Expected a GraphQL body")
+        }
+        let query = try XCTUnwrap(body["query"] as? String)
+        XCTAssertTrue(query.contains("liquidSize"), "query must request liquidSize")
+        XCTAssertTrue(query.contains("bonded"), "query must still request bonded")
+    }
+
+    /// Captured live from the Rujira endpoint for an account holding both
+    /// positions (bonded 16382.3899 RUJI, 13855.94365632 sRUJI shares worth
+    /// 14064.86651509 RUJI).
+    func testAccountResponseDecodesBothPositions() throws {
+        let json = """
+        {"data":{"node":{"stakingV2":[{
+          "account":"thor1qvmeavyusxyet7szr2azjzut7tamw4ycfg08ss",
+          "bonded":{"amount":"1638238990000","asset":{"metadata":{"symbol":"RUJI"}}},
+          "liquidSize":{"amount":"1406486651509"},
+          "pendingRevenue":{"amount":"3112926996","asset":{"metadata":{"symbol":"USDC"}}},
+          "pool":{"summary":{"apr":{"value":"39662357617","status":"AVAILABLE"}}}
+        }]}}}
+        """
+        let decoded = try JSONDecoder().decode(AccountRootData.self, from: Data(json.utf8))
+        let stake = try XCTUnwrap(decoded.data.node?.stakingV2?.first)
+
+        XCTAssertEqual(stake.bonded.amount, "1638238990000")
+        XCTAssertEqual(stake.liquidSize?.amount, "1406486651509")
+        XCTAssertEqual(stake.pendingRevenue?.amount, "3112926996")
+        XCTAssertEqual(try XCTUnwrap(stake.pool?.summary?.apr?.fractionalRate), 0.039662357617, accuracy: 1e-12)
+    }
+
+    // MARK: - Account payload → StakingDetails
+    //
+    // The base-unit scaling is the step that turns `1406486651509` into the
+    // 14064.86651509 RUJI the card renders, and it is the same call the DeFi tab
+    // makes in production.
+
+    private func makeAccountResponse(
+        bonded: String = "1638238990000",
+        liquidSize: String? = "1406486651509",
+        pendingRevenue: String = "3112926996",
+        bondSymbol: String = "RUJI",
+        extraPools: String = ""
+    ) -> String {
+        let liquidSizeField = liquidSize.map { "\"liquidSize\":{\"amount\":\"\($0)\"}," } ?? ""
+        return """
+        {"data":{"node":{"stakingV2":[\(extraPools){
+          "account":"thor1qvmeavyusxyet7szr2azjzut7tamw4ycfg08ss",
+          "bonded":{"amount":"\(bonded)","asset":{"metadata":{"symbol":"\(bondSymbol)"}}},
+          \(liquidSizeField)
+          "pendingRevenue":{"amount":"\(pendingRevenue)","asset":{"metadata":{"symbol":"USDC"}}},
+          "pool":{"summary":{"apr":{"value":"39662357617","status":"AVAILABLE"}}}
+        }]}}}
+        """
+    }
+
+    private func makeDetails(from json: String) throws -> StakingDetails {
+        let decoded = try JSONDecoder().decode(AccountRootData.self, from: Data(json.utf8))
+        return try THORChainStakingService.makeRujiStakingDetails(from: decoded)
+    }
+
+    func testAccountPayloadScalesBothPositionsOutOfBaseUnits() throws {
+        let details = try makeDetails(from: makeAccountResponse())
+
+        XCTAssertEqual(details.stakedAmount, Decimal(string: "16382.3899"))
+        XCTAssertEqual(details.autoCompoundAmount, Decimal(string: "14064.86651509"))
+        XCTAssertEqual(details.rewards, Decimal(string: "31.12926996"))
+        XCTAssertEqual(try XCTUnwrap(details.apr), 0.039662357617, accuracy: 1e-12)
+        XCTAssertEqual(details.rewardsCoin?.ticker, "USDC")
+        XCTAssertEqual(details.rewardsCoin?.decimals, 6)
+    }
+
+    /// The auto-compounding amount must NOT fall back to the bonded one — that
+    /// substitution is the bug the split fixes.
+    func testAccountPayloadKeepsTheTwoAmountsIndependent() throws {
+        let bondedOnly = try makeDetails(from: makeAccountResponse(liquidSize: "0"))
+        XCTAssertEqual(bondedOnly.stakedAmount, Decimal(string: "16382.3899"))
+        XCTAssertEqual(bondedOnly.autoCompoundAmount, 0)
+
+        let compoundOnly = try makeDetails(from: makeAccountResponse(bonded: "0"))
+        XCTAssertEqual(compoundOnly.stakedAmount, 0)
+        XCTAssertEqual(compoundOnly.autoCompoundAmount, Decimal(string: "14064.86651509"))
+    }
+
+    /// `stakingV2` holds one entry per Rujira staking pool the account touches
+    /// and the RUJI one is not necessarily first, so the pool is selected by its
+    /// bond-asset symbol.
+    func testAccountPayloadSelectsTheRujiPoolNotTheFirstOne() throws {
+        let otherPool = """
+        {"account":"thor1other","bonded":{"amount":"999900000000","asset":{"metadata":{"symbol":"TCY"}}},
+         "liquidSize":{"amount":"888800000000"},
+         "pendingRevenue":{"amount":"0","asset":{"metadata":{"symbol":"USDC"}}}},
+        """
+        let details = try makeDetails(from: makeAccountResponse(extraPools: otherPool))
+
+        XCTAssertEqual(details.stakedAmount, Decimal(string: "16382.3899"))
+        XCTAssertEqual(details.autoCompoundAmount, Decimal(string: "14064.86651509"))
+    }
+
+    func testAccountPayloadWithoutARujiPoolIsAGenuineZero() throws {
+        let details = try makeDetails(from: makeAccountResponse(bondSymbol: "TCY"))
+
+        XCTAssertEqual(details.stakedAmount, 0)
+        XCTAssertEqual(details.autoCompoundAmount, 0)
+    }
+
+    /// A partial response must fail rather than report a zero, which would erase
+    /// a live position on the next upsert.
+    func testAccountPayloadWithoutALiquidSizeFailsClosed() {
+        XCTAssertThrowsError(try makeDetails(from: makeAccountResponse(liquidSize: nil)))
+    }
+
+    func testAccountPayloadWithAnUnparseableBondedAmountFailsClosed() {
+        XCTAssertThrowsError(try makeDetails(from: makeAccountResponse(bonded: "not-a-number")))
+    }
+
+    func testAccountPayloadWithAnUnparseableLiquidSizeFailsClosed() {
+        XCTAssertThrowsError(try makeDetails(from: makeAccountResponse(liquidSize: "not-a-number")))
+    }
+
+    /// Revenue is a claim CTA on an otherwise-complete card, so an unparseable
+    /// value must not take the two position balances down with it.
+    func testAccountPayloadKeepsTheBalancesWhenRevenueIsUnparseable() throws {
+        let details = try makeDetails(from: makeAccountResponse(pendingRevenue: "not-a-number"))
+
+        XCTAssertEqual(details.stakedAmount, Decimal(string: "16382.3899"))
+        XCTAssertEqual(details.autoCompoundAmount, Decimal(string: "14064.86651509"))
+        XCTAssertEqual(details.rewards, 0)
+    }
+
+    func testAccountPayloadWithoutANodeFailsClosed() {
+        XCTAssertThrowsError(try makeDetails(from: #"{"data":{"node":null}}"#))
+    }
+
+    func testAccountPayloadWithoutStakingEntriesFailsClosed() {
+        XCTAssertThrowsError(try makeDetails(from: #"{"data":{"node":{"stakingV2":null}}}"#))
     }
 }

--- a/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/THORChainStakeInteractorTests.swift
@@ -45,40 +45,6 @@ final class THORChainStakeInteractorTests: XCTestCase {
         XCTAssertEqual(result, Decimal(string: "0.00000001"))
     }
 
-    // MARK: - resolveRujiStakedAmount (prefer on-chain receipt over API bonded)
-
-    func testResolveRujiStakedAmountPrefersOnChainReceiptOverBonded() {
-        // On-chain receipt read succeeded (raw 8_833_889_972 → 88.33889972); the API `bonded`
-        // amount is ignored even though it differs.
-        let result = THORChainStakeInteractor.resolveRujiStakedAmount(
-            onChainRaw: 8_833_889_972,
-            bonded: Decimal(string: "5")!,
-            decimals: 8
-        )
-        XCTAssertEqual(result, Decimal(string: "88.33889972"))
-    }
-
-    func testResolveRujiStakedAmountSuccessfulOnChainZeroStaysZero() {
-        // A genuine on-chain zero must NOT fall back to a stale non-zero `bonded`.
-        let result = THORChainStakeInteractor.resolveRujiStakedAmount(
-            onChainRaw: 0,
-            bonded: Decimal(string: "5")!,
-            decimals: 8
-        )
-        XCTAssertEqual(result, 0)
-    }
-
-    func testResolveRujiStakedAmountFallsBackToBondedWhenOnChainNil() {
-        // On-chain read failed (nil) → fall back to the API `bonded` amount (already scaled).
-        let bonded = Decimal(string: "12.5")!
-        let result = THORChainStakeInteractor.resolveRujiStakedAmount(
-            onChainRaw: nil,
-            bonded: bonded,
-            decimals: 8
-        )
-        XCTAssertEqual(result, bonded)
-    }
-
     // MARK: - APR fractionalRate
 
     /// Per the Rujira GraphQL schema, `Bigint` decimal scalars are scaled to 12 decimal places.

--- a/VultisigApp/VultisigAppTests/Services/ThorchainSRujiTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ThorchainSRujiTests.swift
@@ -102,11 +102,12 @@ final class ThorchainSRujiTests: XCTestCase {
         XCTAssertTrue(current.matches(TokensStore.sruji))
     }
 
-    // MARK: - 5. On-chain receipt-balance parse (Staked RUJI DeFi-card source of truth)
+    // MARK: - 5. On-chain receipt-balance parse (sizes the `liquid.unbond` funds)
     //
-    // The Staked RUJI card now derives its amount from the on-chain `x/staking-x/ruji`
-    // bank balance (preferred over the Rujira staking API's `bonded.amount`, which can
-    // report zero even while receipts are held). These pin the parse that feeds it.
+    // The `x/staking-x/ruji` bank balance is the vault's sRUJI SHARE count. It is not a
+    // display value (the auto-compounding card shows the staking API's liquid size, i.e.
+    // those shares valued in RUJI) — it sizes the funds of a `liquid.unbond`, which
+    // spends shares. These pin the parse that feeds it.
 
     func testParseStakingReceiptAmountFindsSRujiByOnChainDenom() throws {
         let json = """


### PR DESCRIPTION
Closes #4862

## The bug: RUJI has two positions, iOS renders one card

Rujira's RUJI staking pool gives every account **two independent positions**, and an account can hold both at the same time:

| | **Bonded** ("Standard") | **Auto-compounding** |
|---|---|---|
| Rewards | **USDC, claimed manually** (`account.claim`) | USDC auto-buys more RUJI into the position |
| Receipt token | **none** — contract state only | **sRUJI**, denom `x/staking-x/ruji`, a liquid vault share |
| Stake | `{"account":{"bond":{}}}` funded with `x/ruji` | `{"liquid":{"bond":{}}}` funded with `x/ruji` |
| Unstake | `{"account":{"withdraw":{"amount":"…"}}}`, no funds | `{"liquid":{"unbond":{}}}` funded with `x/staking-x/ruji` **shares** |
| Rujira GraphQL | `stakingV2.bonded.amount` | `stakingV2.liquidSize.amount` |
| APR / claimable USDC | **belongs here** | none — revenue compounds into the amount |

There is only **one** sRUJI denom, so the title's "mixes up sRUJI versions" is really *bonded position vs sRUJI receipt*. iOS rendered a single card and kept swapping which side it read:

- #4794 reported that the card read `bonded`, so auto-compounders saw `0`.
- PR #4797 (v1.42.67) made the card **prefer** the on-chain `x/staking-x/ruji` receipt balance — a successful read, *including a genuine zero*, won.
- #4862 is the mirror image: bonded-only holders now see `0`, and `StakePosition.canUnstake` keys off the displayed amount, so **Unstake is disabled and the funds look stranded**.

Repointing the balance check — the issue's literal "Must Do" — would just re-break #4794. Two further defects were live and are also fixed here: the auto-compounding amount was rendered as a raw **share count** (sRUJI's share price is 1.0151 RUJI today, so the position was understated by ~1.5% and rising), and an auto-compound-only holder got an *enabled* Unstake that routed to `account.withdraw` against an empty bonded position — **iOS had no `liquid.unbond` path for RUJI at all**.

## The fix

Stop picking one; emit **both** positions, modelling the auto-compounding side as its own `.compound` coin (`TokensStore.sruji`) exactly like the shipped sTCY/TCY and ybRUNE/bRUNE integrations. `StakePosition.makeID` is coin-keyed (`chain_contractAddress_pubkey`), so `x/ruji` and `x/staking-x/ruji` produce two distinct persistent rows **with no SwiftData migration**.

- **RUJI card** — bonded amount, `.stake`, carries the APR and the claimable USDC. Unstakes via `account.withdraw` (unchanged).
- **sRUJI card** — the pool's `liquidSize` (the receipt valued in RUJI), `.compound`, stat-free. Unstakes via the new `RUJILiquidUnbondTransactionBuilder`, funded with `x/staking-x/ruji` shares.
- The unstake sheet's ceiling comes from the same source as the card it was opened from; the on-chain receipt balance is retained purely to size the redeemed shares. The slider is percentage-based, so **100% redeems the exact receipt balance** — no rounding dust, and it can't exceed what's held even if the share price moves.
- A one-shot app migration appends `sruji` to `defiPositions[.thorChain].staking` wherever `ruji` is present, so existing auto-compounders don't lose their card behind a newly-introduced toggle.

This ports the substance of vultisig-windows#4398 (plus the `liquidSize` half of #4356 and #4366), in the shape iOS already uses.

## Step 0 — live verification before any code

## A. `stakingV2.liquidSize` exists and is non-null

Schema introspection against the endpoint iOS uses (`https://api.vultisig.com/ruji/api/graphql`, `THORChainStakingAPI.getRujiStaking`):

```
$ curl -s -X POST 'https://api.vultisig.com/ruji/api/graphql' -H 'Content-Type: application/json' \
    -d '{"query":"{ __type(name: \"StakingAccount\") { fields { name description type { kind ofType { name } } } } }"}'

TYPE StakingAccount — "A staking_account represents data about account address related to the staking pool"
  account        NON_NULL Address
  bonded         NON_NULL Balance   | "The balance of bonded token that has been deposited by the account"
  liquid         NON_NULL Balance   | "The balance of liquid staked token that is held by the account"
  liquidShares   NON_NULL Balance   | "The balance of liquid staked token that is held by the account"
  liquidSize     NON_NULL Balance   | "The value of liquid staked token that is held by the account, denominated in the bond token"
  pendingRevenue NON_NULL Balance   | "The balance of pending revenue earned and still not claimed by this account"
  pool           NON_NULL StakingPool
  valueUsd       NON_NULL Bigint
```

`liquidSize` is `NON_NULL` — it is always present.

## B. Account holding BOTH positions

`thor1qvmeavyusxyet7szr2azjzut7tamw4ycfg08ss`, raw GraphQL response:

```json
{
  "data": { "node": { "stakingV2": [ {
    "account": "thor1qvmeavyusxyet7szr2azjzut7tamw4ycfg08ss",
    "bonded":         { "amount": "1638238990000", "asset": { "metadata": { "symbol": "RUJI"  } } },
    "liquid":         { "amount": "1385594365632", "asset": { "metadata": { "symbol": "sRUJI" } } },
    "liquidShares":   { "amount": "1385594365632", "asset": { "metadata": { "symbol": "sRUJI" } } },
    "liquidSize":     { "amount": "1406486651509", "asset": { "metadata": { "symbol": "RUJI"  } } },
    "pendingRevenue": { "amount": "3112926996",    "asset": { "metadata": { "symbol": "USDC"  } } },
    "pool": {
      "address": "thor13g83nn5ef4qzqeafp0508dnvkvm0zqr3sj7eefcn5umu65gqluusrml5cr",
      "bondAsset":    { "metadata": { "symbol": "RUJI"  } },
      "receiptAsset": { "metadata": { "symbol": "sRUJI" } },
      "summary": { "apr": { "status": "AVAILABLE", "value": "39662357617" } }
    }
  } ] } }
}
```

16382.38990000 RUJI bonded **and** 14064.86651509 RUJI auto-compounding, at the same time.

## C. `liquidSize` == on-chain receipt balance × share price

On-chain bank balance for the same address:

```
$ curl -s .../cosmos/bank/v1beta1/balances/thor1qvmeavyusxyet7szr2azjzut7tamw4ycfg08ss/by_denom?denom=x%2Fstaking-x%2Fruji
{"balance":{"denom":"x/staking-x/ruji","amount":"1385594365632"}}
```

Equal to `liquidShares` to the base unit.

Pool share price from the RUJI staking contract (`{"status":{}}` smart query — the same NAV pattern ybRUNE uses):

```
$ curl -s .../cosmwasm/wasm/v1/contract/thor13g83nn5ef4qzqeafp0508dnvkvm0zqr3sj7eefcn5umu65gqluusrml5cr/smart/eyJzdGF0dXMiOnt9fQ==
{"data":{"account_bond":"937410120141049","assigned_revenue":"908578970885",
         "liquid_bond_shares":"2639232181854954","liquid_bond_size":"2679027084756681",
         "undistributed_revenue":"909544541"}}
```

```
share price     = 2679027084756681 / 2639232181854954 = 1.015078212207066
liquidSize/shares = 1406486651509    / 1385594365632   = 1.015078212206406   (12 significant figures)
shares × price  = 1385594365632 × 1.015078212207066 = 1406486651510 (1 base unit = 1e-8 RUJI of rounding)
```

Confirmed: `liquidSize` is the receipt balance converted at the pool share price. Rendering the raw receipt count (what iOS does today) understates the position by ~1.5% and rising.

## D. `bonded` is independent of the liquid side

The contract's own `account` query returns ONLY the bonded position — it is contract state with no receipt token, so it cannot be derived from any bank balance:

```
$ curl -s .../smart/$(echo -n '{"account":{"addr":"thor1qvmeavyusxyet7szr2azjzut7tamw4ycfg08ss"}}' | base64)
{"data":{"addr":"thor1qvmeavyusxyet7szr2azjzut7tamw4ycfg08ss","bonded":"1638238990000","pending_revenue":"3112926996"}}
```

Matches the GraphQL `bonded` exactly, and is unrelated to the 1385594365632 sRUJI shares.

Sweeping the first 40 `x/staking-x/ruji` holders (`/cosmos/bank/v1beta1/denom_owners/x%2Fstaking-x%2Fruji`) through the same query: **37 hold liquid only (`bonded: 0`)** and **3 hold both**. Sample:

```
thor1qqptqxgzwh6dldtr7tk8lwuj8uvgfz7cz8nclp onchain=794752295806  bonded=0            liquidShares=794752295806  liquidSize=806735739574
thor1q8f89jj3ukx40kwmss2cj2zwua42x04s8mfggg onchain=49635523456   bonded=50000000000  liquidShares=49635523456   liquidSize=50383938411
thor1q8ugrrfzjv6uvk8rvne2dkf6j2xs4tvvhcjukq onchain=479480272671  bonded=167661564597 liquidShares=479480272671  liquidSize=486709977971
thor1qvmeavyusxyet7szr2azjzut7tamw4ycfg08ss onchain=1385594365632 bonded=1638238990000 liquidShares=1385594365632 liquidSize=1406486651509
thor1qtyx8nht4cahkjku4xpeh22n4s8al6fcur0gek onchain=99257         bonded=100000       liquidShares=99257         liquidSize=100753
```

In every row `liquidShares == onchain` exactly, and `bonded` moves independently. The 37 `bonded: 0` rows are precisely the users #4794 was filed for; the "both" rows are precisely the users #4862 breaks.

## E. `liquid.unbond` message shape, verified against the deployed contract

Contract info — the RUJI pool is `rujira-staking`:

```
$ curl -s .../cosmwasm/wasm/v1/contract/thor13g83nn5ef4qzqeafp0508dnvkvm0zqr3sj7eefcn5umu65gqluusrml5cr
{"address":"thor13g83nn5…","contract_info":{"code_id":"43","creator":"thor1e0lmk5…","admin":"thor1e0lmk5…",
 "label":"rujira-staking:x/ruji","created":{"block_height":"22081269","tx_index":"13875920"}}}
```

Query-message type, from a deliberately invalid smart query (the error enumerates the accepted variants and names the Rust type):

```
$ curl -s .../smart/$(echo -n '{"__probe__":{}}' | base64)
{"code":2,"message":"Error parsing into type rujira_rs::interfaces::staking::QueryMsg: unknown variant `__probe__`,
 expected one of `config`, `status`, `account`: query wasm contract failed: unknown request"}
```

The bRUNE pool (`thor179fex2rxd45caedmz4hxsnu42sw20lu0djyh4yukyh965sq8muuqptru2g`, `label: rujira-staking:x/brune`) returns the *identical* type path — the same `rujira_rs::interfaces::staking` interface iOS already broadcasts `{"liquid":{"unbond":{}}}` against on mainnet (verified on-device in #4799, tx `FEF5516C…`, code 0).

Config confirms the denoms and that revenue is USDC:

```
$ curl -s .../smart/$(echo -n '{"config":{}}' | base64)
{"data":{"bond_denom":"x/ruji","revenue_denom":"eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
         "revenue_converter":["thor17cawwg2lsnvcne69fek6nsqkf8snma6gc5ccceshul86rl0u3q4s5l5d0a","eyJzd2FwIjoge319","50000000000"],
         "fee":null}}
```

Finally, the deployed bytecode itself (`/cosmwasm/wasm/v1/code/43`, sha256 `9F3A872C75AB4413DD37936F720B81A051062B1B96554C9CB46C7CCDB4FD017E`, 382191 bytes) carries the execute variants in its string table:

```
$ strings -n 4 code43.wasm | grep -E 'rujira-staking/|LiquidMsg'
…OverflowError…QueryMsg LiquidMsg AccountMsg ExecuteMsg ConfigResponse StatusResponse account_bond assigned_revenue liquid_bond_shares liquid_bond_size undistributed_revenue InstantiateMsg
…fee_range ruji_denom rujira-staking/account.bond owner amount rujira-staking/account.claim rujira-staking/account.withdraw rewards rujira-staking/liquid.bond rujira-staking/liquid.unbond FeeConfig percentage recipient
… bondunbond
… claimwithdraw
… liquid
```

`rujira-staking/liquid.unbond` and `rujira-staking/account.withdraw` are both present on **this exact contract**, alongside the `liquid` / `bond` / `unbond` / `claim` / `withdraw` serde variant strings. `{"liquid":{"unbond":{}}}` and `{"account":{"withdraw":{"amount":"…"}}}` are both valid executes here.

**Step 0 verdict: PASS.** `liquidSize` is safe to display, `liquidShares` == the on-chain receipt balance (so a percentage of the receipt balance is an exact share redemption), and the two positions are independent.

## Codex review ledger

| Step | Commit | Findings | Disposition |
|---|---|---|---|
| 1 — `liquidSize` through model/API/service | 7b2d7e225 | 1 MAJOR | **fixed** — missing/unparseable `liquidSize.amount` was coerced to 0, which would erase a live auto-compounding position; now fails closed with `StakingError.invalidResponse`, matching the method's existing `guard let node`/`guard let stakingV2` handling. Round 2: 1 MINOR — `LiquidSize.amount` was non-optional so an absent amount would fail decoding before the guard; made optional so the partial-response guard owns both cases. **fixed** |
| 2 — two positions from the interactor | 90757418e | **No findings** | — (deliberate deviations pre-declared in the prompt and not rebutted: unconditional emission of both sides, and `"SRUJI"` resolving against the RUJI pool) |
| 3 — `liquid.unbond` builder + unstake routing | 6498b9531 | 1 MAJOR | **fixed** — the compound sheet's ceiling now comes from the card amount, which removed TCY/bRUNE's implicit guard, so Continue could build a `.genericContract` tx with a nil wasm payload while the receipt read was pending/failed; `transactionBuilder` now returns nil unless `autocompoundBalance > 0`. Round 2: **No findings** |
| 4+5 — wiring, `liquid.bond` stake routing, opt-in migration | aa2169b21 | **No findings** | — |
| 6 — tests | 78d84a140 | 2 MAJOR (r1) + 1 MAJOR (r2) | **all fixed** — r1: (a) the migration "is registered" test only inspected the version number, so deleting the registration would still pass → now drives the real `AppMigrationService` with a new `MockKeychainService` seeded at the previous version and asserts both the opt-in and the version ratchet, plus an already-migrated no-op test; (b) the raw→scaled conversion was untested (interactor tests inject an already-scaled `StakingDetails`) → parse extracted as a pure `THORChainStakingService.makeRujiStakingDetails(from:)` (mirroring the existing `parseStakingReceiptAmount` precedent) and tested for scaling, independence, pool-selection-by-symbol and the fail-closed cases. r2: an unparseable `bonded.amount` silently became zero — the exact failure mode of this issue — → now fails closed like `liquidSize`, with regression tests; `pendingRevenue` stays lenient on purpose (a claim CTA must not take the balances down with it) and that is pinned by a test. |
| **whole-branch pass** (`git diff origin/main...HEAD`) | 78d84a140 | 1 MAJOR | **half rejected, half fixed** — Codex said the migration must also write `TokensStore.sruji` into `vault.coins` or the card never materialises. **Rejected the coin write:** THORChain token discovery already adds `x/staking-x/ruji` for every vault that holds it (that is why the receipt shows in the wallet list today), and the live LCD denom metadata returns `symbol: "sRUJI"`, so `coinSnapshots`' ticker match resolves it; writing the coin in would put a zero-balance sRUJI row in the wallet list of every RUJI staker, which the issue explicitly forbids ("Don't change the Wallet tab sRUJI display logic"). **Accepted the test request:** added an end-to-end test that migrates a vault holding the receipt and asserts the interactor then emits the compounded card, and spelled the dependency out in the migration's doc comment. |

## Gate

Full suite, dedicated simulator (`ruji4862-gate`, iPhone 17 Pro Max / iOS 26.5, en_US), `make test`:

```
** TEST SUCCEEDED **
     Executed 3418 tests, with 1 test skipped and 0 failures (0 unexpected) in 63.507 (64.574) seconds
```

63 of those are the new/affected RUJI classes (`RUJIStakingTransactionBuilderTests`, `RujiDualPositionWiringTests`, `RujiAutoCompoundPositionMigrationTests`, `THORChainStakeInteractorTests`). SwiftLint clean on every touched file — no new warnings. The known `JoinKeysignDoubleTapGuardTests` flake did not fire.


## Known follow-ups / open questions

- **Wallet-tab sRUJI is unchanged, deliberately.** `Coin.defiOnlyTickers` is still `["STCY","YBRUNE"]`, so sRUJI keeps showing as a spendable wallet token while also being a DeFi card — and sending it away silently empties the staked position. vultisig-windows filters the receipt out via `isRujiStakingReceiptCoin`. The issue says "Don't change the Wallet tab sRUJI display logic", so this PR does not touch it. @realpaaao — say the word and I'll add `"SRUJI"` to `defiOnlyTickers` in a follow-up.
- **sTCY and ybRUNE display receipt shares, not the underlying value** — the same class of defect as (2) above, but different flows and a different regression surface. Out of scope here; filing separately.
- **vultisig-android still has #4794's bug** — `RujiStakingService.kt` reads `bonded` only, so auto-compounders see 0 and there is no `liquid.unbond` path. Filing separately.
- **android + vultisig-sdk select the staking pool with a blind `stakingV2[0]`**, which picks the wrong pool for any account holding several Rujira staking positions. iOS and windows both select by bond-asset symbol. Filing separately.
- **Integer-percent unstake truncation** on the `.compound` path is inherited byte-for-byte from the shipped sTCY/ybRUNE flow (100% is exact, so no funds can strand). Deliberately not diverged here; it stays the shared follow-up already noted on #4799.

## Verification status

- [x] Step 0 live verification against the Rujira GraphQL endpoint and the deployed staking contract (above)
- [x] Full `make test` suite green
- [ ] **On-device mainnet verification PENDING** — a two-device `liquid.unbond` broadcast from a vault holding an auto-compounding RUJI position, plus an `account.withdraw` from a bonded one. Not yet performed; this PR stays a draft until it is.



## Review follow-up (4b0b461da) — one out-of-scope fix declared

CodeRabbit flagged that `RUJILiquidBondTransactionBuilder` emitted `liquid.bond` with **zero funds** for sub-base-unit dust. Confirmed reachable: `AmountBalanceValidator` rejects only an *exact* zero, so `0.000000009` RUJI passes the form, `decimalToCrypto` yields `0.9` base units and `.toInt()` truncates to `0`. Guarded on `>= 1` base unit, matching the guard `RUJILiquidUnbondTransactionBuilder` already carried.

**Declaring a deliberate scope expansion:** the pre-existing bonded builder `RUJIStakeTransactionBuilder` has the same defect and worse. It stringifies the raw `Decimal` via `.description`, so the same dust produces `"0.9"` — a **fractional `CosmosCoin.amount`**, a malformed execute rather than a no-op, which also leaks into the `bond:x/ruji:0.9` memo. That file is untouched by this issue, but it is the identical defect class (and the one already fixed for the bRUNE builder), so it is truncated to whole base units and guarded here rather than left standing beside the hardened one. **Happy to split it into its own PR if reviewers prefer.**

Three tests added: dust guard on each bond path, plus an integer-base-unit-string assertion on the bonded builder.

Gate after the follow-up: `** TEST SUCCEEDED **` — **3421 tests, 1 skipped, 0 failures**. SwiftLint clean on all touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RUJI auto-compounding support (sRUJI) alongside bonded RUJI staking.
  * Introduced liquid bond/unbond flows for auto-compounding positions.
  * Updated staking/ticker routing so SRUJI is handled correctly and shown as a separate position.
  * Added an automatic migration to enable sRUJI for existing vaults.
* **Bug Fixes**
  * Improved staking-details parsing and validation (including liquid size) for more accurate balances and APR.
  * Prevented creating no-op/dust staking and unstaking transactions; RUJI and sRUJI are treated independently.
* **Documentation**
  * Clarified receipt-balance behavior for RUJI/sRUJI.
* **Localization**
  * Added “Withdraw %@ Rewards” text across supported languages.
* **Tests**
  * Expanded coverage for dual-position wiring, builders, and migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
