### PR TITLE
refactor(logging): route chain/blockchain-service Logger declarations through Log.chain facade

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Service/CardanoNativeTokensService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Service/CardanoNativeTokensService.swift
@@ -10,7 +10,7 @@ actor CardanoNativeTokensService {
 
     static let shared = CardanoNativeTokensService()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "cardano-native-tokens")
+    private let logger = Log.chain.other
     private let httpClient: HTTPClientProtocol
     private var assetInfoCache: [String: CachedMetadata] = [:]
     private let cacheTTL: TimeInterval = 7 * 24 * 60 * 60

--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Service/CardanoService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Service/CardanoService.swift
@@ -11,7 +11,7 @@ class CardanoService {
 
     static let shared = CardanoService()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "cardano-service")
+    private let logger = Log.chain.service
     private let httpClient: HTTPClientProtocol
 
     private init(httpClient: HTTPClientProtocol = HTTPClient()) {

--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/Cardano.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/Cardano.swift
@@ -11,7 +11,7 @@ import WalletCore
 import BigInt
 import OSLog
 
-private let cardanoLogger = Logger(subsystem: "com.vultisig.app", category: "cardano-helper")
+private let cardanoLogger = Log.chain.other
 
 /*
  Cardano UTXO Validation & Send Max Recommendations

--- a/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/SwapKitCardanoSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cardano/Signing/SwapKitCardanoSigner.swift
@@ -33,7 +33,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-cardano-signer")
+private let logger = Log.chain.other
 
 enum SwapKitCardanoSignerError: Error, LocalizedError {
     case emptyPayload

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosCoinFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosCoinFinder.swift
@@ -27,7 +27,7 @@ actor CosmosCoinFinder {
 
     static let shared = CosmosCoinFinder()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "cosmos-discovery")
+    private let logger = Log.chain.other
     private let httpClient: HTTPClientProtocol
     private let metadataResolver: CosmosTokenMetadataResolver
 

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosServiceStruct.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosServiceStruct.swift
@@ -6,7 +6,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "cosmos-service")
+private let logger = Log.chain.service
 
 struct CosmosServiceStruct {
     let config: CosmosServiceConfig

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/CosmosTokenMetadataResolver.swift
@@ -33,7 +33,7 @@ actor CosmosTokenMetadataResolver {
 
     static let shared = CosmosTokenMetadataResolver()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "cosmos-discovery")
+    private let logger = Log.chain.other
     private let httpClient: HTTPClientProtocol
 
     /// 24h — mirrors `vultisig-sdk` denom-metadata cache TTL exactly. Long

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingAPYResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingAPYResolver.swift
@@ -47,7 +47,7 @@ actor CosmosStakingAPYResolver: CosmosStakingAPYResolverProtocol {
         httpClient: HTTPClientProtocol = HTTPClient(),
         ttl: TimeInterval = 5 * 60,
         clock: @escaping @Sendable () -> Date = { Date() },
-        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "cosmos-apy-resolver")
+        logger: Logger = Log.chain.other
     ) {
         self.httpClient = httpClient
         self.ttl = ttl

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingService.swift
@@ -28,7 +28,7 @@ struct CosmosStakingService: CosmosStakingServiceProtocol {
 
     init(
         httpClient: HTTPClientProtocol = HTTPClient(),
-        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "cosmos-staking-service")
+        logger: Logger = Log.chain.service
     ) {
         self.httpClient = httpClient
         self.logger = logger

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingSignDataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/CosmosStakingSignDataResolver.swift
@@ -60,10 +60,7 @@ enum CosmosStakingSignDataResolver {
         }
     }
 
-    private static let logger = Logger(
-        subsystem: "com.vultisig.app",
-        category: "cosmos-staking-sign-resolver"
-    )
+    private static let logger = Log.chain.other
 
     /// Resolves the SignDoc artefacts for a secp256k1 staking payload. Caller
     /// passes the immutable `SendTransaction` and the Cosmos chain-specific

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/KeybaseAvatarService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Service/Staking/KeybaseAvatarService.swift
@@ -47,7 +47,7 @@ actor KeybaseAvatarService: KeybaseAvatarServiceProtocol {
         httpClient: HTTPClientProtocol = HTTPClient(),
         ttl: TimeInterval = 60 * 60,
         clock: @escaping @Sendable () -> Date = { Date() },
-        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "keybase-avatar-service")
+        logger: Logger = Log.chain.service
     ) {
         self.httpClient = httpClient
         self.ttl = ttl

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosGasEstimator.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosGasEstimator.swift
@@ -10,7 +10,7 @@ import OSLog
 import WalletCore
 import VultisigCommonData
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "cosmos-gas-estimator")
+private let logger = Log.chain.other
 
 /// Simulates a Cosmos native send via `/cosmos/tx/v1beta1/simulate` and derives
 /// a padded gas limit the initiator relays to co-signers in

--- a/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmCoinFinder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/EVM/Service/EvmCoinFinder.swift
@@ -21,7 +21,7 @@ import BigInt
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "evm-coin-finder")
+private let logger = Log.chain.other
 
 enum EvmCoinFinder {
 

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleRetryPolicy.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleRetryPolicy.swift
@@ -119,7 +119,7 @@ struct RippleRequestRetrier {
     init(
         httpClient: HTTPClientProtocol = HTTPClient(),
         sleep: @escaping Sleeper = RippleRequestRetrier.defaultSleep,
-        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "ripple-retry")
+        logger: Logger = Log.chain.other
     ) {
         self.httpClient = httpClient
         self.sleep = sleep

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Service/RippleService.swift
@@ -139,7 +139,7 @@ class RippleService {
 
     static let shared = RippleService()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "ripple-service")
+    private let logger = Log.chain.service
 
     /// Direct HTTP client for the verify-by-hash `tx` lookup, which runs its
     /// own bespoke retry loop (see `resolveSubmitByHash`).

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -11,7 +11,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "ripple-helper")
+private let logger = Log.chain.other
 
 enum RippleHelper {
 

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -35,7 +35,7 @@ enum SolanaRetryableError: Error, LocalizedError, RetryableBroadcastError {
 class SolanaService {
     static let shared = SolanaService()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "solana-service")
+    private let logger = Log.chain.service
     private let httpClient: HTTPClientProtocol
 
     /// Resolves the Solana custom RPC override. Injected so the API values are

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingService.swift
@@ -70,7 +70,7 @@ actor SolanaStakingService: SolanaStakingServiceProtocol {
         validatorTTL: TimeInterval = 10 * 60,
         inflationTTL: TimeInterval = 10 * 60,
         clock: @escaping @Sendable () -> Date = { Date() },
-        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "solana-staking-service")
+        logger: Logger = Log.chain.service
     ) {
         self.solanaService = solanaService
         self.validatorTTL = validatorTTL

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingSignDataResolver.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/SolanaStakingSignDataResolver.swift
@@ -53,10 +53,7 @@ enum SolanaStakingSignDataResolver {
         }
     }
 
-    private static let logger = Logger(
-        subsystem: "com.vultisig.app",
-        category: "solana-staking-sign-resolver"
-    )
+    private static let logger = Log.chain.other
 
     /// Resolves the `SignSolana` artefact for a delegate payload.
     ///

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/StakewizValidatorMetadataProvider.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/Staking/StakewizValidatorMetadataProvider.swift
@@ -60,7 +60,7 @@ actor StakewizValidatorMetadataProvider: ValidatorMetadataProvider {
         avatarService: KeybaseAvatarServiceProtocol = KeybaseAvatarService(),
         ttl: TimeInterval = 60 * 60,
         clock: @escaping @Sendable () -> Date = { Date() },
-        logger: Logger = Logger(subsystem: "com.vultisig.app", category: "stakewiz-validator-metadata")
+        logger: Logger = Log.chain.other
     ) {
         self.httpClient = httpClient
         self.avatarService = avatarService

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
@@ -14,7 +14,7 @@ import WalletCore
 class SuiService {
     static let shared = SuiService()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "sui-service")
+    private let logger = Log.chain.service
 
     /// Default Sui JSON-RPC host.
     static let defaultRPCURL: URL = {

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Signing/SwapKitSuiSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Signing/SwapKitSuiSigner.swift
@@ -29,7 +29,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-sui-signer")
+private let logger = Log.chain.other
 
 enum SwapKitSuiSignerError: Error, LocalizedError {
     case emptyPayload

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/MayaChainService.swift
@@ -11,7 +11,7 @@ import OSLog
 class MayachainService: ThorchainSwapProvider {
     static let shared = MayachainService()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "mayachain-service")
+    private let logger = Log.chain.service
     private let httpClient: HTTPClientProtocol
     private var cacheInboundAddresses = ThreadSafeDictionary<String, (data: [InboundAddress], timestamp: Date)>()
 

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/SecuredAssetCatalog.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/SecuredAssetCatalog.swift
@@ -12,7 +12,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "secured-asset-catalog")
+private let logger = Log.chain.other
 
 /// One entry from THORNode `/thorchain/securedassets`. `asset` is the uppercase
 /// dash-notation denom (e.g. `ETH-USDC-0X…`, `BTC-BTC`); `supply`/`depth` are

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/Staking/THORChainStakingService.swift
@@ -21,7 +21,7 @@ class THORChainStakingService: THORChainStakingProviding {
     static let shared = THORChainStakingService()
 
     private let httpClient: HTTPClient
-    private let logger = Logger(subsystem: "com.vultisig.wallet", category: "thorchain-staking")
+    private let logger = Log.chain.other
 
     // Cache for TCY constants (they don't change often)
     private var cachedTcyConstants: TcyConstants?

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService.swift
@@ -12,7 +12,7 @@ import OSLog
 class ThorchainService: ThorchainSwapProvider {
     var network: String = ""
     static let shared = ThorchainService()
-    let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-service")
+    let logger = Log.chain.service
 
     /// Injectable so the sign-time halt gate is unit-testable with a stubbed
     /// inbound response (same pattern as `MayachainService`); production uses

--- a/VultisigApp/VultisigApp/Blockchain/Ton/MessageBody/TonCellSlice.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/MessageBody/TonCellSlice.swift
@@ -7,7 +7,7 @@ import Foundation
 import OSLog
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "ton-cell-slice")
+private let logger = Log.chain.other
 
 /// Errors thrown by the minimal TON BOC parser. They are intentionally caught
 /// at decoder boundaries so a malformed/truncated body falls back to "unknown"

--- a/VultisigApp/VultisigApp/Blockchain/Ton/MessageBody/TonMessageBodyDecoder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/MessageBody/TonMessageBodyDecoder.swift
@@ -7,7 +7,7 @@ import Foundation
 import OSLog
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "ton-message-body-decoder")
+private let logger = Log.chain.other
 
 /// Decode the body BOC of a TON internal message into a structured intent.
 ///

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Service/TonExternalMessageEmulator.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Service/TonExternalMessageEmulator.swift
@@ -7,7 +7,7 @@ import Foundation
 import OSLog
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "ton-external-message-emulator")
+private let logger = Log.chain.other
 
 /// Builds a wallet-v4R2 external-message BOC for emulation. Reuses the same
 /// `TheOpenNetworkSigningInput` path that signing uses, then injects a 64-byte

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Service/TonService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Service/TonService.swift
@@ -7,7 +7,7 @@ class TonService {
 
     static let shared = TonService()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "ton-service")
+    private let logger = Log.chain.service
     private let httpClient: HTTPClientProtocol = HTTPClient()
 
     /// Resolves the TON custom RPC override. Injected so the API values are

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Signing/Ton.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Signing/Ton.swift
@@ -11,7 +11,7 @@ import Tss
 import WalletCore
 import BigInt
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "ton-helper")
+private let logger = Log.chain.other
 
 enum TonHelper {
 

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/SwapKitTronSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/SwapKitTronSigner.swift
@@ -32,7 +32,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-tron-signer")
+private let logger = Log.chain.other
 
 enum SwapKitTronSignerError: Error, LocalizedError {
     case emptyPayload

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Service/BlockchairService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Service/BlockchairService.swift
@@ -11,7 +11,7 @@ import OSLog
 
 actor BlockchairService {
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "blockchair-service")
+    private let logger = Log.chain.service
     private let httpClient: HTTPClientProtocol
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Service/ZcashService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Service/ZcashService.swift
@@ -6,7 +6,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "zcash-service")
+private let logger = Log.chain.service
 
 /// Resolves the active ZIP-243 consensus branch id WalletCore needs on the
 /// Zcash transaction plan. The branch id changes at every Zcash network

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/BitcoinPsbtSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/BitcoinPsbtSigner.swift
@@ -17,7 +17,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "btc-psbt-signer")
+private let logger = Log.chain.other
 
 enum BitcoinPsbtSignerError: Error, LocalizedError {
     case noInputs

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitBCHSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitBCHSigner.swift
@@ -34,7 +34,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-bch-signer")
+private let logger = Log.chain.other
 
 enum SwapKitBCHSignerError: Error, LocalizedError {
     case underlying(SwapKitLegacyP2PKHSignerError)

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitBTCSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitBTCSigner.swift
@@ -23,7 +23,7 @@ import Foundation
 import OSLog
 import Tss
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-btc-signer")
+private let logger = Log.chain.other
 
 enum SwapKitBTCSignerError: Error, LocalizedError {
     case missingPSBT

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitDashSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitDashSigner.swift
@@ -30,7 +30,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-dash-signer")
+private let logger = Log.chain.other
 
 enum SwapKitDashSignerError: Error, LocalizedError {
     case underlying(SwapKitLegacyP2PKHSignerError)

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitDogeSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitDogeSigner.swift
@@ -25,7 +25,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-doge-signer")
+private let logger = Log.chain.other
 
 enum SwapKitDogeSignerError: Error, LocalizedError {
     case underlying(SwapKitLegacyP2PKHSignerError)

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitZcashSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/SwapKitZcashSigner.swift
@@ -28,7 +28,7 @@ import OSLog
 import Tss
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-zec-signer")
+private let logger = Log.chain.other
 
 enum SwapKitZcashSignerError: Error, LocalizedError {
     case unsupportedZcashVersion(version: UInt32, group: UInt32)

--- a/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
@@ -13,7 +13,7 @@ import BigInt
 class BalanceService {
 
     static let shared = BalanceService()
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "balance-service")
+    private let logger = Log.chain.service
 
     private let utxo = BlockchairService.shared
     private let sol = SolanaService.shared

--- a/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BlockChainService.swift
@@ -17,7 +17,7 @@ struct BlockSpecificCacheItem {
 }
 final class BlockChainService {
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "blockchain-service")
+    private let logger = Log.chain.service
 
     static func normalizeUTXOFee(_ value: BigInt) -> BigInt {
         return value * 2 + value / 2 // x2.5 fee

--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 import SwiftData
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "coin-service")
+private let logger = Log.chain.service
 
 enum CoinServiceError: LocalizedError, Equatable {
     case chainNotEnabledForKeyImport(Chain)

--- a/VultisigApp/VultisigApp/Core/Services/CryptoPriceService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CryptoPriceService.swift
@@ -98,7 +98,7 @@ enum CryptoPriceAPI: TargetType {
 }
 
 public class CryptoPriceService: ObservableObject {
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "crypto-price-service")
+    private let logger = Log.chain.service
 
     struct ResolvedSources {
         let providerIds: [String]

--- a/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultEligibilityRefresher.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultEligibilityRefresher.swift
@@ -17,7 +17,7 @@ final class FastVaultEligibilityRefresher {
 
     static let shared = FastVaultEligibilityRefresher()
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "fast-vault-cache")
+    private let logger = Log.chain.store
     private let checkEligibility: @MainActor (Vault) async -> Bool
     private let saveStorage: @MainActor () -> Void
     private let now: @MainActor () -> Date

--- a/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultService.swift
@@ -54,7 +54,7 @@ final class FastVaultService {
     static let shared = FastVaultService()
 
     private let httpClient: HTTPClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "fast-vault-service")
+    private let logger = Log.chain.service
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.httpClient = httpClient

--- a/VultisigApp/VultisigApp/Core/Services/SwapTokenListCache.swift
+++ b/VultisigApp/VultisigApp/Core/Services/SwapTokenListCache.swift
@@ -23,7 +23,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swap-token-list-cache")
+private let logger = Log.chain.store
 
 @MainActor
 final class SwapTokenListCache {

--- a/VultisigApp/VultisigApp/Core/Services/TokenMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenMetadataResolver.swift
@@ -12,7 +12,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "token-metadata-resolver")
+private let logger = Log.chain.other
 
 /// Successful metadata lookup. Empty `symbol` is treated as a failure and not cached.
 struct TokenMetadata: Equatable, Sendable {

--- a/VultisigApp/VultisigApp/Core/Services/TokenPriceSource.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenPriceSource.swift
@@ -54,7 +54,7 @@ struct SolanaTokenPriceSource: TokenPriceSource {
 /// without `TokensStore` metadata are skipped rather than priced with default
 /// decimals.
 struct SuiTokenPriceSource: TokenPriceSource {
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "crypto-price-service")
+    private let logger = Log.chain.service
 
     func prices(contracts: [String], coins _: [CoinMeta]) async throws -> [Rate] {
         var rates: [Rate] = []
@@ -86,7 +86,7 @@ struct SuiTokenPriceSource: TokenPriceSource {
 /// is pre-fetched (and persisted) when not already cached.
 struct MayaChainTokenPriceSource: TokenPriceSource {
     let httpClient: HTTPClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "crypto-price-service")
+    private let logger = Log.chain.service
 
     func prices(contracts: [String], coins: [CoinMeta]) async throws -> [Rate] {
         if RateProvider.shared.rate(for: TokensStore.cacao) == nil {
@@ -199,7 +199,7 @@ struct ThorChainTokenPriceSource: TokenPriceSource {
 struct CoinGeckoContractTokenPriceSource: TokenPriceSource {
     let chain: Chain
     let httpClient: HTTPClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "crypto-price-service")
+    private let logger = Log.chain.service
 
     func prices(contracts: [String], coins _: [CoinMeta]) async throws -> [Rate] {
         let currencies = SettingsCurrency.allCases

--- a/VultisigApp/VultisigApp/Core/Services/TonJettonMetadataResolver.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TonJettonMetadataResolver.swift
@@ -25,7 +25,7 @@ import WalletCore
 /// can fall back to the raw integer amount + jetton-wallet contract address.
 enum TonJettonMetadataResolver {
 
-    private static let logger = Logger(subsystem: "com.vultisig.app", category: "ton-jetton-metadata-resolver")
+    private static let logger = Log.chain.other
     private static let httpClient: HTTPClientProtocol = HTTPClient()
 
     /// Builds a `TonAPI` value honoring the user's TON custom-RPC override (host

--- a/VultisigApp/VultisigApp/Core/Services/TonSwapSimulator.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TonSwapSimulator.swift
@@ -6,7 +6,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "ton-swap-simulator")
+private let logger = Log.chain.other
 
 /// Calls TonAPI's `/v2/events/emulate` to detect whether a TonConnect
 /// transaction performs a jetton swap. Used as a fallback when the local BOC

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/PendingTransactionStorage.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/PendingTransactionStorage.swift
@@ -14,7 +14,7 @@ final class StoredPendingTransactionStorage {
     static let shared = StoredPendingTransactionStorage()
 
     private let modelContext: ModelContext
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "pending-tx-storage")
+    private let logger = Log.chain.store
 
     private init() {
         self.modelContext = Storage.shared.modelContext

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TransactionHistoryResetService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TransactionHistoryResetService.swift
@@ -30,7 +30,7 @@ final class TransactionHistoryResetService: TransactionHistoryResetting {
     private let deleteTransactionHistory: @MainActor () throws -> Void
     private let deleteLimitOrders: @MainActor () throws -> Void
     private let notifyChanged: @MainActor () -> Void
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "tx-history-reset")
+    private let logger = Log.chain.other
 
     /// Seams default to the production singletons; tests inject fakes to assert
     /// the teardown order and that both stores are wiped.

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TransactionStatusPoller.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/TransactionStatusPoller.swift
@@ -18,7 +18,7 @@ final class TransactionStatusPoller: ObservableObject {
     private let historyStorage = TransactionHistoryStorage.shared
     private var activeTasks: [String: Task<Void, Never>] = [:]
     private var taskTokens: [String: UUID] = [:]
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "tx-status-poller")
+    private let logger = Log.chain.other
 
     private init() {}
 


### PR DESCRIPTION
## What

Declaration-only migration of the **chain / blockchain-services** logging spoke: the 56 `Logger(subsystem:category:)` declarations in the per-chain services/signers layer and the cross-chain `Core/Services/*` data services are routed through the new `Log.chain.<layer>` facade.

Closes #4950. Part of the logging-facade epic (#4943). **Stacks on `feat/logging-facade`** (base #4945) — retargets to `main` once the base merges.

## How

Only the right-hand side of each declaration changed — `Logger(subsystem: "com.vultisig.app", category: "…")` → `Log.chain.<layer>`. The variable declaration (name, `private`/`static`, type annotation) is byte-identical, and **no call site, log level, or `\(…, privacy:)` interpolation was touched**. Native OSLog semantics are fully preserved (the facade only chooses which `os.Logger` to return).

Layer is derived from the category suffix per the `LogLayer` taxonomy (`LogLayer.swift`):

- `*-service` → `.service`
- `*-store` / `*-storage` / `*-cache` → `.store`
- signers / helpers / resolvers / decoders / finders / catalogs / emulators / simulators / providers → `.other`

## Scope — 56 declarations

**By layer:** `other` 32 · `service` 21 · `store` 3

**Sub-areas (for review navigation):**

| Sub-area | decls | notes |
|---|---:|---|
| UTXO | 8 | `BlockchairService`, `ZcashService`, Bitcoin/BCH/BTC/Dash/Doge/Zcash signers |
| Cosmos | 8 | service struct, coin finder, token-metadata + APY + staking-sign resolvers, staking service, keybase avatar, gas estimator |
| Ton | 5 | service, cell slice, message-body decoder, external-message emulator, signing helper |
| Solana | 4 | service, staking service, staking-sign resolver, Stakewiz validator metadata |
| Cardano | 4 | service, native-tokens service, signing helper, SwapKit signer |
| THORChain / Maya | 4 | Thorchain + MayaChain services, secured-asset catalog, staking service |
| Ripple | 3 | service, retry policy, signing helper |
| Sui | 2 | service, SwapKit signer |
| EVM | 1 | coin finder |
| Tron | 1 | SwapKit signer |
| **Core/Services** | 16 | balance / coin / crypto-price (×4) / blockchain-dispatcher / fast-vault services, token + jetton metadata resolvers, ton-swap simulator, swap-token-list + fast-vault + pending-tx stores, tx-history-reset + tx-status-poller |

## Ownership boundaries (left for other spokes)

Intentionally **not** touched — owned by sibling spokes:

- `Blockchain/Swaps/**` → swap (#4947)
- `Blockchain/Cosmos/**/QBTC*` → qbtc (#4952)
- `Blockchain/States/Keygen`, `Blockchain/States/Keysign` → keygen/keysign (#4946)
- `Blockchain/Tss/**`, `Blockchain/Common/common.swift` → tss (#4946)

## Testing

- No files added → no `project.yml` change. `make generate` run once only to build.
- Full `make test` on iPhone 16 Plus (en_US locale), worktree-local derived data — green except the pre-existing, spoke-unrelated `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` snapshot flake.
