### PR TITLE
refactor(logging): route wallet + app Logger declarations through Log facade (#4951)

### DIFF
--- a/VultisigApp/VultisigApp/Components/TransactionDone/Pollers/LimitOrderCancelPoller.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/Pollers/LimitOrderCancelPoller.swift
@@ -45,7 +45,7 @@ final class LimitOrderCancelPoller: DoneStatusPoller {
     private let verifier: LimitOrderCancelVerifying
     private let intents: LimitOrderCancelIntentStoring
     private let config: ChainStatusConfig
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "limit-cancel-poller")
+    private let logger = Log.wallet.other
 
     private var pollTask: Task<Void, Never>?
 

--- a/VultisigApp/VultisigApp/Components/TransactionDone/TransactionHistoryRecording.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/TransactionHistoryRecording.swift
@@ -17,7 +17,7 @@ import Foundation
 import OSLog
 import SwiftData
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "tx-history-recorder")
+private let logger = Log.wallet.other
 
 enum TransactionHistoryRecording {
 

--- a/VultisigApp/VultisigApp/Core/Extensions/FileManagerExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/FileManagerExtension.swift
@@ -26,7 +26,7 @@ extension FileManager {
     /// Extract a ZIP file to a destination directory using ZIPFoundation
     /// - Important: Protects against zip-slip attacks and denies symlink extraction
     func unzipItem(at sourceURL: URL, to destinationURL: URL) throws {
-        let logger = Logger(subsystem: "com.vultisig.wallet", category: "zip-extraction")
+        let logger = Log.app.other
 
         guard let archive = try? Archive(url: sourceURL, accessMode: .read, pathEncoding: nil) else {
             logger.error("Failed to open ZIP archive at: \(sourceURL.path, privacy: .public)")

--- a/VultisigApp/VultisigApp/Core/Networking/HTTPClient.swift
+++ b/VultisigApp/VultisigApp/Core/Networking/HTTPClient.swift
@@ -26,7 +26,7 @@ final class HTTPClient: HTTPClientProtocol {
         session: URLSession = .shared,
         jsonEncoder: JSONEncoder = JSONEncoder(),
         jsonDecoder: JSONDecoder = JSONDecoder(),
-        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "http-client")
+        logger: Logger = Log.app.other
     ) {
         self.session = session
         self.jsonEncoder = jsonEncoder

--- a/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
+++ b/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
@@ -25,10 +25,7 @@ class PushNotificationManager: ObservableObject {
 
     private let keychainService: KeychainService
     private let notificationService: NotificationServicing
-    private let logger = Logger(
-        subsystem: "com.vultisig.wallet",
-        category: "PushNotifications"
-    )
+    private let logger = Log.app.other
 
     private let notificationDelegate = NotificationDelegate()
 

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Utils/LocalNetworkAuthorization.swift
@@ -49,7 +49,7 @@ enum LocalNetworkAuthorization {
 /// need a live run loop, and the browser/timeout are scheduled there too so no
 /// locking is required.
 private final class Prober: NSObject, NetServiceDelegate, @unchecked Sendable {
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "local-network-authorization")
+    private let logger = Log.app.other
     /// The probe type MUST be one of the app's declared `NSBonjourServices`
     /// entries. iOS refuses to publish or browse an undeclared type even when
     /// Local Network access is *granted* — `NetService` fails with

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Services/MacScreenCaptureService.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Services/MacScreenCaptureService.swift
@@ -9,7 +9,7 @@ import CoreImage
 import SwiftUI
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "screen-capture")
+private let logger = Log.app.other
 
 /// Thread-safe normalized rect (0..1) in screen coordinates (bottom-left origin).
 /// Written by the preview NSView, read by the stream output for cropping QR detection.

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidExtensions.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidExtensions.swift
@@ -253,7 +253,7 @@ private extension BlockaidTransactionScanResponseJson {
 private extension String {
 
     func toWarningType() -> SecurityRiskLevel {
-        let logger = Logger(subsystem: "com.vultisig.app", category: "security-scanner")
+        let logger = Log.app.other
 
         switch self.lowercased() {
         case "benign", "info":

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidScannerService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidScannerService.swift
@@ -12,7 +12,7 @@ import OSLog
 class BlockaidScannerService: BlockaidScannerServiceProtocol {
 
     private let blockaidRpcClient: BlockaidRpcClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "blockaid-scanner")
+    private let logger = Log.app.other
 
     init(blockaidRpcClient: BlockaidRpcClientProtocol) {
         self.blockaidRpcClient = blockaidRpcClient

--- a/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Providers/Blockaid/BlockaidSimulationService.swift
@@ -34,7 +34,7 @@ actor BlockaidSimulationService {
     )
 
     private let rpcClient: BlockaidRpcClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "blockaid-simulation")
+    private let logger = Log.app.other
 
     private var cache: [CacheKey: BlockaidKeysignScanResult] = [:]
     private var inflight: [CacheKey: Task<BlockaidKeysignScanResult, Error>] = [:]

--- a/VultisigApp/VultisigApp/Core/Security/SecurityScannerService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/SecurityScannerService.swift
@@ -17,7 +17,7 @@ class SecurityScannerService: SecurityScannerServiceProtocol {
     private let providers: [BlockaidScannerServiceProtocol]
     private let settingsService: SecurityScannerSettingsServiceProtocol
     private let factory: SecurityScannerTransactionFactoryProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "security-scanner-service")
+    private let logger = Log.app.service
 
     // Thread-safe set for disabled provider names
     private let disabledProvidersQueue = DispatchQueue(label: "com.vultisig.security-scanner.providers", attributes: .concurrent)

--- a/VultisigApp/VultisigApp/Core/Stores/CustomRPCStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/CustomRPCStore.swift
@@ -29,7 +29,7 @@ final class CustomRPCStore: @unchecked Sendable {
 
     private let lock = NSLock()
     private var mirror: [String: String] = [:]
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "custom-rpc-store")
+    private let logger = Log.wallet.store
 
     private init() {}
 

--- a/VultisigApp/VultisigApp/Core/Utils/Utils.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Utils.swift
@@ -14,7 +14,7 @@ import SwiftUI
 // Legacy callback-based HTTP helpers predating `HTTPClient`/`TargetType`.
 // Disabled file-wide rather than per-call; new code should use `HTTPClient`.
 enum Utils {
-    static let logger = Logger(subsystem: "util", category: "network")
+    static let logger = Log.app.other
     static let context = CIContext()
     static func sendRequest<T: Codable>(urlString: String, method: String, headers: [String: String]? = nil, body: T?, completion: @escaping (Bool) -> Void) {
         logger.debug("url:\(urlString)")

--- a/VultisigApp/VultisigApp/Core/Utils/VaultBackupEncryption.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/VaultBackupEncryption.swift
@@ -3,7 +3,7 @@ import CryptoKit
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "vault-backup-encryption")
+private let logger = Log.app.other
 
 protocol VaultBackupEncryption: Sendable {
     func encrypt(data: Data, password: String) async throws -> Data

--- a/VultisigApp/VultisigApp/Core/ViewModels/ShareSheetViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/ShareSheetViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "share-sheet-view-model")
+private let logger = Log.wallet.viewModel
 
 @MainActor
 class ShareSheetViewModel: ObservableObject {

--- a/VultisigApp/VultisigApp/Features/Common/Views/Banners/BannersCarousel.swift
+++ b/VultisigApp/VultisigApp/Features/Common/Views/Banners/BannersCarousel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "banners-carousel")
+private let logger = Log.app.view
 
 struct BannersCarousel<Banner: CarouselBannerType>: View {
     @Binding var banners: [Banner]

--- a/VultisigApp/VultisigApp/Features/CustomRPC/Service/RPCHealthProbe.swift
+++ b/VultisigApp/VultisigApp/Features/CustomRPC/Service/RPCHealthProbe.swift
@@ -81,7 +81,7 @@ private struct TronProbeResponse: Decodable {
 struct RPCHealthProbe {
 
     private let httpClient: HTTPClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "rpc-health-probe")
+    private let logger = Log.app.other
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.httpClient = httpClient

--- a/VultisigApp/VultisigApp/Features/Home/Service/VaultDefiChainsService.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Service/VaultDefiChainsService.swift
@@ -8,7 +8,7 @@
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "vault-defi-chains-service")
+private let logger = Log.wallet.service
 
 // Enables Defi chains for the first time for vaults that were created before Defi features where released
 // TODO: - To be removed after release

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/ChainsSetup/KeyImportChainsSetupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/ChainsSetup/KeyImportChainsSetupViewModel.swift
@@ -44,7 +44,7 @@ final class KeyImportChainsSetupViewModel: ObservableObject {
     @Published var isLoading: Bool = false
 
     private var chainBalanceResults = [ChainBalanceResult]()
-    private let logger = Logger(subsystem: "com.vultisig.VultisigApp", category: "KeyImport")
+    private let logger = Log.app.other
     private var wallet: HDWallet?
 
     /// Chains that have alternative derivation paths to check during import.

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/EditReferralDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/EditReferralDetailsViewModel.swift
@@ -22,7 +22,7 @@ import VultisigCommonData
 @Observable
 final class EditReferralDetailsViewModel {
 
-    @ObservationIgnored private let logger = Logger(subsystem: "com.vultisig.app", category: "edit-referral-details-vm")
+    @ObservationIgnored private let logger = Log.wallet.viewModel
     @ObservationIgnored private let interactor: SendInteractor
     @ObservationIgnored private let thorchainService: THORChainAPIService
     @ObservationIgnored private let addCoinIfNeeded: @MainActor (THORChainAsset, Vault) throws -> Coin?

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/ReferralDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/ReferralDetailsViewModel.swift
@@ -46,7 +46,7 @@ final class ReferralDetailsViewModel {
         }
     }
 
-    @ObservationIgnored private let logger = Logger(subsystem: "com.vultisig.app", category: "referral-details-vm")
+    @ObservationIgnored private let logger = Log.wallet.viewModel
     @ObservationIgnored private let interactor: SendInteractor
     @ObservationIgnored private let thorchainService: THORChainAPIService
     @ObservationIgnored private let saveReferralCode: @MainActor (ReferralCode) -> Void

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Services/TransactionHistoryRecorder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Services/TransactionHistoryRecorder.swift
@@ -11,7 +11,7 @@ final class TransactionHistoryRecorder {
     static let shared = TransactionHistoryRecorder()
 
     private let storage = TransactionHistoryStorage.shared
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "tx-history-recorder")
+    private let logger = Log.wallet.other
 
     private init() {}
 

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryScreen.swift
@@ -6,7 +6,7 @@
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "transaction-history-screen")
+private let logger = Log.wallet.view
 
 struct TransactionHistoryScreen: View {
     @StateObject private var viewModel: TransactionHistoryViewModel

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryViewModel.swift
@@ -53,7 +53,7 @@ class TransactionHistoryViewModel: ObservableObject {
     private let limitOrderStorage = LimitOrderStorageService()
     private let poller: TransactionHistoryNativePoller
     private let registry: SwapTrackingRegistry
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "tx-history-viewmodel")
+    private let logger = Log.wallet.viewModel
 
     init(
         pubKeyECDSA: String,

--- a/VultisigApp/VultisigApp/Features/UpdateCheck/ViewModels/PhoneCheckUpdateViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/UpdateCheck/ViewModels/PhoneCheckUpdateViewModel.swift
@@ -18,7 +18,7 @@ class PhoneCheckUpdateViewModel: ObservableObject {
     @Published var latestVersionString: String = ""
     @Published var currentVersionString: String = ""
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "update-check")
+    private let logger = Log.app.other
     private let logic = PhoneCheckUpdateLogic()
 
     func checkForUpdates(isAutoCheck: Bool = false) {

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
@@ -10,7 +10,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "vult-tier-service")
+private let logger = Log.app.service
 
 struct VultTierService {
     let vultTicker = "VULT"

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -34,7 +34,7 @@ class EncryptedBackupViewModel: ObservableObject {
     @Published var extractedFilesDirectory: URL?
     @Published var pendingEncryptedVaults: [(fileName: String, data: Data)] = []
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "encrypted-backup")
+    private let logger = Log.wallet.other
     private let keychain = DefaultKeychainService.shared
     private let backupEncryption: VaultBackupEncryption = Pbkdf2VaultBackupEncryption()
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TransactionStatusViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TransactionStatusViewModel.swift
@@ -18,7 +18,7 @@ class TransactionStatusViewModel: ObservableObject {
     private let config: ChainStatusConfig
     private let service = TransactionStatusService.shared
     private let storage = StoredPendingTransactionStorage.shared
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "tx-status-viewmodel")
+    private let logger = Log.wallet.viewModel
 
     // Optional metadata for persistence
     private let coinTicker: String?

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/PasswordVerifyReminderView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/PasswordVerifyReminderView.swift
@@ -8,7 +8,7 @@
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "password-verify-reminder")
+private let logger = Log.wallet.other
 
 struct PasswordVerifyReminderView: View {
     let vault: Vault


### PR DESCRIPTION
## Wallet + App logging spoke — route `Logger` declarations through the `Log` facade

Closes #4951. Part of the logging-facade epic (#4943). **Stacks on `feat/logging-facade`** (PR base #4945); retargets to `main` after the base merges.

### What

Declaration-only migration of the **29** wallet/app-area `Logger(subsystem:category:)` declarations onto the `Log` facade added by the base branch. Each declaration becomes `Log.<feature>.<layer>`, which hands back a configured `os.Logger` (real logger when the category is enabled, `Logger(.disabled)` otherwise).

- **No call-site changes.** Levels, `\(…, privacy:)` redaction, and Console/`log stream` filtering are all preserved — the facade only chooses *which* `os.Logger` to return; it never wraps the message.
- **Variable names unchanged** (`logger`, and the `logger:` default parameter in `HTTPClient`).
- Normalizes three stray subsystems (`"util"`, `"com.vultisig.wallet"`, `"com.vultisig.VultisigApp"`) onto the facade's single `"com.vultisig.app"` subsystem.

### Feature / layer breakdown

Feature ownership follows the survey-driven spoke map (wiki `logging-wrapper/impl-plan.md`): `wallet` = `Features/{Wallet,TransactionHistory,Home,Referral}` + `Core/{Stores,ViewModels}` + `Components/*`; `app` = `Core/{Networking,Security,Platform,Utils,Extensions,Notifications}` + `Features/{UpdateCheck,Onboarding,VultDiscountTiers,Common,CustomRPC}`. Layer derived from each original category string per the `LogLayer` taxonomy.

**wallet (13)**

| category (was) | → | mapped |
|---|---|---|
| `password-verify-reminder` | | `Log.wallet.other` |
| `tx-status-viewmodel` | | `Log.wallet.viewModel` |
| `encrypted-backup` | | `Log.wallet.other` |
| `tx-history-viewmodel` | | `Log.wallet.viewModel` |
| `transaction-history-screen` | | `Log.wallet.view` |
| `tx-history-recorder` (Services) | | `Log.wallet.other` |
| `referral-details-vm` | | `Log.wallet.viewModel` |
| `edit-referral-details-vm` | | `Log.wallet.viewModel` |
| `vault-defi-chains-service` | | `Log.wallet.service` |
| `custom-rpc-store` | | `Log.wallet.store` |
| `share-sheet-view-model` | | `Log.wallet.viewModel` |
| `tx-history-recorder` (Components) | | `Log.wallet.other` |
| `limit-cancel-poller` | | `Log.wallet.other` |

**app (16)**

| category (was) | → | mapped |
|---|---|---|
| `http-client` | | `Log.app.other` |
| `security-scanner-service` | | `Log.app.service` |
| `blockaid-simulation` | | `Log.app.other` |
| `blockaid-scanner` | | `Log.app.other` |
| `security-scanner` | | `Log.app.other` |
| `screen-capture` | | `Log.app.other` |
| `local-network-authorization` | | `Log.app.other` |
| `PushNotifications` | | `Log.app.other` |
| `vault-backup-encryption` | | `Log.app.other` |
| `network` (Utils) | | `Log.app.other` |
| `zip-extraction` | | `Log.app.other` |
| `update-check` | | `Log.app.other` |
| `vult-tier-service` | | `Log.app.service` |
| `KeyImport` | | `Log.app.other` |
| `banners-carousel` | | `Log.app.view` |
| `rpc-health-probe` | | `Log.app.other` |

### Notes

- `Core/Services/*` (incl. `TransactionStatus/*`) is owned by the `chain` spoke per the map, not touched here.
- No files added/removed, so no `project.yml`/pbxproj change.

### Test plan

- Full `xcodebuild test` on iPhone 15 sim (worktree-local derived data). Green apart from the known-flaky `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` snapshot case.
