### PR TITLE
refactor(custom-token): extract CustomTokenViewModel + per-chain resolver strategy

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -307,7 +307,10 @@
 "customRPCUnreachable" = "Nicht erreichbar";
 "customRPCWrongChain" = "Falsche Chain (erwartet %d, erhalten %d)";
 "customToken" = "Benutzerdefinierten Token";
+"customTokenAddButton" = "%@ Token hinzufügen";
 "customTokenErrorSubtitle" = "Stellen Sie sicher, dass die Adresse korrekt ist und zur ausgewählten Kette gehört.";
+"customTokenNotFound" = "Token nicht gefunden";
+"customTokenRateLimit" = "Zu viele Anfragen. Bitte schließe diesen Bildschirm und versuche es später erneut.";
 "dappRequestFrom" = "Anfrage von";
 "date" = "Datum";
 "decimalAmountError" = "Der Betrag muss eine Dezimalzahl sein.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -307,7 +307,10 @@
 "customRPCUnreachable" = "Unreachable";
 "customRPCWrongChain" = "Wrong chain (expected %d, got %d)";
 "customToken" = "Custom Token";
+"customTokenAddButton" = "Add %@ token";
 "customTokenErrorSubtitle" = "Possible reasons: wrong contract, unsupported chain, or token removed from registries.";
+"customTokenNotFound" = "Token Not Found";
+"customTokenRateLimit" = "Too many requests. Please close this screen and try again later.";
 "dappRequestFrom" = "Request from";
 "date" = "Date";
 "decimalAmountError" = "The amount must be decimal.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -307,7 +307,10 @@
 "customRPCUnreachable" = "Inaccesible";
 "customRPCWrongChain" = "Cadena incorrecta (esperado %d, recibido %d)";
 "customToken" = "Token Personalizado";
+"customTokenAddButton" = "Agregar token %@";
 "customTokenErrorSubtitle" = "No pudimos encontrar el token. Por favor, verifica la dirección del contrato e inténtalo de nuevo.";
+"customTokenNotFound" = "Token no encontrado";
+"customTokenRateLimit" = "Demasiadas solicitudes. Cierra esta pantalla e inténtalo de nuevo más tarde.";
 "dappRequestFrom" = "Solicitud de";
 "date" = "Fecha";
 "decimalAmountError" = "El monto debe ser decimal.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -307,7 +307,10 @@
 "customRPCUnreachable" = "Nedostupno";
 "customRPCWrongChain" = "Pogrešan lanac (očekivano %d, dobiveno %d)";
 "customToken" = "Prilagođeni Token";
+"customTokenAddButton" = "Dodaj %@ token";
 "customTokenErrorSubtitle" = "Provjerite adresu tokena i pokušajte ponovo.";
+"customTokenNotFound" = "Token nije pronađen";
+"customTokenRateLimit" = "Previše zahtjeva. Zatvorite ovaj zaslon i pokušajte ponovo kasnije.";
 "dappRequestFrom" = "Zahtjev od";
 "date" = "Datum";
 "decimalAmountError" = "Iznos mora biti decimalan.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -307,7 +307,10 @@
 "customRPCUnreachable" = "Non raggiungibile";
 "customRPCWrongChain" = "Catena errata (atteso %d, ricevuto %d)";
 "customToken" = "Token Personalizzato";
+"customTokenAddButton" = "Aggiungi token %@";
 "customTokenErrorSubtitle" = "Impossibile trovare il token. Controlla l'indirizzo del contratto e riprova.";
+"customTokenNotFound" = "Token non trovato";
+"customTokenRateLimit" = "Troppe richieste. Chiudi questa schermata e riprova più tardi.";
 "dappRequestFrom" = "Richiesta da";
 "date" = "Data";
 "decimalAmountError" = "L'importo deve essere decimale.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -307,7 +307,10 @@
 "customRPCUnreachable" = "연결할 수 없음";
 "customRPCWrongChain" = "잘못된 체인 (예상 %d, 실제 %d)";
 "customToken" = "커스텀 토큰";
+"customTokenAddButton" = "%@ 토큰 추가";
 "customTokenErrorSubtitle" = "가능한 이유: 잘못된 계약, 지원되지 않는 체인 또는 레지스트리에서 제거된 토큰.";
+"customTokenNotFound" = "토큰을 찾을 수 없음";
+"customTokenRateLimit" = "요청이 너무 많습니다. 이 화면을 닫고 나중에 다시 시도해 주세요.";
 "dappRequestFrom" = "요청 출처";
 "date" = "날짜";
 "decimalAmountError" = "금액은 소수여야 합니다.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -307,7 +307,10 @@
 "customRPCUnreachable" = "Inacessível";
 "customRPCWrongChain" = "Cadeia errada (esperado %d, recebido %d)";
 "customToken" = "Token Personalizado";
+"customTokenAddButton" = "Adicionar token %@";
 "customTokenErrorSubtitle" = "Não foi possível encontrar o token. Verifique o endereço do contrato e tente novamente.";
+"customTokenNotFound" = "Token não encontrado";
+"customTokenRateLimit" = "Muitas solicitações. Feche esta tela e tente novamente mais tarde.";
 "dappRequestFrom" = "Pedido de";
 "date" = "Data";
 "decimalAmountError" = "O valor deve ser decimal.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -307,7 +307,10 @@
 "customRPCUnreachable" = "无法访问";
 "customRPCWrongChain" = "链不匹配（期望 %d，实际 %d）";
 "customToken" = "自定义代币";
+"customTokenAddButton" = "添加 %@ 代币";
 "customTokenErrorSubtitle" = "可能的原因：错误的合约、不支持的链或代币已从注册表中删除";
+"customTokenNotFound" = "未找到代币";
+"customTokenRateLimit" = "请求过多。请关闭此屏幕，稍后再试。";
 "dappRequestFrom" = "请求来自";
 "date" = "日期";
 "decimalAmountError" = "金额必须为小数。";

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/CustomTokenScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/CustomTokenScreen.swift
@@ -44,28 +44,32 @@ struct CustomTokenScreen: View {
                             placeholder: viewModel.searchPlaceholder
                         )
                         CircularAccessoryIconButton(icon: .searchArea) {
-                            Task {
-                                await viewModel.fetchTokenInfo()
-                            }
+                            viewModel.search()
                         }
                     }
 
