### PR TITLE
feat(review): ask for an App Store review after a confirmed transaction

### DIFF
--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -216,6 +216,13 @@ extension VultisigApp {
                 // funnel can read them without touching @Model.
                 CustomRPCStore.shared.reloadFromStore()
 
+                // Stamp the install date the App Store review throttle waits
+                // on. Idempotent, and deliberately placed at launch rather
+                // than at the first confirmed transaction: the 7-day rule has
+                // to be measured from when the user got the app, not from
+                // when they first happened to transact.
+                AppReviewService.shared.seedInstallDateIfNeeded()
+
                 if ProcessInfo.processInfo.isiOSAppOnMac {
                     continueLogin()
                 }

--- a/VultisigApp/VultisigApp/Components/TransactionDone/DoneScreen.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/DoneScreen.swift
@@ -24,6 +24,9 @@
 //
 
 import SwiftUI
+#if os(iOS)
+import StoreKit
+#endif
 
 struct DoneScreen<
     TokenContent: View,
@@ -33,6 +36,10 @@ struct DoneScreen<
     let input: TransactionDonePayload
 
     @StateObject private var statusService: DoneStatusService
+
+    #if os(iOS)
+    @Environment(\.requestReview) private var requestReview
+    #endif
 
     /// Nav-bar title for the screen. Defaults to "Done"; the initiator
     /// Send/Swap flows pass "Overview" so the in-place keysign→overview
@@ -145,23 +152,61 @@ struct DoneScreen<
         }
         .onDisappear { statusService.stop() }
         .task { await revealAfterHold() }
+        #if os(iOS)
+        .onChange(of: statusService.status) { _, _ in
+            handleConfirmedTransactionIfNeeded()
+        }
+        #endif
     }
 
     /// Holds the centered hero for `revealDelay`, then springs to the
     /// expanded layout. Reduce Motion skips the hold and the animation.
     private func revealAfterHold() async {
-        guard !reduceMotion else {
+        if reduceMotion {
             revealPhase = .expanded
-            return
+        } else {
+            try? await Task.sleep(nanoseconds: revealDelay)
+            // Respect `.task` cancellation on disappear — don't flip state /
+            // animate a view that's already gone (e.g. after `restart()`).
+            guard !Task.isCancelled else { return }
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.85)) {
+                revealPhase = .expanded
+            }
         }
-        try? await Task.sleep(nanoseconds: revealDelay)
-        // Respect `.task` cancellation on disappear — don't flip state /
-        // animate a view that's already gone (e.g. after `restart()`).
-        guard !Task.isCancelled else { return }
-        withAnimation(.spring(response: 0.55, dampingFraction: 0.85)) {
-            revealPhase = .expanded
-        }
+        #if os(iOS)
+        // Covers the case where the poller seeds `.confirmed` before the
+        // screen ever appears, so `onChange` never fires.
+        handleConfirmedTransactionIfNeeded()
+        #endif
     }
+
+    #if os(iOS)
+    /// Counts a confirmed transaction and, if the throttle allows, asks for an
+    /// App Store review.
+    ///
+    /// Deliberately safe to call repeatedly: this is the one place in the app
+    /// where "confirmed" is decided for every flow, and the view is not
+    /// guaranteed to observe it once — a re-render, a re-entry, or the poller
+    /// re-reporting a terminal status all land here again. `AppReviewService`
+    /// keys the tally on the transaction hash so the extra calls are inert.
+    ///
+    /// Waiting for `isExpanded` keeps the system sheet from landing on top of
+    /// the hero settle animation.
+    ///
+    /// The ask is recorded even though StoreKit may silently decline to show
+    /// anything — the API reports nothing back, so the only safe assumption is
+    /// that the ask was spent.
+    private func handleConfirmedTransactionIfNeeded() {
+        guard statusService.status == .confirmed, isExpanded else { return }
+
+        let service = AppReviewService.shared
+        service.recordConfirmedTransaction(id: input.hash)
+
+        guard service.shouldRequestReview() else { return }
+        service.recordPromptShown()
+        requestReview()
+    }
+    #endif
 }
 
 // MARK: - Default slot constructors

--- a/VultisigApp/VultisigApp/Components/TransactionDone/DoneScreen.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/DoneScreen.swift
@@ -39,6 +39,12 @@ struct DoneScreen<
 
     #if os(iOS)
     @Environment(\.requestReview) private var requestReview
+
+    /// Flipped once the arrival animation has actually finished. The review
+    /// sheet waits on this rather than on `isExpanded`, which only says the
+    /// spring has been *scheduled* — it flips synchronously inside
+    /// `withAnimation`, half a second before the hero has arrived.
+    @State private var hasSettled = false
     #endif
 
     /// Nav-bar title for the screen. Defaults to "Done"; the initiator
@@ -68,6 +74,11 @@ struct DoneScreen<
     /// then the hero holds ~0.8s — so the crossfade and the settle-up read
     /// as two sequential beats instead of overlapping into one blur.
     private let revealDelay: UInt64 = 1_150_000_000 // ≈ 0.35s crossfade + 0.8s hold
