### PR TITLE
fix: standardize BCH address explorer host to blockchair

### DIFF
--- a/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Endpoint.swift
@@ -255,7 +255,7 @@ class Endpoint {
         case .bitcoin:
             return "https://mempool.space/address/\(address)"
         case .bitcoinCash:
-            return "https://explorer.bitcoin.com/bch/address/\(address)"
+            return "https://blockchair.com/bitcoin-cash/address/\(address)"
         case .litecoin:
             return "https://blockchair.com/litecoin/address/\(address)"
         case .dogecoin:

--- a/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
@@ -306,4 +306,35 @@ final class ExplorerLinkBuilderTests: XCTestCase {
             "https://explorer.qbtc.net/qbtc/account/addr"
         )
     }
+
+    // MARK: - Bitcoin Cash explorer host consistency
+
+    /// Bitcoin Cash transaction and address links must resolve to the same
+    /// explorer host across every code path. The address host had drifted:
+    /// `Endpoint.getExplorerByAddressURLByGroup` pointed at explorer.bitcoin.com
+    /// while the tx URL and `ExplorerLinkBuilder.getExplorerByAddressURL` both
+    /// used blockchair. Lock all three to blockchair so tx + address agree.
+    func testBitcoinCashExplorerHostsAreConsistent() {
+        let address = "bitcoincash:qtestaddress"
+
+        let txHost = URL(
+            string: ExplorerLinkBuilder.getExplorerURL(chain: .bitcoinCash, txid: txHash)
+        )?.host
+        let addressHost = ExplorerLinkBuilder
+            .getExplorerByAddressURL(chain: .bitcoinCash, address: address)
+            .flatMap { URL(string: $0)?.host }
+        let groupAddressHost = Endpoint
+            .getExplorerByAddressURLByGroup(chain: .bitcoinCash, address: address)
+            .flatMap { URL(string: $0)?.host }
+
+        XCTAssertEqual(txHost, "blockchair.com")
+        XCTAssertEqual(addressHost, "blockchair.com")
+        XCTAssertEqual(groupAddressHost, "blockchair.com")
+        XCTAssertEqual(txHost, addressHost, "BCH tx and address hosts must match")
+        XCTAssertEqual(
+            addressHost,
+            groupAddressHost,
+            "BCH address hosts must match across both explorer functions"
+        )
+    }
 }


### PR DESCRIPTION
Closes #4905

## Root cause
The chain→explorer-host mapping is duplicated across several switch statements, and it had drifted for **Bitcoin Cash addresses**. Two functions that should agree returned different hosts:

- `ExplorerLinkBuilder.getExplorerByAddressURL` (BCH) → `blockchair.com/bitcoin-cash/address/…`
- `Endpoint.getExplorerByAddressURLByGroup` (BCH) → `explorer.bitcoin.com/bch/address/…`

So a BCH address opened on a different explorer depending on which code path produced the link — and diverged from the BCH **transaction** link (`ExplorerLinkBuilder.getExplorerURL` → `blockchair.com/bitcoin-cash/transaction/…`).

## Fix
Point `Endpoint.getExplorerByAddressURLByGroup`'s Bitcoin Cash arm at `blockchair.com/bitcoin-cash/address/…`.

### Which host, and why
Standardized on **blockchair.com** (`bitcoin-cash`). It was already the canonical host for BCH:
- BCH **tx** URL (`getExplorerURL`) uses blockchair.
- BCH **address** URL (`getExplorerByAddressURL`) uses blockchair.
- Every sibling UTXO chain (Litecoin, Dogecoin, Dash, Zcash) uses blockchair for **both** tx and address in **both** functions.

Only the group-address BCH arm had drifted to `explorer.bitcoin.com`, which is the less reliable path for BCH addresses. Aligning it to blockchair makes BCH tx + address share one host family and matches the rest of the UTXO chains — the minimal change that resolves the divergence.

**Scope:** intentionally minimal — only the BCH host divergence. Collapsing the duplicated explorer switches into a single registry is a separate, larger refactor and is out of scope here.

## Test
Added `testBitcoinCashExplorerHostsAreConsistent` in `ExplorerLinkBuilderTests`, asserting that the BCH tx URL, the BCH address URL, and the BCH group-address URL all resolve to `blockchair.com`, and that the address hosts match across both functions.

## Gate
`make test` on iOS Simulator (iPhone 16 Pro / iOS 26.5): **`** TEST SUCCEEDED **`** — Executed 3819 tests, 1 skipped, 0 failures. SwiftLint clean on changed files. Cross-model (Codex) read-only review: no issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Bitcoin Cash address explorer links to use Blockchair, keeping them consistent with transaction links.
  * Improved reliability of Bitcoin Cash explorer navigation.

* **Tests**
  * Added coverage to verify that Bitcoin Cash transaction and address links use the same explorer host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->