### PR TITLE
fix(swap): tag native quotes via a per-service Strategy, not a type-probe

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -468,18 +468,7 @@ private extension SwapService {
                 liquidityToleranceBps: liquidityToleranceBps
             )
 
-            switch service {
-            case _ as ThorchainService:
-                return .thorchain(quote)
-            case _ as ThorchainChainnetService:
-                return .thorchainChainnet(quote)
-            case _ as ThorchainStagenetService:
-                return .thorchainStagenet(quote)
-            case _ as MayachainService:
-                return .mayachain(quote)
-            default:
-                return .thorchain(quote)
-            }
+            return service.makeSwapQuote(quote)
         } catch let error as ThorchainSwapError {
             logger.error("THORChain swap error: code=\(error.code, privacy: .public), message=\(error.message, privacy: .public)")
             throw Self.mapThorchainSwapError(error)

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
@@ -29,6 +29,10 @@ class MayachainService: ThorchainSwapProvider {
         self.resolver = resolver
     }
 
+    func makeSwapQuote(_ quote: ThorchainSwapQuote) -> SwapQuote {
+        .mayachain(quote)
+    }
+
     /// The override-aware Mayanode host. Falls back to the default host when no
     /// override is set.
     private var resolvedHost: URL {

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
@@ -39,6 +39,10 @@ class ThorchainService: ThorchainSwapProvider {
         self.httpClient = httpClient
     }
 
+    func makeSwapQuote(_ quote: ThorchainSwapQuote) -> SwapQuote {
+        .thorchain(quote)
+    }
+
     /// The override-aware THORChain LCD host. Falls back to the default host
     /// when no override is set. Exposed so the broadcast path can reuse it. The
     /// single `.thorChain` override intentionally replaces both the LCD and RPC

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenet2Service.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenet2Service.swift
@@ -21,6 +21,10 @@ class ThorchainStagenetService: ThorchainSwapProvider {
 
     private init() {}
 
+    func makeSwapQuote(_ quote: ThorchainSwapQuote) -> SwapQuote {
+        .thorchainStagenet(quote)
+    }
+
     // MARK: - Helpers
 
     /// The environment for this service is `.stagenet` — Vultisig's internal

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainStagenetService.swift
@@ -21,6 +21,10 @@ class ThorchainChainnetService: ThorchainSwapProvider {
 
     private init() {}
 
+    func makeSwapQuote(_ quote: ThorchainSwapQuote) -> SwapQuote {
+        .thorchainChainnet(quote)
+    }
+
     // MARK: - Helpers
 
     /// The environment for this service is fixed at `.chainnet` — the file

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainSwapProvider.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainSwapProvider.swift
@@ -19,6 +19,15 @@ protocol ThorchainSwapProvider {
         referredCode: String,
         vultTierDiscount: Int
     ) async throws -> ThorchainSwapQuote
+
+    /// Wraps a fetched native quote in the `SwapQuote` case that identifies this
+    /// service's network. The concrete service type is the only thing that
+    /// carries the THORChain network (mainnet vs chainnet vs stagenet) — the
+    /// coarser `SwapProvider` has no such distinction — so each conformer
+    /// declares its own tag here. Making this a protocol requirement means a
+    /// newly added service fails to compile until it maps itself, which is what
+    /// prevents a silent mislabel.
+    func makeSwapQuote(_ quote: ThorchainSwapQuote) -> SwapQuote
 }
 
 extension ThorchainSwapProvider {

--- a/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ThorchainAntiRektTests.swift
@@ -223,6 +223,35 @@ final class ThorchainAntiRektTests: XCTestCase {
         XCTAssertEqual(mock.callCount, 0, "Maya is out of scope and must not trigger a second fetch")
     }
 
+    // MARK: - makeSwapQuote network tagging
+
+    func testMakeSwapQuoteTagsEachServiceWithItsNetworkCase() {
+        // Pins the concrete-service → SwapQuote-case mapping. The network
+        // (mainnet / chainnet / stagenet) is carried only by the service type,
+        // so a future edit that drops or misroutes a case regresses here.
+        let quote = makeQuote(expectedAmountOut: "100", feesTotal: "0")
+
+        guard case .thorchain(let thorMapped) = ThorchainService.shared.makeSwapQuote(quote) else {
+            return XCTFail("ThorchainService must map to .thorchain")
+        }
+        XCTAssertEqual(thorMapped, quote)
+
+        guard case .thorchainChainnet(let chainnetMapped) = ThorchainChainnetService.shared.makeSwapQuote(quote) else {
+            return XCTFail("ThorchainChainnetService must map to .thorchainChainnet")
+        }
+        XCTAssertEqual(chainnetMapped, quote)
+
+        guard case .thorchainStagenet(let stagenetMapped) = ThorchainStagenetService.shared.makeSwapQuote(quote) else {
+            return XCTFail("ThorchainStagenetService must map to .thorchainStagenet")
+        }
+        XCTAssertEqual(stagenetMapped, quote)
+
+        guard case .mayachain(let mayaMapped) = MayachainService.shared.makeSwapQuote(quote) else {
+            return XCTFail("MayachainService must map to .mayachain")
+        }
+        XCTAssertEqual(mayaMapped, quote)
+    }
+
     // MARK: - Helpers
 
     private func makeQuote(
@@ -290,5 +319,9 @@ private final class MockSwapProvider: ThorchainSwapProvider {
         lastStreamingQuantity = streamingQuantity
         lastLiquidityToleranceBps = liquidityToleranceBps
         return try response.get()
+    }
+
+    func makeSwapQuote(_ quote: ThorchainSwapQuote) -> SwapQuote {
+        .thorchain(quote)
     }
 }


### PR DESCRIPTION
Closes #4901

## Root cause
`SwapService.fetchCrossChainQuote` tagged a fetched THORChain/Maya quote to a `SwapQuote` case by **type-probing the service instance** inside a `switch service { … }` that ended with a mislabeling catch-all:

```swift
default: return .thorchain(quote)   // silent mislabel
```

Any conforming service that wasn't one of the four explicitly matched cases (e.g. a newly added network) would be silently tagged as **mainnet THORChain** — the exact three-network distinction (`.thorchain` / `.thorchainChainnet` / `.thorchainStagenet`) the result depends on, quietly collapsed.

## Why switching on `provider` is insufficient
The obvious "switch on the `provider:` param instead" does **not** work: `SwapProvider` only has `.thorchain` / `.maya` (plus the aggregators) — it has **no chainnet/stagenet distinction**, so it is too coarse to produce the three separate `SwapQuote` cases. The concrete service **type** is the only thing that carries the network.

## Fix — Strategy on the service
Add a requirement to the `ThorchainSwapProvider` protocol so each concrete service declares its own tag, then call it at the site (no type-probe, no `default:`):

```swift
func makeSwapQuote(_ quote: ThorchainSwapQuote) -> SwapQuote
```

- `ThorchainService` → `.thorchain`
- `ThorchainChainnetService` → `.thorchainChainnet`
- `ThorchainStagenetService` → `.thorchainStagenet`
- `MayachainService` → `.mayachain`

The call site becomes `return service.makeSwapQuote(quote)`. The four mappings are **byte-identical** to what the old type-probe produced. Because it is now a protocol requirement, adding a new conforming service is a **compile error** until it declares its tag — that's the point: the silent `default:` mislabel is impossible now.

## Test
Adds `testMakeSwapQuoteTagsEachServiceWithItsNetworkCase`, which pins each of the 4 concrete services to its correct `SwapQuote` case (and verifies the payload passes through unchanged) so a future edit can't silently regress the mapping.

## Out of scope
The catch-all `catch { throw SwapError.swapAmountTooSmall }` in `fetchCrossChainQuote` is a separate issue (#4902) and is intentionally left untouched.

## Gate
`make test` → `** TEST SUCCEEDED **` — **3819 tests, 1 skipped, 0 failures**. SwiftLint clean. Cross-model Codex read-only review: no concrete issues (confirmed byte-identical mappings, removing `default:` cannot drop/mislabel a case, MockSwapProvider/tests correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-chain swap quote handling to ensure quotes are correctly tagged for their corresponding network.
  * Added support for consistent quote identification across THORChain, stagenet, chainnet, and MayaChain swaps.

* **Tests**
  * Added coverage verifying correct network tagging for each supported swap service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->