### PR TITLE
refactor(explorer): unify provider→tracker dispatch behind one SwapProvider resolver

### DIFF
--- a/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/ExplorerLinkBuilder.swift
@@ -27,7 +27,58 @@ enum ExplorerLinkBuilder {
     /// Used by `SwapCryptoLogic.progressLink` (and any post-swap success view).
     /// Returns a `String?` to match the existing call-site signature.
     static func progressLink(quote: SwapQuote?, txHash: String, fromChain: Chain) -> String? {
-        switch quote {
+        let provider = quote.map { swapProvider(for: $0, sourceChain: fromChain) }
+        return trackerURL(for: provider, txHash: txHash, sourceChain: fromChain)
+            ?? getExplorerURL(chain: fromChain, txid: txHash)
+    }
+
+    /// Used by `KeysignViewModel.getSwapProgressURL`.
+    /// Returns a `String?` to match the existing call-site signature.
+    static func progressLink(swapPayload: SwapPayload?, txHash: String) -> String? {
+        guard let swapPayload else { return nil }
+        let sourceChain = swapPayload.fromCoin.chain
+        return trackerURL(for: swapProvider(for: swapPayload), txHash: txHash, sourceChain: sourceChain)
+            ?? getExplorerURL(chain: sourceChain, txid: txHash)
+    }
+
+    // MARK: - Lower-level resolver (used by tx-history sheet + tests)
+
+    static func url(
+        provider: String?,
+        txHash: String,
+        chainRawValue: String,
+        fallbackExplorerLink: String
+    ) -> URL? {
+        let sourceChain = Chain(rawValue: chainRawValue)
+        if let provider = legacySwapProvider(from: provider, chainRawValue: chainRawValue),
+           let tracker = trackerURL(for: provider, txHash: txHash, sourceChain: sourceChain) {
+            return URL(string: tracker)
+        }
+        if let sourceChain {
+            return URL(string: getExplorerURL(chain: sourceChain, txid: txHash))
+        }
+        return URL(string: fallbackExplorerLink)
+    }
+
+    // MARK: - Provider → tracker resolver
+
+    /// The single provider→tracker mapping shared by all three entry points
+    /// (persisted history string, live `SwapQuote`, keysign `SwapPayload`). Each
+    /// entry point resolves its own identity to a `SwapProvider`, then this is
+    /// the one place that maps a provider to its integration tracker — so adding
+    /// or renaming a tracked provider happens in exactly one switch.
+    ///
+    /// Returns `nil` when the provider has no dedicated tracker (aggregator /
+    /// Jupiter / unknown routes), so the caller falls back to the canonical chain
+    /// explorer. `sourceChain` is the from-chain — only SwapKit reads it, to
+    /// append the chainId hint.
+    private static func trackerURL(
+        for provider: SwapProvider?,
+        txHash: String,
+        sourceChain: Chain?
+    ) -> String? {
+        guard let provider else { return nil }
+        switch provider {
         case .thorchain:
             return thorchainTracker(txid: txHash)
         case .thorchainChainnet:
@@ -39,87 +90,92 @@ enum ExplorerLinkBuilder {
         case .lifi:
             return lifiTracker(txid: txHash)
         case .swapkit:
-            // Phase 1 ships the explorer-link fallback; `/track` polling is
-            // covered by the follow-up tx-history plan. `track.swapkit.dev`
-            // accepts on-chain hashes for the source chain.
-            return swapkitTracker(txid: txHash, chain: fromChain)
-        case .oneinch, .kyberswap, .jupiter, .none:
-            return getExplorerURL(chain: fromChain, txid: txHash)
-        }
-    }
-
-    /// Used by `KeysignViewModel.getSwapProgressURL`.
-    /// Returns a `String?` to match the existing call-site signature.
-    static func progressLink(swapPayload: SwapPayload?, txHash: String) -> String? {
-        switch swapPayload {
-        case .thorchain:
-            return thorchainTracker(txid: txHash)
-        case .thorchainChainnet:
-            return thorchainChainnetTracker(txid: txHash)
-        case .thorchainStagenet:
-            return thorchainStagenetTracker(txid: txHash)
-        case .mayachain:
-            return mayaTracker(txid: txHash)
-        case .generic(let payload):
-            switch payload.provider {
-            case .lifi:
-                return lifiTracker(txid: txHash)
-            case .swapkit:
-                return swapkitTracker(txid: txHash, chain: payload.fromCoin.chain)
-            case .oneInch, .kyberSwap, .jupiter, .unknown:
-                return getExplorerURL(chain: payload.fromCoin.chain, txid: txHash)
-            }
-        case .swapkit(let payload):
-            // Phase 2 ships explorer-link fallback for BTC PSBT routes.
-            // `/track` polling integration is covered by the follow-up
-            // tx-history plan; track.swapkit.dev accepts the on-chain hash.
-            return swapkitTracker(txid: txHash, chain: payload.fromCoin.chain)
-        case .none:
+            return swapkitTracker(txid: txHash, chain: sourceChain)
+        case .oneinch, .kyberswap, .jupiter:
+            // Pure aggregators (and Jupiter) have no dedicated tracker; the tx
+            // shows on the source chain's canonical explorer instead.
             return nil
         }
     }
 
-    // MARK: - Lower-level resolver (used by tx-history sheet + tests)
+    /// Maps a live `SwapQuote` to its `SwapProvider`. Every case maps, so the
+    /// tracker decision stays entirely in `trackerURL(for:)`.
+    private static func swapProvider(for quote: SwapQuote, sourceChain: Chain) -> SwapProvider {
+        switch quote {
+        case .thorchain: return .thorchain
+        case .thorchainChainnet: return .thorchainChainnet
+        case .thorchainStagenet: return .thorchainStagenet
+        case .mayachain: return .mayachain
+        case .lifi: return .lifi
+        case .swapkit: return .swapkit
+        case .oneinch: return .oneinch(sourceChain)
+        case .kyberswap: return .kyberswap(sourceChain)
+        case .jupiter: return .jupiter
+        }
+    }
 
-    static func url(
-        provider: String?,
-        txHash: String,
-        chainRawValue: String,
-        fallbackExplorerLink: String
-    ) -> URL? {
-        if let normalized = provider?
-            .lowercased()
-            .filter({ $0.isLetter || $0.isNumber }) {
-            // Aliases cover every value SwapQuote.displayName and
-            // SwapPayload.providerName can produce, plus the legacy
-            // "thorswap" string from older history entries.
-            switch normalized {
-            case "lifi":
-                return URL(string: lifiTracker(txid: txHash))
-            case "swapkit":
-                return URL(string: swapkitTracker(txid: txHash, chain: Chain(rawValue: chainRawValue)))
-            case "maya", "mayachain", "mayaprotocol":
-                return URL(string: mayaTracker(txid: txHash))
-            case "thorchainstagenet":
-                return URL(string: thorchainStagenetTracker(txid: txHash))
-            case "thorchainchainnet":
-                return URL(string: thorchainChainnetTracker(txid: txHash))
-            case "thorchain", "thorswap":
-                if chainRawValue == Chain.thorChainChainnet.rawValue {
-                    return URL(string: thorchainChainnetTracker(txid: txHash))
-                }
-                if chainRawValue == Chain.thorChainStagenet.rawValue {
-                    return URL(string: thorchainStagenetTracker(txid: txHash))
-                }
-                return URL(string: thorchainTracker(txid: txHash))
-            default:
-                break
+    /// Maps a keysign `SwapPayload` to its `SwapProvider`. An unrecognised
+    /// generic provider yields `nil` so it falls back to the chain explorer,
+    /// matching the pre-refactor behaviour.
+    private static func swapProvider(for payload: SwapPayload) -> SwapProvider? {
+        switch payload {
+        case .thorchain: return .thorchain
+        case .thorchainChainnet: return .thorchainChainnet
+        case .thorchainStagenet: return .thorchainStagenet
+        case .mayachain: return .mayachain
+        case .swapkit: return .swapkit
+        case .generic(let payload):
+            switch payload.provider {
+            case .lifi: return .lifi
+            case .swapkit: return .swapkit
+            case .oneInch: return .oneinch(payload.fromCoin.chain)
+            case .kyberSwap: return .kyberswap(payload.fromCoin.chain)
+            case .jupiter: return .jupiter
+            case .unknown: return nil
             }
         }
-        if let chain = Chain(rawValue: chainRawValue) {
-            return URL(string: getExplorerURL(chain: chain, txid: txHash))
+    }
+
+    // MARK: - Legacy persisted-string aliases
+
+    /// Maps a persisted/history provider string (Transaction History stores only
+    /// the display name) to its `SwapProvider`. Every value `SwapQuote.displayName`
+    /// and `SwapPayload.providerName` can produce normalizes to one of these keys,
+    /// plus the legacy `"thorswap"`/`"mayachain"`/`"mayaprotocol"` strings from
+    /// older history entries. Keys are normalized — lowercased, letters and digits
+    /// only — so `"LI.FI"`, `"Maya protocol"` and `"THORChain-Stagenet"` each
+    /// collapse to a single key.
+    private static let legacyProviderAliases: [String: SwapProvider] = [
+        "lifi": .lifi,
+        "swapkit": .swapkit,
+        "maya": .mayachain,
+        "mayachain": .mayachain,
+        "mayaprotocol": .mayachain,
+        "thorchainstagenet": .thorchainStagenet,
+        "thorchainchainnet": .thorchainChainnet,
+        "thorchain": .thorchain,
+        "thorswap": .thorchain
+    ]
+
+    /// Resolves a raw persisted provider string to its `SwapProvider`, applying
+    /// the same normalization the alias table is keyed on. The persisted
+    /// `"thorchain"`/`"thorswap"` strings carry no network variant, so the
+    /// record's chain disambiguates them into chainnet/stagenet.
+    private static func legacySwapProvider(from provider: String?, chainRawValue: String) -> SwapProvider? {
+        guard let normalized = provider?
+            .lowercased()
+            .filter({ $0.isLetter || $0.isNumber }),
+            let resolved = legacyProviderAliases[normalized] else {
+            return nil
         }
-        return URL(string: fallbackExplorerLink)
+        guard resolved == .thorchain else { return resolved }
+        if chainRawValue == Chain.thorChainChainnet.rawValue {
+            return .thorchainChainnet
+        }
+        if chainRawValue == Chain.thorChainStagenet.rawValue {
+            return .thorchainStagenet
+        }
+        return .thorchain
     }
 
     // MARK: - Chain explorer URL

--- a/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ExplorerLinkBuilderTests.swift
@@ -4,6 +4,7 @@
 //
 
 import XCTest
+import BigInt
 @testable import VultisigApp
 
 final class ExplorerLinkBuilderTests: XCTestCase {
@@ -474,5 +475,196 @@ final class ExplorerLinkBuilderTests: XCTestCase {
             (grouped ?? "").contains("explorer.bitcoin.com"),
             "Bitcoin Cash grouped address URL must no longer use explorer.bitcoin.com"
         )
+    }
+
+    // MARK: - Provider resolver parity (behaviour-preserving refactor, S11)
+    //
+    // All three entry points (persisted history string, live SwapQuote, keysign
+    // SwapPayload) now share one SwapProvider→tracker resolver. These lock the
+    // tracker/URL each provider — including legacy persisted aliases — resolved
+    // to before the refactor, byte-for-byte, so the shared resolver can't drift.
+
+    /// Hex-prefix-stripped form of `txHash`, used by the RuneScan/Maya trackers.
+    private var strippedHash: String { "ABCDEF1234567890" }
+
+    /// Every value `SwapQuote.displayName` and `SwapPayload.providerName` can
+    /// emit, plus the legacy `thorswap`/`mayachain`/`mayaprotocol` history
+    /// strings, mapped to the exact tracker URL they produced pre-refactor.
+    func testLegacyProviderAliasesResolveToExactTracker() {
+        let cases: [(provider: String, chain: String, expected: String)] = [
+            ("LI.FI", mainnetChain, "https://scan.li.fi/tx/\(txHash)"),
+            ("lifi", mainnetChain, "https://scan.li.fi/tx/\(txHash)"),
+            ("Maya protocol", Chain.bitcoin.rawValue, "https://www.explorer.mayachain.info/tx/\(strippedHash)"),
+            ("Maya Protocol", Chain.bitcoin.rawValue, "https://www.explorer.mayachain.info/tx/\(strippedHash)"),
+            ("maya", mainnetChain, "https://www.explorer.mayachain.info/tx/\(strippedHash)"),
+            ("mayachain", mainnetChain, "https://www.explorer.mayachain.info/tx/\(strippedHash)"),
+            ("mayaprotocol", mainnetChain, "https://www.explorer.mayachain.info/tx/\(strippedHash)"),
+            ("THORChain", mainnetChain, "https://runescan.io/tx/\(strippedHash)"),
+            ("THORSwap", mainnetChain, "https://runescan.io/tx/\(strippedHash)"),
+            ("THORChain", Chain.thorChainChainnet.rawValue, "https://runescan.io/tx/\(strippedHash)?network=chainnet"),
+            ("THORChain", stagenetChain, "https://runescan.io/tx/\(strippedHash)?network=stagenet"),
+            ("THORChain-Chainnet", mainnetChain, "https://runescan.io/tx/\(strippedHash)?network=chainnet"),
+            ("THORChain-Stagenet", Chain.bitcoin.rawValue, "https://runescan.io/tx/\(strippedHash)?network=stagenet"),
+            ("SwapKit", Chain.ethereum.rawValue, "https://track.swapkit.dev/?hash=\(txHash)&chainId=1"),
+            ("SwapKit", Chain.osmosis.rawValue, "https://track.swapkit.dev/?hash=\(txHash)")
+        ]
+        for testCase in cases {
+            let url = ExplorerLinkBuilder.url(
+                provider: testCase.provider,
+                txHash: txHash,
+                chainRawValue: testCase.chain,
+                fallbackExplorerLink: fallback
+            )
+            XCTAssertEqual(
+                url?.absoluteString,
+                testCase.expected,
+                "provider \"\(testCase.provider)\" on \(testCase.chain)"
+            )
+        }
+    }
+
+    /// Aggregators (1inch/KyberSwap/Jupiter), the sub-provider-suffixed
+    /// `SwapKit (Chainflip)` form (which normalizes to `swapkitchainflip`, not
+    /// `swapkit`), and unrecognised/empty strings all fall through to the
+    /// canonical chain explorer — exactly as the pre-refactor switch did.
+    func testAggregatorAndUnknownProvidersFallThroughToChainExplorer() {
+        let providers = ["1Inch", "KyberSwap", "Jupiter", "SwapKit (Chainflip)", "totally-unknown", ""]
+        let chain = Chain.ethereum.rawValue
+        let expected = ExplorerLinkBuilder.getExplorerURL(chain: .ethereum, txid: txHash)
+        for provider in providers {
+            let url = ExplorerLinkBuilder.url(
+                provider: provider,
+                txHash: txHash,
+                chainRawValue: chain,
+                fallbackExplorerLink: fallback
+            )
+            XCTAssertEqual(url?.absoluteString, expected, "provider \"\(provider)\" should fall through")
+        }
+    }
+
+    // MARK: - SwapQuote entry point parity
+
+    func testProgressLinkQuoteRoutesEachProviderToExactURL() {
+        let evmQuote = Self.makeEVMQuote()
+        let thorQuote = Self.makeThorchainQuote()
+        let ethExplorer = ExplorerLinkBuilder.getExplorerURL(chain: .ethereum, txid: txHash)
+        // The from-chain is deliberately ethereum for every case: THORChain/Maya
+        // quotes ignore it (network comes from the case), while the aggregators
+        // fall back to it — proving the quote case, not the chain, picks the URL.
+        let cases: [(quote: SwapQuote, expected: String)] = [
+            (.thorchain(thorQuote), "https://runescan.io/tx/\(strippedHash)"),
+            (.thorchainChainnet(thorQuote), "https://runescan.io/tx/\(strippedHash)?network=chainnet"),
+            (.thorchainStagenet(thorQuote), "https://runescan.io/tx/\(strippedHash)?network=stagenet"),
+            (.mayachain(thorQuote), "https://www.explorer.mayachain.info/tx/\(strippedHash)"),
+            (.lifi(evmQuote, fee: nil, integratorFee: nil), "https://scan.li.fi/tx/\(txHash)"),
+            (.oneinch(evmQuote, fee: nil), ethExplorer),
+            (.kyberswap(evmQuote, fee: nil), ethExplorer),
+            (.jupiter(evmQuote, fee: nil, platformFee: 0, feeOnInput: false), ethExplorer)
+        ]
+        for testCase in cases {
+            let link = ExplorerLinkBuilder.progressLink(
+                quote: testCase.quote,
+                txHash: txHash,
+                fromChain: .ethereum
+            )
+            XCTAssertEqual(link, testCase.expected)
+        }
+    }
+
+    func testProgressLinkQuoteNilFallsBackToChainExplorer() {
+        let link = ExplorerLinkBuilder.progressLink(quote: nil, txHash: txHash, fromChain: .ethereum)
+        XCTAssertEqual(link, ExplorerLinkBuilder.getExplorerURL(chain: .ethereum, txid: txHash))
+    }
+
+    // MARK: - SwapPayload entry point parity (generic sub-provider mapping)
+
+    func testProgressLinkSwapPayloadGenericRoutesEachProviderToExactURL() {
+        let ethExplorer = ExplorerLinkBuilder.getExplorerURL(chain: .ethereum, txid: txHash)
+
+        XCTAssertEqual(
+            ExplorerLinkBuilder.progressLink(
+                swapPayload: Self.makeGenericPayload(provider: .lifi, fromChain: .ethereum),
+                txHash: txHash
+            ),
+            "https://scan.li.fi/tx/\(txHash)"
+        )
+        // SwapKit on a non-catalogue chain → base tracker (no chainId hint).
+        XCTAssertEqual(
+            ExplorerLinkBuilder.progressLink(
+                swapPayload: Self.makeGenericPayload(provider: .swapkit, fromChain: .osmosis),
+                txHash: txHash
+            ),
+            "https://track.swapkit.dev/?hash=\(txHash)"
+        )
+        // SwapKit on a catalogue chain → chainId hint appended.
+        XCTAssertEqual(
+            ExplorerLinkBuilder.progressLink(
+                swapPayload: Self.makeGenericPayload(provider: .swapkit, fromChain: .ethereum),
+                txHash: txHash
+            ),
+            "https://track.swapkit.dev/?hash=\(txHash)&chainId=1"
+        )
+        // Aggregators + unknown wire providers → source-chain explorer.
+        for provider in [SwapProviderId.oneInch, .kyberSwap, .jupiter, .unknown("mystery")] {
+            XCTAssertEqual(
+                ExplorerLinkBuilder.progressLink(
+                    swapPayload: Self.makeGenericPayload(provider: provider, fromChain: .ethereum),
+                    txHash: txHash
+                ),
+                ethExplorer,
+                "generic \(provider) should fall back to the chain explorer"
+            )
+        }
+    }
+
+    func testProgressLinkSwapPayloadNilReturnsNil() {
+        XCTAssertNil(ExplorerLinkBuilder.progressLink(swapPayload: nil, txHash: txHash))
+    }
+
+    // MARK: - Fixtures
+
+    private static func makeEVMQuote() -> EVMQuote {
+        EVMQuote(
+            dstAmount: "1",
+            tx: EVMQuote.Transaction(from: "0xfrom", to: "0xto", data: "0x", value: "0", gasPrice: "0", gas: 0)
+        )
+    }
+
+    private static func makeThorchainQuote() -> ThorchainSwapQuote {
+        ThorchainSwapQuote(
+            dustThreshold: nil,
+            expectedAmountOut: "0",
+            expiry: 0,
+            fees: Fees(affiliate: "0", asset: "CACAO", outbound: "0", total: "0", liquidity: nil, slippageBps: nil, totalBps: nil),
+            inboundAddress: nil,
+            inboundConfirmationBlocks: nil,
+            inboundConfirmationSeconds: nil,
+            memo: "memo",
+            notes: "",
+            outboundDelayBlocks: 0,
+            outboundDelaySeconds: 0,
+            recommendedMinAmountIn: "0",
+            slippageBps: nil,
+            totalSwapSeconds: nil,
+            warning: "",
+            router: nil,
+            maxStreamingQuantity: nil
+        )
+    }
+
+    private static func makeCoin(_ chain: Chain, ticker: String) -> Coin {
+        let meta = CoinMeta.make(chain: chain, ticker: ticker, decimals: 18, isNativeToken: true)
+        return Coin(asset: meta, address: "addr-\(ticker)", hexPublicKey: "")
+    }
+
+    private static func makeGenericPayload(provider: SwapProviderId, fromChain: Chain) -> SwapPayload {
+        .generic(GenericSwapPayload(
+            fromCoin: makeCoin(fromChain, ticker: "FROM"),
+            toCoin: makeCoin(.ethereum, ticker: "TO"),
+            fromAmount: BigInt(1),
+            toAmountDecimal: 1,
+            quote: makeEVMQuote(),
+            provider: provider
+        ))
     }
 }


### PR DESCRIPTION
## Problem
`ExplorerLinkBuilder` mapped a swap provider to its "View Progress" tracker URL in **three** separate switches — a persisted Transaction-History string, a live `SwapQuote`, and a keysign `SwapPayload`. The same provider→tracker choices (LI.FI scanner, SwapKit `/track`, RuneScan mainnet/chainnet/stagenet, MayaChain explorer) were triplicated, so a new or renamed provider had to be added in all three places (kept alias-compatible with persisted history) or it silently fell through to the chain explorer.

## Approach — one `SwapProvider`-keyed resolver + an explicit legacy-alias table
- `trackerURL(for: SwapProvider?, txHash:, sourceChain:)` is now the **single** provider→tracker map. It returns `nil` for providers with no dedicated tracker (1inch / KyberSwap / Jupiter / unknown) so the caller falls back to the canonical chain explorer. Only SwapKit reads `sourceChain` (to append the `/track` chainId hint).
- Each entry point resolves its own identity to a `SwapProvider` and delegates to that one resolver:
  - `swapProvider(for: SwapQuote, sourceChain:)` and `swapProvider(for: SwapPayload)` map the live/keysign cases directly (generic `.unknown` → `nil` → chain explorer, as before).
  - `legacyProviderAliases: [String: SwapProvider]` maps normalized persisted/history strings — including the legacy `thorswap` / `mayachain` / `mayaprotocol` forms — into the same resolver. The persisted `thorchain`/`thorswap` strings carry no network variant, so `legacySwapProvider(from:chainRawValue:)` disambiguates them into chainnet/stagenet by the record's chain (localized to this string-resolution step, keeping the quote/payload paths byte-identical).

`SwapProvider` is `Equatable` (not `Hashable`, and `.oneinch`/`.kyberswap` carry a `Chain`), so the resolver is a `switch` function and the alias table holds only the no-payload tracked cases.

## Behavior-preservation
Every known provider + network produces the **byte-identical** tracker/URL as before, and unknown/aggregator providers still fall through to the canonical chain explorer. Preserved subtleties, now pinned by tests:
- THORChain network disambiguation for the unsuffixed `thorchain`/`thorswap` strings (chainnet/stagenet/mainnet by `chainRawValue`).
- Explicit `THORChain-Chainnet` / `THORChain-Stagenet` display names override the recorded chain.
- `SwapKit (Chainflip)` normalizes to `swapkitchainflip` (≠ `swapkit`) and still falls through to the chain explorer.
- SwapKit's source-chain `chainId` hint behavior.
- Nil handling unchanged: nil quote → chain explorer; nil payload → `nil`; unresolvable `chainRawValue` → stored `fallbackExplorerLink`.

## Verification
- Full unit-test gate on iPhone 15 (18.4) sim, `en_US`: **`** TEST SUCCEEDED **`**, 0 failures. `ExplorerLinkBuilderTests` passed.
  - The suite was run excluding one **pre-existing, unrelated** failure: `CreateVaultSnapshotTests/testCreateVaultScreen_iPhone16Pro` (a snapshot pixel-diff of the CreateVault screen with a concurrent network-load failure). This PR touches only `ExplorerLinkBuilder.swift` + its test — no code path into that screen — so its result is invariant to this change (fails identically on `main`).
- SwiftLint: 0 violations on both files.
- Codex read-only cross-review: **"No behavior-preservation regressions found."** — verified every new resolver path against the pre-refactor switches (aliases incl. `thorswap`/`mayachain`/`mayaprotocol`, THORChain disambiguation, SwapQuote/SwapPayload parity incl. generic `.unknown`, SwapKit chainId, nil handling, aggregator fall-through).
- New regression tests pin all three entry points byte-for-byte: legacy-alias parity table, `SwapQuote` per-provider parity, `SwapPayload.generic` per-`SwapProviderId` parity, plus the unknown/aggregator/`SwapKit (Chainflip)` fall-through and nil cases.

## Risks
Low — pure internal refactor of one file; no wire/format/schema change, no locale change. Deferred (non-blocking, per Codex): the `.swapkit` `SwapQuote` arm and the native / top-level `.swapkit` `SwapPayload` arms aren't constructed directly in tests (heavy `SwapKitSwapResponse` / `SwapKitSwapPayload` fixtures); those arms are trivial 1:1 identity maps already exercised through the raw-string `SwapKit` alias and the generic-swapkit payload via the same shared resolver.

Closes #4920


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction and swap progress links across supported providers and chains.
  - Standardized fallback links to the appropriate chain explorer when dedicated tracking is unavailable.
  - Improved compatibility with legacy provider names and persisted swap data.
  - Preserved correct handling for aggregators, unknown providers, and chain-specific routing.

- **Tests**
  - Added comprehensive coverage for transaction links, swap quotes, generic swap payloads, and explorer fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->