### PR TITLE
refactor(defi): extract DefiChainScreenModel from DefiChainMainScreen

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -5,7 +5,6 @@
 //  Created by Gaston Mazzeo on 17/10/2025.
 //
 
-import BigInt
 import SwiftUI
 
 struct DefiChainMainScreen: View {
@@ -20,6 +19,7 @@ struct DefiChainMainScreen: View {
     @StateObject private var cosmosStakeViewModel: CosmosStakeDefiViewModel
     @StateObject private var solanaStakeViewModel: SolanaStakeDefiViewModel
     @StateObject private var governanceViewModel: QBTCGovernanceViewModel
+    @StateObject private var screenModel: DefiChainScreenModel
     @State private var showPositionSelection = false
     @State private var isLoading = false
     @State private var error: HelperError?
@@ -40,28 +40,11 @@ struct DefiChainMainScreen: View {
         self._cosmosStakeViewModel = StateObject(wrappedValue: CosmosStakeDefiViewModel(chain: chain))
         self._solanaStakeViewModel = StateObject(wrappedValue: SolanaStakeDefiViewModel(vault: vault))
         self._governanceViewModel = StateObject(wrappedValue: QBTCGovernanceViewModel())
+        self._screenModel = StateObject(wrappedValue: DefiChainScreenModel(vault: vault, chain: chain))
     }
 
     private var nativeCoin: Coin? {
         vault.nativeCoin(for: chain)
-    }
-
-    /// Whether the native coin balance can cover a governance vote's flat tx
-    /// fee. A vote is an on-chain tx that costs gas, so a 0/dust-balance user
-    /// would otherwise walk verify → ML-DSA keysign only for the broadcast to
-    /// fail. We compare the raw balance against the chain's flat `min_tx_fee`
-    /// (`CosmosStakingConfig`, the single source of truth for QBTC fee). The
-    /// fee is the exact flat floor — `min_gas_price` is 0 on qbtc-testnet, so
-    /// gas is free and the fee doesn't vary by message — so this is a precise
-    /// pre-flight, not an approximation. Gates both vote entry points and
-    /// greys the vote controls with a hint.
-    var canCoverVoteFee: Bool {
-        guard let nativeCoin else { return false }
-        guard let feeAmount = try? CosmosStakingConfig.feeAmount(for: chain) else {
-            // No fee config for this chain — don't block (non-QBTC fallback).
-            return true
-        }
-        return nativeCoin.rawBalance.toBigInt() >= BigInt(feeAmount)
     }
 
     /// Surfaced via the `.withBanner(...)` toast modifier. Only Bond surfaces a refresh error
@@ -213,7 +196,7 @@ struct DefiChainMainScreen: View {
                     onWeightedVote: { proposal, options in
                         onGovernanceWeightedVote(proposal: proposal, options: options)
                     },
-                    canVote: canCoverVoteFee
+                    canVote: screenModel.canCoverVoteFee(nativeCoin: nativeCoin)
                 )
             }
         }
