### PR TITLE
fix(tx-history): swap "via {provider}" badge uses the swapper brand logo

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapProviderKind.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapProviderKind.swift
@@ -1,0 +1,104 @@
+//
+//  SwapProviderKind.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Payload-free canonical identity of a swap provider, and the single source of
+/// truth for its brand **logo** and **display name**.
+///
+/// Both the live swap flow (`SwapQuote`) and persisted Transaction History read
+/// their provider logo/name from here, so the two can never drift. This is pure
+/// presentation — it carries no quote payload and takes no part in Codable,
+/// signing, or wire formats.
+enum SwapProviderKind: Equatable {
+    case thorchain
+    case maya
+    case oneInch
+    case kyberSwap
+    case lifi
+    case swapkit
+    case jupiter
+
+    /// Brand-logo imageset name (in `Crypto/`), matching the imageset filenames.
+    /// kyberswap/swapkit/jupiter have no bundled asset on purpose, so
+    /// `AsyncImageView` falls back to a monogram built from the ticker.
+    var providerLogo: String {
+        switch self {
+        case .thorchain:
+            return "THORChain"
+        case .maya:
+            return "Maya protocol"
+        case .oneInch:
+            return "1Inch"
+        case .lifi:
+            return "LI.FI"
+        case .kyberSwap:
+            return "kyberswap"
+        case .swapkit:
+            return "swapkit"
+        case .jupiter:
+            return "jupiter"
+        }
+    }
+
+    /// Canonical brand display name — coarse, with no network-variant suffix.
+    /// (`SwapQuote.displayName` appends `-Chainnet`/`-Stagenet` for THORChain
+    /// network variants on top of this.)
+    var displayName: String {
+        switch self {
+        case .thorchain:
+            return "THORChain"
+        case .maya:
+            return "Maya protocol"
+        case .oneInch:
+            return "1Inch"
+        case .kyberSwap:
+            return "KyberSwap"
+        case .lifi:
+            return "LI.FI"
+        case .swapkit:
+            return "SwapKit"
+        case .jupiter:
+            return "Jupiter"
+        }
+    }
+
+    /// Resolves a **persisted** provider display string back to its kind.
+    ///
+    /// Transaction History stores only the display name, and it varies by record
+    /// path — network suffixes (`THORChain-Stagenet`), casing (`Maya protocol`
+    /// vs `Maya Protocol`), and sub-provider suffixes (`SwapKit (Chainflip)`) —
+    /// so matching is case-insensitive substring, not exact equality. An
+    /// empty/absent or unrecognised name yields `nil`.
+    init?(persistedName raw: String) {
+        let normalized = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard !normalized.isEmpty else { return nil }
+
+        // SwapKit is checked first: its sub-provider strings carry the underlying
+        // protocol in parentheses (e.g. "SwapKit (THORChain)"), and the outer
+        // brand is what we render. Markers are the full brand token, not a loose
+        // prefix — `thorchain` not `thor` (which is a substring of "Author"), and
+        // `li.fi` with the dot not `lifi` (a substring of "amplifier").
+        if normalized.contains("swapkit") {
+            self = .swapkit
+        } else if normalized.contains("thorchain") {
+            self = .thorchain
+        } else if normalized.contains("maya") {
+            self = .maya
+        } else if normalized.contains("1inch") {
+            self = .oneInch
+        } else if normalized.contains("kyber") {
+            self = .kyberSwap
+        } else if normalized.contains("li.fi") {
+            self = .lifi
+        } else if normalized.contains("jupiter") {
+            self = .jupiter
+        } else {
+            return nil
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapProviderKind.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapProviderKind.swift
@@ -69,36 +69,41 @@ enum SwapProviderKind: Equatable {
     ///
     /// Transaction History stores only the display name, and it varies by record
     /// path — network suffixes (`THORChain-Stagenet`), casing (`Maya protocol`
-    /// vs `Maya Protocol`), and sub-provider suffixes (`SwapKit (Chainflip)`) —
-    /// so matching is case-insensitive substring, not exact equality. An
-    /// empty/absent or unrecognised name yields `nil`.
+    /// vs `Maya Protocol`), and sub-provider suffixes (`SwapKit (Chainflip)`).
+    /// Persisted names are always `<Brand>` plus an optional SEPARATED qualifier,
+    /// so we match the brand as a prefix whose following character (if any) is a
+    /// non-alphanumeric boundary. That way real suffix forms resolve while
+    /// near-matches (`SwapKitty`, `not-thorchain`, `mayachain`) fall through to
+    /// `nil` and get the monogram fallback. An empty/absent or unrecognised name
+    /// yields `nil`.
     init?(persistedName raw: String) {
         let normalized = raw
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         guard !normalized.isEmpty else { return nil }
 
-        // SwapKit is checked first: its sub-provider strings carry the underlying
-        // protocol in parentheses (e.g. "SwapKit (THORChain)"), and the outer
-        // brand is what we render. Markers are the full brand token, not a loose
-        // prefix — `thorchain` not `thor` (which is a substring of "Author"), and
-        // `li.fi` with the dot not `lifi` (a substring of "amplifier").
-        if normalized.contains("swapkit") {
-            self = .swapkit
-        } else if normalized.contains("thorchain") {
-            self = .thorchain
-        } else if normalized.contains("maya") {
-            self = .maya
-        } else if normalized.contains("1inch") {
-            self = .oneInch
-        } else if normalized.contains("kyber") {
-            self = .kyberSwap
-        } else if normalized.contains("li.fi") {
-            self = .lifi
-        } else if normalized.contains("jupiter") {
-            self = .jupiter
-        } else {
-            return nil
+        // SwapKit is first so a sub-provider string that names its underlying
+        // protocol (e.g. "SwapKit (THORChain)") resolves to the outer SwapKit
+        // brand, not the inner protocol.
+        let tokens: [(String, SwapProviderKind)] = [
+            ("swapkit", .swapkit),
+            ("thorchain", .thorchain),
+            ("maya", .maya),
+            ("1inch", .oneInch),
+            ("kyberswap", .kyberSwap),
+            ("li.fi", .lifi),
+            ("jupiter", .jupiter)
+        ]
+
+        for (token, kind) in tokens where normalized.hasPrefix(token) {
+            let next = normalized.dropFirst(token.count).first
+            let isBoundary = next.map { !($0.isLetter || $0.isNumber) } ?? true
+            if isBoundary {
+                self = kind
+                return
+            }
         }
+
+        return nil
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -58,6 +58,28 @@ enum SwapQuote: Hashable {
         }
     }
 
+    /// Payload-free provider identity — the single source of truth for this
+    /// quote's brand logo and display name. Network variants collapse to their
+    /// base kind; `displayName` re-adds the `-Chainnet`/`-Stagenet` suffix.
+    var kind: SwapProviderKind {
+        switch self {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet:
+            return .thorchain
+        case .mayachain:
+            return .maya
+        case .oneinch:
+            return .oneInch
+        case .kyberswap:
+            return .kyberSwap
+        case .lifi:
+            return .lifi
+        case .swapkit:
+            return .swapkit
+        case .jupiter:
+            return .jupiter
+        }
+    }
+
     var router: String? {
         switch self {
         case .thorchain(let quote), .thorchainChainnet(let quote), .thorchainStagenet(let quote), .mayachain(let quote):
@@ -97,49 +119,22 @@ enum SwapQuote: Hashable {
 
     var displayName: String? {
         switch self {
-        case .thorchain:
-            return "THORChain"
+        // Network variants keep their suffix on top of the base brand name; the
+        // sub-provider (e.g. Chainflip on SwapKit) stays on the payload for
+        // routing/explorer links, so the display name stays the clean brand.
         case .thorchainChainnet:
-            return "THORChain-Chainnet"
+            return "\(kind.displayName)-Chainnet"
         case .thorchainStagenet:
-            return "THORChain-Stagenet"
-        case .mayachain:
-            return "Maya protocol"
-        case .oneinch:
-            return "1Inch"
-        case .kyberswap:
-            return "KyberSwap"
-        case .lifi:
-            return "LI.FI"
-        case .swapkit:
-            // The sub-provider (e.g. Chainflip) is carried on the payload for
-            // routing/explorer links; the display name stays the clean brand.
-            return "SwapKit"
-        case .jupiter:
-            return "Jupiter"
+            return "\(kind.displayName)-Stagenet"
+        default:
+            return kind.displayName
         }
     }
 
-    /// Brand-logo asset name for the provider (in `Crypto/`), matching the
-    /// imageset filenames. Providers without a bundled logo (KyberSwap, SwapKit)
-    /// fall back to `AsyncImageView`'s monogram.
+    /// Brand-logo asset name for the provider (in `Crypto/`). Sourced from the
+    /// shared `SwapProviderKind`, so it can't drift from Transaction History.
     var providerLogo: String {
-        switch self {
-        case .thorchain, .thorchainChainnet, .thorchainStagenet:
-            return "THORChain"
-        case .mayachain:
-            return "Maya protocol"
-        case .oneinch:
-            return "1Inch"
-        case .lifi:
-            return "LI.FI"
-        case .kyberswap:
-            return "kyberswap"
-        case .swapkit:
-            return "swapkit"
-        case .jupiter:
-            return "jupiter"
-        }
+        kind.providerLogo
     }
 
     func inboundFeeDecimal(toCoin: Coin) -> Decimal? {

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryData.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryData.swift
@@ -184,6 +184,46 @@ extension TransactionHistoryData {
     }
 }
 
+// MARK: - Provider Logo
+
+extension TransactionHistoryData {
+    /// Brand-logo asset name for the `via {provider}` badge, or `nil` when the
+    /// stored provider has no recognised brand mapping.
+    var swapProviderLogo: String? {
+        Self.providerLogoAsset(for: swapProvider)
+    }
+
+    /// Maps a persisted swap-provider display name to its brand-logo asset name,
+    /// returning the same asset strings as `SwapQuote.providerLogo`.
+    ///
+    /// We map from the display *string* rather than the enum because transaction
+    /// history persists only the provider's display name (`swapProvider`), never
+    /// the payload-carrying `SwapQuote`/`SwapProvider` value — so the enum isn't
+    /// available at render time. The stored string varies by record path: network
+    /// suffixes (`THORChain-Stagenet`), casing (`Maya protocol` vs `Maya
+    /// Protocol`), and sub-provider suffixes (`SwapKit (Chainflip)`). Matching is
+    /// therefore case-insensitive substring, not exact equality. `nil` for an
+    /// empty/absent name or an unrecognised provider.
+    static func providerLogoAsset(for swapProvider: String?) -> String? {
+        guard let normalized = swapProvider?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            !normalized.isEmpty else {
+            return nil
+        }
+
+        if normalized.contains("thorchain") { return "THORChain" }
+        if normalized.contains("maya") { return "Maya protocol" }
+        if normalized.contains("1inch") { return "1Inch" }
+        if normalized.contains("kyber") { return "kyberswap" }
+        if normalized.contains("li.fi") { return "LI.FI" }
+        if normalized.contains("swapkit") { return "swapkit" }
+        if normalized.contains("jupiter") { return "jupiter" }
+
+        return nil
+    }
+}
+
 // MARK: - Conversions
 
 extension TransactionHistoryData {

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryData.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryData.swift
@@ -189,38 +189,13 @@ extension TransactionHistoryData {
 extension TransactionHistoryData {
     /// Brand-logo asset name for the `via {provider}` badge, or `nil` when the
     /// stored provider has no recognised brand mapping.
-    var swapProviderLogo: String? {
-        Self.providerLogoAsset(for: swapProvider)
-    }
-
-    /// Maps a persisted swap-provider display name to its brand-logo asset name,
-    /// returning the same asset strings as `SwapQuote.providerLogo`.
     ///
-    /// We map from the display *string* rather than the enum because transaction
-    /// history persists only the provider's display name (`swapProvider`), never
-    /// the payload-carrying `SwapQuote`/`SwapProvider` value — so the enum isn't
-    /// available at render time. The stored string varies by record path: network
-    /// suffixes (`THORChain-Stagenet`), casing (`Maya protocol` vs `Maya
-    /// Protocol`), and sub-provider suffixes (`SwapKit (Chainflip)`). Matching is
-    /// therefore case-insensitive substring, not exact equality. `nil` for an
-    /// empty/absent name or an unrecognised provider.
-    static func providerLogoAsset(for swapProvider: String?) -> String? {
-        guard let normalized = swapProvider?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased(),
-            !normalized.isEmpty else {
-            return nil
-        }
-
-        if normalized.contains("thorchain") { return "THORChain" }
-        if normalized.contains("maya") { return "Maya protocol" }
-        if normalized.contains("1inch") { return "1Inch" }
-        if normalized.contains("kyber") { return "kyberswap" }
-        if normalized.contains("li.fi") { return "LI.FI" }
-        if normalized.contains("swapkit") { return "swapkit" }
-        if normalized.contains("jupiter") { return "jupiter" }
-
-        return nil
+    /// History persists only the provider's display *name* (`swapProvider`), not
+    /// the payload-carrying quote, so we resolve it back to the shared
+    /// `SwapProviderKind` — the single source of truth both this badge and the
+    /// live swap screens read their logo from.
+    var swapProviderLogo: String? {
+        swapProvider.flatMap { SwapProviderKind(persistedName: $0)?.providerLogo }
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
@@ -300,10 +300,14 @@ struct TransactionHistoryCardView: View {
     private var viaBadge: some View {
         if let provider = transaction.swapProvider {
             HStack(spacing: 8) {
+                // The badge is "via {provider}", so its icon is the swapper's
+                // brand logo — like the route/details screen — not the source
+                // coin. Falls back to the raw provider name (monogram via
+                // `ticker`) when the provider has no bundled brand asset.
                 AsyncImageView(
-                    logo: transaction.coinLogo,
+                    logo: transaction.swapProviderLogo ?? provider,
                     size: CGSize(width: 16, height: 16),
-                    ticker: transaction.coinTicker,
+                    ticker: provider,
                     tokenChainLogo: nil
                 )
 

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryProviderLogoTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryProviderLogoTests.swift
@@ -6,70 +6,94 @@
 import XCTest
 @testable import VultisigApp
 
+/// End-to-end coverage of the tx-history `via {provider}` badge logo: the
+/// persisted display string resolves, through `SwapProviderKind`, to the shared
+/// brand-asset name. Exhaustive per-case coverage of the kind itself lives in
+/// `SwapProviderKindTests`; this pins the Transaction History wiring.
 final class TransactionHistoryProviderLogoTests: XCTestCase {
+
+    private func swapProviderLogo(for swapProvider: String?) -> String? {
+        Self.makeData(swapProvider: swapProvider).swapProviderLogo
+    }
 
     func testThorchainFamilyMapsToThorchainAsset() {
         for name in ["THORChain", "THORChain-Chainnet", "THORChain-Stagenet"] {
-            XCTAssertEqual(
-                TransactionHistoryData.providerLogoAsset(for: name),
-                "THORChain",
-                "expected THORChain asset for \(name)"
-            )
+            XCTAssertEqual(swapProviderLogo(for: name), "THORChain", "for \(name)")
         }
     }
 
     func testMayaBothCasingsMapToMayaProtocolAsset() {
         for name in ["Maya protocol", "Maya Protocol"] {
-            XCTAssertEqual(
-                TransactionHistoryData.providerLogoAsset(for: name),
-                "Maya protocol",
-                "expected Maya protocol asset for \(name)"
-            )
+            XCTAssertEqual(swapProviderLogo(for: name), "Maya protocol", "for \(name)")
         }
     }
 
     func testOneInchMapsToOneInchAsset() {
-        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "1Inch"), "1Inch")
+        XCTAssertEqual(swapProviderLogo(for: "1Inch"), "1Inch")
     }
 
     func testKyberSwapMapsToKyberswapAsset() {
-        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "KyberSwap"), "kyberswap")
+        XCTAssertEqual(swapProviderLogo(for: "KyberSwap"), "kyberswap")
     }
 
     func testLifiMapsToLifiAsset() {
-        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "LI.FI"), "LI.FI")
+        XCTAssertEqual(swapProviderLogo(for: "LI.FI"), "LI.FI")
     }
 
     func testSwapKitAndSubProvidersMapToSwapkitAsset() {
         for name in ["SwapKit", "SwapKit (Chainflip)", "SwapKit (NEAR Intents)"] {
-            XCTAssertEqual(
-                TransactionHistoryData.providerLogoAsset(for: name),
-                "swapkit",
-                "expected swapkit asset for \(name)"
-            )
+            XCTAssertEqual(swapProviderLogo(for: name), "swapkit", "for \(name)")
         }
     }
 
     func testJupiterMapsToJupiterAsset() {
-        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "Jupiter"), "jupiter")
-    }
-
-    func testMatchingIsCaseInsensitive() {
-        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "thorchain"), "THORChain")
-        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "JUPITER"), "jupiter")
-    }
-
-    func testWhitespaceIsTrimmed() {
-        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "  SwapKit  "), "swapkit")
+        XCTAssertEqual(swapProviderLogo(for: "Jupiter"), "jupiter")
     }
 
     func testNilOrEmptyMapsToNil() {
-        XCTAssertNil(TransactionHistoryData.providerLogoAsset(for: nil))
-        XCTAssertNil(TransactionHistoryData.providerLogoAsset(for: ""))
-        XCTAssertNil(TransactionHistoryData.providerLogoAsset(for: "   "))
+        XCTAssertNil(swapProviderLogo(for: nil))
+        XCTAssertNil(swapProviderLogo(for: ""))
+        XCTAssertNil(swapProviderLogo(for: "   "))
     }
 
     func testUnknownProviderMapsToNil() {
-        XCTAssertNil(TransactionHistoryData.providerLogoAsset(for: "SomeUnknownProvider"))
+        XCTAssertNil(swapProviderLogo(for: "SomeUnknownProvider"))
+    }
+
+    // MARK: - Helper
+
+    /// Minimal `TransactionHistoryData` fixture — `swapProviderLogo` depends only
+    /// on `swapProvider`, so every other field is placeholder.
+    private static func makeData(swapProvider: String?) -> TransactionHistoryData {
+        TransactionHistoryData(
+            id: UUID(),
+            txHash: "",
+            approveTxHash: nil,
+            pubKeyECDSA: "",
+            type: .swap,
+            status: .successful,
+            chainRawValue: "",
+            coinTicker: "",
+            coinLogo: "",
+            coinChainLogo: nil,
+            amountCrypto: "",
+            amountFiat: "",
+            fromAddress: "",
+            toAddress: "",
+            toCoinTicker: nil,
+            toCoinLogo: nil,
+            toCoinChainLogo: nil,
+            toAmountCrypto: nil,
+            toAmountFiat: nil,
+            swapProvider: swapProvider,
+            feeCrypto: "",
+            feeFiat: "",
+            network: "",
+            explorerLink: "",
+            createdAt: Date(),
+            completedAt: nil,
+            estimatedTime: nil,
+            errorMessage: nil
+        )
     }
 }

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryProviderLogoTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TransactionHistoryProviderLogoTests.swift
@@ -1,0 +1,75 @@
+//
+//  TransactionHistoryProviderLogoTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class TransactionHistoryProviderLogoTests: XCTestCase {
+
+    func testThorchainFamilyMapsToThorchainAsset() {
+        for name in ["THORChain", "THORChain-Chainnet", "THORChain-Stagenet"] {
+            XCTAssertEqual(
+                TransactionHistoryData.providerLogoAsset(for: name),
+                "THORChain",
+                "expected THORChain asset for \(name)"
+            )
+        }
+    }
+
+    func testMayaBothCasingsMapToMayaProtocolAsset() {
+        for name in ["Maya protocol", "Maya Protocol"] {
+            XCTAssertEqual(
+                TransactionHistoryData.providerLogoAsset(for: name),
+                "Maya protocol",
+                "expected Maya protocol asset for \(name)"
+            )
+        }
+    }
+
+    func testOneInchMapsToOneInchAsset() {
+        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "1Inch"), "1Inch")
+    }
+
+    func testKyberSwapMapsToKyberswapAsset() {
+        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "KyberSwap"), "kyberswap")
+    }
+
+    func testLifiMapsToLifiAsset() {
+        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "LI.FI"), "LI.FI")
+    }
+
+    func testSwapKitAndSubProvidersMapToSwapkitAsset() {
+        for name in ["SwapKit", "SwapKit (Chainflip)", "SwapKit (NEAR Intents)"] {
+            XCTAssertEqual(
+                TransactionHistoryData.providerLogoAsset(for: name),
+                "swapkit",
+                "expected swapkit asset for \(name)"
+            )
+        }
+    }
+
+    func testJupiterMapsToJupiterAsset() {
+        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "Jupiter"), "jupiter")
+    }
+
+    func testMatchingIsCaseInsensitive() {
+        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "thorchain"), "THORChain")
+        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "JUPITER"), "jupiter")
+    }
+
+    func testWhitespaceIsTrimmed() {
+        XCTAssertEqual(TransactionHistoryData.providerLogoAsset(for: "  SwapKit  "), "swapkit")
+    }
+
+    func testNilOrEmptyMapsToNil() {
+        XCTAssertNil(TransactionHistoryData.providerLogoAsset(for: nil))
+        XCTAssertNil(TransactionHistoryData.providerLogoAsset(for: ""))
+        XCTAssertNil(TransactionHistoryData.providerLogoAsset(for: "   "))
+    }
+
+    func testUnknownProviderMapsToNil() {
+        XCTAssertNil(TransactionHistoryData.providerLogoAsset(for: "SomeUnknownProvider"))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapProviderKindTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapProviderKindTests.swift
@@ -92,6 +92,15 @@ final class SwapProviderKindTests: XCTestCase {
         XCTAssertNil(SwapProviderKind(persistedName: "SomeUnknownProvider"))
     }
 
+    /// A brand token that continues into more letters is a different word, not a
+    /// qualified variant, so it must not resolve — the char after the brand
+    /// prefix has to be a non-alphanumeric boundary.
+    func testInitRejectsNearMatchesWithoutABoundary() {
+        for name in ["SwapKitty", "not-thorchain", "mayachain"] {
+            XCTAssertNil(SwapProviderKind(persistedName: name), "for \(name)")
+        }
+    }
+
     /// `li.fi` must match with the dot, not the bare `lifi` substring, which
     /// appears inside unrelated words such as "amplifier".
     func testInitDoesNotFalseMatchLifiSubstring() {

--- a/VultisigApp/VultisigAppTests/Swap/SwapProviderKindTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapProviderKindTests.swift
@@ -1,0 +1,106 @@
+//
+//  SwapProviderKindTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapProviderKindTests: XCTestCase {
+
+    // MARK: - providerLogo
+
+    func testProviderLogoPerCase() {
+        XCTAssertEqual(SwapProviderKind.thorchain.providerLogo, "THORChain")
+        XCTAssertEqual(SwapProviderKind.maya.providerLogo, "Maya protocol")
+        XCTAssertEqual(SwapProviderKind.oneInch.providerLogo, "1Inch")
+        XCTAssertEqual(SwapProviderKind.kyberSwap.providerLogo, "kyberswap")
+        XCTAssertEqual(SwapProviderKind.lifi.providerLogo, "LI.FI")
+        XCTAssertEqual(SwapProviderKind.swapkit.providerLogo, "swapkit")
+        XCTAssertEqual(SwapProviderKind.jupiter.providerLogo, "jupiter")
+    }
+
+    // MARK: - displayName
+
+    func testDisplayNamePerCase() {
+        XCTAssertEqual(SwapProviderKind.thorchain.displayName, "THORChain")
+        XCTAssertEqual(SwapProviderKind.maya.displayName, "Maya protocol")
+        XCTAssertEqual(SwapProviderKind.oneInch.displayName, "1Inch")
+        XCTAssertEqual(SwapProviderKind.kyberSwap.displayName, "KyberSwap")
+        XCTAssertEqual(SwapProviderKind.lifi.displayName, "LI.FI")
+        XCTAssertEqual(SwapProviderKind.swapkit.displayName, "SwapKit")
+        XCTAssertEqual(SwapProviderKind.jupiter.displayName, "Jupiter")
+    }
+
+    // MARK: - init(persistedName:)
+
+    func testInitResolvesThorchainFamily() {
+        for name in ["THORChain", "THORChain-Chainnet", "THORChain-Stagenet", "thorchain"] {
+            XCTAssertEqual(SwapProviderKind(persistedName: name), .thorchain, "for \(name)")
+        }
+    }
+
+    func testInitResolvesMayaBothCasings() {
+        for name in ["Maya protocol", "Maya Protocol"] {
+            XCTAssertEqual(SwapProviderKind(persistedName: name), .maya, "for \(name)")
+        }
+    }
+
+    func testInitResolvesOneInch() {
+        XCTAssertEqual(SwapProviderKind(persistedName: "1Inch"), .oneInch)
+    }
+
+    func testInitResolvesKyberSwap() {
+        XCTAssertEqual(SwapProviderKind(persistedName: "KyberSwap"), .kyberSwap)
+    }
+
+    func testInitResolvesLifi() {
+        XCTAssertEqual(SwapProviderKind(persistedName: "LI.FI"), .lifi)
+    }
+
+    func testInitResolvesSwapKitAndSubProviders() {
+        for name in ["SwapKit", "SwapKit (Chainflip)", "SwapKit (NEAR Intents)"] {
+            XCTAssertEqual(SwapProviderKind(persistedName: name), .swapkit, "for \(name)")
+        }
+    }
+
+    /// A SwapKit sub-provider naming its underlying protocol still resolves to
+    /// the outer SwapKit brand, not the inner protocol.
+    func testInitPrefersOuterSwapKitBrandOverInnerProtocol() {
+        XCTAssertEqual(SwapProviderKind(persistedName: "SwapKit (THORChain)"), .swapkit)
+    }
+
+    func testInitResolvesJupiter() {
+        XCTAssertEqual(SwapProviderKind(persistedName: "Jupiter"), .jupiter)
+    }
+
+    func testInitIsCaseInsensitive() {
+        XCTAssertEqual(SwapProviderKind(persistedName: "JUPITER"), .jupiter)
+        XCTAssertEqual(SwapProviderKind(persistedName: "kyberswap"), .kyberSwap)
+    }
+
+    func testInitTrimsWhitespace() {
+        XCTAssertEqual(SwapProviderKind(persistedName: "  SwapKit  "), .swapkit)
+    }
+
+    func testInitRejectsEmptyOrWhitespace() {
+        XCTAssertNil(SwapProviderKind(persistedName: ""))
+        XCTAssertNil(SwapProviderKind(persistedName: "   "))
+    }
+
+    func testInitRejectsUnknownProvider() {
+        XCTAssertNil(SwapProviderKind(persistedName: "SomeUnknownProvider"))
+    }
+
+    /// `li.fi` must match with the dot, not the bare `lifi` substring, which
+    /// appears inside unrelated words such as "amplifier".
+    func testInitDoesNotFalseMatchLifiSubstring() {
+        XCTAssertNil(SwapProviderKind(persistedName: "amplifier"))
+    }
+
+    /// `thorchain` (full token), not the bare `thor` substring, which appears
+    /// inside unrelated words such as "author".
+    func testInitDoesNotFalseMatchThorSubstring() {
+        XCTAssertNil(SwapProviderKind(persistedName: "Author"))
+    }
+}


### PR DESCRIPTION
Closes #4880

## Problem
On the Transaction History screen, a swap card's **"via {provider}"** badge rendered the **source-coin** icon instead of the **swapper's brand logo** — unlike the swap route/details screen, which shows the provider's brand.

## Approach: one shared source of truth
Rather than duplicate the brand-asset names, this extracts a single canonical provider identity that both the live swap flow and persisted Transaction History read from, so the two can never drift.

- **New `SwapProviderKind`** (`Blockchain/Swaps/Common/SwapProviderKind.swift`) — a payload-free enum owning:
  - `providerLogo` — the brand imageset name (same strings as before).
  - `displayName` — the canonical brand display name.
  - `init?(persistedName:)` — a tolerant resolver from a **persisted** display string (history stores only the display name, and it varies: `THORChain-Stagenet`, `Maya protocol`/`Maya Protocol`, `SwapKit (Chainflip)`, …), using case-insensitive substring matching.
  - Pure presentation — no Codable/signing/wire involvement.
- **`SwapQuote`** now delegates `providerLogo` → `kind.providerLogo` and `displayName` → `kind.displayName`. The `displayName` output stays **byte-identical** to before (network variants keep their `-Chainnet` / `-Stagenet` suffix), because that string is persisted.
- **`TransactionHistoryData.swapProviderLogo`** resolves via `SwapProviderKind(persistedName:)?.providerLogo` (the bespoke `providerLogoAsset(for:)` map was deleted).
- **`viaBadge`** uses `logo: transaction.swapProviderLogo ?? provider` and `ticker: provider`, so providers without a bundled asset fall back to `AsyncImageView`'s monogram from the provider's initial. Size stays 16×16.

Matching uses the full brand tokens (`thorchain` / `li.fi`), not the loose `thor` / `lifi` substrings (which collide with words like "Author" / "amplifier"), and resolves the outer **SwapKit** brand before its inner protocol for sub-provider strings. No schema change, no new user-facing strings.

## Local gate result
- **Build/Test:** `** TEST SUCCEEDED **` (`XCODEBUILD_EXIT=0`) — full suite, **3505 tests, 1 skipped, 0 failures**, on iPhone 16 sim. Includes `SwapProviderKindTests` and the repointed end-to-end `TransactionHistoryProviderLogoTests`.
- **Lint:** SwiftLint `0 violations` on all changed files.
- **Cross-model review:** one read-only Codex pass over the branch diff. It confirmed the `SwapQuote` display/logo/kind mappings are byte-identical/correct, and flagged one Medium issue — a loose `thor` marker false-matching "Author" and mis-ordering a `SwapKit (THORChain)` sub-provider. **Fixed** (full-token match + swapkit-first ordering) with regression tests; re-ran green.

## Test coverage
- `SwapProviderKindTests` — `providerLogo` + `displayName` per case; `init(persistedName:)` for every variant/casing/whitespace/sub-provider suffix; nil for empty/unknown; and the `Author`/`amplifier` false-match + `SwapKit (THORChain)` ordering regressions.
- `TransactionHistoryProviderLogoTests` — end-to-end `swapProviderLogo` for every documented persisted string → expected asset, and nil/empty/unknown → nil.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branded swap-provider logos to transaction history “via {provider}” badges.
  * Introduced a unified swap-provider identity to keep provider naming and branding consistent across swap quotes and transaction history.
* **Bug Fixes**
  * Improved mapping from persisted provider strings to the correct brand, including trimming, case-insensitive matching, and safer token-boundary detection.
  * Updated badge rendering to use swapper branding when available (and fall back appropriately when not).
* **Tests**
  * Added new test suites covering provider logo/name resolution and persisted-name parsing, including network variants and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->