### PR TITLE
fix(swap): stop relabeling unknown/internal failures as money errors (#4902, #4903)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -478,7 +478,11 @@ private extension SwapService {
         } catch let error as SwapError {
             throw error
         } catch {
-            throw SwapError.swapAmountTooSmall
+            // Any error not classified above (timeout, TLS, decode, node 5xx)
+            // is unknown here — surface the real error instead of a confident
+            // "amount too small" money verdict the app cannot actually justify.
+            logger.error("Cross-chain quote failed with unclassified error: \(error.localizedDescription, privacy: .public)")
+            throw error
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -9,6 +9,9 @@
 
 import BigInt
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "swap-payload-builder")
 
 extension SwapCryptoLogic {
 
@@ -49,15 +52,31 @@ extension SwapCryptoLogic {
                     planFee = BigInt(plan.fee)
                 }
 
-                if planFee <= 0 && fromAmount > 0 {
-                    throw Errors.insufficientFunds
+                // A non-positive planned fee is an anomalous planner result, not
+                // a funding verdict: fail closed with an internal error rather
+                // than reserving a zero network fee downstream (or, as before,
+                // inferring "insufficient funds" from it).
+                guard planFee > 0 || fromAmount <= 0 else {
+                    logger.error("UTXO/Cardano fee planner returned a non-positive fee")
+                    throw Errors.unexpectedError
                 }
                 return planFee
+            } catch let error as KeysignPayloadFactory.Errors {
+                // The UTXO/Cardano transfer builder raises typed funding errors
+                // (notEnoughUTXO / utxoTooSmall / utxoSelectionFailed) — trust
+                // them as the authoritative "insufficient funds" signal.
+                throw error
+            } catch let error as Errors {
+                // Our own internal verdict (e.g. the non-positive-fee guard
+                // above) is already correctly typed — rethrow without relabeling.
+                throw error
             } catch {
-                if error is KeysignPayloadFactory.Errors {
-                    throw error
-                }
-                throw Errors.insufficientFunds
+                // Any other failure (fee-plan build, decode, transport) is not a
+                // funding verdict — log and surface the real error instead of
+                // inferring "insufficient funds" (previously also inferred from a
+                // non-positive planned fee).
+                logger.error("UTXO/Cardano swap-fee planning failed: \(error.localizedDescription, privacy: .public)")
+                throw error
             }
 
         case .Cosmos, .THORChain, .Polkadot, .MayaChain, .Solana, .Sui, .Ton, .Ripple, .Tron:
@@ -214,9 +233,11 @@ extension SwapCryptoLogic {
         )
 
         // Limit orders never reach this builder — they construct their
-        // payload via `LimitSwapPayloadAssembler`. Guard for symmetry.
+        // payload via `LimitSwapPayloadAssembler`. A missing quote here is an
+        // internal/state inconsistency, not a funding problem, so surface it as
+        // an internal error rather than a confident "insufficient funds" verdict.
         guard let quote = transaction.quote else {
-            throw Errors.insufficientFunds
+            throw Errors.unexpectedError
         }
 
         switch quote {
@@ -313,6 +334,13 @@ extension SwapCryptoLogic {
             )
 
         case let .oneinch(evmQuote, _), let .lifi(evmQuote, _, _), let .kyberswap(evmQuote, _):
+            // Never stamp the signed payload with a guessed provider. All three
+            // grouped cases resolve `swapProviderId` to a concrete non-nil value
+            // by construction; a nil here is an internal inconsistency, not a
+            // reason to silently default to 1inch.
+            guard let provider = quote.swapProviderId else {
+                throw Errors.unexpectedError
+            }
             // Attribute the affiliate fee to its coin so peers holding only
             // the serialized payload (the co-signer has no live quote) don't
             // guess. `swapFeeCoin` is what the initiator's own fiat display
@@ -337,7 +365,7 @@ extension SwapCryptoLogic {
                 fromAmount: amountInCoin,
                 toAmountDecimal: toDecimal,
                 quote: evmQuote,
-                provider: quote.swapProviderId ?? .oneInch,
+                provider: provider,
                 swapFeeChain: swapFeeChain,
                 swapFeeTokenId: swapFeeTokenId,
                 swapFeeDecimals: swapFeeDecimals

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -858,14 +858,11 @@ private extension SwapDetailsViewModel {
 
             logger.warning("Update fees error: \(error.localizedDescription)")
 
-            switch error {
-            case KeysignPayloadFactory.Errors.notEnoughUTXOError,
-                 KeysignPayloadFactory.Errors.utxoTooSmallError,
-                 KeysignPayloadFactory.Errors.utxoSelectionFailedError:
-                self.error = error
-            default:
-                self.error = SwapCryptoLogic.Errors.insufficientGas
-            }
+            // Surface the real failure. Typed UTXO errors already flow through
+            // unchanged; every other error (timeout, decode, TLS, node 5xx) was
+            // previously relabeled as `insufficientGas` — a confident money
+            // verdict the app cannot actually justify.
+            self.error = error
         }
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapDetailsViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapDetailsViewModelTests.swift
@@ -320,6 +320,32 @@ final class SwapDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.advancedSettings, .default, "A new swap session (load) must start at default advanced settings")
     }
 
+    // MARK: - Fee-error surfacing (real error, not a money verdict)
+
+    func testUpdateFeesSurfacesRealErrorInsteadOfInsufficientGas() async {
+        // A non-UTXO fee failure (timeout / decode / TLS) must surface as itself.
+        // It was previously relabeled by the `default:` branch as
+        // `insufficientGas` — a confident money verdict the app can't justify.
+        // Driven through the public quote→fee pipeline: the quote resolves, then
+        // the fee computation throws, exercising `updateFees`' catch.
+        struct ProbeFeeError: Error {}
+        let interactor = MockSwapInteractor(
+            quote: .thorchain(makeThorQuote(expectedAmountOut: "100000000")),
+            computeFeeError: ProbeFeeError()
+        )
+        let vm = makeVM(interactor: interactor)
+        vm.fromCoin = makeCoin(.thorChain, ticker: "RUNE", balance: "100000000000")
+        vm.toCoin = makeCoin(.bitcoin, ticker: "BTC")
+        vm.fromAmount = "1"
+
+        vm.updateFromAmount(vault: makeVault(), referredCode: "", immediate: true)
+        await vm.waitForQuoteTask()
+
+        XCTAssertNotNil(vm.quote, "Precondition: the quote must resolve so updateFees runs")
+        XCTAssertTrue(vm.error is ProbeFeeError, "The real fee error must surface, got \(String(describing: vm.error))")
+        XCTAssertFalse(vm.error is SwapCryptoLogic.Errors, "A generic fee failure must not be relabeled as a money error")
+    }
+
     // MARK: - Fixtures
 
     private func makeVM(interactor: SwapInteractor? = nil) -> SwapDetailsViewModel {
@@ -399,10 +425,12 @@ private extension SwapDetailsViewModel {
 @MainActor
 private final class MockSwapInteractor: SwapInteractor {
     private let stubbedQuote: SwapQuote?
+    private let computeFeeError: Error?
     private(set) var fetchQuoteCallCount = 0
 
-    init(quote: SwapQuote?) {
+    init(quote: SwapQuote?, computeFeeError: Error? = nil) {
         self.stubbedQuote = quote
+        self.computeFeeError = computeFeeError
     }
 
     func fetchQuote(
@@ -436,7 +464,10 @@ private final class MockSwapInteractor: SwapInteractor {
         fromAmount: Decimal,
         vault: Vault
     ) async throws -> BigInt {
-        .zero
+        if let computeFeeError {
+            throw computeFeeError
+        }
+        return .zero
     }
 
     func buildSwapKeysignPayload(transaction: SwapTransaction, vault: Vault) async throws -> KeysignPayload {

--- a/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapPayloadBuilderTests.swift
@@ -516,6 +516,46 @@ final class SwapPayloadBuilderTests: XCTestCase {
         XCTAssertNil(SwapCryptoLogic.buildApprovePayload(fromCoin: usdc, amount: 100, quote: nil))
     }
 
+    // MARK: - Missing-quote guard (internal error, not a money error)
+
+    func testBuildSwapKeysignPayloadThrowsInternalErrorWhenQuoteMissing() async {
+        // A market transaction with no quote is an internal/state inconsistency
+        // (limit orders build their payload via `LimitSwapPayloadAssembler`).
+        // It must surface as the internal `unexpectedError`, never as the money
+        // error `insufficientFunds`.
+        let vault = makeVault()
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let transaction = SwapTransaction(
+            fromCoin: usdc,
+            toCoin: eth,
+            fromAmount: 100,
+            kind: .market(nil),
+            gas: 0,
+            gasLimit: 0,
+            thorchainFee: 0,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: eth,
+            advancedSettings: .default
+        )
+
+        do {
+            _ = try await SwapCryptoLogic.buildSwapKeysignPayload(
+                transaction: transaction,
+                chainSpecific: ethereumChainSpecific(),
+                vault: vault,
+                now: fixedNow
+            )
+            XCTFail("Expected a throw for a missing market quote")
+        } catch let error as SwapCryptoLogic.Errors {
+            XCTAssertEqual(error, .unexpectedError)
+            XCTAssertNotEqual(error, .insufficientFunds, "A nil quote must not surface as a money error")
+        } catch {
+            XCTFail("Expected SwapCryptoLogic.Errors.unexpectedError, got \(error)")
+        }
+    }
+
     // MARK: - Fixtures
 
     private func makeVault() -> Vault {


### PR DESCRIPTION
## Problem

Five sites in the swap flow turned **unclassified or internal-state failures** (request timeout, TLS error, JSON decode failure, node 5xx, a `nil` market quote, a guessed provider) into confident, user-facing **"money" verdicts** — "amount too small", "insufficient gas", "insufficient funds". This masks the real cause and actively misleads users about their balances on a money path.

Closes two issues:
- **#4902** — unknown failures relabeled as money errors.
- **#4903** — an internal bug (`nil` quote) reported as a funding problem, and a grouped-EVM code path that defaulted a `nil` provider to `.oneInch` (which would sign a LI.FI / KyberSwap payload as 1inch).

## Root cause

Each site substituted a hard-coded `SwapError` / `SwapCryptoLogic.Errors` money case for *any* error it didn't otherwise handle, rather than surfacing the real error or an honest internal-error signal.

## Fix

**#4902 — surface the real error instead of inventing a money error:**
- `SwapService.fetchCrossChainQuote`: the final catch-all mapped every unclassified error to `SwapError.swapAmountTooSmall`; now logs and rethrows the real error. The typed `ThorchainSwapError` / `MayachainSwapError` / `SwapError` catches above are untouched.
- `SwapDetailsViewModel.updateFees`: the `default:` relabeled every non-UTXO fee failure as `insufficientGas`; now surfaces the real error. Typed UTXO cases already flowed through, so the switch collapses to `self.error = error`.
- `SwapPayloadBuilder.thorchainFee` (UTXO/Cardano): dropped the catch-all `insufficientFunds` relabel; typed `KeysignPayloadFactory.Errors` still pass through, other errors log + rethrow. A **non-positive planned fee** — previously inferred as `insufficientFunds` — is now reclassified as the internal `unexpectedError` and **fails closed** (it never propagates a zero network-fee reservation downstream), rather than either a false money verdict or silent acceptance.

**#4903 — internal bug / guessed provider:**
- `SwapPayloadBuilder.buildSwapKeysignPayload`: a `nil` market quote is an internal/state inconsistency (limit orders build via `LimitSwapPayloadAssembler`), so it now throws the internal `unexpectedError` instead of `insufficientFunds`.
- The grouped EVM case (`.oneinch` / `.lifi` / `.kyberswap`) no longer defaults `provider` to `.oneInch` when `swapProviderId` is `nil`; `swapProviderId` is non-nil for all three by construction, so a `guard let` + throw fails closed instead of mis-attributing the signed payload. **Fail-closed, never mis-signs.**

## Reconciliation with #4901 / #4907

This branch was cut before **#4907** ("tag native quotes via a per-service Strategy, not a type-probe", issue #4901) merged. #4907 touches the **same method**, `SwapService.fetchCrossChainQuote`, but a different, non-overlapping hunk: it replaced the top-of-function `switch service { … default: .thorchain }` quote-tagging block with `service.makeSwapQuote(quote)`. This branch replaces the **final catch-all**. #4907's own commit message states the catch-all "is a separate issue and is intentionally left alone", confirming they are complementary. The rebase auto-merged cleanly; the reconciled function keeps **both** changes with the three typed catches preserved between them. All 5 sites were re-verified post-merge — none were pre-empted by #4901.

## Verification

- **Full test gate** (`xcodebuild test`, whole VultisigApp suite, iPhone 16 Pro Max sim): `Executed 3896 tests, with 1 test skipped and 1 failure`. **No false-green claim:** the run reports `** TEST FAILED **`, but the *sole* failing test is `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` — a pre-existing ~sub-pixel anti-aliasing snapshot artifact on the CreateVault screen that fails identically on `main`, unrelated to swap code (a sibling PR is already tracking it). **Zero swap tests failed** — `SwapService` / `SwapPayloadBuilder` / `SwapDetailsViewModel` all green, and both new tests pass.
- **Cross-model Codex review (2 rounds):** round 1 raised one P1 — dropping the non-positive-fee guard removed a fail-closed invariant; addressed by reintroducing it as an internal `unexpectedError` (with a typed `catch let error as Errors` so it rethrows intact, not relabeled). Round 2: **no findings** — confirmed fail-closed restored, catch-ordering correct, provider guard never mis-signs, `nil`-quote change breaks no caller.
- New unit tests: `buildSwapKeysignPayload` throws `unexpectedError` (not `insufficientFunds`) on a missing quote; `updateFees` surfaces an injected generic fee error instead of `insufficientGas`.

## Risks

- **Behavior change on a money/signing path.** Errors previously swallowed into a friendly money message now surface as their real error (generic title + raw localized description). This is the intent, but the arbitrary-error UI copy should be sanity-checked on device.
- **Deferred:** a unit test for a *zero planned fee* (vs. a thrown planner failure) — `thorchainFee` is a static function with no injection seam for the UTXO/Cardano planner, so forcing a zero fee needs harness work beyond this fix's scope. The new guard's logic is covered by the Codex review.
- Touches the swap **payload/signing** path → **requires human review + on-device review** before merge.

Closes #4902
Closes #4903

🤖 Generated with [Claude Code](https://claude.com/claude-code)
