### PR TITLE
fix(send): gate invalid recipient with a visible inline error (#4861)

### DIFF
--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
@@ -93,6 +93,13 @@ struct SendDetailsAddressFields: View {
                 viewModel.errorMessage = nil
                 viewModel.addressSetupDone = true
                 viewModel.onSelect(tab: .amount)
+            } else {
+                // Paste/QR/address-book value that neither matches the current
+                // chain nor one we can switch to. A same-chain-valid value
+                // advances via the shared `toAddress` onChange; an ENS/TNS name
+                // still needs async resolution. Only a value that can never
+                // resolve is flagged now, so Next is disabled *with a reason*.
+                viewModel.markInvalidRecipientIfUnresolvable()
             }
         }
     }

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressTab.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressTab.swift
@@ -78,6 +78,10 @@ struct SendDetailsAddressTab: View {
         }
         if !viewModel.toAddress.isEmpty {
             guard await viewModel.validateToAddress() else {
+                // Collapsing the address tab on an unresolved recipient is a
+                // definitive failure — surface the inline reason rather than
+                // just leaving Next disabled.
+                viewModel.markInvalidRecipient()
                 viewModel.addressSetupDone = false
                 if viewModel.selectedTab == .amount {
                     viewModel.onSelect(tab: .address)

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -583,6 +583,7 @@
 "invalidIntegerError" = "Ungültige Ganzzahl";
 "invalidLPUnits" = "Ungültige LP-Einheiten";
 "invalidOperatorFee" = "Ungültige Betreibergebühr";
+"invalidRecipientAddressError" = "Dieser Empfänger ist keine gültige Adresse für diese Kette.";
 "invalidVaultData" = "Ungültige Tresordaten";
 "Italian" = "Italienisch";
 "iUnderstand" = "Ich verstehe";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -581,6 +581,7 @@
 "invalidIntegerError" = "Invalid integer amount";
 "invalidLPUnits" = "Invalid LP units";
 "invalidOperatorFee" = "Invalid operator fee";
+"invalidRecipientAddressError" = "That recipient is not a valid address for this chain.";
 "invalidVaultData" = "Invalid vault data";
 "Italian" = "Italian";
 "iUnderstand" = "I understand";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -583,6 +583,7 @@
 "invalidIntegerError" = "Cantidad entera inválida";
 "invalidLPUnits" = "Unidades LP inválidas";
 "invalidOperatorFee" = "Tarifa de operador inválida";
+"invalidRecipientAddressError" = "Ese destinatario no es una dirección válida para esta cadena.";
 "invalidVaultData" = "Datos del almacén no válidos";
 "Italian" = "Italiano";
 "iUnderstand" = "Entiendo";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -583,6 +583,7 @@
 "invalidIntegerError" = "Nevažeći cijeli broj";
 "invalidLPUnits" = "Nevažeće LP jedinice";
 "invalidOperatorFee" = "Nevažeća naknada operatora";
+"invalidRecipientAddressError" = "Taj primatelj nije važeća adresa za ovaj lanac.";
 "invalidVaultData" = "Nevažeći podaci spremišta";
 "Italian" = "Talijanski";
 "iUnderstand" = "Razumijem";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -583,6 +583,7 @@
 "invalidIntegerError" = "Importo intero non valido";
 "invalidLPUnits" = "Unità LP non valide";
 "invalidOperatorFee" = "Commissione operatore non valida";
+"invalidRecipientAddressError" = "Quel destinatario non è un indirizzo valido per questa catena.";
 "invalidVaultData" = "Dati del caveau non validi";
 "Italian" = "Italiano";
 "iUnderstand" = "Ho capito";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -581,6 +581,7 @@
 "invalidIntegerError" = "유효하지 않은 정수 금액";
 "invalidLPUnits" = "유효하지 않은 LP 단위";
 "invalidOperatorFee" = "유효하지 않은 운영자 수수료";
+"invalidRecipientAddressError" = "이 수신자는 이 체인에 유효한 주소가 아닙니다.";
 "invalidVaultData" = "유효하지 않은 볼트 데이터";
 "Italian" = "이탈리아어";
 "iUnderstand" = "이해합니다";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -583,6 +583,7 @@
 "invalidIntegerError" = "Quantidade inteira inválida";
 "invalidLPUnits" = "Unidades LP inválidas";
 "invalidOperatorFee" = "Taxa de operador inválida";
+"invalidRecipientAddressError" = "Esse destinatário não é um endereço válido para essa cadeia.";
 "invalidVaultData" = "Dados do cofre inválidos";
 "Italian" = "Italiano";
 "iUnderstand" = "Eu entendo";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -583,6 +583,7 @@
 "invalidIntegerError" = "无效的整数数量";
 "invalidLPUnits" = "无效的 LP 单位";
 "invalidOperatorFee" = "无效的运营商费用";
+"invalidRecipientAddressError" = "该收款人不是此链的有效地址";
 "invalidVaultData" = "无效的保险库数据";
 "Italian" = "意大利语";
 "iUnderstand" = "我了解";

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -127,6 +127,11 @@ final class SendDetailsViewModel {
 
     // MARK: - Cancellation
     @ObservationIgnored private var addressResolutionTask: Task<Void, Never>?
+    /// Monotonic token bumped on every new/cancelled resolution request. The
+    /// resolver may not honor `Task` cancellation, so the async body compares
+    /// this before publishing — a stale verdict must never overwrite the
+    /// pending (`nil`) state and flash an error on the current input.
+    @ObservationIgnored private var addressResolutionGeneration = 0
     @ObservationIgnored private var amountValidationTask: Task<Void, Never>?
 
     /// Background fee refine for the native-coin Max path. Exposed so the UI
@@ -365,17 +370,31 @@ final class SendDetailsViewModel {
     /// — `validateToAddress` must complete before any `loadGasInfo` call.
     func debouncedResolveAddress() {
         addressResolutionTask?.cancel()
+        addressResolutionGeneration &+= 1
         isAddressResolved = nil
+        // Resolution is pending — keep the inline error cleared so it doesn't
+        // flash while the user is still typing; a definitive failure re-shows it.
+        showAddressAlert = false
+        let generation = addressResolutionGeneration
         addressResolutionTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(1))
             guard let self, !Task.isCancelled else { return }
-            isAddressResolved = await validateToAddress()
+            // Resolve through the generation-guarded path: a late/uncancelled
+            // resolver must neither publish a stale verdict nor rewrite
+            // `toAddress` over a newer recipient the user has since typed.
+            guard let resolved = await self.resolveToAddressIfCurrent(generation: generation) else { return }
+            self.isAddressResolved = resolved
         }
     }
 
     func cancelAddressResolution() {
         addressResolutionTask?.cancel()
+        addressResolutionGeneration &+= 1
         isAddressResolved = nil
+        // Dropping the in-flight verdict returns to the pending state — clear
+        // any stale inline error so editing the recipient never leaves a
+        // no-longer-true message on screen.
+        showAddressAlert = false
     }
 
     /// XRP address seam: when the destination input is a mainnet X-address,
@@ -415,29 +434,91 @@ final class SendDetailsViewModel {
         addressSetupDone = false
         toAddressLabel = nil
         lastResolvedAddress = nil
+        // An empty field is not an "invalid recipient" — drop any inline error
+        // so it doesn't hang under a blank input.
+        showAddressAlert = false
         rippleTag.releaseLockedTag()
+    }
+
+    /// Surfaces the chain-general "invalid recipient" inline error under the
+    /// destination field, so a definitive resolution failure disables Continue
+    /// *with a visible reason* rather than silently. No-op for an empty field:
+    /// the empty state is owned by `onToAddressCleared`, and an error under a
+    /// blank input would just be noise. The error clears on correction — a
+    /// valid format (`isValidAddressFormat`), a cleared field
+    /// (`onToAddressCleared`), or a fresh resolution attempt
+    /// (`cancelAddressResolution` / `debouncedResolveAddress`) all reset it.
+    func markInvalidRecipient() {
+        guard !toAddress.isEmpty else { return }
+        setAddressError(message: "invalidRecipientAddressError")
+    }
+
+    /// Paste / QR / address-book commit that did not switch chains: surface the
+    /// inline error only for a value that can never resolve to a valid
+    /// recipient. A value that is valid for the current chain, or a name-service
+    /// candidate (ENS/`.sol`, or a THORChain-family TNS name) that async
+    /// resolution might still resolve, is deliberately left alone so those never
+    /// flash an error before the async path (`isAddressResolved`) reaches a
+    /// definitive verdict.
+    func markInvalidRecipientIfUnresolvable() {
+        guard !toAddress.isEmpty else { return }
+        guard !AddressService.validateAddress(address: toAddress, chain: coin.chain) else { return }
+        guard !toAddress.isENSNameService() else { return }
+        let resolvesNames: Set<Chain> = [.thorChain, .thorChainChainnet, .thorChainStagenet]
+        guard !resolvesNames.contains(coin.chain) else { return }
+        markInvalidRecipient()
     }
 
     func validateToAddress() async -> Bool {
         guard !toAddress.isEmpty else { return false }
         normalizeRippleXAddressIfNeeded()
+        let originalInput = toAddress
         do {
-            let originalInput = toAddress
             let resolvedAddress = try await addressResolver(originalInput, coin.chain)
-            if originalInput != resolvedAddress {
-                toAddress = resolvedAddress
-                toAddressLabel = originalInput
-                lastResolvedAddress = resolvedAddress
-            } else if originalInput != lastResolvedAddress {
-                toAddressLabel = nil
-                lastResolvedAddress = nil
-            }
-            isNamespaceResolved = true
+            commitResolvedAddress(originalInput: originalInput, resolvedAddress: resolvedAddress)
             return true
         } catch {
             isNamespaceResolved = false
             return false
         }
+    }
+
+    /// Generation-guarded resolution for the debounced background task. Resolves
+    /// the current input but commits *nothing* — neither the address rewrite nor
+    /// the verdict — when a newer request has bumped `addressResolutionGeneration`
+    /// during the (possibly network-bound) await. Because `addressResolver` may
+    /// not honor `Task` cancellation, this guard is what prevents a late verdict
+    /// from clobbering a recipient the user has since re-typed. Returns `nil`
+    /// when the request was superseded.
+    private func resolveToAddressIfCurrent(generation: Int) async -> Bool? {
+        guard !toAddress.isEmpty else { return false }
+        normalizeRippleXAddressIfNeeded()
+        let originalInput = toAddress
+        do {
+            let resolvedAddress = try await addressResolver(originalInput, coin.chain)
+            guard addressResolutionGeneration == generation else { return nil }
+            commitResolvedAddress(originalInput: originalInput, resolvedAddress: resolvedAddress)
+            return true
+        } catch {
+            guard addressResolutionGeneration == generation else { return nil }
+            isNamespaceResolved = false
+            return false
+        }
+    }
+
+    /// Applies a successful resolution to the address fields. Shared by the
+    /// synchronous-await path (`validateToAddress`) and the generation-guarded
+    /// background path so both commit identically.
+    private func commitResolvedAddress(originalInput: String, resolvedAddress: String) {
+        if originalInput != resolvedAddress {
+            toAddress = resolvedAddress
+            toAddressLabel = originalInput
+            lastResolvedAddress = resolvedAddress
+        } else if originalInput != lastResolvedAddress {
+            toAddressLabel = nil
+            lastResolvedAddress = nil
+        }
+        isNamespaceResolved = true
     }
 
     func isValidAddressFormat() -> Bool {
@@ -756,7 +837,7 @@ final class SendDetailsViewModel {
     /// Rejects malformed addresses for the current coin's chain.
     func validateAddressFormat() -> Bool {
         guard isValidAddressFormat() else {
-            setAddressError(message: "invalidAddressError")
+            setAddressError(message: "invalidRecipientAddressError")
             return false
         }
         return true
@@ -764,7 +845,7 @@ final class SendDetailsViewModel {
 
     func validateAddressResolved() async -> Bool {
         guard await validateToAddress() else {
-            setAddressError(message: "invalidAddressError")
+            setAddressError(message: "invalidRecipientAddressError")
             return false
         }
         return true

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
@@ -102,8 +102,14 @@ struct SendDetailsScreen: View {
                 viewModel.addressSetupDone = resolved
                 if resolved {
                     viewModel.onSelect(tab: .amount)
-                } else if viewModel.selectedTab == .amount {
-                    viewModel.onSelect(tab: .address)
+                } else {
+                    // Definitive resolution failure on a non-empty recipient:
+                    // keep Next disabled *with a visible reason* instead of
+                    // silently. `markInvalidRecipient` no-ops on an empty field.
+                    viewModel.markInvalidRecipient()
+                    if viewModel.selectedTab == .amount {
+                        viewModel.onSelect(tab: .address)
+                    }
                 }
                 viewModel.debouncedValidateAmount()
             }

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelTests.swift
@@ -459,4 +459,176 @@ final class SendDetailsViewModelTests: XCTestCase {
         // Reaching here without crashing is the assertion.
         XCTAssertTrue(true)
     }
+
+    // MARK: - Invalid-recipient inline error (#4861)
+    //
+    // The recipient field must be a first-class, chain-general, user-facing
+    // gate: a definitive resolution failure shows a clear inline error and
+    // keeps Next disabled *with that visible reason*, and a valid replacement
+    // clears it. `showAddressAlert` gates the inline message under the field;
+    // `errorMessage` carries the localization key the field renders.
+
+    // A real ETH transaction id (0x + 64 hex) — the exact "txid pasted into the
+    // recipient field" case from the issue. It is not a 40-hex address, so it
+    // can never be a valid recipient.
+    private let ethTransactionId =
+        "0x88df016429689c079f3b2f6ad39fa052532c56795b733da78a91ebe6a713944b"
+
+    func testMarkInvalidRecipientSurfacesInlineErrorForEthTxid() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.toAddress = ethTransactionId
+
+        vm.markInvalidRecipient()
+
+        XCTAssertTrue(vm.showAddressAlert, "A definitive invalid recipient must show the inline error.")
+        XCTAssertEqual(vm.errorMessage, "invalidRecipientAddressError")
+        XCTAssertFalse((vm.errorMessage ?? "").isEmpty, "The inline error must carry a non-empty message.")
+    }
+
+    func testMarkInvalidRecipientIgnoresEmptyAddress() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.toAddress = ""
+
+        vm.markInvalidRecipient()
+
+        XCTAssertFalse(vm.showAddressAlert, "An empty field is not an invalid recipient — no error under a blank input.")
+    }
+
+    func testValidateFormFlagsInvalidEthRecipientTxid() async {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH(rawBalance: "1000000000000000000"))
+        vm.toAddress = ethTransactionId
+        vm.amount = "0.1"
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid, "A txid recipient must never pass form validation.")
+        XCTAssertTrue(vm.showAddressAlert)
+        XCTAssertFalse((vm.errorMessage ?? "").isEmpty)
+    }
+
+    func testValidateFormFlagsInvalidCosmosRecipient() async {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeATOM())
+        vm.toAddress = "cosmos1invalidrecipientvalue"
+        vm.amount = "0.1"
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid)
+        XCTAssertTrue(vm.showAddressAlert)
+        XCTAssertFalse((vm.errorMessage ?? "").isEmpty)
+    }
+
+    func testValidateFormFlagsInvalidUtxoRecipient() async {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeBTC())
+        vm.toAddress = "notabitcoinaddress"
+        vm.amount = "0.001"
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid)
+        XCTAssertTrue(vm.showAddressAlert)
+        XCTAssertFalse((vm.errorMessage ?? "").isEmpty)
+    }
+
+    func testValidateFormFlagsInvalidSolanaRecipient() async {
+        let sol = SendFormFixture.makeCoin(.solana, ticker: "SOL", decimals: 9, isNative: true, rawBalance: "1000000000")
+        let vm = SendFormFixture.make(coin: sol)
+        vm.toAddress = "not-a-solana-address"
+        vm.amount = "0.1"
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid)
+        XCTAssertTrue(vm.showAddressAlert)
+        XCTAssertFalse((vm.errorMessage ?? "").isEmpty)
+    }
+
+    func testValidateFormFlagsInvalidXrpRecipient() async {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeXRP())
+        vm.toAddress = "notarippleaddress"
+        vm.amount = "1"
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertFalse(isValid)
+        XCTAssertTrue(vm.showAddressAlert)
+        XCTAssertFalse((vm.errorMessage ?? "").isEmpty)
+    }
+
+    func testValidRecipientReplacementClearsInlineError() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.toAddress = ethTransactionId
+        vm.markInvalidRecipient()
+        XCTAssertTrue(vm.showAddressAlert)
+
+        // User replaces the txid with a valid ETH address — the sync format
+        // check that fires on every edit must clear the inline error.
+        vm.toAddress = "0x1111111111111111111111111111111111111111"
+
+        XCTAssertTrue(vm.isValidAddressFormat(), "A plain valid ETH address must pass the format check.")
+        XCTAssertFalse(vm.showAddressAlert, "A valid replacement recipient clears the inline error.")
+        XCTAssertNil(vm.errorMessage)
+    }
+
+    func testValidRecipientReplacementEnablesForm() async {
+        // Passthrough resolver: `AddressService.resolveInput` rejects otherwise-
+        // valid addresses in unit tests, so inject an identity resolver to
+        // exercise the happy path end-to-end.
+        let eth = SendFormFixture.makeETH(rawBalance: "1000000000000000000")
+        let vm = SendFormFixture.make(coin: eth, addressResolver: { input, _ in input })
+        vm.markInvalidRecipient()          // simulate a prior invalid-recipient state
+        vm.toAddress = "0x1111111111111111111111111111111111111111"
+        vm.amount = "0.1"
+        vm.gas = BigInt(21_000)
+        vm.fee = BigInt(21_000)
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertTrue(isValid, "A valid recipient must enable the flow.")
+        XCTAssertFalse(vm.showAddressAlert, "The inline error must not survive a valid submission.")
+    }
+
+    // MARK: - Regression: name-service recipients must not error prematurely
+
+    func testEnsNameResolvesWithoutInlineError() async {
+        let resolved = "0x1111111111111111111111111111111111111111"
+        let eth = SendFormFixture.makeETH(rawBalance: "1000000000000000000")
+        let vm = SendFormFixture.make(coin: eth, addressResolver: { _, _ in resolved })
+        vm.toAddress = "vitalik.eth"
+        vm.amount = "0.1"
+        vm.gas = BigInt(21_000)
+        vm.fee = BigInt(21_000)
+
+        let isValid = await vm.validateForm()
+
+        XCTAssertTrue(isValid, "A resolvable ENS name is a valid recipient.")
+        XCTAssertFalse(vm.showAddressAlert, "ENS names must never flash the invalid-recipient error.")
+    }
+
+    func testMarkInvalidRecipientIfUnresolvableFlagsEthTxid() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.toAddress = ethTransactionId
+
+        vm.markInvalidRecipientIfUnresolvable()
+
+        XCTAssertTrue(vm.showAddressAlert, "A paste that can never resolve must flag immediately.")
+    }
+
+    func testMarkInvalidRecipientIfUnresolvableSkipsEnsName() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.toAddress = "vitalik.eth"
+
+        vm.markInvalidRecipientIfUnresolvable()
+
+        XCTAssertFalse(vm.showAddressAlert, "ENS names are left to async resolution, not flagged on paste.")
+    }
+
+    func testMarkInvalidRecipientIfUnresolvableSkipsValidAddress() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.toAddress = "0x1111111111111111111111111111111111111111"
+
+        vm.markInvalidRecipientIfUnresolvable()
+
+        XCTAssertFalse(vm.showAddressAlert, "A valid same-chain address must not be flagged on paste.")
+    }
 }

