### PR TITLE
fix(keysign): guard missing encryption key on keysign kickoff

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -774,6 +774,7 @@
 "mintCoin" = "%@ prägen";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"missingEncryptionKey" = "Verschlüsselungsschlüssel fehlt. Bitte versuche es erneut.";
 "MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Geben Sie die 12 oder 24 Wörter Ihrer Seed-Phrase ein";
 "modules" = "Module";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -772,6 +772,7 @@
 "mintCoin" = "Mint %@";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"missingEncryptionKey" = "Encryption key is missing. Please try again.";
 "MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Enter the 12 or 24 words of your seedphrase";
 "modules" = "Modules";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -774,6 +774,7 @@
 "mintCoin" = "Acuñar %@";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"missingEncryptionKey" = "Falta la clave de cifrado. Inténtalo de nuevo.";
 "MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Ingresa las 12 o 24 palabras de tu frase semilla";
 "modules" = "Módulos";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -774,6 +774,7 @@
 "mintCoin" = "Kovaj %@";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"missingEncryptionKey" = "Nedostaje ključ za šifriranje. Pokušajte ponovno.";
 "MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Unesite 12 ili 24 riječi svoje seed fraze";
 "modules" = "Moduli";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -774,6 +774,7 @@
 "mintCoin" = "Conia %@";
 "mintSecuredAsset" = "Conia Asset Garantito (SECURE+)";
 "mintTransaction" = "2. Transazione di conio asset garantito";
+"missingEncryptionKey" = "Chiave di crittografia mancante. Riprova.";
 "MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Inserisci le 12 o 24 parole della tua seed phrase";
 "modules" = "Moduli";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -772,6 +772,7 @@
 "mintCoin" = "%@ 민트";
 "mintSecuredAsset" = "보안 자산 민트 (SECURE+)";
 "mintTransaction" = "2. 보안 자산 민트 트랜잭션";
+"missingEncryptionKey" = "암호화 키가 없습니다. 다시 시도해 주세요.";
 "MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "시드 문구의 12개 또는 24개 단어를 입력하세요";
 "modules" = "모듈";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -774,6 +774,7 @@
 "mintCoin" = "Cunhar %@";
 "mintSecuredAsset" = "Mint Secured Asset (SECURE+)";
 "mintTransaction" = "2. Mint secured asset transaction";
+"missingEncryptionKey" = "Chave de criptografia ausente. Tente novamente.";
 "MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "Digite as 12 ou 24 palavras da sua frase semente";
 "modules" = "Módulos";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -774,6 +774,7 @@
 "mintCoin" = "铸造 %@";
 "mintSecuredAsset" = "铸造担保资产 (SECURE+)";
 "mintTransaction" = "2. 铸造担保资产交易";