@@ -332,149 +315,40 @@ struct DefiChainMainScreen: View {
     }
 
     func onStake(position: StakePosition) {
-        if position.coin.chain == .ton {
-            // Add-more reuses the existing pool; a first-time stake (no pool yet)
-            // routes with `nil` so the screen prompts for the pool address.
-            onTransactionToPresent(.tonStake(
-                coin: position.coin,
-                poolAddress: position.poolAddress,
-                poolImplementation: position.poolImplementation
-            ))
-            return
-        }
-        switch position.type {
-        case .stake:
-            onTransactionToPresent(.stake(coin: position.coin, isAutocompound: false))
-        case .compound:
-            onTransactionToPresent(.stake(coin: stakeCoin(for: position.coin), isAutocompound: true))
-        case .index:
-            onTransactionToPresent(.mint(coin: coin(for: position.coin), yCoin: position.coin))
-        }
+        onTransactionToPresent(screenModel.stakeTransactionType(for: position))
     }
 
     func onUnstake(position: StakePosition) {
-        if position.coin.chain == .ton {
-            guard let poolAddress = position.poolAddress, !poolAddress.isEmpty else { return }
-            onTransactionToPresent(
-                .tonUnstake(
-                    coin: position.coin,
-                    poolAddress: poolAddress,
-                    poolImplementation: position.poolImplementation,
-                    stakedAmount: position.amount
-                )
-            )
-            return
-        }
-        switch position.type {
-        case .stake:
-            onTransactionToPresent(
-                .unstake(
-                    coin: position.coin,
-                    isAutocompound: false,
-                    availableToUnstake: position.availableToUnstake
-                )
-            )
-        case .compound:
-            onTransactionToPresent(
-                .unstake(
-                    coin: stakeCoin(for: position.coin),
-                    isAutocompound: true,
-                    availableToUnstake: position.amount
-                )
-            )
-        case .index:
-            onTransactionToPresent(.redeem(coin: coin(for: position.coin), yCoin: position.coin))
-        }
+        guard let type = screenModel.unstakeTransactionType(for: position) else { return }
+        onTransactionToPresent(type)
     }
 
     func onTransfer(position: StakePosition) {
-        guard let coin = vault.coins.first(where: { $0.toCoinMeta() == position.coin }) else {
-            return
-        }
+        guard let coin = screenModel.transferCoin(for: position) else { return }
         router.navigate(to: HomeRoute.vaultAction(
             action: .send(coin: coin, hasPreselectedCoin: true),
             vault: vault
         ))
     }
 
-    func stakeCoin(for compoundCoin: CoinMeta) -> CoinMeta {
-        switch compoundCoin.ticker.uppercased() {
-        case "STCY":
-            return TokensStore.tcy
-        case "YBRUNE":
-            return TokensStore.brune
-        case "SRUJI":
-            return TokensStore.ruji
-        default:
-            return compoundCoin
-        }
-    }
-
-    func coin(for yCoin: CoinMeta) -> CoinMeta {
-        let coin: CoinMeta
-        switch yCoin {
-        case TokensStore.yrune:
-            coin = TokensStore.rune
-        case TokensStore.ytcy:
-            coin = TokensStore.tcy
-        default:
-            coin = TokensStore.rune
-        }
-        return coin
-    }
-
-    /// Builds a single-option QBTC governance vote tx straight from the
-    /// proposal + chosen option and pushes it to the existing verify → ML-DSA
-    /// keysign flow. The memo (`QBTC_VOTE:<OPTION>:<ID>`) is what
-    /// `QBTCHelper.buildMsgVote` consumes; the dictionary is display-only so
-    /// verify reads "Vote <OPTION> on Proposal #N" rather than the raw memo.
     func onGovernanceVote(proposal: CosmosGovProposal, choice: CosmosGovVoteChoice) {
-        guard let nativeCoin, canCoverVoteFee else { return }
-        let memo = QBTCGovVoteMemo.singleVote(proposalID: proposal.id, choice: choice)
-        let displayDictionary: [String: String] = [
-            "action": "governanceVoteAction".localized,
-            "vote": choice.displayTitle,
-            "proposal": String(format: "governanceProposalNumber".localized, String(proposal.id))
-        ]
-        let tx = SendTransaction.empty(coin: nativeCoin, vault: vault).copy(
-            memo: memo,
-            transactionType: .vote,
-            memoFunctionDictionary: displayDictionary
-        )
+        guard let tx = screenModel.makeGovernanceVoteTransaction(proposal: proposal, choice: choice) else { return }
         router.navigate(to: FunctionCallRoute.verify(tx: tx, vault: vault))
     }
 
