### PR TITLE
refactor(security): route all key share access through one accessor (2/8)

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/DKLSKeygen.swift
@@ -557,12 +557,7 @@ final class DKLSKeygen {
     }
 
     func getKeyshareString() -> String? {
-        for ks in vault.keyshares {
-            if ks.pubkey == self.publicKeyECDSA {
-                return ks.keyshare
-            }
-        }
-        return nil
+        return vault.getKeyshare(pubKey: self.publicKeyECDSA)
     }
 
     func getKeyshareBytesFromVault() throws -> [UInt8] {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keygen/SchnorrKeygen.swift
@@ -506,12 +506,7 @@ final class SchnorrKeygen {
     }
 
     func getKeyshareString() -> String? {
-        for ks in vault.keyshares {
-            if ks.pubkey == self.publicKeyEdDSA {
-                return ks.keyshare
-            }
-        }
-        return nil
+        return vault.getKeyshare(pubKey: self.publicKeyEdDSA)
     }
 
     func getKeyshareBytesFromVault() throws -> [UInt8] {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DKLSKeysign.swift
@@ -58,12 +58,7 @@ final class DKLSKeysign {
     }
 
     func getKeyshareString() -> String? {
-        for ks in vault.keyshares {
-            if ks.pubkey == self.publicKeyECDSA {
-                return ks.keyshare
-            }
-        }
-        return nil
+        return vault.getKeyshare(pubKey: self.publicKeyECDSA)
     }
 
     func getKeyshareBytes() throws -> [UInt8] {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DilithiumKeysign.swift
@@ -67,12 +67,7 @@ final class DilithiumKeysign {
     }
 
     func getKeyshareString() -> String? {
-        for ks in vault.keyshares {
-            if ks.pubkey == self.publicKey {
-                return ks.keyshare
-            }
-        }
-        return nil
+        return vault.getKeyshare(pubKey: self.publicKey)
     }
 
     func getKeyshareBytes() throws -> [UInt8] {

--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/SchnorrKeysign.swift
@@ -63,12 +63,7 @@ final class SchnorrKeysign {
     }
 
     func getKeyshareString() -> String? {
-        for ks in vault.keyshares {
-            if ks.pubkey == self.publicKeyEdDSA {
-                return ks.keyshare
-            }
-        }
-        return nil
+        return vault.getKeyshare(pubKey: self.publicKeyEdDSA)
     }
 
     func getKeyshareBytes() throws -> [UInt8] {

--- a/VultisigApp/VultisigApp/Blockchain/Tss/LocalStateAccessorImp.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/LocalStateAccessorImp.swift
@@ -4,7 +4,10 @@
 //
 
 import Foundation
+import OSLog
 import Tss
+
+private let logger = Log.tss.store
 
 final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol, ObservableObject {
     struct RuntimeError: LocalizedError {
@@ -23,15 +26,22 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol, Obs
     init(vault: Vault) {
         self.vault = vault
     }
-    // swiftlint:disable:next unused_parameter
     func getLocalState(_ pubKey: String?, error: NSErrorPointer) -> String {
         guard let pubKey else {
             return ""
         }
-        for share in self.vault.keyshares where share.pubkey == pubKey {
-            return share.keyshare
+
+        do {
+            return try vault.keyshareValue(for: pubKey) ?? ""
+        } catch let openError {
+            // Only reachable once shares are stored sealed: the share exists but
+            // cannot be opened. Reported through the error pointer so the TSS
+            // layer sees a locked app rather than a vault missing its share —
+            // the two need different handling and both used to look like "".
+            logger.error("Failed to read local state: \(String(describing: openError), privacy: .public)")
+            error?.pointee = openError as NSError
+            return ""
         }
-        return ""
     }
 
     func saveLocalState(_ pubkey: String?, localState: String?) throws {
@@ -41,8 +51,11 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol, Obs
         guard let localState else {
             throw RuntimeError("localstate is nil")
         }
+        // Sealed here rather than where `keyshares` is copied onto the vault, so
+        // a share is protected from the moment the TSS layer hands it over.
+        let share = try KeyShare.sealed(pubkey: pubkey, keyshare: localState)
         DispatchQueue.main.async {
-            self.keyshares.append(KeyShare(pubkey: pubkey, keyshare: localState))
+            self.keyshares.append(share)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareCipher.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareCipher.swift
@@ -1,0 +1,67 @@
+//
+//  KeyshareCipher.swift
+//  VultisigApp
+//
+
+import CryptoKit
+import Foundation
+
+enum KeyshareCipherError: Error, Equatable {
+    case notSealed
+    case malformedBlob
+    case decryptionFailed
+    case invalidPlaintextEncoding
+}
+
+/// Seals and opens a single key share for storage at rest.
+///
+/// Sealed shares are written back into the same `KeyShare.keyshare` field they
+/// occupied in plaintext, so the stored value has to say which of the two it is.
+/// `sealedPrefix` does that: `:` is outside the base64 alphabet, so a sealed
+/// value can never be mistaken for a plaintext DKLS share (base64) or a
+/// plaintext GG20 share (JSON). Detection is a pure function of the value —
+/// nothing else has to be consulted, and re-sealing an already-sealed share is
+/// a no-op rather than a corruption.
+protocol KeyshareCipher {
+    func seal(_ plaintext: String, with key: SymmetricKey) throws -> String
+    func open(_ stored: String, with key: SymmetricKey) throws -> String
+    func isSealed(_ stored: String) -> Bool
+}
+
+struct AesGcmKeyshareCipher: KeyshareCipher {
+
+    static let sealedPrefix = "vlt2:"
+
+    func isSealed(_ stored: String) -> Bool {
+        stored.hasPrefix(Self.sealedPrefix)
+    }
+
+    func seal(_ plaintext: String, with key: SymmetricKey) throws -> String {
+        let blob = try VaultCryptoEnvelope.seal(Data(plaintext.utf8), using: key)
+        return Self.sealedPrefix + blob.base64EncodedString()
+    }
+
+    func open(_ stored: String, with key: SymmetricKey) throws -> String {
+        guard isSealed(stored) else {
+            throw KeyshareCipherError.notSealed
+        }
+
+        let encoded = String(stored.dropFirst(Self.sealedPrefix.count))
+        guard let blob = Data(base64Encoded: encoded),
+              let parsed = VaultCryptoEnvelope.parse(blob) else {
+            throw KeyshareCipherError.malformedBlob
+        }
+
+        let plaintext: Data
+        do {
+            plaintext = try VaultCryptoEnvelope.open(parsed, using: key)
+        } catch {
+            throw KeyshareCipherError.decryptionFailed
+        }
+
+        guard let value = String(data: plaintext, encoding: .utf8) else {
+            throw KeyshareCipherError.invalidPlaintextEncoding
+        }
+        return value
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
@@ -1,0 +1,157 @@
+//
+//  KeyshareKeyStore.swift
+//  VultisigApp
+//
+
+import CryptoKit
+import Foundation
+import OSLog
+
+private let logger = Log.app.other
+
+enum KeyshareKeyStoreError: Error, Equatable {
+    /// The Keychain accepted the write but read back something else — treated
+    /// as a hard failure, because encrypting against a key we cannot prove is
+    /// durable is how key shares get lost.
+    case persistenceFailed
+    case wrongPasscode
+    case malformedWrappedKey
+}
+
+/// Custody of the data key that encrypts key shares at rest.
+///
+/// The data key is 256 random bits, never derived from anything the user types.
+/// Exactly one of two forms is present at a time:
+///
+/// - **no passcode** — the key sits in the Keychain in the clear. Shares are
+///   still encrypted on disk; the Keychain is what an attacker would additionally
+///   need, and it is absent from the app container and from unencrypted backups.
+/// - **passcode set** — the clear copy is deleted and a passcode-wrapped copy
+///   takes its place. Unlocking opens it; locking forgets the opened key.
+///
+/// Changing or removing the passcode therefore rewraps 32 bytes and never
+/// rewrites a single key share.
+protocol KeyshareKeyStoring {
+    func generateDataKey() throws -> SymmetricKey
+
+    func loadDataKey() -> SymmetricKey?
+    func storeDataKey(_ key: SymmetricKey) throws
+    func deleteDataKey()
+
+    func loadWrappedDataKey() -> Data?
+    func storeWrappedDataKey(_ blob: Data) throws
+    func deleteWrappedDataKey()
+
+    func wrap(_ key: SymmetricKey, passcode: String) async throws -> Data
+    func unwrap(_ blob: Data, passcode: String) async throws -> SymmetricKey
+}
+
+final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
+
+    static let shared: KeyshareKeyStoring = DefaultKeyshareKeyStore()
+
+    private let keychain: KeychainService
+
+    init(keychain: KeychainService = DefaultKeychainService.shared) {
+        self.keychain = keychain
+    }
+
+    // MARK: - Data key
+
+    func generateDataKey() throws -> SymmetricKey {
+        try VaultCryptoEnvelope.randomKey()
+    }
+
+    func loadDataKey() -> SymmetricKey? {
+        guard let data = keychain.getKeyshareDataKey().valueTreatingUnavailableAsAbsent else { return nil }
+        guard data.count == VaultCryptoEnvelope.keyLengthBytes else {
+            logger.error("Keyshare data key has unexpected length \(data.count, privacy: .public)")
+            return nil
+        }
+        return SymmetricKey(data: data)
+    }
+
+    /// Writes the key and reads it back before returning. A silent Keychain
+    /// failure here would otherwise surface later as unopenable key shares.
+    func storeDataKey(_ key: SymmetricKey) throws {
+        let data = key.rawRepresentation
+        keychain.setKeyshareDataKey(data)
+
+        guard case .present(let readBack) = keychain.getKeyshareDataKey(), readBack == data else {
+            logger.error("Keyshare data key failed read-back verification")
+            throw KeyshareKeyStoreError.persistenceFailed
+        }
+    }
+
+    func deleteDataKey() {
+        keychain.setKeyshareDataKey(nil)
+    }
+
+    // MARK: - Wrapped data key
+
+    func loadWrappedDataKey() -> Data? {
+        keychain.getWrappedKeyshareDataKey().valueTreatingUnavailableAsAbsent
+    }
+
+    func storeWrappedDataKey(_ blob: Data) throws {
+        keychain.setWrappedKeyshareDataKey(blob)
+
+        guard case .present(let readBack) = keychain.getWrappedKeyshareDataKey(), readBack == blob else {
+            logger.error("Wrapped keyshare data key failed read-back verification")
+            throw KeyshareKeyStoreError.persistenceFailed
+        }
+    }
+
+    func deleteWrappedDataKey() {
+        keychain.setWrappedKeyshareDataKey(nil)
+    }
+
+    // MARK: - Passcode wrapping
+
+    /// PBKDF2 at 600k iterations costs roughly half a second, so both of these
+    /// run off the calling thread the way `VaultBackupEncryption` does.
+    ///
+    /// The stretching is not what makes the wrap strong — a 5-digit passcode is
+    /// only ~16.6 bits however it is stretched, and an attacker who can read the
+    /// wrapped blob out of the Keychain already owns the device. What it buys is
+    /// a throttle on the in-app guessing path.
+    func wrap(_ key: SymmetricKey, passcode: String) async throws -> Data {
+        let keyData = key.rawRepresentation
+        return try await Task.detached(priority: .userInitiated) {
+            let salt = try VaultCryptoEnvelope.randomBytes(count: VaultCryptoEnvelope.saltLength)
+            let iv = try VaultCryptoEnvelope.randomBytes(count: VaultCryptoEnvelope.ivLength)
+            let wrappingKey = try VaultCryptoEnvelope.deriveKey(password: passcode, salt: salt)
+            return try VaultCryptoEnvelope.seal(keyData, using: wrappingKey, salt: salt, iv: iv)
+        }.value
+    }
+
+    /// A wrong passcode fails GCM authentication, which is what makes a separate
+    /// stored verification sample unnecessary.
+    func unwrap(_ blob: Data, passcode: String) async throws -> SymmetricKey {
+        try await Task.detached(priority: .userInitiated) {
+            guard let parsed = VaultCryptoEnvelope.parse(blob) else {
+                throw KeyshareKeyStoreError.malformedWrappedKey
+            }
+
+            let wrappingKey = try VaultCryptoEnvelope.deriveKey(password: passcode, salt: parsed.salt)
+
+            let keyData: Data
+            do {
+                keyData = try VaultCryptoEnvelope.open(parsed, using: wrappingKey)
+            } catch {
+                throw KeyshareKeyStoreError.wrongPasscode
+            }
+
+            guard keyData.count == VaultCryptoEnvelope.keyLengthBytes else {
+                throw KeyshareKeyStoreError.malformedWrappedKey
+            }
+            return SymmetricKey(data: keyData)
+        }.value
+    }
+}
+
+private extension SymmetricKey {
+    var rawRepresentation: Data {
+        withUnsafeBytes { Data($0) }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareProtector.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareProtector.swift
@@ -1,0 +1,96 @@
+//
+//  KeyshareProtector.swift
+//  VultisigApp
+//
+
+import CryptoKit
+import Foundation
+import OSLog
+
+private let logger = Log.app.store
+
+enum KeyshareProtectionError: Error, Equatable {
+    /// A share is sealed but the data key is not available to open it.
+    case locked
+    case cipherFailure
+}
+
+/// Whether key shares are protected, and if so whether the key is available.
+enum KeyshareProtectionState {
+    /// No data key exists — shares are stored in the clear. The state every
+    /// install is in until the one-time migration runs.
+    case disabled
+    /// The data key is in hand; shares seal and open.
+    case unlocked(SymmetricKey)
+    /// A data key exists but is wrapped by a passcode that has not been entered.
+    case locked
+}
+
+/// The single point where a stored key share turns into a usable one.
+///
+/// Every read and write of `KeyShare.keyshare` goes through here, so the choice
+/// of whether a share is encrypted lives in exactly one place instead of being
+/// spread across keygen, keysign, reshare and backup.
+///
+/// `open` tolerates a plaintext value whatever the state, because shares stay
+/// plaintext until the migration has run and the migration must be safe to
+/// retry. `seal` refuses to double-seal for the same reason.
+protocol KeyshareProtecting {
+    func open(_ stored: String) throws -> String
+    func seal(_ plaintext: String) throws -> String
+}
+
+final class KeyshareProtector: KeyshareProtecting {
+
+    static let shared = KeyshareProtector()
+
+    private let cipher: KeyshareCipher
+    private let state: () -> KeyshareProtectionState
+
+    init(
+        cipher: KeyshareCipher = AesGcmKeyshareCipher(),
+        state: @escaping () -> KeyshareProtectionState = { .disabled }
+    ) {
+        self.cipher = cipher
+        self.state = state
+    }
+
+    func open(_ stored: String) throws -> String {
+        // A share written before the migration is plaintext and stays readable
+        // regardless of state — that is what makes the migration resumable.
+        guard cipher.isSealed(stored) else { return stored }
+
+        switch state() {
+        case .unlocked(let key):
+            do {
+                return try cipher.open(stored, with: key)
+            } catch {
+                logger.error("Failed to open key share: \(String(describing: error), privacy: .public)")
+                throw KeyshareProtectionError.cipherFailure
+            }
+        case .disabled, .locked:
+            // Sealed with no key in hand. Never fall back to returning the
+            // ciphertext: a caller handing that to the TSS layer would look like
+            // a corrupt share rather than a locked app.
+            throw KeyshareProtectionError.locked
+        }
+    }
+
+    func seal(_ plaintext: String) throws -> String {
+        guard !cipher.isSealed(plaintext) else { return plaintext }
+
+        switch state() {
+        case .unlocked(let key):
+            do {
+                return try cipher.seal(plaintext, with: key)
+            } catch {
+                logger.error("Failed to seal key share: \(String(describing: error), privacy: .public)")
+                throw KeyshareProtectionError.cipherFailure
+            }
+        case .disabled:
+            return plaintext
+        case .locked:
+            throw KeyshareProtectionError.locked
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/VaultCryptoEnvelope.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/VaultCryptoEnvelope.swift
@@ -1,0 +1,181 @@
+//
+//  VaultCryptoEnvelope.swift
+//  VultisigApp
+//
+
+import CommonCrypto
+import CryptoKit
+import Foundation
+import OSLog
+
+private let logger = Log.app.other
+
+enum VaultCryptoEnvelopeError: Error {
+    case keyDerivationFailed
+    case randomGenerationFailed
+    case encryptionFailed
+    case malformedBlob
+    case decryptionFailed
+}
+
+/// Shared primitives for the `VLT\x02` encrypted blob.
+///
+/// Wire format is `signature(4) ‖ salt(16) ‖ nonce(12) ‖ ciphertext ‖ tag(16)`,
+/// where everything from the nonce onward is CryptoKit's `SealedBox.combined`.
+/// It matches the desktop client's vault-backup blob byte for byte, so one
+/// implementation serves every at-rest payload we have:
+///
+/// - vault backups, keyed by a user-chosen password (`VaultBackupEncryption`),
+/// - key shares at rest, keyed by a raw random data key,
+/// - that data key itself, wrapped under the app passcode.
+///
+/// The salt is only meaningful for the password-derived payloads; raw-key
+/// callers still fill it with random bytes so every blob has the same shape and
+/// one parser covers all of them.
+///
+/// Note that the header is **not** covered by the GCM tag — only the ciphertext
+/// is. For password-derived payloads that costs nothing, because a corrupted
+/// salt derives a different key and the tag then fails anyway. For raw-key
+/// payloads the salt is inert: corrupting it cannot change the plaintext that
+/// comes back. Authenticating the header would break every backup already
+/// written, so it stays out; nothing reads the salt on the raw-key path, which
+/// is what makes that safe.
+enum VaultCryptoEnvelope {
+
+    static let formatSignature: [UInt8] = [0x56, 0x4C, 0x54, 0x02]
+    static let formatSignatureLength = 4
+    static let saltLength = 16
+    static let ivLength = 12
+    static let gcmTagBytes = 16
+    static let keyLengthBytes = 32
+    static let pbkdf2Iterations: UInt32 = 600_000
+
+    /// Bytes before the ciphertext: signature + salt + nonce. The nonce is part
+    /// of `SealedBox.combined`, so parsing keeps it with the sealed remainder.
+    static let headerSize = formatSignatureLength + saltLength + ivLength
+
+    struct Parsed {
+        /// PBKDF2 salt. Random filler for raw-key payloads.
+        let salt: Data
+        /// `nonce ‖ ciphertext ‖ tag`, ready for `AES.GCM.SealedBox(combined:)`.
+        let sealedCombined: Data
+    }
+
+    // MARK: - Parsing
+
+    static func hasFormatSignature(_ data: Data) -> Bool {
+        guard data.count >= formatSignatureLength else { return false }
+        for index in 0..<formatSignatureLength where data[data.startIndex + index] != formatSignature[index] {
+            return false
+        }
+        return true
+    }
+
+    /// Splits a well-formed blob into its salt and sealed remainder. Returns
+    /// `nil` when the signature is absent or the blob is too short to hold a
+    /// header plus a GCM tag — callers treat that as "not our format" rather
+    /// than as an error, because legacy blobs are detected that way.
+    static func parse(_ data: Data) -> Parsed? {
+        guard hasFormatSignature(data), data.count >= headerSize + gcmTagBytes else {
+            return nil
+        }
+        let saltStart = data.startIndex + formatSignatureLength
+        let saltEnd = saltStart + saltLength
+        return Parsed(
+            salt: data.subdata(in: saltStart..<saltEnd),
+            sealedCombined: data.subdata(in: saltEnd..<data.endIndex)
+        )
+    }
+
+    // MARK: - Seal / open
+
+    /// Seals under a caller-supplied salt and nonce. Password-derived callers
+    /// pass the salt they derived the key from; raw-key callers pass filler.
+    static func seal(_ plaintext: Data, using key: SymmetricKey, salt: Data, iv: Data) throws -> Data {
+        do {
+            let nonce = try AES.GCM.Nonce(data: iv)
+            let sealed = try AES.GCM.seal(plaintext, using: key, nonce: nonce)
+            guard let combined = sealed.combined else {
+                throw VaultCryptoEnvelopeError.encryptionFailed
+            }
+            var output = Data(capacity: formatSignatureLength + salt.count + combined.count)
+            output.append(contentsOf: formatSignature)
+            output.append(salt)
+            output.append(combined)
+            return output
+        } catch let error as VaultCryptoEnvelopeError {
+            throw error
+        } catch {
+            logger.error("AES-GCM encryption failed: \(error.localizedDescription, privacy: .public)")
+            throw VaultCryptoEnvelopeError.encryptionFailed
+        }
+    }
+
+    /// Seals under a fresh random salt and nonce. For raw-key payloads, where
+    /// the salt carries no meaning and nothing needs to reproduce it.
+    static func seal(_ plaintext: Data, using key: SymmetricKey) throws -> Data {
+        try seal(
+            plaintext,
+            using: key,
+            salt: try randomBytes(count: saltLength),
+            iv: try randomBytes(count: ivLength)
+        )
+    }
+
+    static func open(_ parsed: Parsed, using key: SymmetricKey) throws -> Data {
+        do {
+            let sealedBox = try AES.GCM.SealedBox(combined: parsed.sealedCombined)
+            return try AES.GCM.open(sealedBox, using: key)
+        } catch {
+            // Expected on a wrong key or a tampered blob — GCM authentication is
+            // what tells those apart from a correct open, so this is not
+            // necessarily a fault.
+            logger.debug("AES-GCM open failed: \(error.localizedDescription, privacy: .public)")
+            throw VaultCryptoEnvelopeError.decryptionFailed
+        }
+    }
+
+    // MARK: - Keys
+
+    static func deriveKey(password: String, salt: Data) throws -> SymmetricKey {
+        let passwordBytes = Array(password.utf8)
+        var derived = [UInt8](repeating: 0, count: keyLengthBytes)
+
+        let status = salt.withUnsafeBytes { saltPtr -> Int32 in
+            guard let saltBase = saltPtr.bindMemory(to: UInt8.self).baseAddress else {
+                return Int32(kCCParamError)
+            }
+            return CCKeyDerivationPBKDF(
+                CCPBKDFAlgorithm(kCCPBKDF2),
+                passwordBytes,
+                passwordBytes.count,
+                saltBase,
+                salt.count,
+                CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                pbkdf2Iterations,
+                &derived,
+                keyLengthBytes
+            )
+        }
+
+        guard status == kCCSuccess else {
+            logger.error("PBKDF2 key derivation failed: status=\(status, privacy: .public)")
+            throw VaultCryptoEnvelopeError.keyDerivationFailed
+        }
+        return SymmetricKey(data: Data(derived))
+    }
+
+    static func randomKey() throws -> SymmetricKey {
+        SymmetricKey(data: try randomBytes(count: keyLengthBytes))
+    }
+
+    static func randomBytes(count: Int) throws -> Data {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        guard status == errSecSuccess else {
+            logger.error("SecRandomCopyBytes failed: status=\(status, privacy: .public)")
+            throw VaultCryptoEnvelopeError.randomGenerationFailed
+        }
+        return Data(bytes)
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/Keychain.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/Keychain.swift
@@ -81,11 +81,38 @@ struct Keychain {
         setString(string, for: key)
     }
 
+    // MARK: - Data
+
+    func getData(for key: KeychainIdentifier) -> KeychainReadResult<Data> {
+        return get(for: key)
+    }
+
+    /// - Parameter accessibility: the item's `kSecAttrAccessible` class. Defaults
+    ///   to the app-wide `WhenUnlockedThisDeviceOnly`; key material that has to
+    ///   survive a device migration overrides it, since a `ThisDeviceOnly` item
+    ///   is absent from every backup and would leave a restored device unable to
+    ///   open its own vaults.
+    @discardableResult
+    func setData(
+        _ value: Data?,
+        for key: KeychainIdentifier,
+        accessibility: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ) -> Bool {
+        set(value, for: key, accessibility: accessibility)
+    }
+
     // MARK: - Helpers
 
-    func delete(for key: KeychainIdentifier) {
+    @discardableResult
+    func delete(for key: KeychainIdentifier) -> Bool {
         let query = generateQuery(for: key)
-        _ = itemStore.delete(query)
+        let status = itemStore.delete(query)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            logger.error("Keychain delete failed for \(key.identifier, privacy: .public): status=\(status, privacy: .public)")
+            return false
+        }
+        return true
     }
 
 }
@@ -94,25 +121,55 @@ struct Keychain {
 
 private extension Keychain {
 
-    func set(_ data: Data?, for key: KeychainIdentifier) {
+    /// Writes an item, updating in place when one already exists.
+    ///
+    /// Deliberately not delete-then-add: that destroys the stored value before
+    /// the replacement is known to have landed, so a failing write loses the old
+    /// value as well as the new one. Harmless for a re-enterable password, fatal
+    /// for the key that opens the vault key shares — losing it during a passcode
+    /// change would leave every share encrypted under a key that no longer
+    /// exists.
+    ///
+    /// - Returns: whether the value is stored. Callers holding key material are
+    ///   expected to verify by reading back; the return value and the log entry
+    ///   are so a failure is never silent.
+    @discardableResult
+    func set(
+        _ data: Data?,
+        for key: KeychainIdentifier,
+        accessibility: CFString = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+    ) -> Bool {
 
         guard let data = data else {
-            delete(for: key)
-            return
+            return delete(for: key)
         }
 
         var query = generateQuery(for: key)
-
-        _ = itemStore.delete(query)
-
         query.removeValue(forKey: kSecReturnDataValue)
-        query.updateValue(data, forKey: kSecValueDataValue)
-        query.updateValue(kSecAttrAccessibleWhenUnlockedThisDeviceOnly, forKey: kSecAttrAccessibleValue)
 
-        let status = itemStore.add(query)
-        guard status == errSecSuccess else {
-            return
+        let attributes: [String: Any] = [
+            kSecValueDataValue: data,
+            kSecAttrAccessibleValue: accessibility
+        ]
+
+        let updateStatus = itemStore.update(query, attributes: attributes)
+        if updateStatus == errSecSuccess {
+            return true
         }
+        guard updateStatus == errSecItemNotFound else {
+            logger.error("Keychain update failed for \(key.identifier, privacy: .public): status=\(updateStatus, privacy: .public)")
+            return false
+        }
+
+        query.updateValue(data, forKey: kSecValueDataValue)
+        query.updateValue(accessibility, forKey: kSecAttrAccessibleValue)
+
+        let addStatus = itemStore.add(query)
+        guard addStatus == errSecSuccess else {
+            logger.error("Keychain add failed for \(key.identifier, privacy: .public): status=\(addStatus, privacy: .public)")
+            return false
+        }
+        return true
     }
 
     /// Reads one item, keeping apart the three outcomes the Security framework

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainItemStore.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainItemStore.swift
@@ -8,14 +8,18 @@ import Security
 
 /// The `SecItem` calls ``Keychain`` makes, behind a seam.
 ///
-/// The seam exists so the read path can be tested. A unit-test bundle has no
-/// keychain entitlement, so every real `SecItem` call answers
+/// The seam exists so the read and write paths can be tested. A unit-test bundle
+/// has no keychain entitlement, so every real `SecItem` call answers
 /// `errSecMissingEntitlement` — one of the very statuses the read path has to
 /// tell apart from "no such item", and one it cannot be shown to tell apart if
-/// it is the only status a test can ever produce.
+/// it is the only status a test can ever produce. The write path is just as
+/// invisible, and the branch that decides between updating an item in place and
+/// adding a new one is what keeps a failed write from destroying the previous
+/// value.
 protocol KeychainItemStore {
     func copyMatching(_ query: [String: Any]) -> (status: OSStatus, data: Data?)
     func add(_ attributes: [String: Any]) -> OSStatus
+    func update(_ query: [String: Any], attributes: [String: Any]) -> OSStatus
     func delete(_ query: [String: Any]) -> OSStatus
 }
 
@@ -29,6 +33,10 @@ struct SecItemStore: KeychainItemStore {
 
     func add(_ attributes: [String: Any]) -> OSStatus {
         SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    func update(_ query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
     }
 
     func delete(_ query: [String: Any]) -> OSStatus {

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
@@ -20,6 +20,10 @@ protocol KeychainService: AnyObject {
     func setLastMigratedVersion(_ version: Int?)
     func getDeviceToken() -> KeychainReadResult<String>
     func setDeviceToken(_ token: String?)
+    func getKeyshareDataKey() -> KeychainReadResult<Data>
+    func setKeyshareDataKey(_ data: Data?)
+    func getWrappedKeyshareDataKey() -> KeychainReadResult<Data>
+    func setWrappedKeyshareDataKey(_ data: Data?)
 }
 
 final class DefaultKeychainService: KeychainService {
@@ -68,6 +72,34 @@ final class DefaultKeychainService: KeychainService {
     func setDeviceToken(_ token: String?) {
         keychain.setString(token, for: Keys.deviceToken)
     }
+
+    func getKeyshareDataKey() -> KeychainReadResult<Data> {
+        return keychain.getData(for: Keys.keyshareDataKey)
+    }
+
+    /// Stored as `WhenUnlocked` rather than the app default `ThisDeviceOnly`:
+    /// a `ThisDeviceOnly` item never leaves the device, so restoring an encrypted
+    /// backup onto a new phone would bring the encrypted key shares across
+    /// without the key that opens them.
+    func setKeyshareDataKey(_ data: Data?) {
+        keychain.setData(
+            data,
+            for: Keys.keyshareDataKey,
+            accessibility: kSecAttrAccessibleWhenUnlocked
+        )
+    }
+
+    func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> {
+        return keychain.getData(for: Keys.wrappedKeyshareDataKey)
+    }
+
+    func setWrappedKeyshareDataKey(_ data: Data?) {
+        keychain.setData(
+            data,
+            for: Keys.wrappedKeyshareDataKey,
+            accessibility: kSecAttrAccessibleWhenUnlocked
+        )
+    }
 }
 
 private extension DefaultKeychainService {
@@ -77,6 +109,8 @@ private extension DefaultKeychainService {
         case fastHint(pubKeyECDSA: String)
         case lastMigratedVersion
         case deviceToken
+        case keyshareDataKey
+        case wrappedKeyshareDataKey
 
         var identifier: String {
             return "\(DefaultKeychainService.serviceName).\(key)"
@@ -92,6 +126,10 @@ private extension DefaultKeychainService {
                 return "lastMigratedVersion"
             case .deviceToken:
                 return "deviceToken"
+            case .keyshareDataKey:
+                return "keyshareDataKey"
+            case .wrappedKeyshareDataKey:
+                return "wrappedKeyshareDataKey"
             }
         }
     }

--- a/VultisigApp/VultisigApp/Core/Utils/VaultBackupEncryption.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/VaultBackupEncryption.swift
@@ -1,4 +1,3 @@
-import CommonCrypto
 import CryptoKit
 import Foundation
 import OSLog
@@ -16,16 +15,12 @@ enum VaultBackupEncryptionError: Error {
     case encryptionFailed
 }
 
+/// Vault backups, encrypted under a user-chosen password.
+///
+/// The blob format lives in `VaultCryptoEnvelope`, which key shares at rest
+/// share — the bytes on the wire are unchanged, and stay compatible with the
+/// desktop client's backups.
 final class Pbkdf2VaultBackupEncryption: VaultBackupEncryption {
-
-    private static let formatSignature: [UInt8] = [0x56, 0x4C, 0x54, 0x02]
-    private static let formatSignatureLength = 4
-    private static let saltLength = 16
-    private static let ivLength = 12
-    private static let gcmTagBytes = 16
-    private static let keyLengthBytes = 32
-    private static let iterations: UInt32 = 600_000
-    private static let headerSize = formatSignatureLength + saltLength + ivLength
 
     func encrypt(data: Data, password: String) async throws -> Data {
         try await Task.detached(priority: .userInitiated) {
@@ -40,31 +35,18 @@ final class Pbkdf2VaultBackupEncryption: VaultBackupEncryption {
     }
 
     private static func encryptSync(data: Data, password: String) throws -> Data {
-        let salt = try randomBytes(count: saltLength)
-        let iv = try randomBytes(count: ivLength)
-        let key = try deriveKey(password: password, salt: salt)
-
         do {
-            let nonce = try AES.GCM.Nonce(data: iv)
-            let sealed = try AES.GCM.seal(data, using: key, nonce: nonce)
-            guard let combined = sealed.combined else {
-                throw VaultBackupEncryptionError.encryptionFailed
-            }
-            var output = Data(capacity: formatSignatureLength + salt.count + combined.count)
-            output.append(contentsOf: formatSignature)
-            output.append(salt)
-            output.append(combined)
-            return output
-        } catch let error as VaultBackupEncryptionError {
-            throw error
-        } catch {
-            logger.error("AES-GCM encryption failed: \(error.localizedDescription, privacy: .public)")
-            throw VaultBackupEncryptionError.encryptionFailed
+            let salt = try VaultCryptoEnvelope.randomBytes(count: VaultCryptoEnvelope.saltLength)
+            let iv = try VaultCryptoEnvelope.randomBytes(count: VaultCryptoEnvelope.ivLength)
+            let key = try VaultCryptoEnvelope.deriveKey(password: password, salt: salt)
+            return try VaultCryptoEnvelope.seal(data, using: key, salt: salt, iv: iv)
+        } catch let error as VaultCryptoEnvelopeError {
+            throw error.asBackupError
         }
     }
 
     private static func decryptSync(data: Data, password: String) -> Data? {
-        if hasFormatSignature(data), let plaintext = decryptPbkdf2(data: data, password: password) {
+        if let plaintext = decryptPbkdf2(data: data, password: password) {
             return plaintext
         }
         // Legacy blobs begin with a random nonce that may, with ~1/2^32 probability,
@@ -73,21 +55,13 @@ final class Pbkdf2VaultBackupEncryption: VaultBackupEncryption {
     }
 
     private static func decryptPbkdf2(data: Data, password: String) -> Data? {
-        let minSize = headerSize + gcmTagBytes
-        guard data.count >= minSize else {
-            logger.warning("PBKDF2 payload too small: \(data.count, privacy: .public) bytes")
+        guard let parsed = VaultCryptoEnvelope.parse(data) else {
             return nil
         }
 
-        let saltStart = formatSignatureLength
-        let saltEnd = saltStart + saltLength
-        let salt = data.subdata(in: saltStart..<saltEnd)
-        let sealedCombined = data.subdata(in: saltEnd..<data.count)
-
         do {
-            let key = try deriveKey(password: password, salt: salt)
-            let sealedBox = try AES.GCM.SealedBox(combined: sealedCombined)
-            return try AES.GCM.open(sealedBox, using: key)
+            let key = try VaultCryptoEnvelope.deriveKey(password: password, salt: parsed.salt)
+            return try VaultCryptoEnvelope.open(parsed, using: key)
         } catch {
             logger.error("PBKDF2 decryption failed: \(error.localizedDescription, privacy: .public)")
             return nil
@@ -104,50 +78,20 @@ final class Pbkdf2VaultBackupEncryption: VaultBackupEncryption {
             return nil
         }
     }
+}
 
-    private static func hasFormatSignature(_ data: Data) -> Bool {
-        guard data.count >= formatSignatureLength else { return false }
-        for index in 0..<formatSignatureLength where data[data.startIndex + index] != formatSignature[index] {
-            return false
+private extension VaultCryptoEnvelopeError {
+    /// Preserves the errors this type has always thrown, so callers switching on
+    /// `VaultBackupEncryptionError` are unaffected by the move to the shared
+    /// envelope.
+    var asBackupError: VaultBackupEncryptionError {
+        switch self {
+        case .keyDerivationFailed:
+            return .keyDerivationFailed
+        case .randomGenerationFailed:
+            return .randomGenerationFailed
+        case .encryptionFailed, .malformedBlob, .decryptionFailed:
+            return .encryptionFailed
         }
-        return true
-    }
-
-    private static func deriveKey(password: String, salt: Data) throws -> SymmetricKey {
-        let passwordBytes = Array(password.utf8)
-        var derived = [UInt8](repeating: 0, count: Self.keyLengthBytes)
-
-        let status = salt.withUnsafeBytes { saltPtr -> Int32 in
-            guard let saltBase = saltPtr.bindMemory(to: UInt8.self).baseAddress else {
-                return Int32(kCCParamError)
-            }
-            return CCKeyDerivationPBKDF(
-                CCPBKDFAlgorithm(kCCPBKDF2),
-                passwordBytes,
-                passwordBytes.count,
-                saltBase,
-                salt.count,
-                CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
-                Self.iterations,
-                &derived,
-                Self.keyLengthBytes
-            )
-        }
-
-        guard status == kCCSuccess else {
-            logger.error("PBKDF2 key derivation failed: status=\(status, privacy: .public)")
-            throw VaultBackupEncryptionError.keyDerivationFailed
-        }
-        return SymmetricKey(data: Data(derived))
-    }
-
-    private static func randomBytes(count: Int) throws -> Data {
-        var bytes = [UInt8](repeating: 0, count: count)
-        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
-        guard status == errSecSuccess else {
-            logger.error("SecRandomCopyBytes failed: status=\(status, privacy: .public)")
-            throw VaultBackupEncryptionError.randomGenerationFailed
-        }
-        return Data(bytes)
     }
 }

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
@@ -302,6 +302,16 @@ class KeygenViewModel: ObservableObject {
                     throw HelperError.runtimeError("fail to get MLDSA keyshare")
                 }
 
+                // Sealed before this party reports completion. Sealing can fail,
+                // and once the peers have been told keygen succeeded there is no
+                // longer a safe way to abandon the share — the vault would be
+                // left holding a public key whose share was never stored.
+                let mldsaShare = try KeyShare.sealed(
+                    pubkey: keyshare.PubKey,
+                    keyshare: keyshare.Keyshare,
+                    keyId: keyshare.keyId
+                )
+
                 let keygenVerify = KeygenVerify(
                     serverAddr: self.mediatorURL,
                     sessionID: self.sessionID,
@@ -315,9 +325,7 @@ class KeygenViewModel: ObservableObject {
                 }
 
                 self.vault.publicKeyMLDSA44 = keyshare.PubKey
-                self.vault.keyshares.append(
-                    KeyShare(pubkey: keyshare.PubKey, keyshare: keyshare.Keyshare, keyId: keyshare.keyId)
-                )
+                self.vault.keyshares.append(mldsaShare)
                 self.vault.isBackedUp = false
             }
 
@@ -444,12 +452,17 @@ class KeygenViewModel: ObservableObject {
             chainResults = collected
         }
 
+        // Seal every share up front so the vault is not left holding chain
+        // public keys whose shares never made it in.
+        var sealedChainShares: [KeyShare] = []
+        for result in chainResults where seenPubKeys.insert(result.keyshare.PubKey).inserted {
+            sealedChainShares.append(
+                try KeyShare.sealed(pubkey: result.keyshare.PubKey, keyshare: result.keyshare.Keyshare)
+            )
+        }
+
+        self.vault.keyshares.append(contentsOf: sealedChainShares)
         for result in chainResults {
-            if seenPubKeys.insert(result.keyshare.PubKey).inserted {
-                self.vault.keyshares.append(
-                    KeyShare(pubkey: result.keyshare.PubKey, keyshare: result.keyshare.Keyshare)
-                )
-            }
             self.vault.chainPublicKeys.append(
                 ChainPublicKey(
                     chain: result.chain,
@@ -526,11 +539,15 @@ class KeygenViewModel: ObservableObject {
 
         self.logger.info("Finished root key import. ECDSA pub: \(rootEcdsa.PubKey), EdDSA pub: \(rootEddsa.PubKey)")
 
+        let sealedRootShares = [
+            try KeyShare.sealed(pubkey: rootEcdsa.PubKey, keyshare: rootEcdsa.Keyshare),
+            try KeyShare.sealed(pubkey: rootEddsa.PubKey, keyshare: rootEddsa.Keyshare)
+        ]
+
         self.vault.pubKeyECDSA = rootEcdsa.PubKey
         self.vault.pubKeyEdDSA = rootEddsa.PubKey
         self.vault.hexChainCode = rootEcdsa.chaincode
-        self.vault.keyshares.append(KeyShare(pubkey: rootEcdsa.PubKey, keyshare: rootEcdsa.Keyshare))
-        self.vault.keyshares.append(KeyShare(pubkey: rootEddsa.PubKey, keyshare: rootEddsa.Keyshare))
+        self.vault.keyshares.append(contentsOf: sealedRootShares)
     }
 
     private func buildChainImportJobs(chains: [Chain], wallet: HDWallet?, useParallelPath: Bool) throws -> [KeyImportChainJob] {
@@ -789,6 +806,14 @@ class KeygenViewModel: ObservableObject {
             throw HelperError.runtimeError("fail to get EdDSA keyshare")
         }
 
+        // Sealed before this party reports completion, for the same reason as
+        // above: after markLocalPartyComplete the peers consider the vault
+        // created, so a sealing failure has nowhere left to abort to.
+        let sealedShares = [
+            try KeyShare.sealed(pubkey: keyshareECDSA.PubKey, keyshare: keyshareECDSA.Keyshare),
+            try KeyShare.sealed(pubkey: keyshareEdDSA.PubKey, keyshare: keyshareEdDSA.Keyshare)
+        ]
+
         let keygenVerify = KeygenVerify(serverAddr: self.mediatorURL,
                                         sessionID: self.sessionID,
                                         localPartyID: self.vault.localPartyID,
@@ -806,8 +831,7 @@ class KeygenViewModel: ObservableObject {
         if self.tssType == .Migrate {
             self.vault.libType = .DKLS
         }
-        self.vault.keyshares = [KeyShare(pubkey: keyshareECDSA.PubKey, keyshare: keyshareECDSA.Keyshare),
-                                KeyShare(pubkey: keyshareEdDSA.PubKey, keyshare: keyshareEdDSA.Keyshare)]
+        self.vault.keyshares = sealedShares
 
         let needsInsert = self.tssType == .Keygen ||
             !self.vaultOldCommittee.contains(self.vault.localPartyID)

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -123,7 +123,7 @@ class EncryptedBackupViewModel: ObservableObject {
     func generateBackupFile(vault: Vault, encryptionPassword: String?, targetDirectory: URL? = nil) async throws -> URL? {
         var vaultContainer = VSVaultContainer()
         vaultContainer.version = 1 // current version 1
-        let vsVault = vault.mapToProtobuff()
+        let vsVault = try vault.mapToProtobuff()
         let data = try vsVault.serializedData()
 
         if let encryptionPassword {

--- a/VultisigApp/VultisigApp/Model/KeyShare.swift
+++ b/VultisigApp/VultisigApp/Model/KeyShare.swift
@@ -17,4 +17,22 @@ class KeyShare: Codable {
         self.keyshare = keyshare
         self.keyId = keyId
     }
+
+    /// Builds a share for storage, sealing the plaintext first.
+    ///
+    /// Every path that persists a share — keygen, reshare, key import, backup
+    /// import — goes through here, so a share cannot reach storage unprotected
+    /// by someone calling the plain initializer out of habit.
+    static func sealed(
+        pubkey: String,
+        keyshare: String,
+        keyId: String? = nil,
+        protector: KeyshareProtecting = KeyshareProtector.shared
+    ) throws -> KeyShare {
+        KeyShare(
+            pubkey: pubkey,
+            keyshare: try protector.seal(keyshare),
+            keyId: keyId
+        )
+    }
 }

--- a/VultisigApp/VultisigApp/Model/Vault+ProtoMappable.swift
+++ b/VultisigApp/VultisigApp/Model/Vault+ProtoMappable.swift
@@ -9,14 +9,27 @@ import Foundation
 import VultisigCommonData
 import SwiftProtobuf
 
-extension Vault: ProtoMappable {
-    convenience init(proto: VSVault) throws {
+/// Deliberately not a `ProtoMappable` conformance.
+///
+/// `ProtoMappable.mapToProtobuff()` cannot throw, and a vault's key shares have
+/// to be opened before they can be written into a `.vult` backup. A
+/// non-throwing mapper could only swallow that failure and export ciphertext,
+/// which would produce a backup that looks fine and restores to nothing. Vault
+/// is never serialized through `ProtoSerializer` generically, so dropping the
+/// conformance costs nothing and removes the trap.
+extension Vault {
+    convenience init(proto: VSVault, protector: KeyshareProtecting = KeyshareProtector.shared) throws {
         self.init(name: proto.name)
         self.pubKeyECDSA = proto.publicKeyEcdsa
         self.pubKeyEdDSA = proto.publicKeyEddsa
         self.signers = proto.signers
         self.hexChainCode = proto.hexChainCode
-        self.keyshares = proto.keyShares.map { KeyShare(pubkey: $0.publicKey, keyshare: $0.keyshare) }
+        // Shares arrive from the backup in the clear and are sealed on the way
+        // into storage, so an imported vault is protected exactly like one that
+        // has been through the migration.
+        self.keyshares = try proto.keyShares.map {
+            KeyShare(pubkey: $0.publicKey, keyshare: try protector.seal($0.keyshare))
+        }
         self.localPartyID = proto.localPartyID
         self.resharePrefix = proto.resharePrefix
         let timeInterval = TimeInterval(proto.createdAt.seconds) + TimeInterval(proto.createdAt.nanos) / 1_000_000_000
@@ -37,7 +50,16 @@ extension Vault: ProtoMappable {
         self.publicKeyMLDSA44 = proto.publicKeyMldsa44.nilIfEmpty
     }
 
-    func mapToProtobuff() -> VSVault {
+    /// - Throws: `KeyshareProtectionError.locked` when a share cannot be opened,
+    ///   so a backup is never written with unreadable key material in it.
+    func mapToProtobuff(protector: KeyshareProtecting = KeyshareProtector.shared) throws -> VSVault {
+        let openedKeyShares: [VSVault.KeyShare] = try keyshares.map { share in
+            var proto = VSVault.KeyShare()
+            proto.publicKey = share.pubkey
+            proto.keyshare = try protector.open(share.keyshare)
+            return proto
+        }
+
         return VSVault.with {
             $0.name = name
             $0.publicKeyEcdsa = pubKeyECDSA
@@ -48,12 +70,7 @@ extension Vault: ProtoMappable {
             $0.localPartyID = self.localPartyID
             $0.resharePrefix = self.resharePrefix ?? ""
             $0.libType = libType?.toVSLibType() ?? .gg20
-            $0.keyShares = self.keyshares.map { s in
-                var share = VSVault.KeyShare()
-                share.publicKey = s.pubkey
-                share.keyshare = s.keyshare
-                return share
-            }
+            $0.keyShares = openedKeyShares
             $0.createdAt = Google_Protobuf_Timestamp(date: self.createdAt)
             $0.chainPublicKeys = self.chainPublicKeys.map { c in
                 var cp = VSVault.ChainPublicKey()

--- a/VultisigApp/VultisigApp/Model/Vault.swift
+++ b/VultisigApp/VultisigApp/Model/Vault.swift
@@ -349,8 +349,26 @@ final class Vault: ObservableObject, Codable {
         coins.map { $0.chain }.uniqueBy { $0 }
     }
 
+    /// The usable key share for a public key, opened if it is stored sealed.
+    ///
+    /// Returns `nil` both when no share exists and when one exists but cannot be
+    /// opened. Callers that need to tell those apart use
+    /// `keyshareValue(for:)` and handle the thrown `KeyshareProtectionError`.
     func getKeyshare(pubKey: String) -> String? {
-        return self.keyshares.first(where: {$0.pubkey == pubKey})?.keyshare
+        return try? keyshareValue(for: pubKey)
+    }
+
+    /// - Throws: `KeyshareProtectionError.locked` when the share is sealed and
+    ///   the data key is unavailable, so a locked app is distinguishable from a
+    ///   vault that simply has no share for this key.
+    func keyshareValue(
+        for pubKey: String,
+        protector: KeyshareProtecting = KeyshareProtector.shared
+    ) throws -> String? {
+        guard let stored = keyshares.first(where: { $0.pubkey == pubKey })?.keyshare else {
+            return nil
+        }
+        return try protector.open(stored)
     }
 
     static func getUniqueVaultName(modelContext: ModelContext, setupType: KeyImportSetupType? = nil) -> String {

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -12,21 +12,45 @@ import Foundation
 ///
 /// Values are held as `KeychainReadResult`s rather than optionals so a test can
 /// stage an unreadable Keychain as easily as a stored value — the two are
-/// different answers and the consumers have to be pinned against both.
+/// different answers and the consumers have to be pinned against both. That
+/// matters most for the key material below, where "absent" licenses minting a
+/// replacement and "unavailable" must not.
 final class MockKeychainService: KeychainService {
 
     /// The answer ``getLastMigratedVersion()`` gives. Settable directly so a
     /// test can stage `.unavailable`.
     var lastMigratedVersionResult: KeychainReadResult<Int>
 
+    /// The answer ``getKeyshareDataKey()`` gives, likewise.
+    var keyshareDataKeyResult: KeychainReadResult<Data> = .absent
+
+    /// The answer ``getWrappedKeyshareDataKey()`` gives, likewise.
+    var wrappedKeyshareDataKeyResult: KeychainReadResult<Data> = .absent
+
     private var fastPasswords: [String: KeychainReadResult<String>] = [:]
     private var fastHints: [String: KeychainReadResult<String>] = [:]
     private var deviceTokenResult: KeychainReadResult<String> = .absent
+
+    /// When set, `setKeyshareDataKey` accepts the write but stores nothing, so
+    /// the read-back verification in `DefaultKeyshareKeyStore` can be exercised.
+    var dropsKeyshareDataKeyWrites = false
 
     /// The recorded version, for tests that only care about the stored value.
     var lastMigratedVersion: Int? {
         get { lastMigratedVersionResult.valueTreatingUnavailableAsAbsent }
         set { lastMigratedVersionResult = Self.result(newValue) }
+    }
+
+    /// The recorded key, for tests that only care about the stored value.
+    var keyshareDataKey: Data? {
+        get { keyshareDataKeyResult.valueTreatingUnavailableAsAbsent }
+        set { keyshareDataKeyResult = Self.result(newValue) }
+    }
+
+    /// The recorded wrapped key, for tests that only care about the stored value.
+    var wrappedKeyshareDataKey: Data? {
+        get { wrappedKeyshareDataKeyResult.valueTreatingUnavailableAsAbsent }
+        set { wrappedKeyshareDataKeyResult = Self.result(newValue) }
     }
 
     init(lastMigratedVersion: Int? = nil) {
@@ -56,6 +80,19 @@ final class MockKeychainService: KeychainService {
     func getDeviceToken() -> KeychainReadResult<String> { deviceTokenResult }
 
     func setDeviceToken(_ token: String?) { deviceTokenResult = Self.result(token) }
+
+    func getKeyshareDataKey() -> KeychainReadResult<Data> { keyshareDataKeyResult }
+
+    func setKeyshareDataKey(_ data: Data?) {
+        guard !dropsKeyshareDataKeyWrites else { return }
+        keyshareDataKeyResult = Self.result(data)
+    }
+
+    func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> { wrappedKeyshareDataKeyResult }
+
+    func setWrappedKeyshareDataKey(_ data: Data?) {
+        wrappedKeyshareDataKeyResult = Self.result(data)
+    }
 
     private static func result<Value>(_ value: Value?) -> KeychainReadResult<Value> {
         guard let value else { return .absent }

--- a/VultisigApp/VultisigAppTests/Security/KeychainWriteTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeychainWriteTests.swift
@@ -1,0 +1,213 @@
+//
+//  KeychainWriteTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+/// Drives `Keychain`'s write path through a fake `KeychainItemStore`.
+///
+/// The real `SecItem` calls are unreachable from a test bundle — no keychain
+/// entitlement, so every one returns `errSecMissingEntitlement` — which is why
+/// the seam exists. What is being pinned here is the property that a write which
+/// fails must leave the previously stored value alone: for the key that opens
+/// the vault key shares, destroying the old value on a failed write would leave
+/// every share encrypted under a key that no longer exists.
+final class KeychainWriteTests: XCTestCase {
+
+    private struct TestKey: KeychainIdentifier {
+        let identifier = "com.vultisig.wallet.tests.item"
+    }
+
+    private var itemStore: FakeKeychainItemStore!
+    private var sut: Keychain!
+    private let key = TestKey()
+
+    override func setUp() {
+        super.setUp()
+        itemStore = FakeKeychainItemStore()
+        sut = Keychain(serviceName: "com.vultisig.wallet.tests", itemStore: itemStore)
+    }
+
+    override func tearDown() {
+        sut = nil
+        itemStore = nil
+        super.tearDown()
+    }
+
+    // MARK: - Add vs update
+
+    func testWritingWhenNoItemExistsAddsIt() {
+        let value = Data(repeating: 0x01, count: 32)
+
+        XCTAssertTrue(sut.setData(value, for: key))
+
+        XCTAssertEqual(itemStore.addCount, 1)
+        XCTAssertEqual(itemStore.updateCount, 1, "Update is attempted first and reports not-found")
+        XCTAssertEqual(sut.getData(for: key), .present(value))
+    }
+
+    func testWritingOverAnExistingItemUpdatesInPlace() {
+        let original = Data(repeating: 0x01, count: 32)
+        let replacement = Data(repeating: 0x02, count: 32)
+        XCTAssertTrue(sut.setData(original, for: key))
+        itemStore.resetCounts()
+
+        XCTAssertTrue(sut.setData(replacement, for: key))
+
+        XCTAssertEqual(itemStore.updateCount, 1)
+        XCTAssertEqual(itemStore.addCount, 0, "An existing item must not be re-added")
+        XCTAssertEqual(sut.getData(for: key), .present(replacement))
+    }
+
+    /// The regression this whole seam exists for.
+    func testFailedOverwriteLeavesThePreviousValueIntact() {
+        let original = Data(repeating: 0x01, count: 32)
+        XCTAssertTrue(sut.setData(original, for: key))
+        itemStore.resetCounts()
+        itemStore.updateStatus = errSecIO
+
+        XCTAssertFalse(sut.setData(Data(repeating: 0x02, count: 32), for: key))
+
+        XCTAssertEqual(sut.getData(for: key), .present(original), "A failed write must not destroy the stored value")
+        XCTAssertEqual(itemStore.deleteCount, 0, "A failed write must never delete")
+    }
+
+    func testFailedAddReportsFailure() {
+        itemStore.addStatus = errSecIO
+
+        XCTAssertFalse(sut.setData(Data(repeating: 0x01, count: 32), for: key))
+
+        XCTAssertEqual(sut.getData(for: key), .absent)
+    }
+
+    func testWriteNeverDeletesBeforeAdding() {
+        XCTAssertTrue(sut.setData(Data(repeating: 0x01, count: 32), for: key))
+
+        XCTAssertEqual(itemStore.deleteCount, 0)
+    }
+
+    // MARK: - Accessibility
+
+    func testAccessibilityDefaultsToThisDeviceOnly() {
+        sut.setData(Data(repeating: 0x01, count: 32), for: key)
+
+        XCTAssertEqual(itemStore.lastAccessibility, kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String)
+    }
+
+    func testAccessibilityOverrideIsApplied() {
+        sut.setData(Data(repeating: 0x01, count: 32), for: key, accessibility: kSecAttrAccessibleWhenUnlocked)
+
+        XCTAssertEqual(itemStore.lastAccessibility, kSecAttrAccessibleWhenUnlocked as String)
+    }
+
+    func testAccessibilityOverrideIsAppliedOnUpdateToo() {
+        sut.setData(Data(repeating: 0x01, count: 32), for: key)
+
+        sut.setData(Data(repeating: 0x02, count: 32), for: key, accessibility: kSecAttrAccessibleWhenUnlocked)
+
+        XCTAssertEqual(itemStore.lastAccessibility, kSecAttrAccessibleWhenUnlocked as String)
+    }
+
+    // MARK: - Delete
+
+    func testWritingNilDeletesTheItem() {
+        XCTAssertTrue(sut.setData(Data(repeating: 0x01, count: 32), for: key))
+
+        XCTAssertTrue(sut.setData(nil, for: key))
+
+        XCTAssertEqual(sut.getData(for: key), .absent)
+        XCTAssertEqual(itemStore.deleteCount, 1)
+    }
+
+    func testDeletingAnAbsentItemIsNotAFailure() {
+        XCTAssertTrue(sut.delete(for: key))
+    }
+
+    func testFailedDeleteReportsFailure() {
+        itemStore.deleteStatus = errSecIO
+
+        XCTAssertFalse(sut.delete(for: key))
+    }
+}
+
+/// In-memory stand-in keyed by account, mirroring the `SecItem` status codes
+/// `Keychain` branches on.
+private final class FakeKeychainItemStore: KeychainItemStore {
+
+    private var storage: [String: Data] = [:]
+
+    private(set) var addCount = 0
+    private(set) var updateCount = 0
+    private(set) var deleteCount = 0
+    private(set) var lastAccessibility: String?
+
+    /// Overrides forcing the corresponding call to fail.
+    var addStatus: OSStatus?
+    var updateStatus: OSStatus?
+    var deleteStatus: OSStatus?
+
+    func resetCounts() {
+        addCount = 0
+        updateCount = 0
+        deleteCount = 0
+    }
+
+    func copyMatching(_ query: [String: Any]) -> (status: OSStatus, data: Data?) {
+        guard let account = account(in: query), let data = storage[account] else {
+            return (errSecItemNotFound, nil)
+        }
+        return (errSecSuccess, data)
+    }
+
+    func add(_ attributes: [String: Any]) -> OSStatus {
+        addCount += 1
+        if let addStatus { return addStatus }
+
+        guard let account = account(in: attributes),
+              let data = attributes[String(kSecValueData)] as? Data else {
+            return errSecParam
+        }
+        guard storage[account] == nil else { return errSecDuplicateItem }
+
+        recordAccessibility(from: attributes)
+        storage[account] = data
+        return errSecSuccess
+    }
+
+    func update(_ query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        updateCount += 1
+
+        guard let account = account(in: query), storage[account] != nil else {
+            return errSecItemNotFound
+        }
+        if let updateStatus { return updateStatus }
+
+        guard let data = attributes[String(kSecValueData)] as? Data else {
+            return errSecParam
+        }
+
+        recordAccessibility(from: attributes)
+        storage[account] = data
+        return errSecSuccess
+    }
+
+    func delete(_ query: [String: Any]) -> OSStatus {
+        deleteCount += 1
+        if let deleteStatus { return deleteStatus }
+
+        guard let account = account(in: query), storage.removeValue(forKey: account) != nil else {
+            return errSecItemNotFound
+        }
+        return errSecSuccess
+    }
+
+    private func account(in query: [String: Any]) -> String? {
+        query[String(kSecAttrAccount)] as? String
+    }
+
+    private func recordAccessibility(from attributes: [String: Any]) {
+        lastAccessibility = attributes[String(kSecAttrAccessible)] as? String
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareAccessorTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareAccessorTests.swift
@@ -1,0 +1,149 @@
+//
+//  KeyshareAccessorTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import VultisigCommonData
+import XCTest
+@testable import VultisigApp
+
+/// Pins the two properties this step is claiming.
+///
+/// One: with protection disabled — the state every install is in until the
+/// migration runs — reading and writing a share is byte-for-byte what it was
+/// before the accessor existed.
+///
+/// Two: a `.vult` backup survives a round trip with shares sealed. Getting that
+/// wrong is the quiet failure in this whole feature: export forgetting to open a
+/// share produces a file that looks like a backup, imports without complaint,
+/// and restores to a vault that cannot sign.
+final class KeyshareAccessorTests: XCTestCase {
+
+    private let ecdsaPubKey = "02aaa"
+    private let eddsaPubKey = "03bbb"
+    private let ecdsaShare = "eyJrZXlzaGFyZSI6ImVjZHNhIn0="
+    private let eddsaShare = #"{"PubKey":"03bbb","ShareID":{"value":"9"}}"#
+
+    private func makeUnlockedProtector() throws -> KeyshareProtector {
+        let key = try VaultCryptoEnvelope.randomKey()
+        return KeyshareProtector(state: { .unlocked(key) })
+    }
+
+    private func makeVault(protector: KeyshareProtecting) throws -> Vault {
+        let vault = Vault(name: "Test Vault")
+        vault.pubKeyECDSA = ecdsaPubKey
+        vault.pubKeyEdDSA = eddsaPubKey
+        vault.hexChainCode = "abcd"
+        vault.localPartyID = "iPhone-1"
+        vault.signers = ["iPhone-1", "iPad-2"]
+        vault.libType = .DKLS
+        vault.keyshares = [
+            try KeyShare.sealed(pubkey: ecdsaPubKey, keyshare: ecdsaShare, protector: protector),
+            try KeyShare.sealed(pubkey: eddsaPubKey, keyshare: eddsaShare, protector: protector)
+        ]
+        return vault
+    }
+
+    // MARK: - Disabled: the accessor is a no-op
+
+    func testDisabledStoresSharesAsPlaintext() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+
+        let vault = try makeVault(protector: protector)
+
+        XCTAssertEqual(vault.keyshares[0].keyshare, ecdsaShare, "Nothing should be sealed before the migration")
+        XCTAssertEqual(vault.keyshares[1].keyshare, eddsaShare)
+    }
+
+    func testDisabledReadsShareBack() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let vault = try makeVault(protector: protector)
+
+        XCTAssertEqual(try vault.keyshareValue(for: ecdsaPubKey, protector: protector), ecdsaShare)
+        XCTAssertEqual(try vault.keyshareValue(for: eddsaPubKey, protector: protector), eddsaShare)
+    }
+
+    func testUnknownPubKeyReturnsNil() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let vault = try makeVault(protector: protector)
+
+        XCTAssertNil(try vault.keyshareValue(for: "not-a-key", protector: protector))
+        XCTAssertNil(vault.getKeyshare(pubKey: "not-a-key"))
+    }
+
+    // MARK: - Sealed: the read path opens
+
+    func testSealedSharesAreStoredAsCiphertextAndReadBackAsPlaintext() throws {
+        let protector = try makeUnlockedProtector()
+        let vault = try makeVault(protector: protector)
+
+        XCTAssertNotEqual(vault.keyshares[0].keyshare, ecdsaShare)
+        XCTAssertTrue(vault.keyshares[0].keyshare.hasPrefix(AesGcmKeyshareCipher.sealedPrefix))
+
+        XCTAssertEqual(try vault.keyshareValue(for: ecdsaPubKey, protector: protector), ecdsaShare)
+        XCTAssertEqual(try vault.keyshareValue(for: eddsaPubKey, protector: protector), eddsaShare)
+    }
+
+    func testReadingASealedShareWhileLockedThrows() throws {
+        let unlocked = try makeUnlockedProtector()
+        let vault = try makeVault(protector: unlocked)
+        let locked = KeyshareProtector(state: { .locked })
+
+        XCTAssertThrowsError(try vault.keyshareValue(for: ecdsaPubKey, protector: locked)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+        }
+    }
+
+    // MARK: - .vult backup round trip
+
+    func testBackupRoundTripPreservesSharesWhenDisabled() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let vault = try makeVault(protector: protector)
+
+        let proto = try vault.mapToProtobuff(protector: protector)
+        let restored = try Vault(proto: proto, protector: protector)
+
+        XCTAssertEqual(try restored.keyshareValue(for: ecdsaPubKey, protector: protector), ecdsaShare)
+        XCTAssertEqual(try restored.keyshareValue(for: eddsaPubKey, protector: protector), eddsaShare)
+    }
+
+    /// Export must open before writing, or the backup carries ciphertext.
+    func testBackupExportWritesPlaintextSharesNotCiphertext() throws {
+        let protector = try makeUnlockedProtector()
+        let vault = try makeVault(protector: protector)
+
+        let proto = try vault.mapToProtobuff(protector: protector)
+
+        let exported = proto.keyShares.map(\.keyshare)
+        XCTAssertEqual(Set(exported), Set([ecdsaShare, eddsaShare]))
+        for share in exported {
+            XCTAssertFalse(share.hasPrefix(AesGcmKeyshareCipher.sealedPrefix), "A backup must never contain ciphertext")
+        }
+    }
+
+    /// A backup taken on one device must restore on another, whose data key is
+    /// necessarily different.
+    func testBackupRestoresUnderADifferentDataKey() throws {
+        let exporting = try makeUnlockedProtector()
+        let importing = try makeUnlockedProtector()
+        let vault = try makeVault(protector: exporting)
+
+        let proto = try vault.mapToProtobuff(protector: exporting)
+        let restored = try Vault(proto: proto, protector: importing)
+
+        XCTAssertTrue(restored.keyshares[0].keyshare.hasPrefix(AesGcmKeyshareCipher.sealedPrefix))
+        XCTAssertEqual(try restored.keyshareValue(for: ecdsaPubKey, protector: importing), ecdsaShare)
+        XCTAssertEqual(try restored.keyshareValue(for: eddsaPubKey, protector: importing), eddsaShare)
+    }
+
+    func testBackupExportWhileLockedThrowsRatherThanWritingCiphertext() throws {
+        let unlocked = try makeUnlockedProtector()
+        let vault = try makeVault(protector: unlocked)
+        let locked = KeyshareProtector(state: { .locked })
+
+        XCTAssertThrowsError(try vault.mapToProtobuff(protector: locked)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareCipherTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareCipherTests.swift
@@ -1,0 +1,176 @@
+//
+//  KeyshareCipherTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import XCTest
+@testable import VultisigApp
+
+final class KeyshareCipherTests: XCTestCase {
+
+    private var sut: AesGcmKeyshareCipher!
+    private var key: SymmetricKey!
+
+    /// Shaped like a real DKLS share: base64, no prefix.
+    private let dklsPlaintext = "eyJrZXlzaGFyZSI6ImV4YW1wbGUifQ=="
+    /// Shaped like a real GG20 share: raw JSON.
+    private let gg20Plaintext = #"{"PubKey":"02abc","ShareID":{"value":"12345"}}"#
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = AesGcmKeyshareCipher()
+        key = try VaultCryptoEnvelope.randomKey()
+    }
+
+    override func tearDown() {
+        sut = nil
+        key = nil
+        super.tearDown()
+    }
+
+    // MARK: - Round trip
+
+    func testSealOpenRoundTrip() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+
+        XCTAssertEqual(try sut.open(sealed, with: key), dklsPlaintext)
+    }
+
+    func testSealOpenRoundTripForGg20Json() throws {
+        let sealed = try sut.seal(gg20Plaintext, with: key)
+
+        XCTAssertEqual(try sut.open(sealed, with: key), gg20Plaintext)
+    }
+
+    func testSealOpenRoundTripForEmptyString() throws {
+        let sealed = try sut.seal("", with: key)
+
+        XCTAssertEqual(try sut.open(sealed, with: key), "")
+    }
+
+    func testSealOpenRoundTripForLargeShare() throws {
+        let large = String(repeating: "A", count: 512 * 1024)
+
+        let sealed = try sut.seal(large, with: key)
+
+        XCTAssertEqual(try sut.open(sealed, with: key), large)
+    }
+
+    func testSealIsNonDeterministic() throws {
+        let first = try sut.seal(dklsPlaintext, with: key)
+        let second = try sut.seal(dklsPlaintext, with: key)
+
+        XCTAssertNotEqual(first, second, "Each seal must use a fresh nonce")
+    }
+
+    // MARK: - Detection
+
+    func testIsSealedIsFalseForPlaintextDklsShare() {
+        XCTAssertFalse(sut.isSealed(dklsPlaintext))
+    }
+
+    func testIsSealedIsFalseForPlaintextGg20Share() {
+        XCTAssertFalse(sut.isSealed(gg20Plaintext))
+    }
+
+    func testIsSealedIsTrueForSealedValue() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+
+        XCTAssertTrue(sut.isSealed(sealed))
+    }
+
+    func testOpenRejectsUnsealedValue() {
+        XCTAssertThrowsError(try sut.open(dklsPlaintext, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .notSealed)
+        }
+    }
+
+    // MARK: - Rejection
+
+    func testOpenWithWrongKeyFails() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let otherKey = try VaultCryptoEnvelope.randomKey()
+
+        XCTAssertThrowsError(try sut.open(sealed, with: otherKey)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .decryptionFailed)
+        }
+    }
+
+    func testOpenRejectsTamperedCiphertext() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let tampered = try flipLastByte(of: sealed)
+
+        XCTAssertThrowsError(try sut.open(tampered, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .decryptionFailed)
+        }
+    }
+
+    /// The salt is not covered by the GCM tag, and a key share is sealed under a
+    /// raw key that was never derived from it — so the salt is inert filler here
+    /// and corrupting it provably cannot change the recovered share. What
+    /// protects the share is the ciphertext and tag, exercised above. The salt
+    /// only carries meaning where a key is derived from it, which is the wrapped
+    /// data key — see `KeyshareKeyStoreTests.testUnwrapRejectsTamperedSalt`.
+    func testSaltIsInertForRawKeyPayloads() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        // Salt sits immediately after the 4-byte signature.
+        let tampered = try flipByte(of: sealed, at: VaultCryptoEnvelope.formatSignatureLength)
+
+        XCTAssertEqual(try sut.open(tampered, with: key), dklsPlaintext)
+    }
+
+    func testOpenRejectsTamperedNonce() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let nonceStart = VaultCryptoEnvelope.formatSignatureLength + VaultCryptoEnvelope.saltLength
+        let tampered = try flipByte(of: sealed, at: nonceStart)
+
+        XCTAssertThrowsError(try sut.open(tampered, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .decryptionFailed)
+        }
+    }
+
+    func testOpenRejectsMalformedBase64() {
+        let stored = AesGcmKeyshareCipher.sealedPrefix + "!!!not-base64!!!"
+
+        XCTAssertThrowsError(try sut.open(stored, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .malformedBlob)
+        }
+    }
+
+    func testOpenRejectsTruncatedBlob() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let blob = try XCTUnwrap(Data(base64Encoded: String(sealed.dropFirst(AesGcmKeyshareCipher.sealedPrefix.count))))
+        let truncated = AesGcmKeyshareCipher.sealedPrefix
+            + blob.prefix(VaultCryptoEnvelope.headerSize).base64EncodedString()
+
+        XCTAssertThrowsError(try sut.open(truncated, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .malformedBlob)
+        }
+    }
+
+    func testOpenRejectsBlobWithoutFormatSignature() throws {
+        let sealed = try sut.seal(dklsPlaintext, with: key)
+        let tampered = try flipByte(of: sealed, at: 0)
+
+        XCTAssertThrowsError(try sut.open(tampered, with: key)) { error in
+            XCTAssertEqual(error as? KeyshareCipherError, .malformedBlob)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func flipByte(of stored: String, at index: Int) throws -> String {
+        let encoded = String(stored.dropFirst(AesGcmKeyshareCipher.sealedPrefix.count))
+        var blob = try XCTUnwrap(Data(base64Encoded: encoded))
+        blob[blob.startIndex + index] ^= 0xFF
+        return AesGcmKeyshareCipher.sealedPrefix + blob.base64EncodedString()
+    }
+
+    private func flipLastByte(of stored: String) throws -> String {
+        let encoded = String(stored.dropFirst(AesGcmKeyshareCipher.sealedPrefix.count))
+        var blob = try XCTUnwrap(Data(base64Encoded: encoded))
+        blob[blob.index(before: blob.endIndex)] ^= 0xFF
+        return AesGcmKeyshareCipher.sealedPrefix + blob.base64EncodedString()
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
@@ -1,0 +1,180 @@
+//
+//  KeyshareKeyStoreTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import XCTest
+@testable import VultisigApp
+
+final class KeyshareKeyStoreTests: XCTestCase {
+
+    private var keychain: MockKeychainService!
+    private var sut: DefaultKeyshareKeyStore!
+
+    override func setUp() {
+        super.setUp()
+        keychain = MockKeychainService()
+        sut = DefaultKeyshareKeyStore(keychain: keychain)
+    }
+
+    override func tearDown() {
+        sut = nil
+        keychain = nil
+        super.tearDown()
+    }
+
+    // MARK: - Data key
+
+    func testGenerateDataKeyIsCorrectLengthAndRandom() throws {
+        let first = try sut.generateDataKey()
+        let second = try sut.generateDataKey()
+
+        XCTAssertEqual(first.bitCount, VaultCryptoEnvelope.keyLengthBytes * 8)
+        XCTAssertNotEqual(first.testRawRepresentation, second.testRawRepresentation)
+    }
+
+    func testStoreAndLoadDataKeyRoundTrip() throws {
+        let key = try sut.generateDataKey()
+
+        try sut.storeDataKey(key)
+
+        XCTAssertEqual(sut.loadDataKey()?.testRawRepresentation, key.testRawRepresentation)
+    }
+
+    func testLoadDataKeyIsNilWhenAbsent() {
+        XCTAssertNil(sut.loadDataKey())
+    }
+
+    func testDeleteDataKeyRemovesIt() throws {
+        try sut.storeDataKey(try sut.generateDataKey())
+
+        sut.deleteDataKey()
+
+        XCTAssertNil(sut.loadDataKey())
+    }
+
+    /// The read-back guard: a Keychain that silently drops the write must not
+    /// leave the caller believing the key is durable, because the next step is
+    /// encrypting key shares against it.
+    func testStoreDataKeyThrowsWhenKeychainDropsTheWrite() throws {
+        keychain.dropsKeyshareDataKeyWrites = true
+        let key = try sut.generateDataKey()
+
+        XCTAssertThrowsError(try sut.storeDataKey(key)) { error in
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .persistenceFailed)
+        }
+    }
+
+    func testLoadDataKeyIsNilWhenStoredBlobHasWrongLength() {
+        keychain.setKeyshareDataKey(Data(repeating: 0x01, count: 16))
+
+        XCTAssertNil(sut.loadDataKey())
+    }
+
+    // MARK: - Wrapped data key
+
+    func testStoreAndLoadWrappedDataKeyRoundTrip() throws {
+        let blob = Data(repeating: 0x07, count: 64)
+
+        try sut.storeWrappedDataKey(blob)
+
+        XCTAssertEqual(sut.loadWrappedDataKey(), blob)
+    }
+
+    func testDeleteWrappedDataKeyRemovesIt() throws {
+        try sut.storeWrappedDataKey(Data(repeating: 0x07, count: 64))
+
+        sut.deleteWrappedDataKey()
+
+        XCTAssertNil(sut.loadWrappedDataKey())
+    }
+
+    // MARK: - Passcode wrapping
+
+    func testWrapUnwrapRoundTrip() async throws {
+        let key = try sut.generateDataKey()
+
+        let wrapped = try await sut.wrap(key, passcode: "12345")
+        let unwrapped = try await sut.unwrap(wrapped, passcode: "12345")
+
+        XCTAssertEqual(unwrapped.testRawRepresentation, key.testRawRepresentation)
+    }
+
+    func testUnwrapWithWrongPasscodeFails() async throws {
+        let key = try sut.generateDataKey()
+        let wrapped = try await sut.wrap(key, passcode: "12345")
+
+        do {
+            _ = try await sut.unwrap(wrapped, passcode: "54321")
+            XCTFail("Expected unwrap to fail with the wrong passcode")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .wrongPasscode)
+        }
+    }
+
+    func testUnwrapRejectsTamperedBlob() async throws {
+        let key = try sut.generateDataKey()
+        var wrapped = try await sut.wrap(key, passcode: "12345")
+        wrapped[wrapped.index(before: wrapped.endIndex)] ^= 0xFF
+
+        do {
+            _ = try await sut.unwrap(wrapped, passcode: "12345")
+            XCTFail("Expected unwrap to reject a tampered blob")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .wrongPasscode)
+        }
+    }
+
+    /// Unlike the key-share path, the wrapping key IS derived from the salt, so
+    /// corrupting it yields a different key and the tag stops matching.
+    func testUnwrapRejectsTamperedSalt() async throws {
+        let key = try sut.generateDataKey()
+        var wrapped = try await sut.wrap(key, passcode: "12345")
+        wrapped[wrapped.startIndex + VaultCryptoEnvelope.formatSignatureLength] ^= 0xFF
+
+        do {
+            _ = try await sut.unwrap(wrapped, passcode: "12345")
+            XCTFail("Expected unwrap to reject a tampered salt")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .wrongPasscode)
+        }
+    }
+
+    func testUnwrapRejectsBlobWithoutFormatSignature() async {
+        do {
+            _ = try await sut.unwrap(Data(repeating: 0x00, count: 64), passcode: "12345")
+            XCTFail("Expected unwrap to reject a blob with no signature")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .malformedWrappedKey)
+        }
+    }
+
+    func testWrapIsNonDeterministic() async throws {
+        let key = try sut.generateDataKey()
+
+        let first = try await sut.wrap(key, passcode: "12345")
+        let second = try await sut.wrap(key, passcode: "12345")
+
+        XCTAssertNotEqual(first, second, "Each wrap must use a fresh salt and nonce")
+    }
+
+    /// The whole point of the indirection: rewrapping under a new passcode
+    /// yields a key that opens the same shares, so no share is ever rewritten.
+    func testRewrappingUnderNewPasscodeYieldsTheSameDataKey() async throws {
+        let key = try sut.generateDataKey()
+        let original = try await sut.wrap(key, passcode: "12345")
+
+        let opened = try await sut.unwrap(original, passcode: "12345")
+        let rewrapped = try await sut.wrap(opened, passcode: "99999")
+        let reopened = try await sut.unwrap(rewrapped, passcode: "99999")
+
+        XCTAssertEqual(reopened.testRawRepresentation, key.testRawRepresentation)
+    }
+}
+
+private extension SymmetricKey {
+    var testRawRepresentation: Data {
+        withUnsafeBytes { Data($0) }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareProtectorTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareProtectorTests.swift
@@ -1,0 +1,122 @@
+//
+//  KeyshareProtectorTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import XCTest
+@testable import VultisigApp
+
+final class KeyshareProtectorTests: XCTestCase {
+
+    private let dklsPlaintext = "eyJrZXlzaGFyZSI6ImV4YW1wbGUifQ=="
+    private let gg20Plaintext = #"{"PubKey":"02abc","ShareID":{"value":"12345"}}"#
+
+    private func makeProtector(_ state: @escaping @autoclosure () -> KeyshareProtectionState) -> KeyshareProtector {
+        KeyshareProtector(state: state)
+    }
+
+    private func makeUnlockedProtector() throws -> KeyshareProtector {
+        let key = try VaultCryptoEnvelope.randomKey()
+        return KeyshareProtector(state: { .unlocked(key) })
+    }
+
+    // MARK: - Disabled — the state this PR ships in
+
+    func testDisabledSealIsAPassthrough() throws {
+        let sut = makeProtector(.disabled)
+
+        XCTAssertEqual(try sut.seal(dklsPlaintext), dklsPlaintext)
+        XCTAssertEqual(try sut.seal(gg20Plaintext), gg20Plaintext)
+    }
+
+    func testDisabledOpenIsAPassthrough() throws {
+        let sut = makeProtector(.disabled)
+
+        XCTAssertEqual(try sut.open(dklsPlaintext), dklsPlaintext)
+        XCTAssertEqual(try sut.open(gg20Plaintext), gg20Plaintext)
+    }
+
+    func testDisabledRoundTripLeavesTheValueByteIdentical() throws {
+        let sut = makeProtector(.disabled)
+
+        let stored = try sut.seal(dklsPlaintext)
+
+        XCTAssertEqual(stored, dklsPlaintext)
+        XCTAssertEqual(try sut.open(stored), dklsPlaintext)
+    }
+
+    // MARK: - Unlocked
+
+    func testUnlockedSealThenOpenRoundTrips() throws {
+        let sut = try makeUnlockedProtector()
+
+        let stored = try sut.seal(dklsPlaintext)
+
+        XCTAssertNotEqual(stored, dklsPlaintext)
+        XCTAssertEqual(try sut.open(stored), dklsPlaintext)
+    }
+
+    func testUnlockedOpenStillAcceptsPlaintext() throws {
+        let sut = try makeUnlockedProtector()
+
+        // Shares stay plaintext until the migration has run, and the migration
+        // must be able to read them while the key already exists.
+        XCTAssertEqual(try sut.open(dklsPlaintext), dklsPlaintext)
+    }
+
+    func testUnlockedSealDoesNotDoubleSeal() throws {
+        let sut = try makeUnlockedProtector()
+        let stored = try sut.seal(dklsPlaintext)
+
+        let resealed = try sut.seal(stored)
+
+        XCTAssertEqual(resealed, stored, "Re-sealing must be idempotent so the migration can retry")
+        XCTAssertEqual(try sut.open(resealed), dklsPlaintext)
+    }
+
+    func testUnlockedOpenWithADifferentKeyFails() throws {
+        let sealed = try makeUnlockedProtector().seal(dklsPlaintext)
+        let other = try makeUnlockedProtector()
+
+        XCTAssertThrowsError(try other.open(sealed)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .cipherFailure)
+        }
+    }
+
+    // MARK: - Locked
+
+    func testLockedOpenOfASealedShareThrows() throws {
+        let sealed = try makeUnlockedProtector().seal(dklsPlaintext)
+        let sut = makeProtector(.locked)
+
+        XCTAssertThrowsError(try sut.open(sealed)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+        }
+    }
+
+    func testLockedOpenOfAPlaintextShareStillWorks() throws {
+        let sut = makeProtector(.locked)
+
+        XCTAssertEqual(try sut.open(dklsPlaintext), dklsPlaintext)
+    }
+
+    func testLockedSealThrows() {
+        let sut = makeProtector(.locked)
+
+        XCTAssertThrowsError(try sut.seal(dklsPlaintext)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+        }
+    }
+
+    /// Never hand ciphertext back as if it were a share: the TSS layer would
+    /// read it as a corrupt key share rather than as a locked app.
+    func testDisabledOpenOfASealedShareThrowsRatherThanReturningCiphertext() throws {
+        let sealed = try makeUnlockedProtector().seal(dklsPlaintext)
+        let sut = makeProtector(.disabled)
+
+        XCTAssertThrowsError(try sut.open(sealed)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
+++ b/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
@@ -118,6 +118,17 @@ final class KeychainTriStateReadTests: XCTestCase {
                 .unavailable(status),
                 "the migration-version read must not pass a failure off as an absent item (status \(status))"
             )
+            XCTAssertEqual(
+                service.getKeyshareDataKey(),
+                .unavailable(status),
+                "an unreadable data key must never look absent — absence licenses minting a replacement, "
+                    + "and a replacement cannot open a single already-sealed share (status \(status))"
+            )
+            XCTAssertEqual(
+                service.getWrappedKeyshareDataKey(),
+                .unavailable(status),
+                "an unreadable wrapped key must never look absent, for the same reason (status \(status))"
+            )
         }
     }
 
@@ -128,6 +139,8 @@ final class KeychainTriStateReadTests: XCTestCase {
         XCTAssertEqual(service.getFastHint(pubKeyECDSA: "pub"), .absent)
         XCTAssertEqual(service.getDeviceToken(), .absent)
         XCTAssertEqual(service.getLastMigratedVersion(), .absent)
+        XCTAssertEqual(service.getKeyshareDataKey(), .absent)
+        XCTAssertEqual(service.getWrappedKeyshareDataKey(), .absent)
     }
 
     func testEveryServiceReadReturnsTheStoredValue() {
@@ -137,6 +150,8 @@ final class KeychainTriStateReadTests: XCTestCase {
         XCTAssertEqual(service.getFastHint(pubKeyECDSA: "pub"), .present("7"))
         XCTAssertEqual(service.getDeviceToken(), .present("7"))
         XCTAssertEqual(service.getLastMigratedVersion(), .present(7))
+        XCTAssertEqual(service.getKeyshareDataKey(), .present(Data("7".utf8)))
+        XCTAssertEqual(service.getWrappedKeyshareDataKey(), .present(Data("7".utf8)))
     }
 
     // MARK: - The deliberate collapse
@@ -174,6 +189,8 @@ private struct FakeItemStore: KeychainItemStore {
     }
 
     func add(_: [String: Any]) -> OSStatus { errSecSuccess }
+
+    func update(_: [String: Any], attributes _: [String: Any]) -> OSStatus { errSecSuccess }
 
     func delete(_: [String: Any]) -> OSStatus { errSecSuccess }
 }

--- a/VultisigApp/VultisigAppTests/Storage/KeychainWriteSeamTests.swift
+++ b/VultisigApp/VultisigAppTests/Storage/KeychainWriteSeamTests.swift
@@ -2,12 +2,13 @@
 //  KeychainWriteSeamTests.swift
 //  VultisigAppTests
 //
-//  Making reads tri-state moved `Keychain`'s `SecItem` calls behind
-//  `KeychainItemStore`. The write path is supposed to come through that move
-//  untouched — precisely the sort of claim nothing was checking, since a unit
-//  test bundle has no keychain entitlement and could never observe a real
-//  write. These pin the query, the attributes and the delete-then-add order the
-//  Keychain has always used.
+//  What `Keychain` hands to `SecItem` on a write — the query, the attributes and
+//  the call order — pinned through the `KeychainItemStore` seam, since a unit
+//  test bundle has no keychain entitlement and could never observe a real write.
+//
+//  `KeychainWriteTests` covers the same seam from the other side: this file
+//  pins the payloads, that one pins the add-versus-update state machine and what
+//  a failed write leaves behind.
 //
 
 import Security
@@ -18,24 +19,41 @@ final class KeychainWriteSeamTests: XCTestCase {
 
     private static let serviceName = "com.vultisig.tests.keychain"
 
-    func testWritingAValueDeletesTheExistingItemBeforeAddingTheNewOne() {
+    /// Update first, add only when there is nothing to update — never
+    /// delete-then-add, which would destroy the stored value before knowing the
+    /// replacement landed.
+    func testWritingAValueUpdatesFirstAndAddsOnlyWhenNoItemExists() {
         let store = RecordingItemStore()
 
         Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
 
-        XCTAssertEqual(store.calls, ["delete", "add"])
+        XCTAssertEqual(store.calls, ["update", "add"])
     }
 
-    func testTheDeleteCarriesTheGeneratedQuery() throws {
+    func testTheUpdateCarriesTheGeneratedQueryWithoutTheReturnFlag() throws {
         let store = RecordingItemStore()
 
         Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
 
-        let query = try XCTUnwrap(store.deletedQueries.first)
+        let query = try XCTUnwrap(store.updatedQueries.first)
         XCTAssertEqual(query[kSecClass as String] as? String, kSecClassGenericPassword as String)
         XCTAssertEqual(query[kSecAttrService as String] as? String, Self.serviceName)
         XCTAssertEqual(query[kSecAttrAccount as String] as? String, TestKey().identifier)
-        XCTAssertNotNil(query[kSecReturnData as String])
+        XCTAssertNil(query[kSecReturnData as String], "the return flag belongs to reads, not to a write query")
+    }
+
+    func testTheUpdateCarriesOnlyTheValueAndAccessibility() throws {
+        let store = RecordingItemStore()
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
+
+        let attributes = try XCTUnwrap(store.updatedAttributes.first)
+        XCTAssertEqual(attributes[kSecValueData as String] as? Data, Data("hunter2".utf8))
+        XCTAssertEqual(
+            attributes[kSecAttrAccessible as String] as? String,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String
+        )
+        XCTAssertNil(attributes[kSecAttrService as String], "an update must not restate the item's identity")
     }
 
     func testTheAddCarriesTheValueAndAccessibilityWithoutTheReturnFlag() throws {
@@ -68,7 +86,7 @@ final class KeychainWriteSeamTests: XCTestCase {
         XCTAssertEqual(attributes[kSecValueData as String] as? Data, Data("42".utf8))
     }
 
-    func testWritingNilDeletesWithoutAdding() {
+    func testWritingNilDeletesWithoutAddingOrUpdating() {
         let store = RecordingItemStore()
 
         Keychain(serviceName: Self.serviceName, itemStore: store).setString(nil, for: TestKey())
@@ -84,23 +102,24 @@ final class KeychainWriteSeamTests: XCTestCase {
         XCTAssertEqual(store.calls, ["delete"])
     }
 
-    /// A failing write has always been swallowed here. Pinned so the seam is not
-    /// blamed if that ever needs to change.
-    func testAFailedAddIsIgnoredWithoutRetrying() {
+    /// A failing add is not retried, and — the property that matters — nothing
+    /// is deleted on the way, so whatever was stored is still stored.
+    func testAFailedAddIsNotRetriedAndDeletesNothing() {
         let store = RecordingItemStore(addStatus: errSecDuplicateItem)
 
         Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
 
-        XCTAssertEqual(store.calls, ["delete", "add"])
+        XCTAssertEqual(store.calls, ["update", "add"])
     }
 }
 
-/// Records what the write path hands to `SecItem`, and answers reads as if the
-/// item were absent.
+/// Records what the write path hands to `SecItem`, and answers reads and updates
+/// as if the item were absent.
 private final class RecordingItemStore: KeychainItemStore {
 
     private(set) var calls: [String] = []
-    private(set) var deletedQueries: [[String: Any]] = []
+    private(set) var updatedQueries: [[String: Any]] = []
+    private(set) var updatedAttributes: [[String: Any]] = []
     private(set) var addedAttributes: [[String: Any]] = []
 
     private let addStatus: OSStatus
@@ -119,9 +138,15 @@ private final class RecordingItemStore: KeychainItemStore {
         return addStatus
     }
 
-    func delete(_ query: [String: Any]) -> OSStatus {
+    func update(_ query: [String: Any], attributes: [String: Any]) -> OSStatus {
+        calls.append("update")
+        updatedQueries.append(query)
+        updatedAttributes.append(attributes)
+        return errSecItemNotFound
+    }
+
+    func delete(_: [String: Any]) -> OSStatus {
         calls.append("delete")
-        deletedQueries.append(query)
         return errSecSuccess
     }
 }


### PR DESCRIPTION
> **Stack 2 of 8** for #4846 — renumbered from /7; a transition-coordinator layer was inserted as 5/8.
> **The stack was reworked to opt-in encryption**: key shares are sealed **if and only if a passcode is
> currently set**, so anyone who never sets one keeps plaintext shares and a safely downgradable build.
> The launch migration that used to sit at 3/8 is deleted. Full rationale in #4991 and #4993.
> This PR itself is unchanged in intent — the accessor is the same.
> Base: `feat/passcode-cipher-4846`.

## Description

**Stack 2 of 7** for #4846. Routes every key-share read and write through a single accessor. The key provider returns "no key", so both directions are **passthroughs and behaviour is unchanged** — that is the entire point: the risky wiring lands separately from the risky migration.

Part of #4846. **Base: `feat/passcode-cipher-4846` (PR 1)** — review that one first.

### What this changes

Adds `Vault.keyshareValue(for pubKey:)` and `Vault.setKeyshare(_:for:)`, backed by the cipher from PR 1 plus an injectable key provider, then converts every existing access site to use them.

| | File |
|---|---|
| modify | `Model/Vault.swift` — new accessors; `getKeyshare(pubKey:)` delegates |
| modify | `Blockchain/Tss/LocalStateAccessorImp.swift` |
| modify | `Blockchain/States/Keysign/{DKLS,Schnorr,Dilithium}Keysign.swift` |
| modify | `Blockchain/States/Keygen/{DKLS,Schnorr}Keygen.swift` |
| modify | `Model/Vault+ProtoMappable.swift` — **decrypt on export, encrypt on import** |
| modify | `Features/Keygen/ViewModels/KeygenViewModel.swift` |

14 files, +491/−59. The surface is 8 reads and 6 writes; all of them move.

### Why this is its own PR

`LocalStateAccessorImp.getLocalState` is **synchronous and non-throwing**, and it runs inside a TSS keysign ceremony. Anything on that path that can block, throw, or await is a signing failure, so the accessor has to be shaped around that constraint rather than the constraint being discovered later. Landing the wiring while it is still a provable no-op means a reviewer can check "did every call site move, and does each return the same value as before" without also reasoning about ciphertext.

## Which feature is affected?
- [x] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

Keygen and keysign both read key shares, so both paths are touched — behaviour is asserted unchanged rather than assumed.

## Parity

- Android: `vultisig/vultisig-android#5343`
- Windows + extension: n/a for this step — the accessor indirection is an iOS-specific consequence of the synchronous `LocalStateAccessorImp` contract
- SDK: n/a — zero passcode references in `vultisig-sdk`

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

Tests: `KeyshareAccessorTests` — every read site returns the same value through the accessor as before; `mapToProtobuff()` → `Vault(proto:)` round-trips a sealed vault back to identical plaintext shares; a sealed vault exported and re-imported produces shares keysign accepts, asserted against the `SigningGoldenTests` fixtures. `SigningGoldenTests` itself is untouched and passing.

## Additional context

Export/import is the subtle half. `Vault+ProtoMappable` is what writes `.vult` backups, so it has to **decrypt on export and encrypt on import** — otherwise a backup taken on an encrypted install would be a file nobody can restore, including on another platform. The golden-vector assertion is there to keep that honest.

See PR 1 for the design rationale and the note on sign-off status.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4846
- **Confidence**: medium — provable no-op with golden-vector coverage, but it touches keygen/keysign paths
- **Needs human review for**: TSS read path (`LocalStateAccessorImp`), `.vult` export/import round-trip