+
+    /// Response of the settle spring, and so roughly how long the hero takes
+    /// to arrive. Named rather than inlined because the review prompt has to
+    /// wait it out, and a second literal would drift away from the animation.
+    private let settleResponse: Double = 0.55
 
     /// Construct via `DoneStatusServiceFactory`. The
     /// `statusService` autoclosure is evaluated lazily by `@StateObject`
@@ -169,13 +180,22 @@ struct DoneScreen<
             // Respect `.task` cancellation on disappear — don't flip state /
             // animate a view that's already gone (e.g. after `restart()`).
             guard !Task.isCancelled else { return }
-            withAnimation(.spring(response: 0.55, dampingFraction: 0.85)) {
+            withAnimation(.spring(response: settleResponse, dampingFraction: 0.85)) {
                 revealPhase = .expanded
             }
+            #if os(iOS)
+            // `withAnimation` returns as soon as the spring is scheduled, so
+            // wait it out before anything may present over the settling hero.
+            try? await Task.sleep(nanoseconds: UInt64(settleResponse * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            #endif
         }
         #if os(iOS)
-        // Covers the case where the poller seeds `.confirmed` before the
-        // screen ever appears, so `onChange` never fires.
+        hasSettled = true
+        // The only call site that can see a `.confirmed` which `onChange`
+        // never delivers — one the poller seeded before the screen appeared —
+        // and the one that retries a `.confirmed` that arrived mid-reveal and
+        // was turned away for not having settled yet.
         handleConfirmedTransactionIfNeeded()
         #endif
     }
@@ -188,22 +208,16 @@ struct DoneScreen<
     /// where "confirmed" is decided for every flow, and the view is not
     /// guaranteed to observe it once — a re-render, a re-entry, or the poller
     /// re-reporting a terminal status all land here again. `AppReviewService`
-    /// keys the tally on the transaction hash so the extra calls are inert.
+    /// keys everything on the transaction hash, so the extra calls are inert
+    /// and, importantly, cannot spend an ask on a transaction already counted.
     ///
-    /// Waiting for `isExpanded` keeps the system sheet from landing on top of
+    /// Waiting for `hasSettled` keeps the system sheet from landing on top of
     /// the hero settle animation.
-    ///
-    /// The ask is recorded even though StoreKit may silently decline to show
-    /// anything — the API reports nothing back, so the only safe assumption is
-    /// that the ask was spent.
     private func handleConfirmedTransactionIfNeeded() {
-        guard statusService.status == .confirmed, isExpanded else { return }
-
-        let service = AppReviewService.shared
-        service.recordConfirmedTransaction(id: input.hash)
-
-        guard service.shouldRequestReview() else { return }
-        service.recordPromptShown()
+        guard statusService.status == .confirmed, hasSettled else { return }
+        guard AppReviewService.shared.claimReviewPrompt(forConfirmedTransaction: input.hash) else {
+            return
+        }
         requestReview()
     }
     #endif

--- a/VultisigApp/VultisigApp/Core/Services/Review/AppReviewPolicy.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Review/AppReviewPolicy.swift
@@ -1,0 +1,74 @@
+//
+//  AppReviewPolicy.swift
+//  VultisigApp
+//
+//  Decides whether the app may ask for an App Store review right now.
+//
+//  Deliberately a pure function over (state, now) with no persistence,
+//  no clock and no StoreKit: the throttle is the part that carries real
+//  cost when it is wrong — asking too early burns the system's ~3
+//  prompts/year budget and our own 120-day window — so it is kept
+//  isolated and exhaustively unit-tested. `AppReviewService` owns the
+//  storage and feeds a snapshot in.
+//
+//  All three windows are lower bounds, so every comparison is `>=`:
+//  hitting exactly the threshold is eligible.
+//
+
+import Foundation
+
+/// Snapshot of the persisted review state the policy decides over.
+struct AppReviewState: Equatable {
+    /// Lifetime count of distinct on-chain-confirmed transactions the user
+    /// has watched complete.
+    var confirmedTransactionCount: Int
+
+    /// When the app first launched on this device. `nil` until seeded,
+    /// which blocks the prompt — a missing install date is treated as
+    /// "just installed", never as "installed long ago".
+    var installDate: Date?
+
+    /// When the review sheet was last requested, or `nil` if never.
+    var lastPromptDate: Date?
+}
+
+enum AppReviewPolicy {
+    /// Enough completed transactions that the user has a formed opinion.
+    static let minimumConfirmedTransactions = 3
+
+    /// Enough time on the device that the rating reflects the app, not the
+    /// onboarding.
+    static let minimumTimeSinceInstall: TimeInterval = 7 * 24 * 60 * 60
+
+    /// Cooldown between two asks. Well above Apple's own ~3-per-year cap so
+    /// we never spend the budget faster than the system would allow.
+    static let minimumTimeBetweenPrompts: TimeInterval = 120 * 24 * 60 * 60
+
+    /// Whether the review sheet may be requested at `now`.
+    ///
+    /// `now` is injected so the boundaries can be pinned deterministically;
+    /// production callers pass the current date.
+    static func shouldRequestReview(state: AppReviewState, now: Date) -> Bool {
+        guard state.confirmedTransactionCount >= minimumConfirmedTransactions else {
+            return false
+        }
+
+        // A missing install date means the seeding step has not run yet.
+        // Fail closed rather than treating "unknown" as "old enough".
+        guard let installDate = state.installDate else {
+            return false
+        }
+
+        // A negative interval (device clock moved backwards, or a restored
+        // backup carrying a future-dated seed) also fails this check, which
+        // is the conservative direction.
+        guard now.timeIntervalSince(installDate) >= minimumTimeSinceInstall else {
+            return false
+        }
+
+        guard let lastPromptDate = state.lastPromptDate else {
+            return true
+        }
+        return now.timeIntervalSince(lastPromptDate) >= minimumTimeBetweenPrompts
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
@@ -109,6 +109,27 @@ final class AppReviewService {
 
     // MARK: - Decision
 
+    /// Records a just-confirmed transaction and reports whether this is the
+    /// moment to show the review sheet, consuming the ask when it is.
+    ///
+    /// Returns `true` only when the call counted a *new* transaction **and**
+    /// the throttle allows an ask. Requiring a new count is what stops an ask
+    /// being spent without a transaction behind it — a repeat observation of
+    /// a hash already counted, or a done screen that carries no hash of its
+    /// own, as custom-message signing does. Both otherwise arrive at a
+    /// throttle that is already satisfied from earlier transactions and would
+    /// pass.
+    ///
+    /// Composed here rather than at the call site so the ordering — count
+    /// first, then decide, then spend — is covered by unit tests instead of
+    /// living in a view.
+    func claimReviewPrompt(forConfirmedTransaction id: String) -> Bool {
+        guard recordConfirmedTransaction(id: id) else { return false }
+        guard shouldRequestReview() else { return false }
+        recordPromptShown()
+        return true
+    }
+
     /// Whether the throttle currently allows asking for a review.
     func shouldRequestReview() -> Bool {
         AppReviewPolicy.shouldRequestReview(state: state, now: now())

--- a/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Review/AppReviewService.swift
@@ -1,0 +1,140 @@
+//
+//  AppReviewService.swift
+//  VultisigApp
+//
+//  Owns the persisted inputs to `AppReviewPolicy`: when the app was
+//  installed, how many distinct transactions the user has watched
+//  confirm, and when we last asked for a review.
+//
+//  Stored in `UserDefaults` rather than SwiftData on purpose — this is
+//  preference-shaped device state, not model data. It must survive
+//  independently of any vault, since a user can delete every vault and
+//  restore another one without that resetting how often we may ask.
+//
+//  Idempotency is the whole point of `recordConfirmedTransaction(id:)`.
+//  The done screen can observe the same `.confirmed` status more than
+//  once — a re-render, a re-entry, or the poller re-reporting a terminal
+//  status — so the tally is keyed on the transaction hash and a bounded
+//  ring of already-counted hashes is kept alongside it. Counting per
+//  observation would inflate the tally and fire the prompt early, which
+//  on a 120-day cooldown is not a cheap mistake.
+//
+
+import Foundation
+
+@MainActor
+final class AppReviewService {
+    static let shared = AppReviewService()
+
+    /// How many recently-counted transaction hashes are retained for the
+    /// duplicate check. The ring only has to be long enough that a hash is
+    /// still remembered while the same done screen can re-report it, so a
+    /// session's worth of transactions is already generous; the bound exists
+    /// so the key cannot grow without limit over the lifetime of the install.
+    /// Once the ring does wrap, the tally is necessarily far past the
+    /// 3-transaction threshold, where an extra increment changes nothing.
+    static let countedTransactionIDLimit = 100
+
+    private enum Key {
+        static let installDate = "appReview.installDate"
+        static let confirmedTransactionCount = "appReview.confirmedTransactionCount"
+        static let lastPromptDate = "appReview.lastPromptDate"
+        static let countedTransactionIDs = "appReview.countedTransactionIDs"
+    }
+
+    private let defaults: UserDefaults
+    private let now: () -> Date
+    private let logger = Log.app.service
+
+    /// `now` is injected so tests can pin the 7-day / 120-day boundaries
+    /// without sleeping; production callers take the default.
+    init(defaults: UserDefaults = .standard, now: @escaping () -> Date = { Date() }) {
+        self.defaults = defaults
+        self.now = now
+    }
+
+    // MARK: - Install date
+
+    /// Stamps the install date the first time it is called and never again.
+    ///
+    /// Users upgrading into the first build that ships this are stamped with
+    /// the upgrade date, not their real install date, so they serve the full
+    /// 7-day wait. That is deliberate: the alternative — backdating so the
+    /// rule is already satisfied — would fire the prompt at the entire
+    /// existing base within days of the release, which is exactly the
+    /// audience whose ratings we least want to spend on a rushed ask.
+    func seedInstallDateIfNeeded() {
+        guard defaults.object(forKey: Key.installDate) == nil else { return }
+        defaults.set(now().timeIntervalSince1970, forKey: Key.installDate)
+        logger.info("[AppReview] Seeded install date")
+    }
+
+    // MARK: - Recording
+
+    /// Counts a confirmed transaction towards the review threshold, at most
+    /// once per transaction hash.
+    ///
+    /// - Parameter id: the transaction hash. An empty id carries no identity,
+    ///   so it cannot be de-duplicated and is not counted — undercounting is
+    ///   the safe direction here.
+    /// - Returns: whether this call actually incremented the tally.
+    @discardableResult
+    func recordConfirmedTransaction(id: String) -> Bool {
+        guard !id.isEmpty else { return false }
+
+        var counted = countedTransactionIDs
+        guard !counted.contains(id) else { return false }
+
+        counted.append(id)
+        if counted.count > Self.countedTransactionIDLimit {
+            counted.removeFirst(counted.count - Self.countedTransactionIDLimit)
+        }
+        defaults.set(counted, forKey: Key.countedTransactionIDs)
+
+        let updatedCount = confirmedTransactionCount + 1
+        defaults.set(updatedCount, forKey: Key.confirmedTransactionCount)
+        logger.info("[AppReview] Confirmed transaction count is now \(updatedCount, privacy: .public)")
+        return true
+    }
+
+    /// Records that the review sheet was requested.
+    ///
+    /// Called whenever `requestReview` is invoked, even though StoreKit may
+    /// silently decline to show anything — the API reports nothing back, so
+    /// the only safe assumption is that the ask was spent.
+    func recordPromptShown() {
+        defaults.set(now().timeIntervalSince1970, forKey: Key.lastPromptDate)
+        logger.info("[AppReview] Recorded review prompt request")
+    }
+
+    // MARK: - Decision
+
+    /// Whether the throttle currently allows asking for a review.
+    func shouldRequestReview() -> Bool {
+        AppReviewPolicy.shouldRequestReview(state: state, now: now())
+    }
+
+    /// Current persisted snapshot, as the policy sees it.
+    var state: AppReviewState {
+        AppReviewState(
+            confirmedTransactionCount: confirmedTransactionCount,
+            installDate: date(forKey: Key.installDate),
+            lastPromptDate: date(forKey: Key.lastPromptDate)
+        )
+    }
+
+    // MARK: - Storage
+
+    private var confirmedTransactionCount: Int {
+        defaults.integer(forKey: Key.confirmedTransactionCount)
+    }
+
+    private var countedTransactionIDs: [String] {
+        defaults.stringArray(forKey: Key.countedTransactionIDs) ?? []
+    }
+
+    private func date(forKey key: String) -> Date? {
+        guard defaults.object(forKey: key) != nil else { return nil }
+        return Date(timeIntervalSince1970: defaults.double(forKey: key))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/Review/AppReviewPolicyTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/Review/AppReviewPolicyTests.swift
@@ -1,0 +1,199 @@
+//
+//  AppReviewPolicyTests.swift
+//  VultisigAppTests
+//
+//  Exhaustive coverage of the review throttle: each rule in isolation,
+//  each boundary (exactly 3 transactions, exactly 7 days, exactly 120
+//  days) and the combined gate. Every date is pinned — the policy takes
+//  `now` as a parameter, so nothing here sleeps.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class AppReviewPolicyTests: XCTestCase {
+
+    private let day: TimeInterval = 24 * 60 * 60
+    private let installed = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// A state that satisfies every rule, so each test can break exactly one.
+    private func eligibleState() -> AppReviewState {
+        AppReviewState(
+            confirmedTransactionCount: 3,
+            installDate: installed,
+            lastPromptDate: nil
+        )
+    }
+
+    private func now(daysAfterInstall days: Double) -> Date {
+        installed.addingTimeInterval(days * day)
+    }
+
+    // MARK: - Combined gate
+
+    func testPromptsWhenEveryRuleIsSatisfied() {
+        XCTAssertTrue(
+            AppReviewPolicy.shouldRequestReview(
+                state: eligibleState(),
+                now: now(daysAfterInstall: 7)
+            )
+        )
+    }
+
+    func testDoesNotPromptWhenEveryRuleFails() {
+        let state = AppReviewState(
+            confirmedTransactionCount: 0,
+            installDate: installed,
+            lastPromptDate: installed
+        )
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 1))
+        )
+    }
+
+    // MARK: - Transaction count
+
+    func testDoesNotPromptBelowTransactionThreshold() {
+        var state = eligibleState()
+        state.confirmedTransactionCount = 2
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
+        )
+    }
+
+    func testPromptsAtExactlyThreeTransactions() {
+        var state = eligibleState()
+        state.confirmedTransactionCount = 3
+        XCTAssertTrue(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
+        )
+    }
+
+    func testPromptsAboveTransactionThreshold() {
+        var state = eligibleState()
+        state.confirmedTransactionCount = 50
+        XCTAssertTrue(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
+        )
+    }
+
+    func testDoesNotPromptWithZeroTransactions() {
+        var state = eligibleState()
+        state.confirmedTransactionCount = 0
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
+        )
+    }
+
+    // MARK: - Install age
+
+    func testDoesNotPromptBeforeSevenDaysSinceInstall() {
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(
+                state: eligibleState(),
+                now: installed.addingTimeInterval(7 * day - 1)
+            )
+        )
+    }
+
+    func testPromptsAtExactlySevenDaysSinceInstall() {
+        XCTAssertTrue(
+            AppReviewPolicy.shouldRequestReview(
+                state: eligibleState(),
+                now: installed.addingTimeInterval(7 * day)
+            )
+        )
+    }
+
+    func testDoesNotPromptWithoutAnInstallDate() {
+        var state = eligibleState()
+        state.installDate = nil
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 365))
+        )
+    }
+
+    func testDoesNotPromptWhenInstallDateIsInTheFuture() {
+        var state = eligibleState()
+        state.installDate = now(daysAfterInstall: 30)
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: installed)
+        )
+    }
+
+    // MARK: - Prompt cooldown
+
+    func testDoesNotPromptBeforeOneHundredTwentyDaysSinceLastPrompt() {
+        var state = eligibleState()
+        state.lastPromptDate = now(daysAfterInstall: 10)
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(
+                state: state,
+                now: now(daysAfterInstall: 10).addingTimeInterval(120 * day - 1)
+            )
+        )
+    }
+
+    func testPromptsAtExactlyOneHundredTwentyDaysSinceLastPrompt() {
+        var state = eligibleState()
+        state.lastPromptDate = now(daysAfterInstall: 10)
+        XCTAssertTrue(
+            AppReviewPolicy.shouldRequestReview(
+                state: state,
+                now: now(daysAfterInstall: 10).addingTimeInterval(120 * day)
+            )
+        )
+    }
+
+    func testPromptsWhenNeverPromptedBefore() {
+        var state = eligibleState()
+        state.lastPromptDate = nil
+        XCTAssertTrue(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 7))
+        )
+    }
+
+    func testDoesNotPromptWhenLastPromptIsInTheFuture() {
+        var state = eligibleState()
+        state.lastPromptDate = now(daysAfterInstall: 400)
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 30))
+        )
+    }
+
+    // MARK: - One failing rule vetoes the rest
+
+    func testTransactionCountVetoesAnOtherwiseEligibleState() {
+        var state = eligibleState()
+        state.confirmedTransactionCount = 2
+        state.lastPromptDate = nil
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 1_000))
+        )
+    }
+
+    func testInstallAgeVetoesAnOtherwiseEligibleState() {
+        var state = eligibleState()
+        state.confirmedTransactionCount = 100
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 6))
+        )
+    }
+
+    func testCooldownVetoesAnOtherwiseEligibleState() {
+        var state = eligibleState()
+        state.confirmedTransactionCount = 100
+        state.lastPromptDate = now(daysAfterInstall: 100)
+        XCTAssertFalse(
+            AppReviewPolicy.shouldRequestReview(state: state, now: now(daysAfterInstall: 200))
+        )
+    }
+
+    // MARK: - Thresholds
+
+    func testThresholdsMatchTheAgreedPolicy() {
+        XCTAssertEqual(AppReviewPolicy.minimumConfirmedTransactions, 3)
+        XCTAssertEqual(AppReviewPolicy.minimumTimeSinceInstall, 7 * day)
+        XCTAssertEqual(AppReviewPolicy.minimumTimeBetweenPrompts, 120 * day)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
@@ -216,6 +216,71 @@ final class AppReviewServiceTests: XCTestCase {
         XCTAssertFalse(service.shouldRequestReview())
     }
 
+    // MARK: - Claiming the ask
+
+    /// Brings a service to the point where only a fresh transaction is
+    /// missing: seeded, past the 7-day wait, two transactions counted.
+    private func makeAlmostEligibleService() -> AppReviewService {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+        service.recordConfirmedTransaction(id: "hash-a")
+        service.recordConfirmedTransaction(id: "hash-b")
+        advance(days: 30)
+        return service
+    }
+
+    func testClaimingAsksOnceTheThirdTransactionConfirms() {
+        let service = makeAlmostEligibleService()
+        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-c"))
+        XCTAssertEqual(service.state.lastPromptDate, clock)
+    }
+
+    /// The ask must follow a *newly counted* transaction. Re-observing a hash
+    /// that already counted has no transaction behind it, so it must not ask
+    /// even when every throttle rule is otherwise satisfied.
+    func testClaimingRequiresANewlyCountedTransaction() {
+        let service = makeAlmostEligibleService()
+        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-c"))
+
+        advance(days: 200)
+        XCTAssertFalse(
+            service.claimReviewPrompt(forConfirmedTransaction: "hash-c"),
+            "a repeat observation of an already-counted hash must not ask again"
+        )
+    }
+
+    /// The custom-message signing flow renders the done screen already
+    /// `.confirmed` with an empty hash. Signing a message is not a
+    /// transaction, so it must never spend an ask.
+    func testClaimingWithAnEmptyIDNeverAsks() {
+        let service = makeAlmostEligibleService()
+        service.recordConfirmedTransaction(id: "hash-c")
+
+        XCTAssertTrue(service.shouldRequestReview(), "the throttle is otherwise satisfied")
+        XCTAssertFalse(service.claimReviewPrompt(forConfirmedTransaction: ""))
+        XCTAssertNil(service.state.lastPromptDate)
+    }
+
+    func testClaimingDoesNotSpendTheAskWhenTheThrottleRefuses() {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+
+        XCTAssertFalse(service.claimReviewPrompt(forConfirmedTransaction: "hash-a"))
+        XCTAssertNil(service.state.lastPromptDate)
+        XCTAssertEqual(service.state.confirmedTransactionCount, 1, "the transaction still counts")
+    }
+
+    func testClaimingClosesTheWindowForOneHundredTwentyDays() {
+        let service = makeAlmostEligibleService()
+        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-c"))
+
+        advance(days: 119)
+        XCTAssertFalse(service.claimReviewPrompt(forConfirmedTransaction: "hash-d"))
+
+        advance(days: 1)
+        XCTAssertTrue(service.claimReviewPrompt(forConfirmedTransaction: "hash-e"))
+    }
+
     func testStateIsIsolatedPerDefaultsSuite() {
         let service = makeService()
         service.seedInstallDateIfNeeded()

--- a/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/Review/AppReviewServiceTests.swift
@@ -1,0 +1,232 @@
+//
+//  AppReviewServiceTests.swift
+//  VultisigAppTests
+//
+//  Persistence + idempotency coverage for the review throttle's state
+//  layer. Each test gets its own `UserDefaults` suite so nothing touches
+//  `.standard`, and the clock is injected so the 7-day / 120-day windows
+//  are crossed by moving a variable, never by sleeping.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class AppReviewServiceTests: XCTestCase {
+
+    private let day: TimeInterval = 24 * 60 * 60
+    private var suiteName = ""
+    private var defaults = UserDefaults.standard
+    private var clock = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "AppReviewServiceTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        clock = Date(timeIntervalSince1970: 1_700_000_000)
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        try await super.tearDown()
+    }
+
+    private func makeService() -> AppReviewService {
+        AppReviewService(defaults: defaults, now: { [unowned self] in self.clock })
+    }
+
+    private func advance(days: Double) {
+        clock = clock.addingTimeInterval(days * day)
+    }
+
+    // MARK: - Install date seeding
+
+    func testSeedInstallDateStoresTheCurrentDate() {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+        XCTAssertEqual(service.state.installDate, clock)
+    }
+
+    func testSeedInstallDateIsWrittenOnlyOnce() {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+        let seeded = clock
+
+        advance(days: 30)
+        service.seedInstallDateIfNeeded()
+
+        XCTAssertEqual(service.state.installDate, seeded)
+    }
+
+    func testInstallDateIsNilBeforeSeeding() {
+        XCTAssertNil(makeService().state.installDate)
+    }
+
+    func testInstallDateSurvivesANewServiceInstance() {
+        let first = makeService()
+        first.seedInstallDateIfNeeded()
+
+        advance(days: 5)
+        let second = makeService()
+        second.seedInstallDateIfNeeded()
+
+        XCTAssertEqual(second.state.installDate, first.state.installDate)
+    }
+
+    // MARK: - Counting
+
+    func testRecordingIncrementsTheCount() {
+        let service = makeService()
+        XCTAssertTrue(service.recordConfirmedTransaction(id: "hash-a"))
+        XCTAssertTrue(service.recordConfirmedTransaction(id: "hash-b"))
+        XCTAssertEqual(service.state.confirmedTransactionCount, 2)
+    }
+
+    /// The main correctness risk: the done screen can observe the same
+    /// `.confirmed` status repeatedly, so re-recording one hash must be inert.
+    func testRepeatedObservationsOfTheSameTransactionCountOnce() {
+        let service = makeService()
+        XCTAssertTrue(service.recordConfirmedTransaction(id: "hash-a"))
+        XCTAssertFalse(service.recordConfirmedTransaction(id: "hash-a"))
+        XCTAssertFalse(service.recordConfirmedTransaction(id: "hash-a"))
+        XCTAssertEqual(service.state.confirmedTransactionCount, 1)
+    }
+
+    /// A remount builds a fresh service against the same defaults; the
+    /// duplicate check has to survive that, not just live in memory.
+    func testDuplicateSuppressionSurvivesANewServiceInstance() {
+        makeService().recordConfirmedTransaction(id: "hash-a")
+        let remounted = makeService()
+
+        XCTAssertFalse(remounted.recordConfirmedTransaction(id: "hash-a"))
+        XCTAssertEqual(remounted.state.confirmedTransactionCount, 1)
+    }
+
+    func testEmptyTransactionIDIsNotCounted() {
+        let service = makeService()
+        XCTAssertFalse(service.recordConfirmedTransaction(id: ""))
+        XCTAssertFalse(service.recordConfirmedTransaction(id: ""))
+        XCTAssertEqual(service.state.confirmedTransactionCount, 0)
+    }
+
+    func testCountedTransactionIDsAreBounded() {
+        let service = makeService()
+        let overflow = AppReviewService.countedTransactionIDLimit + 10
+        for index in 0..<overflow {
+            XCTAssertTrue(service.recordConfirmedTransaction(id: "hash-\(index)"))
+        }
+
+        XCTAssertEqual(service.state.confirmedTransactionCount, overflow)
+        let stored = defaults.stringArray(forKey: "appReview.countedTransactionIDs") ?? []
+        XCTAssertEqual(stored.count, AppReviewService.countedTransactionIDLimit)
+        // Oldest hashes are evicted first; the most recent ones stay guarded.
+        XCTAssertFalse(stored.contains("hash-0"))
+        XCTAssertTrue(stored.contains("hash-\(overflow - 1)"))
+    }
+
+    func testCountSurvivesANewServiceInstance() {
+        makeService().recordConfirmedTransaction(id: "hash-a")
+        makeService().recordConfirmedTransaction(id: "hash-b")
+        XCTAssertEqual(makeService().state.confirmedTransactionCount, 2)
+    }
+
+    // MARK: - Prompt recording
+
+    func testRecordPromptShownStoresTheCurrentDate() {
+        let service = makeService()
+        XCTAssertNil(service.state.lastPromptDate)
+
+        service.recordPromptShown()
+        XCTAssertEqual(service.state.lastPromptDate, clock)
+    }
+
+    func testRecordPromptShownOverwritesThePreviousDate() {
+        let service = makeService()
+        service.recordPromptShown()
+
+        advance(days: 200)
+        service.recordPromptShown()
+
+        XCTAssertEqual(service.state.lastPromptDate, clock)
+    }
+
+    // MARK: - End-to-end throttle
+
+    func testDoesNotAskBeforeTheThresholdsAreMet() {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+
+        service.recordConfirmedTransaction(id: "hash-a")
+        service.recordConfirmedTransaction(id: "hash-b")
+        advance(days: 10)
+        XCTAssertFalse(service.shouldRequestReview(), "two transactions is below the threshold")
+
+        service.recordConfirmedTransaction(id: "hash-c")
+        XCTAssertTrue(service.shouldRequestReview())
+    }
+
+    func testDoesNotAskWithinTheFirstWeek() {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+
+        for id in ["hash-a", "hash-b", "hash-c"] {
+            service.recordConfirmedTransaction(id: id)
+        }
+
+        advance(days: 6)
+        XCTAssertFalse(service.shouldRequestReview())
+
+        advance(days: 1)
+        XCTAssertTrue(service.shouldRequestReview())
+    }
+
+    func testAskingClosesTheWindowForOneHundredTwentyDays() {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+        for id in ["hash-a", "hash-b", "hash-c"] {
+            service.recordConfirmedTransaction(id: id)
+        }
+        advance(days: 7)
+        XCTAssertTrue(service.shouldRequestReview())
+
+        service.recordPromptShown()
+        XCTAssertFalse(service.shouldRequestReview())
+
+        advance(days: 119)
+        service.recordConfirmedTransaction(id: "hash-d")
+        XCTAssertFalse(service.shouldRequestReview())
+
+        advance(days: 1)
+        XCTAssertTrue(service.shouldRequestReview())
+    }
+
+    /// Re-observing the same three hashes must not push a two-transaction
+    /// user over the threshold.
+    func testRepeatedObservationsDoNotUnlockThePromptEarly() {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+        advance(days: 30)
+
+        for _ in 0..<5 {
+            service.recordConfirmedTransaction(id: "hash-a")
+            service.recordConfirmedTransaction(id: "hash-b")
+        }
+
+        XCTAssertEqual(service.state.confirmedTransactionCount, 2)
+        XCTAssertFalse(service.shouldRequestReview())
+    }
+
+    func testStateIsIsolatedPerDefaultsSuite() {
+        let service = makeService()
+        service.seedInstallDateIfNeeded()
+        service.recordConfirmedTransaction(id: "hash-a")
+
+        let otherSuiteName = "AppReviewServiceTests-other-\(UUID().uuidString)"
+        let otherDefaults = UserDefaults(suiteName: otherSuiteName)!
+        defer { otherDefaults.removePersistentDomain(forName: otherSuiteName) }
+        let other = AppReviewService(defaults: otherDefaults, now: { [unowned self] in self.clock })
+
+        XCTAssertEqual(other.state.confirmedTransactionCount, 0)
+        XCTAssertNil(other.state.installDate)
+    }
+}