-    /// Builds a weighted QBTC governance vote tx from per-option weights and
-    /// pushes it to verify → ML-DSA keysign. The memo
-    /// (`QBTC_VOTEW:<ID>:OPT=W,...`) is what `QBTCHelper.buildMsgVoteWeighted`
-    /// consumes; weights are passed as plain decimals and the helper
-    /// canonicalizes them to the 18-decimal `cosmos.Dec` form.
     func onGovernanceWeightedVote(proposal: CosmosGovProposal, options: [CosmosGovVoteOption]) {
-        guard let nativeCoin, canCoverVoteFee, !options.isEmpty else { return }
-        let memo = QBTCGovVoteMemo.weightedVote(proposalID: proposal.id, options: options)
-        let displayValue = QBTCGovVoteMemo.weightedDisplayValue(options: options)
-        let displayDictionary: [String: String] = [
-            "action": "governanceVoteAction".localized,
-            "vote": displayValue,
-            "proposal": String(format: "governanceProposalNumber".localized, String(proposal.id))
-        ]
-        let tx = SendTransaction.empty(coin: nativeCoin, vault: vault).copy(
-            memo: memo,
-            transactionType: .vote,
-            memoFunctionDictionary: displayDictionary
-        )
+        guard let tx = screenModel.makeGovernanceWeightedVoteTransaction(proposal: proposal, options: options) else {
+            return
+        }
         router.navigate(to: FunctionCallRoute.verify(tx: tx, vault: vault))
     }
 
     func onTransactionToPresent(_ type: FunctionTransactionType) {
         Task { @MainActor in
-            let vaultCoins = vault.coins.map { $0.toCoinMeta() }
-            let shouldAdd = type.coins.contains { !vaultCoins.contains($0) }
-
-            if shouldAdd {
+            if screenModel.needsCoinAddition(for: type) {
                 isLoading = true
                 do {
-                    try await CoinService.addToChain(assets: type.coins, to: vault)
+                    try await screenModel.addCoins(for: type)
                 } catch {
                     self.error = HelperError.runtimeError("Failed to add coins")
                     isLoading = false
@@ -493,21 +367,13 @@ struct DefiChainMainScreen: View {
     /// Builds the unsigned tx and pushes straight to Verify — used by the Solana
     /// unstake/withdraw rows, which have no editable field and are already gated
     /// upstream (active/activating for unstake, fully inactive for withdraw), so
-    /// the intermediate confirm screen would be redundant. Mirrors
-    /// `FunctionTransactionScreen.onVerify`: pre-fetch the chain-specific gas so
-    /// Verify shows the fee immediately; it is re-fetched there anyway, so a
-    /// failure here is non-fatal.
+    /// the intermediate confirm screen would be redundant. The chain-specific
+    /// gas is pre-fetched inside the model so Verify shows the fee immediately.
     func presentVerify(for builder: TransactionBuilder) {
         Task { @MainActor in
             isLoading = true
             defer { isLoading = false }
-            var sendTx = builder.buildSendTransaction(vault: vault)
-            do {
-                let chainSpecific = try await BlockChainService.shared.fetchSpecific(tx: sendTx)
-                sendTx = sendTx.copy(gas: chainSpecific.gas)
-            } catch {
-                // Non-fatal: gas is re-fetched during Verify.
-            }
+            let sendTx = await screenModel.buildVerifyTransaction(for: builder)
             router.navigate(to: FunctionCallRoute.verify(tx: sendTx, vault: vault))
         }
     }
@@ -618,6 +484,7 @@ private extension DefiChainMainScreen {
         bondViewModel.update(vault: vault)
         lpsViewModel.update(vault: vault)
         stakeViewModel.update(vault: vault)
+        screenModel.update(vault: vault)
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainScreenModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainScreenModel.swift
@@ -1,0 +1,226 @@
+//
+//  DefiChainScreenModel.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 17/10/2025.
+//
+
+import BigInt
+import Foundation
+
+/// Owns the business logic behind `DefiChainMainScreen`: the governance
+/// vote-fee preflight, the compound/index coin mappings, the stake/unstake
+/// intent → `FunctionTransactionType` translation, the governance memo/tx
+/// builders, and the async coin-add / gas-fetch orchestration. Every method
+/// returns a value (a built `SendTransaction`, a `FunctionTransactionType`,
+/// a coin, or a bool) — navigation stays in the view, which consumes these
+/// and forwards them to `router.navigate`.
+@MainActor
+final class DefiChainScreenModel: ObservableObject {
+    private(set) var vault: Vault
+    let chain: Chain
+
+    init(vault: Vault, chain: Chain) {
+        self.vault = vault
+        self.chain = chain
+    }
+
+    func update(vault: Vault) {
+        self.vault = vault
+    }
+
+    var nativeCoin: Coin? {
+        vault.nativeCoin(for: chain)
+    }
+
+    // MARK: - Governance vote-fee preflight
+
+    /// Whether the given native coin balance can cover a governance vote's flat
+    /// tx fee. A vote is an on-chain tx that costs gas, so a 0/dust-balance user
+    /// would otherwise walk verify → ML-DSA keysign only for the broadcast to
+    /// fail. We compare the raw balance against the chain's flat `min_tx_fee`
+    /// (`CosmosStakingConfig`, the single source of truth for QBTC fee). The
+    /// fee is the exact flat floor — `min_gas_price` is 0 on qbtc-testnet, so
+    /// gas is free and the fee doesn't vary by message — so this is a precise
+    /// pre-flight, not an approximation. Gates both vote entry points and
+    /// greys the vote controls with a hint.
+    func canCoverVoteFee(nativeCoin: Coin?) -> Bool {
+        guard let nativeCoin else { return false }
+        guard let feeAmount = try? CosmosStakingConfig.feeAmount(for: chain) else {
+            // No fee config for this chain — don't block (non-QBTC fallback).
+            return true
+        }
+        return nativeCoin.rawBalance.toBigInt() >= BigInt(feeAmount)
+    }
+
+    // MARK: - Coin mapping
+
+    func stakeCoin(for compoundCoin: CoinMeta) -> CoinMeta {
+        switch compoundCoin.ticker.uppercased() {
+        case "STCY":
+            return TokensStore.tcy
+        case "YBRUNE":
+            return TokensStore.brune
+        case "SRUJI":
+            return TokensStore.ruji
+        default:
+            return compoundCoin
+        }
+    }
+
+    func coin(for yCoin: CoinMeta) -> CoinMeta {
+        let coin: CoinMeta
+        switch yCoin {
+        case TokensStore.yrune:
+            coin = TokensStore.rune
+        case TokensStore.ytcy:
+            coin = TokensStore.tcy
+        default:
+            coin = TokensStore.rune
+        }
+        return coin
+    }
+
+    // MARK: - Stake / unstake / transfer intents
+
+    /// Maps a stake action on a position to the function-call transaction the
+    /// view should present. TON reuses/initialises its nominator pool; the
+    /// other chains route stake / compound / index through their respective
+    /// `FunctionTransactionType` cases.
+    func stakeTransactionType(for position: StakePosition) -> FunctionTransactionType {
+        if position.coin.chain == .ton {
+            // Add-more reuses the existing pool; a first-time stake (no pool yet)
+            // routes with `nil` so the screen prompts for the pool address.
+            return .tonStake(
+                coin: position.coin,
+                poolAddress: position.poolAddress,
+                poolImplementation: position.poolImplementation
+            )
+        }
+        switch position.type {
+        case .stake:
+            return .stake(coin: position.coin, isAutocompound: false)
+        case .compound:
+            return .stake(coin: stakeCoin(for: position.coin), isAutocompound: true)
+        case .index:
+            return .mint(coin: coin(for: position.coin), yCoin: position.coin)
+        }
+    }
+
+    /// Maps an unstake action to the function-call transaction, or `nil` when the
+    /// action is a no-op (a TON unstake with no pool address to unwind).
+    func unstakeTransactionType(for position: StakePosition) -> FunctionTransactionType? {
+        if position.coin.chain == .ton {
+            guard let poolAddress = position.poolAddress, !poolAddress.isEmpty else { return nil }
+            return .tonUnstake(
+                coin: position.coin,
+                poolAddress: poolAddress,
+                poolImplementation: position.poolImplementation,
+                stakedAmount: position.amount
+            )
+        }
+        switch position.type {
+        case .stake:
+            return .unstake(
+                coin: position.coin,
+                isAutocompound: false,
+                availableToUnstake: position.availableToUnstake
+            )
+        case .compound:
+            return .unstake(
+                coin: stakeCoin(for: position.coin),
+                isAutocompound: true,
+                availableToUnstake: position.amount
+            )
+        case .index:
+            return .redeem(coin: coin(for: position.coin), yCoin: position.coin)
+        }
+    }
+
+    /// The vault coin matching a stake position, used to seed the send flow for
+    /// a transfer. `nil` when the vault doesn't hold the position's coin.
+    func transferCoin(for position: StakePosition) -> Coin? {
+        vault.coins.first(where: { $0.toCoinMeta() == position.coin })
+    }
+
+    // MARK: - Governance vote builders
+
+    /// Builds a single-option QBTC governance vote tx straight from the
+    /// proposal + chosen option for the existing verify → ML-DSA keysign flow.
+    /// The memo (`QBTC_VOTE:<OPTION>:<ID>`) is what `QBTCHelper.buildMsgVote`
+    /// consumes; the dictionary is display-only so verify reads
+    /// "Vote <OPTION> on Proposal #N" rather than the raw memo. Returns `nil`
+    /// when there is no native coin or the balance can't cover the vote fee.
+    func makeGovernanceVoteTransaction(
+        proposal: CosmosGovProposal,
+        choice: CosmosGovVoteChoice
+    ) -> SendTransaction? {
+        guard let nativeCoin, canCoverVoteFee(nativeCoin: nativeCoin) else { return nil }
+        let memo = QBTCGovVoteMemo.singleVote(proposalID: proposal.id, choice: choice)
+        let displayDictionary: [String: String] = [
+            "action": "governanceVoteAction".localized,
+            "vote": choice.displayTitle,
+            "proposal": String(format: "governanceProposalNumber".localized, String(proposal.id))
+        ]
+        return SendTransaction.empty(coin: nativeCoin, vault: vault).copy(
+            memo: memo,
+            transactionType: .vote,
+            memoFunctionDictionary: displayDictionary
+        )
+    }
+
+    /// Builds a weighted QBTC governance vote tx from per-option weights for the
+    /// verify → ML-DSA keysign flow. The memo (`QBTC_VOTEW:<ID>:OPT=W,...`) is
+    /// what `QBTCHelper.buildMsgVoteWeighted` consumes; weights are passed as
+    /// plain decimals and the helper canonicalizes them to the 18-decimal
+    /// `cosmos.Dec` form. Returns `nil` when there is no native coin, the
+    /// balance can't cover the vote fee, or no options were supplied.
+    func makeGovernanceWeightedVoteTransaction(
+        proposal: CosmosGovProposal,
+        options: [CosmosGovVoteOption]
+    ) -> SendTransaction? {
+        guard let nativeCoin, canCoverVoteFee(nativeCoin: nativeCoin), !options.isEmpty else { return nil }
+        let memo = QBTCGovVoteMemo.weightedVote(proposalID: proposal.id, options: options)
+        let displayValue = QBTCGovVoteMemo.weightedDisplayValue(options: options)
+        let displayDictionary: [String: String] = [
+            "action": "governanceVoteAction".localized,
+            "vote": displayValue,
+            "proposal": String(format: "governanceProposalNumber".localized, String(proposal.id))
+        ]
+        return SendTransaction.empty(coin: nativeCoin, vault: vault).copy(
+            memo: memo,
+            transactionType: .vote,
+            memoFunctionDictionary: displayDictionary
+        )
+    }
+
+    // MARK: - Coin-add / gas-fetch orchestration
+
+    /// Whether presenting the given transaction requires adding one or more of
+    /// its coins to the vault first.
+    func needsCoinAddition(for type: FunctionTransactionType) -> Bool {
+        let vaultCoins = vault.coins.map { $0.toCoinMeta() }
+        return type.coins.contains { !vaultCoins.contains($0) }
+    }
+
+    /// Adds the transaction's coins to the vault. Only call when
+    /// `needsCoinAddition(for:)` is `true`.
+    func addCoins(for type: FunctionTransactionType) async throws {
+        try await CoinService.addToChain(assets: type.coins, to: vault)
+    }
+
+    /// Builds the unsigned tx and pre-fetches the chain-specific gas so Verify
+    /// shows the fee immediately. Mirrors `FunctionTransactionScreen.onVerify`:
+    /// the gas is re-fetched during Verify anyway, so a fetch failure here is
+    /// non-fatal and the un-gassed tx is returned unchanged.
+    func buildVerifyTransaction(for builder: TransactionBuilder) async -> SendTransaction {
+        var sendTx = builder.buildSendTransaction(vault: vault)
+        do {
+            let chainSpecific = try await BlockChainService.shared.fetchSpecific(tx: sendTx)
+            sendTx = sendTx.copy(gas: chainSpecific.gas)
+        } catch {
+            // Non-fatal: gas is re-fetched during Verify.
+        }
+        return sendTx
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/RujiDualPositionWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/RujiDualPositionWiringTests.swift
@@ -33,14 +33,14 @@ final class RujiDualPositionWiringTests: XCTestCase {
     func testCompoundedCardMapsBackToTheRujiBondCoin() throws {
         let token = try TestStore.installInMemoryContainer()
         defer { TestStore.restore(token) }
-        let screen = DefiChainMainScreen(vault: TestStore.makeVault(), chain: .thorChain)
+        let model = DefiChainScreenModel(vault: TestStore.makeVault(), chain: .thorChain)
 
-        XCTAssertEqual(screen.stakeCoin(for: TokensStore.sruji), TokensStore.ruji)
+        XCTAssertEqual(model.stakeCoin(for: TokensStore.sruji), TokensStore.ruji)
         // Unchanged siblings.
-        XCTAssertEqual(screen.stakeCoin(for: TokensStore.stcy), TokensStore.tcy)
-        XCTAssertEqual(screen.stakeCoin(for: TokensStore.ybrune), TokensStore.brune)
+        XCTAssertEqual(model.stakeCoin(for: TokensStore.stcy), TokensStore.tcy)
+        XCTAssertEqual(model.stakeCoin(for: TokensStore.ybrune), TokensStore.brune)
         // A non-compound coin maps to itself.
-        XCTAssertEqual(screen.stakeCoin(for: TokensStore.ruji), TokensStore.ruji)
+        XCTAssertEqual(model.stakeCoin(for: TokensStore.ruji), TokensStore.ruji)
     }
 
     /// The two cards are keyed on different denoms, which is what gives them


### PR DESCRIPTION
Closes #4919

## Summary

Behavior-preserving refactor (Tier-3 "L2") that moves the business logic out of the `DefiChainMainScreen` view into a new `@MainActor` `DefiChainScreenModel` (`ObservableObject`), so the view is purely declarative UI that renders, forwards taps, and keeps `router.navigate`.

### Extracted into `DefiChainScreenModel`
- **`canCoverVoteFee(nativeCoin:)`** — the governance vote-fee preflight (raw balance vs. `CosmosStakingConfig.feeAmount`, BigInt compare). Now a pure function of `(coin, chain)`.
- **`stakeCoin(for:)` / `coin(for:)`** — the compound- and index-token coin mappings, as pure testable functions.
- **`stakeTransactionType(for:)` / `unstakeTransactionType(for:)`** — the stake/unstake intent → `FunctionTransactionType` translation (TON pool handling + stake/compound/index routing).
- **`transferCoin(for:)`** — the vault-coin lookup for the transfer action.
- **`makeGovernanceVoteTransaction(...)` / `makeGovernanceWeightedVoteTransaction(...)`** — the QBTC governance memo + `SendTransaction` builders; return the built tx (or `nil`), the view navigates.
- **`needsCoinAddition(for:)` / `addCoins(for:)`** — the `CoinService.addToChain` orchestration split into a pure decision + the async side-effect.
- **`buildVerifyTransaction(for:)`** — the gas-fetch orchestration (`BlockChainService.fetchSpecific`), returning a built `SendTransaction`.

### View responsibilities kept
Rendering, tap forwarding, `router.navigate` (consuming the VM-built transactions), and the view-local `isLoading` / `error` UI state around the async calls. The model's `vault` is kept in sync via `update(vault:)`.

Same fee thresholds, memo strings, coin mappings, and navigation — no behavior change. The one existing `stakeCoin` unit test (`RujiDualPositionWiringTests`) was repointed from the view to the model (identical assertions), which is the mapping's new owner.

## Verification
- SwiftLint: 0 violations on changed files.
- Unit test gate: `** TEST SUCCEEDED **` — 3817 tests, 0 failures (iPhone 17 Pro Max, iOS 26.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved DeFi staking, unstaking, transfers, and governance vote handling.
  * Added support for weighted governance votes and required coin preparation before transactions.
  * Improved transaction verification by automatically preparing chain-specific gas when available.

* **Bug Fixes**
  * Improved token mapping for compound and chain-specific staking positions.
  * Governance voting now better validates fee coverage before proceeding.

* **Tests**
  * Updated DeFi token-mapping coverage for Ruji positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->