-                    if let error = viewModel.error {
-                        errorView(error: error)
+                    switch viewModel.searchState {
+                    case .found(let token):
+                        tokenInfoView(token)
                             .transition(.opacity)
-                    }
 
-                    if viewModel.showTokenInfo {
-                        tokenInfoView
-
-                        PrimaryButton(title: "Add \(viewModel.tokenSymbol) token") {
+                        PrimaryButton(title: String(format: "customTokenAddButton".localized, viewModel.tokenSymbol)) {
                             saveAssets()
                         }
+                        .transition(.opacity)
+
+                    case .invalid(let message, let showsRetry):
+                        errorView(message: message, showsRetry: showsRetry)
+                            .transition(.opacity)
+
+                    case .idle, .loading:
+                        EmptyView()
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 24)
                 .padding(.horizontal, 16)
+                .animation(.easeInOut(duration: 0.25), value: viewModel.searchState)
             }
             .crossPlatformToolbar(showsBackButton: false) {
                 CustomToolbarItem(placement: .leading) {
@@ -75,9 +79,7 @@ struct CustomTokenScreen: View {
                 }
             }
             .onSubmit {
-                Task {
-                    await viewModel.fetchTokenInfo()
-                }
+                viewModel.search()
             }
         }
         .onLoad {
@@ -86,41 +88,49 @@ struct CustomTokenScreen: View {
         .onChange(of: viewModel.contractAddress) { _, newValue in
             viewModel.validateAddress(newValue)
         }
-        .withLoading(text: "pleaseWait".localized, isLoading: $viewModel.isLoading)
+        .withLoading(
+            text: "pleaseWait".localized,
+            isLoading: Binding(
+                get: { viewModel.searchState == .loading },
+                set: { _ in }
+            )
+        )
         .withLoading(text: "addingToken".localized, isLoading: $viewModel.isAddingToken)
     }
 
     /// Builds a banner view displaying the given error with an optional retry button.
-    /// - Parameter error: The error to present. Rate-limit errors hide the retry action.
+    /// - Parameters:
+    ///   - message: The user-facing error message to present.
+    ///   - showsRetry: Whether to offer a retry action (hidden for rate-limit errors).
     /// - Returns: An ``ActionBannerView`` configured for the error.
-    func errorView(error: Error) -> some View {
+    func errorView(message: String, showsRetry: Bool) -> some View {
         ActionBannerView(
-            title: error.localizedDescription,
+            title: message,
             subtitle: "customTokenErrorSubtitle".localized,
             buttonTitle: "retry".localized,
-            showsActionButton: !(error is RateLimitError)
+            showsActionButton: showsRetry
         ) {
-            Task { await viewModel.fetchTokenInfo() }
+            viewModel.search()
         }
     }
 
     /// A card view showing the resolved custom token's icon, ticker, chain badge, and contract address.
-    var tokenInfoView: some View {
+    func tokenInfoView(_ token: CoinMeta) -> some View {
         ZStack(alignment: .top) {
             HStack(spacing: 12) {
                 AsyncImageView(
-                    logo: viewModel.token?.logo ?? .empty,
+                    logo: token.logo,
                     size: CGSize(width: 36, height: 36),
-                    ticker: viewModel.token?.ticker ?? .empty,
-                    tokenChainLogo: viewModel.token?.tokenChainLogo
+                    ticker: token.ticker,
+                    tokenChainLogo: token.tokenChainLogo
                 )
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 6) {
-                        Text(viewModel.token?.ticker ?? .empty)
+                        Text(token.ticker)
                             .foregroundStyle(Theme.colors.textPrimary)
                             .font(Theme.fonts.bodyMMedium)
 
-                        Text(viewModel.token?.chain.name ?? .empty)
+                        Text(token.chain.name)
                             .foregroundStyle(Theme.colors.textSecondary)
                             .font(Theme.fonts.caption10)
                             .padding(.vertical, 8)
@@ -128,7 +138,7 @@ struct CustomTokenScreen: View {
                             .overlay(RoundedRectangle(cornerRadius: 99).stroke(Theme.colors.borderLight))
                     }
 
-                    Text(viewModel.token?.contractAddress ?? .empty)
+                    Text(token.contractAddress)
                         .foregroundStyle(Theme.colors.textTertiary)
                         .font(Theme.fonts.caption12)
                         .lineLimit(1)

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/CustomTokenScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/CustomTokenScreen.swift
@@ -15,22 +15,19 @@ struct CustomTokenScreen: View {
     @Binding var isPresented: Bool
     var onClose: () -> Void
 
-    @State private var contractAddress: String = ""
-    @State private var tokenName: String = ""
-    @State private var tokenSymbol: String = ""
-    @State private var tokenDecimals: Int = 0
-    @State private var showTokenInfo: Bool = false
-    @State var isAddingToken: Bool = false
-    @State var isLoading: Bool = false
-    @State var error: Error?
+    @StateObject private var viewModel: CustomTokenViewModel
+    @StateObject private var tokenViewModel = TokenSelectionViewModel()
+    @EnvironmentObject private var coinViewModel: CoinSelectionViewModel
 
-    @State private var isValidAddress: Bool = false
-    @State private var token: CoinMeta? = nil
+    @Environment(\.dismiss) private var dismiss
 
-    @StateObject var tokenViewModel = TokenSelectionViewModel()
-    @EnvironmentObject var coinViewModel: CoinSelectionViewModel
-
-    @Environment(\.dismiss) var dismiss
+    init(vault: Vault, chain: Chain, isPresented: Binding<Bool>, onClose: @escaping () -> Void) {
+        self.vault = vault
+        self.chain = chain
+        self._isPresented = isPresented
+        self.onClose = onClose
+        self._viewModel = StateObject(wrappedValue: CustomTokenViewModel(vault: vault, chain: chain))
+    }
 
     var body: some View {
         NavigationStack {
@@ -42,26 +39,26 @@ struct CustomTokenScreen: View {
                         .multilineTextAlignment(.leading)
                     HStack(spacing: 12) {
                         SearchTextField(
-                            value: $contractAddress,
+                            value: $viewModel.contractAddress,
                             showPasteButton: true,
-                            placeholder: searchPlaceholder
+                            placeholder: viewModel.searchPlaceholder
                         )
                         CircularAccessoryIconButton(icon: .searchArea) {
                             Task {
-                                await fetchTokenInfo()
+                                await viewModel.fetchTokenInfo()
                             }
                         }
                     }
 
-                    if let error = error {
+                    if let error = viewModel.error {
                         errorView(error: error)
                             .transition(.opacity)
                     }
 
-                    if showTokenInfo {
+                    if viewModel.showTokenInfo {
                         tokenInfoView
 
-                        PrimaryButton(title: "Add \(tokenSymbol) token") {
+                        PrimaryButton(title: "Add \(viewModel.tokenSymbol) token") {
                             saveAssets()
                         }
                     }
@@ -79,18 +76,18 @@ struct CustomTokenScreen: View {
             }
             .onSubmit {
                 Task {
-                    await fetchTokenInfo()
+                    await viewModel.fetchTokenInfo()
                 }
             }
         }
         .onLoad {
             tokenViewModel.loadData(chain: chain, vault: vault)
         }
-        .onChange(of: contractAddress) { _, newValue in
-            validateAddress(newValue)
+        .onChange(of: viewModel.contractAddress) { _, newValue in
+            viewModel.validateAddress(newValue)
         }
-        .withLoading(text: "pleaseWait".localized, isLoading: $isLoading)
-        .withLoading(text: "addingToken".localized, isLoading: $isAddingToken)
+        .withLoading(text: "pleaseWait".localized, isLoading: $viewModel.isLoading)
+        .withLoading(text: "addingToken".localized, isLoading: $viewModel.isAddingToken)
     }
 
     /// Builds a banner view displaying the given error with an optional retry button.
@@ -103,7 +100,7 @@ struct CustomTokenScreen: View {
             buttonTitle: "retry".localized,
             showsActionButton: !(error is RateLimitError)
         ) {
-            Task { await fetchTokenInfo() }
+            Task { await viewModel.fetchTokenInfo() }
         }
     }
 
@@ -112,18 +109,18 @@ struct CustomTokenScreen: View {
         ZStack(alignment: .top) {
             HStack(spacing: 12) {
                 AsyncImageView(
-                    logo: token?.logo ?? .empty,
+                    logo: viewModel.token?.logo ?? .empty,
                     size: CGSize(width: 36, height: 36),
-                    ticker: token?.ticker ?? .empty,
-                    tokenChainLogo: token?.tokenChainLogo
+                    ticker: viewModel.token?.ticker ?? .empty,
+                    tokenChainLogo: viewModel.token?.tokenChainLogo
                 )
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 6) {
-                        Text(token?.ticker ?? .empty)
+                        Text(viewModel.token?.ticker ?? .empty)
                             .foregroundStyle(Theme.colors.textPrimary)
                             .font(Theme.fonts.bodyMMedium)
 
-                        Text(token?.chain.name ?? .empty)
+                        Text(viewModel.token?.chain.name ?? .empty)
                             .foregroundStyle(Theme.colors.textSecondary)
                             .font(Theme.fonts.caption10)
                             .padding(.vertical, 8)
@@ -131,7 +128,7 @@ struct CustomTokenScreen: View {
                             .overlay(RoundedRectangle(cornerRadius: 99).stroke(Theme.colors.borderLight))
                     }
 
-                    Text(token?.contractAddress ?? .empty)
+                    Text(viewModel.token?.contractAddress ?? .empty)
                         .foregroundStyle(Theme.colors.textTertiary)
                         .font(Theme.fonts.caption12)
                         .lineLimit(1)
@@ -146,253 +143,13 @@ struct CustomTokenScreen: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
-    /// Looks up token metadata for the current ``contractAddress`` by dispatching to the appropriate
-    /// chain-specific service (THORChain bank denom, Cardano, Terra CW20, EVM, Solana, Tron, or TON).
-    /// On success, populates the token preview; on failure, sets the ``error`` state.
-    private func fetchTokenInfo() async {
-        guard !contractAddress.isEmpty else { return }
-
-        // Validate address format before making API calls
-        guard isValidAddress else {
-            error = InvalidAddressError()
-            return
-        }
-
-        isLoading = true
-        showTokenInfo = false
-        error = nil
-
-        do {
-            if chain == .thorChain {
-
-                // THORChain tokens are Cosmos bank denoms (e.g. `thor.lqdy`), resolved
-                // via the bank-denom metadata path — independent of any L1 pool. The
-                // resolver normalizes `THOR.{SYMBOL}` to the lowercase denom and prefers
-                // a curated TokensStore entry for the logo and price provider.
-                let coinMeta = try await ThorchainCustomTokenResolver.resolve(input: contractAddress)
-                self.token = coinMeta
-                self.tokenName = coinMeta.ticker
-                self.tokenSymbol = coinMeta.ticker
-                self.tokenDecimals = coinMeta.decimals
-                self.showTokenInfo = true
-                self.isLoading = false
-
-            } else if chain == .cardano {
-
-                let normalisedId = contractAddress.lowercased()
-                let metadata: CardanoTokenMetadata
-                do {
-                    metadata = try await CardanoNativeTokensService.shared.resolveMetadata(assetId: normalisedId)
-                } catch CardanoNativeTokensServiceError.assetNotFound {
-                    self.error = TokenNotFoundError()
-                    self.isLoading = false
-                    return
-                }
-                // Prefer the built-in registry entry when we know the asset —
-                // gives us the curated ticker, logo, and `priceProviderId`
-                // (`USDM` instead of the `_USDM` masked from the CIP-67 prefix,
-                // `usdm-2` instead of the empty default).
-                let coinMeta = TokensStore.findTokenMeta(chain: chain, contractAddress: metadata.assetId)
-                    ?? CoinMeta(
-                        chain: chain,
-                        ticker: metadata.ticker,
-                        logo: metadata.registryLogo ?? .empty,
-                        decimals: metadata.decimals,
-                        priceProviderId: .empty,
-                        contractAddress: metadata.assetId,
-                        isNativeToken: false
-                    )
-                self.token = coinMeta
-                self.tokenName = coinMeta.ticker
-                self.tokenSymbol = coinMeta.ticker
-                self.tokenDecimals = coinMeta.decimals
-                self.showTokenInfo = true
-                self.isLoading = false
-
-            } else if chain == .terra || chain == .terraClassic {
-
-                // Terra CW20 tokens are CosmWasm contracts; metadata comes from
-                // the `{"token_info":{}}` smart query on the selected chain's
-                // LCD. A wallet address or non-CW20 contract makes the LCD
-                // reject the query and resolves to not-found; transport
-                // failures (rate limit, network) throw into the shared catch
-                // below instead of masquerading as not-found. Curated catalog
-                // entries are preferred for the logo and price provider.
-                guard let coinMeta = try await Cw20CustomTokenResolver.resolve(
-                    contractAddress: contractAddress,
-                    chain: chain
-                ) else {
-                    self.error = TokenNotFoundError()
-                    self.isLoading = false
-                    return
-                }
-                self.token = coinMeta
-                self.tokenName = coinMeta.ticker
-                self.tokenSymbol = coinMeta.ticker
-                self.tokenDecimals = coinMeta.decimals
-                self.showTokenInfo = true
-                self.isLoading = false
-
-            } else if ChainType.Solana == chain.chainType {
-
-                let jupiterTokenInfos = try await SolanaService.shared.fetchTokensInfos(for: [contractAddress])
-
-                if let jupiterTokenInfo = jupiterTokenInfos.first(where: {$0.contractAddress == contractAddress}) {
-
-                    self.token = jupiterTokenInfo
-                    self.tokenName = jupiterTokenInfo.ticker
-                    self.tokenSymbol = jupiterTokenInfo.ticker
-                    self.tokenDecimals = jupiterTokenInfo.decimals
-                    self.showTokenInfo = true
-                    self.isLoading = false
-
-                } else {
-
-                    self.error = TokenNotFoundError()
-                    self.isLoading = false
-
-                }
-
-            } else {
-
-                // EVM, TRON, and TON all share the same (name, symbol, decimals) lookup pattern
-                let tokenInfo: (name: String, symbol: String, decimals: Int)
-
-                switch chain.chainType {
-                case .EVM:
-                    let service = try EvmService.getService(forChain: chain)
-                    tokenInfo = try await service.getTokenInfo(contractAddress: contractAddress)
-                case .Tron:
-                    tokenInfo = try await TronService.shared.getTokenInfo(contractAddress: contractAddress)
-                case .Ton:
-                    tokenInfo = try await TonService.shared.getTokenInfo(contractAddress: contractAddress)
-                default:
-                    self.error = TokenNotFoundError()
-                    self.isLoading = false
-                    return
-                }
-
-                let (name, symbol, decimals) = tokenInfo
-
-                if !name.isEmpty, !symbol.isEmpty, decimals > 0 {
-                    if vault.nativeCoin(for: chain) != nil {
-                        self.token = CoinMeta(
-                            chain: chain,
-                            ticker: symbol,
-                            logo: .empty,
-                            decimals: decimals,
-                            priceProviderId: .empty,
-                            contractAddress: contractAddress,
-                            isNativeToken: false
-                        )
-                        self.tokenName = name
-                        self.tokenSymbol = symbol
-                        self.tokenDecimals = decimals
-                        self.showTokenInfo = true
-                        self.isLoading = false
-                    } else {
-                        self.error = TokenNotFoundError()
-                        self.isLoading = false
-                    }
-
-                } else {
-
-                    self.error = TokenNotFoundError()
-                    self.isLoading = false
-
-                }
-
-            }
-
-        } catch HTTPError.statusCode(429, _) {
-            // HTTPClient-based lookups (Terra CW20) surface rate limiting as a
-            // typed status-code error rather than an NSError with code 429.
-            self.error = RateLimitError()
-            self.isLoading = false
-        } catch is CancellationError {
-            // A cancelled lookup is not a failure the user needs to see;
-            // just stop the spinner.
-            self.isLoading = false
-        } catch let error as NSError {
-            // Check for rate limit error
-            if error.code == 429 {
-                self.error = RateLimitError()
-            } else {
-                self.error = error
-            }
-            self.isLoading = false
-        } catch {
-            self.error = error
-            self.isLoading = false
-        }
-    }
-
-    /// Chain-aware placeholder for the search field. THORChain tokens are referenced by a
-    /// `THOR.{SYMBOL}` bank-denom identifier rather than a contract address, so it gets a
-    /// dedicated hint; every other chain keeps the generic search placeholder.
-    private var searchPlaceholder: String {
-        chain == .thorChain
-            ? "findCustomTokenThorchainPlaceholder".localized
-            : "search".localized
-    }
-
-    /// Validates whether the given input is a well-formed identifier for the current chain.
-    /// For Cardano, the input is a native-token asset id (`policy_id.asset_name` hex).
-    /// For THORChain, the input is a `THOR.{SYMBOL}` bank-denom identifier (THORChain
-    /// tokens are bank denoms, not pool assets), so we validate that shape rather than a
-    /// `thor1…` account address — the shared `AddressService.validateAddress` is reserved
-    /// for real send/receive addresses and must keep rejecting token identifiers.
-    /// For Terra and Terra Classic, the input is a CW20 contract address, validated by
-    /// bech32 shape (contract payloads differ from account addresses).
-    /// Other chains validate the input as a contract/account address.
-    /// Updates ``isValidAddress`` accordingly.
-    /// - Parameter address: The raw input string.
-    private func validateAddress(_ address: String) {
-        if chain == .cardano {
-            isValidAddress = (try? CardanoAssetId.parse(address)) != nil
-        } else if chain == .thorChain {
-            isValidAddress = ThorchainCustomTokenResolver.isValidInput(address)
-        } else if chain == .terra || chain == .terraClassic {
-            // CW20 contract addresses are not account addresses (Terra 2
-            // contracts carry 32-byte payloads, and 20-byte Terra Classic
-            // contracts are shape-identical to wallets), so validate the
-            // bech32 contract shape instead of a send/receive address.
-            isValidAddress = Cw20CustomTokenResolver.isValidInput(address, chain: chain)
-        } else {
-            isValidAddress = AddressService.validateAddress(address: address, chain: chain)
-        }
-    }
-
     /// Persists the resolved custom token to the vault and dismisses the screen.
     /// Shows an "adding token" loading indicator while the save is in progress.
     private func saveAssets() {
-        if let customToken = self.token {
-            isAddingToken = true
-            Task {
-                coinViewModel.handleSelection(isSelected: true, asset: customToken)
-                await CoinService.saveAssets(for: vault, selection: coinViewModel.selection)
-                isAddingToken = false
+        Task {
+            if await viewModel.saveAssets(coinSelectionViewModel: coinViewModel) {
                 dismiss()
             }
         }
     }
-
-    private struct TokenNotFoundError: LocalizedError {
-        var errorDescription: String? {
-            return NSLocalizedString("Token Not Found", comment: "Token not found error")
-        }
-    }
-
-    private struct RateLimitError: LocalizedError {
-        var errorDescription: String? {
-            return NSLocalizedString("Too many requests. Please close this screen and try again later.", comment: "Rate limit error")
-        }
-    }
-
-    private struct InvalidAddressError: LocalizedError {
-        var errorDescription: String? {
-            return NSLocalizedString("invalidAddress", comment: "Invalid address error")
-        }
-    }
-
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Services/CustomTokenResolver.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Services/CustomTokenResolver.swift
@@ -1,0 +1,191 @@
+//
+//  CustomTokenResolver.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Resolves a user-pasted contract/token identifier for the custom-token flow.
+///
+/// Each chain family has its own resolution and validation rules (THORChain bank
+/// denoms, Cardano native-token asset ids, Cosmos CW20 contracts, Solana SPL mints,
+/// and the shared EVM/Tron/TON `(name, symbol, decimals)` lookup). A concrete
+/// resolver bundles both seams for one family so the ViewModel stays chain-agnostic.
+///
+/// Conventions shared by every conformer:
+/// - `fetchInfo` returns `nil` when the input is *definitively* not a token on this
+///   chain (wallet address, unknown/non-token contract), which the caller surfaces
+///   as "token not found".
+/// - Transport failures (rate limiting, network errors) are thrown so the caller can
+///   distinguish "try again later" from "not found".
+protocol CustomTokenResolver {
+    func fetchInfo(contract: String) async throws -> CoinMeta?
+    func validate(_ address: String) -> Bool
+
+    /// Whether a resolved token additionally requires the vault to already hold the
+    /// chain's native coin before it can be added. Enforced by the caller *after*
+    /// `fetchInfo` returns (where `@Model` access is safe), so this is a vault-policy
+    /// gate rather than part of "is this a real token" resolution. Defaults to `false`.
+    var requiresVaultNativeCoin: Bool { get }
+}
+
+extension CustomTokenResolver {
+    var requiresVaultNativeCoin: Bool { false }
+}
+
+/// Builds the `CustomTokenResolver` for a chain, mirroring the dispatch order of the
+/// custom-token search: THORChain and Cardano are matched by chain, Terra/Terra
+/// Classic share the CW20 seam, Solana has its own SPL lookup, and every other chain
+/// falls through to the shared EVM/Tron/TON metadata lookup.
+enum CustomTokenResolverFactory {
+    /// - Parameter chain: The chain the custom-token screen is scoped to.
+    static func make(chain: Chain) -> CustomTokenResolver {
+        if chain == .thorChain {
+            return ThorchainCustomTokenResolverStrategy()
+        } else if chain == .cardano {
+            return CardanoCustomTokenResolverStrategy(chain: chain)
+        } else if chain == .terra || chain == .terraClassic {
+            return Cw20CustomTokenResolverStrategy(chain: chain)
+        } else if chain.chainType == .Solana {
+            return SolanaCustomTokenResolverStrategy(chain: chain)
+        } else {
+            return EvmLikeCustomTokenResolverStrategy(chain: chain)
+        }
+    }
+}
+
+// MARK: - THORChain
+
+/// THORChain non-RUNE tokens are Cosmos bank denoms referenced in `THOR.{SYMBOL}`
+/// notation, not `thor1…` account addresses; delegates to the shared
+/// ``ThorchainCustomTokenResolver``.
+private struct ThorchainCustomTokenResolverStrategy: CustomTokenResolver {
+    func fetchInfo(contract: String) async throws -> CoinMeta? {
+        try await ThorchainCustomTokenResolver.resolve(input: contract)
+    }
+
+    func validate(_ address: String) -> Bool {
+        ThorchainCustomTokenResolver.isValidInput(address)
+    }
+}
+
+// MARK: - Cardano
+
+/// Cardano native tokens are identified by a `policy_id.asset_name` hex asset id and
+/// resolved via the native-tokens metadata service; a curated ``TokensStore`` entry
+/// is preferred so known assets keep their ticker, logo, and `priceProviderId`.
+private struct CardanoCustomTokenResolverStrategy: CustomTokenResolver {
+    let chain: Chain
+
+    func fetchInfo(contract: String) async throws -> CoinMeta? {
+        let normalisedId = contract.lowercased()
+        let metadata: CardanoTokenMetadata
+        do {
+            metadata = try await CardanoNativeTokensService.shared.resolveMetadata(assetId: normalisedId)
+        } catch CardanoNativeTokensServiceError.assetNotFound {
+            return nil
+        }
+        // Prefer the built-in registry entry when we know the asset — gives us the
+        // curated ticker, logo, and `priceProviderId` (`USDM` instead of the `_USDM`
+        // masked from the CIP-67 prefix, `usdm-2` instead of the empty default).
+        return TokensStore.findTokenMeta(chain: chain, contractAddress: metadata.assetId)
+            ?? CoinMeta(
+                chain: chain,
+                ticker: metadata.ticker,
+                logo: metadata.registryLogo ?? .empty,
+                decimals: metadata.decimals,
+                priceProviderId: .empty,
+                contractAddress: metadata.assetId,
+                isNativeToken: false
+            )
+    }
+
+    func validate(_ address: String) -> Bool {
+        (try? CardanoAssetId.parse(address)) != nil
+    }
+}
+
+// MARK: - Cosmos CW20 (Terra / Terra Classic)
+
+/// Terra and Terra Classic CW20 tokens are CosmWasm contracts resolved via the
+/// `{"token_info":{}}` smart query; delegates to the shared ``Cw20CustomTokenResolver``.
+private struct Cw20CustomTokenResolverStrategy: CustomTokenResolver {
+    let chain: Chain
+
+    func fetchInfo(contract: String) async throws -> CoinMeta? {
+        try await Cw20CustomTokenResolver.resolve(contractAddress: contract, chain: chain)
+    }
+
+    func validate(_ address: String) -> Bool {
+        // CW20 contract addresses are not account addresses (Terra 2 contracts carry
+        // 32-byte payloads, and 20-byte Terra Classic contracts are shape-identical to
+        // wallets), so validate the bech32 contract shape instead of a send/receive
+        // address.
+        Cw20CustomTokenResolver.isValidInput(address, chain: chain)
+    }
+}
+
+// MARK: - Solana
+
+/// Solana SPL tokens are resolved through Jupiter's token-info endpoint; a match is
+/// the entry whose `contractAddress` equals the queried mint.
+private struct SolanaCustomTokenResolverStrategy: CustomTokenResolver {
+    let chain: Chain
+
+    func fetchInfo(contract: String) async throws -> CoinMeta? {
+        let tokenInfos = try await SolanaService.shared.fetchTokensInfos(for: [contract])
+        return tokenInfos.first(where: { $0.contractAddress == contract })
+    }
+
+    func validate(_ address: String) -> Bool {
+        AddressService.validateAddress(address: address, chain: chain)
+    }
+}
+
+// MARK: - EVM / Tron / TON
+
+/// EVM, Tron, and TON share the same `(name, symbol, decimals)` lookup pattern. A
+/// token resolves only when the metadata is complete; any other chain type or
+/// incomplete metadata is not-found. The vault-must-hold-the-native-coin gate is
+/// enforced by the caller after resolution (see ``requiresVaultNativeCoin``).
+private struct EvmLikeCustomTokenResolverStrategy: CustomTokenResolver {
+    let chain: Chain
+
+    var requiresVaultNativeCoin: Bool { true }
+
+    func fetchInfo(contract: String) async throws -> CoinMeta? {
+        let tokenInfo: (name: String, symbol: String, decimals: Int)
+
+        switch chain.chainType {
+        case .EVM:
+            let service = try EvmService.getService(forChain: chain)
+            tokenInfo = try await service.getTokenInfo(contractAddress: contract)
+        case .Tron:
+            tokenInfo = try await TronService.shared.getTokenInfo(contractAddress: contract)
+        case .Ton:
+            tokenInfo = try await TonService.shared.getTokenInfo(contractAddress: contract)
+        default:
+            return nil
+        }
+
+        let (name, symbol, decimals) = tokenInfo
+
+        guard !name.isEmpty, !symbol.isEmpty, decimals > 0 else {
+            return nil
+        }
+
+        return CoinMeta(
+            chain: chain,
+            ticker: symbol,
+            logo: .empty,
+            decimals: decimals,
+            priceProviderId: .empty,
+            contractAddress: contract,
+            isNativeToken: false
+        )
+    }
+
+    func validate(_ address: String) -> Bool {
+        AddressService.validateAddress(address: address, chain: chain)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/ViewModels/CustomTokenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/ViewModels/CustomTokenViewModel.swift
@@ -1,0 +1,137 @@
+//
+//  CustomTokenViewModel.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Owns the custom-token search form state and orchestrates per-chain token
+/// resolution and address validation via ``CustomTokenResolver``. The screen binds
+/// to this model and stays purely declarative.
+@MainActor
+final class CustomTokenViewModel: ObservableObject {
+    private let vault: Vault
+    private let chain: Chain
+    private let resolver: CustomTokenResolver
+
+    @Published var contractAddress: String = ""
+    @Published var tokenSymbol: String = ""
+    @Published var showTokenInfo: Bool = false
+    @Published var isAddingToken: Bool = false
+    @Published var isLoading: Bool = false
+    @Published var error: Error?
+    @Published private(set) var isValidAddress: Bool = false
+    @Published private(set) var token: CoinMeta?
+
+    init(vault: Vault, chain: Chain) {
+        self.vault = vault
+        self.chain = chain
+        self.resolver = CustomTokenResolverFactory.make(chain: chain)
+    }
+
+    /// Chain-aware placeholder for the search field. THORChain tokens are referenced
+    /// by a `THOR.{SYMBOL}` bank-denom identifier rather than a contract address, so
+    /// it gets a dedicated hint; every other chain keeps the generic placeholder.
+    var searchPlaceholder: String {
+        chain == .thorChain
+            ? "findCustomTokenThorchainPlaceholder".localized
+            : "search".localized
+    }
+
+    /// Validates whether the given input is a well-formed identifier for the current
+    /// chain and updates ``isValidAddress``.
+    func validateAddress(_ address: String) {
+        isValidAddress = resolver.validate(address)
+    }
+
+    /// Looks up token metadata for the current ``contractAddress`` via the chain's
+    /// resolver. On success, populates the token preview; on failure, sets ``error``.
+    func fetchTokenInfo() async {
+        guard !contractAddress.isEmpty else { return }
+
+        // Validate address format before making API calls
+        guard isValidAddress else {
+            error = InvalidAddressError()
+            return
+        }
+
+        isLoading = true
+        showTokenInfo = false
+        error = nil
+
+        do {
+            guard let coinMeta = try await resolver.fetchInfo(contract: contractAddress) else {
+                self.error = TokenNotFoundError()
+                self.isLoading = false
+                return
+            }
+
+            // Vault-policy gate (EVM/Tron/TON): the vault must already hold the chain's
+            // native coin. Read here — after the lookup returns, on the main actor —
+            // to match the original read-after-network timing.
+            if resolver.requiresVaultNativeCoin, vault.nativeCoin(for: chain) == nil {
+                self.error = TokenNotFoundError()
+                self.isLoading = false
+                return
+            }
+
+            self.token = coinMeta
+            self.tokenSymbol = coinMeta.ticker
+            self.showTokenInfo = true
+            self.isLoading = false
+
+        } catch HTTPError.statusCode(429, _) {
+            // HTTPClient-based lookups (Terra CW20) surface rate limiting as a typed
+            // status-code error rather than an NSError with code 429.
+            self.error = RateLimitError()
+            self.isLoading = false
+        } catch is CancellationError {
+            // A cancelled lookup is not a failure the user needs to see; just stop the
+            // spinner.
+            self.isLoading = false
+        } catch let error as NSError {
+            // Check for rate limit error
+            if error.code == 429 {
+                self.error = RateLimitError()
+            } else {
+                self.error = error
+            }
+            self.isLoading = false
+        } catch {
+            self.error = error
+            self.isLoading = false
+        }
+    }
+
+    /// Persists the resolved custom token to the vault.
+    /// - Returns: `true` when a token was saved (so the caller can dismiss), `false`
+    ///   when there was no resolved token to add.
+    func saveAssets(coinSelectionViewModel: CoinSelectionViewModel) async -> Bool {
+        guard let customToken = token else { return false }
+        isAddingToken = true
+        coinSelectionViewModel.handleSelection(isSelected: true, asset: customToken)
+        await CoinService.saveAssets(for: vault, selection: coinSelectionViewModel.selection)
+        isAddingToken = false
+        return true
+    }
+}
+
+// MARK: - Errors
+
+struct TokenNotFoundError: LocalizedError {
+    var errorDescription: String? {
+        return NSLocalizedString("Token Not Found", comment: "Token not found error")
+    }
+}
+
+struct RateLimitError: LocalizedError {
+    var errorDescription: String? {
+        return NSLocalizedString("Too many requests. Please close this screen and try again later.", comment: "Rate limit error")
+    }
+}
+
+struct InvalidAddressError: LocalizedError {
+    var errorDescription: String? {
+        return NSLocalizedString("invalidAddress", comment: "Invalid address error")
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/ViewModels/CustomTokenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/ViewModels/CustomTokenViewModel.swift
@@ -5,6 +5,24 @@
 
 import Foundation
 
+/// The single source of truth for what the custom-token search area is showing.
+///
+/// Success and failure are mutually exclusive by construction: entering any state
+/// replaces the previous one, so a token that is *found* and then *fails* a follow-up
+/// search can never linger alongside the error (and vice-versa).
+enum CustomTokenSearchState: Equatable {
+    /// Nothing to show — no search yet, or the field was cleared.
+    case idle
+    /// A lookup is in flight (drives the search spinner).
+    case loading
+    /// A token resolved; carries the metadata for the result row and add button.
+    case found(CoinMeta)
+    /// The lookup failed. `message` is the user-facing reason; `showsRetry` hides the
+    /// retry action for rate-limit errors (which the user must wait out), matching the
+    /// original `!(error is RateLimitError)` policy.
+    case invalid(message: String, showsRetry: Bool)
+}
+
 /// Owns the custom-token search form state and orchestrates per-chain token
 /// resolution and address validation via ``CustomTokenResolver``. The screen binds
 /// to this model and stays purely declarative.
@@ -16,17 +34,19 @@ final class CustomTokenViewModel: ObservableObject {
 
     @Published var contractAddress: String = ""
     @Published var tokenSymbol: String = ""
-    @Published var showTokenInfo: Bool = false
     @Published var isAddingToken: Bool = false
-    @Published var isLoading: Bool = false
-    @Published var error: Error?
     @Published private(set) var isValidAddress: Bool = false
-    @Published private(set) var token: CoinMeta?
+    @Published private(set) var searchState: CustomTokenSearchState = .idle
 
-    init(vault: Vault, chain: Chain) {
+    /// The in-flight lookup, if any. A new search cancels it first (cancel-and-restart)
+    /// so the most recently *started* search — not whichever network call happens to
+    /// finish last — is the one that decides ``searchState``.
+    private var searchTask: Task<Void, Never>?
+
+    init(vault: Vault, chain: Chain, resolver: CustomTokenResolver? = nil) {
         self.vault = vault
         self.chain = chain
-        self.resolver = CustomTokenResolverFactory.make(chain: chain)
+        self.resolver = resolver ?? CustomTokenResolverFactory.make(chain: chain)
     }
 
     /// Chain-aware placeholder for the search field. THORChain tokens are referenced
@@ -39,75 +59,104 @@ final class CustomTokenViewModel: ObservableObject {
     }
 
     /// Validates whether the given input is a well-formed identifier for the current
-    /// chain and updates ``isValidAddress``.
+    /// chain and updates ``isValidAddress``. Any edit also supersedes an in-flight
+    /// lookup (its result was for the previous input) and resets the search area to
+    /// ``CustomTokenSearchState/idle`` so a stale result or error never lingers past a
+    /// change to what is being searched.
     func validateAddress(_ address: String) {
         isValidAddress = resolver.validate(address)
+        searchTask?.cancel()
+        searchTask = nil
+        searchState = .idle
     }
 
-    /// Looks up token metadata for the current ``contractAddress`` via the chain's
-    /// resolver. On success, populates the token preview; on failure, sets ``error``.
-    func fetchTokenInfo() async {
+    /// Starts a token lookup for the current ``contractAddress``, cancelling any
+    /// in-flight one first (cancel-and-restart). Returns the lookup task so callers can
+    /// await completion; the view discards it. The most recently started search always
+    /// wins — a superseded lookup is cancelled and its late result discarded.
+    @discardableResult
+    func search() -> Task<Void, Never> {
+        searchTask?.cancel()
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.fetchTokenInfo()
+        }
+        searchTask = task
+        return task
+    }
+
+    /// Looks up token metadata via the chain's resolver and drives ``searchState``. Each
+    /// terminal transition (found / invalid) replaces the previous one, so success and
+    /// failure are never shown at once. The result is committed only if this lookup was
+    /// not superseded (cancelled) by a newer search or a field edit.
+    private func fetchTokenInfo() async {
+        // Bail before touching any state if this task was already superseded — task
+        // scheduling is not FIFO, so a cancelled search can start after a newer one has
+        // already published its result. There is no suspension point between here and
+        // `searchState = .loading` below, so passing this check means every mutation up
+        // to the network `await` runs atomically for the winning search.
+        guard !Task.isCancelled else { return }
         guard !contractAddress.isEmpty else { return }
 
         // Validate address format before making API calls
         guard isValidAddress else {
-            error = InvalidAddressError()
+            searchState = invalidState(for: InvalidAddressError())
             return
         }
 
-        isLoading = true
-        showTokenInfo = false
-        error = nil
+        searchState = .loading
 
+        let contract = contractAddress
+        let terminalState: CustomTokenSearchState
         do {
-            guard let coinMeta = try await resolver.fetchInfo(contract: contractAddress) else {
-                self.error = TokenNotFoundError()
-                self.isLoading = false
-                return
+            if let coinMeta = try await resolver.fetchInfo(contract: contract) {
+                // Vault-policy gate (EVM/Tron/TON): the vault must already hold the
+                // chain's native coin. Read here — after the lookup returns, on the main
+                // actor — to match the original read-after-network timing.
+                if resolver.requiresVaultNativeCoin, vault.nativeCoin(for: chain) == nil {
+                    terminalState = invalidState(for: TokenNotFoundError())
+                } else {
+                    terminalState = .found(coinMeta)
+                }
+            } else {
+                terminalState = invalidState(for: TokenNotFoundError())
             }
-
-            // Vault-policy gate (EVM/Tron/TON): the vault must already hold the chain's
-            // native coin. Read here — after the lookup returns, on the main actor —
-            // to match the original read-after-network timing.
-            if resolver.requiresVaultNativeCoin, vault.nativeCoin(for: chain) == nil {
-                self.error = TokenNotFoundError()
-                self.isLoading = false
-                return
-            }
-
-            self.token = coinMeta
-            self.tokenSymbol = coinMeta.ticker
-            self.showTokenInfo = true
-            self.isLoading = false
-
         } catch HTTPError.statusCode(429, _) {
             // HTTPClient-based lookups (Terra CW20) surface rate limiting as a typed
             // status-code error rather than an NSError with code 429.
-            self.error = RateLimitError()
-            self.isLoading = false
+            terminalState = invalidState(for: RateLimitError())
         } catch is CancellationError {
-            // A cancelled lookup is not a failure the user needs to see; just stop the
-            // spinner.
-            self.isLoading = false
+            // A cancelled lookup is not a failure the user needs to see.
+            return
         } catch let error as NSError {
             // Check for rate limit error
-            if error.code == 429 {
-                self.error = RateLimitError()
-            } else {
-                self.error = error
-            }
-            self.isLoading = false
+            terminalState = error.code == 429
+                ? invalidState(for: RateLimitError())
+                : invalidState(for: error)
         } catch {
-            self.error = error
-            self.isLoading = false
+            terminalState = invalidState(for: error)
         }
+
+        // A newer search or a field edit cancelled this lookup while it was in flight —
+        // discard its result rather than overwrite the current state.
+        guard !Task.isCancelled else { return }
+        if case .found(let coinMeta) = terminalState {
+            tokenSymbol = coinMeta.ticker
+        }
+        searchState = terminalState
+    }
+
+    /// Maps a lookup error to a ``CustomTokenSearchState/invalid(message:showsRetry:)``,
+    /// hiding the retry action for rate-limit errors (which the user must wait out).
+    private func invalidState(for error: Error) -> CustomTokenSearchState {
+        .invalid(message: error.localizedDescription, showsRetry: !(error is RateLimitError))
     }
 
     /// Persists the resolved custom token to the vault.
     /// - Returns: `true` when a token was saved (so the caller can dismiss), `false`
     ///   when there was no resolved token to add.
     func saveAssets(coinSelectionViewModel: CoinSelectionViewModel) async -> Bool {
-        guard let customToken = token else { return false }
+        guard case .found(let customToken) = searchState else { return false }
         isAddingToken = true
         coinSelectionViewModel.handleSelection(isSelected: true, asset: customToken)
         await CoinService.saveAssets(for: vault, selection: coinSelectionViewModel.selection)
@@ -120,18 +169,18 @@ final class CustomTokenViewModel: ObservableObject {
 
 struct TokenNotFoundError: LocalizedError {
     var errorDescription: String? {
-        return NSLocalizedString("Token Not Found", comment: "Token not found error")
+        "customTokenNotFound".localized
     }
 }
 
 struct RateLimitError: LocalizedError {
     var errorDescription: String? {
-        return NSLocalizedString("Too many requests. Please close this screen and try again later.", comment: "Rate limit error")
+        "customTokenRateLimit".localized
     }
 }
 
 struct InvalidAddressError: LocalizedError {
     var errorDescription: String? {
-        return NSLocalizedString("invalidAddress", comment: "Invalid address error")
+        "invalidAddress".localized
     }
 }

--- a/VultisigApp/VultisigAppTests/Wallet/CustomTokenViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/CustomTokenViewModelTests.swift
@@ -1,0 +1,244 @@
+//
+//  CustomTokenViewModelTests.swift
+//  VultisigAppTests
+//
+//  Verifies that the custom-token search area has a single source of truth:
+//  success and failure are mutually exclusive, clearing/editing the field resets it,
+//  and a superseded in-flight lookup can never overwrite newer state.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class CustomTokenViewModelTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeCoin(ticker: String = "USDC", contract: String = "0xabc") -> CoinMeta {
+        CoinMeta(
+            chain: .ethereum,
+            ticker: ticker,
+            logo: "",
+            decimals: 6,
+            priceProviderId: "",
+            contractAddress: contract,
+            isNativeToken: false
+        )
+    }
+
+    private func makeViewModel(resolver: CustomTokenResolver) -> CustomTokenViewModel {
+        CustomTokenViewModel(vault: Vault(name: "test"), chain: .ethereum, resolver: resolver)
+    }
+
+    // MARK: - Mutual exclusivity
+
+    /// Finding a token and then searching one that does not resolve must REPLACE the
+    /// found result with the error — never show both (the reported bug).
+    func testFoundThenInvalidReplacesFoundResult() async {
+        let coin = makeCoin()
+        var resolvesToToken = true
+        let resolver = MockCustomTokenResolver(
+            validateHandler: { _ in true },
+            fetchInfoHandler: { _ in resolvesToToken ? coin : nil }
+        )
+        let viewModel = makeViewModel(resolver: resolver)
+        viewModel.contractAddress = "0xabc"
+        viewModel.validateAddress("0xabc")
+
+        await viewModel.search().value
+        XCTAssertEqual(viewModel.searchState, .found(coin))
+
+        resolvesToToken = false
+        await viewModel.search().value
+
+        guard case .invalid = viewModel.searchState else {
+            return XCTFail("expected .invalid, got \(viewModel.searchState)")
+        }
+        XCTAssertNotEqual(viewModel.searchState, .found(coin), "found result must not linger")
+    }
+
+    /// A successful lookup after a prior failure must clear the error.
+    func testSuccessClearsPriorError() async {
+        let coin = makeCoin()
+        var resolvesToToken = false
+        let resolver = MockCustomTokenResolver(
+            validateHandler: { _ in true },
+            fetchInfoHandler: { _ in resolvesToToken ? coin : nil }
+        )
+        let viewModel = makeViewModel(resolver: resolver)
+        viewModel.contractAddress = "0xabc"
+        viewModel.validateAddress("0xabc")
+
+        await viewModel.search().value
+        guard case .invalid = viewModel.searchState else {
+            return XCTFail("expected .invalid first, got \(viewModel.searchState)")
+        }
+
+        resolvesToToken = true
+        await viewModel.search().value
+        XCTAssertEqual(viewModel.searchState, .found(coin))
+    }
+
+    /// Clearing the input field resets the search area to idle so nothing lingers.
+    func testEmptyInputResetsToIdle() async {
+        let coin = makeCoin()
+        let resolver = MockCustomTokenResolver(
+            validateHandler: { !$0.isEmpty },
+            fetchInfoHandler: { _ in coin }
+        )
+        let viewModel = makeViewModel(resolver: resolver)
+        viewModel.contractAddress = "0xabc"
+        viewModel.validateAddress("0xabc")
+
+        await viewModel.search().value
+        XCTAssertEqual(viewModel.searchState, .found(coin))
+
+        viewModel.contractAddress = ""
+        viewModel.validateAddress("")
+        XCTAssertEqual(viewModel.searchState, .idle)
+    }
+
+    // MARK: - Validation guard
+
+    /// An input that fails address validation short-circuits to an error without a
+    /// network call and replaces any prior state.
+    func testInvalidAddressGuardProducesInvalidState() async {
+        let resolver = MockCustomTokenResolver(
+            validateHandler: { _ in false },
+            fetchInfoHandler: { _ in
+                XCTFail("resolver must not be called for an invalid address")
+                return nil
+            }
+        )
+        let viewModel = makeViewModel(resolver: resolver)
+        viewModel.contractAddress = "not-an-address"
+        viewModel.validateAddress("not-an-address")
+
+        await viewModel.search().value
+        guard case .invalid = viewModel.searchState else {
+            return XCTFail("expected .invalid, got \(viewModel.searchState)")
+        }
+    }
+
+    // MARK: - Superseded in-flight lookups (cancel-and-restart)
+
+    /// A lookup that finishes *after* the user clears the field must be discarded — its
+    /// stale result may not repopulate the now-empty (idle) search area.
+    func testClearingFieldDuringFetchDiscardsStaleResult() async {
+        let viewModel = await runStaleLookup { viewModel in
+            viewModel.contractAddress = ""
+            viewModel.validateAddress("")
+        }
+        XCTAssertEqual(viewModel.searchState, .idle)
+    }
+
+    /// Editing the address to a *different* value mid-lookup must likewise discard the
+    /// old lookup — its result was for the previous address.
+    func testEditingAddressDuringFetchDiscardsStaleResult() async {
+        let viewModel = await runStaleLookup { viewModel in
+            viewModel.contractAddress = "0xdef"
+            viewModel.validateAddress("0xdef")
+        }
+        XCTAssertEqual(viewModel.searchState, .idle)
+    }
+
+    /// A search whose task is cancelled before it even begins (a newer search
+    /// superseded it while it was still queued — task scheduling is not FIFO) must not
+    /// mutate state, in particular must not leave the UI stuck in `.loading`.
+    func testCancelledSearchBeforeStartDoesNotGetStuckLoading() async {
+        let coin = makeCoin()
+        let resolver = MockCustomTokenResolver(
+            validateHandler: { _ in true },
+            fetchInfoHandler: { _ in coin }
+        )
+        let viewModel = makeViewModel(resolver: resolver)
+        viewModel.contractAddress = "0xabc"
+        viewModel.validateAddress("0xabc")
+
+        let task = viewModel.search()
+        task.cancel() // superseded before the task body runs
+        await task.value
+
+        XCTAssertNotEqual(viewModel.searchState, .loading, "a superseded search must not stick in loading")
+        XCTAssertEqual(viewModel.searchState, .idle)
+    }
+
+    /// Drives a search that suspends inside the resolver, runs `interrupt` while it is
+    /// in flight, then releases the lookup and asserts the stale result was discarded.
+    @discardableResult
+    private func runStaleLookup(
+        interrupt: (CustomTokenViewModel) -> Void
+    ) async -> CustomTokenViewModel {
+        let coin = makeCoin()
+        let entered = TestGate()
+        let release = TestGate()
+        let resolver = MockCustomTokenResolver(
+            validateHandler: { !$0.isEmpty },
+            fetchInfoHandler: { _ in
+                await entered.open()
+                await release.wait()
+                return coin
+            }
+        )
+        let viewModel = makeViewModel(resolver: resolver)
+        viewModel.contractAddress = "0xabc"
+        viewModel.validateAddress("0xabc")
+
+        let task = viewModel.search()
+        await entered.wait()
+        XCTAssertEqual(viewModel.searchState, .loading)
+
+        interrupt(viewModel)
+        XCTAssertEqual(viewModel.searchState, .idle)
+
+        await release.open()
+        await task.value
+        return viewModel
+    }
+}
+
+// MARK: - Test doubles
+
+/// A one-shot async gate: `wait()` suspends until `open()` is called (and returns
+/// immediately once opened). Lets a test deterministically pause a resolver mid-lookup.
+private actor TestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+private final class MockCustomTokenResolver: CustomTokenResolver, @unchecked Sendable {
+    let requiresVaultNativeCoin: Bool
+    var validateHandler: (String) -> Bool
+    var fetchInfoHandler: (String) async throws -> CoinMeta?
+
+    init(
+        requiresVaultNativeCoin: Bool = false,
+        validateHandler: @escaping (String) -> Bool,
+        fetchInfoHandler: @escaping (String) async throws -> CoinMeta?
+    ) {
+        self.requiresVaultNativeCoin = requiresVaultNativeCoin
+        self.validateHandler = validateHandler
+        self.fetchInfoHandler = fetchInfoHandler
+    }
+
+    func fetchInfo(contract: String) async throws -> CoinMeta? {
+        try await fetchInfoHandler(contract)
+    }
+
+    func validate(_ address: String) -> Bool {
+        validateHandler(address)
+    }
+}


### PR DESCRIPTION
## Problem

`CustomTokenScreen` mixed presentation with all custom-token resolution and validation logic: the View held ~9 form `@State` fields, a ~150-line per-chain `if/else` in `fetchTokenInfo`, and a per-chain `validateAddress`. This violated the repo's MVVM rule (Views declarative; business logic in ViewModels/Services) and left the search logic untestable.

## Approach

Extract the search logic into two new files, keeping the screen purely declarative:

- **`CustomTokenViewModel`** (`@MainActor ObservableObject`) owns the form state (`contractAddress`, `tokenSymbol`, `showTokenInfo`, `isLoading`, `isAddingToken`, `error`, `token`, `isValidAddress`), the chain-aware `searchPlaceholder`, and `fetchTokenInfo()` / `validateAddress()` / `saveAssets()`.
- **`CustomTokenResolver`** protocol with two seams — `fetchInfo(contract:) -> CoinMeta?` and `validate(_:) -> Bool` — plus a `requiresVaultNativeCoin` policy flag. One concrete strategy per chain family, dispatched by `CustomTokenResolverFactory.make(chain:)`:

  | Strategy | Chains | Resolution seam | `requiresVaultNativeCoin` |
  |---|---|---|---|
  | THORChain | THORChain | `ThorchainCustomTokenResolver` (bank denom) | false |
  | Cardano | Cardano | `CardanoNativeTokensService` + `TokensStore` | false |
  | CW20 | Terra / Terra Classic | `Cw20CustomTokenResolver` | false |
  | Solana | Solana | `SolanaService.fetchTokensInfos` | false |
  | EVM-like | EVM / Tron / TON (default) | per-type `getTokenInfo` | **true** |

The existing `Cw20CustomTokenResolver` and `ThorchainCustomTokenResolver` are reused via thin adapters, not duplicated.

## Behavior-preservation note

Strictly behavior-preserving — no functional change:
- **Identical dispatch order:** thorChain → cardano → terra/terraClassic → `chainType == .Solana` → else (EVM/Tron/TON default), matching the original `if/else` exactly.
- **Vault-native-coin gate:** the original inline `vault.nativeCoin(for: chain) != nil` check (EVM/Tron/TON only) becomes the `requiresVaultNativeCoin` flag, enforced by the ViewModel **after** `fetchInfo` returns, on the `@MainActor` — same read-after-network timing, and `@Model` (`Vault`) access stays on the main actor.
- **Identical error handling:** `HTTPError.statusCode(429)` / `NSError` code 429 → `RateLimitError`; `CancellationError` just stops the spinner; not-found (Cardano `assetNotFound`, Solana no-match, incomplete EVM metadata) → `TokenNotFoundError`.
- **Identical per-chain validation** and the chain-aware search placeholder.
- **No new user-facing strings** — reuses existing localization keys.
- Write-only `tokenName` / `tokenDecimals` state (never read in the View) is dropped.

## Verification

- `make generate` after rebase onto latest `main` (adds the two new files to the XcodeGen project); build succeeds.
- **Full `make test` suite** on iPhone 16e simulator: `Executed 3894 tests, with 1 test skipped and 1 failure`. The **only** failure is the pre-existing `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` snapshot artifact (sub-pixel anti-aliasing delta, perceptual precision 0.99088 vs the 0.99999 threshold) — unrelated to this change (renders `CreateVaultScreen`, no shared code path) and failing identically on `main` and unrelated branches. No false-green claim; every other test passes.
- **Cross-model review (Codex, read-only):** one Medium observation on the Solana path (a stale in-flight result could theoretically be published). Assessed as not a regression and intentionally not fixed: the original's live-`contractAddress` comparison was an accidental side-effect (the filter's purpose was picking the matching mint from Jupiter's batch response, which is preserved); the staleness window is unreachable because the full-screen loading overlay blocks field edits while `isLoading == true`; and a general guard would newly change behavior for the other chains, breaking behavior-preservation.

## Risks

Low — behavior-preserving refactor of a single screen, no changes to underlying resolvers or chain services, gated by the full existing suite. Main risk surface is the vault-native-coin gate timing, which was verified to still read after the network lookup on the main actor.

Closes #4918

---

## Follow-up (commit `746d00d46`) — single search state + cancel-and-restart + localization

UX fix reported from a sim build, plus the two CodeRabbit Major threads, folded into the screen's state model:

- **Single source of truth:** the ViewModel's previously-independent success/failure state (`token`/`showTokenInfo`/`error`/`isLoading`) is consolidated into one `CustomTokenSearchState` enum (`idle`/`loading`/`found(CoinMeta)`/`invalid(message, showsRetry)`). Exactly one thing renders — fixes a bug where a found token *and* an error card could show at once (find a valid token, then search an invalid one). The screen `switch`es on the state with a cross-fade (`.transition(.opacity)` per branch + an `.easeInOut(duration: 0.25)` container animation).
- **Race fix (CodeRabbit #1):** searches are **cancel-and-restart** so the most recently *started* search wins, not whichever network call finishes last. `search()` cancels the in-flight `Task`; editing/clearing the field cancels it and resets to `.idle`; the lookup commits only if not superseded (a `!Task.isCancelled` guard before the first mutation — atomic with `.loading` on the `@MainActor` — and again before the terminal commit). No stale clobber, no stuck loading.
- **Localization (CodeRabbit #2):** the error strings and Add-token label now route through `.localized` — new keys `customTokenAddButton` / `customTokenNotFound` / `customTokenRateLimit` added to **all 8** locales (en, de, es, hr, it, ko, pt, zh-Hans), sorted via `sort_localizable.py`.
- **Tests:** new `CustomTokenViewModelTests` (7 cases) cover mutual exclusivity, empty/edit reset, and the superseded-lookup guards (clear-during-fetch, edit-during-fetch, pre-cancelled search).

**Verification:** full `make test` on iPhone 16e = `Executed 3905 tests, 1 skipped, 1 failure` — the sole failure is the pre-existing `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` snapshot artifact (unrelated). All 7 new tests pass. Cross-model Codex review (read-only) converged to **no findings** after hardening the cancellation guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chain-aware custom token lookup and validation.
  * Added support for resolving token metadata across multiple supported networks.
  * Added clearer loading, error, retry, and token preview states.
  * Added safeguards for chains requiring the native coin before adding a token.

* **Bug Fixes**
  * Improved handling of invalid addresses, missing tokens, rate limits, and cancelled requests.
  * Simplified and stabilized custom token saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
