### PR TITLE
refactor(coin-service): resolve token discovery via TokenDiscoverer strategy registry

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -222,42 +222,8 @@ struct CoinService {
     }
 
     static func fetchDiscoveredTokens(nativeCoin: CoinMeta, address: String) async throws -> [CoinMeta] {
-        var tokens: [CoinMeta] = []
-        switch nativeCoin.chain.chainType {
-        case .EVM:
-            let service = try EvmService.getService(forChain: nativeCoin.chain)
-            tokens = try await service.getTokens(nativeToken: nativeCoin, address: address)
-        case .Solana:
-            tokens = try await SolanaService.shared.fetchTokens(for: address)
-        case .Sui:
-            tokens = try await SuiService.shared.getAllTokensWithMetadata(address: address)
-        case .THORChain:
-            switch nativeCoin.chain {
-            case .thorChain, .thorChainChainnet, .thorChainStagenet:
-                let service = ThorchainServiceFactory.getService(for: nativeCoin.chain)
-                tokens = try await service.fetchTokens(address)
-            case .mayaChain:
-                tokens = try await MayachainService.shared.fetchTokens(address)
-            default:
-                tokens = []
-            }
-        case .Cosmos where CosmosCoinFinder.allowlistedChains.contains(nativeCoin.chain):
-            // Terra + TerraClassic auto-discover held bank denoms via the
-            // Cosmos finder. Hidden-by-default denoms are surfaced separately
-            // through `addDiscoveredHiddenTokens` so they don't pollute the
-            // visible coin list — only `!isHidden` discoveries land here.
-            let discovered = try await CosmosCoinFinder.shared.discoverBankDenoms(
-                chain: nativeCoin.chain,
-                address: address
-            )
-            tokens = discovered
-                .filter { !$0.isHidden }
-                .map { $0.toCoinMeta(chain: nativeCoin.chain) }
-        default:
-            tokens = []
-        }
-
-        return tokens
+        let discoverer = TokenDiscovererRegistry.discoverer(for: nativeCoin.chain)
+        return try await discoverer.discoverTokens(nativeCoin: nativeCoin, address: address)
     }
 
     /// Migrate coins and hidden tokens that reference stale contract addresses.

--- a/VultisigApp/VultisigApp/Core/Services/TokenDiscoverer.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenDiscoverer.swift
@@ -1,0 +1,126 @@
+//
+//  TokenDiscoverer.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Strategy that auto-discovers the non-native tokens an address holds for a
+/// given native coin's chain. Each chain family that supports discovery has a
+/// concrete conformer; chains without discovery resolve to `NoTokenDiscoverer`,
+/// so "this chain does not discover tokens" is a declared choice rather than a
+/// silent fall-through.
+@MainActor
+protocol TokenDiscoverer {
+    func discoverTokens(nativeCoin: CoinMeta, address: String) async throws -> [CoinMeta]
+}
+
+// MARK: - Concrete discoverers
+
+/// EVM chains: the per-chain `EvmService` enumerates ERC-20 balances held by
+/// `address`.
+struct EVMTokenDiscoverer: TokenDiscoverer {
+    func discoverTokens(nativeCoin: CoinMeta, address: String) async throws -> [CoinMeta] {
+        let service = try EvmService.getService(forChain: nativeCoin.chain)
+        return try await service.getTokens(nativeToken: nativeCoin, address: address)
+    }
+}
+
+struct SolanaTokenDiscoverer: TokenDiscoverer {
+    func discoverTokens(nativeCoin _: CoinMeta, address: String) async throws -> [CoinMeta] {
+        try await SolanaService.shared.fetchTokens(for: address)
+    }
+}
+
+struct SuiTokenDiscoverer: TokenDiscoverer {
+    func discoverTokens(nativeCoin _: CoinMeta, address: String) async throws -> [CoinMeta] {
+        try await SuiService.shared.getAllTokensWithMetadata(address: address)
+    }
+}
+
+/// THORChain / Chainnet / Stagenet — the network-specific service is resolved
+/// through `ThorchainServiceFactory`.
+struct ThorchainTokenDiscoverer: TokenDiscoverer {
+    func discoverTokens(nativeCoin: CoinMeta, address: String) async throws -> [CoinMeta] {
+        let service = ThorchainServiceFactory.getService(for: nativeCoin.chain)
+        return try await service.fetchTokens(address)
+    }
+}
+
+struct MayachainTokenDiscoverer: TokenDiscoverer {
+    func discoverTokens(nativeCoin _: CoinMeta, address: String) async throws -> [CoinMeta] {
+        try await MayachainService.shared.fetchTokens(address)
+    }
+}
+
+/// Cosmos bank-denom discovery for the allowlisted chains (Terra + Terra
+/// Classic). Only visible (`!isHidden`) denoms land here; hidden-by-default
+/// denoms are surfaced through a separate path so they don't pollute the
+/// visible coin list.
+struct CosmosBankDenomTokenDiscoverer: TokenDiscoverer {
+    func discoverTokens(nativeCoin: CoinMeta, address: String) async throws -> [CoinMeta] {
+        let discovered = try await CosmosCoinFinder.shared.discoverBankDenoms(
+            chain: nativeCoin.chain,
+            address: address
+        )
+        return discovered
+            .filter { !$0.isHidden }
+            .map { $0.toCoinMeta(chain: nativeCoin.chain) }
+    }
+}
+
+/// Explicit no-op for chains that do not support token auto-discovery.
+/// Registered by name so "no discovery" is a declared choice rather than an
+/// implicit empty fall-through.
+struct NoTokenDiscoverer: TokenDiscoverer {
+    func discoverTokens(nativeCoin _: CoinMeta, address _: String) -> [CoinMeta] {
+        []
+    }
+}
+
+// MARK: - Registry
+
+/// Resolves the `TokenDiscoverer` for a chain. The switch is exhaustive over
+/// `ChainType` with no `default`, so adding a new chain family forces an
+/// explicit decision here — either declare its discoverer or map it to
+/// `NoTokenDiscoverer`.
+///
+/// Main-actor-isolated because the `TokenDiscoverer` conformers it constructs
+/// inherit `@MainActor` from the protocol; the sole caller
+/// (`CoinService.fetchDiscoveredTokens`) is already `@MainActor`, so resolution
+/// stays a synchronous same-actor call.
+@MainActor
+enum TokenDiscovererRegistry {
+    static func discoverer(for chain: Chain) -> TokenDiscoverer {
+        switch chain.chainType {
+        case .EVM:
+            return EVMTokenDiscoverer()
+        case .Solana:
+            return SolanaTokenDiscoverer()
+        case .Sui:
+            return SuiTokenDiscoverer()
+        case .THORChain:
+            return thorchainFamilyDiscoverer(for: chain)
+        case .Cosmos:
+            return CosmosCoinFinder.allowlistedChains.contains(chain)
+                ? CosmosBankDenomTokenDiscoverer()
+                : NoTokenDiscoverer()
+        case .UTXO, .Cardano, .Polkadot, .Ton, .Ripple, .Tron:
+            return NoTokenDiscoverer()
+        }
+    }
+
+    /// THORChain-family sub-resolution: the three THORChain networks share the
+    /// factory-selected service, MayaChain has its own, and any other
+    /// THORChain-type chain declares no discovery.
+    private static func thorchainFamilyDiscoverer(for chain: Chain) -> TokenDiscoverer {
+        switch chain {
+        case .thorChain, .thorChainChainnet, .thorChainStagenet:
+            return ThorchainTokenDiscoverer()
+        case .mayaChain:
+            return MayachainTokenDiscoverer()
+        default:
+            return NoTokenDiscoverer()
+        }
+    }
+}