+"missingEncryptionKey" = "缺少加密密钥。请重试。";
 "MLDSA" = "MLDSA";
 "mnemonicPlaceholder" = "输入您的助记词的12个或24个单词";
 "modules" = "模块";

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignDiscoveryViewModel.swift
@@ -182,6 +182,12 @@ class KeysignDiscoveryViewModel: ObservableObject {
         }
 
         if let fastVaultPassword, let coin {
+            guard let encryptionKeyHex = self.encryptionKeyHex, !encryptionKeyHex.isEmpty else {
+                self.status = .FailToStart
+                self.errorMessage = "missingEncryptionKey".localized
+                return
+            }
+
             // when fast sign, always using relay server
             serverAddr = Endpoint.vultisigRelay
 
@@ -190,7 +196,7 @@ class KeysignDiscoveryViewModel: ObservableObject {
                     publicKeyEcdsa: vault.pubKeyECDSA,
                     keysignMessages: self.keysignMessages,
                     sessionID: self.sessionID,
-                    hexEncryptionKey: self.encryptionKeyHex!,
+                    hexEncryptionKey: encryptionKeyHex,
                     derivePath: coin.coinType.derivationPath(),
                     isECDSA: coin.chain.isECDSA,
                     vaultPassword: fastVaultPassword,
@@ -255,7 +261,13 @@ class KeysignDiscoveryViewModel: ObservableObject {
         return selections.count >= (vault.getThreshold() + 1)
     }
 
-    @MainActor func startKeysign(vault: Vault) -> KeysignInput {
+    @MainActor func startKeysign(vault: Vault) -> KeysignInput? {
+        guard let encryptionKeyHex, !encryptionKeyHex.isEmpty else {
+            status = .FailToStart
+            errorMessage = "missingEncryptionKey".localized
+            return nil
+        }
+
         kickoffKeysign(allParticipants: self.selections.map { $0 })
         participantDiscovery?.stop()
 
@@ -268,7 +280,7 @@ class KeysignDiscoveryViewModel: ObservableObject {
             messsageToSign: keysignMessages, // need to figure out all the prekeysign hashes
             keysignPayload: keysignPayload,
             customMessagePayload: customMessagePayload,
-            encryptionKeyHex: encryptionKeyHex ?? "",
+            encryptionKeyHex: encryptionKeyHex,
             isInitiateDevice: true
         )
     }

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
@@ -342,7 +342,7 @@ struct KeysignDiscoveryView: View {
 
     func startKeysign() {
         if viewModel.isValidPeers(vault: vault) {
-            let keysignInput = viewModel.startKeysign(vault: vault)
+            guard let keysignInput = viewModel.startKeysign(vault: vault) else { return }
             onKeysignInput(keysignInput)
         }
     }

--- a/VultisigApp/VultisigAppTests/Keysign/KeysignEncryptionKeyGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/KeysignEncryptionKeyGuardTests.swift
@@ -1,0 +1,67 @@
+//
+//  KeysignEncryptionKeyGuardTests.swift
+//  VultisigApp
+//
+//  Pins the guard that keeps a missing or empty keysign encryption key from
+//  starting a ceremony unsafely. `KeysignDiscoveryViewModel.encryptionKeyHex`
+//  is optional and can also be assigned an empty string from a preset session,
+//  and the signing kickoff used to consume it with `!` / `?? ""`. A nil OR
+//  empty key must instead route to `.FailToStart` with a real localized
+//  message — never crash, and never fall through to an empty key that peers
+//  cannot decrypt (which stalls the whole committee).
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class KeysignEncryptionKeyGuardTests: XCTestCase {
+
+    @MainActor
+    func testStartKeysignWithNilEncryptionKeyFailsToStartInsteadOfEmptyKey() {
+        assertStartKeysignFailsToStart(withKey: nil)
+    }
+
+    @MainActor
+    func testStartKeysignWithEmptyEncryptionKeyFailsToStartInsteadOfEmptyKey() {
+        assertStartKeysignFailsToStart(withKey: "")
+    }
+
+    @MainActor
+    private func assertStartKeysignFailsToStart(
+        withKey key: String?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let viewModel = KeysignDiscoveryViewModel()
+        viewModel.encryptionKeyHex = key
+
+        let input = viewModel.startKeysign(vault: .example)
+
+        XCTAssertNil(
+            input,
+            "A missing/empty encryption key must not produce a KeysignInput carrying an unusable key",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(viewModel.status, .FailToStart, file: file, line: line)
+
+        // The message must be the resolved localization — not an empty fallback
+        // and not the raw key that `NSLocalizedString` returns when the string
+        // is absent. Assert the lookup actually resolved, so this doesn't pass
+        // as a tautology against the same failing lookup.
+        XCTAssertEqual(viewModel.errorMessage, "missingEncryptionKey".localized, file: file, line: line)
+        XCTAssertFalse(
+            viewModel.errorMessage.isEmpty,
+            "Localized error message must not be empty",
+            file: file,
+            line: line
+        )
+        XCTAssertNotEqual(
+            viewModel.errorMessage,
+            "missingEncryptionKey",
+            "errorMessage must be the localized string, not the raw key (missing localization)",
+            file: file,
+            line: line
+        )
+    }
+}


### PR DESCRIPTION
## Problem
`KeysignDiscoveryViewModel.encryptionKeyHex` is optional (it comes from `Encryption.getEncryptionKey()`, which returns `nil` on RNG failure), but both keysign-kickoff paths consumed it unsafely:

- **Fast-vault ceremony** used `self.encryptionKeyHex!` — a `nil` key **crashes the app** at the exact moment signing initiates.
- **Manual / QR `startKeysign`** used `encryptionKeyHex ?? ""` — a `nil` key silently becomes an **empty key**, so this device starts keysign with a key peers cannot use to decrypt relay messages; the whole committee then **stalls / times out** with no clear cause.

## Root cause
An optional that can legitimately be `nil` was force-unwrapped on one path and defaulted to `""` on the other, instead of being validated before the ceremony starts.

## Fix
Route `nil -> .FailToStart` with a real localized error at each kickoff entry, instead of `!` / `?? ""`:

- Fast-vault branch adds a `guard let encryptionKeyHex` before building the `FastVaultKeysign` request.
- `startKeysign(vault:)` now returns `KeysignInput?`; it guards the key **before** `kickoffKeysign` / `participantDiscovery.stop()` (no partial side effects) and returns `nil` on a missing key.
- The single caller (`KeysignDiscoveryView.startKeysign()`) skips `onKeysignInput` on `nil` — the VM has already surfaced the `.FailToStart` error, so no extra UI plumbing is needed.
- Adds a user-facing `missingEncryptionKey` string to **all 8 shipped locales** (de, en, es, hr, it, ko, pt, zh-Hans).
- **Happy path (non-nil key) is byte-for-byte unchanged.**

Adds a focused unit test (`KeysignEncryptionKeyGuardTests`) pinning that a `nil` key produces no `KeysignInput` and routes to `.FailToStart` with the localized message.

## Verification
- Full test gate on iPhone 16 Pro simulator (`xcodebuild test`, worktree-local derived data): **3888 tests passed, 1 failed** → overall marker `** TEST FAILED **`.
- The **only** failure is `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` — a SwiftUI snapshot pixel-comparison that failed at **99.9873% pixel match vs a 99.999% threshold** (a ~0.013% sub-pixel anti-aliasing delta). This is a simulator-runtime rendering artifact on the **CreateVault** screen, a feature this PR does not touch. It is **pre-existing environmental noise, unrelated to this change** (re-recording an unrelated screen's reference was deliberately avoided). CI, which runs against a matching snapshot reference, is expected to be green.
- This PR's own test (`KeysignEncryptionKeyGuardTests.testStartKeysignWithNilEncryptionKeyFailsToStartInsteadOfEmptyKey`) **passed**, and every other suite reported **0 failures**.
- **Codex read-only review (cross-model gate):** verdict positive — "the signing-path change is sound: both Fast Vault and manual initiation now fail closed before starting a ceremony; the manual path validates the key before side effects; no `KeysignInput` can carry an empty key; the optional-return call site correctly prevents navigation into signing; all eight locales updated." Its one Medium finding (that the test might not compile because `KeysignDiscoveryStatus` lacks explicit `Equatable`) was **empirically rejected**: a Swift enum with no associated values is implicitly `Equatable` in a generic `Equatable` context (verified via `swiftc`, and confirmed by the test compiling and passing in the gate). Its minor "no Fast Vault test coverage" note is deferred as a non-blocking follow-up (Codex itself said it would not block the fix).

## Risks
- **Signing-kickoff behavior change.** A missing key now aborts the ceremony (fail-closed) instead of crashing / emitting an empty key. This is the intended safer behavior, but it must be confirmed on-device with a **real keysign** — unit tests cannot exercise the relay / MPC layer.
- `missingEncryptionKey` copy is user-facing; localizations are machine-plausible but not professionally reviewed.

> ⚠️ **Requires human review + on-device (real keysign) verification** before merge — this changes the signing-kickoff path. Draft until then.

Closes #4906


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fast vault signing now safely halts when the encryption key is unavailable, preventing invalid signing attempts.
  * The keysign flow no longer proceeds without a valid encryption key and shows the localized error message instead.
* **Localization**
  * Added the `missingEncryptionKey` error message to English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.
* **Tests**
  * Added coverage verifying that signing is blocked when the encryption key is missing/empty and that the correct error state is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->