### PR TITLE
feat(security): opt-in keyshare encryption — seal at set-passcode, unseal at disable (6/8)

### DIFF
--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -208,6 +208,12 @@ extension VultisigApp {
                 }
                 #endif
 
+                // The Keychain outlives the app, so a reinstall can start
+                // with key material the container knows nothing about. Clears
+                // what a previous install left behind and puts the lock mode
+                // back in front of a key that survived.
+                KeyshareInstallReconciler().reconcile()
+
                 // Run migrations on app launch
                 AppMigrationService().performMigrationsIfNeeded()
 
@@ -266,6 +272,12 @@ extension VultisigApp {
             .buttonStyle(BorderlessButtonStyle())
             .frame(minWidth: 900, minHeight: 600)
             .onAppear {
+                // The Keychain outlives the app, so a reinstall can start
+                // with key material the container knows nothing about. Clears
+                // what a previous install left behind and puts the lock mode
+                // back in front of a key that survived.
+                KeyshareInstallReconciler().reconcile()
+
                 // Run migrations on app launch
                 AppMigrationService().performMigrationsIfNeeded()
 

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -653,6 +653,7 @@
 "keygenInstructionsCar7Title" = "Funktionshighlight";
 "keys" = "Schlüssel";
 "keysharesUnreadableVaultNotSaved" = "Die Key Shares dieses Tresors konnten nicht gelesen werden, daher wurde er nicht gespeichert. Entsperren Sie die App und versuchen Sie es erneut — bleibt das Problem bestehen, erstellen Sie den Tresor neu.";
+"keysharesUnsealableVaultNotSaved" = "Die Key Shares dieses Tresors konnten nicht für die Speicherung geschützt werden, daher wurde er nicht gespeichert. Entsperren Sie die App und versuchen Sie es erneut.";
 "keysign" = "Schlüsselsignatur";
 "keysignDiscoveryDisclaimer" = "Scanne den QR-Code, um die Transaktion zu signieren.";
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -652,6 +652,7 @@
 "keygenInstructionsCar7DescriptionPart3" = " zu und verbessere so die Flexibilität, ohne die Sicherheit zu vernachlässigen.";
 "keygenInstructionsCar7Title" = "Funktionshighlight";
 "keys" = "Schlüssel";
+"keysharesUnreadableVaultNotSaved" = "Die Key Shares dieses Tresors konnten nicht gelesen werden, daher wurde er nicht gespeichert. Entsperren Sie die App und versuchen Sie es erneut — bleibt das Problem bestehen, erstellen Sie den Tresor neu.";
 "keysign" = "Schlüsselsignatur";
 "keysignDiscoveryDisclaimer" = "Scanne den QR-Code, um die Transaktion zu signieren.";
 "keysignDiscoveryDisclaimerDevice" = "-Gerätescan erforderlich.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -653,6 +653,7 @@
 "keygenInstructionsCar7Title" = "Feature Highlight";
 "keys" = "Keys";
 "keysharesUnreadableVaultNotSaved" = "This vault's key shares could not be read, so it was not saved. Unlock the app and try again — if this keeps happening, create the vault again.";
+"keysharesUnsealableVaultNotSaved" = "This vault's key shares could not be protected for storage, so it was not saved. Unlock the app and try again.";
 "keysign" = "Keysign";
 "keysignDiscoveryDisclaimer" = "Scan QR code to sign transaction. ";
 "keysignDiscoveryDisclaimerDevice" = "-device scan required.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -652,6 +652,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", enhancing flexibility without compromising security.";
 "keygenInstructionsCar7Title" = "Feature Highlight";
 "keys" = "Keys";
+"keysharesUnreadableVaultNotSaved" = "This vault's key shares could not be read, so it was not saved. Unlock the app and try again — if this keeps happening, create the vault again.";
 "keysign" = "Keysign";
 "keysignDiscoveryDisclaimer" = "Scan QR code to sign transaction. ";
 "keysignDiscoveryDisclaimerDevice" = "-device scan required.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -652,6 +652,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", mejorando la flexibilidad sin comprometer la seguridad.";
 "keygenInstructionsCar7Title" = "Destacado de funciones";
 "keys" = "Llaves";
+"keysharesUnreadableVaultNotSaved" = "No se pudieron leer las key shares de esta bóveda, por lo que no se guardó. Desbloquea la app e inténtalo de nuevo; si sigue fallando, crea la bóveda otra vez.";
 "keysign" = "Firma de Clave";
 "keysignDiscoveryDisclaimer" = "Escanea el código QR para firmar la transacción.";
 "keysignDiscoveryDisclaimerDevice" = "-se requiere escanear el dispositivo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -653,6 +653,7 @@
 "keygenInstructionsCar7Title" = "Destacado de funciones";
 "keys" = "Llaves";
 "keysharesUnreadableVaultNotSaved" = "No se pudieron leer las key shares de esta bóveda, por lo que no se guardó. Desbloquea la app e inténtalo de nuevo; si sigue fallando, crea la bóveda otra vez.";
+"keysharesUnsealableVaultNotSaved" = "No se pudieron proteger las key shares de esta bóveda para su almacenamiento, por lo que no se guardó. Desbloquea la app e inténtalo de nuevo.";
 "keysign" = "Firma de Clave";
 "keysignDiscoveryDisclaimer" = "Escanea el código QR para firmar la transacción.";
 "keysignDiscoveryDisclaimerDevice" = "-se requiere escanear el dispositivo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -653,6 +653,7 @@
 "keygenInstructionsCar7Title" = "Istaknuta značajka";
 "keys" = "Ključ";
 "keysharesUnreadableVaultNotSaved" = "Key shareovi ovog trezora nisu se mogli pročitati pa trezor nije spremljen. Otključajte aplikaciju i pokušajte ponovno; ako se nastavi, stvorite trezor iznova.";
+"keysharesUnsealableVaultNotSaved" = "Key shareovi ovog trezora nisu se mogli zaštititi za pohranu pa trezor nije spremljen. Otključajte aplikaciju i pokušajte ponovno.";
 "keysign" = "Potpis ključa";
 "keysignDiscoveryDisclaimer" = "Skenirajte QR kod kako biste potpisali transakciju.";
 "keysignDiscoveryDisclaimerDevice" = "-potrebno skeniranje uređaja.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -652,6 +652,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", povećavajući fleksibilnost bez ugrožavanja sigurnosti.";
 "keygenInstructionsCar7Title" = "Istaknuta značajka";
 "keys" = "Ključ";
+"keysharesUnreadableVaultNotSaved" = "Key shareovi ovog trezora nisu se mogli pročitati pa trezor nije spremljen. Otključajte aplikaciju i pokušajte ponovno; ako se nastavi, stvorite trezor iznova.";
 "keysign" = "Potpis ključa";
 "keysignDiscoveryDisclaimer" = "Skenirajte QR kod kako biste potpisali transakciju.";
 "keysignDiscoveryDisclaimerDevice" = "-potrebno skeniranje uređaja.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -652,6 +652,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", migliorando la flessibilità senza compromettere la sicurezza.";
 "keygenInstructionsCar7Title" = "In evidenza";
 "keys" = "Chiavi";
+"keysharesUnreadableVaultNotSaved" = "Non è stato possibile leggere le key share di questo vault, quindi non è stato salvato. Sblocca l'app e riprova; se continua a fallire, crea di nuovo il vault.";
 "keysign" = "Firma Chiave";
 "keysignDiscoveryDisclaimer" = "Scansiona il codice QR per firmare la transazione.";
 "keysignDiscoveryDisclaimerDevice" = "-scansione del dispositivo richiesta.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -653,6 +653,7 @@
 "keygenInstructionsCar7Title" = "In evidenza";
 "keys" = "Chiavi";
 "keysharesUnreadableVaultNotSaved" = "Non è stato possibile leggere le key share di questo vault, quindi non è stato salvato. Sblocca l'app e riprova; se continua a fallire, crea di nuovo il vault.";
+"keysharesUnsealableVaultNotSaved" = "Non è stato possibile proteggere le key share di questo vault per l'archiviazione, quindi non è stato salvato. Sblocca l'app e riprova.";
 "keysign" = "Firma Chiave";
 "keysignDiscoveryDisclaimer" = "Scansiona il codice QR per firmare la transazione.";
 "keysignDiscoveryDisclaimerDevice" = "-scansione del dispositivo richiesta.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -653,6 +653,7 @@
 "keygenInstructionsCar7Title" = "기능 하이라이트";
 "keys" = "키";
 "keysharesUnreadableVaultNotSaved" = "이 볼트의 키 셰어를 읽을 수 없어 저장되지 않았습니다. 앱을 잠금 해제한 후 다시 시도하세요. 계속 실패하면 볼트를 다시 생성하세요.";
+"keysharesUnsealableVaultNotSaved" = "이 볼트의 키 셰어를 저장용으로 보호할 수 없어 저장되지 않았습니다. 앱을 잠금 해제한 후 다시 시도하세요.";
 "keysign" = "키사인";
 "keysignDiscoveryDisclaimer" = "QR 코드를 스캔하여 트랜잭션에 서명하세요. ";
 "keysignDiscoveryDisclaimerDevice" = "기기 스캔이 필요합니다.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -652,6 +652,7 @@
 "keygenInstructionsCar7DescriptionPart3" = " Vultisig 볼트에 액세스하여 보안을 유지하면서 유연성을 높입니다.";
 "keygenInstructionsCar7Title" = "기능 하이라이트";
 "keys" = "키";
+"keysharesUnreadableVaultNotSaved" = "이 볼트의 키 셰어를 읽을 수 없어 저장되지 않았습니다. 앱을 잠금 해제한 후 다시 시도하세요. 계속 실패하면 볼트를 다시 생성하세요.";
 "keysign" = "키사인";
 "keysignDiscoveryDisclaimer" = "QR 코드를 스캔하여 트랜잭션에 서명하세요. ";
 "keysignDiscoveryDisclaimerDevice" = "기기 스캔이 필요합니다.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -653,6 +653,7 @@
 "keygenInstructionsCar7Title" = "Destaque de recursos";
 "keys" = "Chaves";
 "keysharesUnreadableVaultNotSaved" = "Não foi possível ler as key shares deste cofre, por isso não foi guardado. Desbloqueie a app e tente novamente; se continuar a falhar, crie o cofre de novo.";
+"keysharesUnsealableVaultNotSaved" = "Não foi possível proteger as key shares deste cofre para armazenamento, por isso não foi guardado. Desbloqueie a app e tente novamente.";
 "keysign" = "Assinatura de Chave";
 "keysignDiscoveryDisclaimer" = "Escaneie o código QR para assinar a transação.";
 "keysignDiscoveryDisclaimerDevice" = "-é necessário escanear o dispositivo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -652,6 +652,7 @@
 "keygenInstructionsCar7DescriptionPart3" = ", aumentando a flexibilidade sem comprometer a segurança.";
 "keygenInstructionsCar7Title" = "Destaque de recursos";
 "keys" = "Chaves";
+"keysharesUnreadableVaultNotSaved" = "Não foi possível ler as key shares deste cofre, por isso não foi guardado. Desbloqueie a app e tente novamente; se continuar a falhar, crie o cofre de novo.";
 "keysign" = "Assinatura de Chave";
 "keysignDiscoveryDisclaimer" = "Escaneie o código QR para assinar a transação.";
 "keysignDiscoveryDisclaimerDevice" = "-é necessário escanear o dispositivo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -653,6 +653,7 @@
 "keygenInstructionsCar7Title" = "功能亮点";
 "keys" = "密钥";
 "keysharesUnreadableVaultNotSaved" = "无法读取此保险库的密钥分片，因此未保存。请解锁应用后重试；若仍然失败，请重新创建保险库。";
+"keysharesUnsealableVaultNotSaved" = "无法为存储保护此保险库的密钥分片，因此未保存。请解锁应用后重试。";
 "keysign" = "密钥签名";
 "keysignDiscoveryDisclaimer" = "扫描二维码以签署交易";
 "keysignDiscoveryDisclaimerDevice" = "-需要设备扫描";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -652,6 +652,7 @@
 "keygenInstructionsCar7DescriptionPart3" = "访问您的 Vultisig 保险库，在不影响安全性的情况下增强灵活性";
 "keygenInstructionsCar7Title" = "功能亮点";
 "keys" = "密钥";
+"keysharesUnreadableVaultNotSaved" = "无法读取此保险库的密钥分片，因此未保存。请解锁应用后重试；若仍然失败，请重新创建保险库。";
 "keysign" = "密钥签名";
 "keysignDiscoveryDisclaimer" = "扫描二维码以签署交易";
 "keysignDiscoveryDisclaimerDevice" = "-需要设备扫描";

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
@@ -76,19 +76,38 @@ struct KeyshareInstallReconciler {
         self.defaults = defaults
     }
 
+    /// What the container's store says about whether it is new.
+    ///
+    /// Three cases and not a `Bool`, because "I could not read the store" is
+    /// neither of the other two and every way of pretending otherwise is wrong:
+    /// read as *occupied* it retires the clear permanently on a container that
+    /// may well be new, and read as *empty* it would delete key material a full
+    /// store still depends on.
+    enum StoreOccupancy {
+        case empty
+        case occupied
+        case unknown
+    }
+
     @MainActor
     func reconcile() {
-        // A store that cannot be read counts as "not empty". Being unable to
-        // tell must never be mistaken for a new container.
-        var isStoreEmpty = false
-        if let context = Storage.shared.modelContext,
-           let count = try? context.fetchCount(FetchDescriptor<Vault>()) {
-            isStoreEmpty = count == 0
+        reconcile(occupancy: storeOccupancy())
+    }
+
+    @MainActor
+    private func storeOccupancy() -> StoreOccupancy {
+        guard let context = Storage.shared.modelContext,
+              let count = try? context.fetchCount(FetchDescriptor<Vault>()) else {
+            return .unknown
         }
-        reconcile(isStoreEmpty: isStoreEmpty)
+        return count == 0 ? .empty : .occupied
     }
 
     func reconcile(isStoreEmpty: Bool) {
+        reconcile(occupancy: isStoreEmpty ? .empty : .occupied)
+    }
+
+    func reconcile(occupancy: StoreOccupancy) {
         // Both halves read the wrapped key and act on what they read, so both
         // have to be indivisible against a passcode transition. Without this a
         // launch could clear a wrapper `setPasscode` had just made durable, or
@@ -100,37 +119,61 @@ struct KeyshareInstallReconciler {
         }
         defer { coordinator.end(lease) }
 
-        clearInheritedKeyMaterialIfContainerIsNew(isStoreEmpty: isStoreEmpty)
+        clearInheritedKeyMaterialIfContainerIsNew(occupancy: occupancy)
         alignLockModeWithTheWrappedKey()
     }
 
     // MARK: - Inherited key material
 
-    private func clearInheritedKeyMaterialIfContainerIsNew(isStoreEmpty: Bool) {
+    private func clearInheritedKeyMaterialIfContainerIsNew(occupancy: StoreOccupancy) {
         guard !defaults.bool(forKey: Self.markerKey) else { return }
 
-        // Existing users reach this line exactly once, on the first launch of the
-        // build that introduces the marker — with a full store. Clearing their
-        // wrapped key would orphan every sealed share, which in this app is lost
-        // funds, so the store having anything in it ends the matter here.
-        //
-        // It also has to be the store rather than "is anything sealed": a user
-        // part-way through enabling a passcode has a wrapper and unsealed
-        // shares, and one who has never set one has neither, so emptiness is the
-        // only thing that distinguishes a new container.
-        guard isStoreEmpty else {
+        switch occupancy {
+        case .occupied:
+            // Existing users reach this line exactly once, on the first launch
+            // of the build that introduces the marker — with a full store.
+            // Clearing their wrapped key would orphan every sealed share, which
+            // in this app is lost funds, so the store having anything in it ends
+            // the matter here.
+            //
+            // It also has to be the store rather than "is anything sealed": a
+            // user part-way through enabling a passcode has a wrapper and
+            // unsealed shares, and one who has never set one has neither, so
+            // emptiness is the only thing that distinguishes a new container.
             defaults.set(true, forKey: Self.markerKey)
             return
+        case .unknown:
+            // The marker is permanent, so it must never be written on a guess.
+            // Setting it here would retire the clear for good on a container
+            // that may be new — and a new container that keeps the previous
+            // install's wrapped key is a passcode gate the user cannot open and
+            // cannot get rid of by reinstalling, which is the whole reason this
+            // type exists. A deferred launch costs nothing.
+            logger.info("Reconciliation deferred: the vault store could not be read")
+            return
+        case .empty:
+            break
         }
 
-        // A first-ever install inherits nothing, and clearing nothing still
-        // costs a Keychain delete and its read-back per item. Someone who never
-        // sets a passcode must see no launch-time Keychain mutation at all, so
-        // confirmed absence ends it here — the marker is `UserDefaults`, which
-        // the acceptance test does not speak about.
-        guard hasInheritedKeyMaterial() else {
+        switch inheritedKeyMaterial() {
+        case .nothing:
+            // A first-ever install inherits nothing, and clearing nothing still
+            // costs a Keychain delete and its read-back per item. Someone who
+            // never sets a passcode must see no launch-time Keychain mutation at
+            // all, so confirmed absence ends it here — the marker is
+            // `UserDefaults`, which the acceptance test does not speak about.
             defaults.set(true, forKey: Self.markerKey)
             return
+        case .unknown:
+            // Same rule, and this is the case that keeps the acceptance test
+            // absolute rather than merely usual: issuing deletes over reads that
+            // failed is a launch-time Keychain mutation for someone who has
+            // never touched this feature. Deferring writes nothing at all and
+            // the next launch decides with an answer.
+            logger.info("Reconciliation deferred: inherited key material could not be determined")
+            return
+        case .something:
+            break
         }
 
         do {
@@ -144,18 +187,32 @@ struct KeyshareInstallReconciler {
         }
     }
 
-    /// Whether any passcode artifact might have been inherited.
+    /// What, if anything, this container inherited.
     ///
-    /// Only a **confirmed** absence counts as "nothing here". `.unavailable`
-    /// means the item may well be present, and a read failure that skipped the
-    /// clear would also set the marker — making the skip permanent, and leaving
-    /// exactly the inherited-passcode state this type exists to remove.
-    private func hasInheritedKeyMaterial() -> Bool {
-        if case .absent = keyStore.loadWrappedDataKey(),
-           case .absent = keychain.getPasscodeAttemptState() {
-            return false
-        }
-        return true
+    /// Three cases for the same reason the store's is: only a **confirmed**
+    /// absence means "nothing here", and an unreadable item is neither that nor
+    /// evidence of something. Collapsing `.unknown` into `.some` would issue
+    /// deletes on a first-ever install whose Keychain answered badly for a
+    /// moment; collapsing it into `.none` would set the marker and make the skip
+    /// permanent, leaving exactly the inherited-passcode state this type exists
+    /// to remove.
+    enum InheritedKeyMaterial {
+        /// Named `nothing`/`something` rather than `none`/`some` so neither can
+        /// be read as `Optional`'s cases at a call site.
+        case nothing
+        case something
+        case unknown
+    }
+
+    private func inheritedKeyMaterial() -> InheritedKeyMaterial {
+        let wrapper = keyStore.loadWrappedDataKey()
+        let attempts = keychain.getPasscodeAttemptState()
+
+        if case .present = wrapper { return .something }
+        if case .present = attempts { return .something }
+        if case .unavailable = wrapper { return .unknown }
+        if case .unavailable = attempts { return .unknown }
+        return .nothing
     }
 
     /// Only ever reached with an empty store, so none of what it removes can be

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
@@ -14,8 +14,8 @@ private let logger = Log.app.store
 ///
 /// The Keychain outlives the app. Deleting the app removes the SwiftData store
 /// and every `UserDefaults` value, but leaves every Keychain item exactly where
-/// it was — so a reinstall begins with no vaults and no lock mode while the data
-/// key, its wrapped copy and the attempt counter all survive.
+/// it was — so a reinstall begins with no vaults and no lock mode while the
+/// wrapped data key and the attempt counter both survive.
 ///
 /// Once a passcode exists that asymmetry is fatal. `AppLockService.mode` lives in
 /// `UserDefaults`, so it reverts to device auth and the passcode screen is never
@@ -28,11 +28,19 @@ private let logger = Log.app.store
 ///
 /// 1. **Inherited key material** is cleared when the container is new. Bounded by
 ///    two conditions so it can never destroy a key something depends on.
-/// 2. **The lock mode** is forced back to `.passcode` whenever a wrapped key
-///    exists without a clear one, so key material always has a door in front of
-///    it even if the first step could not run.
+/// 2. **The lock mode is made to agree with the wrapped key**, in both
+///    directions: a wrapper with no passcode mode means key material with no
+///    door in front of it, and a passcode mode with no wrapper means a door with
+///    nothing behind it — `unlock` has nothing to verify against, so it could
+///    never be opened.
 ///
-/// Runs on every launch, before migrations.
+/// Runs on every launch, before migrations, and under
+/// ``KeyshareWriteCoordinator``'s transition lease: it deletes and re-decides
+/// exactly the state `PasscodeService` is moving during a set or a disable, and
+/// a launch landing in the middle of one could delete a wrapper the set had just
+/// verified — leaving the key adopted in memory with nothing on disk that wraps
+/// it. If the lease cannot be taken, reconciliation is skipped entirely and the
+/// container is left unmarked so the next launch tries again.
 struct KeyshareInstallReconciler {
 
     enum ReconcileError: Error, Equatable {
@@ -51,17 +59,20 @@ struct KeyshareInstallReconciler {
     private let keychain: KeychainService
     private let keyStore: KeyshareKeyStoring
     private let lockService: AppLockService
+    private let coordinator: KeyshareWriteCoordinator
     private let defaults: UserDefaults
 
     init(
         keychain: KeychainService = DefaultKeychainService.shared,
         keyStore: KeyshareKeyStoring = DefaultKeyshareKeyStore.shared,
         lockService: AppLockService = .shared,
+        coordinator: KeyshareWriteCoordinator = .shared,
         defaults: UserDefaults = .standard
     ) {
         self.keychain = keychain
         self.keyStore = keyStore
         self.lockService = lockService
+        self.coordinator = coordinator
         self.defaults = defaults
     }
 
@@ -78,8 +89,19 @@ struct KeyshareInstallReconciler {
     }
 
     func reconcile(isStoreEmpty: Bool) {
+        // Both halves read the wrapped key and act on what they read, so both
+        // have to be indivisible against a passcode transition. Without this a
+        // launch could clear a wrapper `setPasscode` had just made durable, or
+        // decide the lock mode from a snapshot a concurrent disable has already
+        // invalidated.
+        guard let lease = try? coordinator.beginTransition() else {
+            logger.info("Reconciliation skipped: a passcode transition or key-share write is in progress")
+            return
+        }
+        defer { coordinator.end(lease) }
+
         clearInheritedKeyMaterialIfContainerIsNew(isStoreEmpty: isStoreEmpty)
-        restoreLockModeIfKeyIsWrapped()
+        alignLockModeWithTheWrappedKey()
     }
 
     // MARK: - Inherited key material
@@ -89,20 +111,20 @@ struct KeyshareInstallReconciler {
 
         // Existing users reach this line exactly once, on the first launch of the
         // build that introduces the marker — with a full store. Clearing their
-        // data key would orphan every sealed share, which in this app is lost
+        // wrapped key would orphan every sealed share, which in this app is lost
         // funds, so the store having anything in it ends the matter here.
         //
         // It also has to be the store rather than "is anything sealed": a user
-        // who has a passcode set but is mid-way through enabling it has both
-        // forms on disk, and one who has never set one has neither, so
-        // emptiness is the only thing that distinguishes a new container.
+        // part-way through enabling a passcode has a wrapper and unsealed
+        // shares, and one who has never set one has neither, so emptiness is the
+        // only thing that distinguishes a new container.
         guard isStoreEmpty else {
             defaults.set(true, forKey: Self.markerKey)
             return
         }
 
         // A first-ever install inherits nothing, and clearing nothing still
-        // costs three Keychain deletes and their read-backs. Someone who never
+        // costs a Keychain delete and its read-back per item. Someone who never
         // sets a passcode must see no launch-time Keychain mutation at all, so
         // confirmed absence ends it here — the marker is `UserDefaults`, which
         // the acceptance test does not speak about.
@@ -116,7 +138,7 @@ struct KeyshareInstallReconciler {
             defaults.set(true, forKey: Self.markerKey)
         } catch {
             // The marker is deliberately left unset so the next launch tries
-            // again. Until it succeeds, `restoreLockModeIfKeyIsWrapped` is what
+            // again. Until it succeeds, the lock-mode alignment below is what
             // keeps the app reachable rather than silently unusable.
             logger.error("Could not clear inherited key material: \(String(describing: error), privacy: .public)")
         }
@@ -129,8 +151,7 @@ struct KeyshareInstallReconciler {
     /// clear would also set the marker — making the skip permanent, and leaving
     /// exactly the inherited-passcode state this type exists to remove.
     private func hasInheritedKeyMaterial() -> Bool {
-        if case .absent = keyStore.loadDataKey(),
-           case .absent = keyStore.loadWrappedDataKey(),
+        if case .absent = keyStore.loadWrappedDataKey(),
            case .absent = keychain.getPasscodeAttemptState() {
             return false
         }
@@ -143,7 +164,6 @@ struct KeyshareInstallReconciler {
     private func clearInheritedKeyMaterial() throws {
         logger.info("New app container over surviving Keychain state — clearing inherited key material")
 
-        try keyStore.deleteDataKey()
         try keyStore.deleteWrappedDataKey()
 
         // The attempt limiter keeps its state in the Keychain on purpose, so a
@@ -167,31 +187,38 @@ struct KeyshareInstallReconciler {
 
     // MARK: - Lock mode
 
-    /// A wrapped data key with no clear copy means a passcode is set, whatever
-    /// `UserDefaults` happens to say. Without this the app can hold key material
-    /// it has no way to ask for.
+    /// The wrapped key is the whole of the persisted passcode state, so the lock
+    /// mode has to agree with it — and being wrong in either direction locks
+    /// someone out or leaves key material undefended.
     ///
-    /// Each read fails closed in its own direction, and they are not the same
-    /// direction:
+    /// Only a **confirmed** answer moves the mode. An unreadable Keychain leaves
+    /// it exactly as it is: taking `.unavailable` for presence would raise a gate
+    /// with nothing behind it, and taking it for absence would take a real gate
+    /// down.
     ///
-    /// - the **wrapped** key must be *confirmed present*. Restoring the passcode
-    ///   mode on an unreadable read would put up a gate with no wrapper behind
-    ///   it, and `unlock` has nothing to verify against — a lock screen that can
-    ///   never open.
-    /// - the **clear** key must be *confirmed present* to suppress restoration.
-    ///   An unreadable clear key is not a reason to leave key material
-    ///   undefended, so it does not suppress anything.
-    private func restoreLockModeIfKeyIsWrapped() {
-        guard case .present = keyStore.loadWrappedDataKey() else { return }
-        guard !isClearDataKeyPresent() else { return }
-        guard lockService.mode != .passcode else { return }
-
-        logger.warning("A wrapped data key exists but the lock mode was \(lockService.mode.rawValue, privacy: .public); restoring passcode mode")
-        lockService.mode = .passcode
-    }
-
-    private func isClearDataKeyPresent() -> Bool {
-        if case .present = keyStore.loadDataKey() { return true }
-        return false
+    /// Each direction repairs a different interruption:
+    ///
+    /// - **present ⇒ `.passcode`** covers a removal that stopped half way.
+    ///   `disablePasscode` changes the mode *before* deleting the wrapper, so a
+    ///   crash in between leaves plaintext shares, a surviving wrapper and a
+    ///   persisted `.deviceAuth`. Putting the gate back up is what makes that
+    ///   ordering safe to choose in the first place.
+    /// - **absent ⇒ `.deviceAuth`** covers a wrapper that went away underneath a
+    ///   persisted `.passcode` — a reinstall clear, or the crash order the
+    ///   disable deliberately avoids. `unlock` has nothing to verify a passcode
+    ///   against, so that gate could never be opened.
+    private func alignLockModeWithTheWrappedKey() {
+        switch keyStore.loadWrappedDataKey() {
+        case .present:
+            guard lockService.mode != .passcode else { return }
+            logger.warning("A wrapped data key exists but the lock mode was \(lockService.mode.rawValue, privacy: .public); restoring passcode mode")
+            lockService.mode = .passcode
+        case .absent:
+            guard lockService.mode == .passcode else { return }
+            logger.warning("The lock mode was passcode with no wrapped data key behind it; falling back to device auth")
+            lockService.mode = .deviceAuth
+        case .unavailable:
+            return
+        }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
@@ -101,6 +101,16 @@ struct KeyshareInstallReconciler {
             return
         }
 
+        // A first-ever install inherits nothing, and clearing nothing still
+        // costs three Keychain deletes and their read-backs. Someone who never
+        // sets a passcode must see no launch-time Keychain mutation at all, so
+        // confirmed absence ends it here — the marker is `UserDefaults`, which
+        // the acceptance test does not speak about.
+        guard hasInheritedKeyMaterial() else {
+            defaults.set(true, forKey: Self.markerKey)
+            return
+        }
+
         do {
             try clearInheritedKeyMaterial()
             defaults.set(true, forKey: Self.markerKey)
@@ -110,6 +120,21 @@ struct KeyshareInstallReconciler {
             // keeps the app reachable rather than silently unusable.
             logger.error("Could not clear inherited key material: \(String(describing: error), privacy: .public)")
         }
+    }
+
+    /// Whether any passcode artifact might have been inherited.
+    ///
+    /// Only a **confirmed** absence counts as "nothing here". `.unavailable`
+    /// means the item may well be present, and a read failure that skipped the
+    /// clear would also set the marker — making the skip permanent, and leaving
+    /// exactly the inherited-passcode state this type exists to remove.
+    private func hasInheritedKeyMaterial() -> Bool {
+        if case .absent = keyStore.loadDataKey(),
+           case .absent = keyStore.loadWrappedDataKey(),
+           case .absent = keychain.getPasscodeAttemptState() {
+            return false
+        }
+        return true
     }
 
     /// Only ever reached with an empty store, so none of what it removes can be
@@ -127,7 +152,9 @@ struct KeyshareInstallReconciler {
         // along with the data it protected, so keeping the counter would only
         // start a new install inside a lockout guarding nothing.
         keychain.setPasscodeAttemptState(nil)
-        guard keychain.getPasscodeAttemptState().valueTreatingUnavailableAsAbsent == nil else {
+        // A confirmed absence, not merely an unreadable one: the marker is set
+        // on success, so "probably gone" would never be revisited.
+        guard case .absent = keychain.getPasscodeAttemptState() else {
             throw ReconcileError.clearFailed(item: "passcodeAttemptState")
         }
 
@@ -144,15 +171,27 @@ struct KeyshareInstallReconciler {
     /// `UserDefaults` happens to say. Without this the app can hold key material
     /// it has no way to ask for.
     ///
-    /// Fails closed by construction: `loadDataKey` returns `nil` for any failure
-    /// rather than only for absence, so a transient Keychain fault can add a lock
-    /// screen but never remove one.
+    /// Each read fails closed in its own direction, and they are not the same
+    /// direction:
+    ///
+    /// - the **wrapped** key must be *confirmed present*. Restoring the passcode
+    ///   mode on an unreadable read would put up a gate with no wrapper behind
+    ///   it, and `unlock` has nothing to verify against — a lock screen that can
+    ///   never open.
+    /// - the **clear** key must be *confirmed present* to suppress restoration.
+    ///   An unreadable clear key is not a reason to leave key material
+    ///   undefended, so it does not suppress anything.
     private func restoreLockModeIfKeyIsWrapped() {
-        guard keyStore.loadDataKey() == nil,
-              keyStore.loadWrappedDataKey() != nil,
-              lockService.mode != .passcode else { return }
+        guard case .present = keyStore.loadWrappedDataKey() else { return }
+        guard !isClearDataKeyPresent() else { return }
+        guard lockService.mode != .passcode else { return }
 
         logger.warning("A wrapped data key exists but the lock mode was \(lockService.mode.rawValue, privacy: .public); restoring passcode mode")
         lockService.mode = .passcode
+    }
+
+    private func isClearDataKeyPresent() -> Bool {
+        if case .present = keyStore.loadDataKey() { return true }
+        return false
     }
 }

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
@@ -1,0 +1,158 @@
+//
+//  KeyshareInstallReconciler.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+import SwiftData
+
+private let logger = Log.app.store
+
+/// Brings Keychain-held key material back into agreement with the app container
+/// at launch.
+///
+/// The Keychain outlives the app. Deleting the app removes the SwiftData store
+/// and every `UserDefaults` value, but leaves every Keychain item exactly where
+/// it was — so a reinstall begins with no vaults and no lock mode while the data
+/// key, its wrapped copy and the attempt counter all survive.
+///
+/// Once a passcode exists that asymmetry is fatal. `AppLockService.mode` lives in
+/// `UserDefaults`, so it reverts to device auth and the passcode screen is never
+/// shown; the wrapped data key lives in the Keychain, so `KeyshareKeySession`
+/// reports `.locked`. Nothing can open the key and nothing can ask for the
+/// passcode, so every vault created or imported afterwards fails to seal — and
+/// deleting the app again, the obvious way out, is what caused it.
+///
+/// Two things are reconciled, in order:
+///
+/// 1. **Inherited key material** is cleared when the container is new. Bounded by
+///    two conditions so it can never destroy a key something depends on.
+/// 2. **The lock mode** is forced back to `.passcode` whenever a wrapped key
+///    exists without a clear one, so key material always has a door in front of
+///    it even if the first step could not run.
+///
+/// Runs on every launch, before migrations.
+struct KeyshareInstallReconciler {
+
+    enum ReconcileError: Error, Equatable {
+        /// A Keychain item was still readable after being cleared.
+        case clearFailed(item: String)
+    }
+
+    /// Marks a container that has already been reconciled.
+    ///
+    /// In `UserDefaults` deliberately: it has to disappear along with the
+    /// container, because its *absence* is the only evidence that the container
+    /// is new. Anything Keychain-held would survive the reinstall it is meant to
+    /// detect.
+    private static let markerKey = "keyshareInstallReconciled"
+
+    private let keychain: KeychainService
+    private let keyStore: KeyshareKeyStoring
+    private let lockService: AppLockService
+    private let defaults: UserDefaults
+
+    init(
+        keychain: KeychainService = DefaultKeychainService.shared,
+        keyStore: KeyshareKeyStoring = DefaultKeyshareKeyStore.shared,
+        lockService: AppLockService = .shared,
+        defaults: UserDefaults = .standard
+    ) {
+        self.keychain = keychain
+        self.keyStore = keyStore
+        self.lockService = lockService
+        self.defaults = defaults
+    }
+
+    @MainActor
+    func reconcile() {
+        // A store that cannot be read counts as "not empty". Being unable to
+        // tell must never be mistaken for a new container.
+        var isStoreEmpty = false
+        if let context = Storage.shared.modelContext,
+           let count = try? context.fetchCount(FetchDescriptor<Vault>()) {
+            isStoreEmpty = count == 0
+        }
+        reconcile(isStoreEmpty: isStoreEmpty)
+    }
+
+    func reconcile(isStoreEmpty: Bool) {
+        clearInheritedKeyMaterialIfContainerIsNew(isStoreEmpty: isStoreEmpty)
+        restoreLockModeIfKeyIsWrapped()
+    }
+
+    // MARK: - Inherited key material
+
+    private func clearInheritedKeyMaterialIfContainerIsNew(isStoreEmpty: Bool) {
+        guard !defaults.bool(forKey: Self.markerKey) else { return }
+
+        // Existing users reach this line exactly once, on the first launch of the
+        // build that introduces the marker — with a full store. Clearing their
+        // data key would orphan every sealed share, which in this app is lost
+        // funds, so the store having anything in it ends the matter here.
+        //
+        // It also has to be the store rather than "is anything sealed": a user
+        // who has a passcode set but is mid-way through enabling it has both
+        // forms on disk, and one who has never set one has neither, so
+        // emptiness is the only thing that distinguishes a new container.
+        guard isStoreEmpty else {
+            defaults.set(true, forKey: Self.markerKey)
+            return
+        }
+
+        do {
+            try clearInheritedKeyMaterial()
+            defaults.set(true, forKey: Self.markerKey)
+        } catch {
+            // The marker is deliberately left unset so the next launch tries
+            // again. Until it succeeds, `restoreLockModeIfKeyIsWrapped` is what
+            // keeps the app reachable rather than silently unusable.
+            logger.error("Could not clear inherited key material: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Only ever reached with an empty store, so none of what it removes can be
+    /// guarding anything: an empty store holds no sealed share, and the shares
+    /// the previous install's key opened went with the store itself.
+    private func clearInheritedKeyMaterial() throws {
+        logger.info("New app container over surviving Keychain state — clearing inherited key material")
+
+        try keyStore.deleteDataKey()
+        try keyStore.deleteWrappedDataKey()
+
+        // The attempt limiter keeps its state in the Keychain on purpose, so a
+        // lockout cannot be shaken off by reinstalling. That reasoning does not
+        // reach this path: the passcode being throttled has just been removed
+        // along with the data it protected, so keeping the counter would only
+        // start a new install inside a lockout guarding nothing.
+        keychain.setPasscodeAttemptState(nil)
+        guard keychain.getPasscodeAttemptState().valueTreatingUnavailableAsAbsent == nil else {
+            throw ReconcileError.clearFailed(item: "passcodeAttemptState")
+        }
+
+        // `lastMigratedVersion` is deliberately left alone. It is Keychain-held
+        // so it survives reinstalls, and clearing it would re-run every ordinary
+        // migration on a container that has no passcode artifact of any kind —
+        // a launch-time write for people who never touched this feature, which
+        // is exactly what must not happen.
+    }
+
+    // MARK: - Lock mode
+
+    /// A wrapped data key with no clear copy means a passcode is set, whatever
+    /// `UserDefaults` happens to say. Without this the app can hold key material
+    /// it has no way to ask for.
+    ///
+    /// Fails closed by construction: `loadDataKey` returns `nil` for any failure
+    /// rather than only for absence, so a transient Keychain fault can add a lock
+    /// screen but never remove one.
+    private func restoreLockModeIfKeyIsWrapped() {
+        guard keyStore.loadDataKey() == nil,
+              keyStore.loadWrappedDataKey() != nil,
+              lockService.mode != .passcode else { return }
+
+        logger.warning("A wrapped data key exists but the lock mode was \(lockService.mode.rawValue, privacy: .public); restoring passcode mode")
+        lockService.mode = .passcode
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeySession.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeySession.swift
@@ -30,6 +30,9 @@ final class KeyshareKeySession {
     private let store: KeyshareKeyStoring
     private let lock = NSLock()
     private var cachedKey: SymmetricKey?
+    /// Bumped on every `clear()`. An unlock that began before a lock happened
+    /// must not install its result afterwards.
+    private var generation: Int = 0
 
     init(store: KeyshareKeyStoring = DefaultKeyshareKeyStore.shared) {
         self.store = store
@@ -63,10 +66,35 @@ final class KeyshareKeySession {
         cachedKey = key
     }
 
+    /// The generation to pass back to `adopt(_:ifGeneration:)`.
+    var currentGeneration: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return generation
+    }
+
+    /// Adopts the key only if no `clear()` happened in the meantime.
+    ///
+    /// Unlocking runs PBKDF2, which takes long enough for the app to be
+    /// backgrounded and locked mid-derivation. Without this check the unlock
+    /// would finish afterwards and quietly undo the lock.
+    ///
+    /// - Returns: whether the key was adopted.
+    @discardableResult
+    func adopt(_ key: SymmetricKey, ifGeneration expected: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard generation == expected else { return false }
+        cachedKey = key
+        return true
+    }
+
     /// Forgets the key. Sealed shares become unreadable until it is restored.
     func clear() {
         lock.lock()
         defer { lock.unlock() }
         cachedKey = nil
+        generation &+= 1
     }
 }

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeySession.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeySession.swift
@@ -19,9 +19,9 @@ import Foundation
 /// no key, the session reports `.disabled`, and stored shares stay plaintext —
 /// the state the great majority of installs are in and stay in.
 ///
-/// No path writes an *unwrapped* key: removing the passcode opens every share
-/// rather than stashing the key beside them, so the two forms of the invariant
-/// agree.
+/// There is no unwrapped form of the key anywhere: the Keychain holds it only
+/// passcode-wrapped, and removing the passcode opens every share rather than
+/// stashing the key beside them.
 ///
 /// The presence of the **wrapped** key is therefore the whole of the persisted
 /// state, and reading it is the one place a Keychain failure could do real harm:

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeySession.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeySession.swift
@@ -19,10 +19,9 @@ import Foundation
 /// no key, the session reports `.disabled`, and stored shares stay plaintext —
 /// the state the great majority of installs are in and stay in.
 ///
-/// `disablePasscode` is the one path that still writes an *unwrapped* key, left
-/// over from an earlier design and unreadable from here, so a store it leaves
-/// behind reads as `.disabled` on the next launch. That path is rewired to
-/// unseal instead, at which point no unwrapped key is ever written.
+/// No path writes an *unwrapped* key: removing the passcode opens every share
+/// rather than stashing the key beside them, so the two forms of the invariant
+/// agree.
 ///
 /// The presence of the **wrapped** key is therefore the whole of the persisted
 /// state, and reading it is the one place a Keychain failure could do real harm:

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeySession.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeySession.swift
@@ -8,21 +8,29 @@ import Foundation
 
 /// Holds the data key for the life of an unlocked session.
 ///
-/// The key is read from the Keychain once and kept in memory afterwards, because
-/// the read path runs inside TSS keygen and keysign — `getLocalState` is called
-/// per share by the signing layer, and paying a Keychain round trip each time
-/// would put that cost in the middle of signing.
+/// The key never comes out of the Keychain *here*: an unlock hands the opened
+/// key over through `adopt`, and it is then held in memory, because the read
+/// path runs inside TSS keygen and keysign — `getLocalState` is called per share
+/// by the signing layer, and paying a Keychain round trip each time would put
+/// that cost in the middle of signing. Forgetting it is therefore all `clear()`
+/// has to do to lock the app.
 ///
 /// A data key exists only while a passcode does. With none set the store holds
 /// no key, the session reports `.disabled`, and stored shares stay plaintext —
-/// the state the great majority of installs are in and stay in. Once a passcode
-/// is set the key is persisted only in wrapped form, so an unlock is what fills
-/// this in, which is what makes `clear()` equivalent to locking.
+/// the state the great majority of installs are in and stay in.
 ///
-/// `currentState()` also still recognises an unwrapped `keyshareDataKey`, which
-/// is what remains of an earlier design that kept one. No code writes that item
-/// any more; it is read so an install that somehow holds one is reported as
-/// unlocked rather than silently as unprotected.
+/// `disablePasscode` is the one path that still writes an *unwrapped* key, left
+/// over from an earlier design and unreadable from here, so a store it leaves
+/// behind reads as `.disabled` on the next launch. That path is rewired to
+/// unseal instead, at which point no unwrapped key is ever written.
+///
+/// The presence of the **wrapped** key is therefore the whole of the persisted
+/// state, and reading it is the one place a Keychain failure could do real harm:
+/// answering `.disabled` when the key is merely unreadable would tell every
+/// caller that shares are plaintext, and the next `seal` would write one in the
+/// clear behind a passcode that is still set. So an unreadable Keychain reads as
+/// `.locked` — the app refuses to touch key material until it can see its own
+/// state again.
 final class KeyshareKeySession {
 
     static let shared = KeyshareKeySession()
@@ -38,9 +46,11 @@ final class KeyshareKeySession {
         self.store = store
     }
 
-    /// - `disabled` — no data key of either form: shares are still plaintext.
     /// - `unlocked` — the key is in hand.
-    /// - `locked` — a wrapped key exists but has not been opened.
+    /// - `locked` — a wrapped key exists but has not been opened, **or** the
+    ///   Keychain could not be read and so may hold one.
+    /// - `disabled` — the Keychain positively answered that there is no wrapped
+    ///   key: no passcode, and shares are plaintext.
     func currentState() -> KeyshareProtectionState {
         lock.lock()
         defer { lock.unlock() }
@@ -48,14 +58,28 @@ final class KeyshareKeySession {
         if let cachedKey {
             return .unlocked(cachedKey)
         }
-        if let key = store.loadDataKey() {
-            cachedKey = key
-            return .unlocked(key)
-        }
-        if store.loadWrappedDataKey() != nil {
+        switch store.loadWrappedDataKey() {
+        case .present:
+            return .locked
+        case .absent:
+            return .disabled
+        case .unavailable:
+            // Fail closed, and the cost is understood: `seal` throws on
+            // `.locked`, so a Keychain that cannot be read fails a keygen or an
+            // import rather than completing it. That is the better half of the
+            // trade. `.disabled` is a licence to write plaintext, and taking it
+            // wrongly writes an unprotected share behind a passcode that is
+            // still set — silently, and only for the users who opted in.
+            // Failing is visible and the user retries.
+            //
+            // The exposure is also narrower than it looks: with no passcode
+            // there is no wrapped item, and a query matching no item answers
+            // `errSecItemNotFound` whatever the device's lock state. Reaching
+            // this line without a passcode takes a Keychain-wide fault, which
+            // the fast-vault password and device-token reads would be failing
+            // on too.
             return .locked
         }
-        return .disabled
     }
 
     /// Adopts a key without going back to the Keychain — used when a key has

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
@@ -36,8 +36,9 @@ enum KeyshareKeyStoreError: Error, Equatable {
 ///
 /// The unwrapped-key API (`loadDataKey` / `storeDataKey` / `deleteDataKey`) is
 /// what remains of an earlier design that kept a clear copy alongside the
-/// shares. `disablePasscode` is its last writer and stops being one when the
-/// disable path is rewired to unseal instead.
+/// shares. **Nothing writes one any more** — the disable path opens every share
+/// instead of stashing the key — so what is left is a read path that recognises
+/// an item inherited from such a build, and it goes with the item itself.
 ///
 /// **Every read answers with a ``KeychainReadResult``, and the distinction is
 /// load-bearing rather than decorative.** `.absent` is the only answer that

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
@@ -6,6 +6,7 @@
 import CryptoKit
 import Foundation
 import OSLog
+import Security
 
 private let logger = Log.app.other
 
@@ -35,15 +36,23 @@ enum KeyshareKeyStoreError: Error, Equatable {
 ///
 /// The unwrapped-key API (`loadDataKey` / `storeDataKey` / `deleteDataKey`) is
 /// what remains of an earlier design that kept a clear copy alongside the
-/// shares. Nothing writes one any more.
+/// shares. `disablePasscode` is its last writer and stops being one when the
+/// disable path is rewired to unseal instead.
+///
+/// **Every read answers with a ``KeychainReadResult``, and the distinction is
+/// load-bearing rather than decorative.** `.absent` is the only answer that
+/// licenses minting a fresh data key, and a fresh key cannot open a single
+/// share the old one sealed — so an unreadable Keychain reported as absence is
+/// a direct path to permanently orphaned key material. Deletions verify against
+/// a *confirmed* absence for the same reason.
 protocol KeyshareKeyStoring {
     func generateDataKey() throws -> SymmetricKey
 
-    func loadDataKey() -> SymmetricKey?
+    func loadDataKey() -> KeychainReadResult<SymmetricKey>
     func storeDataKey(_ key: SymmetricKey) throws
     func deleteDataKey() throws
 
-    func loadWrappedDataKey() -> Data?
+    func loadWrappedDataKey() -> KeychainReadResult<Data>
     func storeWrappedDataKey(_ blob: Data) throws
     func deleteWrappedDataKey() throws
 
@@ -67,13 +76,23 @@ final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
         try VaultCryptoEnvelope.randomKey()
     }
 
-    func loadDataKey() -> SymmetricKey? {
-        guard let data = keychain.getKeyshareDataKey().valueTreatingUnavailableAsAbsent else { return nil }
-        guard data.count == VaultCryptoEnvelope.keyLengthBytes else {
-            logger.error("Keyshare data key has unexpected length \(data.count, privacy: .public)")
-            return nil
+    /// - Returns: ``KeychainReadResult/unavailable(_:)`` with `errSecDecode` when
+    ///   an item exists but is not a 256-bit key. It is present and unusable,
+    ///   which is not the same as absent: reporting absence would let a caller
+    ///   write a replacement over key material that is still there.
+    func loadDataKey() -> KeychainReadResult<SymmetricKey> {
+        switch keychain.getKeyshareDataKey() {
+        case .absent:
+            return .absent
+        case .unavailable(let status):
+            return .unavailable(status)
+        case .present(let data):
+            guard data.count == VaultCryptoEnvelope.keyLengthBytes else {
+                logger.error("Keyshare data key has unexpected length \(data.count, privacy: .public)")
+                return .unavailable(errSecDecode)
+            }
+            return .present(SymmetricKey(data: data))
         }
-        return SymmetricKey(data: data)
     }
 
     /// Writes the key and reads it back before returning. A silent Keychain
@@ -93,19 +112,22 @@ final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
     /// A silent deletion failure here is what makes a passcode cosmetic: the
     /// clear copy would survive, and the next lock would simply reload it from
     /// the Keychain and carry on signing.
+    ///
+    /// Only a **confirmed** absence counts. An unreadable item may still be
+    /// there, and callers record a successful clear as done and never retry it.
     func deleteDataKey() throws {
         keychain.setKeyshareDataKey(nil)
 
-        guard keychain.getKeyshareDataKey().valueTreatingUnavailableAsAbsent == nil else {
-            logger.error("Keyshare data key still present after deletion")
+        guard case .absent = keychain.getKeyshareDataKey() else {
+            logger.error("Keyshare data key still present or unreadable after deletion")
             throw KeyshareKeyStoreError.deletionFailed
         }
     }
 
     // MARK: - Wrapped data key
 
-    func loadWrappedDataKey() -> Data? {
-        keychain.getWrappedKeyshareDataKey().valueTreatingUnavailableAsAbsent
+    func loadWrappedDataKey() -> KeychainReadResult<Data> {
+        keychain.getWrappedKeyshareDataKey()
     }
 
     func storeWrappedDataKey(_ blob: Data) throws {
@@ -117,11 +139,13 @@ final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
         }
     }
 
+    /// Verified against a confirmed absence, for the same reason
+    /// ``deleteDataKey()`` is.
     func deleteWrappedDataKey() throws {
         keychain.setWrappedKeyshareDataKey(nil)
 
-        guard keychain.getWrappedKeyshareDataKey().valueTreatingUnavailableAsAbsent == nil else {
-            logger.error("Wrapped keyshare data key still present after deletion")
+        guard case .absent = keychain.getWrappedKeyshareDataKey() else {
+            logger.error("Wrapped keyshare data key still present or unreadable after deletion")
             throw KeyshareKeyStoreError.deletionFailed
         }
     }

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
@@ -110,8 +110,8 @@ final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
     /// PBKDF2 at 600k iterations costs roughly half a second, so both of these
     /// run off the calling thread the way `VaultBackupEncryption` does.
     ///
-    /// The stretching is not what makes the wrap strong — a 5-digit passcode is
-    /// only ~16.6 bits however it is stretched, and an attacker who can read the
+    /// The stretching is not what makes the wrap strong — a 6-digit passcode is
+    /// only ~19.9 bits however it is stretched, and an attacker who can read the
     /// wrapped blob out of the Keychain already owns the device. What it buys is
     /// a throttle on the in-app guessing path.
     func wrap(_ key: SymmetricKey, passcode: String) async throws -> Data {

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
@@ -16,6 +16,8 @@ enum KeyshareKeyStoreError: Error, Equatable {
     case persistenceFailed
     case wrongPasscode
     case malformedWrappedKey
+    /// The Keychain reported success but the item is still readable.
+    case deletionFailed
 }
 
 /// Custody of the data key that encrypts key shares at rest.
@@ -39,11 +41,11 @@ protocol KeyshareKeyStoring {
 
     func loadDataKey() -> SymmetricKey?
     func storeDataKey(_ key: SymmetricKey) throws
-    func deleteDataKey()
+    func deleteDataKey() throws
 
     func loadWrappedDataKey() -> Data?
     func storeWrappedDataKey(_ blob: Data) throws
-    func deleteWrappedDataKey()
+    func deleteWrappedDataKey() throws
 
     func wrap(_ key: SymmetricKey, passcode: String) async throws -> Data
     func unwrap(_ blob: Data, passcode: String) async throws -> SymmetricKey
@@ -86,8 +88,18 @@ final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
         }
     }
 
-    func deleteDataKey() {
+    /// Verifies the item is actually gone.
+    ///
+    /// A silent deletion failure here is what makes a passcode cosmetic: the
+    /// clear copy would survive, and the next lock would simply reload it from
+    /// the Keychain and carry on signing.
+    func deleteDataKey() throws {
         keychain.setKeyshareDataKey(nil)
+
+        guard keychain.getKeyshareDataKey().valueTreatingUnavailableAsAbsent == nil else {
+            logger.error("Keyshare data key still present after deletion")
+            throw KeyshareKeyStoreError.deletionFailed
+        }
     }
 
     // MARK: - Wrapped data key
@@ -105,8 +117,13 @@ final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
         }
     }
 
-    func deleteWrappedDataKey() {
+    func deleteWrappedDataKey() throws {
         keychain.setWrappedKeyshareDataKey(nil)
+
+        guard keychain.getWrappedKeyshareDataKey().valueTreatingUnavailableAsAbsent == nil else {
+            logger.error("Wrapped keyshare data key still present after deletion")
+            throw KeyshareKeyStoreError.deletionFailed
+        }
     }
 
     // MARK: - Passcode wrapping

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareKeyStore.swift
@@ -34,11 +34,10 @@ enum KeyshareKeyStoreError: Error, Equatable {
 /// Because a share is sealed under the data key rather than under the passcode,
 /// changing the passcode rewraps 32 bytes and never rewrites a single key share.
 ///
-/// The unwrapped-key API (`loadDataKey` / `storeDataKey` / `deleteDataKey`) is
-/// what remains of an earlier design that kept a clear copy alongside the
-/// shares. **Nothing writes one any more** — the disable path opens every share
-/// instead of stashing the key — so what is left is a read path that recognises
-/// an item inherited from such a build, and it goes with the item itself.
+/// **There is no unwrapped resting state.** The key exists in the Keychain only
+/// in passcode-wrapped form and in memory only while the app is unlocked, so
+/// there is no third place it can be found and no state in which a share is
+/// sealed but reachable without the passcode.
 ///
 /// **Every read answers with a ``KeychainReadResult``, and the distinction is
 /// load-bearing rather than decorative.** `.absent` is the only answer that
@@ -48,10 +47,6 @@ enum KeyshareKeyStoreError: Error, Equatable {
 /// a *confirmed* absence for the same reason.
 protocol KeyshareKeyStoring {
     func generateDataKey() throws -> SymmetricKey
-
-    func loadDataKey() -> KeychainReadResult<SymmetricKey>
-    func storeDataKey(_ key: SymmetricKey) throws
-    func deleteDataKey() throws
 
     func loadWrappedDataKey() -> KeychainReadResult<Data>
     func storeWrappedDataKey(_ blob: Data) throws
@@ -77,60 +72,16 @@ final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
         try VaultCryptoEnvelope.randomKey()
     }
 
-    /// - Returns: ``KeychainReadResult/unavailable(_:)`` with `errSecDecode` when
-    ///   an item exists but is not a 256-bit key. It is present and unusable,
-    ///   which is not the same as absent: reporting absence would let a caller
-    ///   write a replacement over key material that is still there.
-    func loadDataKey() -> KeychainReadResult<SymmetricKey> {
-        switch keychain.getKeyshareDataKey() {
-        case .absent:
-            return .absent
-        case .unavailable(let status):
-            return .unavailable(status)
-        case .present(let data):
-            guard data.count == VaultCryptoEnvelope.keyLengthBytes else {
-                logger.error("Keyshare data key has unexpected length \(data.count, privacy: .public)")
-                return .unavailable(errSecDecode)
-            }
-            return .present(SymmetricKey(data: data))
-        }
-    }
-
-    /// Writes the key and reads it back before returning. A silent Keychain
-    /// failure here would otherwise surface later as unopenable key shares.
-    func storeDataKey(_ key: SymmetricKey) throws {
-        let data = key.rawRepresentation
-        keychain.setKeyshareDataKey(data)
-
-        guard case .present(let readBack) = keychain.getKeyshareDataKey(), readBack == data else {
-            logger.error("Keyshare data key failed read-back verification")
-            throw KeyshareKeyStoreError.persistenceFailed
-        }
-    }
-
-    /// Verifies the item is actually gone.
-    ///
-    /// A silent deletion failure here is what makes a passcode cosmetic: the
-    /// clear copy would survive, and the next lock would simply reload it from
-    /// the Keychain and carry on signing.
-    ///
-    /// Only a **confirmed** absence counts. An unreadable item may still be
-    /// there, and callers record a successful clear as done and never retry it.
-    func deleteDataKey() throws {
-        keychain.setKeyshareDataKey(nil)
-
-        guard case .absent = keychain.getKeyshareDataKey() else {
-            logger.error("Keyshare data key still present or unreadable after deletion")
-            throw KeyshareKeyStoreError.deletionFailed
-        }
-    }
-
     // MARK: - Wrapped data key
 
     func loadWrappedDataKey() -> KeychainReadResult<Data> {
         keychain.getWrappedKeyshareDataKey()
     }
 
+    /// Writes the wrapper and reads it back before returning. A silent Keychain
+    /// failure here would otherwise surface later as unopenable key shares: the
+    /// sweep that follows seals every share against a key whose only durable
+    /// copy is this blob.
     func storeWrappedDataKey(_ blob: Data) throws {
         keychain.setWrappedKeyshareDataKey(blob)
 
@@ -140,8 +91,11 @@ final class DefaultKeyshareKeyStore: KeyshareKeyStoring {
         }
     }
 
-    /// Verified against a confirmed absence, for the same reason
-    /// ``deleteDataKey()`` is.
+    /// Verifies the item is actually gone, and only a **confirmed** absence
+    /// counts: an unreadable item may still be there, and the caller records a
+    /// successful removal as done and never retries it. The corollary matters
+    /// just as much — a throw here does *not* prove the item survived, so a
+    /// rollback has to re-establish it rather than assume it.
     func deleteWrappedDataKey() throws {
         keychain.setWrappedKeyshareDataKey(nil)
 

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareNormalizer.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareNormalizer.swift
@@ -1,0 +1,186 @@
+//
+//  KeyshareNormalizer.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+
+private let logger = Log.app.store
+
+/// Why a share could not be put into the form the current protection state
+/// requires. Each caller maps this onto its own error surface — the two commit
+/// paths report failures to very different screens.
+enum KeyshareNormalizationFailure: Error {
+    /// A sealed share does not open under the current session. `open` reports a
+    /// key that is gone, a key that does not fit, and a key merely not yet
+    /// unwrapped identically, so this names the share and nothing else.
+    case unreadable(pubkey: String)
+    /// A readable share cannot be sealed under the current session, or the seal
+    /// it produced does not open back to it. Carries the protector's own error,
+    /// for a caller that would rather surface that.
+    case unsealable(pubkey: String, underlying: Error)
+}
+
+/// Puts a vault's key shares on the side of the invariant the passcode is
+/// currently on, at the moment they are written — or refuses the write.
+///
+/// A share is sealed if and only if a passcode is currently set. Two paths hold
+/// shares in memory across an interval a passcode transition can run inside: a
+/// backup import, across its password prompt and vault picker, and a keygen,
+/// across the whole "Review Your Vaults" screen. Neither set of shares is in the
+/// store, so the sweep that rewrites every *stored* share cannot reach them —
+/// the protection state they were computed under is not necessarily the one they
+/// are saved in, and both directions of that mismatch break something:
+///
+/// - **Sealed, passcode since removed.** The data key is gone, so the persisted
+///   vault looks complete, nothing ever revisits it, and every signature it is
+///   asked for fails.
+/// - **Plaintext, passcode since set.** Key material lands in a protected store
+///   in the clear, readable while the app is locked, and stays that way
+///   indefinitely, because the sweep that would have sealed it already ran.
+///
+/// Verifying only closes the first: plaintext is readable, so a readability
+/// check waves it through. So the shares are *normalized* rather than checked —
+/// opened, then re-sealed under the state in force right now — and the write is
+/// refused when that cannot be done. Both callers normalize under a write lease,
+/// so "right now" cannot move underneath the save that follows.
+///
+/// The asymmetry is deliberate. A plaintext share is normalized rather than
+/// refused: throwing away a finished keygen — which cannot be repeated without
+/// every co-signer back on the same screen — to prevent an exposure that this
+/// very write is about to end would cost far more than it saves. A share that
+/// does not open has no such repair, and is refused.
+///
+/// > Note: re-sealing an already-correctly-sealed share produces different bytes
+/// > — AES-GCM takes a fresh nonce per seal — so the persisted value is not
+/// > byte-identical to the one in memory. It opens to the same share under the
+/// > same key, which is the property that matters, and paying a nonce to keep
+/// > one code path is cheaper than a "leave it alone if it already verifies"
+/// > branch that would have to be right about what "already" means.
+///
+/// The isolation is on the methods rather than the type: all of the work is
+/// main-actor work because `Vault` is a main-actor-only `@Model`, but the value
+/// itself is one immutable reference, and the types that own one hold it as a
+/// stored property.
+struct KeyshareNormalizer {
+
+    private let protector: KeyshareProtecting
+
+    init(protector: KeyshareProtecting) {
+        self.protector = protector
+    }
+
+    /// Opens every sealed share and changes nothing.
+    ///
+    /// The first half of ``normalizedShares(of:)``, for a caller that wants to
+    /// reject an input it cannot open before it has done anything else with it.
+    /// It says nothing about whether the shares can be *stored*; only the
+    /// normalization does.
+    @MainActor
+    func verify(_ vault: Vault) throws {
+        for share in vault.keyshares where protector.isSealed(share.keyshare) {
+            _ = try opened(share.keyshare, pubkey: share.pubkey)
+        }
+    }
+
+    /// Every share of the vault, sealed if a passcode is set and plaintext if
+    /// not, ready to be assigned back as a whole array.
+    ///
+    /// A value that opens to *another* sealed value is refused rather than
+    /// unwrapped again, matching ``KeyshareSweeper``: an envelope around an
+    /// envelope is not a share, and accepting one because its outer layer
+    /// authenticated would write `vlt2:` to disk under the name of a key share.
+    @MainActor
+    func normalizedShares(of vault: Vault) throws -> [KeyShare] {
+        try vault.keyshares.map { share in
+            let plaintext = protector.isSealed(share.keyshare)
+                ? try opened(share.keyshare, pubkey: share.pubkey)
+                : share.keyshare
+
+            // A passthrough with no passcode set, which is what keeps an
+            // unprotected install byte-identical to one without this feature.
+            return KeyShare(
+                pubkey: share.pubkey,
+                keyshare: try sealed(plaintext, pubkey: share.pubkey),
+                keyId: share.keyId
+            )
+        }
+    }
+
+    // MARK: - Privates
+
+    private func opened(_ stored: String, pubkey: String) throws -> String {
+        let opened: String
+        do {
+            opened = try protector.open(stored)
+        } catch {
+            logger.error(
+                "Key share \(pubkey, privacy: .public) could not be opened: \(String(describing: error), privacy: .public)"
+            )
+            throw KeyshareNormalizationFailure.unreadable(pubkey: pubkey)
+        }
+
+        guard !protector.isSealed(opened) else {
+            logger.error(
+                "Key share \(pubkey, privacy: .public) opened to another sealed value; refusing to treat it as a share"
+            )
+            throw KeyshareNormalizationFailure.unreadable(pubkey: pubkey)
+        }
+        return opened
+    }
+
+    /// The share as it should be stored, proved to open back to what went in.
+    ///
+    /// ``KeyshareSweeper`` makes two checks after every seal and only one of
+    /// them transfers. Its `isSealed` check catches "no data key is in hand",
+    /// which is a failure *there* because the sweep is on its way to sealed;
+    /// here a plaintext result is the correct answer whenever no passcode is
+    /// set, and asserting otherwise would break every unprotected install.
+    ///
+    /// The round trip does transfer, and for a sharper reason than the sweep
+    /// has: this is the last moment a freshly generated share's plaintext
+    /// exists anywhere. Storing ciphertext that does not open back would be
+    /// precisely the dead vault the caller is here to prevent, and it would be
+    /// stored looking perfectly healthy. A no-passcode install pays nothing for
+    /// it — both halves are passthroughs.
+    ///
+    /// > Note: the write lease keeps a passcode *transition* out of this, but
+    /// > `PasscodeService.lock()` is `nonisolated` and takes no lease, so the
+    /// > key can be forgotten between the seal and the proof. That is why the
+    /// > proof separates "could not open" from "opened to the wrong thing": the
+    /// > first is a lock landing mid-normalization, and the caller is told that
+    /// > rather than a cipher fault it can do nothing about. Either way the
+    /// > write is refused, which is the correct direction to fail — the share is
+    /// > intact and the next unlock stores it.
+    private func sealed(_ plaintext: String, pubkey: String) throws -> String {
+        let sealed: String
+        do {
+            sealed = try protector.seal(plaintext)
+        } catch {
+            logger.error(
+                "Key share \(pubkey, privacy: .public) could not be sealed: \(String(describing: error), privacy: .public)"
+            )
+            throw KeyshareNormalizationFailure.unsealable(pubkey: pubkey, underlying: error)
+        }
+
+        let reopened: String
+        do {
+            reopened = try protector.open(sealed)
+        } catch {
+            logger.error(
+                "Key share \(pubkey, privacy: .public) could not be read back after sealing: \(String(describing: error), privacy: .public)"
+            )
+            throw KeyshareNormalizationFailure.unsealable(pubkey: pubkey, underlying: error)
+        }
+
+        guard reopened == plaintext else {
+            logger.error("Key share \(pubkey, privacy: .public) did not open back to its original value")
+            throw KeyshareNormalizationFailure.unsealable(
+                pubkey: pubkey,
+                underlying: KeyshareProtectionError.cipherFailure
+            )
+        }
+        return sealed
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareSweeper.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareSweeper.swift
@@ -27,18 +27,37 @@ enum KeyshareSweeperError: Error, Equatable {
 /// mistake here is lost funds rather than a bad screen.
 ///
 /// `PasscodeService` is an `actor` and `Vault` is a SwiftData `@Model` that may
-/// only be touched on the main actor, so the sweep is its own `@MainActor` type
-/// behind this protocol and is injected rather than reached for.
-@MainActor
+/// only be touched on the main actor, so the sweep is main-actor work behind
+/// this protocol and is injected rather than reached for.
+///
+/// The isolation is stated **per requirement** rather than on the protocol.
+/// Attributing the protocol would infer main-actor isolation onto the whole
+/// conforming type, singleton included — and the actor that injects one has to
+/// name that singleton as a default argument, which no `await` can reach.
 protocol KeyshareSweeping {
     /// Seals every plaintext share **and authenticates every already-sealed
     /// one**. See ``KeyshareSweeper`` for why the second half is not optional.
-    func sealAll() throws
+    @MainActor func sealAll() throws
 
     /// Opens every sealed share back to plaintext. The GCM tag check inside
     /// `open` *is* the verification here — a successful open is proof that the
     /// value was sealed under the key in hand.
-    func unsealAll() throws
+    @MainActor func unsealAll() throws
+
+    /// Whether any stored share is already sealed.
+    ///
+    /// Asked before a fresh data key is minted, and it is the last guard against
+    /// the worst outcome this feature has: a sealed share with no readable
+    /// wrapper means a key already exists somewhere, and a replacement opens
+    /// none of the ciphertext the original produced. A `Bool` is the right
+    /// answer here — unlike a plaintext/sealed *census*, this asks a question
+    /// about the stored form rather than about whether a value verifies.
+    ///
+    /// - Throws: when the store cannot be read, **including when it is carrying
+    ///   unsaved work**. Not knowing must never be mistaken for "nothing is
+    ///   sealed": a pending edit or deletion can hide a share that is still
+    ///   sealed on disk, and the answer is used to license minting a key.
+    @MainActor func hasSealedShare() throws -> Bool
 }
 
 /// The sweep, in two phases over a context nobody else is using.
@@ -71,7 +90,12 @@ protocol KeyshareSweeping {
 /// retries. Autosave — on by default — is suspended for the transaction, since
 /// phase two dirties every swept vault at once and only the explicit save that
 /// follows may write them.
-@MainActor
+///
+/// **The isolation is on the methods, not on the type.** All of the *work* is
+/// main-actor work, but the value itself is two immutable references, and
+/// `PasscodeService` is an `actor` that has to hold one as a stored property —
+/// which a main-actor-isolated singleton could not be handed to without a hop
+/// in the middle of its initializer.
 final class KeyshareSweeper: KeyshareSweeping {
 
     static let shared = KeyshareSweeper()
@@ -87,6 +111,30 @@ final class KeyshareSweeper: KeyshareSweeping {
         self.context = context
     }
 
+    @MainActor
+    func hasSealedShare() throws -> Bool {
+        guard let context = context() else {
+            throw KeyshareSweeperError.missingModelContext
+        }
+
+        // The same refusal `sweep` makes, and for a sharper reason. A fetch
+        // answers from the context's *pending* state, so an unsaved edit or an
+        // uncommitted deletion can present a vault as plaintext — or not at all
+        // — while the durable row is still sealed. This answer licenses minting
+        // a fresh data key, and a key minted over a sealed share that then comes
+        // back from disk opens nothing.
+        guard !context.hasChanges else {
+            logger.warning("Sealed-share scan refused: the store has unsaved changes")
+            throw KeyshareSweeperError.busy
+        }
+
+        return try context.fetch(FetchDescriptor<Vault>())
+            .contains { vault in
+                vault.keyshares.contains { protector.isSealed($0.keyshare) }
+            }
+    }
+
+    @MainActor
     func sealAll() throws {
         try sweep(describedAs: "seal") { stored in
             guard !self.protector.isSealed(stored) else {
@@ -113,6 +161,7 @@ final class KeyshareSweeper: KeyshareSweeping {
         }
     }
 
+    @MainActor
     func unsealAll() throws {
         try sweep(describedAs: "unseal") { stored in
             guard self.protector.isSealed(stored) else { return nil }
@@ -154,6 +203,7 @@ private extension KeyshareSweeper {
 
     /// - Parameter transform: the new value for a share's stored bytes, or
     ///   `nil` to leave the share exactly as it is.
+    @MainActor
     func sweep(describedAs operation: String, _ transform: (String) throws -> String?) throws {
         guard let context = context() else {
             throw KeyshareSweeperError.missingModelContext
@@ -202,6 +252,7 @@ private extension KeyshareSweeper {
     /// The vault's shares after the transform, or `nil` when none of them
     /// changed. Builds a whole array for the caller to assign through the
     /// property setter — see rule 2.
+    @MainActor
     func rewrittenShares(of vault: Vault, _ transform: (String) throws -> String?) throws -> [KeyShare]? {
         var result: [KeyShare] = []
         var changed = false

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareSweeper.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareSweeper.swift
@@ -1,0 +1,228 @@
+//
+//  KeyshareSweeper.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+import SwiftData
+
+private let logger = Log.app.store
+
+enum KeyshareSweeperError: Error, Equatable {
+    /// The store could not be reached at all.
+    case missingModelContext
+    /// The main context is carrying somebody else's unsaved work.
+    case busy
+    /// A share did not survive its round trip, or an already-sealed value could
+    /// not be opened. Carries the share's public key so the log names it.
+    case verificationFailed(pubkey: String)
+}
+
+/// Moves every stored key share to the side of the invariant the passcode is on.
+///
+/// A share is sealed if and only if a passcode is currently set, so setting a
+/// passcode has to seal every share and removing one has to open every share.
+/// This is the only thing in the feature that rewrites key material, and a
+/// mistake here is lost funds rather than a bad screen.
+///
+/// `PasscodeService` is an `actor` and `Vault` is a SwiftData `@Model` that may
+/// only be touched on the main actor, so the sweep is its own `@MainActor` type
+/// behind this protocol and is injected rather than reached for.
+@MainActor
+protocol KeyshareSweeping {
+    /// Seals every plaintext share **and authenticates every already-sealed
+    /// one**. See ``KeyshareSweeper`` for why the second half is not optional.
+    func sealAll() throws
+
+    /// Opens every sealed share back to plaintext. The GCM tag check inside
+    /// `open` *is* the verification here — a successful open is proof that the
+    /// value was sealed under the key in hand.
+    func unsealAll() throws
+}
+
+/// The sweep, in two phases over a context nobody else is using.
+///
+/// Four rules, and each one is a failure someone has already had:
+///
+/// 1. **Two phases.** Everything is computed and verified in memory before a
+///    single model is touched. Applying a vault as soon as it verifies leaves
+///    earlier vaults mutated in the live context when a later one fails, and an
+///    unrelated save would flush that half-swept state to disk.
+/// 2. **Whole-array assignment.** `vault.keyshares = newArray`, never
+///    `keyshares[i] = …` — assigning into an element is not a dependable way to
+///    mark a `@Model` dirty, and a sweep that reported success while persisting
+///    nothing leaves plaintext shares sitting behind a passcode.
+/// 3. **Save, and `rollback()` if the save fails**, so the context cannot carry
+///    a partial sweep forward.
+/// 4. **Already-sealed values are opened before they are accepted, and what
+///    comes out has to be a share.** `KeyshareProtector.seal` returns an
+///    already-sealed value *unchanged and unauthenticated*, so a sweep that took
+///    it on trust would report success over a share sealed under a key nobody
+///    holds any more — a dead vault, and nothing ever revisits it because the
+///    sweep said it was fine. A value that opens to *another* sealed value is
+///    refused outright rather than unwrapped again.
+///
+/// **The context has to be clean.** Flushing foreign pending changes would
+/// commit somebody's half-finished keygen, reshare or import merely because the
+/// user enabled a passcode, and some code defers persistence deliberately until
+/// a flow is confirmed; rolling them back would throw that work away instead.
+/// Neither is this type's to do, so a dirty context is `.busy` and the user
+/// retries. Autosave — on by default — is suspended for the transaction, since
+/// phase two dirties every swept vault at once and only the explicit save that
+/// follows may write them.
+@MainActor
+final class KeyshareSweeper: KeyshareSweeping {
+
+    static let shared = KeyshareSweeper()
+
+    private let protector: KeyshareProtecting
+    private let context: () -> ModelContext?
+
+    init(
+        protector: KeyshareProtecting = KeyshareProtector.shared,
+        context: @escaping () -> ModelContext? = { Storage.shared.modelContext }
+    ) {
+        self.protector = protector
+        self.context = context
+    }
+
+    func sealAll() throws {
+        try sweep(describedAs: "seal") { stored in
+            guard !self.protector.isSealed(stored) else {
+                // Rule 4. Opening it is the only way to know the key in hand is
+                // the key it was sealed under.
+                try self.openedShare(from: stored)
+                return nil
+            }
+
+            let sealed = try self.protector.seal(stored)
+
+            // `seal` is a passthrough when no key is held, so a sweep with
+            // nothing to seal with would otherwise report success over shares it
+            // left in the clear.
+            guard self.protector.isSealed(sealed) else {
+                logger.error("Sealing produced a plaintext value — no data key is in hand")
+                throw SweepFailure.unverified
+            }
+            guard try self.protector.open(sealed) == stored else {
+                logger.error("A sealed key share did not open back to its original value")
+                throw SweepFailure.unverified
+            }
+            return sealed
+        }
+    }
+
+    func unsealAll() throws {
+        try sweep(describedAs: "unseal") { stored in
+            guard self.protector.isSealed(stored) else { return nil }
+            return try self.openedShare(from: stored)
+        }
+    }
+}
+
+// MARK: - Privates
+
+private extension KeyshareSweeper {
+
+    /// Raised by a transform to mean "this share did not verify"; the caller
+    /// attaches the public key.
+    enum SweepFailure: Error {
+        case unverified
+    }
+
+    /// The plaintext share inside a sealed value, refusing anything that is
+    /// *still* sealed once opened.
+    ///
+    /// A value that opens to another sealed value is an envelope wrapped around
+    /// an envelope, not a share. Nothing here produces one — `seal` will not
+    /// seal an already-sealed value — but an imported `.vult` or JSON backup can
+    /// carry whatever bytes it likes, and unwrapping only the outer layer would
+    /// write `vlt2:` back to disk while reporting the store fully unsealed. The
+    /// disable that follows then deletes the key, and what is left cannot be
+    /// opened by anything, ever. Unwrapping recursively is not the answer: it
+    /// would accept adversarial input rather than reject it.
+    @discardableResult
+    func openedShare(from stored: String) throws -> String {
+        let opened = try protector.open(stored)
+        guard !protector.isSealed(opened) else {
+            logger.error("A key share opened to another sealed value; refusing to treat it as a share")
+            throw SweepFailure.unverified
+        }
+        return opened
+    }
+
+    /// - Parameter transform: the new value for a share's stored bytes, or
+    ///   `nil` to leave the share exactly as it is.
+    func sweep(describedAs operation: String, _ transform: (String) throws -> String?) throws {
+        guard let context = context() else {
+            throw KeyshareSweeperError.missingModelContext
+        }
+
+        guard !context.hasChanges else {
+            logger.warning("Key-share \(operation, privacy: .public) refused: the store has unsaved changes")
+            throw KeyshareSweeperError.busy
+        }
+
+        let wasAutosaveEnabled = context.autosaveEnabled
+        context.autosaveEnabled = false
+        defer { context.autosaveEnabled = wasAutosaveEnabled }
+
+        // Phase one — compute and verify everything, mutating nothing.
+        var pending: [(vault: Vault, shares: [KeyShare])] = []
+        for vault in try context.fetch(FetchDescriptor<Vault>()) {
+            if let shares = try rewrittenShares(of: vault, transform) {
+                pending.append((vault, shares))
+            }
+        }
+
+        guard !pending.isEmpty else {
+            logger.info("Nothing to \(operation, privacy: .public)")
+            return
+        }
+
+        // Phase two — every share across every vault has been proved
+        // recoverable, so the writes go in together.
+        for entry in pending {
+            entry.vault.keyshares = entry.shares
+        }
+
+        do {
+            try context.save()
+        } catch {
+            context.rollback()
+            logger.error("Key-share \(operation, privacy: .public) failed to save, rolled back: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+
+        let count = pending.reduce(0) { $0 + $1.shares.count }
+        logger.info("Swept \(count, privacy: .public) key shares across \(pending.count, privacy: .public) vaults (\(operation, privacy: .public))")
+    }
+
+    /// The vault's shares after the transform, or `nil` when none of them
+    /// changed. Builds a whole array for the caller to assign through the
+    /// property setter — see rule 2.
+    func rewrittenShares(of vault: Vault, _ transform: (String) throws -> String?) throws -> [KeyShare]? {
+        var result: [KeyShare] = []
+        var changed = false
+
+        for share in vault.keyshares {
+            let rewritten: String?
+            do {
+                rewritten = try transform(share.keyshare)
+            } catch {
+                logger.error("A key share did not verify: \(String(describing: error), privacy: .public)")
+                throw KeyshareSweeperError.verificationFailed(pubkey: share.pubkey)
+            }
+
+            guard let rewritten else {
+                result.append(share)
+                continue
+            }
+            result.append(KeyShare(pubkey: share.pubkey, keyshare: rewritten, keyId: share.keyId))
+            changed = true
+        }
+
+        return changed ? result : nil
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareWriteCoordinator.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareWriteCoordinator.swift
@@ -104,22 +104,34 @@ final class KeyshareWriteCoordinator {
     /// - Throws: `KeyshareWriteCoordinatorError.busy` if a transition holds the
     ///   coordinator, or whatever `body` throws.
     func withWriteLease<T>(_ body: () throws -> T) throws -> T {
-        lock.lock()
-        guard !isTransitionHeld else {
-            lock.unlock()
-            logger.info("Key-share write refused; a passcode transition is in progress")
-            throw KeyshareWriteCoordinatorError.busy
-        }
-        writesInFlight += 1
-        lock.unlock()
-
-        defer {
-            lock.lock()
-            writesInFlight -= 1
-            lock.unlock()
-        }
-
+        try claimWrite()
+        defer { releaseWrite() }
         return try body()
+    }
+
+    /// The same claim as ``withWriteLease(_:)``, held as a token, for the one
+    /// caller that has to `await` in the middle of it: the app unlock, which
+    /// unwraps the data key and then finishes any sweep an interrupted
+    /// transition left behind.
+    ///
+    /// **A write and not a transition, deliberately.** A transition is refused
+    /// while a vault-creation episode is open, and keygen holds one from the
+    /// protocol starting through the deferred commit — so an app that locked on
+    /// the review screen could never be opened again: the flow cannot be
+    /// finished without unlocking, and unlocking cannot happen while the flow is
+    /// open. Excluding transitions is all an unlock needs, and that is exactly
+    /// what a write lease does.
+    ///
+    /// - Throws: `KeyshareWriteCoordinatorError.busy` if a transition is held.
+    func beginWrite() throws -> WriteLease {
+        try claimWrite()
+        return WriteLease { self.releaseWrite() }
+    }
+
+    /// Releases a write lease. Calling it twice, or after the lease has already
+    /// been dropped, is a no-op.
+    func end(_ lease: WriteLease) {
+        lease.release()
     }
 
     // MARK: - Episodes
@@ -155,6 +167,23 @@ final class KeyshareWriteCoordinator {
     }
 
     // MARK: - Privates
+
+    private func claimWrite() throws {
+        lock.lock()
+        guard !isTransitionHeld else {
+            lock.unlock()
+            logger.info("Key-share write refused; a passcode transition is in progress")
+            throw KeyshareWriteCoordinatorError.busy
+        }
+        writesInFlight += 1
+        lock.unlock()
+    }
+
+    private func releaseWrite() {
+        lock.lock()
+        writesInFlight -= 1
+        lock.unlock()
+    }
 
     private func releaseTransition() {
         lock.lock()
@@ -214,6 +243,9 @@ class KeyshareLease {
 
 /// Held for the duration of one passcode set, change, disable or resume.
 final class TransitionLease: KeyshareLease {}
+
+/// Held for the duration of one key-share write that has to `await`.
+final class WriteLease: KeyshareLease {}
 
 /// Held for the duration of one keygen, reshare or vault import.
 final class EpisodeLease: KeyshareLease {}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
@@ -1,0 +1,202 @@
+//
+//  ProtectedVaultImporter.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+import SwiftData
+
+private let logger = Log.app.store
+
+enum ProtectedVaultImportError: Error, Equatable {
+    /// A passcode transition is in progress. The import is refused rather than
+    /// queued: the transition is about to rewrite every stored share, and a
+    /// vault inserted underneath it would never be seen.
+    case busy
+    /// An incoming share is sealed and does not open here — the wrong key, or a
+    /// value that is not a share at all.
+    case unreadableShare(pubkey: String)
+}
+
+/// The one way an imported vault reaches storage.
+///
+/// Every backup format the app accepts funnels through here: protobuf `.vult`,
+/// encrypted protobuf, `BackupVault` JSON, bare `Vault` JSON, the old fallback
+/// path and the multi-file ZIP. Before this existed only the protobuf path went
+/// through the protector — `Vault.init(from: Decoder)` decodes `[KeyShare]`
+/// straight off the wire — so a JSON import with a passcode set wrote
+/// **plaintext shares into a protected store**, readable even while the app was
+/// locked and left that way indefinitely.
+///
+/// Three things have to be true of an import, and they are why this is a type
+/// rather than a helper:
+///
+/// 1. **An incoming sealed value is authenticated, not trusted.** A `.vult` or
+///    JSON blob can legitimately carry a `vlt2:` string — it was exported from a
+///    sealed store by a build that wrote the stored bytes — and accepting one
+///    unchecked imports a share nobody can open. It is opened under the current
+///    session or the import is refused. A value that opens to *another* sealed
+///    value is refused outright rather than unwrapped again, for the same reason
+///    ``KeyshareSweeper`` refuses it: that is adversarial input, not a share.
+/// 2. **Every share is normalized under the protection state at the moment it is
+///    stored** — sealed if a passcode is set, plaintext if not — so an imported
+///    vault lands on the same side of the invariant as everything already there.
+/// 3. **The insert and its `save()` happen inside one episode lease.** Leaving
+///    the insert to an autosave puts it outside any span a passcode transition
+///    can be excluded from, which is exactly how a share ends up computed under
+///    one protection state and persisted under another.
+///
+/// > Note: the lease brackets normalize → insert → save rather than decode →
+/// > insert → save. Decoding is separated from committing by a password prompt on
+/// > the multi-file path, and a lease held across a modal is a lease that leaks
+/// > when the user walks away — which blocks every passcode change until the app
+/// > is relaunched. Re-normalizing at commit time under the lease gives the same
+/// > guarantee without that failure mode: whatever the state was at decode, what
+/// > reaches disk agrees with the state the save runs in.
+///
+/// The isolation is stated per method rather than on the type: everything it
+/// *does* is main-actor work, because `Vault` is a main-actor-only `@Model`, but
+/// the value itself is two immutable references and the view models that own one
+/// name it as a default argument.
+struct ProtectedVaultImporter {
+
+    private let protector: KeyshareProtecting
+    private let coordinator: KeyshareWriteCoordinator
+
+    init(
+        protector: KeyshareProtecting = KeyshareProtector.shared,
+        coordinator: KeyshareWriteCoordinator = .shared
+    ) {
+        self.protector = protector
+        self.coordinator = coordinator
+    }
+
+    /// Refuses a backup carrying a share this device cannot open, before the
+    /// user is told anything about it.
+    ///
+    /// Separate from ``commit(_:into:)`` only so a bad file fails at the point
+    /// it is read rather than after a password prompt and a vault picker; the
+    /// commit re-checks everything it does here.
+    @MainActor
+    func validate(_ vault: Vault) throws {
+        for share in vault.keyshares where protector.isSealed(share.keyshare) {
+            _ = try openedShare(share.keyshare, pubkey: share.pubkey)
+        }
+    }
+
+    /// Normalizes every share, inserts, and saves — all inside one episode lease.
+    ///
+    /// Two phases, like the sweep: every share of every vault is normalized and
+    /// verified before a single vault is inserted, so a bad share in the third
+    /// file of a ZIP does not leave the first two half-imported.
+    ///
+    /// - Parameter prepare: run per vault inside the lease, once the vault is
+    ///   provably stored. Anything that touches the context on a vault's behalf
+    ///   — default coins are the case that exists — belongs here rather than at
+    ///   the call site: done before, it leaves rows behind when the import is
+    ///   refused, and the token discovery it starts is unstructured work that
+    ///   outlives this call and must never be aimed at a vault that could still
+    ///   be withdrawn.
+    @MainActor
+    func commit(
+        _ vaults: [Vault],
+        into context: ModelContext,
+        prepare: (Vault) -> Void = { _ in }
+    ) throws {
+        // Nothing to do is not a reason to save: an all-duplicate ZIP would
+        // otherwise flush whatever unrelated work the context is carrying.
+        guard !vaults.isEmpty else { return }
+
+        guard let episode = coordinator.beginEpisode() else {
+            logger.warning("Vault import refused: a passcode transition is in progress")
+            throw ProtectedVaultImportError.busy
+        }
+        defer { coordinator.end(episode) }
+
+        let normalized = try vaults.map { try normalizedShares(of: $0) }
+
+        // Whatever the context was already carrying decides how a failure is
+        // undone below, and it has to be sampled before anything is inserted.
+        let wasCarryingOtherWork = context.hasChanges
+
+        for (vault, shares) in zip(vaults, normalized) {
+            // Whole-array assignment, never element assignment: assigning into
+            // an element is not a dependable way to mark a `@Model` dirty.
+            vault.keyshares = shares
+            context.insert(vault)
+        }
+
+        do {
+            try context.save()
+        } catch {
+            withdraw(vaults, from: context, rollingBack: !wasCarryingOtherWork)
+            logger.error("Vault import failed to save: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+
+        // Only now, over vaults that are provably on disk, and still inside the
+        // lease so the rows land before a transition can begin. A failure here
+        // is not an import failure: the vaults are stored and openable, and
+        // their default coins are derived state that any later launch rebuilds.
+        vaults.forEach(prepare)
+        do {
+            try context.save()
+        } catch {
+            logger.error("Imported vaults were stored but their default coins were not: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Privates
+
+    /// Undoes a failed import without taking anybody else's work with it.
+    ///
+    /// `rollback()` discards *every* pending change in the context, and episodes
+    /// deliberately overlap — a keygen can be part-way through its own writes
+    /// while an import runs. So it is only used when the context was clean on
+    /// the way in and the pending changes are provably ours; otherwise the
+    /// imported vaults are withdrawn one by one and the rest is left alone.
+    @MainActor
+    private func withdraw(_ vaults: [Vault], from context: ModelContext, rollingBack: Bool) {
+        guard !rollingBack else {
+            context.rollback()
+            return
+        }
+        for vault in vaults {
+            context.delete(vault)
+        }
+    }
+
+    @MainActor
+    private func normalizedShares(of vault: Vault) throws -> [KeyShare] {
+        try vault.keyshares.map { share in
+            let plaintext = protector.isSealed(share.keyshare)
+                ? try openedShare(share.keyshare, pubkey: share.pubkey)
+                : share.keyshare
+
+            // A passthrough with no passcode set, which is what keeps an
+            // unprotected install byte-identical to one without this feature.
+            return KeyShare(
+                pubkey: share.pubkey,
+                keyshare: try protector.seal(plaintext),
+                keyId: share.keyId
+            )
+        }
+    }
+
+    private func openedShare(_ stored: String, pubkey: String) throws -> String {
+        let opened: String
+        do {
+            opened = try protector.open(stored)
+        } catch {
+            logger.error("An imported key share could not be opened: \(String(describing: error), privacy: .public)")
+            throw ProtectedVaultImportError.unreadableShare(pubkey: pubkey)
+        }
+
+        guard !protector.isSealed(opened) else {
+            logger.error("An imported key share opened to another sealed value; refusing to treat it as a share")
+            throw ProtectedVaultImportError.unreadableShare(pubkey: pubkey)
+        }
+        return opened
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
@@ -42,6 +42,8 @@ enum ProtectedVaultImportError: Error, Equatable {
 /// 2. **Every share is normalized under the protection state at the moment it is
 ///    stored** — sealed if a passcode is set, plaintext if not — so an imported
 ///    vault lands on the same side of the invariant as everything already there.
+///    That is ``KeyshareNormalizer``'s job, shared with the keygen commit, which
+///    holds its shares across an interval with the same shape.
 /// 3. **The insert and its `save()` happen inside one episode lease.** Leaving
 ///    the insert to an autosave puts it outside any span a passcode transition
 ///    can be excluded from, which is exactly how a share ends up computed under
@@ -61,14 +63,14 @@ enum ProtectedVaultImportError: Error, Equatable {
 /// name it as a default argument.
 struct ProtectedVaultImporter {
 
-    private let protector: KeyshareProtecting
+    private let normalizer: KeyshareNormalizer
     private let coordinator: KeyshareWriteCoordinator
 
     init(
         protector: KeyshareProtecting = KeyshareProtector.shared,
         coordinator: KeyshareWriteCoordinator = .shared
     ) {
-        self.protector = protector
+        self.normalizer = KeyshareNormalizer(protector: protector)
         self.coordinator = coordinator
     }
 
@@ -80,9 +82,7 @@ struct ProtectedVaultImporter {
     /// commit re-checks everything it does here.
     @MainActor
     func validate(_ vault: Vault) throws {
-        for share in vault.keyshares where protector.isSealed(share.keyshare) {
-            _ = try openedShare(share.keyshare, pubkey: share.pubkey)
-        }
+        try statedAsAnImportFailure { try normalizer.verify(vault) }
     }
 
     /// Normalizes every share, inserts, and saves — all inside one episode lease.
@@ -114,7 +114,9 @@ struct ProtectedVaultImporter {
         }
         defer { coordinator.end(episode) }
 
-        let normalized = try vaults.map { try normalizedShares(of: $0) }
+        let normalized = try statedAsAnImportFailure {
+            try vaults.map { try normalizer.normalizedShares(of: $0) }
+        }
 
         // Whatever the context was already carrying decides how a failure is
         // undone below, and it has to be sampled before anything is inserted.
@@ -167,36 +169,29 @@ struct ProtectedVaultImporter {
         }
     }
 
+    /// Restates a normalization failure in the import's own terms.
+    ///
+    /// A share that does not open is the *file's* problem, and `unreadableShare`
+    /// names it. A share that cannot be sealed is the *session's* — `seal` fails
+    /// only when there is no key to seal with — and the raw
+    /// `KeyshareProtectionError` is what this surface has always raised for it,
+    /// so it passes through unchanged. Not because a call site renders it: they
+    /// all show a fixed "restore failed" string. Because the error a caller
+    /// catches is part of what the import promises, and this change is not the
+    /// place to renegotiate it.
     @MainActor
-    private func normalizedShares(of vault: Vault) throws -> [KeyShare] {
-        try vault.keyshares.map { share in
-            let plaintext = protector.isSealed(share.keyshare)
-                ? try openedShare(share.keyshare, pubkey: share.pubkey)
-                : share.keyshare
-
-            // A passthrough with no passcode set, which is what keeps an
-            // unprotected install byte-identical to one without this feature.
-            return KeyShare(
-                pubkey: share.pubkey,
-                keyshare: try protector.seal(plaintext),
-                keyId: share.keyId
-            )
-        }
-    }
-
-    private func openedShare(_ stored: String, pubkey: String) throws -> String {
-        let opened: String
+    private func statedAsAnImportFailure<T>(_ body: () throws -> T) throws -> T {
         do {
-            opened = try protector.open(stored)
-        } catch {
-            logger.error("An imported key share could not be opened: \(String(describing: error), privacy: .public)")
-            throw ProtectedVaultImportError.unreadableShare(pubkey: pubkey)
+            return try body()
+        } catch let failure as KeyshareNormalizationFailure {
+            switch failure {
+            case .unreadable(let pubkey):
+                logger.error("Vault import refused: key share \(pubkey, privacy: .public) could not be opened")
+                throw ProtectedVaultImportError.unreadableShare(pubkey: pubkey)
+            case .unsealable(let pubkey, let underlying):
+                logger.error("Vault import refused: key share \(pubkey, privacy: .public) could not be sealed")
+                throw underlying
+            }
         }
-
-        guard !protector.isSealed(opened) else {
-            logger.error("An imported key share opened to another sealed value; refusing to treat it as a share")
-            throw ProtectedVaultImportError.unreadableShare(pubkey: pubkey)
-        }
-        return opened
     }
 }

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeAttemptLimiter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeAttemptLimiter.swift
@@ -20,8 +20,8 @@ enum PasscodeAttemptLimiterError: Error, Equatable {
 
 /// Throttles passcode guessing in the app.
 ///
-/// This is the only thing standing between five digits and 100,000 tries, and it
-/// protects the in-app path *only* — it is irrelevant to anyone holding the
+/// This is the only thing standing between six digits and 1,000,000 tries, and
+/// it protects the in-app path *only* — it is irrelevant to anyone holding the
 /// stored blob, which is why the data key is a random 256 bits rather than
 /// something derived from the passcode.
 ///

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeAttemptLimiter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeAttemptLimiter.swift
@@ -176,8 +176,25 @@ final class PasscodeAttemptLimiter: PasscodeAttemptLimiting {
         }
     }
 
-    /// - Returns: `nil` when no record exists at all — a genuinely fresh start.
+    /// - Returns: `nil` when no record exists — a genuinely fresh start.
     /// - Throws: when a record exists but cannot be decoded.
+    ///
+    /// An unreadable Keychain is deliberately collapsed into "no record", which
+    /// is the one place in this feature where the strict reading is **not** the
+    /// safe one. `remainingLockout` answers an unreadable state with a flat
+    /// maximum delay that never decays and that a correct passcode cannot clear,
+    /// because clearing it needs a write this Keychain will not accept — so a
+    /// persistently unreadable item would put a permanent lockout in front of a
+    /// passcode the user knows and a wrapper that reads perfectly well.
+    ///
+    /// And the strictness would buy nothing. Anyone able to make this item
+    /// unreadable can equally delete it, and a deleted item is `.absent`, which
+    /// is legitimately a fresh start; the record is stored `WhenUnlocked`, the
+    /// same class as the wrapped key, so a lock-state read failure takes the
+    /// wrapper with it and `unlock` refuses before a guess is ever evaluated.
+    /// The throttle therefore rests on the record surviving ordinary use, not on
+    /// surviving Keychain tampering, and the collapse is spelled out rather than
+    /// inherited from an optional.
     private func loadState() throws -> State? {
         guard let data = keychain.getPasscodeAttemptState().valueTreatingUnavailableAsAbsent else {
             return nil

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeAttemptLimiter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeAttemptLimiter.swift
@@ -1,0 +1,216 @@
+//
+//  PasscodeAttemptLimiter.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+
+private let logger = Log.app.store
+
+enum PasscodeAttemptLimiterError: Error, Equatable {
+    /// The attempt state could not be stored. Treated as fatal for the attempt:
+    /// if failures cannot be recorded, the throttle does not exist.
+    case persistenceFailed
+    /// State is present but unreadable. Distinct from absent, because treating
+    /// corruption as "no failures yet" would let corrupting the record reset the
+    /// only throttle there is.
+    case stateUnreadable
+}
+
+/// Throttles passcode guessing in the app.
+///
+/// This is the only thing standing between five digits and 100,000 tries, and it
+/// protects the in-app path *only* — it is irrelevant to anyone holding the
+/// stored blob, which is why the data key is a random 256 bits rather than
+/// something derived from the passcode.
+///
+/// State lives in the Keychain rather than `UserDefaults` so it survives a
+/// reinstall; a lockout that can be cleared by deleting and reinstalling the app
+/// is not a lockout.
+protocol PasscodeAttemptLimiting {
+    /// How long the caller must wait before another attempt is allowed.
+    func remainingLockout(now: Date) -> TimeInterval
+    /// - Throws: when the failure could not be recorded, so the caller can
+    ///   refuse the attempt rather than let an unthrottled one through.
+    func recordFailure(now: Date) throws
+    func recordSuccess()
+}
+
+final class PasscodeAttemptLimiter: PasscodeAttemptLimiting {
+
+    /// No delay for the first few slips — fat fingers are not an attack.
+    static let freeAttempts = 3
+    /// Doubles per failure past the free ones: 5s, 10s, 20s, … capped below.
+    static let baseDelay: TimeInterval = 5
+    static let maximumDelay: TimeInterval = 15 * 60
+
+    private let keychain: KeychainService
+    private let uptime: () -> TimeInterval
+    private let lock = NSLock()
+
+    init(
+        keychain: KeychainService = DefaultKeychainService.shared,
+        uptime: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
+        self.keychain = keychain
+        self.uptime = uptime
+    }
+
+    func remainingLockout(now: Date = Date()) -> TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let state: State?
+        do {
+            state = try loadState()
+        } catch {
+            // Unreadable state fails closed: the alternative is that corrupting
+            // one Keychain item removes the throttle entirely.
+            return Self.maximumDelay
+        }
+
+        guard let state, state.failureCount > Self.freeAttempts, let lastFailure = state.lastFailure else {
+            return 0
+        }
+
+        guard let elapsed = elapsed(since: lastFailure, storedUptime: state.lastFailureUptime, now: now) else {
+            // The device rebooted, so the stored uptime belongs to a different
+            // boot and the wall clock cannot be trusted on its own. Restart the
+            // delay from now rather than honour a possibly-manipulated interval,
+            // and rebase the record so the lockout can actually expire.
+            do {
+                try store(State(failureCount: state.failureCount, lastFailure: now, lastFailureUptime: uptime()))
+            } catch {
+                // Without the rebase the stale high uptime is re-read on every
+                // check and the delay restarts forever, so this must not pass
+                // quietly as an ordinary, expiring lockout.
+                logger.error("Could not rebase passcode lockout after reboot")
+                return Self.maximumDelay
+            }
+            return delay(forFailureCount: state.failureCount)
+        }
+
+        let remaining = delay(forFailureCount: state.failureCount) - elapsed
+        return max(0, min(remaining, Self.maximumDelay))
+    }
+
+    func recordFailure(now: Date = Date()) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let existing: State?
+        do {
+            existing = try loadState()
+        } catch {
+            // Unreadable rather than absent. Resuming from zero would mean
+            // corrupting one Keychain item buys a fresh set of free attempts, so
+            // it resumes from the throttled ceiling instead.
+            existing = State(failureCount: Self.freeAttempts, lastFailure: now, lastFailureUptime: uptime())
+        }
+
+        let updated = State(
+            failureCount: (existing?.failureCount ?? 0) + 1,
+            lastFailure: now,
+            lastFailureUptime: uptime()
+        )
+        try store(updated)
+        logger.warning("Passcode attempt failed (\(updated.failureCount, privacy: .public) consecutive)")
+    }
+
+    func recordSuccess() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        // Best effort: a failure to clear leaves the user throttled, which is
+        // the safe direction, so it does not need to abort anything.
+        try? store(State(failureCount: 0, lastFailure: nil, lastFailureUptime: nil))
+    }
+
+    // MARK: - Elapsed time
+
+    /// How much time counts as having passed since the last failure, or `nil`
+    /// when the device has rebooted and no trustworthy answer exists.
+    ///
+    /// Wall time alone is user-adjustable — moving the device clock forward
+    /// would clear every backoff — so within a single boot the monotonic uptime
+    /// is used as well and the **smaller** of the two wins. Falling back to wall
+    /// time across a reboot would hand back the whole bypass: set the clock
+    /// forward, reboot, and the lockout is gone. So a reboot returns `nil` and
+    /// the caller restarts the delay instead.
+    private func elapsed(since lastFailure: Date, storedUptime: TimeInterval?, now: Date) -> TimeInterval? {
+        let wallElapsed = max(0, now.timeIntervalSince(lastFailure))
+
+        guard let storedUptime else { return wallElapsed }
+
+        let uptimeElapsed = uptime() - storedUptime
+        guard uptimeElapsed >= 0 else { return nil }
+
+        return min(wallElapsed, uptimeElapsed)
+    }
+
+    private func delay(forFailureCount count: Int) -> TimeInterval {
+        let excess = count - Self.freeAttempts
+        guard excess > 0 else { return 0 }
+
+        // Bound the exponent first: 2^excess overflows long before the delay cap
+        // would otherwise bite.
+        let doublings = min(excess - 1, 16)
+        return min(Self.baseDelay * pow(2, Double(doublings)), Self.maximumDelay)
+    }
+
+    // MARK: - Storage
+
+    private struct State: Codable {
+        var failureCount: Int
+        var lastFailure: Date?
+        /// Monotonic uptime at the moment of the failure, for the clock check.
+        var lastFailureUptime: TimeInterval?
+
+        /// Any recorded failure must carry both clocks, or the checks that
+        /// depend on them silently do nothing.
+        var isSelfConsistent: Bool {
+            guard failureCount >= 0 else { return false }
+            guard failureCount > 0 else { return true }
+            return lastFailure != nil && lastFailureUptime != nil
+        }
+    }
+
+    /// - Returns: `nil` when no record exists at all — a genuinely fresh start.
+    /// - Throws: when a record exists but cannot be decoded.
+    private func loadState() throws -> State? {
+        guard let data = keychain.getPasscodeAttemptState().valueTreatingUnavailableAsAbsent else {
+            return nil
+        }
+        guard let state = try? JSONDecoder().decode(State.self, from: data) else {
+            logger.error("Passcode attempt state is present but unreadable")
+            throw PasscodeAttemptLimiterError.stateUnreadable
+        }
+
+        // Decoding is not enough. A record with failures but no timestamp would
+        // slip past the lockout entirely, and one with no uptime would restore
+        // the clock-forward bypass — both are reachable by editing the stored
+        // blob, so they count as unreadable rather than as valid state.
+        guard state.isSelfConsistent else {
+            logger.error("Passcode attempt state is internally inconsistent")
+            throw PasscodeAttemptLimiterError.stateUnreadable
+        }
+        return state
+    }
+
+    /// Verifies the write landed. A silently dropped write would mean failures
+    /// stop being counted, i.e. the throttle quietly stops existing.
+    private func store(_ state: State) throws {
+        guard let data = try? JSONEncoder().encode(state) else {
+            logger.error("Failed to encode passcode attempt state")
+            throw PasscodeAttemptLimiterError.persistenceFailed
+        }
+
+        keychain.setPasscodeAttemptState(data)
+
+        guard case .present(let readBack) = keychain.getPasscodeAttemptState(), readBack == data else {
+            logger.error("Passcode attempt state failed read-back verification")
+            throw PasscodeAttemptLimiterError.persistenceFailed
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -61,7 +61,7 @@ actor PasscodeService {
 
     static let shared = PasscodeService()
 
-    static let passcodeLength = 5
+    static let passcodeLength = 6
 
     private let keyStore: KeyshareKeyStoring
     private let session: KeyshareKeySession

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -60,8 +60,18 @@ actor PasscodeService {
         self.limiter = limiter
     }
 
+    /// Fails closed. An unreadable Keychain may well hold a wrapped key, and the
+    /// one thing that must never happen is a fresh data key being minted over an
+    /// existing one — a new key opens none of the shares the old one sealed, so
+    /// every vault on the device would be gone. Refusing to set a passcode
+    /// because the Keychain is momentarily unreadable costs a retry.
     var isSet: Bool {
-        keyStore.loadWrappedDataKey() != nil
+        switch keyStore.loadWrappedDataKey() {
+        case .present, .unavailable:
+            return true
+        case .absent:
+            return false
+        }
     }
 
     // MARK: - Set
@@ -70,10 +80,13 @@ actor PasscodeService {
         try validate(passcode)
         guard !isSet else { throw PasscodeError.alreadySet }
 
-        guard let dataKey = keyStore.loadDataKey() else {
+        guard case .present(let dataKey) = keyStore.loadDataKey() else {
             // Nothing is encrypted yet, so there is no key to put behind a
             // passcode. Wrapping a key we just invented would leave the shares
             // readable without it and misrepresent what the passcode protects.
+            //
+            // An unreadable key lands here too, and must: the alternative is
+            // inventing a replacement for a key that is still on the device.
             throw PasscodeError.noDataKey
         }
 
@@ -113,8 +126,17 @@ actor PasscodeService {
             throw PasscodeError.lockedOut(remaining: lockout)
         }
 
-        guard let wrapped = keyStore.loadWrappedDataKey() else {
+        let wrapped: Data
+        switch keyStore.loadWrappedDataKey() {
+        case .present(let blob):
+            wrapped = blob
+        case .absent:
             throw PasscodeError.notSet
+        case .unavailable:
+            // Not "there is no passcode". The item may be there and momentarily
+            // unreadable, and `notSet` is what sends the UI off to offer setting
+            // one — over the top of a wrapper that still exists.
+            throw PasscodeError.storageFailure
         }
 
         // Captured before the derivation, which takes long enough for the app to
@@ -174,8 +196,13 @@ actor PasscodeService {
 
     /// Puts the data key back in the clear and removes the wrapped copy.
     ///
-    /// Shares stay sealed on disk — at-rest encryption does not depend on the
-    /// passcode, so turning the passcode off does not turn encryption off.
+    /// **Not yet the inverse of `setPasscode`, and the gap is visible from
+    /// here.** The invariant is that a share is sealed if and only if a passcode
+    /// is set, so removing the passcode has to unseal every share. This still
+    /// does what an earlier design needed — leaves the shares sealed and keeps a
+    /// clear copy of the key so they stay readable — and the session no longer
+    /// reads that clear copy, so the shares survive only as long as the process
+    /// does. Both halves go when the disable path is rewired to unseal.
     func disablePasscode(current: String, now: Date = Date()) async throws {
         let dataKey = try await unlock(with: current, now: now)
 

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -86,7 +86,18 @@ actor PasscodeService {
         // Verified, and the mode is only switched afterwards: a silently failed
         // deletion would leave the clear copy readable, so locking would just
         // reload it from the Keychain and the passcode would be decorative.
-        try keyStore.deleteDataKey()
+        do {
+            try keyStore.deleteDataKey()
+        } catch {
+            // Both copies exist. Left alone, `isSet` would report a passcode
+            // while the mode stayed on device auth and every retry failed with
+            // `alreadySet` — a passcode screen protecting nothing, with no way
+            // out. Undo the wrapped copy so the app is back where it started.
+            guard (try? keyStore.deleteWrappedDataKey()) != nil else {
+                throw PasscodeError.inconsistentState
+            }
+            throw error
+        }
 
         session.adopt(dataKey)
         lockService.mode = .passcode

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -5,6 +5,9 @@
 
 import CryptoKit
 import Foundation
+import OSLog
+
+private let logger = Log.app.store
 
 enum PasscodeError: Error, Equatable {
     case wrongPasscode
@@ -23,6 +26,15 @@ enum PasscodeError: Error, Equatable {
     /// The app locked while the passcode was being verified. The passcode was
     /// not necessarily wrong; the unlock simply no longer applies.
     case cancelledByLock
+    /// Another passcode transition, key-share write or vault-creation episode
+    /// is in flight, or the store is carrying somebody else's unsaved work.
+    /// Retryable, and the honest answer: the alternative is a settings toggle
+    /// that appears to hang while a keygen finishes.
+    case busy
+    /// A stored key share is already sealed while no wrapped key can be read.
+    /// Minting a fresh data key over that would orphan it permanently, so the
+    /// set is refused rather than completed.
+    case sealedSharesWithoutKey
 }
 
 /// Sets, changes, removes and verifies the app passcode.
@@ -37,6 +49,14 @@ enum PasscodeError: Error, Equatable {
 /// state. Concurrent failed unlocks could otherwise each read the same attempt
 /// count and collapse a burst of guesses into one recorded failure, which is the
 /// throttle this feature depends on.
+///
+/// An actor is not enough on its own, though, and that is what the transition
+/// lease is for: actors are reentrant at every `await`, and both of the
+/// operations below suspend across key derivation. Two callers could otherwise
+/// clear their own preconditions and interleave, and a key-share write landing
+/// mid-transition could persist a value computed under the other protection
+/// state. Every transition therefore takes ``KeyshareWriteCoordinator``'s
+/// exclusive lease **before its first `await`**.
 actor PasscodeService {
 
     static let shared = PasscodeService()
@@ -47,17 +67,23 @@ actor PasscodeService {
     private let session: KeyshareKeySession
     private let lockService: AppLockService
     private let limiter: PasscodeAttemptLimiting
+    private let coordinator: KeyshareWriteCoordinator
+    private let sweeper: KeyshareSweeping
 
     init(
         keyStore: KeyshareKeyStoring = DefaultKeyshareKeyStore.shared,
         session: KeyshareKeySession = .shared,
         lockService: AppLockService = .shared,
-        limiter: PasscodeAttemptLimiting = PasscodeAttemptLimiter()
+        limiter: PasscodeAttemptLimiting = PasscodeAttemptLimiter(),
+        coordinator: KeyshareWriteCoordinator = .shared,
+        sweeper: KeyshareSweeping = KeyshareSweeper.shared
     ) {
         self.keyStore = keyStore
         self.session = session
         self.lockService = lockService
         self.limiter = limiter
+        self.coordinator = coordinator
+        self.sweeper = sweeper
     }
 
     /// Fails closed. An unreadable Keychain may well hold a wrapped key, and the
@@ -76,44 +102,68 @@ actor PasscodeService {
 
     // MARK: - Set
 
+    /// Mints a data key, puts it behind the passcode, and seals every stored
+    /// share under it.
+    ///
+    /// The order below is the whole design, and each step sits where it does to
+    /// close a specific way of losing key material:
+    ///
+    /// - the **wrapper is durable before anything is sealed**. Mint, sweep, then
+    ///   store would orphan every sealed share if the process died in between,
+    ///   because the key only ever lived in memory;
+    /// - the **mode switches the moment the wrapper verifies**, not at the end.
+    ///   With it at the end, a failed sweep left a durable wrapper behind
+    ///   `.deviceAuth`: the retry failed `alreadySet`, and the resume that would
+    ///   have finished the job only runs on a passcode unlock the mode would
+    ///   never present — a passcode both durable and unreachable;
+    /// - a **failed sweep does not delete the wrapper**. Sealing may already
+    ///   have begun, and a wrapper deleted over half-sealed shares strands them:
+    ///   a later set mints a *different* key, which opens none of that
+    ///   ciphertext. The app stays in the pending-passcode state instead, and
+    ///   the next unlock's resume finishes it.
     func setPasscode(_ passcode: String) async throws {
+        let lease = try beginTransition()
+        defer { coordinator.end(lease) }
+
+        // Read first, before anything else in this method. A background `lock()`
+        // is `nonisolated` and stays outside the coordinator on purpose — it
+        // must never block on a transition — so it can land at any point from
+        // here on, and `adopt(_:ifGeneration:)` at the end is how it wins.
+        // Reading this any later would silently undo a lock that landed in
+        // between, leaving the key live in memory behind a lock screen. The
+        // window cannot be closed entirely while `lock()` is deliberately
+        // unsynchronized; it can be made as small as the first instruction.
+        let generation = session.currentGeneration
+
         try validate(passcode)
         guard !isSet else { throw PasscodeError.alreadySet }
 
-        guard case .present(let dataKey) = keyStore.loadDataKey() else {
-            // Nothing is encrypted yet, so there is no key to put behind a
-            // passcode. Wrapping a key we just invented would leave the shares
-            // readable without it and misrepresent what the passcode protects.
-            //
-            // An unreadable key lands here too, and must: the alternative is
-            // inventing a replacement for a key that is still on the device.
-            throw PasscodeError.noDataKey
+        // Never mint over evidence. A sealed share with no readable wrapper
+        // means a key already exists somewhere, and the one generated below
+        // opens none of what it sealed. A *completed* disable leaves nothing
+        // sealed, so re-enabling still works; an *interrupted* set leaves a
+        // wrapper, so `isSet` above refuses first and resume — not a fresh
+        // mint — is the recovery.
+        guard try await !storeHoldsASealedShare() else {
+            throw PasscodeError.sealedSharesWithoutKey
         }
+
+        let dataKey = try keyStore.generateDataKey()
 
         let wrapped = try await keyStore.wrap(dataKey, passcode: passcode)
         try keyStore.storeWrappedDataKey(wrapped)
 
-        // Only once the wrapped copy is stored and verified does the clear copy
-        // go. The other order loses the key outright if the write fails.
-        //
-        // Verified, and the mode is only switched afterwards: a silently failed
-        // deletion would leave the clear copy readable, so locking would just
-        // reload it from the Keychain and the passcode would be decorative.
-        do {
-            try keyStore.deleteDataKey()
-        } catch {
-            // Both copies exist. Left alone, `isSet` would report a passcode
-            // while the mode stayed on device auth and every retry failed with
-            // `alreadySet` — a passcode screen protecting nothing, with no way
-            // out. Undo the wrapped copy so the app is back where it started.
-            guard (try? keyStore.deleteWrappedDataKey()) != nil else {
-                throw PasscodeError.inconsistentState
-            }
-            throw error
+        lockService.mode = .passcode
+
+        guard session.adopt(dataKey, ifGeneration: generation) else {
+            // A lock landed mid-derivation. The wrapper is durable and the gate
+            // is up, so the app is in the pending-passcode state and the next
+            // unlock seals what this call did not.
+            throw PasscodeError.cancelledByLock
         }
 
-        session.adopt(dataKey)
-        lockService.mode = .passcode
+        try await sealEverything()
+
         limiter.recordSuccess()
     }
 
@@ -121,6 +171,12 @@ actor PasscodeService {
 
     @discardableResult
     func unlock(with passcode: String, now: Date = Date()) async throws -> SymmetricKey {
+        // First instruction, for the same reason it is in `setPasscode`: a
+        // `nonisolated` lock() can land during the Keychain read below as easily
+        // as during the derivation, and a generation read afterwards would let
+        // the adopt undo it.
+        let generation = session.currentGeneration
+
         let lockout = limiter.remainingLockout(now: now)
         guard lockout <= 0 else {
             throw PasscodeError.lockedOut(remaining: lockout)
@@ -138,11 +194,6 @@ actor PasscodeService {
             // one — over the top of a wrapper that still exists.
             throw PasscodeError.storageFailure
         }
-
-        // Captured before the derivation, which takes long enough for the app to
-        // be backgrounded and locked while it runs. Adopting the result
-        // afterwards would silently undo that lock.
-        let generation = session.currentGeneration
 
         do {
             let dataKey = try await keyStore.unwrap(wrapped, passcode: passcode)
@@ -184,7 +235,14 @@ actor PasscodeService {
 
     /// Rewraps the same data key under a new passcode. **No key share is read or
     /// written**, which is what makes this safe to do casually.
+    ///
+    /// It still takes the transition lease: it rewrites the one item every
+    /// sealed share depends on, and interleaving with a set or a disable is how
+    /// the wrapper ends up holding a key that matches nothing on disk.
     func changePasscode(current: String, new: String, now: Date = Date()) async throws {
+        let lease = try beginTransition()
+        defer { coordinator.end(lease) }
+
         try validate(new)
 
         let dataKey = try await unlock(with: current, now: now)
@@ -194,45 +252,137 @@ actor PasscodeService {
 
     // MARK: - Disable
 
-    /// Puts the data key back in the clear and removes the wrapped copy.
+    /// The exact inverse of ``setPasscode(_:)``: opens every share back to
+    /// plaintext and removes the wrapped key, leaving the device
+    /// byte-for-byte in the state it would have been in had a passcode never
+    /// been set.
     ///
-    /// **Not yet the inverse of `setPasscode`, and the gap is visible from
-    /// here.** The invariant is that a share is sealed if and only if a passcode
-    /// is set, so removing the passcode has to unseal every share. This still
-    /// does what an earlier design needed — leaves the shares sealed and keeps a
-    /// clear copy of the key so they stay readable — and the session no longer
-    /// reads that clear copy, so the shares survive only as long as the process
-    /// does. Both halves go when the disable path is rewired to unseal.
+    /// Two orderings carry the weight:
+    ///
+    /// - **the mode changes before the wrapper is deleted.** With the reverse
+    ///   order, a crash after the deletion but before the mode change leaves
+    ///   plaintext shares behind `.passcode` and no wrapper to unlock against —
+    ///   a gate that can never open. The smaller window this creates (plaintext
+    ///   shares, wrapper present, `.deviceAuth` persisted) is the one launch
+    ///   reconciliation already repairs;
+    /// - **anything else holding a copy of the data key goes first**, before a
+    ///   single share moves. A biometric copy of the key is the case that
+    ///   exists: it holds the *same* key, so a survivor would quietly work again
+    ///   the next time a passcode was set, and failing to remove it after the
+    ///   shares had already been opened would report an error over a passcode
+    ///   that was half gone. Nothing has changed yet at that point, so aborting
+    ///   there is clean.
+    ///
+    /// If the deletion fails there is one protocol, not a choice: prove the
+    /// wrapper is durable, restore `.passcode`, reseal transactionally, throw.
+    /// The app is back to a working passcode and the user retries. Proving the
+    /// wrapper first is not belt and braces — `deleteWrappedDataKey` reports
+    /// failure on an *unreadable* read-back too, so "it threw" does not mean
+    /// "the item is still there", and resealing over a wrapper that is in fact
+    /// gone would leave ciphertext whose only key is in memory until the next
+    /// lock.
     func disablePasscode(current: String, now: Date = Date()) async throws {
-        let dataKey = try await unlock(with: current, now: now)
+        let lease = try beginTransition()
+        defer { coordinator.end(lease) }
 
-        // Clear copy first, and it verifies its own read-back: deleting the
-        // wrapped copy before the replacement is durable would leave no way to
-        // reach the shares at all.
-        try keyStore.storeDataKey(dataKey)
+        _ = try await unlock(with: current, now: now)
+
+        // The exact bytes, kept for the rollback below. `unlock` has just proved
+        // they open, so this is the one moment they are known good.
+        let wrapped = keyStore.loadWrappedDataKey().valueTreatingUnavailableAsAbsent
+
+        // The GCM tag check inside every open is the verification: a share that
+        // comes back out is provably recoverable, and the key is still in hand
+        // if the rest of this has to be undone.
+        try await unsealEverything()
+
+        lockService.mode = .deviceAuth
 
         do {
             try keyStore.deleteWrappedDataKey()
         } catch {
-            // Both copies now exist, which would leave the app claiming a
-            // passcode while the readable clear key makes it meaningless. Undo
-            // the clear copy so the passcode keeps protecting something.
-            guard (try? keyStore.deleteDataKey()) != nil else {
-                // Neither copy can be removed. The clear key is readable, so
-                // there is no gate — say so rather than let the app assert one
-                // it does not have.
-                lockService.mode = .deviceAuth
-                throw PasscodeError.inconsistentState
-            }
+            try await restorePasscodeAfterFailedRemoval(wrapped: wrapped)
             throw error
         }
 
-        session.adopt(dataKey)
-        lockService.mode = .deviceAuth
-        limiter.recordSuccess()
+        // Nothing is sealed any more, so the key has no further use. Clearing
+        // also bumps the session generation, which invalidates the resume latch.
+        session.clear()
+    }
+
+    /// Puts the passcode back after a wrapper deletion that reported failure.
+    ///
+    /// The wrapper is re-stored — and therefore read-back-verified — *before* a
+    /// single share is resealed, because a deletion that threw may still have
+    /// removed the item. If it cannot be made durable, nothing is resealed:
+    /// plaintext shares with no key anywhere is precisely the no-passcode
+    /// resting state, and it is the only outcome here that loses nothing.
+    private func restorePasscodeAfterFailedRemoval(wrapped: Data?) async throws {
+        do {
+            guard let wrapped else { throw PasscodeError.inconsistentState }
+            try keyStore.storeWrappedDataKey(wrapped)
+        } catch {
+            // No provable wrapper, so the key in memory must go with it.
+            // Leaving it cached would let a keygen or a reshare seal a *new*
+            // share against a key nothing on disk wraps, and the first lock
+            // after that makes the share unreadable forever.
+            session.clear()
+            logger.error("Could not restore the wrapped key after a failed passcode removal: \(String(describing: error), privacy: .public)")
+            throw PasscodeError.inconsistentState
+        }
+
+        lockService.mode = .passcode
+
+        do {
+            try await sealEverything()
+        } catch {
+            // Plaintext shares behind a live passcode: weaker than where this
+            // started, but nothing is lost — the wrapper is provably there, so
+            // the next unlock's resume seals them.
+            logger.error("Could not reseal after a failed passcode removal: \(String(describing: error), privacy: .public)")
+            throw PasscodeError.inconsistentState
+        }
     }
 
     // MARK: - Helpers
+
+    /// Claims the coordinator for one transition, mapping contention onto the
+    /// service's own vocabulary.
+    ///
+    /// Contention is reported rather than queued: a passcode change that waits
+    /// silently for a keygen to finish looks like a hang, and "finish creating
+    /// your vault first" is the honest version of the guarantee.
+    private func beginTransition() throws -> TransitionLease {
+        do {
+            return try coordinator.beginTransition()
+        } catch {
+            throw PasscodeError.busy
+        }
+    }
+
+    private func storeHoldsASealedShare() async throws -> Bool {
+        do {
+            return try await sweeper.hasSealedShare()
+        } catch KeyshareSweeperError.busy {
+            throw PasscodeError.busy
+        }
+    }
+
+    private func sealEverything() async throws {
+        do {
+            try await sweeper.sealAll()
+        } catch KeyshareSweeperError.busy {
+            throw PasscodeError.busy
+        }
+    }
+
+    private func unsealEverything() async throws {
+        do {
+            try await sweeper.unsealAll()
+        } catch KeyshareSweeperError.busy {
+            throw PasscodeError.busy
+        }
+    }
 
     private func validate(_ passcode: String) throws {
         guard passcode.count == Self.passcodeLength,

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -67,6 +67,24 @@ actor PasscodeService {
     private let coordinator: KeyshareWriteCoordinator
     private let sweeper: KeyshareSweeping
 
+    /// The session generation whose resume sweep has already run, so it runs at
+    /// most once per unlocked session. `lock()` bumps the generation, and that is
+    /// what resets this — there is nothing to clear, which matters because
+    /// `lock()` is `nonisolated` and cannot touch actor state.
+    private var resumedGeneration: Int?
+
+    /// Set while an app unlock is in flight, and while a passcode is being
+    /// verified. Neither is covered by the coordinator — an unlock takes a
+    /// *write* lease, and writes do not exclude each other — and neither is
+    /// covered by the actor either, because both suspend across key derivation
+    /// and actors are reentrant at every `await`. Two overlapping verifications
+    /// would both clear the attempt limiter's lockout check before either
+    /// recorded a failure, which is the throttle switching itself off; two
+    /// overlapping app unlocks would let the slower one's post-sweep generation
+    /// check clear the faster one's perfectly good session.
+    private var isAppUnlockInFlight = false
+    private var isVerifyingPasscode = false
+
     init(
         keyStore: KeyshareKeyStoring = DefaultKeyshareKeyStore.shared,
         session: KeyshareKeySession = .shared,
@@ -166,12 +184,114 @@ actor PasscodeService {
 
     // MARK: - Unlock
 
+    /// Opens the app on the lock screen.
+    ///
+    /// Distinct from ``unlock(with:now:)``, which is passcode *verification* and
+    /// is what change and disable use. This one holds the coordinator for the
+    /// whole operation and finishes any sweep an earlier transition left half
+    /// done before the caller is told the app is open, so the lock screen is the
+    /// one place the invariant is re-established.
+    ///
+    /// It takes a **write** lease rather than a transition lease, and that is
+    /// the difference between a recoverable app and a bricked one: a transition
+    /// is refused while a vault-creation episode is open, keygen holds one
+    /// through the deferred "Looks Good" commit, and an app that auto-locked on
+    /// that screen could then never be unlocked — the flow cannot be finished
+    /// without unlocking, and unlocking could not happen while the flow is open.
+    /// A write lease excludes set, change and disable, which is all an unlock
+    /// needs, and is refused by none of them.
+    @discardableResult
+    func unlockApp(with passcode: String, now: Date = Date()) async throws -> SymmetricKey {
+        // Write leases do not exclude each other, so this is what keeps two app
+        // unlocks apart. Read and set with no `await` between them, which is
+        // what makes it atomic inside the actor.
+        guard !isAppUnlockInFlight else { throw PasscodeError.busy }
+        isAppUnlockInFlight = true
+        defer { isAppUnlockInFlight = false }
+
+        let lease = try beginUnlock()
+        defer { coordinator.end(lease) }
+
+        let generation = session.currentGeneration
+        let dataKey = try await unlock(with: passcode, now: now)
+        await resumeSweepUnlocked()
+
+        // `unlock` only guards the *adoption* against a lock. A lock landing
+        // during the sweep would otherwise be followed by a successful return,
+        // and the caller would dismiss the lock screen over a session that is
+        // locked again.
+        guard session.currentGeneration == generation else {
+            session.clear()
+            throw PasscodeError.cancelledByLock
+        }
+        return dataKey
+    }
+
+    /// One rule: **with the data key in hand and a wrapper present, seal any
+    /// share that is still plaintext.**
+    ///
+    /// That finishes an interrupted `setPasscode`, re-establishes the invariant
+    /// after an interrupted `disablePasscode` (whose wrapper goes last, so an
+    /// interruption leaves it present and the shares get sealed again — the user
+    /// simply presses disable twice), and closes "plaintext introduced by a
+    /// downgrade stays plaintext forever" as a side effect. It deliberately does
+    /// *not* try to tell an interrupted disable from an interrupted set: with the
+    /// wrapper present there is no way to, and guessing "disable" would silently
+    /// remove protection.
+    ///
+    /// **Non-acquiring, and there is deliberately no acquiring variant.** Both
+    /// app-unlock paths already hold a lease that excludes transitions, and an
+    /// acquiring version would ask the coordinator for one from inside it — which
+    /// is exactly what the coordinator refuses, so it would throw `.busy` on the
+    /// single path that has to work every time.
+    ///
+    /// **Failures do not fail the unlock.** The key has already been adopted by
+    /// the time this runs, so the session *is* open; reporting an error would
+    /// leave the lock screen up over an unlocked session, and a persistent cause
+    /// — an unsaved edit somewhere in the store, one share that will not open —
+    /// would lock the user out of an app whose passcode they know. Shares staying
+    /// plaintext for another lock cycle is the lesser failure, and the latch is
+    /// only set on success, so the next unlock tries again.
+    ///
+    /// The latch is per unlocked session: `lock()` bumps the session generation,
+    /// which is what invalidates it, so plaintext introduced after a successful
+    /// sweep is picked up on the next lock cycle rather than never.
+    func resumeSweepUnlocked() async {
+        guard case .unlocked = session.currentState() else { return }
+        guard case .present = keyStore.loadWrappedDataKey() else { return }
+
+        let generation = session.currentGeneration
+        guard resumedGeneration != generation else { return }
+
+        do {
+            try await sweeper.sealAll()
+            resumedGeneration = generation
+        } catch {
+            logger.error("Resume sweep failed; the app stays unlocked and the next unlock retries: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Verifies a passcode and puts the data key back in the session.
+    ///
+    /// **Not the app-unlock path.** Change and disable use this to check the
+    /// current passcode, so it takes no lease and runs no resume sweep. A lock
+    /// screen wired to this instead of ``unlockApp(with:now:)`` would look
+    /// identical and silently never finish an interrupted transition.
     @discardableResult
     func unlock(with passcode: String, now: Date = Date()) async throws -> SymmetricKey {
-        // First instruction, for the same reason it is in `setPasscode`: a
-        // `nonisolated` lock() can land during the Keychain read below as easily
-        // as during the derivation, and a generation read afterwards would let
-        // the adopt undo it.
+        // One verification at a time. The lockout is checked here and the
+        // failure recorded after the derivation, so overlapping attempts would
+        // all clear the check before any of them recorded anything — a burst of
+        // guesses collapsing into one counted failure, which is the throttle
+        // this feature depends on switching itself off.
+        guard !isVerifyingPasscode else { throw PasscodeError.busy }
+        isVerifyingPasscode = true
+        defer { isVerifyingPasscode = false }
+
+        // First instruction after that, for the same reason it is in
+        // `setPasscode`: a `nonisolated` lock() can land during the Keychain
+        // read below as easily as during the derivation, and a generation read
+        // afterwards would let the adopt undo it.
         let generation = session.currentGeneration
 
         let lockout = limiter.remainingLockout(now: now)
@@ -223,7 +343,10 @@ actor PasscodeService {
     /// unlock, which is the point — a locked app cannot sign.
     ///
     /// `nonisolated` because it touches no actor state and is called from
-    /// scene-phase hooks; `KeyshareKeySession` does its own locking.
+    /// scene-phase hooks; `KeyshareKeySession` does its own locking. Bumping the
+    /// session generation is also what resets the resume latch, which is why the
+    /// latch is keyed on the generation rather than being a flag this would have
+    /// to reach into the actor to clear.
     nonisolated func lock() {
         session.clear()
     }
@@ -352,6 +475,16 @@ actor PasscodeService {
     private func beginTransition() throws -> TransitionLease {
         do {
             return try coordinator.beginTransition()
+        } catch {
+            throw PasscodeError.busy
+        }
+    }
+
+    /// Refused only by another passcode transition — see ``unlockApp(with:now:)``
+    /// for why an unlock must not be refused by anything else.
+    private func beginUnlock() throws -> WriteLease {
+        do {
+            return try coordinator.beginWrite()
         } catch {
             throw PasscodeError.busy
         }

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -1,0 +1,205 @@
+//
+//  PasscodeService.swift
+//  VultisigApp
+//
+
+import CryptoKit
+import Foundation
+
+enum PasscodeError: Error, Equatable {
+    case wrongPasscode
+    case notSet
+    case alreadySet
+    /// No data key to wrap — the migration has not run, so there is nothing to
+    /// protect yet.
+    case noDataKey
+    case lockedOut(remaining: TimeInterval)
+    case invalidLength
+    /// The stored wrapped key is unreadable. Distinct from a wrong passcode:
+    /// no amount of retrying fixes it, and it must not be counted as a guess.
+    case storageFailure
+    /// A partial state change could not be completed or rolled back.
+    case inconsistentState
+    /// The app locked while the passcode was being verified. The passcode was
+    /// not necessarily wrong; the unlock simply no longer applies.
+    case cancelledByLock
+}
+
+/// Sets, changes, removes and verifies the app passcode.
+///
+/// Every operation here moves 32 bytes. The passcode wraps the data key; it does
+/// not encrypt key shares, so changing or removing it rewraps that one small blob
+/// and leaves every share on disk exactly as it was. The desktop client re-encrypts
+/// every share of every vault on each of these operations, which puts a full
+/// rewrite of key material behind a routine settings toggle.
+///
+/// An `actor` because these are read-modify-write sequences over shared Keychain
+/// state. Concurrent failed unlocks could otherwise each read the same attempt
+/// count and collapse a burst of guesses into one recorded failure, which is the
+/// throttle this feature depends on.
+actor PasscodeService {
+
+    static let shared = PasscodeService()
+
+    static let passcodeLength = 5
+
+    private let keyStore: KeyshareKeyStoring
+    private let session: KeyshareKeySession
+    private let lockService: AppLockService
+    private let limiter: PasscodeAttemptLimiting
+
+    init(
+        keyStore: KeyshareKeyStoring = DefaultKeyshareKeyStore.shared,
+        session: KeyshareKeySession = .shared,
+        lockService: AppLockService = .shared,
+        limiter: PasscodeAttemptLimiting = PasscodeAttemptLimiter()
+    ) {
+        self.keyStore = keyStore
+        self.session = session
+        self.lockService = lockService
+        self.limiter = limiter
+    }
+
+    var isSet: Bool {
+        keyStore.loadWrappedDataKey() != nil
+    }
+
+    // MARK: - Set
+
+    func setPasscode(_ passcode: String) async throws {
+        try validate(passcode)
+        guard !isSet else { throw PasscodeError.alreadySet }
+
+        guard let dataKey = keyStore.loadDataKey() else {
+            // Nothing is encrypted yet, so there is no key to put behind a
+            // passcode. Wrapping a key we just invented would leave the shares
+            // readable without it and misrepresent what the passcode protects.
+            throw PasscodeError.noDataKey
+        }
+
+        let wrapped = try await keyStore.wrap(dataKey, passcode: passcode)
+        try keyStore.storeWrappedDataKey(wrapped)
+
+        // Only once the wrapped copy is stored and verified does the clear copy
+        // go. The other order loses the key outright if the write fails.
+        //
+        // Verified, and the mode is only switched afterwards: a silently failed
+        // deletion would leave the clear copy readable, so locking would just
+        // reload it from the Keychain and the passcode would be decorative.
+        try keyStore.deleteDataKey()
+
+        session.adopt(dataKey)
+        lockService.mode = .passcode
+        limiter.recordSuccess()
+    }
+
+    // MARK: - Unlock
+
+    @discardableResult
+    func unlock(with passcode: String, now: Date = Date()) async throws -> SymmetricKey {
+        let lockout = limiter.remainingLockout(now: now)
+        guard lockout <= 0 else {
+            throw PasscodeError.lockedOut(remaining: lockout)
+        }
+
+        guard let wrapped = keyStore.loadWrappedDataKey() else {
+            throw PasscodeError.notSet
+        }
+
+        // Captured before the derivation, which takes long enough for the app to
+        // be backgrounded and locked while it runs. Adopting the result
+        // afterwards would silently undo that lock.
+        let generation = session.currentGeneration
+
+        do {
+            let dataKey = try await keyStore.unwrap(wrapped, passcode: passcode)
+
+            // A lock landed while the derivation was running. Returning the key
+            // anyway would let the caller — change or disable — carry on and
+            // adopt it, undoing that lock by the back door.
+            guard session.adopt(dataKey, ifGeneration: generation) else {
+                throw PasscodeError.cancelledByLock
+            }
+
+            limiter.recordSuccess()
+            return dataKey
+        } catch KeyshareKeyStoreError.malformedWrappedKey {
+            // Not a guess. Counting it would bury an unrecoverable storage
+            // problem under a growing lockout and tell the user the wrong thing.
+            throw PasscodeError.storageFailure
+        } catch PasscodeError.cancelledByLock {
+            // Not a guess: the passcode may well have been right.
+            throw PasscodeError.cancelledByLock
+        } catch {
+            // If the failure cannot be recorded there is no throttle, so refuse
+            // the attempt rather than let an uncounted guess through.
+            try limiter.recordFailure(now: now)
+            throw PasscodeError.wrongPasscode
+        }
+    }
+
+    /// Forgets the data key. Sealed shares become unreadable until the next
+    /// unlock, which is the point — a locked app cannot sign.
+    ///
+    /// `nonisolated` because it touches no actor state and is called from
+    /// scene-phase hooks; `KeyshareKeySession` does its own locking.
+    nonisolated func lock() {
+        session.clear()
+    }
+
+    // MARK: - Change
+
+    /// Rewraps the same data key under a new passcode. **No key share is read or
+    /// written**, which is what makes this safe to do casually.
+    func changePasscode(current: String, new: String, now: Date = Date()) async throws {
+        try validate(new)
+
+        let dataKey = try await unlock(with: current, now: now)
+        let rewrapped = try await keyStore.wrap(dataKey, passcode: new)
+        try keyStore.storeWrappedDataKey(rewrapped)
+    }
+
+    // MARK: - Disable
+
+    /// Puts the data key back in the clear and removes the wrapped copy.
+    ///
+    /// Shares stay sealed on disk — at-rest encryption does not depend on the
+    /// passcode, so turning the passcode off does not turn encryption off.
+    func disablePasscode(current: String, now: Date = Date()) async throws {
+        let dataKey = try await unlock(with: current, now: now)
+
+        // Clear copy first, and it verifies its own read-back: deleting the
+        // wrapped copy before the replacement is durable would leave no way to
+        // reach the shares at all.
+        try keyStore.storeDataKey(dataKey)
+
+        do {
+            try keyStore.deleteWrappedDataKey()
+        } catch {
+            // Both copies now exist, which would leave the app claiming a
+            // passcode while the readable clear key makes it meaningless. Undo
+            // the clear copy so the passcode keeps protecting something.
+            guard (try? keyStore.deleteDataKey()) != nil else {
+                // Neither copy can be removed. The clear key is readable, so
+                // there is no gate — say so rather than let the app assert one
+                // it does not have.
+                lockService.mode = .deviceAuth
+                throw PasscodeError.inconsistentState
+            }
+            throw error
+        }
+
+        session.adopt(dataKey)
+        lockService.mode = .deviceAuth
+        limiter.recordSuccess()
+    }
+
+    // MARK: - Helpers
+
+    private func validate(_ passcode: String) throws {
+        guard passcode.count == Self.passcodeLength,
+              passcode.allSatisfy(\.isNumber) else {
+            throw PasscodeError.invalidLength
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -36,11 +36,14 @@ enum PasscodeError: Error, Equatable {
 
 /// Sets, changes, removes and verifies the app passcode.
 ///
-/// Every operation here moves 32 bytes. The passcode wraps the data key; it does
-/// not encrypt key shares, so changing or removing it rewraps that one small blob
-/// and leaves every share on disk exactly as it was. The desktop client re-encrypts
-/// every share of every vault on each of these operations, which puts a full
-/// rewrite of key material behind a routine settings toggle.
+/// A key share is sealed **if and only if a passcode is currently set**, so the
+/// operations here split in two. `changePasscode` moves 32 bytes: the passcode
+/// wraps the data key rather than the shares, so rewrapping that one small blob
+/// leaves every share on disk exactly as it was — where the desktop client
+/// re-encrypts every share of every vault for the same toggle. `setPasscode` and
+/// `disablePasscode` are the other kind: they cross the invariant, so each one
+/// does rewrite every stored share, which is why both are transactional, both
+/// take the exclusive lease, and both are resumable.
 ///
 /// An `actor` because these are read-modify-write sequences over shared Keychain
 /// state. Concurrent failed unlocks could otherwise each read the same attempt
@@ -113,6 +116,18 @@ actor PasscodeService {
         case .absent:
             return false
         }
+    }
+
+    /// Whether the data key is currently held.
+    ///
+    /// `nonisolated` on purpose: the caller is the lock screen, deciding whether
+    /// it may still come down, and it has to be able to ask without an `await`.
+    /// An `await` would be a suspension point between the answer and the act,
+    /// which is exactly the gap this is meant to close — `lock()` is
+    /// `nonisolated` too and can land in it.
+    nonisolated var isSessionUnlocked: Bool {
+        if case .unlocked = session.currentState() { return true }
+        return false
     }
 
     // MARK: - Set
@@ -188,9 +203,15 @@ actor PasscodeService {
     ///
     /// Distinct from ``unlock(with:now:)``, which is passcode *verification* and
     /// is what change and disable use. This one holds the coordinator for the
-    /// whole operation and finishes any sweep an earlier transition left half
+    /// whole operation and *attempts* any sweep an earlier transition left half
     /// done before the caller is told the app is open, so the lock screen is the
     /// one place the invariant is re-established.
+    ///
+    /// **Attempts, not guarantees.** ``resumeSweepUnlocked()`` swallows its own
+    /// failures on purpose — see its documentation — so a successful return here
+    /// means the session is open, not that every share is sealed. A persistent
+    /// resume failure therefore leaves plaintext shares behind a live passcode,
+    /// logged and surfaced nowhere else.
     ///
     /// It takes a **write** lease rather than a transition lease, and that is
     /// the difference between a recoverable app and a bricked one: a transition

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -130,6 +130,36 @@ actor PasscodeService {
         return false
     }
 
+    /// Whether a passcode gate still has a passcode behind it.
+    ///
+    /// A lock screen is raised from ``AppLockService/mode`` and then *held* by
+    /// whatever put it up, so it is a cache of a value a transition can move
+    /// underneath it — and one transition invalidates that cache in the worst
+    /// possible way. A `disablePasscode` that completes while the gate is up
+    /// leaves `.deviceAuth`, no wrapper, and a screen whose only exit calls
+    /// ``unlockApp(with:now:)`` — which now has nothing to verify against and can
+    /// only ever throw `notSet`. Nothing the user types opens it and force
+    /// quitting is the only way out.
+    ///
+    /// So the gate is not a flag anyone may keep: it is this question, asked
+    /// again. Nothing may leave a lock screen standing while this is `false`,
+    /// and ``disablePasscode(current:now:)`` guarantees it is `false` by the time
+    /// it returns.
+    ///
+    /// Only a **confirmed** absence lowers it. An unreadable Keychain leaves the
+    /// gate up — the item may well be there, and taking a real gate down over a
+    /// momentary read failure is the one mistake available here that removes
+    /// protection rather than restoring access.
+    ///
+    /// `nonisolated` for the same reason ``isSessionUnlocked`` is: the caller is
+    /// the lock screen, and an `await` between the answer and the act is exactly
+    /// the gap this exists to close.
+    nonisolated var isPasscodeGateRequired: Bool {
+        guard lockService.mode == .passcode else { return false }
+        if case .absent = keyStore.loadWrappedDataKey() { return false }
+        return true
+    }
+
     // MARK: - Set
 
     /// Mints a data key, puts it behind the passcode, and seals every stored
@@ -152,18 +182,19 @@ actor PasscodeService {
     ///   ciphertext. The app stays in the pending-passcode state instead, and
     ///   the next unlock's resume finishes it.
     func setPasscode(_ passcode: String) async throws {
+        // Literally the first statement, and ahead of the lease deliberately. A
+        // background `lock()` is `nonisolated` and stays outside the coordinator
+        // on purpose — it must never block on a transition — so it can land at
+        // any point from here on, including while the lease is being claimed,
+        // and `adopt(_:ifGeneration:)` at the end is how it wins. Reading this
+        // any later would silently undo a lock that landed in between, leaving
+        // the key live in memory behind a lock screen. The window cannot be
+        // closed entirely while `lock()` is deliberately unsynchronized; it can
+        // be made as small as the first instruction, and that is what this is.
+        let generation = session.currentGeneration
+
         let lease = try beginTransition()
         defer { coordinator.end(lease) }
-
-        // Read first, before anything else in this method. A background `lock()`
-        // is `nonisolated` and stays outside the coordinator on purpose — it
-        // must never block on a transition — so it can land at any point from
-        // here on, and `adopt(_:ifGeneration:)` at the end is how it wins.
-        // Reading this any later would silently undo a lock that landed in
-        // between, leaving the key live in memory behind a lock screen. The
-        // window cannot be closed entirely while `lock()` is deliberately
-        // unsynchronized; it can be made as small as the first instruction.
-        let generation = session.currentGeneration
 
         try validate(passcode)
         guard !isSet else { throw PasscodeError.alreadySet }
@@ -223,6 +254,11 @@ actor PasscodeService {
     /// needs, and is refused by none of them.
     @discardableResult
     func unlockApp(with passcode: String, now: Date = Date()) async throws -> SymmetricKey {
+        // First statement, ahead of the flag and the lease, for the reason
+        // spelled out on `setPasscode`: `lock()` can land while either is being
+        // claimed, and a generation read afterwards would not see it.
+        let generation = session.currentGeneration
+
         // Write leases do not exclude each other, so this is what keeps two app
         // unlocks apart. Read and set with no `await` between them, which is
         // what makes it atomic inside the actor.
@@ -233,8 +269,21 @@ actor PasscodeService {
         let lease = try beginUnlock()
         defer { coordinator.end(lease) }
 
-        let generation = session.currentGeneration
-        let dataKey = try await unlock(with: passcode, now: now)
+        let dataKey: SymmetricKey
+        do {
+            dataKey = try await unlock(with: passcode, now: now, anchoredTo: generation)
+        } catch PasscodeError.notSet {
+            // A gate with nothing behind it, and the user is standing in front
+            // of it. `notSet` comes only from a **confirmed** absence, so this
+            // is not a Keychain that went quiet: the passcode is genuinely gone
+            // and no entry on this screen can ever be right. Leaving the mode at
+            // `.passcode` would keep asking for it until the app is force quit,
+            // so the same repair launch reconciliation performs is done here,
+            // now, while somebody is actually locked out by it.
+            lowerThePasscodeGateWithNothingBehindIt()
+            throw PasscodeError.notSet
+        }
+
         await resumeSweepUnlocked()
 
         // `unlock` only guards the *adoption* against a lock. A lock landing
@@ -300,6 +349,24 @@ actor PasscodeService {
     /// identical and silently never finish an interrupted transition.
     @discardableResult
     func unlock(with passcode: String, now: Date = Date()) async throws -> SymmetricKey {
+        // The argument is evaluated first, so this reads the generation as the
+        // first thing this call does. Nothing ran before it, so the generation
+        // as it stands here *is* the generation this operation started at.
+        try await unlock(with: passcode, now: now, anchoredTo: session.currentGeneration)
+    }
+
+    /// The verification, anchored to the session generation its **caller**
+    /// observed as that caller's own first act.
+    ///
+    /// There is no variant that reads the generation for itself, and that is the
+    /// point. `changePasscode`, `disablePasscode` and `unlockApp` are already
+    /// under way by the time they reach here, and `lock()` is `nonisolated` and
+    /// synchronizes with nothing — so a lock landing in between would be
+    /// invisible to a generation read at this depth, the adopt below would
+    /// succeed, and the lock would be undone by the back door. For the disable
+    /// that is worse than a lost lock: it goes on to remove the very passcode
+    /// the lock screen is waiting for.
+    private func unlock(with passcode: String, now: Date, anchoredTo generation: Int) async throws -> SymmetricKey {
         // One verification at a time. The lockout is checked here and the
         // failure recorded after the derivation, so overlapping attempts would
         // all clear the check before any of them recorded anything — a burst of
@@ -309,11 +376,13 @@ actor PasscodeService {
         isVerifyingPasscode = true
         defer { isVerifyingPasscode = false }
 
-        // First instruction after that, for the same reason it is in
-        // `setPasscode`: a `nonisolated` lock() can land during the Keychain
-        // read below as easily as during the derivation, and a generation read
-        // afterwards would let the adopt undo it.
-        let generation = session.currentGeneration
+        // A lock that has already landed has already won. Half a second of key
+        // derivation whose result may not be adopted buys nothing, and the
+        // attempt is deliberately not counted — the passcode may well have been
+        // right, and it was never tested.
+        guard session.currentGeneration == generation else {
+            throw PasscodeError.cancelledByLock
+        }
 
         let lockout = limiter.remainingLockout(now: now)
         guard lockout <= 0 else {
@@ -380,14 +449,37 @@ actor PasscodeService {
     /// It still takes the transition lease: it rewrites the one item every
     /// sealed share depends on, and interleaving with a set or a disable is how
     /// the wrapper ends up holding a key that matches nothing on disk.
+    ///
+    /// A background `lock()` wins over it, on both sides of the verification.
+    /// The generation is read before the first `await` and carried through, so
+    /// the verification cannot adopt over a lock that landed while this was
+    /// getting under way, and the rewrapped key is not stored if one landed
+    /// during the derivation. Nothing durable has moved at that point, so
+    /// stopping costs the user a retry and keeps the lock they asked for.
     func changePasscode(current: String, new: String, now: Date = Date()) async throws {
+        // First statement, ahead of the lease, exactly as `setPasscode` reads
+        // it. `lock()` is `nonisolated` and stays outside the coordinator on
+        // purpose, so it can land from here on — and a generation read inside
+        // the verification below would be read *after* such a lock, letting the
+        // adopt undo it.
+        let generation = session.currentGeneration
+
         let lease = try beginTransition()
         defer { coordinator.end(lease) }
 
         try validate(new)
 
-        let dataKey = try await unlock(with: current, now: now)
+        let dataKey = try await unlock(with: current, now: now, anchoredTo: generation)
         let rewrapped = try await keyStore.wrap(dataKey, passcode: new)
+
+        // The last instant before the one durable change this method makes. A
+        // lock landing during the rewrap loses nothing — the key never left
+        // memory and every share is untouched — so the honest outcome is to
+        // leave the passcode exactly as the user locked it behind.
+        guard session.currentGeneration == generation else {
+            throw PasscodeError.cancelledByLock
+        }
+
         try keyStore.storeWrappedDataKey(rewrapped)
     }
 
@@ -414,6 +506,21 @@ actor PasscodeService {
     ///   that was half gone. Nothing has changed yet at that point, so aborting
     ///   there is clean.
     ///
+    /// A background `lock()` wins, but only up to a point, and the point is
+    /// marked in the body. Until the unseal begins, nothing durable has moved
+    /// and honouring the lock costs a retry. From the unseal onwards there is no
+    /// way back — putting the shares behind the passcode again needs the data
+    /// key in the session, and the lock is what removed it — so the call runs to
+    /// completion rather than stranding plaintext key material behind a passcode
+    /// that is still demanded.
+    ///
+    /// **Postcondition, and it is the one that keeps a user out of a lock screen
+    /// they cannot open.** When this returns without throwing, the passcode is
+    /// gone and ``isPasscodeGateRequired`` is therefore `false`. A gate raised
+    /// before the mode moved is stale from that instant, and stale is not
+    /// harmless here: its only exit is an unlock, and there is nothing left for
+    /// an unlock to verify against.
+    ///
     /// If the deletion fails there is one protocol, not a choice: prove the
     /// wrapper is durable, restore `.passcode`, reseal transactionally, throw.
     /// The app is back to a working passcode and the user retries. Proving the
@@ -423,6 +530,13 @@ actor PasscodeService {
     /// gone would leave ciphertext whose only key is in memory until the next
     /// lock.
     func disablePasscode(current: String, now: Date = Date()) async throws {
+        // First statement, ahead of the lease, exactly as `setPasscode` reads it
+        // — and here it is load-bearing twice over. It anchors the verification
+        // below, so a `lock()` landing while this was getting under way cannot
+        // be adopted over; and it is what the abort decision further down is
+        // made against.
+        let generation = session.currentGeneration
+
         let lease = try beginTransition()
         defer { coordinator.end(lease) }
 
@@ -434,10 +548,35 @@ actor PasscodeService {
         // "plaintext shares behind a mode that says there is no passcode".
         let wrappedBeforeVerification = keyStore.loadWrappedDataKey().valueTreatingUnavailableAsAbsent
 
-        _ = try await unlock(with: current, now: now)
+        _ = try await unlock(with: current, now: now, anchoredTo: generation)
 
         let wrapped = wrappedBeforeVerification
             ?? keyStore.loadWrappedDataKey().valueTreatingUnavailableAsAbsent
+
+        // **The abort cut-off, and it is a one-way door.** Everything above this
+        // line is reversible by doing nothing: no share has moved, the wrapper
+        // is untouched and the gate is still up, so a lock that landed while the
+        // passcode was being verified is honoured simply by stopping. Past this
+        // line it is not. The unseal writes plaintext key material to disk, and
+        // the only thing that could put it back is a reseal — which needs the
+        // data key *in the session*, which is precisely what a lock has just
+        // taken away. Aborting there would leave every share in the clear behind
+        // a passcode that is still set and still demanded, which is worse than
+        // finishing: finishing at least ends somewhere consistent.
+        //
+        // So: stop here, or see it through. There is no third option.
+        guard session.currentGeneration == generation else {
+            throw PasscodeError.cancelledByLock
+        }
+
+        // And the same line is where the rollback material has to exist. The
+        // verification cannot have succeeded without reading this item as
+        // `.present`, so both reads around it coming back empty means the
+        // Keychain went quiet either side of one that answered — not that the
+        // wrapper is gone. Crossing without those bytes would leave a failed
+        // removal with nothing to put back, and the reseal it needs is on the
+        // wrong side of the door. Nothing has moved yet, so refuse.
+        guard let wrapped else { throw PasscodeError.storageFailure }
 
         // The GCM tag check inside every open is the verification: a share that
         // comes back out is provably recoverable, and the key is still in hand
@@ -465,9 +604,12 @@ actor PasscodeService {
     /// removed the item. If it cannot be made durable, nothing is resealed:
     /// plaintext shares with no key anywhere is precisely the no-passcode
     /// resting state, and it is the only outcome here that loses nothing.
-    private func restorePasscodeAfterFailedRemoval(wrapped: Data?) async throws {
+    ///
+    /// The bytes are non-optional because the removal never begins without
+    /// them: a disable that cannot see the wrapper on either side of its own
+    /// verification refuses before it opens a single share.
+    private func restorePasscodeAfterFailedRemoval(wrapped: Data) async throws {
         do {
-            guard let wrapped else { throw PasscodeError.inconsistentState }
             try keyStore.storeWrappedDataKey(wrapped)
         } catch {
             // No provable wrapper, so the key in memory must go with it.
@@ -493,6 +635,19 @@ actor PasscodeService {
     }
 
     // MARK: - Helpers
+
+    /// Drops the persisted passcode mode once the passcode is confirmed gone.
+    ///
+    /// The same rule ``KeyshareInstallReconciler`` applies at launch, applied at
+    /// the one other moment it matters: a `.passcode` mode with no wrapper
+    /// behind it is a door with nothing to open it, and whoever is looking at
+    /// that door needs ``isPasscodeGateRequired`` to start answering `false`
+    /// before they will take it away.
+    private func lowerThePasscodeGateWithNothingBehindIt() {
+        guard lockService.mode == .passcode else { return }
+        logger.warning("A passcode gate outlived its wrapped key; falling back to device auth")
+        lockService.mode = .deviceAuth
+    }
 
     /// Claims the coordinator for one transition, mapping contention onto the
     /// service's own vocabulary.

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -426,11 +426,18 @@ actor PasscodeService {
         let lease = try beginTransition()
         defer { coordinator.end(lease) }
 
+        // Read on **both** sides of the verification, and kept for the rollback
+        // below. `unlock` cannot succeed without reading this same item, so a
+        // read that comes back unreadable on one side of it is transient rather
+        // than meaningful — and without these bytes the rollback has nothing to
+        // restore, which is the difference between "the passcode is back" and
+        // "plaintext shares behind a mode that says there is no passcode".
+        let wrappedBeforeVerification = keyStore.loadWrappedDataKey().valueTreatingUnavailableAsAbsent
+
         _ = try await unlock(with: current, now: now)
 
-        // The exact bytes, kept for the rollback below. `unlock` has just proved
-        // they open, so this is the one moment they are known good.
-        let wrapped = keyStore.loadWrappedDataKey().valueTreatingUnavailableAsAbsent
+        let wrapped = wrappedBeforeVerification
+            ?? keyStore.loadWrappedDataKey().valueTreatingUnavailableAsAbsent
 
         // The GCM tag check inside every open is the verification: a share that
         // comes back out is provably recoverable, and the key is still in hand

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -13,9 +13,6 @@ enum PasscodeError: Error, Equatable {
     case wrongPasscode
     case notSet
     case alreadySet
-    /// No data key to wrap — the migration has not run, so there is nothing to
-    /// protect yet.
-    case noDataKey
     case lockedOut(remaining: TimeInterval)
     case invalidLength
     /// The stored wrapped key is unreadable. Distinct from a wrong passcode:

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
@@ -24,6 +24,8 @@ protocol KeychainService: AnyObject {
     func setKeyshareDataKey(_ data: Data?)
     func getWrappedKeyshareDataKey() -> KeychainReadResult<Data>
     func setWrappedKeyshareDataKey(_ data: Data?)
+    func getPasscodeAttemptState() -> KeychainReadResult<Data>
+    func setPasscodeAttemptState(_ data: Data?)
 }
 
 final class DefaultKeychainService: KeychainService {
@@ -100,6 +102,20 @@ final class DefaultKeychainService: KeychainService {
             accessibility: kSecAttrAccessibleWhenUnlocked
         )
     }
+
+    func getPasscodeAttemptState() -> KeychainReadResult<Data> {
+        return keychain.getData(for: Keys.passcodeAttemptState)
+    }
+
+    /// Kept in the Keychain, not `UserDefaults`, so a lockout is not cleared by
+    /// deleting and reinstalling the app.
+    func setPasscodeAttemptState(_ data: Data?) {
+        keychain.setData(
+            data,
+            for: Keys.passcodeAttemptState,
+            accessibility: kSecAttrAccessibleWhenUnlocked
+        )
+    }
 }
 
 private extension DefaultKeychainService {
@@ -111,6 +127,7 @@ private extension DefaultKeychainService {
         case deviceToken
         case keyshareDataKey
         case wrappedKeyshareDataKey
+        case passcodeAttemptState
 
         var identifier: String {
             return "\(DefaultKeychainService.serviceName).\(key)"
@@ -130,6 +147,8 @@ private extension DefaultKeychainService {
                 return "keyshareDataKey"
             case .wrappedKeyshareDataKey:
                 return "wrappedKeyshareDataKey"
+            case .passcodeAttemptState:
+                return "passcodeAttemptState"
             }
         }
     }

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
@@ -20,8 +20,6 @@ protocol KeychainService: AnyObject {
     func setLastMigratedVersion(_ version: Int?)
     func getDeviceToken() -> KeychainReadResult<String>
     func setDeviceToken(_ token: String?)
-    func getKeyshareDataKey() -> KeychainReadResult<Data>
-    func setKeyshareDataKey(_ data: Data?)
     func getWrappedKeyshareDataKey() -> KeychainReadResult<Data>
     func setWrappedKeyshareDataKey(_ data: Data?)
     func getPasscodeAttemptState() -> KeychainReadResult<Data>
@@ -75,26 +73,14 @@ final class DefaultKeychainService: KeychainService {
         keychain.setString(token, for: Keys.deviceToken)
     }
 
-    func getKeyshareDataKey() -> KeychainReadResult<Data> {
-        return keychain.getData(for: Keys.keyshareDataKey)
+    func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> {
+        return keychain.getData(for: Keys.wrappedKeyshareDataKey)
     }
 
     /// Stored as `WhenUnlocked` rather than the app default `ThisDeviceOnly`:
     /// a `ThisDeviceOnly` item never leaves the device, so restoring an encrypted
     /// backup onto a new phone would bring the encrypted key shares across
     /// without the key that opens them.
-    func setKeyshareDataKey(_ data: Data?) {
-        keychain.setData(
-            data,
-            for: Keys.keyshareDataKey,
-            accessibility: kSecAttrAccessibleWhenUnlocked
-        )
-    }
-
-    func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> {
-        return keychain.getData(for: Keys.wrappedKeyshareDataKey)
-    }
-
     func setWrappedKeyshareDataKey(_ data: Data?) {
         keychain.setData(
             data,
@@ -125,7 +111,6 @@ private extension DefaultKeychainService {
         case fastHint(pubKeyECDSA: String)
         case lastMigratedVersion
         case deviceToken
-        case keyshareDataKey
         case wrappedKeyshareDataKey
         case passcodeAttemptState
 
@@ -143,8 +128,6 @@ private extension DefaultKeychainService {
                 return "lastMigratedVersion"
             case .deviceToken:
                 return "deviceToken"
-            case .keyshareDataKey:
-                return "keyshareDataKey"
             case .wrappedKeyshareDataKey:
                 return "wrappedKeyshareDataKey"
             case .passcodeAttemptState:

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
@@ -20,6 +20,28 @@ enum KeygenCommitError: Error, Equatable, LocalizedError {
     /// the protection state in force right now. Carries the share's public key.
     case unreadableKeyshare(pubkey: String)
 
+    /// A share about to be persisted reads back fine but cannot be protected
+    /// under the state in force right now, so persisting it would put plaintext
+    /// key material into a protected store.
+    ///
+    /// The split is by *operation* — could not be read back, could not be
+    /// protected — and nothing finer, because nothing finer is knowable here. A
+    /// locked app produces one or the other depending only on which form the
+    /// shares happen to be in, and neither case can tell a recoverable lock from
+    /// a key that is gone. What the two do earn is separate copy: "we could not
+    /// read this" and "we could not protect this" are different sentences, and
+    /// pointing both at the first would make the second one false.
+    case unsealableKeyshare(pubkey: String)
+
+    init(_ failure: KeyshareNormalizationFailure) {
+        switch failure {
+        case .unreadable(let pubkey):
+            self = .unreadableKeyshare(pubkey: pubkey)
+        case .unsealable(let pubkey, _):
+            self = .unsealableKeyshare(pubkey: pubkey)
+        }
+    }
+
     /// The review screen renders `error.localizedDescription`. Without this the
     /// alert would fall back to the raw `NSError` form and tell the user
     /// nothing about what actually happened.
@@ -32,6 +54,8 @@ enum KeygenCommitError: Error, Equatable, LocalizedError {
         switch self {
         case .unreadableKeyshare:
             return "keysharesUnreadableVaultNotSaved".localized
+        case .unsealableKeyshare:
+            return "keysharesUnsealableVaultNotSaved".localized
         }
     }
 }
@@ -254,7 +278,11 @@ class KeygenViewModel: ObservableObject {
         try KeyshareWriteCoordinator.shared.withWriteLease {
             // Ahead of everything else, so a refusal leaves the context exactly
             // as it found it — `setDefaultCoinsOnce` builds coins onto the vault.
-            try verifyKeysharesAreReadable(of: vault, protector: protector)
+            let shares = try normalizedKeyshares(of: vault, protector: protector)
+
+            // Whole-array assignment, never element assignment: assigning into
+            // an element is not a dependable way to mark a `@Model` dirty.
+            vault.keyshares = shares
 
             VaultDefaultCoinService(context: context)
                 .setDefaultCoinsOnce(vault: vault)
@@ -263,48 +291,44 @@ class KeygenViewModel: ObservableObject {
         }
     }
 
-    /// Proves every share still opens before any of them is persisted.
+    /// The vault's shares in the form the current protection state requires,
+    /// computed before any of them is persisted.
     ///
     /// The write lease above only excludes a transition running *concurrently*
     /// with the insert; one that has already finished leaves nothing to exclude.
     /// And the deferred-persistence flow holds its shares in memory across the
-    /// whole review screen, where the sweep cannot reach them — so a passcode
-    /// disabled during the review unseals every *stored* share and deletes the
-    /// data key without ever seeing these. Inserting them anyway stores a vault
-    /// sealed under a key that no longer exists: it looks complete, nothing
-    /// revisits it, and every signature it is ever asked for fails.
+    /// whole review screen, where the sweep cannot reach them — so whichever way
+    /// the passcode moved during the review, these shares missed it:
     ///
-    /// A plaintext share passes untouched — that is the no-passcode case, which
-    /// is nearly every install, and `open` is a passthrough for it in every
-    /// state.
+    /// - Disabled during the review, and the sweep unsealed every *stored* share
+    ///   and deleted the data key without ever seeing these. Persisting them
+    ///   stores a vault sealed under a key that no longer exists: it looks
+    ///   complete, nothing revisits it, and every signature it is asked for
+    ///   fails. Nothing here can repair that, so it is refused.
+    /// - Set during the review, and the sweep sealed every *stored* share
+    ///   without ever seeing these. Persisting them puts plaintext key material
+    ///   into a store with an active passcode, readable while the app is locked
+    ///   and left that way, because the sweep has already run. That one *is*
+    ///   repairable — sealing it here is the repair — and refusing instead would
+    ///   destroy a finished keygen to prevent an exposure this very write ends.
     ///
-    /// A value that opens to *another* sealed value is refused rather than
-    /// unwrapped again, matching `KeyshareSweeper` and `ProtectedVaultImporter`:
-    /// an envelope around an envelope is not a share, and accepting one because
-    /// its outer layer authenticated would write `vlt2:` to disk under the name
-    /// of a key share.
+    /// So the shares are normalized rather than merely checked, by the same
+    /// ``KeyshareNormalizer`` a backup import uses across its own gap. Verifying
+    /// alone would close only the first case: plaintext is readable.
     @MainActor
-    private static func verifyKeysharesAreReadable(
+    private static func normalizedKeyshares(
         of vault: Vault,
         protector: KeyshareProtecting
-    ) throws {
-        for share in vault.keyshares {
-            let opened: String
-            do {
-                opened = try protector.open(share.keyshare)
-            } catch {
-                commitLogger.error(
-                    "Refusing to persist a vault: key share \(share.pubkey, privacy: .public) cannot be opened: \(String(describing: error), privacy: .public)"
-                )
-                throw KeygenCommitError.unreadableKeyshare(pubkey: share.pubkey)
-            }
-
-            guard !protector.isSealed(opened) else {
-                commitLogger.error(
-                    "Refusing to persist a vault: key share \(share.pubkey, privacy: .public) opened to another sealed value"
-                )
-                throw KeygenCommitError.unreadableKeyshare(pubkey: share.pubkey)
-            }
+    ) throws -> [KeyShare] {
+        do {
+            return try KeyshareNormalizer(protector: protector).normalizedShares(of: vault)
+        } catch let failure as KeyshareNormalizationFailure {
+            // The share is named here as well as in the normalizer's own line:
+            // a vault carries one share per curve and key import adds one per
+            // chain, and the alert the user sees carries no pubkey at all.
+            let refusal = KeygenCommitError(failure)
+            commitLogger.error("Refusing to persist a vault: \(String(describing: refusal), privacy: .public)")
+            throw refusal
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
@@ -11,6 +11,31 @@ import WalletCore
 import CryptoKit
 import BigInt
 
+/// `commitVault` is `static`, so it cannot reach the view model's own logger.
+private let commitLogger = Log.keygen.viewModel
+
+/// Why a finished vault could not be committed to the store.
+enum KeygenCommitError: Error, Equatable, LocalizedError {
+    /// A share about to be persisted cannot be turned back into a share under
+    /// the protection state in force right now. Carries the share's public key.
+    case unreadableKeyshare(pubkey: String)
+
+    /// The review screen renders `error.localizedDescription`. Without this the
+    /// alert would fall back to the raw `NSError` form and tell the user
+    /// nothing about what actually happened.
+    ///
+    /// The copy states only what is known. `open` reports a key that is gone, a
+    /// key that does not fit, and a key merely not yet unwrapped as the same two
+    /// errors, so naming a cause here would assert something the check cannot
+    /// establish — and two of the three are recoverable by unlocking.
+    var errorDescription: String? {
+        switch self {
+        case .unreadableKeyshare:
+            return "keysharesUnreadableVaultNotSaved".localized
+        }
+    }
+}
+
 enum KeygenStatus {
     case CreatingInstance
     case KeygenECDSA
@@ -217,16 +242,69 @@ class KeygenViewModel: ObservableObject {
     /// leaves its name reusable. Inserting on the unique `pubKeyECDSA` upserts, so
     /// re-running keygen that reproduces an existing vault replaces it as before.
     @MainActor
-    static func commitVault(_ vault: Vault, context: ModelContext) throws {
+    static func commitVault(
+        _ vault: Vault,
+        context: ModelContext,
+        protector: KeyshareProtecting = KeyshareProtector.shared
+    ) throws {
         // The insert and the save are one write span. The episode lease already
         // keeps a transition out of the whole review interval, but this is the
         // moment the shares actually reach the store, so it carries its own
         // guarantee rather than relying on a lease held elsewhere.
         try KeyshareWriteCoordinator.shared.withWriteLease {
+            // Ahead of everything else, so a refusal leaves the context exactly
+            // as it found it — `setDefaultCoinsOnce` builds coins onto the vault.
+            try verifyKeysharesAreReadable(of: vault, protector: protector)
+
             VaultDefaultCoinService(context: context)
                 .setDefaultCoinsOnce(vault: vault)
             context.insert(vault)
             try context.save()
+        }
+    }
+
+    /// Proves every share still opens before any of them is persisted.
+    ///
+    /// The write lease above only excludes a transition running *concurrently*
+    /// with the insert; one that has already finished leaves nothing to exclude.
+    /// And the deferred-persistence flow holds its shares in memory across the
+    /// whole review screen, where the sweep cannot reach them — so a passcode
+    /// disabled during the review unseals every *stored* share and deletes the
+    /// data key without ever seeing these. Inserting them anyway stores a vault
+    /// sealed under a key that no longer exists: it looks complete, nothing
+    /// revisits it, and every signature it is ever asked for fails.
+    ///
+    /// A plaintext share passes untouched — that is the no-passcode case, which
+    /// is nearly every install, and `open` is a passthrough for it in every
+    /// state.
+    ///
+    /// A value that opens to *another* sealed value is refused rather than
+    /// unwrapped again, matching `KeyshareSweeper` and `ProtectedVaultImporter`:
+    /// an envelope around an envelope is not a share, and accepting one because
+    /// its outer layer authenticated would write `vlt2:` to disk under the name
+    /// of a key share.
+    @MainActor
+    private static func verifyKeysharesAreReadable(
+        of vault: Vault,
+        protector: KeyshareProtecting
+    ) throws {
+        for share in vault.keyshares {
+            let opened: String
+            do {
+                opened = try protector.open(share.keyshare)
+            } catch {
+                commitLogger.error(
+                    "Refusing to persist a vault: key share \(share.pubkey, privacy: .public) cannot be opened: \(String(describing: error), privacy: .public)"
+                )
+                throw KeygenCommitError.unreadableKeyshare(pubkey: share.pubkey)
+            }
+
+            guard !protector.isSealed(opened) else {
+                commitLogger.error(
+                    "Refusing to persist a vault: key share \(share.pubkey, privacy: .public) opened to another sealed value"
+                )
+                throw KeygenCommitError.unreadableKeyshare(pubkey: share.pubkey)
+            }
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -37,6 +37,15 @@ class EncryptedBackupViewModel: ObservableObject {
     private let logger = Log.wallet.other
     private let keychain = DefaultKeychainService.shared
     private let backupEncryption: VaultBackupEncryption = Pbkdf2VaultBackupEncryption()
+    /// Every format below reaches storage through this and only through this.
+    /// `Vault.init(from: Decoder)` decodes `[KeyShare]` straight off the wire, so
+    /// the JSON paths would otherwise write plaintext shares into a store that
+    /// has a passcode set.
+    private let importer: ProtectedVaultImporter
+
+    init(importer: ProtectedVaultImporter = ProtectedVaultImporter()) {
+        self.importer = importer
+    }
 
     func resetData() {
         showVaultExporter = false
@@ -409,7 +418,17 @@ class EncryptedBackupViewModel: ObservableObject {
     }
 
     /// Decode a vault from file data
+    ///
+    /// Whatever the format, the result is validated before it is offered to the
+    /// user: a backup carrying a share this device cannot open is refused at the
+    /// point it is read rather than after a vault picker.
     private func decodeVaultFromData(_ data: Data) throws -> Vault? {
+        guard let vault = decodeVaultInAnyFormat(data) else { return nil }
+        try importer.validate(vault)
+        return vault
+    }
+
+    private func decodeVaultInAnyFormat(_ data: Data) -> Vault? {
         // Try protobuf format first
         if let vault = tryDecodeProtobuf(data) {
             return vault
@@ -457,6 +476,7 @@ class EncryptedBackupViewModel: ObservableObject {
                 do {
                     let vsVault = try VSVault(serializedBytes: decryptedData)
                     let vault = try Vault(proto: vsVault)
+                    try importer.validate(vault)
                     allVaults.append(vault)
                 } catch {
                     logger.error("❌ Failed to parse decrypted data (\(fileName, privacy: .public)): \(error.localizedDescription, privacy: .public)")
@@ -486,28 +506,38 @@ class EncryptedBackupViewModel: ObservableObject {
 
     /// Restore multiple vaults to the database
     func restoreMultipleVaults(modelContext: ModelContext, vaults: [Vault]) {
-        let results = importVaults(multipleVaultsToImport, to: modelContext, existing: vaults)
-
-        selectedVault = results.imported.first
-        showImportResults(results)
+        do {
+            let results = try importVaults(multipleVaultsToImport, to: modelContext, existing: vaults)
+            selectedVault = results.imported.first
+            showImportResults(results)
+        } catch {
+            logger.error("fail to restore vaults: \(error.localizedDescription, privacy: .public)")
+            showError("vaultRestoreFailed")
+        }
         cleanup()
     }
 
-    private func importVaults(_ vaultsToImport: [Vault], to modelContext: ModelContext, existing: [Vault]) -> (imported: [Vault], duplicates: Int, skippedNames: [String]) {
+    private func importVaults(_ vaultsToImport: [Vault], to modelContext: ModelContext, existing: [Vault]) throws -> (imported: [Vault], duplicates: Int, skippedNames: [String]) {
         var imported: [Vault] = []
         var duplicates = 0
         var skippedNames: [String] = []
 
         for vault in vaultsToImport {
             if isVaultUnique(backupVault: vault, vaults: existing + imported) {
-                VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
-                modelContext.insert(vault)
                 imported.append(vault)
             } else {
                 duplicates += 1
                 skippedNames.append(vault.name)
                 logger.info("Skipped duplicate vault during zip import: \(vault.name)")
             }
+        }
+
+        // One lease, one save, for the whole batch: a partial import would leave
+        // some vaults on one side of the passcode invariant and some on the other.
+        // Default coins are added inside it, because they insert rows of their
+        // own and doing that first strands them when the import is refused.
+        try importer.commit(imported, into: modelContext) { vault in
+            VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
         }
 
         return (imported, duplicates, skippedNames)
@@ -610,9 +640,9 @@ class EncryptedBackupViewModel: ObservableObject {
                 vault.libType = LibType.DKLS
             }
 
-            VaultDefaultCoinService(context: modelContext)
-                .setDefaultCoinsOnce(vault: vault)
-            modelContext.insert(vault)
+            try importer.commit([vault], into: modelContext) { vault in
+                VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
+            }
             selectedVault = vault
             isVaultImported = true
         } catch {
@@ -636,48 +666,49 @@ class EncryptedBackupViewModel: ObservableObject {
             return
         }
 
+        // Decoding and storing are separated deliberately. The fallback below
+        // exists for a *format* that the new decoder cannot read; letting a
+        // failed store fall into it would re-attempt the same bytes as a
+        // different format and report the wrong reason for the failure.
         let decoder = JSONDecoder()
+        let decoded: Vault
         do {
-            let backupVault = try decoder.decode(BackupVault.self,
-                                                 from: vaultData)
             // if version get updated , then we can process the migration here
-            if !isVaultUnique(backupVault: backupVault.vault, vaults: vaults) {
-                alertTitle = "vaultAlreadyExists"
-                showAlert = true
-                isVaultImported = false
-                return
-            }
-            VaultDefaultCoinService(context: modelContext)
-                .setDefaultCoinsOnce(vault: backupVault.vault)
-            modelContext.insert(backupVault.vault)
-            selectedVault = backupVault.vault
-            showAlert = false
-            isVaultImported = true
+            decoded = try decoder.decode(BackupVault.self, from: vaultData).vault
         } catch {
             logger.warning("failed to import with new format , fallback to the old format instead. \(error.localizedDescription, privacy: .public)")
 
             // fallback
             do {
-                let vault = try decoder.decode(Vault.self, from: vaultData)
-
-                if !isVaultUnique(backupVault: vault, vaults: vaults) {
-                    alertTitle = "vaultAlreadyExists"
-                    showAlert = true
-                    isVaultImported = false
-                    return
-                }
-                VaultDefaultCoinService(context: modelContext)
-                    .setDefaultCoinsOnce(vault: vault)
-                modelContext.insert(vault)
-                selectedVault = vault
-                showAlert = false
-                isVaultImported = true
+                decoded = try decoder.decode(Vault.self, from: vaultData)
             } catch {
                 logger.error("fail to restore vault: \(error.localizedDescription)")
                 alertTitle = "vaultRestoreFailed"
                 showAlert = true
                 isVaultImported = false
+                return
             }
+        }
+
+        guard isVaultUnique(backupVault: decoded, vaults: vaults) else {
+            alertTitle = "vaultAlreadyExists"
+            showAlert = true
+            isVaultImported = false
+            return
+        }
+
+        do {
+            try importer.commit([decoded], into: modelContext) { vault in
+                VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
+            }
+            selectedVault = decoded
+            showAlert = false
+            isVaultImported = true
+        } catch {
+            logger.error("fail to restore vault: \(error.localizedDescription)")
+            alertTitle = "vaultRestoreFailed"
+            showAlert = true
+            isVaultImported = false
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Helpers/KeychainReadResultAssertions.swift
+++ b/VultisigApp/VultisigAppTests/Helpers/KeychainReadResultAssertions.swift
@@ -1,0 +1,71 @@
+//
+//  KeychainReadResultAssertions.swift
+//  VultisigAppTests
+//
+//  Asserting on a `KeychainReadResult` directly, rather than collapsing it to an
+//  optional first. Two reasons: it is only `Equatable` when its value is, and
+//  `SymmetricKey` is not; and "absent" has to be asserted rather than
+//  approximated by "not present", because the third answer is neither and the
+//  whole point of the type is that the difference decides whether key material
+//  may be overwritten.
+//
+
+import Security
+import XCTest
+@testable import VultisigApp
+
+func XCTAssertAbsent<Value>(
+    _ result: KeychainReadResult<Value>,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    guard case .absent = result else {
+        XCTFail(describeFailure(expected: "absent", got: result, message()), file: file, line: line)
+        return
+    }
+}
+
+func XCTAssertUnavailable<Value>(
+    _ result: KeychainReadResult<Value>,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    guard case .unavailable = result else {
+        XCTFail(describeFailure(expected: "unavailable", got: result, message()), file: file, line: line)
+        return
+    }
+}
+
+/// The stored value, failing the test if the Keychain answered anything else.
+func XCTUnwrapPresent<Value>(
+    _ result: KeychainReadResult<Value>,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> Value {
+    guard case .present(let value) = result else {
+        XCTFail(describeFailure(expected: "present", got: result, message()), file: file, line: line)
+        throw XCTSkip("not present")
+    }
+    return value
+}
+
+private func describeFailure<Value>(
+    expected: String,
+    got result: KeychainReadResult<Value>,
+    _ message: String
+) -> String {
+    let actual: String
+    switch result {
+    case .absent:
+        actual = "absent"
+    case .present:
+        actual = "present"
+    case .unavailable(let status):
+        actual = "unavailable(\(status))"
+    }
+    let detail = "expected \(expected), got \(actual)"
+    return message.isEmpty ? detail : "\(message) — \(detail)"
+}

--- a/VultisigApp/VultisigAppTests/Keygen/KeygenVaultCommitTests.swift
+++ b/VultisigApp/VultisigAppTests/Keygen/KeygenVaultCommitTests.swift
@@ -41,6 +41,12 @@ final class KeygenVaultCommitTests: XCTestCase {
     /// silently collapses to a single row while every assertion still passes.
     /// (`publicKeyMLDSA44` is unique too but stays `nil`, which does not
     /// collapse — a unique index treats NULLs as distinct.)
+    ///
+    /// Every share carries a `keyId`, which is not unique and does not collapse
+    /// anything — it is here because the MLDSA share carries one in production
+    /// and `DilithiumKeysign` builds its setup message from it, so a commit that
+    /// dropped the field would leave a quantum vault unable to sign. Leaving it
+    /// `nil` in every fixture would make that silent.
     private func makeVault(name: String, shares: [String] = []) -> Vault {
         Vault(
             name: name,
@@ -48,7 +54,11 @@ final class KeygenVaultCommitTests: XCTestCase {
             pubKeyECDSA: "02\(name.lowercased())ecdsa",
             pubKeyEdDSA: "ed\(name.lowercased())eddsa",
             keyshares: shares.enumerated().map { index, value in
-                KeyShare(pubkey: "\(name.lowercased())-share-\(index)", keyshare: value)
+                KeyShare(
+                    pubkey: "\(name.lowercased())-share-\(index)",
+                    keyshare: value,
+                    keyId: "\(name.lowercased())-keyid-\(index)"
+                )
             },
             localPartyID: "iPhone-Local",
             hexChainCode: "00",
@@ -152,12 +162,12 @@ final class KeygenVaultCommitTests: XCTestCase {
         XCTAssertEqual(try persistedVaultCount(), 1)
     }
 
-    // MARK: - The shares have to still be readable
+    // MARK: - The shares have to land on the side of the invariant the passcode is on
 
     /// The overwhelmingly common case: no passcode has ever been set, so the
-    /// shares are plaintext and `open` is a passthrough. This has to stay a
-    /// passthrough — a verification that rejected plaintext would break vault
-    /// creation for nearly every install.
+    /// shares are plaintext and both halves of the normalization are
+    /// passthroughs. This has to stay byte-identical — a commit that rewrote
+    /// plaintext would change what nearly every install stores.
     func testCommitVaultPersistsPlaintextSharesWhenNoPasscodeIsSet() throws {
         let vault = makeVault(name: "Treasury", shares: [firstShare, secondShare])
 
@@ -172,7 +182,13 @@ final class KeygenVaultCommitTests: XCTestCase {
     }
 
     /// A passcode is set and stayed set: the shares were sealed under the key
-    /// still in hand, so they commit, byte for byte as keygen produced them.
+    /// still in hand, so they commit and stay sealed.
+    ///
+    /// Not byte-identical, deliberately. Normalizing opens and re-seals, and
+    /// AES-GCM takes a fresh nonce per seal, so the stored ciphertext differs
+    /// from the one keygen held. What has to hold is that it is still sealed and
+    /// still opens to the same share — the invariant is about the *form* a value
+    /// is in, not about its bytes.
     func testCommitVaultPersistsSharesSealedUnderTheCurrentKey() throws {
         // Captured once: a closure that minted a key per call would hand the
         // commit a different key from the one that sealed.
@@ -187,7 +203,90 @@ final class KeygenVaultCommitTests: XCTestCase {
         try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
 
         XCTAssertEqual(try persistedVaultCount(), 1)
-        XCTAssertEqual(try persistedShares(), [sealed], "the commit must not rewrite the share")
+        let stored = try XCTUnwrap(persistedShares().first)
+        XCTAssertTrue(protector.isSealed(stored), "a passcode is set, so the stored share must be sealed")
+        XCTAssertEqual(try protector.open(stored), firstShare, "and must open to exactly what keygen produced")
+        XCTAssertNotEqual(
+            stored,
+            sealed,
+            "an already-sealed share still goes through the seal, so the nonce — and the bytes — must differ"
+        )
+    }
+
+    /// **The mirror regression.** The readability check the commit used to make
+    /// closed only one direction: plaintext *is* readable, so a passcode **set**
+    /// during the review sailed through it.
+    ///
+    /// Same broken lease as the disable case, run the other way. Keygen produced
+    /// plaintext shares because no passcode existed at the time; the user then
+    /// sets one, and the sweep seals every *stored* share while these sit in
+    /// memory where it cannot reach them. Committing them as they are writes
+    /// plaintext key material into a store with an active passcode — readable
+    /// while the app is locked, and left that way indefinitely, since the sweep
+    /// that would have sealed it has already run.
+    ///
+    /// Unlike the disable case this is repairable, so it is repaired rather than
+    /// refused: refusing would destroy a finished keygen — unrepeatable without
+    /// every co-signer back on the same screen — to prevent an exposure that
+    /// this very write is about to end.
+    func testCommitVaultSealsPlaintextSharesWhenThePasscodeWasSetDuringTheReview() throws {
+        // Keygen brackets the whole vault-creation episode, with no passcode in
+        // force, so the shares it produces are plaintext…
+        let episode = try XCTUnwrap(KeyshareWriteCoordinator.shared.beginEpisode())
+
+        var state: KeyshareProtectionState = .disabled
+        let protector = KeyshareProtector(state: { state })
+        let vault = makeVault(name: "Treasury", shares: [firstShare, secondShare])
+
+        // …but nothing guarantees the lease outlives the review screen.
+        KeyshareWriteCoordinator.shared.end(episode)
+
+        // With the episode gone the transition is allowed through: it mints a
+        // data key and seals every share it can find in the store. These are not
+        // in the store.
+        let key = SymmetricKey(size: .bits256)
+        let transition = try KeyshareWriteCoordinator.shared.beginTransition()
+        state = .unlocked(key)
+        KeyshareWriteCoordinator.shared.end(transition)
+
+        try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+
+        XCTAssertEqual(try persistedVaultCount(), 1)
+        let stored = try persistedShares()
+        XCTAssertEqual(stored.count, 2)
+        for share in stored {
+            XCTAssertTrue(
+                protector.isSealed(share),
+                "a passcode is set, so no share may reach the store in the clear"
+            )
+        }
+        XCTAssertEqual(
+            try stored.map { try protector.open($0) }.sorted(),
+            [firstShare, secondShare].sorted(),
+            "sealing must be reversible — the stored shares have to open back to what keygen produced"
+        )
+    }
+
+    /// Normalizing rewrites the vault the caller handed over, not a copy of it,
+    /// so the review screen is not left holding plaintext shares after the store
+    /// has been told they are sealed. And it carries the rest of the share
+    /// across — a `KeyShare` is rebuilt, not mutated, so a dropped field would
+    /// be silent.
+    func testCommitVaultRewritesTheVaultItWasHandedRatherThanACopy() throws {
+        let key = SymmetricKey(size: .bits256)
+        let protector = KeyshareProtector(state: { .unlocked(key) })
+        let vault = makeVault(name: "Treasury", shares: [firstShare])
+
+        try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+
+        let share = try XCTUnwrap(vault.keyshares.first)
+        XCTAssertTrue(protector.isSealed(share.keyshare), "the vault the caller still holds must not keep plaintext")
+        XCTAssertEqual(share.pubkey, "treasury-share-0", "normalizing must not lose the pubkey")
+        XCTAssertEqual(
+            share.keyId,
+            "treasury-keyid-0",
+            "nor the key identifier — an MLDSA share cannot be signed with without it"
+        )
     }
 
     /// **The regression.** The episode lease is retained on the view model and
@@ -302,6 +401,31 @@ final class KeygenVaultCommitTests: XCTestCase {
         XCTAssertEqual(try persistedVaultCount(), 0)
     }
 
+    /// Locked with *plaintext* shares in hand is the other half of the same
+    /// refusal, and the one normalizing introduces: the shares read back
+    /// perfectly — plaintext always does — but there is no key to seal them
+    /// with, so the only two options are to store key material in the clear
+    /// behind an active passcode or to refuse. It refuses, under its own error:
+    /// nothing is lost here, and the next unlock stores the vault correctly.
+    func testCommitVaultThrowsWhenPlaintextSharesCannotBeSealedWhileLocked() throws {
+        let vault = makeVault(name: "Treasury", shares: [firstShare])
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: KeyshareProtector(state: { .locked })
+            )
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .unsealableKeyshare(pubkey: "treasury-share-0"))
+        }
+        XCTAssertEqual(try persistedVaultCount(), 0, "plaintext must never reach a store with a passcode set")
+        XCTAssertFalse(
+            Storage.shared.modelContext.hasChanges,
+            "a refused commit must not leave a partial write in the context"
+        )
+    }
+
     /// The loop has to name the share that failed, not the first one it looked
     /// at — a vault carries a share per curve, and key import adds one per chain.
     func testTheRefusalNamesTheShareThatCouldNotBeOpened() throws {
@@ -344,20 +468,82 @@ final class KeygenVaultCommitTests: XCTestCase {
     /// The review screen renders `error.localizedDescription`. Without the
     /// `LocalizedError` conformance the user would be shown
     /// "(VultisigApp.KeygenCommitError error 0.)" for a dead vault.
-    func testTheRefusalIsReportedInWordsRatherThanAsAnNSError() {
-        let key = "keysharesUnreadableVaultNotSaved"
-        let error = KeygenCommitError.unreadableKeyshare(pubkey: "treasury-share-0")
+    func testEveryRefusalIsReportedInWordsRatherThanAsAnNSError() {
+        let cases: [(KeygenCommitError, String)] = [
+            (.unreadableKeyshare(pubkey: "treasury-share-0"), "keysharesUnreadableVaultNotSaved"),
+            (.unsealableKeyshare(pubkey: "treasury-share-0"), "keysharesUnsealableVaultNotSaved")
+        ]
 
-        // `.localized` hands back the key itself when the key is missing, so
-        // comparing against `key.localized` alone would pass over an untranslated
-        // build. This is what proves the copy actually exists.
-        XCTAssertNotEqual(key.localized, key, "the string must be present in the bundled locale")
+        for (error, key) in cases {
+            // `.localized` hands back the key itself when the key is missing, so
+            // comparing against `key.localized` alone would pass over an
+            // untranslated build. This is what proves the copy actually exists.
+            XCTAssertNotEqual(key.localized, key, "\(key) must be present in the bundled locale")
 
-        XCTAssertEqual(error.errorDescription, key.localized)
-        XCTAssertEqual(error.localizedDescription, key.localized)
-        XCTAssertFalse(
-            error.localizedDescription.contains("KeygenCommitError"),
-            "the alert must not fall back to the raw NSError form"
+            XCTAssertEqual(error.errorDescription, key.localized)
+            XCTAssertEqual(error.localizedDescription, key.localized)
+            XCTAssertFalse(
+                error.localizedDescription.contains("KeygenCommitError"),
+                "the alert must not fall back to the raw NSError form"
+            )
+        }
+    }
+
+    /// The seal is proved to open back before it is stored, and this is the
+    /// only way to exercise that: `AesGcmKeyshareCipher` either round-trips or
+    /// throws, so nothing built on the real cipher can reach the guard.
+    ///
+    /// Without the proof this commit stores ciphertext that opens to something
+    /// other than the share — a vault that looks complete and signs nothing,
+    /// which is the exact outcome the whole check exists to prevent, arrived at
+    /// from the other side.
+    func testCommitVaultThrowsWhenASealDoesNotOpenBackToWhatWentIn() throws {
+        let vault = makeVault(name: "Treasury", shares: [firstShare])
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: SealThatDoesNotOpenBack()
+            )
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .unsealableKeyshare(pubkey: "treasury-share-0"))
+        }
+        XCTAssertEqual(try persistedVaultCount(), 0, "a share that cannot be read back must not reach the store")
+    }
+
+    /// The two refusals exist because they describe different operations — one
+    /// share could not be read back, the other could not be protected — and
+    /// pointing both at "could not be read" would make the second one false.
+    /// It pins the copy, and only the copy.
+    func testTheTwoRefusalsDoNotSayTheSameThing() {
+        XCTAssertNotEqual(
+            KeygenCommitError.unreadableKeyshare(pubkey: "treasury-share-0").errorDescription,
+            KeygenCommitError.unsealableKeyshare(pubkey: "treasury-share-0").errorDescription
         )
+    }
+}
+
+/// A protector that seals to something `open` will not give back.
+///
+/// It exists because the production cipher cannot express this: AES-GCM either
+/// returns the plaintext it authenticated or throws, so the round-trip proof has
+/// no reachable failure on the real wiring — and an unreachable guard that is
+/// never exercised is an unverified one.
+private struct SealThatDoesNotOpenBack: KeyshareProtecting {
+
+    func isSealed(_ stored: String) -> Bool {
+        stored.hasPrefix("vlt2:")
+    }
+
+    func seal(_ plaintext: String) throws -> String {
+        isSealed(plaintext) ? plaintext : "vlt2:\(plaintext)"
+    }
+
+    func open(_ stored: String) throws -> String {
+        // Plaintext still passes through, so the share reaches the seal exactly
+        // as it would in production and only the proof is what fails.
+        guard isSealed(stored) else { return stored }
+        return "a different share entirely"
     }
 }

--- a/VultisigApp/VultisigAppTests/Keygen/KeygenVaultCommitTests.swift
+++ b/VultisigApp/VultisigAppTests/Keygen/KeygenVaultCommitTests.swift
@@ -9,6 +9,7 @@
 //
 
 @testable import VultisigApp
+import CryptoKit
 import SwiftData
 import XCTest
 
@@ -16,6 +17,9 @@ import XCTest
 final class KeygenVaultCommitTests: XCTestCase {
 
     private var token: TestContextToken?
+
+    private let firstShare = "eyJrZXlzaGFyZSI6ImRrbHMtb25lIn0="
+    private let secondShare = "eyJrZXlzaGFyZSI6ImRrbHMtdHdvIn0="
 
     override func setUp() async throws {
         try await super.setUp()
@@ -30,13 +34,22 @@ final class KeygenVaultCommitTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeVault(name: String) -> Vault {
+    /// Every unique `String` attribute — `name`, `pubKeyECDSA`, `pubKeyEdDSA` —
+    /// gets a value derived from `name`, so two differently named vaults are two
+    /// rows. Sharing one, which `TestStore.makeVault` does with `pubKeyEdDSA`,
+    /// makes SwiftData *upsert* rather than fail, and a fixture built that way
+    /// silently collapses to a single row while every assertion still passes.
+    /// (`publicKeyMLDSA44` is unique too but stays `nil`, which does not
+    /// collapse — a unique index treats NULLs as distinct.)
+    private func makeVault(name: String, shares: [String] = []) -> Vault {
         Vault(
             name: name,
             signers: ["iPhone-Local", "iPad-Peer"],
             pubKeyECDSA: "02\(name.lowercased())ecdsa",
             pubKeyEdDSA: "ed\(name.lowercased())eddsa",
-            keyshares: [],
+            keyshares: shares.enumerated().map { index, value in
+                KeyShare(pubkey: "\(name.lowercased())-share-\(index)", keyshare: value)
+            },
             localPartyID: "iPhone-Local",
             hexChainCode: "00",
             resharePrefix: nil,
@@ -48,11 +61,18 @@ final class KeygenVaultCommitTests: XCTestCase {
         try Storage.shared.modelContext.fetch(FetchDescriptor<Vault>()).count
     }
 
+    private func persistedShares() throws -> [String] {
+        try Storage.shared.modelContext
+            .fetch(FetchDescriptor<Vault>())
+            .flatMap(\.keyshares)
+            .map(\.keyshare)
+    }
+
     // MARK: - Tests
 
     /// Aborting the review screen never calls `commitVault`, so an in-memory vault
     /// that was generated but not confirmed leaves nothing in the store and keeps
-    /// its name available. This is the regression from #4493.
+    /// its name available.
     func test_abortedKeygen_doesNotPersistVault_andNameStaysReusable() throws {
         let name = "Treasury"
 
@@ -130,5 +150,214 @@ final class KeygenVaultCommitTests: XCTestCase {
         try KeygenViewModel.commitVault(makeVault(name: "Treasury"), context: Storage.shared.modelContext)
 
         XCTAssertEqual(try persistedVaultCount(), 1)
+    }
+
+    // MARK: - The shares have to still be readable
+
+    /// The overwhelmingly common case: no passcode has ever been set, so the
+    /// shares are plaintext and `open` is a passthrough. This has to stay a
+    /// passthrough — a verification that rejected plaintext would break vault
+    /// creation for nearly every install.
+    func testCommitVaultPersistsPlaintextSharesWhenNoPasscodeIsSet() throws {
+        let vault = makeVault(name: "Treasury", shares: [firstShare, secondShare])
+
+        try KeygenViewModel.commitVault(
+            vault,
+            context: Storage.shared.modelContext,
+            protector: KeyshareProtector(state: { .disabled })
+        )
+
+        XCTAssertEqual(try persistedVaultCount(), 1)
+        XCTAssertEqual(try persistedShares().sorted(), [firstShare, secondShare].sorted())
+    }
+
+    /// A passcode is set and stayed set: the shares were sealed under the key
+    /// still in hand, so they commit, byte for byte as keygen produced them.
+    func testCommitVaultPersistsSharesSealedUnderTheCurrentKey() throws {
+        // Captured once: a closure that minted a key per call would hand the
+        // commit a different key from the one that sealed.
+        let key = SymmetricKey(size: .bits256)
+        let protector = KeyshareProtector(state: { .unlocked(key) })
+
+        let sealed = try protector.seal(firstShare)
+        XCTAssertTrue(protector.isSealed(sealed), "the fixture must actually be sealed")
+
+        let vault = makeVault(name: "Treasury", shares: [sealed])
+
+        try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+
+        XCTAssertEqual(try persistedVaultCount(), 1)
+        XCTAssertEqual(try persistedShares(), [sealed], "the commit must not rewrite the share")
+    }
+
+    /// **The regression.** The episode lease is retained on the view model and
+    /// released by `deinit`, so it lasts only as long as SwiftUI keeps a screen
+    /// the user has navigated away from. Drop it early and the sequence below is
+    /// reachable: the disable unseals every *stored* share and deletes the data
+    /// key, these shares are in memory rather than in the store so the sweep
+    /// never sees them, and committing afterwards writes a vault sealed under a
+    /// key that no longer exists — complete-looking, permanently unsignable, and
+    /// nothing ever revisits it.
+    func testCommitVaultThrowsWhenThePasscodeWasDisabledDuringTheReview() throws {
+        // Keygen brackets the whole vault-creation episode…
+        let episode = try XCTUnwrap(KeyshareWriteCoordinator.shared.beginEpisode())
+
+        let key = SymmetricKey(size: .bits256)
+        var state: KeyshareProtectionState = .unlocked(key)
+        let protector = KeyshareProtector(state: { state })
+
+        let sealed = try protector.seal(firstShare)
+        let vault = makeVault(name: "Treasury", shares: [sealed])
+
+        // …but nothing guarantees the lease outlives the review screen.
+        KeyshareWriteCoordinator.shared.end(episode)
+
+        // With the episode gone the transition is allowed through: it sweeps the
+        // store, deletes the wrapped key and clears the session.
+        let transition = try KeyshareWriteCoordinator.shared.beginTransition()
+        state = .disabled
+        KeyshareWriteCoordinator.shared.end(transition)
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .unreadableKeyshare(pubkey: "treasury-share-0"))
+        }
+        XCTAssertEqual(try persistedVaultCount(), 0, "a vault nothing can open must not reach the store")
+    }
+
+    /// The refusal is only worth anything if it happens before the write, so on
+    /// *this* path there is no vault, no coins, and nothing left dirty for an
+    /// unrelated save to flush. (It says nothing about a failure inside
+    /// `context.save()`, which is a separate, pre-existing path.)
+    func testARefusedCommitLeavesTheStoreExactlyAsItWas() throws {
+        let existing = makeVault(name: "Savings", shares: [secondShare])
+        try KeygenViewModel.commitVault(
+            existing,
+            context: Storage.shared.modelContext,
+            protector: KeyshareProtector(state: { .disabled })
+        )
+        let before = try persistedShares()
+
+        let key = SymmetricKey(size: .bits256)
+        var state: KeyshareProtectionState = .unlocked(key)
+        let protector = KeyshareProtector(state: { state })
+        let vault = makeVault(name: "Treasury", shares: [try protector.seal(firstShare)])
+        state = .disabled
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+        ) { error in
+            // Named, so a transition lease leaked by another test cannot satisfy
+            // this with a `.busy` that proves nothing about the new check.
+            XCTAssertEqual(error as? KeygenCommitError, .unreadableKeyshare(pubkey: "treasury-share-0"))
+        }
+
+        XCTAssertEqual(try persistedVaultCount(), 1, "the refused vault must not reach the store")
+        XCTAssertEqual(try persistedShares(), before, "the refusal must leave every stored share alone")
+        XCTAssertFalse(
+            Storage.shared.modelContext.hasChanges,
+            "a refused commit must not leave a partial write in the context"
+        )
+    }
+
+    /// A share sealed under a key that is present but wrong fails the same way.
+    /// This is the interrupted-set shape — a wrapper exists, so the session is
+    /// not `.disabled`, but it does not open these bytes.
+    func testCommitVaultThrowsWhenTheKeyInHandDoesNotOpenTheShare() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(firstShare, with: SymmetricKey(size: .bits256))
+        let vault = makeVault(name: "Treasury", shares: [foreign])
+        let held = SymmetricKey(size: .bits256)
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: KeyshareProtector(state: { .unlocked(held) })
+            )
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .unreadableKeyshare(pubkey: "treasury-share-0"))
+        }
+        XCTAssertEqual(try persistedVaultCount(), 0)
+    }
+
+    /// The `.locked` state is the one the check cannot see through: a wrapped
+    /// key exists but is not in hand, so nothing here can tell a share sealed
+    /// under it from a share sealed under a key that is gone. Fail closed —
+    /// persisting a share nobody can prove is recoverable is the outcome this
+    /// whole verification exists to prevent.
+    func testCommitVaultThrowsWhileTheAppIsLocked() throws {
+        let key = SymmetricKey(size: .bits256)
+        var state: KeyshareProtectionState = .unlocked(key)
+        let protector = KeyshareProtector(state: { state })
+        let vault = makeVault(name: "Treasury", shares: [try protector.seal(firstShare)])
+
+        state = .locked
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .unreadableKeyshare(pubkey: "treasury-share-0"))
+        }
+        XCTAssertEqual(try persistedVaultCount(), 0)
+    }
+
+    /// The loop has to name the share that failed, not the first one it looked
+    /// at — a vault carries a share per curve, and key import adds one per chain.
+    func testTheRefusalNamesTheShareThatCouldNotBeOpened() throws {
+        let key = SymmetricKey(size: .bits256)
+        let protector = KeyshareProtector(state: { .unlocked(key) })
+        let foreign = try AesGcmKeyshareCipher().seal(secondShare, with: SymmetricKey(size: .bits256))
+        let vault = makeVault(name: "Treasury", shares: [try protector.seal(firstShare), foreign])
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .unreadableKeyshare(pubkey: "treasury-share-1"))
+        }
+        XCTAssertEqual(try persistedVaultCount(), 0)
+    }
+
+    /// A sealed envelope wrapped around another one is not a share. Nothing in
+    /// the app produces one — `seal` refuses to double-seal — but the two
+    /// sibling commit paths (`KeyshareSweeper`, `ProtectedVaultImporter`) both
+    /// refuse it, and unwrapping only the outer layer would write `vlt2:` to
+    /// disk under the name of a key share.
+    func testCommitVaultThrowsOnAnEnvelopeWrappedAroundAnotherEnvelope() throws {
+        let key = SymmetricKey(size: .bits256)
+        let cipher = AesGcmKeyshareCipher()
+        let nested = try cipher.seal(try cipher.seal(firstShare, with: key), with: key)
+        let vault = makeVault(name: "Treasury", shares: [nested])
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: KeyshareProtector(state: { .unlocked(key) })
+            )
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .unreadableKeyshare(pubkey: "treasury-share-0"))
+        }
+        XCTAssertEqual(try persistedVaultCount(), 0)
+    }
+
+    /// The review screen renders `error.localizedDescription`. Without the
+    /// `LocalizedError` conformance the user would be shown
+    /// "(VultisigApp.KeygenCommitError error 0.)" for a dead vault.
+    func testTheRefusalIsReportedInWordsRatherThanAsAnNSError() {
+        let key = "keysharesUnreadableVaultNotSaved"
+        let error = KeygenCommitError.unreadableKeyshare(pubkey: "treasury-share-0")
+
+        // `.localized` hands back the key itself when the key is missing, so
+        // comparing against `key.localized` alone would pass over an untranslated
+        // build. This is what proves the copy actually exists.
+        XCTAssertNotEqual(key.localized, key, "the string must be present in the bundled locale")
+
+        XCTAssertEqual(error.errorDescription, key.localized)
+        XCTAssertEqual(error.localizedDescription, key.localized)
+        XCTAssertFalse(
+            error.localizedDescription.contains("KeygenCommitError"),
+            "the alert must not fall back to the raw NSError form"
+        )
     }
 }

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -45,6 +45,10 @@ final class MockKeychainService: KeychainService {
     /// Same, for the wrapped copy, so the disable rollback can be exercised.
     var ignoresWrappedKeyshareDataKeyDeletion = false
 
+    /// When set, clearing the attempt state silently does nothing, so the
+    /// verified clear in `KeyshareInstallReconciler` can be exercised.
+    var ignoresPasscodeAttemptStateDeletion = false
+
     /// The recorded version, for tests that only care about the stored value.
     var lastMigratedVersion: Int? {
         get { lastMigratedVersionResult.valueTreatingUnavailableAsAbsent }
@@ -114,7 +118,10 @@ final class MockKeychainService: KeychainService {
 
     func getPasscodeAttemptState() -> KeychainReadResult<Data> { passcodeAttemptStateResult }
 
-    func setPasscodeAttemptState(_ data: Data?) { passcodeAttemptStateResult = Self.result(data) }
+    func setPasscodeAttemptState(_ data: Data?) {
+        if data == nil && ignoresPasscodeAttemptStateDeletion { return }
+        passcodeAttemptStateResult = Self.result(data)
+    }
 
     private static func result<Value>(_ value: Value?) -> KeychainReadResult<Value> {
         guard let value else { return .absent }

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -27,6 +27,9 @@ final class MockKeychainService: KeychainService {
     /// The answer ``getWrappedKeyshareDataKey()`` gives, likewise.
     var wrappedKeyshareDataKeyResult: KeychainReadResult<Data> = .absent
 
+    /// The answer ``getPasscodeAttemptState()`` gives, likewise.
+    var passcodeAttemptStateResult: KeychainReadResult<Data> = .absent
+
     private var fastPasswords: [String: KeychainReadResult<String>] = [:]
     private var fastHints: [String: KeychainReadResult<String>] = [:]
     private var deviceTokenResult: KeychainReadResult<String> = .absent
@@ -34,6 +37,13 @@ final class MockKeychainService: KeychainService {
     /// When set, `setKeyshareDataKey` accepts the write but stores nothing, so
     /// the read-back verification in `DefaultKeyshareKeyStore` can be exercised.
     var dropsKeyshareDataKeyWrites = false
+
+    /// When set, deletion of the clear data key silently does nothing, so the
+    /// verified-deletion path can be exercised.
+    var ignoresKeyshareDataKeyDeletion = false
+
+    /// Same, for the wrapped copy, so the disable rollback can be exercised.
+    var ignoresWrappedKeyshareDataKeyDeletion = false
 
     /// The recorded version, for tests that only care about the stored value.
     var lastMigratedVersion: Int? {
@@ -51,6 +61,12 @@ final class MockKeychainService: KeychainService {
     var wrappedKeyshareDataKey: Data? {
         get { wrappedKeyshareDataKeyResult.valueTreatingUnavailableAsAbsent }
         set { wrappedKeyshareDataKeyResult = Self.result(newValue) }
+    }
+
+    /// The recorded attempt state, for tests that only care about the stored value.
+    var passcodeAttemptState: Data? {
+        get { passcodeAttemptStateResult.valueTreatingUnavailableAsAbsent }
+        set { passcodeAttemptStateResult = Self.result(newValue) }
     }
 
     init(lastMigratedVersion: Int? = nil) {
@@ -85,14 +101,20 @@ final class MockKeychainService: KeychainService {
 
     func setKeyshareDataKey(_ data: Data?) {
         guard !dropsKeyshareDataKeyWrites else { return }
+        if data == nil && ignoresKeyshareDataKeyDeletion { return }
         keyshareDataKeyResult = Self.result(data)
     }
 
     func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> { wrappedKeyshareDataKeyResult }
 
     func setWrappedKeyshareDataKey(_ data: Data?) {
+        if data == nil && ignoresWrappedKeyshareDataKeyDeletion { return }
         wrappedKeyshareDataKeyResult = Self.result(data)
     }
+
+    func getPasscodeAttemptState() -> KeychainReadResult<Data> { passcodeAttemptStateResult }
+
+    func setPasscodeAttemptState(_ data: Data?) { passcodeAttemptStateResult = Self.result(data) }
 
     private static func result<Value>(_ value: Value?) -> KeychainReadResult<Value> {
         guard let value else { return .absent }

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -22,9 +22,6 @@ final class MockKeychainService: KeychainService {
     /// test can stage `.unavailable`.
     var lastMigratedVersionResult: KeychainReadResult<Int>
 
-    /// The answer ``getKeyshareDataKey()`` gives, likewise.
-    var keyshareDataKeyResult: KeychainReadResult<Data> = .absent
-
     /// The answer ``getWrappedKeyshareDataKey()`` gives, likewise.
     var wrappedKeyshareDataKeyResult: KeychainReadResult<Data> = .absent
 
@@ -35,19 +32,12 @@ final class MockKeychainService: KeychainService {
     private var fastHints: [String: KeychainReadResult<String>] = [:]
     private var deviceTokenResult: KeychainReadResult<String> = .absent
 
-    /// When set, `setKeyshareDataKey` accepts the write but stores nothing, so
-    /// the read-back verification in `DefaultKeyshareKeyStore` can be exercised.
-    var dropsKeyshareDataKeyWrites = false
-
-    /// Same, for the wrapped copy: the write is accepted and nothing is stored,
-    /// so the read-back verification that guards `setPasscode` can be driven.
+    /// When set, the write is accepted and nothing is stored, so the read-back
+    /// verification that guards `setPasscode` can be driven.
     var dropsWrappedKeyshareDataKeyWrites = false
 
-    /// When set, deletion of the clear data key silently does nothing, so the
-    /// verified-deletion path can be exercised.
-    var ignoresKeyshareDataKeyDeletion = false
-
-    /// Same, for the wrapped copy, so the disable rollback can be exercised.
+    /// When set, deleting the wrapped copy silently does nothing, so the
+    /// verified-deletion path and the disable rollback can be exercised.
     var ignoresWrappedKeyshareDataKeyDeletion = false
 
     /// When set, deleting the wrapped copy **succeeds** but leaves the item
@@ -76,12 +66,6 @@ final class MockKeychainService: KeychainService {
     var lastMigratedVersion: Int? {
         get { lastMigratedVersionResult.valueTreatingUnavailableAsAbsent }
         set { lastMigratedVersionResult = Self.result(newValue) }
-    }
-
-    /// The recorded key, for tests that only care about the stored value.
-    var keyshareDataKey: Data? {
-        get { keyshareDataKeyResult.valueTreatingUnavailableAsAbsent }
-        set { keyshareDataKeyResult = Self.result(newValue) }
     }
 
     /// The recorded wrapped key, for tests that only care about the stored value.
@@ -130,15 +114,6 @@ final class MockKeychainService: KeychainService {
     func setDeviceToken(_ token: String?) {
         writes.append("deviceToken")
         deviceTokenResult = Self.result(token)
-    }
-
-    func getKeyshareDataKey() -> KeychainReadResult<Data> { keyshareDataKeyResult }
-
-    func setKeyshareDataKey(_ data: Data?) {
-        writes.append("keyshareDataKey")
-        guard !dropsKeyshareDataKeyWrites else { return }
-        if data == nil && ignoresKeyshareDataKeyDeletion { return }
-        keyshareDataKeyResult = Self.result(data)
     }
 
     func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> { wrappedKeyshareDataKeyResult }

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -49,6 +49,17 @@ final class MockKeychainService: KeychainService {
     /// verified clear in `KeyshareInstallReconciler` can be exercised.
     var ignoresPasscodeAttemptStateDeletion = false
 
+    /// Every mutating call, in order, whether or not it changed anything.
+    ///
+    /// A delete of an item that was never there still reaches `SecItemDelete`,
+    /// so it is a Keychain mutation as far as the acceptance test is concerned:
+    /// a user who never sets a passcode must see none of them at launch. Only a
+    /// counter can assert that — asserting on the stored values cannot tell a
+    /// no-op write apart from no write at all.
+    private(set) var writes: [String] = []
+
+    func resetWrites() { writes = [] }
+
     /// The recorded version, for tests that only care about the stored value.
     var lastMigratedVersion: Int? {
         get { lastMigratedVersionResult.valueTreatingUnavailableAsAbsent }
@@ -82,6 +93,7 @@ final class MockKeychainService: KeychainService {
     }
 
     func setFastPassword(_ fastPassword: String?, pubKeyECDSA: String) {
+        writes.append("fastPassword")
         fastPasswords[pubKeyECDSA] = Self.result(fastPassword)
     }
 
@@ -90,20 +102,28 @@ final class MockKeychainService: KeychainService {
     }
 
     func setFastHint(_ fastHint: String?, pubKeyECDSA: String) {
+        writes.append("fastHint")
         fastHints[pubKeyECDSA] = Self.result(fastHint)
     }
 
     func getLastMigratedVersion() -> KeychainReadResult<Int> { lastMigratedVersionResult }
 
-    func setLastMigratedVersion(_ version: Int?) { lastMigratedVersionResult = Self.result(version) }
+    func setLastMigratedVersion(_ version: Int?) {
+        writes.append("lastMigratedVersion")
+        lastMigratedVersionResult = Self.result(version)
+    }
 
     func getDeviceToken() -> KeychainReadResult<String> { deviceTokenResult }
 
-    func setDeviceToken(_ token: String?) { deviceTokenResult = Self.result(token) }
+    func setDeviceToken(_ token: String?) {
+        writes.append("deviceToken")
+        deviceTokenResult = Self.result(token)
+    }
 
     func getKeyshareDataKey() -> KeychainReadResult<Data> { keyshareDataKeyResult }
 
     func setKeyshareDataKey(_ data: Data?) {
+        writes.append("keyshareDataKey")
         guard !dropsKeyshareDataKeyWrites else { return }
         if data == nil && ignoresKeyshareDataKeyDeletion { return }
         keyshareDataKeyResult = Self.result(data)
@@ -112,6 +132,7 @@ final class MockKeychainService: KeychainService {
     func getWrappedKeyshareDataKey() -> KeychainReadResult<Data> { wrappedKeyshareDataKeyResult }
 
     func setWrappedKeyshareDataKey(_ data: Data?) {
+        writes.append("wrappedKeyshareDataKey")
         if data == nil && ignoresWrappedKeyshareDataKeyDeletion { return }
         wrappedKeyshareDataKeyResult = Self.result(data)
     }
@@ -119,6 +140,7 @@ final class MockKeychainService: KeychainService {
     func getPasscodeAttemptState() -> KeychainReadResult<Data> { passcodeAttemptStateResult }
 
     func setPasscodeAttemptState(_ data: Data?) {
+        writes.append("passcodeAttemptState")
         if data == nil && ignoresPasscodeAttemptStateDeletion { return }
         passcodeAttemptStateResult = Self.result(data)
     }

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import Security
 @testable import VultisigApp
 
 /// In-memory `KeychainService` so migration-ordering behaviour can be driven
@@ -38,12 +39,23 @@ final class MockKeychainService: KeychainService {
     /// the read-back verification in `DefaultKeyshareKeyStore` can be exercised.
     var dropsKeyshareDataKeyWrites = false
 
+    /// Same, for the wrapped copy: the write is accepted and nothing is stored,
+    /// so the read-back verification that guards `setPasscode` can be driven.
+    var dropsWrappedKeyshareDataKeyWrites = false
+
     /// When set, deletion of the clear data key silently does nothing, so the
     /// verified-deletion path can be exercised.
     var ignoresKeyshareDataKeyDeletion = false
 
     /// Same, for the wrapped copy, so the disable rollback can be exercised.
     var ignoresWrappedKeyshareDataKeyDeletion = false
+
+    /// When set, deleting the wrapped copy **succeeds** but leaves the item
+    /// unreadable. `deleteWrappedDataKey` verifies against a *confirmed*
+    /// absence, so it reports `deletionFailed` over a deletion that in fact
+    /// happened — the case a rollback must not read as "the wrapper is still
+    /// there".
+    var wrappedKeyshareDataKeyBecomesUnreadableOnDeletion = false
 
     /// When set, clearing the attempt state silently does nothing, so the
     /// verified clear in `KeyshareInstallReconciler` can be exercised.
@@ -133,7 +145,12 @@ final class MockKeychainService: KeychainService {
 
     func setWrappedKeyshareDataKey(_ data: Data?) {
         writes.append("wrappedKeyshareDataKey")
+        if data != nil && dropsWrappedKeyshareDataKeyWrites { return }
         if data == nil && ignoresWrappedKeyshareDataKeyDeletion { return }
+        if data == nil && wrappedKeyshareDataKeyBecomesUnreadableOnDeletion {
+            wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+            return
+        }
         wrappedKeyshareDataKeyResult = Self.result(data)
     }
 

--- a/VultisigApp/VultisigAppTests/Security/BackupImportProtectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/BackupImportProtectionTests.swift
@@ -1,0 +1,140 @@
+//
+//  BackupImportProtectionTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import SwiftData
+import XCTest
+@testable import VultisigApp
+
+/// Routing, end to end through `EncryptedBackupViewModel`.
+///
+/// `ProtectedVaultImporterTests` pins what the importer does; these pin that the
+/// import *paths* actually reach it. That distinction is the whole bug: the
+/// importer's rules were already true of the protobuf path, and the JSON paths
+/// simply never went near it.
+@MainActor
+final class BackupImportProtectionTests: XCTestCase {
+
+    private var token: TestContextToken!
+    private var context: ModelContext!
+    private var key: SymmetricKey!
+
+    private let share = "eyJrZXlzaGFyZSI6ImRrbHMifQ=="
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        token = try TestStore.installInMemoryContainer()
+        context = token.container.mainContext
+        key = SymmetricKey(size: .bits256)
+    }
+
+    override func tearDown() {
+        key = nil
+        context = nil
+        TestStore.restore(token)
+        token = nil
+        super.tearDown()
+    }
+
+    /// The bug this closes, through the real code path: a `BackupVault` JSON
+    /// import used to store its shares exactly as decoded, so with a passcode
+    /// set the store ended up holding plaintext behind a lock screen.
+    func testALegacyJsonImportIsSealedWhenAPasscodeIsSet() throws {
+        let sut = makeViewModel(state: .unlocked(key))
+        sut.decryptedContent = try backupVaultJSONHex()
+
+        sut.restoreVault(modelContext: context, vaults: [])
+
+        XCTAssertTrue(sut.isVaultImported)
+        let protector = KeyshareProtector(state: { [key] in .unlocked(key!) })
+        let stored = try XCTUnwrap(try storedShares().first)
+        XCTAssertTrue(protector.isSealed(stored), "a JSON import must not put plaintext behind a passcode")
+        XCTAssertEqual(try protector.open(stored), share)
+    }
+
+    /// The acceptance test on the same path: with no passcode the stored bytes
+    /// are exactly what the backup carried.
+    func testTheSameImportStaysByteIdenticalWithNoPasscodeSet() throws {
+        let sut = makeViewModel(state: .disabled)
+        sut.decryptedContent = try backupVaultJSONHex()
+
+        sut.restoreVault(modelContext: context, vaults: [])
+
+        XCTAssertTrue(sut.isVaultImported)
+        XCTAssertEqual(try storedShares(), [share])
+    }
+
+    /// The bare-`Vault` fallback is a separate decode with its own store, and it
+    /// used to have its own copy of the bypass.
+    func testTheOldFormatFallbackIsAlsoProtected() throws {
+        let sut = makeViewModel(state: .unlocked(key))
+        sut.decryptedContent = try JSONEncoder().encode(makeVault()).hexString
+
+        sut.restoreVault(modelContext: context, vaults: [])
+
+        XCTAssertTrue(sut.isVaultImported)
+        let protector = KeyshareProtector(state: { [key] in .unlocked(key!) })
+        XCTAssertTrue(protector.isSealed(try XCTUnwrap(try storedShares().first)))
+    }
+
+    /// A backup carrying a share this device cannot open is refused rather than
+    /// stored, and the user is told the import failed.
+    func testAnImportCarryingAnUnopenableShareIsRefused() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(share, with: SymmetricKey(size: .bits256))
+        let sut = makeViewModel(state: .unlocked(key))
+        sut.decryptedContent = try backupVaultJSONHex(shareValue: foreign)
+
+        sut.restoreVault(modelContext: context, vaults: [])
+
+        XCTAssertFalse(sut.isVaultImported)
+        XCTAssertEqual(sut.alertTitle, "vaultRestoreFailed")
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Vault>()), 0)
+    }
+
+    /// And nothing of the import survives the refusal — including the default
+    /// coins, which insert rows of their own.
+    func testARefusedImportLeavesNothingInTheStore() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(share, with: SymmetricKey(size: .bits256))
+        let sut = makeViewModel(state: .unlocked(key))
+        sut.decryptedContent = try backupVaultJSONHex(shareValue: foreign)
+
+        sut.restoreVault(modelContext: context, vaults: [])
+
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Coin>()), 0, "default coins must not outlive a refused import")
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(state: KeyshareProtectionState) -> EncryptedBackupViewModel {
+        EncryptedBackupViewModel(
+            importer: ProtectedVaultImporter(
+                protector: KeyshareProtector(state: { state }),
+                coordinator: KeyshareWriteCoordinator()
+            )
+        )
+    }
+
+    private func makeVault(shareValue: String? = nil) -> Vault {
+        Vault(
+            name: "Imported",
+            signers: ["a", "b"],
+            pubKeyECDSA: "ecdsa-imported",
+            pubKeyEdDSA: "eddsa-imported",
+            keyshares: [KeyShare(pubkey: "ecdsa-imported", keyshare: shareValue ?? share)],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+    }
+
+    private func backupVaultJSONHex(shareValue: String? = nil) throws -> String {
+        try JSONEncoder().encode(BackupVault(version: .v1, vault: makeVault(shareValue: shareValue))).hexString
+    }
+
+    private func storedShares() throws -> [String] {
+        try context.fetch(FetchDescriptor<Vault>()).flatMap(\.keyshares).map(\.keyshare)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
@@ -119,18 +119,45 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         XCTAssertEqual(keychain.writes, [])
     }
 
-    /// The other half of the same rule: skipping the clear is only allowed on a
-    /// *confirmed* absence. Skipping on a read failure would also set the marker,
-    /// so the inherited passcode would survive forever.
-    func testAnUnreadableKeychainIsNotMistakenForNothingToClear() {
+    /// The other half of the same rule, and the reason an unreadable Keychain is
+    /// a *deferral* rather than either answer. Skipping the clear would set the
+    /// marker, so the inherited passcode would survive forever; running it would
+    /// issue deletes on a first-ever install whose Keychain merely stuttered,
+    /// which is the launch-time mutation the acceptance test forbids. Neither is
+    /// acceptable, so nothing is written and the next launch decides with an
+    /// answer.
+    func testAnUnreadableKeychainDefersTheClearWithoutWritingAnything() {
         keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
 
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertTrue(
-            keychain.writes.contains("wrappedKeyshareDataKey"),
-            "an item that could not be read may well be there, so the clear must still run"
-        )
+        XCTAssertEqual(keychain.writes, [], "an unreadable Keychain must not be answered with writes")
+
+        // A deferral, not a decision: once the item can be read, the clear runs.
+        keychain.wrappedKeyshareDataKeyResult = .present(wrappedBlob)
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
+    }
+
+    /// A store that cannot be read is not an occupied one. Treating it as
+    /// occupied wrote the marker, and the marker is permanent — so a genuinely
+    /// new container whose store happened to be unreadable at launch would keep
+    /// the previous install's wrapped key for good: a passcode gate that cannot
+    /// be opened and cannot be reinstalled away, which is the exact failure this
+    /// type exists to prevent.
+    func testAnUnreadableStoreDefersReconciliationRatherThanRetiringIt() throws {
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+        keychain.resetWrites()
+
+        sut.reconcile(occupancy: .unknown)
+
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .present(wrappedBlob), "nothing is decided yet")
+        XCTAssertEqual(keychain.writes, [])
+
+        sut.reconcile(occupancy: .empty)
+
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent, "the deferred launch must still clear")
     }
 
     /// The marker is the only evidence a container has been seen before, and it

--- a/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
@@ -1,0 +1,210 @@
+//
+//  KeyshareInstallReconcilerTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import XCTest
+@testable import VultisigApp
+
+/// The Keychain outlives the app while `UserDefaults` does not, so a reinstall
+/// inherits key material the container knows nothing about. These pin both
+/// directions of that: the inherited state is cleared when the container is new,
+/// and it is never touched when anything could still depend on it.
+final class KeyshareInstallReconcilerTests: XCTestCase {
+
+    private var keychain: MockKeychainService!
+    private var keyStore: DefaultKeyshareKeyStore!
+    private var lockService: AppLockService!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var sut: KeyshareInstallReconciler!
+
+    private let wrappedBlob = Data(repeating: 7, count: 60)
+    private let attemptState = Data(repeating: 3, count: 16)
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        suiteName = "KeyshareInstallReconcilerTests.\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+
+        keychain = MockKeychainService()
+        keyStore = DefaultKeyshareKeyStore(keychain: keychain)
+        lockService = AppLockService(defaults: defaults)
+
+        sut = KeyshareInstallReconciler(
+            keychain: keychain,
+            keyStore: keyStore,
+            lockService: lockService,
+            defaults: defaults
+        )
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        sut = nil
+        lockService = nil
+        keyStore = nil
+        keychain = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - A new container
+
+    /// The reported failure: passcode set, app deleted, app reinstalled. The
+    /// wrapped key survives while the lock mode does not, so the passcode screen
+    /// is never shown and nothing can ever be sealed again.
+    func testANewContainerClearsAPasscodeInheritedFromAPreviousInstall() throws {
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+        keychain.setPasscodeAttemptState(attemptState)
+        keychain.setLastMigratedVersion(4)
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertNil(keyStore.loadWrappedDataKey(), "The inherited passcode must not survive a new container")
+        XCTAssertNil(keyStore.loadDataKey())
+        XCTAssertEqual(keychain.getPasscodeAttemptState(), .absent, "A new install must not start inside a lockout")
+        XCTAssertEqual(
+            keychain.getLastMigratedVersion(),
+            .present(4),
+            "Ordinary migrations are none of this type's business and must not be made to re-run"
+        )
+    }
+
+    func testANewContainerClearsAnInheritedClearDataKey() throws {
+        try keyStore.storeDataKey(SymmetricKey(size: .bits256))
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertNil(keyStore.loadDataKey())
+    }
+
+    /// The acceptance test in one assertion: someone who never set a passcode
+    /// must see no launch-time Keychain write they would not have seen before
+    /// this feature existed, and re-running every ordinary migration on a fresh
+    /// container is exactly such a write.
+    func testANewContainerLeavesTheMigrationVersionAlone() throws {
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+        keychain.setLastMigratedVersion(4)
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertNil(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(keychain.getLastMigratedVersion(), .present(4))
+    }
+
+    func testAFirstEverInstallHasNothingToClear() {
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertNil(keyStore.loadDataKey())
+        XCTAssertNil(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(lockService.mode, .deviceAuth)
+    }
+
+    /// The marker is the only evidence a container has been seen before, and it
+    /// is written only when the clear reports success. A clear that reported
+    /// failure without failing would leave the marker unset and repeat the
+    /// destructive path on every single launch afterwards — so a passcode set
+    /// after the first launch would be silently removed on the second.
+    func testASuccessfulClearMarksTheContainerSoItIsNeverClearedAgain() throws {
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+
+        sut.reconcile(isStoreEmpty: true)
+        XCTAssertNil(keyStore.loadWrappedDataKey())
+
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertEqual(
+            keyStore.loadWrappedDataKey(),
+            wrappedBlob,
+            "the container was reconciled on the previous launch and must not be purged again"
+        )
+    }
+
+    // MARK: - Containers that must never be purged
+
+    /// The one that would cost funds. Every existing user reaches the marker
+    /// check for the first time on the launch that introduces it, with a full
+    /// store — clearing their key would orphan every sealed share.
+    func testAStoreWithVaultsIsNeverPurged() throws {
+        try keyStore.storeDataKey(SymmetricKey(size: .bits256))
+        let storedKey = keychain.getKeyshareDataKey()
+        keychain.setLastMigratedVersion(4)
+
+        sut.reconcile(isStoreEmpty: false)
+
+        XCTAssertEqual(keychain.getKeyshareDataKey(), storedKey, "The key every sealed share depends on must survive")
+        XCTAssertEqual(keychain.getLastMigratedVersion(), .present(4), "An upgrading user must not re-run every migration")
+    }
+
+    /// Deleting every vault is not the same as reinstalling. Without the marker
+    /// this would silently remove a passcode the user still expects to have.
+    func testDeletingEveryVaultDoesNotRemoveThePasscode() throws {
+        // A launch with vaults present marks the container as known.
+        sut.reconcile(isStoreEmpty: false)
+
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), wrappedBlob)
+    }
+
+    // MARK: - Lock mode invariant
+
+    func testAWrappedKeyWithoutAClearOneRestoresPasscodeMode() throws {
+        sut.reconcile(isStoreEmpty: false)
+        lockService.mode = .deviceAuth
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+
+        sut.reconcile(isStoreEmpty: false)
+
+        XCTAssertEqual(lockService.mode, .passcode, "Key material must never be locked with no way to ask for it")
+    }
+
+    func testAClearDataKeyLeavesTheLockModeAlone() throws {
+        lockService.mode = .deviceAuth
+        try keyStore.storeDataKey(SymmetricKey(size: .bits256))
+
+        sut.reconcile(isStoreEmpty: false)
+
+        XCTAssertEqual(lockService.mode, .deviceAuth)
+    }
+
+    // MARK: - Failure
+
+    /// A clear that silently did not happen is the failure shape this whole
+    /// feature keeps producing. It must leave the container unmarked so the next
+    /// launch tries again, and must still put a lock screen in front of the key
+    /// that survived.
+    func testAFailedClearIsRetriedOnTheNextLaunch() throws {
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+        keychain.ignoresWrappedKeyshareDataKeyDeletion = true
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), wrappedBlob)
+        XCTAssertEqual(lockService.mode, .passcode, "The surviving key needs a door while the clear is retried")
+
+        keychain.ignoresWrappedKeyshareDataKeyDeletion = false
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertNil(keyStore.loadWrappedDataKey())
+    }
+
+    func testAFailedAttemptStateClearIsRetried() throws {
+        keychain.setPasscodeAttemptState(attemptState)
+        keychain.ignoresPasscodeAttemptStateDeletion = true
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertEqual(keychain.getPasscodeAttemptState(), .present(attemptState))
+
+        keychain.ignoresPasscodeAttemptStateDeletion = false
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertEqual(keychain.getPasscodeAttemptState(), .absent)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
@@ -4,6 +4,7 @@
 //
 
 import CryptoKit
+import Security
 import XCTest
 @testable import VultisigApp
 
@@ -63,8 +64,8 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
 
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertNil(keyStore.loadWrappedDataKey(), "The inherited passcode must not survive a new container")
-        XCTAssertNil(keyStore.loadDataKey())
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent, "The inherited passcode must not survive a new container")
+        XCTAssertAbsent(keyStore.loadDataKey())
         XCTAssertEqual(keychain.getPasscodeAttemptState(), .absent, "A new install must not start inside a lockout")
         XCTAssertEqual(
             keychain.getLastMigratedVersion(),
@@ -78,7 +79,7 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
 
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertNil(keyStore.loadDataKey())
+        XCTAssertAbsent(keyStore.loadDataKey())
     }
 
     /// The acceptance test in one assertion: someone who never set a passcode
@@ -91,16 +92,41 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
 
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertNil(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
         XCTAssertEqual(keychain.getLastMigratedVersion(), .present(4))
     }
 
     func testAFirstEverInstallHasNothingToClear() {
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertNil(keyStore.loadDataKey())
-        XCTAssertNil(keyStore.loadWrappedDataKey())
+        XCTAssertAbsent(keyStore.loadDataKey())
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
         XCTAssertEqual(lockService.mode, .deviceAuth)
+    }
+
+    /// The acceptance test, asserted rather than argued: someone who never sets
+    /// a passcode must see **no** launch-time Keychain mutation. Clearing an
+    /// artifact that was never there still issues three `SecItemDelete` calls
+    /// and three read-backs, and no assertion on stored values can tell that
+    /// apart from doing nothing — hence the write log.
+    func testAFirstEverInstallWritesNothingToTheKeychain() {
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertEqual(keychain.writes, [])
+    }
+
+    /// The other half of the same rule: skipping the clear is only allowed on a
+    /// *confirmed* absence. Skipping on a read failure would also set the marker,
+    /// so the inherited passcode would survive forever.
+    func testAnUnreadableKeychainIsNotMistakenForNothingToClear() {
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertTrue(
+            keychain.writes.contains("wrappedKeyshareDataKey"),
+            "an item that could not be read may well be there, so the clear must still run"
+        )
     }
 
     /// The marker is the only evidence a container has been seen before, and it
@@ -112,14 +138,14 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         try keyStore.storeWrappedDataKey(wrappedBlob)
 
         sut.reconcile(isStoreEmpty: true)
-        XCTAssertNil(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
 
         try keyStore.storeWrappedDataKey(wrappedBlob)
         sut.reconcile(isStoreEmpty: true)
 
         XCTAssertEqual(
             keyStore.loadWrappedDataKey(),
-            wrappedBlob,
+            .present(wrappedBlob),
             "the container was reconciled on the previous launch and must not be purged again"
         )
     }
@@ -149,7 +175,7 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         try keyStore.storeWrappedDataKey(wrappedBlob)
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertEqual(keyStore.loadWrappedDataKey(), wrappedBlob)
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .present(wrappedBlob))
     }
 
     // MARK: - Lock mode invariant
@@ -173,6 +199,31 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         XCTAssertEqual(lockService.mode, .deviceAuth)
     }
 
+    /// Fail closed, but in the direction that keeps the app usable: a gate with
+    /// no wrapper behind it has nothing for `unlock` to verify against, so it
+    /// could never be opened.
+    func testAnUnreadableWrappedKeyDoesNotManufactureAPasscodeGate() {
+        lockService.mode = .deviceAuth
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        sut.reconcile(isStoreEmpty: false)
+
+        XCTAssertEqual(lockService.mode, .deviceAuth)
+    }
+
+    /// And the opposite direction on the other read: an unreadable clear key is
+    /// not a reason to leave key material with no door in front of it.
+    func testAnUnreadableClearKeyDoesNotSuppressTheLockScreen() throws {
+        sut.reconcile(isStoreEmpty: false)
+        lockService.mode = .deviceAuth
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+        keychain.keyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        sut.reconcile(isStoreEmpty: false)
+
+        XCTAssertEqual(lockService.mode, .passcode)
+    }
+
     // MARK: - Failure
 
     /// A clear that silently did not happen is the failure shape this whole
@@ -185,13 +236,13 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
 
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertEqual(keyStore.loadWrappedDataKey(), wrappedBlob)
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .present(wrappedBlob))
         XCTAssertEqual(lockService.mode, .passcode, "The surviving key needs a door while the clear is retried")
 
         keychain.ignoresWrappedKeyshareDataKeyDeletion = false
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertNil(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
     }
 
     func testAFailedAttemptStateClearIsRetried() throws {

--- a/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
@@ -3,7 +3,6 @@
 //  VultisigAppTests
 //
 
-import CryptoKit
 import Security
 import XCTest
 @testable import VultisigApp
@@ -17,6 +16,7 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
     private var keychain: MockKeychainService!
     private var keyStore: DefaultKeyshareKeyStore!
     private var lockService: AppLockService!
+    private var coordinator: KeyshareWriteCoordinator!
     private var defaults: UserDefaults!
     private var suiteName: String!
     private var sut: KeyshareInstallReconciler!
@@ -33,10 +33,12 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         keyStore = DefaultKeyshareKeyStore(keychain: keychain)
         lockService = AppLockService(defaults: defaults)
 
+        coordinator = KeyshareWriteCoordinator()
         sut = KeyshareInstallReconciler(
             keychain: keychain,
             keyStore: keyStore,
             lockService: lockService,
+            coordinator: coordinator,
             defaults: defaults
         )
     }
@@ -44,6 +46,7 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
     override func tearDown() {
         defaults.removePersistentDomain(forName: suiteName)
         sut = nil
+        coordinator = nil
         lockService = nil
         keyStore = nil
         keychain = nil
@@ -65,7 +68,6 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         sut.reconcile(isStoreEmpty: true)
 
         XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent, "The inherited passcode must not survive a new container")
-        XCTAssertAbsent(keyStore.loadDataKey())
         XCTAssertEqual(keychain.getPasscodeAttemptState(), .absent, "A new install must not start inside a lockout")
         XCTAssertEqual(
             keychain.getLastMigratedVersion(),
@@ -74,12 +76,15 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         )
     }
 
-    func testANewContainerClearsAnInheritedClearDataKey() throws {
-        try keyStore.storeDataKey(SymmetricKey(size: .bits256))
+    /// The attempt counter is inherited on its own when the previous install
+    /// was mid-lockout, and keeping it would start a new install inside a
+    /// throttle guarding a passcode that no longer exists.
+    func testANewContainerClearsAnInheritedAttemptCounter() {
+        keychain.setPasscodeAttemptState(attemptState)
 
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertAbsent(keyStore.loadDataKey())
+        XCTAssertEqual(keychain.getPasscodeAttemptState(), .absent)
     }
 
     /// The acceptance test in one assertion: someone who never set a passcode
@@ -99,16 +104,15 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
     func testAFirstEverInstallHasNothingToClear() {
         sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertAbsent(keyStore.loadDataKey())
         XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
         XCTAssertEqual(lockService.mode, .deviceAuth)
     }
 
     /// The acceptance test, asserted rather than argued: someone who never sets
     /// a passcode must see **no** launch-time Keychain mutation. Clearing an
-    /// artifact that was never there still issues three `SecItemDelete` calls
-    /// and three read-backs, and no assertion on stored values can tell that
-    /// apart from doing nothing — hence the write log.
+    /// artifact that was never there still issues a `SecItemDelete` and its
+    /// read-back per item, and no assertion on stored values can tell that apart
+    /// from doing nothing — hence the write log.
     func testAFirstEverInstallWritesNothingToTheKeychain() {
         sut.reconcile(isStoreEmpty: true)
 
@@ -156,13 +160,16 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
     /// check for the first time on the launch that introduces it, with a full
     /// store — clearing their key would orphan every sealed share.
     func testAStoreWithVaultsIsNeverPurged() throws {
-        try keyStore.storeDataKey(SymmetricKey(size: .bits256))
-        let storedKey = keychain.getKeyshareDataKey()
+        try keyStore.storeWrappedDataKey(wrappedBlob)
         keychain.setLastMigratedVersion(4)
 
         sut.reconcile(isStoreEmpty: false)
 
-        XCTAssertEqual(keychain.getKeyshareDataKey(), storedKey, "The key every sealed share depends on must survive")
+        XCTAssertEqual(
+            keyStore.loadWrappedDataKey(),
+            .present(wrappedBlob),
+            "The key every sealed share depends on must survive"
+        )
         XCTAssertEqual(keychain.getLastMigratedVersion(), .present(4), "An upgrading user must not re-run every migration")
     }
 
@@ -180,7 +187,7 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
 
     // MARK: - Lock mode invariant
 
-    func testAWrappedKeyWithoutAClearOneRestoresPasscodeMode() throws {
+    func testAWrappedKeyRestoresPasscodeMode() throws {
         sut.reconcile(isStoreEmpty: false)
         lockService.mode = .deviceAuth
         try keyStore.storeWrappedDataKey(wrappedBlob)
@@ -190,13 +197,27 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         XCTAssertEqual(lockService.mode, .passcode, "Key material must never be locked with no way to ask for it")
     }
 
-    func testAClearDataKeyLeavesTheLockModeAlone() throws {
-        lockService.mode = .deviceAuth
-        try keyStore.storeDataKey(SymmetricKey(size: .bits256))
+    /// The inverse, and the half that keeps a user from being locked out. A
+    /// passcode mode with no wrapper behind it is a gate `unlock` can never
+    /// satisfy — there is nothing to verify a passcode against — so a confirmed
+    /// absence takes it back down.
+    func testAPasscodeModeWithNoWrappedKeyFallsBackToDeviceAuth() {
+        lockService.mode = .passcode
 
         sut.reconcile(isStoreEmpty: false)
 
         XCTAssertEqual(lockService.mode, .deviceAuth)
+    }
+
+    /// Only a *confirmed* absence, though: taking an unreadable Keychain for an
+    /// empty one would remove a real passcode from in front of real key material.
+    func testAnUnreadableWrappedKeyDoesNotTakeThePasscodeGateDown() {
+        lockService.mode = .passcode
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        sut.reconcile(isStoreEmpty: false)
+
+        XCTAssertEqual(lockService.mode, .passcode)
     }
 
     /// Fail closed, but in the direction that keeps the app usable: a gate with
@@ -211,17 +232,42 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         XCTAssertEqual(lockService.mode, .deviceAuth)
     }
 
-    /// And the opposite direction on the other read: an unreadable clear key is
-    /// not a reason to leave key material with no door in front of it.
-    func testAnUnreadableClearKeyDoesNotSuppressTheLockScreen() throws {
-        sut.reconcile(isStoreEmpty: false)
-        lockService.mode = .deviceAuth
+    // MARK: - Serialization
+
+    /// Launch reconciliation deletes and re-decides exactly the state a passcode
+    /// set or removal is moving, so it has to be indivisible against one.
+    /// Without the lease, a launch landing between `setPasscode` making its
+    /// wrapper durable and adopting the key would delete that wrapper and mark
+    /// the container done — leaving the key live in memory with nothing on disk
+    /// that wraps it, and every share sealed afterwards unreadable.
+    func testReconciliationIsSkippedWhileAPasscodeTransitionIsHeld() throws {
         try keyStore.storeWrappedDataKey(wrappedBlob)
-        keychain.keyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+        lockService.mode = .deviceAuth
+        keychain.resetWrites()
+        let lease = try coordinator.beginTransition()
+        defer { coordinator.end(lease) }
 
-        sut.reconcile(isStoreEmpty: false)
+        sut.reconcile(isStoreEmpty: true)
 
-        XCTAssertEqual(lockService.mode, .passcode)
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .present(wrappedBlob), "a wrapper mid-transition must survive")
+        XCTAssertEqual(keychain.writes, [])
+        XCTAssertEqual(lockService.mode, .deviceAuth, "the mode must not be decided from a snapshot a transition is changing")
+    }
+
+    /// And the skip leaves the container unmarked, so the next launch reconciles
+    /// it properly rather than treating the skip as done.
+    func testASkippedReconciliationIsRetriedOnTheNextLaunch() throws {
+        try keyStore.storeWrappedDataKey(wrappedBlob)
+        let lease = try coordinator.beginTransition()
+        sut.reconcile(isStoreEmpty: true)
+        // Without the lease the wrapper would already be gone here, and the
+        // assertion below would pass over a reconciliation that never skipped.
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .present(wrappedBlob))
+        coordinator.end(lease)
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
     }
 
     // MARK: - Failure

--- a/VultisigApp/VultisigAppTests/Security/KeyshareKeySessionTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareKeySessionTests.swift
@@ -4,6 +4,7 @@
 //
 
 import CryptoKit
+import Security
 import XCTest
 @testable import VultisigApp
 
@@ -50,8 +51,19 @@ final class KeyshareKeySessionTests: XCTestCase {
         _ = sut.currentState()
         _ = sut.currentState()
 
-        XCTAssertEqual(keychain.getKeyshareDataKey(), .absent)
-        XCTAssertEqual(keychain.getWrappedKeyshareDataKey(), .absent)
+        XCTAssertEqual(keychain.writes, [], "an install with no passcode must see no Keychain mutation at all")
+    }
+
+    /// The whole of the persisted state is whether a wrapped key exists, so an
+    /// unreadable Keychain must not be read as "no passcode". `.disabled` is a
+    /// licence to write plaintext, and the next `seal` would take it.
+    func testAnUnreadableKeychainReportsLockedRatherThanDisabled() {
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+        let sut = makeSession()
+
+        guard case .locked = sut.currentState() else {
+            return XCTFail("Expected .locked when the Keychain cannot be read")
+        }
     }
 
     // MARK: - Wrapped key present
@@ -90,24 +102,36 @@ final class KeyshareKeySessionTests: XCTestCase {
         XCTAssertFalse(sut.currentState().isLocked)
     }
 
-    /// The unwrapped item is legacy — nothing writes one — but while the API
-    /// exists an install holding one must be reported as unlocked rather than as
-    /// unprotected, or its sealed shares would look like plaintext.
-    func testAnUnwrappedKeyIsStillRecognisedAndCached() throws {
-        let key = try store.generateDataKey()
-        try store.storeDataKey(key)
+    /// The unwrapped item no longer participates in the state at all: a share is
+    /// sealed if and only if a passcode is set, and the wrapped key is the only
+    /// evidence of a passcode. Pinned rather than left implicit, because it is
+    /// the visible consequence of collapsing the state read — a store holding a
+    /// clear key and nothing else reads as having no passcode.
+    func testAnUnwrappedKeyAloneIsNotAPasscode() throws {
+        try store.storeDataKey(try store.generateDataKey())
         let sut = makeSession()
 
+        guard case .disabled = sut.currentState() else {
+            return XCTFail("Expected .disabled — only a wrapped key means a passcode is set")
+        }
+    }
+
+    /// The key is held in memory once adopted, so the read path does not pay a
+    /// Keychain round trip per share inside TSS keygen and keysign.
+    func testAnAdoptedKeyIsCachedRatherThanRereadPerCall() throws {
+        let key = try store.generateDataKey()
+        let sut = makeSession()
+        sut.adopt(key)
+
+        keychain.resetWrites()
+        _ = sut.currentState()
+        _ = sut.currentState()
+
         guard case .unlocked(let held) = sut.currentState() else {
-            return XCTFail("Expected .unlocked from an unwrapped key")
+            return XCTFail("Expected the adopted key to stay in memory")
         }
         XCTAssertEqual(held.testRawRepresentation, key.testRawRepresentation)
-
-        // Cached, so the read path does not pay a Keychain round trip per share.
-        keychain.setKeyshareDataKey(nil)
-        guard case .unlocked = sut.currentState() else {
-            return XCTFail("Expected the key to be held in memory after the first read")
-        }
+        XCTAssertEqual(keychain.writes, [])
     }
 
     // MARK: - Clearing

--- a/VultisigApp/VultisigAppTests/Security/KeyshareKeySessionTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareKeySessionTests.swift
@@ -102,20 +102,6 @@ final class KeyshareKeySessionTests: XCTestCase {
         XCTAssertFalse(sut.currentState().isLocked)
     }
 
-    /// The unwrapped item no longer participates in the state at all: a share is
-    /// sealed if and only if a passcode is set, and the wrapped key is the only
-    /// evidence of a passcode. Pinned rather than left implicit, because it is
-    /// the visible consequence of collapsing the state read — a store holding a
-    /// clear key and nothing else reads as having no passcode.
-    func testAnUnwrappedKeyAloneIsNotAPasscode() throws {
-        try store.storeDataKey(try store.generateDataKey())
-        let sut = makeSession()
-
-        guard case .disabled = sut.currentState() else {
-            return XCTFail("Expected .disabled — only a wrapped key means a passcode is set")
-        }
-    }
-
     /// The key is held in memory once adopted, so the read path does not pay a
     /// Keychain round trip per share inside TSS keygen and keysign.
     func testAnAdoptedKeyIsCachedRatherThanRereadPerCall() throws {

--- a/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
@@ -49,7 +49,7 @@ final class KeyshareKeyStoreTests: XCTestCase {
     func testDeleteDataKeyRemovesIt() throws {
         try sut.storeDataKey(try sut.generateDataKey())
 
-        sut.deleteDataKey()
+        try sut.deleteDataKey()
 
         XCTAssertNil(sut.loadDataKey())
     }
@@ -85,7 +85,7 @@ final class KeyshareKeyStoreTests: XCTestCase {
     func testDeleteWrappedDataKeyRemovesIt() throws {
         try sut.storeWrappedDataKey(Data(repeating: 0x07, count: 64))
 
-        sut.deleteWrappedDataKey()
+        try sut.deleteWrappedDataKey()
 
         XCTAssertNil(sut.loadWrappedDataKey())
     }

--- a/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
@@ -35,61 +35,15 @@ final class KeyshareKeyStoreTests: XCTestCase {
         XCTAssertNotEqual(first.testRawRepresentation, second.testRawRepresentation)
     }
 
-    func testStoreAndLoadDataKeyRoundTrip() throws {
-        let key = try sut.generateDataKey()
+    /// A generated key exists in memory and nowhere else. There is no unwrapped
+    /// resting place for it, so nothing on the device changes until the wrapped
+    /// form is written — which is what makes an abandoned `setPasscode` leave no
+    /// trace.
+    func testGeneratingADataKeyWritesNothing() throws {
+        _ = try sut.generateDataKey()
 
-        try sut.storeDataKey(key)
-
-        XCTAssertEqual(try XCTUnwrapPresent(sut.loadDataKey()).testRawRepresentation, key.testRawRepresentation)
-    }
-
-    func testLoadDataKeyReportsAbsentWhenThereIsNoItem() {
-        XCTAssertAbsent(sut.loadDataKey())
-    }
-
-    func testDeleteDataKeyRemovesIt() throws {
-        try sut.storeDataKey(try sut.generateDataKey())
-
-        try sut.deleteDataKey()
-
-        XCTAssertAbsent(sut.loadDataKey())
-    }
-
-    /// The read-back guard: a Keychain that silently drops the write must not
-    /// leave the caller believing the key is durable, because the next step is
-    /// encrypting key shares against it.
-    func testStoreDataKeyThrowsWhenKeychainDropsTheWrite() throws {
-        keychain.dropsKeyshareDataKeyWrites = true
-        let key = try sut.generateDataKey()
-
-        XCTAssertThrowsError(try sut.storeDataKey(key)) { error in
-            XCTAssertEqual(error as? KeyshareKeyStoreError, .persistenceFailed)
-        }
-    }
-
-    /// Present and unusable is not the same as absent — absence is what licenses
-    /// minting a replacement, and a replacement opens none of the sealed shares.
-    func testLoadDataKeyReportsUnavailableWhenTheStoredBlobIsTheWrongLength() {
-        keychain.setKeyshareDataKey(Data(repeating: 0x01, count: 16))
-
-        XCTAssertUnavailable(sut.loadDataKey())
-    }
-
-    func testLoadDataKeyPropagatesAnUnreadableKeychain() {
-        keychain.keyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
-
-        XCTAssertUnavailable(sut.loadDataKey())
-    }
-
-    /// The clear is recorded as done by its caller, so "probably gone" must not
-    /// pass for gone.
-    func testDeleteDataKeyThrowsWhenTheKeychainCannotConfirmItIsGone() {
-        keychain.ignoresKeyshareDataKeyDeletion = true
-        keychain.keyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
-
-        XCTAssertThrowsError(try sut.deleteDataKey()) { error in
-            XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
-        }
+        XCTAssertEqual(keychain.writes, [])
+        XCTAssertEqual(sut.loadWrappedDataKey(), .absent)
     }
 
     // MARK: - Wrapped data key
@@ -102,6 +56,10 @@ final class KeyshareKeyStoreTests: XCTestCase {
         XCTAssertEqual(sut.loadWrappedDataKey(), .present(blob))
     }
 
+    func testLoadWrappedDataKeyReportsAbsentWhenThereIsNoItem() {
+        XCTAssertEqual(sut.loadWrappedDataKey(), .absent)
+    }
+
     func testDeleteWrappedDataKeyRemovesIt() throws {
         try sut.storeWrappedDataKey(Data(repeating: 0x07, count: 64))
 
@@ -110,12 +68,36 @@ final class KeyshareKeyStoreTests: XCTestCase {
         XCTAssertEqual(sut.loadWrappedDataKey(), .absent)
     }
 
+    /// The read-back guard: a Keychain that silently drops the write must not
+    /// leave the caller believing the wrapper is durable, because the next step
+    /// is sealing every key share against the key it wraps.
+    func testStoreWrappedDataKeyThrowsWhenKeychainDropsTheWrite() {
+        keychain.dropsWrappedKeyshareDataKeyWrites = true
+
+        XCTAssertThrowsError(try sut.storeWrappedDataKey(Data(repeating: 0x07, count: 64))) { error in
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .persistenceFailed)
+        }
+    }
+
+    /// An unreadable read-back is not a successful write either: `.present` with
+    /// the same bytes is the only answer that proves durability.
+    func testStoreWrappedDataKeyThrowsWhenTheReadBackIsUnreadable() {
+        keychain.dropsWrappedKeyshareDataKeyWrites = true
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        XCTAssertThrowsError(try sut.storeWrappedDataKey(Data(repeating: 0x07, count: 64))) { error in
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .persistenceFailed)
+        }
+    }
+
     func testLoadWrappedDataKeyPropagatesAnUnreadableKeychain() {
         keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
 
         XCTAssertEqual(sut.loadWrappedDataKey(), .unavailable(errSecInteractionNotAllowed))
     }
 
+    /// The removal is recorded as done by its caller, so "probably gone" must not
+    /// pass for gone.
     func testDeleteWrappedDataKeyThrowsWhenTheKeychainCannotConfirmItIsGone() {
         keychain.ignoresWrappedKeyshareDataKeyDeletion = true
         keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)

--- a/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareKeyStoreTests.swift
@@ -4,6 +4,7 @@
 //
 
 import CryptoKit
+import Security
 import XCTest
 @testable import VultisigApp
 
@@ -39,11 +40,11 @@ final class KeyshareKeyStoreTests: XCTestCase {
 
         try sut.storeDataKey(key)
 
-        XCTAssertEqual(sut.loadDataKey()?.testRawRepresentation, key.testRawRepresentation)
+        XCTAssertEqual(try XCTUnwrapPresent(sut.loadDataKey()).testRawRepresentation, key.testRawRepresentation)
     }
 
-    func testLoadDataKeyIsNilWhenAbsent() {
-        XCTAssertNil(sut.loadDataKey())
+    func testLoadDataKeyReportsAbsentWhenThereIsNoItem() {
+        XCTAssertAbsent(sut.loadDataKey())
     }
 
     func testDeleteDataKeyRemovesIt() throws {
@@ -51,7 +52,7 @@ final class KeyshareKeyStoreTests: XCTestCase {
 
         try sut.deleteDataKey()
 
-        XCTAssertNil(sut.loadDataKey())
+        XCTAssertAbsent(sut.loadDataKey())
     }
 
     /// The read-back guard: a Keychain that silently drops the write must not
@@ -66,10 +67,29 @@ final class KeyshareKeyStoreTests: XCTestCase {
         }
     }
 
-    func testLoadDataKeyIsNilWhenStoredBlobHasWrongLength() {
+    /// Present and unusable is not the same as absent — absence is what licenses
+    /// minting a replacement, and a replacement opens none of the sealed shares.
+    func testLoadDataKeyReportsUnavailableWhenTheStoredBlobIsTheWrongLength() {
         keychain.setKeyshareDataKey(Data(repeating: 0x01, count: 16))
 
-        XCTAssertNil(sut.loadDataKey())
+        XCTAssertUnavailable(sut.loadDataKey())
+    }
+
+    func testLoadDataKeyPropagatesAnUnreadableKeychain() {
+        keychain.keyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        XCTAssertUnavailable(sut.loadDataKey())
+    }
+
+    /// The clear is recorded as done by its caller, so "probably gone" must not
+    /// pass for gone.
+    func testDeleteDataKeyThrowsWhenTheKeychainCannotConfirmItIsGone() {
+        keychain.ignoresKeyshareDataKeyDeletion = true
+        keychain.keyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        XCTAssertThrowsError(try sut.deleteDataKey()) { error in
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
+        }
     }
 
     // MARK: - Wrapped data key
@@ -79,7 +99,7 @@ final class KeyshareKeyStoreTests: XCTestCase {
 
         try sut.storeWrappedDataKey(blob)
 
-        XCTAssertEqual(sut.loadWrappedDataKey(), blob)
+        XCTAssertEqual(sut.loadWrappedDataKey(), .present(blob))
     }
 
     func testDeleteWrappedDataKeyRemovesIt() throws {
@@ -87,7 +107,22 @@ final class KeyshareKeyStoreTests: XCTestCase {
 
         try sut.deleteWrappedDataKey()
 
-        XCTAssertNil(sut.loadWrappedDataKey())
+        XCTAssertEqual(sut.loadWrappedDataKey(), .absent)
+    }
+
+    func testLoadWrappedDataKeyPropagatesAnUnreadableKeychain() {
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        XCTAssertEqual(sut.loadWrappedDataKey(), .unavailable(errSecInteractionNotAllowed))
+    }
+
+    func testDeleteWrappedDataKeyThrowsWhenTheKeychainCannotConfirmItIsGone() {
+        keychain.ignoresWrappedKeyshareDataKeyDeletion = true
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        XCTAssertThrowsError(try sut.deleteWrappedDataKey()) { error in
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
+        }
     }
 
     // MARK: - Passcode wrapping

--- a/VultisigApp/VultisigAppTests/Security/KeyshareProtectorTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareProtectorTests.swift
@@ -120,3 +120,62 @@ final class KeyshareProtectorTests: XCTestCase {
         }
     }
 }
+
+/// The generation token that stops a slow unlock from undoing a lock that landed
+/// while it was still deriving.
+///
+/// Driven directly rather than through `PasscodeService`: the end-to-end race
+/// needs the lock to land inside the window between capturing the generation and
+/// adopting the key, and there is no way to place it there deterministically
+/// without adding a synchronization point to production code purely for tests.
+final class KeyshareKeySessionGenerationTests: XCTestCase {
+
+    private func makeSession() -> KeyshareKeySession {
+        KeyshareKeySession(store: DefaultKeyshareKeyStore(keychain: MockKeychainService()))
+    }
+
+    func testAdoptSucceedsWhenNoLockIntervened() throws {
+        let session = makeSession()
+        let key = try VaultCryptoEnvelope.randomKey()
+
+        let generation = session.currentGeneration
+
+        XCTAssertTrue(session.adopt(key, ifGeneration: generation))
+    }
+
+    func testAdoptIsRejectedWhenAClearHappenedAfterTheGenerationWasCaptured() throws {
+        let session = makeSession()
+        let key = try VaultCryptoEnvelope.randomKey()
+        session.adopt(key)
+
+        let generation = session.currentGeneration
+        session.clear()
+
+        XCTAssertFalse(session.adopt(key, ifGeneration: generation), "A lock that landed mid-unlock must win")
+    }
+
+    func testRejectedAdoptLeavesTheSessionLocked() throws {
+        let session = makeSession()
+        let key = try VaultCryptoEnvelope.randomKey()
+        session.adopt(key)
+        let generation = session.currentGeneration
+        session.clear()
+
+        _ = session.adopt(key, ifGeneration: generation)
+
+        guard case .disabled = session.currentState() else {
+            return XCTFail("Expected the session to remain without a key")
+        }
+    }
+
+    func testEachClearInvalidatesAnEarlierGeneration() throws {
+        let session = makeSession()
+        let key = try VaultCryptoEnvelope.randomKey()
+        let first = session.currentGeneration
+        session.clear()
+        let second = session.currentGeneration
+
+        XCTAssertFalse(session.adopt(key, ifGeneration: first))
+        XCTAssertTrue(session.adopt(key, ifGeneration: second))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareSweeperTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareSweeperTests.swift
@@ -1,0 +1,299 @@
+//
+//  KeyshareSweeperTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import SwiftData
+import XCTest
+@testable import VultisigApp
+
+/// The sweep is the only thing in the passcode feature that rewrites key
+/// material, so these are less about behaviour than about the four ways it could
+/// destroy a vault: half-applying, failing to persist, saving a partial result,
+/// and accepting an already-sealed value nobody can open.
+@MainActor
+final class KeyshareSweeperTests: XCTestCase {
+
+    private var token: TestContextToken!
+    private var context: ModelContext!
+    private var key: SymmetricKey!
+    private var protector: KeyshareProtector!
+    private var sut: KeyshareSweeper!
+
+    private let firstShare = "eyJrZXlzaGFyZSI6ImRrbHMtb25lIn0="
+    private let secondShare = "eyJrZXlzaGFyZSI6ImRrbHMtdHdvIn0="
+    private let thirdShare = "eyJrZXlzaGFyZSI6ImRrbHMtdGhyZWUifQ=="
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        token = try TestStore.installInMemoryContainer()
+        context = token.container.mainContext
+
+        key = SymmetricKey(size: .bits256)
+        let heldKey = key!
+        protector = KeyshareProtector(state: { .unlocked(heldKey) })
+        sut = KeyshareSweeper(protector: protector, context: { [context] in context })
+    }
+
+    override func tearDown() {
+        sut = nil
+        protector = nil
+        key = nil
+        context = nil
+        TestStore.restore(token)
+        token = nil
+        super.tearDown()
+    }
+
+    // MARK: - Sealing
+
+    func testSealAllSealsEveryShareOfEveryVault() throws {
+        try givenVaults([
+            ("vault-one", [firstShare, secondShare]),
+            ("vault-two", [thirdShare])
+        ])
+
+        try sut.sealAll()
+
+        let stored = try storedShares()
+        XCTAssertEqual(stored.count, 3)
+        for value in stored {
+            XCTAssertTrue(protector.isSealed(value), "every share must be sealed once a passcode is set")
+        }
+        XCTAssertEqual(try stored.map { try protector.open($0) }.sorted(), [firstShare, secondShare, thirdShare].sorted())
+    }
+
+    func testSealAllPersistsThroughAFreshFetch() throws {
+        try givenVaults([("vault-one", [firstShare])])
+
+        try sut.sealAll()
+
+        // Read through a context that never saw the in-memory objects. This is
+        // the reason the sweep assigns a whole array rather than an element:
+        // element assignment is not a dependable way to dirty a `@Model`, and a
+        // change that never reached the store would leave plaintext on disk
+        // while every in-process read looked correct.
+        let fresh = ModelContext(token.container)
+        let stored = try fresh.fetch(FetchDescriptor<Vault>()).flatMap(\.keyshares).map(\.keyshare)
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertTrue(protector.isSealed(try XCTUnwrap(stored.first)))
+    }
+
+    func testSealAllIsIdempotent() throws {
+        try givenVaults([("vault-one", [firstShare, secondShare])])
+        try sut.sealAll()
+        let afterFirst = try storedShares()
+
+        try sut.sealAll()
+
+        XCTAssertEqual(try storedShares().sorted(), afterFirst.sorted(), "re-sealing must not re-encrypt")
+    }
+
+    func testSealAllOverAStoreWithNoVaultsDoesNothing() throws {
+        try sut.sealAll()
+
+        XCTAssertFalse(context.hasChanges)
+    }
+
+    /// Rule 4, and the one that costs funds. `KeyshareProtector.seal` returns an
+    /// already-sealed value unchanged and unauthenticated, so a sweep that took
+    /// it on trust would report success over a share sealed under a key nobody
+    /// holds — a dead vault that nothing ever revisits, because the sweep said
+    /// it was fine.
+    func testAnAlreadySealedShareSealedUnderAnotherKeyAbortsTheSweep() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(firstShare, with: SymmetricKey(size: .bits256))
+        try givenVaults([("vault-one", [foreign])])
+
+        XCTAssertThrowsError(try sut.sealAll()) { error in
+            XCTAssertEqual(error as? KeyshareSweeperError, .verificationFailed(pubkey: "vault-one-0"))
+        }
+    }
+
+    /// A sealed envelope wrapped around another one is not a share. Nothing here
+    /// produces one — `seal` will not seal an already-sealed value — but an
+    /// imported backup can carry whatever bytes it likes, and the outer layer
+    /// authenticates perfectly well, so accepting it on that basis is exactly
+    /// the mistake rule 4 exists to stop.
+    func testAnEnvelopeWrappedAroundAnotherEnvelopeAbortsTheSeal() throws {
+        try givenVaults([("vault-one", [try nestedEnvelope()])])
+
+        XCTAssertThrowsError(try sut.sealAll()) { error in
+            XCTAssertEqual(error as? KeyshareSweeperError, .verificationFailed(pubkey: "vault-one-0"))
+        }
+    }
+
+    /// The same value on the way out, where the consequence is worse: unwrapping
+    /// only the outer layer would write `vlt2:` back to disk and report the
+    /// store fully unsealed, and the disable that follows deletes the key.
+    func testAnEnvelopeWrappedAroundAnotherEnvelopeAbortsTheUnseal() throws {
+        let nested = try nestedEnvelope()
+        try givenVaults([("vault-one", [nested])])
+
+        XCTAssertThrowsError(try sut.unsealAll()) { error in
+            XCTAssertEqual(error as? KeyshareSweeperError, .verificationFailed(pubkey: "vault-one-0"))
+        }
+        XCTAssertEqual(try storedShares(), [nested], "the refusal must leave the value alone")
+    }
+
+    /// Two-phase, proved: one bad share anywhere leaves every other share — in
+    /// every other vault — exactly as it was, and leaves nothing dirty behind
+    /// for an unrelated save to flush.
+    func testAFailureAnywhereLeavesEveryShareUntouched() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(thirdShare, with: SymmetricKey(size: .bits256))
+        try givenVaults([
+            ("vault-one", [firstShare, secondShare]),
+            ("vault-two", [foreign])
+        ])
+
+        XCTAssertThrowsError(try sut.sealAll())
+
+        XCTAssertEqual(try storedShares().sorted(), [firstShare, secondShare, foreign].sorted())
+        XCTAssertFalse(context.hasChanges, "a failed sweep must not leave a partial result in the context")
+    }
+
+    // MARK: - Unsealing
+
+    func testUnsealAllRestoresTheExactOriginalPlaintext() throws {
+        try givenVaults([
+            ("vault-one", [firstShare, secondShare]),
+            ("vault-two", [thirdShare])
+        ])
+        try sut.sealAll()
+
+        try sut.unsealAll()
+
+        XCTAssertEqual(try storedShares().sorted(), [firstShare, secondShare, thirdShare].sorted())
+    }
+
+    func testUnsealAllIsIdempotent() throws {
+        try givenVaults([("vault-one", [firstShare])])
+        try sut.sealAll()
+        try sut.unsealAll()
+
+        try sut.unsealAll()
+
+        XCTAssertEqual(try storedShares(), [firstShare])
+    }
+
+    /// A sealed value that does not authenticate cannot be turned back into a
+    /// share, and reporting the disable as done would leave it unreadable
+    /// forever with no passcode left to ask for.
+    func testUnsealAllAbortsOnAShareItCannotOpen() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(firstShare, with: SymmetricKey(size: .bits256))
+        try givenVaults([("vault-one", [foreign])])
+
+        XCTAssertThrowsError(try sut.unsealAll()) { error in
+            XCTAssertEqual(error as? KeyshareSweeperError, .verificationFailed(pubkey: "vault-one-0"))
+        }
+        XCTAssertEqual(try storedShares(), [foreign])
+    }
+
+    // MARK: - The context
+
+    /// Flushing somebody's pending work would commit a half-finished keygen
+    /// merely because the user enabled a passcode; discarding it would throw
+    /// their work away. Neither is the sweep's to do.
+    func testADirtyContextIsRefusedAndNothingIsChanged() throws {
+        let vaults = try givenVaults([("vault-one", [firstShare])])
+        vaults[0].name = "renamed but not saved"
+        XCTAssertTrue(context.hasChanges)
+
+        XCTAssertThrowsError(try sut.sealAll()) { error in
+            XCTAssertEqual(error as? KeyshareSweeperError, .busy)
+        }
+
+        XCTAssertEqual(try storedShares(), [firstShare], "the refusal must change nothing")
+    }
+
+    func testAMissingModelContextIsReported() {
+        let orphan = KeyshareSweeper(protector: protector, context: { nil })
+
+        XCTAssertThrowsError(try orphan.sealAll()) { error in
+            XCTAssertEqual(error as? KeyshareSweeperError, .missingModelContext)
+        }
+    }
+
+    /// With no key in hand `seal` is a passthrough, so a sweep would otherwise
+    /// report success over shares it left in the clear.
+    func testSealingWithNoDataKeyInHandFailsRatherThanSilentlyDoingNothing() throws {
+        try givenVaults([("vault-one", [firstShare])])
+        let disabled = KeyshareSweeper(
+            protector: KeyshareProtector(state: { .disabled }),
+            context: { [context] in context }
+        )
+
+        XCTAssertThrowsError(try disabled.sealAll()) { error in
+            XCTAssertEqual(error as? KeyshareSweeperError, .verificationFailed(pubkey: "vault-one-0"))
+        }
+        XCTAssertEqual(try storedShares(), [firstShare])
+    }
+
+    /// `keyId` is part of the share's identity for MLDSA, and rebuilding the
+    /// array is exactly where it would get dropped.
+    func testSweepingPreservesTheKeyIdentifier() throws {
+        let vaults = try givenVaults([("vault-one", [firstShare])])
+        vaults[0].keyshares = [KeyShare(pubkey: "vault-one-0", keyshare: firstShare, keyId: "mldsa-key-id")]
+        try context.save()
+
+        try sut.sealAll()
+
+        let share = try XCTUnwrap(try allShares().first)
+        XCTAssertEqual(share.keyId, "mldsa-key-id")
+    }
+
+    // MARK: - Helpers
+
+    /// Every `@Attribute(.unique)` field is given a distinct value per vault.
+    /// `TestStore.makeVault` leaves `pubKeyEdDSA` at a shared constant, and
+    /// SwiftData answers a duplicate unique key with an *upsert* rather than an
+    /// error — so a multi-vault fixture built that way silently collapses to one
+    /// row and every multi-vault assertion below would pass vacuously. The count
+    /// check is here so that failure is loud if it ever comes back.
+    @discardableResult
+    private func givenVaults(_ vaults: [(String, [String])]) throws -> [Vault] {
+        let inserted = vaults.map { pubKey, shares in
+            let vault = Vault(
+                name: "Vault \(pubKey)",
+                signers: [],
+                pubKeyECDSA: "ecdsa-\(pubKey)",
+                pubKeyEdDSA: "eddsa-\(pubKey)",
+                keyshares: shares.enumerated().map { index, value in
+                    KeyShare(pubkey: "\(pubKey)-\(index)", keyshare: value)
+                },
+                localPartyID: "party-\(pubKey)",
+                hexChainCode: "hex",
+                resharePrefix: nil,
+                libType: .DKLS
+            )
+            context.insert(vault)
+            return vault
+        }
+        try context.save()
+
+        XCTAssertEqual(
+            try context.fetchCount(FetchDescriptor<Vault>()),
+            vaults.count,
+            "the fixture collapsed — a unique attribute is shared between vaults"
+        )
+        return inserted
+    }
+
+    /// A share sealed twice under the key in hand. Built with the cipher
+    /// directly, because `KeyshareProtector.seal` refuses to seal an
+    /// already-sealed value — which is why the app can never produce one and an
+    /// import is the only way in.
+    private func nestedEnvelope() throws -> String {
+        let cipher = AesGcmKeyshareCipher()
+        let inner = try cipher.seal(firstShare, with: key)
+        return try cipher.seal(inner, with: key)
+    }
+
+    private func allShares() throws -> [KeyShare] {
+        try context.fetch(FetchDescriptor<Vault>()).flatMap(\.keyshares)
+    }
+
+    private func storedShares() throws -> [String] {
+        try allShares().map(\.keyshare)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -1,0 +1,463 @@
+//
+//  PasscodeServiceTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import XCTest
+@testable import VultisigApp
+
+final class PasscodeServiceTests: XCTestCase {
+
+    private var keychain: MockKeychainService!
+    private var keyStore: DefaultKeyshareKeyStore!
+    private var session: KeyshareKeySession!
+    private var protector: KeyshareProtector!
+    private var lockService: AppLockService!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var sut: PasscodeService!
+
+    /// Driven manually so backoff can be tested without sleeping, and so the
+    /// clock-vs-uptime interaction is observable.
+    private var uptime: TimeInterval = 1_000
+
+    private let passcode = "12345"
+    private let newPasscode = "98765"
+    private let share = "eyJrZXlzaGFyZSI6ImRrbHMifQ=="
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        suiteName = "PasscodeServiceTests.\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+
+        keychain = MockKeychainService()
+        let store = DefaultKeyshareKeyStore(keychain: keychain)
+        let keySession = KeyshareKeySession(store: store)
+        keyStore = store
+        session = keySession
+        protector = KeyshareProtector(state: { keySession.currentState() })
+        lockService = AppLockService(defaults: defaults)
+
+        sut = PasscodeService(
+            keyStore: store,
+            session: keySession,
+            lockService: lockService,
+            limiter: PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime })
+        )
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        sut = nil
+        lockService = nil
+        protector = nil
+        session = nil
+        keyStore = nil
+        keychain = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    /// Puts the app in the state the migration leaves it in: a data key exists
+    /// in the clear and a share is sealed under it.
+    @discardableResult
+    private func givenMigratedState() throws -> String {
+        let key = try keyStore.generateDataKey()
+        try keyStore.storeDataKey(key)
+        session.adopt(key)
+        return try protector.seal(share)
+    }
+
+    // MARK: - Set
+
+    func testSetPasscodeReplacesTheClearKeyWithAWrappedOne() async throws {
+        try givenMigratedState()
+
+        try await sut.setPasscode(passcode)
+
+        XCTAssertNil(keyStore.loadDataKey(), "The clear copy must be gone")
+        XCTAssertNotNil(keyStore.loadWrappedDataKey())
+        let isSet = await sut.isSet
+        XCTAssertTrue(isSet)
+    }
+
+    func testSetPasscodeSwitchesTheLockMode() async throws {
+        try givenMigratedState()
+
+        try await sut.setPasscode(passcode)
+
+        XCTAssertEqual(lockService.mode, .passcode)
+    }
+
+    func testSetPasscodeKeepsSharesReadableInTheSameSession() async throws {
+        let sealed = try givenMigratedState()
+
+        try await sut.setPasscode(passcode)
+
+        XCTAssertEqual(try protector.open(sealed), share)
+    }
+
+    func testSetPasscodeRefusesWhenNothingIsEncryptedYet() async {
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected .noDataKey")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .noDataKey)
+        }
+    }
+
+    func testSetPasscodeRefusesWhenOneIsAlreadySet() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+
+        do {
+            try await sut.setPasscode(newPasscode)
+            XCTFail("Expected .alreadySet")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .alreadySet)
+        }
+    }
+
+    func testSetPasscodeRejectsAWrongLength() async throws {
+        try givenMigratedState()
+
+        for candidate in ["1234", "123456", "abcde", ""] {
+            do {
+                try await sut.setPasscode(candidate)
+                XCTFail("Expected .invalidLength for \(candidate)")
+            } catch {
+                XCTAssertEqual(error as? PasscodeError, .invalidLength)
+            }
+        }
+    }
+
+    // MARK: - Lock / unlock
+
+    func testLockMakesSealedSharesUnreadable() async throws {
+        let sealed = try givenMigratedState()
+        try await sut.setPasscode(passcode)
+
+        sut.lock()
+
+        XCTAssertThrowsError(try protector.open(sealed)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+        }
+    }
+
+    func testUnlockRestoresAccess() async throws {
+        let sealed = try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        sut.lock()
+
+        try await sut.unlock(with: passcode)
+
+        XCTAssertEqual(try protector.open(sealed), share)
+    }
+
+    func testUnlockWithTheWrongPasscodeLeavesTheAppLocked() async throws {
+        let sealed = try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        sut.lock()
+
+        do {
+            try await sut.unlock(with: "00000")
+            XCTFail("Expected .wrongPasscode")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
+        }
+
+        XCTAssertThrowsError(try protector.open(sealed))
+    }
+
+    func testUnlockWithoutAPasscodeSetThrows() async {
+        do {
+            try await sut.unlock(with: passcode)
+            XCTFail("Expected .notSet")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .notSet)
+        }
+    }
+
+    // MARK: - Change — the claim the whole design rests on
+
+    /// Changing the passcode must rewrap 32 bytes and leave every key share
+    /// byte-for-byte identical. The desktop client re-encrypts every share of
+    /// every vault at this moment; if this assertion ever fails, that risk has
+    /// been imported along with it.
+    func testChangingThePasscodeLeavesKeyShareCiphertextByteIdentical() async throws {
+        let sealed = try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        let before = sealed
+
+        try await sut.changePasscode(current: passcode, new: newPasscode)
+
+        XCTAssertEqual(sealed, before, "No key share may be rewritten by a passcode change")
+        XCTAssertEqual(try protector.open(sealed), share)
+    }
+
+    func testChangedPasscodeUnlocksAndTheOldOneDoesNot() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        try await sut.changePasscode(current: passcode, new: newPasscode)
+        sut.lock()
+
+        try await sut.unlock(with: newPasscode)
+
+        sut.lock()
+        do {
+            try await sut.unlock(with: passcode)
+            XCTFail("The old passcode must stop working")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
+        }
+    }
+
+    func testChangeWithTheWrongCurrentPasscodeChangesNothing() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        let wrappedBefore = keyStore.loadWrappedDataKey()
+
+        do {
+            try await sut.changePasscode(current: "00000", new: newPasscode)
+            XCTFail("Expected .wrongPasscode")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
+        }
+
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), wrappedBefore)
+    }
+
+    func testChangeRejectsAnInvalidNewPasscode() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+
+        do {
+            try await sut.changePasscode(current: passcode, new: "1")
+            XCTFail("Expected .invalidLength")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .invalidLength)
+        }
+    }
+
+    // MARK: - Disable
+
+    func testDisableRestoresTheClearKeyAndRemovesTheWrappedOne() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+
+        try await sut.disablePasscode(current: passcode)
+
+        XCTAssertNotNil(keyStore.loadDataKey())
+        XCTAssertNil(keyStore.loadWrappedDataKey())
+        let isSet = await sut.isSet
+        XCTAssertFalse(isSet)
+    }
+
+    /// Turning the passcode off must not turn at-rest encryption off — the
+    /// shares stay sealed, they are simply reachable without a passcode again.
+    func testDisableLeavesSharesSealedAndReadable() async throws {
+        let sealed = try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        let before = sealed
+
+        try await sut.disablePasscode(current: passcode)
+
+        XCTAssertEqual(sealed, before, "No key share may be rewritten by disabling the passcode")
+        XCTAssertTrue(sealed.hasPrefix(AesGcmKeyshareCipher.sealedPrefix))
+        XCTAssertEqual(try protector.open(sealed), share)
+    }
+
+    func testDisableWithTheWrongPasscodeChangesNothing() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+
+        do {
+            try await sut.disablePasscode(current: "00000")
+            XCTFail("Expected .wrongPasscode")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
+        }
+
+        XCTAssertNil(keyStore.loadDataKey())
+        XCTAssertNotNil(keyStore.loadWrappedDataKey())
+    }
+
+    /// If the wrapped copy cannot be removed, both copies would exist and the
+    /// readable clear key would make the passcode meaningless. The clear copy is
+    /// rolled back so the passcode keeps protecting something.
+    func testDisableRollsBackWhenTheWrappedKeyCannotBeDeleted() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        keychain.ignoresWrappedKeyshareDataKeyDeletion = true
+
+        do {
+            try await sut.disablePasscode(current: passcode)
+            XCTFail("Expected the deletion failure to surface")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
+        }
+
+        XCTAssertNil(keyStore.loadDataKey(), "The clear copy must have been rolled back")
+        XCTAssertNotNil(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(lockService.mode, .passcode, "The passcode is still in force")
+    }
+
+    func testDisableReturnsTheLockToDeviceAuth() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+
+        try await sut.disablePasscode(current: passcode)
+
+        XCTAssertEqual(lockService.mode, .deviceAuth)
+    }
+
+    // MARK: - Attempt limiting
+
+    // MARK: - Deletion must be verified
+
+    /// If the clear copy survives, locking just reloads it from the Keychain and
+    /// the passcode is decorative. Setting one must fail loudly instead.
+    func testSetPasscodeFailsWhenTheClearKeyCannotBeDeleted() async throws {
+        try givenMigratedState()
+        keychain.ignoresKeyshareDataKeyDeletion = true
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected .deletionFailed")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
+        }
+
+        XCTAssertNotEqual(lockService.mode, .passcode, "The mode must not switch on a failed deletion")
+    }
+
+    // MARK: - A malformed wrapped key is not a guess
+
+    func testAMalformedWrappedKeyIsReportedAsStorageFailureAndNotCounted() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        keychain.setWrappedKeyshareDataKey(Data(repeating: 0x00, count: 64))
+
+        for _ in 0..<10 {
+            do {
+                try await sut.unlock(with: passcode)
+                XCTFail("Expected .storageFailure")
+            } catch {
+                XCTAssertEqual(error as? PasscodeError, .storageFailure)
+            }
+        }
+
+        // Ten storage failures must not have accrued a lockout.
+        XCTAssertEqual(PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime }).remainingLockout(now: Date()), 0)
+    }
+
+    // MARK: - Clock manipulation
+
+    /// Wall time alone is user-adjustable, so a backoff has to survive the clock
+    /// being moved forward.
+    func testMovingTheClockForwardDoesNotClearALockout() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        for _ in 0...PasscodeAttemptLimiter.freeAttempts {
+            _ = try? await sut.unlock(with: "00000", now: start)
+        }
+
+        // A year later by the wall clock, but the device has not been up that
+        // long — the monotonic reading is what counts.
+        do {
+            try await sut.unlock(with: passcode, now: start.addingTimeInterval(365 * 24 * 3600))
+            XCTFail("Expected the lockout to survive a clock change")
+        } catch {
+            guard case .lockedOut? = error as? PasscodeError else {
+                return XCTFail("Expected .lockedOut, got \(error)")
+            }
+        }
+    }
+
+    func testRepeatedFailuresEventuallyLockOut() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+        for _ in 0..<PasscodeAttemptLimiter.freeAttempts {
+            _ = try? await sut.unlock(with: "00000", now: start)
+        }
+        // The next failure crosses into the throttled range.
+        _ = try? await sut.unlock(with: "00000", now: start)
+
+        do {
+            try await sut.unlock(with: passcode, now: start)
+            XCTFail("Expected a lockout")
+        } catch {
+            guard case .lockedOut(let remaining)? = error as? PasscodeError else {
+                return XCTFail("Expected .lockedOut, got \(error)")
+            }
+            XCTAssertGreaterThan(remaining, 0)
+        }
+    }
+
+    /// Both clocks have to advance: wall time alone is the clock-manipulation
+    /// bypass, and the limiter deliberately refuses to honour it.
+    func testLockoutExpiresOnceTimeGenuinelyPasses() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        for _ in 0...PasscodeAttemptLimiter.freeAttempts {
+            _ = try? await sut.unlock(with: "00000", now: start)
+        }
+
+        uptime += 3600
+        try await sut.unlock(with: passcode, now: start.addingTimeInterval(3600))
+    }
+
+    func testASuccessfulUnlockClearsTheFailureCount() async throws {
+        try givenMigratedState()
+        try await sut.setPasscode(passcode)
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        for _ in 0..<PasscodeAttemptLimiter.freeAttempts {
+            _ = try? await sut.unlock(with: "00000", now: start)
+        }
+
+        try await sut.unlock(with: passcode, now: start)
+
+        // Fresh budget: the free attempts are available again.
+        for _ in 0..<PasscodeAttemptLimiter.freeAttempts {
+            _ = try? await sut.unlock(with: "00000", now: start)
+        }
+        try await sut.unlock(with: passcode, now: start)
+    }
+}
+
+extension PasscodeServiceTests {
+
+    /// Failures with no recorded timestamp would slip past the lockout, so a
+    /// decodable-but-inconsistent record counts as unreadable and fails closed.
+    func testInconsistentAttemptStateFailsClosed() throws {
+        let corrupt = #"{"failureCount":99}"#.data(using: .utf8)
+        keychain.setPasscodeAttemptState(corrupt)
+
+        let limiter = PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime })
+
+        XCTAssertEqual(limiter.remainingLockout(now: Date()), PasscodeAttemptLimiter.maximumDelay)
+    }
+
+    /// An absent record is a genuinely fresh start and must not be throttled.
+    func testAbsentAttemptStateIsNotThrottled() {
+        let limiter = PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime })
+
+        XCTAssertEqual(limiter.remainingLockout(now: Date()), 0)
+    }
+
+    /// A record whose failure count is within the free allowance needs no
+    /// timestamps and stays valid.
+    func testZeroFailureStateIsAccepted() throws {
+        keychain.setPasscodeAttemptState(#"{"failureCount":0}"#.data(using: .utf8))
+
+        let limiter = PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime })
+
+        XCTAssertEqual(limiter.remainingLockout(now: Date()), 0)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -865,6 +865,38 @@ final class PasscodeServiceTests: XCTestCase {
         XCTAssertEqual(lockService.mode, .passcode)
     }
 
+    /// The bytes the rollback needs are taken **before** the verification, not
+    /// after it. `unlock` cannot succeed without reading the same item, so a
+    /// read that comes back unreadable on the far side of it is transient — and
+    /// a rollback with nothing to restore leaves plaintext shares behind a mode
+    /// that says there is no passcode, which is protection removed while the
+    /// call reports failure.
+    func testDisableStillRestoresTheWrapperWhenItCannotBeReReadAfterVerification() async throws {
+        try givenVaults([("vault-one", [share])])
+
+        let hooked = HookedKeyshareKeyStore(wrapping: keyStore, duringUnwrap: { [keychain] in
+            // The item stops answering the moment the passcode is proved, and
+            // the deletion that follows cannot be confirmed either.
+            keychain?.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+            keychain?.wrappedKeyshareDataKeyBecomesUnreadableOnDeletion = true
+        })
+        let service = makeService(keyStore: hooked)
+        try await service.setPasscode(passcode)
+
+        do {
+            try await service.disablePasscode(current: passcode)
+            XCTFail("Expected the deletion failure to surface")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
+        }
+
+        let restored = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
+        XCTAssertFalse(restored.isEmpty, "the passcode has to be put back, not lost to an unreadable moment")
+        let stored = try XCTUnwrap(try storedShares().first)
+        XCTAssertTrue(protector.isSealed(stored), "protection must not come off while the call reports failure")
+        XCTAssertEqual(lockService.mode, .passcode)
+    }
+
     /// And when the wrapper cannot be made durable again, nothing is resealed.
     /// Plaintext shares with no key of any form is the no-passcode resting
     /// state — the only outcome here that loses nothing.

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -466,6 +466,245 @@ final class PasscodeServiceTests: XCTestCase {
         }
     }
 
+    // MARK: - Resume on unlock
+
+    /// The recovery the whole pending-passcode design depends on: a share left
+    /// plaintext behind a live passcode is sealed the next time the app is
+    /// opened, with no completion marker and no ordering to fall behind.
+    func testUnlockingTheAppSealsAShareLeftPlaintext() async throws {
+        try await sut.setPasscode(passcode)
+        try givenVaults([("vault-one", [share])])
+        sut.lock()
+
+        try await sut.unlockApp(with: passcode)
+
+        let stored = try XCTUnwrap(try storedShares().first)
+        XCTAssertTrue(protector.isSealed(stored), "an unlock must finish what an interrupted transition started")
+        XCTAssertEqual(try protector.open(stored), share)
+    }
+
+    /// Verification is not an app unlock. `unlock(with:)` is what change and
+    /// disable call, and a resume from there would fire in the middle of a
+    /// transition that is about to move every share itself.
+    func testVerifyingAPasscodeDoesNotResume() async throws {
+        try await sut.setPasscode(passcode)
+        try givenVaults([("vault-one", [share])])
+        sut.lock()
+
+        try await sut.unlock(with: passcode)
+
+        XCTAssertEqual(try storedShares(), [share])
+    }
+
+    func testChangingThePasscodeDoesNotResume() async throws {
+        try await sut.setPasscode(passcode)
+        try givenVaults([("vault-one", [share])])
+
+        try await sut.changePasscode(current: passcode, new: newPasscode)
+
+        XCTAssertEqual(try storedShares(), [share])
+    }
+
+    /// The self-deadlock regression. The app-unlock path already holds the
+    /// transition lease, and a lease is not reentrant — an acquiring resume
+    /// would throw `.busy` on the one path that has to work every time.
+    func testResumingFromInsideAHeldTransitionStillSweeps() async throws {
+        try await sut.setPasscode(passcode)
+        try givenVaults([("vault-one", [share])])
+        let lease = try coordinator.beginTransition()
+        defer { coordinator.end(lease) }
+
+        await sut.resumeSweepUnlocked()
+
+        XCTAssertTrue(protector.isSealed(try XCTUnwrap(try storedShares().first)))
+    }
+
+    func testTheResumeRunsAtMostOncePerUnlockedSession() async throws {
+        let counting = CountingKeyshareSweeper(wrapping: sweeper)
+        let service = makeService(sweeper: counting)
+        try await service.setPasscode(passcode)
+        counting.reset()
+
+        await service.resumeSweepUnlocked()
+        await service.resumeSweepUnlocked()
+
+        XCTAssertEqual(counting.sealCount, 1)
+    }
+
+    /// And the latch is per session, reset by `lock()` bumping the session
+    /// generation — so plaintext introduced after a successful sweep is picked
+    /// up on the next lock cycle rather than never.
+    func testLockingResetsTheResumeLatch() async throws {
+        let counting = CountingKeyshareSweeper(wrapping: sweeper)
+        let service = makeService(sweeper: counting)
+        try await service.setPasscode(passcode)
+        counting.reset()
+        await service.resumeSweepUnlocked()
+
+        service.lock()
+        try await service.unlockApp(with: passcode)
+
+        XCTAssertEqual(counting.sealCount, 2)
+    }
+
+    /// The key is already adopted by the time the resume runs, so the session is
+    /// open whatever happens next. Reporting a failure would leave the lock
+    /// screen up over an unlocked app, and a persistent cause would lock the user
+    /// out of an app whose passcode they know.
+    func testAFailedResumeDoesNotFailTheUnlock() async throws {
+        let counting = CountingKeyshareSweeper(wrapping: sweeper)
+        try await sut.setPasscode(passcode)
+        try givenVaults([("vault-one", [share])])
+        let service = makeService(sweeper: counting)
+        service.lock()
+        counting.sealFailure = KeyshareSweeperError.busy
+
+        try await service.unlockApp(with: passcode)
+
+        let isUnlocked: Bool
+        if case .unlocked = session.currentState() { isUnlocked = true } else { isUnlocked = false }
+        XCTAssertTrue(isUnlocked, "the key is adopted before the resume runs, so the session is open either way")
+        XCTAssertEqual(
+            try storedShares(),
+            [share],
+            "the exposure the trade-off accepts: the share stays plaintext until a later unlock succeeds"
+        )
+    }
+
+    /// The latch is only set on success, so a failure is retried rather than
+    /// remembered as done.
+    func testAFailedResumeIsNotLatched() async throws {
+        let counting = CountingKeyshareSweeper(wrapping: sweeper)
+        let service = makeService(sweeper: counting)
+        try await service.setPasscode(passcode)
+        counting.reset()
+        counting.sealFailure = KeyshareSweeperError.busy
+        await service.resumeSweepUnlocked()
+
+        counting.sealFailure = nil
+        await service.resumeSweepUnlocked()
+
+        XCTAssertEqual(counting.sealCount, 2)
+    }
+
+    /// No wrapper means no passcode, and sealing there would write ciphertext
+    /// nothing can open.
+    func testTheResumeDoesNothingWithNoPasscodeSet() async throws {
+        try givenVaults([("vault-one", [share])])
+        let counting = CountingKeyshareSweeper(wrapping: sweeper)
+
+        await makeService(sweeper: counting).resumeSweepUnlocked()
+
+        XCTAssertEqual(counting.sealCount, 0)
+        XCTAssertEqual(try storedShares(), [share])
+    }
+
+    /// Nor does it run while the app is locked: there is no key to seal with,
+    /// and `seal` would throw on every share.
+    func testTheResumeDoesNothingWhileLocked() async throws {
+        try await sut.setPasscode(passcode)
+        try givenVaults([("vault-one", [share])])
+        let counting = CountingKeyshareSweeper(wrapping: sweeper)
+        let service = makeService(sweeper: counting)
+        service.lock()
+
+        await service.resumeSweepUnlocked()
+
+        XCTAssertEqual(counting.sealCount, 0)
+        XCTAssertEqual(try storedShares(), [share])
+    }
+
+    /// The lockout this design has to avoid. A vault-creation episode outlives
+    /// the screen that started it — keygen holds one through the deferred
+    /// "Looks Good" commit — so an app that auto-locked there would be
+    /// unopenable if the unlock claimed a transition: the flow cannot be
+    /// finished without unlocking, and unlocking could not happen while the flow
+    /// is open.
+    func testUnlockingTheAppSucceedsWhileAVaultCreationEpisodeIsOpen() async throws {
+        try await sut.setPasscode(passcode)
+        try givenVaults([("vault-one", [share])])
+        sut.lock()
+        let episode = try XCTUnwrap(coordinator.beginEpisode())
+        defer { coordinator.end(episode) }
+
+        try await sut.unlockApp(with: passcode)
+
+        XCTAssertTrue(protector.isSealed(try XCTUnwrap(try storedShares().first)))
+    }
+
+    /// It is still excluded against the operations that move the same state.
+    func testAnAppUnlockIsRefusedWhileAPasscodeTransitionIsHeld() async throws {
+        try await sut.setPasscode(passcode)
+        sut.lock()
+        let lease = try coordinator.beginTransition()
+        defer { coordinator.end(lease) }
+
+        do {
+            try await sut.unlockApp(with: passcode)
+            XCTFail("Expected .busy")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .busy)
+        }
+    }
+
+    /// `unlock` guards only the adoption. Without a second check, a lock landing
+    /// during the sweep would be followed by a successful return and the caller
+    /// would dismiss the lock screen over a session that is locked again.
+    func testALockDuringTheResumeSweepCancelsTheUnlock() async throws {
+        try await sut.setPasscode(passcode)
+        try givenVaults([("vault-one", [share])])
+        let locking = CountingKeyshareSweeper(wrapping: sweeper)
+        locking.duringSeal = { [session] in session?.clear() }
+        let service = makeService(sweeper: locking)
+        service.lock()
+
+        do {
+            try await service.unlockApp(with: passcode)
+            XCTFail("Expected .cancelledByLock")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .cancelledByLock)
+        }
+
+        if case .unlocked = session.currentState() {
+            XCTFail("the lock must stand")
+        }
+    }
+
+    /// Write leases do not exclude each other, so the coordinator alone does not
+    /// keep two app unlocks apart — and two of them are not merely wasteful. The
+    /// slower one's post-sweep generation check would clear the faster one's
+    /// perfectly good session, and both would clear the attempt limiter's
+    /// lockout check before either recorded a failure.
+    ///
+    /// Driven from inside the key derivation, so the overlap is deterministic
+    /// rather than a matter of scheduling.
+    func testASecondAppUnlockIsRefusedWhileOneIsInFlight() async throws {
+        try await sut.setPasscode(passcode)
+        sut.lock()
+
+        var nested: [PasscodeError?] = []
+        var service: PasscodeService!
+        let hooked = HookedKeyshareKeyStore(wrapping: keyStore) {
+            do {
+                try await service.unlockApp(with: self.passcode)
+                nested.append(nil)
+            } catch {
+                nested.append(error as? PasscodeError)
+            }
+            do {
+                try await service.unlock(with: self.passcode)
+                nested.append(nil)
+            } catch {
+                nested.append(error as? PasscodeError)
+            }
+        }
+        service = makeService(keyStore: hooked)
+
+        try await service.unlockApp(with: passcode)
+
+        XCTAssertEqual(nested, [.busy, .busy], "a reentrant unlock must be refused, not run alongside")
+    }
+
     // MARK: - Change — the claim the whole design rests on
 
     /// Changing the passcode must rewrap 32 bytes and leave every key share
@@ -908,6 +1147,35 @@ extension PasscodeServiceTests {
 
 // MARK: - Test doubles
 
+/// A sweeper that counts seals and can be made to fail one, so the resume
+/// latch — which is invisible from the store, because a second sweep over an
+/// already-sealed store changes nothing — can be observed.
+@MainActor
+private final class CountingKeyshareSweeper: KeyshareSweeping {
+
+    private let wrapped: KeyshareSweeping
+    private(set) var sealCount = 0
+    var sealFailure: Error?
+    /// Runs inside the sweep, so a lock landing mid-sweep is deterministic.
+    var duringSeal: (() -> Void)?
+
+    init(wrapping wrapped: KeyshareSweeping) {
+        self.wrapped = wrapped
+    }
+
+    func reset() { sealCount = 0 }
+
+    func sealAll() throws {
+        sealCount += 1
+        duringSeal?()
+        if let sealFailure { throw sealFailure }
+        try wrapped.sealAll()
+    }
+
+    func unsealAll() throws { try wrapped.unsealAll() }
+    func hasSealedShare() throws -> Bool { try wrapped.hasSealedShare() }
+}
+
 /// A sweeper that runs a hook inside the sealed-share scan — the *first*
 /// suspension point of a set, and the one a generation captured too late would
 /// leave unguarded.
@@ -939,10 +1207,16 @@ private final class HookedKeyshareKeyStore: KeyshareKeyStoring {
 
     private let wrapped: KeyshareKeyStoring
     private let duringWrap: @MainActor () throws -> Void
+    private let duringUnwrap: @MainActor () async throws -> Void
 
-    init(wrapping wrapped: KeyshareKeyStoring, duringWrap: @escaping @MainActor () throws -> Void) {
+    init(
+        wrapping wrapped: KeyshareKeyStoring,
+        duringWrap: @escaping @MainActor () throws -> Void = {},
+        duringUnwrap: @escaping @MainActor () async throws -> Void = {}
+    ) {
         self.wrapped = wrapped
         self.duringWrap = duringWrap
+        self.duringUnwrap = duringUnwrap
     }
 
     func generateDataKey() throws -> SymmetricKey { try wrapped.generateDataKey() }
@@ -958,6 +1232,8 @@ private final class HookedKeyshareKeyStore: KeyshareKeyStoring {
     }
 
     func unwrap(_ blob: Data, passcode: String) async throws -> SymmetricKey {
-        try await wrapped.unwrap(blob, passcode: passcode)
+        let key = try await wrapped.unwrap(blob, passcode: passcode)
+        try await duringUnwrap()
+        return key
     }
 }

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -1119,6 +1119,207 @@ extension PasscodeServiceTests {
     }
 }
 
+// MARK: - A background lock wins over a change or a disable
+
+extension PasscodeServiceTests {
+
+    /// The window a generation captured inside the verification cannot see. A
+    /// `lock()` landing after the disable is under way but before `unlock` reads
+    /// the generation for itself would be adopted straight over: the key goes
+    /// back into the session, the lock is undone, and the removal carries on to
+    /// delete the very passcode the lock screen is waiting for.
+    ///
+    /// Driven from the disable's own pre-verification wrapper read, which is the
+    /// one collaborator it touches before the verification begins.
+    func testALockLandingBeforeADisableVerifiesWins() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+        let sealed = try storedShares()
+        let hooked = HookedKeyshareKeyStore(wrapping: keyStore, duringFirstLoad: { [session] in
+            session?.clear()
+        })
+
+        do {
+            try await makeService(keyStore: hooked).disablePasscode(current: passcode)
+            XCTFail("Expected .cancelledByLock")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .cancelledByLock)
+        }
+
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(lockService.mode, .passcode, "the passcode the lock screen asks for must still exist")
+        XCTAssertEqual(try storedShares(), sealed, "nothing durable may move on the wrong side of a lock")
+        if case .unlocked = session.currentState() {
+            XCTFail("the lock must not have been undone")
+        }
+    }
+
+    /// The same contract on the change, asserted where it is observable: the
+    /// rewrapped key is the one durable thing this call produces, and a lock
+    /// landing before it is stored means the passcode stays exactly as the user
+    /// locked the app behind it.
+    ///
+    /// The change's own pre-verification window has no collaborator in it —
+    /// nothing between the lease and the verification can be driven from a test
+    /// — so the anchor it shares with the disable is covered above, and this
+    /// pins the half that is reachable.
+    func testALockDuringAChangeStoresNoNewWrapper() async throws {
+        try await sut.setPasscode(passcode)
+        let wrappedBefore = keyStore.loadWrappedDataKey()
+        let hooked = HookedKeyshareKeyStore(wrapping: keyStore, duringWrap: { [session] in
+            session?.clear()
+        })
+
+        do {
+            try await makeService(keyStore: hooked).changePasscode(current: passcode, new: newPasscode)
+            XCTFail("Expected .cancelledByLock")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .cancelledByLock)
+        }
+
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), wrappedBefore, "no new wrapper may be stored over a lock")
+        if case .unlocked = session.currentState() {
+            XCTFail("the lock must not have been undone")
+        }
+        try await sut.unlock(with: passcode)
+        sut.lock()
+        do {
+            try await sut.unlock(with: newPasscode)
+            XCTFail("The passcode must not have moved")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
+        }
+    }
+
+    /// The cut-off is also where the rollback material has to exist. A Keychain
+    /// that goes quiet on either side of the one read that answered leaves the
+    /// disable with no bytes to put back, and the reseal that would be needed
+    /// instead is on the wrong side of the door — so it refuses before it opens
+    /// a single share rather than discovering it at the deletion.
+    func testADisableRefusesWhenItCannotSeeTheWrapperAroundItsOwnVerification() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+        let sealed = try storedShares()
+        let scripted = ScriptedReadKeyshareKeyStore(
+            wrapping: keyStore,
+            reads: [.unavailable(errSecInteractionNotAllowed), nil, .unavailable(errSecInteractionNotAllowed)]
+        )
+
+        do {
+            try await makeService(keyStore: scripted).disablePasscode(current: passcode)
+            XCTFail("Expected .storageFailure")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .storageFailure)
+        }
+
+        XCTAssertEqual(try storedShares(), sealed, "no share may be opened without a way back")
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(lockService.mode, .passcode)
+    }
+
+    /// And with no lock in sight both still do exactly what they did before.
+    func testAChangeAndADisableAreUnaffectedWhenNoLockLands() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+
+        try await sut.changePasscode(current: passcode, new: newPasscode)
+        try await sut.disablePasscode(current: newPasscode)
+
+        XCTAssertEqual(try storedShares(), [share])
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
+        XCTAssertEqual(lockService.mode, .deviceAuth)
+    }
+}
+
+// MARK: - The gate never outlives the passcode
+
+extension PasscodeServiceTests {
+
+    /// The trapped user, and the reason the cut-off is where it is. Past the
+    /// unseal a lock cannot be honoured — resealing needs the data key the lock
+    /// has just discarded — so the disable finishes, and it has to finish
+    /// somewhere the app can be got back into.
+    ///
+    /// A gate raised while the mode still said `.passcode` is stale the instant
+    /// this returns, and the state it is stale against is the dangerous one: no
+    /// wrapper, so the unlock behind that gate can only ever answer `notSet`,
+    /// forever, until the app is force quit.
+    func testADisableThatCompletesAcrossALockLeavesNoGateStanding() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+
+        var wasGateUpWhenTheLockLanded: Bool?
+        var service: PasscodeService!
+        let locking = CountingKeyshareSweeper(wrapping: sweeper)
+        locking.afterUnseal = { [session] in
+            session?.clear()
+            wasGateUpWhenTheLockLanded = service.isPasscodeGateRequired
+        }
+        service = makeService(sweeper: locking)
+
+        try await service.disablePasscode(current: passcode)
+
+        XCTAssertEqual(wasGateUpWhenTheLockLanded, true, "the gate was legitimately up when the lock landed")
+        XCTAssertFalse(service.isPasscodeGateRequired, "no gate may be left standing over a passcode that is gone")
+        XCTAssertEqual(try storedShares(), [share], "the shares are back in the clear, as a completed disable requires")
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
+        XCTAssertEqual(lockService.mode, .deviceAuth)
+        if case .disabled = session.currentState() {} else {
+            XCTFail("with no key left the session must report .disabled")
+        }
+    }
+
+    /// The way back in, without relaunching. Someone standing in front of a gate
+    /// that outlived its passcode types the only thing they know, and the answer
+    /// has to be more than an error that repeats forever: the mode drops to
+    /// device auth on the spot, so the gate stops being required and comes down.
+    func testAnAppUnlockAgainstARemovedPasscodeTakesTheGateDown() async throws {
+        try await sut.setPasscode(passcode)
+        // The state a disable completing behind a raised gate leaves.
+        keychain.setWrappedKeyshareDataKey(nil)
+        lockService.mode = .passcode
+        sut.lock()
+
+        do {
+            try await sut.unlockApp(with: passcode)
+            XCTFail("Expected .notSet")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .notSet)
+        }
+
+        XCTAssertEqual(lockService.mode, .deviceAuth)
+        XCTAssertFalse(sut.isPasscodeGateRequired, "a gate with nothing behind it must stop being required")
+    }
+
+    func testTheGateIsRequiredWhileAPasscodeIsSet() async throws {
+        try await sut.setPasscode(passcode)
+
+        XCTAssertTrue(sut.isPasscodeGateRequired)
+    }
+
+    func testTheGateIsNotRequiredWithNoPasscodeSet() {
+        XCTAssertFalse(sut.isPasscodeGateRequired)
+    }
+
+    func testTheGateIsNotRequiredOnceThePasscodeIsRemoved() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+
+        try await sut.disablePasscode(current: passcode)
+
+        XCTAssertFalse(sut.isPasscodeGateRequired)
+    }
+
+    /// Failing closed, here too. An unreadable wrapper may well be there, and a
+    /// gate taken down over a momentary read failure is protection removed.
+    func testTheGateStaysRequiredWhenTheWrapperCannotBeRead() async throws {
+        try await sut.setPasscode(passcode)
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        XCTAssertTrue(sut.isPasscodeGateRequired)
+    }
+}
+
 // MARK: - The attempt limiter's own record
 
 extension PasscodeServiceTests {
@@ -1190,6 +1391,9 @@ private final class CountingKeyshareSweeper: KeyshareSweeping {
     var sealFailure: Error?
     /// Runs inside the sweep, so a lock landing mid-sweep is deterministic.
     var duringSeal: (() -> Void)?
+    /// Runs once the unseal has been saved — the far side of the disable's abort
+    /// cut-off, where a lock can no longer be honoured.
+    var afterUnseal: (() -> Void)?
 
     init(wrapping wrapped: KeyshareSweeping) {
         self.wrapped = wrapped
@@ -1204,7 +1408,10 @@ private final class CountingKeyshareSweeper: KeyshareSweeping {
         try wrapped.sealAll()
     }
 
-    func unsealAll() throws { try wrapped.unsealAll() }
+    func unsealAll() throws {
+        try wrapped.unsealAll()
+        afterUnseal?()
+    }
     func hasSealedShare() throws -> Bool { try wrapped.hasSealedShare() }
 }
 
@@ -1231,29 +1438,80 @@ private final class HookedKeyshareSweeper: KeyshareSweeping {
     @MainActor func unsealAll() throws { try wrapped.unsealAll() }
 }
 
+/// A key store whose wrapper reads are scripted call by call, so a Keychain that
+/// answers differently either side of a verification can be reproduced. `nil`
+/// means "delegate", and anything past the end of the script delegates too.
+private final class ScriptedReadKeyshareKeyStore: KeyshareKeyStoring {
+
+    private let wrapped: KeyshareKeyStoring
+    private let reads: [KeychainReadResult<Data>?]
+    private var readCount = 0
+
+    init(wrapping wrapped: KeyshareKeyStoring, reads: [KeychainReadResult<Data>?]) {
+        self.wrapped = wrapped
+        self.reads = reads
+    }
+
+    func loadWrappedDataKey() -> KeychainReadResult<Data> {
+        defer { readCount += 1 }
+        guard readCount < reads.count, let scripted = reads[readCount] else {
+            return wrapped.loadWrappedDataKey()
+        }
+        return scripted
+    }
+
+    func generateDataKey() throws -> SymmetricKey { try wrapped.generateDataKey() }
+    func storeWrappedDataKey(_ blob: Data) throws { try wrapped.storeWrappedDataKey(blob) }
+    func deleteWrappedDataKey() throws { try wrapped.deleteWrappedDataKey() }
+
+    func wrap(_ key: SymmetricKey, passcode: String) async throws -> Data {
+        try await wrapped.wrap(key, passcode: passcode)
+    }
+
+    func unwrap(_ blob: Data, passcode: String) async throws -> SymmetricKey {
+        try await wrapped.unwrap(blob, passcode: passcode)
+    }
+}
+
 /// A key store that runs a hook inside `wrap`, which is the one long suspension
 /// point in a transition. Everything a background lock or a concurrent write
 /// could do mid-transition happens there, and driving it by hand is the only way
 /// to make those races deterministic rather than timing-dependent.
+///
+/// `duringFirstLoad` covers the other end: a transition's *first* wrapper read
+/// happens before it verifies anything, so a hook there lands in the window
+/// between the transition starting and the verification taking its own view of
+/// the session.
 private final class HookedKeyshareKeyStore: KeyshareKeyStoring {
 
     private let wrapped: KeyshareKeyStoring
     private let duringWrap: @MainActor () throws -> Void
+    private let duringFirstLoad: () -> Void
     private let duringUnwrap: @MainActor () async throws -> Void
+    private var didLoad = false
 
+    /// `duringUnwrap` stays last so a trailing closure still lands on it.
     init(
         wrapping wrapped: KeyshareKeyStoring,
         duringWrap: @escaping @MainActor () throws -> Void = {},
+        duringFirstLoad: @escaping () -> Void = {},
         duringUnwrap: @escaping @MainActor () async throws -> Void = {}
     ) {
         self.wrapped = wrapped
         self.duringWrap = duringWrap
+        self.duringFirstLoad = duringFirstLoad
         self.duringUnwrap = duringUnwrap
     }
 
     func generateDataKey() throws -> SymmetricKey { try wrapped.generateDataKey() }
 
-    func loadWrappedDataKey() -> KeychainReadResult<Data> { wrapped.loadWrappedDataKey() }
+    func loadWrappedDataKey() -> KeychainReadResult<Data> {
+        if !didLoad {
+            didLoad = true
+            duringFirstLoad()
+        }
+        return wrapped.loadWrappedDataKey()
+    }
     func storeWrappedDataKey(_ blob: Data) throws { try wrapped.storeWrappedDataKey(blob) }
     func deleteWrappedDataKey() throws { try wrapped.deleteWrappedDataKey() }
 

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -540,19 +540,18 @@ final class PasscodeServiceTests: XCTestCase {
         XCTAssertFalse(isSet)
     }
 
-    /// No unwrapped key is left behind. An earlier design stashed one beside the
-    /// shares; a store left in that state reads as "no passcode" while its
-    /// shares are still ciphertext.
-    func testDisableLeavesNoKeyMaterialOfAnyFormBehind() async throws {
+    /// No key material of any form is left behind, and the session says so. An
+    /// earlier design stashed an unwrapped copy beside the shares; a store left
+    /// in that state reads as "no passcode" while its shares are ciphertext.
+    func testDisableLeavesNoKeyMaterialBehind() async throws {
         try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
 
         try await sut.disablePasscode(current: passcode)
 
-        XCTAssertAbsent(keyStore.loadDataKey(), "removing the passcode must not stash the key in the clear")
         XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
         if case .disabled = session.currentState() {} else {
-            XCTFail("with no key of either form the session must report .disabled")
+            XCTFail("with no key left the session must report .disabled")
         }
     }
 
@@ -947,10 +946,6 @@ private final class HookedKeyshareKeyStore: KeyshareKeyStoring {
     }
 
     func generateDataKey() throws -> SymmetricKey { try wrapped.generateDataKey() }
-
-    func loadDataKey() -> KeychainReadResult<SymmetricKey> { wrapped.loadDataKey() }
-    func storeDataKey(_ key: SymmetricKey) throws { try wrapped.storeDataKey(key) }
-    func deleteDataKey() throws { try wrapped.deleteDataKey() }
 
     func loadWrappedDataKey() -> KeychainReadResult<Data> { wrapped.loadWrappedDataKey() }
     func storeWrappedDataKey(_ blob: Data) throws { try wrapped.storeWrappedDataKey(blob) }

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -4,6 +4,7 @@
 //
 
 import CryptoKit
+import Security
 import XCTest
 @testable import VultisigApp
 
@@ -77,8 +78,8 @@ final class PasscodeServiceTests: XCTestCase {
 
         try await sut.setPasscode(passcode)
 
-        XCTAssertNil(keyStore.loadDataKey(), "The clear copy must be gone")
-        XCTAssertNotNil(keyStore.loadWrappedDataKey())
+        XCTAssertAbsent(keyStore.loadDataKey(), "The clear copy must be gone")
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
         let isSet = await sut.isSet
         XCTAssertTrue(isSet)
     }
@@ -249,8 +250,8 @@ final class PasscodeServiceTests: XCTestCase {
 
         try await sut.disablePasscode(current: passcode)
 
-        XCTAssertNotNil(keyStore.loadDataKey())
-        XCTAssertNil(keyStore.loadWrappedDataKey())
+        _ = try XCTUnwrapPresent(keyStore.loadDataKey())
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
         let isSet = await sut.isSet
         XCTAssertFalse(isSet)
     }
@@ -280,8 +281,8 @@ final class PasscodeServiceTests: XCTestCase {
             XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
         }
 
-        XCTAssertNil(keyStore.loadDataKey())
-        XCTAssertNotNil(keyStore.loadWrappedDataKey())
+        XCTAssertAbsent(keyStore.loadDataKey())
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
     }
 
     /// If the wrapped copy cannot be removed, both copies would exist and the
@@ -299,8 +300,8 @@ final class PasscodeServiceTests: XCTestCase {
             XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
         }
 
-        XCTAssertNil(keyStore.loadDataKey(), "The clear copy must have been rolled back")
-        XCTAssertNotNil(keyStore.loadWrappedDataKey())
+        XCTAssertAbsent(keyStore.loadDataKey(), "The clear copy must have been rolled back")
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
         XCTAssertEqual(lockService.mode, .passcode, "The passcode is still in force")
     }
 
@@ -459,5 +460,88 @@ extension PasscodeServiceTests {
         let limiter = PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime })
 
         XCTAssertEqual(limiter.remainingLockout(now: Date()), 0)
+    }
+
+    /// The one deliberate exception to failing closed, pinned so it is a
+    /// decision rather than an oversight. Answering an unreadable record with
+    /// the maximum delay would never decay and could not be cleared by a correct
+    /// passcode — clearing it needs a write the same Keychain would refuse — so
+    /// it is a permanent lockout, and it buys nothing: deleting the item yields
+    /// `.absent`, which is legitimately a fresh start anyway.
+    func testAnUnreadableAttemptStateIsTreatedAsNoRecordRatherThanALockout() {
+        keychain.passcodeAttemptStateResult = .unavailable(errSecInteractionNotAllowed)
+
+        let limiter = PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime })
+
+        XCTAssertEqual(limiter.remainingLockout(now: Date()), 0)
+    }
+
+    /// A *corrupt* record is a different matter and still fails closed: it is
+    /// present, so someone edited it, and resuming from zero would make editing
+    /// the blob a way to buy free attempts.
+    func testACorruptAttemptStateStillFailsClosed() {
+        keychain.setPasscodeAttemptState(Data("not json".utf8))
+
+        let limiter = PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime })
+
+        XCTAssertEqual(limiter.remainingLockout(now: Date()), PasscodeAttemptLimiter.maximumDelay)
+    }
+}
+
+// MARK: - Failing closed on an unreadable Keychain
+
+extension PasscodeServiceTests {
+
+    /// The lost-funds path this whole tri-state exercise exists to close. If an
+    /// unreadable wrapper read as "no passcode", `setPasscode` would mint a
+    /// fresh data key and store a wrapper over the top of the existing one —
+    /// and the new key opens none of the shares the old one sealed.
+    func testIsSetFailsClosedWhenTheWrapperCannotBeRead() async {
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        let isSet = await sut.isSet
+
+        XCTAssertTrue(isSet, "An unreadable wrapper may well be there and must be treated as one")
+    }
+
+    func testSetPasscodeIsRefusedWhenTheWrapperCannotBeRead() async throws {
+        try givenMigratedState()
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+        keychain.resetWrites()
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected the set to be refused")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .alreadySet)
+        }
+
+        XCTAssertEqual(keychain.writes, [], "Nothing may be written while the Keychain cannot be read")
+    }
+
+    /// `notSet` is what sends the UI off to offer creating a passcode, over the
+    /// top of a wrapper that may still exist.
+    func testUnlockReportsStorageFailureRatherThanNotSetWhenTheWrapperCannotBeRead() async {
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        do {
+            _ = try await sut.unlock(with: passcode)
+            XCTFail("Expected the unlock to fail")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .storageFailure)
+        }
+    }
+
+    /// An unreadable clear key must not be mistaken for "nothing is encrypted
+    /// yet", which is the one state that would license inventing a new key.
+    func testSetPasscodeIsRefusedWhenTheClearKeyCannotBeRead() async {
+        keychain.keyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected the set to be refused")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .noDataKey)
+        }
     }
 }

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -5,16 +5,26 @@
 
 import CryptoKit
 import Security
+import SwiftData
 import XCTest
 @testable import VultisigApp
 
+/// Driven against a **real** `KeyshareSweeper` over an in-memory store rather
+/// than a stub, because the thing worth pinning is not that the service calls a
+/// collaborator — it is that a passcode set leaves no plaintext share behind and
+/// a passcode removal leaves no sealed one.
+@MainActor
 final class PasscodeServiceTests: XCTestCase {
 
+    private var token: TestContextToken!
+    private var context: ModelContext!
     private var keychain: MockKeychainService!
     private var keyStore: DefaultKeyshareKeyStore!
     private var session: KeyshareKeySession!
     private var protector: KeyshareProtector!
     private var lockService: AppLockService!
+    private var coordinator: KeyshareWriteCoordinator!
+    private var sweeper: KeyshareSweeper!
     private var defaults: UserDefaults!
     private var suiteName: String!
     private var sut: PasscodeService!
@@ -26,11 +36,15 @@ final class PasscodeServiceTests: XCTestCase {
     private let passcode = "12345"
     private let newPasscode = "98765"
     private let share = "eyJrZXlzaGFyZSI6ImRrbHMifQ=="
+    private let otherShare = "eyJrZXlzaGFyZSI6ImRrbHMtdHdvIn0="
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         suiteName = "PasscodeServiceTests.\(UUID().uuidString)"
         defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+
+        token = try TestStore.installInMemoryContainer()
+        context = token.container.mainContext
 
         keychain = MockKeychainService()
         let store = DefaultKeyshareKeyStore(keychain: keychain)
@@ -39,78 +53,91 @@ final class PasscodeServiceTests: XCTestCase {
         session = keySession
         protector = KeyshareProtector(state: { keySession.currentState() })
         lockService = AppLockService(defaults: defaults)
+        coordinator = KeyshareWriteCoordinator()
+        sweeper = KeyshareSweeper(protector: protector, context: { [context] in context })
 
-        sut = PasscodeService(
-            keyStore: store,
-            session: keySession,
-            lockService: lockService,
-            limiter: PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime })
-        )
+        sut = makeService()
     }
 
     override func tearDown() {
         defaults.removePersistentDomain(forName: suiteName)
         sut = nil
+        sweeper = nil
+        coordinator = nil
         lockService = nil
         protector = nil
         session = nil
         keyStore = nil
         keychain = nil
+        context = nil
+        TestStore.restore(token)
+        token = nil
         defaults = nil
         suiteName = nil
         super.tearDown()
     }
 
-    /// Puts the app in the state the migration leaves it in: a data key exists
-    /// in the clear and a share is sealed under it.
-    @discardableResult
-    private func givenMigratedState() throws -> String {
-        let key = try keyStore.generateDataKey()
-        try keyStore.storeDataKey(key)
-        session.adopt(key)
-        return try protector.seal(share)
+    private func makeService(
+        keyStore: KeyshareKeyStoring? = nil,
+        sweeper: KeyshareSweeping? = nil
+    ) -> PasscodeService {
+        PasscodeService(
+            keyStore: keyStore ?? self.keyStore,
+            session: session,
+            lockService: lockService,
+            limiter: PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime }),
+            coordinator: coordinator,
+            sweeper: sweeper ?? self.sweeper
+        )
     }
 
     // MARK: - Set
 
-    func testSetPasscodeReplacesTheClearKeyWithAWrappedOne() async throws {
-        try givenMigratedState()
-
+    func testSetPasscodeStoresTheWrappedKeyAndReportsItselfSet() async throws {
         try await sut.setPasscode(passcode)
 
-        XCTAssertAbsent(keyStore.loadDataKey(), "The clear copy must be gone")
         _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
         let isSet = await sut.isSet
         XCTAssertTrue(isSet)
     }
 
     func testSetPasscodeSwitchesTheLockMode() async throws {
-        try givenMigratedState()
-
         try await sut.setPasscode(passcode)
 
         XCTAssertEqual(lockService.mode, .passcode)
     }
 
-    func testSetPasscodeKeepsSharesReadableInTheSameSession() async throws {
-        let sealed = try givenMigratedState()
+    /// The invariant, in one assertion: with a passcode set, no stored share is
+    /// unsealed. Opt-in encryption makes an accessor bypass *silent* — it writes
+    /// plaintext and only breaks for passcode users — so this is the loud
+    /// failure that would otherwise be missing.
+    func testSetPasscodeSealsEveryStoredShare() async throws {
+        try givenVaults([("vault-one", [share, otherShare]), ("vault-two", [share])])
 
         try await sut.setPasscode(passcode)
 
-        XCTAssertEqual(try protector.open(sealed), share)
+        let stored = try storedShares()
+        XCTAssertEqual(stored.count, 3)
+        for value in stored {
+            XCTAssertTrue(protector.isSealed(value), "no stored share may stay plaintext behind a passcode")
+        }
+        XCTAssertEqual(try stored.map { try protector.open($0) }.sorted(), [share, share, otherShare].sorted())
     }
 
-    func testSetPasscodeRefusesWhenNothingIsEncryptedYet() async {
-        do {
-            try await sut.setPasscode(passcode)
-            XCTFail("Expected .noDataKey")
-        } catch {
-            XCTAssertEqual(error as? PasscodeError, .noDataKey)
-        }
+    /// Nothing to sweep is the common case — most people set a passcode on an
+    /// empty or freshly restored device.
+    func testSetPasscodeWithNoVaultsStoresTheWrapperAndNothingElse() async throws {
+        try await sut.setPasscode(passcode)
+
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(
+            Set(keychain.writes),
+            ["wrappedKeyshareDataKey", "passcodeAttemptState"],
+            "only the wrapper and the attempt counter may be touched"
+        )
     }
 
     func testSetPasscodeRefusesWhenOneIsAlreadySet() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
 
         do {
@@ -122,8 +149,6 @@ final class PasscodeServiceTests: XCTestCase {
     }
 
     func testSetPasscodeRejectsAWrongLength() async throws {
-        try givenMigratedState()
-
         for candidate in ["1234", "123456", "abcde", ""] {
             do {
                 try await sut.setPasscode(candidate)
@@ -134,11 +159,269 @@ final class PasscodeServiceTests: XCTestCase {
         }
     }
 
+    /// Never mint over evidence. A sealed share with no readable wrapper means a
+    /// key already exists somewhere; the fresh one minted here would open none
+    /// of what it sealed, and storing its wrapper would make that permanent.
+    func testSetPasscodeIsRefusedWhenAShareIsAlreadySealed() async throws {
+        let foreign = try AesGcmKeyshareCipher().seal(share, with: SymmetricKey(size: .bits256))
+        try givenVaults([("vault-one", [foreign])])
+        keychain.resetWrites()
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected .sealedSharesWithoutKey")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .sealedSharesWithoutKey)
+        }
+
+        XCTAssertEqual(keychain.writes, [], "no key may be minted over a store that is already sealed")
+        XCTAssertEqual(try storedShares(), [foreign])
+    }
+
+    /// A completed disable leaves nothing sealed, so the guard above does not
+    /// make the feature one-shot.
+    func testAPasscodeCanBeSetAgainAfterBeingRemoved() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+        try await sut.disablePasscode(current: passcode)
+
+        try await sut.setPasscode(newPasscode)
+
+        XCTAssertEqual(lockService.mode, .passcode)
+        XCTAssertTrue(protector.isSealed(try XCTUnwrap(try storedShares().first)))
+    }
+
+    // MARK: - Set: interruption leaves a recoverable state
+
+    /// The failure the ordering exists for. A sweep that cannot finish must
+    /// leave the wrapper **and** the gate in place: deleting the wrapper would
+    /// strand whatever had already been sealed, and dropping back to
+    /// `.deviceAuth` would hide the passcode screen that the resume runs behind.
+    func testAFailedSweepKeepsTheWrapperAndThePasscodeGate() async throws {
+        let foreign = try AesGcmKeyshareCipher().seal(share, with: SymmetricKey(size: .bits256))
+        try givenVaults([("vault-one", [share])])
+
+        // Slipped in after the sealed-share guard has already run, so the sweep
+        // is what fails rather than the precondition.
+        let hooked = HookedKeyshareKeyStore(wrapping: keyStore) { [context] in
+            let vault = try XCTUnwrap(try context?.fetch(FetchDescriptor<Vault>()).first)
+            vault.keyshares = [KeyShare(pubkey: "vault-one-0", keyshare: foreign)]
+            try context?.save()
+        }
+
+        do {
+            try await makeService(keyStore: hooked).setPasscode(passcode)
+            XCTFail("Expected the sweep to fail")
+        } catch {
+            XCTAssertEqual(error as? KeyshareSweeperError, .verificationFailed(pubkey: "vault-one-0"))
+        }
+
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(lockService.mode, .passcode, "the gate the resume runs behind must be up")
+    }
+
+    /// The other suspension point, and the one a late generation capture would
+    /// miss: a lock landing while the store is scanned must win too, or the app
+    /// finishes the set with the key live in memory behind a lock screen.
+    func testALockDuringTheSealedShareScanWins() async throws {
+        try givenVaults([("vault-one", [share])])
+        let hooked = HookedKeyshareSweeper(wrapping: sweeper) { [session] in
+            session?.clear()
+        }
+
+        do {
+            try await makeService(sweeper: hooked).setPasscode(passcode)
+            XCTFail("Expected .cancelledByLock")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .cancelledByLock)
+        }
+
+        XCTAssertEqual(try storedShares(), [share], "nothing may be sealed under a key the lock discarded")
+        if case .unlocked = session.currentState() {
+            XCTFail("the lock must not have been undone")
+        }
+    }
+
+    /// A background lock landing mid-derivation wins, and the app is left in the
+    /// pending-passcode state rather than silently unlocked: wrapper durable,
+    /// gate up, key not adopted.
+    func testALockDuringKeyDerivationWinsAndLeavesPendingPasscode() async throws {
+        try givenVaults([("vault-one", [share])])
+        let hooked = HookedKeyshareKeyStore(wrapping: keyStore) { [session] in
+            session?.clear()
+        }
+
+        do {
+            try await makeService(keyStore: hooked).setPasscode(passcode)
+            XCTFail("Expected .cancelledByLock")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .cancelledByLock)
+        }
+
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(lockService.mode, .passcode)
+        XCTAssertEqual(try storedShares(), [share], "the lock stands, so nothing was sealed under a forgotten key")
+        if case .unlocked = session.currentState() {
+            XCTFail("the lock must not have been undone")
+        }
+    }
+
+    /// The wrapper has to be durable before a single share moves. A Keychain
+    /// that accepts the write and stores nothing must therefore abort the set
+    /// with the store untouched.
+    func testAWrapperThatCannotBeStoredSealsNothing() async throws {
+        try givenVaults([("vault-one", [share])])
+        keychain.dropsWrappedKeyshareDataKeyWrites = true
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected .persistenceFailed")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .persistenceFailed)
+        }
+
+        XCTAssertEqual(try storedShares(), [share])
+        XCTAssertNotEqual(lockService.mode, .passcode)
+    }
+
+    // MARK: - Serialization
+
+    /// Actors are reentrant at every `await`, so the lease — not the actor — is
+    /// what keeps two transitions apart. The refusal has to land **before** any
+    /// Keychain write, mode change or share rewrite, which is what the
+    /// after-assertions pin: an implementation that took the lease late would
+    /// still throw `.busy` and would still be wrong.
+    func testATransitionIsRefusedWhileAnotherIsHeld() async throws {
+        try givenVaults([("vault-one", [share])])
+        keychain.resetWrites()
+        let lease = try coordinator.beginTransition()
+        defer { coordinator.end(lease) }
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected .busy")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .busy)
+        }
+
+        XCTAssertEqual(keychain.writes, [])
+        XCTAssertEqual(try storedShares(), [share])
+        XCTAssertNotEqual(lockService.mode, .passcode)
+    }
+
+    /// The interval a per-write counter misses: TSS hands over a share long
+    /// before `commitVault` stores it, and a passcode set landing in between
+    /// would sweep a store that has never seen it.
+    func testATransitionIsRefusedWhileAVaultCreationEpisodeIsOpen() async throws {
+        try givenVaults([("vault-one", [share])])
+        keychain.resetWrites()
+        let episode = try XCTUnwrap(coordinator.beginEpisode())
+        defer { coordinator.end(episode) }
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected .busy")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .busy)
+        }
+
+        XCTAssertEqual(keychain.writes, [])
+        XCTAssertEqual(try storedShares(), [share])
+    }
+
+    func testDisableIsRefusedWhileATransitionIsHeld() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+        let sealed = try storedShares()
+        keychain.resetWrites()
+        let lease = try coordinator.beginTransition()
+        defer { coordinator.end(lease) }
+
+        do {
+            try await sut.disablePasscode(current: passcode)
+            XCTFail("Expected .busy")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .busy)
+        }
+
+        XCTAssertEqual(keychain.writes, [], "a refused disable must not touch the wrapper or the attempt counter")
+        XCTAssertEqual(try storedShares(), sealed, "a refused disable must not open a single share")
+        XCTAssertEqual(lockService.mode, .passcode)
+    }
+
+    func testChangeIsRefusedWhileATransitionIsHeld() async throws {
+        try await sut.setPasscode(passcode)
+        let wrappedBefore = keyStore.loadWrappedDataKey()
+        keychain.resetWrites()
+        let lease = try coordinator.beginTransition()
+        defer { coordinator.end(lease) }
+
+        do {
+            try await sut.changePasscode(current: passcode, new: newPasscode)
+            XCTFail("Expected .busy")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .busy)
+        }
+
+        XCTAssertEqual(keychain.writes, [])
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), wrappedBefore)
+    }
+
+    /// A refused transition must not leave a lease behind, or the next attempt
+    /// fails for a reason that no longer exists.
+    func testARefusedTransitionDoesNotStrandALease() async throws {
+        let episode = try XCTUnwrap(coordinator.beginEpisode())
+        _ = try? await sut.setPasscode(passcode)
+        coordinator.end(episode)
+
+        try await sut.setPasscode(passcode)
+
+        XCTAssertEqual(lockService.mode, .passcode)
+    }
+
+    /// The other half: a transition that *acquired* the lease and then threw
+    /// somewhere downstream has to release it on the way out.
+    func testATransitionThatFailsDownstreamReleasesItsLease() async throws {
+        keychain.dropsWrappedKeyshareDataKeyWrites = true
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected the wrapper write to fail")
+        } catch {
+            XCTAssertEqual(error as? KeyshareKeyStoreError, .persistenceFailed)
+        }
+        keychain.dropsWrappedKeyshareDataKeyWrites = false
+
+        try await sut.setPasscode(passcode)
+
+        XCTAssertEqual(lockService.mode, .passcode)
+    }
+
+    /// A store carrying somebody else's unsaved work cannot answer "is anything
+    /// sealed?" truthfully — a pending edit or deletion hides the durable row —
+    /// so the set is refused before a key is minted rather than after.
+    func testASetIsRefusedOverADirtyStoreBeforeAnythingIsWritten() async throws {
+        let vaults = try givenVaults([("vault-one", [share])])
+        vaults[0].name = "renamed but not saved"
+        XCTAssertTrue(context.hasChanges)
+        keychain.resetWrites()
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected .busy")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .busy)
+        }
+
+        XCTAssertEqual(keychain.writes, [], "no wrapper may be stored over a store that cannot be scanned")
+        XCTAssertNotEqual(lockService.mode, .passcode)
+    }
+
     // MARK: - Lock / unlock
 
     func testLockMakesSealedSharesUnreadable() async throws {
-        let sealed = try givenMigratedState()
+        try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
+        let sealed = try XCTUnwrap(try storedShares().first)
 
         sut.lock()
 
@@ -148,8 +431,9 @@ final class PasscodeServiceTests: XCTestCase {
     }
 
     func testUnlockRestoresAccess() async throws {
-        let sealed = try givenMigratedState()
+        try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
+        let sealed = try XCTUnwrap(try storedShares().first)
         sut.lock()
 
         try await sut.unlock(with: passcode)
@@ -158,8 +442,9 @@ final class PasscodeServiceTests: XCTestCase {
     }
 
     func testUnlockWithTheWrongPasscodeLeavesTheAppLocked() async throws {
-        let sealed = try givenMigratedState()
+        try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
+        let sealed = try XCTUnwrap(try storedShares().first)
         sut.lock()
 
         do {
@@ -188,18 +473,17 @@ final class PasscodeServiceTests: XCTestCase {
     /// every vault at this moment; if this assertion ever fails, that risk has
     /// been imported along with it.
     func testChangingThePasscodeLeavesKeyShareCiphertextByteIdentical() async throws {
-        let sealed = try givenMigratedState()
+        try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
-        let before = sealed
+        let before = try storedShares()
 
         try await sut.changePasscode(current: passcode, new: newPasscode)
 
-        XCTAssertEqual(sealed, before, "No key share may be rewritten by a passcode change")
-        XCTAssertEqual(try protector.open(sealed), share)
+        XCTAssertEqual(try storedShares(), before, "No key share may be rewritten by a passcode change")
+        XCTAssertEqual(try protector.open(try XCTUnwrap(before.first)), share)
     }
 
     func testChangedPasscodeUnlocksAndTheOldOneDoesNot() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
         try await sut.changePasscode(current: passcode, new: newPasscode)
         sut.lock()
@@ -216,7 +500,6 @@ final class PasscodeServiceTests: XCTestCase {
     }
 
     func testChangeWithTheWrongCurrentPasscodeChangesNothing() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
         let wrappedBefore = keyStore.loadWrappedDataKey()
 
@@ -231,7 +514,6 @@ final class PasscodeServiceTests: XCTestCase {
     }
 
     func testChangeRejectsAnInvalidNewPasscode() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
 
         do {
@@ -244,35 +526,48 @@ final class PasscodeServiceTests: XCTestCase {
 
     // MARK: - Disable
 
-    func testDisableRestoresTheClearKeyAndRemovesTheWrappedOne() async throws {
-        try givenMigratedState()
+    /// The inverse, asserted as such: the store comes back to the exact bytes it
+    /// held before the passcode existed.
+    func testDisableRestoresTheOriginalPlaintextAndRemovesTheWrappedKey() async throws {
+        try givenVaults([("vault-one", [share, otherShare])])
         try await sut.setPasscode(passcode)
 
         try await sut.disablePasscode(current: passcode)
 
-        _ = try XCTUnwrapPresent(keyStore.loadDataKey())
+        XCTAssertEqual(try storedShares().sorted(), [share, otherShare].sorted())
         XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
         let isSet = await sut.isSet
         XCTAssertFalse(isSet)
     }
 
-    /// Turning the passcode off must not turn at-rest encryption off — the
-    /// shares stay sealed, they are simply reachable without a passcode again.
-    func testDisableLeavesSharesSealedAndReadable() async throws {
-        let sealed = try givenMigratedState()
+    /// No unwrapped key is left behind. An earlier design stashed one beside the
+    /// shares; a store left in that state reads as "no passcode" while its
+    /// shares are still ciphertext.
+    func testDisableLeavesNoKeyMaterialOfAnyFormBehind() async throws {
+        try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
-        let before = sealed
 
         try await sut.disablePasscode(current: passcode)
 
-        XCTAssertEqual(sealed, before, "No key share may be rewritten by disabling the passcode")
-        XCTAssertTrue(sealed.hasPrefix(AesGcmKeyshareCipher.sealedPrefix))
-        XCTAssertEqual(try protector.open(sealed), share)
+        XCTAssertAbsent(keyStore.loadDataKey(), "removing the passcode must not stash the key in the clear")
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
+        if case .disabled = session.currentState() {} else {
+            XCTFail("with no key of either form the session must report .disabled")
+        }
+    }
+
+    func testDisableReturnsTheLockToDeviceAuth() async throws {
+        try await sut.setPasscode(passcode)
+
+        try await sut.disablePasscode(current: passcode)
+
+        XCTAssertEqual(lockService.mode, .deviceAuth)
     }
 
     func testDisableWithTheWrongPasscodeChangesNothing() async throws {
-        try givenMigratedState()
+        try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
+        let sealed = try storedShares()
 
         do {
             try await sut.disablePasscode(current: "00000")
@@ -281,15 +576,15 @@ final class PasscodeServiceTests: XCTestCase {
             XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
         }
 
-        XCTAssertAbsent(keyStore.loadDataKey())
+        XCTAssertEqual(try storedShares(), sealed)
         _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
     }
 
-    /// If the wrapped copy cannot be removed, both copies would exist and the
-    /// readable clear key would make the passcode meaningless. The clear copy is
-    /// rolled back so the passcode keeps protecting something.
-    func testDisableRollsBackWhenTheWrappedKeyCannotBeDeleted() async throws {
-        try givenMigratedState()
+    /// One protocol, not a choice: restore `.passcode`, reseal transactionally,
+    /// keep the wrapper, throw. The app is back to a working passcode and the
+    /// user retries — the alternative leaves plaintext shares behind a gate.
+    func testDisableResealsWhenTheWrappedKeyCannotBeDeleted() async throws {
+        try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
         keychain.ignoresWrappedKeyshareDataKeyDeletion = true
 
@@ -300,44 +595,86 @@ final class PasscodeServiceTests: XCTestCase {
             XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
         }
 
-        XCTAssertAbsent(keyStore.loadDataKey(), "The clear copy must have been rolled back")
+        let stored = try XCTUnwrap(try storedShares().first)
+        XCTAssertTrue(protector.isSealed(stored), "the shares must go back behind the passcode that still exists")
+        XCTAssertEqual(try protector.open(stored), share)
         _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
         XCTAssertEqual(lockService.mode, .passcode, "The passcode is still in force")
     }
 
-    func testDisableReturnsTheLockToDeviceAuth() async throws {
-        try givenMigratedState()
+    /// The rollback must not take "the deletion threw" to mean "the wrapper is
+    /// still there". `deleteWrappedDataKey` verifies against a *confirmed*
+    /// absence, so an unreadable read-back reports failure over a deletion that
+    /// in fact happened — and resealing on that assumption would leave
+    /// ciphertext whose only key is in memory until the next lock.
+    func testDisableRestoresTheWrapperBeforeResealingWhenTheDeletionCannotBeConfirmed() async throws {
+        try givenVaults([("vault-one", [share])])
         try await sut.setPasscode(passcode)
-
-        try await sut.disablePasscode(current: passcode)
-
-        XCTAssertEqual(lockService.mode, .deviceAuth)
-    }
-
-    // MARK: - Attempt limiting
-
-    // MARK: - Deletion must be verified
-
-    /// If the clear copy survives, locking just reloads it from the Keychain and
-    /// the passcode is decorative. Setting one must fail loudly instead.
-    func testSetPasscodeFailsWhenTheClearKeyCannotBeDeleted() async throws {
-        try givenMigratedState()
-        keychain.ignoresKeyshareDataKeyDeletion = true
+        keychain.wrappedKeyshareDataKeyBecomesUnreadableOnDeletion = true
 
         do {
-            try await sut.setPasscode(passcode)
-            XCTFail("Expected .deletionFailed")
+            try await sut.disablePasscode(current: passcode)
+            XCTFail("Expected the deletion failure to surface")
         } catch {
             XCTAssertEqual(error as? KeyshareKeyStoreError, .deletionFailed)
         }
 
-        XCTAssertNotEqual(lockService.mode, .passcode, "The mode must not switch on a failed deletion")
+        let restored = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
+        XCTAssertFalse(restored.isEmpty)
+        let stored = try XCTUnwrap(try storedShares().first)
+        XCTAssertTrue(protector.isSealed(stored))
+        XCTAssertEqual(try protector.open(stored), share)
+        XCTAssertEqual(lockService.mode, .passcode)
     }
+
+    /// And when the wrapper cannot be made durable again, nothing is resealed.
+    /// Plaintext shares with no key of any form is the no-passcode resting
+    /// state — the only outcome here that loses nothing.
+    func testDisableLeavesSharesPlaintextWhenTheWrapperCannotBeRestored() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+        keychain.wrappedKeyshareDataKeyBecomesUnreadableOnDeletion = true
+        keychain.dropsWrappedKeyshareDataKeyWrites = true
+
+        do {
+            try await sut.disablePasscode(current: passcode)
+            XCTFail("Expected .inconsistentState")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .inconsistentState)
+        }
+
+        XCTAssertEqual(try storedShares(), [share], "shares must stay readable when no wrapper can be proved")
+        XCTAssertEqual(lockService.mode, .deviceAuth, "a gate with no wrapper behind it could never be opened")
+        if case .unlocked = session.currentState() {
+            XCTFail("a key with no durable wrapper must not stay cached — the next write would seal against it")
+        }
+    }
+
+    /// A share that cannot be opened aborts the disable *before* the wrapper is
+    /// touched. Reporting the removal as done would leave that value sealed with
+    /// no passcode left to ask for.
+    func testDisableAbortsWhenAShareCannotBeOpened() async throws {
+        try await sut.setPasscode(passcode)
+        let foreign = try AesGcmKeyshareCipher().seal(share, with: SymmetricKey(size: .bits256))
+        try givenVaults([("vault-one", [foreign])])
+
+        do {
+            try await sut.disablePasscode(current: passcode)
+            XCTFail("Expected the unseal to fail")
+        } catch {
+            XCTAssertEqual(error as? KeyshareSweeperError, .verificationFailed(pubkey: "vault-one-0"))
+        }
+
+        _ = try XCTUnwrapPresent(keyStore.loadWrappedDataKey())
+        XCTAssertEqual(lockService.mode, .passcode)
+        XCTAssertEqual(try storedShares(), [foreign])
+    }
+
+    // MARK: - Attempt limiting
 
     // MARK: - A malformed wrapped key is not a guess
 
     func testAMalformedWrappedKeyIsReportedAsStorageFailureAndNotCounted() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
         keychain.setWrappedKeyshareDataKey(Data(repeating: 0x00, count: 64))
 
@@ -359,7 +696,6 @@ final class PasscodeServiceTests: XCTestCase {
     /// Wall time alone is user-adjustable, so a backoff has to survive the clock
     /// being moved forward.
     func testMovingTheClockForwardDoesNotClearALockout() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         for _ in 0...PasscodeAttemptLimiter.freeAttempts {
@@ -379,7 +715,6 @@ final class PasscodeServiceTests: XCTestCase {
     }
 
     func testRepeatedFailuresEventuallyLockOut() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
         let start = Date(timeIntervalSince1970: 1_700_000_000)
 
@@ -403,7 +738,6 @@ final class PasscodeServiceTests: XCTestCase {
     /// Both clocks have to advance: wall time alone is the clock-manipulation
     /// bypass, and the limiter deliberately refuses to honour it.
     func testLockoutExpiresOnceTimeGenuinelyPasses() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         for _ in 0...PasscodeAttemptLimiter.freeAttempts {
@@ -415,7 +749,6 @@ final class PasscodeServiceTests: XCTestCase {
     }
 
     func testASuccessfulUnlockClearsTheFailureCount() async throws {
-        try givenMigratedState()
         try await sut.setPasscode(passcode)
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         for _ in 0..<PasscodeAttemptLimiter.freeAttempts {
@@ -430,7 +763,93 @@ final class PasscodeServiceTests: XCTestCase {
         }
         try await sut.unlock(with: passcode, now: start)
     }
+
+    // MARK: - Helpers
+
+    /// Every `@Attribute(.unique)` field is given a distinct value per vault.
+    /// `TestStore.makeVault` leaves `pubKeyEdDSA` at a shared constant, and
+    /// SwiftData answers a duplicate unique key with an *upsert* rather than an
+    /// error — so a multi-vault fixture built that way silently collapses to one
+    /// row and every multi-vault assertion passes vacuously.
+    @discardableResult
+    private func givenVaults(_ vaults: [(String, [String])]) throws -> [Vault] {
+        let inserted = vaults.map { pubKey, shares in
+            let vault = Vault(
+                name: "Vault \(pubKey)",
+                signers: [],
+                pubKeyECDSA: "ecdsa-\(pubKey)",
+                pubKeyEdDSA: "eddsa-\(pubKey)",
+                keyshares: shares.enumerated().map { index, value in
+                    KeyShare(pubkey: "\(pubKey)-\(index)", keyshare: value)
+                },
+                localPartyID: "party-\(pubKey)",
+                hexChainCode: "hex",
+                resharePrefix: nil,
+                libType: .DKLS
+            )
+            context.insert(vault)
+            return vault
+        }
+        try context.save()
+
+        XCTAssertEqual(
+            try context.fetchCount(FetchDescriptor<Vault>()),
+            vaults.count,
+            "the fixture collapsed — a unique attribute is shared between vaults"
+        )
+        return inserted
+    }
+
+    private func storedShares() throws -> [String] {
+        try context.fetch(FetchDescriptor<Vault>()).flatMap(\.keyshares).map(\.keyshare)
+    }
 }
+
+// MARK: - Failing closed on an unreadable Keychain
+
+extension PasscodeServiceTests {
+
+    /// The lost-funds path this whole tri-state exercise exists to close. If an
+    /// unreadable wrapper read as "no passcode", `setPasscode` would mint a
+    /// fresh data key and store a wrapper over the top of the existing one —
+    /// and the new key opens none of the shares the old one sealed.
+    func testIsSetFailsClosedWhenTheWrapperCannotBeRead() async {
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        let isSet = await sut.isSet
+
+        XCTAssertTrue(isSet, "An unreadable wrapper may well be there and must be treated as one")
+    }
+
+    func testSetPasscodeIsRefusedWhenTheWrapperCannotBeRead() async throws {
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+        keychain.resetWrites()
+
+        do {
+            try await sut.setPasscode(passcode)
+            XCTFail("Expected the set to be refused")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .alreadySet)
+        }
+
+        XCTAssertEqual(keychain.writes, [], "Nothing may be written while the Keychain cannot be read")
+    }
+
+    /// `notSet` is what sends the UI off to offer creating a passcode, over the
+    /// top of a wrapper that may still exist.
+    func testUnlockReportsStorageFailureRatherThanNotSetWhenTheWrapperCannotBeRead() async {
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        do {
+            _ = try await sut.unlock(with: passcode)
+            XCTFail("Expected the unlock to fail")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .storageFailure)
+        }
+    }
+}
+
+// MARK: - The attempt limiter's own record
 
 extension PasscodeServiceTests {
 
@@ -488,60 +907,62 @@ extension PasscodeServiceTests {
     }
 }
 
-// MARK: - Failing closed on an unreadable Keychain
+// MARK: - Test doubles
 
-extension PasscodeServiceTests {
+/// A sweeper that runs a hook inside the sealed-share scan — the *first*
+/// suspension point of a set, and the one a generation captured too late would
+/// leave unguarded.
+private final class HookedKeyshareSweeper: KeyshareSweeping {
 
-    /// The lost-funds path this whole tri-state exercise exists to close. If an
-    /// unreadable wrapper read as "no passcode", `setPasscode` would mint a
-    /// fresh data key and store a wrapper over the top of the existing one —
-    /// and the new key opens none of the shares the old one sealed.
-    func testIsSetFailsClosedWhenTheWrapperCannotBeRead() async {
-        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+    private let wrapped: KeyshareSweeping
+    private let duringScan: () throws -> Void
 
-        let isSet = await sut.isSet
-
-        XCTAssertTrue(isSet, "An unreadable wrapper may well be there and must be treated as one")
+    init(wrapping wrapped: KeyshareSweeping, duringScan: @escaping () throws -> Void) {
+        self.wrapped = wrapped
+        self.duringScan = duringScan
     }
 
-    func testSetPasscodeIsRefusedWhenTheWrapperCannotBeRead() async throws {
-        try givenMigratedState()
-        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
-        keychain.resetWrites()
-
-        do {
-            try await sut.setPasscode(passcode)
-            XCTFail("Expected the set to be refused")
-        } catch {
-            XCTAssertEqual(error as? PasscodeError, .alreadySet)
-        }
-
-        XCTAssertEqual(keychain.writes, [], "Nothing may be written while the Keychain cannot be read")
+    @MainActor
+    func hasSealedShare() throws -> Bool {
+        try duringScan()
+        return try wrapped.hasSealedShare()
     }
 
-    /// `notSet` is what sends the UI off to offer creating a passcode, over the
-    /// top of a wrapper that may still exist.
-    func testUnlockReportsStorageFailureRatherThanNotSetWhenTheWrapperCannotBeRead() async {
-        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+    @MainActor func sealAll() throws { try wrapped.sealAll() }
+    @MainActor func unsealAll() throws { try wrapped.unsealAll() }
+}
 
-        do {
-            _ = try await sut.unlock(with: passcode)
-            XCTFail("Expected the unlock to fail")
-        } catch {
-            XCTAssertEqual(error as? PasscodeError, .storageFailure)
-        }
+/// A key store that runs a hook inside `wrap`, which is the one long suspension
+/// point in a transition. Everything a background lock or a concurrent write
+/// could do mid-transition happens there, and driving it by hand is the only way
+/// to make those races deterministic rather than timing-dependent.
+private final class HookedKeyshareKeyStore: KeyshareKeyStoring {
+
+    private let wrapped: KeyshareKeyStoring
+    private let duringWrap: @MainActor () throws -> Void
+
+    init(wrapping wrapped: KeyshareKeyStoring, duringWrap: @escaping @MainActor () throws -> Void) {
+        self.wrapped = wrapped
+        self.duringWrap = duringWrap
     }
 
-    /// An unreadable clear key must not be mistaken for "nothing is encrypted
-    /// yet", which is the one state that would license inventing a new key.
-    func testSetPasscodeIsRefusedWhenTheClearKeyCannotBeRead() async {
-        keychain.keyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+    func generateDataKey() throws -> SymmetricKey { try wrapped.generateDataKey() }
 
-        do {
-            try await sut.setPasscode(passcode)
-            XCTFail("Expected the set to be refused")
-        } catch {
-            XCTAssertEqual(error as? PasscodeError, .noDataKey)
-        }
+    func loadDataKey() -> KeychainReadResult<SymmetricKey> { wrapped.loadDataKey() }
+    func storeDataKey(_ key: SymmetricKey) throws { try wrapped.storeDataKey(key) }
+    func deleteDataKey() throws { try wrapped.deleteDataKey() }
+
+    func loadWrappedDataKey() -> KeychainReadResult<Data> { wrapped.loadWrappedDataKey() }
+    func storeWrappedDataKey(_ blob: Data) throws { try wrapped.storeWrappedDataKey(blob) }
+    func deleteWrappedDataKey() throws { try wrapped.deleteWrappedDataKey() }
+
+    func wrap(_ key: SymmetricKey, passcode: String) async throws -> Data {
+        let blob = try await wrapped.wrap(key, passcode: passcode)
+        try await MainActor.run { try duringWrap() }
+        return blob
+    }
+
+    func unwrap(_ blob: Data, passcode: String) async throws -> SymmetricKey {
+        try await wrapped.unwrap(blob, passcode: passcode)
     }
 }

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -33,8 +33,8 @@ final class PasscodeServiceTests: XCTestCase {
     /// clock-vs-uptime interaction is observable.
     private var uptime: TimeInterval = 1_000
 
-    private let passcode = "12345"
-    private let newPasscode = "98765"
+    private let passcode = "123456"
+    private let newPasscode = "987654"
     private let share = "eyJrZXlzaGFyZSI6ImRrbHMifQ=="
     private let otherShare = "eyJrZXlzaGFyZSI6ImRrbHMtdHdvIn0="
 
@@ -149,7 +149,7 @@ final class PasscodeServiceTests: XCTestCase {
     }
 
     func testSetPasscodeRejectsAWrongLength() async throws {
-        for candidate in ["1234", "123456", "abcde", ""] {
+        for candidate in ["12345", "1234567", "abcdef", ""] {
             do {
                 try await sut.setPasscode(candidate)
                 XCTFail("Expected .invalidLength for \(candidate)")
@@ -448,7 +448,7 @@ final class PasscodeServiceTests: XCTestCase {
         sut.lock()
 
         do {
-            try await sut.unlock(with: "00000")
+            try await sut.unlock(with: "000000")
             XCTFail("Expected .wrongPasscode")
         } catch {
             XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
@@ -743,7 +743,7 @@ final class PasscodeServiceTests: XCTestCase {
         let wrappedBefore = keyStore.loadWrappedDataKey()
 
         do {
-            try await sut.changePasscode(current: "00000", new: newPasscode)
+            try await sut.changePasscode(current: "000000", new: newPasscode)
             XCTFail("Expected .wrongPasscode")
         } catch {
             XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
@@ -808,7 +808,7 @@ final class PasscodeServiceTests: XCTestCase {
         let sealed = try storedShares()
 
         do {
-            try await sut.disablePasscode(current: "00000")
+            try await sut.disablePasscode(current: "000000")
             XCTFail("Expected .wrongPasscode")
         } catch {
             XCTAssertEqual(error as? PasscodeError, .wrongPasscode)
@@ -969,7 +969,7 @@ final class PasscodeServiceTests: XCTestCase {
         try await sut.setPasscode(passcode)
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         for _ in 0...PasscodeAttemptLimiter.freeAttempts {
-            _ = try? await sut.unlock(with: "00000", now: start)
+            _ = try? await sut.unlock(with: "000000", now: start)
         }
 
         // A year later by the wall clock, but the device has not been up that
@@ -989,10 +989,10 @@ final class PasscodeServiceTests: XCTestCase {
         let start = Date(timeIntervalSince1970: 1_700_000_000)
 
         for _ in 0..<PasscodeAttemptLimiter.freeAttempts {
-            _ = try? await sut.unlock(with: "00000", now: start)
+            _ = try? await sut.unlock(with: "000000", now: start)
         }
         // The next failure crosses into the throttled range.
-        _ = try? await sut.unlock(with: "00000", now: start)
+        _ = try? await sut.unlock(with: "000000", now: start)
 
         do {
             try await sut.unlock(with: passcode, now: start)
@@ -1011,7 +1011,7 @@ final class PasscodeServiceTests: XCTestCase {
         try await sut.setPasscode(passcode)
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         for _ in 0...PasscodeAttemptLimiter.freeAttempts {
-            _ = try? await sut.unlock(with: "00000", now: start)
+            _ = try? await sut.unlock(with: "000000", now: start)
         }
 
         uptime += 3600
@@ -1022,14 +1022,14 @@ final class PasscodeServiceTests: XCTestCase {
         try await sut.setPasscode(passcode)
         let start = Date(timeIntervalSince1970: 1_700_000_000)
         for _ in 0..<PasscodeAttemptLimiter.freeAttempts {
-            _ = try? await sut.unlock(with: "00000", now: start)
+            _ = try? await sut.unlock(with: "000000", now: start)
         }
 
         try await sut.unlock(with: passcode, now: start)
 
         // Fresh budget: the free attempts are available again.
         for _ in 0..<PasscodeAttemptLimiter.freeAttempts {
-            _ = try? await sut.unlock(with: "00000", now: start)
+            _ = try? await sut.unlock(with: "000000", now: start)
         }
         try await sut.unlock(with: passcode, now: start)
     }

--- a/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
@@ -1,0 +1,237 @@
+//
+//  ProtectedVaultImporterTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import SwiftData
+import XCTest
+@testable import VultisigApp
+
+/// The hole this closes was silent by construction: `Vault.init(from: Decoder)`
+/// decodes `[KeyShare]` straight off the wire, so a JSON import with a passcode
+/// set stored plaintext shares in a protected store and nothing ever complained.
+@MainActor
+final class ProtectedVaultImporterTests: XCTestCase {
+
+    private var token: TestContextToken!
+    private var context: ModelContext!
+    private var key: SymmetricKey!
+    private var coordinator: KeyshareWriteCoordinator!
+
+    private let firstShare = "eyJrZXlzaGFyZSI6ImRrbHMtb25lIn0="
+    private let secondShare = "eyJrZXlzaGFyZSI6ImRrbHMtdHdvIn0="
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        token = try TestStore.installInMemoryContainer()
+        context = token.container.mainContext
+        key = SymmetricKey(size: .bits256)
+        coordinator = KeyshareWriteCoordinator()
+    }
+
+    override func tearDown() {
+        coordinator = nil
+        key = nil
+        context = nil
+        TestStore.restore(token)
+        token = nil
+        super.tearDown()
+    }
+
+    // MARK: - Normalizing under the current state
+
+    /// The bug, asserted. A legacy JSON backup carries plaintext shares; with a
+    /// passcode set they must not reach disk that way.
+    func testAPlaintextImportIsSealedWhenAPasscodeIsSet() throws {
+        let sut = makeImporter(state: .unlocked(key))
+        let vault = makeVault(shares: [firstShare, secondShare])
+
+        try sut.commit([vault], into: context)
+
+        let protector = KeyshareProtector(state: { [key] in .unlocked(key!) })
+        let stored = try storedShares()
+        XCTAssertEqual(stored.count, 2)
+        for value in stored {
+            XCTAssertTrue(protector.isSealed(value), "an imported share must land on the same side of the invariant as the store")
+        }
+        XCTAssertEqual(try stored.map { try protector.open($0) }.sorted(), [firstShare, secondShare].sorted())
+    }
+
+    /// And the other half of the acceptance test: with no passcode, the stored
+    /// bytes are byte-identical to what a build without this feature writes.
+    func testAPlaintextImportStaysByteIdenticalWithNoPasscodeSet() throws {
+        let sut = makeImporter(state: .disabled)
+        let vault = makeVault(shares: [firstShare, secondShare])
+
+        try sut.commit([vault], into: context)
+
+        XCTAssertEqual(try storedShares(), [firstShare, secondShare])
+    }
+
+    /// A `.vult` exported from a sealed store legitimately carries `vlt2:`
+    /// values. With the same key in hand they open, and the import is accepted.
+    func testAnAlreadySealedImportIsAcceptedWhenItAuthenticates() throws {
+        let sealed = try AesGcmKeyshareCipher().seal(firstShare, with: key)
+        let sut = makeImporter(state: .unlocked(key))
+
+        try sut.commit([makeVault(shares: [sealed])], into: context)
+
+        let protector = KeyshareProtector(state: { [key] in .unlocked(key!) })
+        XCTAssertEqual(try protector.open(try XCTUnwrap(try storedShares().first)), firstShare)
+    }
+
+    /// With no passcode set the same value is refused rather than stored: there
+    /// is no key to open it with, so importing it would store a share nobody can
+    /// ever read while reporting success.
+    func testAnAlreadySealedImportIsRefusedWithNoPasscodeSet() throws {
+        let sealed = try AesGcmKeyshareCipher().seal(firstShare, with: key)
+        let sut = makeImporter(state: .disabled)
+
+        XCTAssertThrowsError(try sut.commit([makeVault(shares: [sealed])], into: context)) { error in
+            XCTAssertEqual(error as? ProtectedVaultImportError, .unreadableShare(pubkey: "vault-one-0"))
+        }
+        XCTAssertEqual(try storedShares(), [])
+    }
+
+    // MARK: - Authenticating what comes in
+
+    /// The rule that makes the import a boundary rather than a funnel: a sealed
+    /// value from another device authenticates against nothing here, and storing
+    /// it would import a share nobody can open.
+    func testAShareSealedUnderAnotherKeyIsRefused() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(firstShare, with: SymmetricKey(size: .bits256))
+        let sut = makeImporter(state: .unlocked(key))
+
+        XCTAssertThrowsError(try sut.commit([makeVault(shares: [foreign])], into: context)) { error in
+            XCTAssertEqual(error as? ProtectedVaultImportError, .unreadableShare(pubkey: "vault-one-0"))
+        }
+        XCTAssertEqual(try storedShares(), [])
+    }
+
+    /// An envelope wrapped around another envelope is not a share, and the outer
+    /// layer authenticates perfectly well — so accepting it on that basis is
+    /// exactly the mistake the check exists to stop.
+    func testAnEnvelopeWrappedAroundAnotherEnvelopeIsRefused() throws {
+        let cipher = AesGcmKeyshareCipher()
+        let nested = try cipher.seal(try cipher.seal(firstShare, with: key), with: key)
+        let sut = makeImporter(state: .unlocked(key))
+
+        XCTAssertThrowsError(try sut.commit([makeVault(shares: [nested])], into: context)) { error in
+            XCTAssertEqual(error as? ProtectedVaultImportError, .unreadableShare(pubkey: "vault-one-0"))
+        }
+    }
+
+    func testValidateRefusesABackupTheDeviceCannotOpen() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(firstShare, with: SymmetricKey(size: .bits256))
+        let sut = makeImporter(state: .unlocked(key))
+
+        XCTAssertThrowsError(try sut.validate(makeVault(shares: [foreign]))) { error in
+            XCTAssertEqual(error as? ProtectedVaultImportError, .unreadableShare(pubkey: "vault-one-0"))
+        }
+    }
+
+    func testValidateAcceptsAPlaintextBackup() throws {
+        let sut = makeImporter(state: .unlocked(key))
+
+        XCTAssertNoThrow(try sut.validate(makeVault(shares: [firstShare])))
+    }
+
+    // MARK: - The commit itself
+
+    /// Two phases: one bad share anywhere means nothing is inserted, so a ZIP
+    /// whose third file is corrupt does not leave the first two half-imported.
+    func testABadShareInOneVaultImportsNoneOfThem() throws {
+        let foreign = try AesGcmKeyshareCipher().seal(firstShare, with: SymmetricKey(size: .bits256))
+        let sut = makeImporter(state: .unlocked(key))
+        let good = makeVault(name: "vault-one", shares: [firstShare])
+        let bad = makeVault(name: "vault-two", shares: [foreign])
+
+        XCTAssertThrowsError(try sut.commit([good, bad], into: context))
+
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Vault>()), 0)
+    }
+
+    /// The insert is saved explicitly rather than left to an autosave that could
+    /// land after a passcode transition has begun. Read back through a context
+    /// that never saw the in-memory objects.
+    func testTheImportIsSavedRatherThanLeftToAnAutosave() throws {
+        let sut = makeImporter(state: .unlocked(key))
+
+        try sut.commit([makeVault(shares: [firstShare])], into: context)
+
+        let fresh = ModelContext(token.container)
+        XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Vault>()), 1)
+        XCTAssertFalse(context.hasChanges)
+    }
+
+    /// A transition is about to rewrite every stored share, and a vault inserted
+    /// underneath it would never be swept — plaintext behind a live passcode.
+    func testAnImportIsRefusedWhileAPasscodeTransitionIsHeld() throws {
+        let sut = makeImporter(state: .unlocked(key))
+        let lease = try coordinator.beginTransition()
+        defer { coordinator.end(lease) }
+
+        XCTAssertThrowsError(try sut.commit([makeVault(shares: [firstShare])], into: context)) { error in
+            XCTAssertEqual(error as? ProtectedVaultImportError, .busy)
+        }
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Vault>()), 0)
+    }
+
+    /// A locked app has no key to normalize with, and `seal` says so rather than
+    /// quietly storing plaintext.
+    func testAnImportIsRefusedWhileTheAppIsLocked() throws {
+        let sut = makeImporter(state: .locked)
+
+        XCTAssertThrowsError(try sut.commit([makeVault(shares: [firstShare])], into: context)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+        }
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Vault>()), 0)
+    }
+
+    /// `keyId` is part of a share's identity for MLDSA, and rebuilding the array
+    /// is exactly where it would get dropped.
+    func testTheImportPreservesTheKeyIdentifier() throws {
+        let sut = makeImporter(state: .unlocked(key))
+        let vault = makeVault(shares: [])
+        vault.keyshares = [KeyShare(pubkey: "vault-one-0", keyshare: firstShare, keyId: "mldsa-key-id")]
+
+        try sut.commit([vault], into: context)
+
+        let stored = try XCTUnwrap(try context.fetch(FetchDescriptor<Vault>()).flatMap(\.keyshares).first)
+        XCTAssertEqual(stored.keyId, "mldsa-key-id")
+    }
+
+    // MARK: - Helpers
+
+    private func makeImporter(state: KeyshareProtectionState) -> ProtectedVaultImporter {
+        ProtectedVaultImporter(
+            protector: KeyshareProtector(state: { state }),
+            coordinator: coordinator
+        )
+    }
+
+    /// Built directly rather than through `TestStore.makeVault`, which leaves
+    /// `pubKeyEdDSA` at a shared constant — SwiftData answers a duplicate
+    /// `@Attribute(.unique)` with an upsert rather than an error, so a
+    /// multi-vault fixture built that way collapses to one row.
+    private func makeVault(name: String = "vault-one", shares: [String]) -> Vault {
+        Vault(
+            name: "Vault \(name)",
+            signers: [],
+            pubKeyECDSA: "ecdsa-\(name)",
+            pubKeyEdDSA: "eddsa-\(name)",
+            keyshares: shares.enumerated().map { index, value in
+                KeyShare(pubkey: "\(name)-\(index)", keyshare: value)
+            },
+            localPartyID: "party-\(name)",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+    }
+
+    private func storedShares() throws -> [String] {
+        try context.fetch(FetchDescriptor<Vault>()).flatMap(\.keyshares).map(\.keyshare)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
+++ b/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
@@ -119,15 +119,10 @@ final class KeychainTriStateReadTests: XCTestCase {
                 "the migration-version read must not pass a failure off as an absent item (status \(status))"
             )
             XCTAssertEqual(
-                service.getKeyshareDataKey(),
-                .unavailable(status),
-                "an unreadable data key must never look absent — absence licenses minting a replacement, "
-                    + "and a replacement cannot open a single already-sealed share (status \(status))"
-            )
-            XCTAssertEqual(
                 service.getWrappedKeyshareDataKey(),
                 .unavailable(status),
-                "an unreadable wrapped key must never look absent, for the same reason (status \(status))"
+                "an unreadable wrapped key must never look absent — absence licenses minting a replacement, "
+                    + "and a replacement cannot open a single already-sealed share (status \(status))"
             )
             XCTAssertEqual(
                 service.getPasscodeAttemptState(),
@@ -145,7 +140,6 @@ final class KeychainTriStateReadTests: XCTestCase {
         XCTAssertEqual(service.getFastHint(pubKeyECDSA: "pub"), .absent)
         XCTAssertEqual(service.getDeviceToken(), .absent)
         XCTAssertEqual(service.getLastMigratedVersion(), .absent)
-        XCTAssertEqual(service.getKeyshareDataKey(), .absent)
         XCTAssertEqual(service.getWrappedKeyshareDataKey(), .absent)
         XCTAssertEqual(service.getPasscodeAttemptState(), .absent)
     }
@@ -157,7 +151,6 @@ final class KeychainTriStateReadTests: XCTestCase {
         XCTAssertEqual(service.getFastHint(pubKeyECDSA: "pub"), .present("7"))
         XCTAssertEqual(service.getDeviceToken(), .present("7"))
         XCTAssertEqual(service.getLastMigratedVersion(), .present(7))
-        XCTAssertEqual(service.getKeyshareDataKey(), .present(Data("7".utf8)))
         XCTAssertEqual(service.getWrappedKeyshareDataKey(), .present(Data("7".utf8)))
         XCTAssertEqual(service.getPasscodeAttemptState(), .present(Data("7".utf8)))
     }

--- a/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
+++ b/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
@@ -129,6 +129,12 @@ final class KeychainTriStateReadTests: XCTestCase {
                 .unavailable(status),
                 "an unreadable wrapped key must never look absent, for the same reason (status \(status))"
             )
+            XCTAssertEqual(
+                service.getPasscodeAttemptState(),
+                .unavailable(status),
+                "an unreadable attempt state must never look absent — absence means no failures yet, "
+                    + "which is the throttle switching itself off (status \(status))"
+            )
         }
     }
 
@@ -141,6 +147,7 @@ final class KeychainTriStateReadTests: XCTestCase {
         XCTAssertEqual(service.getLastMigratedVersion(), .absent)
         XCTAssertEqual(service.getKeyshareDataKey(), .absent)
         XCTAssertEqual(service.getWrappedKeyshareDataKey(), .absent)
+        XCTAssertEqual(service.getPasscodeAttemptState(), .absent)
     }
 
     func testEveryServiceReadReturnsTheStoredValue() {
@@ -152,6 +159,7 @@ final class KeychainTriStateReadTests: XCTestCase {
         XCTAssertEqual(service.getLastMigratedVersion(), .present(7))
         XCTAssertEqual(service.getKeyshareDataKey(), .present(Data("7".utf8)))
         XCTAssertEqual(service.getWrappedKeyshareDataKey(), .present(Data("7".utf8)))
+        XCTAssertEqual(service.getPasscodeAttemptState(), .present(Data("7".utf8)))
     }
 
     // MARK: - The deliberate collapse


### PR DESCRIPTION
> **Updated after a whole-branch review.** Two further defects were found and fixed here:
> `commitVault` now **normalizes** rather than only verifying — it opens each share and re-seals it under
> the state in force at commit, so a passcode set during the vault-review interval can no longer persist
> plaintext key material behind a live passcode. And **a background `lock()` now wins over `changePasscode`
> and `disablePasscode`**: both capture the session generation before their first `await`, which
> `setPasscode` already did and they did not. The disable case was the sharp one — a lock landing mid-disable
> left the overlay up with the wrapper deleted, so every unlock returned `notSet` and the user was trapped
> until they force-quit.

## Description

**Stack 6 of 8** for #4846, and the one that carries the actual behaviour. Setting a passcode seals every key share; disabling it unseals them. **Anyone who never sets a passcode is byte-for-byte identical to production today.**

Part of #4846. **Base: `feat/passcode-coordinator-4846` (PR 5)** — review PRs 1–5 first.

### The invariant

> **A key share is sealed if and only if a passcode is currently set.**

Stated as "is currently set", not "has ever been set" — so **disable must unseal**. That is what makes the passcode a reversible choice rather than a one-way door, and it is what `vultisig-windows` already does.

Concretely, with no passcode set: plaintext shares on disk, **no Keychain item**, no launch-time key rewrite, unchanged `.vult` bytes, unchanged values reaching `LocalStateAccessorImp`, and a downgrade to any older build that keeps working forever.

### Ordering is the safety argument

**`setPasscode`** — the wrapper must be durable before anything is sealed. The tempting order is fatal:

| Order | Crash mid-way | |
|---|---|---|
| mint → seal all → wrap → store | the key only ever lived in memory. **Every sealed share orphaned** | ❌ |
| mint → wrap → store wrapped → adopt → seal all | wrapper survives; some sealed, some plaintext | ✅ |

Mixed state is readable both ways, so a half-swept store still signs.

Two positions in that sequence are load-bearing and should not be rearranged:
- **`mode = .passcode` fires as soon as the wrapper verifies**, before adoption and the sweep. Set at the end instead, a failed sweep leaves a durable passcode with **no gate to reach it** — retries fail `alreadySet` and resume never runs, because resume only fires on an app-passcode unlock the mode would never present.
- **A failed sweep does not delete the wrapper.** Once sealing may have begun, deleting it strands whatever got sealed, and "a later set re-sweeps idempotently" is false — a newly minted key cannot open ciphertext from the discarded one. The app stays in a pending-passcode state that resume completes.

**`disablePasscode`** — biometrics first, then unseal, then `mode = .deviceAuth`, and the wrapper delete **last**. The mode change precedes the delete because the reverse leaves plaintext shares behind `mode == .passcode` with no wrapper to unlock against: a gate that can never open.

**`changePasscode` is untouched** — it rewraps 32 bytes and writes no key share. The most frequent operation stays O(1).

### Verification, not optimism

- Every share this replaces is **proved to open back to its original** before it replaces anything, and the sweep is two-phase: nothing is assigned until every share in every vault has passed.
- **Already-sealed values are authenticated, never accepted on sight.** `KeyshareProtector.seal` returns an already-sealed value unchanged and unchecked, so a sweep that trusted it would report success over a share sealed under a key we no longer hold — a dead vault nothing revisits.
- **Double-sealed values are refused rather than unwrapped.** `seal(seal(share))` authenticates on its outer layer, so unsealing would write the inner `vlt2:` back out and report success, after which disable deletes the key.
- **Keychain reads are tri-state** (PR to `main`, #5054). `getData` returning `nil` for every failure meant a transient read looked identical to "no item" — enough for `setPasscode` to mint over an existing wrapper and orphan every sealed share. Every security decision here fails closed on `unavailable`, and no key is minted while any sealed share exists.

### Also closed here

**Legacy JSON imports bypassed protection entirely.** `Vault.init(from: Decoder)` decodes `[KeyShare]` directly, and `EncryptedBackupViewModel` reached it at four sites — so a JSON import under a live passcode stored plaintext shares, readable even while locked. `ProtectedVaultImporter` now owns every format: it authenticates incoming `vlt2:` values, normalizes under the current state, and inserts and saves inside one lease.

### Known and deliberate

- **A persistently failing resume sweep is logged and nowhere else.** Propagating it would hold the lock screen up over an already-adopted session and lock out a user whose passcode is correct. A degraded-protection indicator is unclaimed follow-up work.
- **`storeWrappedDataKey` cannot distinguish "write landed, read-back unavailable"**, so `changePasscode` may report failure over a passcode that did change. Recoverable and narrow; the fix is an error-taxonomy change deserving its own round.
- **If you enabled the passcode QA flag on an earlier build of this stack, erase the simulator or delete the app before running this branch.** Shares sealed by the old launch migration are not recoverable here — the clear-key read path is gone. Nothing has merged to `main` and the flag is off by default, so this should affect nobody.

### Testing

`Executed 4971 tests, with 1 test skipped and 0 failures`, plus `build-for-testing` green on all 8 layers independently. Coverage includes concurrent set/set and set/disable, a lock landing mid-PBKDF2, TSS callbacks crossing a transition in both directions, `unavailable` Keychain reads at every decision point, crash-and-relaunch states, and a store-wide invariant test asserting no share is unsealed while a passcode is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

