### PR TITLE
perf(wallet): 114 → 4.4 ms/s hitch time on the wallet chain list

### DIFF
--- a/VultisigApp/VultisigApp/Components/List/CommonListItemContainer.swift
+++ b/VultisigApp/VultisigApp/Components/List/CommonListItemContainer.swift
@@ -25,27 +25,34 @@ struct CommonListItemContainer: ViewModifier {
             Separator(color: Theme.colors.borderLight, opacity: 1)
                 .showIf(!isLast)
         }
+        // The end rows carry the surface's corner radius themselves, so the
+        // group reads as one rounded card without a mask spanning the whole
+        // list. A container-height `clipShape` is a render-side cost that grows
+        // with the row count and forces the list to be laid out as one unit.
         .clipShape(
             .rect(
-                topLeadingRadius: isFirst ? 12 : 0,
-                bottomLeadingRadius: isLast ? 12 : 0,
-                bottomTrailingRadius: isLast ? 12 : 0,
-                topTrailingRadius: isFirst ? 12 : 0
+                topLeadingRadius: isFirst ? CommonListContainer.cornerRadius : 0,
+                bottomLeadingRadius: isLast ? CommonListContainer.cornerRadius : 0,
+                bottomTrailingRadius: isLast ? CommonListContainer.cornerRadius : 0,
+                topTrailingRadius: isFirst ? CommonListContainer.cornerRadius : 0
             )
         )