--- a/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendDetailsViewModelValidationTests.swift
@@ -55,7 +55,7 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         vm.toAddress = "not-a-real-btc-address"
         let isValid = await vm.validateForm()
         XCTAssertFalse(isValid)
-        XCTAssertEqual(vm.errorMessage, "invalidAddressError")
+        XCTAssertEqual(vm.errorMessage, "invalidRecipientAddressError")
         XCTAssertTrue(vm.showAddressAlert)
     }
 
@@ -78,7 +78,7 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         // we at least confirmed validation rejected — the precise error label
         // depends on AddressService internals and isn't the test's contract.
         XCTAssertTrue(
-            vm.errorMessage == "walletBalanceExceededError" || vm.errorMessage == "invalidAddressError",
+            vm.errorMessage == "walletBalanceExceededError" || vm.errorMessage == "invalidRecipientAddressError",
             "Expected balance or address error, got \(vm.errorMessage ?? "nil")"
         )
     }
@@ -98,7 +98,7 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         // Either gas-balance branch fires (insufficientGasTokenError) or
         // address-format check rejects first. Both are rejections.
         XCTAssertTrue(
-            (vm.errorMessage?.contains("ETH") ?? false) || vm.errorMessage == "invalidAddressError",
+            (vm.errorMessage?.contains("ETH") ?? false) || vm.errorMessage == "invalidRecipientAddressError",
             "Expected ETH-gas error or invalid-address rejection, got \(vm.errorMessage ?? "nil")"
         )
     }
