### PR TITLE
refactor(logging): replace remaining in-app print( with the Log facade (#4953)

### DIFF
--- a/VultisigApp/VultisigApp/App/AppDelegate.swift
+++ b/VultisigApp/VultisigApp/App/AppDelegate.swift
@@ -5,6 +5,7 @@
 
 #if os(iOS)
 import UIKit
+import OSLog
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(
@@ -28,7 +29,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _: UIApplication,
         didFailToRegisterForRemoteNotificationsWithError error: Error
     ) {
-        print("Failed to register for remote notifications: \(error.localizedDescription)")
+        Log.app.other.error("Failed to register for remote notifications: \(error.localizedDescription, privacy: .public)")
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/App/MacAppDelegate.swift
+++ b/VultisigApp/VultisigApp/App/MacAppDelegate.swift
@@ -5,6 +5,7 @@
 
 #if os(macOS)
 import AppKit
+import OSLog
 
 class MacAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_: Notification) {
@@ -24,7 +25,7 @@ class MacAppDelegate: NSObject, NSApplicationDelegate {
         _: NSApplication,
         didFailToRegisterForRemoteNotificationsWithError error: Error
     ) {
-        print("Failed to register for remote notifications: \(error.localizedDescription)")
+        Log.app.other.error("Failed to register for remote notifications: \(error.localizedDescription, privacy: .public)")
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/Blockchain/Common/CoinFactory.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Common/CoinFactory.swift
@@ -8,6 +8,7 @@
 import Foundation
 import WalletCore
 import CryptoKit
+import OSLog
 
 struct CoinFactory {
     private init() { }
@@ -123,7 +124,7 @@ extension CoinFactory {
 
                 // Create ed25519Cardano public key
                 guard let cardanoKey = PublicKey(data: cardanoExtendedKey, type: .ed25519Cardano) else {
-                    print("Failed to create ed25519Cardano key from properly structured data")
+                    Log.chain.other.error("Failed to create ed25519Cardano key from properly structured data")
                     throw Errors.invalidPublicKey(pubKey: "Failed to create Cardano extended key")
                 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Common/publickey.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Common/publickey.swift
@@ -5,13 +5,14 @@
 
 import Foundation
 import Tss
+import OSLog
 
 enum PublicKeyHelper {
     static func getDerivedPubKey(hexPubKey: String, hexChainCode: String, derivePath: String) -> String {
         var nsErr: NSError?
         let derivedPubKey = TssGetDerivedPubKey(hexPubKey, hexChainCode, derivePath, false, &nsErr)
         if let nsErr {
-            print("fail to get derived pubkey:\(nsErr.localizedDescription)")
+            Log.chain.other.error("fail to get derived pubkey:\(nsErr.localizedDescription, privacy: .public)")
             return ""
         }
         return derivedPubKey

--- a/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosHelperStruct.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Cosmos/Signing/CosmosHelperStruct.swift
@@ -10,6 +10,7 @@ import WalletCore
 import Tss
 import CryptoSwift
 import VultisigCommonData
+import OSLog
 
 struct CosmosHelperStruct {
     let config: CosmosHelperConfig
@@ -200,7 +201,7 @@ struct CosmosHelperStruct {
         let hashes = TransactionCompiler.preImageHashes(coinType: config.coinType, txInputData: inputData)
         let preSigningOutput = try TxCompilerPreSigningOutput(serializedBytes: hashes)
         if !preSigningOutput.errorMessage.isEmpty {
-            print("Error getPreSignedImageHash: \(preSigningOutput.errorMessage)")
+            Log.chain.other.error("Error getPreSignedImageHash: \(preSigningOutput.errorMessage, privacy: .public)")
             throw HelperError.runtimeError(preSigningOutput.errorMessage)
         }
 
@@ -231,7 +232,7 @@ struct CosmosHelperStruct {
             let signatureProvider = SignatureProvider(signatures: signatures)
             let signature = signatureProvider.getSignatureWithRecoveryID(preHash: preSigningOutput.dataHash)
             guard publicKey.verify(signature: signature, message: preSigningOutput.dataHash) else {
-                print("getSignedTransaction signature is invalid")
+                Log.chain.other.error("getSignedTransaction signature is invalid")
                 throw HelperError.runtimeError("fail to verify signature")
             }
 
@@ -244,7 +245,7 @@ struct CosmosHelperStruct {
             let output = try CosmosSigningOutput(serializedBytes: compileWithSignature)
 
             if output.errorMessage.isNotEmpty {
-                print("getSignedTransaction Error message: \(output.errorMessage)")
+                Log.chain.other.error("getSignedTransaction Error message: \(output.errorMessage, privacy: .public)")
             }
 
             let serializedData = output.serialized

--- a/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Polkadot/Service/PolkadotService.swift
@@ -9,6 +9,7 @@ import Foundation
 import BigInt
 import VultisigCommonData
 import WalletCore
+import OSLog
 
 class PolkadotService: RpcService {
     static let rpcEndpoint = Endpoint.polkadotServiceRpc
@@ -253,7 +254,7 @@ class PolkadotService: RpcService {
         do {
             partialFee = try await getPartialFee(serializedTransaction: serializedTransaction)
         } catch {
-            print("PolkadotService > calculateDynamicFee > Error fetching partial fee: \(error)")
+            Log.chain.service.error("calculateDynamicFee > Error fetching partial fee: \(error.localizedDescription, privacy: .public)")
         }
 
         return partialFee

--- a/VultisigApp/VultisigApp/Blockchain/Polkadot/Signing/Polkadot.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Polkadot/Signing/Polkadot.swift
@@ -7,6 +7,7 @@ import Foundation
 import Tss
 import WalletCore
 import BigInt
+import OSLog
 
 enum PolkadotHelper {
 
@@ -106,7 +107,7 @@ enum PolkadotHelper {
         let dummyPrivateKey = PrivateKey()
         let dummyPublicKey = dummyPrivateKey.getPublicKeyEd25519()
         let publicKeyData = dummyPublicKey.data
-        print("[Polkadot] getZeroSignedTransaction: Using DUMMY public key for fee calculation: \(publicKeyData.hexString.prefix(16))...")
+        Log.chain.other.debug("getZeroSignedTransaction: Using DUMMY public key for fee calculation: \(String(publicKeyData.hexString.prefix(16)), privacy: .public)...")
 
         let allSignatures = DataVector()
         let publicKeys = DataVector()

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -31,7 +31,7 @@ enum RippleHelper {
             case .Ripple(let sequence, let gas, let lastLedgerSequence, let fieldDestinationTag) = keysignPayload
                 .chainSpecific
         else {
-            print("keysignPayload.chainSpecific is not Ripple")
+            logger.error("keysignPayload.chainSpecific is not Ripple")
             throw HelperError.runtimeError(
                 "getPreSignedInputData: fail to get account number and sequence"
             )
@@ -406,7 +406,7 @@ enum RippleHelper {
         let preSigningOutput = try TxCompilerPreSigningOutput(
             serializedBytes: hashes)
         if !preSigningOutput.errorMessage.isEmpty {
-            print(preSigningOutput.errorMessage)
+            logger.error("\(preSigningOutput.errorMessage, privacy: .public)")
             throw HelperError.runtimeError(preSigningOutput.errorMessage)
         }
         return [preSigningOutput.dataHash.hexString]
@@ -429,7 +429,7 @@ enum RippleHelper {
             serializedBytes: hashes)
 
         if !preSigningOutput.errorMessage.isEmpty {
-            print(preSigningOutput.errorMessage)
+            logger.error("\(preSigningOutput.errorMessage, privacy: .public)")
             throw HelperError.runtimeError(preSigningOutput.errorMessage)
         }
 
@@ -446,7 +446,7 @@ enum RippleHelper {
                 signature: signature, message: preSigningOutput.dataHash)
         else {
             let errorMessage = "Invalid signature"
-            print("\(errorMessage)")
+            logger.error("\(errorMessage, privacy: .public)")
             throw HelperError.runtimeError(errorMessage)
         }
 
@@ -464,7 +464,7 @@ enum RippleHelper {
         // The error is HERE it accepted it as a DER previously
         if !output.errorMessage.isEmpty {
             let errorMessage = output.errorMessage
-            print("errorMessage: \(errorMessage)")
+            logger.error("errorMessage: \(errorMessage, privacy: .public)")
             throw HelperError.runtimeError(errorMessage)
         }
 

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -225,7 +225,7 @@ class SolanaService {
                 [String: SolanaFmTokenInfo].self, from: dataResponse)
             return tokenInfo
         } catch {
-            print("Error in fetchSolanaTokenInfoList:")
+            logger.error("Error in fetchSolanaTokenInfoList:")
             return [:]
         }
     }
@@ -246,13 +246,13 @@ class SolanaService {
             return tokenInfo
         } catch let error as NSError {
             if error.code == 429 {
-                print("Error in fetchSolanaJupiterTokenInfoList: Rate limit exceeded (429)")
+                logger.warning("Error in fetchSolanaJupiterTokenInfoList: Rate limit exceeded (429)")
             } else {
-                print("Error in fetchSolanaJupiterTokenInfoList: \(error.localizedDescription) (Code: \(error.code))")
+                logger.error("Error in fetchSolanaJupiterTokenInfoList: \(error.localizedDescription, privacy: .public) (Code: \(error.code))")
             }
             throw error
         } catch {
-            print("Error in fetchSolanaJupiterTokenInfoList: \(error.localizedDescription)")
+            logger.error("Error in fetchSolanaJupiterTokenInfoList: \(error.localizedDescription, privacy: .public)")
             throw error
         }
     }
@@ -279,13 +279,13 @@ class SolanaService {
             }
         } catch let error as NSError {
             if error.code == 429 {
-                print("Error in fetchSolanaJupiterTokenList: Rate limit exceeded (429)")
+                logger.warning("Error in fetchSolanaJupiterTokenList: Rate limit exceeded (429)")
             } else {
-                print("Error in fetchSolanaJupiterTokenList: \(error.localizedDescription) (Code: \(error.code))")
+                logger.error("Error in fetchSolanaJupiterTokenList: \(error.localizedDescription, privacy: .public) (Code: \(error.code))")
             }
             throw error
         } catch {
-            print("Error in fetchSolanaJupiterTokenList: \(error.localizedDescription)")
+            logger.error("Error in fetchSolanaJupiterTokenList: \(error.localizedDescription, privacy: .public)")
             throw error
         }
     }
@@ -397,7 +397,7 @@ class SolanaService {
 
             return nil
         } catch {
-            print("Error in fetchTokenBalance: \(error.localizedDescription)")
+            logger.error("Error in fetchTokenBalance: \(error.localizedDescription, privacy: .public)")
             throw error
         }
     }
@@ -417,7 +417,7 @@ class SolanaService {
             let tokens = try await fetchTokensInfos(for: tokenAddresses)
             return tokens
         } catch {
-            print("Error in fetchTokens: \(error)")
+            logger.error("Error in fetchTokens: \(error.localizedDescription, privacy: .public)")
             throw error
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
@@ -163,7 +163,7 @@ final class DKLSKeygen {
         }
 
         if result != DKLS_LIB_OK {
-            print("fail to get outbound message: \(result)")
+            logger.error("fail to get outbound message: \(String(describing: result), privacy: .public)")
             return (result, [])
         }
         return (result, Array(UnsafeBufferPointer(start: buf.ptr, count: Int(buf.len))))
@@ -185,7 +185,7 @@ final class DKLSKeygen {
         }
 
         if receiverResult != DKLS_LIB_OK {
-            print("fail to get receiver message,error: \(receiverResult)")
+            logger.error("fail to get receiver message,error: \(String(describing: receiverResult), privacy: .public)")
             return []
         }
         return Array(UnsafeBufferPointer(start: buf_receiver.ptr, count: Int(buf_receiver.len)))
@@ -195,7 +195,7 @@ final class DKLSKeygen {
         repeat {
             let (result, outboundMessage) = GetDKLSOutboundMessage(handle: handle)
             if result != DKLS_LIB_OK {
-                print("fail to get outbound message,\(result)")
+                logger.error("fail to get outbound message,\(String(describing: result), privacy: .public)")
             }
             if outboundMessage.isEmpty {
                 return
@@ -211,7 +211,7 @@ final class DKLSKeygen {
                     break
                 }
                 let receiverString = String(bytes: receiverArray, encoding: .utf8)!
-                print("sending message from \(self.localPartyID) to: \(receiverString) , length:\(outboundMessage.count)")
+                logger.debug("sending message from \(self.localPartyID, privacy: .public) to: \(receiverString, privacy: .public) , length:\(outboundMessage.count)")
                 try await self.messenger.send(self.localPartyID, to: receiverString, body: encodedOutboundMessage)
             }
         } while 1 > 0
@@ -271,7 +271,7 @@ final class DKLSKeygen {
         for msg in sortedMsgs {
             let key = "\(self.sessionID)-\(self.localPartyID)-\(msg.hash)" as NSString
             if self.cache.object(forKey: key) != nil {
-                print("message with key:\(key) has been applied before")
+                logger.debug("message with key:\(key, privacy: .public) has been applied before")
                 continue
             }
 
@@ -298,7 +298,7 @@ final class DKLSKeygen {
             if result != DKLS_LIB_OK {
                 throw HelperError.runtimeError("fail to apply message to dkls,\(result)")
             } else {
-                print("successfully applied inbound message to dkls, isFinished:\(isFinished), hash:\(msg.hash), from:\(msg.from), to:\(msg.to) , length:\(decodedMsg.count)")
+                logger.debug("successfully applied inbound message to dkls, isFinished:\(isFinished), hash:\(msg.hash, privacy: .public), from:\(msg.from, privacy: .public), to:\(msg.to, privacy: .public) , length:\(decodedMsg.count)")
             }
             self.cache.setObject(NSObject(), forKey: key)
             try await Task.sleep(for: .milliseconds(50))
@@ -372,7 +372,7 @@ final class DKLSKeygen {
     // DKLSKeygenWithRetry tries to do keygen with retry mechanism
     // routing.setupMessageId isolates setup payload, routing.exchangeMessageId isolates TSS exchange
     func DKLSKeygenWithRetry(attempt: UInt8, routing: KeygenRouting = .default) async throws {
-        print("keygen committee: \(self.keygenCommittee)")
+        logger.debug("keygen committee: \(String(describing: self.keygenCommittee), privacy: .public)")
         self.cache.removeAllObjects()
         self.messenger.messageID = routing.exchangeMessageId
         do {
@@ -454,7 +454,7 @@ final class DKLSKeygen {
             defer {
                 let sessionFreeResult = dkls_keygen_session_free(&handler)
                 if sessionFreeResult != DKLS_LIB_OK {
-                    print("fail to free keygen session \(sessionFreeResult)")
+                    logger.error("fail to free keygen session \(String(describing: sessionFreeResult), privacy: .public)")
                 }
             }
             let h = handler
@@ -471,7 +471,7 @@ final class DKLSKeygen {
                 defer {
                     let freeResult = dkls_keyshare_free(&keyshareHandler)
                     if freeResult != DKLS_LIB_OK {
-                        print("fail to free keyshare \(freeResult)")
+                        logger.error("fail to free keyshare \(String(describing: freeResult), privacy: .public)")
                     }
                 }
                 let keyshareBytes = try getKeyshareBytes(handle: keyshareHandler)
@@ -480,16 +480,16 @@ final class DKLSKeygen {
                 self.keyshare = DKLSKeyshare(PubKey: publicKeyECDSA.toHexString(),
                                              Keyshare: keyshareBytes.toBase64(),
                                              chaincode: chainCodeBytes.toHexString())
-                print("publicKeyECDSA:\(publicKeyECDSA.toHexString())")
-                print("chaincode: \(chainCodeBytes.toHexString())")
+                logger.debug("publicKeyECDSA:\(publicKeyECDSA.toHexString(), privacy: .public)")
+                logger.debug("chaincode: \(chainCodeBytes.toHexString(), privacy: .public)")
                 try await Task.sleep(for: .milliseconds(500))
             }
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            print("Failed to generate key, error: \(error.localizedDescription)")
+            logger.error("Failed to generate key, error: \(error.localizedDescription, privacy: .public)")
             if attempt < 3 { // let's retry
-                print("keygen/reshare retry, attemp: \(attempt)")
+                logger.warning("keygen/reshare retry, attemp: \(attempt)")
                 try await DKLSKeygenWithRetry(attempt: attempt + 1, routing: routing)
             } else {
                 throw error
@@ -632,7 +632,7 @@ final class DKLSKeygen {
             defer {
                 let sessionFreeResult = dkls_qc_session_free(&handler)
                 if sessionFreeResult != DKLS_LIB_OK {
-                    print("fail to free reshare session \(sessionFreeResult)")
+                    logger.error("fail to free reshare session \(String(describing: sessionFreeResult), privacy: .public)")
                 }
             }
             let h = handler
@@ -648,7 +648,7 @@ final class DKLSKeygen {
                 defer {
                     let freeResult = dkls_keyshare_free(&newKeyshareHandler)
                     if freeResult != DKLS_LIB_OK {
-                        print("fail to free keyshare \(freeResult)")
+                        logger.error("fail to free keyshare \(String(describing: freeResult), privacy: .public)")
                     }
                 }
                 let keyshareBytes = try getKeyshareBytes(handle: newKeyshareHandler)
@@ -657,17 +657,17 @@ final class DKLSKeygen {
                 self.keyshare = DKLSKeyshare(PubKey: publicKeyECDSA.toHexString(),
                                              Keyshare: keyshareBytes.toBase64(),
                                              chaincode: chainCodeBytes.toHexString())
-                print("reshare ECDSA key successfully")
-                print("publicKeyECDSA:\(publicKeyECDSA.toHexString())")
-                print("chaincode: \(chainCodeBytes.toHexString())")
+                logger.info("reshare ECDSA key successfully")
+                logger.debug("publicKeyECDSA:\(publicKeyECDSA.toHexString(), privacy: .public)")
+                logger.debug("chaincode: \(chainCodeBytes.toHexString(), privacy: .public)")
                 try await Task.sleep(for: .milliseconds(500))
             }
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            print("Failed to reshare key, error: \(error.localizedDescription)")
+            logger.error("Failed to reshare key, error: \(error.localizedDescription, privacy: .public)")
             if attempt < 3 { // let's retry
-                print("keygen/reshare retry, attemp: \(attempt)")
+                logger.warning("keygen/reshare retry, attemp: \(attempt)")
                 try await DKLSReshareWithRetry(attempt: attempt + 1, routing: routing)
             } else {
                 throw error

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DilithiumKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DilithiumKeygen.swift
@@ -84,7 +84,7 @@ final class DilithiumKeygen {
         }
         let result = mldsa_keygen_session_output_message(handle, &buf)
         if result != MLDSA_LIB_OK {
-            print("fail to get outbound message: \(result)")
+            logger.error("fail to get outbound message: \(String(describing: result), privacy: .public)")
             return (result, [])
         }
         return (result, Array(UnsafeBufferPointer(start: buf.ptr, count: Int(buf.len))))
@@ -98,7 +98,7 @@ final class DilithiumKeygen {
         var mutableMessage = message
         let receiverResult = mldsa_keygen_session_message_receiver(handle, &mutableMessage, idx, &buf_receiver)
         if receiverResult != MLDSA_LIB_OK {
-            print("fail to get receiver message,error: \(receiverResult)")
+            logger.error("fail to get receiver message,error: \(String(describing: receiverResult), privacy: .public)")
             return []
         }
         return Array(UnsafeBufferPointer(start: buf_receiver.ptr, count: Int(buf_receiver.len)))
@@ -108,7 +108,7 @@ final class DilithiumKeygen {
         repeat {
             let (result, outboundMessage) = GetDilithiumOutboundMessage(handle: handle)
             if result != MLDSA_LIB_OK {
-                print("fail to get outbound message,\(result)")
+                logger.error("fail to get outbound message,\(String(describing: result), privacy: .public)")
             }
             if outboundMessage.isEmpty {
                 return
@@ -124,7 +124,7 @@ final class DilithiumKeygen {
                     break
                 }
                 let receiverString = String(bytes: receiverArray, encoding: .utf8)!
-                print("sending message from \(self.localPartyID) to: \(receiverString) , length:\(outboundMessage.count)")
+                logger.debug("sending message from \(self.localPartyID, privacy: .public) to: \(receiverString, privacy: .public) , length:\(outboundMessage.count)")
                 try await self.messenger.send(self.localPartyID, to: receiverString, body: encodedOutboundMessage)
             }
         } while 1 > 0
@@ -183,7 +183,7 @@ final class DilithiumKeygen {
         for msg in sortedMsgs {
             let key = "\(self.sessionID)-\(self.localPartyID)-\(msg.hash)" as NSString
             if self.cache.object(forKey: key) != nil {
-                print("message with key:\(key) has been applied before")
+                logger.debug("message with key:\(key, privacy: .public) has been applied before")
                 continue
             }
 
@@ -202,7 +202,7 @@ final class DilithiumKeygen {
             if result != MLDSA_LIB_OK {
                 throw HelperError.runtimeError("fail to apply message to mldsa,\(result)")
             } else {
-                print("successfully applied inbound message to mldsa, isFinished:\(isFinished), hash:\(msg.hash), from:\(msg.from), to:\(msg.to) , length:\(decodedMsg.count)")
+                logger.debug("successfully applied inbound message to mldsa, isFinished:\(isFinished), hash:\(msg.hash, privacy: .public), from:\(msg.from, privacy: .public), to:\(msg.to, privacy: .public) , length:\(decodedMsg.count)")
             }
             self.cache.setObject(NSObject(), forKey: key)
             try await Task.sleep(for: .milliseconds(50))
@@ -231,7 +231,7 @@ final class DilithiumKeygen {
     }
 
     func DilithiumKeygenWithRetry(attempt: UInt8) async throws {
-        print("keygen committee: \(self.keygenCommittee)")
+        logger.debug("keygen committee: \(String(describing: self.keygenCommittee), privacy: .public)")
         self.cache.removeAllObjects()
         do {
             var keygenSetupMsg: [UInt8]
@@ -257,7 +257,7 @@ final class DilithiumKeygen {
             defer {
                 let sessionFreeResult = mldsa_keygen_session_free(handler)
                 if sessionFreeResult != MLDSA_LIB_OK {
-                    print("fail to free keygen session \(sessionFreeResult)")
+                    logger.error("fail to free keygen session \(String(describing: sessionFreeResult), privacy: .public)")
                 }
             }
             let h = handler
@@ -274,7 +274,7 @@ final class DilithiumKeygen {
                     var keyshareHandlerPtr = keyshareHandler
                     let freeResult = mldsa_keyshare_free(&keyshareHandlerPtr)
                     if freeResult != MLDSA_LIB_OK {
-                        print("fail to free keyshare \(freeResult)")
+                        logger.error("fail to free keyshare \(String(describing: freeResult), privacy: .public)")
                     }
                 }
                 let keyshareBytes = try getKeyshareBytes(handle: keyshareHandler)
@@ -283,14 +283,14 @@ final class DilithiumKeygen {
                 self.keyshare = DilithiumKeyshare(PubKey: publicKeyBytes.toHexString(),
                                                   Keyshare: keyshareBytes.toBase64(),
                                                   keyId: keyIdBytes.toHexString())
-                print("publicKey:\(publicKeyBytes.toHexString())")
-                print("keyId: \(keyIdBytes.toHexString())")
+                logger.debug("publicKey:\(publicKeyBytes.toHexString(), privacy: .public)")
+                logger.debug("keyId: \(keyIdBytes.toHexString(), privacy: .public)")
                 try await Task.sleep(for: .milliseconds(500))
             }
         } catch {
-            print("Failed to generate key, error: \(error.localizedDescription)")
+            logger.error("Failed to generate key, error: \(error.localizedDescription, privacy: .public)")
             if attempt < 3 {
-                print("keygen retry, attemp: \(attempt)")
+                logger.warning("keygen retry, attemp: \(attempt)")
                 try await DilithiumKeygenWithRetry(attempt: attempt + 1)
             } else {
                 throw error

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
@@ -123,7 +123,7 @@ final class SchnorrKeygen {
         }
 
         if result != .schnorrLibOK {
-            print("fail to get outbound message: \(result)")
+            logger.error("fail to get outbound message: \(String(describing: result), privacy: .public)")
             return (result, [])
         }
         return (result, Array(UnsafeBufferPointer(start: buf.ptr, count: Int(buf.len))))
@@ -143,7 +143,7 @@ final class SchnorrKeygen {
             receiverResult = schnorr_qc_session_message_receiver(handle, &mutableMessage, idx, &buf_receiver)
         }
         if receiverResult != .schnorrLibOK {
-            print("fail to get receiver message,error: \(receiverResult)")
+            logger.error("fail to get receiver message,error: \(String(describing: receiverResult), privacy: .public)")
             return []
         }
         return Array(UnsafeBufferPointer(start: buf_receiver.ptr, count: Int(buf_receiver.len)))
@@ -153,7 +153,7 @@ final class SchnorrKeygen {
         repeat {
             let (result, outboundMessage) = GetSchnorrOutboundMessage(handle: handle)
             if result != .schnorrLibOK {
-                print("fail to get outbound message")
+                logger.error("fail to get outbound message")
             }
             if outboundMessage.isEmpty {
                 return
@@ -170,7 +170,7 @@ final class SchnorrKeygen {
                     continue
                 }
                 let receiverString = String(bytes: receiverArray, encoding: .utf8)!
-                print("sending message from \(self.localPartyID) to: \(receiverString)")
+                logger.debug("sending message from \(self.localPartyID, privacy: .public) to: \(receiverString, privacy: .public)")
                 try await self.messenger.send(self.localPartyID, to: receiverString, body: encodedOutboundMessage)
             }
         } while 1 > 0
@@ -231,7 +231,7 @@ final class SchnorrKeygen {
         for msg in sortedMsgs {
             let key = "\(self.sessionID)-\(self.localPartyID)-\(msg.hash)" as NSString
             if self.cache.object(forKey: key) != nil {
-                print("message with key:\(key) has been applied before")
+                logger.debug("message with key:\(key, privacy: .public) has been applied before")
                 continue
             }
             guard let decryptedBody = msg.body.aesDecryptGCM(key: self.encryptionKeyHex) else {
@@ -256,7 +256,7 @@ final class SchnorrKeygen {
             if result != .schnorrLibOK {
                 throw HelperError.runtimeError("fail to apply message to dkls,\(result)")
             } else {
-                print("successfully applied inbound message to schnorr, isFinished:\(isFinished), hash:\(msg.hash) ,sequence_no:\(msg.sequence_no), from: \(msg.from) , to: \(msg.to) , size: \(decodedMsg.count) ")
+                logger.debug("successfully applied inbound message to schnorr, isFinished:\(isFinished), hash:\(msg.hash, privacy: .public) ,sequence_no:\(msg.sequence_no), from: \(msg.from, privacy: .public) , to: \(msg.to, privacy: .public) , size: \(decodedMsg.count) ")
             }
             self.cache.setObject(NSObject(), forKey: key)
             try await Task.sleep(for: .milliseconds(50))
@@ -352,7 +352,7 @@ final class SchnorrKeygen {
     // routing.setupMessageId is used to differentiate the setup message when doing key import
     // routing.exchangeMessageId isolates TSS message exchange on the relay
     func SchnorrKeygenWithRetry(attempt: UInt8, routing: KeygenRouting = .default) async throws {
-        print("start Schnorr keygen/migration/keyimport , attempt:\(attempt)")
+        logger.info("start Schnorr keygen/migration/keyimport , attempt:\(attempt)")
         self.cache.removeAllObjects()
         self.messenger.messageID = routing.exchangeMessageId
         do {
@@ -443,14 +443,14 @@ final class SchnorrKeygen {
                 self.keyshare = DKLSKeyshare(PubKey: publicKeyEdDSA.toHexString(),
                                              Keyshare: keyshareBytes.toBase64(),
                                              chaincode: "")
-                print("publicKeyEdDSA:\(publicKeyEdDSA.toHexString())")
+                logger.debug("publicKeyEdDSA:\(publicKeyEdDSA.toHexString(), privacy: .public)")
             }
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            print("Failed to generate key, error: \(error.localizedDescription)")
+            logger.error("Failed to generate key, error: \(error.localizedDescription, privacy: .public)")
             if attempt < 3 { // let's retry
-                print("keygen/reshare retry, attemp: \(attempt)")
+                logger.warning("keygen/reshare retry, attemp: \(attempt)")
                 try await SchnorrKeygenWithRetry(attempt: attempt + 1, routing: routing)
             } else {
                 throw error
@@ -544,7 +544,7 @@ final class SchnorrKeygen {
     }
 
     func SchnorrReshareWithRetry(attempt: UInt8, routing: KeygenRouting = .default) async throws {
-        print("start Schnorr reshare , attempt:\(attempt) , keygenCommittee: \(self.keygenCommittee)")
+        logger.info("start Schnorr reshare , attempt:\(attempt) , keygenCommittee: \(String(describing: self.keygenCommittee), privacy: .public)")
         self.cache.removeAllObjects()
         self.messenger.messageID = routing.exchangeMessageId
         // In sequential mode (.default), use "eddsa" to separate from DKLS setup.
@@ -586,7 +586,7 @@ final class SchnorrKeygen {
             defer {
                 let sessionFreeResult = schnorr_qc_session_free(&handler)
                 if sessionFreeResult != .schnorrLibOK {
-                    print("fail to free reshare session \(sessionFreeResult)")
+                    logger.error("fail to free reshare session \(String(describing: sessionFreeResult), privacy: .public)")
                 }
             }
             let h = handler
@@ -606,15 +606,15 @@ final class SchnorrKeygen {
                 self.keyshare = DKLSKeyshare(PubKey: publicKeyEdDSA.toHexString(),
                                              Keyshare: keyshareBytes.toBase64(),
                                              chaincode: "")
-                print("reshare EdDSA successfully")
-                print("publicKeyEdDSA:\(publicKeyEdDSA.toHexString())")
+                logger.info("reshare EdDSA successfully")
+                logger.debug("publicKeyEdDSA:\(publicKeyEdDSA.toHexString(), privacy: .public)")
             }
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            print("Failed to reshare key, error: \(error.localizedDescription)")
+            logger.error("Failed to reshare key, error: \(error.localizedDescription, privacy: .public)")
             if attempt < 3 { // let's retry
-                print("keygen/reshare retry, attemp: \(attempt)")
+                logger.warning("keygen/reshare retry, attemp: \(attempt)")
                 try await SchnorrReshareWithRetry(attempt: attempt + 1, routing: routing)
             } else {
                 throw error

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -93,7 +93,7 @@ final class DKLSKeysign {
         defer {
             let freeResult = dkls_keyshare_free(&h)
             if freeResult != DKLS_LIB_OK {
-                print("fail to free keyshare \(freeResult)")
+                logger.error("fail to free keyshare \(String(describing: freeResult), privacy: .public)")
             }
         }
         let keyIDResult = dkls_keyshare_key_id(h, &buf)
@@ -163,7 +163,7 @@ final class DKLSKeysign {
         var mutableMessage = message
         let receiverResult = dkls_sign_session_message_receiver(handle, &mutableMessage, idx, &buf_receiver)
         if receiverResult != DKLS_LIB_OK {
-            print("fail to get receiver message,error: \(receiverResult)")
+            logger.error("fail to get receiver message,error: \(String(describing: receiverResult), privacy: .public)")
             return []
         }
         return Array(UnsafeBufferPointer(start: buf_receiver.ptr, count: Int(buf_receiver.len)))
@@ -176,7 +176,7 @@ final class DKLSKeysign {
         }
         let result = dkls_sign_session_output_message(handle, &buf)
         if result != DKLS_LIB_OK {
-            print("fail to get outbound message: \(result)")
+            logger.error("fail to get outbound message: \(String(describing: result), privacy: .public)")
             return (result, [])
         }
         return (result, Array(UnsafeBufferPointer(start: buf.ptr, count: Int(buf.len))))
@@ -191,7 +191,7 @@ final class DKLSKeysign {
             try Task.checkCancellation()
             let (result, outboundMessage) = GetDKLSOutboundMessage(handle: handle)
             if result != DKLS_LIB_OK {
-                print("fail to get outbound message,\(result)")
+                logger.error("fail to get outbound message,\(String(describing: result), privacy: .public)")
             }
             if outboundMessage.isEmpty {
                 return
@@ -207,7 +207,7 @@ final class DKLSKeysign {
                     break
                 }
                 let receiverString = String(bytes: receiverArray, encoding: .utf8)!
-                print("sending message from \(self.localPartyID) to: \(receiverString), content length:\(encodedOutboundMessage.count)")
+                logger.debug("sending message from \(self.localPartyID, privacy: .public) to: \(receiverString, privacy: .public), content length:\(encodedOutboundMessage.count)")
                 try await self.messenger?.send(self.localPartyID,
                                          to: receiverString,
                                          body: encodedOutboundMessage)
@@ -273,10 +273,10 @@ final class DKLSKeysign {
         for msg in sortedMsgs {
             let key = "\(self.sessionID)-\(self.localPartyID)-\(messageID)-\(msg.hash)" as NSString
             if self.cache.object(forKey: key) != nil {
-                print("message with key:\(key) has been applied before")
+                logger.debug("message with key:\(key, privacy: .public) has been applied before")
                 continue
             }
-            print("Got message from: \(msg.from), to: \(msg.to), key:\(key)")
+            logger.debug("Got message from: \(msg.from, privacy: .public), to: \(msg.to, privacy: .public), key:\(key, privacy: .public)")
             guard let decryptedBody = msg.body.aesDecryptGCM(key: self.encryptionKeyHex) else {
                 throw HelperError.runtimeError("fail to decrypted message body")
             }

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
@@ -102,7 +102,7 @@ final class DilithiumKeysign {
         defer {
             let freeResult = mldsa_keyshare_free(&h)
             if freeResult != MLDSA_LIB_OK {
-                print("fail to free keyshare \(freeResult)")
+                logger.error("fail to free keyshare \(String(describing: freeResult), privacy: .public)")
             }
         }
 
@@ -147,7 +147,7 @@ final class DilithiumKeysign {
         var mutableMessage = message
         let receiverResult = mldsa_sign_session_message_receiver(handle, &mutableMessage, idx, &buf_receiver)
         if receiverResult != MLDSA_LIB_OK {
-            print("fail to get receiver message,error: \(receiverResult)")
+            logger.error("fail to get receiver message,error: \(String(describing: receiverResult), privacy: .public)")
             return []
         }
         return Array(UnsafeBufferPointer(start: buf_receiver.ptr, count: Int(buf_receiver.len)))
@@ -160,7 +160,7 @@ final class DilithiumKeysign {
         }
         let result = mldsa_sign_session_output_message(handle, &buf)
         if result != MLDSA_LIB_OK {
-            print("fail to get outbound message: \(result)")
+            logger.error("fail to get outbound message: \(String(describing: result), privacy: .public)")
             return (result, [])
         }
         return (result, Array(UnsafeBufferPointer(start: buf.ptr, count: Int(buf.len))))
@@ -175,7 +175,7 @@ final class DilithiumKeysign {
             try Task.checkCancellation()
             let (result, outboundMessage) = GetDilithiumOutboundMessage(handle: handle)
             if result != MLDSA_LIB_OK {
-                print("fail to get outbound message,\(result)")
+                logger.error("fail to get outbound message,\(String(describing: result), privacy: .public)")
             }
             if outboundMessage.isEmpty {
                 return
@@ -191,7 +191,7 @@ final class DilithiumKeysign {
                     break
                 }
                 let receiverString = String(bytes: receiverArray, encoding: .utf8)!
-                print("sending message from \(self.localPartyID) to: \(receiverString), content length:\(encodedOutboundMessage.count)")
+                logger.debug("sending message from \(self.localPartyID, privacy: .public) to: \(receiverString, privacy: .public), content length:\(encodedOutboundMessage.count)")
                 try await self.messenger?.send(self.localPartyID,
                                          to: receiverString,
                                          body: encodedOutboundMessage)
@@ -257,10 +257,10 @@ final class DilithiumKeysign {
         for msg in sortedMsgs {
             let key = "\(self.sessionID)-\(self.localPartyID)-\(messageID)-\(msg.hash)" as NSString
             if self.cache.object(forKey: key) != nil {
-                print("message with key:\(key) has been applied before")
+                logger.debug("message with key:\(key, privacy: .public) has been applied before")
                 continue
             }
-            print("Got message from: \(msg.from), to: \(msg.to), key:\(key)")
+            logger.debug("Got message from: \(msg.from, privacy: .public), to: \(msg.to, privacy: .public), key:\(key, privacy: .public)")
             guard let decryptedBody = msg.body.aesDecryptGCM(key: self.encryptionKeyHex) else {
                 throw HelperError.runtimeError("fail to decrypted message body")
             }
@@ -378,7 +378,7 @@ final class DilithiumKeysign {
             // A cancellation is not a signing failure — never retry it,
             // propagate so the abandoned ceremony unwinds immediately.
             if error is CancellationError { throw error }
-            print("Failed to sign message (\(messageToSign)), error: \(error.localizedDescription)")
+            logger.error("Failed to sign message (\(messageToSign, privacy: .public)), error: \(error.localizedDescription, privacy: .public)")
             if attempt < 3 {
                 try await DilithiumKeysignOneMessageWithRetry(attempt: attempt+1, messageToSign: messageToSign)
             } else {
@@ -405,7 +405,7 @@ final class DilithiumKeysign {
             let header = ["message_id": message]
             _ = try await Utils.asyncPostRequest(urlString: keySignVerify.urlString, headers: header, body: jsonData)
         } catch {
-            print("Failed to send request to mediator, error:\(error)")
+            logger.error("Failed to send request to mediator, error:\(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
@@ -149,7 +149,7 @@ final class SchnorrKeysign {
         var mutableMessage = message
         let receiverResult = schnorr_sign_session_message_receiver(handle, &mutableMessage, idx, &buf_receiver)
         if receiverResult != .schnorrLibOK {
-            print("fail to get receiver message,error: \(receiverResult)")
+            logger.error("fail to get receiver message,error: \(String(describing: receiverResult), privacy: .public)")
             return []
         }
         return Array(UnsafeBufferPointer(start: buf_receiver.ptr, count: Int(buf_receiver.len)))
@@ -162,7 +162,7 @@ final class SchnorrKeysign {
         }
         let result = schnorr_sign_session_output_message(handle, &buf)
         if result != .schnorrLibOK {
-            print("fail to get outbound message: \(result)")
+            logger.error("fail to get outbound message: \(String(describing: result), privacy: .public)")
             return (result, [])
         }
         return (result, Array(UnsafeBufferPointer(start: buf.ptr, count: Int(buf.len))))
@@ -177,7 +177,7 @@ final class SchnorrKeysign {
             try Task.checkCancellation()
             let (result, outboundMessage) = GetSchnorrOutboundMessage(handle: handle)
             if result != .schnorrLibOK {
-                print("fail to get outbound message")
+                logger.error("fail to get outbound message")
             }
             if outboundMessage.isEmpty {
                 return
@@ -193,7 +193,7 @@ final class SchnorrKeysign {
                     break
                 }
                 let receiverString = String(bytes: receiverArray, encoding: .utf8)!
-                print("sending message from \(self.localPartyID) to: \(receiverString), content length:\(encodedOutboundMessage.count)")
+                logger.debug("sending message from \(self.localPartyID, privacy: .public) to: \(receiverString, privacy: .public), content length:\(encodedOutboundMessage.count)")
                 try await self.messenger?.send(self.localPartyID,
                                          to: receiverString,
                                          body: encodedOutboundMessage)
@@ -259,10 +259,10 @@ final class SchnorrKeysign {
         for msg in sortedMsgs {
             let key = "\(self.sessionID)-\(self.localPartyID)-\(messageID)-\(msg.hash)" as NSString
             if self.cache.object(forKey: key) != nil {
-                print("message with key:\(key) has been applied before")
+                logger.debug("message with key:\(key, privacy: .public) has been applied before")
                 continue
             }
-            print("Got message from: \(msg.from), to: \(msg.to), key:\(key)")
+            logger.debug("Got message from: \(msg.from, privacy: .public), to: \(msg.to, privacy: .public), key:\(key, privacy: .public)")
             guard let decryptedBody = msg.body.aesDecryptGCM(key: self.encryptionKeyHex) else {
                 throw HelperError.runtimeError("fail to decrypted message body")
             }
@@ -394,7 +394,7 @@ final class SchnorrKeysign {
             // A cancellation is not a signing failure — never retry it,
             // propagate so the abandoned ceremony unwinds immediately.
             if error is CancellationError { throw error }
-            print("Failed to sign message (\(messageToSign)), error: \(error.localizedDescription)")
+            logger.error("Failed to sign message (\(messageToSign, privacy: .public)), error: \(error.localizedDescription, privacy: .public)")
             if attempt < 3 {
                 try await KeysignOneMessageWithRetry(attempt: attempt+1, messageToSign: messageToSign)
             }

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Service/SuiService.swift
@@ -72,7 +72,7 @@ class SuiService {
 
             return "0"
         } catch {
-            print("Error fetching suix_getAllBalances: \(error.localizedDescription)")
+            logger.error("Error fetching suix_getAllBalances: \(error.localizedDescription, privacy: .public)")
             return "0"
         }
     }
@@ -145,10 +145,10 @@ class SuiService {
                 let intResult = resultString.toBigInt()
                 return intResult
             } else {
-                print("JSON decoding error")
+                logger.error("JSON decoding error")
             }
         } catch {
-            print("Error fetching balance: \(error.localizedDescription)")
+            logger.error("Error fetching balance: \(error.localizedDescription, privacy: .public)")
             throw error
         }
         return BigInt.zero
@@ -230,10 +230,10 @@ class SuiService {
 
                 return tokens
             } else {
-                print("Failed to decode owned objects")
+                logger.error("Failed to decode owned objects")
             }
         } catch {
-            print("Error fetching tokens: \(error.localizedDescription)")
+            logger.error("Error fetching tokens: \(error.localizedDescription, privacy: .public)")
             throw error
         }
         return []
@@ -279,7 +279,7 @@ class SuiService {
 
                     tokensWithMetadata.append(coinMeta)
                 } catch {
-                    print("Error fetching metadata for \(objType): \(error.localizedDescription)")
+                    logger.error("Error fetching metadata for \(String(describing: objType), privacy: .public): \(error.localizedDescription, privacy: .public)")
                 }
             }
         }
@@ -334,7 +334,7 @@ class SuiService {
         } catch let error as Errors {
             throw error
         } catch {
-            print("Error in dry run transaction: \(error.localizedDescription)")
+            logger.error("Error in dry run transaction: \(error.localizedDescription, privacy: .public)")
             throw Errors.dryRunFailed(error.localizedDescription)
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+TCYStake.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/ThorchainService+TCYStake.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 
 extension ThorchainService {
 
@@ -19,7 +20,7 @@ extension ThorchainService {
             }
             return Decimal(amount)
         } catch {
-            print("Error fetching or decoding staked amount: \(error.localizedDescription)")
+            Log.chain.service.error("Error fetching or decoding staked amount: \(error.localizedDescription, privacy: .public)")
             return .zero
         }
     }

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -9,6 +9,7 @@ import Foundation
 import Tss
 import WalletCore
 import BigInt
+import OSLog
 
 enum TronHelper {
 
@@ -386,7 +387,7 @@ enum TronHelper {
             serializedBytes: hashes
         )
         if !preSigningOutput.errorMessage.isEmpty {
-            print(preSigningOutput.errorMessage)
+            Log.chain.other.error("\(preSigningOutput.errorMessage, privacy: .public)")
             throw HelperError.runtimeError(preSigningOutput.errorMessage)
         }
         return [preSigningOutput.dataHash.hexString]
@@ -419,7 +420,7 @@ enum TronHelper {
         )
         guard publicKey
             .verify(signature: signature, message: preSigningOutput.dataHash) else {
-            print("fail to verify signature")
+            Log.chain.other.error("fail to verify signature")
             throw HelperError.runtimeError("fail to verify signature")
         }
 
@@ -435,7 +436,7 @@ enum TronHelper {
         )
 
         if !output.errorMessage.isEmpty {
-            print(output.errorMessage)
+            Log.chain.other.error("\(output.errorMessage, privacy: .public)")
             throw HelperError.runtimeError("fail to sign transaction")
         }
 

--- a/VultisigApp/VultisigApp/Blockchain/Tss/ServiceDelegate.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/ServiceDelegate.swift
@@ -39,7 +39,7 @@ final class ServiceDelegate: NSObject, NetServiceDelegate, ObservableObject {
                 if ipAddress != nil { break }
             }
         }
-        print("Resolved service address: \(ipAddress ?? "unknown")")
+        logger.debug("Resolved service address: \(ipAddress ?? "unknown", privacy: .public)")
         logger.info("Service found: \(sender.name), \(sender.hostName ?? ""), port \(sender.port) in domain \(sender.domain)")
         serverURL = "http://\(ipAddress ?? sender.hostName ?? ""):\(sender.port)"
     }

--- a/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
+++ b/VultisigApp/VultisigApp/Blockchain/UTXO/Signing/UTXOChainsHelper.swift
@@ -6,6 +6,7 @@
 import Foundation
 import Tss
 import WalletCore
+import OSLog
 
 struct UtxoInfo: Codable, Hashable {
     let hash: String
@@ -448,7 +449,7 @@ class UTXOChainsHelper {
             throw HelperError.runtimeError("Generated transaction is empty")
         }
 
-        print("ZERO SIGNED TX: \(transactionHex)")
+        Log.chain.other.debug("ZERO SIGNED TX: \(transactionHex, privacy: .public)")
 
         return transactionHex
     }

--- a/VultisigApp/VultisigApp/Components/AddressBook/AddressBookTextField.swift
+++ b/VultisigApp/VultisigApp/Components/AddressBook/AddressBookTextField.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 import UniformTypeIdentifiers
 
 struct AddressBookTextField: View {
@@ -36,7 +37,7 @@ struct AddressBookTextField: View {
                     let qrCode = try Utils.handleQrCodeFromImage(result: result)
                     handleImageQrCode(data: qrCode)
                 } catch {
-                    print(error)
+                    Log.app.view.error("\(error.localizedDescription, privacy: .public)")
                 }
             }
     }

--- a/VultisigApp/VultisigApp/Components/Cells/ImportFileCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/ImportFileCell.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 struct ImportFileCell: View {
 
@@ -50,7 +51,7 @@ struct ImportFileCell: View {
 
 #Preview {
     func reset() {
-        print("RESET")
+        Log.app.view.debug("RESET")
     }
 
     return ImportFileCell(name: "File", resetData: reset)

--- a/VultisigApp/VultisigApp/Components/FileQRCodeImporterMac.swift
+++ b/VultisigApp/VultisigApp/Components/FileQRCodeImporterMac.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 import UniformTypeIdentifiers
 
 struct FileQRCodeImporterMac: View {
@@ -99,11 +100,11 @@ struct FileQRCodeImporterMac: View {
 
 #Preview {
     func reset() {
-        print("RESET")
+        Log.app.view.debug("RESET")
     }
 
     func handleFileImport(_: Result<[URL], Error>) {
-        print("IMPORTED")
+        Log.app.view.debug("IMPORTED")
     }
 
     return FileQRCodeImporterMac(fileName: "File", resetData: reset, handleFileImport: handleFileImport, selectedImage: nil)

--- a/VultisigApp/VultisigApp/Components/GeneralQRImportMacView.swift
+++ b/VultisigApp/VultisigApp/Components/GeneralQRImportMacView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import OSLog
 
 struct GeneralQRImportMacView: View {
     let type: DeeplinkFlowType
@@ -129,7 +130,7 @@ struct GeneralQRImportMacView: View {
             setValues(urls)
             importResult = result
         case .failure(let error):
-            print("Error importing file: \(error.localizedDescription)")
+            Log.app.view.error("Error importing file: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -147,7 +148,7 @@ struct GeneralQRImportMacView: View {
                 isButtonEnabled = true
             }
         } catch {
-            print(error)
+            Log.app.view.error("\(error.localizedDescription, privacy: .public)")
         }
     }
     #endif

--- a/VultisigApp/VultisigApp/Components/HapticFeedbackManager.swift
+++ b/VultisigApp/VultisigApp/Components/HapticFeedbackManager.swift
@@ -7,8 +7,11 @@
 
 import SwiftUI
 import CoreHaptics
+import OSLog
 
 #if os(iOS)
+private let logger = Log.app.other
+
 class HapticFeedbackManager {
     private var timer: Timer?
     private var stopWorkItem: DispatchWorkItem?
@@ -36,16 +39,16 @@ class HapticFeedbackManager {
                 do {
                     try self?.hapticEngine?.start()
                 } catch {
-                    print("Failed to restart haptic engine: \(error)")
+                    logger.error("Failed to restart haptic engine: \(error.localizedDescription, privacy: .public)")
                 }
             }
 
             // Handle engine stopped
             hapticEngine?.stoppedHandler = { reason in
-                print("Haptic engine stopped: \(reason)")
+                logger.info("Haptic engine stopped: \(String(describing: reason), privacy: .public)")
             }
         } catch {
-            print("Failed to create haptic engine: \(error)")
+            logger.error("Failed to create haptic engine: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -55,7 +58,7 @@ class HapticFeedbackManager {
         }
 
         guard let url = Bundle.main.url(forResource: fileName, withExtension: "ahap") else {
-            print("AHAP file '\(fileName).ahap' not found")
+            logger.error("AHAP file '\(fileName, privacy: .public).ahap' not found")
             return
         }
 
@@ -75,7 +78,7 @@ class HapticFeedbackManager {
             // Play the pattern
             try hapticPlayer?.start(atTime: CHHapticTimeImmediate)
         } catch {
-            print("Failed to play AHAP file: \(error)")
+            logger.error("Failed to play AHAP file: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -84,7 +87,7 @@ class HapticFeedbackManager {
             try hapticPlayer?.stop(atTime: CHHapticTimeImmediate)
             hapticPlayer = nil
         } catch {
-            print("Failed to stop AHAP playback: \(error)")
+            logger.error("Failed to stop AHAP playback: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Core/Extensions/FileManagerExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/FileManagerExtension.swift
@@ -19,7 +19,7 @@ extension FileManager {
                 try self.removeItem(atPath: path)
             }
         } catch {
-            print(error)
+            Log.app.other.error("clearTmpDirectory failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import BigInt
+import OSLog
 
 // MARK: - String Extensions for Padding and Hex Processing
 
@@ -168,7 +169,7 @@ extension String {
             return .zero
         }
         guard let number = parseInput() else {
-            print("Failed to convert to Decimal: \(self)")
+            Log.app.other.error("Failed to convert to Decimal: \(self, privacy: .public)")
             return .zero
         }
 

--- a/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 
 /// Service responsible for handling app migrations
 /// Migrations are executed once per migration version on app launch
@@ -15,6 +16,7 @@ import Foundation
 /// 1. Persist across app reinstalls - prevents re-running migrations for existing users
 /// 2. Detect fresh installations - new devices have no Keychain entry, so migrations are skipped
 struct AppMigrationService {
+    private let logger = Log.app.service
     private let keychainService: KeychainService
 
     init(keychainService: KeychainService = DefaultKeychainService.shared) {
@@ -27,7 +29,7 @@ struct AppMigrationService {
 
         // Get the highest migration version available
         guard let latestMigrationVersion = migrations.map(\.version).max() else {
-            print("✅ [Migration] No migrations registered")
+            logger.info("✅ [Migration] No migrations registered")
             return
         }
 
@@ -39,16 +41,16 @@ struct AppMigrationService {
 
         // If already migrated to the latest version, skip
         if lastVersion >= latestMigrationVersion {
-            print("✅ [Migration] Already migrated to version \(lastVersion)")
+            logger.info("✅ [Migration] Already migrated to version \(lastVersion)")
             return
         }
 
-        print("🔄 [Migration] Starting migrations from version \(lastVersion) to \(latestMigrationVersion)")
+        logger.info("🔄 [Migration] Starting migrations from version \(lastVersion) to \(latestMigrationVersion)")
 
         // Execute migrations in order
         executeMigrations(from: lastVersion, migrations: migrations)
 
-        print("✅ [Migration] Completed all migrations")
+        logger.info("✅ [Migration] Completed all migrations")
     }
 
     /// Executes all necessary migrations after the last migrated version
@@ -58,13 +60,13 @@ struct AppMigrationService {
 
         // Execute each migration that hasn't been run yet
         for migration in sortedMigrations where migration.version > lastVersion {
-            print("🔄 [Migration] Executing migration #\(migration.version): \(migration.description)")
+            logger.info("🔄 [Migration] Executing migration #\(migration.version): \(migration.description, privacy: .public)")
             do {
                 try migration.migrate()
                 keychainService.setLastMigratedVersion(migration.version)
-                print("✅ [Migration] Successfully completed migration #\(migration.version)")
+                logger.info("✅ [Migration] Successfully completed migration #\(migration.version)")
             } catch {
-                print("❌ [Migration] Failed migration #\(migration.version): \(error.localizedDescription)")
+                logger.error("❌ [Migration] Failed migration #\(migration.version): \(error.localizedDescription, privacy: .public)")
                 // Stop executing further migrations if one fails
                 break
             }

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/ShareSheetViewController.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/ShareSheetViewController.swift
@@ -6,6 +6,7 @@
 //
 #if os(iOS)
 import SwiftUI
+import OSLog
 
 extension View {
     func shareSheet(isPresented: Binding<Bool>, activityItems: [Any], completion: ((Bool) -> Void)?, applicationActivities: [UIActivity]? = nil) -> some View {
@@ -62,7 +63,7 @@ private struct ShareSheetViewController: UIViewControllerRepresentable {
             context.coordinator.hasCompleted = true
 
             if let error = error {
-                print("Error sharing: \(error.localizedDescription)")
+                Log.app.other.error("Error sharing: \(error.localizedDescription, privacy: .public)")
             }
 
             // Dismiss the sheet first

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/ServerBackupVerificationView.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/ServerBackupVerificationView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftData
 import RiveRuntime
+import OSLog
 
 struct ServerBackupVerificationScreen: View {
     let tssType: TssType
@@ -317,7 +318,7 @@ struct ServerBackupVerificationScreen: View {
             isPresented = false
             onBackToEmailSetup()
         } catch {
-            print("Error: \(error)")
+            Log.wallet.view.error("Error: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Utils/OnDropQRUtils.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Utils/OnDropQRUtils.swift
@@ -8,6 +8,7 @@
 #if os(macOS)
 import AppKit
 import UniformTypeIdentifiers
+import OSLog
 
 enum OnDropQRError: Error {
     case noItems
@@ -18,13 +19,13 @@ class OnDropQRUtils {
 
     static func handleOnDrop(providers: [NSItemProvider], handleImageQrCode: @escaping (Data) -> Void) -> Bool {
         guard let provider = providers.first(where: { $0.hasItemConformingToTypeIdentifier("public.image") }) else {
-            print("Invalid file type. Please drop an image.")
+            Log.app.other.error("Invalid file type. Please drop an image.")
             return false
         }
 
         provider.loadDataRepresentation(forTypeIdentifier: "public.image") { data, error in
             guard let data = data, let image = NSImage(data: data) else {
-                print(error?.localizedDescription ?? "Failed to load image.")
+                Log.app.other.error("\(error?.localizedDescription ?? "Failed to load image.", privacy: .public)")
                 return
             }
 
@@ -34,7 +35,7 @@ class OnDropQRUtils {
                     handleImageQrCode(qrData)
                 }
             } else {
-                print("No QR code detected in the image.")
+                Log.app.other.debug("No QR code detected in the image.")
             }
         }
 

--- a/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
@@ -563,7 +563,7 @@ private extension BalanceService {
                     )
                 }
             } catch {
-                print("Error fetching MayaChain bonded nodes: \(error.localizedDescription)")
+                logger.error("Error fetching MayaChain bonded nodes: \(error.localizedDescription, privacy: .public)")
                 return nil
             }
 
@@ -632,7 +632,7 @@ private extension BalanceService {
                 let stakedAmountBigInt = stakedAmountInAtomicUnits.description.toBigInt()
                 return stakedAmountBigInt.description
             } catch {
-                print("Error fetching MayaChain CACAO staking balance: \(error.localizedDescription)")
+                logger.error("Error fetching MayaChain CACAO staking balance: \(error.localizedDescription, privacy: .public)")
                 return "0"
             }
 

--- a/VultisigApp/VultisigApp/Core/Services/CoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/CoinService.swift
@@ -142,7 +142,7 @@ struct CoinService {
                     let priceProviderID  = try await CryptoPriceService.shared.resolvePriceProviderID(symbol: asset.ticker, contract: asset.contractAddress)
                     assetPriceProviderId = priceProviderID ?? ""
                 } catch {
-                    print("Error resolving price provider ID for \(asset.ticker): \(error.localizedDescription)")
+                    logger.error("Error resolving price provider ID for \(asset.ticker, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 }
             }
             if let newCoin = try addToChain(asset: asset, to: vault, priceProviderId: assetPriceProviderId) {
@@ -627,12 +627,12 @@ struct CoinService {
         }
 
         if !alreadyHidden {
-            print("🙈 Hiding Token: \(coin.ticker) (\(coin.contractAddress))")
+            logger.debug("🙈 Hiding Token: \(coin.ticker, privacy: .public) (\(coin.contractAddress, privacy: .public))")
             let hiddenToken = HiddenToken(coin: coin)
             vault.hiddenTokens.append(hiddenToken)
             Storage.shared.insert([hiddenToken])
         } else {
-            print("🙈 Token already hidden: \(coin.ticker)")
+            logger.debug("🙈 Token already hidden: \(coin.ticker, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Core/Services/FeatureFlagService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FeatureFlagService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 enum FeatureFlag: String {
     case EncryptGCM
 
@@ -46,11 +47,11 @@ final class FeatureFlagService {
             if let result = features[feature.name] as? Bool {
                 return result
             } else {
-                print("Feature flag for \(feature) is not a boolean value")
+                Log.app.service.warning("Feature flag for \(String(describing: feature), privacy: .public) is not a boolean value")
             }
 
         } catch {
-            print("fail to get features \(error)")
+            Log.app.service.error("fail to get features \(error.localizedDescription, privacy: .public)")
         }
         return false
     }

--- a/VultisigApp/VultisigApp/Core/Services/PendingTransactionManager.swift
+++ b/VultisigApp/VultisigApp/Core/Services/PendingTransactionManager.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+import OSLog
+
+private let logger = Log.chain.service
 
 // MARK: - Pending Transaction Management
 
@@ -46,7 +49,7 @@ class PendingTransactionManager {
     func addPendingTransaction(txHash: String, address: String, chain: Chain, sequence: UInt64) {
         let transaction = PendingTransaction(txHash: txHash, address: address, chain: chain, sequence: sequence)
         self.pendingTransactions.setSync(txHash, transaction)
-        print("Added pending transaction: \(txHash) for address: \(address) with sequence: \(sequence)")
+        logger.debug("Added pending transaction: \(txHash, privacy: .public) for address: \(address, privacy: .public) with sequence: \(sequence)")
 
         // Start polling only for this specific chain
         self.startPollingForChain(chain)
@@ -76,7 +79,7 @@ class PendingTransactionManager {
 
     /// Force check pending transactions immediately (useful for UI refresh)
     func forceCheckPendingTransactions() async {
-        print("PendingTransactionManager: Force checking pending transactions")
+        logger.debug("Force checking pending transactions")
         // Check all pending transactions across all chains
         let allPending = Array(pendingTransactions.allItems().values.filter { !$0.isConfirmed })
 
@@ -104,7 +107,7 @@ class PendingTransactionManager {
             return
         }
 
-        print("PendingTransactionManager: Starting polling for chain: \(chain)")
+        logger.info("Starting polling for chain: \(String(describing: chain), privacy: .public)")
 
         let t = Task {
             while !Task.isCancelled {
@@ -114,11 +117,11 @@ class PendingTransactionManager {
                     // Wait 10 seconds before next check
                     try await Task.sleep(for: .seconds(10))
                 } catch {
-                    print("PendingTransactionManager: Polling error for \(chain): \(error)")
+                    logger.error("Polling error for \(String(describing: chain), privacy: .public): \(error.localizedDescription, privacy: .public)")
                     try? await Task.sleep(for: .seconds(10))
                 }
             }
-            print("PendingTransactionManager: Polling task cancelled for chain: \(chain)")
+            logger.debug("Polling task cancelled for chain: \(String(describing: chain), privacy: .public)")
         }
         self.pollingTasks.setSync(chain, t)
 
@@ -128,7 +131,7 @@ class PendingTransactionManager {
     func stopPollingForChain(_ chain: Chain) {
         self.pollingTasks.get(chain)?.cancel()
         self.pollingTasks.remove(chain)
-        print("PendingTransactionManager: Stopped polling for chain: \(chain)")
+        logger.info("Stopped polling for chain: \(String(describing: chain), privacy: .public)")
 
     }
 
@@ -136,7 +139,7 @@ class PendingTransactionManager {
     func stopAllPolling() {
         for (chain, task) in self.pollingTasks.allItems() {
             task.cancel()
-            print("PendingTransactionManager: Stopped polling for chain: \(chain)")
+            logger.info("Stopped polling for chain: \(String(describing: chain), privacy: .public)")
         }
         self.pollingTasks.clear()
     }
@@ -149,7 +152,7 @@ class PendingTransactionManager {
         }
 
         if !chainPending.isEmpty {
-            print("PendingTransactionManager: Checking \(chainPending.count) pending transactions for \(chain)")
+            logger.debug("Checking \(chainPending.count) pending transactions for \(String(describing: chain), privacy: .public)")
         }
 
         for transaction in chainPending {
@@ -171,13 +174,13 @@ class PendingTransactionManager {
 
     private func checkTransactionConfirmation(transaction: PendingTransaction) async {
         do {
-            print("PendingTransactionManager: Checking status for \(transaction.txHash.prefix(8))... on \(transaction.chain)")
+            logger.debug("Checking status for \(String(transaction.txHash.prefix(8)), privacy: .public)... on \(String(describing: transaction.chain), privacy: .public)")
             let isConfirmed = try await checkTransactionStatus(txHash: transaction.txHash, chain: transaction.chain)
-            print("PendingTransactionManager: Transaction \(transaction.txHash.prefix(8))... confirmed: \(isConfirmed)")
+            logger.debug("Transaction \(String(transaction.txHash.prefix(8)), privacy: .public)... confirmed: \(isConfirmed)")
 
             if isConfirmed {
                 pendingTransactions.remove(transaction.txHash)
-                print("PendingTransactionManager: ✅ Transaction confirmed and removed: \(transaction.txHash.prefix(8))...")
+                logger.info("✅ Transaction confirmed and removed: \(String(transaction.txHash.prefix(8)), privacy: .public)...")
 
                 // Clear cache to force fresh nonce fetch for next transaction (background thread)
                 BlockChainService.shared.clearCacheForAddress()
@@ -193,7 +196,7 @@ class PendingTransactionManager {
             }
 
         } catch {
-            print("PendingTransactionManager: ❌ Failed to check transaction status for \(transaction.txHash.prefix(8))...: \(error)")
+            logger.error("❌ Failed to check transaction status for \(String(transaction.txHash.prefix(8)), privacy: .public)...: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -220,23 +223,23 @@ class PendingTransactionManager {
             return false
         }
 
-        print("PendingTransactionManager: Checking nonce for address: \(transaction.address)")
-        print("PendingTransactionManager: Expected sequence > \(transaction.sequence)")
+        logger.debug("Checking nonce for address: \(transaction.address, privacy: .public)")
+        logger.debug("Expected sequence > \(transaction.sequence)")
 
         // Fetch current account info to get latest sequence number
         let account = try await ThorchainService.shared.fetchAccountNumber(transaction.address)
 
         guard let currentSequenceString = account?.sequence,
               let currentSequence = UInt64(currentSequenceString) else {
-            print("PendingTransactionManager: Failed to get current sequence")
+            logger.error("Failed to get current sequence")
             return false
         }
 
-        print("PendingTransactionManager: Current sequence: \(currentSequence)")
+        logger.debug("Current sequence: \(currentSequence)")
 
         // If current sequence is greater than the transaction sequence, it means the transaction was processed
         let isConfirmed = currentSequence > transaction.sequence
-        print("PendingTransactionManager: Nonce-based confirmation: \(isConfirmed)")
+        logger.debug("Nonce-based confirmation: \(isConfirmed)")
 
         return isConfirmed
     }
@@ -247,23 +250,23 @@ class PendingTransactionManager {
             return false
         }
 
-        print("PendingTransactionManager: Checking MayaChain nonce for address: \(transaction.address)")
-        print("PendingTransactionManager: Expected sequence > \(transaction.sequence)")
+        logger.debug("Checking MayaChain nonce for address: \(transaction.address, privacy: .public)")
+        logger.debug("Expected sequence > \(transaction.sequence)")
 
         // Fetch current account info to get latest sequence number
         let account = try await MayachainService.shared.fetchAccountNumber(transaction.address)
 
         guard let currentSequenceString = account?.sequence,
               let currentSequence = UInt64(currentSequenceString) else {
-            print("PendingTransactionManager: Failed to get current MayaChain sequence")
+            logger.error("Failed to get current MayaChain sequence")
             return false
         }
 
-        print("PendingTransactionManager: Current MayaChain sequence: \(currentSequence)")
+        logger.debug("Current MayaChain sequence: \(currentSequence)")
 
         // If current sequence is greater than the transaction sequence, it means the transaction was processed
         let isConfirmed = currentSequence > transaction.sequence
-        print("PendingTransactionManager: MayaChain nonce-based confirmation: \(isConfirmed)")
+        logger.debug("MayaChain nonce-based confirmation: \(isConfirmed)")
 
         return isConfirmed
     }
@@ -274,8 +277,8 @@ class PendingTransactionManager {
             return false
         }
 
-        print("PendingTransactionManager: Checking \(chain) nonce for address: \(transaction.address)")
-        print("PendingTransactionManager: Expected sequence > \(transaction.sequence)")
+        logger.debug("Checking \(String(describing: chain), privacy: .public) nonce for address: \(transaction.address, privacy: .public)")
+        logger.debug("Expected sequence > \(transaction.sequence)")
 
         // Fetch current account info to get latest sequence number
         let service = try CosmosService.getService(forChain: chain)
@@ -283,15 +286,15 @@ class PendingTransactionManager {
 
         guard let currentSequenceString = account?.sequence,
               let currentSequence = UInt64(currentSequenceString) else {
-            print("PendingTransactionManager: Failed to get current \(chain) sequence")
+            logger.error("Failed to get current \(String(describing: chain), privacy: .public) sequence")
             return false
         }
 
-        print("PendingTransactionManager: Current \(chain) sequence: \(currentSequence)")
+        logger.debug("Current \(String(describing: chain), privacy: .public) sequence: \(currentSequence)")
 
         // If current sequence is greater than the transaction sequence, it means the transaction was processed
         let isConfirmed = currentSequence > transaction.sequence
-        print("PendingTransactionManager: \(chain) nonce-based confirmation: \(isConfirmed)")
+        logger.debug("\(String(describing: chain), privacy: .public) nonce-based confirmation: \(isConfirmed)")
 
         return isConfirmed
     }
@@ -307,11 +310,11 @@ class PendingTransactionManager {
 
         for (txHash, transaction) in veryOldTransactions {
             pendingTransactions.remove(txHash)
-            print("Very old transaction removed (safety cleanup): \(txHash) for address: \(transaction.address)")
+            logger.info("Very old transaction removed (safety cleanup): \(txHash, privacy: .public) for address: \(transaction.address, privacy: .public)")
         }
 
         if !veryOldTransactions.isEmpty {
-            print("Safety cleanup: removed \(veryOldTransactions.count) very old transactions (>10 minutes)")
+            logger.info("Safety cleanup: removed \(veryOldTransactions.count) very old transactions (>10 minutes)")
         }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Combine
 import SwiftData
+import OSLog
 
 final class RateProvider {
 
@@ -80,7 +81,7 @@ final class RateProvider {
                 // value recompute instead of waiting on a network refresh.
                 self.ratesDidChange.send()
             } catch {
-                print("Failed to load rates: \(error.localizedDescription)")
+                Log.chain.service.error("Failed to load rates: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/VultisigApp/VultisigApp/Core/Services/TransactionStatus/BackgroundTransactionPoller.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TransactionStatus/BackgroundTransactionPoller.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import OSLog
 
 @MainActor
 class BackgroundTransactionPoller: ObservableObject {
@@ -22,7 +23,7 @@ class BackgroundTransactionPoller: ObservableObject {
         do {
             let pendingTransactions = try storage.getAllPending()
 
-            print("BackgroundTransactionPoller: Found \(pendingTransactions.count) pending transactions")
+            Log.chain.service.debug("Found \(pendingTransactions.count) pending transactions")
 
             for transaction in pendingTransactions {
                 // Check if already being polled
@@ -35,13 +36,13 @@ class BackgroundTransactionPoller: ObservableObject {
                 pollingViewModels[transaction.txHash] = viewModel
                 viewModel.startPolling()
 
-                print("BackgroundTransactionPoller: Resumed polling for \(transaction.txHash.prefix(8))...")
+                Log.chain.service.debug("Resumed polling for \(String(transaction.txHash.prefix(8)), privacy: .public)...")
             }
 
             // Cleanup old transactions
             try storage.cleanupOld()
         } catch {
-            print("BackgroundTransactionPoller: Error resuming transactions: \(error)")
+            Log.chain.service.error("Error resuming transactions: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftData
+import OSLog
 
 class VaultDefaultCoinService {
     let context: ModelContext
@@ -27,7 +28,7 @@ class VaultDefaultCoinService {
 
     func setDefaultCoins(for vault: Vault) {
         // Add default coins when the vault doesn't have any coins in it
-        print("set default chains to vault")
+        Log.chain.service.info("set default chains to vault")
         if vault.coins.isEmpty {
             let defaultChains = getDefaultChains(for: vault)
             let chains: [CoinMeta] = TokensStore.TokenSelectionAssets

--- a/VultisigApp/VultisigApp/Core/Utils/Encryption.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Encryption.swift
@@ -8,6 +8,7 @@
 import Foundation
 import CommonCrypto
 import CryptoKit
+import OSLog
 
 enum AESError: Error {
     case encryptionFailed
@@ -163,7 +164,7 @@ class Encryption {
         if result == errSecSuccess {
             return keyData.hexString
         } else {
-            print("Problem generating random bytes")
+            Log.app.other.error("Problem generating random bytes")
             return nil
         }
     }

--- a/VultisigApp/VultisigApp/Core/Utils/Utils.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/Utils.swift
@@ -172,7 +172,7 @@ enum Utils {
 
         if uri.hasPrefix("ton://") {
             guard let url = URLComponents(string: uri) else {
-                print("invalid URI")
+                logger.error("invalid URI")
                 return (.empty, .empty, .empty)
             }
 
@@ -192,13 +192,13 @@ enum Utils {
                 case "amount":
                     amount = item.value ?? ""
                 default:
-                    print("Unknown query item: \(item.name)")
+                    logger.debug("Unknown query item: \(item.name, privacy: .public)")
                 }
             }
         } else {
 
             guard let url = URLComponents(string: uri) else {
-                print("Invalid URI")
+                logger.error("Invalid URI")
                 return (.empty, .empty, .empty)
             }
 
@@ -213,7 +213,7 @@ enum Utils {
                         message += (message.isEmpty ? "" : " ") + value
                     }
                 default:
-                    print("Unknown query item: \(item.name)")
+                    logger.debug("Unknown query item: \(item.name, privacy: .public)")
                 }
             }
         }
@@ -225,7 +225,7 @@ enum Utils {
         let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
 
         guard status == errSecSuccess else {
-            print("Error generating random bytes: \(status)")
+            logger.error("Error generating random bytes: \(status)")
             return nil
         }
 
@@ -244,7 +244,7 @@ enum Utils {
                 return try JSONDecoder().decode(T.self, from: resultData)
             }
         } catch {
-            print("Error processing JSON: \(error)")
+            logger.error("Error processing JSON: \(error.localizedDescription, privacy: .public)")
         }
         return nil
     }
@@ -254,7 +254,7 @@ enum Utils {
             let json = try JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
             return getValueFromJson(for: path, in: json)
         } catch {
-            print("JSON decoding error: \(error)")
+            logger.error("JSON decoding error: \(error.localizedDescription, privacy: .public)")
         }
         return nil
     }
@@ -377,7 +377,7 @@ enum Utils {
     static func handleQrCodeFromImage(image: UIImage) -> Data {
         let qrStrings = detectQRCode(image)
         if qrStrings.isEmpty {
-            print("No QR codes detected.")
+            logger.debug("No QR codes detected.")
             return Data()
         } else {
             for qrString in qrStrings {
@@ -412,7 +412,7 @@ enum Utils {
     static func handleQrCodeFromImage(image: NSImage) -> Data {
         let qrStrings = detectQRCode(image)
         if qrStrings.isEmpty {
-            print("No QR codes detected.")
+            logger.debug("No QR codes detected.")
             return Data()
         } else {
             for qrString in qrStrings {
@@ -478,7 +478,7 @@ enum Utils {
 
 #if os(iOS)
             guard success else {
-                print("Failed to access URL")
+                logger.error("Failed to access URL")
                 throw UtilsQrCodeFromImageError.URLInaccessible
             }
 
@@ -486,7 +486,7 @@ enum Utils {
                 let qrStrings = Utils.detectQRCode(selectedImage)
 
                 if qrStrings.isEmpty {
-                    print("No QR codes detected.")
+                    logger.debug("No QR codes detected.")
                     throw UtilsQrCodeFromImageError.NoQRCodesDetected
                 } else {
                     for qrString in qrStrings {
@@ -494,7 +494,7 @@ enum Utils {
                     }
                 }
             } else {
-                print("Failed to load image from URL")
+                logger.error("Failed to load image from URL")
                 throw UtilsQrCodeFromImageError.FailedToLoadImage
             }
 #elseif os(macOS)
@@ -502,7 +502,7 @@ enum Utils {
                 let qrStrings = Utils.detectQRCode(selectedImage)
 
                 if qrStrings.isEmpty {
-                    print("No QR codes detected.")
+                    logger.debug("No QR codes detected.")
                     throw UtilsQrCodeFromImageError.NoQRCodesDetected
                 } else {
                     for qrString in qrStrings {
@@ -510,13 +510,13 @@ enum Utils {
                     }
                 }
             } else {
-                print("Failed to load image from URL")
+                logger.error("Failed to load image from URL")
                 throw UtilsQrCodeFromImageError.FailedToLoadImage
             }
 #endif
 
         case .failure(let error):
-            print("Error selecting file: \(error.localizedDescription)")
+            logger.error("Error selecting file: \(error.localizedDescription, privacy: .public)")
         }
         return Data()
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/AssetSelectionList/MayaAssetsDataSource.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/AssetSelectionList/MayaAssetsDataSource.swift
@@ -5,6 +5,8 @@
 //  Created by Gaston Mazzeo on 24/11/2025.
 //
 
+import OSLog
+
 struct MayaAssetsDataSource: AssetSelectionDataSource {
     private let mayaChainAPIService = MayaChainAPIService()
 
@@ -14,7 +16,7 @@ struct MayaAssetsDataSource: AssetSelectionDataSource {
             let assets = try await mayaChainAPIService.getDepositAssets()
             return assets
         } catch {
-            print("Error fetching Maya deposit assets: \(error.localizedDescription)")
+            Log.send.service.error("Error fetching Maya deposit assets: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/AssetSelectionList/MayaBondedAssetsDataSource.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/AssetSelectionList/MayaBondedAssetsDataSource.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import OSLog
 
 /// Data source for Unbond screen - fetches user's bonded LP positions on a specific node
 class MayaBondedAssetsDataSource: AssetSelectionDataSource {
@@ -44,7 +45,7 @@ class MayaBondedAssetsDataSource: AssetSelectionDataSource {
 
             return assets
         } catch {
-            print("Error fetching bonded LP positions: \(error.localizedDescription)")
+            Log.send.service.error("Error fetching bonded LP positions: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/AssetSelectionList/MayaUserLPAssetsDataSource.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/AssetSelectionList/MayaUserLPAssetsDataSource.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 
 /// Data source for Bond screen - fetches user's LP positions that are in bondable pools
 struct MayaUserLPAssetsDataSource: AssetSelectionDataSource {
@@ -50,7 +51,7 @@ struct MayaUserLPAssetsDataSource: AssetSelectionDataSource {
 
             return assets
         } catch {
-            print("Error fetching user LP positions: \(error.localizedDescription)")
+            Log.send.service.error("Error fetching user LP positions: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/BondMaya/BondMayaTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Maya/BondMaya/BondMayaTransactionViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import OSLog
 
 final class BondMayaTransactionViewModel: ObservableObject, Form {
     let coin: Coin
@@ -135,7 +136,7 @@ final class BondMayaTransactionViewModel: ObservableObject, Form {
                     // On error, allow bonding attempt (server will reject if not whitelisted)
                     canBondToNode = true
                 }
-                print("Error checking whitelist: \(error.localizedDescription)")
+                Log.send.viewModel.error("Error checking whitelist: \(error.localizedDescription, privacy: .public)")
             }
         }
     }
@@ -164,7 +165,7 @@ final class BondMayaTransactionViewModel: ObservableObject, Form {
                 userLPPositions = p
             }
         } catch {
-            print("Error fetching user LP positions: \(error.localizedDescription)")
+            Log.send.viewModel.error("Error fetching user LP positions: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -8,6 +8,7 @@
 import SwiftData
 import SwiftUI
 import WalletCore
+import OSLog
 
 struct HomeScreen: View {
     @Environment(\.router) var router
@@ -419,7 +420,7 @@ extension HomeScreen {
         do {
             vaults = try modelContext.fetch(fetchVaultDescriptor)
         } catch {
-            print(error)
+            Log.wallet.view.error("\(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/JoinKeygenViewModel.swift
@@ -354,7 +354,7 @@ class JoinKeygenViewModel: ObservableObject {
             }
             handleDeeplinkScan(URL(string: urlString))
         } catch {
-            print(error)
+            logger.error("\(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenPeerDiscoveryViewModel.swift
@@ -51,7 +51,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
     @Published var serverAddr = "http://127.0.0.1:18080"
     @Published var selectedNetwork = VultisigRelay.IsRelayEnabled ? NetworkPromptType.Internet : NetworkPromptType.Local {
         didSet {
-            print("selected network changed: \(selectedNetwork)")
+            logger.debug("selected network changed: \(String(describing: self.selectedNetwork), privacy: .public)")
             VultisigRelay.IsRelayEnabled = NetworkPromptType.Internet == selectedNetwork
         }
     }

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/FastVaultEnterPasswordView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/FastVaultEnterPasswordView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 struct FastVaultEnterPasswordView: View {
     @AppStorage("isBiometryEnabled") var isBiometryEnabled: Bool = true
@@ -152,7 +153,7 @@ struct FastVaultEnterPasswordView: View {
             },
             onError: { error in
                 // Log authentication error - don't fail silently
-                print("Fast Vault authentication error: \(error.localizedDescription)")
+                Log.keygen.view.error("Fast Vault authentication error: \(error.localizedDescription, privacy: .public)")
                 // Error is shown by system dialog, no need to show another alert
             })
     }

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
@@ -3,6 +3,7 @@
 //  VultisigApp
 
 import SwiftUI
+import OSLog
 
 struct JoinKeysignView: View {
     let vault: Vault
@@ -27,7 +28,7 @@ struct JoinKeysignView: View {
                 do {
                     _ = try await ThorchainService.shared.getTHORChainChainID()
                 } catch {
-                    print("fail to get thorchain network id, \(error.localizedDescription)")
+                    Log.keysign.view.error("fail to get thorchain network id, \(error.localizedDescription, privacy: .public)")
                 }
             }
     }

--- a/VultisigApp/VultisigApp/Features/Referral/ViewModels/PreferredAssetSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/ViewModels/PreferredAssetSelectionViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 class PreferredAssetSelectionViewModel: ObservableObject {
     @Published var searchText: String = ""
@@ -33,7 +34,7 @@ class PreferredAssetSelectionViewModel: ObservableObject {
             await MainActor.run { self.assets = assets }
         } catch {
             // Will show empty state
-            print("No pools found: \(error)")
+            Log.wallet.viewModel.error("No pools found: \(error.localizedDescription, privacy: .public)")
         }
         await MainActor.run { isLoading = false }
     }

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -11,6 +11,7 @@
 import SwiftUI
 import BigInt
 import WalletCore
+import OSLog
 
 @MainActor
 class SendCryptoVerifyViewModel: ObservableObject {
@@ -150,7 +151,7 @@ class SendCryptoVerifyViewModel: ObservableObject {
             isCalculatingFee = false
             isLoading = false
         } catch {
-            print("DEBUG: Error calculating fee: \(error)")
+            Log.send.viewModel.error("Error calculating fee: \(error.localizedDescription, privacy: .public)")
             errorMessage = error.localizedDescription
             showAlert = true
             isCalculatingFee = false

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendGasSettingsView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendGasSettingsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 import BigInt
 
 protocol SendGasSettingsOutput {
@@ -154,7 +155,7 @@ struct SendGasSettingsView: View {
             do {
                 try await viewModel.fetch(chain: viewModel.chain)
             } catch {
-                print("Error fetching gas settings: \(error)")
+                Log.send.view.error("Error fetching gas settings: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Screens/VaultManagementSheet.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Screens/VaultManagementSheet.swift
@@ -7,6 +7,7 @@
 
 import SwiftData
 import SwiftUI
+import OSLog
 
 private enum VaultSheetType: Equatable {
     case main
@@ -169,7 +170,7 @@ private extension VaultManagementSheet {
         do {
             try modelContext.save()
         } catch {
-            print("Error while deleting folder: \(error)")
+            Log.wallet.view.error("Error while deleting folder: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -270,7 +270,7 @@ class EncryptedBackupViewModel: ObservableObject {
 
                 importedVaults = processVaultFiles(vaultFiles)
             } catch {
-                print("⚠️ DEBUG: unzipItem failed: \(error)")
+                logger.error("⚠️ unzipItem failed: \(error.localizedDescription, privacy: .public)")
                 extractedSuccessfully = false
             }
 
@@ -292,19 +292,19 @@ class EncryptedBackupViewModel: ObservableObject {
                             // Process vault files
                             importedVaults = self.processVaultFiles(vaultFiles)
                         } else {
-                            print("❌ DEBUG: Coordinator didn't extract the ZIP")
+                            self.logger.error("❌ Coordinator didn't extract the ZIP")
                         }
                     }
                 }
 
                 if let error = coordinatorError {
-                    print("❌ DEBUG: Coordinator error: \(error)")
+                    self.logger.error("❌ Coordinator error: \(error.localizedDescription, privacy: .public)")
                     throw ZipFileError.failedToExtractZIP(error.localizedDescription)
                 }
             }
 
         } catch {
-            print("❌ DEBUG: Error during extraction: \(error)")
+            logger.error("❌ Error during extraction: \(error.localizedDescription, privacy: .public)")
             cleanupExtractedFiles()
             throw error
         }
@@ -335,7 +335,7 @@ class EncryptedBackupViewModel: ObservableObject {
             includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
             options: [.skipsHiddenFiles]
         ) else {
-            print("❌ DEBUG: Failed to create enumerator for: \(directory.path)")
+            logger.error("❌ Failed to create enumerator for: \(directory.path, privacy: .public)")
             return []
         }
 
@@ -361,7 +361,7 @@ class EncryptedBackupViewModel: ObservableObject {
                     }
                 }
             } catch {
-                print("  ⚠️ Error checking file: \(fileURL.lastPathComponent) - \(error)")
+                logger.warning("⚠️ Error checking file: \(fileURL.lastPathComponent, privacy: .public) - \(error.localizedDescription, privacy: .public)")
             }
         }
 
@@ -388,7 +388,7 @@ class EncryptedBackupViewModel: ObservableObject {
                     processedVaults.append(vault)
                 }
             } catch {
-                print("    ❌ Failed: \(error.localizedDescription)")
+                logger.error("❌ Failed: \(error.localizedDescription, privacy: .public)")
                 logger.warning("Failed to import vault from \(fileURL.lastPathComponent): \(error.localizedDescription)")
             }
         }
@@ -455,11 +455,11 @@ class EncryptedBackupViewModel: ObservableObject {
                     let vault = try Vault(proto: vsVault)
                     allVaults.append(vault)
                 } catch {
-                    print("  ❌ Failed to parse decrypted data (\(fileName)): \(error.localizedDescription)")
+                    logger.error("❌ Failed to parse decrypted data (\(fileName, privacy: .public)): \(error.localizedDescription, privacy: .public)")
                     failedVaults.append(fileName)
                 }
             } else {
-                print("  ❌ Failed to decrypt: \(fileName)")
+                logger.error("❌ Failed to decrypt: \(fileName, privacy: .public)")
                 failedVaults.append(fileName)
             }
         }
@@ -587,7 +587,7 @@ class EncryptedBackupViewModel: ObservableObject {
             let matches = regex.matches(in: filename, range: NSRange(filename.startIndex..., in: filename))
             return !matches.isEmpty
         } catch {
-            print("Error checking if filename is a DKLS backup: \(error.localizedDescription)")
+            logger.error("Error checking if filename is a DKLS backup: \(error.localizedDescription, privacy: .public)")
             return false
         }
     }
@@ -650,7 +650,7 @@ class EncryptedBackupViewModel: ObservableObject {
             showAlert = false
             isVaultImported = true
         } catch {
-            print("failed to import with new format , fallback to the old format instead. \(error.localizedDescription)")
+            logger.warning("failed to import with new format , fallback to the old format instead. \(error.localizedDescription, privacy: .public)")
 
             // fallback
             do {
@@ -736,13 +736,13 @@ class EncryptedBackupViewModel: ObservableObject {
 
     func handleOnDrop(providers: [NSItemProvider]) async {
         guard let provider = providers.first(where: { $0.hasItemConformingToTypeIdentifier(UTType.data.identifier) }) else {
-            print("Invalid file type.")
+            logger.error("Invalid file type.")
             return
         }
         do {
             let dragDropData = try await provider.loadItem(forTypeIdentifier: UTType.data.identifier)
             if let urlData = dragDropData as? NSURL {
-                print("File Path as NSURL: \(urlData)")
+                logger.debug("File Path as NSURL: \(String(describing: urlData), privacy: .public)")
                 provider.loadDataRepresentation(forTypeIdentifier: UTType.data.identifier) { data, _ in
                     if let data {
                         let url = urlData as URL
@@ -762,7 +762,7 @@ class EncryptedBackupViewModel: ObservableObject {
                 self.alertTitle = "failedToLoadFileData"
                 self.showAlert = true
             }
-            print("fail to process drag and drop file: \(error.localizedDescription)")
+            logger.error("fail to process drag and drop file: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/Backup/VaultBackupContainerView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/Backup/VaultBackupContainerView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import OSLog
 
 struct VaultBackupContainerView<Content: View>: View {
     @Binding var presentFileExporter: Bool
@@ -32,7 +33,7 @@ struct VaultBackupContainerView<Content: View>: View {
                         dismissView()
                     }
                 case .failure(let error):
-                    print("Error saving file: \(error.localizedDescription)")
+                    Log.wallet.view.error("Error saving file: \(error.localizedDescription, privacy: .public)")
                     backupViewModel.alertTitle = "errorSavingFile"
                     backupViewModel.showAlert = true
                 }

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/VaultDeletionConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/VaultDeletionConfirmView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import SwiftData
+import OSLog
 
 struct VaultDeletionConfirmView: View {
     let vault: Vault
@@ -117,7 +118,7 @@ struct VaultDeletionConfirmView: View {
                 }
                 try modelContext.save()
             } catch {
-                print("Error: \(error)")
+                Log.wallet.view.error("Error: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -5,6 +5,7 @@
 import Foundation
 import SwiftData
 import WalletCore
+import OSLog
 
 @Model
 final class Vault: ObservableObject, Codable {
@@ -385,7 +386,7 @@ final class Vault: ObservableObject, Codable {
                 idx += 1
             } while idx < 1000
         } catch {
-            print("fail to load all vaults")
+            Log.wallet.store.error("fail to load all vaults")
         }
         return "Main Vault"
     }


### PR DESCRIPTION
## Replace remaining in-app `print(` with the `Log` facade

Closes #4953. Cross-cutting spoke of the logging-facade effort: converts the remaining in-app `print(` statements to the `Log.<feature>.<layer>.<level>(…)` facade (native OSLog under the gate).

### Base / stacking
Branches off `feat/logging-facade` (PR base `feat/logging-facade`, **not** `main`). Retargets to `main` after the base PR #4945 merges.

### What changed
- **222 `print(` sites converted** across **57 files**.
- Each site's feature+layer was picked by the file's location/role, per the authoritative taxonomy in `LogFeature.swift` / `LogLayer.swift`:
  - `Blockchain/States/Keygen/*` → `Log.keygen.tss`; `Blockchain/States/Keysign/*` → `Log.keysign.tss`
  - `Blockchain/Tss/ServiceDelegate` → `Log.tss.network`
  - per-chain services → `Log.chain.service`; per-chain signers/helpers → `Log.chain.other`; `Core/Services/*` cross-chain data services → `Log.chain.service`
  - `Features/Send` + `Features/FunctionTransaction/Maya/*` → `Log.send.*`
  - wallet home / backup / referral / vault-management / `Model/Vault` → `Log.wallet.*`
  - app bootstrap, utils, platform, notifications, feature flags, migrations → `Log.app.*`
- **Level mapping:** failures/`Failed…`/`Error…` → `.error`; recoverable (rate-limit 429, retries, fallbacks, non-boolean flag) → `.warning`; operational (`Starting…`, `reshare … successfully`, version/migration progress) → `.info`; verbose per-message/per-item diagnostics (MPC message passing, nonce/sequence checks, pubkey/chaincode dumps) → `.debug`.
- **Loggers:** files that already had a `logger` reuse it (this spoke only touches `print(` lines — the other spokes convert the `Logger(...)` declarations). Files with no logger use inline `Log.<feature>.<layer>` (added `import OSLog`); three high-volume files (`PendingTransactionManager` 29 sites, `AppMigrationService`, `HapticFeedbackManager`) got a stored `private let logger = Log.<f>.<l>` for readability.

### Privacy
No newly-leaked secrets. Everything converted was already fully visible via `print()`, and OSLog defaults interpolations to redacted. Diagnostic values (error descriptions, tx hashes, addresses, party IDs, public keys, chain codes, tickers) are marked `privacy: .public` to preserve their prior visibility, matching the established house style (87 pre-existing `privacy: .public` usages). No private keys, mnemonics, seeds, passwords, or keyshare bytes are logged. C-enum MPC status codes (`godkls`/`mldsa`/`goschnorr` `lib_error`) are wrapped in `String(describing:)` (no OSLog overload otherwise).

### Skipped (10 sites, all intentional)
- `App/VultisigApp.swift:40,42` — the macOS `--version` CLI path writes to **stdout** for the user; converting to OSLog would break `--version`. Left as `print()`.
- `Core/Platform/iOS/Native/GeneralCodeScannerView.swift:65–67` (3) and `Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift:110–116` (4) — inside `#Preview` blocks (preview-only closures).
- `Blockchain/States/Keygen/DKLSKeygen.swift:278` (1) — already a commented-out line; left as-is.

### Judgment calls (flag on review if undesired)
- `Blockchain/Common/CoinFactory.swift` and `publickey.swift` → `Log.chain.other` (coin/key derivation), even though the taxonomy lists `Blockchain/Common` under the `tss` feature — their role is chain-level, not MPC transport.
- `Features/FunctionTransaction/Maya/*` (Maya bond/LP data sources + VM) → `Log.send.*` per the taxonomy's explicit `Features/FunctionTransaction` → `send` mapping (rather than `defi`).

### Overlap / retarget note
This spoke changes `print(` lines; the sibling logging spokes change `Logger(...)` **declarations** on some of the same files — different lines, separate branches, so no live conflict. A retarget-to-`main` rebase (after the base merges) may need trivial conflict resolution where a sibling spoke's declaration change lands next to a converted call.

### Verification
- `swiftlint lint` on all 57 changed files: clean (no new warnings).
- Full `xcodebuild test` (unit tests, VultisigApp scheme) — see PR checks / gate.
