### PR TITLE
refactor(logging): migrate signing subsystem to Log facade (keygen/keysign/tss)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Common/common.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Common/common.swift
@@ -21,7 +21,7 @@ enum HelperError: Error, LocalizedError, Identifiable {
 }
 
 struct SignatureProvider {
-    let logger = Logger(subsystem: "chains", category: "tss")
+    let logger = Log.tss.tss
     let signatures: [String: TssKeysignResponse]
 
     func getDerSignature(preHash: Data) -> Data {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
@@ -41,7 +41,7 @@ struct DKLSKeyshare {
     let chaincode: String
 }
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dkls-keygen")
+private let logger = Log.keygen.network
 
 final class DKLSKeygen {
     let vault: Vault

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DilithiumKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DilithiumKeygen.swift
@@ -16,7 +16,7 @@ struct DilithiumKeyshare {
     let keyId: String
 }
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dilithium-keygen")
+private let logger = Log.keygen.network
 
 final class DilithiumKeygen {
     let vault: Vault

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
@@ -18,7 +18,7 @@ private extension goschnorr.schnorr_lib_error {
     static let schnorrLibOK = goschnorr.schnorr_lib_error(rawValue: 0)
 }
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "net-schnorr-keygen")
+private let logger = Log.keygen.network
 
 final class SchnorrKeygen {
     let vault: Vault

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -11,7 +11,7 @@ import OSLog
 import Mediator
 import Tss
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dkls-keysign")
+private let logger = Log.keysign.network
 
 final class DKLSKeysign {
     let keysignCommittee: [String]

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
@@ -20,7 +20,7 @@ struct DilithiumKeysignResponse: Codable {
     }
 }
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dilithium-keysign")
+private let logger = Log.keysign.network
 
 final class DilithiumKeysign {
     let keysignCommittee: [String]

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
@@ -19,7 +19,7 @@ private extension goschnorr.schnorr_lib_error {
     static let schnorrLibOK = goschnorr.schnorr_lib_error(rawValue: 0)
 }
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "net-schnorr-keysign")
+private let logger = Log.keysign.network
 
 final class SchnorrKeysign {
     let keysignCommittee: [String]

--- a/VultisigApp/VultisigApp/Blockchain/Tss/DKLSMessenger.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/DKLSMessenger.swift
@@ -10,7 +10,7 @@ import Mediator
 import OSLog
 import CryptoKit
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "net-dkls-messenger")
+private let logger = Log.tss.network
 final class DKLSMessenger {
     let mediatorURL: String
     let sessionID: String

--- a/VultisigApp/VultisigApp/Blockchain/Tss/ServiceDelegate.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/ServiceDelegate.swift
@@ -8,7 +8,7 @@ import OSLog
 import SwiftUI
 
 final class ServiceDelegate: NSObject, NetServiceDelegate, ObservableObject {
-    private let logger = Logger(subsystem: "service-delegate", category: "communication")
+    private let logger = Log.tss.network
     @Published var serverURL: String?
     /// Set when local-mode Bonjour resolution fails or times out. Observed by the
     /// join flow to surface a recoverable error instead of hanging on "Discovering".

--- a/VultisigApp/VultisigApp/Blockchain/Tss/TssMessenger.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/TssMessenger.swift
@@ -9,7 +9,7 @@ import Mediator
 import OSLog
 import Tss
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "net-tss-messenger")
+private let logger = Log.tss.network
 final class TssMessengerImpl: NSObject, TssMessengerProtocol {
     let mediatorUrl: String
     let sessionID: String

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
@@ -24,7 +24,7 @@ enum JoinKeygenStatus {
 
 @MainActor
 class JoinKeygenViewModel: ObservableObject {
-    private let logger = Logger(subsystem: "join-keygen", category: "viewmodel")
+    private let logger = Log.keygen.viewModel
     var vault: Vault
     var serviceDelegate: ServiceDelegate?
 

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
@@ -26,7 +26,7 @@ struct VaultRegistrationSnapshot {
 
 class KeygenPeerDiscoveryViewModel: ObservableObject {
 
-    private let logger = Logger(subsystem: "peers-discory-viewmodel", category: "communication")
+    private let logger = Log.keygen.network
 
     var tssType: TssType
     var vault: Vault

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenVerify.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenVerify.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 
 class KeygenVerify: ObservableObject {
-    private let logger = Logger(subsystem: "keygen-verify", category: "communication")
+    private let logger = Log.keygen.network
     let serverAddr: String
     let sessionID: String
     let localPartyID: String

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
@@ -57,7 +57,7 @@ struct KeyImportInput: Hashable {
 
 @MainActor
 class KeygenViewModel: ObservableObject {
-    private let logger = Logger(subsystem: "keygen-viewmodel", category: "tss")
+    private let logger = Log.keygen.tss
 
     /// Maps derivationPath to WalletCore Derivation for each chain.
     /// Add new chains/derivations here to support additional derivation types.

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
@@ -29,7 +29,7 @@ struct JoinKeygenView: View {
     @EnvironmentObject var homeViewModel: HomeViewModel
     @Environment(\.router) var router
 
-    let logger = Logger(subsystem: "join-keygen", category: "communication")
+    let logger = Log.keygen.network
 
     var body: some View {
         content

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/MessagePuller.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/MessagePuller.swift
@@ -13,7 +13,7 @@ class MessagePuller: ObservableObject {
     let vaultPubKey: String
     var cache = NSCache<NSString, AnyObject>()
     private var pollingInboundMessages = true
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "net-message-puller")
+    private let logger = Log.keygen.network
     private var currentTask: Task<Void, Error>? = nil
     let encryptGCM: Bool
     private let httpClient: HTTPClientProtocol

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/ReviewYourVaultsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/ReviewYourVaultsScreen.swift
@@ -7,7 +7,7 @@ import OSLog
 import SwiftUI
 import RiveRuntime
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "review-your-vaults")
+private let logger = Log.keygen.view
 
 struct ReviewYourVaultsScreen: View {
     let vault: Vault

--- a/VultisigApp/VultisigApp/Features/Keysign/Navigation/SigningRouter.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Navigation/SigningRouter.swift
@@ -16,7 +16,7 @@ import OSLog
 import SwiftData
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "signing-router")
+private let logger = Log.keysign.other
 
 struct SigningRouter {
 

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/FastVaultKeysignBootstrap.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/FastVaultKeysignBootstrap.swift
@@ -75,7 +75,7 @@ struct FastVaultKeysignBootstrap {
     static let fastVaultPeerWaitSeconds: TimeInterval = 60
 
     private let sessionService: FastVaultKeysignSessionProviding
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "fast-vault-keysign-bootstrap")
+    private let logger = Log.keysign.other
 
     init(sessionService: FastVaultKeysignSessionProviding = KeysignSessionService()) {
         self.sessionService = sessionService

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignSessionService.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/KeysignSessionService.swift
@@ -84,7 +84,7 @@ final class KeysignSessionService: KeysignSessionServicing {
     private nonisolated(unsafe) let mediator: Mediator
     private nonisolated(unsafe) let fastVaultService: FastVaultService
     private let httpClient: HTTPClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "keysign-session")
+    private let logger = Log.keysign.service
 
     nonisolated init(
         mediator: Mediator = .shared,

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -40,7 +40,7 @@ enum JoinKeysignStatus {
 @MainActor
 class JoinKeysignViewModel: ObservableObject {
 
-    private let logger = Logger(subsystem: "join-keysign", category: "viewmodel")
+    private let logger = Log.keysign.viewModel
 
     var vault: Vault
     var serviceDelegate: ServiceDelegate?

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignDiscoveryViewModel.swift
@@ -16,7 +16,7 @@ enum KeysignDiscoveryStatus {
 }
 
 class KeysignDiscoveryViewModel: ObservableObject {
-    private let logger = Logger(subsystem: "keysign-discovery", category: "viewmodel")
+    private let logger = Log.keysign.viewModel
     private var cancellables = Set<AnyCancellable>()
 
     var vault: Vault

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -43,7 +43,7 @@ enum TssKeysignError: Error {
 }
 @MainActor
 class KeysignViewModel: ObservableObject {
-    private let logger = Logger(subsystem: "keysign", category: "tss")
+    private let logger = Log.keysign.tss
 
     @Published var status: KeysignStatus = .CreatingInstance
     @Published var keysignError: String = .empty

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignAnimationView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignAnimationView.swift
@@ -7,7 +7,7 @@ import OSLog
 import SwiftUI
 import RiveRuntime
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "keysign-animation")
+private let logger = Log.keysign.view
 
 struct KeysignAnimationView: View {
 

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignVerify.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignVerify.swift
@@ -10,7 +10,7 @@ import OSLog
 import Tss
 
 class KeysignVerify: ObservableObject {
-    private let logger = Logger(subsystem: "keysign-verify", category: "communication")
+    private let logger = Log.keysign.network
     let serverAddr: String
     let sessionID: String
     let urlString: String

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignView.swift
@@ -5,7 +5,7 @@
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "keysign-view")
+private let logger = Log.keysign.view
 
 struct KeysignView: View {
     /// The keysign ceremony view-model, owned by the host (initiator, cosigner,

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/ParticipantDiscovery.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/ParticipantDiscovery.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 
 class ParticipantDiscovery: ObservableObject {
-    private let logger = Logger(subsystem: "participant-discovery", category: "communication")
+    private let logger = Log.keysign.network
     private let httpClient: HTTPClientProtocol
 
     @Published var peersFound = [String]()

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/SigningKeysignScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/SigningKeysignScreen.swift
@@ -18,7 +18,7 @@ import Mediator
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "signing-keysign")
+private let logger = Log.keysign.view
 
 struct SigningKeysignScreen: View {
     @Environment(\.router) var router


### PR DESCRIPTION
## What

Declaration-only migration of the **signing subsystem** (Keygen + Keysign + TSS/communication) from raw `Logger(subsystem: "com.vultisig.app", category: "…")` declarations to the `Log.<feature>.<layer>` facade introduced by the base PR (#4945).

Closes #4946.

> Stacked on `feat/logging-facade`. **Retarget this PR to `main` once the base #4945 merges.**

## Scope — 28 declarations swapped

Only the logger **declaration line** changed in each file. The variable keeps the same name (`logger`), so every call site (`logger.debug/info/error(…, privacy:)`) is byte-for-byte untouched — no log level, message, or `privacy:` interpolation was altered. `Log.<feature>.<layer>` returns a native `os.Logger`, so OSLog levels, privacy redaction, and Console/`log stream` category filtering are all preserved.

| Feature | Count | Layers |
|---|---|---|
| `keygen` | 10 | network 7, tss 1, view 1, viewModel 1 |
| `keysign` | 14 | network 5, view 3, viewModel 2, other 2, service 1, tss 1 |
| `tss` | 4 | network 3, tss 1 |
| **Total** | **28** | |

Mapping followed the facade taxonomy in `LogFeature.swift` / `LogLayer.swift`: category **suffix → layer** (`net-*`/`communication`/`*-messenger` → network, literal `tss` → tss, `viewmodel` → viewModel, `*-service` → service, screens/views/animation → view, router/bootstrap utilities → other); **directory → feature** (Keygen → keygen, Keysign → keysign, `Blockchain/Tss` + `Blockchain/Common` → tss).

The `Mediator` SPM package has its own subsystem and was intentionally left untouched. No files were added, so no `make generate` was required for the change itself.

### Note on `communication` categories
The base facade's `LogLayer.swift` explicitly documents `communication` (peer-discovery / mediator transport) under the **network** layer, alongside `net-*` and `*-messenger`. Accordingly the 6 `communication`-category loggers (ServiceDelegate, KeygenPeerDiscovery, KeygenVerify, JoinKeygenView, KeysignVerify, ParticipantDiscovery) map to `.network`. The 3 loggers whose category was the literal string `tss` (KeygenViewModel, KeysignViewModel, common.swift `SignatureProvider`) correctly stay on `.tss`. A cross-model (Codex) review independently flagged this same `communication → network` mapping.

## Verification
- **Full test gate** on iPhone 16 Pro (worktree-local `-derivedDataPath`): **3916 tests, 1 skipped, exactly 1 failure (0 unexpected)** — the sole failure is the pre-existing `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` snapshot artifact, unrelated to this change. Green modulo that known artifact. Runtime logs confirm the new categories resolve (e.g. `[tss.network] fail to download setup message`).
- **Codex read-only review** (2 passes): `CODEX_EXIT=0` — "declaration-only, no call site/level/privacy changed, all feature/layer mappings match `LogFeature.swift`/`LogLayer.swift`."

## Out of scope
Some migrated files now retain an unused `import OSLog` — left in place deliberately to keep this a strict declaration-only swap; a later cleanup can prune them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
