### PR TITLE
fix(ui): swap coin + chain pickers — 24pt container, borderLight border, solid separators

### DIFF
--- a/VultisigApp/VultisigApp/Components/Cells/SwapChainCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SwapChainCell.swift
@@ -31,7 +31,7 @@ struct SwapChainCell: View {
     var label: some View {
         VStack(spacing: 0) {
             content
-            GradientListSeparator()
+            Separator(color: Theme.colors.borderLight, opacity: 1)
         }
         .background(isSelected ? Theme.colors.bgSurface2 : Theme.colors.bgSurface1)
     }

--- a/VultisigApp/VultisigApp/Components/Cells/SwapCoinCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SwapCoinCell.swift
@@ -41,7 +41,7 @@ struct SwapCoinCell: View {
     var label: some View {
         VStack(spacing: 0) {
             content
-            GradientListSeparator()
+            Separator(color: Theme.colors.borderLight, opacity: 1)
         }
         .background(isSelected ? Theme.colors.bgSurface2 : Theme.colors.bgSurface1)
     }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapChainPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapChainPickerView.swift
@@ -94,7 +94,12 @@ struct SwapChainPickerView: View {
                 )
             }
         }
-        .cornerRadius(12)
+        .background(Theme.colors.bgSurface1)
+        .clipShape(RoundedRectangle(cornerRadius: 24))
+        .overlay(
+            RoundedRectangle(cornerRadius: 24)
+                .strokeBorder(Theme.colors.borderLight, lineWidth: 1)
+        )
     }
 
     var emptyMessage: some View {

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapCoinPickerView.swift
@@ -86,7 +86,7 @@ struct SwapCoinPickerView: View {
             .padding(.horizontal, 16)
 
             VStack(spacing: 12) {
-                GradientListSeparator()
+                Separator(color: Theme.colors.borderLight, opacity: 1)
                 Text("selectChain".localized)
                     .font(Theme.fonts.caption12)
                     .foregroundStyle(Theme.colors.textTertiary)
@@ -162,7 +162,12 @@ struct SwapCoinPickerView: View {
                 }
             }
         }
-        .cornerRadius(12)
+        .background(Theme.colors.bgSurface1)
+        .clipShape(RoundedRectangle(cornerRadius: 24))
+        .overlay(
+            RoundedRectangle(cornerRadius: 24)
+                .strokeBorder(Theme.colors.borderLight, lineWidth: 1)
+        )
     }
 
     var emptyMessage: some View {
@@ -226,7 +231,7 @@ struct SwapCoinPickerView: View {
                     .frame(width: itemSize)
                     .background(
                         Capsule()
-                            .strokeBorder(Theme.colors.bgSurface2, lineWidth: 1)
+                            .strokeBorder(Theme.colors.borderLight, lineWidth: 1)
                             .fill(Theme.colors.bgPrimary)
                     )
                     .padding(.horizontal, 4)


### PR DESCRIPTION
Closes #4890

## What
Restyle the swap **coin** picker and swap **chain** picker to the 2026 list style — a 24pt rounded, `borderLight`-bordered `bgSurface1` container with solid separators (gradient removed).

## Changes
- `SwapCoinPickerView` + `SwapChainPickerView` — list container: `bgSurface1`, 24pt `RoundedRectangle` clip, 1px `borderLight` `strokeBorder`.
- Solid `borderLight` separators replacing `GradientListSeparator()` in `SwapCoinCell` (coin rows) and `SwapChainCell` (chain rows), plus the chain-section header divider in `SwapCoinPickerView`.
- Figma tokens → `Theme.colors`; no hardcoded hex.

## Shared-cell ripples (intentional — flagged for review)
- `SwapCoinCell` changed outright → also restyles Referral `PreferredAssetSelectionView` + Maya `AssetSelectionListScreen`.
- `SwapChainCell` is picker-exclusive; `SwapChainPickerView` is presented from both swap (`SwapDetailsScreen`) and send (`SendDetailsScreen`).

## Verification
- Build `** BUILD SUCCEEDED **`, SwiftLint 0. Codex: no findings.
- Visual: populated chain picker renders the 24pt bordered container. (Inter-row separator not capturable live — sandbox sim yields ≤1 populated row per picker — but it's code-identical across cells and Codex-verified.)

## Design
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=78713-104547&m=dev
