### PR TITLE
fix(evm): average two central samples for even-length priority-fee sets

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceStruct.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmServiceStruct.swift
@@ -99,13 +99,12 @@ struct EvmServiceStruct {
             return [.safeLow: low, .normal: normal, .fast: fast]
         }
 
-        guard !history.isEmpty else {
+        guard let normal = history.median() else {
             let value = try await fetchMaxPriorityFeePerGas()
             return priorityFeesMap(low: value, normal: value, fast: value)
         }
 
         let low = history[0]
-        let normal = history[history.count / 2]
         let fast = history[history.count - 1]
 
         return priorityFeesMap(low: low, normal: normal, fast: fast)

--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/RpcEvmService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/RpcEvmService.swift
@@ -52,13 +52,12 @@ class RpcEvmService: RpcService {
             return [.safeLow: low, .normal: normal, .fast: fast]
         }
 
-        guard !history.isEmpty else {
+        guard let normal = history.median() else {
             let value = try await fetchMaxPriorityFeePerGas()
             return priorityFeesMap(low: value, normal: value, fast: value)
         }
 
         let low = history[0]
-        let normal = history[history.count / 2]
         let fast = history[history.count - 1]
 
         return priorityFeesMap(low: low, normal: normal, fast: fast)

--- a/VultisigApp/VultisigApp/Core/Extensions/BigIntExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/BigIntExtension.swift
@@ -1,0 +1,20 @@
+//
+//  BigIntExtension.swift
+//  VultisigApp
+//
+
+import BigInt
+
+extension Array where Element == BigInt {
+    /// Median of this array (already sorted ascending), or nil when empty. Averages the two
+    /// central elements for an even-length array instead of picking a single upper-middle one.
+    func median() -> BigInt? {
+        guard !isEmpty else { return nil }
+        let mid = count / 2
+        if count % 2 == 0 {
+            return (self[mid - 1] + self[mid]) / 2
+        } else {
+            return self[mid]
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Extensions/BigIntExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/BigIntExtensionTests.swift
@@ -1,0 +1,53 @@
+//
+//  BigIntExtensionTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+import BigInt
+
+final class BigIntExtensionTests: XCTestCase {
+
+    func test_median_ofEmptyArray_isNil() {
+        XCTAssertNil([BigInt]().median())
+    }
+
+    func test_median_ofSingleElementArray_isThatElement() {
+        XCTAssertEqual([BigInt(500)].median(), BigInt(500))
+    }
+
+    func test_median_ofOddLengthArray_isTheMiddleElement() {
+        let samples = [100, 200, 300].map { BigInt($0) }
+        XCTAssertEqual(samples.median(), BigInt(200))
+    }
+
+    func test_median_ofEvenLengthArray_averagesTheTwoCentralElements() {
+        // Regression case: the upper-middle element (800) is wrong; the true median is
+        // (200+800)/2 = 500.
+        let samples = [100, 200, 800, 900].map { BigInt($0) }
+        XCTAssertEqual(samples.median(), BigInt(500))
+    }
+
+    func test_median_ofTwoElements_averagesBoth() {
+        let samples = [100, 300].map { BigInt($0) }
+        XCTAssertEqual(samples.median(), BigInt(200))
+    }
+
+    func test_median_ofEvenLengthArrayWithOddSum_truncatesDownInsteadOfRounding() {
+        let samples = [100, 100, 201, 300].map { BigInt($0) }
+        // (100 + 201) / 2 = 150 (BigInt division truncates toward zero for non-negative values).
+        XCTAssertEqual(samples.median(), BigInt(150))
+    }
+
+    func test_median_ofTenElementArray_matchesTheRealGetFeeHistoryWindowShape() {
+        // eth_feeHistory is always requested with a fixed 10-block window.
+        let samples = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map { BigInt($0) }
+        XCTAssertEqual(samples.median(), BigInt(55)) // avg(50, 60) = 55
+    }
+
+    func test_median_ofLargeValues_doesNotOverflow() {
+        let samples = [BigInt("9999999999999999999"), BigInt("10000000000000000001")]
+        XCTAssertEqual(samples.median(), BigInt("10000000000000000000"))
+    }
+}


### PR DESCRIPTION
Fixes #4878

`fetchMaxPriorityFeesPerGas` indexed straight into `history[history.count / 2]`, the upper-middle element of the sorted `eth_feeHistory` reward window. That's correct for an odd sample count but wrong for an even one — `getFeeHistory` always requests a fixed 10-block window, so this fired on effectively every quote, not just an edge case.

`RpcEvmService` (class) and `EvmServiceStruct` (struct, the newer rewrite used by `EvmService`, the main fee-calculation facade) both had an identical copy of this function. Extracted the fix into a shared `Array<BigInt>.median()` in a new `BigIntExtension.swift` so the two mirrored implementations can't drift from each other, and both now delegate to it.

Mirrors the equivalent fix already shipped on Android (vultisig-android#5375 for Solana, vultisig-android#5376 for the identical EVM case).

## Test plan
- New `BigIntExtensionTests` (8 cases: empty, single, odd, even, two-element, odd-sum-truncation, ten-element matching the real `getFeeHistory` shape, large values) — `xcodebuild test -only-testing:VultisigAppTests/BigIntExtensionTests` — 8/8 green.
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` on the touched files — 0 violations.
- `make build-check` — build succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM gas priority fee calculations by using a more representative median for normal fees.
  * Added a reliable fallback when fee history is unavailable or insufficient, ensuring safe, normal, and fast fee estimates remain available.

* **Tests**
  * Added coverage for median calculations, including empty, even-length, large-value, and edge-case inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->