### PR TITLE
refactor(logging): route Send-area Logger declarations through Log.send facade (#4948)

### DIFF
--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -20,7 +20,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-add-thor-lp")
+private let logger = Log.send.other
 
 @Observable
 @MainActor

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosSwitch.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosSwitch.swift
@@ -13,7 +13,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-cosmos-switch")
+private let logger = Log.send.other
 
 /*
  2) COSMOS - FUNCTION: "SWITCH THORCHAIN"

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosUnmerge.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallCosmosUnmerge.swift
@@ -16,7 +16,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-cosmos-unmerge")
+private let logger = Log.send.other
 
 @Observable
 @MainActor

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
@@ -16,7 +16,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-secured-asset")
+private let logger = Log.send.other
 
 @Observable
 @MainActor

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
@@ -16,7 +16,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-withdraw-secured-asset")
+private let logger = Log.send.other
 
 @Observable
 @MainActor

--- a/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/ViewModels/FunctionCallViewModel.swift
@@ -29,7 +29,7 @@ class FunctionCallViewModel: ObservableObject {
 
     private let mediator = Mediator.shared
 
-    let logger = Logger(subsystem: "deposit-input-details", category: "deposity")
+    let logger = Log.send.other
 
     /// The fiat figure printed beside the crypto fee row.
     ///

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Views/FunctionCallDetailsScreen.swift
@@ -3,7 +3,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "function-call-details-screen")
+private let logger = Log.send.view
 
 struct FunctionCallDetailsScreen: View {
     @Environment(\.router) var router

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/FunctionTransactionScreen.swift
@@ -8,7 +8,7 @@
 import OSLog
 import SwiftUI
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "function-transaction-screen")
+private let logger = Log.send.view
 
 struct FunctionTransactionScreen: View {
     @Environment(\.router) var router

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/Unstake/UnstakeTransactionViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 import OSLog
 
-private let logger = Logger(subsystem: "com.vultisig.app", category: "unstake-transaction-view-model")
+private let logger = Log.send.viewModel
 
 final class UnstakeTransactionViewModel: ObservableObject, Form {
     let coin: Coin

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -30,7 +30,7 @@ enum SendDetailsFocusedTab: String {
 @MainActor
 @Observable
 final class SendDetailsViewModel {
-    @ObservationIgnored private let logger = Logger(subsystem: "com.vultisig.app", category: "send-details-form-vm")
+    @ObservationIgnored private let logger = Log.send.viewModel
     @ObservationIgnored private let interactor: SendInteractor
     @ObservationIgnored private let addressResolver: (String, Chain) async throws -> String
 

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/TonSignDisplayViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/TonSignDisplayViewModel.swift
@@ -38,7 +38,7 @@ final class TonSignDisplayViewModel: ObservableObject {
     @Published private(set) var simulationSwap: TonSwapSimulator.SwapInfo?
     @Published private(set) var isSimulating: Bool = false
 
-    private let logger = Logger(subsystem: "com.vultisig.app", category: "ton-sign-display-view-model")
+    private let logger = Log.send.viewModel
 
     private var lastDecodedKey: [String]?
 


### PR DESCRIPTION
## Summary

Migrates the **Send area** to the `Log.send.<layer>` logging facade introduced by the base branch (`feat/logging-facade`, #4945). This is a **declaration-only** swap: every `Logger(subsystem: "com.vultisig.app", category: "…")` declaration in the Send flow is replaced with the equivalent `Log.send.<layer>` accessor. Variable names, log levels, `\(…, privacy:)` redaction, and **all call sites are unchanged** — the facade hands back a configured `os.Logger`, so native OSLog behaviour (levels, privacy, Console/`log stream` category filtering) is fully preserved.

Closes #4948. Stacks on #4945 — retargets to `main` once the base merges.

## Scope

11 declarations across the three directories the base taxonomy assigns to the `send` feature (`LogFeature.send` doc comment: *"Send / deposit / function-call transaction composition — `Features/Send`, `Features/FunctionCall`, `Features/FunctionTransaction`"*):

| Directory | Files |
|---|---|
| `Features/Send` | 2 |
| `Features/FunctionCall` | 7 |
| `Features/FunctionTransaction` | 2 |

No declarations remain in those directories, and nothing outside them was touched.

## Layer mapping

Layers were assigned from the **authoritative `LogLayer` doc-comment category→layer rules** (category suffix), not the file's role:

| Layer | Count | Declarations |
|---|---|---|
| `Log.send.viewModel` | 3 | `SendDetailsViewModel` (`send-details-form-vm`), `TonSignDisplayViewModel` (`ton-sign-display-view-model`), `UnstakeTransactionViewModel` (`unstake-transaction-view-model`) |
| `Log.send.view` | 2 | `FunctionCallDetailsScreen` (`…-details-screen`), `FunctionTransactionScreen` (`function-transaction-screen`) |
| `Log.send.other` | 6 | `FunctionCallCosmosSwitch`, `FunctionCallCosmosUnmerge`, `FunctionCallAddThorLP`, `FunctionCallSecuredAsset`, `FunctionCallWithdrawSecuredAsset`, `FunctionCallViewModel` |

### Notes on judgement calls

- **`send` vs `defi` routing:** all `Features/FunctionCall` + `Features/FunctionTransaction` files (staking/deposit/LP/bond actions) are routed to `send`, **none to `defi`**. The authoritative `LogFeature` taxonomy explicitly lists both directories under `send`, and reserves `defi` for `Features/Defi` — none of these files live there. Defi's own spoke covers `Features/Defi` separately.
- **`FunctionCallViewModel` → `other`:** its original category was the malformed `"deposity"` (with a wrong subsystem `"deposit-input-details"`). Although the file is a view-model, `"deposity"` matches no view-model suffix, so under the authoritative suffix mapping it falls under "everything else" → `Log.send.other`. This was confirmed by the cross-model review pass.

## Verification

- Full `make test` (unit tests) on iPhone 16e (en_US), worktree-local derived data — green (sole allowed exception: `CreateVaultSnapshotTests.testCreateVaultScreen_iPhone16Pro`).
- Read-only Codex review pass on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