### PR DESCRIPTION
## Description

Fixes #4961

Fires the native App Store review sheet at the moment of highest satisfaction — a **confirmed** transaction — behind a throttle. iOS has 62 US ratings against Trust Wallet's ~1.7M, and ratings volume caps what the ASO work can convert.

Prompts when **all** hold: **≥3 confirmed transactions** · **≥7 days since install** · **not prompted in the last 120 days**. Uses SwiftUI's `@Environment(\.requestReview)` (deployment target is iOS 17, so no `SKStoreReviewController` and no window-scene plumbing). Native sheet only — no custom chrome, no incentives.

## 🔴 One acceptance criterion was deliberately not met

The issue asks for an **analytics event when the prompt is shown**. **This app has no analytics of any kind** — no Firebase, Mixpanel, Amplitude, Segment or PostHog (a repo-wide grep returns 48 hits for "Segment", all `SegmentedControl` UI). And `PrivacyInfo.xcprivacy` declares:

```
NSPrivacyTracking:     None
collected data types:  NONE
tracking domains:      NONE
```

Meeting the criterion would mean introducing telemetry to a self-custody wallet that has deliberately never collected anything, updating the privacy manifest, and changing the App Store data-collection disclosure. That's a product and privacy decision, not an implementation detail — so it's **out of scope here and left to its own issue and its own privacy review** (decision: Gaston, 2026-07-29).