@@ -213,7 +213,7 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         let vm = SendFormFixture.make()
         vm.toAddress = ""
         XCTAssertFalse(vm.validateAddressFormat())
-        XCTAssertEqual(vm.errorMessage, "invalidAddressError")
+        XCTAssertEqual(vm.errorMessage, "invalidRecipientAddressError")
         XCTAssertTrue(vm.showAddressAlert)
     }
 
@@ -221,7 +221,7 @@ final class SendDetailsViewModelValidationTests: XCTestCase {
         let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
         vm.toAddress = "not-a-valid-eth-address"
         XCTAssertFalse(vm.validateAddressFormat())
-        XCTAssertEqual(vm.errorMessage, "invalidAddressError")
+        XCTAssertEqual(vm.errorMessage, "invalidRecipientAddressError")
     }
 
     func testValidateBalanceShortCircuitsForTronStaking() {


### PR DESCRIPTION
Closes #4861

## Problem

The Send flow accepted an invalid recipient (e.g. a **transaction id pasted into the recipient field** on an ETH/USDC send) and merely **disabled the Next button with no explanation**. The user was stuck with no idea why they couldn't continue.

## Root cause

The recipient field only renders an error when `showAddressAlert == true`, which was set **exclusively** inside `validateForm()`'s sub-validators. But `validateForm()` runs on the final Continue from the amount tab — a step that is **unreachable while the address is invalid**, because every address-commit path sets `addressSetupDone = false` and stops, without ever setting the error:

1. `SendDetailsScreen.onChange(of: isAddressResolved)` — async resolution failed (`resolved == false`).
2. `SendDetailsAddressTab.handleClose` — collapsing the tab on an unresolved recipient.
3. `SendDetailsAddressFields.handle(addressResult:)` — paste/QR/address-book no-detect path.

Latent bug: the key `invalidAddressError` referenced by `validateForm`'s address sub-validators **did not exist in any `.strings` file**, so `CommonTextField` (which renders `Text(error.localized)`) would have shown the raw key.

## Fix (chain-general — the Send screen is shared across all chains)

- Added `SendDetailsViewModel.markInvalidRecipient()` and a guarded `markInvalidRecipientIfUnresolvable()` (for the paste/QR path) that surface a clear inline error under the destination field while keeping Next disabled **with that visible reason**.
- Wired all three address-commit failure paths to show the reason.
- The error **clears on correction**: valid format, cleared field, or a fresh resolution attempt. While async resolution is pending (`isAddressResolved == nil`) the error is kept cleared so it never flashes while the user is still typing — it only appears on a **definitive** failure.
- Repointed both `validateForm` address sub-validators off the non-existent `invalidAddressError` to the new key, so no path can ever render a raw key.
- Hardened the debounced resolver against a stale/late verdict clobbering a newer recipient: resolution now commits (both the verdict and the address rewrite) only when a monotonic generation token still matches, so an uncancelled in-flight resolver can't overwrite what the user has since typed or flash an error mid-resolution.

### Regressions guarded
- **ENS/TNS names** (`.eth`/`.sol`, THORChain-family TNS) legitimately fail the sync format check and resolve async — they are deliberately left to the async path and never flash an error prematurely.
- **Chain-switch-on-paste** (Terra, #4843) still succeeds silently — detection runs before any invalid-marking.

## Localization

New key `invalidRecipientAddressError` = "That recipient is not a valid address for this chain." added to **all 8 locales** (en, de, es, hr, it, **ko**, pt, zh-Hans), translated per locale and sorted via `scripts/sort_localizable.py`.

## Tests

Added 15 camelCase tests in `SendDetailsViewModelTests` covering: the ETH-txid case from the issue, invalid Cosmos / UTXO / Solana / XRP recipients through the full `validateForm()` pipeline, valid-replacement clearing + flow-enable, and the ENS / paste-guard regressions. Updated the 5 stale `invalidAddressError` assertions in `SendDetailsViewModelValidationTests` to the new key.

## Gate

`make test` (full suite, dedicated en_US simulator): **`** TEST SUCCEEDED **`** — `Executed 3831 tests, with 1 test skipped and 0 failures`.

Cross-model review: two rounds of `codex exec` (read-only) — round 1 caught the stale test-key assertions + a resolver-race edge; round 2 caught that the generation guard needed to also protect the in-`validateToAddress` address mutation. Both triaged and fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recipient validation for invalid, unsupported, or unresolvable addresses.
  - Displays a clear inline error when a recipient is invalid for the selected chain.
  - Prevents outdated address-resolution results from overwriting newer input.
  - Keeps resolvable name-service addresses eligible for asynchronous resolution.
  - Returns users to the recipient field when validation fails, with “Next” disabled.

- **Localization**
  - Added translated invalid-recipient messages across supported languages.

- **Tests**
  - Expanded coverage for invalid recipients, valid replacements, unresolved names, and multiple blockchain address formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->