### PR TITLE
refactor(tokens): migrate direct TokensStore list/picker readers to the catalog provider (#4966)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Stores/TokensStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/TokensStore.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+/// Curated, hand-maintained catalog of supported coins.
+///
+/// Two consumption paths, kept deliberately separate:
+///  - **List / picker / discovery surfaces** (browsable token lists) must NOT read
+///    `TokenSelectionAssets` directly. They go through the app-wide catalog —
+///    `BundledTokensProvider` / `TokenCatalogRepository` — so the curated preset
+///    list, its chain-visibility gates, and (on network-backed surfaces) the
+///    dynamic 1inch/Jupiter overlay all flow through one place.
+///  - **Named-static curated-coin readers** (`rune`/`cacao`/`tcy`/`sruji`/`qbtc`/…
+///    and `findTokenMeta(chain:contractAddress:)`) remain the curated source of
+///    truth for a *specific* coin — pricing, referral, VultTier, keysign, DeFi,
+///    default-coin seeding, native-token lookups. These intentionally stay here.
 class TokensStore {
 
     static let TokenSelectionAssets = [

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/CoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/CoinSelectionViewModel.swift
@@ -71,45 +71,27 @@ class CoinSelectionViewModel: ObservableObject {
     }
 
     private func groupAssets(vault: Vault) {
-        groupedAssets = [:]
+        // Curated tokens now come through the catalog's bundled provider rather
+        // than reading `TokensStore.TokenSelectionAssets` directly, so the preset
+        // list and its chain-visibility gates (sepolia / thorchain-chainnet /
+        // QBTC-MLDSA, plus the Sepolia-native injection) live in one place.
+        // The vault-specific MLDSA-key gate stays here because the provider is
+        // vault-independent: QBTC (the only MLDSA chain today) is hidden unless
+        // the feature flag is on AND the vault has an MLDSA key (or the caller
+        // opted into showing it before keygen).
+        let defaults = UserDefaults.standard
+        let hasMLDSAKey = !(vault.publicKeyMLDSA44 ?? "").isEmpty
 
-        // Filter out Sepolia and Thorchain Stagenet based on settings
-        let enableETHSepolia = UserDefaults.standard.bool(forKey: "sepolia")
-        let enableThorchainChainnet = UserDefaults.standard.bool(forKey: "thorchainChainnet")
-        let hasMLDSAKey = vault.publicKeyMLDSA44 != nil && !vault.publicKeyMLDSA44!.isEmpty
-
-        let filteredAssets = TokensStore.TokenSelectionAssets.filter { asset in
-            if asset.chain == .ethereumSepolia {
-                return enableETHSepolia
+        let filteredAssets: [CoinMeta] = Chain.allCases.flatMap { chain -> [CoinMeta] in
+            if chain.signingKeyType == .MLDSA, !(hasMLDSAKey || showMldsaChainsWithoutKey) {
+                return []
             }
-            if asset.chain == .thorChainChainnet {
-                return enableThorchainChainnet
-            }
-            if asset.chain == .thorChainStagenet {
-                return enableThorchainChainnet
-            }
-            if asset.chain.signingKeyType == .MLDSA {
-                // QBTC is the only MLDSA chain today. The feature flag gates
-                // visibility in addition to MLDSA-key presence so flag-off
-                // users never see QBTC in the picker. When MLDSA is later
-                // used for non-QBTC chains, narrow this guard to `.qbtc`.
-                guard QBTCConfig.isFeatureEnabled else { return false }
-                return hasMLDSAKey || showMldsaChainsWithoutKey
-            }
-            return true
+            return BundledTokensProvider.curatedTokens(for: chain, defaults: defaults)
         }
 
         groupedAssets = Dictionary(grouping: filteredAssets.sorted(by: { first, _ in
-            if first.isNativeToken {
-                return true
-            }
-            return false
+            first.isNativeToken
         })) { $0.chain }
-
-        // Add Sepolia if enabled (it's not in TokenSelectionAssets)
-        if enableETHSepolia {
-            groupedAssets[TokensStore.Token.ethSepolia.chain] = [TokensStore.Token.ethSepolia]
-        }
     }
 
     func isSelected(asset: CoinMeta) -> Bool {

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
@@ -114,9 +114,12 @@ struct TokenSelectionLogic {
             .filter { !$0.isNativeToken }
             .map { $0.ticker.lowercased() }
 
-        return TokensStore.TokenSelectionAssets
+        // The curated per-chain floor is sourced through the catalog's bundled
+        // provider (already scoped to `chain`) rather than reading the preset
+        // array directly. The dynamic overlay for this screen is unchanged — it
+        // still flows through `loadExternalTokens` -> `TokenSearchService`.
+        return BundledTokensProvider.curatedTokens(for: chain, defaults: .standard)
             .filter { token in
-                token.chain == chain &&
                 !token.isNativeToken &&
                 !tickers.contains(token.ticker.lowercased()) &&
                 !hiddenTokens.contains { $0.matches(token) }

--- a/VultisigApp/VultisigAppTests/Features/Wallet/CoinSelectionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Wallet/CoinSelectionViewModelTests.swift
@@ -1,0 +1,115 @@
+//
+//  CoinSelectionViewModelTests.swift
+//  VultisigAppTests
+//
+//  Parity guard for the migration of `CoinSelectionViewModel.groupAssets` off a
+//  direct `TokensStore.TokenSelectionAssets` read onto the catalog's bundled
+//  provider (`BundledTokensProvider`). The grouped output must be byte-identical
+//  to the pre-migration algorithm — same curated set, same per-chain ordering
+//  (native first), same sepolia / thorchain-chainnet / QBTC-MLDSA gates.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class CoinSelectionViewModelTests: XCTestCase {
+
+    // The pre-migration algorithm, reproduced verbatim, as the parity reference.
+    private func legacyGroupedAssets(
+        for vault: Vault,
+        showMldsaChainsWithoutKey: Bool
+    ) -> [Chain: [CoinMeta]] {
+        let enableETHSepolia = UserDefaults.standard.bool(forKey: "sepolia")
+        let enableThorchainChainnet = UserDefaults.standard.bool(forKey: "thorchainChainnet")
+        let hasMLDSAKey = vault.publicKeyMLDSA44 != nil && !(vault.publicKeyMLDSA44 ?? "").isEmpty
+
+        let filteredAssets = TokensStore.TokenSelectionAssets.filter { asset in
+            if asset.chain == .ethereumSepolia { return enableETHSepolia }
+            if asset.chain == .thorChainChainnet { return enableThorchainChainnet }
+            if asset.chain == .thorChainStagenet { return enableThorchainChainnet }
+            if asset.chain.signingKeyType == .MLDSA {
+                guard QBTCConfig.isFeatureEnabled else { return false }
+                return hasMLDSAKey || showMldsaChainsWithoutKey
+            }
+            return true
+        }
+
+        var grouped = Dictionary(grouping: filteredAssets.sorted(by: { first, _ in
+            first.isNativeToken
+        })) { $0.chain }
+
+        if enableETHSepolia {
+            grouped[TokensStore.Token.ethSepolia.chain] = [TokensStore.Token.ethSepolia]
+        }
+        return grouped
+    }
+
+    private func idMap(_ grouped: [Chain: [CoinMeta]]) -> [Chain: [String]] {
+        grouped.mapValues { $0.map(\.uniqueId) }
+    }
+
+    /// Order-sensitive, whole-dictionary parity against the legacy algorithm.
+    func testGroupAssetsMatchesLegacyAlgorithm() {
+        let vault = Vault.example
+        let viewModel = CoinSelectionViewModel()
+
+        viewModel.setData(for: vault, checkForSelected: false)
+
+        let expected = legacyGroupedAssets(for: vault, showMldsaChainsWithoutKey: false)
+        XCTAssertEqual(idMap(viewModel.groupedAssets), idMap(expected))
+    }
+
+    /// Same parity when the caller opts into showing MLDSA chains before keygen.
+    func testGroupAssetsMatchesLegacyAlgorithmShowingMldsaChains() {
+        let vault = Vault.example
+        let viewModel = CoinSelectionViewModel()
+        viewModel.showMldsaChainsWithoutKey = true
+
+        viewModel.setData(for: vault, checkForSelected: false)
+
+        let expected = legacyGroupedAssets(for: vault, showMldsaChainsWithoutKey: true)
+        XCTAssertEqual(idMap(viewModel.groupedAssets), idMap(expected))
+    }
+
+    /// A curated (bundled-only) chain surfaces exactly its `TokensStore` set.
+    func testCuratedChainSurfacesExactTokensStoreSet() {
+        let viewModel = CoinSelectionViewModel()
+        viewModel.setData(for: .example, checkForSelected: false)
+
+        for chain in [Chain.ethereum, .bitcoin, .thorChain, .solana] {
+            let expected = TokensStore.TokenSelectionAssets.filter { $0.chain == chain }
+            XCTAssertEqual(
+                Set(viewModel.groupedAssets[chain]?.map(\.uniqueId) ?? []),
+                Set(expected.map(\.uniqueId)),
+                "\(chain) should surface exactly its curated TokensStore tokens"
+            )
+        }
+    }
+
+    /// The native token sorts first within every surfaced chain group.
+    func testNativeTokenIsFirstInEachGroup() {
+        let viewModel = CoinSelectionViewModel()
+        viewModel.setData(for: .example, checkForSelected: false)
+
+        for (chain, tokens) in viewModel.groupedAssets {
+            guard tokens.contains(where: { $0.isNativeToken }) else { continue }
+            XCTAssertTrue(
+                tokens.first?.isNativeToken == true,
+                "\(chain) group must lead with its native token"
+            )
+        }
+    }
+
+    /// Sepolia is gated off by default (flag absent), matching the provider gate.
+    func testSepoliaGatedOffByDefault() {
+        let suiteName = "CoinSelectionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        // Provider gate is the single source of truth for chain visibility.
+        XCTAssertTrue(
+            BundledTokensProvider.curatedTokens(for: .ethereumSepolia, defaults: defaults).isEmpty
+        )
+    }
+}


### PR DESCRIPTION
## What & why

**Step 7** of the dynamic-token-datasource work (analysis: `wiki/pages/projects/vultisig/dynamic-token-datasource/analysis.md`). Closes #4966.

`#4941`/`#4954` built `TokenCatalogRepository` + `BundledTokensProvider` and routed the token **search** flow through it, but `TokensStore.TokenSelectionAssets` was still read **directly** in ~30 sites. This PR migrates the **list/picker surfaces that read the whole preset array to build a browsable list** onto the catalog's bundled provider, and **leaves** the named-static curated-coin readers (`TokensStore.rune`/`cacao`/`tcy`/`sruji`/`qbtc`/…, `findTokenMeta(chain:contract:)`, native-token lookups) as the curated source of truth for *specific* coins.

Both migrations are **behavior-preserving**: they route the same curated set through `BundledTokensProvider.curatedTokens(for:defaults:)` (the purpose-built synchronous accessor) instead of reading `TokensStore` directly, so the sepolia / thorchain-chainnet / QBTC-MLDSA visibility gates now live in one place.

> Stacks on #4954 — base `feat/dynamic-token-catalog-4941` (retargets to `main` after #4954 merges).

## Design note: bundled provider, not the async `catalog(for:)`

The migrated surfaces route through the **bundled** provider (curated, synchronous), **not** the network-fanning async `catalog(for:)`. The dynamic 1inch/Jupiter overlay is a *token-search* concern and already flows through the migrated `TokenSearchService.loadTokens` on the dedicated add-token screen. `CoinSelectionViewModel.groupedAssets` in particular drives a **chain-selection grid** whose dict is consumed synchronously by the address book, send tab, and chain detail; making it async + injecting hundreds of dynamic tokens into those consumers would not be behavior-preserving. The migration value is real regardless: the duplicated gate logic collapses into `BundledTokensProvider`, and `TokensStore` is accessed *through* a provider. **Flagged for human review** — if the maintainers want the full dynamic catalog surfaced on the chain grid, that's a follow-up with proper async plumbing + UX review.

## Migrate/leave ledger

Only **2** sites are genuine whole-preset browsable-list readers; the rest want a specific coin / native / price.

### MIGRATE (2)

| Site | Surface | Change |
|---|---|---|
| `CoinSelectionViewModel.groupAssets` (`CoinSelectionViewModel.swift:81`) | Chain/token selection grid (`VaultSelectChainScreen`, address book, send tab) | Iterates `Chain.allCases` → `BundledTokensProvider.curatedTokens(for:)`; keeps only the vault-specific MLDSA-key gate in the VM (the provider is vault-independent). Byte-identical grouped output. |
| `TokenSelectionLogic.preExistingTokens` (`TokenSelectionViewModel.swift:117`) | Per-chain curated add-token floor | Sources the synchronous curated floor via `BundledTokensProvider.curatedTokens(for:)` (already chain-scoped). The dynamic `loadExternalTokens` → `TokenSearchService` path (#4954) is untouched. |

### LEAVE (all other `TokensStore` reads)

Grouped by why they want a *specific* curated coin, not the browsable catalog. Conservative bias: ambiguous/risky ⇒ LEAVE.

**Named statics (`.rune`/`.cacao`/`.tcy`/`.sruji`/`.qbtc`/`.ethUSDC`/…) — curated named-coin source of truth:**
`DefiPositionsService` (`:14–54`), `DefiChainScreenModel` (`:61–79`), `TokenPriceSource` (cacao `:92,95,101`), `MayaChainLPsInteractor` (`:58`), `THORChainTokenMetadataFactory` (`:36,42,47`), `ThorchainService+TCYStake` (`:107,118`), `THORChainStakingService` (`:193`), `ThorchainService+Yield+Prices` (rune rate `:90`), `UnstakeMetadata` (`:87`), `BRUNEUnstakeTransactionBuilder` (`:50`), `RUJILiquidUnbondTransactionBuilder` (`:59`), `DefiChainListView` (ethUSDC `:84`), `RujiAutoCompoundPositionMigration` (`:59`), `CoinService` (sruji contract `:277`), `HiddenToken` (sruji contract `:53`), `Token.*` derivation/ticker statics (`KeysignViewModel:456,633`, `SuiService:277`, `EvmServiceConfig:40`, `FunctionCallCosmosIBC:63`).

**`findTokenMeta(chain:contractAddress:)` — resolve ONE known coin by contract:**
`TonJettonMetadataResolver` (`:79`), `BalanceService` (`:735`), `EvmCoinFinder` (`:109,131`), `CosmosCoinFinder` (`:132`), `Cw20CustomTokenResolver` (`:81`), `BlockaidSimulationParser` (`:192`), `ThorchainCustomTokenResolver` (`:114`), `JoinKeysignViewModel` (`:580`), `LimitOrderCancelSigningAsset` (`:120`), `CustomTokenScreen` (`:195`).

**Native-token / specific-coin lookups (`.first`/`.filter` for one coin, not a list):**
`PolkadotService` (`:210`), `SwapKitService` (`:343`), `QBTCClaimCoinResolver` (`:95`), `ChainDetailScreen` (qbtc native `:427`), `FunctionCallAddThorLP` (`:80`), `ReferralViewModel` (`:89`), `THORChainAssetFactory` (referral `:31`), `THORChainLPsInteractor` (`:62,69`), `MayaChainLPsInteractor` (`:70`), `MayaChainService` (`:62`), `ThorchainService`/`ThorchainStagenetService`/`ThorchainStagenet2Service` (localAsset-by-ticker `:94/:68/:66`), `ThorchainService+Yield+Prices` (yield ticker `:41`), `SuiService` (priceProviderId-by-ticker `:263`), `VultTierService` (VULT+eth native `:157,167`), `JoinKeysignSwapFeeViewModel` (`:87`), `JoinKeysignGasViewModel` (`:14`), `SwapCryptoLogic` (`:328`), `DefiPositionsService.nativeSolanaMeta` (`:66`), `EvmServiceStruct` (balanceOf probe `:361`).

**Provider-internal curated resolve (already part of the catalog/discovery seams):**
`NativePoolTokenProvider` (`:197`), `SecuredAssetCatalog` (`:45`).

**Vault-seeding / balance-scan / on-save (want natives, not a browse list):**
`VaultDefaultCoinService` (default-chain seeding `:33`), `KeyImportChainsSetupViewModel` (native-coin balance scan for active-chain discovery `:149,233`), `DefiSelectChainViewModel.save` (native coins to enable selected chains `:84`).

**Swap pickers (explicitly out of scope):** `SwapCoinSelectionViewModel` (`:295`).

**SwiftUI `#Preview` data:** `DefiChainLPPositionView` (`:107,109,124,126`).

Issue-named LEAVE anchors confirmed left as-is: `VaultDefaultCoinService`, pricing (here `TokenPriceSource`/`ThorchainService+Yield+Prices`/`SuiService` — this branch has no `CryptoPriceService.swift`), referral, VultTier, keysign, DeFi paths.

**Borderline (considered, left with reason):** `KeyImportChainsSetupViewModel` and `DefiSelectChainViewModel.save` filter the preset array but only to obtain *native* coins for a balance probe / chain-enable-on-save — routing them through the catalog adds no browse value and would add a network dependency, so they stay.

## Tests

`CoinSelectionViewModelTests` (new): whole-dictionary, order-sensitive parity of `groupAssets` output vs the pre-migration algorithm for `Vault.example` (both default and `showMldsaChainsWithoutKey`), plus curated-chain exact-set, native-first ordering, and the sepolia gate.

## Docs

`TokensStore` now carries a header comment splitting the two consumption paths: list/picker/discovery surfaces go through the catalog provider; named statics + `findTokenMeta` remain the curated source of truth for specific named coins.

## Must-NOT-do compliance

No change to the enable/disable model (`vault.coins`/`HiddenToken`), the swap source/destination pickers, the migrated search path (#4954), or the unverified toggle (#4960).

## Verification

- SwiftLint: clean on all changed files.
- Cross-model review loop: per-commit + whole-branch read-only Codex passes — all **PASS**, zero findings.
- `make test` on iPhone 16 Pro Max (en_US): see PR checks / commit status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