It also buys less than it appears: **Apple never reports whether the user actually rated.** The event would record only *"we asked"* — which marketing can already derive from the release date plus these throttle rules, correlated against ratings velocity in App Store Connect.

## Design

`DoneScreen` is the single shared completion component behind every flow — send, swap, co-signer, QBTC claim **and custom-message signing** — so this is one hook rather than five. It observes `statusService.status` reaching `.confirmed`.

- `AppReviewPolicy` — a pure decision function over `(state, now)`. No I/O, fully unit-tested at every boundary (exactly 3, exactly 7 days, exactly 120 days).
- `AppReviewService` — persistence (`UserDefaults`; preference-shaped, and must survive independently of any vault), install-date seeding, and an injected clock so tests never sleep.

## The bug worth reading about

The first cut of the hook counted the transaction and asked the throttle as two **independent** questions, discarding `recordConfirmedTransaction`'s `Bool`. Caught in review, and the exploit is reachable in production:

`DoneStatusServiceFactory.signedMessage()` returns `NoPoller(initialStatus: .confirmed)`, so `SigningKeysignScreen.signedMessageBranch` renders a `DoneScreen` that is **`.confirmed` from the first frame, with an empty hash, and is not a transaction at all**. The empty hash correctly counted nothing — and then it prompted anyway. **Signing a custom message would have burned the 120-day window on a non-transaction.** Same shape for re-entering an already-counted hash after a cooldown lapsed.

