### PR TITLE
fix(ui): list style — 24pt bordered container, solid separators (main / chain-detail / defi)

### DIFF
--- a/VultisigApp/VultisigApp/Components/List/CommonListItemContainer.swift
+++ b/VultisigApp/VultisigApp/Components/List/CommonListItemContainer.swift
@@ -21,8 +21,6 @@ struct CommonListItemContainer: ViewModifier {
 
     func body(content: Content) -> some View {
         VStack(spacing: 0) {
-            GradientListSeparator()
-                .showIf(isFirst)
             content
             Separator(color: Theme.colors.borderLight, opacity: 1)
                 .showIf(!isLast)
@@ -39,8 +37,27 @@ struct CommonListItemContainer: ViewModifier {
     }
 }
 
+/// Wrapping container for a group of `commonListItemContainer` rows: a single
+/// rounded surface with a hairline border, matching the Figma list style.
+struct CommonListContainer: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(Theme.colors.bgSurface1)
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+            .overlay(
+                RoundedRectangle(cornerRadius: 24)
+                    .strokeBorder(Theme.colors.borderLight, lineWidth: 1)
+                    .allowsHitTesting(false)
+            )
+    }
+}
+
 extension View {
     func commonListItemContainer(index: Int, itemsCount: Int) -> some View {
         modifier(CommonListItemContainer(index: index, itemsCount: itemsCount))
+    }
+
+    func commonListContainer() -> some View {
+        modifier(CommonListContainer())
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/View/DefiChainListView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/View/DefiChainListView.swift
@@ -36,17 +36,20 @@ struct DefiChainListView: View {
     }
 
     var chainList: some View {
-        ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-            Button {
-                handleSelection(item)
-            } label: {
-                cell(for: item)
-                    .commonListItemContainer(
-                        index: index,
-                        itemsCount: items.count
-                    )
+        VStack(spacing: 0) {
+            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                Button {
+                    handleSelection(item)
+                } label: {
+                    cell(for: item)
+                        .commonListItemContainer(
+                            index: index,
+                            itemsCount: items.count
+                        )
+                }
             }
         }
+        .commonListContainer()
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Screens/AddFolderScreen.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Screens/AddFolderScreen.swift
@@ -61,16 +61,20 @@ struct AddFolderScreen: View {
     }
 
     var vaultsList: some View {
-        ForEach(Array(filteredVaults.enumerated()), id: \.element) { index, vault in
-            AddFolderVaultCellView(
-                vault: vault,
-                isSelected: folderViewModel.selectedVaults.contains(vault),
-                onSelection: {
-                    handleSelection(vault: vault, isSelected: $0)
-                }
-            )
-            .commonListItemContainer(index: index, itemsCount: filteredVaults.count)
+        VStack(spacing: 0) {
+            ForEach(Array(filteredVaults.enumerated()), id: \.element) { index, vault in
+                AddFolderVaultCellView(
+                    vault: vault,
+                    isSelected: folderViewModel.selectedVaults.contains(vault),
+                    onSelection: {
+                        handleSelection(vault: vault, isSelected: $0)
+                    }
+                )
+                .commonListItemContainer(index: index, itemsCount: filteredVaults.count)
+            }
         }
+        .commonListContainer()
+        .plainListItem()
     }
 
     var saveButton: some View {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/ChainDetailListView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/ChainDetailListView.swift
@@ -21,17 +21,20 @@ struct ChainDetailListView: View {
     }
 
     var tokensList: some View {
-        ForEach(Array(viewModel.filteredTokens.enumerated()), id: \.element.id) { index, token in
-            Button {
-                onPress(token)
-            } label: {
-                TokenCellView(coin: token)
-                    .commonListItemContainer(
-                        index: index,
-                        itemsCount: viewModel.filteredTokens.count
-                    )
+        VStack(spacing: 0) {
+            ForEach(Array(viewModel.filteredTokens.enumerated()), id: \.element.id) { index, token in
+                Button {
+                    onPress(token)
+                } label: {
+                    TokenCellView(coin: token)
+                        .commonListItemContainer(
+                            index: index,
+                            itemsCount: viewModel.filteredTokens.count
+                        )
+                }
             }
         }
+        .commonListContainer()
     }
 
     var addTokensView: some View {

--- a/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ReceiveChainSelectionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ReceiveChainSelectionScreen.swift
@@ -39,7 +39,6 @@ struct ReceiveChainSelectionScreen: View {
                         emptyMessage
                     }
                 }
-                .cornerRadius(12)
             }
         }
         .screenTitle("selectChain".localized)
@@ -83,6 +82,7 @@ struct ReceiveChainSelectionScreen: View {
                     .commonListItemContainer(index: offset, itemsCount: filteredChains.count)
             }
         }
+        .commonListContainer()
     }
 
     func cell(for chain: Chain) -> some View {

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/ChainList/VaultMainChainListView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/ChainList/VaultMainChainListView.swift
@@ -32,15 +32,18 @@ struct VaultMainChainListView: View {
     }
 
     var chainList: some View {
-        ForEach(Array(filteredRows.enumerated()), id: \.element.id) { index, row in
-            VaultChainCellView(row: row, vault: vault) {
-                onCopy(row.chain)
+        VStack(spacing: 0) {
+            ForEach(Array(filteredRows.enumerated()), id: \.element.id) { index, row in
+                VaultChainCellView(row: row, vault: vault) {
+                    onCopy(row.chain)
+                }
+                .commonListItemContainer(
+                    index: index,
+                    itemsCount: filteredRows.count
+                )
             }
-            .commonListItemContainer(
-                index: index,
-                itemsCount: filteredRows.count
-            )
         }
+        .commonListContainer()
     }
 }
 


### PR DESCRIPTION
Closes #4888

## What
Update the shared list style (main / chain-detail / defi + 2 more screens) to the 2026 Figma: a single 24pt rounded, `borderLight`-bordered `bgSurface1` container with solid separators.

## Changes
- `CommonListItemContainer` → a wrapping `commonListContainer()` modifier: `bgSurface1` bg, 24pt `RoundedRectangle` clip, 1px `borderLight` `strokeBorder` overlay with `.allowsHitTesting(false)`; dropped the top `GradientListSeparator()`.
- Applied at all 5 call sites: `VaultMainChainListView`, `ChainDetailListView`, `DefiChainListView`, `ReceiveChainSelectionScreen` (removed a now-redundant `.cornerRadius(12)`), `AddFolderScreen`.
- Figma tokens → `Theme.colors`; no hardcoded hex.

## Verification
- Build `** BUILD SUCCEEDED **`, SwiftLint 0 violations.
- Visual: main portfolio + chain-detail lists render the 24pt bordered container with solid separators (defi uses the byte-identical shared modifier).
- Codex: fixed a Major (border overlay could intercept taps → `allowsHitTesting(false)`); accepted a Minor (`AddFolderScreen` loses `List` virtualization) as an intentional tradeoff.

## Design
https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=48948-113621&m=dev
