### PR TITLE
refactor(logging): route QBTC loggers through Log.qbtc facade (#4952)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Models/QBTC/QBTCClaimRequest.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Models/QBTC/QBTCClaimRequest.swift
@@ -10,7 +10,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-claim-request")
+private let logger = Log.qbtc.other
 
 /// One UTXO reference in the `/prove` request — `txid` + `vout` only,
 /// no amount (the chain doesn't need amount; that's BTC-side data for UI).

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/QBTC/QBTCChainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/QBTC/QBTCChainService.swift
@@ -40,7 +40,7 @@ struct QBTCParamResponse: Codable {
 
 final class QBTCChainService {
     private let httpClient: HTTPClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-chain")
+    private let logger = Log.qbtc.other
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.httpClient = httpClient

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/QBTC/QBTCGovService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/QBTC/QBTCGovService.swift
@@ -34,7 +34,7 @@ struct QBTCGovService: QBTCGovServiceProtocol {
 
     init(
         httpClient: HTTPClientProtocol = HTTPClient(),
-        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-gov-service")
+        logger: Logger = Log.qbtc.service
     ) {
         self.httpClient = httpClient
         self.logger = logger

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/QBTC/QBTCProofService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/QBTC/QBTCProofService.swift
@@ -11,7 +11,7 @@ import OSLog
 
 final class QBTCProofService {
     private let httpClient: HTTPClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-proof")
+    private let logger = Log.qbtc.other
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.httpClient = httpClient

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/QBTCGovernanceViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/QBTCGovernanceViewModel.swift
@@ -43,10 +43,7 @@ final class QBTCGovernanceViewModel: ObservableObject {
     private static let myVoteRecentPastLimit = 10
 
     private let service: QBTCGovServiceProtocol
-    private let logger = Logger(
-        subsystem: "com.vultisig.app",
-        category: "qbtc-governance-vm"
-    )
+    private let logger = Log.qbtc.viewModel
 
     init(service: QBTCGovServiceProtocol = QBTCGovService()) {
         self.service = service

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimEligibilityChecker.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimEligibilityChecker.swift
@@ -46,10 +46,7 @@ protocol QBTCChainServiceClaimable: Sendable {
     ) -> [ClaimableUtxo]
 }
 
-private let confirmationGateLogger = Logger(
-    subsystem: "com.vultisig.app",
-    category: "qbtc-confirmation-gate"
-)
+private let confirmationGateLogger = Log.qbtc.other
 
 extension QBTCChainServiceClaimable {
     /// Applies the confirmation gate. Fetches `MinUtxoConfirmationBlocks` and
@@ -106,7 +103,7 @@ final class QBTCClaimEligibilityChecker: ObservableObject {
     private let blockchairService: BlockchairServiceClaimable
     private let chainService: QBTCChainServiceClaimable
     private let cacheStore: UserDefaults
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-eligibility")
+    private let logger = Log.qbtc.other
 
     /// Address most recently checked. A subsequent `check()` with a
     /// different address always re-runs; same-address calls also re-run

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimJoinDriver.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimJoinDriver.swift
@@ -70,7 +70,7 @@ final class QBTCClaimJoinDriver: ObservableObject {
     private let session: KeysignSessionInfo
     private let sessionService: KeysignSessionServicing
     private let coinResolver: QBTCClaimCoinResolver
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-claim-join")
+    private let logger = Log.qbtc.other
 
     /// Cap on how long to wait for kickoff. Generous because the
     /// initiator may also be waiting on the user to confirm.

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimOrchestrator.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimOrchestrator.swift
@@ -53,7 +53,7 @@ final class QBTCClaimOrchestrator: ObservableObject {
     private let runBtcRound: RunBtcRound
     private let pushTxHash: PushTxHash?
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-claim")
+    private let logger = Log.qbtc.other
 
     init(
         generateProof: @escaping GenerateProof,

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimRoundRunner.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimRoundRunner.swift
@@ -38,7 +38,7 @@ final class QBTCClaimRoundRunner {
     static let fastVaultPeerWaitSeconds: TimeInterval = 60
 
     private let sessionService: KeysignSessionService
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-round-runner")
+    private let logger = Log.qbtc.other
 
     init(sessionService: KeysignSessionService = KeysignSessionService()) {
         self.sessionService = sessionService

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimSecureVaultRoundDriver.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Services/QBTCClaimSecureVaultRoundDriver.swift
@@ -21,7 +21,7 @@ final class QBTCClaimSecureVaultRoundDriver {
     private let session: KeysignSessionInfo
     private let participants: [String]
     private let sessionService: KeysignSessionServicing
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-securevault-driver")
+    private let logger = Log.qbtc.other
 
     init(
         session: KeysignSessionInfo,

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/ViewModels/QBTCClaimKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/ViewModels/QBTCClaimKeysignViewModel.swift
@@ -29,7 +29,7 @@ final class QBTCClaimKeysignViewModel: ObservableObject {
 
     private let orchestratorFactory: () -> QBTCClaimOrchestrator
     private var orchestrator: QBTCClaimOrchestrator?
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-claim-keysign-vm")
+    private let logger = Log.qbtc.viewModel
 
     init(
         vault: Vault,

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/ViewModels/QBTCClaimViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/ViewModels/QBTCClaimViewModel.swift
@@ -108,7 +108,7 @@ final class QBTCClaimViewModel: ObservableObject {
     private let blockchairService: BlockchairService
     private let sessionService: KeysignSessionService
     private let coinResolver: QBTCClaimCoinResolver
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "qbtc-claim-vm")
+    private let logger = Log.qbtc.viewModel
 
     init(
         vault: Vault,


### PR DESCRIPTION
## What

Mechanical, **declaration-only** swap of the QBTC surface onto the `Log` logging facade (the base from #4945 on `feat/logging-facade`). Each `Logger(subsystem: "com.vultisig.app", category: "qbtc-…")` declaration is replaced with the corresponding `Log.qbtc.<layer>` accessor.

Closes #4952.

## Scope

- **13 declarations across 12 files** in `Features/QBTCClaim/**`, `Blockchain/Cosmos/**/QBTC*`, and the QBTC governance view-model.
- Layer chosen mechanically by category **suffix** (`-service`→`service`, `-vm`→`viewModel`, else `other`):
  - `service` (1): `qbtc-gov-service`
  - `viewModel` (3): `qbtc-governance-vm`, `qbtc-claim-keysign-vm`, `qbtc-claim-vm`
  - `other` (9): `qbtc-claim-request`, `qbtc-chain`, `qbtc-proof`, `qbtc-confirmation-gate`, `qbtc-eligibility`, `qbtc-claim-join`, `qbtc-claim`, `qbtc-round-runner`, `qbtc-securevault-driver`

## Guarantees

- Only the **declaration** lines changed. Variable names are preserved (`logger`, `confirmationGateLogger`, and the `logger:` default-parameter in `QBTCGovService`), so **no call site, log level, or `privacy:` interpolation was touched**. No non-logging behavior change.
- `import OSLog` retained where the `Logger` type is still named.
- No files added → no `make generate` / `project.yml` change required.
- Generic (non-QBTC) Cosmos/UTXO loggers (e.g. `BlockchairService`'s `blockchair-service`) were **left for the chain spoke**.

## Verification

- Gate: full `make test` (unit suite) on iPhone 16e, worktree-local DerivedData → **`** TEST FAILED **`** solely due to the known pre-existing snapshot artifact `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro`; every other suite executed with 0 failures.
- Codex read-only review of the full diff: **"No deviations found"** — declaration-only, variable names preserved, layer mapping matches the suffix rule, no behavior change.

## Note

Stacked on `feat/logging-facade`. **Retarget to `main` once the base #4945 merges.**