Fixed by composing the sequence in the service rather than guarding at the call site, so the ordering is under unit test instead of living in a view:

```swift
func claimReviewPrompt(forConfirmedTransaction id: String) -> Bool {
    guard recordConfirmedTransaction(id: id) else { return false }
    guard shouldRequestReview() else { return false }
    recordPromptShown()
    return true
}
```

An ask can now only be spent off a **newly counted** transaction. Note the service already had idempotency tests — the gap was one layer up, in the view's *use* of them, which service-level tests could never have seen.

Second review finding, also real: `withAnimation` only *schedules* the spring, so the reveal flag flipped ~0.55 s before the hero arrived and the sheet could land on the very animation the guard existed to avoid. Replaced with `hasSettled`, set after awaiting the spring; a `.confirmed` arriving mid-reveal is turned away and retried at the tail of the reveal task, so nothing is dropped.

## Decisions worth a second opinion

- **Install date is seeded honestly, not backdated.** Upgrading users are stamped at upgrade and serve the full 7 days. Backdating would fire at the entire existing base within days of release — the users most likely to have formed opinions, spent on a rushed ask against a 120-day window.
- **Seeding placement is load-bearing.** It sits in the iOS-only `extension VultisigApp` `.onAppear`, before the `-UITesting` early return. ⚠️ `.onAppear` is **not** guaranteed once per launch (the shared `content` backs both `WindowGroup` and `DocumentGroup`) — the **persistence guard**, not the placement, is what makes it a single stamp.
- **Counted-id ring is bounded at 100.** Done screens are reachable only from post-signing flows, never from history, so a 100-transactions-ago hash can't be re-observed; and past a count of 3, an extra increment changes nothing.
- **Co-signer completions count** toward the tally even though the transaction isn't the user's own — a heavy co-signer can reach the threshold without ever sending.
- **The ask is recorded when `requestReview` is called**, even though Apple may silently no-op. There's no feedback from the API, so this can burn the window without a sheet appearing. The issue explicitly accepts that.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

