### PR TITLE
feat(ripple): XRP trust lines + issued-currency token sends (#4757, #4758)

### DIFF
--- a/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VultisigApp/VultisigApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,7 +32,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vultisig/commondata",
       "state" : {
-        "revision" : "c91f2ea7db5eb03cf6bb637da19e4ed93b07dc46"
+        "revision" : "a16c710f0b0dfb6e2c8debde54b72414a04feb9a"
       }
     },
     {

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDestinationTag.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDestinationTag.swift
@@ -70,7 +70,7 @@ enum RippleDestinationTag {
     /// does NOT fall through to the memo.
     static func displayTag(for payload: KeysignPayload) -> UInt32? {
         guard payload.coin.chain == .ripple, payload.swapPayload == nil else { return nil }
-        if case .Ripple(_, _, _, let fieldTag) = payload.chainSpecific, let fieldTag {
+        if case .Ripple(_, _, _, let fieldTag, _) = payload.chainSpecific, let fieldTag {
             return fieldTag == 0 ? nil : fieldTag
         }
         return payload.memo.flatMap(parseTag)

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustLine.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustLine.swift
@@ -3,7 +3,42 @@
 //  VultisigApp
 //
 
+import BigInt
 import Foundation
+
+/// Trust-line limit defaults for the `TrustSet` we originate.
+///
+/// A TrustSet's amount IS the line's limit — the maximum of the issuer's
+/// currency this account is willing to hold. There is no "unlimited" encoding on
+/// XRPL, so opening a line means committing to a number, and the number has to
+/// come from somewhere other than a call site inventing one.
+enum RippleTrustLineLimit {
+
+    /// Limit signed when opening a trust line: one quadrillion (1e15) units.
+    ///
+    /// Sized to be effectively unlimited for any real holding while staying
+    /// EXACTLY representable: an XRPL issued-currency value carries 15
+    /// significant decimal digits, and `1e15` is a single significant digit
+    /// followed by zeros, so it round-trips through
+    /// `formatIssuedCurrencyValue` / `parseIssuedCurrencyValue` without
+    /// truncation. A limit built from 15 nines (`999_999_999_999_999`) would sit
+    /// at the precision boundary and is deliberately avoided.
+    ///
+    /// Expressed in base units at ``RippleIssuedCurrency/issuedCurrencyDecimals``
+    /// because that is the scale every keysign amount uses, so it needs no
+    /// special-casing on the signing path.
+    static let defaultLimit = BigInt(10).power(RippleIssuedCurrency.issuedCurrencyDecimals + 15)
+
+    /// The default limit as the XRPL value string that will be signed — the
+    /// number the reserve-warning sheet shows the user, so the limit riding the
+    /// TrustSet is never invisible.
+    static func defaultLimitDisplayValue() -> String? {
+        try? RippleIssuedCurrency.formatIssuedCurrencyValue(
+            amount: defaultLimit,
+            decimals: RippleIssuedCurrency.issuedCurrencyDecimals
+        )
+    }
+}
 
 /// One XRPL trust line as returned by `account_lines`, always from the
 /// perspective of the account the request was made for.

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustLineActivation.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustLineActivation.swift
@@ -1,0 +1,62 @@
+//
+//  RippleTrustLineActivation.swift
+//  VultisigApp
+//
+
+import BigInt
+import Foundation
+
+/// What opening one XRPL trust line costs, and whether this account can afford
+/// it.
+///
+/// Every ledger object an account owns — a trust line included — raises its
+/// reserve floor by one **owner reserve increment**, and the increment is a
+/// validator-voted network parameter (0.2 XRP on mainnet today, but a value, not
+/// a constant). It is read live from `server_state`'s `reserve_inc` through the
+/// existing live → cache → seed chain, so this never hardcodes it.
+///
+/// Kept a pure value type so the affordability rule can be pinned without a
+/// network round-trip.
+struct RippleTrustLineActivationQuote: Equatable {
+    /// Live owner-reserve increment in drops — the XRP this trust line locks up
+    /// for as long as it exists.
+    let ownerReserveDrops: BigInt
+    /// Transaction fee in drops for the TrustSet itself.
+    let feeDrops: BigInt
+    /// Spendable XRP in drops. The XRP coin's balance is ALREADY reserve-net
+    /// (`RippleService.getBalance` subtracts the current floor), so this is what
+    /// is genuinely available to newly lock up and spend.
+    let spendableDrops: BigInt
+    /// The trust-line limit that will be signed, as the XRPL value string that
+    /// goes on the wire — shown so the signed limit is never invisible.
+    let limitValue: String
+    /// On-ledger currency code being trusted.
+    let currencyCode: String
+    /// Issuer whose currency is being trusted.
+    let issuer: String
+
+    /// Total XRP this activation consumes: the reserve it locks up plus the fee
+    /// it burns. The reserve is not spent — it is immobilized — but from the
+    /// user's spendable balance both come out the same way.
+    var totalCostDrops: BigInt {
+        ownerReserveDrops + feeDrops
+    }
+
+    /// Spendable XRP once the line exists. Never negative: an unaffordable
+    /// activation is reported by `isAffordable`, not by a negative balance.
+    var remainingSpendableDrops: BigInt {
+        max(spendableDrops - totalCostDrops, BigInt(0))
+    }
+
+    /// Whether spendable XRP covers `reserve_inc + fee`. Below this the TrustSet
+    /// fails on-ledger (`tecINSUFFICIENT_RESERVE`) after the ceremony, with the
+    /// fee already burned — so it must block before signing starts.
+    var isAffordable: Bool {
+        spendableDrops >= totalCostDrops
+    }
+
+    /// Human-readable ticker for the currency being trusted.
+    var currencyTicker: String {
+        RippleIssuedCurrency.toIssuedCurrencyTicker(currencyCode)
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustSetPresentation.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustSetPresentation.swift
@@ -1,0 +1,88 @@
+//
+//  RippleTrustSetPresentation.swift
+//  VultisigApp
+//
+
+import Foundation
+import VultisigCommonData
+
+/// What a co-signer is shown for an XRPL `TrustSet`.
+///
+/// A TrustSet has no destination and no transfer amount, so the Payment rows are
+/// all wrong for it: the "to" row would show an address the transaction never
+/// pays, and the "amount" row would present a trust-line LIMIT as if funds were
+/// moving. It gets its own row set instead — issuer, currency, and the limit
+/// being signed.
+///
+/// Everything here is derived from the KEYSIGN PAYLOAD alone, deliberately. A
+/// Secure Vault co-signer holds nothing else: these rows are the only thing
+/// between a peer device and a blind signature, so they cannot depend on state
+/// only the initiator has.
+enum RippleTrustSetPresentation {
+
+    struct Display: Equatable {
+        /// Human-readable ticker of the currency being trusted.
+        let ticker: String
+        /// On-ledger currency code as it will be signed.
+        let currencyCode: String
+        /// Account whose currency is being trusted.
+        let issuer: String
+        /// Trust-line limit, as the XRPL value string that goes on the wire.
+        let limitValue: String
+    }
+
+    /// Whether `payload` is an XRPL TrustSet.
+    static func isTrustSet(payload: KeysignPayload?) -> Bool {
+        guard let payload, payload.coin.chain == .ripple else { return false }
+        guard case .Ripple(_, _, _, _, let transactionType) = payload.chainSpecific else { return false }
+        return transactionType == VSTransactionType.rippleTrustSet.rawValue
+    }
+
+    /// The rows to show for a TrustSet, or `nil` when the payload is not one (or
+    /// carries a token id / amount that cannot be rendered — in which case the
+    /// signer will refuse it anyway, and showing nothing is better than showing a
+    /// guess).
+    static func display(for payload: KeysignPayload?) -> Display? {
+        guard isTrustSet(payload: payload), let payload else { return nil }
+
+        guard let (currency, issuer) = try? RippleIssuedCurrency.parseRippleTokenId(payload.coin.contractAddress),
+              let currencyCode = try? RippleIssuedCurrency.toXrplCurrencyCode(currency),
+              let limitValue = try? RippleIssuedCurrency.formatIssuedCurrencyValue(
+                  amount: payload.toAmount,
+                  decimals: payload.coin.decimals
+              ) else {
+            return nil
+        }
+
+        return Display(
+            ticker: RippleIssuedCurrency.toIssuedCurrencyTicker(currencyCode),
+            currencyCode: currencyCode,
+            issuer: issuer,
+            limitValue: limitValue
+        )
+    }
+
+    /// The same rows for the INITIATOR, whose Verify screen renders before any
+    /// keysign payload exists (it is built on confirm). Reads the identical
+    /// fields off the transaction that will produce that payload, so the two
+    /// surfaces cannot present different numbers.
+    static func display(for tx: SendTransaction) -> Display? {
+        guard tx.coin.chain == .ripple, tx.transactionType == .rippleTrustSet else { return nil }
+
+        guard let (currency, issuer) = try? RippleIssuedCurrency.parseRippleTokenId(tx.coin.contractAddress),
+              let currencyCode = try? RippleIssuedCurrency.toXrplCurrencyCode(currency),
+              let limitValue = try? RippleIssuedCurrency.formatIssuedCurrencyValue(
+                  amount: tx.amountInRaw,
+                  decimals: tx.coin.decimals
+              ) else {
+            return nil
+        }
+
+        return Display(
+            ticker: RippleIssuedCurrency.toIssuedCurrencyTicker(currencyCode),
+            currencyCode: currencyCode,
+            issuer: issuer,
+            limitValue: limitValue
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustSetPresentation.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustSetPresentation.swift
@@ -31,11 +31,46 @@ enum RippleTrustSetPresentation {
         let limitValue: String
     }
 
-    /// Whether `payload` is an XRPL TrustSet.
+    /// What the summary should render for this transaction.
+    ///
+    /// The distinction between `.unreviewable` and "not a TrustSet" is the whole
+    /// point: whether an operation IS a TrustSet is decided by the discriminator
+    /// alone, never by whether we managed to render it. Keying the UI off a
+    /// successful render would drop an unrenderable TrustSet into the ordinary
+    /// Payment rows — showing `toAddress` as a recipient and the LIMIT as a
+    /// transfer — which is exactly the false review a co-signer must never be
+    /// given.
+    enum State: Equatable {
+        /// Not an XRPL TrustSet — render the transaction normally.
+        case notTrustSet
+        /// A TrustSet whose terms can be shown.
+        case reviewable(Display)
+        /// A TrustSet whose token id, currency or amount cannot be read, so its
+        /// real terms cannot be shown. The signer refuses these payloads too, so
+        /// nothing can be signed from here — but the review surface has to say so
+        /// rather than fall back to describing a payment.
+        case unreviewable
+    }
+
+    /// Whether `payload` is an XRPL TrustSet, decided by the wire discriminator
+    /// alone.
     static func isTrustSet(payload: KeysignPayload?) -> Bool {
         guard let payload, payload.coin.chain == .ripple else { return false }
         guard case .Ripple(_, _, _, _, let transactionType) = payload.chainSpecific else { return false }
         return transactionType == VSTransactionType.rippleTrustSet.rawValue
+    }
+
+    /// Render state for a co-signer, from the payload it holds.
+    static func state(for payload: KeysignPayload?) -> State {
+        guard isTrustSet(payload: payload) else { return .notTrustSet }
+        return display(for: payload).map(State.reviewable) ?? .unreviewable
+    }
+
+    /// Render state for the initiator, from the transaction it is about to turn
+    /// into a payload.
+    static func state(for tx: SendTransaction) -> State {
+        guard tx.coin.chain == .ripple, tx.transactionType == .rippleTrustSet else { return .notTrustSet }
+        return display(for: tx).map(State.reviewable) ?? .unreviewable
     }
 
     /// The rows to show for a TrustSet, or `nil` when the payload is not one (or

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustSetPresentation.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustSetPresentation.swift
@@ -120,4 +120,37 @@ enum RippleTrustSetPresentation {
             limitValue: limitValue
         )
     }
+
+    // MARK: - Done screen
+
+    /// Done-screen hero for a TrustSet, from a CO-SIGNER's payload.
+    ///
+    /// A TrustSet's `toAmount` is the trust-line LIMIT, not a transfer. The
+    /// default done slot renders `toAmountWithTickerString`, so without a hero
+    /// the screen announces a quadrillion-token payment that never happened —
+    /// and prices it in fiat. Supplying a hero replaces that block outright
+    /// (`DoneTokenContent` prefers `hero` over the coin amount), which is the
+    /// same escape hatch the limit-order cancel uses for the same reason: the
+    /// transaction is not a transfer and must not be described as one.
+    ///
+    /// The limit is deliberately NOT the caption. It belongs on the screens
+    /// where the user is deciding whether to sign it — the reserve sheet and the
+    /// verify summary — not on the receipt for a decision already made. The
+    /// issuer is what identifies WHICH line was opened.
+    static func hero(for payload: KeysignPayload?) -> HeroContent? {
+        display(for: payload).map(heroContent)
+    }
+
+    /// The same hero for the INITIATOR, whose done screen is driven by the
+    /// transaction rather than by a payload.
+    static func hero(for tx: SendTransaction) -> HeroContent? {
+        display(for: tx).map(heroContent)
+    }
+
+    private static func heroContent(for display: Display) -> HeroContent {
+        .title(
+            text: String(format: "rippleTrustLineHeroTitle".localized, display.ticker),
+            caption: display.issuer
+        )
+    }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleCustomTokenResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleCustomTokenResolver.swift
@@ -1,0 +1,127 @@
+//
+//  RippleCustomTokenResolver.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Resolves a user-typed XRPL issued-currency identifier into a ``CoinMeta`` for
+/// the custom-token flow.
+///
+/// XRPL keys a token by the **(currency, issuer) pair**, not by a single contract
+/// address, so the identifier is the composite `<currency>.<issuer>` token id
+/// (`USD.rHb9…`) that ``RippleIssuedCurrency/rippleTokenId(currency:issuer:)``
+/// produces. The shared `AddressService.validateAddress` would reject that shape
+/// outright — it is reserved for real send/receive addresses — so validation is
+/// split: the issuer half goes through `AddressService`, the currency half is
+/// checked against XRPL's on-ledger currency-code shapes.
+///
+/// **There is nothing to fetch.** Unlike an ERC-20's `name()` / `symbol()` /
+/// `decimals()`, XRPL has no on-ledger token metadata registry, so a
+/// well-formed pair cannot be confirmed to be a real, reputable token — only to
+/// be well-formed. Everything this resolver returns is derived from the
+/// identifier itself (or from a curated ``TokensStore`` entry), and the UI must
+/// not imply validation it cannot perform.
+///
+/// Kept as a standalone, network-free type so it drops straight into the
+/// `CustomTokenResolver` protocol + factory once the custom-token view-model
+/// refactor lands, rather than living inline in the view.
+enum RippleCustomTokenResolver {
+
+    enum ResolverError: Error, LocalizedError {
+        case invalidFormat
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFormat:
+                return "rippleCustomTokenInvalidFormat".localized
+            }
+        }
+    }
+
+    /// XRPL standard currency codes are exactly 3 characters; anything else must
+    /// already be written as the 160-bit (40-hex-character) form.
+    private static let standardCurrencyCodeLength = 3
+    private static let hexCurrencyCodeLength = 40
+
+    /// A trust line cannot exist without a funded XRP account to own it (it costs
+    /// an owner reserve), so the custom-token flow must refuse to add an XRPL
+    /// token to a vault that hasn't enabled XRP.
+    static let requiresVaultNativeCoin = true
+
+    /// Whether `input` is a well-formed XRPL token id, without touching the
+    /// network. Ports the SDK's `isValidTokenId` Ripple arm:
+    ///
+    /// 1. it splits into a non-empty currency and issuer on the first `.`;
+    /// 2. the currency is a valid ON-LEDGER code — a 3-character standard code
+    ///    (`USD`) or the 40-character hex form. A bare `RLUSD` is deliberately
+    ///    NOT valid: 5 characters is neither, and accepting it would let two
+    ///    spellings of the same token become two different coins. It is valid
+    ///    only once normalized to hex (which is how the curated catalog entry
+    ///    and the token picker spell it);
+    /// 3. the issuer is a real XRPL address.
+    static func isValidInput(_ input: String) -> Bool {
+        normalized(from: input) != nil
+    }
+
+    /// The `(currency, issuer)` pair for a valid input, with the currency
+    /// normalized to its on-ledger code, or `nil` when the input is malformed.
+    static func normalized(from input: String) -> (currency: String, issuer: String)? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let token = try? RippleIssuedCurrency.parseRippleTokenId(trimmed) else {
+            return nil
+        }
+        guard isValidOnLedgerCurrencyCode(token.currency) else { return nil }
+        guard AddressService.validateAddress(address: token.issuer, chain: .ripple) else {
+            return nil
+        }
+        guard let code = try? RippleIssuedCurrency.toXrplCurrencyCode(token.currency) else {
+            return nil
+        }
+        return (code, token.issuer)
+    }
+
+    /// A currency code the ledger itself can carry: a 3-character standard code,
+    /// or the 40-character hex form (case-insensitive, normalized to uppercase
+    /// downstream).
+    private static func isValidOnLedgerCurrencyCode(_ currency: String) -> Bool {
+        if currency.utf16.count == standardCurrencyCodeLength {
+            // The standard form excludes `XRP` itself — that spelling is
+            // reserved for the native asset and can never be an issued currency.
+            return currency.uppercased() != "XRP"
+        }
+        guard currency.utf16.count == hexCurrencyCodeLength else { return false }
+        return currency.allSatisfy { $0.isHexDigit && $0.isASCII }
+    }
+
+    /// Resolves a validated token id into a ``CoinMeta``.
+    ///
+    /// No network call: `decimals` is always
+    /// ``RippleIssuedCurrency/issuedCurrencyDecimals`` (15) because XRPL carries
+    /// 15 significant digits for every issued currency rather than a per-token
+    /// on-chain scale, and the ticker is decoded back out of the currency code
+    /// (`524C555344…00` → `RLUSD`). A curated ``TokensStore`` entry wins when one
+    /// exists: it carries the bundled logo and a working `priceProviderId`,
+    /// neither of which the ledger can supply.
+    static func resolve(input: String) throws -> CoinMeta {
+        guard let (currency, issuer) = normalized(from: input) else {
+            throw ResolverError.invalidFormat
+        }
+
+        let tokenId = "\(currency).\(issuer)"
+
+        if let curated = TokensStore.findTokenMeta(chain: .ripple, contractAddress: tokenId) {
+            return curated
+        }
+
+        return CoinMeta(
+            chain: .ripple,
+            ticker: RippleIssuedCurrency.toIssuedCurrencyTicker(currency),
+            logo: .empty,
+            decimals: RippleIssuedCurrency.issuedCurrencyDecimals,
+            priceProviderId: .empty,
+            contractAddress: tokenId,
+            isNativeToken: false
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleCustomTokenResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleCustomTokenResolver.swift
@@ -43,6 +43,9 @@ enum RippleCustomTokenResolver {
     /// already be written as the 160-bit (40-hex-character) form.
     private static let standardCurrencyCodeLength = 3
     private static let hexCurrencyCodeLength = 40
+    /// XRPL currency codes are 160 bits, so a packable ticker is at most 20 bytes.
+    private static let maximumCurrencyCodeBytes = 20
+    private static let printableAscii: ClosedRange<UInt8> = 0x20...0x7E
 
     /// A trust line cannot exist without a funded XRP account to own it (it costs
     /// an owner reserve), so the custom-token flow must refuse to add an XRPL
@@ -53,12 +56,14 @@ enum RippleCustomTokenResolver {
     /// network. Ports the SDK's `isValidTokenId` Ripple arm:
     ///
     /// 1. it splits into a non-empty currency and issuer on the first `.`;
-    /// 2. the currency is a valid ON-LEDGER code — a 3-character standard code
-    ///    (`USD`) or the 40-character hex form. A bare `RLUSD` is deliberately
-    ///    NOT valid: 5 characters is neither, and accepting it would let two
-    ///    spellings of the same token become two different coins. It is valid
-    ///    only once normalized to hex (which is how the curated catalog entry
-    ///    and the token picker spell it);
+    /// 2. the currency is a code the ledger can carry — a 3-character standard
+    ///    code (`USD`), the 40-character hex form, or a ticker short enough to
+    ///    pack into that hex form (`SOLO`, `RLUSD`). All three normalize
+    ///    through `toXrplCurrencyCode`, so the typed spelling and the hex
+    ///    spelling of one token collapse to a single token id and therefore a
+    ///    single coin — accepting the human spelling cannot fork a token in
+    ///    two. Requiring the hex would have meant asking a user to type
+    ///    `534F4C4F00000000000000000000000000000000` to add SOLO;
     /// 3. the issuer is a real XRPL address.
     static func isValidInput(_ input: String) -> Bool {
         normalized(from: input) != nil
@@ -71,27 +76,58 @@ enum RippleCustomTokenResolver {
         guard let token = try? RippleIssuedCurrency.parseRippleTokenId(trimmed) else {
             return nil
         }
-        guard isValidOnLedgerCurrencyCode(token.currency) else { return nil }
+        // Trim the currency BEFORE validating it, so the gate inspects exactly
+        // the string the encoder will consume. `parseRippleTokenId` splits on
+        // the separator without trimming either half, while
+        // `toXrplCurrencyCode` trims — and that gap is exploitable: `XRP .rHb9…`
+        // reaches the gate as a 4-byte printable ticker, skipping the
+        // 3-character branch that reserves `XRP` for the native asset, and then
+        // normalizes straight back to `XRP`.
+        let currency = token.currency.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isValidOnLedgerCurrencyCode(currency) else { return nil }
         guard AddressService.validateAddress(address: token.issuer, chain: .ripple) else {
             return nil
         }
-        guard let code = try? RippleIssuedCurrency.toXrplCurrencyCode(token.currency) else {
+        guard let code = try? RippleIssuedCurrency.toXrplCurrencyCode(currency) else {
             return nil
         }
         return (code, token.issuer)
     }
 
-    /// A currency code the ledger itself can carry: a 3-character standard code,
-    /// or the 40-character hex form (case-insensitive, normalized to uppercase
-    /// downstream).
+    /// A currency the ledger can carry: a 3-character standard code, the
+    /// 40-character hex form (case-insensitive, normalized to uppercase
+    /// downstream), or a ticker short enough to pack into that hex form.
     private static func isValidOnLedgerCurrencyCode(_ currency: String) -> Bool {
         if currency.utf16.count == standardCurrencyCodeLength {
             // The standard form excludes `XRP` itself — that spelling is
             // reserved for the native asset and can never be an issued currency.
             return currency.uppercased() != "XRP"
         }
-        guard currency.utf16.count == hexCurrencyCodeLength else { return false }
-        return currency.allSatisfy { $0.isHexDigit && $0.isASCII }
+        if currency.utf16.count == hexCurrencyCodeLength,
+           currency.allSatisfy({ $0.isHexDigit && $0.isASCII }) {
+            return true
+        }
+        return isPackableTicker(currency)
+    }
+
+    /// Whether `currency` is a ticker that `toXrplCurrencyCode` can pack into
+    /// the 160-bit form: 1–20 bytes of printable ASCII.
+    ///
+    /// This is what lets a user type the spelling they actually know — `SOLO`,
+    /// `RLUSD` — rather than 40 hex characters. Order matters: a 3-character
+    /// ticker never reaches here because the standard-code branch claims it
+    /// first, and it MUST, since the ASCII-packed hex of a 3-character code is
+    /// a genuinely different currency on the ledger.
+    ///
+    /// Printable ASCII is enforced here rather than left to
+    /// `asciiToHexCurrencyCode`, which encodes whatever UTF-8 bytes it is
+    /// handed. Without this gate a non-ASCII string would pack into a
+    /// well-formed but meaningless code, and the flow would accept a token that
+    /// cannot correspond to anything a user meant.
+    private static func isPackableTicker(_ currency: String) -> Bool {
+        let bytes = Array(currency.utf8)
+        guard (1...maximumCurrencyCodeBytes).contains(bytes.count) else { return false }
+        return bytes.allSatisfy { printableAscii.contains($0) }
     }
 
     /// Resolves a validated token id into a ``CoinMeta``.

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleDestinationReserveValidator.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleDestinationReserveValidator.swift
@@ -24,6 +24,15 @@ struct RippleDestinationReserveValidator: SendAmountValidator {
     /// side-effect-free) rather than the UI's `addressSetupDone` flag keeps the
     /// lookup from firing against a half-typed destination while the resolver is
     /// still in flight.
+    ///
+    /// ⚠️ `isNativeToken` is deliberate and must NOT be widened now that
+    /// non-native XRP coins exist. The rule is "an account is created by
+    /// receiving at least the base reserve **in XRP**"; an issued-currency
+    /// Payment delivers no XRP, so it can neither create the destination nor
+    /// satisfy that minimum, and applying this check to a token would show an XRP
+    /// minimum against an amount denominated in the token. The check that DOES
+    /// apply to a token — whether the destination holds a trust line for it —
+    /// lives in `SendCryptoVerifyLogic.validateDestinationTrustLineIfNeeded`.
     func isApplicable(to input: SendAmountValidationInput) -> Bool {
         input.chain == .ripple
             && input.isNativeToken

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -600,7 +600,17 @@ class RippleService {
     /// performed instead of adding one network call per token row. A `nil` peek
     /// means "not observed yet", which callers must treat as unknown rather than
     /// as "no line". Internal (with the key) so tests can seed it.
-    let trustLinesCache = TTLCache<String, [RippleTrustLine]>()
+    let trustLinesCache = TTLCache<String, RippleTrustLineSnapshot>()
+
+    /// How long a recorded walk is treated as evidence.
+    ///
+    /// `peek` deliberately ignores TTL, so the snapshot carries its own timestamp
+    /// and an expired one degrades to `.unknown` rather than `.absent`. Without
+    /// that, a line opened on ANOTHER device (or a walk that has been failing for
+    /// a while) would keep offering `Activate` indefinitely on evidence that is no
+    /// longer true. Generous, because the balance refresh rewrites the snapshot
+    /// every cycle; the TTL only matters once refreshes stop succeeding.
+    private static let trustLinesTTL: TimeInterval = 60 * 5
 
     /// Cache key for an address's trust lines, host-scoped for the same reason as
     /// `reserveValuesCacheKey`: a custom RPC override can point at a different
@@ -735,24 +745,43 @@ class RippleService {
     /// Records a completed trust-line walk so UI affordances can read the
     /// ledger's trust-line state without their own network call.
     private func recordTrustLines(_ lines: [RippleTrustLine], for address: String, host: URL) async {
-        await trustLinesCache.setCached(lines, for: Self.trustLinesCacheKey(for: host, address: address))
+        await trustLinesCache.setCached(
+            RippleTrustLineSnapshot(lines: lines, recordedAt: Date()),
+            for: Self.trustLinesCacheKey(for: host, address: address)
+        )
     }
 
-    /// Whether `address` already holds a trust line for `coin`'s issued currency,
-    /// answered from the trust lines the last balance refresh already read.
+    /// Whether `address` already holds trust lines for each of `coins`, answered
+    /// from the walk the last balance refresh already performed.
     ///
-    /// Never performs a network call: a token row must not cost one
-    /// `account_lines` request per row. `.unknown` means no walk has been
-    /// recorded for this address yet (or the token id is unreadable), and callers
-    /// must treat it as "don't know" rather than "no line" — offering to open a
-    /// line we have no evidence is missing would invite a pointless ceremony.
-    func trustLineState(for coin: CoinMeta, address: String) async -> RippleTrustLinePresence {
-        guard let lines = await trustLinesCache.peek(
-            Self.trustLinesCacheKey(for: resolvedHost, address: address)
-        ) else {
-            return .unknown
+    /// Never performs a network call: a token list must not cost one
+    /// `account_lines` request per row. The host is resolved ONCE for the whole
+    /// batch, so a custom-RPC change mid-loop can't assemble one answer set from
+    /// two networks' snapshots.
+    ///
+    /// `.unknown` means no walk has been recorded for this address (or the
+    /// recording has gone stale, or the token id is unreadable). Callers must
+    /// treat it as "don't know" rather than "no line": offering to open a line we
+    /// have no current evidence is missing would invite a pointless ceremony, and
+    /// a fee.
+    func trustLineStates(for coins: [CoinMeta], address: String) async -> [String: RippleTrustLinePresence] {
+        let key = Self.trustLinesCacheKey(for: resolvedHost, address: address)
+        guard let snapshot = await trustLinesCache.peek(key),
+              Date().timeIntervalSince(snapshot.recordedAt) < Self.trustLinesTTL else {
+            return coins.reduce(into: [:]) { $0[$1.contractAddress] = .unknown }
         }
 
+        return coins.reduce(into: [:]) { result, coin in
+            result[coin.contractAddress] = Self.presence(of: coin, in: snapshot.lines)
+        }
+    }
+
+    /// Single-coin convenience over `trustLineStates(for:address:)`.
+    func trustLineState(for coin: CoinMeta, address: String) async -> RippleTrustLinePresence {
+        await trustLineStates(for: [coin], address: address)[coin.contractAddress] ?? .unknown
+    }
+
+    private static func presence(of coin: CoinMeta, in lines: [RippleTrustLine]) -> RippleTrustLinePresence {
         guard let (currency, issuer) = try? RippleIssuedCurrency.parseRippleTokenId(coin.contractAddress),
               let currencyCode = try? RippleIssuedCurrency.toXrplCurrencyCode(currency) else {
             return .unknown
@@ -843,6 +872,17 @@ class RippleService {
             return .unknown
         }
     }
+}
+
+/// One completed `account_lines` walk, with the moment it was recorded.
+///
+/// The timestamp is carried in the value rather than left to the cache because
+/// the presence read uses `peek`, which ignores TTL by design — a UI affordance
+/// must never trigger a fetch. Carrying it here lets an expired snapshot degrade
+/// to "don't know" instead of silently standing in for current ledger state.
+struct RippleTrustLineSnapshot {
+    let lines: [RippleTrustLine]
+    let recordedAt: Date
 }
 
 /// Whether an account holds a trust line for a given issued currency.

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -68,10 +68,32 @@ enum RippleReserve {
     /// copy. Shared by the throwing Verify guard and the non-throwing send-form
     /// check so the two can never present a different minimum.
     static func minimumActivationXRP(baseReserveDrops: BigInt) -> String {
-        // drops → XRP. toDecimal(decimals:) truncates rather than scales, so
-        // divide; reserves are always positive, so no fallback default is needed.
-        (baseReserveDrops.toDecimal(decimals: 6) / pow(10, 6)).description
+        xrpAmount(drops: baseReserveDrops)
     }
+
+    /// A drops amount rendered as whole XRP for user-facing copy. Every
+    /// reserve/fee figure the UI shows goes through this one conversion so two
+    /// surfaces can never disagree on the same number.
+    static func xrpAmount(drops: BigInt) -> String {
+        // toDecimal(decimals:) truncates rather than scales, so divide. XRP has
+        // 6 decimals (1 XRP = 1,000,000 drops).
+        (drops.toDecimal(decimals: 6) / pow(10, 6)).description
+    }
+}
+
+/// Whether an XRPL destination can receive a given issued currency.
+///
+/// A Payment to an account holding no trust line for the currency fails
+/// on-ledger (`tecPATH_DRY` / `tecNO_LINE`) — after the ceremony, with the fee
+/// burned.
+enum RippleDestinationTrustLine: Equatable {
+    /// The destination holds a line for this currency, or IS its issuer (an
+    /// issuer can always receive its own obligations back).
+    case canReceive
+    /// Positive proof the destination holds no line for this currency.
+    case noTrustLine
+    /// Could not be determined — the caller must fail open and not block.
+    case unknown
 }
 
 /// Non-throwing, send-form counterpart to `validateDestinationActivation`.
@@ -567,6 +589,26 @@ class RippleService {
     /// marker forever from looping indefinitely.
     private static let maxAccountLinesPages = 25
 
+    /// Trust lines last seen for an address, recorded by every successful
+    /// `fetchAccountLines` walk.
+    ///
+    /// Write-through only: this is never the source of a `fetchAccountLines`
+    /// result (so the balance read keeps its own fail-closed error semantics
+    /// exactly as they are) and is read only with `peek`, by UI affordances that
+    /// need the ledger's trust-line state. That keeps the "does this token have a
+    /// line?" question free — it reuses the read the balance refresh already
+    /// performed instead of adding one network call per token row. A `nil` peek
+    /// means "not observed yet", which callers must treat as unknown rather than
+    /// as "no line". Internal (with the key) so tests can seed it.
+    let trustLinesCache = TTLCache<String, [RippleTrustLine]>()
+
+    /// Cache key for an address's trust lines, host-scoped for the same reason as
+    /// `reserveValuesCacheKey`: a custom RPC override can point at a different
+    /// network, whose lines must never be served for another.
+    static func trustLinesCacheKey(for host: URL, address: String) -> String {
+        "xrpl-trust-lines|\(host.absoluteString)|\(address)"
+    }
+
     /// Every trust line held by `walletAddress`, following `account_lines`
     /// pagination to completion.
     ///
@@ -614,6 +656,9 @@ class RippleService {
                 guard rpcError == "actNotFound", marker == nil else {
                     throw RippleTrustLineError.accountLinesFailed(code: rpcError)
                 }
+                // An unfunded account demonstrably holds no lines — a definitive
+                // answer worth recording, not an absence of information.
+                await recordTrustLines([], for: walletAddress, host: pinnedHost)
                 return []
             }
 
@@ -626,13 +671,100 @@ class RippleService {
             lines.append(contentsOf: pageLines)
 
             guard let next = result?.marker, !next.isEmpty else {
-                return Self.deduplicated(lines)
+                let complete = Self.deduplicated(lines)
+                await recordTrustLines(complete, for: walletAddress, host: pinnedHost)
+                return complete
             }
             marker = next
             logger.debug("fetchAccountLines: following marker to page \(page + 1, privacy: .public)")
         }
 
         throw RippleTrustLineError.paginationLimitExceeded(pages: Self.maxAccountLinesPages)
+    }
+
+    /// Whether `destination` can receive `coin`'s issued currency.
+    ///
+    /// An XRPL Payment of an issued currency to an account with no trust line for
+    /// it fails on-ledger with `tecPATH_DRY` / `tecNO_LINE` — after the ceremony,
+    /// with the fee burned — so it is worth catching before signing starts.
+    ///
+    /// Same FAIL-OPEN posture as `validateDestinationActivation`: a verdict is
+    /// returned only on positive proof, and a transport failure, an RPC error or
+    /// an unreadable response all resolve to `.unknown`. A send that worked
+    /// yesterday must not start being blocked because a node is briefly
+    /// unreachable; the on-ledger engine result remains the real backstop.
+    ///
+    /// An unfunded destination resolves to `.noTrustLine`: `fetchAccountLines`
+    /// answers `actNotFound` with an empty set, and an account that does not
+    /// exist certainly holds no line. (Whether that account could be *created* is
+    /// the native reserve check's business — an issued-currency Payment delivers
+    /// no XRP and cannot create one.)
+    ///
+    /// The destination being the ISSUER itself is `.canReceive`: paying an
+    /// obligation back to its issuer needs no line on the issuer's side.
+    func destinationTrustLine(for coin: CoinMeta, destination: String) async -> RippleDestinationTrustLine {
+        guard let (currency, issuer) = try? RippleIssuedCurrency.parseRippleTokenId(coin.contractAddress),
+              let currencyCode = try? RippleIssuedCurrency.toXrplCurrencyCode(currency) else {
+            return .unknown
+        }
+
+        // Base58 issuer addresses are case-SENSITIVE, so this is an exact match.
+        if destination == issuer {
+            return .canReceive
+        }
+
+        let lines: [RippleTrustLine]
+        do {
+            lines = try await fetchAccountLines(for: destination)
+        } catch is CancellationError {
+            return .unknown
+        } catch {
+            // Transport failure, a node error, or an uninterpretable body — none
+            // of which is evidence the destination can't receive.
+            logger.warning("destinationTrustLine: lookup failed, allowing send: \(error.localizedDescription)")
+            return .unknown
+        }
+
+        let canReceive = lines.contains { line in
+            line.account == issuer
+                && (try? RippleIssuedCurrency.toXrplCurrencyCode(line.currency)) == currencyCode
+        }
+        return canReceive ? .canReceive : .noTrustLine
+    }
+
+    /// Records a completed trust-line walk so UI affordances can read the
+    /// ledger's trust-line state without their own network call.
+    private func recordTrustLines(_ lines: [RippleTrustLine], for address: String, host: URL) async {
+        await trustLinesCache.setCached(lines, for: Self.trustLinesCacheKey(for: host, address: address))
+    }
+
+    /// Whether `address` already holds a trust line for `coin`'s issued currency,
+    /// answered from the trust lines the last balance refresh already read.
+    ///
+    /// Never performs a network call: a token row must not cost one
+    /// `account_lines` request per row. `.unknown` means no walk has been
+    /// recorded for this address yet (or the token id is unreadable), and callers
+    /// must treat it as "don't know" rather than "no line" — offering to open a
+    /// line we have no evidence is missing would invite a pointless ceremony.
+    func trustLineState(for coin: CoinMeta, address: String) async -> RippleTrustLinePresence {
+        guard let lines = await trustLinesCache.peek(
+            Self.trustLinesCacheKey(for: resolvedHost, address: address)
+        ) else {
+            return .unknown
+        }
+
+        guard let (currency, issuer) = try? RippleIssuedCurrency.parseRippleTokenId(coin.contractAddress),
+              let currencyCode = try? RippleIssuedCurrency.toXrplCurrencyCode(currency) else {
+            return .unknown
+        }
+
+        // Issuer addresses are base58 and case-SENSITIVE, so this comparison must
+        // not be relaxed — matching `getTokenBalance`.
+        let matches = lines.contains { line in
+            line.account == issuer
+                && (try? RippleIssuedCurrency.toXrplCurrencyCode(line.currency)) == currencyCode
+        }
+        return matches ? .present : .absent
     }
 
     /// Collapses trust lines that repeat across pages. The ledger holds at most
@@ -711,6 +843,17 @@ class RippleService {
             return .unknown
         }
     }
+}
+
+/// Whether an account holds a trust line for a given issued currency.
+///
+/// `.unknown` is deliberately distinct from `.absent`: an account_lines walk we
+/// have not performed (or could not interpret) is not evidence that a line is
+/// missing, and the two drive different UI.
+enum RippleTrustLinePresence: Equatable {
+    case present
+    case absent
+    case unknown
 }
 
 /// Whether an XRPL destination requires a destination tag on incoming

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -280,17 +280,36 @@ enum RippleHelper {
         case issuedCurrency
     }
 
-    /// Classifies the payload's coin, refusing anything in between.
+    /// Classifies the payload's coin, refusing anything structurally
+    /// inconsistent.
     ///
-    /// A non-native coin with NO token id is the dangerous middle: it satisfies
-    /// no issued-currency branch, so it would fall through to the native encoding
-    /// and have its token base units serialized as XRP DROPS — a silent
-    /// token→native crossing that moves real XRP. Nothing legitimate produces
-    /// such a coin (`Coin.contractAddress` is the `<currency>.<issuer>` id every
-    /// XRPL token carries), and the whole `Coin` arrives proto-relayed from a
-    /// peer, so it is refused rather than interpreted.
+    /// The whole `Coin` arrives proto-relayed from a peer, and `isNativeToken`
+    /// and `contractAddress` between them decide which AMOUNT ENCODING gets
+    /// signed — so the two must agree before either is trusted. Both
+    /// contradictions are refused rather than interpreted:
+    ///
+    /// - **non-native with NO token id** satisfies no issued-currency branch, so
+    ///   it would fall through to the native encoding and have its token base
+    ///   units serialized as XRP DROPS — a silent token→native crossing that
+    ///   moves real XRP;
+    /// - **native WITH a token id** is the mirror image: metadata that names an
+    ///   issuer while asking to be signed as drops. Nothing legitimate produces
+    ///   it (`Coin.contractAddress` is empty for native XRP everywhere in the
+    ///   app), and a payload that cannot describe its own asset coherently is
+    ///   not one to sign.
+    ///
+    /// Deeper metadata (ticker, decimals) is NOT policed here: those vary
+    /// legitimately across platforms, and rejecting on them would false-reject
+    /// valid payloads from a peer rather than catch an attack.
     private static func issuedCurrencyKind(coin: Coin) throws -> RippleCoinKind {
-        guard !coin.isNativeToken else { return .native }
+        if coin.isNativeToken {
+            guard coin.contractAddress.isEmpty else {
+                throw HelperError.runtimeError(
+                    "XRP coin claims to be native but carries an issued-currency token id"
+                )
+            }
+            return .native
+        }
         guard !coin.contractAddress.isEmpty else {
             throw HelperError.runtimeError(
                 "XRP non-native coin is missing its issued-currency token id"

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -78,17 +78,47 @@ enum RippleHelper {
         // (2) before (3) is what makes a mixed-version TrustSet ceremony work: a
         // co-signer predating `transaction_type` sees only "non-native Ripple
         // coin" and builds a TrustSet from the same limit, which is byte-identical
-        // to what this branch produces. (3) has no representation on an old
-        // co-signer, so a token Payment diverges and the ceremony fails without
-        // moving funds — fail-safe, and the accepted posture for this rollout.
-        if fieldTransactionType == VSTransactionType.rippleTrustSet.rawValue {
+        // to what this branch produces.
+        //
+        // ⚠️ The converse is NOT symmetric, and it is a deliberate trade rather
+        // than an oversight. Because an absent discriminator is indistinguishable
+        // from `.unspecified`, arm (3) claims the "non-native, no discriminator"
+        // case that every shipped signer today reads as a TrustSet. That is the
+        // only way an issued-currency Payment can be expressed at all — inferring
+        // TrustSet from the coin alone is precisely why sending XRPL tokens has
+        // been impossible. The consequences, in full:
+        //   - a token send whose committee includes a signer predating the field
+        //     DIVERGES → the ceremony fails and no funds move (fail-safe);
+        //   - a TrustSet ORIGINATED by a signer predating the field would be read
+        //     here as a token Payment. No shipped client can originate one (no
+        //     platform builds XRPL token payloads at all yet — this app is the
+        //     first), so the case is unreachable today; it stops being reachable
+        //     for good once every platform sets the field.
+        // Both are stated in the PR body rather than left to be rediscovered.
+        switch fieldTransactionType {
+        case VSTransactionType.unspecified.rawValue:
+            break
+        case VSTransactionType.rippleTrustSet.rawValue:
             return try trustSetSigningInput(
                 keysignPayload: keysignPayload,
                 gas: gas,
                 sequence: sequence,
                 lastLedgerSequence: lastLedgerSequence
             )
+        default:
+            // A discriminator this build doesn't recognise — another chain's
+            // operation relayed onto a Ripple payload, or a future XRPL
+            // operation. Refuse: the peer is describing something other than
+            // what these branches would build, so signing anything at all would
+            // be signing an operation nobody reviewed.
+            throw HelperError.runtimeError(
+                "XRP payload carries an unsupported transaction type (\(fieldTransactionType))"
+            )
         }
+
+        // Classify the coin ONCE, before any operation is built, so an
+        // ill-formed coin can never slip into the wrong encoding further down.
+        let coinKind = try issuedCurrencyKind(coin: keysignPayload.coin)
 
         guard AnyAddress(string: keysignPayload.toAddress, coin: .xrp) != nil else {
             throw HelperError.runtimeError("fail to get to address")
@@ -207,7 +237,7 @@ enum RippleHelper {
         // AFTER the tag resolution above so the tag rides a token Payment
         // exactly as it rides a native one — the tag is orthogonal to how the
         // amount is encoded.
-        if !keysignPayload.coin.isNativeToken, !keysignPayload.coin.contractAddress.isEmpty {
+        if coinKind == .issuedCurrency {
             return try tokenPaymentSigningInput(
                 keysignPayload: keysignPayload,
                 destinationTag: destinationTag,
@@ -242,6 +272,33 @@ enum RippleHelper {
 
     // MARK: - Issued currency (trust-line tokens)
 
+    /// Which amount encoding a coin is entitled to on the XRPL signing path.
+    private enum RippleCoinKind {
+        /// Native XRP: the amount is drops.
+        case native
+        /// A trust-line token: the amount is a `CurrencyAmount` triple.
+        case issuedCurrency
+    }
+
+    /// Classifies the payload's coin, refusing anything in between.
+    ///
+    /// A non-native coin with NO token id is the dangerous middle: it satisfies
+    /// no issued-currency branch, so it would fall through to the native encoding
+    /// and have its token base units serialized as XRP DROPS — a silent
+    /// token→native crossing that moves real XRP. Nothing legitimate produces
+    /// such a coin (`Coin.contractAddress` is the `<currency>.<issuer>` id every
+    /// XRPL token carries), and the whole `Coin` arrives proto-relayed from a
+    /// peer, so it is refused rather than interpreted.
+    private static func issuedCurrencyKind(coin: Coin) throws -> RippleCoinKind {
+        guard !coin.isNativeToken else { return .native }
+        guard !coin.contractAddress.isEmpty else {
+            throw HelperError.runtimeError(
+                "XRP non-native coin is missing its issued-currency token id"
+            )
+        }
+        return .issuedCurrency
+    }
+
     /// Signing input for a `TrustSet`: open or modify the trust line that lets
     /// this account hold an issuer's currency.
     ///
@@ -271,7 +328,7 @@ enum RippleHelper {
         // A TrustSet is meaningless for native XRP: there is no issuer to trust.
         // Fail closed rather than emitting a SigningInput whose limitAmount
         // names an empty currency and issuer.
-        guard !coin.isNativeToken, !coin.contractAddress.isEmpty else {
+        guard try issuedCurrencyKind(coin: coin) == .issuedCurrency else {
             throw HelperError.runtimeError("XRP TrustSet requires an issued-currency coin carrying a token id")
         }
 
@@ -601,12 +658,13 @@ enum RippleHelper {
         publicKey: PublicKey
     ) throws -> Data {
         // FAIL CLOSED: this rawJson encodes `Amount` as a DROPS string, which is
-        // only correct for native XRP. An issued-currency coin reaching here
-        // would be signed as a native XRP transfer of the token's base units —
-        // a real, silent loss of funds. WalletCore's typed payment has no memo
-        // slot and a token rawJson Payment is not part of the wire contract yet,
-        // so refuse rather than guess.
-        guard keysignPayload.coin.isNativeToken || keysignPayload.coin.contractAddress.isEmpty else {
+        // only correct for native XRP. ANY non-native coin reaching here would be
+        // signed as a native XRP transfer of the token's base units — a real,
+        // silent loss of funds — so the check is on `isNativeToken` alone, not on
+        // whether a token id happens to be present. WalletCore's typed payment
+        // has no memo slot and a token rawJson Payment is not part of the wire
+        // contract yet, so refuse rather than guess.
+        guard keysignPayload.coin.isNativeToken else {
             throw HelperError.runtimeError("XRP issued-currency payments cannot carry an on-chain memo")
         }
 

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -9,6 +9,7 @@ import BigInt
 import Foundation
 import OSLog
 import Tss
+import VultisigCommonData
 import WalletCore
 
 private let logger = Log.chain.other
@@ -28,8 +29,13 @@ enum RippleHelper {
         }
 
         guard
-            case .Ripple(let sequence, let gas, let lastLedgerSequence, let fieldDestinationTag) = keysignPayload
-                .chainSpecific
+            case .Ripple(
+                let sequence,
+                let gas,
+                let lastLedgerSequence,
+                let fieldDestinationTag,
+                let fieldTransactionType
+            ) = keysignPayload.chainSpecific
         else {
             logger.error("keysignPayload.chainSpecific is not Ripple")
             throw HelperError.runtimeError(
@@ -52,6 +58,32 @@ enum RippleHelper {
             return try dappSigningInput(
                 keysignPayload: keysignPayload,
                 rawJson: signRipple.rawJson,
+                gas: gas,
+                sequence: sequence,
+                lastLedgerSequence: lastLedgerSequence
+            )
+        }
+
+        // Issued-currency (trust-line token) operations. Both sit AFTER the
+        // dApp branch — a rawJson transaction is always signed verbatim — and
+        // BEFORE the `toAddress` guard, because a TrustSet has no destination at
+        // all, exactly like the dApp offer case that already skips it.
+        //
+        // The precedence is deliberate and load-bearing for MPC byte-parity:
+        //   1. `signRipple`                      → verbatim rawJson
+        //   2. `transaction_type == trustSet`    → opTrustSet (amount = LIMIT)
+        //   3. non-native coin with a token id   → opPayment.currencyAmount
+        //   4. native XRP                        → opPayment.amount (drops)
+        //
+        // (2) before (3) is what makes a mixed-version TrustSet ceremony work: a
+        // co-signer predating `transaction_type` sees only "non-native Ripple
+        // coin" and builds a TrustSet from the same limit, which is byte-identical
+        // to what this branch produces. (3) has no representation on an old
+        // co-signer, so a token Payment diverges and the ceremony fails without
+        // moving funds — fail-safe, and the accepted posture for this rollout.
+        if fieldTransactionType == VSTransactionType.rippleTrustSet.rawValue {
+            return try trustSetSigningInput(
+                keysignPayload: keysignPayload,
                 gas: gas,
                 sequence: sequence,
                 lastLedgerSequence: lastLedgerSequence
@@ -170,6 +202,22 @@ enum RippleHelper {
             destinationTag = nil
         }
 
+        // An issued-currency Payment encodes its amount as a `CurrencyAmount`
+        // (currency / issuer / decimal value string), never as drops. Branch
+        // AFTER the tag resolution above so the tag rides a token Payment
+        // exactly as it rides a native one — the tag is orthogonal to how the
+        // amount is encoded.
+        if !keysignPayload.coin.isNativeToken, !keysignPayload.coin.contractAddress.isEmpty {
+            return try tokenPaymentSigningInput(
+                keysignPayload: keysignPayload,
+                destinationTag: destinationTag,
+                gas: gas,
+                sequence: sequence,
+                lastLedgerSequence: lastLedgerSequence,
+                publicKey: publicKey
+            )
+        }
+
         let operation = RippleOperationPayment.with {
             $0.destination = keysignPayload.toAddress
             $0.amount = Int64(keysignPayload.toAmount.description) ?? 0
@@ -190,6 +238,202 @@ enum RippleHelper {
         logger.info("Creating XRP payment, destinationTag: \(destinationTag.map(String.init) ?? "none", privacy: .public), lastLedgerSequence: \(lastLedgerSequence)")
 
         return try input.serializedData()
+    }
+
+    // MARK: - Issued currency (trust-line tokens)
+
+    /// Signing input for a `TrustSet`: open or modify the trust line that lets
+    /// this account hold an issuer's currency.
+    ///
+    /// **The keysign `toAmount` IS the trust line's limit**, not a transfer — the
+    /// maximum of that currency this account is willing to hold. That identity is
+    /// the SDK resolver's convention (`getTrustSet`), and preserving it is what
+    /// makes a mixed-version ceremony work: a co-signer predating
+    /// `RippleSpecific.transaction_type` infers "TrustSet" from a non-native
+    /// Ripple coin and formats the very same amount as the limit, producing
+    /// byte-identical bytes. Do not "improve" it into a separate limit field
+    /// without changing the wire contract on every platform first.
+    ///
+    /// A TrustSet has no destination and no `Amount`, so this runs before the
+    /// `toAddress` guard — like the dApp offer case.
+    ///
+    /// `SigningInput.flags` is deliberately left unset. WalletCore stamps
+    /// `tfFullyCanonicalSig` on typed operations and the SDK sets no flags;
+    /// writing `tfSetNoRipple` here would risk clobbering that default and break
+    /// byte-parity with every other signer.
+    private static func trustSetSigningInput(
+        keysignPayload: KeysignPayload,
+        gas: UInt64,
+        sequence: UInt64,
+        lastLedgerSequence: UInt64
+    ) throws -> Data {
+        let coin = keysignPayload.coin
+        // A TrustSet is meaningless for native XRP: there is no issuer to trust.
+        // Fail closed rather than emitting a SigningInput whose limitAmount
+        // names an empty currency and issuer.
+        guard !coin.isNativeToken, !coin.contractAddress.isEmpty else {
+            throw HelperError.runtimeError("XRP TrustSet requires an issued-currency coin carrying a token id")
+        }
+
+        let limitAmount = try issuedCurrencyAmount(
+            coin: coin,
+            amount: keysignPayload.toAmount,
+            role: "TrustSet limit"
+        )
+        let envelope = try signingEnvelope(
+            keysignPayload: keysignPayload,
+            gas: gas,
+            sequence: sequence,
+            lastLedgerSequence: lastLedgerSequence
+        )
+
+        let input = RippleSigningInput.with {
+            $0.fee = envelope.fee
+            $0.sequence = envelope.sequence
+            $0.account = coin.address
+            $0.publicKey = envelope.publicKey.data
+            $0.lastLedgerSequence = envelope.lastLedgerSequence
+            $0.opTrustSet = RippleOperationTrustSet.with { $0.limitAmount = limitAmount }
+        }
+
+        logger.info("Creating XRP TrustSet, lastLedgerSequence: \(lastLedgerSequence)")
+
+        return try input.serializedData()
+    }
+
+    /// Signing input for an issued-currency `Payment`: transfer a trust-line
+    /// token to `toAddress`.
+    ///
+    /// Uses `opPayment.currencyAmount` — the `oneof` alternative to the drops
+    /// `amount` — so the value rides as a decimal string against the coin's
+    /// (currency, issuer) pair. `destinationTag` is whatever the shared
+    /// tag/memo resolution already decided; the tag is an independent XRPL field
+    /// and applies to a token Payment exactly as it does to a native one.
+    ///
+    /// There is no old-signer counterpart for this operation (every signer
+    /// predating `transaction_type` reads a non-native coin as a TrustSet), so a
+    /// mixed-version committee diverges here and the ceremony fails without
+    /// moving funds — fail-safe, and stated plainly rather than papered over.
+    private static func tokenPaymentSigningInput(
+        keysignPayload: KeysignPayload,
+        destinationTag: UInt64?,
+        gas: UInt64,
+        sequence: UInt64,
+        lastLedgerSequence: UInt64,
+        publicKey: PublicKey
+    ) throws -> Data {
+        let currencyAmount = try issuedCurrencyAmount(
+            coin: keysignPayload.coin,
+            amount: keysignPayload.toAmount,
+            role: "Payment amount"
+        )
+
+        let operation = RippleOperationPayment.with {
+            $0.destination = keysignPayload.toAddress
+            // Setting `currencyAmount` selects the oneof arm, so the drops
+            // `amount` is not on the wire at all — a token Payment must never
+            // carry a drops amount.
+            $0.currencyAmount = currencyAmount
+            if let destinationTag {
+                $0.destinationTag = destinationTag
+            }
+        }
+
+        let envelope = try signingEnvelope(
+            keysignPayload: keysignPayload,
+            gas: gas,
+            sequence: sequence,
+            lastLedgerSequence: lastLedgerSequence
+        )
+
+        let input = RippleSigningInput.with {
+            $0.fee = envelope.fee
+            $0.sequence = envelope.sequence
+            $0.account = keysignPayload.coin.address
+            $0.publicKey = publicKey.data
+            $0.opPayment = operation
+            $0.lastLedgerSequence = envelope.lastLedgerSequence
+        }
+
+        logger.info(
+            "Creating XRP issued-currency payment, destinationTag: \(destinationTag.map(String.init) ?? "none", privacy: .public), lastLedgerSequence: \(lastLedgerSequence)"
+        )
+
+        return try input.serializedData()
+    }
+
+    /// Builds the WalletCore `CurrencyAmount` for `coin`'s token id at `amount`
+    /// base units.
+    ///
+    /// Every `RippleIssuedCurrency` helper throws rather than trapping precisely
+    /// so a hostile token id or `decimals` becomes a REJECTED transaction instead
+    /// of a crashed signer. `role` names which field failed so the surfaced error
+    /// says what the signer refused to build.
+    private static func issuedCurrencyAmount(
+        coin: Coin,
+        amount: BigInt,
+        role: String
+    ) throws -> RippleCurrencyAmount {
+        let token: (currency: String, issuer: String)
+        do {
+            token = try RippleIssuedCurrency.parseRippleTokenId(coin.contractAddress)
+        } catch {
+            throw HelperError.runtimeError("XRP \(role): malformed token id '\(coin.contractAddress)'")
+        }
+
+        let currencyCode: String
+        do {
+            currencyCode = try RippleIssuedCurrency.toXrplCurrencyCode(token.currency)
+        } catch {
+            throw HelperError.runtimeError("XRP \(role): invalid currency code '\(token.currency)'")
+        }
+
+        let value: String
+        do {
+            value = try RippleIssuedCurrency.formatIssuedCurrencyValue(
+                amount: amount,
+                decimals: coin.decimals
+            )
+        } catch {
+            throw HelperError.runtimeError("XRP \(role): value is not representable at \(coin.decimals) decimals")
+        }
+
+        return RippleCurrencyAmount.with {
+            $0.currency = currencyCode
+            $0.issuer = token.issuer
+            $0.value = value
+        }
+    }
+
+    /// Envelope fields shared by every typed XRPL operation.
+    ///
+    /// The proto-relayed fee / sequence / ledger sequence are narrowed with
+    /// `exactly:` so a hostile out-of-range value throws (fail closed) instead of
+    /// trapping the signer — the convention `dappSigningInput` established. Real
+    /// XRPL values always fit, so this is byte-identical to the unchecked
+    /// conversions for every legitimate payload.
+    private static func signingEnvelope(
+        keysignPayload: KeysignPayload,
+        gas: UInt64,
+        sequence: UInt64,
+        lastLedgerSequence: UInt64
+    ) throws -> (fee: Int64, sequence: UInt32, lastLedgerSequence: UInt32, publicKey: PublicKey) {
+        guard let publicKeyData = Data(hexString: keysignPayload.coin.hexPublicKey) else {
+            throw HelperError.runtimeError("invalid hex public key")
+        }
+        guard let publicKey = PublicKey(data: publicKeyData, type: .secp256k1) else {
+            throw HelperError.runtimeError("invalid public key data")
+        }
+        guard let fee = Int64(exactly: gas) else {
+            throw HelperError.runtimeError("XRP fee is out of range")
+        }
+        guard let sequence32 = UInt32(exactly: sequence) else {
+            throw HelperError.runtimeError("XRP sequence is out of range")
+        }
+        guard let lastLedgerSequence32 = UInt32(exactly: lastLedgerSequence) else {
+            throw HelperError.runtimeError("XRP lastLedgerSequence is out of range")
+        }
+        return (fee, sequence32, lastLedgerSequence32, publicKey)
     }
 
     /// Builds the signing input for a dApp-supplied XRPL transaction carried
@@ -356,6 +600,16 @@ enum RippleHelper {
         lastLedgerSequence: UInt64,
         publicKey: PublicKey
     ) throws -> Data {
+        // FAIL CLOSED: this rawJson encodes `Amount` as a DROPS string, which is
+        // only correct for native XRP. An issued-currency coin reaching here
+        // would be signed as a native XRP transfer of the token's base units —
+        // a real, silent loss of funds. WalletCore's typed payment has no memo
+        // slot and a token rawJson Payment is not part of the wire contract yet,
+        // so refuse rather than guess.
+        guard keysignPayload.coin.isNativeToken || keysignPayload.coin.contractAddress.isEmpty else {
+            throw HelperError.runtimeError("XRP issued-currency payments cannot carry an on-chain memo")
+        }
+
         var txJson: [String: Any] = [
             "TransactionType": "Payment",
             "Account": keysignPayload.coin.address,

--- a/VultisigApp/VultisigApp/Components/ImageView/AsyncImageView.swift
+++ b/VultisigApp/VultisigApp/Components/ImageView/AsyncImageView.swift
@@ -44,6 +44,11 @@ struct AsyncImageView: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: size.width, height: size.height)
+                            // Matched to the `.resource` branch above. Bundled coin
+                            // art is drawn circular, but remote art is whatever the
+                            // source published — square logos (SOLO, EQ) rendered as
+                            // squares in a list of circles until this clip existed.
+                            .clipShape(Circle())
                     } placeholder: {
                         ProgressView()
                             .frame(width: size.width, height: size.height)

--- a/VultisigApp/VultisigApp/Components/Sheet/View+SheetStyling.swift
+++ b/VultisigApp/VultisigApp/Components/Sheet/View+SheetStyling.swift
@@ -16,13 +16,17 @@ extension View {
         #endif
     }
 
-    func sheetStyle(padding: CGFloat? = nil) -> some View {
+    /// - Parameter detents: iOS presentation detents. Defaults to `.large` — the
+    ///   height every existing caller was written against — so passing a smaller
+    ///   detent is opt-in for sheets whose content genuinely doesn't fill the
+    ///   screen. Ignored on macOS, which sizes sheets by frame rather than detent.
+    func sheetStyle(padding: CGFloat? = nil, detents: Set<PresentationDetent> = [.large]) -> some View {
         #if os(iOS)
         self
             .padding(.top, padding ?? 8)
             .presentationBackground(Theme.colors.bgPrimary)
             .presentationDragIndicator(.visible)
-            .presentationDetents([.large])
+            .presentationDetents(detents)
         #else
         self
             .background(Theme.colors.bgPrimary)

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "fastVaultSecureTextDescription" = "Nur 1 Gerät erforderlich\nKleine Beträge für schnelle Aktionen speichern\nVultiserver unterzeichnet sofort";
 "fee" = "Gebühr";
 "filterByAsset" = "Nach Asset filtern";
+"findCustomTokenRipplePlaceholder" = "currency.issuer eingeben, z. B. USD.rHb9CJ…";
 "findCustomTokens" = "Finde Deinen Benutzerdefinierten Token";
 "findCustomTokenThorchainPlaceholder" = "Token eingeben, z. B. THOR.LQDY";
 "folder" = "Ordner";
@@ -1052,6 +1053,7 @@
 "restart" = "Bitte starte die App neu, um die neuen Spracheinstellungen zu übernehmen.";
 "retry" = "Erneut versuchen";
 "reviewYourVaultDevices" = "Überprüfe deine Tresor-Geräte";
+"rippleCustomTokenInvalidFormat" = "Geben Sie einen XRP-Token als currency.issuer ein — ein 3-Buchstaben-Code oder ein 40-stelliger Hex-Code, dann die Emittenten-Adresse.";
 "rippleFieldAmount" = "Betrag";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Ziel";
@@ -1065,6 +1067,19 @@
 "rippleFieldType" = "Typ";
 "rippleTransaction" = "XRP-Transaktion";
 "rippleTransactionSummary" = "Transaktionsübersicht";
+"rippleTrustLineActivateAction" = "Aktivieren";
+"rippleTrustLineActivationSubtitle" = "%@ benötigt eine Trust Line im XRP Ledger, bevor Ihr Konto es halten kann. Das Öffnen sperrt dauerhaft einen Teil Ihrer XRP als Owner-Reserve.";
+"rippleTrustLineActivationTitle" = "Trust Line aktivieren";
+"rippleTrustLineCurrency" = "Währung";
+"rippleTrustLineHeroTitle" = "%@-Trust-Line wird aktiviert";
+"rippleTrustLineInsufficientXrpError" = "Nicht genügend verfügbare XRP. Das Öffnen dieser Trust Line benötigt %@ XRP für Owner-Reserve und Gebühr.";
+"rippleTrustLineInvalidTokenError" = "Währung und Emittent dieses Tokens konnten nicht gelesen werden.";
+"rippleTrustLineIssuer" = "Emittent";
+"rippleTrustLineIssuerCheck" = "Der Emittent ist korrekt";
+"rippleTrustLineLimit" = "Trust-Line-Limit";
+"rippleTrustLineLimitCheck" = "Das Trust-Line-Limit ist korrekt";
+"rippleTrustLineOwnerReserve" = "Gesperrte Reserve";
+"rippleTrustLineSpendableAfter" = "Verfügbare XRP danach";
 "rippleUndecodedNotice" = "Diese Transaktion konnte nicht dekodiert werden. Überprüfe das rohe JSON sorgfältig, bevor du signierst.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
@@ -1584,6 +1599,7 @@
 "x" = "x";
 "xrpDestinationLookupFailedError" = "Das XRP-Zielkonto konnte nicht überprüft werden (%@). Bitte versuchen Sie es erneut.";
 "xrpDestinationNotActivatedError" = "Die XRP-Zieladresse ist noch nicht aktiviert. Eine erste Überweisung an sie muss mindestens %@ XRP betragen (die Basisreserve des Netzwerks). Erhöhen Sie den Betrag oder überprüfen Sie die Adresse.";
+"xrpDestinationNoTrustLineError" = "Der Empfänger hat keine %@-Trust-Line, daher würde diese Zahlung vom XRP Ledger abgelehnt.";
 "yes" = "Ja";
 "yesterday" = "Gestern";
 "yieldClaimAmount" = "%@ beanspruchen";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1053,7 +1053,7 @@
 "restart" = "Bitte starte die App neu, um die neuen Spracheinstellungen zu übernehmen.";
 "retry" = "Erneut versuchen";
 "reviewYourVaultDevices" = "Überprüfe deine Tresor-Geräte";
-"rippleCustomTokenInvalidFormat" = "Geben Sie einen XRP-Token als currency.issuer ein — ein 3-Buchstaben-Code oder ein 40-stelliger Hex-Code, dann die Emittenten-Adresse.";
+"rippleCustomTokenInvalidFormat" = "Geben Sie einen XRP-Token als currency.issuer ein — den Token-Code (z. B. USD oder SOLO), dann die Emittenten-Adresse.";
 "rippleFieldAmount" = "Betrag";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Ziel";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1078,8 +1078,11 @@
 "rippleTrustLineIssuerCheck" = "Der Emittent ist korrekt";
 "rippleTrustLineLimit" = "Trust-Line-Limit";
 "rippleTrustLineLimitCheck" = "Das Trust-Line-Limit ist korrekt";
+"rippleTrustLineNoXrpAccountError" = "Eine Trust Line benötigt ein XRP-Konto als Eigentümer. Fügen Sie diesem Vault zuerst XRP hinzu.";
 "rippleTrustLineOwnerReserve" = "Gesperrte Reserve";
 "rippleTrustLineSpendableAfter" = "Verfügbare XRP danach";
+"rippleTrustLineUnreviewable" = "Prüfung nicht möglich";
+"rippleTrustLineUnreviewableValue" = "Währung, Emittent oder Limit dieser Trust Line konnten nicht gelesen werden, daher lassen sich ihre Bedingungen nicht anzeigen. Nicht signieren.";
 "rippleUndecodedNotice" = "Diese Transaktion konnte nicht dekodiert werden. Überprüfe das rohe JSON sorgfältig, bevor du signierst.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1051,7 +1051,7 @@
 "restart" = "Please restart the app to apply the new language settings.";
 "retry" = "Retry";
 "reviewYourVaultDevices" = "Review your vault devices";
-"rippleCustomTokenInvalidFormat" = "Enter an XRP token as currency.issuer — a 3-letter code or 40-character hex code, then the issuer address.";
+"rippleCustomTokenInvalidFormat" = "Enter an XRP token as currency.issuer — the token code (e.g. USD or SOLO), then the issuer address.";
 "rippleFieldAmount" = "Amount";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destination";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -467,6 +467,7 @@
 "fastVaultSecureTextDescription" = "Only 1 device needed\nStore small funds for quick actions\nVultiserver co-signs instantly";
 "fee" = "Fee";
 "filterByAsset" = "Filter by Asset";
+"findCustomTokenRipplePlaceholder" = "Enter currency.issuer, e.g. USD.rHb9CJ…";
 "findCustomTokens" = "Find custom token";
 "findCustomTokenThorchainPlaceholder" = "Enter token, e.g. THOR.LQDY";
 "folder" = "Folder";
@@ -1050,6 +1051,7 @@
 "restart" = "Please restart the app to apply the new language settings.";
 "retry" = "Retry";
 "reviewYourVaultDevices" = "Review your vault devices";
+"rippleCustomTokenInvalidFormat" = "Enter an XRP token as currency.issuer — a 3-letter code or 40-character hex code, then the issuer address.";
 "rippleFieldAmount" = "Amount";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destination";
@@ -1063,6 +1065,19 @@
 "rippleFieldType" = "Type";
 "rippleTransaction" = "XRP Transaction";
 "rippleTransactionSummary" = "Transaction summary";
+"rippleTrustLineActivateAction" = "Activate";
+"rippleTrustLineActivationSubtitle" = "%@ needs a trust line on the XRP Ledger before your account can hold it. Opening one permanently locks part of your XRP as an owner reserve.";
+"rippleTrustLineActivationTitle" = "Activate trust line";
+"rippleTrustLineCurrency" = "Currency";
+"rippleTrustLineHeroTitle" = "Activating the %@ trust line";
+"rippleTrustLineInsufficientXrpError" = "Not enough spendable XRP. Opening this trust line needs %@ XRP for the owner reserve and fee.";
+"rippleTrustLineInvalidTokenError" = "This token's currency and issuer could not be read.";
+"rippleTrustLineIssuer" = "Issuer";
+"rippleTrustLineIssuerCheck" = "The issuer is correct";
+"rippleTrustLineLimit" = "Trust line limit";
+"rippleTrustLineLimitCheck" = "The trust line limit is correct";
+"rippleTrustLineOwnerReserve" = "Reserve locked";
+"rippleTrustLineSpendableAfter" = "Spendable XRP after";
 "rippleUndecodedNotice" = "This transaction couldn't be decoded. Review the raw JSON carefully before signing.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
@@ -1582,6 +1597,7 @@
 "x" = "X (Twitter)";
 "xrpDestinationLookupFailedError" = "The destination XRP account couldn't be verified (%@). Please try again.";
 "xrpDestinationNotActivatedError" = "The destination XRP address is not activated yet. A first transfer to it must be at least %@ XRP (the network base reserve). Increase the amount or double-check the address.";
+"xrpDestinationNoTrustLineError" = "The recipient has no %@ trust line, so this payment would be rejected by the XRP Ledger.";
 "yes" = "Yes";
 "yesterday" = "Yesterday";
 "yieldClaimAmount" = "Claim %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1076,8 +1076,11 @@
 "rippleTrustLineIssuerCheck" = "The issuer is correct";
 "rippleTrustLineLimit" = "Trust line limit";
 "rippleTrustLineLimitCheck" = "The trust line limit is correct";
+"rippleTrustLineNoXrpAccountError" = "A trust line needs an XRP account to own it. Add XRP to this vault first.";
 "rippleTrustLineOwnerReserve" = "Reserve locked";
 "rippleTrustLineSpendableAfter" = "Spendable XRP after";
+"rippleTrustLineUnreviewable" = "Cannot review";
+"rippleTrustLineUnreviewableValue" = "This trust line's currency, issuer or limit could not be read, so its terms cannot be shown. Do not sign it.";
 "rippleUndecodedNotice" = "This transaction couldn't be decoded. Review the raw JSON carefully before signing.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1078,8 +1078,11 @@
 "rippleTrustLineIssuerCheck" = "El emisor es correcto";
 "rippleTrustLineLimit" = "Límite de la línea de confianza";
 "rippleTrustLineLimitCheck" = "El límite de la línea de confianza es correcto";
+"rippleTrustLineNoXrpAccountError" = "Una línea de confianza necesita una cuenta XRP que la posea. Añade XRP a esta bóveda primero.";
 "rippleTrustLineOwnerReserve" = "Reserva bloqueada";
 "rippleTrustLineSpendableAfter" = "XRP disponibles después";
+"rippleTrustLineUnreviewable" = "No se puede revisar";
+"rippleTrustLineUnreviewableValue" = "No se pudo leer la moneda, el emisor o el límite de esta línea de confianza, así que no se pueden mostrar sus condiciones. No la firmes.";
 "rippleUndecodedNotice" = "No se pudo decodificar esta transacción. Revisa cuidadosamente el JSON sin procesar antes de firmar.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "fastVaultSecureTextDescription" = "Solo se necesita 1 dispositivo\nGuarda fondos pequeños para acciones rápidas\nVultiserver cofirma al instante";
 "fee" = "Tarifa";
 "filterByAsset" = "Filtrar por activo";
+"findCustomTokenRipplePlaceholder" = "Introduce currency.issuer, p. ej. USD.rHb9CJ…";
 "findCustomTokens" = "Encuentra Tu Token Personalizado";
 "findCustomTokenThorchainPlaceholder" = "Introduce el token, p. ej. THOR.LQDY";
 "folder" = "Carpeta";
@@ -1052,6 +1053,7 @@
 "restart" = "Por favor, reinicie la aplicación para aplicar los nuevos ajustes de idioma.";
 "retry" = "Reintentar";
 "reviewYourVaultDevices" = "Revisa los dispositivos de tu bóveda";
+"rippleCustomTokenInvalidFormat" = "Introduce un token XRP como currency.issuer: un código de 3 letras o de 40 caracteres hexadecimales, y luego la dirección del emisor.";
 "rippleFieldAmount" = "Cantidad";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destino";
@@ -1065,6 +1067,19 @@
 "rippleFieldType" = "Tipo";
 "rippleTransaction" = "Transacción XRP";
 "rippleTransactionSummary" = "Resumen de la transacción";
+"rippleTrustLineActivateAction" = "Activar";
+"rippleTrustLineActivationSubtitle" = "%@ necesita una línea de confianza en el XRP Ledger antes de que tu cuenta pueda mantenerlo. Abrirla bloquea permanentemente parte de tus XRP como reserva de propietario.";
+"rippleTrustLineActivationTitle" = "Activar línea de confianza";
+"rippleTrustLineCurrency" = "Moneda";
+"rippleTrustLineHeroTitle" = "Activando la línea de confianza de %@";
+"rippleTrustLineInsufficientXrpError" = "No hay suficientes XRP disponibles. Abrir esta línea de confianza requiere %@ XRP para la reserva de propietario y la comisión.";
+"rippleTrustLineInvalidTokenError" = "No se pudo leer la moneda ni el emisor de este token.";
+"rippleTrustLineIssuer" = "Emisor";
+"rippleTrustLineIssuerCheck" = "El emisor es correcto";
+"rippleTrustLineLimit" = "Límite de la línea de confianza";
+"rippleTrustLineLimitCheck" = "El límite de la línea de confianza es correcto";
+"rippleTrustLineOwnerReserve" = "Reserva bloqueada";
+"rippleTrustLineSpendableAfter" = "XRP disponibles después";
 "rippleUndecodedNotice" = "No se pudo decodificar esta transacción. Revisa cuidadosamente el JSON sin procesar antes de firmar.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
@@ -1584,6 +1599,7 @@
 "x" = "X (Twitter)";
 "xrpDestinationLookupFailedError" = "No se pudo verificar la cuenta XRP de destino (%@). Inténtalo de nuevo.";
 "xrpDestinationNotActivatedError" = "La dirección XRP de destino aún no está activada. Una primera transferencia debe ser de al menos %@ XRP (la reserva base de la red). Aumenta el importe o verifica la dirección.";
+"xrpDestinationNoTrustLineError" = "El destinatario no tiene una línea de confianza de %@, por lo que el XRP Ledger rechazaría este pago.";
 "yes" = "Sí";
 "yesterday" = "Ayer";
 "yieldClaimAmount" = "Reclamar %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1053,7 +1053,7 @@
 "restart" = "Por favor, reinicie la aplicación para aplicar los nuevos ajustes de idioma.";
 "retry" = "Reintentar";
 "reviewYourVaultDevices" = "Revisa los dispositivos de tu bóveda";
-"rippleCustomTokenInvalidFormat" = "Introduce un token XRP como currency.issuer: un código de 3 letras o de 40 caracteres hexadecimales, y luego la dirección del emisor.";
+"rippleCustomTokenInvalidFormat" = "Introduce un token XRP como currency.issuer: el código del token (p. ej. USD o SOLO) y luego la dirección del emisor.";
 "rippleFieldAmount" = "Cantidad";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destino";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1078,8 +1078,11 @@
 "rippleTrustLineIssuerCheck" = "Izdavatelj je ispravan";
 "rippleTrustLineLimit" = "Ograničenje linije povjerenja";
 "rippleTrustLineLimitCheck" = "Ograničenje linije povjerenja je ispravno";
+"rippleTrustLineNoXrpAccountError" = "Liniju povjerenja mora posjedovati XRP račun. Najprije dodajte XRP u ovaj trezor.";
 "rippleTrustLineOwnerReserve" = "Zaključana rezerva";
 "rippleTrustLineSpendableAfter" = "Raspoloživi XRP nakon";
+"rippleTrustLineUnreviewable" = "Pregled nije moguć";
+"rippleTrustLineUnreviewableValue" = "Valuta, izdavatelj ili ograničenje ove linije povjerenja nisu se mogli pročitati, pa se njezini uvjeti ne mogu prikazati. Nemojte je potpisati.";
 "rippleUndecodedNotice" = "Ovu transakciju nije bilo moguće dekodirati. Pažljivo pregledajte neobrađeni JSON prije potpisivanja.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "fastVaultSecureTextDescription" = "Potrebno je samo 1 uređaj\nPohrani manja sredstva za brze radnje\nVultiserver trenutno supotpisuje";
 "fee" = "Naknada";
 "filterByAsset" = "Filtriraj po imovini";
+"findCustomTokenRipplePlaceholder" = "Unesite currency.issuer, npr. USD.rHb9CJ…";
 "findCustomTokens" = "Pronađite Svoj Prilagođeni Token";
 "findCustomTokenThorchainPlaceholder" = "Unesite token, npr. THOR.LQDY";
 "folder" = "Mapa";
@@ -1052,6 +1053,7 @@
 "restart" = "Molimo ponovno pokrenite aplikaciju kako biste primijenili nove postavke jezika.";
 "retry" = "Pokušaj ponovo";
 "reviewYourVaultDevices" = "Pregledajte uređaje svog trezora";
+"rippleCustomTokenInvalidFormat" = "Unesite XRP token kao currency.issuer — kod od 3 slova ili 40 heksadecimalnih znakova, a zatim adresu izdavatelja.";
 "rippleFieldAmount" = "Iznos";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Odredište";
@@ -1065,6 +1067,19 @@
 "rippleFieldType" = "Vrsta";
 "rippleTransaction" = "XRP transakcija";
 "rippleTransactionSummary" = "Sažetak transakcije";
+"rippleTrustLineActivateAction" = "Aktiviraj";
+"rippleTrustLineActivationSubtitle" = "%@ zahtijeva liniju povjerenja na XRP Ledgeru prije nego što ga vaš račun može držati. Otvaranje trajno zaključava dio vaših XRP kao rezervu vlasnika.";
+"rippleTrustLineActivationTitle" = "Aktiviraj liniju povjerenja";
+"rippleTrustLineCurrency" = "Valuta";
+"rippleTrustLineHeroTitle" = "Aktiviranje linije povjerenja za %@";
+"rippleTrustLineInsufficientXrpError" = "Nema dovoljno raspoloživih XRP. Otvaranje ove linije povjerenja zahtijeva %@ XRP za rezervu vlasnika i naknadu.";
+"rippleTrustLineInvalidTokenError" = "Valuta i izdavatelj ovog tokena nisu se mogli pročitati.";
+"rippleTrustLineIssuer" = "Izdavatelj";
+"rippleTrustLineIssuerCheck" = "Izdavatelj je ispravan";
+"rippleTrustLineLimit" = "Ograničenje linije povjerenja";
+"rippleTrustLineLimitCheck" = "Ograničenje linije povjerenja je ispravno";
+"rippleTrustLineOwnerReserve" = "Zaključana rezerva";
+"rippleTrustLineSpendableAfter" = "Raspoloživi XRP nakon";
 "rippleUndecodedNotice" = "Ovu transakciju nije bilo moguće dekodirati. Pažljivo pregledajte neobrađeni JSON prije potpisivanja.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
@@ -1584,6 +1599,7 @@
 "x" = "x";
 "xrpDestinationLookupFailedError" = "Odredišni XRP račun nije bilo moguće provjeriti (%@). Pokušajte ponovno.";
 "xrpDestinationNotActivatedError" = "Odredišna XRP adresa još nije aktivirana. Prvi prijenos na nju mora iznositi najmanje %@ XRP (osnovna rezerva mreže). Povećajte iznos ili provjerite adresu.";
+"xrpDestinationNoTrustLineError" = "Primatelj nema %@ liniju povjerenja, pa bi XRP Ledger odbio ovu uplatu.";
 "yes" = "Da";
 "yesterday" = "Jučer";
 "yieldClaimAmount" = "Preuzmi %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1053,7 +1053,7 @@
 "restart" = "Molimo ponovno pokrenite aplikaciju kako biste primijenili nove postavke jezika.";
 "retry" = "Pokušaj ponovo";
 "reviewYourVaultDevices" = "Pregledajte uređaje svog trezora";
-"rippleCustomTokenInvalidFormat" = "Unesite XRP token kao currency.issuer — kod od 3 slova ili 40 heksadecimalnih znakova, a zatim adresu izdavatelja.";
+"rippleCustomTokenInvalidFormat" = "Unesite XRP token kao currency.issuer — kod tokena (npr. USD ili SOLO), a zatim adresu izdavatelja.";
 "rippleFieldAmount" = "Iznos";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Odredište";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1078,8 +1078,11 @@
 "rippleTrustLineIssuerCheck" = "L'emittente è corretto";
 "rippleTrustLineLimit" = "Limite della linea di fiducia";
 "rippleTrustLineLimitCheck" = "Il limite della linea di fiducia è corretto";
+"rippleTrustLineNoXrpAccountError" = "Una linea di fiducia deve essere posseduta da un account XRP. Aggiungi prima XRP a questo vault.";
 "rippleTrustLineOwnerReserve" = "Riserva bloccata";
 "rippleTrustLineSpendableAfter" = "XRP disponibili dopo";
+"rippleTrustLineUnreviewable" = "Impossibile verificare";
+"rippleTrustLineUnreviewableValue" = "Non è stato possibile leggere valuta, emittente o limite di questa linea di fiducia, quindi le sue condizioni non possono essere mostrate. Non firmarla.";
 "rippleUndecodedNotice" = "Impossibile decodificare questa transazione. Controlla attentamente il JSON grezzo prima di firmare.";
 "routerNotAvailable" = "Router non disponibile per approvazioni su %@. Riprova più tardi.";
 "rune" = "RUNE";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "fastVaultSecureTextDescription" = "Solo 1 dispositivo necessario\nConserva piccoli fondi per azioni rapide\nVultiserver cofirma istantaneamente";
 "fee" = "Commissione";
 "filterByAsset" = "Filtra per asset";
+"findCustomTokenRipplePlaceholder" = "Inserisci currency.issuer, ad es. USD.rHb9CJ…";
 "findCustomTokens" = "Trova Il Tuo Token Personalizzato";
 "findCustomTokenThorchainPlaceholder" = "Inserisci il token, ad es. THOR.LQDY";
 "folder" = "Cartella";
@@ -1052,6 +1053,7 @@
 "restart" = "Si prega di riavviare l'app per applicare le nuove impostazioni della lingua.";
 "retry" = "Riprova";
 "reviewYourVaultDevices" = "Controlla i dispositivi del tuo vault";
+"rippleCustomTokenInvalidFormat" = "Inserisci un token XRP come currency.issuer: un codice di 3 lettere o di 40 caratteri esadecimali, poi l'indirizzo dell'emittente.";
 "rippleFieldAmount" = "Importo";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destinazione";
@@ -1065,6 +1067,19 @@
 "rippleFieldType" = "Tipo";
 "rippleTransaction" = "Transazione XRP";
 "rippleTransactionSummary" = "Riepilogo della transazione";
+"rippleTrustLineActivateAction" = "Attiva";
+"rippleTrustLineActivationSubtitle" = "%@ richiede una linea di fiducia sull'XRP Ledger prima che il tuo account possa detenerlo. Aprirla blocca in modo permanente parte dei tuoi XRP come riserva del proprietario.";
+"rippleTrustLineActivationTitle" = "Attiva linea di fiducia";
+"rippleTrustLineCurrency" = "Valuta";
+"rippleTrustLineHeroTitle" = "Attivazione della linea di fiducia %@";
+"rippleTrustLineInsufficientXrpError" = "XRP disponibili insufficienti. Aprire questa linea di fiducia richiede %@ XRP per la riserva del proprietario e la commissione.";
+"rippleTrustLineInvalidTokenError" = "Non è stato possibile leggere la valuta e l'emittente di questo token.";
+"rippleTrustLineIssuer" = "Emittente";
+"rippleTrustLineIssuerCheck" = "L'emittente è corretto";
+"rippleTrustLineLimit" = "Limite della linea di fiducia";
+"rippleTrustLineLimitCheck" = "Il limite della linea di fiducia è corretto";
+"rippleTrustLineOwnerReserve" = "Riserva bloccata";
+"rippleTrustLineSpendableAfter" = "XRP disponibili dopo";
 "rippleUndecodedNotice" = "Impossibile decodificare questa transazione. Controlla attentamente il JSON grezzo prima di firmare.";
 "routerNotAvailable" = "Router non disponibile per approvazioni su %@. Riprova più tardi.";
 "rune" = "RUNE";
@@ -1584,6 +1599,7 @@
 "x" = "X (Twitter)";
 "xrpDestinationLookupFailedError" = "Impossibile verificare l'account XRP di destinazione (%@). Riprova.";
 "xrpDestinationNotActivatedError" = "L'indirizzo XRP di destinazione non è ancora attivato. Un primo trasferimento deve essere di almeno %@ XRP (la riserva base della rete). Aumenta l'importo o verifica l'indirizzo.";
+"xrpDestinationNoTrustLineError" = "Il destinatario non ha una linea di fiducia %@, quindi questo pagamento verrebbe rifiutato dall'XRP Ledger.";
 "yes" = "Sì";
 "yesterday" = "Ieri";
 "yieldClaimAmount" = "Riscuoti %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1053,7 +1053,7 @@
 "restart" = "Si prega di riavviare l'app per applicare le nuove impostazioni della lingua.";
 "retry" = "Riprova";
 "reviewYourVaultDevices" = "Controlla i dispositivi del tuo vault";
-"rippleCustomTokenInvalidFormat" = "Inserisci un token XRP come currency.issuer: un codice di 3 lettere o di 40 caratteri esadecimali, poi l'indirizzo dell'emittente.";
+"rippleCustomTokenInvalidFormat" = "Inserisci un token XRP come currency.issuer: il codice del token (es. USD o SOLO), poi l'indirizzo dell'emittente.";
 "rippleFieldAmount" = "Importo";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destinazione";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1076,8 +1076,11 @@
 "rippleTrustLineIssuerCheck" = "발행자가 정확합니다";
 "rippleTrustLineLimit" = "신뢰선 한도";
 "rippleTrustLineLimitCheck" = "신뢰선 한도가 정확합니다";
+"rippleTrustLineNoXrpAccountError" = "신뢰선을 보유하려면 XRP 계정이 필요합니다. 먼저 이 볼트에 XRP를 추가하세요.";
 "rippleTrustLineOwnerReserve" = "잠긴 준비금";
 "rippleTrustLineSpendableAfter" = "이후 사용 가능한 XRP";
+"rippleTrustLineUnreviewable" = "검토할 수 없음";
+"rippleTrustLineUnreviewableValue" = "이 신뢰선의 통화, 발행자 또는 한도를 읽을 수 없어 조건을 표시할 수 없습니다. 서명하지 마세요.";
 "rippleUndecodedNotice" = "이 트랜잭션을 디코딩할 수 없습니다. 서명하기 전에 원시 JSON을 주의 깊게 확인하세요.";
 "routerNotAvailable" = "%@에서 승인을 위한 라우터를 사용할 수 없습니다. 나중에 다시 시도하세요.";
 "rune" = "RUNE";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1051,7 +1051,7 @@
 "restart" = "새 언어 설정을 적용하려면 앱을 재시작하세요.";
 "retry" = "재시도";
 "reviewYourVaultDevices" = "볼트 기기 검토";
-"rippleCustomTokenInvalidFormat" = "XRP 토큰을 currency.issuer 형식으로 입력하세요 — 3자 코드 또는 40자 16진수 코드 다음에 발행자 주소를 입력합니다.";
+"rippleCustomTokenInvalidFormat" = "XRP 토큰을 currency.issuer 형식으로 입력하세요 — 토큰 코드(예: USD 또는 SOLO) 다음에 발행자 주소를 입력합니다.";
 "rippleFieldAmount" = "금액";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "수신처";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -467,6 +467,7 @@
 "fastVaultSecureTextDescription" = "기기 1개만 필요\n빠른 작업을 위한 소액 자금 저장\nVultiserver가 즉시 공동 서명";
 "fee" = "수수료";
 "filterByAsset" = "자산으로 필터링";
+"findCustomTokenRipplePlaceholder" = "currency.issuer 입력, 예: USD.rHb9CJ…";
 "findCustomTokens" = "커스텀 토큰 찾기";
 "findCustomTokenThorchainPlaceholder" = "토큰 입력, 예: THOR.LQDY";
 "folder" = "폴더";
@@ -1050,6 +1051,7 @@
 "restart" = "새 언어 설정을 적용하려면 앱을 재시작하세요.";
 "retry" = "재시도";
 "reviewYourVaultDevices" = "볼트 기기 검토";
+"rippleCustomTokenInvalidFormat" = "XRP 토큰을 currency.issuer 형식으로 입력하세요 — 3자 코드 또는 40자 16진수 코드 다음에 발행자 주소를 입력합니다.";
 "rippleFieldAmount" = "금액";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "수신처";
@@ -1063,6 +1065,19 @@
 "rippleFieldType" = "유형";
 "rippleTransaction" = "XRP 트랜잭션";
 "rippleTransactionSummary" = "트랜잭션 요약";
+"rippleTrustLineActivateAction" = "활성화";
+"rippleTrustLineActivationSubtitle" = "%@을(를) 보유하려면 먼저 XRP Ledger에 신뢰선이 필요합니다. 신뢰선을 열면 XRP의 일부가 소유자 준비금으로 영구히 잠깁니다.";
+"rippleTrustLineActivationTitle" = "신뢰선 활성화";
+"rippleTrustLineCurrency" = "통화";
+"rippleTrustLineHeroTitle" = "%@ 신뢰선 활성화 중";
+"rippleTrustLineInsufficientXrpError" = "사용 가능한 XRP가 부족합니다. 이 신뢰선을 열려면 소유자 준비금과 수수료로 %@ XRP가 필요합니다.";
+"rippleTrustLineInvalidTokenError" = "이 토큰의 통화와 발행자를 읽을 수 없습니다.";
+"rippleTrustLineIssuer" = "발행자";
+"rippleTrustLineIssuerCheck" = "발행자가 정확합니다";
+"rippleTrustLineLimit" = "신뢰선 한도";
+"rippleTrustLineLimitCheck" = "신뢰선 한도가 정확합니다";
+"rippleTrustLineOwnerReserve" = "잠긴 준비금";
+"rippleTrustLineSpendableAfter" = "이후 사용 가능한 XRP";
 "rippleUndecodedNotice" = "이 트랜잭션을 디코딩할 수 없습니다. 서명하기 전에 원시 JSON을 주의 깊게 확인하세요.";
 "routerNotAvailable" = "%@에서 승인을 위한 라우터를 사용할 수 없습니다. 나중에 다시 시도하세요.";
 "rune" = "RUNE";
@@ -1545,6 +1560,7 @@
 "x" = "X (Twitter)";
 "xrpDestinationLookupFailedError" = "대상 XRP 계정을 확인할 수 없습니다 (%@). 다시 시도해 주세요.";
 "xrpDestinationNotActivatedError" = "대상 XRP 주소가 아직 활성화되지 않았습니다. 첫 송금은 최소 %@ XRP(네트워크 기본 준비금) 이상이어야 합니다. 금액을 늘리거나 주소를 다시 확인하세요.";
+"xrpDestinationNoTrustLineError" = "수신자에게 %@ 신뢰선이 없으므로 이 결제는 XRP Ledger에서 거부됩니다.";
 "yes" = "예";
 "yesterday" = "어제";
 "yieldClaimAmount" = "%@ 수령";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1078,8 +1078,11 @@
 "rippleTrustLineIssuerCheck" = "O emissor está correto";
 "rippleTrustLineLimit" = "Limite da linha de confiança";
 "rippleTrustLineLimitCheck" = "O limite da linha de confiança está correto";
+"rippleTrustLineNoXrpAccountError" = "Uma linha de confiança precisa de uma conta XRP que a detenha. Adicione XRP a este cofre primeiro.";
 "rippleTrustLineOwnerReserve" = "Reserva bloqueada";
 "rippleTrustLineSpendableAfter" = "XRP disponíveis depois";
+"rippleTrustLineUnreviewable" = "Não é possível rever";
+"rippleTrustLineUnreviewableValue" = "Não foi possível ler a moeda, o emissor ou o limite desta linha de confiança, por isso as suas condições não podem ser mostradas. Não a assine.";
 "rippleUndecodedNotice" = "Não foi possível decodificar esta transação. Revise cuidadosamente o JSON bruto antes de assinar.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1053,7 +1053,7 @@
 "restart" = "Por favor, reinicie o aplicativo para aplicar as novas configurações de idioma.";
 "retry" = "Tentar novamente";
 "reviewYourVaultDevices" = "Revise os dispositivos do seu cofre";
-"rippleCustomTokenInvalidFormat" = "Insira um token XRP como currency.issuer — um código de 3 letras ou de 40 caracteres hexadecimais, seguido do endereço do emissor.";
+"rippleCustomTokenInvalidFormat" = "Insira um token XRP como currency.issuer — o código do token (ex.: USD ou SOLO), seguido do endereço do emissor.";
 "rippleFieldAmount" = "Valor";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destino";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "fastVaultSecureTextDescription" = "Apenas 1 dispositivo necessário\nArmazene pequenos fundos para ações rápidas\nVultiserver coassina instantaneamente";
 "fee" = "Taxa";
 "filterByAsset" = "Filtrar por ativo";
+"findCustomTokenRipplePlaceholder" = "Insira currency.issuer, ex.: USD.rHb9CJ…";
 "findCustomTokens" = "Encontre Seu Token Personalizado";
 "findCustomTokenThorchainPlaceholder" = "Insira o token, ex.: THOR.LQDY";
 "folder" = "Pasta";
@@ -1052,6 +1053,7 @@
 "restart" = "Por favor, reinicie o aplicativo para aplicar as novas configurações de idioma.";
 "retry" = "Tentar novamente";
 "reviewYourVaultDevices" = "Revise os dispositivos do seu cofre";
+"rippleCustomTokenInvalidFormat" = "Insira um token XRP como currency.issuer — um código de 3 letras ou de 40 caracteres hexadecimais, seguido do endereço do emissor.";
 "rippleFieldAmount" = "Valor";
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destino";
@@ -1065,6 +1067,19 @@
 "rippleFieldType" = "Tipo";
 "rippleTransaction" = "Transação XRP";
 "rippleTransactionSummary" = "Resumo da transação";
+"rippleTrustLineActivateAction" = "Ativar";
+"rippleTrustLineActivationSubtitle" = "%@ precisa de uma linha de confiança no XRP Ledger antes de a sua conta poder mantê-lo. Abri-la bloqueia permanentemente parte dos seus XRP como reserva de proprietário.";
+"rippleTrustLineActivationTitle" = "Ativar linha de confiança";
+"rippleTrustLineCurrency" = "Moeda";
+"rippleTrustLineHeroTitle" = "A ativar a linha de confiança de %@";
+"rippleTrustLineInsufficientXrpError" = "XRP disponíveis insuficientes. Abrir esta linha de confiança requer %@ XRP para a reserva de proprietário e a taxa.";
+"rippleTrustLineInvalidTokenError" = "Não foi possível ler a moeda e o emissor deste token.";
+"rippleTrustLineIssuer" = "Emissor";
+"rippleTrustLineIssuerCheck" = "O emissor está correto";
+"rippleTrustLineLimit" = "Limite da linha de confiança";
+"rippleTrustLineLimitCheck" = "O limite da linha de confiança está correto";
+"rippleTrustLineOwnerReserve" = "Reserva bloqueada";
+"rippleTrustLineSpendableAfter" = "XRP disponíveis depois";
 "rippleUndecodedNotice" = "Não foi possível decodificar esta transação. Revise cuidadosamente o JSON bruto antes de assinar.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
@@ -1584,6 +1599,7 @@
 "x" = "x";
 "xrpDestinationLookupFailedError" = "Não foi possível verificar a conta XRP de destino (%@). Tente novamente.";
 "xrpDestinationNotActivatedError" = "O endereço XRP de destino ainda não está ativado. Uma primeira transferência deve ser de pelo menos %@ XRP (a reserva base da rede). Aumente o valor ou verifique o endereço.";
+"xrpDestinationNoTrustLineError" = "O destinatário não tem uma linha de confiança de %@, por isso este pagamento seria rejeitado pelo XRP Ledger.";
 "yes" = "Sim";
 "yesterday" = "Ontem";
 "yieldClaimAmount" = "Resgatar %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1078,8 +1078,11 @@
 "rippleTrustLineIssuerCheck" = "发行方正确";
 "rippleTrustLineLimit" = "信任线上限";
 "rippleTrustLineLimitCheck" = "信任线上限正确";
+"rippleTrustLineNoXrpAccountError" = "信任线需要由一个 XRP 账户持有。请先向此保险库添加 XRP。";
 "rippleTrustLineOwnerReserve" = "锁定的准备金";
 "rippleTrustLineSpendableAfter" = "之后可用的 XRP";
+"rippleTrustLineUnreviewable" = "无法审核";
+"rippleTrustLineUnreviewableValue" = "无法读取此信任线的货币、发行方或上限，因此无法显示其条款。请勿签名。";
 "rippleUndecodedNotice" = "无法解码此交易。签名前请仔细核对原始 JSON。";
 "routerNotAvailable" = "%@ 的路由不可用。请稍后再试。";
 "rune" = "RUNE";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -469,6 +469,7 @@
 "fastVaultSecureTextDescription" = "只需 1 个设备\n存储小额资金以进行快速操作\nVultiserver 即时共同签名";
 "fee" = "费用";
 "filterByAsset" = "按资产筛选";
+"findCustomTokenRipplePlaceholder" = "输入 currency.issuer，例如 USD.rHb9CJ…";
 "findCustomTokens" = "查找自定义代币";
 "findCustomTokenThorchainPlaceholder" = "输入代币，例如 THOR.LQDY";
 "folder" = "文件夹";
@@ -1052,6 +1053,7 @@
 "restart" = "请重新启动应用程序以应用新的语言设置";
 "retry" = "重试";
 "reviewYourVaultDevices" = "检查你的保险库设备";
+"rippleCustomTokenInvalidFormat" = "请以 currency.issuer 格式输入 XRP 代币 —— 3 个字母的代码或 40 个字符的十六进制代码，然后是发行方地址。";
 "rippleFieldAmount" = "金额";
 "rippleFieldDeliverMin" = "最小交付额";
 "rippleFieldDestination" = "目标地址";
@@ -1065,6 +1067,19 @@
 "rippleFieldType" = "类型";
 "rippleTransaction" = "XRP 交易";
 "rippleTransactionSummary" = "交易摘要";
+"rippleTrustLineActivateAction" = "激活";
+"rippleTrustLineActivationSubtitle" = "%@ 需要在 XRP Ledger 上建立信任线，您的账户才能持有它。开通信任线会将您的一部分 XRP 永久锁定为所有者准备金。";
+"rippleTrustLineActivationTitle" = "激活信任线";
+"rippleTrustLineCurrency" = "货币";
+"rippleTrustLineHeroTitle" = "正在激活 %@ 信任线";
+"rippleTrustLineInsufficientXrpError" = "可用 XRP 不足。开通此信任线需要 %@ XRP 用于所有者准备金和手续费。";
+"rippleTrustLineInvalidTokenError" = "无法读取此代币的货币和发行方。";
+"rippleTrustLineIssuer" = "发行方";
+"rippleTrustLineIssuerCheck" = "发行方正确";
+"rippleTrustLineLimit" = "信任线上限";
+"rippleTrustLineLimitCheck" = "信任线上限正确";
+"rippleTrustLineOwnerReserve" = "锁定的准备金";
+"rippleTrustLineSpendableAfter" = "之后可用的 XRP";
 "rippleUndecodedNotice" = "无法解码此交易。签名前请仔细核对原始 JSON。";
 "routerNotAvailable" = "%@ 的路由不可用。请稍后再试。";
 "rune" = "RUNE";
@@ -1584,6 +1599,7 @@
 "x" = "X（推特）";
 "xrpDestinationLookupFailedError" = "无法验证目标 XRP 账户 (%@)。请重试。";
 "xrpDestinationNotActivatedError" = "目标 XRP 地址尚未激活。首次向其转账必须至少为 %@ XRP（网络基础准备金）。请增加金额或核对地址。";
+"xrpDestinationNoTrustLineError" = "收款方没有 %@ 信任线，因此此付款会被 XRP Ledger 拒绝。";
 "yes" = "是";
 "yesterday" = "昨天";
 "yieldClaimAmount" = "领取 %@";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1053,7 +1053,7 @@
 "restart" = "请重新启动应用程序以应用新的语言设置";
 "retry" = "重试";
 "reviewYourVaultDevices" = "检查你的保险库设备";
-"rippleCustomTokenInvalidFormat" = "请以 currency.issuer 格式输入 XRP 代币 —— 3 个字母的代码或 40 个字符的十六进制代码，然后是发行方地址。";
+"rippleCustomTokenInvalidFormat" = "请以 currency.issuer 格式输入 XRP 代币 —— 代币代码（例如 USD 或 SOLO），然后是发行方地址。";
 "rippleFieldAmount" = "金额";
 "rippleFieldDeliverMin" = "最小交付额";
 "rippleFieldDestination" = "目标地址";

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/BlockChainSpecific.swift
@@ -36,7 +36,18 @@ enum BlockChainSpecific: Codable, Hashable {
     /// this field and falls back to parsing the memo, so a co-signer that does
     /// not read the field still rebuilds a byte-identical signing input from
     /// the memo. `nil` means "no field present — use the memo".
-    case Ripple(sequence: UInt64, gas: UInt64, lastLedgerSequence: UInt64, destinationTag: UInt32? = nil)
+    ///
+    /// `transactionType` is the wire discriminator that says WHICH XRPL
+    /// operation this payload describes (`RippleSpecific.transaction_type`),
+    /// stored as the enum's raw value like `.THORChain` and `.Cosmos` already
+    /// do. It exists because a non-native Ripple coin is ambiguous on its own:
+    /// the same (currency, issuer) pair can mean "open a trust line for this
+    /// token" — a TrustSet whose amount is the trust-line LIMIT — or "send this
+    /// token", a Payment carrying a `CurrencyAmount`. `0`
+    /// (`TRANSACTION_TYPE_UNSPECIFIED`) is the proto3 default and is absent
+    /// from the wire, so native XRP payloads stay byte-identical to before the
+    /// field existed.
+    case Ripple(sequence: UInt64, gas: UInt64, lastLedgerSequence: UInt64, destinationTag: UInt32? = nil, transactionType: Int = 0)
 
     case Tron(
         timestamp: UInt64,
@@ -96,7 +107,7 @@ enum BlockChainSpecific: Codable, Hashable {
             return dynamicGas
         case .Ton:
             return TonHelper.defaultFee
-        case .Ripple(_, let gas, _, _):
+        case .Ripple(_, let gas, _, _, _):
             return gas.description.toBigInt()
         case .Tron(_, _, _, _, _, _, _, _, let gasFeeEstimation):
             return gasFeeEstimation.description.toBigInt()

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -517,7 +517,11 @@ extension BlockChainSpecific {
                 sequence: value.sequence,
                 gas: value.gas,
                 lastLedgerSequence: value.lastLedgerSequence,
-                destinationTag: value.hasDestinationTag ? value.destinationTag : nil
+                destinationTag: value.hasDestinationTag ? value.destinationTag : nil,
+                // A proto3 enum is never absent — an unset field decodes to
+                // `.unspecified` (0), which is exactly the "no discriminator,
+                // apply the legacy rule" case the signer needs.
+                transactionType: value.transactionType.rawValue
             )
         case .tronSpecific(let value):
             self = .Tron(
@@ -634,7 +638,7 @@ extension BlockChainSpecific {
                 $0.genesisHash = genesisHash
                 $0.gas = UInt64(gas ?? 0)
             })
-        case .Ripple(let sequence, let gas, let lastLedgerSequence, let destinationTag):
+        case .Ripple(let sequence, let gas, let lastLedgerSequence, let destinationTag, let transactionType):
             return .rippleSpecific(.with {
                 $0.sequence = sequence
                 $0.gas = gas
@@ -644,6 +648,11 @@ extension BlockChainSpecific {
                 if let destinationTag {
                     $0.destinationTag = destinationTag
                 }
+                // Assign unconditionally: an unrecognized raw value degrades to
+                // `.unspecified`, which is also the proto3 default, so it stays
+                // off the wire and the payload remains byte-identical to one
+                // built before the field existed.
+                $0.transactionType = VSTransactionType(rawValue: transactionType) ?? .unspecified
             })
 
         case .Tron(

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignMessage+ProtoMappable.swift
@@ -519,8 +519,11 @@ extension BlockChainSpecific {
                 lastLedgerSequence: value.lastLedgerSequence,
                 destinationTag: value.hasDestinationTag ? value.destinationTag : nil,
                 // A proto3 enum is never absent — an unset field decodes to
-                // `.unspecified` (0), which is exactly the "no discriminator,
-                // apply the legacy rule" case the signer needs.
+                // `.unspecified` (0). Relayed VERBATIM, including a value this
+                // build doesn't recognise: the signer refuses an unsupported
+                // discriminator rather than silently degrading it to
+                // `.unspecified`, so it must be able to see what the peer
+                // actually sent.
                 transactionType: value.transactionType.rawValue
             )
         case .tronSpecific(let value):
@@ -648,10 +651,12 @@ extension BlockChainSpecific {
                 if let destinationTag {
                     $0.destinationTag = destinationTag
                 }
-                // Assign unconditionally: an unrecognized raw value degrades to
-                // `.unspecified`, which is also the proto3 default, so it stays
-                // off the wire and the payload remains byte-identical to one
-                // built before the field existed.
+                // Assign unconditionally: `.unspecified` (0) is the proto3 default
+                // and stays off the wire, so a payload with no XRPL operation
+                // discriminator is byte-identical to one built before the field
+                // existed. A raw value this build doesn't know round-trips as
+                // `UNRECOGNIZED` rather than being flattened, so the signer sees
+                // what the peer sent and can refuse it.
                 $0.transactionType = VSTransactionType(rawValue: transactionType) ?? .unspecified
             })
 

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignDoneView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignDoneView.swift
@@ -78,9 +78,13 @@ struct JoinKeysignDoneView: View {
                 coin: keysignPayload.coin,
                 amountCrypto: keysignPayload.toAmountWithTickerString,
                 amountFiat: keysignPayload.toSendAmountFiatString,
-                hero: LimitOrderCancelPresentation.hero(
-                    forSignedMemo: keysignPayload.memo
-                ) ?? viewModel.heroContent,
+                // An XRPL TrustSet carries the trust-line LIMIT in `toAmount`, so
+                // it has to claim the hero before the amount slot describes it as
+                // a transfer of that many tokens.
+                hero: RippleTrustSetPresentation.hero(for: keysignPayload)
+                    ?? LimitOrderCancelPresentation.hero(
+                        forSignedMemo: keysignPayload.memo
+                    ) ?? viewModel.heroContent,
                 hash: viewModel.txid,
                 explorerLink: viewModel.getTransactionExplorerURL(txid: viewModel.txid),
                 memo: viewModel.memo ?? "",

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import BigInt
+import VultisigCommonData
 import WalletCore
 
 struct SendCryptoVerifyLogic {
@@ -236,15 +237,40 @@ struct SendCryptoVerifyLogic {
     /// text; a `nil` tag leaves the field unset, keeping memo-only sends
     /// byte-identical for co-signers that don't read the field. No-op for
     /// non-Ripple.
-    static func dualWritingRippleTag(_ chainSpecific: BlockChainSpecific, tag: UInt32?) -> BlockChainSpecific {
-        guard case .Ripple(let sequence, let gas, let lastLedgerSequence, _) = chainSpecific else {
+    ///
+    /// `transactionType` rides the same seam because it answers a different
+    /// question about the same payload — WHICH XRPL operation to build. A
+    /// non-native Ripple coin alone cannot distinguish "open a trust line"
+    /// (TrustSet, amount = limit) from "send this token" (Payment with a
+    /// `CurrencyAmount`), so the discriminator has to be on the wire. Passing
+    /// `.unspecified` (the default) leaves the field off the wire, so native XRP
+    /// and pre-existing flows produce byte-identical payloads.
+    /// The only XRPL operation discriminator this flow is allowed to put on the
+    /// wire. `SendTransaction.transactionType` is a shared field other chains
+    /// populate with their own operations (`tonDeposit`, `thorMerge`, …); a
+    /// value like that leaking into `RippleSpecific.transaction_type` would tell
+    /// every co-signer something untrue about the XRPL operation. Narrow it to
+    /// the one XRPL value, so anything else — including a future enum case this
+    /// build predates — falls back to `.unspecified` and keeps the legacy
+    /// interpretation.
+    static func rippleTransactionType(tx: SendTransaction) -> VSTransactionType {
+        tx.transactionType == .rippleTrustSet ? .rippleTrustSet : .unspecified
+    }
+
+    static func dualWritingRippleTag(
+        _ chainSpecific: BlockChainSpecific,
+        tag: UInt32?,
+        transactionType: VSTransactionType = .unspecified
+    ) -> BlockChainSpecific {
+        guard case .Ripple(let sequence, let gas, let lastLedgerSequence, _, _) = chainSpecific else {
             return chainSpecific
         }
         return .Ripple(
             sequence: sequence,
             gas: gas,
             lastLedgerSequence: lastLedgerSequence,
-            destinationTag: tag
+            destinationTag: tag,
+            transactionType: transactionType.rawValue
         )
     }
 
@@ -260,7 +286,11 @@ struct SendCryptoVerifyLogic {
             // is the ultimate gate on the tag/memo pair.
             let memo = Self.payloadMemo(tx: tx)
             if tx.coin.chain == .ripple {
-                chainSpecific = Self.dualWritingRippleTag(chainSpecific, tag: tx.destinationTag)
+                chainSpecific = Self.dualWritingRippleTag(
+                    chainSpecific,
+                    tag: tx.destinationTag,
+                    transactionType: Self.rippleTransactionType(tx: tx)
+                )
             }
 
             let basePayload = try await interactor.buildKeysignPayload(

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -85,6 +85,27 @@ struct SendCryptoVerifyLogic {
     }
 
     func validateBalanceWithFee(tx: SendTransaction) -> BalanceValidationResult {
+        // An XRPL TrustSet's amount is the trust-line LIMIT, not a transfer, so
+        // comparing it to the token balance is meaningless — every activation
+        // would fail as "balance exceeded" against a zero balance, which is
+        // exactly the state a trust line is being opened to leave. What must be
+        // affordable is the XRP the operation really costs: the owner reserve it
+        // locks up plus the fee. The activation sheet quotes both live from
+        // `server_state` and blocks there, and the on-ledger
+        // `tecINSUFFICIENT_RESERVE` remains the backstop; the generic native-gas
+        // check below is what applies here.
+        if tx.coin.chain == .ripple, tx.transactionType == .rippleTrustSet {
+            guard let nativeToken = tx.vault.coins.nativeCoin(chain: .ripple) else {
+                return BalanceValidationResult(isValid: true, errorMessage: nil)
+            }
+            let nativeBalance = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
+            if tx.fee > nativeBalance {
+                let errorMessage = String(format: "insufficientGasTokenError".localized, nativeToken.ticker, tx.coin.ticker)
+                return BalanceValidationResult(isValid: false, errorMessage: errorMessage)
+            }
+            return BalanceValidationResult(isValid: true, errorMessage: nil)
+        }
+
         let amount = tx.amountInRaw
         let balance = tx.coin.rawBalance.toBigInt(decimals: tx.coin.decimals)
         // TRON staking operations: skip balance validation entirely
@@ -185,6 +206,16 @@ struct SendCryptoVerifyLogic {
     /// the keysign ceremony, with the fee burned. Gate it here so the failure
     /// surfaces before signing starts; no-op for every other chain. Matches
     /// the guard the SDK and Android run at submit time.
+    ///
+    /// ⚠️ The `isNativeToken` gate is deliberate and must NOT be widened to
+    /// issued-currency coins. The rule it enforces is "an account is created by
+    /// receiving at least the base reserve **in XRP**" — an issued-currency
+    /// Payment delivers no XRP at all, so it can neither create the destination
+    /// nor satisfy that minimum, and applying the check would reject every token
+    /// send to an unfunded account with a message about an XRP amount the
+    /// transaction does not carry. A token send to an account that cannot receive
+    /// is caught by `validateDestinationTrustLineIfNeeded` instead, which tests
+    /// the thing that actually applies: the trust line.
     func validateDestinationIfNeeded(tx: SendTransaction) async throws {
         guard tx.coin.chain == .ripple, tx.coin.isNativeToken else { return }
         do {
@@ -204,6 +235,38 @@ struct SendCryptoVerifyLogic {
             // `buildKeysignPayload` — or the guard would block silently.
             throw HelperError.runtimeError(error.localizedDescription)
         }
+    }
+
+    /// Pre-ceremony guard for an XRPL issued-currency Payment: the destination
+    /// must hold a trust line for the currency, or the Payment fails on-ledger
+    /// (`tecPATH_DRY` / `tecNO_LINE`) after the ceremony with the fee burned.
+    ///
+    /// FAIL OPEN, matching `validateDestinationIfNeeded`: it blocks only on
+    /// positive proof the destination cannot receive. A transport failure, a node
+    /// error or an unreadable response leaves the send to proceed — a lookup we
+    /// couldn't complete must never start blocking a send that worked before this
+    /// guard existed.
+    ///
+    /// No-op for native XRP (which has no trust line) and for a TrustSet (which
+    /// has no destination at all).
+    func validateDestinationTrustLineIfNeeded(tx: SendTransaction) async throws {
+        guard tx.coin.chain == .ripple,
+              !tx.coin.isNativeToken,
+              tx.transactionType != .rippleTrustSet else {
+            return
+        }
+
+        let state = await rippleService.destinationTrustLine(
+            for: tx.coin.toCoinMeta(),
+            destination: tx.toAddress
+        )
+        guard state == .noTrustLine else { return }
+
+        // The Verify screen's alert plumbing presents only `HelperError`, so
+        // rewrap — same convention as `validateDestinationIfNeeded`.
+        throw HelperError.runtimeError(
+            String(format: "xrpDestinationNoTrustLineError".localized, tx.coin.ticker)
+        )
     }
 
     // MARK: - Keysign Payload

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -89,19 +89,17 @@ struct SendCryptoVerifyLogic {
         // comparing it to the token balance is meaningless — every activation
         // would fail as "balance exceeded" against a zero balance, which is
         // exactly the state a trust line is being opened to leave. What must be
-        // affordable is the XRP the operation really costs: the owner reserve it
-        // locks up plus the fee. The activation sheet quotes both live from
-        // `server_state` and blocks there, and the on-ledger
-        // `tecINSUFFICIENT_RESERVE` remains the backstop; the generic native-gas
-        // check below is what applies here.
+        // affordable is the XRP the operation really costs; that is the async
+        // `validateTrustLineReserveIfNeeded`, which reads the live owner reserve.
+        // This synchronous pass only rules out the case that needs no network:
+        // no XRP coin at all.
         if tx.coin.chain == .ripple, tx.transactionType == .rippleTrustSet {
-            guard let nativeToken = tx.vault.coins.nativeCoin(chain: .ripple) else {
-                return BalanceValidationResult(isValid: true, errorMessage: nil)
-            }
-            let nativeBalance = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
-            if tx.fee > nativeBalance {
-                let errorMessage = String(format: "insufficientGasTokenError".localized, nativeToken.ticker, tx.coin.ticker)
-                return BalanceValidationResult(isValid: false, errorMessage: errorMessage)
+            guard tx.vault.coins.nativeCoin(chain: .ripple) != nil else {
+                // A trust line is an object OWNED BY an XRP account and paid for
+                // out of its reserve; without one there is nothing to attach it
+                // to and nothing to pay the fee. Fail closed — an absent coin is
+                // not a reason to let the ceremony start.
+                return BalanceValidationResult(isValid: false, errorMessage: "rippleTrustLineNoXrpAccountError")
             }
             return BalanceValidationResult(isValid: true, errorMessage: nil)
         }
@@ -266,6 +264,49 @@ struct SendCryptoVerifyLogic {
         // rewrap — same convention as `validateDestinationIfNeeded`.
         throw HelperError.runtimeError(
             String(format: "xrpDestinationNoTrustLineError".localized, tx.coin.ticker)
+        )
+    }
+
+    /// Pre-ceremony guard for a TrustSet: spendable XRP must cover the owner
+    /// reserve the new trust line locks up PLUS the fee, or the TrustSet fails
+    /// on-ledger with `tecINSUFFICIENT_RESERVE` after the ceremony, with the fee
+    /// already burned.
+    ///
+    /// The activation sheet quotes the same figures, but that quote is taken when
+    /// the sheet opens. This re-checks at Verify against the freshly loaded
+    /// balance and fee, so a balance that moved in between — a concurrent send, a
+    /// stale reading, or a `SendTransaction` built somewhere other than the sheet
+    /// — cannot walk past it.
+    ///
+    /// The reserve increment is read LIVE (`server_state` → cache → seed), never
+    /// hardcoded, so this and the sheet can never present different arithmetic.
+    /// No-op for every non-TrustSet transaction.
+    func validateTrustLineReserveIfNeeded(tx: SendTransaction) async throws {
+        guard tx.coin.chain == .ripple, tx.transactionType == .rippleTrustSet else { return }
+
+        guard let nativeToken = tx.vault.coins.nativeCoin(chain: .ripple) else {
+            throw HelperError.runtimeError("rippleTrustLineNoXrpAccountError".localized)
+        }
+
+        let reserveValues = try? await rippleService.fetchReserveValues()
+        // `reserve_base` is excluded: the account already exists and already
+        // meets it. What this operation adds is exactly one owner increment.
+        let ownerReserve = RippleReserve.reservedDrops(
+            ownerCount: 1,
+            reserveBase: 0,
+            reserveInc: reserveValues?.reserveInc
+        )
+        // The XRP balance is already reserve-net, so it is what can actually be
+        // locked up and spent.
+        let spendable = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
+        let required = ownerReserve + tx.fee
+        guard spendable < required else { return }
+
+        throw HelperError.runtimeError(
+            String(
+                format: "rippleTrustLineInsufficientXrpError".localized,
+                RippleReserve.xrpAmount(drops: required)
+            )
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -181,6 +181,10 @@ class SendCryptoVerifyViewModel: ObservableObject {
             // trust line for that currency fails on-ledger after the ceremony.
             // Same load pass, same fail-open posture.
             try await logic.validateDestinationTrustLineIfNeeded(tx: transaction)
+            // A TrustSet must be able to afford the owner reserve it locks up.
+            // Re-checked here against the freshly loaded balance and fee, not
+            // just when the activation sheet quoted it.
+            try await logic.validateTrustLineReserveIfNeeded(tx: transaction)
         } catch is CancellationError {
             // Propagate — a cancelled load must abort the whole load pass (its
             // caller returns without running post-load work), not be swallowed
@@ -240,6 +244,7 @@ class SendCryptoVerifyViewModel: ObservableObject {
 
         try await logic.validateDestinationIfNeeded(tx: transaction)
         try await logic.validateDestinationTrustLineIfNeeded(tx: transaction)
+        try await logic.validateTrustLineReserveIfNeeded(tx: transaction)
         try await logic.validateUtxosIfNeeded(tx: transaction)
         let keysignPayload = try await logic.buildKeysignPayload(tx: transaction, vault: transaction.vault)
         return keysignPayload

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -177,6 +177,10 @@ class SendCryptoVerifyViewModel: ObservableObject {
         guard prebuiltKeysignPayload == nil, !hasBalanceError else { return }
         do {
             try await logic.validateDestinationIfNeeded(tx: transaction)
+            // Issued-currency counterpart: a token Payment to an account with no
+            // trust line for that currency fails on-ledger after the ceremony.
+            // Same load pass, same fail-open posture.
+            try await logic.validateDestinationTrustLineIfNeeded(tx: transaction)
         } catch is CancellationError {
             // Propagate — a cancelled load must abort the whole load pass (its
             // caller returns without running post-load work), not be swallowed
@@ -235,6 +239,7 @@ class SendCryptoVerifyViewModel: ObservableObject {
         }
 
         try await logic.validateDestinationIfNeeded(tx: transaction)
+        try await logic.validateDestinationTrustLineIfNeeded(tx: transaction)
         try await logic.validateUtxosIfNeeded(tx: transaction)
         let keysignPayload = try await logic.buildKeysignPayload(tx: transaction, vault: transaction.vault)
         return keysignPayload

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDoneScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDoneScreen.swift
@@ -54,7 +54,10 @@ struct SendDoneScreen: View {
             coin: tx.coin,
             amountCrypto: "\(tx.amount) \(tx.coin.ticker)",
             amountFiat: tx.amountInFiat,
-            hero: LimitOrderCancelPresentation.hero(for: tx),
+            // A TrustSet's amount IS the trust-line limit, so it has to claim the
+            // hero before the amount slot renders it as a transfer.
+            hero: RippleTrustSetPresentation.hero(for: tx)
+                ?? LimitOrderCancelPresentation.hero(for: tx),
             hash: hash,
             explorerLink: ExplorerLinkBuilder.getExplorerURL(chain: chain, txid: hash),
             memo: tx.memo,

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
@@ -7,6 +7,7 @@
 
 import SwiftData
 import SwiftUI
+import VultisigCommonData
 
 struct SendVerifyScreen: View {
     @StateObject private var sendCryptoVerifyViewModel: SendCryptoVerifyViewModel
@@ -118,7 +119,8 @@ struct SendVerifyScreen: View {
                 amount: tx.amount,
                 amountFiat: sendCryptoVerifyViewModel.amountFiat,
                 coinTicker: tx.coin.ticker,
-                keysignPayload: sendCryptoVerifyViewModel.verifyKeysignPayload
+                keysignPayload: sendCryptoVerifyViewModel.verifyKeysignPayload,
+                rippleTrustSet: RippleTrustSetPresentation.display(for: tx)
             ),
             securityScannerState: $sendCryptoVerifyViewModel.securityScannerState
         ) {
@@ -136,12 +138,26 @@ struct SendVerifyScreen: View {
 
     var checkboxes: some View {
         VStack(spacing: 16) {
-            Checkbox(isChecked: $sendCryptoVerifyViewModel.isAmountCorrect, text: "correctAmountCheck")
-            Checkbox(isChecked: $sendCryptoVerifyViewModel.isAddressCorrect, text: "sendingRightAddressCheck")
+            // An XRPL TrustSet sends nothing to anyone, so "the amount is
+            // correct" / "I'm sending to the right address" are both false
+            // framings. What the user is confirming is the limit and the issuer.
+            if isRippleTrustSet {
+                Checkbox(isChecked: $sendCryptoVerifyViewModel.isAmountCorrect, text: "rippleTrustLineLimitCheck")
+                Checkbox(isChecked: $sendCryptoVerifyViewModel.isAddressCorrect, text: "rippleTrustLineIssuerCheck")
+            } else {
+                Checkbox(isChecked: $sendCryptoVerifyViewModel.isAmountCorrect, text: "correctAmountCheck")
+                Checkbox(isChecked: $sendCryptoVerifyViewModel.isAddressCorrect, text: "sendingRightAddressCheck")
+            }
             if sendCryptoVerifyViewModel.isApproveRequired {
                 Checkbox(isChecked: $sendCryptoVerifyViewModel.isApproveCorrect, text: "yieldVerifyApproveCheck")
             }
         }
+    }
+
+    /// Read off the transaction rather than the payload: the payload is only built
+    /// on confirm, and the checkboxes have to be right from the first render.
+    private var isRippleTrustSet: Bool {
+        tx.coin.chain == .ripple && tx.transactionType == .rippleTrustSet
     }
 
     func onSignPress() {

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendVerifyScreen.swift
@@ -120,7 +120,7 @@ struct SendVerifyScreen: View {
                 amountFiat: sendCryptoVerifyViewModel.amountFiat,
                 coinTicker: tx.coin.ticker,
                 keysignPayload: sendCryptoVerifyViewModel.verifyKeysignPayload,
-                rippleTrustSet: RippleTrustSetPresentation.display(for: tx)
+                rippleTrustSet: RippleTrustSetPresentation.state(for: tx)
             ),
             securityScannerState: $sendCryptoVerifyViewModel.securityScannerState
         ) {

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummary.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummary.swift
@@ -58,13 +58,13 @@ struct SendCryptoVerifySummary {
     /// Empty by default, so no existing construction site changes.
     let additionalRows: [SendCryptoVerifySummaryRow]
 
-    /// XRPL trust-line rows for the INITIATOR, whose Verify screen renders before
-    /// a keysign payload exists (it is built on confirm). A co-signer needs
-    /// nothing here — the view derives the same rows from the payload it holds,
-    /// and that derivation WINS whenever a payload is present, so what a peer
-    /// device reads always comes from the thing it will sign. `nil` everywhere
-    /// else.
-    let rippleTrustSet: RippleTrustSetPresentation.Display?
+    /// XRPL trust-line render state for the INITIATOR, whose Verify screen
+    /// renders before a keysign payload exists (it is built on confirm). A
+    /// co-signer needs nothing here — the view derives the same state from the
+    /// payload it holds, and that derivation WINS whenever the payload is a
+    /// TrustSet, so what a peer device reads always comes from the thing it will
+    /// sign. `.notTrustSet` everywhere else.
+    let rippleTrustSet: RippleTrustSetPresentation.State
 
     init(
         fromName: String,
@@ -93,7 +93,7 @@ struct SendCryptoVerifySummary {
         vault: Vault? = nil,
         dappMetadata: DAppMetadata? = nil,
         additionalRows: [SendCryptoVerifySummaryRow] = [],
-        rippleTrustSet: RippleTrustSetPresentation.Display? = nil
+        rippleTrustSet: RippleTrustSetPresentation.State = .notTrustSet
     ) {
         self.fromName = fromName
         self.fromAddress = fromAddress

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummary.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummary.swift
@@ -58,6 +58,14 @@ struct SendCryptoVerifySummary {
     /// Empty by default, so no existing construction site changes.
     let additionalRows: [SendCryptoVerifySummaryRow]
 
+    /// XRPL trust-line rows for the INITIATOR, whose Verify screen renders before
+    /// a keysign payload exists (it is built on confirm). A co-signer needs
+    /// nothing here — the view derives the same rows from the payload it holds,
+    /// and that derivation WINS whenever a payload is present, so what a peer
+    /// device reads always comes from the thing it will sign. `nil` everywhere
+    /// else.
+    let rippleTrustSet: RippleTrustSetPresentation.Display?
+
     init(
         fromName: String,
         fromAddress: String,
@@ -84,7 +92,8 @@ struct SendCryptoVerifySummary {
         tokenDisplayIsUnlimited: Bool = false,
         vault: Vault? = nil,
         dappMetadata: DAppMetadata? = nil,
-        additionalRows: [SendCryptoVerifySummaryRow] = []
+        additionalRows: [SendCryptoVerifySummaryRow] = [],
+        rippleTrustSet: RippleTrustSetPresentation.Display? = nil
     ) {
         self.fromName = fromName
         self.fromAddress = fromAddress
@@ -111,6 +120,7 @@ struct SendCryptoVerifySummary {
         self.vault = vault
         self.dappMetadata = dappMetadata
         self.additionalRows = additionalRows
+        self.rippleTrustSet = rippleTrustSet
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -64,15 +64,33 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
             }
             .showIf(input.fromAddress.isNotEmpty)
 
-            Group {
-                getValueCell(
-                    for: "to",
-                    with: input.toAlias ?? input.toAddress,
-                    bracketValue: input.toAlias != nil ? input.toAddress : nil
-                )
-                Separator()
+            // An XRPL TrustSet opens a trust line: it has no destination and no
+            // transfer amount, so it gets its own rows instead of the Payment
+            // ones. A "to" row would name an account this transaction never pays,
+            // and an "amount" row would present a trust-line LIMIT as if funds
+            // were moving. Dispatched here — the one view both the initiator's
+            // Verify screen and a co-signer's Join screen render — so a peer
+            // device can never be shown Payment framing for a trust line.
+            if let trustSet = rippleTrustSet {
+                Group {
+                    getValueCell(for: "rippleTrustLineIssuer", with: trustSet.issuer)
+                    Separator()
+                    getValueCell(for: "rippleTrustLineCurrency", with: trustSet.ticker)
+                    Separator()
+                    getValueCell(for: "rippleTrustLineLimit", with: "\(trustSet.limitValue) \(trustSet.ticker)")
+                    Separator()
+                }
+            } else {
+                Group {
+                    getValueCell(
+                        for: "to",
+                        with: input.toAlias ?? input.toAddress,
+                        bracketValue: input.toAlias != nil ? input.toAddress : nil
+                    )
+                    Separator()
+                }
+                .showIf(input.toAddress.isNotEmpty)
             }
-            .showIf(input.toAddress.isNotEmpty)
 
             if shouldShowAmountRow, let tokenDisplay = input.tokenDisplay, !tokenDisplay.isEmpty {
                 getValueCell(
@@ -240,7 +258,18 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
 
     @ViewBuilder
     var heroHeader: some View {
-        if let hero = input.hero {
+        // Checked BEFORE `input.hero`: the Join screen derives its hero from a
+        // transaction simulation, which reads a TrustSet as an ordinary send. A
+        // co-signer must not be shown "You're sending <limit> <ticker>" for a
+        // transaction that moves nothing.
+        if let trustSet = rippleTrustSet {
+            // Nothing is being sent — a trust line is being opened.
+            Text(String(format: "rippleTrustLineHeroTitle".localized, trustSet.ticker))
+                .foregroundStyle(Theme.colors.textPrimary)
+                .font(Theme.fonts.bodyMMedium)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 8)
+        } else if let hero = input.hero {
             HeroContentView(content: hero)
                 .padding(.bottom, 8)
         } else if input.keysignPayload?.signSui != nil {
@@ -348,11 +377,26 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
         }
     }
 
+    /// Rows for an XRPL TrustSet.
+    ///
+    /// Derived from the KEYSIGN PAYLOAD whenever one is present, so a co-signer
+    /// reads the transaction it is about to sign rather than anything the
+    /// initiator claims about it. The `input` value is the initiator's Verify
+    /// screen, which renders before its payload is built.
+    var rippleTrustSet: RippleTrustSetPresentation.Display? {
+        RippleTrustSetPresentation.display(for: input.keysignPayload) ?? input.rippleTrustSet
+    }
+
     /// True when the hero doesn't already show a resolved amount/coin, so the
     /// "amount" detail row should render with the fallback `tokenDisplay` value.
     var shouldShowAmountRow: Bool {
         // signSui carries no to_amount; the value lives in the PTB bytes.
         if input.keysignPayload?.signSui != nil {
+            return false
+        }
+        // A TrustSet's amount IS the limit, rendered as its own labelled row.
+        // Showing it as "amount" would read as a transfer.
+        if rippleTrustSet != nil {
             return false
         }
         // signRipple carries the amount inside the raw JSON (and offers have no

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -71,14 +71,28 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
             // were moving. Dispatched here — the one view both the initiator's
             // Verify screen and a co-signer's Join screen render — so a peer
             // device can never be shown Payment framing for a trust line.
-            if let trustSet = rippleTrustSet {
+            if isRippleTrustSet {
                 Group {
-                    getValueCell(for: "rippleTrustLineIssuer", with: trustSet.issuer)
-                    Separator()
-                    getValueCell(for: "rippleTrustLineCurrency", with: trustSet.ticker)
-                    Separator()
-                    getValueCell(for: "rippleTrustLineLimit", with: "\(trustSet.limitValue) \(trustSet.ticker)")
-                    Separator()
+                    if let trustSet = rippleTrustSet {
+                        getValueCell(for: "rippleTrustLineIssuer", with: trustSet.issuer)
+                        Separator()
+                        getValueCell(for: "rippleTrustLineCurrency", with: trustSet.ticker)
+                        Separator()
+                        getValueCell(for: "rippleTrustLineLimit", with: "\(trustSet.limitValue) \(trustSet.ticker)")
+                        Separator()
+                    } else {
+                        // A TrustSet whose terms cannot be read. Say so instead of
+                        // borrowing the Payment rows, which would present the
+                        // limit as a transfer to `toAddress`. The signer refuses
+                        // these payloads as well, so this is a dead end by design.
+                        getValueCell(
+                            for: "rippleTrustLineUnreviewable",
+                            with: "rippleTrustLineUnreviewableValue".localized,
+                            isMultiLine: true,
+                            color: Theme.colors.alertError
+                        )
+                        Separator()
+                    }
                 }
             } else {
                 Group {
@@ -262,13 +276,18 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
         // transaction simulation, which reads a TrustSet as an ordinary send. A
         // co-signer must not be shown "You're sending <limit> <ticker>" for a
         // transaction that moves nothing.
-        if let trustSet = rippleTrustSet {
-            // Nothing is being sent — a trust line is being opened.
-            Text(String(format: "rippleTrustLineHeroTitle".localized, trustSet.ticker))
-                .foregroundStyle(Theme.colors.textPrimary)
-                .font(Theme.fonts.bodyMMedium)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.bottom, 8)
+        if isRippleTrustSet {
+            // Nothing is being sent — a trust line is being opened. When the
+            // terms are unreadable the header stays generic rather than naming a
+            // ticker we couldn't decode.
+            Text(
+                rippleTrustSet.map { String(format: "rippleTrustLineHeroTitle".localized, $0.ticker) }
+                    ?? "rippleTrustLineActivationTitle".localized
+            )
+            .foregroundStyle(Theme.colors.textPrimary)
+            .font(Theme.fonts.bodyMMedium)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 8)
         } else if let hero = input.hero {
             HeroContentView(content: hero)
                 .padding(.bottom, 8)
@@ -377,14 +396,28 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
         }
     }
 
-    /// Rows for an XRPL TrustSet.
+    /// Render state for an XRPL TrustSet.
     ///
-    /// Derived from the KEYSIGN PAYLOAD whenever one is present, so a co-signer
+    /// Taken from the KEYSIGN PAYLOAD whenever one is present, so a co-signer
     /// reads the transaction it is about to sign rather than anything the
-    /// initiator claims about it. The `input` value is the initiator's Verify
+    /// initiator claims about it. The `input` value covers the initiator's Verify
     /// screen, which renders before its payload is built.
+    var rippleTrustSetState: RippleTrustSetPresentation.State {
+        let fromPayload = RippleTrustSetPresentation.state(for: input.keysignPayload)
+        guard fromPayload == .notTrustSet else { return fromPayload }
+        return input.rippleTrustSet
+    }
+
+    /// Terms to render, when they can be read at all.
     var rippleTrustSet: RippleTrustSetPresentation.Display? {
-        RippleTrustSetPresentation.display(for: input.keysignPayload) ?? input.rippleTrustSet
+        guard case .reviewable(let display) = rippleTrustSetState else { return nil }
+        return display
+    }
+
+    /// True for ANY TrustSet, readable or not — the flag that must gate every
+    /// Payment-shaped row, so an unreviewable TrustSet can never borrow them.
+    var isRippleTrustSet: Bool {
+        rippleTrustSetState != .notTrustSet
     }
 
     /// True when the hero doesn't already show a resolved amount/coin, so the
@@ -394,9 +427,10 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
         if input.keysignPayload?.signSui != nil {
             return false
         }
-        // A TrustSet's amount IS the limit, rendered as its own labelled row.
-        // Showing it as "amount" would read as a transfer.
-        if rippleTrustSet != nil {
+        // A TrustSet's amount IS the limit, rendered as its own labelled row (or
+        // withheld when unreadable). Showing it as "amount" would read as a
+        // transfer.
+        if isRippleTrustSet {
             return false
         }
         // signRipple carries the amount inside the raw JSON (and offers have no

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -419,12 +419,18 @@ private extension ChainDetailScreen {
         navigateToAction(action: vaultAction)
     }
 
-    /// Opens the reserve-warning sheet and quotes the activation. Nothing is
+    /// Quotes the activation, THEN opens the reserve-warning sheet. Nothing is
     /// signed here — the cost has to be on screen first.
+    ///
+    /// The order matters for more than intent: the bottom-sheet container measures
+    /// its content once and pins the detent to that height, so presenting first and
+    /// filling in afterwards sizes the sheet to a spinner and clips the real
+    /// content. Quoting first means the sheet only ever renders a terminal state.
     func onActivateTrustLine(_ coin: Coin) {
-        coinToActivate = coin
+        guard !trustLineActivation.isLoading else { return }
         Task {
             await trustLineActivation.load(coin: coin, nativeCoin: nativeCoin)
+            coinToActivate = coin
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -33,6 +33,13 @@ struct ChainDetailScreen: View {
     @State private var addressCopyTask: Task<Void, Never>?
     @State private var coinDetailTask: Task<Void, Never>?
 
+    /// XRPL token awaiting trust-line activation, and the quote for it. The sheet
+    /// is the reserve warning: opening a line permanently raises the XRP
+    /// account's reserve floor, so it is never done without showing the cost and
+    /// the limit that will be signed.
+    @State private var coinToActivate: Coin?
+    @StateObject private var trustLineActivation = RippleTrustLineActivationViewModel()
+
     private let scrollReferenceId = "chainDetailScreenBottomContentId"
 
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
@@ -200,6 +207,21 @@ struct ChainDetailScreen: View {
                 coinToShow = nil
             }
         }
+        .bottomSheet(isPresented: Binding(
+            get: { coinToActivate != nil },
+            set: { if !$0 { coinToActivate = nil } }
+        )) {
+            RippleTrustLineActivationSheet(
+                viewModel: trustLineActivation,
+                coin: coinToActivate,
+                onActivate: {
+                    if let coin = coinToActivate {
+                        confirmTrustLineActivation(for: coin)
+                    }
+                },
+                onDismissRequest: { coinToActivate = nil }
+            )
+        }
         .onChange(of: coins) { _, _ in
             refresh()
         }
@@ -251,11 +273,12 @@ struct ChainDetailScreen: View {
             .frame(height: 42)
             .padding(.bottom, 16)
 
-            ChainDetailListView(viewModel: viewModel) {
-                coinToShow = $0
-            } onManageTokens: {
-                showManageTokens = true
-            }
+            ChainDetailListView(
+                viewModel: viewModel,
+                onPress: { coinToShow = $0 },
+                onManageTokens: { showManageTokens = true },
+                onActivate: onActivateTrustLine
+            )
             .background(
                 // Reference to scroll when search gets presented
                 VStack {}
@@ -394,6 +417,26 @@ private extension ChainDetailScreen {
         guard let vaultAction else { return }
 
         navigateToAction(action: vaultAction)
+    }
+
+    /// Opens the reserve-warning sheet and quotes the activation. Nothing is
+    /// signed here — the cost has to be on screen first.
+    func onActivateTrustLine(_ coin: Coin) {
+        coinToActivate = coin
+        Task {
+            await trustLineActivation.load(coin: coin, nativeCoin: nativeCoin)
+        }
+    }
+
+    /// The user accepted the reserve cost. Hand the TrustSet to the shared
+    /// verify → keysign flow, which is where the payload is built, reviewed and
+    /// signed like any other transaction. Details is skipped: a TrustSet has no
+    /// destination or amount for the user to fill in — the limit is fixed and the
+    /// sheet just showed it.
+    func confirmTrustLineActivation(for coin: Coin) {
+        guard let tx = trustLineActivation.makeActivationTransaction(coin: coin, vault: vault) else { return }
+        coinToActivate = nil
+        router.navigate(to: SendRoute.verify(tx: tx, retrySignal: SendRetrySignal(), vault: vault))
     }
 
     func onCopy() {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ChainDetailScreen.swift
@@ -207,19 +207,22 @@ struct ChainDetailScreen: View {
                 coinToShow = nil
             }
         }
-        .bottomSheet(isPresented: Binding(
+        .crossPlatformSheet(isPresented: Binding(
             get: { coinToActivate != nil },
             set: { if !$0 { coinToActivate = nil } }
         )) {
             RippleTrustLineActivationSheet(
                 viewModel: trustLineActivation,
                 coin: coinToActivate,
+                isPresented: Binding(
+                    get: { coinToActivate != nil },
+                    set: { if !$0 { coinToActivate = nil } }
+                ),
                 onActivate: {
                     if let coin = coinToActivate {
                         confirmTrustLineActivation(for: coin)
                     }
-                },
-                onDismissRequest: { coinToActivate = nil }
+                }
             )
         }
         .onChange(of: coins) { _, _ in
@@ -427,7 +430,10 @@ private extension ChainDetailScreen {
     /// filling in afterwards sizes the sheet to a spinner and clips the real
     /// content. Quoting first means the sheet only ever renders a terminal state.
     func onActivateTrustLine(_ coin: Coin) {
-        guard !trustLineActivation.isLoading else { return }
+        // Claim the slot synchronously. Checking `isLoading` here instead would
+        // race: `load` only raises it after its task starts, so two taps in one
+        // runloop turn would both proceed and their quotes would interleave.
+        guard trustLineActivation.beginLoading() else { return }
         Task {
             await trustLineActivation.load(coin: coin, nativeCoin: nativeCoin)
             coinToActivate = coin

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/ChainDetailListView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/ChainDetailListView.swift
@@ -11,6 +11,9 @@ struct ChainDetailListView: View {
     @ObservedObject var viewModel: ChainDetailViewModel
     var onPress: (Coin) -> Void
     var onManageTokens: () -> Void
+    /// Invoked for an XRPL token with no trust line. `nil` on chains that have no
+    /// activation step.
+    var onActivate: ((Coin) -> Void)?
 
     var body: some View {
         if viewModel.filteredTokens.isEmpty {
@@ -26,15 +29,25 @@ struct ChainDetailListView: View {
                 Button {
                     onPress(token)
                 } label: {
-                    TokenCellView(coin: token)
-                        .commonListItemContainer(
-                            index: index,
-                            itemsCount: viewModel.filteredTokens.count
-                        )
+                    TokenCellView(
+                        coin: token,
+                        onActivate: activateAction(for: token)
+                    )
+                    .commonListItemContainer(
+                        index: index,
+                        itemsCount: viewModel.filteredTokens.count
+                    )
                 }
             }
         }
         .commonListContainer()
+    }
+
+    /// The activation closure for a row, or `nil` when the row should render a
+    /// balance as usual. Resolved here so the cell stays a dumb renderer.
+    private func activateAction(for token: Coin) -> (() -> Void)? {
+        guard let onActivate, viewModel.needsTrustLine(token) else { return nil }
+        return { onActivate(token) }
     }
 
     var addTokensView: some View {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
@@ -30,14 +30,16 @@ struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
         }
     }
 
+    /// The sheet is only presented once the quote has resolved, so this renders a
+    /// terminal state and its height never changes after the first layout pass.
+    /// That is load-bearing: the bottom-sheet container measures its content once
+    /// and pins the detent to that height, so a sheet that grows after being
+    /// presented gets clipped rather than resized.
     private func content(coin: Coin) -> some View {
         VStack(spacing: 24) {
             header(coin: coin)
 
-            if viewModel.isLoading {
-                ProgressView()
-                    .frame(maxWidth: .infinity)
-            } else if let errorMessage = viewModel.errorMessage {
+            if let errorMessage = viewModel.errorMessage {
                 Text(errorMessage)
                     .foregroundStyle(Theme.colors.alertError)
                     .font(Theme.fonts.bodySMedium)
@@ -73,11 +75,35 @@ struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
             row("rippleTrustLineSpendableAfter", value: viewModel.remainingSpendableXRP, ticker: "XRP")
             // The signed limit. Shown without a ticker suffix ambiguity: it is
             // denominated in the token, not in XRP.
-            row("rippleTrustLineLimit", value: viewModel.quote?.limitValue, ticker: coin.ticker)
-            row("rippleTrustLineIssuer", value: viewModel.quote?.issuer, ticker: nil, truncates: true)
+            row("rippleTrustLineLimit", value: viewModel.limitDisplay, ticker: coin.ticker)
+            issuerRow
         }
         .padding(16)
         .background(RoundedRectangle(cornerRadius: 12).fill(Theme.colors.bgSurface2))
+    }
+
+    /// The issuer gets its own full-width line rather than sharing one with its
+    /// label. An XRPL issuer address is 25–35 characters and only just overflows
+    /// a shared row, so a side-by-side layout truncates a couple of characters
+    /// while adding an ellipsis — hiding exactly the detail the row exists to let
+    /// the user check, and hiding it in the middle where lookalike issuers differ.
+    @ViewBuilder
+    private var issuerRow: some View {
+        if let issuer = viewModel.quote?.issuer {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("rippleTrustLineIssuer".localized)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .font(Theme.fonts.bodySMedium)
+
+                Text(issuer)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .font(Theme.fonts.priceBodyS)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 
     @ViewBuilder
@@ -105,7 +131,7 @@ struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
     }
 
     @ViewBuilder
-    private func row(_ title: String, value: String?, ticker: String?, truncates: Bool = false) -> some View {
+    private func row(_ title: String, value: String?, ticker: String?) -> some View {
         if let value {
             HStack(spacing: 8) {
                 Text(title.localized)
@@ -116,7 +142,7 @@ struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
                     .foregroundStyle(Theme.colors.textPrimary)
                     .font(Theme.fonts.priceBodyS)
                     .lineLimit(1)
-                    .truncationMode(truncates ? .middle : .tail)
+                    .minimumScaleFactor(0.8)
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
@@ -16,13 +16,13 @@ import SwiftUI
 /// It also shows the trust-line LIMIT that will be signed. The limit is what the
 /// TrustSet actually commits to, and a signed value the user never saw is a
 /// value they cannot object to.
-struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
+struct RippleTrustLineActivationSheet: View {
     @ObservedObject var viewModel: RippleTrustLineActivationViewModel
     /// Optional so the presenting binding and the content can be driven by the
     /// same `@State` without the sheet body having to exist before a coin does.
     let coin: Coin?
+    @Binding var isPresented: Bool
     let onActivate: () -> Void
-    let onDismissRequest: () -> Void
 
     var body: some View {
         if let coin {
@@ -30,25 +30,34 @@ struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
         }
     }
 
-    /// The sheet is only presented once the quote has resolved, so this renders a
-    /// terminal state and its height never changes after the first layout pass.
-    /// That is load-bearing: the bottom-sheet container measures its content once
-    /// and pins the detent to that height, so a sheet that grows after being
-    /// presented gets clipped rather than resized.
     private func content(coin: Coin) -> some View {
-        VStack(spacing: 24) {
-            header(coin: coin)
+        Screen {
+            VStack(spacing: 24) {
+                header(coin: coin)
 
-            if let errorMessage = viewModel.errorMessage {
-                Text(errorMessage)
-                    .foregroundStyle(Theme.colors.alertError)
-                    .font(Theme.fonts.bodySMedium)
-                    .multilineTextAlignment(.center)
-            } else if viewModel.quote != nil {
-                costRows(coin: coin)
-                blockingMessage
-                actions
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .foregroundStyle(Theme.colors.alertError)
+                        .font(Theme.fonts.bodySMedium)
+                        .multilineTextAlignment(.center)
+                } else if viewModel.quote != nil {
+                    costRows(coin: coin)
+                    blockingMessage
+                    Spacer()
+                    actions
+                }
             }
+        }
+        // iOS dismisses by swipe; macOS has no drag affordance, so it needs an
+        // explicit close, matching every other sheet in the app.
+        .crossPlatformToolbar(showsBackButton: false) {
+            #if os(macOS)
+                CustomToolbarItem(placement: .leading) {
+                    ToolbarButton(image: .xmark) {
+                        isPresented = false
+                    }
+                }
+            #endif
         }
     }
 
@@ -76,34 +85,13 @@ struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
             // The signed limit. Shown without a ticker suffix ambiguity: it is
             // denominated in the token, not in XRP.
             row("rippleTrustLineLimit", value: viewModel.limitDisplay, ticker: coin.ticker)
-            issuerRow
+            // Middle truncation: an issuer's leading and trailing characters are
+            // what distinguish it from a lookalike, so the ellipsis belongs in
+            // the middle rather than at the end.
+            row("rippleTrustLineIssuer", value: viewModel.quote?.issuer, ticker: nil, truncatesInMiddle: true)
         }
         .padding(16)
         .background(RoundedRectangle(cornerRadius: 12).fill(Theme.colors.bgSurface2))
-    }
-
-    /// The issuer gets its own full-width line rather than sharing one with its
-    /// label. An XRPL issuer address is 25–35 characters and only just overflows
-    /// a shared row, so a side-by-side layout truncates a couple of characters
-    /// while adding an ellipsis — hiding exactly the detail the row exists to let
-    /// the user check, and hiding it in the middle where lookalike issuers differ.
-    @ViewBuilder
-    private var issuerRow: some View {
-        if let issuer = viewModel.quote?.issuer {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("rippleTrustLineIssuer".localized)
-                    .foregroundStyle(Theme.colors.textTertiary)
-                    .font(Theme.fonts.bodySMedium)
-
-                Text(issuer)
-                    .foregroundStyle(Theme.colors.textPrimary)
-                    .font(Theme.fonts.priceBodyS)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
     }
 
     @ViewBuilder
@@ -116,22 +104,20 @@ struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
         }
     }
 
+    /// No Cancel button: the sheet is dismissible by swipe on iOS and by the
+    /// toolbar close on macOS, so a third way out is redundant chrome.
     private var actions: some View {
-        VStack(spacing: 8) {
-            PrimaryButton(title: "rippleTrustLineActivateAction".localized, action: onActivate)
-                .disabled(!viewModel.canActivate)
-
-            Button("cancel".localized, action: onDismissRequest)
-                .frame(height: 42, alignment: .center)
-                .foregroundStyle(Theme.colors.textButtonDisabled)
-                .font(Theme.fonts.caption10)
-                .frame(maxWidth: .infinity)
-                .buttonStyle(.plain)
-        }
+        PrimaryButton(title: "rippleTrustLineActivateAction".localized, action: onActivate)
+            .disabled(!viewModel.canActivate)
     }
 
     @ViewBuilder
-    private func row(_ title: String, value: String?, ticker: String?) -> some View {
+    private func row(
+        _ title: String,
+        value: String?,
+        ticker: String?,
+        truncatesInMiddle: Bool = false
+    ) -> some View {
         if let value {
             HStack(spacing: 8) {
                 Text(title.localized)
@@ -142,7 +128,7 @@ struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
                     .foregroundStyle(Theme.colors.textPrimary)
                     .font(Theme.fonts.priceBodyS)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.8)
+                    .truncationMode(truncatesInMiddle ? .middle : .tail)
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
@@ -33,17 +33,29 @@ struct RippleTrustLineActivationSheet: View {
     private func content(coin: Coin) -> some View {
         Screen {
             VStack(spacing: 24) {
-                header(coin: coin)
+                // Scrolls rather than clips. A half-height detent is ample for the
+                // usual row set, but the blocking message wraps and the whole
+                // sheet grows with Dynamic Type — and a reserve cost the user
+                // cannot read is the one thing this sheet must never produce.
+                ScrollView {
+                    VStack(spacing: 24) {
+                        header(coin: coin)
 
-                if let errorMessage = viewModel.errorMessage {
-                    Text(errorMessage)
-                        .foregroundStyle(Theme.colors.alertError)
-                        .font(Theme.fonts.bodySMedium)
-                        .multilineTextAlignment(.center)
-                } else if viewModel.quote != nil {
-                    costRows(coin: coin)
-                    blockingMessage
-                    Spacer()
+                        if let errorMessage = viewModel.errorMessage {
+                            Text(errorMessage)
+                                .foregroundStyle(Theme.colors.alertError)
+                                .font(Theme.fonts.bodySMedium)
+                                .multilineTextAlignment(.center)
+                        } else if viewModel.quote != nil {
+                            costRows(coin: coin)
+                            blockingMessage
+                        }
+                    }
+                }
+                .scrollBounceBehavior(.basedOnSize)
+
+                // Pinned: the primary action stays reachable without scrolling to it.
+                if viewModel.quote != nil, viewModel.errorMessage == nil {
                     actions
                 }
             }
@@ -59,6 +71,11 @@ struct RippleTrustLineActivationSheet: View {
                 }
             #endif
         }
+        // A short, fixed row set — a half-height sheet fits it without the empty
+        // expanse `.large` would leave. The drag indicator comes with it, which
+        // is the affordance that makes swipe-to-dismiss discoverable now that
+        // there is no Cancel button.
+        .sheetStyle(detents: [.medium])
     }
 
     private func header(coin: Coin) -> some View {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
@@ -1,0 +1,123 @@
+//
+//  RippleTrustLineActivationSheet.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Reserve warning shown before opening an XRPL trust line.
+///
+/// Opening a line is a signed on-ledger operation with a real, permanent cost:
+/// it raises the XRP account's reserve floor by one owner-reserve increment for
+/// as long as the line exists. That increment is a validator-voted network
+/// parameter read live from `server_state`, so the figure here is whatever the
+/// network currently says rather than a number baked into the app.
+///
+/// It also shows the trust-line LIMIT that will be signed. The limit is what the
+/// TrustSet actually commits to, and a signed value the user never saw is a
+/// value they cannot object to.
+struct RippleTrustLineActivationSheet: View, BottomSheetProperties {
+    @ObservedObject var viewModel: RippleTrustLineActivationViewModel
+    /// Optional so the presenting binding and the content can be driven by the
+    /// same `@State` without the sheet body having to exist before a coin does.
+    let coin: Coin?
+    let onActivate: () -> Void
+    let onDismissRequest: () -> Void
+
+    var body: some View {
+        if let coin {
+            content(coin: coin)
+        }
+    }
+
+    private func content(coin: Coin) -> some View {
+        VStack(spacing: 24) {
+            header(coin: coin)
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+            } else if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .foregroundStyle(Theme.colors.alertError)
+                    .font(Theme.fonts.bodySMedium)
+                    .multilineTextAlignment(.center)
+            } else if viewModel.quote != nil {
+                costRows(coin: coin)
+                blockingMessage
+                actions
+            }
+        }
+    }
+
+    private func header(coin: Coin) -> some View {
+        VStack(spacing: 12) {
+            Icon(.triangleWarning, color: Theme.colors.alertWarning, size: 24)
+
+            Text("rippleTrustLineActivationTitle".localized)
+                .foregroundStyle(Theme.colors.textPrimary)
+                .font(Theme.fonts.title2)
+                .multilineTextAlignment(.center)
+
+            Text(String(format: "rippleTrustLineActivationSubtitle".localized, coin.ticker))
+                .foregroundStyle(Theme.colors.textTertiary)
+                .font(Theme.fonts.bodySMedium)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private func costRows(coin: Coin) -> some View {
+        VStack(spacing: 12) {
+            row("rippleTrustLineOwnerReserve", value: viewModel.ownerReserveXRP, ticker: "XRP")
+            row("estNetworkFee", value: viewModel.feeXRP, ticker: "XRP")
+            row("rippleTrustLineSpendableAfter", value: viewModel.remainingSpendableXRP, ticker: "XRP")
+            // The signed limit. Shown without a ticker suffix ambiguity: it is
+            // denominated in the token, not in XRP.
+            row("rippleTrustLineLimit", value: viewModel.quote?.limitValue, ticker: coin.ticker)
+            row("rippleTrustLineIssuer", value: viewModel.quote?.issuer, ticker: nil, truncates: true)
+        }
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Theme.colors.bgSurface2))
+    }
+
+    @ViewBuilder
+    private var blockingMessage: some View {
+        if let insufficientXRPMessage = viewModel.insufficientXRPMessage {
+            Text(insufficientXRPMessage)
+                .foregroundStyle(Theme.colors.alertError)
+                .font(Theme.fonts.caption12)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private var actions: some View {
+        VStack(spacing: 8) {
+            PrimaryButton(title: "rippleTrustLineActivateAction".localized, action: onActivate)
+                .disabled(!viewModel.canActivate)
+
+            Button("cancel".localized, action: onDismissRequest)
+                .frame(height: 42, alignment: .center)
+                .foregroundStyle(Theme.colors.textButtonDisabled)
+                .font(Theme.fonts.caption10)
+                .frame(maxWidth: .infinity)
+                .buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private func row(_ title: String, value: String?, ticker: String?, truncates: Bool = false) -> some View {
+        if let value {
+            HStack(spacing: 8) {
+                Text(title.localized)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .font(Theme.fonts.bodySMedium)
+                Spacer(minLength: 8)
+                Text(ticker.map { "\(value) \($0)" } ?? value)
+                    .foregroundStyle(Theme.colors.textPrimary)
+                    .font(Theme.fonts.priceBodyS)
+                    .lineLimit(1)
+                    .truncationMode(truncates ? .middle : .tail)
+            }
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/TokenCellView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/TokenCellView.swift
@@ -11,6 +11,13 @@ struct TokenCellView: View {
     @ObservedObject var coin: Coin
     @EnvironmentObject var homeViewModel: HomeViewModel
 
+    /// Shown for an XRPL issued currency the account holds no trust line for.
+    /// The coin is added locally the moment the user picks it (like every other
+    /// chain), but on XRPL it cannot hold or receive a balance until a TrustSet
+    /// opens the line — so the row has to make that state legible and offer the
+    /// one action that fixes it. `nil` for every other coin.
+    var onActivate: (() -> Void)?
+
     var body: some View {
         HStack {
             HStack(spacing: 12) {
@@ -38,17 +45,26 @@ struct TokenCellView: View {
             }
             HStack(spacing: 8) {
                 Spacer()
-                VStack(alignment: .trailing, spacing: 4) {
-                    Text(homeViewModel.hideVaultBalance ? String.hideBalanceText : coin.balanceInFiatForDisplay)
-                        .font(Theme.fonts.priceBodyS)
-                        .foregroundStyle(Theme.colors.textPrimary)
-                        .contentTransition(.numericText())
-                        .animation(.interpolatingSpring, value: coin.balanceInFiatForDisplay)
-                    Text(homeViewModel.hideVaultBalance ? String.hideBalanceText : coin.balanceStringWithTicker)
-                        .font(Theme.fonts.priceCaption)
-                        .foregroundStyle(Theme.colors.textTertiary)
-                        .contentTransition(.numericText())
-                        .animation(.interpolatingSpring, value: coin.balanceStringWithTicker)
+                if let onActivate {
+                    PrimaryButton(
+                        title: "rippleTrustLineActivateAction".localized,
+                        size: .mini,
+                        action: onActivate
+                    )
+                    .fixedSize()
+                } else {
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Text(homeViewModel.hideVaultBalance ? String.hideBalanceText : coin.balanceInFiatForDisplay)
+                            .font(Theme.fonts.priceBodyS)
+                            .foregroundStyle(Theme.colors.textPrimary)
+                            .contentTransition(.numericText())
+                            .animation(.interpolatingSpring, value: coin.balanceInFiatForDisplay)
+                        Text(homeViewModel.hideVaultBalance ? String.hideBalanceText : coin.balanceStringWithTicker)
+                            .font(Theme.fonts.priceCaption)
+                            .foregroundStyle(Theme.colors.textTertiary)
+                            .contentTransition(.numericText())
+                            .animation(.interpolatingSpring, value: coin.balanceStringWithTicker)
+                    }
                 }
                 Icon(.chevronRightSmall, color: Theme.colors.textPrimary, size: 16)
             }

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
@@ -44,6 +44,9 @@ final class ChainDetailViewModel: ObservableObject {
 
     private let rippleService: RippleService
     private var isRipple: Bool { nativeCoin.chain == .ripple }
+    /// Monotonic tag identifying the most recent trust-line refresh, so an older
+    /// pass that finishes late can't overwrite a newer answer.
+    private var trustLineRefreshGeneration: UInt64 = 0
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -80,23 +83,40 @@ final class ChainDetailViewModel: ObservableObject {
     /// Adds NO network traffic: it reads the trust lines the balance refresh
     /// already fetched for this address, so the answer costs nothing per token
     /// row. No-op on every non-XRPL chain.
+    ///
+    /// Refreshes are generation-guarded. Several can be in flight at once (a
+    /// balance publish, a pull-to-refresh and a token-list recompute all trigger
+    /// one), and without the guard a slower earlier pass could land last and
+    /// replace a newer answer with a staler one — resurrecting an `Activate`
+    /// button on a line that has since been opened.
     func refreshTrustLineState() {
         guard isRipple else { return }
         let tokens = self.tokens.filter { !$0.isNativeToken }
         guard !tokens.isEmpty else {
+            trustLineRefreshGeneration &+= 1
             tokensNeedingTrustLine = []
             return
         }
+        trustLineRefreshGeneration &+= 1
+        let generation = trustLineRefreshGeneration
         let address = nativeCoin.address
-        let identified = tokens.map { (uniqueId: $0.uniqueId, meta: $0.toCoinMeta()) }
+        // Keyed by contract address because that is what the ledger answer is
+        // keyed by; mapped back to `uniqueId` for the row lookup.
+        let identifiers = Dictionary(
+            tokens.map { ($0.contractAddress, $0.uniqueId) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let metas = tokens.map { $0.toCoinMeta() }
         Task { @MainActor [rippleService] in
-            var missing: Set<String> = []
-            for token in identified {
-                if await rippleService.trustLineState(for: token.meta, address: address) == .absent {
-                    missing.insert(token.uniqueId)
-                }
-            }
-            tokensNeedingTrustLine = missing
+            let states = await rippleService.trustLineStates(for: metas, address: address)
+            // A newer pass has already answered — discard this one rather than
+            // overwrite it.
+            guard generation == trustLineRefreshGeneration else { return }
+            tokensNeedingTrustLine = Set(
+                states
+                    .filter { $0.value == .absent }
+                    .compactMap { identifiers[$0.key] }
+            )
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/ChainDetailViewModel.swift
@@ -33,11 +33,24 @@ final class ChainDetailViewModel: ObservableObject {
     let tronLoader: TronResourcesLoader?
     var isTron: Bool { nativeCoin.chain == .tron }
 
+    /// `uniqueId`s of the XRPL issued currencies this account demonstrably holds
+    /// NO trust line for — the tokens that need an `Activate` affordance.
+    ///
+    /// Only coins proven to be missing a line are listed. A state we couldn't
+    /// determine is deliberately absent: offering to open a line we have no
+    /// evidence is missing would invite a keysign ceremony (and a fee) for
+    /// nothing.
+    @Published private(set) var tokensNeedingTrustLine: Set<String> = []
+
+    private let rippleService: RippleService
+    private var isRipple: Bool { nativeCoin.chain == .ripple }
+
     private var cancellables = Set<AnyCancellable>()
 
-    init(vault: Vault, nativeCoin: Coin) {
+    init(vault: Vault, nativeCoin: Coin, rippleService: RippleService = .shared) {
         self.vault = vault
         self.nativeCoin = nativeCoin
+        self.rippleService = rippleService
         self.tronLoader = nativeCoin.chain == .tron ? TronResourcesLoader(address: nativeCoin.address) : nil
         self.tokens = Self.computeTokens(vault: vault, nativeCoin: nativeCoin)
 
@@ -59,6 +72,38 @@ final class ChainDetailViewModel: ObservableObject {
             availableActions = await actionResolver.resolveActions(for: nativeCoin.chain).filtered
         }
         recomputeTokens()
+        refreshTrustLineState()
+    }
+
+    /// Recomputes which XRPL tokens are missing a trust line.
+    ///
+    /// Adds NO network traffic: it reads the trust lines the balance refresh
+    /// already fetched for this address, so the answer costs nothing per token
+    /// row. No-op on every non-XRPL chain.
+    func refreshTrustLineState() {
+        guard isRipple else { return }
+        let tokens = self.tokens.filter { !$0.isNativeToken }
+        guard !tokens.isEmpty else {
+            tokensNeedingTrustLine = []
+            return
+        }
+        let address = nativeCoin.address
+        let identified = tokens.map { (uniqueId: $0.uniqueId, meta: $0.toCoinMeta()) }
+        Task { @MainActor [rippleService] in
+            var missing: Set<String> = []
+            for token in identified {
+                if await rippleService.trustLineState(for: token.meta, address: address) == .absent {
+                    missing.insert(token.uniqueId)
+                }
+            }
+            tokensNeedingTrustLine = missing
+        }
+    }
+
+    /// Whether `coin` should render the `Activate` affordance instead of a
+    /// balance.
+    func needsTrustLine(_ coin: Coin) -> Bool {
+        tokensNeedingTrustLine.contains(coin.uniqueId)
     }
 
     var filteredTokens: [Coin] {
@@ -90,6 +135,7 @@ final class ChainDetailViewModel: ObservableObject {
 
     private func recomputeTokens() {
         tokens = Self.computeTokens(vault: vault, nativeCoin: nativeCoin)
+        refreshTrustLineState()
     }
 
     private static func computeTokens(vault: Vault, nativeCoin: Coin) -> [Coin] {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/RippleTrustLineActivationViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/RippleTrustLineActivationViewModel.swift
@@ -113,6 +113,32 @@ final class RippleTrustLineActivationViewModel: ObservableObject {
         quote.map { RippleReserve.xrpAmount(drops: $0.totalCostDrops) }
     }
 
+    /// The trust-line limit that will be signed, grouped so it can be read.
+    ///
+    /// The raw XRPL value is 16 unseparated digits (`1000000000000000`), which no
+    /// one can check at a glance — and this row exists precisely so the limit
+    /// riding the TrustSet is verifiable before it is signed. Grouping only:
+    /// nothing is rounded or abbreviated, so the figure shown is exactly the
+    /// figure signed. Falls back to the raw string if it will not parse, because
+    /// showing the true value unformatted beats showing nothing.
+    var limitDisplay: String? {
+        guard let limitValue = quote?.limitValue else { return nil }
+        guard let decimal = Decimal(string: limitValue, locale: Locale(identifier: "en_US_POSIX")) else {
+            return limitValue
+        }
+
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.groupingSeparator = Locale.current.groupingSeparator ?? ","
+        formatter.decimalSeparator = Locale.current.decimalSeparator ?? "."
+        formatter.minimumFractionDigits = 0
+        // XRPL issued currencies carry 15 significant digits; never truncate the
+        // fraction of a value the user is about to sign.
+        formatter.maximumFractionDigits = RippleIssuedCurrency.issuedCurrencyDecimals
+        return formatter.string(from: NSDecimalNumber(decimal: decimal)) ?? limitValue
+    }
+
     /// Blocking copy shown when spendable XRP won't cover `reserve_inc + fee`.
     /// `nil` when the activation is affordable (or not yet quoted).
     var insufficientXRPMessage: String? {

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/RippleTrustLineActivationViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/RippleTrustLineActivationViewModel.swift
@@ -5,10 +5,7 @@
 
 import BigInt
 import Foundation
-import OSLog
 import VultisigCommonData
-
-private let logger = Logger(subsystem: "com.vultisig.app", category: "ripple-trust-line-activation")
 
 /// Drives the trust-line activation sheet: what opening the line costs, whether
 /// the vault's XRP covers it, and the `SendTransaction` that carries the TrustSet
@@ -30,6 +27,21 @@ final class RippleTrustLineActivationViewModel: ObservableObject {
 
     init(service: RippleService = .shared) {
         self.service = service
+    }
+
+    /// Claims the single activation slot, or reports that it is already taken.
+    ///
+    /// Guarding on `isLoading` at the call site cannot work: `load` only raises the
+    /// flag once its task starts running, so two taps in the same runloop turn both
+    /// see `false` and both proceed. Two concurrent `load`s then interleave over one
+    /// `quote`, and the sheet can end up pairing one token with another token's
+    /// reserve, limit and issuer. Here the check and the set are a single
+    /// synchronous step on the main actor with no `await` between them, so exactly
+    /// one caller can win.
+    func beginLoading() -> Bool {
+        guard !isLoading else { return false }
+        isLoading = true
+        return true
     }
 
     /// Quotes the activation of `coin`'s trust line, paid for from `nativeCoin`.

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/RippleTrustLineActivationViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/RippleTrustLineActivationViewModel.swift
@@ -1,0 +1,127 @@
+//
+//  RippleTrustLineActivationViewModel.swift
+//  VultisigApp
+//
+
+import BigInt
+import Foundation
+import OSLog
+import VultisigCommonData
+
+private let logger = Logger(subsystem: "com.vultisig.app", category: "ripple-trust-line-activation")
+
+/// Drives the trust-line activation sheet: what opening the line costs, whether
+/// the vault's XRP covers it, and the `SendTransaction` that carries the TrustSet
+/// into the shared verify → keysign flow.
+///
+/// The owner-reserve cost is read LIVE from `server_state`'s `reserve_inc`
+/// through the existing live → cache → seed chain, never hardcoded: "0.2 XRP" is
+/// a current mainnet validator-vote value, not a network constant.
+@MainActor
+final class RippleTrustLineActivationViewModel: ObservableObject {
+
+    @Published private(set) var quote: RippleTrustLineActivationQuote?
+    @Published private(set) var isLoading = false
+    /// Set when the cost can't be quoted at all — the sheet shows this instead of
+    /// an Activate button it can't price.
+    @Published private(set) var errorMessage: String?
+
+    private let service: RippleService
+
+    init(service: RippleService = .shared) {
+        self.service = service
+    }
+
+    /// Quotes the activation of `coin`'s trust line, paid for from `nativeCoin`.
+    ///
+    /// - Parameters:
+    ///   - coin: the issued-currency coin whose line will be opened.
+    ///   - nativeCoin: the vault's XRP coin. Its `rawBalance` is already
+    ///     reserve-net, so it is the genuinely spendable figure.
+    func load(coin: Coin, nativeCoin: Coin) async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        guard let (currency, issuer) = try? RippleIssuedCurrency.parseRippleTokenId(coin.contractAddress),
+              let currencyCode = try? RippleIssuedCurrency.toXrplCurrencyCode(currency),
+              let limitValue = RippleTrustLineLimit.defaultLimitDisplayValue() else {
+            errorMessage = "rippleTrustLineInvalidTokenError".localized
+            return
+        }
+
+        // Live → cache → seed. A seeded value is explicitly acceptable here: the
+        // figure is a validation/display input, and refusing to quote because
+        // `server_state` is briefly unreachable would block a legitimate
+        // activation rather than protect anything.
+        let reserveValues = (try? await service.fetchReserveValues()) ?? nil
+        let ownerReserve = RippleReserve.reservedDrops(
+            ownerCount: 1,
+            reserveBase: 0,
+            reserveInc: reserveValues?.reserveInc
+        )
+        let fee = await service.fetchFee()
+
+        quote = RippleTrustLineActivationQuote(
+            ownerReserveDrops: ownerReserve,
+            feeDrops: fee,
+            spendableDrops: nativeCoin.rawBalance.toBigInt(decimals: nativeCoin.decimals),
+            limitValue: limitValue,
+            currencyCode: currencyCode,
+            issuer: issuer
+        )
+    }
+
+    /// The transaction that opens the trust line.
+    ///
+    /// `amount` is the trust-line LIMIT, and `transactionType` is what tells every
+    /// signing device so — without it the same payload reads as a token transfer.
+    /// `toAddress` is the ISSUER: a TrustSet has no XRPL destination field at all,
+    /// and the signer never reads `toAddress` on this path, but a payload has to
+    /// carry something and the issuer is the account the line is actually with.
+    /// The verify summary suppresses the destination row for a TrustSet and shows
+    /// a labelled issuer row instead, so it is never presented as a recipient.
+    func makeActivationTransaction(coin: Coin, vault: Vault) -> SendTransaction? {
+        guard let quote else { return nil }
+        return SendTransaction.empty(coin: coin, vault: vault)
+            .copy(
+                toAddress: quote.issuer,
+                amount: quote.limitValue,
+                transactionType: .rippleTrustSet
+            )
+    }
+
+    /// Formatted strings for the sheet. Kept here rather than in the view so the
+    /// view stays declarative.
+    var ownerReserveXRP: String? {
+        quote.map { RippleReserve.xrpAmount(drops: $0.ownerReserveDrops) }
+    }
+
+    var feeXRP: String? {
+        quote.map { RippleReserve.xrpAmount(drops: $0.feeDrops) }
+    }
+
+    var spendableXRP: String? {
+        quote.map { RippleReserve.xrpAmount(drops: $0.spendableDrops) }
+    }
+
+    var remainingSpendableXRP: String? {
+        quote.map { RippleReserve.xrpAmount(drops: $0.remainingSpendableDrops) }
+    }
+
+    var totalCostXRP: String? {
+        quote.map { RippleReserve.xrpAmount(drops: $0.totalCostDrops) }
+    }
+
+    /// Blocking copy shown when spendable XRP won't cover `reserve_inc + fee`.
+    /// `nil` when the activation is affordable (or not yet quoted).
+    var insufficientXRPMessage: String? {
+        guard let quote, !quote.isAffordable, let totalCostXRP else { return nil }
+        return String(format: "rippleTrustLineInsufficientXrpError".localized, totalCostXRP)
+    }
+
+    var canActivate: Bool {
+        guard let quote else { return false }
+        return quote.isAffordable
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Services/CustomTokenResolver.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Services/CustomTokenResolver.swift
@@ -48,9 +48,44 @@ enum CustomTokenResolverFactory {
             return Cw20CustomTokenResolverStrategy(chain: chain)
         } else if chain.chainType == .Solana {
             return SolanaCustomTokenResolverStrategy(chain: chain)
+        } else if chain == .ripple {
+            return RippleCustomTokenResolverStrategy()
         } else {
             return EvmLikeCustomTokenResolverStrategy(chain: chain)
         }
+    }
+}
+
+// MARK: - Ripple
+
+/// XRPL issued currencies are keyed by a `(currency, issuer)` **pair**, written as
+/// the composite `<currency>.<issuer>` token id, so the shared
+/// `AddressService.validateAddress` cannot judge the input — only its issuer half is
+/// an address. Delegates to the shared ``RippleCustomTokenResolver``.
+///
+/// Unlike every other strategy here, this one performs **no network call**: XRPL has
+/// no on-ledger token metadata registry, so a well-formed pair cannot be confirmed
+/// to name a real, reputable token — only to be well-formed — and ticker/decimals
+/// come from the identifier itself.
+///
+/// `requiresVaultNativeCoin` is `true` because a trust line costs an owner reserve
+/// on the XRP account that holds it, so the vault must already hold XRP.
+private struct RippleCustomTokenResolverStrategy: CustomTokenResolver {
+    var requiresVaultNativeCoin: Bool { RippleCustomTokenResolver.requiresVaultNativeCoin }
+
+    /// Throws only for input `validate` would already have rejected — the caller
+    /// gates on `isValidAddress` first — so the throw is a guard against a future
+    /// caller skipping validation, not an expected path.
+    ///
+    /// `async` is required by the protocol, not by this implementation: resolution
+    /// is pure normalization with nothing to await, which is the whole point of the
+    /// XRPL seam.
+    func fetchInfo(contract: String) async throws -> CoinMeta? { // swiftlint:disable:this async_without_await
+        try RippleCustomTokenResolver.resolve(input: contract)
+    }
+
+    func validate(_ address: String) -> Bool {
+        RippleCustomTokenResolver.isValidInput(address)
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/ViewModels/CustomTokenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/ViewModels/CustomTokenViewModel.swift
@@ -50,12 +50,18 @@ final class CustomTokenViewModel: ObservableObject {
     }
 
     /// Chain-aware placeholder for the search field. THORChain tokens are referenced
-    /// by a `THOR.{SYMBOL}` bank-denom identifier rather than a contract address, so
-    /// it gets a dedicated hint; every other chain keeps the generic placeholder.
+    /// by a `THOR.{SYMBOL}` bank-denom identifier rather than a contract address, and
+    /// XRPL issued currencies by a `currency.issuer` pair, so both get a dedicated
+    /// hint; every other chain keeps the generic placeholder.
     var searchPlaceholder: String {
-        chain == .thorChain
-            ? "findCustomTokenThorchainPlaceholder".localized
-            : "search".localized
+        switch chain {
+        case .thorChain:
+            return "findCustomTokenThorchainPlaceholder".localized
+        case .ripple:
+            return "findCustomTokenRipplePlaceholder".localized
+        default:
+            return "search".localized
+        }
     }
 
     /// Validates whether the given input is a well-formed identifier for the current

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagThreadingTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDestinationTagThreadingTests.swift
@@ -205,7 +205,7 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
         XCTAssertTrue(ripple.hasDestinationTag)
         XCTAssertEqual(ripple.destinationTag, 4242)
 
-        guard case .Ripple(_, _, _, let tag) = try BlockChainSpecific(proto: original.mapToProtobuff()) else {
+        guard case .Ripple(_, _, _, let tag, _) = try BlockChainSpecific(proto: original.mapToProtobuff()) else {
             return XCTFail("expected Ripple case")
         }
         XCTAssertEqual(tag, 4242)
@@ -223,7 +223,7 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
         }
         XCTAssertFalse(ripple.hasDestinationTag, "no field → unset on the wire")
 
-        guard case .Ripple(_, _, _, let tag) = try BlockChainSpecific(proto: original.mapToProtobuff()) else {
+        guard case .Ripple(_, _, _, let tag, _) = try BlockChainSpecific(proto: original.mapToProtobuff()) else {
             return XCTFail("expected Ripple case")
         }
         XCTAssertNil(tag)
@@ -449,7 +449,7 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
     func testDualWriteSetsFieldFromResolvedTag() throws {
         let base: BlockChainSpecific = .Ripple(sequence: 1, gas: 10, lastLedgerSequence: 100)
         let written = SendCryptoVerifyLogic.dualWritingRippleTag(base, tag: try RippleDestinationTag.validatePayloadMemo("12345"))
-        guard case .Ripple(_, _, _, let fieldTag) = written else { return XCTFail("expected Ripple") }
+        guard case .Ripple(_, _, _, let fieldTag, _) = written else { return XCTFail("expected Ripple") }
         XCTAssertEqual(fieldTag, 12345)
     }
 
@@ -463,14 +463,14 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
 
         let base: BlockChainSpecific = .Ripple(sequence: 1, gas: 10, lastLedgerSequence: 100)
         let written = SendCryptoVerifyLogic.dualWritingRippleTag(base, tag: try RippleDestinationTag.validatePayloadMemo(memo))
-        guard case .Ripple(_, _, _, let fieldTag) = written else { return XCTFail("expected Ripple") }
+        guard case .Ripple(_, _, _, let fieldTag, _) = written else { return XCTFail("expected Ripple") }
         XCTAssertEqual(fieldTag.map(String.init), memo, "field and memo carriers must hold the same value")
     }
 
     func testDualWriteLeavesFieldUnsetForTaglessSend() {
         let base: BlockChainSpecific = .Ripple(sequence: 1, gas: 10, lastLedgerSequence: 100)
         let written = SendCryptoVerifyLogic.dualWritingRippleTag(base, tag: nil)
-        guard case .Ripple(_, _, _, let fieldTag) = written else { return XCTFail("expected Ripple") }
+        guard case .Ripple(_, _, _, let fieldTag, _) = written else { return XCTFail("expected Ripple") }
         XCTAssertNil(fieldTag, "no tag → field unset → byte-identical for memo-only co-signers")
     }
 
@@ -578,7 +578,7 @@ final class RippleDestinationTagThreadingTests: XCTestCase {
         let chainSpecific = SendCryptoVerifyLogic.dualWritingRippleTag(
             .Ripple(sequence: 1, gas: 10, lastLedgerSequence: 100), tag: tx.destinationTag
         )
-        guard case .Ripple(_, _, _, let fieldTag) = chainSpecific else { return XCTFail("expected Ripple") }
+        guard case .Ripple(_, _, _, let fieldTag, _) = chainSpecific else { return XCTFail("expected Ripple") }
         let payload = Self.makeRipplePayload(memo: SendCryptoVerifyLogic.payloadMemo(tx: tx), destinationTagField: fieldTag)
         let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload))
         XCTAssertTrue(input.rawJson.contains("DestinationTag"))

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleIssuedCurrencySigningTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleIssuedCurrencySigningTests.swift
@@ -1,0 +1,644 @@
+//
+//  RippleIssuedCurrencySigningTests.swift
+//  VultisigAppTests
+//
+//  Pins the two XRPL issued-currency keysign operations against the wire
+//  contract they have to agree with, byte for byte:
+//
+//  - a TrustSet (open/modify a trust line, where the keysign amount IS the
+//    line's limit), selected by `RippleSpecific.transaction_type ==
+//    RIPPLE_TRUST_SET`;
+//  - an issued-currency Payment (`opPayment.currencyAmount`), selected by "a
+//    non-native coin with a token id and NO trust-set discriminator".
+//
+//  In MPC keysign every device rebuilds the signing input from the payload, so
+//  a byte divergence between two devices is the failure mode. Three properties
+//  matter and are asserted here rather than assumed:
+//
+//   1. NATIVE XRP IS UNCHANGED — the discriminator is a proto3 enum defaulting
+//      to zero, absent from the wire when unset, so an existing native send
+//      serializes to identical bytes.
+//   2. OLD-CO-SIGNER TRUSTSET PARITY — a signer predating the field infers
+//      TrustSet from "non-native Ripple coin" and formats the same amount as the
+//      limit. This is what makes a mixed-version trust-line ceremony succeed,
+//      and it is only true if this signer's TrustSet is byte-identical to that
+//      legacy rule.
+//   3. DIVERGENCE IS REAL, NOT SILENT — a token Payment and a TrustSet over the
+//      same coin and amount must produce DIFFERENT pre-image hashes, so a
+//      mixed-version token send fails the ceremony instead of signing the wrong
+//      operation.
+//
+
+@testable import VultisigApp
+import BigInt
+import VultisigCommonData
+import WalletCore
+import XCTest
+
+final class RippleIssuedCurrencySigningTests: XCTestCase {
+
+    // Same fixtures as `RippleSignRippleTests` — the signing vault's own XRP
+    // account plus a real secp256k1 public key (the compressed generator point).
+    private static let account = "rPVMhWBsfF9iMXYj3aAzJVkPDTFNSyWdKy"
+    private static let destination = "rEb8TK3gBgk5auZkwc6sHnwrGVJH8DuaLh"
+    private static let issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+    private static let publicKeyHex = "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+
+    private static let sequence: UInt64 = 99
+    private static let gas: UInt64 = 10
+    private static let lastLedgerSequence: UInt64 = 12_345_678
+
+    /// 1.5 tokens at the XRPL issued-currency scale (15 decimals).
+    private static let tokenAmount = BigInt("1500000000000000")
+
+    // MARK: - Fixtures
+
+    private static func makeNativeCoin() -> Coin {
+        let meta = CoinMeta(
+            chain: .ripple,
+            ticker: "XRP",
+            logo: "xrp",
+            decimals: 6,
+            priceProviderId: "ripple",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        return Coin(asset: meta, address: account, hexPublicKey: publicKeyHex)
+    }
+
+    private static func makeTokenCoin(
+        contractAddress: String = "USD.\(issuer)",
+        decimals: Int = RippleIssuedCurrency.issuedCurrencyDecimals
+    ) -> Coin {
+        let meta = CoinMeta(
+            chain: .ripple,
+            ticker: "USD",
+            logo: "xrp",
+            decimals: decimals,
+            priceProviderId: "",
+            contractAddress: contractAddress,
+            isNativeToken: false
+        )
+        return Coin(asset: meta, address: account, hexPublicKey: publicKeyHex)
+    }
+
+    private static func makePayload(
+        coin: Coin,
+        toAddress: String,
+        toAmount: BigInt,
+        memo: String? = nil,
+        destinationTag: UInt32? = nil,
+        transactionType: VSTransactionType = .unspecified
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: toAddress,
+            toAmount: toAmount,
+            chainSpecific: .Ripple(
+                sequence: sequence,
+                gas: gas,
+                lastLedgerSequence: lastLedgerSequence,
+                destinationTag: destinationTag,
+                transactionType: transactionType.rawValue
+            ),
+            utxos: [],
+            memo: memo,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "",
+            vaultLocalPartyID: "iPhone-test",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private static func publicKey() throws -> PublicKey {
+        try XCTUnwrap(PublicKey(data: XCTUnwrap(Data(hexString: publicKeyHex)), type: .secp256k1))
+    }
+
+    private static func preImageHash(of inputData: Data) throws -> String {
+        let hashes = TransactionCompiler.preImageHashes(coinType: .xrp, txInputData: inputData)
+        let output = try TxCompilerPreSigningOutput(serializedBytes: hashes)
+        XCTAssertTrue(output.errorMessage.isEmpty, output.errorMessage)
+        return output.dataHash.hexString
+    }
+
+    // MARK: - 1. Native XRP is byte-identical
+
+    /// A native XRP send whose `transaction_type` is unset serializes to bytes
+    /// IDENTICAL to the pre-change signer. The discriminator is a proto3 enum
+    /// defaulting to zero, so it never reaches the wire for a native send — the
+    /// same argument `testFieldSourcedTagProducesByteIdenticalInputToMemoFallback`
+    /// makes for the destination-tag field.
+    func testNativeSendWithUnsetTransactionTypeIsByteIdenticalToPreChangeSigner() throws {
+        let payload = Self.makePayload(
+            coin: Self.makeNativeCoin(),
+            toAddress: Self.destination,
+            toAmount: BigInt(1_000_000)
+        )
+
+        let produced = try RippleHelper.getPreSignedInputData(keysignPayload: payload)
+
+        // Independently rebuild exactly what the signer produced before the
+        // issued-currency branches existed: a typed opPayment carrying drops.
+        let publicKeyData = try Self.publicKey().data
+        let reference = RippleSigningInput.with {
+            $0.fee = Int64(Self.gas)
+            $0.sequence = UInt32(Self.sequence)
+            $0.account = Self.account
+            $0.publicKey = publicKeyData
+            $0.lastLedgerSequence = UInt32(Self.lastLedgerSequence)
+            $0.opPayment = RippleOperationPayment.with {
+                $0.destination = Self.destination
+                $0.amount = 1_000_000
+            }
+        }
+
+        XCTAssertEqual(
+            produced,
+            try reference.serializedData(),
+            "a native XRP send must serialize byte-identically to the pre-change signer"
+        )
+    }
+
+    /// The same, one level up: the pre-image hash is unchanged, and the native
+    /// payload carries no `opTrustSet` and no `currencyAmount`.
+    func testNativeSendCarriesNoIssuedCurrencyFields() throws {
+        let payload = Self.makePayload(
+            coin: Self.makeNativeCoin(),
+            toAddress: Self.destination,
+            toAmount: BigInt(1_000_000)
+        )
+
+        let input = try RippleSigningInput(
+            serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload)
+        )
+
+        XCTAssertEqual(input.opPayment.amount, 1_000_000)
+        XCTAssertEqual(input.opPayment.amountOneof, .amount(1_000_000))
+        XCTAssertFalse(input.opTrustSet.hasLimitAmount)
+        XCTAssertTrue(input.rawJson.isEmpty)
+    }
+
+    // MARK: - 2. Old-co-signer TrustSet byte parity (load-bearing)
+
+    /// THE load-bearing test for the mixed-version story.
+    ///
+    /// An input built from `transaction_type == RIPPLE_TRUST_SET` must be
+    /// byte-identical to one built by the LEGACY rule every shipped signer uses
+    /// today — "a non-native Ripple coin means TrustSet, and the keysign amount
+    /// is the trust-line limit". The reference input below is that legacy rule,
+    /// transcribed from the SDK resolver's `getTrustSet()`.
+    ///
+    /// If this fails, a new initiator and an old co-signer serialize different
+    /// bytes for the SAME trust-line intent, and opening a trust line stops
+    /// working in mixed-version committees.
+    func testTrustSetIsByteIdenticalToLegacyNonNativeRule() throws {
+        let coin = Self.makeTokenCoin()
+        let payload = Self.makePayload(
+            coin: coin,
+            toAddress: "",
+            toAmount: RippleTrustLineLimit.defaultLimit,
+            transactionType: .rippleTrustSet
+        )
+
+        let produced = try RippleHelper.getPreSignedInputData(keysignPayload: payload)
+
+        // The legacy rule, verbatim: currency normalized to its on-ledger code,
+        // issuer from the token id, value = the keysign amount formatted at the
+        // coin's decimals.
+        let (currency, issuer) = try RippleIssuedCurrency.parseRippleTokenId(coin.contractAddress)
+        let legacyCurrencyCode = try RippleIssuedCurrency.toXrplCurrencyCode(currency)
+        let legacyValue = try RippleIssuedCurrency.formatIssuedCurrencyValue(
+            amount: RippleTrustLineLimit.defaultLimit,
+            decimals: coin.decimals
+        )
+        let publicKeyData = try Self.publicKey().data
+        let legacy = RippleSigningInput.with {
+            $0.fee = Int64(Self.gas)
+            $0.sequence = UInt32(Self.sequence)
+            $0.account = Self.account
+            $0.publicKey = publicKeyData
+            $0.lastLedgerSequence = UInt32(Self.lastLedgerSequence)
+            $0.opTrustSet = RippleOperationTrustSet.with {
+                $0.limitAmount = RippleCurrencyAmount.with {
+                    $0.currency = legacyCurrencyCode
+                    $0.issuer = issuer
+                    $0.value = legacyValue
+                }
+            }
+        }
+
+        XCTAssertEqual(
+            produced,
+            try legacy.serializedData(),
+            "a TrustSet must be byte-identical to what a co-signer predating transaction_type builds"
+        )
+        XCTAssertEqual(
+            try Self.preImageHash(of: produced),
+            try Self.preImageHash(of: legacy.serializedData()),
+            "the TrustSet pre-image hash must match the legacy rule's"
+        )
+    }
+
+    /// The TrustSet's limit is the keysign amount, and it carries no destination
+    /// and no Payment operation. A co-signer reading only the payload sees a
+    /// trust line, never a transfer.
+    func testTrustSetCarriesLimitAmountAndNoPayment() throws {
+        let coin = Self.makeTokenCoin()
+        let payload = Self.makePayload(
+            coin: coin,
+            toAddress: "",
+            toAmount: Self.tokenAmount,
+            transactionType: .rippleTrustSet
+        )
+
+        let input = try RippleSigningInput(
+            serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload)
+        )
+
+        XCTAssertTrue(input.opTrustSet.hasLimitAmount)
+        XCTAssertEqual(input.opTrustSet.limitAmount.currency, "USD")
+        XCTAssertEqual(input.opTrustSet.limitAmount.issuer, Self.issuer)
+        XCTAssertEqual(input.opTrustSet.limitAmount.value, "1.5")
+        XCTAssertTrue(input.opPayment.destination.isEmpty)
+        XCTAssertNil(input.opPayment.amountOneof)
+        XCTAssertTrue(input.rawJson.isEmpty)
+    }
+
+    /// A TrustSet has no destination, so an empty `toAddress` must NOT be
+    /// rejected by the native `toAddress` guard — the branch has to sit before
+    /// it, like the dApp offer case.
+    func testTrustSetDoesNotRequireADestinationAddress() {
+        let payload = Self.makePayload(
+            coin: Self.makeTokenCoin(),
+            toAddress: "",
+            toAmount: Self.tokenAmount,
+            transactionType: .rippleTrustSet
+        )
+        XCTAssertNoThrow(try RippleHelper.getPreSignedInputData(keysignPayload: payload))
+    }
+
+    /// `SigningInput.flags` stays unset: WalletCore stamps its own
+    /// `tfFullyCanonicalSig` on typed operations and the SDK sets no flags, so
+    /// writing one here would diverge from every other signer.
+    func testTrustSetSetsNoSigningFlags() throws {
+        let payload = Self.makePayload(
+            coin: Self.makeTokenCoin(),
+            toAddress: "",
+            toAmount: Self.tokenAmount,
+            transactionType: .rippleTrustSet
+        )
+
+        let input = try RippleSigningInput(
+            serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload)
+        )
+        XCTAssertEqual(input.flags, 0)
+    }
+
+    // MARK: - 3. Divergence is real, not silent
+
+    /// The same coin and the same amount produce DIFFERENT pre-image hashes for
+    /// a TrustSet and a token Payment. That difference is the fail-safe: a
+    /// mixed-version token send aborts the ceremony instead of quietly signing
+    /// a trust line (or vice versa).
+    func testTokenPaymentAndTrustSetProduceDifferentPreImageHashes() throws {
+        let coin = Self.makeTokenCoin()
+
+        let trustSet = Self.makePayload(
+            coin: coin,
+            toAddress: Self.destination,
+            toAmount: Self.tokenAmount,
+            transactionType: .rippleTrustSet
+        )
+        let payment = Self.makePayload(
+            coin: coin,
+            toAddress: Self.destination,
+            toAmount: Self.tokenAmount
+        )
+
+        let trustSetHash = try Self.preImageHash(
+            of: RippleHelper.getPreSignedInputData(keysignPayload: trustSet)
+        )
+        let paymentHash = try Self.preImageHash(
+            of: RippleHelper.getPreSignedInputData(keysignPayload: payment)
+        )
+
+        XCTAssertNotEqual(
+            trustSetHash,
+            paymentHash,
+            "a TrustSet and a token Payment over the same coin+amount must not share a pre-image hash"
+        )
+    }
+
+    // MARK: - 4. Token Payment encoding
+
+    /// `opPayment.currencyAmount` carries currency / issuer / value and the drops
+    /// `amount` is NOT on the wire — the oneof selects one arm, and a token
+    /// Payment must never present a drops amount.
+    func testTokenPaymentCarriesCurrencyAmountAndNoDropsAmount() throws {
+        let coin = Self.makeTokenCoin()
+        let payload = Self.makePayload(
+            coin: coin,
+            toAddress: Self.destination,
+            toAmount: Self.tokenAmount
+        )
+
+        let input = try RippleSigningInput(
+            serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload)
+        )
+
+        XCTAssertEqual(input.opPayment.destination, Self.destination)
+        XCTAssertEqual(input.opPayment.currencyAmount.currency, "USD")
+        XCTAssertEqual(input.opPayment.currencyAmount.issuer, Self.issuer)
+        XCTAssertEqual(input.opPayment.currencyAmount.value, "1.5")
+        XCTAssertEqual(
+            input.opPayment.amountOneof,
+            .currencyAmount(input.opPayment.currencyAmount),
+            "the currencyAmount arm must be selected, so no drops amount is serialized"
+        )
+        XCTAssertEqual(input.opPayment.amount, 0, "the drops accessor defaults to 0 when the oneof holds a currencyAmount")
+        XCTAssertTrue(input.rawJson.isEmpty)
+        XCTAssertFalse(input.opTrustSet.hasLimitAmount)
+    }
+
+    /// A 15-decimal `toAmount` round-trips `formatIssuedCurrencyValue` →
+    /// `parseIssuedCurrencyValue` unchanged, so the value the co-signer reads
+    /// back off the wire is the reviewed amount and not a truncation of it.
+    func testFifteenDecimalAmountRoundTripsThroughTheSignedValue() throws {
+        // 1.234567890123456 would exceed 15 decimals; use the full 15.
+        let amount = BigInt("1234567890123456")
+        let coin = Self.makeTokenCoin()
+        let payload = Self.makePayload(coin: coin, toAddress: Self.destination, toAmount: amount)
+
+        let input = try RippleSigningInput(
+            serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload)
+        )
+
+        XCTAssertEqual(input.opPayment.currencyAmount.value, "1.234567890123456")
+        XCTAssertEqual(
+            try RippleIssuedCurrency.parseIssuedCurrencyValue(input.opPayment.currencyAmount.value),
+            amount,
+            "the signed value must parse back to the exact reviewed base-unit amount"
+        )
+    }
+
+    /// The default trust-line limit is exactly representable at 15 significant
+    /// digits, so it round-trips without truncation — the constant is not
+    /// allowed to sit past the precision boundary.
+    func testDefaultTrustLineLimitRoundTripsExactly() throws {
+        let value = try RippleIssuedCurrency.formatIssuedCurrencyValue(
+            amount: RippleTrustLineLimit.defaultLimit,
+            decimals: RippleIssuedCurrency.issuedCurrencyDecimals
+        )
+        XCTAssertEqual(value, "1000000000000000")
+        XCTAssertEqual(
+            try RippleIssuedCurrency.parseIssuedCurrencyValue(value),
+            RippleTrustLineLimit.defaultLimit
+        )
+        XCTAssertEqual(RippleTrustLineLimit.defaultLimitDisplayValue(), "1000000000000000")
+    }
+
+    // MARK: - Destination tag still applies to a token Payment
+
+    /// The destination tag is an independent XRPL field, orthogonal to how the
+    /// amount is encoded, so a first-class tag rides a token Payment exactly as
+    /// it rides a native one.
+    func testFieldSourcedDestinationTagAppliesToATokenPayment() throws {
+        let payload = Self.makePayload(
+            coin: Self.makeTokenCoin(),
+            toAddress: Self.destination,
+            toAmount: Self.tokenAmount,
+            destinationTag: 42
+        )
+
+        let input = try RippleSigningInput(
+            serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload)
+        )
+
+        XCTAssertEqual(input.opPayment.destinationTag, 42)
+        XCTAssertEqual(input.opPayment.currencyAmount.value, "1.5")
+    }
+
+    /// The legacy memo-carried tag resolves the same way on a token Payment: an
+    /// echoed canonical decimal becomes the tag and does NOT become a Memos blob.
+    func testMemoCarriedDestinationTagAppliesToATokenPayment() throws {
+        let payload = Self.makePayload(
+            coin: Self.makeTokenCoin(),
+            toAddress: Self.destination,
+            toAmount: Self.tokenAmount,
+            memo: "7",
+            destinationTag: 7
+        )
+
+        let input = try RippleSigningInput(
+            serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload)
+        )
+
+        XCTAssertEqual(input.opPayment.destinationTag, 7)
+        XCTAssertTrue(input.rawJson.isEmpty, "an echoed tag carrier must not become a rawJson Memos payment")
+    }
+
+    /// FAIL CLOSED: a genuine text memo on a token Payment would have to go
+    /// through the rawJson path, whose `Amount` is a DROPS string — signing the
+    /// token's base units as native XRP. Refuse instead.
+    func testTextMemoOnATokenPaymentThrowsRatherThanSigningDrops() {
+        let payload = Self.makePayload(
+            coin: Self.makeTokenCoin(),
+            toAddress: Self.destination,
+            toAmount: Self.tokenAmount,
+            memo: "invoice-1234"
+        )
+        XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: payload))
+    }
+
+    // MARK: - Malformed input fails closed rather than trapping
+
+    func testMalformedTokenIdThrowsOnTrustSet() {
+        for contractAddress in ["", "USD", ".rIssuer", "USD.", "no-separator"] {
+            let payload = Self.makePayload(
+                coin: Self.makeTokenCoin(contractAddress: contractAddress),
+                toAddress: "",
+                toAmount: Self.tokenAmount,
+                transactionType: .rippleTrustSet
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+                "token id '\(contractAddress)' must be rejected, not trapped"
+            )
+        }
+    }
+
+    func testMalformedTokenIdThrowsOnTokenPayment() {
+        // A non-native coin with an EMPTY contract address falls through to the
+        // native drops path by design (it carries no token id at all), so the
+        // malformed cases here are the ones that DO look like a token id.
+        for contractAddress in ["USD", ".rIssuer", "USD.", "no-separator"] {
+            let payload = Self.makePayload(
+                coin: Self.makeTokenCoin(contractAddress: contractAddress),
+                toAddress: Self.destination,
+                toAmount: Self.tokenAmount
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+                "token id '\(contractAddress)' must be rejected, not trapped"
+            )
+        }
+    }
+
+    /// A currency code longer than XRPL's 20-byte limit cannot be normalized, so
+    /// the signer rejects it instead of emitting a truncated code.
+    func testOverlongCurrencyCodeThrows() {
+        let payload = Self.makePayload(
+            coin: Self.makeTokenCoin(contractAddress: "THIS_TICKER_IS_FAR_TOO_LONG_FOR_XRPL.\(Self.issuer)"),
+            toAddress: Self.destination,
+            toAmount: Self.tokenAmount
+        )
+        XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: payload))
+    }
+
+    /// Hostile `decimals` (proto-relayed, therefore untrusted) must throw rather
+    /// than index out of bounds or allocate gigabytes of padding.
+    func testHostileDecimalsThrowRatherThanTrap() {
+        for decimals in [-1, 1_000_000] {
+            let payload = Self.makePayload(
+                coin: Self.makeTokenCoin(decimals: decimals),
+                toAddress: Self.destination,
+                toAmount: Self.tokenAmount
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+                "decimals \(decimals) must be rejected, not trapped"
+            )
+        }
+    }
+
+    /// A native coin can never be a TrustSet — there is no issuer to trust — so
+    /// a payload claiming otherwise is rejected rather than signed with an empty
+    /// currency and issuer.
+    func testTrustSetOnANativeCoinThrows() {
+        let payload = Self.makePayload(
+            coin: Self.makeNativeCoin(),
+            toAddress: "",
+            toAmount: BigInt(1_000_000),
+            transactionType: .rippleTrustSet
+        )
+        XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: payload))
+    }
+
+    // MARK: - Precedence
+
+    /// A dApp `signRipple` payload wins over the trust-set discriminator: raw
+    /// JSON is always signed verbatim, so a rawJson transaction can never be
+    /// rewritten into a TrustSet.
+    func testSignRippleTakesPrecedenceOverTheTrustSetDiscriminator() throws {
+        let coin = Self.makeTokenCoin()
+        let rawJson = """
+        {"TransactionType":"OfferCreate","Account":"\(Self.account)","TakerGets":"5000000","TakerPays":{"currency":"USD","issuer":"\(Self.issuer)","value":"10"},"Fee":"10","Sequence":99,"LastLedgerSequence":12345678}
+        """
+        let base = Self.makePayload(
+            coin: coin,
+            toAddress: "",
+            toAmount: Self.tokenAmount,
+            transactionType: .rippleTrustSet
+        )
+        let payload = base.withSignData(.signRipple(SignRipple(rawJson: rawJson)))
+
+        let input = try RippleSigningInput(
+            serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload)
+        )
+
+        XCTAssertEqual(input.rawJson, rawJson)
+        XCTAssertFalse(input.opTrustSet.hasLimitAmount)
+    }
+
+    /// A standard 3-character code and its 40-char hex spelling of the SAME
+    /// currency normalize to the same on-ledger code, so two token ids that
+    /// differ only in spelling sign identical bytes.
+    func testHexAndStandardCurrencySpellingsSignIdenticalBytes() throws {
+        let hexUsd = try RippleIssuedCurrency.toXrplCurrencyCode("USDC") // 4 chars → hex form
+        let hexCoin = Self.makeTokenCoin(contractAddress: "\(hexUsd).\(Self.issuer)")
+        let lowercaseCoin = Self.makeTokenCoin(contractAddress: "\(hexUsd.lowercased()).\(Self.issuer)")
+
+        let hexInput = try RippleHelper.getPreSignedInputData(
+            keysignPayload: Self.makePayload(coin: hexCoin, toAddress: Self.destination, toAmount: Self.tokenAmount)
+        )
+        let lowercaseInput = try RippleHelper.getPreSignedInputData(
+            keysignPayload: Self.makePayload(coin: lowercaseCoin, toAddress: Self.destination, toAmount: Self.tokenAmount)
+        )
+
+        XCTAssertEqual(hexInput, lowercaseInput, "a hex currency code must normalize to uppercase before signing")
+    }
+
+    // MARK: - Discriminator narrowing at the payload-build seam
+
+    /// `SendTransaction.transactionType` is shared with other chains, so only the
+    /// one XRPL value may reach `RippleSpecific.transaction_type`. Anything else
+    /// degrades to `.unspecified`, keeping the legacy interpretation instead of
+    /// telling co-signers something untrue about the operation.
+    func testOnlyTheRippleTrustSetDiscriminatorReachesTheWire() {
+        let vault = Vault.example
+        let coin = Self.makeTokenCoin()
+
+        for (input, expected) in [
+            (VSTransactionType.rippleTrustSet, VSTransactionType.rippleTrustSet),
+            (.unspecified, .unspecified),
+            (.tonDeposit, .unspecified),
+            (.genericContract, .unspecified),
+            (.thorMerge, .unspecified)
+        ] {
+            let tx = SendTransaction.empty(coin: coin, vault: vault).copy(transactionType: input)
+            XCTAssertEqual(
+                SendCryptoVerifyLogic.rippleTransactionType(tx: tx),
+                expected,
+                "\(input) must map to \(expected)"
+            )
+        }
+    }
+
+    /// The dual-write seam carries the discriminator onto the Ripple chain
+    /// specific, and leaves every other chain untouched.
+    func testDualWriteCarriesTheDiscriminatorOntoRippleChainSpecific() {
+        let base = BlockChainSpecific.Ripple(
+            sequence: Self.sequence,
+            gas: Self.gas,
+            lastLedgerSequence: Self.lastLedgerSequence
+        )
+
+        let trustSet = SendCryptoVerifyLogic.dualWritingRippleTag(base, tag: 5, transactionType: .rippleTrustSet)
+        guard case .Ripple(_, _, _, let tag, let transactionType) = trustSet else {
+            return XCTFail("expected a Ripple chain specific")
+        }
+        XCTAssertEqual(tag, 5)
+        XCTAssertEqual(transactionType, VSTransactionType.rippleTrustSet.rawValue)
+
+        // Default keeps the field at the proto3 zero value, so nothing changes
+        // for an ordinary send.
+        let plain = SendCryptoVerifyLogic.dualWritingRippleTag(base, tag: nil)
+        guard case .Ripple(_, _, _, _, let plainType) = plain else {
+            return XCTFail("expected a Ripple chain specific")
+        }
+        XCTAssertEqual(plainType, VSTransactionType.unspecified.rawValue)
+
+        let cosmos = BlockChainSpecific.Cosmos(
+            accountNumber: 1,
+            sequence: 2,
+            gas: 3,
+            transactionType: 0,
+            ibcDenomTrace: nil,
+            gasLimit: nil
+        )
+        XCTAssertEqual(
+            SendCryptoVerifyLogic.dualWritingRippleTag(cosmos, tag: 9, transactionType: .rippleTrustSet),
+            cosmos,
+            "the dual-write seam must be a no-op for non-Ripple chain specifics"
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleIssuedCurrencySigningTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleIssuedCurrencySigningTests.swift
@@ -477,10 +477,7 @@ final class RippleIssuedCurrencySigningTests: XCTestCase {
     }
 
     func testMalformedTokenIdThrowsOnTokenPayment() {
-        // A non-native coin with an EMPTY contract address falls through to the
-        // native drops path by design (it carries no token id at all), so the
-        // malformed cases here are the ones that DO look like a token id.
-        for contractAddress in ["USD", ".rIssuer", "USD.", "no-separator"] {
+        for contractAddress in ["", "USD", ".rIssuer", "USD.", "no-separator"] {
             let payload = Self.makePayload(
                 coin: Self.makeTokenCoin(contractAddress: contractAddress),
                 toAddress: Self.destination,
@@ -532,6 +529,146 @@ final class RippleIssuedCurrencySigningTests: XCTestCase {
         )
         XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: payload))
     }
+
+    /// FAIL CLOSED on the dangerous middle: a NON-native coin carrying no token
+    /// id satisfies no issued-currency branch, so without this guard it would
+    /// fall through to the native encoding and have the token's base units
+    /// serialized as XRP DROPS — a silent token→native crossing that moves real
+    /// XRP. The whole `Coin` is proto-relayed from a peer, so it must be refused
+    /// rather than interpreted.
+    func testNonNativeCoinWithNoTokenIdIsRefusedRatherThanSignedAsDrops() {
+        let coin = Self.makeTokenCoin(contractAddress: "")
+
+        for memo in [nil, "some text memo", "42"] {
+            let payload = Self.makePayload(
+                coin: coin,
+                toAddress: Self.destination,
+                toAmount: Self.tokenAmount,
+                memo: memo
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+                "a non-native coin with no token id must never reach the drops encoding (memo: \(memo ?? "nil"))"
+            )
+        }
+    }
+
+    /// FAIL CLOSED on a discriminator this build doesn't support: another chain's
+    /// operation relayed onto a Ripple payload, or a future XRPL operation. The
+    /// peer is describing something other than what these branches build, so
+    /// signing anything at all would be signing an unreviewed operation. It must
+    /// NOT quietly degrade to "just build a Payment".
+    func testUnsupportedTransactionTypeIsRefused() {
+        for transactionType in [VSTransactionType.tonDeposit, .genericContract, .thorMerge, .qbtcClaimWithProof] {
+            let tokenPayload = Self.makePayload(
+                coin: Self.makeTokenCoin(),
+                toAddress: Self.destination,
+                toAmount: Self.tokenAmount,
+                transactionType: transactionType
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: tokenPayload),
+                "\(transactionType) must be refused on a token payload"
+            )
+
+            let nativePayload = Self.makePayload(
+                coin: Self.makeNativeCoin(),
+                toAddress: Self.destination,
+                toAmount: BigInt(1_000_000),
+                transactionType: transactionType
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: nativePayload),
+                "\(transactionType) must be refused on a native payload"
+            )
+        }
+    }
+
+    /// A raw discriminator value no build knows (an operation added after this
+    /// one) survives the proto round-trip as `UNRECOGNIZED` rather than being
+    /// flattened to `.unspecified`, so the signer can see it and refuse.
+    func testUnrecognizedTransactionTypeRawValueIsRefused() throws {
+        let chainSpecific = BlockChainSpecific.Ripple(
+            sequence: Self.sequence,
+            gas: Self.gas,
+            lastLedgerSequence: Self.lastLedgerSequence,
+            transactionType: 9_999
+        )
+
+        let roundTripped = try BlockChainSpecific(proto: chainSpecific.mapToProtobuff())
+        guard case .Ripple(_, _, _, _, let transactionType) = roundTripped else {
+            return XCTFail("expected a Ripple chain specific")
+        }
+        XCTAssertEqual(transactionType, 9_999, "an unknown discriminator must not be flattened on the wire")
+    }
+
+    // MARK: - Frozen golden vectors
+
+    /// FROZEN BYTES for both new operations.
+    ///
+    /// The parity test above rebuilds its "legacy" reference with the same
+    /// normalization and formatting helpers production uses, so a shared mistake
+    /// in those helpers would let both sides agree while still diverging from
+    /// every other platform. These literals close that hole in the only way a
+    /// single-repo test can: they pin the exact bytes this signer emits for a
+    /// fixed payload, so any future change to currency normalization, value
+    /// formatting, field ordering or the envelope has to be deliberate.
+    ///
+    /// They are iOS-originated (this app is the first client to build XRPL token
+    /// payloads at all). Cross-checking them against the SDK's resolver output is
+    /// tracked as parity work rather than done here — nothing in this repo can
+    /// execute the TypeScript resolver.
+    func testTrustSetSerializesToFrozenBytes() throws {
+        let payload = Self.makePayload(
+            coin: Self.makeTokenCoin(),
+            toAddress: "",
+            toAmount: Self.tokenAmount,
+            transactionType: .rippleTrustSet
+        )
+
+        XCTAssertEqual(
+            try RippleHelper.getPreSignedInputData(keysignPayload: payload).hexString,
+            Self.frozenTrustSetInputHex,
+            "the TrustSet signing input changed — confirm the change is intended and cross-platform"
+        )
+    }
+
+    func testTokenPaymentSerializesToFrozenBytes() throws {
+        let payload = Self.makePayload(
+            coin: Self.makeTokenCoin(),
+            toAddress: Self.destination,
+            toAmount: Self.tokenAmount
+        )
+
+        XCTAssertEqual(
+            try RippleHelper.getPreSignedInputData(keysignPayload: payload).hexString,
+            Self.frozenTokenPaymentInputHex,
+            "the issued-currency Payment signing input changed — confirm the change is intended and cross-platform"
+        )
+    }
+
+    /// TrustSet over `USD.rHb9…` with a limit of `1.5`, fee 10, sequence 99,
+    /// lastLedgerSequence 12345678. Decodes as: fee(1)=10, sequence(2)=99,
+    /// lastLedgerSequence(3)=12345678, account(4), opTrustSet(7){ limitAmount{
+    /// currency="USD", value="1.5", issuer } }, publicKey(15). Note there is NO
+    /// field 5 (`flags`) — that absence is part of what is pinned.
+    private static let frozenTrustSetInputHex = """
+    080a106318cec2f10522227250564d68574273664639694d58596a3361417a4a566b504454464e537957644b79\
+    3a300a2e0a035553441203312e351a2272486239434a4157794234726a39315652576e3936446b756b47346277\
+    64747954687a210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+    """
+
+    /// Issued-currency Payment of `1.5 USD.rHb9…` to `rEb8…`, same envelope.
+    /// Decodes as the same envelope plus opPayment(8){ currencyAmount(2){
+    /// currency, value, issuer }, destination(3) } — with NO field 1 (the drops
+    /// `amount`), which is the property that keeps a token send from ever
+    /// presenting a native XRP amount.
+    private static let frozenTokenPaymentInputHex = """
+    080a106318cec2f10522227250564d68574273664639694d58596a3361417a4a566b504454464e537957644b79\
+    4254122e0a035553441203312e351a2272486239434a4157794234726a39315652576e3936446b756b47346277\
+    64747954681a2272456238544b336742676b3561755a6b77633673486e777247564a48384475614c687a210279\
+    be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+    """
 
     // MARK: - Precedence
 

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleIssuedCurrencySigningTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleIssuedCurrencySigningTests.swift
@@ -553,6 +553,36 @@ final class RippleIssuedCurrencySigningTests: XCTestCase {
         }
     }
 
+    /// FAIL CLOSED on the mirror-image inconsistency: a coin claiming to be
+    /// NATIVE while carrying an issued-currency token id. Metadata that names an
+    /// issuer but asks to be signed as drops describes no coherent asset, and the
+    /// whole `Coin` is proto-relayed, so it is refused rather than interpreted.
+    func testNativeCoinCarryingATokenIdIsRefused() {
+        let meta = CoinMeta(
+            chain: .ripple,
+            ticker: "XRP",
+            logo: "xrp",
+            decimals: 6,
+            priceProviderId: "ripple",
+            contractAddress: "USD.\(Self.issuer)",
+            isNativeToken: true
+        )
+        let coin = Coin(asset: meta, address: Self.account, hexPublicKey: Self.publicKeyHex)
+
+        for memo in [nil, "invoice-1234", "42"] {
+            let payload = Self.makePayload(
+                coin: coin,
+                toAddress: Self.destination,
+                toAmount: BigInt(1_000_000),
+                memo: memo
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+                "a native coin carrying a token id must be refused (memo: \(memo ?? "nil"))"
+            )
+        }
+    }
+
     /// FAIL CLOSED on a discriminator this build doesn't support: another chain's
     /// operation relayed onto a Ripple payload, or a future XRPL operation. The
     /// peer is describing something other than what these branches build, so

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
@@ -592,6 +592,50 @@ final class RippleTrustLineActivationTests: XCTestCase {
         )
     }
 
+    /// Two taps in one runloop turn must not both start a quote. If they do, the
+    /// two `load`s interleave over one `quote` and the sheet can pair one token
+    /// with another token's reserve, limit and issuer.
+    @MainActor
+    func testOnlyOneActivationCanBeInFlightAtATime() {
+        let viewModel = RippleTrustLineActivationViewModel(service: Self.makeService(RippleTrustLineStub()))
+
+        XCTAssertTrue(viewModel.beginLoading(), "the first tap claims the slot")
+        XCTAssertFalse(viewModel.beginLoading(), "a second tap in the same turn must be refused")
+        XCTAssertFalse(viewModel.beginLoading())
+    }
+
+    /// The slot has to be released once the quote resolves, or Activate is dead
+    /// for the rest of the session.
+    @MainActor
+    func testTheActivationSlotIsReleasedAfterLoading() async {
+        let viewModel = RippleTrustLineActivationViewModel(service: Self.makeService(RippleTrustLineStub()))
+        let coin = Coin(
+            asset: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            address: Self.account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        let nativeCoin = Coin(
+            asset: CoinMeta(
+                chain: .ripple,
+                ticker: "XRP",
+                logo: "xrp",
+                decimals: 6,
+                priceProviderId: "ripple",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: Self.account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        nativeCoin.rawBalance = "50000000"
+
+        XCTAssertTrue(viewModel.beginLoading())
+        await viewModel.load(coin: coin, nativeCoin: nativeCoin)
+
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertTrue(viewModel.beginLoading(), "a later tap must be able to quote again")
+    }
+
     /// The sheet shows the limit grouped, because 16 unseparated digits are not a
     /// number a user can check — and this row exists to be checked before signing.
     /// The grouped string must still be the exact figure that gets signed.

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
@@ -220,6 +220,58 @@ final class RippleTrustLineActivationTests: XCTestCase {
         XCTAssertEqual(state, .absent)
     }
 
+    /// A recording that has gone stale degrades to `.unknown`, not `.absent`.
+    /// Without this an `Activate` button would sit there forever on evidence that
+    /// is no longer true — a line opened on another device, or a walk that has
+    /// been failing for a while — inviting a redundant ceremony and its fee.
+    func testStaleTrustLineSnapshotDegradesToUnknown() async {
+        let service = Self.makeService(RippleTrustLineStub())
+        let key = RippleService.trustLinesCacheKey(for: RippleAPI.defaultHost, address: Self.account)
+
+        // Seed a snapshot recorded an hour ago, well past the presence TTL.
+        await service.trustLinesCache.setCached(
+            RippleTrustLineSnapshot(lines: [], recordedAt: Date(timeIntervalSinceNow: -3_600)),
+            for: key
+        )
+
+        let stale = await service.trustLineState(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            address: Self.account
+        )
+        XCTAssertEqual(stale, .unknown)
+
+        // A fresh recording of the same (empty) result IS evidence.
+        await service.trustLinesCache.setCached(
+            RippleTrustLineSnapshot(lines: [], recordedAt: Date()),
+            for: key
+        )
+        let fresh = await service.trustLineState(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            address: Self.account
+        )
+        XCTAssertEqual(fresh, .absent)
+    }
+
+    /// The batch accessor resolves the host ONCE, so one answer set can never be
+    /// assembled from two networks' snapshots, and answers every coin it is given.
+    func testBatchPresenceAnswersEveryCoinFromOneSnapshot() async throws {
+        let stub = RippleTrustLineStub()
+        stub.pages = [Self.linesJSON([Self.line(currency: "USD", issuer: Self.issuer, balance: "5")], marker: nil)]
+        let service = Self.makeService(stub)
+        _ = try await service.fetchAccountLines(for: Self.account)
+
+        let held = Self.coin(tokenId: "USD.\(Self.issuer)")
+        let missing = Self.coin(tokenId: "EUR.\(Self.issuer)")
+        let unreadable = Self.coin(tokenId: "not-a-token-id")
+
+        let states = await service.trustLineStates(for: [held, missing, unreadable], address: Self.account)
+
+        XCTAssertEqual(states[held.contractAddress], .present)
+        XCTAssertEqual(states[missing.contractAddress], .absent)
+        XCTAssertEqual(states[unreadable.contractAddress], .unknown)
+        XCTAssertEqual(stub.callCount, 1, "the batch read must not issue its own request")
+    }
+
     // MARK: - Destination trust-line guard (#4758)
 
     func testDestinationWithAMatchingLineCanReceive() async {
@@ -350,6 +402,59 @@ final class RippleTrustLineActivationTests: XCTestCase {
         XCTAssertEqual(exact.remainingSpendableDrops, .zero)
     }
 
+    /// The limit the sheet DISPLAYS and the limit that gets SIGNED must be the
+    /// same number. The displayed value is a decimal string that travels through
+    /// `Decimal` in `SendCryptoLogic.amountInRaw` before becoming the keysign
+    /// amount, so a precision loss there would sign a different limit than the one
+    /// the user approved.
+    @MainActor
+    func testActivationTransactionSignsExactlyTheDisplayedLimit() async {
+        let viewModel = RippleTrustLineActivationViewModel(service: Self.makeService(RippleTrustLineStub()))
+        let meta = Self.coin(tokenId: "USD.\(Self.issuer)")
+        let coin = Coin(
+            asset: meta,
+            address: Self.account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        let vault = Vault.example
+        let nativeCoin = Coin(
+            asset: CoinMeta(
+                chain: .ripple,
+                ticker: "XRP",
+                logo: "xrp",
+                decimals: 6,
+                priceProviderId: "ripple",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: Self.account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        nativeCoin.rawBalance = "50000000"
+
+        await viewModel.load(coin: coin, nativeCoin: nativeCoin)
+
+        let tx = viewModel.makeActivationTransaction(coin: coin, vault: vault)
+        let transaction = try? XCTUnwrap(tx)
+        guard let transaction else { return XCTFail("expected an activation transaction") }
+
+        XCTAssertEqual(transaction.transactionType, .rippleTrustSet)
+        XCTAssertEqual(transaction.amount, RippleTrustLineLimit.defaultLimitDisplayValue())
+        XCTAssertEqual(
+            transaction.amountInRaw,
+            RippleTrustLineLimit.defaultLimit,
+            "the signed limit must equal the displayed limit exactly"
+        )
+        // And that raw amount formats back to the same string the sheet showed.
+        XCTAssertEqual(
+            try? RippleIssuedCurrency.formatIssuedCurrencyValue(
+                amount: transaction.amountInRaw,
+                decimals: coin.decimals
+            ),
+            viewModel.quote?.limitValue
+        )
+    }
+
     func testQuoteDecodesAHexCurrencyToItsTicker() {
         let quote = RippleTrustLineActivationQuote(
             ownerReserveDrops: BigInt(200_000),
@@ -411,6 +516,100 @@ final class RippleTrustLineActivationTests: XCTestCase {
     func testTrustSetPresentationIsNilForAnUnreadableTokenId() {
         let payload = Self.makeTrustSetPayload(tokenId: "not-a-token-id", toAmount: BigInt(1))
         XCTAssertNil(RippleTrustSetPresentation.display(for: payload))
+    }
+
+    /// THE state distinction that keeps a co-signer safe: whether something IS a
+    /// TrustSet is decided by the discriminator, never by whether we managed to
+    /// render it. An unreadable TrustSet must resolve to `.unreviewable` — if it
+    /// collapsed to "not a TrustSet", the summary would fall back to the Payment
+    /// rows and present `toAddress` as a recipient and the LIMIT as a transfer,
+    /// asking a peer device to join after reviewing a materially false operation.
+    func testUnreadableTrustSetIsUnreviewableRatherThanNotATrustSet() {
+        for tokenId in ["not-a-token-id", "", "USD.", ".rIssuer"] {
+            let payload = Self.makeTrustSetPayload(tokenId: tokenId, toAmount: BigInt(1))
+
+            XCTAssertTrue(
+                RippleTrustSetPresentation.isTrustSet(payload: payload),
+                "'\(tokenId)': the discriminator alone decides the operation"
+            )
+            XCTAssertEqual(
+                RippleTrustSetPresentation.state(for: payload),
+                .unreviewable,
+                "'\(tokenId)' must never fall back to Payment framing"
+            )
+        }
+    }
+
+    /// Hostile `decimals` make the limit unformattable — also `.unreviewable`,
+    /// not a silent fallback to Payment rows.
+    func testTrustSetWithHostileDecimalsIsUnreviewable() {
+        let meta = CoinMeta(
+            chain: .ripple,
+            ticker: "USD",
+            logo: .empty,
+            decimals: -1,
+            priceProviderId: .empty,
+            contractAddress: "USD.\(Self.issuer)",
+            isNativeToken: false
+        )
+        let coin = Coin(
+            asset: meta,
+            address: Self.account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        let payload = KeysignPayload(
+            coin: coin,
+            toAddress: Self.issuer,
+            toAmount: BigInt(1),
+            chainSpecific: .Ripple(
+                sequence: 1,
+                gas: 10,
+                lastLedgerSequence: 100,
+                transactionType: VSTransactionType.rippleTrustSet.rawValue
+            ),
+            utxos: [],
+            memo: nil,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "",
+            vaultLocalPartyID: "iPhone-test",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+
+        XCTAssertEqual(RippleTrustSetPresentation.state(for: payload), .unreviewable)
+        XCTAssertThrowsError(
+            try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+            "an unreviewable TrustSet must also be unsignable"
+        )
+    }
+
+    /// A readable TrustSet resolves to `.reviewable`, and an ordinary send to
+    /// `.notTrustSet` — so nothing else changes shape.
+    func testTrustSetStateDistinguishesReviewableFromNotATrustSet() throws {
+        let readable = Self.makeTrustSetPayload(
+            tokenId: "USD.\(Self.issuer)",
+            toAmount: BigInt("1500000000000000")
+        )
+        guard case .reviewable(let display) = RippleTrustSetPresentation.state(for: readable) else {
+            return XCTFail("expected a reviewable TrustSet")
+        }
+        XCTAssertEqual(display.limitValue, "1.5")
+
+        let payment = Self.makeTrustSetPayload(
+            tokenId: "USD.\(Self.issuer)",
+            toAmount: BigInt(1),
+            transactionType: .unspecified
+        )
+        XCTAssertEqual(RippleTrustSetPresentation.state(for: payment), .notTrustSet)
+        XCTAssertEqual(RippleTrustSetPresentation.state(for: nil), .notTrustSet)
     }
 
     // MARK: - Fixtures

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
@@ -41,13 +41,70 @@ final class RippleTrustLineActivationTests: XCTestCase {
         }
     }
 
-    /// A bare ticker longer than 3 characters is NOT a valid on-ledger code. It is
-    /// only valid once normalized to the 40-char hex form — which is how the
-    /// curated catalog spells it — so accepting the bare spelling here would let
-    /// the same token be added twice under two different ids.
-    func testUnnormalizedTickerIsRejected() {
-        XCTAssertFalse(RippleCustomTokenResolver.isValidInput("RLUSD.\(Self.issuer)"))
-        XCTAssertFalse(RippleCustomTokenResolver.isValidInput("USDC.\(Self.issuer)"))
+    /// A bare ticker longer than 3 characters is accepted and packed into the
+    /// on-ledger hex form. Requiring the hex would have meant asking a user to
+    /// type 40 characters to add SOLO — the flow would technically work and be
+    /// unusable.
+    ///
+    /// The earlier worry that this forks a token into two coins does not hold:
+    /// both spellings normalize through `toXrplCurrencyCode` BEFORE the token id
+    /// is built, so they produce the same id. `testTickerAndHexSpellingsResolve
+    /// ToTheSameToken` is the standing proof of that.
+    func testUnnormalizedTickerIsAcceptedAndNormalized() throws {
+        for ticker in ["RLUSD", "USDC", "SOLO", "USDT"] {
+            XCTAssertTrue(
+                RippleCustomTokenResolver.isValidInput("\(ticker).\(Self.issuer)"),
+                "'\(ticker)' is how a user actually spells the token"
+            )
+            let normalized = try XCTUnwrap(
+                RippleCustomTokenResolver.normalized(from: "\(ticker).\(Self.issuer)")
+            )
+            XCTAssertEqual(normalized.currency, try RippleIssuedCurrency.toXrplCurrencyCode(ticker))
+            XCTAssertEqual(normalized.currency.count, 40, "a >3-char ticker must reach the ledger as hex")
+        }
+    }
+
+    /// The two spellings of one token must resolve to one coin. `CoinMeta`
+    /// identity is `chain-ticker-contractAddress`, so a divergence here would
+    /// put the same trust line in the asset list twice.
+    func testTickerAndHexSpellingsResolveToTheSameToken() throws {
+        let fromTicker = try RippleCustomTokenResolver.resolve(input: "RLUSD.\(Self.issuer)")
+        let fromHex = try RippleCustomTokenResolver.resolve(input: "\(Self.rlusdHex).\(Self.issuer)")
+
+        XCTAssertEqual(fromTicker.contractAddress, fromHex.contractAddress)
+        XCTAssertEqual(fromTicker.uniqueId, fromHex.uniqueId)
+    }
+
+    /// A 3-character ticker must NOT be packed to hex: the ledger carries it as
+    /// a standard code, and the ASCII-packed hex of a 3-character code is a
+    /// different currency. This is the asymmetry that makes the widened rule
+    /// safe rather than a blanket "pack everything".
+    func testThreeCharacterTickerIsStillTreatedAsAStandardCode() throws {
+        let normalized = try XCTUnwrap(RippleCustomTokenResolver.normalized(from: "USD.\(Self.issuer)"))
+
+        XCTAssertEqual(normalized.currency, "USD")
+    }
+
+    /// `asciiToHexCurrencyCode` will encode whatever UTF-8 bytes it is handed,
+    /// so the validator — not the encoder — has to refuse non-ASCII. Otherwise a
+    /// pasted lookalike packs into a well-formed code for a token nobody meant.
+    func testNonAsciiTickerIsRejected() {
+        for ticker in ["SÖLO", "SOL⍺", "🪙"] {
+            XCTAssertFalse(
+                RippleCustomTokenResolver.isValidInput("\(ticker).\(Self.issuer)"),
+                "'\(ticker)' is not a code the ledger can carry"
+            )
+        }
+    }
+
+    /// 20 bytes is the 160-bit ceiling; 21 cannot be represented.
+    func testTickerLongerThanTwentyBytesIsRejected() {
+        XCTAssertTrue(
+            RippleCustomTokenResolver.isValidInput("\(String(repeating: "A", count: 20)).\(Self.issuer)")
+        )
+        XCTAssertFalse(
+            RippleCustomTokenResolver.isValidInput("\(String(repeating: "A", count: 21)).\(Self.issuer)")
+        )
     }
 
     /// `XRP` is reserved for the native asset and can never name an issued
@@ -55,6 +112,31 @@ final class RippleTrustLineActivationTests: XCTestCase {
     func testNativeXrpCurrencyCodeIsRejected() {
         XCTAssertFalse(RippleCustomTokenResolver.isValidInput("XRP.\(Self.issuer)"))
         XCTAssertFalse(RippleCustomTokenResolver.isValidInput("xrp.\(Self.issuer)"))
+    }
+
+    /// Padding `XRP` must not smuggle it past the reservation. The currency
+    /// half is trimmed before validation precisely so the gate cannot see a
+    /// 4-byte ticker where the encoder will see the reserved 3-byte code:
+    /// `parseRippleTokenId` splits without trimming, `toXrplCurrencyCode`
+    /// trims, and the gap between them is the hole.
+    func testWhitespacePaddedNativeXrpCodeIsRejected() {
+        for input in ["XRP .\(Self.issuer)", " XRP.\(Self.issuer)", "xrp\t.\(Self.issuer)"] {
+            XCTAssertFalse(
+                RippleCustomTokenResolver.isValidInput(input),
+                "'\(input)' normalizes to the reserved native code"
+            )
+        }
+    }
+
+    /// Whatever the gate accepted must be what the encoder encodes. A padded
+    /// ticker resolves to the same coin as the clean spelling rather than to a
+    /// second, space-padded currency.
+    func testWhitespacePaddedTickerResolvesToTheSameTokenAsTheCleanSpelling() throws {
+        let padded = try RippleCustomTokenResolver.resolve(input: "RLUSD .\(Self.issuer)")
+        let clean = try RippleCustomTokenResolver.resolve(input: "RLUSD.\(Self.issuer)")
+
+        XCTAssertEqual(padded.uniqueId, clean.uniqueId)
+        XCTAssertEqual(padded.contractAddress, "\(Self.rlusdHex).\(Self.issuer)")
     }
 
     func testMalformedTokenIdsAreRejected() {
@@ -66,11 +148,10 @@ final class RippleTrustLineActivationTests: XCTestCase {
             // Issuer must be a real XRPL address.
             "USD.not-an-address",
             "USD.0x0000000000000000000000000000000000000000",
-            // A 4-char code is neither a standard nor a hex code.
-            "USDT.\(Self.issuer)",
-            // 39 hex characters — one short of the 160-bit form.
+            // 39 characters — one short of the 160-bit hex form, and far past
+            // the 20 bytes a ticker can be packed into.
             "\(String(repeating: "A", count: 39)).\(Self.issuer)",
-            // 40 characters but not hex.
+            // 40 characters but not hex, so it is neither form.
             "\(String(repeating: "Z", count: 40)).\(Self.issuer)"
         ] {
             XCTAssertFalse(RippleCustomTokenResolver.isValidInput(input), "'\(input)' should be rejected")
@@ -118,8 +199,21 @@ final class RippleTrustLineActivationTests: XCTestCase {
     }
 
     func testResolveThrowsOnMalformedInput() {
-        XCTAssertThrowsError(try RippleCustomTokenResolver.resolve(input: "RLUSD.\(Self.issuer)"))
-        XCTAssertThrowsError(try RippleCustomTokenResolver.resolve(input: "not-a-token-id"))
+        for input in [
+            // No separator at all.
+            "not-a-token-id",
+            // Reserved for the native asset.
+            "XRP.\(Self.issuer)",
+            // 21 bytes — one past the 160-bit ceiling, so unpackable.
+            "\(String(repeating: "A", count: 21)).\(Self.issuer)",
+            // Well-formed currency, but the issuer is not an XRPL address.
+            "RLUSD.not-an-address"
+        ] {
+            XCTAssertThrowsError(
+                try RippleCustomTokenResolver.resolve(input: input),
+                "'\(input)' should not resolve"
+            )
+        }
     }
 
     /// A trust line costs an owner reserve on the XRP account that holds it, so

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
@@ -1,0 +1,541 @@
+//
+//  RippleTrustLineActivationTests.swift
+//  VultisigAppTests
+//
+//  Covers the #4757 add-token / activate surfaces that sit around the signing
+//  path: validating a user-typed XRPL token id, deciding which token rows need an
+//  `Activate` affordance, quoting the owner-reserve cost, and the trust-line rows
+//  a co-signer is shown instead of Payment framing.
+//
+//  Canned-JSON HTTP stub, no network and no sleeps, in the style of
+//  `RippleTrustLineTests`.
+//
+
+@testable import VultisigApp
+import BigInt
+import VultisigCommonData
+import XCTest
+
+final class RippleTrustLineActivationTests: XCTestCase {
+
+    private static let account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+    private static let issuer = "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De"
+    private static let otherIssuer = "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+    /// 160-bit hex form of `RLUSD` — the on-ledger code for a >3-character ticker.
+    private static let rlusdHex = "524C555344000000000000000000000000000000"
+
+    // MARK: - Custom-token resolver: validation
+
+    /// A valid id is `<on-ledger currency>.<XRPL issuer address>`.
+    func testValidTokenIdsAreAccepted() {
+        for input in [
+            "USD.\(Self.issuer)",
+            "EUR.\(Self.otherIssuer)",
+            "\(Self.rlusdHex).\(Self.issuer)",
+            // Hex codes are accepted case-insensitively and normalized later.
+            "\(Self.rlusdHex.lowercased()).\(Self.issuer)",
+            // Surrounding whitespace is trimmed (pasted input).
+            "  USD.\(Self.issuer)  "
+        ] {
+            XCTAssertTrue(RippleCustomTokenResolver.isValidInput(input), "'\(input)' should be valid")
+        }
+    }
+
+    /// A bare ticker longer than 3 characters is NOT a valid on-ledger code. It is
+    /// only valid once normalized to the 40-char hex form — which is how the
+    /// curated catalog spells it — so accepting the bare spelling here would let
+    /// the same token be added twice under two different ids.
+    func testUnnormalizedTickerIsRejected() {
+        XCTAssertFalse(RippleCustomTokenResolver.isValidInput("RLUSD.\(Self.issuer)"))
+        XCTAssertFalse(RippleCustomTokenResolver.isValidInput("USDC.\(Self.issuer)"))
+    }
+
+    /// `XRP` is reserved for the native asset and can never name an issued
+    /// currency, so it must not resolve to a token.
+    func testNativeXrpCurrencyCodeIsRejected() {
+        XCTAssertFalse(RippleCustomTokenResolver.isValidInput("XRP.\(Self.issuer)"))
+        XCTAssertFalse(RippleCustomTokenResolver.isValidInput("xrp.\(Self.issuer)"))
+    }
+
+    func testMalformedTokenIdsAreRejected() {
+        for input in [
+            "",
+            "USD",
+            "USD.",
+            ".\(Self.issuer)",
+            // Issuer must be a real XRPL address.
+            "USD.not-an-address",
+            "USD.0x0000000000000000000000000000000000000000",
+            // A 4-char code is neither a standard nor a hex code.
+            "USDT.\(Self.issuer)",
+            // 39 hex characters — one short of the 160-bit form.
+            "\(String(repeating: "A", count: 39)).\(Self.issuer)",
+            // 40 characters but not hex.
+            "\(String(repeating: "Z", count: 40)).\(Self.issuer)"
+        ] {
+            XCTAssertFalse(RippleCustomTokenResolver.isValidInput(input), "'\(input)' should be rejected")
+        }
+    }
+
+    // MARK: - Custom-token resolver: resolution
+
+    /// XRPL has no on-ledger token metadata registry, so decimals are always 15
+    /// (the significant-digit scale the SDK fixes) and the ticker is decoded back
+    /// out of the currency code — nothing is fetched.
+    func testResolveDerivesTickerAndFixedDecimalsWithoutNetwork() throws {
+        let meta = try RippleCustomTokenResolver.resolve(input: "USD.\(Self.issuer)")
+
+        XCTAssertEqual(meta.chain, .ripple)
+        XCTAssertEqual(meta.ticker, "USD")
+        XCTAssertEqual(meta.decimals, RippleIssuedCurrency.issuedCurrencyDecimals)
+        XCTAssertEqual(meta.decimals, 15)
+        XCTAssertEqual(meta.contractAddress, "USD.\(Self.issuer)")
+        XCTAssertFalse(meta.isNativeToken)
+    }
+
+    /// A hex currency code resolves to its human ticker, and the stored id keeps
+    /// the UPPERCASE hex form so two spellings can't become two coins.
+    func testResolveNormalizesHexCurrencyAndDecodesTicker() throws {
+        let meta = try RippleCustomTokenResolver.resolve(input: "\(Self.rlusdHex.lowercased()).\(Self.issuer)")
+
+        XCTAssertEqual(meta.ticker, "RLUSD")
+        XCTAssertEqual(meta.contractAddress, "\(Self.rlusdHex).\(Self.issuer)")
+    }
+
+    /// A curated `TokensStore` entry wins: it carries the bundled logo and a
+    /// working `priceProviderId`, neither of which the ledger can supply.
+    func testResolvePrefersCuratedTokensStoreEntry() throws {
+        let curated = try XCTUnwrap(
+            TokensStore.TokenSelectionAssets.first { $0.chain == .ripple && $0.ticker == "RLUSD" },
+            "the curated RLUSD entry is expected to exist"
+        )
+
+        let meta = try RippleCustomTokenResolver.resolve(input: curated.contractAddress)
+
+        XCTAssertEqual(meta.ticker, curated.ticker)
+        XCTAssertEqual(meta.priceProviderId, curated.priceProviderId)
+        XCTAssertEqual(meta.contractAddress, curated.contractAddress)
+    }
+
+    func testResolveThrowsOnMalformedInput() {
+        XCTAssertThrowsError(try RippleCustomTokenResolver.resolve(input: "RLUSD.\(Self.issuer)"))
+        XCTAssertThrowsError(try RippleCustomTokenResolver.resolve(input: "not-a-token-id"))
+    }
+
+    /// A trust line costs an owner reserve on the XRP account that holds it, so
+    /// the flow must require the vault to have XRP enabled.
+    func testResolverRequiresTheVaultNativeCoin() {
+        XCTAssertTrue(RippleCustomTokenResolver.requiresVaultNativeCoin)
+    }
+
+    // MARK: - Trust-line presence (the Activate affordance)
+
+    /// The presence check reads the lines the balance refresh already fetched —
+    /// it must add NO request of its own, or a token list would cost one
+    /// `account_lines` call per row.
+    func testTrustLinePresenceReusesTheBalanceRefreshResultWithoutANewRequest() async throws {
+        let stub = RippleTrustLineStub()
+        stub.pages = [Self.linesJSON([Self.line(currency: "USD", issuer: Self.issuer, balance: "5")], marker: nil)]
+        let service = Self.makeService(stub)
+
+        // The balance refresh performs the one and only walk.
+        _ = try await service.getTokenBalance(coin: Self.coin(tokenId: "USD.\(Self.issuer)"), address: Self.account)
+        let callsAfterBalance = stub.callCount
+
+        let held = await service.trustLineState(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            address: Self.account
+        )
+        let missing = await service.trustLineState(
+            for: Self.coin(tokenId: "EUR.\(Self.issuer)"),
+            address: Self.account
+        )
+
+        XCTAssertEqual(held, .present)
+        XCTAssertEqual(missing, .absent)
+        XCTAssertEqual(stub.callCount, callsAfterBalance, "the presence check must not issue its own request")
+    }
+
+    /// A currency spelled as a 3-char code in the coin id and as 40-char hex on
+    /// the ledger (or vice versa) is the SAME line.
+    func testTrustLinePresenceMatchesAcrossCurrencySpellings() async throws {
+        let stub = RippleTrustLineStub()
+        stub.pages = [Self.linesJSON([Self.line(currency: Self.rlusdHex, issuer: Self.issuer, balance: "1")], marker: nil)]
+        let service = Self.makeService(stub)
+        _ = try await service.fetchAccountLines(for: Self.account)
+
+        let upper = await service.trustLineState(
+            for: Self.coin(tokenId: "\(Self.rlusdHex).\(Self.issuer)"),
+            address: Self.account
+        )
+        let lower = await service.trustLineState(
+            for: Self.coin(tokenId: "\(Self.rlusdHex.lowercased()).\(Self.issuer)"),
+            address: Self.account
+        )
+
+        XCTAssertEqual(upper, .present)
+        XCTAssertEqual(lower, .present)
+    }
+
+    /// A DIFFERENT issuer's line for the same currency is not this token's line —
+    /// XRPL keys a token by the (currency, issuer) pair.
+    func testTrustLinePresenceIsIssuerSpecific() async throws {
+        let stub = RippleTrustLineStub()
+        stub.pages = [Self.linesJSON([Self.line(currency: "USD", issuer: Self.otherIssuer, balance: "1")], marker: nil)]
+        let service = Self.makeService(stub)
+        _ = try await service.fetchAccountLines(for: Self.account)
+
+        let state = await service.trustLineState(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            address: Self.account
+        )
+        XCTAssertEqual(state, .absent)
+    }
+
+    /// A state never observed is `.unknown`, NOT `.absent`: offering to open a
+    /// line we have no evidence is missing would invite a keysign ceremony (and a
+    /// fee) for nothing.
+    func testTrustLinePresenceIsUnknownBeforeAnyWalk() async {
+        let service = Self.makeService(RippleTrustLineStub())
+
+        let state = await service.trustLineState(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            address: Self.account
+        )
+        XCTAssertEqual(state, .unknown)
+    }
+
+    /// An unfunded account demonstrably holds no lines, which IS evidence — so
+    /// its tokens correctly offer activation.
+    func testUnfundedAccountReportsAbsentRatherThanUnknown() async throws {
+        let stub = RippleTrustLineStub()
+        stub.pages = [#"{"result":{"error":"actNotFound","status":"error"}}"#]
+        let service = Self.makeService(stub)
+        _ = try await service.fetchAccountLines(for: Self.account)
+
+        let state = await service.trustLineState(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            address: Self.account
+        )
+        XCTAssertEqual(state, .absent)
+    }
+
+    // MARK: - Destination trust-line guard (#4758)
+
+    func testDestinationWithAMatchingLineCanReceive() async {
+        let stub = RippleTrustLineStub()
+        stub.pages = [Self.linesJSON([Self.line(currency: "USD", issuer: Self.issuer, balance: "0")], marker: nil)]
+        let service = Self.makeService(stub)
+
+        let state = await service.destinationTrustLine(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            destination: "rDestination111111111111111111111"
+        )
+        XCTAssertEqual(state, .canReceive, "a zero-balance line still receives")
+    }
+
+    func testDestinationWithNoMatchingLineIsBlocked() async {
+        let stub = RippleTrustLineStub()
+        stub.pages = [Self.linesJSON([Self.line(currency: "EUR", issuer: Self.issuer, balance: "1")], marker: nil)]
+        let service = Self.makeService(stub)
+
+        let state = await service.destinationTrustLine(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            destination: "rDestination111111111111111111111"
+        )
+        XCTAssertEqual(state, .noTrustLine)
+    }
+
+    /// The ISSUER can always receive its own obligations back — no line needed on
+    /// its side — so a send to the issuer must not be blocked.
+    func testSendToTheIssuerItselfIsNeverBlocked() async {
+        let stub = RippleTrustLineStub()
+        let service = Self.makeService(stub)
+
+        let state = await service.destinationTrustLine(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            destination: Self.issuer
+        )
+        XCTAssertEqual(state, .canReceive)
+        XCTAssertEqual(stub.callCount, 0, "paying the issuer needs no lookup at all")
+    }
+
+    /// FAIL OPEN: a transport failure is not evidence the destination can't
+    /// receive, and must never start blocking a send that worked before this
+    /// guard existed.
+    func testTransportFailureFailsOpen() async {
+        let stub = RippleTrustLineStub()
+        stub.pages = []  // exhausted → the stub throws
+        let service = Self.makeService(stub)
+
+        let state = await service.destinationTrustLine(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            destination: "rDestination111111111111111111111"
+        )
+        XCTAssertEqual(state, .unknown)
+    }
+
+    /// An uninterpretable HTTP-200 body is also not proof — fail open.
+    func testMalformedResponseFailsOpen() async {
+        let stub = RippleTrustLineStub()
+        stub.pages = [#"{"result":{"status":"success"}}"#]  // no `lines`, no error
+        let service = Self.makeService(stub)
+
+        let state = await service.destinationTrustLine(
+            for: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            destination: "rDestination111111111111111111111"
+        )
+        XCTAssertEqual(state, .unknown)
+    }
+
+    func testUnreadableTokenIdFailsOpen() async {
+        let service = Self.makeService(RippleTrustLineStub())
+
+        let state = await service.destinationTrustLine(
+            for: Self.coin(tokenId: "not-a-token-id"),
+            destination: "rDestination111111111111111111111"
+        )
+        XCTAssertEqual(state, .unknown)
+    }
+
+    // MARK: - Reserve quote (#4757)
+
+    /// The owner-reserve cost comes from the LIVE `reserve_inc`, not from the
+    /// mainnet seed: "0.2 XRP" is a current validator-vote value, not a constant.
+    func testQuoteUsesTheLiveOwnerReserveIncrement() {
+        // 0.5 XRP increment — deliberately NOT the 0.2 XRP mainnet seed.
+        let quote = RippleTrustLineActivationQuote(
+            ownerReserveDrops: BigInt(500_000),
+            feeDrops: BigInt(20),
+            spendableDrops: BigInt(5_000_000),
+            limitValue: "1000000000000000",
+            currencyCode: "USD",
+            issuer: Self.issuer
+        )
+
+        XCTAssertEqual(quote.totalCostDrops, BigInt(500_020))
+        XCTAssertEqual(quote.remainingSpendableDrops, BigInt(4_499_980))
+        XCTAssertTrue(quote.isAffordable)
+        XCTAssertNotEqual(
+            quote.ownerReserveDrops,
+            RippleReserve.seedReserveIncDrops,
+            "the quote must reflect the live value, not the seed"
+        )
+    }
+
+    /// Blocks when spendable XRP won't cover `reserve_inc + fee` — the TrustSet
+    /// would otherwise fail on-ledger with the fee already burned.
+    func testQuoteBlocksWhenSpendableXrpCannotCoverReservePlusFee() {
+        let short = RippleTrustLineActivationQuote(
+            ownerReserveDrops: BigInt(200_000),
+            feeDrops: BigInt(20),
+            spendableDrops: BigInt(200_019),
+            limitValue: "1",
+            currencyCode: "USD",
+            issuer: Self.issuer
+        )
+        XCTAssertFalse(short.isAffordable)
+        XCTAssertEqual(short.remainingSpendableDrops, .zero, "an unaffordable activation never shows a negative balance")
+
+        // Exactly enough is enough.
+        let exact = RippleTrustLineActivationQuote(
+            ownerReserveDrops: BigInt(200_000),
+            feeDrops: BigInt(20),
+            spendableDrops: BigInt(200_020),
+            limitValue: "1",
+            currencyCode: "USD",
+            issuer: Self.issuer
+        )
+        XCTAssertTrue(exact.isAffordable)
+        XCTAssertEqual(exact.remainingSpendableDrops, .zero)
+    }
+
+    func testQuoteDecodesAHexCurrencyToItsTicker() {
+        let quote = RippleTrustLineActivationQuote(
+            ownerReserveDrops: BigInt(200_000),
+            feeDrops: BigInt(10),
+            spendableDrops: BigInt(10_000_000),
+            limitValue: "1",
+            currencyCode: Self.rlusdHex,
+            issuer: Self.issuer
+        )
+        XCTAssertEqual(quote.currencyTicker, "RLUSD")
+    }
+
+    // MARK: - Verify / Join summary rows (#4757 step 16)
+
+    /// A TrustSet gets issuer / currency / limit rows derived from the PAYLOAD, so
+    /// a co-signer that holds nothing else still sees what it is signing rather
+    /// than a blind signature.
+    func testTrustSetPresentationDerivesRowsFromThePayload() throws {
+        let payload = Self.makeTrustSetPayload(
+            tokenId: "USD.\(Self.issuer)",
+            toAmount: BigInt("1500000000000000")
+        )
+
+        let display = try XCTUnwrap(RippleTrustSetPresentation.display(for: payload))
+        XCTAssertEqual(display.issuer, Self.issuer)
+        XCTAssertEqual(display.currencyCode, "USD")
+        XCTAssertEqual(display.ticker, "USD")
+        XCTAssertEqual(display.limitValue, "1.5", "the amount is the trust-line LIMIT, shown as such")
+    }
+
+    func testTrustSetPresentationDecodesAHexCurrencyToItsTicker() throws {
+        let payload = Self.makeTrustSetPayload(
+            tokenId: "\(Self.rlusdHex).\(Self.issuer)",
+            toAmount: RippleTrustLineLimit.defaultLimit
+        )
+
+        let display = try XCTUnwrap(RippleTrustSetPresentation.display(for: payload))
+        XCTAssertEqual(display.ticker, "RLUSD")
+        XCTAssertEqual(display.currencyCode, Self.rlusdHex)
+        XCTAssertEqual(display.limitValue, "1000000000000000")
+    }
+
+    /// Not a TrustSet → no trust-line rows, so an ordinary send keeps the Payment
+    /// framing it always had.
+    func testTrustSetPresentationIsNilForEveryOtherTransaction() {
+        let tokenPayment = Self.makeTrustSetPayload(
+            tokenId: "USD.\(Self.issuer)",
+            toAmount: BigInt(1),
+            transactionType: .unspecified
+        )
+        XCTAssertNil(RippleTrustSetPresentation.display(for: tokenPayment))
+        XCTAssertNil(RippleTrustSetPresentation.display(for: nil))
+        XCTAssertFalse(RippleTrustSetPresentation.isTrustSet(payload: tokenPayment))
+    }
+
+    /// A token id the signer would refuse yields no rows rather than a guess —
+    /// showing invented issuer/limit values for a transaction that cannot be
+    /// built would be worse than showing nothing.
+    func testTrustSetPresentationIsNilForAnUnreadableTokenId() {
+        let payload = Self.makeTrustSetPayload(tokenId: "not-a-token-id", toAmount: BigInt(1))
+        XCTAssertNil(RippleTrustSetPresentation.display(for: payload))
+    }
+
+    // MARK: - Fixtures
+
+    private static func makeService(_ stub: RippleTrustLineStub) -> RippleService {
+        RippleService(resolver: NoOverrideTrustLineResolver(), httpClient: stub, sleep: { _ in })
+    }
+
+    private static func coin(tokenId: String) -> CoinMeta {
+        CoinMeta(
+            chain: .ripple,
+            ticker: "TEST",
+            logo: .empty,
+            decimals: RippleIssuedCurrency.issuedCurrencyDecimals,
+            priceProviderId: .empty,
+            contractAddress: tokenId,
+            isNativeToken: false
+        )
+    }
+
+    private static func makeTrustSetPayload(
+        tokenId: String,
+        toAmount: BigInt,
+        transactionType: VSTransactionType = .rippleTrustSet
+    ) -> KeysignPayload {
+        let meta = coin(tokenId: tokenId)
+        let coin = Coin(
+            asset: meta,
+            address: account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        return KeysignPayload(
+            coin: coin,
+            toAddress: issuer,
+            toAmount: toAmount,
+            chainSpecific: .Ripple(
+                sequence: 1,
+                gas: 10,
+                lastLedgerSequence: 100,
+                transactionType: transactionType.rawValue
+            ),
+            utxos: [],
+            memo: nil,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "",
+            vaultLocalPartyID: "iPhone-test",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+
+    private static func line(currency: String, issuer: String, balance: String) -> [String: Any] {
+        [
+            "account": issuer,
+            "balance": balance,
+            "currency": currency,
+            "limit": "1000000000",
+            "no_ripple": false,
+            "freeze": false
+        ]
+    }
+
+    private static func linesJSON(_ lines: [[String: Any]], marker: String?) -> String {
+        var result: [String: Any] = ["lines": lines, "account": account, "ledger_current_index": 100]
+        if let marker {
+            result["marker"] = marker
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: ["result": result]),
+              let json = String(data: data, encoding: .utf8) else {
+            fatalError("Failed to build an account_lines fixture")
+        }
+        return json
+    }
+}
+
+// MARK: - Test doubles
+
+private final class NoOverrideTrustLineResolver: RPCEndpointResolving {
+    func url(for _: Chain) -> String? { nil }
+}
+
+/// Serves canned `account_lines` bodies in order and counts the calls, so a test
+/// can assert that a surface adds NO request of its own.
+private final class RippleTrustLineStub: HTTPClientProtocol, @unchecked Sendable {
+
+    enum StubError: Error {
+        case unexpectedMethod(String?)
+        case exhausted
+    }
+
+    var pages: [String] = []
+
+    private(set) var callCount = 0
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        await Task.yield()
+        guard Self.rpcMethod(of: target) == "account_lines" else {
+            throw StubError.unexpectedMethod(Self.rpcMethod(of: target))
+        }
+        callCount += 1
+        guard callCount <= pages.count else { throw StubError.exhausted }
+        return HTTPResponse(data: Data(pages[callCount - 1].utf8), response: Self.ok)
+    }
+
+    private static func rpcMethod(of target: TargetType) -> String? {
+        guard case let .requestCodable(body, _) = target.task,
+              let data = try? JSONEncoder().encode(body),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json["method"] as? String
+    }
+
+    private static let ok = HTTPURLResponse(
+        url: RippleAPI.defaultHost,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
@@ -592,6 +592,46 @@ final class RippleTrustLineActivationTests: XCTestCase {
         )
     }
 
+    /// The sheet shows the limit grouped, because 16 unseparated digits are not a
+    /// number a user can check — and this row exists to be checked before signing.
+    /// The grouped string must still be the exact figure that gets signed.
+    @MainActor
+    func testLimitDisplayGroupsTheSignedValueWithoutChangingIt() async {
+        let viewModel = RippleTrustLineActivationViewModel(service: Self.makeService(RippleTrustLineStub()))
+        let coin = Coin(
+            asset: Self.coin(tokenId: "USD.\(Self.issuer)"),
+            address: Self.account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        let nativeCoin = Coin(
+            asset: CoinMeta(
+                chain: .ripple,
+                ticker: "XRP",
+                logo: "xrp",
+                decimals: 6,
+                priceProviderId: "ripple",
+                contractAddress: "",
+                isNativeToken: true
+            ),
+            address: Self.account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        nativeCoin.rawBalance = "50000000"
+
+        await viewModel.load(coin: coin, nativeCoin: nativeCoin)
+
+        let display = viewModel.limitDisplay
+        XCTAssertNotNil(display)
+        XCTAssertNotEqual(display, viewModel.quote?.limitValue, "the raw 16-digit run must be grouped")
+        // Stripping the grouping separators recovers the exact signed value, so
+        // formatting cannot have rounded or abbreviated it.
+        let separator = Locale.current.groupingSeparator ?? ","
+        XCTAssertEqual(
+            display?.replacingOccurrences(of: separator, with: ""),
+            viewModel.quote?.limitValue
+        )
+    }
+
     func testQuoteDecodesAHexCurrencyToItsTicker() {
         let quote = RippleTrustLineActivationQuote(
             ownerReserveDrops: BigInt(200_000),
@@ -632,6 +672,44 @@ final class RippleTrustLineActivationTests: XCTestCase {
         XCTAssertEqual(display.ticker, "RLUSD")
         XCTAssertEqual(display.currencyCode, Self.rlusdHex)
         XCTAssertEqual(display.limitValue, "1000000000000000")
+    }
+
+    // MARK: - Done-screen hero
+
+    /// The done screen renders `toAmountWithTickerString` unless a hero claims the
+    /// slot. A TrustSet's `toAmount` is the trust-line LIMIT, so without a hero the
+    /// receipt announces a 1,000,000,000,000,000-token payment that never happened
+    /// — and prices it in fiat. Observed on mainnet before this existed.
+    func testTrustSetSuppliesADoneHeroSoTheLimitIsNotShownAsATransfer() throws {
+        let payload = Self.makeTrustSetPayload(
+            tokenId: "\(Self.rlusdHex).\(Self.issuer)",
+            toAmount: RippleTrustLineLimit.defaultLimit
+        )
+
+        let hero = try XCTUnwrap(RippleTrustSetPresentation.hero(for: payload))
+
+        guard case .title(let text, let caption) = hero else {
+            return XCTFail("a TrustSet receipt must not use an amount hero")
+        }
+        XCTAssertTrue(text.contains("RLUSD"), "the hero names the token whose line was opened")
+        XCTAssertEqual(caption, Self.issuer, "the issuer identifies WHICH line was opened")
+        XCTAssertFalse(
+            text.contains("1000000000000000"),
+            "the limit must not be presented as an amount transferred"
+        )
+    }
+
+    /// An ordinary token Payment keeps the default amount hero — the fix must not
+    /// swallow the amount on transactions that genuinely have one.
+    func testNonTrustSetGetsNoDoneHeroOverride() {
+        let tokenPayment = Self.makeTrustSetPayload(
+            tokenId: "\(Self.rlusdHex).\(Self.issuer)",
+            toAmount: BigInt("1048869990000000"),
+            transactionType: .unspecified
+        )
+
+        XCTAssertNil(RippleTrustSetPresentation.hero(for: tokenPayment))
+        XCTAssertNil(RippleTrustSetPresentation.hero(for: nil))
     }
 
     /// Not a TrustSet → no trust-line rows, so an ordinary send keeps the Payment

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleTrustLineActivationTests.swift
@@ -222,6 +222,49 @@ final class RippleTrustLineActivationTests: XCTestCase {
         XCTAssertTrue(RippleCustomTokenResolver.requiresVaultNativeCoin)
     }
 
+    /// The curated `EQ` entry has to win on the custom-token path too, not only in
+    /// discovery. Equilibrium's on-ledger code decodes to the long name, so without
+    /// the curated hit a hand-added coin would be tickered `Equilibrium` — a
+    /// different `uniqueId` from the discovered row, and therefore the same trust
+    /// line listed twice.
+    func testCuratedEquilibriumEntryWinsOnTheCustomTokenPath() throws {
+        let curated = try XCTUnwrap(TokensStore.TokenSelectionAssets.first {
+            $0.chain == .ripple && $0.ticker == "EQ"
+        })
+
+        let resolved = try RippleCustomTokenResolver.resolve(input: curated.contractAddress)
+
+        XCTAssertEqual(resolved.ticker, "EQ")
+        XCTAssertEqual(resolved.uniqueId, curated.uniqueId)
+        XCTAssertEqual(resolved.priceProviderId, "equilibrium")
+    }
+
+    /// Typing the name rather than the 40-char code must land on the same curated
+    /// coin — the widened gate and the curated catalog have to agree, or the two
+    /// ways of adding one token produce two coins.
+    func testCuratedEntryIsReachedByTypingTheTickerRatherThanTheHex() throws {
+        let curated = try XCTUnwrap(TokensStore.TokenSelectionAssets.first {
+            $0.chain == .ripple && $0.ticker == "SOLO"
+        })
+        let (_, issuer) = try RippleIssuedCurrency.parseRippleTokenId(curated.contractAddress)
+
+        let resolved = try RippleCustomTokenResolver.resolve(input: "SOLO.\(issuer)")
+
+        XCTAssertEqual(resolved.uniqueId, curated.uniqueId)
+        XCTAssertEqual(resolved.priceProviderId, "solo-coin")
+    }
+
+    /// The factory must route `.ripple` to the XRPL strategy rather than letting it
+    /// fall through to the EVM-like metadata lookup, which would try three
+    /// `eth_call`s against an XRPL token id.
+    func testFactoryRoutesRippleToTheXrplResolver() {
+        let resolver = CustomTokenResolverFactory.make(chain: .ripple)
+
+        XCTAssertTrue(resolver.validate("USD.\(Self.issuer)"))
+        XCTAssertFalse(resolver.validate("0x0000000000000000000000000000000000000000"))
+        XCTAssertTrue(resolver.requiresVaultNativeCoin)
+    }
+
     // MARK: - Trust-line presence (the Activate affordance)
 
     /// The presence check reads the lines the balance refresh already fetched —

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -57,15 +57,30 @@ packages:
     from: 1.17.0
   VultisigCommonData:
     url: https://github.com/vultisig/commondata
-    # Pinned to the merged `main` commit that adds `SignRipple { string raw_json }`
-    # at `sign_ripple = 46` in `KeysignPayload.sign_data` — the XRPL dApp
-    # co-signer passthrough field. This commit is a linear descendant of the
-    # earlier `RippleSpecific.destination_tag` (optional uint32) pin, so it keeps
-    # that first-class XRPL DestinationTag field: the initiator dual-writes the
-    # tag into BOTH the field AND the legacy memo carrier, and signers prefer the
-    # field, falling back to the memo, so mixed-version device pairs stay
-    # byte-identical in MPC keysign.
-    revision: c91f2ea7db5eb03cf6bb637da19e4ed93b07dc46
+    # ⚠️ UNMERGED PIN — points at the open commondata branch that adds
+    # `RippleSpecific.transaction_type = 5` (the existing `TransactionType` enum)
+    # plus `TRANSACTION_TYPE_RIPPLE_TRUST_SET = 10`. Must move to the merged
+    # `main` commit before this can ship.
+    #
+    # Why the field exists: an XRPL issued-currency coin is ambiguous on its own.
+    # The same (currency, issuer) pair can mean "open a trust line for this
+    # token" — a TrustSet whose keysign amount is the trust-line LIMIT — or "send
+    # this token", a Payment carrying a `CurrencyAmount`. Those serialize to
+    # different signed bytes, so in MPC keysign the discriminator has to be on
+    # the wire rather than inferred. A proto3 enum defaults to
+    # `TRANSACTION_TYPE_UNSPECIFIED` and is absent from the wire when unset, so
+    # native XRP payloads stay byte-identical; a signer predating the field still
+    # infers TrustSet from a non-native coin, which keeps a TrustSet
+    # byte-identical across mixed-version committees.
+    #
+    # This commit is a linear descendant of the pin that added `SignRipple {
+    # string raw_json }` at `sign_ripple = 46` (the XRPL dApp co-signer
+    # passthrough) and, before that, `RippleSpecific.destination_tag` (optional
+    # uint32) — the first-class XRPL DestinationTag field the initiator
+    # dual-writes into BOTH the field AND the legacy memo carrier, with signers
+    # preferring the field and falling back to the memo so mixed-version device
+    # pairs stay byte-identical in MPC keysign.
+    revision: a16c710f0b0dfb6e2c8debde54b72414a04feb9a
   WalletCore:
     url: https://github.com/vultisig/walletcore-spm
     # v4.7.1 is the correctly-cut release for wallet-core 4.7.0 (tag →


### PR DESCRIPTION
> ## ⚠️ DRAFT — blocked on commondata#100 (now **in review**)
>
> `VultisigApp/project.yml` pins `VultisigCommonData` to **`a16c710`**, an
> **unmerged** branch (`vultisig/commondata#100`, `feat/ripple-trust-set`). That
> commit adds `RippleSpecific.transaction_type = 5` and
> `TRANSACTION_TYPE_RIPPLE_TRUST_SET = 10` — the wire discriminator this whole PR
> is built on.
>
> commondata#100 is **out of draft and awaiting review**. It is a two-line proto
> change plus regenerated Swift + Go; `buf format && buf lint && buf build && buf
> generate` reproduces the committed output with **zero drift**, so there is
> nothing further to generate there.
>
> **This still cannot merge until commondata#100 does**, after which the pin must
> move to the merged `main` commit and the gate must be re-run — the pin is what
> controls the signed wire bytes. Same hinge discipline as #4749 / commondata#95.

Closes #4757
Closes #4758

> **`closingIssuesReferences` will be empty, and that is expected.** GitHub only
> resolves closing keywords for PRs targeting the default branch. This PR's base
> is `feat/xrp-token-balances-4756`, so the links activate once the base walks
> down to `main`. Not a bug, and not something to "fix" by editing the keywords.

## Stack

This is 3 deep. The base walks down to `main` as each ancestor merges:

```
main                                            #4935 MERGED (c3f75af2)
 └── feat/xrp-token-balances-4756  #4940        (#4756 — read trust-line balances)
      └── THIS PR                               (#4757 + #4758)
```

Both branches have been **rebased onto current `main`**, so this is now 2 deep,
not 3. #4936 (`CustomTokenResolver` protocol + factory) also merged in the
meantime, and this PR now conforms to it — `RippleCustomTokenResolverStrategy`
plugs into `CustomTokenResolverFactory` instead of the old inline chain-`if`
ladder, which no longer exists.

Review the diff against `feat/xrp-token-balances-4756`.

## ✅ Proven on mainnet

Both operations this PR adds have been signed by this build and validated
on XRPL mainnet, from `rLmDygstTzDCmkxWUfhTn4gR3x6HVaudbj`:

| | Result |
|---|---|
| [TrustSet `AF9A315E…29DD9`](https://xrpscan.com/tx/AF9A315EC71615622543A49D60C2E7199BE5F4E7C2F73158423692C38D429DD9) | `tesSUCCESS`, ledger 105911592 — `LimitAmount` = RLUSD hex + curated issuer + `"1000000000000000"`, `Flags: 0`. `account_lines` confirms the line. |
| [Payment `367118D3…52953`](https://xrpscan.com/tx/367118D368F99BE38949EA50F4784E29818144D21761117EBB604C5F62F52953) | `tesSUCCESS`, ledger 105911635 — **`Amount` is a `{currency, issuer, value}` object, not a drops string**, and `delivered_amount` matches. |

Three things that were previously argued from tests are now confirmed against the
real ledger: the curated `TokensStore` token id is byte-correct; the 1e15 default
limit round-trips **exactly** (the "stay inside 15 significant digits" sizing
holds); and `Flags: 0` vindicates not setting `SigningInput.flags`.

> Both were **Fast Vault** ceremonies. VultiServer signs message hashes and never
> rebuilds the signing input, so these prove **ledger correctness only** — they say
> nothing about mixed-version byte parity. A Secure Vault ⨯ extension co-sign is
> still the outstanding verification, and remains the one result that could
> invalidate a design assumption here.

## What this does

Gives iOS/macOS first-class XRPL issued-currency support: **add** a trust-line
token and open its line with an explicit owner-reserve warning (#4757), and
**send** it as a `CurrencyAmount` Payment rather than drops (#4758).

### The blocking problem this solves

The shipped SDK resolver treats **any** non-native Ripple coin as a `TrustSet`:

```ts
...(getRawJson() ?? getTrustSet() ?? getPayment())
```

So under today's contract an issued-currency **Payment has no representation on
the wire at all** — which is exactly why sending XRPL tokens has been impossible,
and why sdk#996 is still open. The same `(currency, issuer)` pair can mean "open
a trust line for this token" (a TrustSet, whose keysign amount is the LIMIT) or
"send this token" (a Payment carrying a `CurrencyAmount`). Those serialize to
different signed bytes, so in MPC keysign the distinction has to be **on the
wire**, not inferred independently by each device.

Hence the commondata field. iOS is the first platform to originate this payload.

## Signing precedence

| # | Condition | Operation |
|---|---|---|
| 1 | `signRipple` set (dApp rawJson) | **unchanged** — verbatim rawJson + fail-closed binding |
| 2 | `transaction_type == rippleTrustSet` | `opTrustSet(limitAmount:)` |
| 3 | non-native coin with a token id | `opPayment.currencyAmount` |
| 4 | native XRP | **unchanged** — `opPayment.amount` (drops), tag/memo logic untouched |

(2) and (3) sit **after** the dApp branch and **before** the `toAddress` guard — a
TrustSet has no destination, exactly like the dApp offer case that already skips
it. `SigningInput.flags` is never set (no `tfSetNoRipple`): WalletCore stamps
`tfFullyCanonicalSig` on typed operations and the SDK sets no flags.

**The keysign `toAmount` IS the trust-line limit.** That matches the SDK's
`getTrustSet()`, and the equivalence is load-bearing rather than incidental — see
below.

## Mixed-version behaviour, stated plainly

- **Native XRP** — `transaction_type` is a proto3 enum defaulting to zero and
  absent from the wire when unset, so existing native sends are **byte-identical**
  to before. Pinned by a test.
- **TrustSet** — a co-signer predating the field sees "non-native Ripple coin" and
  builds a TrustSet from the very same limit. **Byte-identical → the ceremony
  succeeds.** Pinned by a test (see below).
- **Token send** — a new initiator leaves the field unset for a Payment; an old
  co-signer would build a TrustSet instead → hashes diverge → **the ceremony
  fails and no funds move.** Fail-safe, and a real functional gap for Secure Vault
  users pairing iOS with the extension until **sdk#996** adopts the field. Worth
  knowing about in support rather than discovering there.
- Arm (3) claims the "non-native, no discriminator" case that shipped signers read
  as a TrustSet. That is deliberate — it is the only way a token Payment is
  expressible — and it means a TrustSet *originated* by a signer predating the
  field would be read here as a Payment. No shipped client can originate one (no
  platform builds XRPL token payloads at all yet), so it is unreachable today and
  stops being reachable for good once every platform sets the field. Documented at
  the decision site, not left to be rediscovered.

## #4757 — add + activate

- **Add-token resolver.** `currency.issuer` XRPL token ids. Validation is split:
  the issuer half through `AddressService`, the currency half against the two
  shapes the ledger can carry (3-char standard code, or the 40-char 160-bit hex
  form). A bare `RLUSD` is **invalid until normalized** — accepting both spellings
  would let one token become two coins. `XRP` is rejected outright.
  **XRPL has no on-ledger token metadata registry**, so nothing is fetched and a
  well-formed pair cannot be confirmed to name a real, reputable token — only to
  be well-formed. Decimals are always 15; the ticker is decoded out of the
  currency code; a curated `TokensStore` entry wins for logo and price provider.
  The UI claims no more than that.
- **Activate CTA.** The coin is added locally at zero balance like every other
  chain; a token row with no trust line renders `Activate` instead of a balance.
  Deciding that costs **no network traffic** — every `account_lines` walk records
  its result and the presence check reads that recording, so it reuses the read
  the balance refresh already performed. `.unknown` is deliberately distinct from
  `.absent`: offering to open a line we have no current evidence is missing would
  invite a ceremony, and a fee, for nothing.
- **Reserve warning.** Computed **live** from `server_state`'s `reserve_inc`
  through the existing live → cache → seed chain — never hardcoded, because
  "0.2 XRP" is a current mainnet validator-vote value, not a constant. Shows the
  reserve cost, the fee, the spendable-XRP delta, and **the trust-line limit that
  will be signed** (a signed value the user never saw is one they cannot object
  to). Blocks when spendable XRP won't cover `reserve_inc + fee`, and the check is
  re-run at Verify against the freshly loaded balance so a quote taken when the
  sheet opened can't go stale into a ceremony.

## #4758 — send gating, audited rather than blanket-changed

- `validateDestinationIfNeeded` and `RippleDestinationReserveValidator` **stay
  native-only**, now with comments saying why: the rule is "an account is created
  by receiving at least the base reserve **in XRP**", and an issued-currency
  Payment delivers no XRP. Widening them would reject token sends with a message
  about an amount the transaction doesn't carry.
- **New guard** for the thing that does apply: a token Payment to an account with
  no line for that currency fails on-ledger (`tecPATH_DRY` / `tecNO_LINE`). Same
  **fail-open** posture as `validateDestinationActivation` — it blocks only on
  positive proof, so a transport failure never starts blocking a send that worked
  before. Paying the ISSUER is never blocked and costs no lookup.
- `validateBalanceWithFee` gets a TrustSet arm: its amount is the LIMIT, so
  comparing it to the token balance would fail every activation as "balance
  exceeded" against the zero balance the line is being opened to leave.
- Fee row already renders XRP through the existing `feeCoin` — no change needed.

## Verify / Join summary

A TrustSet has no destination and no transfer amount, so it gets its own rows —
issuer, currency, limit — plus its own header and confirmation checkboxes,
instead of the Payment ones. Dispatched in `SendCryptoVerifySummaryView`, the one
view serving both the initiator's Verify screen and a co-signer's Join screen, and
derived from the **keysign payload** whenever one is present so a peer device
reads the transaction it will sign rather than anything the initiator asserts.

Two details that matter for a co-signer, which sees **only** the payload:

- the trust-set check runs **before** the hero, because Join derives its hero from
  a simulation that reads a TrustSet as an ordinary send;
- whether something IS a TrustSet is decided by the **discriminator alone**, never
  by whether we managed to render it. An unreadable one shows an explicit "cannot
  review — do not sign" row rather than falling back to Payment framing (which
  would present `toAddress` as a recipient and the LIMIT as a transfer). The
  signer refuses those payloads too, so it is a dead end by design.

## Tests

Byte-level, in the style of `RippleSignRippleTests`:

1. **Native unchanged** — a native XRP send with `transaction_type` unset
   serializes **byte-identically** to the pre-change signer.
2. **Old-co-signer TrustSet parity — ✅ PASSES.** An input built from
   `transactionType == .rippleTrustSet` is byte-identical to one built by the
   legacy rule (non-native coin ⇒ TrustSet), pre-image hash included. This is what
   makes the mixed-version trust-line story real rather than assumed.
3. **Divergence is real, not silent** — a token Payment and a TrustSet over the
   same coin+amount produce **different** pre-image hashes.
4. `opPayment.currencyAmount` carries currency/issuer/value and **no** drops
   amount; a 15-decimal `toAmount` round-trips
   `formatIssuedCurrencyValue` → `parseIssuedCurrencyValue` unchanged.

Plus: destination tag still applies to a token Payment (field- and memo-sourced);
malformed token ids, overlong currency codes and hostile decimals throw rather
than trap; contradictory coin metadata is refused in both directions; unsupported
discriminators are refused; **frozen byte vectors** for both new operations; the
displayed limit equals the signed limit exactly through the `Decimal` round-trip;
fail-open/fail-closed postures pinned; presence staleness and batch host-scoping
pinned.

**Gate:** `** TEST SUCCEEDED **` — 3992 tests, 1 skipped, 0 failures, on a
dedicated en_US simulator. `swiftlint` clean: zero violations in every changed
file.

## Known gaps and follow-ups

- **The golden-vector matrix (#4925) is not extended here.** It merged to `main`
  *after* this stack's base branched, so it isn't on this branch and pulling it in
  would drag all of `main` into the diff. The two new operations should be added
  to `VultisigAppTests/Blockchain/SigningGolden/` once the stack reaches `main`.
  The frozen hex vectors in `RippleIssuedCurrencySigningTests` cover the same
  property in the meantime.
- **#4936's `CustomTokenResolver` protocol is not on this branch** (still an open
  draft, and not part of this stack). The XRP logic is a standalone, network-free
  `RippleCustomTokenResolver` matching the existing `ThorchainCustomTokenResolver`
  / `Cw20CustomTokenResolver` convention, so it drops into the protocol + factory
  with a one-line adapter once #4936 lands.
- **Two pre-existing signing-path hazards, deliberately not touched here:** the
  native XRP branch converts `gas`/`sequence`/`lastLedgerSequence` unchecked (traps
  on hostile relayed values) and substitutes `0` when `toAmount` doesn't fit
  `Int64` (signs a different amount than reviewed); and
  `BigInt(stringLiteral: proto.toAmount)` in the payload bridge can
  precondition-fail on a malformed relayed amount, for every chain. Both are real
  and worth their own change — but this is the PR whose headline property is that
  native XRP is byte-identical, so widening into that path here is the wrong
  place.
- **Frozen vectors are iOS-originated.** Nothing in this repo can execute the
  TypeScript resolver, so cross-checking them against the SDK is parity work
  (sdk#996).
- **`TokenSelectionLogic` matches held tokens by ticker, not contract address.**
  XRPL lets any issuer mint `USD`, so two issuers' `USD` collide in the picker in
  a way no other chain exposes. Not introduced here; XRP is just the first chain
  that makes it reachable.
- **`CoinService` compares `contractAddress` case-insensitively.** XRPL issuer
  addresses are base58 and case-**sensitive**. Astronomically unlikely to collide,
  but a latent wart. (The comparisons added in this PR are all exact.)
- **`computeMaxAmount` clamps to 8 decimals**, so MAX on a 15-decimal XRP token
  strands dust — consistent with existing 18-decimal ERC-20 behaviour, so not an
  XRP-specific defect.
- Trust-line **closing**, editing a limit, `tfSetNoRipple`, `delivered_amount` and
  XRP token swaps are all out of scope (see the plan).

## Localization

19 new keys in **all 8** locales (`en, de, es, hr, it, ko, pt, zh-Hans` — Korean
included), camelCase, sorted with `sort_localizable.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