### PR DESCRIPTION
## Problem
`CoinService.fetchDiscoveredTokens` resolved token discovery through a nested `switch nativeCoin.chain.chainType -> switch nativeCoin.chain`, with a `where`-guarded Cosmos branch and a silent `default: tokens = []` fall-through. Adding a chain family meant editing the mega-switch, and a chain that fell through the `default` silently discovered nothing with no compile-time signal.

## Approach
Introduce a `TokenDiscoverer` strategy protocol with one concrete conformer per discovery branch — `EVMTokenDiscoverer`, `SolanaTokenDiscoverer`, `SuiTokenDiscoverer`, `ThorchainTokenDiscoverer`, `MayachainTokenDiscoverer`, `CosmosBankDenomTokenDiscoverer` — plus an explicit `NoTokenDiscoverer` no-op. `TokenDiscovererRegistry.discoverer(for:)` resolves the strategy via a switch that is **exhaustive over `ChainType` with no `default`**, so a new chain family must declare its discovery behavior (a real discoverer or `NoTokenDiscoverer`) or the build fails. `fetchDiscoveredTokens` collapses to a two-line lookup + delegate.

The `TokenDiscoverer` protocol and the registry are `@MainActor`. This is not a behavior change: `CoinService` is already `@MainActor`, so `fetchDiscoveredTokens` and its service calls already ran on the main actor — the annotation just makes the existing isolation explicit (and is required so the registry can construct the discoverer values).

## Behavior-preservation note
Every original branch is preserved exactly: EVM, Solana, Sui, the three THORChain networks, and MayaChain invoke the identical services with identical arguments; Cosmos keeps the `.terra`/`.terraClassic` allowlist, the `!isHidden` filter, and the `CoinMeta` conversion. Every formerly-defaulted case (`UTXO, Cardano, Polkadot, Ton, Ripple, Tron`, non-allowlisted Cosmos, and any non-thor/maya `.THORChain` chain) resolves to `NoTokenDiscoverer` returning `[]`, matching the original `default: tokens = []`. No functional change.

## Verification
- Full test suite on iPhone 16 simulator: `Executed 3894 tests, with 1 test skipped and 1 failure`. The full suite passes **except** the pre-existing `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` snapshot artifact — a sub-pixel anti-aliasing delta on the Create Vault screen, unrelated to this diff (which touches only `CoinService`/`TokenDiscoverer`) and failing identically on `main` and other branches. No false-green claim.
- Cross-model Codex review (read-only, two rounds): verdict "behavior-preserving; no regression found" — mapping exhaustive over all 11 `ChainType` cases, no chain case missed, `@MainActor` introduces no actor-hop change for this path.

## Risks
- The exhaustive `ChainType` switch is intentional: adding a chain family will fail to compile until its discovery behavior is declared — a safety property, not a defect.
- `TokenDiscoverer` strategies are `@MainActor`-only; harmless for the sole current caller, but future reuse from a background actor would need to account for it.

Closes #4917


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic token discovery across supported EVM, Solana, Sui, THORChain, MayaChain, and Cosmos networks.
  * Cosmos token discovery now displays only visible bank-denominated assets.
  * Added consistent handling for networks without token-discovery support, returning no results instead of attempting unsupported lookups.
* **Bug Fixes**
  * Improved reliability and consistency when discovering tokens across different blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->