### PR TITLE
fix(send): re-solve Terra Classic burn-tax fixed point on Verify Max (no 1-uluna underfunding)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -196,6 +196,29 @@ enum SendCryptoLogic {
         return scaled < .zero ? 0 : scaled.truncated(toPlaces: coin.decimals)
     }
 
+    /// Re-derive the native-Max raw amount at Verify time from a freshly
+    /// resolved `fee`. The Verify screen refetches the fee after the Details
+    /// screen produced the amount, so a native Max is re-derived here as
+    /// `balance − fee − ED`.
+    ///
+    /// Terra Classic needs a clamp: its fee embeds a proportional burn tax
+    /// computed from the amount the Details screen produced, so `balance − fee`
+    /// re-adds the balance the tax already consumed and overshoots the tax
+    /// fixed point by up to one unit. Sending that candidate underfunds by up
+    /// to 1 uluna once the chain recomputes the tax on the larger amount at
+    /// broadcast. The Details amount already solves the fixed point
+    /// (`terraClassicMaxValue`) and is spendable, so the re-derived candidate
+    /// must never exceed it — clamping down also stays spendable when the fee
+    /// rose (a smaller amount owes no more tax than the Details amount did).
+    ///
+    /// Every other chain keeps `balance − fee − ED` unchanged.
+    static func verifyMaxCandidateRaw(coin: Coin, fee: BigInt, previousAmountRaw: BigInt) -> BigInt {
+        let balance = coin.rawBalance.toBigInt(decimals: coin.decimals)
+        let candidate = balance - fee - existentialDeposit(for: coin)
+        guard coin.chain == .terraClassic else { return candidate }
+        return Swift.min(candidate, previousAmountRaw)
+    }
+
     /// Apply a percentage (0–100) to a max amount string. Used by the
     /// "25% / 50% / 75%" preset buttons in the Details screen.
     ///

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -110,14 +110,19 @@ class SendCryptoVerifyViewModel: ObservableObject {
             var newAmount = transaction.amount
             // Adjust amount for max send if fee changed (only for native tokens where fee is deducted from balance)
             if transaction.sendMaxAmount && transaction.coin.isNativeToken {
-                let balance = transaction.coin.rawBalance.toBigInt(decimals: transaction.coin.decimals)
-                // Reserve the existential deposit so a DOT max-send settles at
-                // `balance − fee − ED`; `transfer_keep_alive` rejects a transfer
-                // that would reap the sender. Zero for non-ED chains — including
-                // TAO (`transfer_allow_death`) and XRP, whose rawBalance is
-                // already reserve-net, so its max settles at `balance − fee`.
-                let existentialDeposit = SendCryptoLogic.existentialDeposit(for: transaction.coin)
-                let candidate = balance - feeResult.fee - existentialDeposit
+                // `balance − fee − ED`. The ED reservation lets a DOT max-send
+                // settle at `balance − fee − ED` (`transfer_keep_alive` rejects
+                // a transfer that would reap the sender); zero for non-ED chains
+                // — including TAO (`transfer_allow_death`) and XRP, whose
+                // rawBalance is already reserve-net. Terra Classic additionally
+                // clamps to the Details amount so the refetched fee's embedded
+                // burn tax can't push the re-derived amount past the tax fixed
+                // point and underfund the send.
+                let candidate = SendCryptoLogic.verifyMaxCandidateRaw(
+                    coin: transaction.coin,
+                    fee: feeResult.fee,
+                    previousAmountRaw: transaction.amountInRaw
+                )
                 if candidate > 0 {
                     let decimals = transaction.coin.decimals
                     let amountDecimal = Decimal(string: String(candidate)) ?? 0

--- a/VultisigApp/VultisigAppTests/Send/SendMaxAmountTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendMaxAmountTests.swift
@@ -129,6 +129,109 @@ final class SendMaxAmountTests: XCTestCase {
         XCTAssertEqual(eth.getMaxValue(.zero), Decimal(string: "1.000000000000123456"))
     }
 
+    // MARK: - verifyMaxCandidateRaw (Verify-screen native-Max re-derivation)
+
+    func testVerifyMaxCandidateRawNonTerraSubtractsFeeWithoutClamping() {
+        // Non-Terra native Max keeps `balance − fee − ED` verbatim; the
+        // previous amount never clamps it (ED = 0 for ETH).
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000000000") // 1 ETH
+        let fee = BigInt(stringLiteral: "10000000000000000") // 0.01 ETH
+        let candidate = SendCryptoLogic.verifyMaxCandidateRaw(
+            coin: eth,
+            fee: fee,
+            previousAmountRaw: BigInt(1) // absurdly small: proves no clamp off Terra
+        )
+        XCTAssertEqual(candidate, BigInt(stringLiteral: "990000000000000000")) // 0.99 ETH
+    }
+
+    func testVerifyMaxCandidateRawTerraClassicClampsToDetailsAmount() {
+        // Terra Classic: `balance − fee` overshoots the Details amount by the
+        // truncation residue; the clamp pins it back to the spendable amount.
+        let lunc = makeCoin(.terraClassic, ticker: "LUNC", decimals: 6, isNative: true,
+                            rawBalance: "8497702")
+        let baseGas = BigInt(TerraClassicTax.ulunaBaseGas)
+        let previousAmountRaw = BigInt(200) // Details amount A = floor(202 / 1.005)
+        let verifyFee = baseGas + TerraClassicTax.burnTax(amount: previousAmountRaw, rate: TerraClassicTax.fallbackBurnTaxRate)
+        // balance − verifyFee = 8497702 − 8497501 = 201 (one uluna over A).
+        let candidate = SendCryptoLogic.verifyMaxCandidateRaw(
+            coin: lunc,
+            fee: verifyFee,
+            previousAmountRaw: previousAmountRaw
+        )
+        XCTAssertEqual(candidate, previousAmountRaw) // clamped from 201 down to 200
+    }
+
+    func testVerifyMaxCandidateRawTerraClassicKeepsCandidateWhenFeeGrew() {
+        // If the refetched fee is high enough that `balance − fee` falls below
+        // the Details amount, the smaller candidate is kept (it owes no more
+        // tax than the Details amount, so it stays spendable).
+        let lunc = makeCoin(.terraClassic, ticker: "LUNC", decimals: 6, isNative: true,
+                            rawBalance: "9000000")
+        let candidate = SendCryptoLogic.verifyMaxCandidateRaw(
+            coin: lunc,
+            fee: BigInt(600000), // leaves 8_400_000
+            previousAmountRaw: BigInt(8_500_000) // larger than balance − fee
+        )
+        XCTAssertEqual(candidate, BigInt(8_400_000)) // not clamped up to the previous amount
+    }
+
+    func testTerraClassicVerifyMaxNeverUnderfundsAcrossSweptBalances() {
+        // Regression for the 1-uluna underfunding: sweep a contiguous balance
+        // range and assert the re-derived Verify amount is always spendable —
+        // `amount + baseGas + burnTax(amount)` never exceeds the balance — while
+        // confirming the pre-fix `balance − fee` formula did overshoot.
+        let baseGas = BigInt(TerraClassicTax.ulunaBaseGas)
+        let rate = TerraClassicTax.fallbackBurnTaxRate
+        let lunc = makeCoin(.terraClassic, ticker: "LUNC", decimals: 6, isNative: true)
+
+        func signedCost(_ amount: BigInt) -> BigInt {
+            baseGas + amount + TerraClassicTax.burnTax(amount: amount, rate: rate)
+        }
+
+        let start = baseGas + 1
+        let count = 4000
+        var oldUnderfunded = 0
+        var newUnderfunded = 0
+
+        for offset in 0..<count {
+            let balance = start + BigInt(offset)
+            lunc.rawBalance = balance.description
+
+            // Details-screen amount A: fee = baseGas only (no amount known yet).
+            let detailsAmountStr = SendCryptoLogic.computeMaxAmount(coin: lunc, fee: baseGas)
+            let aRaw = SendCryptoLogic.amountInRaw(coin: lunc, amount: detailsAmountStr)
+            guard aRaw > 0 else { continue }
+
+            // Verify refetches the fee with amount = A → embeds burnTax(A).
+            let verifyFee = baseGas + TerraClassicTax.burnTax(amount: aRaw, rate: rate)
+
+            // Pre-fix re-derivation (ED = 0 for Terra Classic).
+            let oldCandidate = balance - verifyFee
+            if oldCandidate > 0, signedCost(oldCandidate) > balance {
+                oldUnderfunded += 1
+            }
+
+            // Re-derivation under test.
+            let newCandidate = SendCryptoLogic.verifyMaxCandidateRaw(
+                coin: lunc,
+                fee: verifyFee,
+                previousAmountRaw: aRaw
+            )
+            guard newCandidate > 0 else { continue }
+            if signedCost(newCandidate) > balance {
+                newUnderfunded += 1
+            }
+            XCTAssertLessThanOrEqual(
+                newCandidate, aRaw,
+                "verify amount \(newCandidate) exceeded the spendable Details amount \(aRaw) at balance \(balance)"
+            )
+        }
+
+        XCTAssertGreaterThan(oldUnderfunded, 0, "sweep did not reproduce the pre-fix underfunding — test is not exercising the bug")
+        XCTAssertEqual(newUnderfunded, 0, "clamped re-derivation still underfunded \(newUnderfunded) of \(count) balances")
+    }
+
     // MARK: - applyPercentage
 
     func testApplyPercentageScalesAmountLinearly() {


### PR DESCRIPTION
## Problem

On a Terra Classic (LUNC) native **Max** send, `SendCryptoVerifyViewModel.loadGasInfoForSending()` re-derives the amount at Verify time as `candidate = balance − fee − ED`. The freshly-refetched `fee` embeds a **burn tax computed from the Details-screen amount** (`baseGas + tax(A)`), so `balance − fee` re-adds the balance the tax already consumed and can land **1 uluna above** what the balance actually supports. Once the chain recomputes the tax on the larger candidate at broadcast, the send is underfunded — a **broadcast failure on a Max send** (fund-safety, not a wrong displayed amount).

## Root cause (the fixed-point math)

Writing `A` for the Details amount and `A* = (balance − baseGas)/1.005` for the exact fixed point, with `A = floor(A*)`:

```
candidate − A = (balance − baseGas) − tax(A) − A ≈ 1.005·(A* − A)
```

The overshoot is driven entirely by the truncation residue `A* − A ∈ [0,1)`. `candidate` is therefore `A` or `A+1`; when it is `A+1`, `tax(A+1)` can exceed `tax(A)` by 1 uluna and the send underfunds. The Details-screen Max path (`SendCryptoLogic.terraClassicMaxValue`, correct as of #4848) already solves the fixed point and is spendable; only the Verify re-derivation overshoots.

## Fix

Clamp the Terra Classic Verify re-derivation to the Details amount, which already solves the fixed point:

```swift
static func verifyMaxCandidateRaw(coin:, fee:, previousAmountRaw:) -> BigInt {
    let candidate = balance - fee - existentialDeposit(for: coin)
    guard coin.chain == .terraClassic else { return candidate }
    return Swift.min(candidate, previousAmountRaw)
}
```

The clamp only ever *lowers* the re-derived amount, so it stays spendable in both directions: if the fee is unchanged/lower, it yields the spendable Details amount `A`; if the fee rose so `candidate < A`, the smaller amount owes no more tax than `A` did (`tax(candidate) ≤ tax(A)`), so `candidate + baseGas + tax(candidate) ≤ balance`. **Non-Terra-Classic re-derivation is byte-identical (`balance − fee − ED`); the Details-screen Max path is untouched.**

## Verification

- **Swept-balance regression test** (`SendMaxAmountTests.testTerraClassicVerifyMaxNeverUnderfundsAcrossSweptBalances`): sweeps 4000 contiguous balances at `baseGas = ulunaBaseGas`, rate 0.5%, and asserts (a) the pre-fix `balance − fee` formula **does** overshoot (bug is real, ~20/4000), and (b) the clamped re-derivation is spendable (`amount + baseGas + burnTax(amount) ≤ balance`) for **every** balance — **0 underfunded**. Plus 3 focused unit tests (non-Terra passthrough, Terra clamp-down, fee-grew keeps smaller candidate). **All 4 passed.**
- **Gate** (`make test`, iPhone 16 Plus): `** TEST FAILED **` / `Executed 3898 tests, 1 skipped, 1 failure`. The **sole** failure is the pre-existing, unrelated `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` sub-pixel snapshot artifact (fails identically on `main`, nothing to do with Send/Verify). All Send/Verify/Max suites are green.
- **Codex read-only review:** no correctness or fund-safety blocker; confirmed the monotonicity safety argument and that non-Terra behavior is unchanged. Non-blocking suggestions (add an explicit DOT/ED assertion, a wording nuance) deferred.
- ⚠️ **On-device Max-send broadcast verification is a manual step not performed here** — the fix is validated by the swept-range math test, not an on-chain LUNC Max send.

## Risks

- Live burn-tax rate could exceed the fallback 0.5%; the clamp only lowers the Verify amount, so a higher live rate cannot make it overshoot. Worst case is a slightly conservative Max (strands < 1 uluna), never underfunding.

## Review flags

🛑 **Fund-safety change** (prevents underfunding real Max sends) → requesting **human review + on-device Max-send verification** before merge.

Closes #4854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maximum native-token send amount calculations during transaction verification.
  * Prevented Terra Classic send amounts from exceeding the previously confirmed spendable amount.
  * Reduced rounding and fee-related discrepancies that could cause verified transactions to be underfunded.

* **Tests**
  * Added coverage for maximum-send calculations across supported native-token chains, including Terra Classic edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->