### PR TITLE
refactor(logging): route Defi loggers through Log.defi facade (#4949)

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/Common/Yield/View/DefiYieldProviderRow.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Yield/View/DefiYieldProviderRow.swift
@@ -6,7 +6,7 @@
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-yield-row")
+private let logger = Log.defi.view
 
 /// DeFi-tab list row for a USDC yield provider (e.g. Circle). Provider-specific
 /// copy and logo come from `presentation`; the deposited position is seeded from

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Yield/View/YieldVaultScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Yield/View/YieldVaultScreen.swift
@@ -7,7 +7,7 @@ import OSLog
 import SwiftUI
 import BigInt
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "yield-vault-view")
+private let logger = Log.defi.view
 
 /// Generic yield-vault dashboard, parameterized by a `DefiYieldProvider`.
 /// Providers with different account and redemption models (e.g. Circle's

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/MayaChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/MayaChainBondInteractor.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "mayachain-bond-interactor")
+private let logger = Log.defi.interactor
 
 private struct BondPositionDraft: Sendable {
     let node: BondNode

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Bond/THORChainBondInteractor.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-bond-interactor")
+private let logger = Log.defi.interactor
 
 private struct BondPositionDraft: Sendable {
     let node: BondNode

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/MayaChainLPsInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/MayaChainLPsInteractor.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "mayachain-lps-interactor")
+private let logger = Log.defi.interactor
 
 struct MayaChainLPsInteractor: LPsInteractor {
     private let mayaAPIService = MayaChainAPIService()

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/THORChainLPsInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/LPs/THORChainLPsInteractor.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-lps-interactor")
+private let logger = Log.defi.interactor
 
 struct THORChainLPsInteractor: LPsInteractor {
     private let thorchainAPIService = THORChainAPIService()

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/MayaChainStakeInteractor.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "mayachain-stake-interactor")
+private let logger = Log.defi.interactor
 
 private struct CacaoSnapshot {
     let meta: CoinMeta

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/THORChainStakeInteractor.swift
@@ -7,7 +7,7 @@
 
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-stake-interactor")
+private let logger = Log.defi.interactor
 
 struct THORChainStakeInteractor: StakeInteractor {
     private let stakingService: THORChainStakingProviding

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/TonStakeInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/Interactor/Stake/TonStakeInteractor.swift
@@ -7,7 +7,7 @@ import Foundation
 import OSLog
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "ton-stake-interactor")
+private let logger = Log.defi.interactor
 
 private struct TonStakeSnapshot {
     let meta: CoinMeta

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
@@ -8,7 +8,7 @@
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-chain-select-positions")
+private let logger = Log.defi.view
 
 struct DefiChainSelectPositionsScreen: View {
     @ObservedObject var viewModel: DefiChainMainViewModel

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/CosmosStakeDefiViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/CosmosStakeDefiViewModel.swift
@@ -27,10 +27,7 @@ final class CosmosStakeDefiViewModel: ObservableObject {
 
     private let stakingService: CosmosStakingServiceProtocol
     private let apyResolver: CosmosStakingAPYResolverProtocol
-    private let logger = Logger(
-        subsystem: "com.vultisig.app",
-        category: "cosmos-stake-defi-vm"
-    )
+    private let logger = Log.defi.viewModel
 
     init(
         chain: Chain,

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainBondViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainBondViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-chain-bond-view-model")
+private let logger = Log.defi.viewModel
 
 @MainActor
 final class DefiChainBondViewModel: ObservableObject {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainLPsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainLPsViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-chain-lps-view-model")
+private let logger = Log.defi.viewModel
 
 @MainActor
 final class DefiChainLPsViewModel: ObservableObject {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainStakeViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-chain-stake-view-model")
+private let logger = Log.defi.viewModel
 
 @MainActor
 final class DefiChainStakeViewModel: ObservableObject {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/SolanaStakeDefiViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/SolanaStakeDefiViewModel.swift
@@ -36,10 +36,7 @@ final class SolanaStakeDefiViewModel: ObservableObject {
     private let apyResolver: SolanaStakingAPYResolverProtocol
     private let storage: DefiPositionsStorageService
     private let onInvalidateCaches: @Sendable () -> Void
-    private let logger = Logger(
-        subsystem: "com.vultisig.app",
-        category: "solana-stake-defi-vm"
-    )
+    private let logger = Log.defi.viewModel
 
     init(
         vault: Vault,

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChainSelection/ViewModel/DefiSelectChainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChainSelection/ViewModel/DefiSelectChainViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-select-chain")
+private let logger = Log.defi.viewModel
 
 @MainActor
 class DefiSelectChainViewModel: ObservableObject {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/View/DefiChainListView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/View/DefiChainListView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-chain-list")
+private let logger = Log.defi.view
 
 struct DefiChainListView: View {
     @ObservedObject var vault: Vault

--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/ViewModel/DefiMainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/ViewModel/DefiMainViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "defi-main-view-model")
+private let logger = Log.defi.viewModel
 
 enum DefiMainItem: Identifiable, Hashable {
     case chain(Chain)

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleViewLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Circle/CircleViewLogic.swift
@@ -11,7 +11,7 @@ import BigInt
 import WalletCore
 import VultisigCommonData
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "circle-view-logic")
+private let logger = Log.defi.other
 
 // MARK: - Logic (Methods)
 struct CircleViewLogic {

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronFreezeViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "tron-freeze-view-model")
+private let logger = Log.defi.viewModel
 
 @MainActor
 final class TronFreezeViewModel: ObservableObject, Form {

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronResourcesLoader.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronResourcesLoader.swift
@@ -16,7 +16,7 @@ final class TronResourcesLoader: ObservableObject {
     @Published var isLoading: Bool = false
 
     private let address: String
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "tron-resources")
+    private let logger = Log.defi.service
 
     init(address: String) {
         self.address = address

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronUnfreezeViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "tron-unfreeze-view-model")
+private let logger = Log.defi.viewModel
 
 @MainActor
 final class TronUnfreezeViewModel: ObservableObject, Form {


### PR DESCRIPTION
## What

Declaration-only migration of the DeFi area onto the new `Log` facade (issue #4949, DeFi spoke of the logging rollout). Every `Logger(subsystem: "com.vultisig.app", category: "…")` declaration under `Features/Defi` is replaced with `Log.defi.<layer>`, keeping the same `logger` variable name. **No call sites, log levels, or `\(…, privacy:)` interpolation change** — the facade hands back a plain `os.Logger`, so behavior is identical when the category is enabled and compiles to `Logger(.disabled)` in Release.

Stacks on the base branch `feat/logging-facade` (PR targets that branch; retargets to `main` after the base lands).

## Layer mapping (per `LogLayer` taxonomy)

Layer chosen from the declaring type's architectural role, following the authoritative `LogLayer.swift` doc comments:

| Layer | Count | Files |
|-------|-------|-------|
| `interactor` | 7 | THORChain/MayaChain LPs, Bond, Stake interactors + TonStakeInteractor |
| `viewModel` | 9 | TronFreeze/TronUnfreeze VMs, DefiChain Stake/LPs/Bond VMs, DefiMain VM, DefiSelectChain VM, Cosmos/Solana StakeDefi VMs |
| `view` | 4 | DefiChainSelectPositionsScreen, DefiChainListView, DefiYieldProviderRow, YieldVaultScreen |
| `service` | 1 | TronResourcesLoader (ObservableObject data loader) |
| `other` | 1 | CircleViewLogic (view-logic helper struct) |

Total: **22 declarations across 22 files** → all now `Log.defi.*`.

## Notable boundary decisions

- **`QBTCGovernanceViewModel.swift`** (category `qbtc-governance-vm`, backed by `QBTCGovServiceProtocol`) lives under `Features/Defi/DefiChain/ViewModel/` but is QBTC-domain, not DeFi. It is **intentionally left untouched** for the QBTC spoke (#4952). Flagged so the QBTC spoke picks it up even though it sits outside `Features/QBTCClaim`.
- **`FunctionCall` / `FunctionTransaction`** files (incl. RUJI transaction builders, `FunctionCallAddThorLP`, `FunctionCallCosmosUnmerge`, `UnstakeTransactionViewModel`) are the **Send spoke's** and are not touched here.
- **`Blockchain/**/Service/Staking/*`** (Cosmos/Solana/THORChain staking services) and `Features/Home/Service/VaultDefiChainsService.swift` are chain/wallet-feature files and belong to those spokes — not touched.
- Two categories did not carry a clean layer suffix and were mapped by role: `tron-resources` → `service` (it is a `TronResourcesLoader` data loader) and `circle-view-logic` → `other` (a helper struct, not a view/VM).

## Testing

Full `make test` on iPhone 16 simulator (en_US), worktree-local derived data. Green except the pre-existing allowed snapshot failure `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro`.

Closes #4949

🤖 Generated with [Claude Code](https://claude.com/claude-code)