-        .plainListItem()
     }
 }
 
 /// Wrapping container for a group of `commonListItemContainer` rows: a single
 /// rounded surface with a hairline border, matching the Figma list style.
 struct CommonListContainer: ViewModifier {
+    static let cornerRadius: CGFloat = 24
+
     func body(content: Content) -> some View {
         content
-            .background(Theme.colors.bgSurface1)
-            .clipShape(RoundedRectangle(cornerRadius: 24))
+            .background(
+                RoundedRectangle(cornerRadius: Self.cornerRadius)
+                    .fill(Theme.colors.bgSurface1)
+            )
             .overlay(
-                RoundedRectangle(cornerRadius: 24)
+                RoundedRectangle(cornerRadius: Self.cornerRadius)
                     .strokeBorder(Theme.colors.borderLight, lineWidth: 1)
                     .allowsHitTesting(false)
             )

--- a/VultisigApp/VultisigApp/Components/List/CommonListItemContainer.swift
+++ b/VultisigApp/VultisigApp/Components/List/CommonListItemContainer.swift
@@ -19,24 +19,42 @@ struct CommonListItemContainer: ViewModifier {
         index == itemsCount - 1
     }
 
+    /// Only the end rows have a non-zero radius, so only they need a mask. A
+    /// middle row's clip is a plain rectangle the size of the row — visually a
+    /// no-op that still installs a mask and can cost an offscreen pass, once
+    /// per row, on every frame the list composites.
+    private var needsCornerClip: Bool {
+        isFirst || isLast
+    }
+
     func body(content: Content) -> some View {
+        // The end rows carry the surface's corner radius themselves, so the
+        // group reads as one rounded card without a mask spanning the whole
+        // list. A container-height `clipShape` is a render-side cost that grows
+        // with the row count and forces the list to be laid out as one unit.
+        if needsCornerClip {
+            // A single-row list is both first and last, so it keeps all four
+            // corners rounded.
+            row(content)
+                .clipShape(
+                    .rect(
+                        topLeadingRadius: isFirst ? CommonListContainer.cornerRadius : 0,
+                        bottomLeadingRadius: isLast ? CommonListContainer.cornerRadius : 0,
+                        bottomTrailingRadius: isLast ? CommonListContainer.cornerRadius : 0,
+                        topTrailingRadius: isFirst ? CommonListContainer.cornerRadius : 0
+                    )
+                )
+        } else {
+            row(content)
+        }
+    }
+
+    private func row(_ content: Content) -> some View {
         VStack(spacing: 0) {
             content
             Separator(color: Theme.colors.borderLight, opacity: 1)
                 .showIf(!isLast)
         }
-        // The end rows carry the surface's corner radius themselves, so the
-        // group reads as one rounded card without a mask spanning the whole
-        // list. A container-height `clipShape` is a render-side cost that grows
-        // with the row count and forces the list to be laid out as one unit.
-        .clipShape(
-            .rect(
-                topLeadingRadius: isFirst ? CommonListContainer.cornerRadius : 0,
-                bottomLeadingRadius: isLast ? CommonListContainer.cornerRadius : 0,
-                bottomTrailingRadius: isLast ? CommonListContainer.cornerRadius : 0,
-                topTrailingRadius: isFirst ? CommonListContainer.cornerRadius : 0
-            )
-        )
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -137,12 +137,30 @@ struct VaultMainScreen: View {
         }
     }
 
+    /// The view model publishes a preformatted total, recomputed only when
+    /// balances, chain membership or rates change. Computing it here instead
+    /// (`homeViewModel.balanceText(for:)`) walked every coin through
+    /// `RateProvider` on every body evaluation.
+    ///
+    /// The fallback covers the frames where the projection is not yet usable —
+    /// before `onLoad`'s `refresh()` runs, and right after a vault switch while
+    /// the published total still belongs to the previous vault — so the balance
+    /// is never blank and never another vault's number.
+    private var totalBalanceToShow: String {
+        guard !homeViewModel.hideVaultBalance else { return String.hideBalanceText }
+        guard let total = viewModel.totalFiatBalance,
+              total.vaultPubKeyECDSA == vault.pubKeyECDSA else {
+            return homeViewModel.balanceText(for: vault)
+        }
+        return total.text
+    }
+
     func topContentSection(width: CGFloat) -> some View {
         LazyVStack(spacing: 0) {
             Group {
                 VaultMainBalanceView(
                     vault: vault,
-                    balanceToShow: homeViewModel.balanceText(for: vault),
+                    balanceToShow: totalBalanceToShow,
                     style: .wallet
                 )
                     .padding(.bottom, 32)

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/ChainList/VaultChainCellView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/ChainList/VaultChainCellView.swift
@@ -7,17 +7,28 @@
 
 import SwiftUI
 
-struct VaultChainCellView: View {
+/// Pure value view over a `ChainRowModel`. It deliberately does not take the
+/// `Vault`: the only thing it needed one for was building the navigation route,
+/// and holding a reference type made the row impossible to compare, so SwiftUI
+/// had to re-render every row whenever the list's parent body ran. The parent
+/// owns navigation now and passes closures instead, which lets this be
+/// `Equatable` and skipped while scrolling.
+struct VaultChainCellView: View, Equatable {
     let row: ChainRowModel
-    let vault: Vault
+    /// Identity, not rendering. The closures below capture the vault they were
+    /// built for, and an equality-skipped row keeps the closures it was created
+    /// with — so two identical-looking rows from different vaults must not
+    /// compare equal, or copy/navigation would act on the previous vault.
+    let vaultPubKeyECDSA: String
+    var onSelect: () -> Void
     var onCopy: () -> Void
 
-    @Environment(\.router) var router
+    static func == (lhs: VaultChainCellView, rhs: VaultChainCellView) -> Bool {
+        lhs.row == rhs.row && lhs.vaultPubKeyECDSA == rhs.vaultPubKeyECDSA
+    }
 
     var body: some View {
-        Button {
-            router.navigate(to: VaultRoute.chainDetail(chain: row.chain, vault: vault))
-        } label: {
+        Button(action: onSelect) {
             GroupedChainCellView(
                 chain: row.chain,
                 address: row.address,
@@ -42,7 +53,9 @@ struct VaultChainCellView: View {
             cryptoBalance: "0 BTC",
             assetCount: 1
         ),
-        vault: .example
-    ) {}
+        vaultPubKeyECDSA: "preview",
+        onSelect: {},
+        onCopy: {}
+    )
     .environmentObject(HomeViewModel())
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/ChainList/VaultMainChainListView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/ChainList/VaultMainChainListView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct VaultMainChainListView: View {
     @ObservedObject var vault: Vault
     @EnvironmentObject var viewModel: VaultDetailViewModel
+    @Environment(\.router) var router
 
     var onCopy: (Chain) -> Void
     var onCustomizeChains: () -> Void
@@ -32,18 +33,30 @@ struct VaultMainChainListView: View {
     }
 
     var chainList: some View {
-        VStack(spacing: 0) {
-            ForEach(Array(filteredRows.enumerated()), id: \.element.id) { index, row in
-                VaultChainCellView(row: row, vault: vault) {
-                    onCopy(row.chain)
-                }
+        let rows = filteredRows
+        // Lazy so rows are realized as they scroll in rather than all at once:
+        // the surrounding surface is drawn by `commonListContainer`, which no
+        // longer needs the whole list laid out to clip it.
+        return LazyVStack(spacing: 0) {
+            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                VaultChainCellView(
+                    row: row,
+                    vaultPubKeyECDSA: vault.pubKeyECDSA,
+                    onSelect: { navigate(to: row.chain) },
+                    onCopy: { onCopy(row.chain) }
+                )
+                .equatable()
                 .commonListItemContainer(
                     index: index,
-                    itemsCount: filteredRows.count
+                    itemsCount: rows.count
                 )
             }
         }
         .commonListContainer()
+    }
+
+    private func navigate(to chain: Chain) {
+        router.navigate(to: VaultRoute.chainDetail(chain: chain, vault: vault))
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct HomeMainHeaderView: View {
     @EnvironmentObject var homeViewModel: HomeViewModel
+    @EnvironmentObject var vaultDetailViewModel: VaultDetailViewModel
 
     let vault: Vault
     @Binding var activeTab: HomeTab
@@ -20,8 +21,29 @@ struct HomeMainHeaderView: View {
 
     @State private var showBalanceInternal = false
 
+    /// Wallet total: the same guard-and-fallback shape as
+    /// `VaultMainScreen.totalBalanceToShow`. `VaultDetailViewModel` publishes it
+    /// preformatted, so the header no longer walks every coin through
+    /// `RateProvider` on each body evaluation. The fallback covers the frames
+    /// where the projection is not usable — before the first `refresh()` lands,
+    /// and right after a vault switch while the published total still belongs to
+    /// the previous vault.
+    ///
+    /// DeFi total: kept as an on-the-fly compute. Its only meaningful published
+    /// source would be `DefiMainViewModel`, which `DefiMainScreen` owns as a
+    /// `@StateObject` and is therefore unreachable from here, and
+    /// `VaultDetailViewModel` has no trigger tied to a DeFi balance refresh — a
+    /// value published there would go stale on exactly the tab that shows it.
+    /// The walk is also far cheaper: it is filtered to the vault's DeFi chains
+    /// and only runs while the DeFi tab is active.
     var balanceText: String {
-        activeTab == .defi ? homeViewModel.defiBalanceText(for: vault) : homeViewModel.balanceText(for: vault)
+        guard !homeViewModel.hideVaultBalance else { return String.hideBalanceText }
+        guard activeTab != .defi else { return homeViewModel.defiBalanceText(for: vault) }
+        guard let total = vaultDetailViewModel.totalFiatBalance,
+              total.vaultPubKeyECDSA == vault.pubKeyECDSA else {
+            return homeViewModel.balanceText(for: vault)
+        }
+        return total.text
     }
 
     var body: some View {
@@ -118,4 +140,5 @@ struct HomeMainHeaderView: View {
     }
     .background(Theme.colors.bgPrimary)
     .environmentObject(HomeViewModel())
+    .environmentObject(VaultDetailViewModel())
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainScreenScrollView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainScreenScrollView.swift
@@ -16,13 +16,15 @@ struct VaultMainScreenScrollView<Content: View>: View {
     @Binding var scrollOffset: CGFloat
     @ViewBuilder var content: () -> Content
 
-    private let coordinateSpaceName = UUID()
-
-    // Throttling state for 15fps
-    @State private var lastUpdateTime: CFTimeInterval = 0
-    @State private var pendingValue: CGFloat?
-    @State private var throttleTimer: Timer?
-    private let frameInterval: TimeInterval = 1.0 / 5.0 // 5fps
+    /// Throttle bookkeeping lives in a reference box rather than in `@State`
+    /// scalars. The offset reader below fires once per layout pass — i.e. every
+    /// frame while the user drags — and writing `@State` there would invalidate
+    /// this view's body, re-invoking `content()` (the entire wallet content
+    /// tree) at display rate. That defeated the whole point of the throttle:
+    /// only the `scrollOffset` binding was rate-limited, the expensive rebuild
+    /// was not. Mutating the box's properties is invisible to SwiftUI, so the
+    /// only re-render left is the throttled binding write itself.
+    @State private var throttle = ScrollOffsetThrottle(interval: 1.0 / 5.0)
 
     init(
         axes: Axis.Set = .vertical,
@@ -49,17 +51,15 @@ struct VaultMainScreenScrollView<Content: View>: View {
                         GeometryReader { proxy in
                             Color.clear
                                 .onChange(of: preferenceValue(proxy: proxy)) { _, newValue in
-                                    throttledUpdateOffset(newValue)
+                                    throttle.submit(newValue) { scrollOffset = $0 }
                                 }
                         }
                     )
                 insetView(length: bottomInset)
             }
         }
-        .coordinateSpace(name: coordinateSpaceName)
         .onDisappear {
-            // Clean up timer when view disappears
-            throttleTimer?.invalidate()
+            throttle.cancel()
         }
     }
 }
@@ -87,32 +87,59 @@ private extension VaultMainScreenScrollView {
         let frame = proxy.frame(in: .scrollView)
         return axes == .vertical ? frame.minY : frame.minX
     }
+}
 
-    func throttledUpdateOffset(_ newValue: CGFloat) {
-        let currentTime = CACurrentMediaTime()
+/// Leading-edge throttle for the scroll offset, with a trailing emission so the
+/// last value of a burst is never dropped.
+///
+/// Deliberately a class: it is held in a single `@State` so the per-frame
+/// bookkeeping never invalidates the owning view's body.
+private final class ScrollOffsetThrottle {
+    private let interval: TimeInterval
+    private var lastEmitTime: CFTimeInterval = 0
+    private var pendingValue: CGFloat?
+    private var timer: Timer?
 
-        // Store the latest value
-        pendingValue = newValue
+    init(interval: TimeInterval) {
+        self.interval = interval
+    }
 
-        // If enough time has passed since last update, update immediately
-        if currentTime - lastUpdateTime >= frameInterval {
-            scrollOffset = newValue
-            lastUpdateTime = currentTime
-            pendingValue = nil
+    /// Emits `value` immediately when `interval` has elapsed since the last
+    /// emission, otherwise schedules a single trailing emission of the newest
+    /// value seen in the meantime.
+    func submit(_ value: CGFloat, emit: @escaping (CGFloat) -> Void) {
+        let now = CACurrentMediaTime()
+        pendingValue = value
+
+        if now - lastEmitTime >= interval {
+            flush(now: now, emit: emit)
             return
         }
 
-        // Otherwise, schedule an update if we haven't already
-        if throttleTimer == nil {
-            let remainingTime = frameInterval - (currentTime - lastUpdateTime)
-            throttleTimer = Timer.scheduledTimer(withTimeInterval: remainingTime, repeats: false) { _ in
-                if let value = pendingValue {
-                    scrollOffset = value
-                    lastUpdateTime = CACurrentMediaTime()
-                    pendingValue = nil
-                }
-                throttleTimer = nil
-            }
+        guard timer == nil else { return }
+
+        let trailing = Timer(timeInterval: interval - (now - lastEmitTime), repeats: false) { [weak self] _ in
+            guard let self else { return }
+            self.timer = nil
+            self.flush(now: CACurrentMediaTime(), emit: emit)
         }
+        timer = trailing
+        // `.common` mode, not the default one: the default run loop mode is
+        // suspended for the whole duration of a scroll drag, so a timer
+        // scheduled there never fires while the finger is down — exactly when
+        // the trailing update is needed.
+        RunLoop.main.add(trailing, forMode: .common)
+    }
+
+    func cancel() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func flush(now: CFTimeInterval, emit: (CGFloat) -> Void) {
+        guard let value = pendingValue else { return }
+        pendingValue = nil
+        lastEmitTime = now
+        emit(value)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -10,6 +10,15 @@ import Foundation
 import SwiftUI
 
 class VaultDetailViewModel: ObservableObject {
+    /// Preformatted vault total tagged with the vault it was computed for. The
+    /// tag is load-bearing: on a vault switch the previous vault's total stays
+    /// published until `refresh()` re-seeds, and rendering it would show the
+    /// wrong number for a frame.
+    struct TotalBalance: Equatable {
+        let vaultPubKeyECDSA: String
+        let text: String
+    }
+
     @Published var selectedChain: Chain? = nil
     @Published var chains = [Chain]()
     // Value-type projection the wallet chain list renders off. Rebuilt in
@@ -18,6 +27,12 @@ class VaultDetailViewModel: ObservableObject {
     // (Vault/Coin are @Model + ObservableObject with no @Published members),
     // so the list only repaints when a @Published on this view model changes.
     @Published private(set) var rows: [ChainRowModel] = []
+    /// Preformatted vault total for the wallet header, published on the same
+    /// triggers as `rows`. The screen used to call `HomeViewModel.balanceText(for:)`
+    /// inside its body, which walks every coin through `RateProvider` on every
+    /// body evaluation. `nil` means "not projected yet" so the first frame can
+    /// fall back to an on-the-fly compute instead of rendering blank.
+    @Published private(set) var totalFiatBalance: TotalBalance?
     @Published var searchText: String = ""
     @Published var vaultBanners: [VaultBannerType] = []
 
@@ -66,7 +81,9 @@ class VaultDetailViewModel: ObservableObject {
     /// tail, which keeps the deliberate "no stale-then-fresh double reorder"
     /// behaviour intact. No-ops when nothing changed.
     private func rebuildRowsForRateChange() {
-        guard let vault = rowsVault, !rows.isEmpty else { return }
+        guard let vault = rowsVault else { return }
+        refreshTotalFiatBalance(vault: vault)
+        guard !rows.isEmpty else { return }
         let byChain = Dictionary(
             logic.chainRows(vault: vault).map { ($0.chain, $0) },
             uniquingKeysWith: { _, latest in latest }
@@ -74,6 +91,20 @@ class VaultDetailViewModel: ObservableObject {
         let rebuilt = rows.compactMap { byChain[$0.chain] }
         guard rebuilt.count == rows.count, rebuilt != rows else { return }
         rows = rebuilt
+    }
+
+    /// Recomputes the preformatted vault total. Cheap relative to the row
+    /// projection (one pass over `vault.coins`) but still O(coins × rate
+    /// lookups), which is why it must not live in a view body. No-ops when the
+    /// formatted value is unchanged, so an unrelated rate arrival does not
+    /// republish.
+    private func refreshTotalFiatBalance(vault: Vault) {
+        let total = TotalBalance(
+            vaultPubKeyECDSA: vault.pubKeyECDSA,
+            text: vault.coins.totalBalanceInFiatString
+        )
+        guard total != totalFiatBalance else { return }
+        totalFiatBalance = total
     }
 
     func filteredChains(in vault: Vault) -> [Chain] {
@@ -106,6 +137,10 @@ class VaultDetailViewModel: ObservableObject {
         // chain set is unchanged and the list does not reshuffle.
         let membershipChanged = Set(vault.chainsWithCoins) != Set(chains)
         rowsVault = vault
+        // Unconditional: the total is a scalar, so recomputing it cannot
+        // reorder anything, and a same-vault/same-membership refresh is exactly
+        // the case where balances moved.
+        refreshTotalFiatBalance(vault: vault)
         if chains.isEmpty || chainsVaultPubKeyECDSA != vault.pubKeyECDSA || membershipChanged {
             chains = logic.sortedChains(vault: vault)
             rows = logic.chainRows(vault: vault)
@@ -127,6 +162,7 @@ class VaultDetailViewModel: ObservableObject {
                 await MainActor.run {
                     self.chains = updated
                     self.rows = self.logic.chainRows(vault: vault)
+                    self.refreshTotalFiatBalance(vault: vault)
                     self.chainsVaultPubKeyECDSA = vault.pubKeyECDSA
                 }
             }
@@ -137,6 +173,7 @@ class VaultDetailViewModel: ObservableObject {
         rowsVault = vault
         chains = logic.sortedChains(vault: vault)
         rows = logic.chainRows(vault: vault)
+        refreshTotalFiatBalance(vault: vault)
         chainsVaultPubKeyECDSA = vault.pubKeyECDSA
     }
 

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -274,6 +274,100 @@ final class VaultDetailViewModelTests: XCTestCase {
                        "updateBalance after groupChains for the same vault/membership must not re-seed")
     }
 
+    // MARK: - Published vault total
+
+    /// The wallet header's total used to be computed inside `VaultMainScreen.body`
+    /// via `HomeViewModel.balanceText(for:)` — O(coins) through `RateProvider` on
+    /// every body evaluation. It is now published from here and must be seeded by
+    /// the same synchronous pass that seeds `rows`.
+    func testTotalFiatBalance_seededSynchronouslyByUpdateBalance() {
+        let vault = makeVault(pubKey: "vault-total", chains: [.bitcoin, .ethereum])
+        let vm = VaultDetailViewModel()
+
+        XCTAssertNil(vm.totalFiatBalance, "precondition: nothing projected yet")
+
+        vm.updateBalance(vault: vault)
+
+        XCTAssertEqual(vm.totalFiatBalance?.text, vault.coins.totalBalanceInFiatString)
+        XCTAssertEqual(vm.totalFiatBalance?.vaultPubKeyECDSA, vault.pubKeyECDSA)
+    }
+
+    /// The published total carries the vault it was computed for, and the screen
+    /// renders it only when the tag matches the vault it is displaying. Without
+    /// the tag, the frame between a vault switch and the re-seed shows the
+    /// previous vault's number.
+    func testTotalFiatBalance_isTaggedWithTheVaultItBelongsTo() throws {
+        let vaultA = makeVault(pubKey: "vault-total-a", chains: [.bitcoin])
+        let vaultB = makeVault(pubKey: "vault-total-b", chains: [.solana])
+        let vm = VaultDetailViewModel()
+
+        vm.updateBalance(vault: vaultA)
+
+        // The state the screen sees on the first frame after switching to B,
+        // before `refresh()` has re-seeded: the published total still belongs
+        // to A, so the tag comparison must reject it.
+        let stale = try XCTUnwrap(vm.totalFiatBalance)
+        XCTAssertEqual(stale.vaultPubKeyECDSA, vaultA.pubKeyECDSA)
+        XCTAssertNotEqual(stale.vaultPubKeyECDSA, vaultB.pubKeyECDSA,
+                          "A total tagged with vault A must not be accepted while vault B is displayed")
+
+        vm.updateBalance(vault: vaultB)
+        XCTAssertEqual(vm.totalFiatBalance?.vaultPubKeyECDSA, vaultB.pubKeyECDSA,
+                       "A vault switch must re-tag the total once the seed runs")
+    }
+
+    /// A same-vault, same-membership refresh deliberately skips the row seed
+    /// (the no-stale-then-fresh-double-reorder invariant), but balances are
+    /// exactly what moved — the total must still follow them.
+    func testTotalFiatBalance_recomputesOnSameMembershipRefresh() throws {
+        let providerId = "total-refresh-\(UUID().uuidString.lowercased())"
+        let vault = makeVault(pubKey: "vault-total-refresh", chains: [])
+        let coin = makePricedCoin(chain: .bitcoin, ticker: "BTC", providerId: providerId, rawBalance: "100000000")
+        vault.coins = [coin]
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: providerId, value: 100)
+        ])
+
+        let vm = VaultDetailViewModel()
+        vm.updateBalance(vault: vault)
+        let before = try XCTUnwrap(vm.totalFiatBalance?.text)
+
+        // Membership unchanged, balance doubled.
+        coin.rawBalance = "200000000"
+        vm.updateBalance(vault: vault)
+
+        XCTAssertNotEqual(vm.totalFiatBalance?.text, before,
+                          "The total must track a balance change even when the seed is skipped")
+        XCTAssertEqual(vm.totalFiatBalance?.text, vault.coins.totalBalanceInFiatString)
+    }
+
+    /// The total bakes fiat at projection time, so — like `rows` — it is inert to
+    /// a rate landing afterwards unless the rate signal rebuilds it.
+    func testTotalFiatBalance_refreshesWhenARateLands() async throws {
+        let providerId = "total-rate-\(UUID().uuidString.lowercased())"
+        let vault = makeVault(pubKey: "vault-total-rate", chains: [])
+        vault.coins = [makePricedCoin(chain: .bitcoin, ticker: "BTC", providerId: providerId, rawBalance: "100000000")]
+
+        let vm = VaultDetailViewModel()
+        vm.groupChains(vault: vault)
+        let before = try XCTUnwrap(vm.totalFiatBalance?.text)
+
+        let updated = expectation(description: "total refreshed on rate arrival")
+        updated.assertForOverFulfill = false
+        rateCancellable = vm.$totalFiatBalance
+            .dropFirst()
+            .sink { total in
+                if total?.text != before { updated.fulfill() }
+            }
+
+        try RateProvider.shared.save(rates: [
+            Rate(fiat: SettingsCurrency.current.rawValue, crypto: providerId, value: 30_000)
+        ])
+
+        await fulfillment(of: [updated], timeout: 2)
+        XCTAssertEqual(vm.totalFiatBalance?.text, vault.coins.totalBalanceInFiatString)
+    }
+
     // MARK: - chainRows builder
 
     /// The projection builds one row per chain, ordered to match


### PR DESCRIPTION
## Description

Fixes #4974

Wallet chain list scroll performance. Measured on an iPhone 16 Pro (iOS 26.5.2), 20 s sustained scroll of a many-chain vault, Animation Hitches, `xctrace --attach`, identical instrument sets and the same vault on both sides:

| | before | after |
|---|---|---|
| **hitch time ratio** | **114.2 ms/s** | **4.4 ms/s** |
| hitches | 34 | 8 |
| total hitch time | 2271 ms | 88 ms |
| worst single hitch | 758 ms | 17 ms |
| hitches over 100 ms | 4 | 0 |
| offscreen passes / hitching frame | 256 – 494 (median 426) | negligible |

Apple's bar is < 5 ms/s good, > 10 ms/s user-visible — so this moves the screen from ~12× the user-visible threshold to inside the "good" band.

**Stacked on #4975** (the rate-cache change), which the measurement above includes. GitHub will retarget this to `main` when that merges.

## The commits, and what each one is for

Every hitch narrative in the baseline was render-side, so the masking work is the load-bearing part; the rest are real defects found along the way that the profile confirmed as secondary.

- **`perf(list): clip only the end rows of a common list`** — **the dominant fix.** `CommonListItemContainer` applied `.clipShape(.rect(...))` to *every* row, including middle rows where all four radii are `0` — a visually no-op clip that still installs a mask. An N-row list paid ~N pointless masks. Now only `isFirst || isLast` are clipped (a single-row list is both and keeps all four corners). This alone accounts for the great majority of the improvement.
- **`perf(wallet): stop the scroll-offset throttle invalidating the content tree`** — the throttle kept `pendingValue`/`lastUpdateTime`/`throttleTimer` in `@State` and wrote `pendingValue` on every scroll frame, so the documented 5 fps throttle rate-limited the `scrollOffset` binding but not the body invalidation: `content()` — the whole wallet content tree — was rebuilt at display rate. Moved into a reference box so the bookkeeping is invisible to SwiftUI. Also fixes the trailing `Timer` being scheduled in `.default` mode (it never fires during scroll tracking) and deletes a dead `UUID()` coordinate space. **This view is also the DeFi tab's scroll view, so both tabs benefit.**
- **`perf(wallet): publish the vault total instead of computing it in the body`** — `homeViewModel.balanceText(for: vault)` walked every coin through `RateProvider` on every body evaluation. Now a published, vault-tagged `TotalBalance`, with a fallback to the on-the-fly compute when it is absent or belongs to another vault (the first frame precedes `onLoad`, and a vault switch briefly leaves the previous vault's value).
- **`perf(wallet): read the published vault total in the home header`** — same defect at `HomeMainHeaderView`, same shape of fix. The DeFi branch of that property was deliberately left alone: `VaultDetailViewModel` has no DeFi-balance trigger, and `HomeViewModel.defiBalanceText` and `DefiBalanceService.totalBalanceInFiatString` are already two different formulas that can disagree — reconciling them is separate work, not a hoist.
- **`perf(wallet): restore laziness and equatable rows in the chain list`** — the list was a plain `VStack` (all rows realized up front) and `VaultChainCellView` held a `Vault` reference plus closures, so no row could ever be skipped. Now `LazyVStack` + `.equatable()`, with `vaultPubKeyECDSA` in the equality so an equality-skipped row cannot keep closures captured against a previous vault.

## What was tried and rejected

`.drawingGroup()` on the two `blur(radius: 36)` background gradients was implemented, measured, and **dropped**: 4.7 ms/s with it vs 4.4 ms/s without — no measurable benefit, for roughly 21 MB of persistent texture per live background instance. Recording it here so nobody re-derives it. If the background blurs are ever revisited, the zero-cost answer is not to blur a static gradient at runtime at all.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

<!-- TODO before review: side-by-side of the chain list, DeFi list, chain detail,
     receive picker and folder picker, before vs after, confirming the clip change
     is pixel-identical. -->

## Additional context

`CommonListItemContainer` is shared by five call sites — wallet chain list, DeFi chain list, chain detail, receive chain picker, folder picker. All five were checked: no row draws outside its own bounds, so the middle-row clip was genuinely a no-op and removing it is not observable. `.plainListItem()` was also dropped from the modifier; of the five call sites only `AddFolderScreen` is inside a real `List`, and there the rows sit in a `VStack` that is itself the single list row and carries its own `.plainListItem()`.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4974
- **Confidence**: high on the measurements and the CPU-side changes; medium on visual identity of the clip change, which is argued structurally rather than screenshot-verified
- **Needs human review for**: the rendered output of the clip change across all five list call sites
