### PR TITLE
fix(chain): make supportsPendingTransactions exhaustive; drop dead supportsEip1559 branch

### DIFF
--- a/VultisigApp/VultisigApp/Model/Chain.swift
+++ b/VultisigApp/VultisigApp/Model/Chain.swift
@@ -606,22 +606,20 @@ enum Chain: String, Codable, Hashable, CaseIterable {
 
 extension Chain {
     var supportsEip1559: Bool {
-        switch self {
-        case .bscChain:
-            return false
-        case .ethereum, .avalanche, .arbitrum, .base, .optimism, .polygon, .polygonV2, .blast, .cronosChain, .ethereumSepolia, .mantle, .hyperliquid, .sei:
-            return true
-        default:
-            return true
-        }
+        // Every EVM chain we support advertises EIP-1559 fee markets except BSC,
+        // which still uses legacy gas pricing.
+        self != .bscChain
     }
 
-    /// Indicates if this chain supports pending transaction tracking via sequence numbers (nonce)
+    /// Indicates if this chain supports pending transaction tracking via sequence numbers (nonce).
+    /// Exhaustive on purpose (no `default:`): a newly added nonce/Cosmos-style chain must
+    /// declare its value here or the compiler will flag it, avoiding a silent stale-nonce
+    /// broadcast (this gates `BlockChainService.shouldUseCache` / `setCacheIfAllowed`).
     var supportsPendingTransactions: Bool {
         switch self {
         case .thorChain, .thorChainChainnet, .thorChainStagenet, .mayaChain, .gaiaChain, .kujira, .osmosis, .dydx, .terra, .terraClassic, .noble, .akash, .qbtc:
             return true
-        default:
+        case .solana, .ethereum, .avalanche, .base, .blast, .arbitrum, .polygon, .polygonV2, .optimism, .bscChain, .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash, .cardano, .cronosChain, .sui, .polkadot, .zksync, .ton, .ripple, .tron, .ethereumSepolia, .zcash, .mantle, .hyperliquid, .sei, .bittensor:
             return false
         }
     }

--- a/VultisigApp/VultisigAppTests/Model/ChainPendingTransactionSupportTests.swift
+++ b/VultisigApp/VultisigAppTests/Model/ChainPendingTransactionSupportTests.swift
@@ -1,0 +1,81 @@
+//
+//  ChainPendingTransactionSupportTests.swift
+//  VultisigApp
+//
+//  Pins the per-chain values of `Chain.supportsPendingTransactions` and
+//  `Chain.supportsEip1559` after both were rewritten to remove misleading /
+//  risky `default:` branches:
+//
+//  - `supportsPendingTransactions` is now an exhaustive switch (no `default:`)
+//    so a newly added nonce/Cosmos-style chain cannot silently inherit
+//    `false` and serve a stale nonce from cache. These asserts lock the
+//    true/false split so the exhaustive rewrite stayed byte-identical.
+//  - `supportsEip1559` collapsed a dead explicit allow-list into
+//    `self != .bscChain`; the assert pins that BSC is the only chain without
+//    EIP-1559 fee markets.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class ChainPendingTransactionSupportTests: XCTestCase {
+
+    // MARK: - supportsPendingTransactions
+
+    /// The nonce/sequence-tracking chains that MUST report `true`.
+    /// Preserved exactly from the pre-refactor allow-list.
+    private let pendingTrueChains: [Chain] = [
+        .thorChain, .thorChainChainnet, .thorChainStagenet, .mayaChain,
+        .gaiaChain, .kujira, .osmosis, .dydx, .terra, .terraClassic,
+        .noble, .akash, .qbtc
+    ]
+
+    func testPendingTransactionsTrueForNonceChains() {
+        for chain in pendingTrueChains {
+            XCTAssertTrue(
+                chain.supportsPendingTransactions,
+                "\(chain) must support pending-transaction tracking (nonce/sequence)."
+            )
+        }
+    }
+
+    func testPendingTransactionsFalseForRepresentativeChains() {
+        // A representative sample across UTXO / EVM / other families that
+        // must remain `false` after the exhaustive rewrite.
+        let falseChains: [Chain] = [
+            .bitcoin, .ethereum, .solana, .bscChain, .sui, .ripple,
+            .cardano, .polkadot, .ton, .tron
+        ]
+        for chain in falseChains {
+            XCTAssertFalse(
+                chain.supportsPendingTransactions,
+                "\(chain) must NOT report pending-transaction support."
+            )
+        }
+    }
+
+    /// Belt-and-braces: exactly the allow-list chains (and no others) are
+    /// `true`, so a future edit that widens the `true` branch is caught even
+    /// for chains this file doesn't enumerate explicitly.
+    func testPendingTransactionsTrueSetIsExactlyTheAllowList() {
+        let actualTrue = Set(Chain.allCases.filter { $0.supportsPendingTransactions })
+        XCTAssertEqual(actualTrue, Set(pendingTrueChains))
+    }
+
+    // MARK: - supportsEip1559
+
+    func testEip1559FalseOnlyForBsc() {
+        for chain in Chain.allCases {
+            let expected = chain != .bscChain
+            XCTAssertEqual(
+                chain.supportsEip1559,
+                expected,
+                "\(chain).supportsEip1559 should be \(expected); BSC is the only chain without EIP-1559."
+            )
+        }
+    }
+
+    func testBscDoesNotSupportEip1559() {
+        XCTAssertFalse(Chain.bscChain.supportsEip1559)
+    }
+}


### PR DESCRIPTION
Closes #4904

## Root cause
`Chain.supportsPendingTransactions` ended in `default: return false`. It gates cache-skipping for fresh nonces (`BlockChainService.shouldUseCache` / `setCacheIfAllowed`). A newly added nonce/Cosmos-style `Chain` that isn't listed compiles clean but silently inherits `false` → serves a **stale nonce from cache** → a wrong or failed broadcast. Silent and signing-adjacent.

Related dead code: `Chain.supportsEip1559`'s explicit allow-list (`.ethereum, .avalanche, … → true`) was identical to its `default: return true`, so only `.bscChain → false` was meaningful — the list only misled readers into thinking it was the maintained allow-list.

## Fix
- **`supportsPendingTransactions`** — now an **exhaustive switch over `Chain` (no `default:`)**. The `true` branch is unchanged (thorChain family + gaia/kujira/osmosis/dydx/terra/terraClassic/noble/akash/qbtc); every other case is listed explicitly in the `false` branch. Per-chain values are **byte-identical** to before. Adding a new `Chain` case is now a compile error until its value is set.
- **`supportsEip1559`** — collapsed the dead explicit list to `self != .bscChain`. Same value for every existing chain (BSC is the only chain without EIP-1559 fee markets).

No behavior change for any existing chain.

## Tests
Added `VultisigAppTests/Model/ChainPendingTransactionSupportTests.swift`:
- `supportsPendingTransactions` is `true` for each nonce chain and `false` for a representative UTXO/EVM/other sample.
- The `true` set equals exactly the allow-list across `Chain.allCases` (catches accidental widening).
- `supportsEip1559` is `false` only for `.bscChain`, verified across all `Chain.allCases`.

## Gate
- `make generate` + SwiftLint clean on the changed files.
- Cross-model review (Codex, read-only): no findings — confirmed all 42 `Chain` cases appear exactly once (13 true / 29 false), values match the previous impl, and `supportsEip1559` is value-preserving.
- `make test` on iOS 26.5 simulator: `** TEST SUCCEEDED **` — Executed 3823 tests, 1 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction support detection across blockchain networks.
  * Corrected gas-fee capability handling so EIP-1559 is recognized for supported networks, with BSC retaining legacy gas behavior.
  * Prevented stale nonce-related behavior when new networks are added.

* **Tests**
  * Added coverage validating pending transaction and EIP-1559 support for every network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->