### PR TITLE
fix(tx-history): add top fade gradient below the segmented control

### DIFF
--- a/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryScreen.swift
@@ -180,6 +180,24 @@ struct TransactionHistoryScreen: View {
         .refreshable {
             await viewModel.refresh()
         }
+        .overlay(alignment: .top) {
+            if !grouped.isEmpty {
+                topGradient
+            }
+        }
+    }
+
+    private var topGradient: some View {
+        LinearGradient(
+            colors: [
+                Theme.colors.bgPrimary,
+                Theme.colors.bgPrimary.opacity(0)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+        .frame(height: 24)
+        .allowsHitTesting(false)
     }
 
     private var bottomGradient: some View {

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryScreen.swift
@@ -26,13 +26,13 @@ struct TransactionHistoryScreen: View {
                 content
             }
             .padding(.bottom, 32)
-        }
-        .ignoresSafeArea(edges: .bottom)
-        .overlay(alignment: .bottom) {
-            bottomGradient
+            .overlay(alignment: .bottom) {
+                bottomGradient
+            }
         }
         .screenTitle("transactionHistory".localized)
         .screenEdgeInsets(ScreenEdgeInsets(bottom: 0))
+        .ignoresSafeArea(edges: .bottom)
         .onAppear {
             viewModel.load()
         }
@@ -91,6 +91,7 @@ struct TransactionHistoryScreen: View {
                 viewModel.showAssetFilter = true
             }
         }
+        .padding(.bottom, 4)
     }
 
     // MARK: - Asset Filter Chips


### PR DESCRIPTION
Closes #4881

## Problem
On the Transaction History screen there was no fade between the segmented control (Transactions / Limit-Orders tabs + asset-filter chips) and the scrolling list below it. When scrolling, list rows slid up under the control with a hard cut at the top edge.

## Fix
Add a top fade gradient mirroring the fade this screen already applies at the bottom (`bottomGradient`):

- New `topGradient`: `LinearGradient` from `Theme.colors.bgPrimary` (opaque) → `.opacity(0)`, `startPoint: .top`, `endPoint: .bottom`, `height 24`, `.allowsHitTesting(false)`.
- Applied as `.overlay(alignment: .top)` on the `content` scroll view (not the whole `Screen`), so it sits just below the tab bar / filter chips rather than under the nav title.
- Guarded to the populated state (`if !grouped.isEmpty`) so the empty-state banner isn't faded.

Design-system compliant: `Theme.colors` only, no hardcoded colors, `allowsHitTesting(false)` so it never eats taps. Shared SwiftUI file — works on iOS and macOS. No new strings, no behavior changes.

## Local gate
- `make build-check` → **`** BUILD SUCCEEDED **`** (MAKE_EXIT=0)
- `swiftlint` on the file → 0 violations, 0 serious
- Cross-model review: one read-only Codex pass. Only finding (Low): the top gradient shouldn't fade the empty-state banner → addressed by the `if !grouped.isEmpty` guard, then re-built green. No tap-interception issue; Theme usage compliant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Transaction History screen’s header/footer gradients for clearer scrolling.
  * Added a top fade gradient when transactions are present, without interfering with taps.
  * Refined bottom spacing and overlay placement to better match the screen title layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->