### PR TITLE
feat(security): keyshare cipher + Keychain-held data key (1/8)

### DIFF
--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareCipher.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareCipher.swift
@@ -1,0 +1,67 @@
+//
+//  KeyshareCipher.swift
+//  VultisigApp
+//
+
+import CryptoKit
+import Foundation
+
+enum KeyshareCipherError: Error, Equatable {
+    case notSealed
+    case malformedBlob
+    case decryptionFailed
+    case invalidPlaintextEncoding
+}
+
+/// Seals and opens a single key share for storage at rest.
+///
+/// Sealed shares are written back into the same `KeyShare.keyshare` field they
+/// occupied in plaintext, so the stored value has to say which of the two it is.
+/// `sealedPrefix` does that: `:` is outside the base64 alphabet, so a sealed
+/// value can never be mistaken for a plaintext DKLS share (base64) or a
+/// plaintext GG20 share (JSON). Detection is a pure function of the value —
+/// nothing else has to be consulted, and re-sealing an already-sealed share is
+/// a no-op rather than a corruption.
+protocol KeyshareCipher {
+    func seal(_ plaintext: String, with key: SymmetricKey) throws -> String
+    func open(_ stored: String, with key: SymmetricKey) throws -> String
+    func isSealed(_ stored: String) -> Bool
+}
+
+struct AesGcmKeyshareCipher: KeyshareCipher {
+
+    static let sealedPrefix = "vlt2:"
+
+    func isSealed(_ stored: String) -> Bool {
+        stored.hasPrefix(Self.sealedPrefix)
+    }
+
+    func seal(_ plaintext: String, with key: SymmetricKey) throws -> String {
+        let blob = try VaultCryptoEnvelope.seal(Data(plaintext.utf8), using: key)
+        return Self.sealedPrefix + blob.base64EncodedString()
+    }
+
+    func open(_ stored: String, with key: SymmetricKey) throws -> String {
+        guard isSealed(stored) else {
+            throw KeyshareCipherError.notSealed
+        }
+
+        let encoded = String(stored.dropFirst(Self.sealedPrefix.count))
+        guard let blob = Data(base64Encoded: encoded),
+              let parsed = VaultCryptoEnvelope.parse(blob) else {
+            throw KeyshareCipherError.malformedBlob
+        }
+
+        let plaintext: Data
+        do {
+            plaintext = try VaultCryptoEnvelope.open(parsed, using: key)
+        } catch {
+            throw KeyshareCipherError.decryptionFailed
+        }
+
+        guard let value = String(data: plaintext, encoding: .utf8) else {
+            throw KeyshareCipherError.invalidPlaintextEncoding
+        }
+        return value
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
@@ -1,0 +1,157 @@
+//
+//  KeyshareKeyStore.swift
+//  VultisigApp
+//
+
+import CryptoKit
+import Foundation
+import OSLog
+
+private let logger = Log.app.other
+
+enum KeyshareKeyStoreError: Error, Equatable {
+    /// The Keychain accepted the write but read back something else — treated
+    /// as a hard failure, because encrypting against a key we cannot prove is
+    /// durable is how key shares get lost.
+    case persistenceFailed
+    case wrongPasscode
+    case malformedWrappedKey
+}
+
+/// Custody of the data key that encrypts key shares at rest.
+///
+/// The data key is 256 random bits, never derived from anything the user types.
+/// Exactly one of two forms is present at a time:
+///
+/// - **no passcode** — the key sits in the Keychain in the clear. Shares are
+///   still encrypted on disk; the Keychain is what an attacker would additionally
+///   need, and it is absent from the app container and from unencrypted backups.
+/// - **passcode set** — the clear copy is deleted and a passcode-wrapped copy
+///   takes its place. Unlocking opens it; locking forgets the opened key.
+///
+/// Changing or removing the passcode therefore rewraps 32 bytes and never
+/// rewrites a single key share.
+protocol KeyshareKeyStoring {
+    func generateDataKey() throws -> SymmetricKey
+
+    func loadDataKey() -> SymmetricKey?
+    func storeDataKey(_ key: SymmetricKey) throws
+    func deleteDataKey()
+
+    func loadWrappedDataKey() -> Data?
+    func storeWrappedDataKey(_ blob: Data) throws
+    func deleteWrappedDataKey()
+
+    func wrap(_ key: SymmetricKey, passcode: String) async throws -> Data
+    func unwrap(_ blob: Data, passcode: String) async throws -> SymmetricKey
+}
+
+final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
+
+    static let shared: KeyshareKeyStoring = DefaultKeyshareKeyStore()
+
+    private let keychain: KeychainService
+
+    init(keychain: KeychainService = DefaultKeychainService.shared) {
+        self.keychain = keychain
+    }
+
+    // MARK: - Data key
+
+    func generateDataKey() throws -> SymmetricKey {
+        try VaultCryptoEnvelope.randomKey()
+    }
+
+    func loadDataKey() -> SymmetricKey? {
+        guard let data = keychain.getKeyshareDataKey().valueTreatingUnavailableAsAbsent else { return nil }
+        guard data.count == VaultCryptoEnvelope.keyLengthBytes else {
+            logger.error("Keyshare data key has unexpected length \(data.count, privacy: .public)")
+            return nil
+        }
+        return SymmetricKey(data: data)
+    }
+
+    /// Writes the key and reads it back before returning. A silent Keychain
+    /// failure here would otherwise surface later as unopenable key shares.
+    func storeDataKey(_ key: SymmetricKey) throws {
+        let data = key.rawRepresentation
+        keychain.setKeyshareDataKey(data)
+
+        guard case .present(let readBack) = keychain.getKeyshareDataKey(), readBack == data else {
+            logger.error("Keyshare data key failed read-back verification")
+            throw KeyshareKeyStoreError.persistenceFailed
+        }
+    }
+
+    func deleteDataKey() {
+        keychain.setKeyshareDataKey(nil)
+    }
+
+    // MARK: - Wrapped data key
+
+    func loadWrappedDataKey() -> Data? {
+        keychain.getWrappedKeyshareDataKey().valueTreatingUnavailableAsAbsent
+    }
+
+    func storeWrappedDataKey(_ blob: Data) throws {
+        keychain.setWrappedKeyshareDataKey(blob)
+
+        guard case .present(let readBack) = keychain.getWrappedKeyshareDataKey(), readBack == blob else {
+            logger.error("Wrapped keyshare data key failed read-back verification")
+            throw KeyshareKeyStoreError.persistenceFailed
+        }
+    }
+
+    func deleteWrappedDataKey() {
+        keychain.setWrappedKeyshareDataKey(nil)
+    }
+
+    // MARK: - Passcode wrapping
+
+    /// PBKDF2 at 600k iterations costs roughly half a second, so both of these
+    /// run off the calling thread the way `VaultBackupEncryption` does.
+    ///
+    /// The stretching is not what makes the wrap strong — a 5-digit passcode is
+    /// only ~16.6 bits however it is stretched, and an attacker who can read the
+    /// wrapped blob out of the Keychain already owns the device. What it buys is
+    /// a throttle on the in-app guessing path.
+    func wrap(_ key: SymmetricKey, passcode: String) async throws -> Data {
+        let keyData = key.rawRepresentation
+        return try await Task.detached(priority: .userInitiated) {
+            let salt = try VaultCryptoEnvelope.randomBytes(count: VaultCryptoEnvelope.saltLength)
+            let iv = try VaultCryptoEnvelope.randomBytes(count: VaultCryptoEnvelope.ivLength)
+            let wrappingKey = try VaultCryptoEnvelope.deriveKey(password: passcode, salt: salt)
+            return try VaultCryptoEnvelope.seal(keyData, using: wrappingKey, salt: salt, iv: iv)
+        }.value
+    }
+
+    /// A wrong passcode fails GCM authentication, which is what makes a separate
+    /// stored verification sample unnecessary.
+    func unwrap(_ blob: Data, passcode: String) async throws -> SymmetricKey {
+        try await Task.detached(priority: .userInitiated) {
+            guard let parsed = VaultCryptoEnvelope.parse(blob) else {
+                throw KeyshareKeyStoreError.malformedWrappedKey
+            }
+
+            let wrappingKey = try VaultCryptoEnvelope.deriveKey(password: passcode, salt: parsed.salt)
+
+            let keyData: Data
+            do {
+                keyData = try VaultCryptoEnvelope.open(parsed, using: wrappingKey)
+            } catch {
+                throw KeyshareKeyStoreError.wrongPasscode
+            }
+
+            guard keyData.count == VaultCryptoEnvelope.keyLengthBytes else {
+                throw KeyshareKeyStoreError.malformedWrappedKey
+            }
+            return SymmetricKey(data: keyData)
+        }.value
+    }
+}
+
+private extension SymmetricKey {
+    var rawRepresentation: Data {
+        withUnsafeBytes { Data($0) }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/VaultCryptoEnvelope.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/VaultCryptoEnvelope.swift
@@ -1,0 +1,181 @@
+//
+//  VaultCryptoEnvelope.swift
+//  VultisigApp
+//
+
+import CommonCrypto
+import CryptoKit
+import Foundation
+import OSLog
+
+private let logger = Log.app.other
+
+enum VaultCryptoEnvelopeError: Error {
+    case keyDerivationFailed
+    case randomGenerationFailed
+    case encryptionFailed
+    case malformedBlob
+    case decryptionFailed
+}
+
+/// Shared primitives for the `VLT\x02` encrypted blob.
+///
+/// Wire format is `signature(4) ‖ salt(16) ‖ nonce(12) ‖ ciphertext ‖ tag(16)`,
+/// where everything from the nonce onward is CryptoKit's `SealedBox.combined`.
+/// It matches the desktop client's vault-backup blob byte for byte, so one
+/// implementation serves every at-rest payload we have:
+///
+/// - vault backups, keyed by a user-chosen password (`VaultBackupEncryption`),
+/// - key shares at rest, keyed by a raw random data key,
+/// - that data key itself, wrapped under the app passcode.
+///
+/// The salt is only meaningful for the password-derived payloads; raw-key
+/// callers still fill it with random bytes so every blob has the same shape and
+/// one parser covers all of them.
+///
+/// Note that the header is **not** covered by the GCM tag — only the ciphertext
+/// is. For password-derived payloads that costs nothing, because a corrupted
+/// salt derives a different key and the tag then fails anyway. For raw-key
+/// payloads the salt is inert: corrupting it cannot change the plaintext that
+/// comes back. Authenticating the header would break every backup already
+/// written, so it stays out; nothing reads the salt on the raw-key path, which
+/// is what makes that safe.
+enum VaultCryptoEnvelope {
+
+    static let formatSignature: [UInt8] = [0x56, 0x4C, 0x54, 0x02]
+    static let formatSignatureLength = 4
+    static let saltLength = 16
+    static let ivLength = 12
+    static let gcmTagBytes = 16
+    static let keyLengthBytes = 32
+    static let pbkdf2Iterations: UInt32 = 600_000
+
+    /// Bytes before the ciphertext: signature + salt + nonce. The nonce is part
+    /// of `SealedBox.combined`, so parsing keeps it with the sealed remainder.
+    static let headerSize = formatSignatureLength + saltLength + ivLength
+
+    struct Parsed {
+        /// PBKDF2 salt. Random filler for raw-key payloads.
+        let salt: Data
+        /// `nonce ‖ ciphertext ‖ tag`, ready for `AES.GCM.SealedBox(combined:)`.
+        let sealedCombined: Data
+    }
+
+    // MARK: - Parsing
+
+    static func hasFormatSignature(_ data: Data) -> Bool {
+        guard data.count >= formatSignatureLength else { return false }
+        for index in 0..<formatSignatureLength where data[data.startIndex + index] != formatSignature[index] {
+            return false
+        }
+        return true
+    }
+
+    /// Splits a well-formed blob into its salt and sealed remainder. Returns
+    /// `nil` when the signature is absent or the blob is too short to hold a
+    /// header plus a GCM tag — callers treat that as "not our format" rather
+    /// than as an error, because legacy blobs are detected that way.
+    static func parse(_ data: Data) -> Parsed? {
+        guard hasFormatSignature(data), data.count >= headerSize + gcmTagBytes else {
+            return nil
+        }
+        let saltStart = data.startIndex + formatSignatureLength
+        let saltEnd = saltStart + saltLength
+        return Parsed(
+            salt: data.subdata(in: saltStart..<saltEnd),
+            sealedCombined: data.subdata(in: saltEnd..<data.endIndex)
+        )
+    }
+
+    // MARK: - Seal / open
+
+    /// Seals under a caller-supplied salt and nonce. Password-derived callers
+    /// pass the salt they derived the key from; raw-key callers pass filler.
+    static func seal(_ plaintext: Data, using key: SymmetricKey, salt: Data, iv: Data) throws -> Data {
+        do {
+            let nonce = try AES.GCM.Nonce(data: iv)
+            let sealed = try AES.GCM.seal(plaintext, using: key, nonce: nonce)
+            guard let combined = sealed.combined else {
+                throw VaultCryptoEnvelopeError.encryptionFailed
+            }
+            var output = Data(capacity: formatSignatureLength + salt.count + combined.count)
+            output.append(contentsOf: formatSignature)
+            output.append(salt)
+            output.append(combined)
+            return output
+        } catch let error as VaultCryptoEnvelopeError {
+            throw error
+        } catch {
+            logger.error("AES-GCM encryption failed: \(error.localizedDescription, privacy: .public)")
+            throw VaultCryptoEnvelopeError.encryptionFailed
+        }
+    }
+
+    /// Seals under a fresh random salt and nonce. For raw-key payloads, where
+    /// the salt carries no meaning and nothing needs to reproduce it.
+    static func seal(_ plaintext: Data, using key: SymmetricKey) throws -> Data {
+        try seal(
+            plaintext,
+            using: key,
+            salt: try randomBytes(count: saltLength),
+            iv: try randomBytes(count: ivLength)
+        )
+    }
+
+    static func open(_ parsed: Parsed, using key: SymmetricKey) throws -> Data {
+        do {
+            let sealedBox = try AES.GCM.SealedBox(combined: parsed.sealedCombined)
+            return try AES.GCM.open(sealedBox, using: key)
+        } catch {
+            // Expected on a wrong key or a tampered blob — GCM authentication is
+            // what tells those apart from a correct open, so this is not
+            // necessarily a fault.
+            logger.debug("AES-GCM open failed: \(error.localizedDescription, privacy: .public)")
+            throw VaultCryptoEnvelopeError.decryptionFailed
+        }
+    }
+
+    // MARK: - Keys
+
+    static func deriveKey(password: String, salt: Data) throws -> SymmetricKey {
+        let passwordBytes = Array(password.utf8)
+        var derived = [UInt8](repeating: 0, count: keyLengthBytes)
+
+        let status = salt.withUnsafeBytes { saltPtr -> Int32 in
+            guard let saltBase = saltPtr.bindMemory(to: UInt8.self).baseAddress else {
+                return Int32(kCCParamError)
+            }
+            return CCKeyDerivationPBKDF(
+                CCPBKDFAlgorithm(kCCPBKDF2),
+                passwordBytes,
+                passwordBytes.count,
+                saltBase,
+                salt.count,
+                CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                pbkdf2Iterations,
+                &derived,
+                keyLengthBytes
+            )
+        }
+
+        guard status == kCCSuccess else {
+            logger.error("PBKDF2 key derivation failed: status=\(status, privacy: .public)")
+            throw VaultCryptoEnvelopeError.keyDerivationFailed
+        }
+        return SymmetricKey(data: Data(derived))
+    }
+
+    static func randomKey() throws -> SymmetricKey {
+        SymmetricKey(data: try randomBytes(count: keyLengthBytes))
+    }
+
+    static func randomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        guard status == errSecSuccess else {
+            logger.error("SecRandomCopyBytes failed: status=\(status, privacy: .public)")
+            throw VaultCryptoEnvelopeError.randomGenerationFailed
+        }
+        return Data(bytes)
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/Keychain.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/Keychain.swift
@@ -81,11 +81,38 @@ struct Keychain {
         setString(string, for: key)
     }
 
+    // MARK: - Data
+
+    func getData(for key: KeychainIdentifier) -> KeychainReadResult<Data> {
+        return get(for: key)
+    }
+
+    /// - Parameter accessibility: the item's `kSecAttrAccessible` class. Defaults
+    ///   to the app-wide `WhenUnlockedThisDeviceOnly`; key material that has to
+    ///   survive a device migration overrides it, since a `ThisDeviceOnly` item
+    ///   is absent from every backup and would leave a restored device unable to
+    ///   open its own vaults.
+    @discardableResult
+    func setData(
+        _ value: Data?,
+        for key: KeychainIdentifier,
+        accessibility: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ) -> Bool {
+        set(value, for: key, accessibility: accessibility)
+    }
+
     // MARK: - Helpers
 
-    func delete(for key: KeychainIdentifier) {
+    @discardableResult
+    func delete(for key: KeychainIdentifier) -> Bool {
         let query = generateQuery(for: key)
-        _ = itemStore.delete(query)
+        let status = itemStore.delete(query)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            logger.error("Keychain delete failed for \(key.identifier, privacy: .public): status=\(status, privacy: .public)")
+            return false
+        }
+        return true
     }
 
 }
@@ -94,25 +121,55 @@ struct Keychain {
 
 private extension Keychain {
 
-    func set(_ data: Data?, for key: KeychainIdentifier) {
+    /// Writes an item, updating in place when one already exists.
+    ///
+    /// Deliberately not delete-then-add: that destroys the stored value before
+    /// the replacement is known to have landed, so a failing write loses the old
+    /// value as well as the new one. Harmless for a re-enterable password, fatal
+    /// for the key that opens the vault key shares — losing it during a passcode
+    /// change would leave every share encrypted under a key that no longer
+    /// exists.
+    ///
+    /// - Returns: whether the value is stored. Callers holding key material are
+    ///   expected to verify by reading back; the return value and the log entry
+    ///   are so a failure is never silent.
+    @discardableResult
+    func set(
+        _ data: Data?,
+        for key: KeychainIdentifier,
+        accessibility: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ) -> Bool {
 
         guard let data = data else {
-            delete(for: key)
-            return
+            return delete(for: key)
         }
 
         var query = generateQuery(for: key)
-
-        _ = itemStore.delete(query)
-
         query.removeValue(forKey: kSecReturnDataValue)
-        query.updateValue(data, forKey: kSecValueDataValue)
-        query.updateValue(kSecAttrAccessibleWhenUnlockedThisDeviceOnly, forKey: kSecAttrAccessibleValue)
 
-        let status = itemStore.add(query)
-        guard status == errSecSuccess else {
-            return
+        let attributes: [String: Any] = [
+            kSecValueDataValue: data,
+            kSecAttrAccessibleValue: accessibility
+        ]
+
+        let updateStatus = itemStore.update(query, attributes: attributes)
+        if updateStatus == errSecSuccess {
+            return true
         }
+        guard updateStatus == errSecItemNotFound else {
+            logger.error("Keychain update failed for \(key.identifier, privacy: .public): status=\(updateStatus, privacy: .public)")
+            return false
+        }
+
+        query.updateValue(data, forKey: kSecValueDataValue)
+        query.updateValue(accessibility, forKey: kSecAttrAccessibleValue)
+
+        let addStatus = itemStore.add(query)
+        guard addStatus == errSecSuccess else {
+            logger.error("Keychain add failed for \(key.identifier, privacy: .public): status=\(addStatus, privacy: .public)")
+            return false
+        }
+        return true
     }
 
     /// Reads one item, keeping apart the three outcomes the Security framework

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainItemStore.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainItemStore.swift
@@ -8,14 +8,18 @@ import Security
 
 /// The `SecItem` calls ``Keychain`` makes, behind a seam.
 ///
-/// The seam exists so the read path can be tested. A unit-test bundle has no
-/// keychain entitlement, so every real `SecItem` call answers
+/// The seam exists so the read and write paths can be tested. A unit-test bundle
+/// has no keychain entitlement, so every real `SecItem` call answers
 /// `errSecMissingEntitlement` — one of the very statuses the read path has to
 /// tell apart from "no such item", and one it cannot be shown to tell apart if
-/// it is the only status a test can ever produce.
+/// it is the only status a test can ever produce. The write path is just as
+/// invisible, and the branch that decides between updating an item in place and
+/// adding a new one is what keeps a failed write from destroying the previous
+/// value.
 protocol KeychainItemStore {
     func copyMatching(_ query: [String: Any]) -> (status: OSStatus, data: Data?)
     func add(_ attributes: [String: Any]) -> OSStatus
+    func update(_ query: [String: Any], attributes: [String: Any]) -> OSStatus
     func delete(_ query: [String: Any]) -> OSStatus
 }
 
@@ -29,6 +33,10 @@ struct SecItemStore: KeychainItemStore {
 
     func add(_ attributes: [String: Any]) -> OSStatus {
         SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    func update(_ query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
     }
 
     func delete(_ query: [String: Any]) -> OSStatus {

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
@@ -20,6 +20,10 @@ protocol KeychainService: AnyObject {
     func setLastMigratedVersion(_ version: Int?)
     func getDeviceToken() -> KeychainReadResult<String>
     func setDeviceToken(_ token: String?)
+    func getKeyshareDataKey() -> KeychainReadResult<Data>
+    func setKeyshareDataKey(_ data: Data?)
+    func getWrappedKeyshareDataKey() -> KeychainReadResult<Data>
+    func setWrappedKeyshareDataKey(_ data: Data?)
 }
 
 final class DefaultKeychainService: KeychainService {
@@ -68,6 +72,34 @@ final class DefaultKeychainService: KeychainService {
     func setDeviceToken(_ token: String?) {
         keychain.setString(token, for: Keys.deviceToken)
     }
+
+    func getKeyshareDataKey() -> KeychainReadResult<Data> {
+        return keychain.getData(for: Keys.keyshareDataKey)
+    }
+
+    /// Stored as `WhenUnlocked` rather than the app default `ThisDeviceOnly`:
+    /// a `ThisDeviceOnly` item never leaves the device, so restoring an encrypted
+    /// backup onto a new phone would bring the encrypted key shares across
+    /// without the key that opens them.
+    func setKeyshareDataKey(_ data: Data?) {
+        keychain.setData(
+            data,
+            for: Keys.keyshareDataKey,
+            accessibility: kSecAttrAccessibleWhenUnlocked
+        )
+    }
+
+    func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> {
+        return keychain.getData(for: Keys.wrappedKeyshareDataKey)
+    }
+
+    func setWrappedKeyshareDataKey(_ data: Data?) {
+        keychain.setData(
+            data,
+            for: Keys.wrappedKeyshareDataKey,
+            accessibility: kSecAttrAccessibleWhenUnlocked
+        )
+    }
 }
 
 private extension DefaultKeychainService {
@@ -77,6 +109,8 @@ private extension DefaultKeychainService {
         case fastHint(pubKeyECDSA: String)
         case lastMigratedVersion
         case deviceToken
+        case keyshareDataKey
+        case wrappedKeyshareDataKey
 
         var identifier: String {
             return "\(DefaultKeychainService.serviceName).\(key)"
@@ -92,6 +126,10 @@ private extension DefaultKeychainService {
                 return "lastMigratedVersion"
             case .deviceToken:
                 return "deviceToken"
+            case .keyshareDataKey:
+                return "keyshareDataKey"
+            case .wrappedKeyshareDataKey:
+                return "wrappedKeyshareDataKey"
             }
         }
     }

--- a/VultisigApp/VultisigApp/Core/Utils/VaultBackupEncryption.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/VaultBackupEncryption.swift
@@ -1,4 +1,3 @@
-import CommonCrypto
 import CryptoKit
 import Foundation
 import OSLog
@@ -16,16 +15,12 @@ enum VaultBackupEncryptionError: Error {
     case encryptionFailed
 }
 
+/// Vault backups, encrypted under a user-chosen password.
+///
+/// The blob format lives in `VaultCryptoEnvelope`, which key shares at rest
+/// share — the bytes on the wire are unchanged, and stay compatible with the
+/// desktop client's backups.
 final class Pbkdf2VaultBackupEncryption: VaultBackupEncryption {
-
-    private static let formatSignature: [UInt8] = [0x56, 0x4C, 0x54, 0x02]
-    private static let formatSignatureLength = 4
-    private static let saltLength = 16
-    private static let ivLength = 12
-    private static let gcmTagBytes = 16
-    private static let keyLengthBytes = 32
-    private static let iterations: UInt32 = 600_000
-    private static let headerSize = formatSignatureLength + saltLength + ivLength
 
     func encrypt(data: Data, password: String) async throws -> Data {
         try await Task.detached(priority: .userInitiated) {
@@ -40,31 +35,18 @@ final class Pbkdf2VaultBackupEncryption: VaultBackupEncryption {
     }
 
     private static func encryptSync(data: Data, password: String) throws -> Data {
-        let salt = try randomBytes(count: saltLength)
-        let iv = try randomBytes(count: ivLength)
-        let key = try deriveKey(password: password, salt: salt)
-
         do {
-            let nonce = try AES.GCM.Nonce(data: iv)
-            let sealed = try AES.GCM.seal(data, using: key, nonce: nonce)
-            guard let combined = sealed.combined else {
-                throw VaultBackupEncryptionError.encryptionFailed
-            }
-            var output = Data(capacity: formatSignatureLength + salt.count + combined.count)
-            output.append(contentsOf: formatSignature)
-            output.append(salt)
-            output.append(combined)
-            return output
-        } catch let error as VaultBackupEncryptionError {
-            throw error
-        } catch {
-            logger.error("AES-GCM encryption failed: \(error.localizedDescription, privacy: .public)")
-            throw VaultBackupEncryptionError.encryptionFailed
+            let salt = try VaultCryptoEnvelope.randomBytes(count: VaultCryptoEnvelope.saltLength)
+            let iv = try VaultCryptoEnvelope.randomBytes(count: VaultCryptoEnvelope.ivLength)
+            let key = try VaultCryptoEnvelope.deriveKey(password: password, salt: salt)
+            return try VaultCryptoEnvelope.seal(data, using: key, salt: salt, iv: iv)
+        } catch let error as VaultCryptoEnvelopeError {
+            throw error.asBackupError
         }
     }
 
     private static func decryptSync(data: Data, password: String) -> Data? {
-        if hasFormatSignature(data), let plaintext = decryptPbkdf2(data: data, password: password) {
+        if let plaintext = decryptPbkdf2(data: data, password: password) {
             return plaintext
         }
         // Legacy blobs begin with a random nonce that may, with ~1/2^32 probability,
@@ -73,21 +55,13 @@ final class Pbkdf2VaultBackupEncryption: VaultBackupEncryption {
     }
 
     private static func decryptPbkdf2(data: Data, password: String) -> Data? {
-        let minSize = headerSize + gcmTagBytes
-        guard data.count >= minSize else {
-            logger.warning("PBKDF2 payload too small: \(data.count, privacy: .public) bytes")
+        guard let parsed = VaultCryptoEnvelope.parse(data) else {
             return nil
         }
 
-        let saltStart = formatSignatureLength
-        let saltEnd = saltStart + saltLength
-        let salt = data.subdata(in: saltStart..<saltEnd)
-        let sealedCombined = data.subdata(in: saltEnd..<data.count)
-
         do {
-            let key = try deriveKey(password: password, salt: salt)
-            let sealedBox = try AES.GCM.SealedBox(combined: sealedCombined)
-            return try AES.GCM.open(sealedBox, using: key)
+            let key = try VaultCryptoEnvelope.deriveKey(password: password, salt: parsed.salt)
+            return try VaultCryptoEnvelope.open(parsed, using: key)
         } catch {
             logger.error("PBKDF2 decryption failed: \(error.localizedDescription, privacy: .public)")
             return nil
@@ -104,50 +78,20 @@ final class Pbkdf2VaultBackupEncryption: VaultBackupEncryption {
             return nil
         }
     }
+}
 
-    private static func hasFormatSignature(_ data: Data) -> Bool {
-        guard data.count >= formatSignatureLength else { return false }
-        for index in 0..<formatSignatureLength where data[data.startIndex + index] != formatSignature[index] {
-            return false
+private extension VaultCryptoEnvelopeError {
+    /// Preserves the errors this type has always thrown, so callers switching on
+    /// `VaultBackupEncryptionError` are unaffected by the move to the shared
+    /// envelope.
+    var asBackupError: VaultBackupEncryptionError {
+        switch self {
+        case .keyDerivationFailed:
+            return .keyDerivationFailed
+        case .randomGenerationFailed:
+            return .randomGenerationFailed
+        case .encryptionFailed, .malformedBlob, .decryptionFailed:
+            return .encryptionFailed
         }
-        return true
-    }
-
-    private static func deriveKey(password: String, salt: Data) throws -> SymmetricKey {
-        let passwordBytes = Array(password.utf8)
-        var derived = [UInt8](repeating: 0, count: Self.keyLengthBytes)
-
-        let status = salt.withUnsafeBytes { saltPtr -> Int32 in
-            guard let saltBase = saltPtr.bindMemory(to: UInt8.self).baseAddress else {
-                return Int32(kCCParamError)
-            }
-            return CCKeyDerivationPBKDF(
-                CCPBKDFAlgorithm(kCCPBKDF2),
-                passwordBytes,
-                passwordBytes.count,
-                saltBase,
-                salt.count,
-                CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
-                Self.iterations,
-                &derived,
-                Self.keyLengthBytes
-            )
-        }
-
-        guard status == kCCSuccess else {
-            logger.error("PBKDF2 key derivation failed: status=\(status, privacy: .public)")
-            throw VaultBackupEncryptionError.keyDerivationFailed
-        }
-        return SymmetricKey(data: Data(derived))
-    }
-
-    private static func randomBytes(count: Int) throws -> Data {
-        var bytes = [UInt8](repeating: 0, count: count)
-        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
-        guard status == errSecSuccess else {
-            logger.error("SecRandomCopyBytes failed: status=\(status, privacy: .public)")
-            throw VaultBackupEncryptionError.randomGenerationFailed
-        }
-        return Data(bytes)
     }
 }

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -12,21 +12,45 @@ import Foundation
 ///
 /// Values are held as `KeychainReadResult`s rather than optionals so a test can
 /// stage an unreadable Keychain as easily as a stored value — the two are
-/// different answers and the consumers have to be pinned against both.
+/// different answers and the consumers have to be pinned against both. That
+/// matters most for the key material below, where "absent" licenses minting a
+/// replacement and "unavailable" must not.
 final class MockKeychainService: KeychainService {
 
     /// The answer ``getLastMigratedVersion()`` gives. Settable directly so a
     /// test can stage `.unavailable`.
     var lastMigratedVersionResult: KeychainReadResult<Int>
 
+    /// The answer ``getKeyshareDataKey()`` gives, likewise.
+    var keyshareDataKeyResult: KeychainReadResult<Data> = .absent
+
+    /// The answer ``getWrappedKeyshareDataKey()`` gives, likewise.
+    var wrappedKeyshareDataKeyResult: KeychainReadResult<Data> = .absent
+
     private var fastPasswords: [String: KeychainReadResult<String>] = [:]
     private var fastHints: [String: KeychainReadResult<String>] = [:]
     private var deviceTokenResult: KeychainReadResult<String> = .absent
+
+    /// When set, `setKeyshareDataKey` accepts the write but stores nothing, so
+    /// the read-back verification in `DefaultKeyshareKeyStore` can be exercised.
+    var dropsKeyshareDataKeyWrites = false
 
     /// The recorded version, for tests that only care about the stored value.
     var lastMigratedVersion: Int? {
         get { lastMigratedVersionResult.valueTreatingUnavailableAsAbsent }
         set { lastMigratedVersionResult = Self.result(newValue) }
+    }
+
+    /// The recorded key, for tests that only care about the stored value.
+    var keyshareDataKey: Data? {
+        get { keyshareDataKeyResult.valueTreatingUnavailableAsAbsent }
+        set { keyshareDataKeyResult = Self.result(newValue) }
+    }
+
+    /// The recorded wrapped key, for tests that only care about the stored value.
+    var wrappedKeyshareDataKey: Data? {
+        get { wrappedKeyshareDataKeyResult.valueTreatingUnavailableAsAbsent }
+        set { wrappedKeyshareDataKeyResult = Self.result(newValue) }
     }
 
     init(lastMigratedVersion: Int? = nil) {
@@ -56,6 +80,19 @@ final class MockKeychainService: KeychainService {
     func getDeviceToken() -> KeychainReadResult<String> { deviceTokenResult }
 
     func setDeviceToken(_ token: String?) { deviceTokenResult = Self.result(token) }
+
+    func getKeyshareDataKey() -> KeychainReadResult<Data> { keyshareDataKeyResult }
+
+    func setKeyshareDataKey(_ data: Data?) {
+        guard !dropsKeyshareDataKeyWrites else { return }
+        keyshareDataKeyResult = Self.result(data)
+    }
+
+    func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> { wrappedKeyshareDataKeyResult }
+
+    func setWrappedKeyshareDataKey(_ data: Data?) {
+        wrappedKeyshareDataKeyResult = Self.result(data)
+    }
 
     private static func result<Value>(_ value: Value?) -> KeychainReadResult<Value> {
         guard let value else { return .absent }

--- a/VultisigApp/VultisigAppTests/Security/KeychainWriteTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeychainWriteTests.swift
@@ -1,0 +1,213 @@
+//
+//  KeychainWriteTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+/// Drives `Keychain`'s write path through a fake `KeychainItemStore`.
+///
+/// The real `SecItem` calls are unreachable from a test bundle — no keychain
+/// entitlement, so every one returns `errSecMissingEntitlement` — which is why
+/// the seam exists. What is being pinned here is the property that a write which
+/// fails must leave the previously stored value alone: for the key that opens
+/// the vault key shares, destroying the old value on a failed write would leave
+/// every share encrypted under a key that no longer exists.
+final class KeychainWriteTests: XCTestCase {
+
+    private struct TestKey: KeychainIdentifier {
+        let identifier = "com.vultisig.wallet.tests.item"
+    }
+
+    private var itemStore: FakeKeychainItemStore!
+    private var sut: Keychain!
+    private let key = TestKey()
+
+    override func setUp() {
+        super.setUp()
+        itemStore = FakeKeychainItemStore()
+        sut = Keychain(serviceName: "com.vultisig.wallet.tests", itemStore: itemStore)
+    }
+
+    override func tearDown() {
+        sut = nil
+        itemStore = nil
+        super.tearDown()
+    }
+
+    // MARK: - Add vs update
+
+    func testWritingWhenNoItemExistsAddsIt() {
+        let value = Data(repeating: 0x01, count: 32)
+
+        XCTAssertTrue(sut.setData(value, for: key))
+
+        XCTAssertEqual(itemStore.addCount, 1)
+        XCTAssertEqual(itemStore.updateCount, 1, "Update is attempted first and reports not-found")
+        XCTAssertEqual(sut.getData(for: key), .present(value))
+    }
+
+    func testWritingOverAnExistingItemUpdatesInPlace() {
+        let original = Data(repeating: 0x01, count: 32)
+        let replacement = Data(repeating: 0x02, count: 32)
+        XCTAssertTrue(sut.setData(original, for: key))
+        itemStore.resetCounts()
+
+        XCTAssertTrue(sut.setData(replacement, for: key))
+
+        XCTAssertEqual(itemStore.updateCount, 1)
+        XCTAssertEqual(itemStore.addCount, 0, "An existing item must not be re-added")
+        XCTAssertEqual(sut.getData(for: key), .present(replacement))
+    }
+
+    /// The regression this whole seam exists for.
+    func testFailedOverwriteLeavesThePreviousValueIntact() {
+        let original = Data(repeating: 0x01, count: 32)
+        XCTAssertTrue(sut.setData(original, for: key))
+        itemStore.resetCounts()
+        itemStore.updateStatus = errSecIO
+
+        XCTAssertFalse(sut.setData(Data(repeating: 0x02, count: 32), for: key))
+
+        XCTAssertEqual(sut.getData(for: key), .present(original), "A failed write must not destroy the stored value")
+        XCTAssertEqual(itemStore.deleteCount, 0, "A failed write must never delete")
+    }
+
+    func testFailedAddReportsFailure() {
+        itemStore.addStatus = errSecIO
+
+        XCTAssertFalse(sut.setData(Data(repeating: 0x01, count: 32), for: key))
+
+        XCTAssertEqual(sut.getData(for: key), .absent)
+    }
+
+    func testWriteNeverDeletesBeforeAdding() {
+        XCTAssertTrue(sut.setData(Data(repeating: 0x01, count: 32), for: key))
+
+        XCTAssertEqual(itemStore.deleteCount, 0)
+    }
+
+    // MARK: - Accessibility
+
+    func testAccessibilityDefaultsToThisDeviceOnly() {
+        sut.setData(Data(repeating: 0x01, count: 32), for: key)
+
+        XCTAssertEqual(itemStore.lastAccessibility, kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String)
+    }
+
+    func testAccessibilityOverrideIsApplied() {
+        sut.setData(Data(repeating: 0x01, count: 32), for: key, accessibility: kSecAttrAccessibleWhenUnlocked)
+
+        XCTAssertEqual(itemStore.lastAccessibility, kSecAttrAccessibleWhenUnlocked as String)
+    }
+
+    func testAccessibilityOverrideIsAppliedOnUpdateToo() {
+        sut.setData(Data(repeating: 0x01, count: 32), for: key)
+
+        sut.setData(Data(repeating: 0x02, count: 32), for: key, accessibility: kSecAttrAccessibleWhenUnlocked)
+
+        XCTAssertEqual(itemStore.lastAccessibility, kSecAttrAccessibleWhenUnlocked as String)
+    }
+
+    // MARK: - Delete
+
+    func testWritingNilDeletesTheItem() {
+        XCTAssertTrue(sut.setData(Data(repeating: 0x01, count: 32), for: key))
+
+        XCTAssertTrue(sut.setData(nil, for: key))
+
+        XCTAssertEqual(sut.getData(for: key), .absent)
+        XCTAssertEqual(itemStore.deleteCount, 1)
+    }
+
+    func testDeletingAnAbsentItemIsNotAFailure() {
+        XCTAssertTrue(sut.delete(for: key))
+    }
+
+    func testFailedDeleteReportsFailure() {
+        itemStore.deleteStatus = errSecIO
+
+        XCTAssertFalse(sut.delete(for: key))
+    }
+}
+
+/// In-memory stand-in keyed by account, mirroring the `SecItem` status codes
+/// `Keychain` branches on.
+private final class FakeKeychainItemStore: KeychainItemStore {
+
+    private var storage: [String: Data] = [:]
+
+    private(set) var addCount = 0
+    private(set) var updateCount = 0
+    private(set) var deleteCount = 0
+    private(set) var lastAccessibility: String?
+
+    /// Overrides forcing the corresponding call to fail.
+    var addStatus: OSStatus?
+    var updateStatus: OSStatus?
+    var deleteStatus: OSStatus?
+
+    func resetCounts() {
+        addCount = 0
+        updateCount = 0
+        deleteCount = 0
+    }
+
+    func copyMatching(_ query: [String: Any]) -> (status: OSStatus, data: Data?) {
+        guard let account = account(in: query), let data = storage[account] else {
+            return (errSecItemNotFound, nil)
+        }
+        return (errSecSuccess, data)
+    }
+
+    func add(_ attributes: [String: Any]) -> OSStatus {
+        addCount += 1
+        if let addStatus { return addStatus }
+
+        guard let account = account(in: attributes),
+              let data = attributes[String(kSecValueData)] as? Data else {
+            return errSecParam
+        }
+        guard storage[account] == nil else { return errSecDuplicateItem }
+
+        recordAccessibility(from: attributes)
+        storage[account] = data
+        return errSecSuccess
+    }
+
+    func update(_ query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        updateCount += 1
+
+        guard let account = account(in: query), storage[account] != nil else {
+            return errSecItemNotFound
+        }
+        if let updateStatus { return updateStatus }
+
+        guard let data = attributes[String(kSecValueData)] as? Data else {
+            return errSecParam
+        }
+
+        recordAccessibility(from: attributes)
+        storage[account] = data
+        return errSecSuccess
+    }
+
+    func delete(_ query: [String: Any]) -> OSStatus {
+        deleteCount += 1
+        if let deleteStatus { return deleteStatus }
+
+        guard let account = account(in: query), storage.removeValue(forKey: account) != nil else {
+            return errSecItemNotFound
+        }
+        return errSecSuccess
+    }
+
+    private func account(in query: [String: Any]) -> String? {
+        query[String(kSecAttrAccount)] as? String
+    }
+
+    private func recordAccessibility(from attributes: [String: Any]) {
+        lastAccessibility = attributes[String(kSecAttrAccessible)] as? String
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareCipherTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareCipherTests.swift
@@ -1,0 +1,176 @@
+//
+//  KeyshareCipherTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import XCTest
+@testable import VultisigApp
+
+final class KeyshareCipherTests: XCTestCase {
+
+    private var sut: AesGcmKeyshareCipher!
+    private var key: SymmetricKey!
+
+    /// Shaped like a real DKLS share: base64, no prefix.
+    private let dklsPlaintext = "eyJrZXlzaGFyZSI6ImV4YW1wbGUifQ=="
+    /// Shaped like a real GG20 share: raw JSON.
+    private let gg20Plaintext = #"{"PubKey":"02abc","ShareID":{"value":"12345"}}"#
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = AesGcmKeyshareCipher()
+        key = try VaultCryptoEnvelope.randomKey()
+    }
+
+    override func tearDown() {
+        sut = nil
+        key = nil
+        super.tearDown()
+    }
+
+    // MARK: - Round trip
+
+    func testSealOpenRoundTrip() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+
+        XCTAssertEqual(try sut.open(sealed, with: key), dklsPlaintext)
+    }
+
+    func testSealOpenRoundTripForGg20Json() throws {
+        let sealed = try sut.seal(gg20Plaintext, with: key)
+
+        XCTAssertEqual(try sut.open(sealed, with: key), gg20Plaintext)
+    }
+
+    func testSealOpenRoundTripForEmptyString() throws {
+        let sealed = try sut.seal("", with: key)
+
+        XCTAssertEqual(try sut.open(sealed, with: key), "")
+    }
+
+    func testSealOpenRoundTripForLargeShare() throws {
+        let large = String(repeating: "A", count: 512 * 1024)
+
+        let sealed = try sut.seal(large, with: key)
+
+        XCTAssertEqual(try sut.open(sealed, with: key), large)
+    }
+
+    func testSealIsNonDeterministic() throws {
+        let first = try sut.seal(dklsPlaintext, with: key)
+        let second = try sut.seal(dklsPlaintext, with: key)
+
+        XCTAssertNotEqual(first, second, "Each seal must use a fresh nonce")
+    }
+
+    // MARK: - Detection
+
+    func testIsSealedIsFalseForPlaintextDklsShare() {
+        XCTAssertFalse(sut.isSealed(dklsPlaintext))
+    }
+
+    func testIsSealedIsFalseForPlaintextGg20Share() {
+        XCTAssertFalse(sut.isSealed(gg20Plaintext))
+    }
+
+    func testIsSealedIsTrueForSealedValue() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+
+        XCTAssertTrue(sut.isSealed(sealed))
+    }
+
+    func testOpenRejectsUnsealedValue() {
+        XCTAssertThrowsError(try sut.open(dklsPlaintext, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .notSealed)
+        }
+    }
+
+    // MARK: - Rejection
+
+    func testOpenWithWrongKeyFails() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let otherKey = try VaultCryptoEnvelope.randomKey()
+
+        XCTAssertThrowsError(try sut.open(sealed, with: otherKey)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .decryptionFailed)
+        }
+    }
+
+    func testOpenRejectsTamperedCiphertext() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let tampered = try flipLastByte(of: sealed)
+
+        XCTAssertThrowsError(try sut.open(tampered, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .decryptionFailed)
+        }
+    }
+
+    /// The salt is not covered by the GCM tag, and a key share is sealed under a
+    /// raw key that was never derived from it — so the salt is inert filler here
+    /// and corrupting it provably cannot change the recovered share. What
+    /// protects the share is the ciphertext and tag, exercised above. The salt
+    /// only carries meaning where a key is derived from it, which is the wrapped
+    /// data key — see `KeyshareKeyStoreTests.testUnwrapRejectsTamperedSalt`.
+    func testSaltIsInertForRawKeyPayloads() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        // Salt sits immediately after the 4-byte signature.
+        let tampered = try flipByte(of: sealed, at: VaultCryptoEnvelope.formatSignatureLength)
+
+        XCTAssertEqual(try sut.open(tampered, with: key), dklsPlaintext)
+    }
+
+    func testOpenRejectsTamperedNonce() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let nonceStart = VaultCryptoEnvelope.formatSignatureLength + VaultCryptoEnvelope.saltLength
+        let tampered = try flipByte(of: sealed, at: nonceStart)
+
+        XCTAssertThrowsError(try sut.open(tampered, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .decryptionFailed)
+        }
+    }
+
+    func testOpenRejectsMalformedBase64() {
+        let stored = AesGcmKeyshareCipher.sealedPrefix + "!!!not-base64!!!"
+
+        XCTAssertThrowsError(try sut.open(stored, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .malformedBlob)
+        }
+    }
+
+    func testOpenRejectsTruncatedBlob() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let blob = try XCTUnwrap(Data(base64Encoded: String(sealed.dropFirst(AesGcmKeyshareCipher.sealedPrefix.count))))
+        let truncated = AesGcmKeyshareCipher.sealedPrefix
+            + blob.prefix(VaultCryptoEnvelope.headerSize).base64EncodedString()
+
+        XCTAssertThrowsError(try sut.open(truncated, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .malformedBlob)
+        }
+    }
+
+    func testOpenRejectsBlobWithoutFormatSignature() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let tampered = try flipByte(of: sealed, at: 0)
+
+        XCTAssertThrowsError(try sut.open(tampered, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .malformedBlob)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func flipByte(of stored: String, at index: Int) throws -> String {
+        let encoded = String(stored.dropFirst(AesGcmKeyshareCipher.sealedPrefix.count))
+        var blob = try XCTUnwrap(Data(base64Encoded: encoded))
+        blob[blob.startIndex + index] ^= 0xFF
+        return AesGcmKeyshareCipher.sealedPrefix + blob.base64EncodedString()
+    }
+
+    private func flipLastByte(of stored: String) throws -> String {
+        let encoded = String(stored.dropFirst(AesGcmKeyshareCipher.sealedPrefix.count))
+        var blob = try XCTUnwrap(Data(base64Encoded: encoded))
+        blob[blob.index(before: blob.endIndex)] ^= 0xFF
+        return AesGcmKeyshareCipher.sealedPrefix + blob.base64EncodedString()
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
@@ -1,0 +1,180 @@
+//
+//  KeyshareKeyStoreTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import XCTest
+@testable import VultisigApp
+
+final class KeyshareKeyStoreTests: XCTestCase {
+
+    private var keychain: MockKeychainService!
+    private var sut: DefaultKeyshareKeyStore!
+
+    override func setUp() {
+        super.setUp()
+        keychain = MockKeychainService()
+        sut = DefaultKeyshareKeyStore(keychain: keychain)
+    }
+
+    override func tearDown() {
+        sut = nil
+        keychain = nil
+        super.tearDown()
+    }
+
+    // MARK: - Data key
+
+    func testGenerateDataKeyIsCorrectLengthAndRandom() throws {
+        let first = try sut.generateDataKey()
+        let second = try sut.generateDataKey()
+
+        XCTAssertEqual(first.bitCount, VaultCryptoEnvelope.keyLengthBytes * 8)
+        XCTAssertNotEqual(first.testRawRepresentation, second.testRawRepresentation)
+    }
+
+    func testStoreAndLoadDataKeyRoundTrip() throws {
+        let key = try sut.generateDataKey()
+
+        try sut.storeDataKey(key)
+
+        XCTAssertEqual(sut.loadDataKey()?.testRawRepresentation, key.testRawRepresentation)
+    }
+
+    func testLoadDataKeyIsNilWhenAbsent() {
+        XCTAssertNil(sut.loadDataKey())
+    }
+
+    func testDeleteDataKeyRemovesIt() throws {
+        try sut.storeDataKey(try sut.generateDataKey())
+
+        sut.deleteDataKey()
+
+        XCTAssertNil(sut.loadDataKey())
+    }
+
+    /// The read-back guard: a Keychain that silently drops the write must not
+    /// leave the caller believing the key is durable, because the next step is
+    /// encrypting key shares against it.
+    func testStoreDataKeyThrowsWhenKeychainDropsTheWrite() throws {
+        keychain.dropsKeyshareDataKeyWrites = true
+        let key = try sut.generateDataKey()
+
+        XCTAssertThrowsError(try sut.storeDataKey(key)) { error in
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .persistenceFailed)
+        }
+    }
+
+    func testLoadDataKeyIsNilWhenStoredBlobHasWrongLength() {
+        keychain.setKeyshareDataKey(Data(repeating: 0x01, count: 16))
+
+        XCTAssertNil(sut.loadDataKey())
+    }
+
+    // MARK: - Wrapped data key
+
+    func testStoreAndLoadWrappedDataKeyRoundTrip() throws {
+        let blob = Data(repeating: 0x07, count: 64)
+
+        try sut.storeWrappedDataKey(blob)
+
+        XCTAssertEqual(sut.loadWrappedDataKey(), blob)
+    }
+
+    func testDeleteWrappedDataKeyRemovesIt() throws {
+        try sut.storeWrappedDataKey(Data(repeating: 0x07, count: 64))
+
+        sut.deleteWrappedDataKey()
+
+        XCTAssertNil(sut.loadWrappedDataKey())
+    }
+
+    // MARK: - Passcode wrapping
+
+    func testWrapUnwrapRoundTrip() async throws {
+        let key = try sut.generateDataKey()
+
+        let wrapped = try await sut.wrap(key, passcode: "12345")
+        let unwrapped = try await sut.unwrap(wrapped, passcode: "12345")
+
+        XCTAssertEqual(unwrapped.testRawRepresentation, key.testRawRepresentation)
+    }
+
+    func testUnwrapWithWrongPasscodeFails() async throws {
+        let key = try sut.generateDataKey()
+        let wrapped = try await sut.wrap(key, passcode: "12345")
+
+        do {
+            _ = try await sut.unwrap(wrapped, passcode: "54321")
+            XCTFail("Expected unwrap to fail with the wrong passcode")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .wrongPasscode)
+        }
+    }
+
+    func testUnwrapRejectsTamperedBlob() async throws {
+        let key = try sut.generateDataKey()
+        var wrapped = try await sut.wrap(key, passcode: "12345")
+        wrapped[wrapped.index(before: wrapped.endIndex)] ^= 0xFF
+
+        do {
+            _ = try await sut.unwrap(wrapped, passcode: "12345")
+            XCTFail("Expected unwrap to reject a tampered blob")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .wrongPasscode)
+        }
+    }
+
+    /// Unlike the key-share path, the wrapping key IS derived from the salt, so
+    /// corrupting it yields a different key and the tag stops matching.
+    func testUnwrapRejectsTamperedSalt() async throws {
+        let key = try sut.generateDataKey()
+        var wrapped = try await sut.wrap(key, passcode: "12345")
+        wrapped[wrapped.startIndex + VaultCryptoEnvelope.formatSignatureLength] ^= 0xFF
+
+        do {
+            _ = try await sut.unwrap(wrapped, passcode: "12345")
+            XCTFail("Expected unwrap to reject a tampered salt")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .wrongPasscode)
+        }
+    }
+
+    func testUnwrapRejectsBlobWithoutFormatSignature() async {
+        do {
+            _ = try await sut.unwrap(Data(repeating: 0x00, count: 64), passcode: "12345")
+            XCTFail("Expected unwrap to reject a blob with no signature")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .malformedWrappedKey)
+        }
+    }
+
+    func testWrapIsNonDeterministic() async throws {
+        let key = try sut.generateDataKey()
+
+        let first = try await sut.wrap(key, passcode: "12345")
+        let second = try await sut.wrap(key, passcode: "12345")
+
+        XCTAssertNotEqual(first, second, "Each wrap must use a fresh salt and nonce")
+    }
+
+    /// The whole point of the indirection: rewrapping under a new passcode
+    /// yields a key that opens the same shares, so no share is ever rewritten.
+    func testRewrappingUnderNewPasscodeYieldsTheSameDataKey() async throws {
+        let key = try sut.generateDataKey()
+        let original = try await sut.wrap(key, passcode: "12345")
+
+        let opened = try await sut.unwrap(original, passcode: "12345")
+        let rewrapped = try await sut.wrap(opened, passcode: "99999")
+        let reopened = try await sut.unwrap(rewrapped, passcode: "99999")
+
+        XCTAssertEqual(reopened.testRawRepresentation, key.testRawRepresentation)
+    }
+}
+
+private extension SymmetricKey {
+    var testRawRepresentation: Data {
+        withUnsafeBytes { Data($0) }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
+++ b/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
@@ -118,6 +118,17 @@ final class KeychainTriStateReadTests: XCTestCase {
                 .unavailable(status),
                 "the migration-version read must not pass a failure off as an absent item (status \(status))"
             )
+            XCTAssertEqual(
+                service.getKeyshareDataKey(),
+                .unavailable(status),
+                "an unreadable data key must never look absent — absence licenses minting a replacement, "
+                    + "and a replacement cannot open a single already-sealed share (status \(status))"
+            )
+            XCTAssertEqual(
+                service.getWrappedKeyshareDataKey(),
+                .unavailable(status),
+                "an unreadable wrapped key must never look absent, for the same reason (status \(status))"
+            )
         }
     }
 
@@ -128,6 +139,8 @@ final class KeychainTriStateReadTests: XCTestCase {
         XCTAssertEqual(service.getFastHint(pubKeyECDSA: "pub"), .absent)
         XCTAssertEqual(service.getDeviceToken(), .absent)
         XCTAssertEqual(service.getLastMigratedVersion(), .absent)
+        XCTAssertEqual(service.getKeyshareDataKey(), .absent)
+        XCTAssertEqual(service.getWrappedKeyshareDataKey(), .absent)
     }
 
     func testEveryServiceReadReturnsTheStoredValue() {
@@ -137,6 +150,8 @@ final class KeychainTriStateReadTests: XCTestCase {
         XCTAssertEqual(service.getFastHint(pubKeyECDSA: "pub"), .present("7"))
         XCTAssertEqual(service.getDeviceToken(), .present("7"))
         XCTAssertEqual(service.getLastMigratedVersion(), .present(7))
+        XCTAssertEqual(service.getKeyshareDataKey(), .present(Data("7".utf8)))
+        XCTAssertEqual(service.getWrappedKeyshareDataKey(), .present(Data("7".utf8)))
     }
 
     // MARK: - The deliberate collapse
@@ -174,6 +189,8 @@ private struct FakeItemStore: KeychainItemStore {
     }
 
     func add(_: [String: Any]) -> OSStatus { errSecSuccess }
+
+    func update(_: [String: Any], attributes _: [String: Any]) -> OSStatus { errSecSuccess }
 
     func delete(_: [String: Any]) -> OSStatus { errSecSuccess }
 }

--- a/VultisigApp/VultisigAppTests/Storage/KeychainWriteSeamTests.swift
+++ b/VultisigApp/VultisigAppTests/Storage/KeychainWriteSeamTests.swift
@@ -2,12 +2,13 @@
 //  KeychainWriteSeamTests.swift
 //  VultisigAppTests
 //
-//  Making reads tri-state moved `Keychain`'s `SecItem` calls behind
-//  `KeychainItemStore`. The write path is supposed to come through that move
-//  untouched — precisely the sort of claim nothing was checking, since a unit
-//  test bundle has no keychain entitlement and could never observe a real
-//  write. These pin the query, the attributes and the delete-then-add order the
-//  Keychain has always used.
+//  What `Keychain` hands to `SecItem` on a write — the query, the attributes and
+//  the call order — pinned through the `KeychainItemStore` seam, since a unit
+//  test bundle has no keychain entitlement and could never observe a real write.
+//
+//  `KeychainWriteTests` covers the same seam from the other side: this file
+//  pins the payloads, that one pins the add-versus-update state machine and what
+//  a failed write leaves behind.
 //
 
 import Security
@@ -18,24 +19,41 @@ final class KeychainWriteSeamTests: XCTestCase {
 
     private static let serviceName = "com.vultisig.tests.keychain"
 
-    func testWritingAValueDeletesTheExistingItemBeforeAddingTheNewOne() {
+    /// Update first, add only when there is nothing to update — never
+    /// delete-then-add, which would destroy the stored value before knowing the
+    /// replacement landed.
+    func testWritingAValueUpdatesFirstAndAddsOnlyWhenNoItemExists() {
         let store = RecordingItemStore()
 
         Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
 
-        XCTAssertEqual(store.calls, ["delete", "add"])
+        XCTAssertEqual(store.calls, ["update", "add"])
     }
 
-    func testTheDeleteCarriesTheGeneratedQuery() throws {
+    func testTheUpdateCarriesTheGeneratedQueryWithoutTheReturnFlag() throws {
         let store = RecordingItemStore()
 
         Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
 
-        let query = try XCTUnwrap(store.deletedQueries.first)
+        let query = try XCTUnwrap(store.updatedQueries.first)
         XCTAssertEqual(query[kSecClass as String] as? String, kSecClassGenericPassword as String)
         XCTAssertEqual(query[kSecAttrService as String] as? String, Self.serviceName)
         XCTAssertEqual(query[kSecAttrAccount as String] as? String, TestKey().identifier)
-        XCTAssertNotNil(query[kSecReturnData as String])
+        XCTAssertNil(query[kSecReturnData as String], "the return flag belongs to reads, not to a write query")
+    }
+
+    func testTheUpdateCarriesOnlyTheValueAndAccessibility() throws {
+        let store = RecordingItemStore()
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
+
+        let attributes = try XCTUnwrap(store.updatedAttributes.first)
+        XCTAssertEqual(attributes[kSecValueData as String] as? Data, Data("hunter2".utf8))
+        XCTAssertEqual(
+            attributes[kSecAttrAccessible as String] as? String,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String
+        )
+        XCTAssertNil(attributes[kSecAttrService as String], "an update must not restate the item's identity")
     }
 
     func testTheAddCarriesTheValueAndAccessibilityWithoutTheReturnFlag() throws {
@@ -68,7 +86,7 @@ final class KeychainWriteSeamTests: XCTestCase {
         XCTAssertEqual(attributes[kSecValueData as String] as? Data, Data("42".utf8))
     }
 
-    func testWritingNilDeletesWithoutAdding() {
+    func testWritingNilDeletesWithoutAddingOrUpdating() {
         let store = RecordingItemStore()
 
         Keychain(serviceName: Self.serviceName, itemStore: store).setString(nil, for: TestKey())
@@ -84,23 +102,24 @@ final class KeychainWriteSeamTests: XCTestCase {
         XCTAssertEqual(store.calls, ["delete"])
     }
 
-    /// A failing write has always been swallowed here. Pinned so the seam is not
-    /// blamed if that ever needs to change.
-    func testAFailedAddIsIgnoredWithoutRetrying() {
+    /// A failing add is not retried, and — the property that matters — nothing
+    /// is deleted on the way, so whatever was stored is still stored.
+    func testAFailedAddIsNotRetriedAndDeletesNothing() {
         let store = RecordingItemStore(addStatus: errSecDuplicateItem)
 
         Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
 
-        XCTAssertEqual(store.calls, ["delete", "add"])
+        XCTAssertEqual(store.calls, ["update", "add"])
     }
 }
 
-/// Records what the write path hands to `SecItem`, and answers reads as if the
-/// item were absent.
+/// Records what the write path hands to `SecItem`, and answers reads and updates
+/// as if the item were absent.
 private final class RecordingItemStore: KeychainItemStore {
 
     private(set) var calls: [String] = []
-    private(set) var deletedQueries: [[String: Any]] = []
+    private(set) var updatedQueries: [[String: Any]] = []
+    private(set) var updatedAttributes: [[String: Any]] = []
     private(set) var addedAttributes: [[String: Any]] = []
 
     private let addStatus: OSStatus
@@ -119,9 +138,15 @@ private final class RecordingItemStore: KeychainItemStore {
         return addStatus
     }
 
-    func delete(_ query: [String: Any]) -> OSStatus {
+    func update(_ query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        calls.append("update")
+        updatedQueries.append(query)
+        updatedAttributes.append(attributes)
+        return errSecItemNotFound
+    }
+
+    func delete(_: [String: Any]) -> OSStatus {
         calls.append("delete")
-        deletedQueries.append(query)
         return errSecSuccess
     }
 }


### PR DESCRIPTION
> **Stack 1 of 8** for #4846 — renumbered from /7; a transition-coordinator layer was inserted as 5/8.
> **The stack was reworked to opt-in encryption**: key shares are sealed **if and only if a passcode is
> currently set**, so anyone who never sets one keeps plaintext shares and a safely downgradable build.
> The launch migration that used to sit at 3/8 is deleted. Full rationale in #4991 and #4993.
> This PR itself is unchanged in intent — the primitives are the same.
> Base: `feature/passcode-4846`.

## Description

**Stack 1 of 7** for #4846 (passcode app-lock + at-rest keyshare encryption). This PR adds the encryption primitives and nothing else — **no behaviour change, no passcode, no UI**. Nothing in the app calls the new cipher yet.

Part of #4846. Design and full rationale: internal plan `passcode-app-lock-4846-plan`.

### What this adds

| | File |
|---|---|
| new | `Core/Security/Keyshare/KeyshareCipher.swift` — `seal` / `open` / `isSealed` + `AesGcmKeyshareCipher` implementing the `vlt2:` envelope |
| new | `Core/Security/Keyshare/KeyshareKeyStore.swift` — data-key generate / load / store / wrap / unwrap / delete |
| modify | `Core/Utils/VaultBackupEncryption.swift` — extract raw-key seal/open into a shared helper. **Public API byte-identical**, existing tests untouched |
| modify | `Core/Storage/Keychain/Keychain.swift` — per-item `kSecAttrAccessible`, plus `getData`/`setData` |
| modify | `Core/Storage/Keychain/KeychainService.swift` — `keyshareDEK`, `keyshareDEKWrapped`, `passcodeAttempts` keys |

11 files, +1175/−99.

### The design decision worth reviewing

The passcode **wraps** a random 256-bit data key held in the Keychain; it does **not** derive the storage key. This deliberately diverges from `vultisig-windows`, which keys AES directly off the passcode via PBKDF2-600k.

Five digits is ~16.6 bits of real entropy, so deriving the storage key from it would fall to offline brute force in seconds once the store file leaks. Two consequences that matter beyond that:

- passcode change / disable become 32-byte re-wraps that **never touch a key share**. The desktop client rewrites every share of every vault at both moments — three separate chances to destroy key material on routine settings actions.
- the read path, which runs inside TSS keysign via the **synchronous non-throwing** `LocalStateAccessorImp.getLocalState`, stays one AES-GCM open instead of a 600k-iteration KDF.

### Included review fix

`Keychain.swift` used delete-then-add to replace a value: if `SecItemAdd` failed after `SecItemDelete` succeeded, the stored value was **permanently lost** and the failure was silently swallowed. Pre-existing, but this PR is what routes key material through that path — before it the worst case was a re-enterable fast-vault password; after it, the same code carries the data key that opens every key share. Now `SecItemUpdate` first, `SecItemAdd` only on `errSecItemNotFound`, every other status logged and returned as a failure.

That branch could not be tested against the real keychain — a unit-test bundle has no keychain entitlement and every real `SecItem` call returns `errSecMissingEntitlement` (−34018), confirmed empirically at 21 failures. Added a `KeychainItemStore` seam over the four `SecItem` calls and drove the branch through a fake. The assertion that matters: **a failed overwrite leaves the previous value intact and never calls delete.**

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

None of the above — this is storage/crypto plumbing with no reachable call site yet.

## Parity

- Android: `vultisig/vultisig-android#5343` (sibling issue, unchanged)
- Windows + extension: `core/ui/passcodeEncryption/` is the reference implementation. **We deliberately diverge on key derivation** — see above. Same 5-digit passcode, same feature set, different KDF story
- SDK: n/a — zero passcode references in `vultisig-sdk`

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

Tests: `KeyshareCipherTests`, `KeyshareKeyStoreTests` — round-trip seal/open; wrong key rejected; tampered ciphertext/salt/iv rejected via GCM auth; `isSealed` false for a GG20 JSON share and a DKLS base64 share, true for `seal` output; empty and very large shares; data key persists and reads back with `kSecAttrAccessible` asserted; wrap/unwrap round-trip and wrong-passcode tag failure.

## Additional context

**Review order matters for this stack.** PRs 1–3 are at-rest encryption with no UX and no passcode, and are shippable and defensible on their own. PRs 4–7 are the passcode feature. This one is intentionally the smallest reviewable unit: the primitives, with no caller.

⚠️ **The crypto and migration design has not been signed off yet.** #4846 carries an unwithdrawn objection from @johnnyluo (2026-07-20) that the app should use the native lock rather than reinvent it. Two facts that reframe that, both verified against the checkout: the existing app-lock has **no user-facing toggle** (`isAuthenticationEnabled` is only ever written by `AppViewModel` itself as a side effect of `LAContext` capability), and this is **one target for iOS and macOS** (`project.yml:88-93`), so on a Mac without Touch ID there is effectively no app lock at all. That makes the question "should plaintext key material sit on disk", which is a different question from "should we reinvent the native lock". Opened as a draft precisely so that conversation can happen against real code.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4846
- **Confidence**: medium — code and tests are gated green and Codex-reviewed, but the design is not signed off and the feature itself is contested
- **Needs human review for**: the KDF divergence from Windows, Keychain accessibility class, and the `vlt2:` envelope format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure encryption and decryption for key shares stored on the device.
  * Added protected storage for encryption keys, including passcode-based wrapping and recovery.
  * Added Keychain support for key-share encryption data with configurable accessibility settings.
  * Added a shared encryption format for vault data while preserving compatibility with existing backups.

* **Bug Fixes**
  * Improved detection and handling of corrupted, tampered, malformed, or incorrectly encoded encrypted data.

* **Tests**
  * Added comprehensive coverage for encryption, key storage, Keychain operations, tampering, and backup compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

