### PR TITLE
refactor(logging): swap-area Logger declarations → Log.swap.<layer> facade

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/NativePoolTokenProvider.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/NativePoolTokenProvider.swift
@@ -18,7 +18,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "native-pool-token-provider")
+private let logger = Log.swap.other
 
 /// Which native protocol a pool feed belongs to.
 enum NativeSwapProtocol {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapRecipientVerifier.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapRecipientVerifier.swift
@@ -18,7 +18,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swap-recipient-verify")
+private let logger = Log.swap.other
 
 enum SwapRecipientVerifier {
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -8,7 +8,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swap-service")
+private let logger = Log.swap.service
 
 struct SwapService {
     static let shared = SwapService()

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Jupiter/JupiterService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Jupiter/JupiterService.swift
@@ -15,7 +15,7 @@ import Foundation
 import OSLog
 import WalletCore
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "jupiter-service")
+private let logger = Log.swap.service
 
 struct JupiterService {
 

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -12,7 +12,7 @@ import BigInt
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-service")
+private let logger = Log.swap.service
 
 struct SwapKitService {
     static let shared = SwapKitService()

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTokensCache.swift
@@ -18,7 +18,7 @@
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-tokens-cache")
+private let logger = Log.swap.store
 
 @MainActor
 final class SwapKitTokensCache: DestinationTokenProvider {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTrackingService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitTrackingService.swift
@@ -79,7 +79,7 @@ final class SwapKitTrackingService: ObservableObject, SwapTrackingService {
     private let httpClient: HTTPClientProtocol
     private let storage: SwapTrackingStorage
     private let clock: () -> Date
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "swapkit-tracking")
+    private let logger = Log.swap.other
 
     /// Active poller registry keyed by `txHash` (the local broadcast hash
     /// the row was originally recorded under — not the SwapKit broadcast

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Services/LimitOrderCancelPreparer.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Services/LimitOrderCancelPreparer.swift
@@ -19,7 +19,7 @@ import BigInt
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "limit-order-cancel-preparer")
+private let logger = Log.swap.other
 
 enum LimitOrderCancelPreparationError: LocalizedError, Equatable {
     /// The inbound vault or the dust floor could not be resolved, so there is no

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Services/LimitOrderCancelVerifier.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Services/LimitOrderCancelVerifier.swift
@@ -66,7 +66,7 @@ protocol LimitOrderCancelVerifying {
 struct LimitOrderCancelVerifier: LimitOrderCancelVerifying {
     private let httpClient: HTTPClientProtocol
     private let statusChecker: TransactionStatusChecking
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "limit-cancel-verifier")
+    private let logger = Log.swap.other
 
     init(
         httpClient: HTTPClientProtocol = HTTPClient(),

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Services/LimitOrderTrackingSeams.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Services/LimitOrderTrackingSeams.swift
@@ -56,7 +56,7 @@ enum LimitOrderObservingError: Error, Equatable {
 @MainActor
 struct LimitOrderObserver: LimitOrderObserving {
     private let storage = LimitOrderStorageService()
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "limit-order-observer")
+    private let logger = Log.swap.other
 
     /// Throws — never returns quietly — when the vault can't be resolved.
     ///
@@ -316,7 +316,7 @@ struct MidgardLimitOutcomeResolver: LimitOrderOutcomeResolving {
     }
 
     private let httpClient: HTTPClientProtocol
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "limit-outcome-resolver")
+    private let logger = Log.swap.other
 
     init(httpClient: HTTPClientProtocol = HTTPClient()) {
         self.httpClient = httpClient

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Services/THORChainLimitTrackingService.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Services/THORChainLimitTrackingService.swift
@@ -95,7 +95,7 @@ final class THORChainLimitTrackingService: ObservableObject, SwapTrackingService
     private let outcomes: LimitOrderOutcomeResolving
     private let cancelIntents: LimitOrderCancelIntentStoring
     private let cancelVerifier: LimitOrderCancelVerifying
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-limit-tracking")
+    private let logger = Log.swap.other
 
     /// Rows this service owns, keyed by `txHash`.
     private var tracked: [String: TrackedOrder] = [:]

--- a/VultisigApp/VultisigApp/Features/LimitSwap/ViewModel/LimitSwapFormViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/ViewModel/LimitSwapFormViewModel.swift
@@ -8,7 +8,7 @@ import Foundation
 import Observation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "limit-swap-form")
+private let logger = Log.swap.other
 
 /// View-binding only. Holds the user-editable `LimitSwapDraft` plus derived UI
 /// state (% from market, warning, loading). Service calls + composition live

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
@@ -159,7 +159,7 @@ struct DefaultSwapInteractor: SwapInteractor {
             // Fail closed: an unverifiable inbound re-check must not let a native
             // deposit proceed. Surface the retryable halt message so the user can
             // retry once the fetch recovers.
-            let logger = Logger(subsystem: "com.vultisig.app", category: "swap-interactor")
+            let logger = Log.swap.interactor
             logger.warning("Sign-time halt re-check failed, blocking native route: \(error.localizedDescription, privacy: .public)")
             throw SwapError.tradingHalted
         }

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
@@ -21,7 +21,7 @@ import BigInt
 import Foundation
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "thorchain-memo-limit")
+private let logger = Log.swap.other
 
 enum ThorchainMemoLimit {
 

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/ExternalRecipientViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/ExternalRecipientViewModel.swift
@@ -16,7 +16,7 @@ import SwiftUI
 @MainActor
 @Observable
 final class ExternalRecipientViewModel {
-    @ObservationIgnored private let logger = Logger(subsystem: "com.vultisig.app", category: "external-recipient")
+    @ObservationIgnored private let logger = Log.swap.other
 
     /// Resolves a literal address or a name (ENS/TNS/THORName) to a validated
     /// on-chain address for the given chain, throwing when it can't. Injected so

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -16,7 +16,7 @@ import SwiftUI
 @MainActor
 @Observable
 final class SwapDetailsViewModel {
-    @ObservationIgnored private let logger = Logger(subsystem: "com.vultisig.app", category: "swap-details")
+    @ObservationIgnored private let logger = Log.swap.other
     @ObservationIgnored private let interactor: SwapInteractor
     @ObservationIgnored private var updateQuoteTask: Task<Void, Never>?
 

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapVerifyViewModel.swift
@@ -16,7 +16,7 @@ import SwiftUI
 @MainActor
 @Observable
 final class SwapVerifyViewModel {
-    @ObservationIgnored private let logger = Logger(subsystem: "com.vultisig.app", category: "swap-verify")
+    @ObservationIgnored private let logger = Log.swap.other
     @ObservationIgnored private let interactor: SwapInteractor
     @ObservationIgnored private let securityScanViewModel = SecurityScannerViewModel()
     @ObservationIgnored private var securityScannerCancellable: AnyCancellable?

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDoneScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDoneScreen.swift
@@ -33,7 +33,7 @@
 import SwiftUI
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "swap-done-screen")
+private let logger = Log.swap.view
 
 struct SwapDoneScreen: View {
     let vault: Vault


### PR DESCRIPTION
## What

Mechanical, behavior-preserving migration of the swap area's `Logger(subsystem:category:)` **declarations** to the `Log.swap.<layer>` facade introduced by the logging base (#4945, `feat/logging-facade`).

Closes #4947.

Only the **declaration** RHS changed — the variable name (`logger`) is identical at every site, so **no call site, log level, or `\(…, privacy:)` interpolation changed**. Call sites stay 100% native `os.Logger`; the facade only chooses which configured `Logger` to hand back (live vs `Logger(.disabled)` per the gate).

## Scope

19 declarations across 18 files in the swap area — `Blockchain/Swaps`, `Features/Swap`, `Features/LimitSwap` — which is exactly the scope `LogFeature.swap` documents (`Features/Swap`, `Features/LimitSwap`, `Blockchain/Swaps`).

Layers were assigned strictly by the **category suffix**, per `LogLayer.swift` (the rawValue is the category suffix), not by a guessed heuristic:

| Layer | Count | Categories |
|-------|-------|-----------|
| `service` | 3 | `swap-service`, `swapkit-service`, `jupiter-service` |
| `store` | 1 | `swapkit-tokens-cache` (`-cache` → store) |
| `interactor` | 1 | `swap-interactor` |
| `view` | 1 | `swap-done-screen` (`-screen` → view) |
| `other` | 13 | freeform categories with no layer suffix: `swap-recipient-verify`, `native-pool-token-provider`, `swapkit-tracking`, `thorchain-limit-tracking`, `limit-order-cancel-preparer`, `limit-cancel-verifier`, `limit-order-observer`, `limit-outcome-resolver`, `thorchain-memo-limit`, `limit-swap-form`, `external-recipient`, `swap-verify`, `swap-details` |

Note: several categories that live in ViewModel files (`swap-verify`, `swap-details`, `external-recipient`, `limit-swap-form`) do **not** carry a `-vm`/`-view-model` suffix, so per the authoritative suffix rule in `LogLayer.swift` they map to `.other` (the explicit catch-all for utilities that "don't fit a specific layer") rather than `.viewModel`. This follows the "map by suffix, not heuristic" rule.

### Not in scope
The scattered `swapkit-*` **per-chain signers** (`SwapKitBTCSigner`, `SwapKitSuiSigner`, …) under `Blockchain/<Chain>/Signing/` are **not** included: `LogFeature.chain` documents "per-chain blockchain services & signers", so they belong to the `chain` feature (a separate spoke), not `swap`.

## Base

Stacked on `feat/logging-facade` (base PR #4945). Retarget to `main` after #4945 merges.

## Verification

- Full `make test` on iPhone 16 Pro — `** TEST SUCCEEDED **` (only the pre-existing, allowed `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro` snapshot flake excepted).
- Read-only cross-model (Codex) review of the diff.
</content>
</invoke>
