### PR TITLE
fix(tokens): rank the provider catalogs, bound browse to the top 20 each, unbound search

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaJupiterTokenInfo.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaJupiterTokenInfo.swift
@@ -8,6 +8,7 @@ struct SolanaJupiterToken: Codable {
         case decimals
         case logoURI = "icon"
         case extensions
+        case organicScore
     }
     let address: String?
     let name: String?
@@ -15,6 +16,11 @@ struct SolanaJupiterToken: Codable {
     let decimals: Int?
     let logoURI: String?
     let extensions: SolanaJupiterTokenExtensions?
+    /// Jupiter's own 0–100 token-quality metric, blending organic (non-wash)
+    /// volume, holder distribution and liquidity depth. Present on every entry of
+    /// the verified tag list — see `rankedForCatalog` for why it, and not `mcap`,
+    /// is what the catalog ranks by.
+    let organicScore: Double?
 
     // Custom init to handle missing fields gracefully
     init(from decoder: Decoder) throws {
@@ -25,6 +31,58 @@ struct SolanaJupiterToken: Codable {
         decimals = try? container.decode(Int.self, forKey: .decimals)
         logoURI = try? container.decode(String.self, forKey: .logoURI)
         extensions = try? container.decode(SolanaJupiterTokenExtensions.self, forKey: .extensions)
+        organicScore = try? container.decode(Double.self, forKey: .organicScore)
+    }
+}
+
+extension SolanaJupiterToken {
+    /// The whole tag-list payload → catalog transform: decode, rank best-first,
+    /// map to `CoinMeta`. One place so the ranking can't be bypassed on the path
+    /// the catalog provider actually uses, and so a test can pin that it isn't.
+    static func rankedCatalogMetas(from data: Data) throws -> [CoinMeta] {
+        let tokens = try JSONDecoder().decode([SolanaJupiterToken].self, from: data)
+        return rankedForCatalog(tokens).map { $0.toCoinMeta() }
+    }
+
+    func toCoinMeta() -> CoinMeta {
+        CoinMeta(
+            chain: .solana,
+            ticker: symbol ?? "",
+            logo: logoURI ?? "",
+            decimals: decimals ?? 0,
+            priceProviderId: extensions?.coingeckoId ?? "",
+            contractAddress: address ?? "",
+            isNativeToken: false
+        )
+    }
+
+    /// A missing `organicScore` sorts below every real one. The live score is
+    /// bounded to 0...100, so -1 is unreachable from the wire.
+    private var catalogRank: Double { organicScore ?? -1 }
+
+    /// The Jupiter list ordered best-first, so a consumer that shows only the
+    /// head of it (the token picker's browse list) shows the tokens worth
+    /// showing. Jupiter returns the list in no useful order.
+    ///
+    /// Ranked by `organicScore` rather than `mcap`: market cap is present on only
+    /// ~66% of the list and rewards paper valuation over tradability, so its head
+    /// fills with high-mcap/no-liquidity mirages — tokenised-equity wrappers with
+    /// a billion-dollar cap and four figures of liquidity outrank ETH and USDT.
+    /// `organicScore` is on 100% of entries and its head is the tokens a user
+    /// would actually recognise and trade.
+    ///
+    /// Stable: ties (the ~92% of the list scoring 0) keep Jupiter's own order
+    /// rather than being shuffled between fetches.
+    static func rankedForCatalog(_ tokens: [SolanaJupiterToken]) -> [SolanaJupiterToken] {
+        tokens
+            .enumerated()
+            .sorted { lhs, rhs in
+                guard lhs.element.catalogRank != rhs.element.catalogRank else {
+                    return lhs.offset < rhs.offset
+                }
+                return lhs.element.catalogRank > rhs.element.catalogRank
+            }
+            .map(\.element)
     }
 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -263,20 +263,10 @@ class SolanaService {
             let dataResponse = try await Utils.asyncGetRequest(
                 urlString: urlString, headers: [:])
 
-            let tokenInfos = try JSONDecoder().decode(
-                [SolanaJupiterToken].self, from: dataResponse)
-            return tokenInfos.map { jupiterTokenInfo in
-                let coinMeta = CoinMeta(
-                    chain: .solana,
-                    ticker: jupiterTokenInfo.symbol ?? "",
-                    logo: jupiterTokenInfo.logoURI ?? "",
-                    decimals: jupiterTokenInfo.decimals ?? 0,
-                    priceProviderId: jupiterTokenInfo.extensions?.coingeckoId ?? "",
-                    contractAddress: jupiterTokenInfo.address ?? "",
-                    isNativeToken: false
-                )
-                return coinMeta
-            }
+            // Decoded, ranked best-first and mapped in one place: `CoinMeta`
+            // carries no score, so ordering is the only channel Jupiter's quality
+            // signal has to reach the catalog.
+            return try SolanaJupiterToken.rankedCatalogMetas(from: dataResponse)
         } catch let error as NSError {
             if error.code == 429 {
                 logger.warning("Error in fetchSolanaJupiterTokenList: Rate limit exceeded (429)")

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/OneInch/OneInchToken.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/OneInch/OneInchToken.swift
@@ -83,6 +83,57 @@ extension OneInchToken {
         }
     }
 
+    private static let peggedTagPrefix = "PEG:"
+    private static let bluechipTag = "bluechip"
+    private static let connectorTag = "connector"
+
+    /// A quality **tier**, not a ranking. `/swap/v6.0/{chain}/tokens` carries no
+    /// volume, market-cap or liquidity field, so no true ordering can be derived
+    /// from it — the only quality information it exposes is 1inch's own tag
+    /// curation, which sorts the whitelist into these coarse bands:
+    ///
+    /// - `bluechip` — 1inch's hand-picked majors (41 of Ethereum's 2,225).
+    /// - `PEG:*` — assets pegged to USD / ETH / BTC / EUR: the stables and
+    ///   liquid-staking derivatives a user most often adds by name.
+    /// - `connector` — tokens 1inch routes through, i.e. real liquidity.
+    /// - everything else — on the whitelist, but with nothing said about it.
+    ///
+    /// Within a band 1inch tells us nothing, so the input order is kept.
+    enum CatalogQualityTier: Int, Comparable {
+        case bluechip
+        case pegged
+        case connector
+        case unclassified
+
+        static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+    }
+
+    var catalogQualityTier: CatalogQualityTier {
+        guard let tags else { return .unclassified }
+        if tags.contains(Self.bluechipTag) { return .bluechip }
+        if tags.contains(where: { $0.hasPrefix(Self.peggedTagPrefix) }) { return .pegged }
+        if tags.contains(Self.connectorTag) { return .connector }
+        return .unclassified
+    }
+
+    /// The whitelist ordered best-tier-first, so a consumer showing only the head
+    /// of it (the token picker's browse list) leads with tokens a user would
+    /// recognise instead of whatever sorts first alphabetically.
+    ///
+    /// Stable: equal tiers keep the caller's order, which is the provider's
+    /// name sort.
+    static func rankedForCatalog(_ tokens: [OneInchToken]) -> [OneInchToken] {
+        tokens
+            .enumerated()
+            .sorted { lhs, rhs in
+                guard lhs.element.catalogQualityTier != rhs.element.catalogQualityTier else {
+                    return lhs.offset < rhs.offset
+                }
+                return lhs.element.catalogQualityTier < rhs.element.catalogQualityTier
+            }
+            .map(\.element)
+    }
+
     /// Trust-carrying catalog candidate. `/swap/v6.0/{chain}/tokens` is 1inch's
     /// curated swap whitelist, so membership in it *is* the trust signal —
     /// `.verified(source: "1inch")`. Tokens 1inch itself tags risky are downgraded

--- a/VultisigApp/VultisigApp/Core/Services/TokenCatalog/JupiterCatalogProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenCatalog/JupiterCatalogProvider.swift
@@ -5,8 +5,12 @@
 //  Jupiter's Solana token list as a `TokenCatalogProvider`. The upstream
 //  endpoint is pre-filtered server-side to `?query=verified`, so the whole list
 //  carries implicit "Jupiter-verified" trust — every token is
-//  `.verified("Jupiter")`. Per-token `coingeckoId` is already preserved into
-//  `priceProviderId` by `SolanaService.fetchSolanaJupiterTokenList`.
+//  `.verified("Jupiter")`.
+//
+//  The list is returned best-first, ranked by Jupiter's own `organicScore` (see
+//  `SolanaJupiterToken.rankedForCatalog`). `CatalogToken` carries no rank field,
+//  so order is the contract: a consumer showing only the head of the list — the
+//  token picker's browse list — gets the tokens worth showing.
 //
 //  Like `OneInchCatalogProvider`, freshness is governed upstream by
 //  `SwapTokenListCache`; this provider fetches → tags → write-throughs the disk

--- a/VultisigApp/VultisigApp/Core/Services/TokenCatalog/JupiterCatalogProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenCatalog/JupiterCatalogProvider.swift
@@ -12,9 +12,11 @@
 //  so order is the contract: a consumer showing only the head of the list — the
 //  token picker's browse list — gets the tokens worth showing.
 //
-//  Like `OneInchCatalogProvider`, freshness is governed upstream by
-//  `SwapTokenListCache`; this provider fetches → tags → write-throughs the disk
-//  snapshot, and serves the last-good snapshot on failure (offline floor).
+//  Like `OneInchCatalogProvider`, this fetches → ranks → tags → write-throughs
+//  the disk snapshot and serves the last-good snapshot on failure (offline
+//  floor). Fetch frequency is the caller's: the swap source path is fronted by
+//  `SwapTokenListCache`, the wallet add-token path (`loadCatalog`) deliberately
+//  is not and refetches per screen open.
 //
 
 import Foundation

--- a/VultisigApp/VultisigApp/Core/Services/TokenCatalog/OneInchCatalogProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenCatalog/OneInchCatalogProvider.swift
@@ -13,10 +13,16 @@
 //  discovery on) only exists on the separate `/token/v1.2/{chain}/custom`
 //  endpoint and is absent from every `/tokens` response.
 //
+//  The list is returned best-first by 1inch's own tag curation (see
+//  `OneInchToken.rankedForCatalog`). `CatalogToken` carries no rank field, so
+//  order is the contract: a consumer showing only the head of the list — the
+//  token picker's browse list — gets the majors rather than whatever sorts
+//  first alphabetically.
+//
 //  Freshness (TTL / coalescing / fail-open) is governed by `SwapTokenListCache`
 //  at the `TokenSearchService.loadTokens` layer, so this provider stays thin:
-//  fetch → tag → write-through the disk snapshot; on failure serve the last-good
-//  disk snapshot (the offline floor beneath the in-memory cache).
+//  fetch → rank → tag → write-through the disk snapshot; on failure serve the
+//  last-good disk snapshot (the offline floor beneath the in-memory cache).
 //
 
 import Foundation
@@ -55,9 +61,10 @@ final class OneInchCatalogProvider: TokenCatalogProvider {
         guard service.isChainSupported(chain: chain), let chainID = chain.chainID else { return [] }
         let sourceKind = kind
         do {
-            let tokens = try await service.fetchTokens(chain: chainID)
-                .sorted(by: { $0.name < $1.name })
-                .map { $0.toCatalogToken(chain: chain, sourceKind: sourceKind) }
+            let ranked = try await OneInchToken.rankedForCatalog(
+                service.fetchTokens(chain: chainID).sorted(by: { $0.name < $1.name })
+            )
+            let tokens = ranked.map { $0.toCatalogToken(chain: chain, sourceKind: sourceKind) }
             let cache = disk
             Task.detached(priority: .utility) { cache.save(tokens, chain: chain) }
             return tokens

--- a/VultisigApp/VultisigApp/Core/Services/TokenCatalog/OneInchCatalogProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenCatalog/OneInchCatalogProvider.swift
@@ -19,10 +19,16 @@
 //  token picker's browse list — gets the majors rather than whatever sorts
 //  first alphabetically.
 //
-//  Freshness (TTL / coalescing / fail-open) is governed by `SwapTokenListCache`
-//  at the `TokenSearchService.loadTokens` layer, so this provider stays thin:
-//  fetch → rank → tag → write-through the disk snapshot; on failure serve the
-//  last-good disk snapshot (the offline floor beneath the in-memory cache).
+//  The provider stays thin either way: fetch → rank → tag → write-through the
+//  disk snapshot; on failure serve the last-good disk snapshot. How often that
+//  fetch happens depends on the caller, and the two differ:
+//   - swap source (`TokenSearchService.loadTokens`) — fronted by
+//     `SwapTokenListCache`, which owns the TTL, in-flight coalescing and
+//     fail-open-to-last-good.
+//   - wallet add-token (`TokenSearchService.loadCatalog`) — deliberately NOT
+//     cached there (that cache is `[CoinMeta]`-typed and drives the swap
+//     pickers), so this refetches per screen open with the disk snapshot as its
+//     only floor.
 //
 
 import Foundation

--- a/VultisigApp/VultisigApp/Core/Services/TokenSearchService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenSearchService.swift
@@ -139,19 +139,13 @@ struct TokenSearchResult {
     /// so browse can cap each provider's breadth independently. Threaded as a
     /// side map for the same reason as `verificationByUniqueId`: it keeps the
     /// swap pickers' `[CoinMeta]` list types unchanged.
+    ///
+    /// Deliberately has no default: an omitted map would compile clean while
+    /// collapsing every provider into `cappedPerProvider`'s single unattributed
+    /// bucket, silently turning "the best N per provider" into "N in total".
+    /// Constructed through the synthesized memberwise init so that stays true
+    /// for any field added later.
     let sourceKindByUniqueId: [String: String]
-
-    init(
-        surfaceable: [CoinMeta],
-        unverified: [CoinMeta],
-        verificationByUniqueId: [String: TokenVerification],
-        sourceKindByUniqueId: [String: String] = [:]
-    ) {
-        self.surfaceable = surfaceable
-        self.unverified = unverified
-        self.verificationByUniqueId = verificationByUniqueId
-        self.sourceKindByUniqueId = sourceKindByUniqueId
-    }
 }
 
 /// Cancellation is the only failure this service can report: the catalog's

--- a/VultisigApp/VultisigApp/Core/Services/TokenSearchService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenSearchService.swift
@@ -106,20 +106,27 @@ struct TokenSearchService {
         let unverified = safe.filter { !$0.autoSurfaces }.map { $0.meta }
 
         var verificationByUniqueId: [String: TokenVerification] = [:]
+        var sourceKindByUniqueId: [String: String] = [:]
         for candidate in safe {
             verificationByUniqueId[candidate.uniqueId] = candidate.verification
+            sourceKindByUniqueId[candidate.uniqueId] = candidate.sourceKind
         }
 
         return TokenSearchResult(
             surfaceable: surfaceable,
             unverified: unverified,
-            verificationByUniqueId: verificationByUniqueId
+            verificationByUniqueId: verificationByUniqueId,
+            sourceKindByUniqueId: sourceKindByUniqueId
         )
     }
 }
 
 /// The wallet add-token picker's verification-aware view of the catalog. Kept a
 /// value type so it crosses the actor boundary cleanly.
+///
+/// `surfaceable` and `unverified` arrive in provider order, which is the
+/// providers' ranking (best-first) — see `OneInchToken.rankedForCatalog` /
+/// `SolanaJupiterToken.rankedForCatalog`. Nothing downstream may re-sort them.
 struct TokenSearchResult {
     /// Curated / verified, non-native — the tokens that auto-surface (default).
     let surfaceable: [CoinMeta]
@@ -128,6 +135,23 @@ struct TokenSearchResult {
     let unverified: [CoinMeta]
     /// `CoinMeta.uniqueId → verification` for badging. Only non-native entries.
     let verificationByUniqueId: [String: TokenVerification]
+    /// `CoinMeta.uniqueId → the `TokenCatalogProvider.kind` that won the token`,
+    /// so browse can cap each provider's breadth independently. Threaded as a
+    /// side map for the same reason as `verificationByUniqueId`: it keeps the
+    /// swap pickers' `[CoinMeta]` list types unchanged.
+    let sourceKindByUniqueId: [String: String]
+
+    init(
+        surfaceable: [CoinMeta],
+        unverified: [CoinMeta],
+        verificationByUniqueId: [String: TokenVerification],
+        sourceKindByUniqueId: [String: String] = [:]
+    ) {
+        self.surfaceable = surfaceable
+        self.unverified = unverified
+        self.verificationByUniqueId = verificationByUniqueId
+        self.sourceKindByUniqueId = sourceKindByUniqueId
+    }
 }
 
 /// Cancellation is the only failure this service can report: the catalog's

--- a/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/TokenSelectionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/TokenSelection/Screens/TokenSelectionScreen.swift
@@ -24,8 +24,9 @@ struct TokenSelectionScreen: View {
     @State private var showUnverifiedAddConfirm = false
 
     var elements: [TokenSelectionAsset] {
-        // Local-first: held, then curated presets, then verified provider breadth.
-        // Browse hides `.unverified` — typing a query is what reveals the badged
+        // Local-first: held, then curated presets, then the best N of each
+        // provider's verified breadth. Browse is a shortlist, not the catalog —
+        // typing a query searches the whole of it, including the badged
         // unverified long-tail (`searchedTokens`).
         let assets = tokenViewModel.searchText.isEmpty ?
             tokenViewModel.selectedTokens + tokenViewModel.preExistTokens + tokenViewModel.browseProviderTokens :

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
@@ -21,8 +21,11 @@ class TokenSelectionViewModel: ObservableObject {
     /// Curated `TokensStore` presets not held/hidden (browse, after held). Always
     /// present synchronously — independent of the async provider fetch.
     @Published var preExistTokens: [CoinMeta] = []
-    /// Verified provider breadth for browse (1inch / Jupiter), deduped
-    /// against the local tokens above. Empty until the provider fetch lands.
+    /// Verified provider breadth for browse (1inch / Jupiter), deduped against
+    /// the local tokens above and capped to the best
+    /// `TokenSelectionLogic.browseTokensPerProvider` of EACH provider. Empty
+    /// until the provider fetch lands. Search is not capped this way — it reads
+    /// `searchableTokens`, which holds the full breadth.
     @Published var browseProviderTokens: [CoinMeta] = []
     /// Search results over the full local-first pool (local + verified +
     /// unverified). Unverified rows carry the ⚠ badge — typing is what reveals
@@ -40,11 +43,19 @@ class TokenSelectionViewModel: ObservableObject {
     /// fetch lands — the local presets/held always render regardless.
     private var catalogSurfaceable: [CoinMeta] = []
     private var catalogUnverified: [CoinMeta] = []
+    /// `uniqueId → provider kind`, so browse caps each provider's breadth
+    /// separately (a two-provider chain shows two capped groups, not one).
+    private var catalogSourceKinds: [String: String] = [:]
     /// The full local-first search pool (curated presets + verified + unverified),
     /// filtered by the query into `searchedTokens`. Always contains the presets
     /// so a curated/local token stays searchable even when the provider fetch
     /// is pending or fails.
     private var searchableTokens: [CoinMeta] = []
+    /// The chain the retained catalog above belongs to. A failed fetch keeps the
+    /// last-good catalog (better than blanking the list) — but only for the SAME
+    /// chain: retaining it across a chain change would browse and search another
+    /// chain's tokens.
+    private var catalogChain: Chain?
 
     private var loadingTask: Task<Void, Never>?
 
@@ -77,6 +88,10 @@ class TokenSelectionViewModel: ObservableObject {
     func load(chain: Chain, vault: Vault) async {
         error = nil
 
+        if catalogChain != chain {
+            discardRetainedCatalog()
+        }
+
         let hiddenTokens = vault.hiddenTokens
         let chainCoins = vault.coins(for: chain)
 
@@ -100,6 +115,16 @@ class TokenSelectionViewModel: ObservableObject {
         searchedTokens = logic.filteredTokens(searchText: query, tokens: searchableTokens)
     }
 
+    /// Drop everything derived from a provider fetch. Called when the screen is
+    /// asked for a different chain than the retained catalog belongs to.
+    private func discardRetainedCatalog() {
+        catalogSurfaceable = []
+        catalogUnverified = []
+        catalogSourceKinds = [:]
+        verificationByUniqueId = [:]
+        catalogChain = nil
+    }
+
     private func loadExternalTokens(chain: Chain, chainCoins: [Coin], hiddenTokens: [HiddenToken]) async {
         guard !Task.isCancelled else { return }
 
@@ -114,7 +139,9 @@ class TokenSelectionViewModel: ObservableObject {
             }
             catalogSurfaceable = result.surfaceable
             catalogUnverified = result.unverified
+            catalogSourceKinds = result.sourceKindByUniqueId
             verificationByUniqueId = result.verificationByUniqueId
+            catalogChain = chain
         } catch {
             // Fail open: keep the local presets/held (already rendered) fully
             // searchable rather than blanking the list, and re-derive from what's
@@ -133,7 +160,8 @@ class TokenSelectionViewModel: ObservableObject {
     /// Re-derive every visible list from the local presets/held + the current
     /// (possibly empty) catalog. Ordering is local-first everywhere: held, then
     /// curated presets, then provider breadth (deduped by `uniqueId`). Browse
-    /// shows curated/local + verified; search adds the badged unverified long-tail.
+    /// shows curated/local + the best N of each provider's verified breadth;
+    /// search spans the FULL breadth and adds the badged unverified long-tail.
     private func recompute(chain: Chain, chainCoins: [Coin], hiddenTokens: [HiddenToken]) {
         // Enrich held coins with catalog metadata where available.
         let catalogMetas = catalogSurfaceable + catalogUnverified
@@ -147,7 +175,13 @@ class TokenSelectionViewModel: ObservableObject {
         let verifiedIds = localIds.union(verifiedBreadth.map { $0.uniqueId })
         let unverifiedBreadth = logic.providerTokens(catalogUnverified, excludingLocal: verifiedIds, hiddenTokens: hiddenTokens)
 
-        browseProviderTokens = verifiedBreadth
+        // Cap AFTER the local/hidden exclusion, so a curated or user-hidden
+        // token can't eat one of a provider's slots and leave browse showing
+        // fewer than the cap in genuinely new tokens.
+        browseProviderTokens = TokenSelectionLogic.cappedPerProvider(
+            verifiedBreadth,
+            sourceKindByUniqueId: catalogSourceKinds
+        )
         // Held tokens lead the search pool. Excluding them (they're "already
         // added") makes a search for a token the vault holds return NOTHING,
         // which reads as the catalog being broken — search a held VULT on
@@ -165,7 +199,45 @@ class TokenSelectionViewModel: ObservableObject {
 struct TokenSelectionLogic {
     static let shared = TokenSelectionLogic()
 
+    /// How many of each provider's tokens browse shows before the user types.
+    /// The providers now return their lists best-first, so this is "the best N
+    /// per source", not an arbitrary truncation — 1inch alone offers ~2,200
+    /// tokens on Ethereum, which is not a list anyone scans.
+    ///
+    /// This bounds BROWSE only. `searchableTokens` keeps the full breadth, so
+    /// this can never be the reason a token isn't found.
+    static let browseTokensPerProvider = 20
+
+    /// How many matches a search renders. Unrelated to `browseTokensPerProvider`
+    /// — this one bounds the rendered result of a query, and the query has
+    /// already narrowed the pool.
+    static let searchResultLimit = 20
+
     private init() {}
+
+    /// Takes the first `limit` tokens of EACH provider, preserving order.
+    ///
+    /// Per-provider rather than global: a chain served by two providers shows up
+    /// to `2 × limit`, a chain served by one shows `limit`, and a slow or empty
+    /// provider can't be crowded out by a fast one. Grouping is by the provider
+    /// `kind` that won the token in the catalog merge.
+    ///
+    /// Tokens with no known source share a single bucket rather than escaping
+    /// the cap — an unattributed token should shrink the list, not uncap it.
+    static func cappedPerProvider(
+        _ tokens: [CoinMeta],
+        sourceKindByUniqueId: [String: String],
+        limit: Int = browseTokensPerProvider
+    ) -> [CoinMeta] {
+        var shownPerSource: [String: Int] = [:]
+        return tokens.filter { token in
+            let source = sourceKindByUniqueId[token.uniqueId] ?? .empty
+            let shown = shownPerSource[source, default: 0]
+            guard shown < limit else { return false }
+            shownPerSource[source] = shown + 1
+            return true
+        }
+    }
 
     /// The vault's held non-native coins for browse, enriched with catalog
     /// metadata (logo / priceProviderId) when the catalog carries the SAME token.
@@ -237,7 +309,7 @@ struct TokenSelectionLogic {
 
         let filtered = tokens
             .filter { $0.ticker.lowercased().contains(searchText.lowercased()) }
-            .prefix(20)
+            .prefix(Self.searchResultLimit)
 
         return Array(filtered)
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/TokenSelectionViewModel.swift
@@ -204,14 +204,9 @@ struct TokenSelectionLogic {
     /// per source", not an arbitrary truncation — 1inch alone offers ~2,200
     /// tokens on Ethereum, which is not a list anyone scans.
     ///
-    /// This bounds BROWSE only. `searchableTokens` keeps the full breadth, so
-    /// this can never be the reason a token isn't found.
+    /// This bounds BROWSE only. Search is bounded by nothing, so this can never
+    /// be the reason a token isn't found.
     static let browseTokensPerProvider = 20
-
-    /// How many matches a search renders. Unrelated to `browseTokensPerProvider`
-    /// — this one bounds the rendered result of a query, and the query has
-    /// already narrowed the pool.
-    static let searchResultLimit = 20
 
     private init() {}
 
@@ -296,22 +291,26 @@ struct TokenSelectionLogic {
         }
     }
 
-    /// Ticker matches over the whole local-first pool. Nothing is excluded here:
-    /// the pool already holds each token exactly once (deduped by `uniqueId`),
-    /// held tokens included, so search finds everything browse can show plus the
-    /// badged unverified long-tail. A same-ticker lookalike on a different
-    /// contract is a distinct `uniqueId` and is revealed alongside the real one —
-    /// that visibility is the point of the badge.
+    /// Ticker matches over the whole local-first pool. Nothing is excluded and
+    /// nothing is truncated: the pool already holds each token exactly once
+    /// (deduped by `uniqueId`), held tokens included, so search finds everything
+    /// browse can show plus the badged unverified long-tail. A same-ticker
+    /// lookalike on a different contract is a distinct `uniqueId` and is
+    /// revealed alongside the real one — that visibility is the point of the
+    /// badge.
+    ///
+    /// Results are unbounded on purpose. Browse is the shortlist; search is the
+    /// escape hatch, and a cap here would make a token unreachable purely
+    /// because too many other tickers contain the same substring — the failure
+    /// this whole surface exists to avoid. The grid renders lazily, so the cost
+    /// is bounded by what's on screen rather than by the match count.
     func filteredTokens(searchText: String, tokens: [CoinMeta]) -> [CoinMeta] {
         guard !searchText.isEmpty else {
             return []
         }
 
-        let filtered = tokens
-            .filter { $0.ticker.lowercased().contains(searchText.lowercased()) }
-            .prefix(Self.searchResultLimit)
-
-        return Array(filtered)
+        let query = searchText.lowercased()
+        return tokens.filter { $0.ticker.lowercased().contains(query) }
     }
 
     /// Local-first dedup merge: earlier lists win a `uniqueId` collision (so the

--- a/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
@@ -191,4 +191,188 @@ final class TokenSelectionPoolTests: XCTestCase {
                       "Curated presets render in browse regardless of the provider outcome")
         XCTAssertTrue(vm.browseProviderTokens.isEmpty, "No provider breadth when the fetch failed")
     }
+
+    // MARK: - browse is capped per provider; search is not
+
+    /// `count` provider tokens with distinct tickers/contracts, in rank order.
+    private func rankedBreadth(_ prefix: String, count: Int, sourceKind: String)
+    -> (metas: [CoinMeta], sourceKinds: [String: String], verification: [String: TokenVerification]) {
+        var metas: [CoinMeta] = []
+        var sourceKinds: [String: String] = [:]
+        var verification: [String: TokenVerification] = [:]
+        for index in 0..<count {
+            let token = meta("\(prefix)\(index)", contract: "0x\(prefix)\(index)")
+            metas.append(token)
+            sourceKinds[token.uniqueId] = sourceKind
+            verification[token.uniqueId] = .verified(source: sourceKind)
+        }
+        return (metas, sourceKinds, verification)
+    }
+
+    func testBrowseCapsProviderBreadthButSearchStillReachesTheLongTail() async {
+        // The reason the cap exists: 1inch offers ~2,200 tokens on Ethereum.
+        // Browse must be a shortlist; search must still reach every one of them.
+        let breadth = rankedBreadth("TKN", count: 600, sourceKind: "oneinch")
+        let vm = TokenSelectionViewModel(loadCatalog: { _ in
+            TokenSearchResult(
+                surfaceable: breadth.metas,
+                unverified: [],
+                verificationByUniqueId: breadth.verification,
+                sourceKindByUniqueId: breadth.sourceKinds
+            )
+        })
+
+        await vm.load(chain: .ethereum, vault: .example)
+
+        XCTAssertEqual(vm.browseProviderTokens.count, TokenSelectionLogic.browseTokensPerProvider,
+                       "Browse shows only the head of one provider's list")
+        XCTAssertEqual(vm.browseProviderTokens.first?.ticker, "TKN0", "Best-first order is preserved")
+        XCTAssertEqual(vm.browseProviderTokens.last?.ticker, "TKN19")
+
+        let rank500 = breadth.metas[499]
+        XCTAssertFalse(vm.browseProviderTokens.contains { $0.uniqueId == rank500.uniqueId },
+                       "A token ranked #500 is not in browse")
+
+        vm.searchText = "tkn499"
+        XCTAssertTrue(vm.searchedTokens.contains { $0.uniqueId == rank500.uniqueId },
+                      "…but search still finds it — capping must never be why a token isn't found")
+    }
+
+    func testBrowseCapsEachProviderIndependently() async {
+        let oneInch = rankedBreadth("ONE", count: 50, sourceKind: "oneinch")
+        let jupiter = rankedBreadth("JUP", count: 50, sourceKind: "jupiter")
+        let vm = TokenSelectionViewModel(loadCatalog: { _ in
+            TokenSearchResult(
+                surfaceable: oneInch.metas + jupiter.metas,
+                unverified: [],
+                verificationByUniqueId: oneInch.verification.merging(jupiter.verification) { first, _ in first },
+                sourceKindByUniqueId: oneInch.sourceKinds.merging(jupiter.sourceKinds) { first, _ in first }
+            )
+        })
+
+        await vm.load(chain: .ethereum, vault: .example)
+
+        let limit = TokenSelectionLogic.browseTokensPerProvider
+        XCTAssertEqual(vm.browseProviderTokens.count, limit * 2, "Two providers get a cap each, not one shared cap")
+        XCTAssertEqual(vm.browseProviderTokens.filter { $0.ticker.hasPrefix("ONE") }.count, limit)
+        XCTAssertEqual(vm.browseProviderTokens.filter { $0.ticker.hasPrefix("JUP") }.count, limit)
+    }
+
+    func testChainWithNoRemoteProviderIsUnaffectedByTheCap() async {
+        // A UTXO/Cosmos chain has only the bundled provider, so every curated
+        // token is already local — the cap must be a no-op there, not a
+        // truncation of the curated list.
+        let vm = TokenSelectionViewModel(loadCatalog: { _ in
+            TokenSearchResult(surfaceable: [], unverified: [], verificationByUniqueId: [:])
+        })
+
+        await vm.load(chain: .thorChain, vault: .example)
+
+        let curated = TokenSelectionLogic.shared.preExistingTokens(
+            chain: .thorChain, chainCoins: [], hiddenTokens: []
+        )
+        XCTAssertEqual(vm.preExistTokens.map { $0.uniqueId }, curated.map { $0.uniqueId },
+                       "The whole curated floor still renders")
+        XCTAssertTrue(vm.browseProviderTokens.isEmpty, "Nothing to cap without a remote provider")
+    }
+
+    // MARK: - cappedPerProvider (pure)
+
+    func testCapAppliesAfterLocalExclusionSoBrowseStillGetsAFullSlate() {
+        // Order matters: capping first would let curated/hidden tokens that get
+        // dropped later eat slots, leaving browse short of the cap.
+        let breadth = rankedBreadth("TKN", count: 40, sourceKind: "oneinch")
+        // The first 15 are curated presets already rendered locally.
+        let localIds = Set(breadth.metas.prefix(15).map { $0.uniqueId })
+
+        let afterExclusion = TokenSelectionLogic.shared.providerTokens(
+            breadth.metas, excludingLocal: localIds, hiddenTokens: []
+        )
+        let capped = TokenSelectionLogic.cappedPerProvider(
+            afterExclusion, sourceKindByUniqueId: breadth.sourceKinds
+        )
+
+        XCTAssertEqual(capped.count, TokenSelectionLogic.browseTokensPerProvider,
+                       "Browse still gets a full slate of genuinely new tokens")
+        XCTAssertEqual(capped.first?.ticker, "TKN15", "…starting after the locally-rendered ones")
+    }
+
+    func testBrowseStillGetsAFullSlateWhenTheProvidersHeadIsHeldOrHidden() async {
+        // The same invariant through the view model, which is where the ordering
+        // actually has to hold: capping before the local/hidden exclusion would
+        // let these leading entries eat slots and leave browse short.
+        let breadth = rankedBreadth("TKN", count: 60, sourceKind: "oneinch")
+        let vault = Vault(name: "held-and-hidden")
+        vault.coins = breadth.metas.prefix(10).map {
+            Coin(asset: $0, address: "0xwallet", hexPublicKey: "pub")
+        }
+        vault.hiddenTokens = breadth.metas[10..<15].map {
+            HiddenToken(chain: $0.chain, ticker: $0.ticker, contractAddress: $0.contractAddress)
+        }
+
+        let vm = TokenSelectionViewModel(loadCatalog: { _ in
+            TokenSearchResult(
+                surfaceable: breadth.metas,
+                unverified: [],
+                verificationByUniqueId: breadth.verification,
+                sourceKindByUniqueId: breadth.sourceKinds
+            )
+        })
+        await vm.load(chain: .ethereum, vault: vault)
+
+        XCTAssertEqual(vm.browseProviderTokens.count, TokenSelectionLogic.browseTokensPerProvider,
+                       "The 10 held + 5 hidden leading tokens must not eat browse slots")
+        XCTAssertEqual(vm.browseProviderTokens.first?.ticker, "TKN15")
+        XCTAssertFalse(vm.browseProviderTokens.contains { token in
+            vault.hiddenTokens.contains { $0.matches(token) }
+        }, "A user-hidden token never returns to browse")
+    }
+
+    // MARK: - retained catalog is scoped to its chain
+
+    func testAFailedLoadForAnotherChainDoesNotBrowseThePreviousChainsTokens() async {
+        // A failed fetch keeps the last-good catalog rather than blanking the
+        // list — but only for the same chain. Retaining it across a chain change
+        // would surface Ethereum tokens on a Solana picker.
+        struct FetchError: Error {}
+        let ethereumBreadth = rankedBreadth("ETHTKN", count: 30, sourceKind: "oneinch")
+
+        let vm = TokenSelectionViewModel(loadCatalog: { chain in
+            guard chain == .ethereum else { throw FetchError() }
+            return TokenSearchResult(
+                surfaceable: ethereumBreadth.metas,
+                unverified: [],
+                verificationByUniqueId: ethereumBreadth.verification,
+                sourceKindByUniqueId: ethereumBreadth.sourceKinds
+            )
+        })
+
+        await vm.load(chain: .ethereum, vault: .example)
+        XCTAssertFalse(vm.browseProviderTokens.isEmpty)
+
+        await vm.load(chain: .solana, vault: .example)
+
+        XCTAssertTrue(vm.browseProviderTokens.isEmpty, "The other chain's breadth must be discarded")
+        vm.searchText = "ethtkn"
+        XCTAssertTrue(vm.searchedTokens.isEmpty, "…and must not be searchable either")
+    }
+
+    func testCapKeepsTokensWithAnUnknownSourceBoundedRatherThanUncapped() {
+        let orphans = (0..<40).map { meta("ORPH\($0)", contract: "0xORPH\($0)") }
+
+        let capped = TokenSelectionLogic.cappedPerProvider(orphans, sourceKindByUniqueId: [:])
+
+        XCTAssertEqual(capped.count, TokenSelectionLogic.browseTokensPerProvider,
+                       "An unattributed token shares one bucket — it must not escape the cap")
+    }
+
+    func testCapIsANoOpBelowTheLimit() {
+        let breadth = rankedBreadth("TKN", count: 5, sourceKind: "oneinch")
+
+        let capped = TokenSelectionLogic.cappedPerProvider(
+            breadth.metas, sourceKindByUniqueId: breadth.sourceKinds
+        )
+
+        XCTAssertEqual(capped.map { $0.uniqueId }, breadth.metas.map { $0.uniqueId })
+    }
 }

--- a/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
@@ -238,6 +238,29 @@ final class TokenSelectionPoolTests: XCTestCase {
                       "…but search still finds it — capping must never be why a token isn't found")
     }
 
+    func testSearchIsNotTruncatedWhenManyTickersShareTheQuery() async {
+        // A capped result list would hide a token purely because 100 other
+        // tickers contain the same substring, which is the exact failure the
+        // search escape hatch exists to prevent.
+        // `ZQRY` rather than a real ticker stem, so the count isn't muddied by
+        // curated Ethereum presets that also match.
+        let breadth = rankedBreadth("ZQRY", count: 300, sourceKind: "oneinch")
+        let vm = TokenSelectionViewModel(loadCatalog: { _ in
+            TokenSearchResult(
+                surfaceable: breadth.metas,
+                unverified: [],
+                verificationByUniqueId: breadth.verification,
+                sourceKindByUniqueId: breadth.sourceKinds
+            )
+        })
+        await vm.load(chain: .ethereum, vault: .example)
+
+        vm.searchText = "zqry"
+
+        XCTAssertEqual(vm.searchedTokens.count, 300, "Every match is reachable, not just the first page")
+        XCTAssertEqual(vm.searchedTokens.first?.ticker, "ZQRY0", "Matches keep the providers' ranked order")
+    }
+
     func testBrowseCapsEachProviderIndependently() async {
         let oneInch = rankedBreadth("ONE", count: 50, sourceKind: "oneinch")
         let jupiter = rankedBreadth("JUP", count: 50, sourceKind: "jupiter")

--- a/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Wallet/TokenSelectionPoolTests.swift
@@ -97,6 +97,10 @@ final class TokenSelectionPoolTests: XCTestCase {
             verificationByUniqueId: [
                 verified.uniqueId: .verified(source: "CoinGecko"),
                 unverified.uniqueId: .unverified
+            ],
+            sourceKindByUniqueId: [
+                verified.uniqueId: "oneinch",
+                unverified.uniqueId: "oneinch"
             ]
         )
         let vm = TokenSelectionViewModel(loadCatalog: { _ in result })
@@ -130,7 +134,9 @@ final class TokenSelectionPoolTests: XCTestCase {
         vault.coins = [Coin(asset: vultMeta, address: "0xwallet", hexPublicKey: "pub")]
 
         let vm = TokenSelectionViewModel(loadCatalog: { _ in
-            TokenSearchResult(surfaceable: [], unverified: [], verificationByUniqueId: [:])
+            // Empty catalog: there is no provider token to attribute.
+            TokenSearchResult(surfaceable: [], unverified: [],
+                              verificationByUniqueId: [:], sourceKindByUniqueId: [:])
         })
         await vm.load(chain: .ethereum, vault: vault)
 
@@ -150,7 +156,8 @@ final class TokenSelectionPoolTests: XCTestCase {
             TokenSearchResult(
                 surfaceable: [usdc],
                 unverified: [],
-                verificationByUniqueId: [usdc.uniqueId: .verified(source: "CoinGecko")]
+                verificationByUniqueId: [usdc.uniqueId: .verified(source: "CoinGecko")],
+                sourceKindByUniqueId: [usdc.uniqueId: "oneinch"]
             )
         })
         await vm.load(chain: .ethereum, vault: .example)
@@ -286,7 +293,9 @@ final class TokenSelectionPoolTests: XCTestCase {
         // token is already local — the cap must be a no-op there, not a
         // truncation of the curated list.
         let vm = TokenSelectionViewModel(loadCatalog: { _ in
-            TokenSearchResult(surfaceable: [], unverified: [], verificationByUniqueId: [:])
+            // Empty catalog: there is no provider token to attribute.
+            TokenSearchResult(surfaceable: [], unverified: [],
+                              verificationByUniqueId: [:], sourceKindByUniqueId: [:])
         })
 
         await vm.load(chain: .thorChain, vault: .example)

--- a/VultisigApp/VultisigAppTests/Services/TokenCatalog/JupiterCatalogRankingTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TokenCatalog/JupiterCatalogRankingTests.swift
@@ -1,0 +1,99 @@
+//
+//  JupiterCatalogRankingTests.swift
+//  VultisigAppTests
+//
+//  Pins the Jupiter list's best-first ordering. `CatalogToken` carries no rank
+//  field, so the order the provider returns IS the ranking signal — a consumer
+//  that shows only the head of the list depends on it.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class JupiterCatalogRankingTests: XCTestCase {
+
+    /// `SolanaJupiterToken` is decode-only (it models a wire payload), so the
+    /// fixtures go through JSON — which also pins that `organicScore` decodes.
+    private func decode(_ json: String) throws -> [SolanaJupiterToken] {
+        try JSONDecoder().decode([SolanaJupiterToken].self, from: Data(json.utf8))
+    }
+
+    private func entry(_ symbol: String, organicScore: String) -> String {
+        """
+        { "id": "mint-\(symbol)", "name": "\(symbol)", "symbol": "\(symbol)",
+          "decimals": 6, "icon": "https://logo/\(symbol).png", "organicScore": \(organicScore) }
+        """
+    }
+
+    func testRanksByOrganicScoreDescending() throws {
+        let entries = [
+            entry("LOW", organicScore: "1.5"),
+            entry("HIGH", organicScore: "99.5"),
+            entry("MID", organicScore: "50")
+        ]
+        let tokens = try decode("[\(entries.joined(separator: ","))]")
+
+        let ranked = SolanaJupiterToken.rankedForCatalog(tokens)
+
+        XCTAssertEqual(ranked.map { $0.symbol }, ["HIGH", "MID", "LOW"])
+    }
+
+    func testMissingOrganicScoreRanksLastWithoutCrashing() throws {
+        let missing = """
+        { "id": "mint-NOSCORE", "name": "NOSCORE", "symbol": "NOSCORE", "decimals": 6 }
+        """
+        let tokens = try decode("[\(missing), \(entry("ZERO", organicScore: "0"))]")
+
+        let ranked = SolanaJupiterToken.rankedForCatalog(tokens)
+
+        XCTAssertEqual(ranked.map { $0.symbol }, ["ZERO", "NOSCORE"],
+                       "A missing score ranks below even a real zero")
+        XCTAssertNil(tokens.first(where: { $0.symbol == "NOSCORE" })?.organicScore)
+    }
+
+    func testTiesKeepJupitersOwnOrder() throws {
+        // ~92% of the verified list scores 0. A non-stable sort would reshuffle
+        // that tail between fetches, so equal scores must hold their input order.
+        let tokens = try decode("[\(entry("A", organicScore: "0")), \(entry("B", organicScore: "0")), \(entry("C", organicScore: "0"))]")
+
+        XCTAssertEqual(SolanaJupiterToken.rankedForCatalog(tokens).map { $0.symbol }, ["A", "B", "C"])
+    }
+
+    func testHighMarketCapWithoutOrganicVolumeDoesNotOutrankRealTokens() throws {
+        // Why the rank is `organicScore` and not `mcap`: the live list's mcap
+        // head is dominated by tokenised-equity wrappers carrying a
+        // billion-dollar paper cap against four figures of liquidity, which is
+        // exactly the entry a browse list must not lead with.
+        let paperGiant = """
+        { "id": "mint-PAPER", "name": "PAPER", "symbol": "PAPER", "decimals": 6,
+          "mcap": 13404117224, "liquidity": 57469, "organicScore": 0 }
+        """
+        let realToken = """
+        { "id": "mint-USDC", "name": "USDC", "symbol": "USDC", "decimals": 6,
+          "mcap": 7779892140, "liquidity": 351575478, "organicScore": 100 }
+        """
+        let tokens = try decode("[\(paperGiant), \(realToken)]")
+
+        XCTAssertEqual(SolanaJupiterToken.rankedForCatalog(tokens).map { $0.symbol }, ["USDC", "PAPER"])
+    }
+
+    // MARK: - the transform the service actually calls
+
+    func testPayloadToCatalogMetasIsRankedAndMapped() throws {
+        // Pins the ranking on the path `SolanaService.fetchSolanaJupiterTokenList`
+        // uses: ranking only inside `rankedForCatalog` would let the service drop
+        // the call and still pass every test above.
+        let entries = [
+            entry("TAIL", organicScore: "0"),
+            entry("BEST", organicScore: "100")
+        ]
+
+        let metas = try SolanaJupiterToken.rankedCatalogMetas(from: Data("[\(entries.joined(separator: ","))]".utf8))
+
+        XCTAssertEqual(metas.map { $0.ticker }, ["BEST", "TAIL"], "The payload transform ranks before mapping")
+        XCTAssertEqual(metas.first?.chain, .solana)
+        XCTAssertEqual(metas.first?.contractAddress, "mint-BEST")
+        XCTAssertEqual(metas.first?.decimals, 6)
+        XCTAssertFalse(metas.first?.isNativeToken ?? true)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/TokenCatalog/OneInchCatalogRankingTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TokenCatalog/OneInchCatalogRankingTests.swift
@@ -1,0 +1,75 @@
+//
+//  OneInchCatalogRankingTests.swift
+//  VultisigAppTests
+//
+//  Pins the 1inch whitelist's best-tier-first ordering. `CatalogToken` carries no
+//  rank field, so the order the provider returns IS the quality signal — a
+//  consumer that shows only the head of the list depends on it.
+//
+//  This is a quality TIER, not a ranking: `/swap/v6.0/{chain}/tokens` exposes no
+//  volume, market-cap or liquidity field, so 1inch's own tag curation is all
+//  there is to sort by.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class OneInchCatalogRankingTests: XCTestCase {
+
+    private func token(_ symbol: String, tags: [String]?) -> OneInchToken {
+        OneInchToken(address: "0x\(symbol)", symbol: symbol, name: symbol,
+                     decimals: 18, logoURI: nil, providers: nil, tags: tags)
+    }
+
+    func testTiersOrderBluechipThenPeggedThenConnectorThenRest() {
+        let unclassified = token("RANDOM", tags: ["tokens", "RWA"])
+        let connector = token("CONN", tags: ["connector", "crosschain"])
+        let pegged = token("DAI", tags: ["PEG:USD", "stablecoin"])
+        let bluechip = token("WBTC", tags: ["bluechip", "connector", "PEG:BTC"])
+
+        let ranked = OneInchToken.rankedForCatalog([unclassified, connector, pegged, bluechip])
+
+        XCTAssertEqual(ranked.map { $0.symbol }, ["WBTC", "DAI", "CONN", "RANDOM"])
+    }
+
+    func testBluechipWinsWhenATokenCarriesSeveralTierTags() {
+        // Most bluechips are also connectors and often pegged; the strongest tag
+        // must decide the tier rather than whichever is checked first by accident.
+        XCTAssertEqual(token("WETH", tags: ["connector", "PEG:ETH", "bluechip"]).catalogQualityTier, .bluechip)
+        XCTAssertEqual(token("USDC", tags: ["connector", "PEG:USD"]).catalogQualityTier, .pegged)
+        XCTAssertEqual(token("LINK", tags: ["connector", "defi"]).catalogQualityTier, .connector)
+    }
+
+    func testAnyPegPrefixCountsNotJustUSD() {
+        XCTAssertEqual(token("stETH", tags: ["PEG:ETH"]).catalogQualityTier, .pegged)
+        XCTAssertEqual(token("EURS", tags: ["PEG:EUR"]).catalogQualityTier, .pegged)
+        XCTAssertEqual(token("tBTC", tags: ["PEG:BTC"]).catalogQualityTier, .pegged)
+    }
+
+    func testUntaggedTokenIsUnclassifiedNotACrash() {
+        XCTAssertEqual(token("NOTAGS", tags: nil).catalogQualityTier, .unclassified)
+        XCTAssertEqual(token("EMPTY", tags: []).catalogQualityTier, .unclassified)
+    }
+
+    func testTiesKeepTheCallersOrder() {
+        // The provider hands the list in name order; within a tier 1inch tells us
+        // nothing, so that order must survive rather than being reshuffled.
+        let a = token("AAA", tags: ["bluechip"])
+        let b = token("BBB", tags: ["bluechip"])
+        let c = token("CCC", tags: ["bluechip"])
+
+        XCTAssertEqual(OneInchToken.rankedForCatalog([a, b, c]).map { $0.symbol }, ["AAA", "BBB", "CCC"])
+    }
+
+    func testRankingIsIndependentOfTheRiskDowngrade() {
+        // Tier and trust are orthogonal signals: a RISK-flagged bluechip still
+        // ranks high, and is still withheld from browse by `.unverified`.
+        let risky = token("SUS", tags: ["bluechip", "RISK:suspicious"])
+        let clean = token("PLAIN", tags: ["tokens"])
+
+        let ranked = OneInchToken.rankedForCatalog([clean, risky])
+
+        XCTAssertEqual(ranked.map { $0.symbol }, ["SUS", "PLAIN"])
+        XCTAssertEqual(risky.toCatalogToken(chain: .ethereum, sourceKind: "oneinch").verification, .unverified)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/TokenCatalog/TokenCatalogDiskCacheTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/TokenCatalog/TokenCatalogDiskCacheTests.swift
@@ -57,6 +57,25 @@ final class TokenCatalogDiskCacheTests: XCTestCase {
         XCTAssertTrue(loaded?.allSatisfy { $0.autoSurfaces } ?? false, "Verified tiers still auto-surface offline")
     }
 
+    func testRoundTripPreservesTheProvidersRankedOrder() {
+        // Providers return their lists best-first and `CatalogToken` carries no
+        // rank field, so order IS the ranking. A snapshot that round-tripped
+        // through a set or re-sorted would silently degrade the offline browse
+        // list to an arbitrary 20 tokens.
+        let cache = makeCache()
+        let ranked = (0..<50).map {
+            CatalogToken(meta: coin("TKN\($0)", "0x\($0)"),
+                         verification: .verified(source: "1inch"),
+                         sourceKind: "oneinch")
+        }
+        cache.save(ranked, chain: .ethereum)
+
+        let loaded = cache.load(chain: .ethereum)
+
+        XCTAssertEqual(loaded?.map { $0.meta.ticker }, ranked.map { $0.meta.ticker },
+                       "The offline snapshot must serve the list in the provider's ranked order")
+    }
+
     func testLoadAbsentChainReturnsNil() {
         let cache = makeCache()
         XCTAssertNil(cache.load(chain: .solana))


### PR DESCRIPTION
## Description

Fixes #4979

Follow-up to #4954. Two defects on the add-token picker, the second of which predates that PR.

**Browse was unbounded** — the entire verified provider breadth rendered on open: ~2,200 tokens from 1inch on Ethereum, 4,319 from Jupiter on Solana, in whatever order the provider happened to return. Ethereum opened on `$MBG, ZRX, 0x0, 0xBTC`; Base on `$OLIVIA2.0`.

**Search rendered at most 20 matches** — `filteredTokens` ended in `.prefix(20)`, with no second page. That is on `main` today and predates the catalog work; it was survivable with a few dozen curated presets and is not survivable with thousands. Searching a common substring like `US` returned 20 arbitrary hits out of several hundred, dropping exactly the badged lookalikes the unverified surface exists to reveal.

They interact: bounding browse is only safe if search genuinely reaches everything.

Now: **browse = held + curated presets + top 20 per provider; search is unbounded.**

## Ranking — measured, not assumed

Providers return their list already ranked; the browse layer takes the first 20 per `sourceKind`. No score field was added to `CatalogToken` — ordering carries the ranking, so provider-specific logic stays next to the provider-specific data that justifies it.

**Jupiter → `organicScore`, not `mcap`.** The `/jup/tokens/v2/tag?query=verified` response already carried `mcap`, `liquidity`, `organicScore`, `holderCount` and `fdv`; iOS decoded none of them. Across the live 4,319-token response:

| | coverage | top-20 quality |
|---|---|---|
| `mcap` | 65.8% | polluted — **tSAT** #2 ($13.4B cap, **$57K** liquidity), **HONx** #5 ($1.76B, **zero** liquidity), DHRx, PYPLx — all scoring 0, all outranking ETH, WBTC and PYUSD |
| `organicScore` | **100%** | USDC, USDT, SOL, ETH, JitoSOL, JUP, cbBTC, WBTC, PYUSD, mSOL |

92% of the list scores exactly 0, so the sort is stable — the tail does not reshuffle between fetches.

**1inch → tag tiers.** `/tokens` exposes no ranking field at all, so this ranks by 1inch's own curation: `bluechip` → `PEG:*` → `connector` → rest. Commented in the code as a *quality tier*, not a ranking, because we do not have one.

Post-tier distribution (mutually exclusive, best tier wins):

| chain | total | bluechip | PEG | connector | other |
|---|---:|---:|---:|---:|---:|
| Ethereum | 2,225 | 41 | 178 | 806 | 1,200 |
| BSC | 1,596 | 9 | 33 | 461 | 1,093 |
| Arbitrum | 825 | 8 | 63 | 178 | 576 |
| Polygon | 194 | 7 | 30 | 150 | 7 |
| Base | 165 | 9 | 39 | 77 | 40 |

Resulting browse heads: Ethereum `1INCH, AAVE, LINK, COMP, CRV, WBTC`; Base `USDT, USDC, WETH, DAI, EURC, SOL`.

## Correctness

- The cap applies to `browseProviderTokens` **only**. `searchableTokens` keeps the full breadth, with a test pinning that a token outside the top N is absent from browse and findable by search — capping must never be *why* something can't be found.
- Cap is applied **after** the local/hidden exclusion, so a curated or already-held token cannot consume one of the 20 slots.
- Per provider, not global — grouped by `sourceKind`.
- Chains with only `BundledTokensProvider` are unaffected.
- Disk-cache order is preserved, so the ranking survives the offline path rather than silently degrading to arbitrary.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

**Search-cap removal is a behaviour change beyond the original ask**, called out for review: the cap was raised nowhere — it was removed. Any bound reintroduces the same unreachability at a different threshold, and the grid is a `LazyVGrid` so cost tracks what's on screen rather than the match count. Disagreement welcome; this is the one judgement call here.

Two comment corrections fell out along the way: `JupiterCatalogProvider`'s header claimed `coingeckoId` is preserved into `priceProviderId`, but the v2 endpoints return no `extensions` object at all, so it is always empty and `SolanaJupiterTokenExtensions` is effectively dead (comment fixed, model left alone); and both provider headers credited `SwapTokenListCache` for wallet-path freshness, which it does not provide.

Known and deliberately not addressed: `SwapCoinSelectionViewModel` re-sorts by fiat balance and discards provider rank. That is pre-existing, intentional (the swap picker is balance-ordered), and not made worse here.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4979
- **Confidence**: high on the ranking evidence and the browse/search split, both measured against live provider responses and covered by tests
- **Needs human review for**: the unbounded-search decision above, and whether 20 per provider is the right number once it's on screen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced token catalog ordering using provider quality signals (including Jupiter organic ranking and 1inch tier curation).
  - Search now returns results across the full shortlist (no arbitrary cap) while keeping empty queries empty.
  - Browse results are more fairly capped per provider category, while preserving curated local tokens.
  - Token source attribution is retained to support clearer catalog organization.
  - Catalog rank order is preserved across disk caching.
- **Bug Fixes**
  - Prevented catalog data from one blockchain appearing on another after failed loads.
- **Tests**
  - Added/expanded regression coverage for ranking, ordering, search reach, browse capping, and cache round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->