### PR TITLE
refactor(functioncall): replace conditional with polymorphism in FunctionCallInstance

### DIFF
--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallInstance.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallInstance.swift
@@ -7,8 +7,6 @@
 
 import BigInt
 import Foundation
-import SwiftUI
-import VultisigCommonData
 
 enum FunctionCallInstance {
     case rebond(FunctionCallReBond)
@@ -25,160 +23,57 @@ enum FunctionCallInstance {
     case securedAsset(FunctionCallSecuredAsset)
     case withdrawSecuredAsset(FunctionCallWithdrawSecuredAsset)
 
+    /// The active sub-model, type-erased to the shared surface. Every
+    /// accessor below forwards through here so the closed set is switched
+    /// exactly once instead of once per accessor.
+    @MainActor
+    var model: any FunctionCallSubModel {
+        switch self {
+        case .rebond(let memo): return memo
+        case .bondMaya(let memo): return memo
+        case .unbondMaya(let memo): return memo
+        case .leave(let memo): return memo
+        case .custom(let memo): return memo
+        case .vote(let memo): return memo
+        case .cosmosIBC(let memo): return memo
+        case .merge(let memo): return memo
+        case .unmerge(let memo): return memo
+        case .theSwitch(let memo): return memo
+        case .addThorLP(let memo): return memo
+        case .securedAsset(let memo): return memo
+        case .withdrawSecuredAsset(let memo): return memo
+        }
+    }
+
     @MainActor
     var description: String {
-        switch self {
-        case .rebond(let memo):
-            return memo.description
-        case .bondMaya(let memo):
-            return memo.description
-        case .unbondMaya(let memo):
-            return memo.description
-        case .leave(let memo):
-            return memo.description
-        case .custom(let memo):
-            return memo.description
-        case .vote(let memo):
-            return memo.description
-        case .cosmosIBC(let memo):
-            return memo.description
-        case .merge(let memo):
-            return memo.description
-        case .unmerge(let memo):
-            return memo.description
-        case .theSwitch(let memo):
-            return memo.description
-        case .addThorLP(let memo):
-            return memo.description
-        case .securedAsset(let memo):
-            return memo.description
-        case .withdrawSecuredAsset(let memo):
-            return memo.description
-        }
+        model.description
     }
 
     @MainActor
     var amount: Decimal {
-        switch self {
-        case .rebond:
-            return 0  // REBOND must send 0 RUNE in the transaction
-        case .bondMaya(let memo):
-            return memo.amount
-        case .unbondMaya:
-            return 1 / pow(10, 8)
-        case .leave:
-            return .zero
-        case .custom(let memo):
-            return memo.amount
-        case .vote:
-            return .zero
-        case .cosmosIBC(let memo):
-            return memo.amount
-        case .merge(let memo):
-            return memo.amount
-        case .unmerge(let memo):
-            return memo.amount  // Now amount contains the shares as Decimal
-        case .theSwitch(let memo):
-            return memo.amount
-        case .addThorLP(let memo):
-            return memo.amount
-        case .securedAsset(let memo):
-            return memo.amount
-        case .withdrawSecuredAsset(let memo):
-            return memo.amount
-        }
+        model.amount
     }
 
     @MainActor
     var toAddress: String? {
-        switch self {
-        case .cosmosIBC(let memo):
-            return memo.destinationAddress
-        case .merge(let memo):
-            return memo.destinationAddress
-        case .unmerge(let memo):
-            return memo.destinationAddress
-        case .theSwitch(let memo):
-            return memo.destinationAddress
-        case .addThorLP(let memo):
-            // For addThorLP, return the inbound address that was set by fetchInboundAddress()
-            // This is essential for Bitcoin and other chains to know where to send funds
-            return memo.toAddress.isEmpty ? nil : memo.toAddress
-        case .securedAsset(let memo):
-            // For secured assets (MINT), return the inbound address
-            return memo.toAddress.isEmpty ? nil : memo.toAddress
-        case .withdrawSecuredAsset:
-            return nil // Withdraw is done via MsgDeposit on THORChain
-        default:
-            return nil
-        }
+        model.resolvedToAddress
     }
 
     /// Submit-time validity gate. Threads the active coin to every
     /// sub-model so the amount-against-balance check is part of the
     /// same predicate the Continue button reads — no no-arg path can
     /// drift past `amount <= balance` again. Sub-models that don't
-    /// need the coin keep their existing `isTheFormValid` body and the
-    /// parameter just falls through.
+    /// need the coin bridge to their existing `isTheFormValid` body and
+    /// the parameter just falls through.
     @MainActor
     func isFormValid(for coin: Coin) -> Bool {
-        switch self {
-        // No coin-balance guard: REBOND burns zero RUNE — the optional
-        // rebond amount is memo-only, never an on-chain transfer.
-        case .rebond(let memo):
-            return memo.isTheFormValid
-        // No user-editable amount field — BOND sends a fixed amount.
-        case .bondMaya(let memo):
-            return memo.isTheFormValid
-        // No user-editable amount field — UNBOND sends a fixed dust amount.
-        case .unbondMaya(let memo):
-            return memo.isTheFormValid
-        // No amount: LEAVE burns zero RUNE, unbonds via the memo alone.
-        case .leave(let memo):
-            return memo.isTheFormValid
-        case .custom(let memo):
-            return memo.isFormValid(for: coin)
-        // No amount: vote transactions carry zero value.
-        case .vote(let memo):
-            return memo.isTheFormValid
-        case .cosmosIBC(let memo):
-            return memo.isFormValid(for: coin)
-        case .merge(let memo):
-            return memo.isFormValid(for: coin)
-        // Amount is a share quantity validated against the merged-position
-        // balance (`availableBalance`), not the coin balance.
-        case .unmerge(let memo):
-            return memo.isTheFormValid
-        case .theSwitch(let memo):
-            return memo.isFormValid(for: coin)
-        // Balance is checked internally against the sub-model's owned coin
-        // (mutated by the pool dropdown), not the passed-in coin.
-        case .addThorLP(let memo):
-            return memo.isTheFormValid
-        // Balance is checked internally against the sub-model's owned coin.
-        case .securedAsset(let memo):
-            return memo.isTheFormValid
-        // Amount is validated against the selected secured-asset balance,
-        // not the coin balance.
-        case .withdrawSecuredAsset(let memo):
-            return memo.isTheFormValid
-        }
+        model.isFormValid(for: coin)
     }
 
     @MainActor
     var customErrorMessage: String? {
-        switch self {
-        case .rebond(let memo):
-            return memo.customErrorMessage
-        case .addThorLP(let memo):
-            return memo.customErrorMessage
-        case .securedAsset(let memo):
-            return memo.customErrorMessage
-        case .withdrawSecuredAsset(let memo):
-            return memo.customErrorMessage
-        default:
-            return nil
-        }
+        model.submitErrorMessage
     }
 
     @MainActor
@@ -204,20 +99,8 @@ enum FunctionCallInstance {
         }
     }
 
-    @MainActor
-    var wasmContractPayload: WasmExecuteContractPayload? {
-        switch self {
-        case .securedAsset:
-            return nil // Secured assets don't use WASM contracts
-        case .withdrawSecuredAsset:
-            return nil // Withdraw secured assets don't use WASM contracts
-        default:
-            return nil
-        }
-    }
-
     /// Build the immutable `SendTransaction` for the active sub-model.
-    /// After PR3 (C-2e), every case dispatches through its typed
+    /// Every case dispatches through its typed
     /// `toSendTransaction(coin:vault:gas:)` method.
     @MainActor
     func toSendTransaction(
@@ -225,33 +108,6 @@ enum FunctionCallInstance {
         vault: Vault,
         gas: BigInt
     ) -> SendTransaction {
-        switch self {
-        case .rebond(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .bondMaya(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .unbondMaya(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .leave(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .custom(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .vote(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .cosmosIBC(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .merge(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .unmerge(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .theSwitch(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .addThorLP(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .securedAsset(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        case .withdrawSecuredAsset(let memo):
-            return memo.toSendTransaction(coin: coin, vault: vault, gas: gas)
-        }
+        model.toSendTransaction(coin: coin, vault: vault, gas: gas)
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSubModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSubModel.swift
@@ -1,0 +1,117 @@
+//
+//  FunctionCallSubModel.swift
+//  VultisigApp
+//
+//  Shared surface for the 13 FunctionCall sub-models. Reintroduced so
+//  `FunctionCallInstance` can dispatch through a single `model` accessor
+//  instead of re-`switch`ing the same closed set in every accessor.
+//  Each sub-model already implements the memo / amount / validity /
+//  transaction-building surface directly; this protocol only names it and
+//  supplies nil defaults for the two accessors most sub-models opt out of
+//  (`resolvedToAddress`, `submitErrorMessage`).
+//
+
+import BigInt
+import Foundation
+
+@MainActor
+protocol FunctionCallSubModel {
+    /// On-chain memo preview for this function call.
+    var description: String { get }
+
+    /// Asset amount the transaction carries (memo-only calls emit zero).
+    var amount: Decimal { get }
+
+    /// Destination address surfaced through `FunctionCallInstance.toAddress`.
+    /// Defaults to `nil`; only sub-models that route funds to an explicit
+    /// on-chain destination override it.
+    var resolvedToAddress: String? { get }
+
+    /// Error surfaced through `FunctionCallInstance.customErrorMessage`.
+    /// Defaults to `nil`; only the sub-models whose error the instance
+    /// forwarded before this collapse override it. Kept distinct from the
+    /// sub-models' own `customErrorMessage` slot so a sub-model that tracks
+    /// an internal error (e.g. unmerge) does not leak it through the
+    /// instance accessor, preserving the pre-refactor behaviour.
+    var submitErrorMessage: String? { get }
+
+    /// Submit-time validity gate, threaded the active coin.
+    func isFormValid(for coin: Coin) -> Bool
+
+    /// Build the immutable `SendTransaction` fed into signing.
+    func toSendTransaction(coin: Coin, vault: Vault, gas: BigInt) -> SendTransaction
+}
+
+@MainActor
+extension FunctionCallSubModel {
+    var resolvedToAddress: String? { nil }
+    var submitErrorMessage: String? { nil }
+}
+
+// MARK: - Conformances
+//
+// Each sub-model already declares `description`, `amount` and
+// `toSendTransaction(coin:vault:gas:)` in its primary body; the conformance
+// only adds the shims the protocol can't infer:
+//   • `isFormValid(for:)` bridges to the sub-model's `isTheFormValid` where
+//     the sub-model has no coin-threaded gate.
+//   • `resolvedToAddress` / `submitErrorMessage` reproduce the exact per-case
+//     mapping the old `FunctionCallInstance.toAddress` /
+//     `.customErrorMessage` switches encoded.
+
+extension FunctionCallReBond: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+    var submitErrorMessage: String? { customErrorMessage }
+}
+
+extension FunctionCallBondMayaChain: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+}
+
+extension FunctionCallUnbondMayaChain: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+}
+
+extension FunctionCallLeave: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+}
+
+extension FunctionCallCustom: FunctionCallSubModel {}
+
+extension FunctionCallVote: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+}
+
+extension FunctionCallCosmosIBC: FunctionCallSubModel {
+    var resolvedToAddress: String? { destinationAddress }
+}
+
+extension FunctionCallCosmosMerge: FunctionCallSubModel {
+    var resolvedToAddress: String? { destinationAddress }
+}
+
+extension FunctionCallCosmosUnmerge: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+    var resolvedToAddress: String? { destinationAddress }
+}
+
+extension FunctionCallCosmosSwitch: FunctionCallSubModel {
+    var resolvedToAddress: String? { destinationAddress }
+}
+
+extension FunctionCallAddThorLP: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+    var resolvedToAddress: String? { toAddress.isEmpty ? nil : toAddress }
+    var submitErrorMessage: String? { customErrorMessage }
+}
+
+extension FunctionCallSecuredAsset: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+    var resolvedToAddress: String? { toAddress.isEmpty ? nil : toAddress }
+    var submitErrorMessage: String? { customErrorMessage }
+}
+
+extension FunctionCallWithdrawSecuredAsset: FunctionCallSubModel {
+    func isFormValid(for _: Coin) -> Bool { isTheFormValid }
+    var submitErrorMessage: String? { customErrorMessage }
+}

--- a/VultisigApp/VultisigAppTests/FunctionCall/FunctionCallInstancePolymorphismParityTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionCall/FunctionCallInstancePolymorphismParityTests.swift
@@ -1,0 +1,297 @@
+//
+//  FunctionCallInstancePolymorphismParityTests.swift
+//  VultisigAppTests
+//
+//  Guards the "Replace Conditional with Polymorphism" collapse of
+//  `FunctionCallInstance`: every accessor now forwards through the single
+//  `model` sub-model instead of re-`switch`ing the 13-case enum.
+//
+//  The critical invariant is that `toSendTransaction` — which feeds
+//  signing — stays byte-identical per case. Each test builds a case with
+//  deterministic state, then asserts the instance-produced `SendTransaction`
+//  equals the sub-model's own output (the captured baseline) AND pins the
+//  keysign-relevant fields (memo / transactionType / toAddress) to golden
+//  literals. The shared helper additionally checks that `description`,
+//  `amount`, `toAddress`, `customErrorMessage` and `isFormValid(for:)` all
+//  route to the same sub-model.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class FunctionCallInstancePolymorphismParityTests: XCTestCase {
+
+    // MARK: - Shared forwarding-parity assertion
+
+    /// Asserts every forwarded accessor on `instance` routes to `subModel`,
+    /// with `toSendTransaction` byte-identical to the sub-model's own output.
+    private func assertForwardingParity(
+        _ instance: FunctionCallInstance,
+        forwardsTo subModel: any FunctionCallSubModel,
+        coin: Coin,
+        vault: Vault,
+        gas: BigInt,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let viaInstance = instance.toSendTransaction(coin: coin, vault: vault, gas: gas)
+        let baseline = subModel.toSendTransaction(coin: coin, vault: vault, gas: gas)
+
+        // Byte-identical dispatch: the polymorphic path produces the exact
+        // same signing input as calling the sub-model directly.
+        XCTAssertEqual(
+            viaInstance,
+            baseline,
+            "toSendTransaction must be byte-identical to the sub-model output",
+            file: file,
+            line: line
+        )
+
+        XCTAssertEqual(instance.description, subModel.description, file: file, line: line)
+        XCTAssertEqual(instance.amount, subModel.amount, file: file, line: line)
+        XCTAssertEqual(instance.toAddress, subModel.resolvedToAddress, file: file, line: line)
+        XCTAssertEqual(instance.customErrorMessage, subModel.submitErrorMessage, file: file, line: line)
+        XCTAssertEqual(instance.isFormValid(for: coin), subModel.isFormValid(for: coin), file: file, line: line)
+    }
+
+    // MARK: - Per-case parity
+
+    func testRebondParity() {
+        let model = FunctionCallReBond()
+        model.nodeAddress = "thor1node"
+        model.newAddress = "thor1new"
+        let coin = FunctionCallFixture.makeRUNE()
+        let vault = FunctionCallFixture.makeVault(coins: [coin])
+        let instance = FunctionCallInstance.rebond(model)
+
+        let tx = instance.toSendTransaction(coin: coin, vault: vault, gas: 100)
+        XCTAssertEqual(tx.memo, "REBOND:thor1node:thor1new")
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        XCTAssertEqual(tx.amount, "0")           // REBOND burns zero RUNE
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(instance.toAddress)
+        XCTAssertEqual(instance.amount, .zero)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: coin, vault: vault, gas: 100)
+    }
+
+    func testBondMayaParity() {
+        let model = FunctionCallBondMayaChain(assets: [])
+        model.selectedAsset = IdentifiableString(value: "BTC.BTC")
+        model.fee = 5000
+        model.nodeAddress = "maya1bondnode"
+        let coin = FunctionCallFixture.makeCoin(.mayaChain, ticker: "CACAO", decimals: 8, isNative: true)
+        let vault = FunctionCallFixture.makeVault(coins: [coin])
+        let instance = FunctionCallInstance.bondMaya(model)
+
+        let tx = instance.toSendTransaction(coin: coin, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "BOND:BTC.BTC:5000:maya1bondnode")
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(instance.toAddress)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: coin, vault: vault, gas: 0)
+    }
+
+    func testUnbondMayaParity() {
+        let model = FunctionCallUnbondMayaChain(assets: [])
+        model.selectedAsset = IdentifiableString(value: "BTC.BTC")
+        model.fee = 1234
+        model.nodeAddress = "maya1abc"
+        let coin = FunctionCallFixture.makeCoin(.mayaChain, ticker: "CACAO", decimals: 8, isNative: true)
+        let vault = FunctionCallFixture.makeVault(coins: [coin])
+        let instance = FunctionCallInstance.unbondMaya(model)
+
+        let tx = instance.toSendTransaction(coin: coin, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "UNBOND:BTC.BTC:1234:maya1abc")
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(instance.toAddress)
+        XCTAssertEqual(instance.amount, 1 / pow(Decimal(10), 8))
+
+        assertForwardingParity(instance, forwardsTo: model, coin: coin, vault: vault, gas: 0)
+    }
+
+    func testLeaveParity() {
+        let model = FunctionCallLeave()
+        model.nodeAddress = "thor1abc"
+        let coin = FunctionCallFixture.makeRUNE()
+        let vault = FunctionCallFixture.makeVault(coins: [coin])
+        let instance = FunctionCallInstance.leave(model)
+
+        let tx = instance.toSendTransaction(coin: coin, vault: vault, gas: 100)
+        XCTAssertEqual(tx.memo, "LEAVE:thor1abc")
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        XCTAssertEqual(tx.amount, "0")
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(instance.toAddress)
+        XCTAssertEqual(instance.amount, .zero)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: coin, vault: vault, gas: 100)
+    }
+
+    func testCustomParity() {
+        let coin = FunctionCallFixture.makeRUNE()
+        let vault = FunctionCallFixture.makeVault(coins: [coin])
+        let model = FunctionCallCustom(coin: coin, vault: vault)
+        model.custom = "arbitrary-memo-string"
+        let instance = FunctionCallInstance.custom(model)
+
+        let tx = instance.toSendTransaction(coin: coin, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "arbitrary-memo-string")
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(instance.toAddress)
+        XCTAssertNil(instance.customErrorMessage)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: coin, vault: vault, gas: 0)
+    }
+
+    func testVoteParity() {
+        let model = FunctionCallVote()
+        model.selectedMemo = .yes
+        model.proposalID = 42
+        let coin = FunctionCallFixture.makeCoin(.dydx, ticker: "DYDX", decimals: 18, isNative: true)
+        let vault = FunctionCallFixture.makeVault(coins: [coin])
+        let instance = FunctionCallInstance.vote(model)
+
+        let tx = instance.toSendTransaction(coin: coin, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "DYDX_VOTE:Yes:42")
+        XCTAssertEqual(tx.transactionType, .vote)
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(instance.toAddress)
+        XCTAssertEqual(instance.amount, .zero)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: coin, vault: vault, gas: 0)
+    }
+
+    func testCosmosIBCParity() {
+        let kuji = FunctionCallFixture.makeKUJI()
+        let vault = FunctionCallFixture.makeVault(coins: [kuji])
+        let model = FunctionCallCosmosIBC(coin: kuji, vault: vault)
+        model.selectedChainObject = .gaiaChain
+        model.destinationAddress = "cosmos1abc"
+        let instance = FunctionCallInstance.cosmosIBC(model)
+
+        let tx = instance.toSendTransaction(coin: kuji, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, model.toString())
+        XCTAssertEqual(tx.transactionType, .ibcTransfer)
+        XCTAssertEqual(tx.toAddress, "cosmos1abc")
+        XCTAssertEqual(instance.toAddress, "cosmos1abc")
+
+        assertForwardingParity(instance, forwardsTo: model, coin: kuji, vault: vault, gas: 0)
+    }
+
+    func testMergeParity() {
+        let rune = FunctionCallFixture.makeRUNE()
+        let vault = FunctionCallFixture.makeVault(coins: [rune])
+        let model = FunctionCallCosmosMerge(coin: rune, vault: vault)
+        model.selectedToken = IdentifiableString(value: "THOR.KUJI")
+        model.destinationAddress = "thor1mergeaddress"
+        let instance = FunctionCallInstance.merge(model)
+
+        let tx = instance.toSendTransaction(coin: rune, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "merge:THOR.KUJI")
+        XCTAssertEqual(tx.transactionType, .thorMerge)
+        XCTAssertEqual(tx.toAddress, "thor1mergeaddress")
+        XCTAssertEqual(instance.toAddress, "thor1mergeaddress")
+
+        assertForwardingParity(instance, forwardsTo: model, coin: rune, vault: vault, gas: 0)
+    }
+
+    func testUnmergeParity() {
+        let ruji = FunctionCallFixture.makeRUJI()
+        let vault = FunctionCallFixture.makeVault(coins: [FunctionCallFixture.makeRUNE(), ruji])
+        let model = FunctionCallCosmosUnmerge(coin: ruji, vault: vault)
+        model.selectedToken = IdentifiableString(value: "THOR.RUJI")
+        model.destinationAddress = "thor1mergecontract"
+        model.amount = 1
+        let instance = FunctionCallInstance.unmerge(model)
+
+        let tx = instance.toSendTransaction(coin: ruji, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "unmerge:thor.ruji:100000000")
+        XCTAssertEqual(tx.transactionType, .thorUnmerge)
+        XCTAssertEqual(tx.toAddress, "thor1mergecontract")
+        XCTAssertEqual(instance.toAddress, "thor1mergecontract")
+        // Preserved: the instance never surfaces unmerge's own error slot.
+        XCTAssertNil(instance.customErrorMessage)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: ruji, vault: vault, gas: 0)
+    }
+
+    func testTheSwitchParity() {
+        let atom = FunctionCallFixture.makeATOM()
+        let vault = FunctionCallFixture.makeVault(coins: [atom, FunctionCallFixture.makeRUNE()])
+        let model = FunctionCallCosmosSwitch(coin: atom, vault: vault)
+        model.thorAddress = "thor1switchtarget"
+        model.destinationAddress = "cosmos1inbound"
+        let instance = FunctionCallInstance.theSwitch(model)
+
+        let tx = instance.toSendTransaction(coin: atom, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "SWITCH:thor1switchtarget")
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        XCTAssertEqual(tx.toAddress, "cosmos1inbound")
+        XCTAssertEqual(instance.toAddress, "cosmos1inbound")
+
+        assertForwardingParity(instance, forwardsTo: model, coin: atom, vault: vault, gas: 0)
+    }
+
+    func testAddThorLPParity() {
+        let rune = FunctionCallFixture.makeRUNE()
+        let vault = FunctionCallFixture.makeVault(coins: [rune])
+        // No initialize() — keeps the inbound fetch offline; toAddress stays "".
+        let model = FunctionCallAddThorLP(coin: rune, vault: vault)
+        model.selectedPool = IdentifiableString(value: "BTC.BTC")
+        model.pairedAddress = "thor1paired"
+        let instance = FunctionCallInstance.addThorLP(model)
+
+        let tx = instance.toSendTransaction(coin: rune, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, model.toString())
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(tx.wasmContractPayload)
+        XCTAssertNil(instance.toAddress)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: rune, vault: vault, gas: 0)
+    }
+
+    func testSecuredAssetParity() {
+        let rune = FunctionCallFixture.makeRUNE()
+        let vault = FunctionCallFixture.makeVault(coins: [rune])
+        // No initialize() — offline; toAddress stays "".
+        let model = FunctionCallSecuredAsset(coin: rune, vault: vault)
+        model.thorAddress = "thor1secureplus"
+        let instance = FunctionCallInstance.securedAsset(model)
+
+        let tx = instance.toSendTransaction(coin: rune, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "SECURE+:thor1secureplus")
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(tx.wasmContractPayload)
+        XCTAssertNil(instance.toAddress)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: rune, vault: vault, gas: 0)
+    }
+
+    func testWithdrawSecuredAssetParity() {
+        let rune = FunctionCallFixture.makeRUNE()
+        let vault = FunctionCallFixture.makeVault(coins: [rune])
+        // No initialize() — offline.
+        let model = FunctionCallWithdrawSecuredAsset(coin: rune, vault: vault)
+        model.destinationAddress = "0xL1DestAddr"
+        let instance = FunctionCallInstance.withdrawSecuredAsset(model)
+
+        let tx = instance.toSendTransaction(coin: rune, vault: vault, gas: 0)
+        XCTAssertEqual(tx.memo, "SECURE-:0xL1DestAddr")
+        XCTAssertEqual(tx.transactionType, .unspecified)
+        // Withdraw signs via MsgDeposit — toAddress is intentionally empty
+        // even though `destinationAddress` is set.
+        XCTAssertEqual(tx.toAddress, "")
+        XCTAssertNil(tx.wasmContractPayload)
+        XCTAssertNil(instance.toAddress)
+
+        assertForwardingParity(instance, forwardsTo: model, coin: rune, vault: vault, gas: 0)
+    }
+}


