### PR TITLE
fix(tron): block self-send + stop overstating network fee (#4863)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Service/TronService.swift
@@ -78,12 +78,7 @@ class TronService {
         let expiration = nowMillis + oneHourMillis
 
         let calculatedFee = try await calculateTronFee(coin: coin, to: to, memo: memo, isSwap: isSwap)
-        // For native transfers with a fully bandwidth-discounted fee (calculatedFee == 0),
-        // fall back to the coin's static `feeDefault` so the UI displays a non-zero "Fees"
-        // line. Contract paths (TRC20 / native swap) always return a non-zero feeLimit
-        // from `calculateTronFee` so they bypass this branch.
-        let finalFee = calculatedFee == 0 ? coin.feeDefault.toBigInt() : calculatedFee
-        let estimation = String(finalFee)
+        let estimation = String(calculatedFee)
 
         return BlockChainSpecific.Tron(
             timestamp: currentTimestampMillis,
@@ -193,7 +188,13 @@ class TronService {
             if isSwap {
                 transactionFee = Self.defaultContractFeeLimit(energyPrice: energyPrice)
             } else {
-                transactionFee = (try? await calculateNativeTrxFee(coin: coin)) ?? .zero
+                // A *successfully computed* 0 means sufficient bandwidth — a
+                // genuinely free transfer, surfaced as 0. But a thrown error
+                // (transient account-resource / chain-parameter fetch failure)
+                // is indistinguishable from that once collapsed to `.zero`,
+                // which would render a real transfer as falsely free. Fall back
+                // to the coin's conservative static fee only on that error path.
+                transactionFee = (try? await calculateNativeTrxFee(coin: coin)) ?? coin.feeDefault.toBigInt()
             }
         } else {
             transactionFee = await calculateTrc20FeeLimit(coin: coin, to: to, energyPrice: energyPrice)

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1038,6 +1038,7 @@
 "rippleUndecodedNotice" = "Diese Transaktion konnte nicht dekodiert werden. Überprüfe das rohe JSON sorgfältig, bevor du signierst.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
+"sameAddressError" = "Die Empfängeradresse muss sich von der Absenderadresse unterscheiden.";
 "sameDeviceShareError" = "Gleicher Tresor Teil";
 "sameDeviceShareErrorDescription" = "Bitte ändern Sie die Freigabe zum Signieren. Zwei Geräte können nicht dieselbe Tresorfreigabe zum gemeinsamen Signieren verwenden.";
 "sameNameFolderDescription" = "Bitte wähle einen einzigartigen Namen für den Ordner und versuche es erneut.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1036,6 +1036,7 @@
 "rippleUndecodedNotice" = "This transaction couldn't be decoded. Review the raw JSON carefully before signing.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
+"sameAddressError" = "The to address must be different from the from address";
 "sameDeviceShareError" = "Same vault share";
 "sameDeviceShareErrorDescription" = "Please change the share to sign. Two devices cannot use the same vault share for co-signing.";
 "sameNameFolderDescription" = "That folder name already exists. Try a new one.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1038,6 +1038,7 @@
 "rippleUndecodedNotice" = "No se pudo decodificar esta transacción. Revisa cuidadosamente el JSON sin procesar antes de firmar.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
+"sameAddressError" = "La dirección de destino debe ser diferente de la dirección de origen.";
 "sameDeviceShareError" = "Misma compartir bóveda";
 "sameDeviceShareErrorDescription" = "Cambie la compartición para firmar. Dos dispositivos no pueden usar la misma bóveda compartida para firmar conjuntamente.";
 "sameNameFolderDescription" = "Elija un nombre único para la carpeta e inténtelo de nuevo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1038,6 +1038,7 @@
 "rippleUndecodedNotice" = "Ovu transakciju nije bilo moguće dekodirati. Pažljivo pregledajte neobrađeni JSON prije potpisivanja.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
+"sameAddressError" = "Adresa primatelja mora se razlikovati od adrese pošiljatelja";
 "sameDeviceShareError" = "Isti udio trezora";
 "sameDeviceShareErrorDescription" = "Molimo promijenite dionicu za potpis. Dva uređaja ne mogu koristiti isti dio trezora za zajedničko potpisivanje.";
 "sameNameFolderDescription" = "Odaberite jedinstveno ime za mapu i pokušajte ponovno.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1038,6 +1038,7 @@
 "rippleUndecodedNotice" = "Impossibile decodificare questa transazione. Controlla attentamente il JSON grezzo prima di firmare.";
 "routerNotAvailable" = "Router non disponibile per approvazioni su %@. Riprova più tardi.";
 "rune" = "RUNE";
+"sameAddressError" = "L'indirizzo del destinatario deve essere diverso dall'indirizzo del mittente";
 "sameDeviceShareError" = "Stessa condivisione del Vault";
 "sameDeviceShareErrorDescription" = "Modifica la condivisione per firmare. Due dispositivi non possono usare la stessa condivisione del vault per la co-firma.";
 "sameNameFolderDescription" = "Si prega di scegliere un nome univoco per la cartella e riprovare.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1036,6 +1036,7 @@
 "rippleUndecodedNotice" = "이 트랜잭션을 디코딩할 수 없습니다. 서명하기 전에 원시 JSON을 주의 깊게 확인하세요.";
 "routerNotAvailable" = "%@에서 승인을 위한 라우터를 사용할 수 없습니다. 나중에 다시 시도하세요.";
 "rune" = "RUNE";
+"sameAddressError" = "받는 주소는 보내는 주소와 달라야 합니다";
 "sameDeviceShareError" = "동일한 볼트 공유";
 "sameDeviceShareErrorDescription" = "서명할 공유를 변경해 주세요. 두 기기는 공동 서명에 동일한 볼트 공유를 사용할 수 없습니다.";
 "sameNameFolderDescription" = "해당 폴더 이름이 이미 존재합니다. 새로운 이름을 시도하세요.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1038,6 +1038,7 @@
 "rippleUndecodedNotice" = "Não foi possível decodificar esta transação. Revise cuidadosamente o JSON bruto antes de assinar.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
+"sameAddressError" = "O endereço de destino deve ser diferente do endereço de origem";
 "sameDeviceShareError" = "Mesmo compartilhamento de cofre";
 "sameDeviceShareErrorDescription" = "Por favor, altere a partilha para assinar. Dois dispositivos não podem usar a mesma partilha do cofre para co-assinar.";
 "sameNameFolderDescription" = "Escolha um nome exclusivo para a pasta e tente novamente.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1038,6 +1038,7 @@
 "rippleUndecodedNotice" = "无法解码此交易。签名前请仔细核对原始 JSON。";
 "routerNotAvailable" = "%@ 的路由不可用。请稍后再试。";
 "rune" = "RUNE";
+"sameAddressError" = "收件人地址必须与发件人地址不同";
 "sameDeviceShareError" = "相同的保险库份额";
 "sameDeviceShareErrorDescription" = "请更改份额以签名。两台设备不能使用相同的保险库份额进行联合签名。";
 "sameNameFolderDescription" = "该文件夹名称已存在。尝试一个新的";

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -770,6 +770,17 @@ final class SendDetailsViewModel {
         return true
     }
 
+    /// TRON self-send guard (parity with android DefaultSendStrategy): a plain
+    /// transfer whose destination is the sender's own address just burns fees.
+    /// Staking ops (freeze/unfreeze) are self-directed by design, so they're
+    /// excluded via the existing `isStakingOperation` flag.
+    func validateNotSelfSend() -> Bool {
+        guard coin.chain == .tron, !isStakingOperation else { return true }
+        guard toAddress == coin.address else { return true }
+        setAddressError(message: "sameAddressError")
+        return false
+    }
+
     /// Rejects amount + fee > balance for the source coin. TRON staking is
     /// short-circuited because the validation already ran in
     /// `Tron{Freeze,Unfreeze}View` and the on-screen balance reflects it.
@@ -900,6 +911,7 @@ final class SendDetailsViewModel {
         // embedded tag 0) skip validation on prefill paths that never went
         // through the screen's format check.
         guard await validateAddressResolved() else { return false }
+        guard validateNotSelfSend() else { return false }
         guard validateRippleTagAndMemo() else { return false }
         guard await validateRippleRequireDest() else { return false }
         guard validateBalance() else { return false }

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -773,10 +773,13 @@ final class SendDetailsViewModel {
     /// TRON self-send guard (parity with android DefaultSendStrategy): a plain
     /// transfer whose destination is the sender's own address just burns fees.
     /// Staking ops (freeze/unfreeze) are self-directed by design, so they're
-    /// excluded via the existing `isStakingOperation` flag.
+    /// excluded via the existing `isStakingOperation` flag. Compares against
+    /// `fromAddress` — the sender `makeTransaction()` actually signs with, which
+    /// a hydrated seed can decouple from `coin.address` — so the guard tracks the
+    /// real sender rather than an assumed-equal default.
     func validateNotSelfSend() -> Bool {
         guard coin.chain == .tron, !isStakingOperation else { return true }
-        guard toAddress == coin.address else { return true }
+        guard toAddress == fromAddress else { return true }
         setAddressError(message: "sameAddressError")
         return false
     }

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
@@ -298,6 +298,27 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         XCTAssertTrue(vm.validateNotSelfSend())
     }
 
+    /// The guard keys on `fromAddress` (the sender `makeTransaction()` signs
+    /// with), not `coin.address`. A hydrated seed can decouple the two, so a
+    /// self-send to the *actual* sender must still be blocked even when it
+    /// differs from `coin.address`.
+    func testValidateNotSelfSendKeysOnFromAddressWhenHydratedApart() {
+        let trx = SendFormFixture.makeTRX()
+        let vm = SendFormFixture.make(coin: trx)
+        vm.fromAddress = "TXhydratedSender0000000000000000000"
+
+        // To == the real sender (fromAddress) but != coin.address → blocked.
+        vm.toAddress = vm.fromAddress
+        XCTAssertFalse(vm.validateNotSelfSend())
+        XCTAssertEqual(vm.errorMessage, "sameAddressError")
+
+        // To == coin.address but != the real sender → not a self-send → allowed.
+        let vm2 = SendFormFixture.make(coin: SendFormFixture.makeTRX())
+        vm2.fromAddress = "TXhydratedSender0000000000000000000"
+        vm2.toAddress = vm2.coin.address
+        XCTAssertTrue(vm2.validateNotSelfSend())
+    }
+
     /// End-to-end: a TRON send whose destination equals the sender is rejected
     /// by `validateForm()` with `sameAddressError`, and the guard fires BEFORE
     /// the balance check (balance comfortably covers the amount, so only the

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
@@ -259,6 +259,64 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         XCTAssertTrue(vm.showAlert)
     }
 
+    // MARK: - TRON self-send guard (validateNotSelfSend)
+
+    func testValidateNotSelfSendFailsForTronSameAddress() {
+        let trx = SendFormFixture.makeTRX()
+        let vm = SendFormFixture.make(coin: trx)
+        vm.toAddress = trx.address
+
+        XCTAssertFalse(vm.validateNotSelfSend())
+        XCTAssertEqual(vm.errorMessage, "sameAddressError")
+        XCTAssertTrue(vm.showAddressAlert)
+    }
+
+    func testValidateNotSelfSendPassesForTronStakingOperation() {
+        let trx = SendFormFixture.makeTRX()
+        let vm = SendFormFixture.make(coin: trx)
+        vm.toAddress = trx.address
+        vm.isStakingOperation = true
+
+        XCTAssertTrue(vm.validateNotSelfSend(),
+                      "Freeze/unfreeze are self-directed by design — staking ops are excluded")
+    }
+
+    func testValidateNotSelfSendPassesForTronDifferentAddress() {
+        let trx = SendFormFixture.makeTRX()
+        let vm = SendFormFixture.make(coin: trx)
+        vm.toAddress = "TKt9bGgWeFFu2yRgULxRhmiBADuoEoadq8"
+
+        XCTAssertTrue(vm.validateNotSelfSend())
+    }
+
+    func testValidateNotSelfSendPassesForNonTronSameAddress() {
+        // Guard is TRON-scoped (Android parity) — an EVM self-send is NOT blocked here.
+        let eth = SendFormFixture.makeETH()
+        let vm = SendFormFixture.make(coin: eth)
+        vm.toAddress = eth.address
+
+        XCTAssertTrue(vm.validateNotSelfSend())
+    }
+
+    /// End-to-end: a TRON send whose destination equals the sender is rejected
+    /// by `validateForm()` with `sameAddressError`, and the guard fires BEFORE
+    /// the balance check (balance comfortably covers the amount, so only the
+    /// self-send rule can reject). A passthrough address resolver is injected so
+    /// `validateAddressResolved()` passes regardless of WalletCore's base58
+    /// checksum — isolating the self-send guard, which is what this test pins.
+    func testValidateFormBlocksTronSelfSend() async {
+        let trx = SendFormFixture.makeTRX(rawBalance: "1000000000") // 1000 TRX
+        let vm = SendFormFixture.make(coin: trx, addressResolver: { input, _ in input })
+        vm.toAddress = trx.address
+        vm.amount = "1"
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid)
+        XCTAssertEqual(vm.errorMessage, "sameAddressError")
+        XCTAssertTrue(vm.showAddressAlert)
+    }
+
     func testValidateFormStopsAtFirstFailure() async {
         // Cosmos chain + pending tx + empty amount + bad address: only the
         // first failure (pending) should fire its setter.

--- a/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TronServiceFeeLimitTests.swift
@@ -139,12 +139,13 @@ final class TronServiceFeeLimitTests: XCTestCase {
         XCTAssertEqual(gasFee, UInt64(TronService.defaultContractFeeLimit(energyPrice: 420)))
     }
 
-    /// Native TRX transfer with sufficient bandwidth — bandwidth-discounted
-    /// to 0, then the signing path doesn't write `feeLimit` for plain
-    /// `TransferContract` anyway. `gasFeeEstimation` falls through to
-    /// `coin.feeDefault` for the UI binding (already the prior behavior;
-    /// this test pins that we don't regress it).
-    func testGetBlockInfo_nativeTransfer_returnsZeroForUiFallback() async throws {
+    /// Native TRX transfer with sufficient bandwidth — the daily free-net
+    /// quota covers the 300-byte transfer, so the on-chain fee is genuinely
+    /// 0. `gasFeeEstimation` must report that true 0 (Android parity), not a
+    /// fabricated `coin.feeDefault`. This case is the *only* one where
+    /// `calculateTronFee` returns 0: TRC20 / native-swap / bandwidth-shortfall
+    /// / memo / inactive-destination paths all yield a non-zero fee.
+    func testGetBlockInfo_nativeTransfer_sufficientBandwidth_showsZeroFee() async throws {
         let stub = TronStubHTTPClient()
         stub.stubDefaults(energyUsed: 0)
         // Generous bandwidth — discount kicks in.
@@ -157,9 +158,44 @@ final class TronServiceFeeLimitTests: XCTestCase {
         let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil, isSwap: false)
         let gasFee = extractGasFee(result)
 
-        // Bandwidth-discounted fee is 0, so `getBlockInfo` falls through to
-        // `coin.feeDefault` for the UI binding. For TRX that resolves to
-        // 100_000 sun (0.1 TRX) — see `Coin.feeDefault`.
+        XCTAssertEqual(gasFee, 0)
+    }
+
+    /// Native TRX transfer *without* sufficient bandwidth — the account has no
+    /// free-net quota, so the node consumes the 300-byte bandwidth fee. The
+    /// displayed fee must be the REAL bandwidth cost, not `coin.feeDefault`:
+    /// 300 bytes (`BYTES_PER_COIN_TX`) × 1000 sun (`getTransactionFee` /
+    /// `bandwidthFeePrice`) = 300_000 sun. Memo is 0 (none) and activation is
+    /// 0 (destination "exists" per the stub's getaccount response).
+    func testGetBlockInfo_nativeTransfer_insufficientBandwidth_showsRealBandwidthFee() async throws {
+        let stub = TronStubHTTPClient()
+        // Default getaccountresource has zero available bandwidth.
+        stub.stubDefaults(energyUsed: 0)
+        let service = TronService(httpClient: stub)
+
+        let coin = makeNativeCoin()
+        let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil, isSwap: false)
+        let gasFee = extractGasFee(result)
+
+        XCTAssertEqual(gasFee, 300_000)
+    }
+
+    /// Native TRX transfer where the account-resource fetch FAILS — the true
+    /// bandwidth availability is unknown, so we must not collapse to a false 0
+    /// (which would render a real transfer as free and mislead the max-amount
+    /// calc). The error path falls back to the coin's conservative static fee
+    /// (`coin.feeDefault` = 100_000 sun for TRX), distinct from the genuinely
+    /// free case above which reports a true 0.
+    func testGetBlockInfo_nativeTransfer_resourceFetchError_fallsBackToStaticFee() async throws {
+        let stub = TronStubHTTPClient()
+        stub.stubDefaults(energyUsed: 0)
+        stub.errors["/wallet/getaccountresource"] = HTTPError.invalidResponse
+        let service = TronService(httpClient: stub)
+
+        let coin = makeNativeCoin()
+        let result = try await service.getBlockInfo(coin: coin, to: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", memo: nil, isSwap: false)
+        let gasFee = extractGasFee(result)
+
         XCTAssertEqual(gasFee, 100_000)
     }
 


### PR DESCRIPTION
Fixes two independent defects on the TRON send screen reported in #4863 (both visible in the issue's screenshot: a TRX send where From == To showing an "Est. network fee = 0.1 TRX" despite the account having free bandwidth).

## Defect A — stop overstating the network fee

`TronService.getBlockInfo` computed the correct fee via `calculateTronFee`, then threw it away when it was `0`, substituting the coin's static `feeDefault` (0.1 TRX):

```swift
let finalFee = calculatedFee == 0 ? coin.feeDefault.toBigInt() : calculatedFee
```

But a **successfully computed** `0` occurs **only** for a native TRX transfer with sufficient bandwidth, no memo, and an active destination — the genuinely-free case. TRC20, native-swap, bandwidth-shortfall, memo, and inactive-destination paths all compute a non-zero fee. So the `== 0` fallback fired exactly when the fee really was 0 and overstated it as 0.1 TRX. Android shows `0 TRX`. For native transfers the signing path does not write `feeLimit` (plain `TransferContract`), so `gasFeeEstimation` only drives the UI + the max-amount calc; showing the true `0` is correct.

The fix uses the computed fee directly (`String(calculatedFee)`) and removes the stale comment. To close a gap surfaced in review: `calculateTronFee` swallowed native-fee computation **errors** to `.zero` via `try?`, which is indistinguishable from a genuine free transfer once collapsed. The fallback is therefore **kept, but moved** to the error path only — `(try? await calculateNativeTrxFee(coin:)) ?? coin.feeDefault.toBigInt()` — so a transient account-resource / chain-parameter fetch failure shows a conservative estimate rather than a false `0`, while a genuinely free transfer still shows `0`.

## Defect B — block TRON self-send (Android parity)

The send-form validation pipeline had no guard for destination == sender, so a user could sign a TRON transfer to their own address that just burns fees. Adds a TRON-scoped `validateNotSelfSend()` to `SendDetailsViewModel`, wired into `validateForm()` immediately after address resolution and before the balance checks (so the self-send error wins):

```swift
func validateNotSelfSend() -> Bool {
    guard coin.chain == .tron, !isStakingOperation else { return true }
    guard toAddress == coin.address else { return true }
    setAddressError(message: "sameAddressError")
    return false
}
```

This mirrors android `DefaultSendStrategy.kt` (`if (!isTronStakingOp && srcAddress == dstAddress) throw send_error_same_address`). It is **deliberately TRON-only and excludes staking ops** (freeze/unfreeze are self-directed by design) — matching Android; **not** generalized to other chains (explicit decision). TRON addresses are single-canonical base58check, so an exact string compare matches Android's `srcAddress == dstAddress`.

Adds the new `sameAddressError` localization key to **all 8** locales (en, de, es, hr, it, ko, pt, zh-Hans), reusing android's `send_error_same_address` translations. English (android verbatim): `"The to address must be different from the from address"`.

## Tests

- `TronServiceFeeLimitTests`: flipped the test that pinned the old behavior (was asserting `100_000`) to assert `gasFee == 0` for the sufficient-bandwidth free case; added an insufficient-bandwidth case asserting the real `300_000` sun bandwidth fee; added an account-resource-error case asserting the conservative `100_000` fallback.
- `SendDetailsViewModelValidationTests`: isolated `validateNotSelfSend()` cases (TRON same-address fires `sameAddressError`; staking-op excluded; different address passes; non-TRON same-address passes) plus an end-to-end `validateForm()` test with a real base58 TRON address proving the guard is wired in and fires before the balance check.

## Gate

- Cross-model review loop: each commit codex-reviewed read-only, plus a whole-branch pass — all triaged clean (one major finding on the fee error-path was fixed as described above).
- SwiftLint: clean on all changed files (no new warnings).
- Full suite: `make test` → `** TEST SUCCEEDED **` (3377 tests executed, 1 skipped, 0 failures) on a dedicated en_US simulator (iPhone 17 Pro, iOS 26.5, UDID 802B9C6B-B3EC-4B37-A288-9F0DA03C8024).

## On-device pending

- [ ] TRON send with To == From is blocked with the inline "same address" error.
- [ ] A native TRX send with free bandwidth shows **0 TRX** (not 0.1 TRX).
- [ ] A TRC20 send still shows a real, non-zero fee.
- [ ] A TRON freeze/unfreeze still works (not blocked by the self-send guard).

Closes #4863

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TRON “self-send” validation to block sending to the sender’s own address, with localized error messaging (except for staking operations).
* **Bug Fixes**
  * Improved native TRX fee estimation to correctly distinguish true zero-fee transfers from bandwidth costs and from fallback fees when fee data can’t be retrieved.
  * UI fee display now follows the computed fee consistently.
* **Tests**
  * Added/updated unit and end-to-end tests covering self-send validation and TRON fee estimation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->