**Gate:** iOS `** TEST SUCCEEDED **` — 4065 tests, 1 skipped, 0 failures (`AppReviewPolicyTests` 18/18, `AppReviewServiceTests` 22/22). macOS `** BUILD SUCCEEDED **`, required because `DoneScreen` is cross-platform and gained `#if os(iOS)`. SwiftLint 0 in touched files.

**No new user-facing strings** — the sheet is entirely system-provided, so there's no localisation work.

Pre-existing and untouched: `DoneScreen.swift:72-75` carries a `#4777` issue reference in a comment, against the repo's no-issue-numbers-in-code rule. It's on `main`, not from this branch.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4961
- **Confidence**: high on the policy, persistence and the claim/spend ordering — all directly unit-tested, including the empty-hash case
- **Needs human review for**: **the sheet itself was never observed.** The system throttles `requestReview` and often suppresses it silently with no API feedback, so its presentation is not meaningfully verifiable in a simulator and no claim is made about it. Also worth a second opinion: the honest-vs-backdated install date, and whether co-signer completions should count toward the tally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added App Store review prompts after eligible confirmed transactions.
  - Review requests are limited by transaction count, installation age, and cooldown periods.
  - Duplicate transactions and repeated prompts are automatically prevented.

- **Bug Fixes**
  - Review prompts now wait until transaction completion animations have settled.
  - Install and prompt history persists across app launches.

- **Tests**
  - Added coverage for review eligibility, throttling, persistence, and duplicate transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->