### PR DESCRIPTION
Closes #4916

## What

Behavior-preserving "Replace Conditional with Polymorphism" refactor (Tier-1 S9). `FunctionCallInstance` re-`switch`ed the same 13-case enum in **8 methods**. This collapses them to a single dispatch: a new `FunctionCallSubModel` protocol names the shared surface, one `var model: any FunctionCallSubModel` maps each enum case to its sub-model, and every accessor forwards in one line.

### Changes
- **`FunctionCallSubModel.swift`** (new): protocol (`description`, `amount`, `resolvedToAddress`, `submitErrorMessage`, `isFormValid(for:)`, `toSendTransaction`) with nil defaults for the two opt-out accessors, plus the 13 conformances (each is a thin shim; sub-model internals untouched).
- **`FunctionCallInstance.swift`**: 8 switches → `model`-forwarding one-liners; **deleted** the dead `wasmContractPayload` (all branches returned `nil`, no consumers); **kept** the `getDefault(for:vault:)` factory.

### Per-case mappings preserved exactly
- `toAddress` → `resolvedToAddress`: default `nil`; `destinationAddress` for cosmosIBC/merge/unmerge/theSwitch; `isEmpty ? nil` for addThorLP/securedAsset; `nil` for withdrawSecuredAsset and the default cases.
- `customErrorMessage` → `submitErrorMessage`: default `nil`; forwarded only for rebond/addThorLP/securedAsset/withdrawSecuredAsset. Deliberately kept **distinct** from the sub-models' own `customErrorMessage` slot so unmerge's internal validation error is not leaked through the instance accessor (matches pre-refactor behavior).
- `isFormValid(for:)` bridges to `isTheFormValid` for the 9 sub-models without a coin-threaded gate; custom/cosmosIBC/merge/theSwitch keep native coin-aware validation.

## `toSendTransaction` per-case parity (feeds signing)

Added **`FunctionCallInstancePolymorphismParityTests`** — one test per case (13) asserting the instance-produced `SendTransaction` is **byte-identical** to the sub-model's own output (`SendTransaction ==` covers every keysign-relevant field) and pinning memo / `transactionType` / `toAddress` to golden literals. All 13 pass.

## Gate
- **Full unit suite green** on iPhone 17 Pro Max / iOS 26.5 (matches CI): `** TEST SUCCEEDED **`, `Executed 3831 tests, 1 skipped, 0 failures`.
- SwiftLint clean on the changed files (0 violations).
- Cross-model Codex review (read-only): no concrete bugs; all 13 cases verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized function-call handling across supported transaction types.
  * Improved consistency for transaction details, including descriptions, amounts, destination addresses, validation, and error messages.
  * Maintained consistent transaction-building behavior across supported operations.

* **Tests**
  * Added comprehensive coverage to verify transaction outputs and displayed details across bonding, transfers, voting, memo, IBC, liquidity, and asset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->