### PR TITLE
feat(security): optional biometric unlock shortcut (8/8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Long-form reasoning that does not fit in code comments lives in [`docs/`](docs/)
 | Changing `KeyshareWriteCoordinator`, or any lease/`await` placement around key-share writes | [concurrency-and-leases.md](docs/passcode-keyshare-encryption/concurrency-and-leases.md) |
 | Reordering steps in `setPasscode` / `disablePasscode` / the resume sweep | [transitions.md](docs/passcode-keyshare-encryption/transitions.md) |
 | A guard there looks redundant, or you want to simplify `KeyshareSweeper` | [invariants.md](docs/passcode-keyshare-encryption/invariants.md) |
+| Importing a vault, or changing how a vault's default coins are attached | [invariants.md § the write that did not take](docs/passcode-keyshare-encryption/invariants.md#the-write-that-did-not-take) |
 
 ## Knowledge Base
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ open VultisigApp/VultisigApp.xcodeproj
 
 - Never log key material or vault shares
 - TSS bindings — do not modify without review
-- `Core/Security/Keyshare/` and `Core/Security/Passcode/` hold key material at rest and the passcode that wraps it. A share that cannot be opened is a vault that can never sign again — read [docs/passcode-keyshare-encryption/](docs/passcode-keyshare-encryption/overview.md) before changing anything there, including "obvious" cleanups
+- `Core/Security/Keyshare/` and `Core/Security/Passcode/` hold key material at rest and the passcode that wraps it. A share that cannot be opened is one this device can never sign with again, recoverable only from a user's `.vult` backup or a quorum of the vault's other signers — read [docs/passcode-keyshare-encryption/](docs/passcode-keyshare-encryption/overview.md) before changing anything there, including "obvious" cleanups
 - Never commit `.env`, credentials, or secrets
 - Always test keygen and keysign flows after refactoring
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,20 @@ open VultisigApp/VultisigApp.xcodeproj
 
 - Never log key material or vault shares
 - TSS bindings — do not modify without review
+- `Core/Security/Keyshare/` and `Core/Security/Passcode/` hold key material at rest and the passcode that wraps it. A share that cannot be opened is a vault that can never sign again — read [docs/passcode-keyshare-encryption/](docs/passcode-keyshare-encryption/overview.md) before changing anything there, including "obvious" cleanups
 - Never commit `.env`, credentials, or secrets
 - Always test keygen and keysign flows after refactoring
+
+## In-Repo Docs
+
+Long-form reasoning that does not fit in code comments lives in [`docs/`](docs/). Read the routed page **before** changing the code, not after:
+
+| Situation | Read |
+|-----------|------|
+| Touching passcode or key-share encryption | [docs/passcode-keyshare-encryption/overview.md](docs/passcode-keyshare-encryption/overview.md) |
+| Changing `KeyshareWriteCoordinator`, or any lease/`await` placement around key-share writes | [concurrency-and-leases.md](docs/passcode-keyshare-encryption/concurrency-and-leases.md) |
+| Reordering steps in `setPasscode` / `disablePasscode` / the resume sweep | [transitions.md](docs/passcode-keyshare-encryption/transitions.md) |
+| A guard there looks redundant, or you want to simplify `KeyshareSweeper` | [invariants.md](docs/passcode-keyshare-encryption/invariants.md) |
 
 ## Knowledge Base
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ HIGH — Wallet app with TSS key management. Crypto/JNI changes require maintain
 ## Critical Boundaries
 
 - `VultisigApp/Blockchain/Tss/` — TSS keygen/keysign bindings. Do not modify without explicit review.
-- `VultisigApp/Core/Security/Keyshare/` and `Core/Security/Passcode/` — key material at rest and the passcode that wraps it. A mistake here is lost funds, not a bad screen: a share that cannot be opened is a vault that can never sign again. Read [docs/passcode-keyshare-encryption/](docs/passcode-keyshare-encryption/overview.md) before changing anything, including "obvious" cleanups — most of the guards there exist because a review caught a real fund-loss bug.
+- `VultisigApp/Core/Security/Keyshare/` and `Core/Security/Passcode/` — key material at rest and the passcode that wraps it. A mistake here is lost funds, not a bad screen: a share that cannot be opened is one this device can never sign with again, recoverable only from a user's `.vult` backup or a quorum of the vault's other signers. Read [docs/passcode-keyshare-encryption/](docs/passcode-keyshare-encryption/overview.md) before changing anything, including "obvious" cleanups — most of the guards there exist because a review caught a real fund-loss bug.
 - `VultisigApp/Model/` — SwiftData @Model classes (core entities only: Vault, Coin, Chain, KeyShare, etc.). Schema changes affect migrations.
 - `VultisigApp/project.yml` — XcodeGen spec. The `.xcodeproj` is generated from this file; never edit `project.pbxproj` directly. Run `make generate` (from the repo root) after changing sources or dependencies. See the `/make` skill for all available commands.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Long-form reasoning that does not fit in code comments lives in [`docs/`](docs/)
 | Changing `KeyshareWriteCoordinator`, or any lease/`await` placement around key-share writes | [concurrency-and-leases.md](docs/passcode-keyshare-encryption/concurrency-and-leases.md) |
 | Reordering steps in `setPasscode` / `disablePasscode` / the resume sweep | [transitions.md](docs/passcode-keyshare-encryption/transitions.md) |
 | A guard there looks redundant, or you want to simplify `KeyshareSweeper` | [invariants.md](docs/passcode-keyshare-encryption/invariants.md) |
+| Importing a vault, or changing how a vault's default coins are attached | [invariants.md § the write that did not take](docs/passcode-keyshare-encryption/invariants.md#the-write-that-did-not-take) |
 
 ## Knowledge Base
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ HIGH — Wallet app with TSS key management. Crypto/JNI changes require maintain
 ## Critical Boundaries
 
 - `VultisigApp/Blockchain/Tss/` — TSS keygen/keysign bindings. Do not modify without explicit review.
+- `VultisigApp/Core/Security/Keyshare/` and `Core/Security/Passcode/` — key material at rest and the passcode that wraps it. A mistake here is lost funds, not a bad screen: a share that cannot be opened is a vault that can never sign again. Read [docs/passcode-keyshare-encryption/](docs/passcode-keyshare-encryption/overview.md) before changing anything, including "obvious" cleanups — most of the guards there exist because a review caught a real fund-loss bug.
 - `VultisigApp/Model/` — SwiftData @Model classes (core entities only: Vault, Coin, Chain, KeyShare, etc.). Schema changes affect migrations.
 - `VultisigApp/project.yml` — XcodeGen spec. The `.xcodeproj` is generated from this file; never edit `project.pbxproj` directly. Run `make generate` (from the repo root) after changing sources or dependencies. See the `/make` skill for all available commands.
 
@@ -87,6 +88,17 @@ Domain knowledge loads on-demand via skills:
 | `/check-platforms` | Search Android, Windows, backend repos for feature implementations |
 | `/reference-codebases` | Port features from sibling repos with pattern mapping |
 | `/figma` | Implement UI from Figma designs via MCP with mandatory property mapping |
+
+## In-Repo Docs
+
+Long-form reasoning that does not fit in code comments lives in [`docs/`](docs/). Read the routed page **before** changing the code, not after:
+
+| Situation | Read |
+|-----------|------|
+| Touching passcode or key-share encryption | [docs/passcode-keyshare-encryption/overview.md](docs/passcode-keyshare-encryption/overview.md) |
+| Changing `KeyshareWriteCoordinator`, or any lease/`await` placement around key-share writes | [concurrency-and-leases.md](docs/passcode-keyshare-encryption/concurrency-and-leases.md) |
+| Reordering steps in `setPasscode` / `disablePasscode` / the resume sweep | [transitions.md](docs/passcode-keyshare-encryption/transitions.md) |
+| A guard there looks redundant, or you want to simplify `KeyshareSweeper` | [invariants.md](docs/passcode-keyshare-encryption/invariants.md) |
 
 ## Knowledge Base
 

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -942,6 +942,10 @@
 "partOf" = "Teil %d von %d";
 "passcodeAlreadySet" = "Auf diesem Gerät ist bereits ein Passcode gesetzt. Gehen Sie zurück, um ihn zu ändern oder zu entfernen.";
 "passcodeAutoLockTitle" = "Automatische Sperre";
+"passcodeBiometricDisableFailed" = "Die biometrische Entsperrung konnte nicht deaktiviert werden. Versuchen Sie es erneut.";
+"passcodeBiometricEnableFailed" = "Die biometrische Entsperrung konnte nicht aktiviert werden. Ihr Passcode funktioniert weiterhin.";
+"passcodeBiometricNotAvailable" = "Dieses Gerät kann die biometrische Entsperrung nicht verwenden.";
+"passcodeBiometricNotEnrolled" = "Richten Sie Face ID oder Touch ID in den Geräteeinstellungen ein, um dies zu verwenden.";
 "passcodeBiometricReason" = "Vultisig entsperren";
 "passcodeBiometricToggle" = "Mit Biometrie entsperren";
 "passcodeBiometricUnavailable" = "Die biometrische Entsperrung ist auf diesem Gerät nicht mehr verfügbar. Geben Sie Ihren Passcode ein.";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -942,6 +942,9 @@
 "partOf" = "Teil %d von %d";
 "passcodeAlreadySet" = "Auf diesem Gerät ist bereits ein Passcode gesetzt. Gehen Sie zurück, um ihn zu ändern oder zu entfernen.";
 "passcodeAutoLockTitle" = "Automatische Sperre";
+"passcodeBiometricReason" = "Vultisig entsperren";
+"passcodeBiometricToggle" = "Mit Biometrie entsperren";
+"passcodeBiometricUnavailable" = "Die biometrische Entsperrung ist auf diesem Gerät nicht mehr verfügbar. Geben Sie Ihren Passcode ein.";
 "passcodeBusy" = "Ein anderer Vorgang läuft noch. Warten Sie, bis er abgeschlossen ist, und versuchen Sie es erneut.";
 "passcodeChangeTitle" = "Passcode ändern";
 "passcodeChooseSubtitle" = "6 Ziffern. Sie benötigen ihn, um die App zu öffnen.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -942,6 +942,9 @@
 "partOf" = "part %d of %d";
 "passcodeAlreadySet" = "A passcode is already set on this device. Go back to change or remove it.";
 "passcodeAutoLockTitle" = "Auto-lock";
+"passcodeBiometricReason" = "Unlock Vultisig";
+"passcodeBiometricToggle" = "Unlock with biometrics";
+"passcodeBiometricUnavailable" = "Biometric unlock is no longer available on this device. Enter your passcode.";
 "passcodeBusy" = "Another operation is still in progress. Wait for it to finish, then try again.";
 "passcodeChangeTitle" = "Change passcode";
 "passcodeChooseSubtitle" = "6 digits. You will need it to open the app.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -942,6 +942,10 @@
 "partOf" = "part %d of %d";
 "passcodeAlreadySet" = "A passcode is already set on this device. Go back to change or remove it.";
 "passcodeAutoLockTitle" = "Auto-lock";
+"passcodeBiometricDisableFailed" = "Biometric unlock could not be turned off. Try again.";
+"passcodeBiometricEnableFailed" = "Biometric unlock could not be turned on. Your passcode still works.";
+"passcodeBiometricNotAvailable" = "This device cannot use biometric unlock.";
+"passcodeBiometricNotEnrolled" = "Set up Face ID or Touch ID in your device settings to use this.";
 "passcodeBiometricReason" = "Unlock Vultisig";
 "passcodeBiometricToggle" = "Unlock with biometrics";
 "passcodeBiometricUnavailable" = "Biometric unlock is no longer available on this device. Enter your passcode.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -942,6 +942,9 @@
 "partOf" = "Parte %d de %d";
 "passcodeAlreadySet" = "Ya hay un código establecido en este dispositivo. Vuelve atrás para cambiarlo o quitarlo.";
 "passcodeAutoLockTitle" = "Bloqueo automático";
+"passcodeBiometricReason" = "Desbloquear Vultisig";
+"passcodeBiometricToggle" = "Desbloquear con biometría";
+"passcodeBiometricUnavailable" = "El desbloqueo biométrico ya no está disponible en este dispositivo. Introduce tu código.";
 "passcodeBusy" = "Hay otra operación en curso. Espera a que termine e inténtalo de nuevo.";
 "passcodeChangeTitle" = "Cambiar código";
 "passcodeChooseSubtitle" = "6 dígitos. Lo necesitarás para abrir la app.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -942,6 +942,10 @@
 "partOf" = "Parte %d de %d";
 "passcodeAlreadySet" = "Ya hay un código establecido en este dispositivo. Vuelve atrás para cambiarlo o quitarlo.";
 "passcodeAutoLockTitle" = "Bloqueo automático";
+"passcodeBiometricDisableFailed" = "No se pudo desactivar el desbloqueo biométrico. Inténtalo de nuevo.";
+"passcodeBiometricEnableFailed" = "No se pudo activar el desbloqueo biométrico. Tu código sigue funcionando.";
+"passcodeBiometricNotAvailable" = "Este dispositivo no puede usar el desbloqueo biométrico.";
+"passcodeBiometricNotEnrolled" = "Configura Face ID o Touch ID en los ajustes del dispositivo para usar esto.";
 "passcodeBiometricReason" = "Desbloquear Vultisig";
 "passcodeBiometricToggle" = "Desbloquear con biometría";
 "passcodeBiometricUnavailable" = "El desbloqueo biométrico ya no está disponible en este dispositivo. Introduce tu código.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -942,6 +942,9 @@
 "partOf" = "dio %d od %d";
 "passcodeAlreadySet" = "Na ovom uređaju već je postavljena zaporka. Vratite se natrag da biste je promijenili ili uklonili.";
 "passcodeAutoLockTitle" = "Automatsko zaključavanje";
+"passcodeBiometricReason" = "Otključaj Vultisig";
+"passcodeBiometricToggle" = "Otključavanje biometrijom";
+"passcodeBiometricUnavailable" = "Otključavanje biometrijom više nije dostupno na ovom uređaju. Unesite zaporku.";
 "passcodeBusy" = "Druga radnja je još u tijeku. Pričekajte da završi pa pokušajte ponovno.";
 "passcodeChangeTitle" = "Promijeni zaporku";
 "passcodeChooseSubtitle" = "6 znamenki. Trebat će vam za otvaranje aplikacije.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -942,6 +942,10 @@
 "partOf" = "dio %d od %d";
 "passcodeAlreadySet" = "Na ovom uređaju već je postavljena zaporka. Vratite se natrag da biste je promijenili ili uklonili.";
 "passcodeAutoLockTitle" = "Automatsko zaključavanje";
+"passcodeBiometricDisableFailed" = "Otključavanje biometrijom nije se moglo isključiti. Pokušajte ponovno.";
+"passcodeBiometricEnableFailed" = "Otključavanje biometrijom nije se moglo uključiti. Vaša zaporka i dalje radi.";
+"passcodeBiometricNotAvailable" = "Ovaj uređaj ne može koristiti otključavanje biometrijom.";
+"passcodeBiometricNotEnrolled" = "Postavite Face ID ili Touch ID u postavkama uređaja da biste ovo koristili.";
 "passcodeBiometricReason" = "Otključaj Vultisig";
 "passcodeBiometricToggle" = "Otključavanje biometrijom";
 "passcodeBiometricUnavailable" = "Otključavanje biometrijom više nije dostupno na ovom uređaju. Unesite zaporku.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -942,6 +942,9 @@
 "partOf" = "parte %d di %d";
 "passcodeAlreadySet" = "Su questo dispositivo è già impostato un codice. Torna indietro per cambiarlo o rimuoverlo.";
 "passcodeAutoLockTitle" = "Blocco automatico";
+"passcodeBiometricReason" = "Sblocca Vultisig";
+"passcodeBiometricToggle" = "Sblocca con la biometria";
+"passcodeBiometricUnavailable" = "Lo sblocco con la biometria non è più disponibile su questo dispositivo. Inserisci il codice.";
 "passcodeBusy" = "Un'altra operazione è ancora in corso. Attendi che finisca e riprova.";
 "passcodeChangeTitle" = "Cambia codice";
 "passcodeChooseSubtitle" = "6 cifre. Ti servirà per aprire l'app.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -942,6 +942,10 @@
 "partOf" = "parte %d di %d";
 "passcodeAlreadySet" = "Su questo dispositivo è già impostato un codice. Torna indietro per cambiarlo o rimuoverlo.";
 "passcodeAutoLockTitle" = "Blocco automatico";
+"passcodeBiometricDisableFailed" = "Non è stato possibile disattivare lo sblocco con la biometria. Riprova.";
+"passcodeBiometricEnableFailed" = "Non è stato possibile attivare lo sblocco con la biometria. Il codice continua a funzionare.";
+"passcodeBiometricNotAvailable" = "Questo dispositivo non può usare lo sblocco con la biometria.";
+"passcodeBiometricNotEnrolled" = "Configura Face ID o Touch ID nelle impostazioni del dispositivo per usarlo.";
 "passcodeBiometricReason" = "Sblocca Vultisig";
 "passcodeBiometricToggle" = "Sblocca con la biometria";
 "passcodeBiometricUnavailable" = "Lo sblocco con la biometria non è più disponibile su questo dispositivo. Inserisci il codice.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -942,6 +942,9 @@
 "partOf" = "%d/%d 공유";
 "passcodeAlreadySet" = "이 기기에는 이미 패스코드가 설정되어 있습니다. 뒤로 돌아가 변경하거나 삭제하세요.";
 "passcodeAutoLockTitle" = "자동 잠금";
+"passcodeBiometricReason" = "Vultisig 잠금 해제";
+"passcodeBiometricToggle" = "생체 인식으로 잠금 해제";
+"passcodeBiometricUnavailable" = "이 기기에서는 생체 인식 잠금 해제를 더 이상 사용할 수 없습니다. 패스코드를 입력하세요.";
 "passcodeBusy" = "다른 작업이 아직 진행 중입니다. 완료될 때까지 기다린 뒤 다시 시도하세요.";
 "passcodeChangeTitle" = "패스코드 변경";
 "passcodeChooseSubtitle" = "6자리 숫자입니다. 앱을 열 때 필요합니다.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -942,6 +942,10 @@
 "partOf" = "%d/%d 공유";
 "passcodeAlreadySet" = "이 기기에는 이미 패스코드가 설정되어 있습니다. 뒤로 돌아가 변경하거나 삭제하세요.";
 "passcodeAutoLockTitle" = "자동 잠금";
+"passcodeBiometricDisableFailed" = "생체 인식 잠금 해제를 끄지 못했습니다. 다시 시도하세요.";
+"passcodeBiometricEnableFailed" = "생체 인식 잠금 해제를 켜지 못했습니다. 패스코드는 계속 사용할 수 있습니다.";
+"passcodeBiometricNotAvailable" = "이 기기에서는 생체 인식 잠금 해제를 사용할 수 없습니다.";
+"passcodeBiometricNotEnrolled" = "이 기능을 사용하려면 기기 설정에서 Face ID 또는 Touch ID를 설정하세요.";
 "passcodeBiometricReason" = "Vultisig 잠금 해제";
 "passcodeBiometricToggle" = "생체 인식으로 잠금 해제";
 "passcodeBiometricUnavailable" = "이 기기에서는 생체 인식 잠금 해제를 더 이상 사용할 수 없습니다. 패스코드를 입력하세요.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -942,6 +942,10 @@
 "partOf" = "parte %d de %d";
 "passcodeAlreadySet" = "Já existe um código definido neste dispositivo. Volte atrás para o alterar ou remover.";
 "passcodeAutoLockTitle" = "Bloqueio automático";
+"passcodeBiometricDisableFailed" = "Não foi possível desativar o desbloqueio biométrico. Tente novamente.";
+"passcodeBiometricEnableFailed" = "Não foi possível ativar o desbloqueio biométrico. O seu código continua a funcionar.";
+"passcodeBiometricNotAvailable" = "Este dispositivo não pode usar o desbloqueio biométrico.";
+"passcodeBiometricNotEnrolled" = "Configure o Face ID ou o Touch ID nas definições do dispositivo para usar isto.";
 "passcodeBiometricReason" = "Desbloquear o Vultisig";
 "passcodeBiometricToggle" = "Desbloquear com biometria";
 "passcodeBiometricUnavailable" = "O desbloqueio biométrico já não está disponível neste dispositivo. Introduza o seu código.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -942,6 +942,9 @@
 "partOf" = "parte %d de %d";
 "passcodeAlreadySet" = "Já existe um código definido neste dispositivo. Volte atrás para o alterar ou remover.";
 "passcodeAutoLockTitle" = "Bloqueio automático";
+"passcodeBiometricReason" = "Desbloquear o Vultisig";
+"passcodeBiometricToggle" = "Desbloquear com biometria";
+"passcodeBiometricUnavailable" = "O desbloqueio biométrico já não está disponível neste dispositivo. Introduza o seu código.";
 "passcodeBusy" = "Está ainda em curso outra operação. Aguarde que termine e tente novamente.";
 "passcodeChangeTitle" = "Alterar código";
 "passcodeChooseSubtitle" = "6 dígitos. Vai precisar dele para abrir a app.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -942,6 +942,10 @@
 "partOf" = "第 %d 部分，共 %d 部分";
 "passcodeAlreadySet" = "本设备已设置密码。请返回上一页以修改或移除。";
 "passcodeAutoLockTitle" = "自动锁定";
+"passcodeBiometricDisableFailed" = "无法关闭生物识别解锁。请重试。";
+"passcodeBiometricEnableFailed" = "无法开启生物识别解锁。密码仍然可用。";
+"passcodeBiometricNotAvailable" = "本设备无法使用生物识别解锁。";
+"passcodeBiometricNotEnrolled" = "请在设备设置中设置面容 ID 或触控 ID 后再使用。";
 "passcodeBiometricReason" = "解锁 Vultisig";
 "passcodeBiometricToggle" = "使用生物识别解锁";
 "passcodeBiometricUnavailable" = "本设备已无法使用生物识别解锁。请输入密码。";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -942,6 +942,9 @@
 "partOf" = "第 %d 部分，共 %d 部分";
 "passcodeAlreadySet" = "本设备已设置密码。请返回上一页以修改或移除。";
 "passcodeAutoLockTitle" = "自动锁定";
+"passcodeBiometricReason" = "解锁 Vultisig";
+"passcodeBiometricToggle" = "使用生物识别解锁";
+"passcodeBiometricUnavailable" = "本设备已无法使用生物识别解锁。请输入密码。";
 "passcodeBusy" = "另一项操作仍在进行中。请等待其完成后重试。";
 "passcodeChangeTitle" = "修改密码";
 "passcodeChooseSubtitle" = "6 位数字。打开应用时需要输入。";

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
@@ -58,6 +58,7 @@ struct KeyshareInstallReconciler {
 
     private let keychain: KeychainService
     private let keyStore: KeyshareKeyStoring
+    private let biometrics: BiometricUnlockStore
     private let lockService: AppLockService
     private let coordinator: KeyshareWriteCoordinator
     private let defaults: UserDefaults
@@ -65,12 +66,14 @@ struct KeyshareInstallReconciler {
     init(
         keychain: KeychainService = DefaultKeychainService.shared,
         keyStore: KeyshareKeyStoring = DefaultKeyshareKeyStore.shared,
+        biometrics: BiometricUnlockStore = .shared,
         lockService: AppLockService = .shared,
         coordinator: KeyshareWriteCoordinator = .shared,
         defaults: UserDefaults = .standard
     ) {
         self.keychain = keychain
         self.keyStore = keyStore
+        self.biometrics = biometrics
         self.lockService = lockService
         self.coordinator = coordinator
         self.defaults = defaults
@@ -210,6 +213,11 @@ struct KeyshareInstallReconciler {
 
         if case .present = wrapper { return .something }
         if case .present = attempts { return .something }
+        // The biometric copy has no tri-state to report — presence is checked
+        // without authentication and answers true even when the item exists but
+        // needs a face, so a `false` here is as close to a confirmed absence as
+        // this item gets.
+        if biometrics.isEnabled { return .something }
         if case .unavailable = wrapper { return .unknown }
         if case .unavailable = attempts { return .unknown }
         return .nothing
@@ -222,6 +230,16 @@ struct KeyshareInstallReconciler {
         logger.info("New app container over surviving Keychain state — clearing inherited key material")
 
         try keyStore.deleteWrappedDataKey()
+
+        // The biometric copy is a second copy of the same key and survives the
+        // uninstall too. Left behind it reports biometric unlock as already
+        // enabled — an enablement nobody made on this install — and it is bound
+        // to a wrapper that has just been deleted, so it could only ever be
+        // refused. Deletion tolerates a missing item, so this is a no-op on a
+        // first-ever install, and it is verified rather than fire-and-forget:
+        // a survivor is exactly the silent-shortcut case `disable()` exists to
+        // prevent.
+        try biometrics.disable()
 
         // The attempt limiter keeps its state in the Keychain on purpose, so a
         // lockout cannot be shaken off by reinstalling. That reasoning does not

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
@@ -65,13 +65,19 @@ struct ProtectedVaultImporter {
 
     private let normalizer: KeyshareNormalizer
     private let coordinator: KeyshareWriteCoordinator
+    private let save: @MainActor (ModelContext) throws -> Void
 
+    /// - Parameter save: the store write. A seam, and only a seam: SwiftData
+    ///   offers no way to make an in-memory `save()` fail on demand, and the
+    ///   paths that matter most here are the ones a save failure opens.
     init(
         protector: KeyshareProtecting = KeyshareProtector.shared,
-        coordinator: KeyshareWriteCoordinator = .shared
+        coordinator: KeyshareWriteCoordinator = .shared,
+        save: @escaping @MainActor (ModelContext) throws -> Void = { try $0.save() }
     ) {
         self.normalizer = KeyshareNormalizer(protector: protector)
         self.coordinator = coordinator
+        self.save = save
     }
 
     /// Refuses a backup carrying a share this device cannot open, before the
@@ -94,11 +100,15 @@ struct ProtectedVaultImporter {
     /// - Parameter prepare: run per vault inside the lease, once the vault is
     ///   provably stored. Anything that touches the context on a vault's behalf
     ///   — default coins are the case that exists — belongs here rather than at
-    ///   the call site: done before, it leaves rows behind when the import is
-    ///   refused, and the token discovery it starts is unstructured work that
-    ///   outlives this call and must never be aimed at a vault that could still
-    ///   be withdrawn. It answers whether it did its work, and must be
-    ///   idempotent: a vault it leaves unprepared is put through it again.
+    ///   the call site, where it would leave rows behind when the import is
+    ///   refused. It answers whether it did its work, and must be idempotent: a
+    ///   vault it leaves unprepared is put through it again, against a context
+    ///   the failed attempt has been withdrawn from.
+    ///
+    ///   It must not *start* work that outlives it. Token discovery is the case
+    ///   that exists, and it is aimed at rows this method can still take back —
+    ///   so the caller starts it once `commit` has returned, never from inside
+    ///   `prepare`.
     @MainActor
     func commit(
         _ vaults: [Vault],
@@ -131,7 +141,7 @@ struct ProtectedVaultImporter {
         }
 
         do {
-            try context.save()
+            try save(context)
         } catch {
             withdraw(vaults, from: context, rollingBack: !wasCarryingOtherWork)
             logger.error("Vault import failed to save: \(error.localizedDescription, privacy: .public)")
@@ -173,7 +183,18 @@ struct ProtectedVaultImporter {
     ///
     /// A save that throws makes every vault in the batch unprepared, whatever
     /// `prepare` said: work that is not on disk is work the next launch will not
-    /// find.
+    /// find. And what it wrote is withdrawn before answering, because a failed
+    /// save leaves those inserts *pending*, not gone — the retry would run
+    /// against a context still holding the first attempt's rows, and after a
+    /// second failure the whole import would return with them still eligible for
+    /// an autosave or for the next unrelated `save()` anywhere in the app. That
+    /// is work this method has already given up on reaching disk by a route
+    /// nothing here can see.
+    ///
+    /// `rollback()` and not a per-row withdrawal, and it is safe here in a way
+    /// it is not in ``commit(_:into:prepare:)``: the insert's own save has
+    /// already flushed whatever the context was carrying, so everything pending
+    /// at this point was written by `prepare`.
     @MainActor
     private func vaultsLeftUnprepared(
         among vaults: [Vault],
@@ -182,8 +203,9 @@ struct ProtectedVaultImporter {
     ) -> [Vault] {
         let unprepared = vaults.filter { !prepare($0) }
         do {
-            try context.save()
+            try save(context)
         } catch {
+            context.rollback()
             logger.error("Imported vaults were stored but their default coins were not: \(error.localizedDescription, privacy: .public)")
             return vaults
         }

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
@@ -97,12 +97,13 @@ struct ProtectedVaultImporter {
     ///   the call site: done before, it leaves rows behind when the import is
     ///   refused, and the token discovery it starts is unstructured work that
     ///   outlives this call and must never be aimed at a vault that could still
-    ///   be withdrawn.
+    ///   be withdrawn. It answers whether it did its work, and must be
+    ///   idempotent: a vault it leaves unprepared is put through it again.
     @MainActor
     func commit(
         _ vaults: [Vault],
         into context: ModelContext,
-        prepare: (Vault) -> Void = { _ in }
+        prepare: (Vault) -> Bool = { _ in true }
     ) throws {
         // Nothing to do is not a reason to save: an all-duplicate ZIP would
         // otherwise flush whatever unrelated work the context is carrying.
@@ -139,17 +140,55 @@ struct ProtectedVaultImporter {
 
         // Only now, over vaults that are provably on disk, and still inside the
         // lease so the rows land before a transition can begin. A failure here
-        // is not an import failure: the vaults are stored and openable, and
-        // their default coins are derived state that any later launch rebuilds.
-        vaults.forEach(prepare)
-        do {
-            try context.save()
-        } catch {
-            logger.error("Imported vaults were stored but their default coins were not: \(error.localizedDescription, privacy: .public)")
+        // is not an import failure — the vaults are stored and openable, and
+        // refusing an import that has already reached disk would leave the user
+        // a vault they cannot re-import — so it is reported rather than thrown.
+        //
+        // It is checked as a postcondition and not only as a `catch`, because
+        // the way this went wrong in practice was a save that *succeeded* and
+        // stored nothing: the coins attached to a vault that had already been
+        // saved, where that write does not take. An error-only guard saw a
+        // clean import and said nothing. And nothing else rebuilds this later —
+        // default coins are set at keygen and at import and nowhere else — so a
+        // vault that leaves here unprepared is one the user opens on an empty
+        // wallet, with no error, for good.
+        var unprepared = vaultsLeftUnprepared(among: vaults, by: prepare, in: context)
+        if !unprepared.isEmpty {
+            // `prepare` is idempotent by contract and these vaults are brand
+            // new — nothing else has touched them — so running it again is the
+            // one repair available at a point where the user cannot usefully be
+            // told anything. Once, not in a loop: a preparation that fails twice
+            // fails for a reason a third attempt will not change.
+            unprepared = vaultsLeftUnprepared(among: unprepared, by: prepare, in: context)
+        }
+        if !unprepared.isEmpty {
+            logger.error("Imported vaults were stored without their default coins: \(unprepared.count, privacy: .public) of \(vaults.count, privacy: .public) will open with no chains in them")
         }
     }
 
     // MARK: - Privates
+
+    /// Runs `prepare` over vaults that are already stored, saves what it wrote,
+    /// and answers the ones that did not come out prepared.
+    ///
+    /// A save that throws makes every vault in the batch unprepared, whatever
+    /// `prepare` said: work that is not on disk is work the next launch will not
+    /// find.
+    @MainActor
+    private func vaultsLeftUnprepared(
+        among vaults: [Vault],
+        by prepare: (Vault) -> Bool,
+        in context: ModelContext
+    ) -> [Vault] {
+        let unprepared = vaults.filter { !prepare($0) }
+        do {
+            try context.save()
+        } catch {
+            logger.error("Imported vaults were stored but their default coins were not: \(error.localizedDescription, privacy: .public)")
+            return vaults
+        }
+        return unprepared
+    }
 
     /// Undoes a failed import without taking anybody else's work with it.
     ///

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
@@ -102,8 +102,10 @@ struct ProtectedVaultImporter {
     ///   — default coins are the case that exists — belongs here rather than at
     ///   the call site, where it would leave rows behind when the import is
     ///   refused. It answers whether it did its work, and must be idempotent: a
-    ///   vault it leaves unprepared is put through it again, against a context
-    ///   the failed attempt has been withdrawn from.
+    ///   vault it leaves unprepared is put through it again. Where the first
+    ///   attempt left nothing behind — its save threw, and this method rolled it
+    ///   back — the second attempt is a real repair; where it kept what it could
+    ///   do, the second attempt simply answers the same way again.
     ///
     ///   It must not *start* work that outlives it. Token discovery is the case
     ///   that exists, and it is aimed at rows this method can still take back —
@@ -160,15 +162,18 @@ struct ProtectedVaultImporter {
         // saved, where that write does not take. An error-only guard saw a
         // clean import and said nothing. And nothing else rebuilds this later —
         // default coins are set at keygen and at import and nowhere else — so a
-        // vault that leaves here unprepared is one the user opens on an empty
-        // wallet, with no error, for good.
+        // vault that leaves here unprepared is one the user opens missing
+        // chains, with no error, for good.
         var unprepared = vaultsLeftUnprepared(among: vaults, by: prepare, in: context)
         if !unprepared.isEmpty {
-            // `prepare` is idempotent by contract and these vaults are brand
-            // new — nothing else has touched them — so running it again is the
-            // one repair available at a point where the user cannot usefully be
-            // told anything. Once, not in a loop: a preparation that fails twice
-            // fails for a reason a third attempt will not change.
+            // The second pass repairs the kind of failure that left nothing
+            // behind — a save that threw and was rolled back — because `prepare`
+            // is idempotent and running it again is the one repair available at
+            // a point where the user cannot usefully be told anything. Where it
+            // repairs nothing, it costs nothing and answers the same way twice,
+            // which is what reaches the log below. Once, not in a loop: a
+            // preparation that fails twice fails for a reason a third attempt
+            // will not change.
             unprepared = vaultsLeftUnprepared(among: unprepared, by: prepare, in: context)
         }
         if !unprepared.isEmpty {

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
@@ -172,7 +172,7 @@ struct ProtectedVaultImporter {
             unprepared = vaultsLeftUnprepared(among: unprepared, by: prepare, in: context)
         }
         if !unprepared.isEmpty {
-            logger.error("Imported vaults were stored without their default coins: \(unprepared.count, privacy: .public) of \(vaults.count, privacy: .public) will open with no chains in them")
+            logger.error("Imported vaults were stored without their default coins: \(unprepared.count, privacy: .public) of \(vaults.count, privacy: .public) will open missing at least one of their default chains")
         }
     }
 

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/BiometricUnlockStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/BiometricUnlockStore.swift
@@ -11,12 +11,40 @@ import Security
 
 private let logger = Log.app.store
 
+/// Whether this device can hold a biometry-guarded copy of the data key *right
+/// now*, and if not, why.
+///
+/// The reason is worth carrying rather than collapsing to a `Bool`, because the
+/// two failures need opposite things from the user. Nothing enrolled is fixed in
+/// Settings in ten seconds; no hardware is not fixable at all, and offering a
+/// switch that can only ever refuse is worse than not offering it.
+///
+/// Deliberately asked *before* the Keychain write rather than inferred from its
+/// failure. `SecItemAdd` under `.biometryCurrentSet` answers a handful of
+/// statuses for "the access control cannot be satisfied", they are not
+/// documented as an exhaustive set, and mapping them backwards into a reason
+/// would be guessing at what the user has to do next.
+enum BiometricAvailability: Equatable {
+    case available
+    /// Hardware is present, nothing is enrolled on it. Also the state a
+    /// simulator is in until Face ID is enrolled from the Features menu, which
+    /// is where this most often bites during development.
+    case notEnrolled
+    /// No biometric hardware, biometry locked out after too many failures, or a
+    /// device with no passcode — none of which the app can do anything about.
+    case unavailable
+}
+
 enum BiometricUnlockError: Error, Equatable {
     case notEnabled
     case unavailable
     case cancelled
     case failed
     case storageFailed
+    /// Nothing is enrolled, so the item could never be guarded. Distinct from
+    /// `.storageFailed` because it is the user's to fix and the message can say
+    /// how.
+    case notEnrolled
     /// The stored copy was made for a different wrapped key, so it holds a data
     /// key nothing on disk wraps any more.
     case supersededCopy
@@ -76,13 +104,28 @@ final class BiometricUnlockStore {
     private static var blobLength: Int { bindingLength + VaultCryptoEnvelope.keyLengthBytes }
 
     private let keychain: BiometricKeychainProtecting
+    /// Its own seam rather than a member of ``BiometricKeychainProtecting``.
+    /// That protocol has four conformers spread across this stack's branches, and
+    /// none of the other three has anything to say about `LAContext` — adding a
+    /// requirement would have made every one of them answer a question it does
+    /// not own, with `.available` as the only answer available to them. A
+    /// fail-closed component should not acquire a default that fails open.
+    private let biometryAvailability: () -> BiometricAvailability
 
-    init(keychain: BiometricKeychainProtecting = BiometricKeychain()) {
+    init(
+        keychain: BiometricKeychainProtecting = BiometricKeychain(),
+        biometryAvailability: @escaping () -> BiometricAvailability = BiometricKeychain.currentAvailability
+    ) {
         self.keychain = keychain
+        self.biometryAvailability = biometryAvailability
     }
 
     var isEnabled: Bool {
         keychain.exists(account: Self.account)
+    }
+
+    var availability: BiometricAvailability {
+        biometryAvailability()
     }
 
     /// Stores the data key behind biometry, bound to the wrapped key it belongs
@@ -92,6 +135,19 @@ final class BiometricUnlockStore {
     /// Writing the item never prompts for biometry; only reading does. That is
     /// what makes rebinding after a passcode change silent.
     func enable(dataKey: SymmetricKey, boundTo wrappedDataKey: Data) throws {
+        // Asked first, so the common refusal arrives as something the user can
+        // act on. Without it every one of these came back as a bare storage
+        // failure, and the screen above said nothing at all — the switch simply
+        // returned to off, which reads as the app ignoring the tap.
+        switch biometryAvailability() {
+        case .available:
+            break
+        case .notEnrolled:
+            throw BiometricUnlockError.notEnrolled
+        case .unavailable:
+            throw BiometricUnlockError.unavailable
+        }
+
         var blob = Self.binding(for: wrappedDataKey)
         blob.append(dataKey.withUnsafeBytes { Data($0) })
 
@@ -206,7 +262,35 @@ struct BiometricKeychain: BiometricKeychainProtecting {
         // into `errSecDuplicateItem`.
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
+            // The status is the only thing that says *why*, and it is about to
+            // be thrown away by the mapping. Everything upstream sees
+            // `.storageFailed`, so without this line a failure here is
+            // undiagnosable from a device log.
+            let message = SecCopyErrorMessageString(status, nil) as String? ?? "unknown"
+            logger.error(
+                "SecItemAdd for the biometric data key failed: \(status, privacy: .public) (\(message, privacy: .public))"
+            )
             throw BiometricUnlockError.storageFailed
+        }
+    }
+
+    static func currentAvailability() -> BiometricAvailability {
+        var error: NSError?
+        let context = LAContext()
+        guard !context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            return .available
+        }
+
+        // `.biometryNotEnrolled` and `.passcodeNotSet` are both "turn something
+        // on in Settings", and they arrive together: enrolling a face requires a
+        // device passcode, so a device with neither reports whichever it checks
+        // first. Treating them as one state keeps the message honest without
+        // pretending to know which of the two the user is missing.
+        switch (error as? LAError)?.code {
+        case .biometryNotEnrolled, .passcodeNotSet:
+            return .notEnrolled
+        default:
+            return .unavailable
         }
     }
 

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/BiometricUnlockStore.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/BiometricUnlockStore.swift
@@ -1,0 +1,279 @@
+//
+//  BiometricUnlockStore.swift
+//  VultisigApp
+//
+
+import CryptoKit
+import Foundation
+import LocalAuthentication
+import OSLog
+import Security
+
+private let logger = Log.app.store
+
+enum BiometricUnlockError: Error, Equatable {
+    case notEnabled
+    case unavailable
+    case cancelled
+    case failed
+    case storageFailed
+    /// The stored copy was made for a different wrapped key, so it holds a data
+    /// key nothing on disk wraps any more.
+    case supersededCopy
+    /// The stored copy is not the right shape to be a bound data key.
+    ///
+    /// Separate from `.failed` because the biometric match *succeeded*: the user
+    /// watched it work and then nothing happened, which is worth telling them
+    /// about, whereas a mismatch or a lockout is not.
+    case malformedCopy
+}
+
+/// Seam over the biometry-protected Keychain item, so the fail-closed behaviour
+/// can be tested without a device and without real Face ID.
+protocol BiometricKeychainProtecting {
+    /// Adds the item. It is an add and not an upsert, so the caller removes any
+    /// existing item first — which is what `BiometricUnlockStore.enable` does,
+    /// where a test can see it.
+    func store(_ data: Data, account: String) throws
+    func read(account: String, prompt: String) throws -> Data
+    func delete(account: String) throws
+    func exists(account: String) -> Bool
+}
+
+/// An optional shortcut past the passcode, never a replacement for it.
+///
+/// Holds a second copy of the data key behind `SecAccessControl(.biometryCurrentSet)`.
+/// The passcode-wrapped copy is untouched and always works, so this can be
+/// removed, invalidated or fail without the user losing access to anything.
+///
+/// `.biometryCurrentSet` rather than `.biometryAny`: the copy is destroyed by the
+/// system if the enrolled biometrics change, so enrolling a new face or finger
+/// does not silently inherit access to the wallet.
+///
+/// **Everything here fails closed.** Any error — unavailable, cancelled, lockout,
+/// changed enrolment, missing item — throws, and the caller falls back to the
+/// passcode. A biometric lock that fails *open* is worse than no lock, and we
+/// have shipped that bug before in another app.
+///
+/// **The copy is bound to the wrapper it was made for**, and that is what makes
+/// it safe to unlock with. Nothing here can prove a stored key opens anything:
+/// the passcode-wrapped copy cannot be unwrapped without the passcode, and an
+/// interrupted `setPasscode` can leave a store with no sealed share to test
+/// against. So a copy surviving from a previous install would otherwise hand
+/// back key A while the durable wrapper holds key B — and the resume sweep that
+/// follows every app unlock would then seal every share under A, which no
+/// wrapper holds and nothing can ever open. Binding to the wrapped blob's digest
+/// makes that mismatch detectable *before* the key is adopted, and the stale copy
+/// is removed rather than left to fail again.
+final class BiometricUnlockStore {
+
+    static let shared = BiometricUnlockStore()
+
+    private static let account = "com.vultisig.wallet.biometricDataKey"
+
+    /// The stored blob is the binding followed by the data key.
+    private static let bindingLength = SHA256.byteCount
+    private static var blobLength: Int { bindingLength + VaultCryptoEnvelope.keyLengthBytes }
+
+    private let keychain: BiometricKeychainProtecting
+
+    init(keychain: BiometricKeychainProtecting = BiometricKeychain()) {
+        self.keychain = keychain
+    }
+
+    var isEnabled: Bool {
+        keychain.exists(account: Self.account)
+    }
+
+    /// Stores the data key behind biometry, bound to the wrapped key it belongs
+    /// to. Requires the caller to already hold the data key, i.e. to be
+    /// unlocked — this never mints or unwraps a key itself.
+    ///
+    /// Writing the item never prompts for biometry; only reading does. That is
+    /// what makes rebinding after a passcode change silent.
+    func enable(dataKey: SymmetricKey, boundTo wrappedDataKey: Data) throws {
+        var blob = Self.binding(for: wrappedDataKey)
+        blob.append(dataKey.withUnsafeBytes { Data($0) })
+
+        // Replace, never update in place: an item's access control cannot be
+        // changed after the fact, and adding over one that is already there
+        // answers `errSecDuplicateItem`. That matters because rebinding after a
+        // passcode change goes through here — without the removal, the change
+        // would silently leave the shortcut bound to the old wrapper and the
+        // next unlock would refuse it.
+        //
+        // The removal is not verified: `store` below is the operation that has
+        // to succeed, and a stale item that somehow survives is refused by its
+        // binding rather than trusted.
+        try? keychain.delete(account: Self.account)
+
+        do {
+            try keychain.store(blob, account: Self.account)
+        } catch {
+            logger.error("Failed to store the biometric data key: \(String(describing: error), privacy: .public)")
+            throw BiometricUnlockError.storageFailed
+        }
+    }
+
+    /// - Throws: when the copy could not be confirmed gone. A survivor holds the
+    ///   same data key, so it would quietly become a working shortcut again the
+    ///   next time a passcode is set — an enablement the user never made.
+    func disable() throws {
+        try keychain.delete(account: Self.account)
+
+        guard !isEnabled else {
+            logger.error("Biometric data key still present after deletion")
+            throw BiometricUnlockError.storageFailed
+        }
+    }
+
+    /// - Parameter wrappedDataKey: the wrapper the app is unlocking against. The
+    ///   stored copy has to have been made for exactly this blob.
+    /// - Returns: the data key, only on a successful biometric match against a
+    ///   copy that still belongs to the current wrapper.
+    /// - Throws: on every other outcome, so the caller shows the passcode screen.
+    func unlock(reason: String, boundTo wrappedDataKey: Data) throws -> SymmetricKey {
+        guard isEnabled else { throw BiometricUnlockError.notEnabled }
+
+        let raw: Data
+        do {
+            raw = try keychain.read(account: Self.account, prompt: reason)
+        } catch let error as BiometricUnlockError {
+            throw error
+        } catch {
+            logger.error("Biometric unlock failed: \(String(describing: error), privacy: .public)")
+            throw BiometricUnlockError.failed
+        }
+
+        guard raw.count == Self.blobLength else {
+            // Present but the wrong shape. Remove it rather than leave a
+            // shortcut that cannot work; the passcode still opens the app.
+            logger.error("Biometric data key has unexpected length \(raw.count, privacy: .public)")
+            try? disable()
+            throw BiometricUnlockError.malformedCopy
+        }
+
+        guard raw.prefix(Self.bindingLength) == Self.binding(for: wrappedDataKey) else {
+            // The wrapper this copy was made for is not the one on disk: a
+            // previous install's leftover, or one a passcode change could not
+            // rebind. The key inside opens nothing the current wrapper protects,
+            // and adopting it would let the resume sweep seal every share under
+            // a key nothing wraps.
+            logger.error("Biometric data key belongs to a superseded wrapped key; removing it")
+            try? disable()
+            throw BiometricUnlockError.supersededCopy
+        }
+
+        return SymmetricKey(data: raw.suffix(VaultCryptoEnvelope.keyLengthBytes))
+    }
+
+    /// Not a secret, and not an authenticator: the blob it digests already sits
+    /// unprotected in the Keychain. All it establishes is that two wrapped keys
+    /// are the same one — the half of the item worth protecting is the key that
+    /// follows it.
+    private static func binding(for wrappedDataKey: Data) -> Data {
+        Data(SHA256.hash(data: wrappedDataKey))
+    }
+}
+
+/// The real Keychain item, guarded by `SecAccessControl`.
+struct BiometricKeychain: BiometricKeychainProtecting {
+
+    func store(_ data: Data, account: String) throws {
+        var accessError: Unmanaged<CFError>?
+        guard let access = SecAccessControlCreateWithFlags(
+            nil,
+            // `WhenPasscodeSetThisDeviceOnly`: a device with no passcode cannot
+            // meaningfully protect this, and the item must never leave the device.
+            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+            .biometryCurrentSet,
+            &accessError
+        ) else {
+            throw BiometricUnlockError.unavailable
+        }
+
+        let query: [String: Any] = [
+            String(kSecClass): String(kSecClassGenericPassword),
+            String(kSecAttrAccount): account,
+            String(kSecValueData): data,
+            String(kSecAttrAccessControl): access
+        ]
+
+        // A pure add. Removing whatever was there is the caller's job, and it
+        // has to be — `SecItemDelete` takes a *search* query, so handing it this
+        // dictionary would ask it to match on the value and access control it is
+        // about to add, and a delete that quietly matches nothing turns the add
+        // into `errSecDuplicateItem`.
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw BiometricUnlockError.storageFailed
+        }
+    }
+
+    func read(account: String, prompt: String) throws -> Data {
+        let context = LAContext()
+        context.localizedReason = prompt
+        // Hides the fallback button. Note that this is presentation only — what
+        // actually prevents the device passcode from satisfying this read is the
+        // access control: `.biometryCurrentSet` demands currently-enrolled
+        // biometry, and device-passcode authorisation would require
+        // `.devicePasscode` or `.userPresence`, neither of which is requested.
+        // So a biometric lockout fails here rather than falling back, which is
+        // the point: someone who knows only the device passcode must not reach a
+        // wallet the app passcode exists to protect.
+        context.localizedFallbackTitle = ""
+
+        let query: [String: Any] = [
+            String(kSecClass): String(kSecClassGenericPassword),
+            String(kSecAttrAccount): account,
+            String(kSecReturnData): kCFBooleanTrue as Any,
+            String(kSecMatchLimit): String(kSecMatchLimitOne),
+            String(kSecUseAuthenticationContext): context
+        ]
+
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data else { throw BiometricUnlockError.failed }
+            return data
+        case errSecUserCanceled:
+            throw BiometricUnlockError.cancelled
+        case errSecItemNotFound:
+            throw BiometricUnlockError.notEnabled
+        default:
+            // Everything else — lockout, changed enrolment, no hardware — is a
+            // failure that sends the user to the passcode.
+            throw BiometricUnlockError.failed
+        }
+    }
+
+    func delete(account: String) throws {
+        let query: [String: Any] = [
+            String(kSecClass): String(kSecClassGenericPassword),
+            String(kSecAttrAccount): account
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw BiometricUnlockError.storageFailed
+        }
+    }
+
+    func exists(account: String) -> Bool {
+        // Deliberately does not read the data: presence must be checkable
+        // without prompting for a face every time a settings screen appears.
+        let query: [String: Any] = [
+            String(kSecClass): String(kSecClassGenericPassword),
+            String(kSecAttrAccount): account,
+            String(kSecReturnData): kCFBooleanFalse as Any,
+            String(kSecUseAuthenticationUI): kSecUseAuthenticationUISkip
+        ]
+
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        // `interactionNotAllowed` means the item exists but needs authentication,
+        // which is exactly the state we are asking about.
+        return status == errSecSuccess || status == errSecInteractionNotAllowed
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -111,6 +111,12 @@ actor PasscodeService {
         biometrics.isEnabled
     }
 
+    /// Whether this device could hold the shortcut at all, so Settings can say
+    /// why the switch is refusing instead of just returning it to off.
+    var biometricAvailability: BiometricAvailability {
+        biometrics.availability
+    }
+
     /// Fails closed. An unreadable Keychain may well hold a wrapped key, and the
     /// one thing that must never happen is a fresh data key being minted over an
     /// existing one — a new key opens none of the shares the old one sealed, so

--- a/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Passcode/PasscodeService.swift
@@ -69,6 +69,7 @@ actor PasscodeService {
     private let limiter: PasscodeAttemptLimiting
     private let coordinator: KeyshareWriteCoordinator
     private let sweeper: KeyshareSweeping
+    private let biometrics: BiometricUnlockStore
 
     /// The session generation whose resume sweep has already run, so it runs at
     /// most once per unlocked session. `lock()` bumps the generation, and that is
@@ -94,7 +95,8 @@ actor PasscodeService {
         lockService: AppLockService = .shared,
         limiter: PasscodeAttemptLimiting = PasscodeAttemptLimiter(),
         coordinator: KeyshareWriteCoordinator = .shared,
-        sweeper: KeyshareSweeping = KeyshareSweeper.shared
+        sweeper: KeyshareSweeping = KeyshareSweeper.shared,
+        biometrics: BiometricUnlockStore = .shared
     ) {
         self.keyStore = keyStore
         self.session = session
@@ -102,6 +104,11 @@ actor PasscodeService {
         self.limiter = limiter
         self.coordinator = coordinator
         self.sweeper = sweeper
+        self.biometrics = biometrics
+    }
+
+    var isBiometricUnlockEnabled: Bool {
+        biometrics.isEnabled
     }
 
     /// Fails closed. An unreadable Keychain may well hold a wrapped key, and the
@@ -209,6 +216,17 @@ actor PasscodeService {
             throw PasscodeError.sealedSharesWithoutKey
         }
 
+        // A biometric copy with no passcode behind it is a leftover — a previous
+        // install's, or one a reconciliation could not clear. It is bound to a
+        // wrapper that no longer exists, so it could never open the app anyway;
+        // what it *can* do is report biometric unlock as already enabled for a
+        // passcode the user is only now creating. Failing here is deliberate:
+        // the invariant is that a copy exists only alongside the wrapper it
+        // belongs to.
+        if biometrics.isEnabled {
+            try biometrics.disable()
+        }
+
         let dataKey = try keyStore.generateDataKey()
 
         let wrapped = try await keyStore.wrap(dataKey, passcode: passcode)
@@ -295,6 +313,118 @@ actor PasscodeService {
             throw PasscodeError.cancelledByLock
         }
         return dataKey
+    }
+
+    // MARK: - Biometric shortcut
+
+    /// Opens the app on a biometric match, and is the app-unlock path in every
+    /// respect the passcode one is — same in-flight guard, same **write** lease
+    /// (never a transition lease: a transition is refused while a keygen episode
+    /// is open, so an app that locked on the review screen could never be
+    /// opened), same resume sweep, same generation check on both sides of it.
+    /// Anything less and the shortcut would be a second, weaker way in.
+    ///
+    /// **Fails closed, and only against a confirmed-present wrapper.** `isSet`
+    /// deliberately reads an *unreadable* Keychain as "set", which is right for
+    /// refusing to mint a second key over an existing one and wrong here: the
+    /// stored copy has to be checked against the wrapper's actual bytes, and
+    /// there is nothing to check against if it cannot be read. Every other
+    /// outcome — cancelled, locked out, enrolment changed, item gone, copy
+    /// superseded — throws, and the passcode screen stays where it is.
+    ///
+    /// The biometric read is synchronous and blocks the actor while the system
+    /// prompt is up. That is the same shape the passcode path has while deriving
+    /// a key, and it is what keeps the generation capture genuinely ahead of
+    /// every suspension point in this method.
+    @discardableResult
+    func unlockWithBiometrics(reason: String) async throws -> SymmetricKey {
+        guard !isAppUnlockInFlight else { throw PasscodeError.busy }
+        isAppUnlockInFlight = true
+        defer { isAppUnlockInFlight = false }
+
+        let lease = try beginUnlock()
+        defer { coordinator.end(lease) }
+
+        let generation = session.currentGeneration
+
+        let wrapped: Data
+        switch keyStore.loadWrappedDataKey() {
+        case .present(let blob):
+            wrapped = blob
+        case .absent:
+            throw PasscodeError.notSet
+        case .unavailable:
+            throw PasscodeError.storageFailure
+        }
+
+        let dataKey = try biometrics.unlock(reason: reason, boundTo: wrapped)
+
+        guard session.adopt(dataKey, ifGeneration: generation) else {
+            throw PasscodeError.cancelledByLock
+        }
+        // A biometric match is a successful authentication, so it clears the
+        // passcode throttle exactly as a correct passcode does.
+        limiter.recordSuccess()
+
+        await resumeSweepUnlocked()
+
+        guard session.currentGeneration == generation else {
+            session.clear()
+            throw PasscodeError.cancelledByLock
+        }
+        return dataKey
+    }
+
+    /// Stores a biometry-guarded copy of the data key, bound to the wrapper it
+    /// belongs to. Requires the app to be unlocked, since it never unwraps
+    /// anything itself.
+    ///
+    /// Takes a write lease: it writes a copy of the key that a concurrent
+    /// `disablePasscode` is in the middle of removing, and a copy created after
+    /// that removal is precisely the orphan the binding exists to catch. A write
+    /// lease excludes every transition, which is all this needs.
+    func enableBiometricUnlock() throws {
+        let lease = try beginBiometricWrite()
+        defer { coordinator.end(lease) }
+
+        let wrapped: Data
+        switch keyStore.loadWrappedDataKey() {
+        case .present(let blob):
+            wrapped = blob
+        case .absent:
+            throw PasscodeError.notSet
+        case .unavailable:
+            throw PasscodeError.storageFailure
+        }
+
+        let generation = session.currentGeneration
+        guard case .unlocked(let dataKey) = session.currentState() else {
+            throw PasscodeError.cancelledByLock
+        }
+
+        try biometrics.enable(dataKey: dataKey, boundTo: wrapped)
+
+        // A lock can land between reading the key and storing it. Storing a
+        // shortcut for a session the user has since locked would enable one they
+        // never completed, so it is undone.
+        guard session.currentGeneration == generation else {
+            do {
+                try biometrics.disable()
+            } catch {
+                // The copy survived the rollback. Reporting only "cancelled"
+                // would leave a working shortcut behind that the UI believes
+                // does not exist.
+                throw PasscodeError.inconsistentState
+            }
+            throw PasscodeError.cancelledByLock
+        }
+    }
+
+    func disableBiometricUnlock() throws {
+        let lease = try beginBiometricWrite()
+        defer { coordinator.end(lease) }
+
+        try biometrics.disable()
     }
 
     /// One rule: **with the data key in hand and a wrapper present, seal any
@@ -481,6 +611,33 @@ actor PasscodeService {
         }
 
         try keyStore.storeWrappedDataKey(rewrapped)
+
+        rebindTheBiometricCopy(to: rewrapped, dataKey: dataKey)
+    }
+
+    /// The biometric copy is bound to the exact wrapped blob it was made for,
+    /// and a change replaces that blob — so without this the shortcut would stop
+    /// working the moment anyone changed their passcode.
+    ///
+    /// Rebinding costs no prompt: writing the item never asks for a face, only
+    /// reading does, and the data key has just been verified. If it cannot be
+    /// rebound the copy is removed instead — a stale binding is refused at the
+    /// next unlock anyway, and leaving one advertises a shortcut the app will
+    /// not honour. A failure to remove it is logged rather than thrown: the
+    /// passcode change itself succeeded, and the leftover cannot open anything.
+    private func rebindTheBiometricCopy(to wrapped: Data, dataKey: SymmetricKey) {
+        guard biometrics.isEnabled else { return }
+
+        do {
+            try biometrics.enable(dataKey: dataKey, boundTo: wrapped)
+        } catch {
+            logger.error("Could not rebind the biometric copy after a passcode change; removing it: \(String(describing: error), privacy: .public)")
+            do {
+                try biometrics.disable()
+            } catch {
+                logger.error("The superseded biometric copy could not be removed either; it will be refused and cleared at the next unlock: \(String(describing: error), privacy: .public)")
+            }
+        }
     }
 
     // MARK: - Disable
@@ -549,6 +706,17 @@ actor PasscodeService {
         let wrappedBeforeVerification = keyStore.loadWrappedDataKey().valueTreatingUnavailableAsAbsent
 
         _ = try await unlock(with: current, now: now, anchoredTo: generation)
+
+        // The biometric copy goes first, before a single share moves. It holds
+        // the same data key, so a survivor would quietly work again the next
+        // time a passcode is set, and failing to remove it after the shares had
+        // already been opened would report an error over a passcode that was
+        // half gone. Nothing has changed yet at this point, so aborting is clean.
+        //
+        // Called directly rather than through `disableBiometricUnlock()`: this
+        // already holds the transition lease, and that one takes a write lease
+        // the transition excludes.
+        try biometrics.disable()
 
         let wrapped = wrappedBeforeVerification
             ?? keyStore.loadWrappedDataKey().valueTreatingUnavailableAsAbsent
@@ -666,6 +834,18 @@ actor PasscodeService {
     /// Refused only by another passcode transition — see ``unlockApp(with:now:)``
     /// for why an unlock must not be refused by anything else.
     private func beginUnlock() throws -> WriteLease {
+        do {
+            return try coordinator.beginWrite()
+        } catch {
+            throw PasscodeError.busy
+        }
+    }
+
+    /// The same claim, for the two operations that move the biometric copy.
+    /// They are not transitions — no share is touched and no wrapper is written
+    /// — but they must not interleave with one, because a set and a disable both
+    /// decide what the copy should be.
+    private func beginBiometricWrite() throws -> WriteLease {
         do {
             return try coordinator.beginWrite()
         } catch {

--- a/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
@@ -74,13 +74,32 @@ class VaultDefaultCoinService {
         // one of those is the failure this reports.
         guard !defaultChains.isEmpty else { return true }
 
-        // What the vault has to come out holding: the chains it was asked for,
-        // never what happened to build. Reading the expectation off the
-        // successes is what let the original failure survive its own fix — a
-        // `CoinFactory` failure simply left the list, so the postcondition was
-        // checked against the survivors, and against none of them it holds
-        // vacuously. A vault with no chains in it at all passed as prepared.
-        let expectedChains = Set(defaultChains)
+        let chains: [CoinMeta] = TokensStore.TokenSelectionAssets
+                .filter { asset in defaultChains.contains(where: { $0 == asset.chain }) }
+
+        // What the vault has to come out holding, and it is neither "the chains
+        // asked for" nor "the coins that happened to build".
+        //
+        // Not the successes: reading the expectation off those is what let the
+        // original failure survive its own fix — a `CoinFactory` failure simply
+        // left the list, so the postcondition was checked against the survivors,
+        // and against none of them it holds vacuously. A vault with no chains in
+        // it at all passed as prepared.
+        //
+        // Not the chains asked for either, because one of them cannot be built
+        // by anybody: `ethereumSepolia` is offered in the key-import chain
+        // picker and has no native asset in `TokenSelectionAssets` at all, so
+        // expecting a coin for it would report every Sepolia import as broken,
+        // forever, with nothing the user or a retry could do about it. A chain
+        // with nothing to build is not a chain that failed to build.
+        //
+        // That exclusion is stated out loud rather than left to the filter,
+        // because a chain quietly dropping out of its own expectation is the
+        // exact shape of the `try?` this whole thread began with.
+        let expectedChains = Set(chains.filter(\.isNativeToken).map(\.chain))
+        for chain in Set(defaultChains).subtracting(expectedChains) {
+            Log.chain.service.error("No native asset in the catalog for \(chain.name, privacy: .public), so \(vault.name, privacy: .public) cannot be given one")
+        }
 
         // Answered rather than assumed. A vault that already holds coins is not
         // built again — but *whether it holds every chain it was asked for* is a
@@ -88,9 +107,6 @@ class VaultDefaultCoinService {
         // `true` here is what blesses a half-prepared vault as done and makes
         // the import's retry meaningless.
         guard vault.coins.isEmpty else { return holdsANativeCoin(forEach: expectedChains, in: vault) }
-
-        let chains: [CoinMeta] = TokensStore.TokenSelectionAssets
-                .filter { asset in defaultChains.contains(where: { $0 == asset.chain }) }
 
         var coins: [Coin] = []
         for asset in chains {
@@ -189,19 +205,29 @@ class VaultDefaultCoinService {
     /// Starts discovering held tokens for the coins this service attached, and
     /// forgets them so a second call cannot start the same work twice.
     ///
-    /// Call it once the save that stores those coins has **succeeded**. It is
-    /// deliberately not started from ``setDefaultCoins(for:)``: discovery is
-    /// unstructured work that outlives the call, suspends on the network, and
-    /// then writes through `Storage.shared`. Started before the save, it can
-    /// come back and persist a vault whose save failed and which the caller has
-    /// already withdrawn — turning a refused keygen or a rolled-back import into
-    /// a stored one. A caller whose save threw simply never calls this.
+    /// Call it once the save that stores those coins has **succeeded**. That is
+    /// a contract with the caller and not something this method can check: a
+    /// SwiftData fetch resolves pending inserts too, so no lookup here can tell
+    /// a saved row from an unsaved one. What it can do is not start the work at
+    /// all, which is why it is deliberately not started from
+    /// ``setDefaultCoins(for:)``: discovery is unstructured work that outlives
+    /// the call, suspends on the network, and then writes through
+    /// `Storage.shared`. Started before the save, it can come back and persist a
+    /// vault whose save failed and which the caller has already withdrawn —
+    /// turning a refused keygen or a rolled-back import into a stored one. A
+    /// caller whose save threw simply never calls this.
     ///
-    /// That leaves what can happen *after* a successful save — the user deletes
-    /// the vault, a rollback takes the coins back, the context is reset — which
-    /// is why nothing live is carried across the gap. Every coin is re-resolved
-    /// from the store immediately before its own discovery runs, and one that no
-    /// longer resolves, or is no longer this vault's, is skipped.
+    /// The re-resolution covers what can happen *after* that: the user deletes
+    /// the vault, a rollback takes the coins back, the context is reset. Nothing
+    /// live is carried across the gap; every coin is looked up again through its
+    /// vault immediately before its own discovery runs, and one that no longer
+    /// resolves, or is no longer this vault's, is skipped.
+    ///
+    /// > Note: `CoinService.addDiscoveredTokens` then suspends on the network
+    /// > holding the pair, so a vault deleted *during* that call is still
+    /// > reachable. That window is `CoinService`'s and is shared with every
+    /// > other caller of it; this narrows the exposure to it, and does not
+    /// > close it.
     ///
     /// - Returns: the task doing the work, so a caller that needs to observe it
     ///   can wait. Production discards it.

--- a/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
@@ -18,54 +18,76 @@ class VaultDefaultCoinService {
         self.context = context
     }
 
-    func setDefaultCoinsOnce(vault: Vault) {
+    /// - Returns: whether the vault holds every default coin this device could
+    ///   derive for it. See ``setDefaultCoins(for:)``.
+    @discardableResult
+    func setDefaultCoinsOnce(vault: Vault) -> Bool {
         semaphore.wait()
         defer {
             semaphore.signal()
         }
-        setDefaultCoins(for: vault)
+        return setDefaultCoins(for: vault)
     }
 
-    func setDefaultCoins(for vault: Vault) {
+    /// - Returns: whether the vault holds every default coin this device could
+    ///   derive for it. `false` means the coins were built but did not attach,
+    ///   which the caller cannot see any other way: the rows are written, the
+    ///   save succeeds, and the vault opens with no chains in it.
+    ///
+    ///   A vault this device can derive nothing for — a legacy key-import vault
+    ///   with no `chainPublicKeys` — is `true`, not a failure. So is a vault
+    ///   that already had coins.
+    @discardableResult
+    func setDefaultCoins(for vault: Vault) -> Bool {
         // Add default coins when the vault doesn't have any coins in it
         Log.chain.service.info("set default chains to vault")
-        if vault.coins.isEmpty {
-            let defaultChains = getDefaultChains(for: vault)
-            let chains: [CoinMeta] = TokensStore.TokenSelectionAssets
-                    .filter { asset in defaultChains.contains(where: { $0 == asset.chain }) }
+        guard vault.coins.isEmpty else { return true }
 
-            let coins = chains
-                .compactMap { c in
-                    let pubKey = vault.chainPublicKeys.first { $0.chain == c.chain}?.publicKeyHex
-                    let isDerived = pubKey != nil
-                    return try? CoinFactory.create(
-                        asset: c,
-                        publicKeyECDSA: pubKey ?? vault.pubKeyECDSA,
-                        publicKeyEdDSA: pubKey ?? vault.pubKeyEdDSA,
-                        hexChainCode: vault.hexChainCode,
-                        isDerived: isDerived,
-                        publicKeyMLDSA44: vault.publicKeyMLDSA44
-                    )
-                }
+        let defaultChains = getDefaultChains(for: vault)
+        let chains: [CoinMeta] = TokensStore.TokenSelectionAssets
+                .filter { asset in defaultChains.contains(where: { $0 == asset.chain }) }
 
-            for coin in coins {
-                if coin.isNativeToken {
-                    self.context.insert(coin)
-
-                    // Only append if SwiftData inverse relationship didn't auto-populate
-                    if !vault.coins.contains(where: { $0.id == coin.id }) {
-                        vault.coins.append(coin)
-                    }
-
-                    Task {
-                        await CoinService.addDiscoveredTokens(nativeToken: coin, to: vault)
-                    }
-                }
+        let coins = chains
+            .compactMap { c in
+                let pubKey = vault.chainPublicKeys.first { $0.chain == c.chain}?.publicKeyHex
+                let isDerived = pubKey != nil
+                return try? CoinFactory.create(
+                    asset: c,
+                    publicKeyECDSA: pubKey ?? vault.pubKeyECDSA,
+                    publicKeyEdDSA: pubKey ?? vault.pubKeyEdDSA,
+                    hexChainCode: vault.hexChainCode,
+                    isDerived: isDerived,
+                    publicKeyMLDSA44: vault.publicKeyMLDSA44
+                )
             }
 
-            // Enable default Defi chains
-            vault.defiChains = Array(Set(coins.map(\.chain).filter { CoinAction.defiChains.contains($0) }))
+        let natives = coins.filter(\.isNativeToken)
+        for coin in natives where !vault.coins.contains(where: { $0.id == coin.id }) {
+            self.context.insert(coin)
+
+            // Attach from the coin's side. Writing the to-many side instead —
+            // `vault.coins.append(coin)` — only works while the vault is still
+            // unsaved: once it has been through a `save()`, appending a coin
+            // that is itself still a temporary object does not register on the
+            // vault at all. The relationship re-faults to its persisted value,
+            // and the next save writes that back over the inverse the append
+            // had set, leaving the coin rows on disk with no vault and the
+            // vault with no chains. `CoinService.addToChain` sidesteps the same
+            // trap by saving the coin before appending; here there is no save
+            // to hang that on, and the to-one write is what survives either
+            // way. Do not "simplify" this back to an append.
+            coin.vault = vault
+
+            Task {
+                await CoinService.addDiscoveredTokens(nativeToken: coin, to: vault)
+            }
         }
+
+        // Enable default Defi chains
+        vault.defiChains = Array(Set(coins.map(\.chain).filter { CoinAction.defiChains.contains($0) }))
+
+        let attached = Set(vault.coins.map(\.id))
+        return natives.allSatisfy { attached.contains($0.id) }
     }
 
     func getDefaultChains(for vault: Vault) -> [Chain] {

--- a/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
@@ -18,8 +18,8 @@ class VaultDefaultCoinService {
         self.context = context
     }
 
-    /// - Returns: whether the vault holds every default coin this device could
-    ///   derive for it. See ``setDefaultCoins(for:)``.
+    /// - Returns: whether the vault holds a native coin for every default chain
+    ///   this device was asked to build. See ``setDefaultCoins(for:)``.
     @discardableResult
     func setDefaultCoinsOnce(vault: Vault) -> Bool {
         semaphore.wait()
@@ -29,10 +29,11 @@ class VaultDefaultCoinService {
         return setDefaultCoins(for: vault)
     }
 
-    /// - Returns: whether the vault holds every default coin this device could
-    ///   derive for it. `false` means the coins were built but did not attach,
-    ///   which the caller cannot see any other way: the rows are written, the
-    ///   save succeeds, and the vault opens with no chains in it.
+    /// - Returns: whether the vault holds a native coin for every default chain
+    ///   this device was asked to build. `false` means the vault will open with
+    ///   chains missing, which the caller cannot see any other way: the rows are
+    ///   written or not written, the save succeeds either way, and nothing later
+    ///   in the app rebuilds what this writes.
     ///
     ///   A vault this device can derive nothing for — a legacy key-import vault
     ///   with no `chainPublicKeys` — is `true`, not a failure. So is a vault
@@ -44,22 +45,50 @@ class VaultDefaultCoinService {
         guard vault.coins.isEmpty else { return true }
 
         let defaultChains = getDefaultChains(for: vault)
+        // Nothing to derive is not a failure to derive. A legacy key-import
+        // vault predates `chainPublicKeys` and carries none, so this device has
+        // nothing to build for it and nothing is missing. Every vault past this
+        // line is expected to come out holding coins, and an empty outcome for
+        // one of those is the failure this reports.
+        guard !defaultChains.isEmpty else { return true }
+
         let chains: [CoinMeta] = TokensStore.TokenSelectionAssets
                 .filter { asset in defaultChains.contains(where: { $0 == asset.chain }) }
 
-        let coins = chains
-            .compactMap { c in
-                let pubKey = vault.chainPublicKeys.first { $0.chain == c.chain}?.publicKeyHex
-                let isDerived = pubKey != nil
-                return try? CoinFactory.create(
-                    asset: c,
-                    publicKeyECDSA: pubKey ?? vault.pubKeyECDSA,
-                    publicKeyEdDSA: pubKey ?? vault.pubKeyEdDSA,
-                    hexChainCode: vault.hexChainCode,
-                    isDerived: isDerived,
-                    publicKeyMLDSA44: vault.publicKeyMLDSA44
+        // What the vault has to come out holding, read off the chains asked for
+        // and never off what happened to build. Reading it off the successes is
+        // what let the original failure survive its own fix: a `CoinFactory`
+        // failure simply left the list, so the postcondition was checked against
+        // the survivors — and against none of them it holds vacuously, which
+        // means a vault with no chains in it at all passed as prepared.
+        let expectedChains = Set(chains.filter(\.isNativeToken).map(\.chain))
+        guard !expectedChains.isEmpty else {
+            Log.chain.service.error("No native asset to build for any default chain of \(vault.name, privacy: .public)")
+            return false
+        }
+
+        var coins: [Coin] = []
+        for asset in chains {
+            let pubKey = vault.chainPublicKeys.first { $0.chain == asset.chain }?.publicKeyHex
+            let isDerived = pubKey != nil
+            do {
+                coins.append(
+                    try CoinFactory.create(
+                        asset: asset,
+                        publicKeyECDSA: pubKey ?? vault.pubKeyECDSA,
+                        publicKeyEdDSA: pubKey ?? vault.pubKeyEdDSA,
+                        hexChainCode: vault.hexChainCode,
+                        isDerived: isDerived,
+                        publicKeyMLDSA44: vault.publicKeyMLDSA44
+                    )
                 )
+            } catch {
+                // Kept rather than dropped. A `try?` here is indistinguishable
+                // from a chain that was never asked for, and a chain that cannot
+                // be built is a chain the user will not have.
+                Log.chain.service.error("Could not build \(asset.ticker, privacy: .public) on \(asset.chain.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
+        }
 
         let natives = coins.filter(\.isNativeToken)
         var inserted: [Coin] = []
@@ -85,8 +114,13 @@ class VaultDefaultCoinService {
         let previousDefiChains = vault.defiChains
         vault.defiChains = Array(Set(coins.map(\.chain).filter { CoinAction.defiChains.contains($0) }))
 
-        let attached = Set(vault.coins.map(\.id))
-        guard natives.allSatisfy({ attached.contains($0.id) }) else {
+        let attachedIDs = Set(vault.coins.map(\.id))
+        let attachedChains = Set(vault.coins.filter(\.isNativeToken).map(\.chain))
+        // Two separate ways this pass can come up short, and neither is visible
+        // in the other. A coin that was built and did not attach; and a chain
+        // whose coin was never built at all.
+        guard natives.allSatisfy({ attachedIDs.contains($0.id) }),
+              expectedChains.isSubset(of: attachedChains) else {
             // All of it or none of it. A coin that did not attach is a row
             // belonging to no vault — invisible in the app and with nothing
             // left to find it by — and a vault left holding *some* of its coins
@@ -95,6 +129,10 @@ class VaultDefaultCoinService {
             // vault is exactly as it was found, which is the whole reason
             // running this again is safe.
             for coin in inserted {
+                // Detached from the coin's side before the delete, for the same
+                // reason it was attached from that side: the to-one write is the
+                // one that takes on a vault that has been through a `save()`.
+                coin.vault = nil
                 context.delete(coin)
             }
             vault.defiChains = previousDefiChains

--- a/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
@@ -62,6 +62,7 @@ class VaultDefaultCoinService {
             }
 
         let natives = coins.filter(\.isNativeToken)
+        var inserted: [Coin] = []
         for coin in natives where !vault.coins.contains(where: { $0.id == coin.id }) {
             self.context.insert(coin)
 
@@ -77,17 +78,40 @@ class VaultDefaultCoinService {
             // to hang that on, and the to-one write is what survives either
             // way. Do not "simplify" this back to an append.
             coin.vault = vault
+            inserted.append(coin)
+        }
 
+        // Enable default Defi chains
+        let previousDefiChains = vault.defiChains
+        vault.defiChains = Array(Set(coins.map(\.chain).filter { CoinAction.defiChains.contains($0) }))
+
+        let attached = Set(vault.coins.map(\.id))
+        guard natives.allSatisfy({ attached.contains($0.id) }) else {
+            // All of it or none of it. A coin that did not attach is a row
+            // belonging to no vault — invisible in the app and with nothing
+            // left to find it by — and a vault left holding *some* of its coins
+            // is worse still: the `coins.isEmpty` guard above would read it as
+            // already prepared and never look again. Undone, `false` means the
+            // vault is exactly as it was found, which is the whole reason
+            // running this again is safe.
+            for coin in inserted {
+                context.delete(coin)
+            }
+            vault.defiChains = previousDefiChains
+            return false
+        }
+
+        // Only over coins that are provably attached. Token discovery is
+        // unstructured work that outlives this call, and pointing it at a coin
+        // that is about to be withdrawn is the same mistake the import's own
+        // ordering exists to avoid.
+        for coin in inserted {
             Task {
                 await CoinService.addDiscoveredTokens(nativeToken: coin, to: vault)
             }
         }
 
-        // Enable default Defi chains
-        vault.defiChains = Array(Set(coins.map(\.chain).filter { CoinAction.defiChains.contains($0) }))
-
-        let attached = Set(vault.coins.map(\.id))
-        return natives.allSatisfy { attached.contains($0.id) }
+        return true
     }
 
     func getDefaultChains(for vault: Vault) -> [Chain] {

--- a/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
@@ -10,12 +10,35 @@ import SwiftData
 import OSLog
 
 class VaultDefaultCoinService {
+
+    /// A coin the pass attached, named by value rather than held by reference.
+    ///
+    /// Token discovery outlives the call that asks for it, and a live `@Model`
+    /// carried across that gap is a reference to something the store may no
+    /// longer have: a vault withdrawn after a failed save, deleted by the user,
+    /// or dropped by a context reset. Touching one of those traps, and writing
+    /// through one persists a vault the caller had already given up on. These
+    /// two strings are re-resolved against the store at the moment the work
+    /// actually runs, and the work is skipped if they no longer resolve.
+    private struct AttachedCoin: Hashable {
+        let vaultPubKeyECDSA: String
+        let coinID: String
+    }
+
     let context: ModelContext
     private let semaphore = DispatchSemaphore(value: 1)
+    private let discoverTokens: @MainActor (Coin, Vault) async -> Void
+    private var attachedCoins: [AttachedCoin] = []
     let baseDefaultChains = [Chain.bitcoin, Chain.ethereum, Chain.thorChain, Chain.solana, Chain.bscChain]
 
-    init(context: ModelContext) {
+    init(
+        context: ModelContext,
+        discoverTokens: @escaping @MainActor (Coin, Vault) async -> Void = { coin, vault in
+            await CoinService.addDiscoveredTokens(nativeToken: coin, to: vault)
+        }
+    ) {
         self.context = context
+        self.discoverTokens = discoverTokens
     }
 
     /// - Returns: whether the vault holds a native coin for every default chain
@@ -139,17 +162,77 @@ class VaultDefaultCoinService {
             return false
         }
 
-        // Only over coins that are provably attached. Token discovery is
-        // unstructured work that outlives this call, and pointing it at a coin
-        // that is about to be withdrawn is the same mistake the import's own
-        // ordering exists to avoid.
-        for coin in inserted {
-            Task {
-                await CoinService.addDiscoveredTokens(nativeToken: coin, to: vault)
+        // Recorded, not started. Only coins that are provably attached get this
+        // far, but "attached" is not "stored": the caller's save has not run
+        // yet, and until it has, this vault may still be withdrawn.
+        // ``startTokenDiscovery()`` is where the work begins.
+        attachedCoins.append(
+            contentsOf: inserted.map {
+                AttachedCoin(vaultPubKeyECDSA: vault.pubKeyECDSA, coinID: $0.id)
             }
-        }
+        )
 
         return true
+    }
+
+    /// Starts discovering held tokens for the coins this service attached, and
+    /// forgets them so a second call cannot start the same work twice.
+    ///
+    /// Call it once the save that stores those coins has **succeeded**. It is
+    /// deliberately not started from ``setDefaultCoins(for:)``: discovery is
+    /// unstructured work that outlives the call, suspends on the network, and
+    /// then writes through `Storage.shared`. Started before the save, it can
+    /// come back and persist a vault whose save failed and which the caller has
+    /// already withdrawn — turning a refused keygen or a rolled-back import into
+    /// a stored one. A caller whose save threw simply never calls this.
+    ///
+    /// That leaves what can happen *after* a successful save — the user deletes
+    /// the vault, a rollback takes the coins back, the context is reset — which
+    /// is why nothing live is carried across the gap. Every coin is re-resolved
+    /// from the store immediately before its own discovery runs, and one that no
+    /// longer resolves, or is no longer this vault's, is skipped.
+    ///
+    /// - Returns: the task doing the work, so a caller that needs to observe it
+    ///   can wait. Production discards it.
+    @MainActor
+    @discardableResult
+    func startTokenDiscovery() -> Task<Void, Never> {
+        var seen: Set<AttachedCoin> = []
+        // A retried preparation records the same coin twice; discovery is
+        // idempotent but the round trip is not free.
+        let pending = attachedCoins.filter { seen.insert($0).inserted }
+        attachedCoins = []
+
+        return Task {
+            for attached in pending {
+                guard let (vault, coin) = stored(attached) else {
+                    Log.chain.service.info("Skipping token discovery: the coin is no longer stored against its vault")
+                    continue
+                }
+                await discoverTokens(coin, vault)
+            }
+        }
+    }
+
+    /// The vault and coin an ``AttachedCoin`` names, or `nil` if the store no
+    /// longer holds them related that way.
+    ///
+    /// The vault is fetched by its unique key rather than kept, and the coin is
+    /// looked up *through* the vault, so this answers existence and the
+    /// relationship in one step — which is the pair of facts discovery needs and
+    /// the pair the original failure lost.
+    @MainActor
+    private func stored(_ attached: AttachedCoin) -> (Vault, Coin)? {
+        let pubKeyECDSA = attached.vaultPubKeyECDSA
+        var descriptor = FetchDescriptor<Vault>(
+            predicate: #Predicate<Vault> { $0.pubKeyECDSA == pubKeyECDSA }
+        )
+        descriptor.fetchLimit = 1
+        guard let vault = try? context.fetch(descriptor).first,
+              let coin = vault.coins.first(where: { $0.id == attached.coinID }) else {
+            return nil
+        }
+        return (vault, coin)
     }
 
     func getDefaultChains(for vault: Vault) -> [Chain] {

--- a/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VaultDefaultCoinService.swift
@@ -41,8 +41,9 @@ class VaultDefaultCoinService {
         self.discoverTokens = discoverTokens
     }
 
-    /// - Returns: whether the vault holds a native coin for every default chain
-    ///   this device was asked to build. See ``setDefaultCoins(for:)``.
+    /// - Returns: whether the vault holds an attached native coin for every
+    ///   default chain this device was asked to build. See
+    ///   ``setDefaultCoins(for:)``.
     @discardableResult
     func setDefaultCoinsOnce(vault: Vault) -> Bool {
         semaphore.wait()
@@ -52,20 +53,18 @@ class VaultDefaultCoinService {
         return setDefaultCoins(for: vault)
     }
 
-    /// - Returns: whether the vault holds a native coin for every default chain
-    ///   this device was asked to build. `false` means the vault will open with
-    ///   chains missing, which the caller cannot see any other way: the rows are
-    ///   written or not written, the save succeeds either way, and nothing later
-    ///   in the app rebuilds what this writes.
+    /// - Returns: whether the vault holds an attached native coin for every
+    ///   default chain this device was asked to build. `false` means the vault
+    ///   will open missing at least one chain, which the caller cannot see any
+    ///   other way: the rows are written or not written, the save succeeds
+    ///   either way, and nothing later in the app rebuilds what this writes.
     ///
     ///   A vault this device can derive nothing for — a legacy key-import vault
-    ///   with no `chainPublicKeys` — is `true`, not a failure. So is a vault
-    ///   that already had coins.
+    ///   with no `chainPublicKeys` — is `true`, not a failure.
     @discardableResult
     func setDefaultCoins(for vault: Vault) -> Bool {
         // Add default coins when the vault doesn't have any coins in it
         Log.chain.service.info("set default chains to vault")
-        guard vault.coins.isEmpty else { return true }
 
         let defaultChains = getDefaultChains(for: vault)
         // Nothing to derive is not a failure to derive. A legacy key-import
@@ -75,20 +74,23 @@ class VaultDefaultCoinService {
         // one of those is the failure this reports.
         guard !defaultChains.isEmpty else { return true }
 
+        // What the vault has to come out holding: the chains it was asked for,
+        // never what happened to build. Reading the expectation off the
+        // successes is what let the original failure survive its own fix — a
+        // `CoinFactory` failure simply left the list, so the postcondition was
+        // checked against the survivors, and against none of them it holds
+        // vacuously. A vault with no chains in it at all passed as prepared.
+        let expectedChains = Set(defaultChains)
+
+        // Answered rather than assumed. A vault that already holds coins is not
+        // built again — but *whether it holds every chain it was asked for* is a
+        // question about the vault, not about this pass, and an unconditional
+        // `true` here is what blesses a half-prepared vault as done and makes
+        // the import's retry meaningless.
+        guard vault.coins.isEmpty else { return holdsANativeCoin(forEach: expectedChains, in: vault) }
+
         let chains: [CoinMeta] = TokensStore.TokenSelectionAssets
                 .filter { asset in defaultChains.contains(where: { $0 == asset.chain }) }
-
-        // What the vault has to come out holding, read off the chains asked for
-        // and never off what happened to build. Reading it off the successes is
-        // what let the original failure survive its own fix: a `CoinFactory`
-        // failure simply left the list, so the postcondition was checked against
-        // the survivors — and against none of them it holds vacuously, which
-        // means a vault with no chains in it at all passed as prepared.
-        let expectedChains = Set(chains.filter(\.isNativeToken).map(\.chain))
-        guard !expectedChains.isEmpty else {
-            Log.chain.service.error("No native asset to build for any default chain of \(vault.name, privacy: .public)")
-            return false
-        }
 
         var coins: [Coin] = []
         for asset in chains {
@@ -138,19 +140,13 @@ class VaultDefaultCoinService {
         vault.defiChains = Array(Set(coins.map(\.chain).filter { CoinAction.defiChains.contains($0) }))
 
         let attachedIDs = Set(vault.coins.map(\.id))
-        let attachedChains = Set(vault.coins.filter(\.isNativeToken).map(\.chain))
-        // Two separate ways this pass can come up short, and neither is visible
-        // in the other. A coin that was built and did not attach; and a chain
-        // whose coin was never built at all.
-        guard natives.allSatisfy({ attachedIDs.contains($0.id) }),
-              expectedChains.isSubset(of: attachedChains) else {
-            // All of it or none of it. A coin that did not attach is a row
-            // belonging to no vault — invisible in the app and with nothing
-            // left to find it by — and a vault left holding *some* of its coins
-            // is worse still: the `coins.isEmpty` guard above would read it as
-            // already prepared and never look again. Undone, `false` means the
-            // vault is exactly as it was found, which is the whole reason
-            // running this again is safe.
+        guard natives.allSatisfy({ attachedIDs.contains($0.id) }) else {
+            // The attachment failure, and only it, is all or nothing. A coin
+            // that was built and did not attach is a row belonging to no vault
+            // — invisible in the app, with nothing left to find it by, and
+            // `Coin.id` is not unique so a second pass writes another one
+            // beside it. Undone, the vault is exactly as it was found, which is
+            // what makes running this again safe.
             for coin in inserted {
                 // Detached from the coin's side before the delete, for the same
                 // reason it was attached from that side: the to-one write is the
@@ -172,7 +168,22 @@ class VaultDefaultCoinService {
             }
         )
 
-        return true
+        // A chain that could not be *built* is reported and not undone, and the
+        // difference from the case above is the whole reason they are separate.
+        // Nothing was written for it, so there is no orphan row to take back —
+        // and keygen ignores this answer, so undoing here would cost a vault
+        // with one bad key every chain it *could* derive, to report a chain it
+        // could not. Partial beats empty when nothing rebuilds either.
+        return holdsANativeCoin(forEach: expectedChains, in: vault)
+    }
+
+    /// Whether every one of `chains` has a native coin attached to the vault.
+    ///
+    /// Read from `vault.coins` rather than from anything this pass built, so it
+    /// answers the same question for a vault that arrived already holding coins
+    /// as for one this pass just filled.
+    private func holdsANativeCoin(forEach chains: Set<Chain>, in vault: Vault) -> Bool {
+        chains.isSubset(of: Set(vault.coins.filter(\.isNativeToken).map(\.chain)))
     }
 
     /// Starts discovering held tokens for the coins this service attached, and

--- a/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
@@ -25,6 +25,7 @@ enum AccessibilityID {
         static let faqCell = "settings.faqCell"
         static let managePasscodeCell = "settings.managePasscodeCell"
         static let autoLockCell = "settings.autoLockCell"
+        static let biometricUnlockToggle = "settings.biometricUnlockToggle"
     }
 
     enum Passcode {

--- a/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
@@ -26,6 +26,7 @@ enum AccessibilityID {
         static let managePasscodeCell = "settings.managePasscodeCell"
         static let autoLockCell = "settings.autoLockCell"
         static let biometricUnlockToggle = "settings.biometricUnlockToggle"
+        static let biometricUnlockNote = "settings.biometricUnlockNote"
     }
 
     enum Passcode {

--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
@@ -271,6 +271,8 @@ class KeygenViewModel: ObservableObject {
         context: ModelContext,
         protector: KeyshareProtecting = KeyshareProtector.shared
     ) throws {
+        let coinService = VaultDefaultCoinService(context: context)
+
         // The insert and the save are one write span. The episode lease already
         // keeps a transition out of the whole review interval, but this is the
         // moment the shares actually reach the store, so it carries its own
@@ -284,11 +286,14 @@ class KeygenViewModel: ObservableObject {
             // an element is not a dependable way to mark a `@Model` dirty.
             vault.keyshares = shares
 
-            VaultDefaultCoinService(context: context)
-                .setDefaultCoinsOnce(vault: vault)
+            coinService.setDefaultCoinsOnce(vault: vault)
             context.insert(vault)
             try context.save()
         }
+
+        // Past every way this can refuse, so the network work it starts is
+        // aimed at a vault that is provably stored and cannot be withdrawn.
+        coinService.startTokenDiscovery()
     }
 
     /// The vault's shares in the form the current protection state requires,
@@ -634,10 +639,14 @@ class KeygenViewModel: ObservableObject {
             // confirmation would leave orphan rows the autosave could flush.
             // `KeygenViewModel.commitVault` does the full insert at "Looks Good".
             if !self.deferVaultPersistence {
-                VaultDefaultCoinService(context: modelContext)
-                    .setDefaultCoinsOnce(vault: self.vault)
+                let coinService = VaultDefaultCoinService(context: modelContext)
+                coinService.setDefaultCoinsOnce(vault: self.vault)
                 modelContext.insert(self.vault)
                 try modelContext.save()
+                // Only once the save has landed. Token discovery outlives this
+                // call and writes on its own, so a vault whose save threw must
+                // never have it pointed at it.
+                coinService.startTokenDiscovery()
             }
         } else {
             try modelContext.save()
@@ -987,10 +996,14 @@ class KeygenViewModel: ObservableObject {
             // confirmation would leave orphan rows the autosave could flush.
             // `KeygenViewModel.commitVault` does the full insert at "Looks Good".
             if !self.deferVaultPersistence {
-                VaultDefaultCoinService(context: context)
-                    .setDefaultCoinsOnce(vault: self.vault)
+                let coinService = VaultDefaultCoinService(context: context)
+                coinService.setDefaultCoinsOnce(vault: self.vault)
                 context.insert(self.vault)
                 try context.save()
+                // Only once the save has landed. Token discovery outlives this
+                // call and writes on its own, so a vault whose save threw must
+                // never have it pointed at it.
+                coinService.startTokenDiscovery()
             }
         } else {
             try context.save()
@@ -1060,10 +1073,14 @@ class KeygenViewModel: ObservableObject {
                 // confirmation would leave orphan rows the autosave could flush.
                 // `KeygenViewModel.commitVault` does the full insert at "Looks Good".
                 if !self.deferVaultPersistence {
-                    VaultDefaultCoinService(context: context)
-                        .setDefaultCoinsOnce(vault: self.vault)
+                    let coinService = VaultDefaultCoinService(context: context)
+                    coinService.setDefaultCoinsOnce(vault: self.vault)
                     context.insert(self.vault)
                     try context.save()
+                    // Only once the save has landed. Token discovery outlives
+                    // this call and writes on its own, so a vault whose save
+                    // threw must never have it pointed at it.
+                    coinService.startTokenDiscovery()
                 }
             } else {
                 try context.save()

--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/PasscodeViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/PasscodeViewModel.swift
@@ -43,6 +43,55 @@ final class PasscodeViewModel: ObservableObject {
         self.stage = stage
     }
 
+    // MARK: - Biometric shortcut
+
+    @Published var isBiometricUnlockAvailable = false
+
+    func refreshBiometricAvailability() async {
+        isBiometricUnlockAvailable = await service.isBiometricUnlockEnabled
+    }
+
+    /// Attempts the shortcut, and stays quiet about the failures the user just
+    /// caused and can already see.
+    func unlockWithBiometrics(reason: String) async {
+        do {
+            _ = try await service.unlockWithBiometrics(reason: reason)
+            // A lock can land between adopting the key and dismissing the lock
+            // screen. Confirming the session still holds the key means a later
+            // lock always wins rather than being cleared by an unlock that had
+            // already been overtaken.
+            didFinish = service.isSessionUnlocked
+        } catch {
+            errorMessage = Self.biometricMessage(for: error)
+        }
+    }
+
+    /// Cancelling, a face that did not match, biometry being unavailable: the
+    /// user watched those happen, the passcode field is already on screen, and
+    /// "Face ID failed" adds nothing. The rest are different — the *match*
+    /// succeeded and nothing happened — and silence there reads as the app
+    /// ignoring them.
+    private static func biometricMessage(for error: Error) -> String? {
+        switch error as? BiometricUnlockError {
+        case .supersededCopy, .malformedCopy:
+            // The match worked and the shortcut was withdrawn anyway — because
+            // the stored copy belongs to a wrapper that is gone, or is not the
+            // right shape to be a key. Either way the toggle in Settings now
+            // reads off, and saying nothing would make a successful face look
+            // like a failed one.
+            return "passcodeBiometricUnavailable".localized
+        default:
+            break
+        }
+
+        switch error as? PasscodeError {
+        case .busy, .storageFailure:
+            return message(for: error)
+        default:
+            return nil
+        }
+    }
+
     // MARK: - Unlock
 
     /// The lock screen's unlock, and it must stay on ``PasscodeService/unlockApp(with:now:)``.

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/EnterPasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/EnterPasscodeScreen.swift
@@ -42,6 +42,13 @@ struct EnterPasscodeScreen: View {
         .screenNavigationBarHidden(true)
         .screenBackground(.gradient)
         .accessibilityIdentifier(AccessibilityID.Passcode.enterScreen)
+        .task {
+            await viewModel.refreshBiometricAvailability()
+            guard viewModel.isBiometricUnlockAvailable else { return }
+            // Offered immediately so the common case is one glance rather than
+            // five taps. Declining or failing leaves the passcode field ready.
+            await viewModel.unlockWithBiometrics(reason: "passcodeBiometricReason".localized)
+        }
         .onChange(of: viewModel.didFinish) { _, finished in
             guard finished else { return }
             onUnlocked()

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -11,6 +11,7 @@ struct ManagePasscodeScreen: View {
 
     @Environment(\.router) var router
     @State private var isSet: Bool = false
+    @State private var isBiometricEnabled: Bool = false
     @State private var showDisable = false
 
     private let service: PasscodeService
@@ -24,7 +25,7 @@ struct ManagePasscodeScreen: View {
     /// shared list container where it sits, which is what rounds the end rows
     /// and draws the separators between them.
     private var rows: [Row] {
-        isSet ? [.change, .autoLock, .disable] : [.set]
+        isSet ? [.change, .autoLock, .biometrics, .disable] : [.set]
     }
 
     var body: some View {
@@ -33,16 +34,8 @@ struct ManagePasscodeScreen: View {
                 VStack(alignment: .leading, spacing: 12) {
                     VStack(spacing: .zero) {
                         ForEach(Array(rows.enumerated()), id: \.element) { index, row in
-                            Button {
-                                handle(row)
-                            } label: {
-                                SettingsCommonOptionView(
-                                    icon: .lockPassword,
-                                    title: row.title,
-                                    type: .normal
-                                )
-                            }
-                            .commonListItemContainer(index: index, itemsCount: rows.count)
+                            rowView(for: row)
+                                .commonListItemContainer(index: index, itemsCount: rows.count)
                         }
                     }
                     .commonListContainer()
@@ -84,14 +77,51 @@ struct ManagePasscodeScreen: View {
         case set
         case change
         case autoLock
+        case biometrics
         case disable
 
-        var title: String {
+        /// The localization key rather than the localized string:
+        /// `SettingToggleCell` localizes its own title, so the key is what has
+        /// to travel for the biometric row.
+        var titleKey: String {
             switch self {
-            case .set: "passcodeSetTitle".localized
-            case .change: "passcodeChangeTitle".localized
-            case .autoLock: "passcodeAutoLockTitle".localized
-            case .disable: "passcodeDisableNavTitle".localized
+            case .set: "passcodeSetTitle"
+            case .change: "passcodeChangeTitle"
+            case .autoLock: "passcodeAutoLockTitle"
+            case .biometrics: "passcodeBiometricToggle"
+            case .disable: "passcodeDisableNavTitle"
+            }
+        }
+    }
+
+    /// Biometrics is a toggle rather than a destination, so it renders as the
+    /// app's standard toggle row instead of a navigation cell. Both go through
+    /// the same list container, which is what keeps the separators and the
+    /// rounded end rows consistent across the group.
+    @ViewBuilder
+    private func rowView(for row: Row) -> some View {
+        switch row {
+        case .biometrics:
+            // A shortcut past the passcode, not a replacement — the passcode
+            // always works, and turning this off never locks anyone out.
+            SettingToggleCell(
+                title: row.titleKey,
+                icon: "faceid",
+                isEnabled: Binding(
+                    get: { isBiometricEnabled },
+                    set: { newValue in Task { await setBiometric(enabled: newValue) } }
+                )
+            )
+            .accessibilityIdentifier(AccessibilityID.Settings.biometricUnlockToggle)
+        default:
+            Button {
+                handle(row)
+            } label: {
+                SettingsCommonOptionView(
+                    icon: .lockPassword,
+                    title: row.titleKey.localized,
+                    type: .normal
+                )
             }
         }
     }
@@ -106,10 +136,33 @@ struct ManagePasscodeScreen: View {
             router.navigate(to: SettingsRoute.autoLock)
         case .disable:
             showDisable = true
+        case .biometrics:
+            // Rendered as a toggle, never as a tappable destination.
+            break
         }
+    }
+
+    private func setBiometric(enabled: Bool) async {
+        if enabled {
+            // Enabling needs the data key in hand, so it can only be done while
+            // unlocked. A failure leaves the toggle off rather than implying a
+            // shortcut exists.
+            do {
+                try await service.enableBiometricUnlock()
+            } catch {
+                isBiometricEnabled = false
+                return
+            }
+        } else {
+            // A failure here leaves the copy in place, so the toggle must not
+            // claim it is gone.
+            try? await service.disableBiometricUnlock()
+        }
+        await refresh()
     }
 
     private func refresh() async {
         isSet = await service.isSet
+        isBiometricEnabled = await service.isBiometricUnlockEnabled
     }
 }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -12,6 +12,8 @@ struct ManagePasscodeScreen: View {
     @Environment(\.router) var router
     @State private var isSet: Bool = false
     @State private var isBiometricEnabled: Bool = false
+    @State private var biometricAvailability: BiometricAvailability = .available
+    @State private var biometricError: String?
     @State private var showDisable = false
 
     private let service: PasscodeService
@@ -40,6 +42,15 @@ struct ManagePasscodeScreen: View {
                     }
                     .commonListContainer()
 
+                    if let biometricNote {
+                        Text(biometricNote)
+                            .font(Theme.fonts.caption12)
+                            .foregroundStyle(Theme.colors.alertError)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .accessibilityIdentifier(AccessibilityID.Settings.biometricUnlockNote)
+                    }
+
                     explanation
                 }
             }
@@ -58,6 +69,27 @@ struct ManagePasscodeScreen: View {
         .onChange(of: showDisable) { _, isShowing in
             guard !isShowing else { return }
             Task { await refresh() }
+        }
+    }
+
+    /// What the biometric row currently has to say for itself, if anything.
+    ///
+    /// The standing reason comes first and does not need a tap to find: a device
+    /// with nothing enrolled cannot hold the shortcut, and letting someone
+    /// discover that only by flipping a switch that flips back is the behaviour
+    /// this screen was reported for. A failure from an actual attempt replaces
+    /// it, because that one is about what just happened.
+    private var biometricNote: String? {
+        if let biometricError { return biometricError }
+        guard rows.contains(.biometrics) else { return nil }
+
+        switch biometricAvailability {
+        case .available:
+            return nil
+        case .notEnrolled:
+            return "passcodeBiometricNotEnrolled".localized
+        case .unavailable:
+            return "passcodeBiometricNotAvailable".localized
         }
     }
 
@@ -143,26 +175,62 @@ struct ManagePasscodeScreen: View {
     }
 
     private func setBiometric(enabled: Bool) async {
+        // Moved before the call, so the switch follows the finger instead of
+        // snapping back for the length of a Keychain round trip and then
+        // returning. `refresh()` below overwrites it with what actually
+        // happened, so an optimistic value can never outlive the attempt.
+        isBiometricEnabled = enabled
+        biometricError = nil
+
         if enabled {
             // Enabling needs the data key in hand, so it can only be done while
             // unlocked. A failure leaves the toggle off rather than implying a
-            // shortcut exists.
+            // shortcut exists — and now says why, which is the whole of this
+            // change: every one of these used to be swallowed, so a device with
+            // nothing enrolled produced a switch that returned to off and no
+            // explanation anywhere.
             do {
                 try await service.enableBiometricUnlock()
             } catch {
-                isBiometricEnabled = false
-                return
+                biometricError = Self.message(for: error)
             }
         } else {
             // A failure here leaves the copy in place, so the toggle must not
-            // claim it is gone.
-            try? await service.disableBiometricUnlock()
+            // claim it is gone. `refresh()` re-reads it either way.
+            do {
+                try await service.disableBiometricUnlock()
+            } catch {
+                biometricError = "passcodeBiometricDisableFailed".localized
+            }
         }
         await refresh()
+    }
+
+    /// Says what the user has to do, where there is anything they can do.
+    @MainActor
+    private static func message(for error: Error) -> String {
+        switch error as? BiometricUnlockError {
+        case .notEnrolled:
+            return "passcodeBiometricNotEnrolled".localized
+        case .unavailable:
+            return "passcodeBiometricNotAvailable".localized
+        default:
+            break
+        }
+
+        // A passcode-side refusal is not about biometry at all — the app locked
+        // mid-flight, or another transition holds the lease — and
+        // `PasscodeViewModel` already has the wording for those.
+        if let passcodeError = error as? PasscodeError {
+            return PasscodeViewModel.message(for: passcodeError)
+        }
+
+        return "passcodeBiometricEnableFailed".localized
     }
 
     private func refresh() async {
         isSet = await service.isSet
         isBiometricEnabled = await service.isBiometricUnlockEnabled
+        biometricAvailability = await service.biometricAvailability
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -536,9 +536,13 @@ class EncryptedBackupViewModel: ObservableObject {
         // some vaults on one side of the passcode invariant and some on the other.
         // Default coins are added inside it, because they insert rows of their
         // own and doing that first strands them when the import is refused.
+        let coinService = VaultDefaultCoinService(context: modelContext)
         try importer.commit(imported, into: modelContext) { vault in
-            VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
+            coinService.setDefaultCoinsOnce(vault: vault)
         }
+        // Outside the commit, because the commit is what stores the rows that
+        // discovery goes on to write against.
+        coinService.startTokenDiscovery()
 
         return (imported, duplicates, skippedNames)
     }
@@ -640,9 +644,13 @@ class EncryptedBackupViewModel: ObservableObject {
                 vault.libType = LibType.DKLS
             }
 
+            let coinService = VaultDefaultCoinService(context: modelContext)
             try importer.commit([vault], into: modelContext) { vault in
-                VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
+                coinService.setDefaultCoinsOnce(vault: vault)
             }
+            // Outside the commit, because the commit is what stores the rows
+            // that discovery goes on to write against.
+            coinService.startTokenDiscovery()
             selectedVault = vault
             isVaultImported = true
         } catch {
@@ -698,9 +706,13 @@ class EncryptedBackupViewModel: ObservableObject {
         }
 
         do {
+            let coinService = VaultDefaultCoinService(context: modelContext)
             try importer.commit([decoded], into: modelContext) { vault in
-                VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
+                coinService.setDefaultCoinsOnce(vault: vault)
             }
+            // Outside the commit, because the commit is what stores the rows
+            // that discovery goes on to write against.
+            coinService.startTokenDiscovery()
             selectedVault = decoded
             showAlert = false
             isVaultImported = true

--- a/VultisigApp/VultisigAppTests/Helpers/TestStore.swift
+++ b/VultisigApp/VultisigAppTests/Helpers/TestStore.swift
@@ -74,6 +74,56 @@ enum TestStore {
         return container
     }
 
+    /// Containers held for the lifetime of the test process.
+    private static var retained: [ModelContainer] = []
+
+    /// Keeps a test's container alive past its `tearDown`.
+    ///
+    /// For tests that exercise code starting unstructured work — `setDefaultCoins`
+    /// fires a token-discovery `Task` per coin — which resumes after the test
+    /// method returns and touches the `@Model` objects it captured. Letting the
+    /// container go first turns that into a trap ("this model instance was
+    /// destroyed by calling ModelContext.reset") that fails whichever test
+    /// happens to be running. The app's container is process-lifetime, so this
+    /// makes the test resemble production rather than papering over anything.
+    static func retain(_ container: ModelContainer) {
+        retained.append(container)
+    }
+
+    /// A vault carrying real secp256k1 / ed25519 key material, so `CoinFactory`
+    /// derives actual addresses and `setDefaultCoins` produces actual coins.
+    ///
+    /// Placeholder keys are not good enough for anything about default coins:
+    /// `CoinFactory.create` throws on them and `compactMap` drops the failure, so
+    /// a vault built that way derives nothing at all — and a test asserting on its
+    /// coins passes just as happily against an import that attaches none of them.
+    ///
+    /// Not inserted; the caller decides when it reaches a context. `index` picks a
+    /// distinct key pair, because `name`, `pubKeyECDSA` and `pubKeyEdDSA` are all
+    /// `@Attribute(.unique)` and SwiftData answers a duplicate with an upsert
+    /// rather than an error — two fixtures sharing one collapse into a single row.
+    static func makeDerivableVault(index: Int = 0, keyshare: String) -> Vault {
+        let ecdsa = [
+            "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "0342d6eb3e536bd1d6f57a8388afb09936aa64160c5e2ebee76d791b4844a06770"
+        ]
+        let eddsa = [
+            "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5",
+            "86815b267977dd277171acfe16edb857767ab5310cb4186429cee1f407549d8e"
+        ]
+        return Vault(
+            name: "Derivable Vault \(index)",
+            signers: [],
+            pubKeyECDSA: ecdsa[index],
+            pubKeyEdDSA: eddsa[index],
+            keyshares: [KeyShare(pubkey: ecdsa[index], keyshare: keyshare)],
+            localPartyID: "party-\(index)",
+            hexChainCode: "c9b189a8232b872b8d9ccd867d0db316dd10f56e729c310fe072adf5fd204ae7",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+    }
+
     /// Insert a populated Vault matching `pubKeyECDSA` so position upserts have a
     /// parent to attach via inverse relationships.
     static func makeVault(pubKey: String = "test-pub-ecdsa") -> Vault {

--- a/VultisigApp/VultisigAppTests/Helpers/TestStore.swift
+++ b/VultisigApp/VultisigAppTests/Helpers/TestStore.swift
@@ -79,13 +79,14 @@ enum TestStore {
 
     /// Keeps a test's container alive past its `tearDown`.
     ///
-    /// For tests that exercise code starting unstructured work — `setDefaultCoins`
-    /// fires a token-discovery `Task` per coin — which resumes after the test
-    /// method returns and touches the `@Model` objects it captured. Letting the
-    /// container go first turns that into a trap ("this model instance was
-    /// destroyed by calling ModelContext.reset") that fails whichever test
-    /// happens to be running. The app's container is process-lifetime, so this
-    /// makes the test resemble production rather than papering over anything.
+    /// For tests that exercise code starting unstructured work — the token
+    /// discovery `VaultDefaultCoinService.startTokenDiscovery()` hands out is
+    /// the case here — which resumes after the test method returns and touches
+    /// the models it resolved. Letting the container go first turns that into a
+    /// trap ("this model instance was destroyed by calling ModelContext.reset")
+    /// that fails whichever test happens to be running. The app's container is
+    /// process-lifetime, so this makes the test resemble production rather than
+    /// papering over anything.
     static func retain(_ container: ModelContainer) {
         retained.append(container)
     }

--- a/VultisigApp/VultisigAppTests/Helpers/TestStore.swift
+++ b/VultisigApp/VultisigAppTests/Helpers/TestStore.swift
@@ -90,38 +90,54 @@ enum TestStore {
         retained.append(container)
     }
 
-    /// A vault carrying real secp256k1 / ed25519 key material, so `CoinFactory`
-    /// derives actual addresses and `setDefaultCoins` produces actual coins.
+    /// The chains ``makeDerivableVault(index:keyshare:)`` derives.
+    ///
+    /// Both are real ECDSA chains, and both resolve to `NoTokenDiscoverer` — see
+    /// the note on the fixture for why that matters. Tron is here so the DeFi
+    /// chains `setDefaultCoins` derives alongside the coins are non-empty.
+    static let derivableChains: [Chain] = [.bitcoin, .tron]
+
+    /// A vault carrying real secp256k1 key material, so `CoinFactory` derives
+    /// actual addresses and `setDefaultCoins` produces actual coins.
     ///
     /// Placeholder keys are not good enough for anything about default coins:
     /// `CoinFactory.create` throws on them and `compactMap` drops the failure, so
     /// a vault built that way derives nothing at all — and a test asserting on its
     /// coins passes just as happily against an import that attaches none of them.
     ///
-    /// Not inserted; the caller decides when it reaches a context. `index` picks a
-    /// distinct key pair, because `name`, `pubKeyECDSA` and `pubKeyEdDSA` are all
-    /// `@Attribute(.unique)` and SwiftData answers a duplicate with an upsert
+    /// Key-import with explicit per-chain keys rather than a DKLS vault on the
+    /// base default chains, so the fixture is hermetic. `setDefaultCoins` starts
+    /// an unstructured token-discovery `Task` per coin which outlives the test,
+    /// goes to the network, and writes through `Storage.shared` — by then the
+    /// *next* test's container. Relating a row from that store to this vault
+    /// traps, and it takes down the whole test host rather than one test.
+    /// ``derivableChains`` have no token discoverer behind them, so nothing is
+    /// fetched and nothing outlives the test.
+    ///
+    /// Not inserted; the caller decides when it reaches a context. `index` picks
+    /// distinct key material, because `name`, `pubKeyECDSA` and `pubKeyEdDSA` are
+    /// all `@Attribute(.unique)` and SwiftData answers a duplicate with an upsert
     /// rather than an error — two fixtures sharing one collapse into a single row.
     static func makeDerivableVault(index: Int = 0, keyshare: String) -> Vault {
         let ecdsa = [
             "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
             "0342d6eb3e536bd1d6f57a8388afb09936aa64160c5e2ebee76d791b4844a06770"
         ]
-        let eddsa = [
-            "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5",
-            "86815b267977dd277171acfe16edb857767ab5310cb4186429cee1f407549d8e"
-        ]
-        return Vault(
+        let vault = Vault(
             name: "Derivable Vault \(index)",
             signers: [],
             pubKeyECDSA: ecdsa[index],
-            pubKeyEdDSA: eddsa[index],
+            pubKeyEdDSA: "eddsa-\(index)",
             keyshares: [KeyShare(pubkey: ecdsa[index], keyshare: keyshare)],
             localPartyID: "party-\(index)",
             hexChainCode: "c9b189a8232b872b8d9ccd867d0db316dd10f56e729c310fe072adf5fd204ae7",
             resharePrefix: nil,
-            libType: .DKLS
+            libType: .KeyImport
         )
+        vault.chainPublicKeys = derivableChains.map {
+            ChainPublicKey(chain: $0, publicKeyHex: ecdsa[index], isEddsa: false)
+        }
+        return vault
     }
 
     /// Insert a populated Vault matching `pubKeyECDSA` so position upserts have a

--- a/VultisigApp/VultisigAppTests/Security/BackupImportProtectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/BackupImportProtectionTests.swift
@@ -105,7 +105,53 @@ final class BackupImportProtectionTests: XCTestCase {
         XCTAssertEqual(try context.fetchCount(FetchDescriptor<Coin>()), 0, "default coins must not outlive a refused import")
     }
 
+    // MARK: - What the restored vault opens on
+
+    /// The reported regression, through the JSON entry point and with no
+    /// passcode set — the configuration nearly every install is in. Both entry
+    /// points now derive default coins after the vault is stored, and attaching
+    /// them there is exactly what stopped working: the vault imported, its coin
+    /// rows were written belonging to nobody, and the wallet came up empty with
+    /// no error anywhere.
+    func testAJsonImportComesBackWithItsDefaultCoins() throws {
+        TestStore.retain(token.container)
+        let sut = makeViewModel(state: .disabled)
+        sut.decryptedContent = try JSONEncoder()
+            .encode(BackupVault(version: .v1, vault: makeDerivableVault()))
+            .hexString
+
+        sut.restoreVault(modelContext: context, vaults: [])
+
+        XCTAssertTrue(sut.isVaultImported)
+        let stored = try XCTUnwrap(try ModelContext(token.container).fetch(FetchDescriptor<Vault>()).first)
+        XCTAssertEqual(
+            Set(stored.coins.map(\.chain)),
+            Set(VaultDefaultCoinService(context: context).baseDefaultChains)
+        )
+    }
+
+    /// And through the batch entry point, which is the one that imports several
+    /// vaults under a single lease.
+    func testAZipImportComesBackWithDefaultCoinsForEveryVault() throws {
+        TestStore.retain(token.container)
+        let sut = makeViewModel(state: .disabled)
+        sut.multipleVaultsToImport = [makeDerivableVault(index: 0), makeDerivableVault(index: 1)]
+
+        sut.restoreMultipleVaults(modelContext: context, vaults: [])
+
+        XCTAssertTrue(sut.isVaultImported)
+        let stored = try ModelContext(token.container).fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(stored.count, 2)
+        for vault in stored {
+            XCTAssertFalse(vault.coins.isEmpty, "\(vault.name) came back with no chains")
+        }
+    }
+
     // MARK: - Helpers
+
+    private func makeDerivableVault(index: Int = 0) -> Vault {
+        TestStore.makeDerivableVault(index: index, keyshare: share)
+    }
 
     private func makeViewModel(state: KeyshareProtectionState) -> EncryptedBackupViewModel {
         EncryptedBackupViewModel(

--- a/VultisigApp/VultisigAppTests/Security/BackupImportProtectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/BackupImportProtectionTests.swift
@@ -107,13 +107,43 @@ final class BackupImportProtectionTests: XCTestCase {
 
     // MARK: - What the restored vault opens on
 
-    /// The reported regression, through the JSON entry point and with no
+    /// The reported regression, through the batch entry point and with no
     /// passcode set — the configuration nearly every install is in. Both entry
-    /// points now derive default coins after the vault is stored, and attaching
-    /// them there is exactly what stopped working: the vault imported, its coin
-    /// rows were written belonging to nobody, and the wallet came up empty with
-    /// no error anywhere.
-    func testAJsonImportComesBackWithItsDefaultCoins() throws {
+    /// points derive default coins after the vault is stored, and attaching them
+    /// there is exactly what stopped working: the vaults imported, their coin
+    /// rows were written belonging to nobody, and the wallet came up with no
+    /// chains in it and no error anywhere.
+    ///
+    /// Several vaults, because this is the path that imports a batch under one
+    /// lease and prepares them in a single pass.
+    func testAZipImportComesBackWithDefaultCoinsForEveryVault() throws {
+        TestStore.retain(token.container)
+        let sut = makeViewModel(state: .disabled)
+        sut.multipleVaultsToImport = [makeDerivableVault(index: 0), makeDerivableVault(index: 1)]
+
+        sut.restoreMultipleVaults(modelContext: context, vaults: [])
+
+        XCTAssertTrue(sut.isVaultImported)
+        let fresh = ModelContext(token.container)
+        let stored = try fresh.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(stored.count, 2, "distinct key material, so two rows and not one upserted over the other")
+        for vault in stored {
+            XCTAssertEqual(Set(vault.coins.map(\.chain)), Set(TestStore.derivableChains), "\(vault.name) came back with the wrong chains")
+        }
+        XCTAssertTrue(
+            try fresh.fetch(FetchDescriptor<Coin>()).allSatisfy { $0.vault != nil },
+            "no coin row may be left on disk with no vault to belong to"
+        )
+    }
+
+    /// The other entry point, and the case the reporting must not get wrong.
+    ///
+    /// The JSON backup format carries no per-chain public keys, so a key-import
+    /// vault restored from one has nothing this device can derive — and nothing
+    /// to derive is not a failure to derive. The import now *reports* whether the
+    /// preparation did its work, and reading this as "it did not" would mark
+    /// every legacy JSON import as broken.
+    func testAJsonImportWithNothingToDeriveIsStillReportedAsImported() throws {
         TestStore.retain(token.container)
         let sut = makeViewModel(state: .disabled)
         sut.decryptedContent = try JSONEncoder()
@@ -123,28 +153,10 @@ final class BackupImportProtectionTests: XCTestCase {
         sut.restoreVault(modelContext: context, vaults: [])
 
         XCTAssertTrue(sut.isVaultImported)
-        let stored = try XCTUnwrap(try ModelContext(token.container).fetch(FetchDescriptor<Vault>()).first)
-        XCTAssertEqual(
-            Set(stored.coins.map(\.chain)),
-            Set(VaultDefaultCoinService(context: context).baseDefaultChains)
-        )
-    }
-
-    /// And through the batch entry point, which is the one that imports several
-    /// vaults under a single lease.
-    func testAZipImportComesBackWithDefaultCoinsForEveryVault() throws {
-        TestStore.retain(token.container)
-        let sut = makeViewModel(state: .disabled)
-        sut.multipleVaultsToImport = [makeDerivableVault(index: 0), makeDerivableVault(index: 1)]
-
-        sut.restoreMultipleVaults(modelContext: context, vaults: [])
-
-        XCTAssertTrue(sut.isVaultImported)
-        let stored = try ModelContext(token.container).fetch(FetchDescriptor<Vault>())
-        XCTAssertEqual(stored.count, 2)
-        for vault in stored {
-            XCTAssertFalse(vault.coins.isEmpty, "\(vault.name) came back with no chains")
-        }
+        XCTAssertFalse(sut.showAlert)
+        let fresh = ModelContext(token.container)
+        XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Vault>()), 1)
+        XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Coin>()), 0, "nothing derived means nothing written, not orphan rows")
     }
 
     // MARK: - Helpers

--- a/VultisigApp/VultisigAppTests/Security/BiometricUnlockStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/BiometricUnlockStoreTests.swift
@@ -1,0 +1,247 @@
+//
+//  BiometricUnlockStoreTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import XCTest
+@testable import VultisigApp
+
+/// Every test here pins one of two properties: **the shortcut fails closed**,
+/// and **it only ever hands back a key that belongs to the wrapper on disk.**
+///
+/// Real biometry cannot be driven from a test bundle, which is why the Keychain
+/// access sits behind a seam. A biometric lock that fails *open* is worse than no
+/// lock at all, and shipping one is a mistake this org has already made once — so
+/// what is verified is that no failure path returns a key.
+final class BiometricUnlockStoreTests: XCTestCase {
+
+    private var keychain: FakeBiometricKeychain!
+    private var sut: BiometricUnlockStore!
+
+    /// Stands in for the passcode-wrapped data key the copy is bound to. Only
+    /// its bytes matter here — the store digests them, it never unwraps them.
+    private let wrapper = Data("wrapped-key-one".utf8)
+    private let otherWrapper = Data("wrapped-key-two".utf8)
+
+    override func setUp() {
+        super.setUp()
+        keychain = FakeBiometricKeychain()
+        sut = BiometricUnlockStore(keychain: keychain)
+    }
+
+    override func tearDown() {
+        sut = nil
+        keychain = nil
+        super.tearDown()
+    }
+
+    private func makeKey() throws -> SymmetricKey {
+        try VaultCryptoEnvelope.randomKey()
+    }
+
+    private func raw(_ key: SymmetricKey) -> Data {
+        key.withUnsafeBytes { Data($0) }
+    }
+
+    // MARK: - Enable / disable
+
+    func testNotEnabledByDefault() {
+        XCTAssertFalse(sut.isEnabled)
+    }
+
+    func testEnableStoresTheKey() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+
+        XCTAssertTrue(sut.isEnabled)
+    }
+
+    func testEnableSurfacesAStorageFailure() throws {
+        keychain.storeError = BiometricUnlockError.storageFailed
+
+        XCTAssertThrowsError(try sut.enable(dataKey: try makeKey(), boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .storageFailed)
+        }
+        XCTAssertFalse(sut.isEnabled)
+    }
+
+    func testDisableRemovesTheKey() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+
+        try sut.disable()
+
+        XCTAssertFalse(sut.isEnabled)
+    }
+
+    /// A survivor holds the same data key, so it would quietly work again the
+    /// next time a passcode is set — an enablement the user never made.
+    func testDisableThrowsWhenTheCopyCannotBeRemoved() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+        keychain.deleteError = BiometricUnlockError.storageFailed
+
+        XCTAssertThrowsError(try sut.disable()) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .storageFailed)
+        }
+        XCTAssertTrue(sut.isEnabled, "The copy is still there and must be reported as such")
+    }
+
+    /// The whole point of storing the binding rather than reading it back: a
+    /// passcode change rewraps the key, and rebinding must not cost a prompt.
+    func testStoringDoesNotPromptForBiometrics() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+        try sut.enable(dataKey: try makeKey(), boundTo: otherWrapper)
+
+        XCTAssertEqual(keychain.readCount, 0)
+    }
+
+    // MARK: - The happy path
+
+    func testUnlockReturnsTheStoredKey() throws {
+        let key = try makeKey()
+        try sut.enable(dataKey: key, boundTo: wrapper)
+
+        let unlocked = try sut.unlock(reason: "test", boundTo: wrapper)
+
+        XCTAssertEqual(raw(unlocked), raw(key))
+    }
+
+    // MARK: - The binding
+
+    /// The fund-loss case. A copy from an earlier install holds key A while the
+    /// wrapper on disk holds key B; nothing else can detect that, because the
+    /// wrapper cannot be unwrapped without the passcode and a pending store may
+    /// have no sealed share to test against. Adopting A would let the resume
+    /// sweep seal every share under a key nothing wraps.
+    func testUnlockRefusesACopyBoundToAnotherWrapper() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+
+        XCTAssertThrowsError(try sut.unlock(reason: "test", boundTo: otherWrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .supersededCopy)
+        }
+    }
+
+    /// A shortcut that can only ever fail is worse than none: it advertises
+    /// itself as enabled in Settings and prompts for a face that leads nowhere.
+    func testUnlockRemovesACopyBoundToAnotherWrapper() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+
+        _ = try? sut.unlock(reason: "test", boundTo: otherWrapper)
+
+        XCTAssertFalse(sut.isEnabled)
+    }
+
+    /// Rebinding is what a passcode change does, and it has to make the copy
+    /// usable against the new wrapper and only that one.
+    func testRebindingMovesTheCopyToTheNewWrapper() throws {
+        let key = try makeKey()
+        try sut.enable(dataKey: key, boundTo: wrapper)
+
+        try sut.enable(dataKey: key, boundTo: otherWrapper)
+
+        XCTAssertEqual(raw(try sut.unlock(reason: "test", boundTo: otherWrapper)), raw(key))
+    }
+
+    // MARK: - Every failure must throw, never return a key
+
+    func testUnlockThrowsWhenNotEnabled() {
+        XCTAssertThrowsError(try sut.unlock(reason: "test", boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .notEnabled)
+        }
+    }
+
+    func testUnlockThrowsWhenCancelled() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+        keychain.readError = BiometricUnlockError.cancelled
+
+        XCTAssertThrowsError(try sut.unlock(reason: "test", boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .cancelled)
+        }
+    }
+
+    func testUnlockThrowsWhenBiometryIsUnavailable() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+        keychain.readError = BiometricUnlockError.unavailable
+
+        XCTAssertThrowsError(try sut.unlock(reason: "test", boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .unavailable)
+        }
+    }
+
+    /// What `.biometryCurrentSet` produces when a new face or finger is enrolled:
+    /// the item is gone, and enrolment must not inherit access.
+    func testUnlockThrowsWhenEnrolmentChangedAndTheItemVanished() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+        keychain.readError = BiometricUnlockError.notEnabled
+
+        XCTAssertThrowsError(try sut.unlock(reason: "test", boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .notEnabled)
+        }
+    }
+
+    func testUnlockThrowsOnAnUnexpectedError() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+        keychain.readError = CocoaError(.fileReadUnknown)
+
+        XCTAssertThrowsError(try sut.unlock(reason: "test", boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .failed)
+        }
+    }
+
+    /// A stored blob of the wrong shape cannot open anything, so the shortcut is
+    /// removed rather than left in place to fail forever. The passcode is
+    /// unaffected. The bare 32 bytes are what a copy written before the binding
+    /// existed would look like.
+    func testUnlockRejectsAndRemovesAMalformedKey() throws {
+        keychain.stored = Data(repeating: 0x01, count: VaultCryptoEnvelope.keyLengthBytes)
+
+        XCTAssertThrowsError(try sut.unlock(reason: "test", boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .malformedCopy)
+        }
+        XCTAssertFalse(sut.isEnabled, "A key that cannot work should not be left behind")
+    }
+
+    func testExistenceCheckDoesNotReadTheKey() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+
+        _ = sut.isEnabled
+
+        XCTAssertEqual(keychain.readCount, 0, "Checking presence must not prompt for biometrics")
+    }
+}
+
+/// In-memory stand-in. `exists` deliberately does not go through `read`, mirroring
+/// the real implementation's use of `kSecUseAuthenticationUISkip`.
+private final class FakeBiometricKeychain: BiometricKeychainProtecting {
+
+    var stored: Data?
+    var storeError: Error?
+    var readError: Error?
+    private(set) var readCount = 0
+
+    /// An add, not an upsert — `SecItemAdd` answers `errSecDuplicateItem` over
+    /// an existing item, so a fake that overwrote would hide the one bug this
+    /// seam exists to expose.
+    func store(_ data: Data, account _: String) throws {
+        if let storeError { throw storeError }
+        guard stored == nil else { throw BiometricUnlockError.storageFailed }
+        stored = data
+    }
+
+    func read(account _: String, prompt _: String) throws -> Data {
+        readCount += 1
+        if let readError { throw readError }
+        guard let stored else { throw BiometricUnlockError.notEnabled }
+        return stored
+    }
+
+    var deleteError: Error?
+
+    func delete(account _: String) throws {
+        if let deleteError { throw deleteError }
+        stored = nil
+    }
+
+    func exists(account _: String) -> Bool {
+        stored != nil
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/BiometricUnlockStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/BiometricUnlockStoreTests.swift
@@ -18,6 +18,9 @@ final class BiometricUnlockStoreTests: XCTestCase {
 
     private var keychain: FakeBiometricKeychain!
     private var sut: BiometricUnlockStore!
+    /// Available unless a test says otherwise, so every case that is not about
+    /// availability reads exactly as it did before this seam existed.
+    private var availability: BiometricAvailability = .available
 
     /// Stands in for the passcode-wrapped data key the copy is bound to. Only
     /// its bytes matter here — the store digests them, it never unwraps them.
@@ -27,7 +30,11 @@ final class BiometricUnlockStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         keychain = FakeBiometricKeychain()
-        sut = BiometricUnlockStore(keychain: keychain)
+        availability = .available
+        sut = BiometricUnlockStore(
+            keychain: keychain,
+            biometryAvailability: { [unowned self] in self.availability }
+        )
     }
 
     override func tearDown() {
@@ -63,6 +70,59 @@ final class BiometricUnlockStoreTests: XCTestCase {
             XCTAssertEqual(error as? BiometricUnlockError, .storageFailed)
         }
         XCTAssertFalse(sut.isEnabled)
+    }
+
+    /// The reported bug: a device with nothing enrolled refused the switch and
+    /// said nothing. It has to refuse — but as its own error, so the screen can
+    /// tell the user what to go and do.
+    func testEnableRefusesWithItsOwnErrorWhenNothingIsEnrolled() throws {
+        availability = .notEnrolled
+
+        XCTAssertThrowsError(try sut.enable(dataKey: try makeKey(), boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .notEnrolled)
+        }
+        XCTAssertFalse(sut.isEnabled)
+    }
+
+    func testEnableRefusesWhenBiometryIsUnavailable() throws {
+        availability = .unavailable
+
+        XCTAssertThrowsError(try sut.enable(dataKey: try makeKey(), boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .unavailable)
+        }
+        XCTAssertFalse(sut.isEnabled)
+    }
+
+    /// Availability is checked *before* the write, not after it fails. A refusal
+    /// that had already touched the Keychain would have deleted whatever was
+    /// there — `enable` removes before it adds — and left the user with the
+    /// shortcut they had turned on earlier silently gone.
+    func testAnUnavailableDeviceLeavesAnExistingCopyAlone() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+        availability = .notEnrolled
+
+        XCTAssertThrowsError(try sut.enable(dataKey: try makeKey(), boundTo: wrapper))
+        XCTAssertTrue(sut.isEnabled, "the copy that was already there survives a refusal")
+    }
+
+    /// The residual, pinned rather than claimed away. The preflight only moves
+    /// the refusals it can *see coming*; the delete-then-add is not atomic, so
+    /// enrolment changing in the gap — or the Keychain failing for its own
+    /// reasons — still loses an existing copy.
+    ///
+    /// Left as it is deliberately. Restoring it would mean reading the old blob
+    /// out before deleting, which means a biometric prompt on a path that is
+    /// documented not to need one, and the whole loss is an *optional shortcut*:
+    /// the passcode-wrapped copy is untouched and still opens everything. What
+    /// must not happen is discovering this from a bug report, so it is a test.
+    func testAStoreFailureAfterTheDeleteStillCostsTheExistingCopy() throws {
+        try sut.enable(dataKey: try makeKey(), boundTo: wrapper)
+        keychain.storeError = BiometricUnlockError.storageFailed
+
+        XCTAssertThrowsError(try sut.enable(dataKey: try makeKey(), boundTo: wrapper)) { error in
+            XCTAssertEqual(error as? BiometricUnlockError, .storageFailed)
+        }
+        XCTAssertFalse(sut.isEnabled, "known residual: the delete already happened")
     }
 
     func testDisableRemovesTheKey() throws {
@@ -244,4 +304,5 @@ private final class FakeBiometricKeychain: BiometricKeychainProtecting {
     func exists(account _: String) -> Bool {
         stored != nil
     }
+
 }

--- a/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
@@ -34,7 +34,14 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         keychain = MockKeychainService()
         keyStore = DefaultKeyshareKeyStore(keychain: keychain)
         biometricKeychain = StubBiometricKeychain()
-        biometrics = BiometricUnlockStore(keychain: biometricKeychain)
+        // Availability is stated rather than inherited: the default reads this
+        // runner's real `LAContext`, which reports nothing enrolled on a
+        // simulator, and reconciliation is not about whether biometry works —
+        // it is about removing a copy a previous install left behind.
+        biometrics = BiometricUnlockStore(
+            keychain: biometricKeychain,
+            biometryAvailability: { .available }
+        )
         lockService = AppLockService(defaults: defaults)
 
         coordinator = KeyshareWriteCoordinator()

--- a/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
@@ -15,6 +15,8 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
 
     private var keychain: MockKeychainService!
     private var keyStore: DefaultKeyshareKeyStore!
+    private var biometricKeychain: StubBiometricKeychain!
+    private var biometrics: BiometricUnlockStore!
     private var lockService: AppLockService!
     private var coordinator: KeyshareWriteCoordinator!
     private var defaults: UserDefaults!
@@ -31,12 +33,15 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
 
         keychain = MockKeychainService()
         keyStore = DefaultKeyshareKeyStore(keychain: keychain)
+        biometricKeychain = StubBiometricKeychain()
+        biometrics = BiometricUnlockStore(keychain: biometricKeychain)
         lockService = AppLockService(defaults: defaults)
 
         coordinator = KeyshareWriteCoordinator()
         sut = KeyshareInstallReconciler(
             keychain: keychain,
             keyStore: keyStore,
+            biometrics: biometrics,
             lockService: lockService,
             coordinator: coordinator,
             defaults: defaults
@@ -48,6 +53,8 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         sut = nil
         coordinator = nil
         lockService = nil
+        biometrics = nil
+        biometricKeychain = nil
         keyStore = nil
         keychain = nil
         defaults = nil
@@ -330,5 +337,84 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         sut.reconcile(isStoreEmpty: true)
 
         XCTAssertEqual(keychain.getPasscodeAttemptState(), .absent)
+    }
+
+    // MARK: - The biometric copy
+
+    /// A second copy of the same key, and it survives the uninstall too. Left
+    /// behind it reports biometric unlock as already enabled and is bound to a
+    /// wrapper this pass has just deleted, so it could only ever be refused.
+    func testANewContainerClearsTheBiometricCopy() throws {
+        try biometrics.enable(dataKey: try VaultCryptoEnvelope.randomKey(), boundTo: wrappedBlob)
+        XCTAssertTrue(biometrics.isEnabled)
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertFalse(biometrics.isEnabled)
+    }
+
+    func testAStoreWithVaultsKeepsItsBiometricCopy() throws {
+        try biometrics.enable(dataKey: try VaultCryptoEnvelope.randomKey(), boundTo: wrappedBlob)
+
+        sut.reconcile(isStoreEmpty: false)
+
+        XCTAssertTrue(biometrics.isEnabled)
+    }
+
+    func testAFailedBiometricClearIsRetriedOnTheNextLaunch() throws {
+        try biometrics.enable(dataKey: try VaultCryptoEnvelope.randomKey(), boundTo: wrappedBlob)
+        biometricKeychain.failsDeletion = true
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertTrue(biometrics.isEnabled)
+
+        biometricKeychain.failsDeletion = false
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertFalse(biometrics.isEnabled)
+    }
+
+    /// The short-circuit that keeps a first-ever install from writing anything
+    /// has to count the biometric copy too. A container carrying only that one
+    /// would otherwise be judged to have inherited nothing, get marked as
+    /// reconciled, and keep the leftover shortcut for good.
+    func testAnInheritedBiometricCopyAloneStillTriggersTheClear() throws {
+        try biometrics.enable(dataKey: try VaultCryptoEnvelope.randomKey(), boundTo: wrappedBlob)
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent)
+        XCTAssertEqual(keychain.getPasscodeAttemptState(), .absent)
+
+        sut.reconcile(isStoreEmpty: true)
+
+        XCTAssertFalse(biometrics.isEnabled)
+    }
+}
+
+/// In-memory stand-in for the biometry-protected Keychain item — the real one
+/// needs an entitlement and a device with biometrics enrolled.
+private final class StubBiometricKeychain: BiometricKeychainProtecting {
+
+    var failsDeletion = false
+
+    private var items: [String: Data] = [:]
+
+    /// An add, not an upsert, mirroring `SecItemAdd`.
+    func store(_ data: Data, account: String) throws {
+        guard items[account] == nil else { throw BiometricUnlockError.storageFailed }
+        items[account] = data
+    }
+
+    func read(account: String, prompt _: String) throws -> Data {
+        guard let data = items[account] else { throw BiometricUnlockError.notEnabled }
+        return data
+    }
+
+    func delete(account: String) throws {
+        guard !failsDeletion else { throw BiometricUnlockError.storageFailed }
+        items[account] = nil
+    }
+
+    func exists(account: String) -> Bool {
+        items[account] != nil
     }
 }

--- a/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
@@ -64,7 +64,10 @@ final class PasscodeGateWiringTests: XCTestCase {
             protector: KeyshareProtector(state: { keySession.currentState() }),
             context: { [context] in context }
         )
-        biometrics = BiometricUnlockStore(keychain: InMemoryBiometricKeychain())
+        biometrics = BiometricUnlockStore(
+            keychain: InMemoryBiometricKeychain(),
+            biometryAvailability: { .available }
+        )
         service = makeService()
 
         for key in borrowedDefaultsKeys {

--- a/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
@@ -35,6 +35,7 @@ final class PasscodeGateWiringTests: XCTestCase {
     private var lockService: AppLockService!
     private var coordinator: KeyshareWriteCoordinator!
     private var sweeper: KeyshareSweeper!
+    private var biometrics: BiometricUnlockStore!
     private var service: PasscodeService!
     /// `AppViewModel`'s login flags are `@AppStorage`, so they read and write the
     /// standard defaults no matter which suite the lock service is on.
@@ -63,6 +64,7 @@ final class PasscodeGateWiringTests: XCTestCase {
             protector: KeyshareProtector(state: { keySession.currentState() }),
             context: { [context] in context }
         )
+        biometrics = BiometricUnlockStore(keychain: InMemoryBiometricKeychain())
         service = makeService()
 
         for key in borrowedDefaultsKeys {
@@ -81,6 +83,7 @@ final class PasscodeGateWiringTests: XCTestCase {
         standardDefaults = [:]
         defaults.removePersistentDomain(forName: suiteName)
         service = nil
+        biometrics = nil
         sweeper = nil
         coordinator = nil
         lockService = nil
@@ -95,6 +98,12 @@ final class PasscodeGateWiringTests: XCTestCase {
         super.tearDown()
     }
 
+    /// `biometrics` is injected rather than defaulted, and it is **not** optional
+    /// polish: `BiometricUnlockStore.shared` reaches the device Keychain, so
+    /// `disablePasscode` — which removes the shortcut before any share moves —
+    /// throws `.storageFailed` out of a simulator against the default. The
+    /// dependency is invisible from the layer below, where this file was written
+    /// and passed.
     private func makeService(sweeper: KeyshareSweeping? = nil) -> PasscodeService {
         PasscodeService(
             keyStore: keyStore,
@@ -102,7 +111,8 @@ final class PasscodeGateWiringTests: XCTestCase {
             lockService: lockService,
             limiter: PasscodeAttemptLimiter(keychain: keychain, uptime: { 1_000 }),
             coordinator: coordinator,
-            sweeper: sweeper ?? self.sweeper
+            sweeper: sweeper ?? self.sweeper,
+            biometrics: biometrics
         )
     }
 
@@ -347,4 +357,26 @@ private final class LockingKeyshareSweeper: KeyshareSweeping {
     }
 
     @MainActor func hasSealedShare() throws -> Bool { try wrapped.hasSealedShare() }
+}
+
+/// The biometric shortcut's store, in memory. An add rather than an upsert,
+/// mirroring `SecItemAdd` — production cannot overwrite in place, and a double
+/// that could would make the rebinding path look like something it is not.
+private final class InMemoryBiometricKeychain: BiometricKeychainProtecting {
+
+    private var stored: Data?
+
+    func store(_ data: Data, account _: String) throws {
+        guard stored == nil else { throw BiometricUnlockError.storageFailed }
+        stored = data
+    }
+
+    func read(account _: String, prompt _: String) throws -> Data {
+        guard let stored else { throw BiometricUnlockError.notEnabled }
+        return stored
+    }
+
+    func delete(account _: String) throws { stored = nil }
+
+    func exists(account _: String) -> Bool { stored != nil }
 }

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -25,6 +25,8 @@ final class PasscodeServiceTests: XCTestCase {
     private var lockService: AppLockService!
     private var coordinator: KeyshareWriteCoordinator!
     private var sweeper: KeyshareSweeper!
+    private var biometricKeychain: InMemoryBiometricKeychain!
+    private var biometrics: BiometricUnlockStore!
     private var defaults: UserDefaults!
     private var suiteName: String!
     private var sut: PasscodeService!
@@ -55,6 +57,8 @@ final class PasscodeServiceTests: XCTestCase {
         lockService = AppLockService(defaults: defaults)
         coordinator = KeyshareWriteCoordinator()
         sweeper = KeyshareSweeper(protector: protector, context: { [context] in context })
+        biometricKeychain = InMemoryBiometricKeychain()
+        biometrics = BiometricUnlockStore(keychain: biometricKeychain)
 
         sut = makeService()
     }
@@ -62,6 +66,8 @@ final class PasscodeServiceTests: XCTestCase {
     override func tearDown() {
         defaults.removePersistentDomain(forName: suiteName)
         sut = nil
+        biometrics = nil
+        biometricKeychain = nil
         sweeper = nil
         coordinator = nil
         lockService = nil
@@ -79,7 +85,8 @@ final class PasscodeServiceTests: XCTestCase {
 
     private func makeService(
         keyStore: KeyshareKeyStoring? = nil,
-        sweeper: KeyshareSweeping? = nil
+        sweeper: KeyshareSweeping? = nil,
+        biometrics: BiometricUnlockStore? = nil
     ) -> PasscodeService {
         PasscodeService(
             keyStore: keyStore ?? self.keyStore,
@@ -87,7 +94,8 @@ final class PasscodeServiceTests: XCTestCase {
             lockService: lockService,
             limiter: PasscodeAttemptLimiter(keychain: keychain, uptime: { self.uptime }),
             coordinator: coordinator,
-            sweeper: sweeper ?? self.sweeper
+            sweeper: sweeper ?? self.sweeper,
+            biometrics: biometrics ?? self.biometrics
         )
     }
 
@@ -1526,4 +1534,183 @@ private final class HookedKeyshareKeyStore: KeyshareKeyStoring {
         try await duringUnwrap()
         return key
     }
+}
+
+// MARK: - The biometric shortcut
+
+extension PasscodeServiceTests {
+
+    /// The shortcut has to be a full app unlock, not a lighter one: it adopts
+    /// the key **and** finishes a sweep an interrupted set left behind. A
+    /// biometric path that skipped the resume would leave a passcode user with
+    /// plaintext shares for as long as they never typed their digits.
+    func testABiometricUnlockOpensTheAppAndFinishesAnInterruptedSweep() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+        try await sut.enableBiometricUnlock()
+
+        // Plaintext arriving after the set — a downgrade, or an interruption.
+        let vault = try XCTUnwrap(try context.fetch(FetchDescriptor<Vault>()).first)
+        vault.keyshares = [KeyShare(pubkey: "vault-one-0", keyshare: share)]
+        try context.save()
+
+        sut.lock()
+        XCTAssertFalse(sut.isSessionUnlocked)
+
+        try await sut.unlockWithBiometrics(reason: "test")
+
+        XCTAssertTrue(sut.isSessionUnlocked)
+        XCTAssertTrue(protector.isSealed(try XCTUnwrap(try storedShares().first)))
+    }
+
+    /// The fund-loss path the binding exists for. A copy left behind by an
+    /// earlier install holds key A; the wrapper on disk holds key B. Adopting A
+    /// would let the resume sweep seal every share under a key no wrapper holds,
+    /// and nothing would ever revisit them.
+    func testACopyBoundToASupersededWrapperIsRefusedAndRemoved() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+        try await sut.enableBiometricUnlock()
+
+        // The wrapper moves underneath the copy. Reached in the field by a
+        // reinstall whose reconciliation cleared the wrapper but not the
+        // shortcut, after which a new passcode mints a different key; written
+        // directly here because every route through the service now removes the
+        // copy on the way, which is the belt to this braces.
+        try keyStore.storeWrappedDataKey(Data(repeating: 9, count: 60))
+        sut.lock()
+
+        do {
+            try await sut.unlockWithBiometrics(reason: "test")
+            XCTFail("Expected the superseded copy to be refused")
+        } catch {
+            XCTAssertEqual(error as? BiometricUnlockError, .supersededCopy)
+        }
+
+        XCTAssertFalse(biometrics.isEnabled, "a copy that can never work must not be left behind")
+        XCTAssertFalse(sut.isSessionUnlocked)
+    }
+
+    /// A transition lease here would be the circular lockout: keygen holds an
+    /// episode through its deferred commit, transitions are refused while one is
+    /// open, and the flow cannot be finished without unlocking first.
+    func testABiometricUnlockSucceedsWhileAVaultCreationEpisodeIsOpen() async throws {
+        try await sut.setPasscode(passcode)
+        try await sut.enableBiometricUnlock()
+        sut.lock()
+
+        let episode = try XCTUnwrap(coordinator.beginEpisode())
+        defer { coordinator.end(episode) }
+
+        try await sut.unlockWithBiometrics(reason: "test")
+
+        XCTAssertTrue(sut.isSessionUnlocked)
+    }
+
+    /// Fails closed on an unreadable wrapper rather than on `isSet`, which reads
+    /// `.unavailable` as "set" on purpose. There is nothing to check the stored
+    /// copy against, so there is no basis for letting it through.
+    func testABiometricUnlockIsRefusedWhenTheWrapperCannotBeRead() async throws {
+        try await sut.setPasscode(passcode)
+        try await sut.enableBiometricUnlock()
+        sut.lock()
+
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        do {
+            try await sut.unlockWithBiometrics(reason: "test")
+            XCTFail("Expected an unreadable wrapper to refuse the shortcut")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .storageFailure)
+        }
+        XCTAssertFalse(sut.isSessionUnlocked)
+    }
+
+    func testABiometricUnlockIsRefusedWhenNoPasscodeIsSet() async throws {
+        do {
+            try await sut.unlockWithBiometrics(reason: "test")
+            XCTFail("Expected no passcode to refuse the shortcut")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .notSet)
+        }
+    }
+
+    /// A change rewraps the same key under new digits, so the blob the copy is
+    /// bound to moves. Without rebinding, every passcode change would silently
+    /// turn the shortcut off at its next use.
+    func testAPasscodeChangeKeepsTheShortcutWorking() async throws {
+        try await sut.setPasscode(passcode)
+        try await sut.enableBiometricUnlock()
+
+        try await sut.changePasscode(current: passcode, new: newPasscode)
+        sut.lock()
+
+        try await sut.unlockWithBiometrics(reason: "test")
+
+        XCTAssertTrue(sut.isSessionUnlocked)
+    }
+
+    /// The copy holds the same data key, so leaving it would make it a working
+    /// shortcut again the next time a passcode was set — an enablement nobody
+    /// made.
+    func testRemovingThePasscodeRemovesTheShortcut() async throws {
+        try givenVaults([("vault-one", [share])])
+        try await sut.setPasscode(passcode)
+        try await sut.enableBiometricUnlock()
+        XCTAssertTrue(biometrics.isEnabled)
+
+        try await sut.disablePasscode(current: passcode)
+
+        XCTAssertFalse(biometrics.isEnabled)
+    }
+
+    /// A leftover copy with no passcode behind it reports the shortcut as
+    /// already enabled for a passcode the user is only now creating.
+    func testSettingAPasscodeClearsALeftoverCopy() async throws {
+        try biometrics.enable(dataKey: SymmetricKey(size: .bits256), boundTo: Data([0x09]))
+
+        try await sut.setPasscode(passcode)
+
+        XCTAssertFalse(biometrics.isEnabled)
+    }
+
+    /// Enabling needs the key in hand. Doing it from a locked session would
+    /// store nothing usable, and reporting success would advertise a shortcut
+    /// that does not exist.
+    func testTheShortcutCannotBeEnabledWhileLocked() async throws {
+        try await sut.setPasscode(passcode)
+        sut.lock()
+
+        do {
+            try await sut.enableBiometricUnlock()
+            XCTFail("Expected a locked session to refuse enabling the shortcut")
+        } catch {
+            XCTAssertEqual(error as? PasscodeError, .cancelledByLock)
+        }
+        XCTAssertFalse(biometrics.isEnabled)
+    }
+}
+
+/// The real biometric Keychain is unreachable from a test bundle — it needs an
+/// entitlement and enrolled biometrics — so the passcode tests drive an
+/// in-memory stand-in. The store's own failure behaviour is covered by
+/// `BiometricUnlockStoreTests`.
+private final class InMemoryBiometricKeychain: BiometricKeychainProtecting {
+
+    private var stored: Data?
+
+    /// An add, not an upsert, mirroring `SecItemAdd`.
+    func store(_ data: Data, account _: String) throws {
+        guard stored == nil else { throw BiometricUnlockError.storageFailed }
+        stored = data
+    }
+
+    func read(account _: String, prompt _: String) throws -> Data {
+        guard let stored else { throw BiometricUnlockError.notEnabled }
+        return stored
+    }
+
+    func delete(account _: String) throws { stored = nil }
+
+    func exists(account _: String) -> Bool { stored != nil }
 }

--- a/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeServiceTests.swift
@@ -58,7 +58,12 @@ final class PasscodeServiceTests: XCTestCase {
         coordinator = KeyshareWriteCoordinator()
         sweeper = KeyshareSweeper(protector: protector, context: { [context] in context })
         biometricKeychain = InMemoryBiometricKeychain()
-        biometrics = BiometricUnlockStore(keychain: biometricKeychain)
+        // Stated, not inherited — the default asks this runner's real
+        // `LAContext`, which reports nothing enrolled on a simulator.
+        biometrics = BiometricUnlockStore(
+            keychain: biometricKeychain,
+            biometryAvailability: { .available }
+        )
 
         sut = makeService()
     }

--- a/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
@@ -264,6 +264,33 @@ final class ProtectedVaultImporterTests: XCTestCase {
         }
     }
 
+    /// End to end, through the ordering that made the original failure silent.
+    /// The import stores the vault, prepares it, and the preparation comes up a
+    /// chain short — Bitcoin builds, Tron cannot. What must not reach disk is a
+    /// vault holding only the chains that did build: the second pass sees coins
+    /// on it, reads that as prepared, and never looks again.
+    func testAnImportWhoseCoinsCannotAllBeBuiltStoresNoneOfThem() throws {
+        TestStore.retain(token.container)
+        let sut = makeImporter(state: .disabled)
+        let vault = derivableVault()
+        let usable = try XCTUnwrap(vault.chainPublicKeys.first).publicKeyHex
+        vault.chainPublicKeys = [
+            ChainPublicKey(chain: .bitcoin, publicKeyHex: usable, isEddsa: false),
+            ChainPublicKey(chain: .tron, publicKeyHex: "not-a-public-key", isEddsa: false)
+        ]
+        var attempts = 0
+
+        try sut.commit([vault], into: context) { vault in
+            attempts += 1
+            return self.settingDefaultCoins(vault)
+        }
+
+        XCTAssertEqual(attempts, 2, "a preparation that came up short is retried once")
+        let fresh = ModelContext(token.container)
+        XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Vault>()), 1, "the vault is stored and openable — this is not an import failure")
+        XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Coin>()), 0, "no half-prepared vault, and no rows belonging to nobody")
+    }
+
     /// A preparation that did not take is not a silent success. It is retried,
     /// because it is idempotent by contract and the vault is new — and because
     /// nothing later in the app rebuilds what it writes.

--- a/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
@@ -202,7 +202,104 @@ final class ProtectedVaultImporterTests: XCTestCase {
         XCTAssertEqual(stored.keyId, "mldsa-key-id")
     }
 
+    // MARK: - Preparing a vault that is already stored
+
+    /// The regression, asserted where it happened. `commit` derives default
+    /// coins *after* the vault has been inserted and saved, and attaching them
+    /// by mutating `vault.coins` does not take on a vault that has been through
+    /// a `save()`: the relationship re-faults to its persisted value and the
+    /// next save writes that back over the inverse. The import reported
+    /// success, five coin rows were written belonging to nobody, and the user
+    /// opened a wallet with no chains in it.
+    ///
+    /// Written against the no-passcode state on purpose — that is the state
+    /// almost every install is in, and the one the report came from.
+    func testAnImportedVaultKeepsItsDefaultCoinsWithNoPasscodeSet() throws {
+        TestStore.retain(token.container)
+        let sut = makeImporter(state: .disabled)
+
+        try sut.commit([derivableVault()], into: context, prepare: settingDefaultCoins)
+
+        let fresh = ModelContext(token.container)
+        let stored = try XCTUnwrap(try fresh.fetch(FetchDescriptor<Vault>()).first)
+        XCTAssertEqual(
+            Set(stored.coins.map(\.chain)),
+            Set(VaultDefaultCoinService(context: context).baseDefaultChains),
+            "an imported vault must open on the same chains a freshly generated one does"
+        )
+        XCTAssertTrue(
+            try fresh.fetch(FetchDescriptor<Coin>()).allSatisfy { $0.vault != nil },
+            "no coin row may be left on disk with no vault to belong to"
+        )
+        XCTAssertTrue(stored.defiChains.contains(.thorChain), "the DeFi chains derived alongside the coins must persist too")
+    }
+
+    /// The same, with a passcode set: the shares take a different route to disk
+    /// and the coins must not.
+    func testAnImportedVaultKeepsItsDefaultCoinsWithAPasscodeSet() throws {
+        TestStore.retain(token.container)
+        let sut = makeImporter(state: .unlocked(key))
+
+        try sut.commit([derivableVault()], into: context, prepare: settingDefaultCoins)
+
+        let fresh = ModelContext(token.container)
+        let stored = try XCTUnwrap(try fresh.fetch(FetchDescriptor<Vault>()).first)
+        XCTAssertEqual(stored.coins.count, VaultDefaultCoinService(context: context).baseDefaultChains.count)
+    }
+
+    /// Every vault in a batch, not just the first — the ZIP path imports several
+    /// at once and they are prepared in one pass.
+    func testEveryVaultInABatchKeepsItsDefaultCoins() throws {
+        TestStore.retain(token.container)
+        let sut = makeImporter(state: .disabled)
+        let vaults = [derivableVault(index: 0), derivableVault(index: 1)]
+
+        try sut.commit(vaults, into: context, prepare: settingDefaultCoins)
+
+        let fresh = ModelContext(token.container)
+        let stored = try fresh.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(stored.count, 2, "distinct key material, so two rows and not one upserted over the other")
+        for vault in stored {
+            XCTAssertFalse(vault.coins.isEmpty, "\(vault.name) came back with no chains")
+        }
+    }
+
+    /// A preparation that did not take is not a silent success. It is retried,
+    /// because it is idempotent by contract and the vault is new — and because
+    /// nothing later in the app rebuilds what it writes.
+    func testAPreparationThatDidNotTakeIsRunAgain() throws {
+        let sut = makeImporter(state: .disabled)
+        var attempts = 0
+
+        try sut.commit([makeVault(shares: [firstShare])], into: context) { _ in
+            attempts += 1
+            return false
+        }
+
+        XCTAssertEqual(attempts, 2, "one retry, and only one — a preparation that keeps failing is reported, not looped")
+    }
+
+    func testAPreparationThatTookIsNotRunAgain() throws {
+        let sut = makeImporter(state: .disabled)
+        var attempts = 0
+
+        try sut.commit([makeVault(shares: [firstShare])], into: context) { _ in
+            attempts += 1
+            return true
+        }
+
+        XCTAssertEqual(attempts, 1)
+    }
+
     // MARK: - Helpers
+
+    private func derivableVault(index: Int = 0) -> Vault {
+        TestStore.makeDerivableVault(index: index, keyshare: firstShare)
+    }
+
+    private func settingDefaultCoins(_ vault: Vault) -> Bool {
+        VaultDefaultCoinService(context: context).setDefaultCoinsOnce(vault: vault)
+    }
 
     private func makeImporter(state: KeyshareProtectionState) -> ProtectedVaultImporter {
         ProtectedVaultImporter(

--- a/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
@@ -318,7 +318,40 @@ final class ProtectedVaultImporterTests: XCTestCase {
         XCTAssertEqual(attempts, 1)
     }
 
+    /// A preparation whose save fails must not leave its work pending. Left
+    /// there, the retry runs against a context still holding the first
+    /// attempt's rows — and after the second failure `commit` returns with them
+    /// still attached and still eligible for the next autosave, or for any
+    /// unrelated `save()` anywhere in the app. That is work the import has
+    /// already given up on, reaching disk by a route nothing here can see.
+    func testAFailedPreparationSaveLeavesNothingPending() throws {
+        TestStore.retain(token.container)
+        var saves = 0
+        let sut = makeImporter(state: .disabled) { context in
+            saves += 1
+            // The insert's own save has to land — it is the preparation's that
+            // this test is about.
+            guard saves > 1 else { return try context.save() }
+            throw SaveFailure.refused
+        }
+
+        try sut.commit([derivableVault()], into: context, prepare: settingDefaultCoins)
+
+        XCTAssertEqual(saves, 3, "the insert's save, then the preparation's and the one retry")
+        XCTAssertFalse(context.hasChanges, "a preparation that could not be saved must leave nothing pending behind it")
+
+        try context.save()
+        XCTAssertEqual(
+            try ModelContext(token.container).fetchCount(FetchDescriptor<Coin>()), 0,
+            "an unrelated later save must not flush what the import gave up on"
+        )
+    }
+
     // MARK: - Helpers
+
+    private enum SaveFailure: Error {
+        case refused
+    }
 
     private func derivableVault(index: Int = 0) -> Vault {
         TestStore.makeDerivableVault(index: index, keyshare: firstShare)
@@ -328,10 +361,14 @@ final class ProtectedVaultImporterTests: XCTestCase {
         VaultDefaultCoinService(context: context).setDefaultCoinsOnce(vault: vault)
     }
 
-    private func makeImporter(state: KeyshareProtectionState) -> ProtectedVaultImporter {
+    private func makeImporter(
+        state: KeyshareProtectionState,
+        save: @escaping @MainActor (ModelContext) throws -> Void = { try $0.save() }
+    ) -> ProtectedVaultImporter {
         ProtectedVaultImporter(
             protector: KeyshareProtector(state: { state }),
-            coordinator: coordinator
+            coordinator: coordinator,
+            save: save
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
@@ -209,7 +209,7 @@ final class ProtectedVaultImporterTests: XCTestCase {
     /// by mutating `vault.coins` does not take on a vault that has been through
     /// a `save()`: the relationship re-faults to its persisted value and the
     /// next save writes that back over the inverse. The import reported
-    /// success, five coin rows were written belonging to nobody, and the user
+    /// success, the coin rows were written belonging to nobody, and the user
     /// opened a wallet with no chains in it.
     ///
     /// Written against the no-passcode state on purpose — that is the state
@@ -224,14 +224,14 @@ final class ProtectedVaultImporterTests: XCTestCase {
         let stored = try XCTUnwrap(try fresh.fetch(FetchDescriptor<Vault>()).first)
         XCTAssertEqual(
             Set(stored.coins.map(\.chain)),
-            Set(VaultDefaultCoinService(context: context).baseDefaultChains),
-            "an imported vault must open on the same chains a freshly generated one does"
+            Set(TestStore.derivableChains),
+            "an imported vault must come back holding every chain it can derive"
         )
         XCTAssertTrue(
             try fresh.fetch(FetchDescriptor<Coin>()).allSatisfy { $0.vault != nil },
             "no coin row may be left on disk with no vault to belong to"
         )
-        XCTAssertTrue(stored.defiChains.contains(.thorChain), "the DeFi chains derived alongside the coins must persist too")
+        XCTAssertTrue(stored.defiChains.contains(.tron), "the DeFi chains derived alongside the coins must persist too")
     }
 
     /// The same, with a passcode set: the shares take a different route to disk
@@ -244,7 +244,7 @@ final class ProtectedVaultImporterTests: XCTestCase {
 
         let fresh = ModelContext(token.container)
         let stored = try XCTUnwrap(try fresh.fetch(FetchDescriptor<Vault>()).first)
-        XCTAssertEqual(stored.coins.count, VaultDefaultCoinService(context: context).baseDefaultChains.count)
+        XCTAssertEqual(stored.coins.count, TestStore.derivableChains.count)
     }
 
     /// Every vault in a batch, not just the first — the ZIP path imports several

--- a/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/ProtectedVaultImporterTests.swift
@@ -266,10 +266,12 @@ final class ProtectedVaultImporterTests: XCTestCase {
 
     /// End to end, through the ordering that made the original failure silent.
     /// The import stores the vault, prepares it, and the preparation comes up a
-    /// chain short — Bitcoin builds, Tron cannot. What must not reach disk is a
-    /// vault holding only the chains that did build: the second pass sees coins
-    /// on it, reads that as prepared, and never looks again.
-    func testAnImportWhoseCoinsCannotAllBeBuiltStoresNoneOfThem() throws {
+    /// chain short — Bitcoin builds, Tron cannot.
+    ///
+    /// What must not happen is the retry reading the Bitcoin coin as proof the
+    /// vault is prepared and reporting a clean import. It is retried once, it
+    /// still comes up short, and it is still reported as unprepared.
+    func testAnImportWhoseCoinsCannotAllBeBuiltIsStillReportedAsUnprepared() throws {
         TestStore.retain(token.container)
         let sut = makeImporter(state: .disabled)
         let vault = derivableVault()
@@ -285,10 +287,14 @@ final class ProtectedVaultImporterTests: XCTestCase {
             return self.settingDefaultCoins(vault)
         }
 
-        XCTAssertEqual(attempts, 2, "a preparation that came up short is retried once")
+        XCTAssertEqual(attempts, 2, "a preparation that came up short is retried once, and the retry does not bless it")
         let fresh = ModelContext(token.container)
         XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Vault>()), 1, "the vault is stored and openable — this is not an import failure")
-        XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Coin>()), 0, "no half-prepared vault, and no rows belonging to nobody")
+        XCTAssertEqual(
+            try fresh.fetch(FetchDescriptor<Coin>()).map(\.chain), [.bitcoin],
+            "the chain that could be built is kept, exactly once, and belongs to the vault"
+        )
+        XCTAssertTrue(try fresh.fetch(FetchDescriptor<Coin>()).allSatisfy { $0.vault != nil })
     }
 
     /// A preparation that did not take is not a silent success. It is retried,

--- a/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
@@ -139,20 +139,44 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
     /// builds, Tron cannot, and what must not happen is a vault stored holding
     /// only Bitcoin and called done.
     func testAChainThatCouldNotBeBuiltIsReportedAsUnprepared() throws {
-        let vault = TestStore.makeDerivableVault(keyshare: share)
-        let usable = try XCTUnwrap(vault.chainPublicKeys.first).publicKeyHex
-        vault.chainPublicKeys = [
-            ChainPublicKey(chain: .bitcoin, publicKeyHex: usable, isEddsa: false),
-            ChainPublicKey(chain: .tron, publicKeyHex: "not-a-public-key", isEddsa: false)
-        ]
+        let vault = vaultWithOneChainItCannotBuild()
         context.insert(vault)
         try context.save()
 
         XCTAssertFalse(makeService().setDefaultCoinsOnce(vault: vault), "a chain that could not be built is a chain the user will not have")
         try context.save()
 
-        XCTAssertTrue(vault.coins.isEmpty, "a pass that came up short leaves the vault exactly as it was found")
-        XCTAssertEqual(try ModelContext(token.container).fetchCount(FetchDescriptor<Coin>()), 0)
+        XCTAssertEqual(
+            try storedChains(), [.bitcoin],
+            "the chain that could be built is kept — keygen ignores this answer, so undoing would cost it every chain it can derive"
+        )
+    }
+
+    /// The `coins.isEmpty` short-circuit used to answer `true` for a vault
+    /// holding any coin at all. That is what made the import's retry
+    /// meaningless: the first pass comes up a chain short, the second sees
+    /// coins on the vault and blesses it as prepared, and the reporting the
+    /// whole postcondition exists for reports nothing.
+    func testAVaultStillMissingAChainIsNotBlessedOnASecondRun() throws {
+        let vault = vaultWithOneChainItCannotBuild()
+        context.insert(vault)
+        try context.save()
+        XCTAssertFalse(makeService().setDefaultCoinsOnce(vault: vault))
+        try context.save()
+
+        XCTAssertFalse(makeService().setDefaultCoinsOnce(vault: vault), "still missing Tron, so still unprepared")
+        XCTAssertEqual(try storedChains(), [.bitcoin], "and a second run must not write a second Bitcoin beside the first")
+    }
+
+    /// The expectation is the chains the vault was asked for, so a default
+    /// chain the catalog carries no native asset for could never be satisfied.
+    /// Nothing else in the app states that correspondence, and the catalog is
+    /// edited far more often than this file is.
+    func testEveryBaseDefaultChainHasANativeAssetToBuild() {
+        let natives = Set(TokensStore.TokenSelectionAssets.filter(\.isNativeToken).map(\.chain))
+        for chain in makeService().baseDefaultChains {
+            XCTAssertTrue(natives.contains(chain), "\(chain.name) is a default chain with no native asset in the catalog")
+        }
     }
 
     /// And the degenerate case the same `allSatisfy` answered `true` for:
@@ -254,6 +278,18 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
 
     private func makeService() -> VaultDefaultCoinService {
         VaultDefaultCoinService(context: context)
+    }
+
+    /// Bitcoin builds from a usable per-chain key; Tron cannot build at all.
+    /// Both resolve to `NoTokenDiscoverer`, so the fixture stays hermetic.
+    private func vaultWithOneChainItCannotBuild() -> Vault {
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        let usable = vault.chainPublicKeys.first?.publicKeyHex ?? ""
+        vault.chainPublicKeys = [
+            ChainPublicKey(chain: .bitcoin, publicKeyHex: usable, isEddsa: false),
+            ChainPublicKey(chain: .tron, publicKeyHex: "not-a-public-key", isEddsa: false)
+        ]
+        return vault
     }
 
     private func makeService(discoveringWith recorder: DiscoveryRecorder) -> VaultDefaultCoinService {

--- a/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
@@ -128,6 +128,55 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
         XCTAssertTrue(vault.coins.isEmpty)
     }
 
+    // MARK: - A chain that could not be built
+
+    /// The half the first fix was blind to. `CoinFactory.create` throwing for
+    /// one chain used to leave that chain out of the list the postcondition was
+    /// then checked against — so a vault missing a chain reported itself fully
+    /// prepared, which is the symptom that was reported in the first place.
+    ///
+    /// One corrupt per-chain key is the narrowest way to say it: Bitcoin still
+    /// builds, Tron cannot, and what must not happen is a vault stored holding
+    /// only Bitcoin and called done.
+    func testAChainThatCouldNotBeBuiltIsReportedAsUnprepared() throws {
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        let usable = try XCTUnwrap(vault.chainPublicKeys.first).publicKeyHex
+        vault.chainPublicKeys = [
+            ChainPublicKey(chain: .bitcoin, publicKeyHex: usable, isEddsa: false),
+            ChainPublicKey(chain: .tron, publicKeyHex: "not-a-public-key", isEddsa: false)
+        ]
+        context.insert(vault)
+        try context.save()
+
+        XCTAssertFalse(makeService().setDefaultCoinsOnce(vault: vault), "a chain that could not be built is a chain the user will not have")
+        try context.save()
+
+        XCTAssertTrue(vault.coins.isEmpty, "a pass that came up short leaves the vault exactly as it was found")
+        XCTAssertEqual(try ModelContext(token.container).fetchCount(FetchDescriptor<Coin>()), 0)
+    }
+
+    /// And the degenerate case the same `allSatisfy` answered `true` for:
+    /// nothing built at all. An empty list satisfies every postcondition, so the
+    /// check passed at exactly the moment there was nothing to check.
+    func testAVaultNothingCouldBeBuiltForIsReportedAsUnprepared() throws {
+        let vault = Vault(
+            name: "Unusable keys",
+            signers: [],
+            pubKeyECDSA: "not-a-public-key",
+            pubKeyEdDSA: "not-a-public-key-either",
+            keyshares: [],
+            localPartyID: "party",
+            hexChainCode: "not-a-chain-code",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        context.insert(vault)
+        try context.save()
+
+        XCTAssertFalse(makeService().setDefaultCoinsOnce(vault: vault), "no chains at all is the failure being reported, not a vacuous success")
+        XCTAssertTrue(vault.coins.isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func makeService() -> VaultDefaultCoinService {

--- a/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
@@ -177,15 +177,108 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
         XCTAssertTrue(vault.coins.isEmpty)
     }
 
+    // MARK: - When token discovery is allowed to run
+
+    /// The point of the split. Discovery is network work that outlives the call
+    /// and writes on its own; started while the vault is only *attached* it can
+    /// come back and persist one whose save failed. So the pass records, the
+    /// caller starts — and only once its save has landed.
+    func testDiscoveryRunsForEveryCoinThePassAttached() async throws {
+        let recorder = DiscoveryRecorder()
+        let service = makeService(discoveringWith: recorder)
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        context.insert(vault)
+        try context.save()
+
+        XCTAssertTrue(service.setDefaultCoinsOnce(vault: vault))
+        try context.save()
+        await service.startTokenDiscovery().value
+
+        XCTAssertEqual(Set(recorder.chains), Set(TestStore.derivableChains))
+    }
+
+    /// Started twice, it does not do the same round trip twice.
+    func testDiscoveryIsNotStartedAgainForCoinsItAlreadyCovered() async throws {
+        let recorder = DiscoveryRecorder()
+        let service = makeService(discoveringWith: recorder)
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        context.insert(vault)
+        try context.save()
+        service.setDefaultCoinsOnce(vault: vault)
+        try context.save()
+
+        await service.startTokenDiscovery().value
+        await service.startTokenDiscovery().value
+
+        XCTAssertEqual(recorder.chains.count, TestStore.derivableChains.count)
+    }
+
+    /// The withdrawal case, which is what a failed preparation save leaves
+    /// behind: the coins were attached, the save did not take, and the context
+    /// took them back. Discovery must not write against them — writing is what
+    /// would persist a vault the import gave up on.
+    func testDiscoveryDoesNotRunForCoinsAFailedSaveTookBack() async throws {
+        let recorder = DiscoveryRecorder()
+        let service = makeService(discoveringWith: recorder)
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        context.insert(vault)
+        try context.save()
+        service.setDefaultCoinsOnce(vault: vault)
+
+        context.rollback()
+        await service.startTokenDiscovery().value
+
+        XCTAssertTrue(recorder.chains.isEmpty, "the coins are not stored, so there is nothing to discover against")
+    }
+
+    /// And the case that traps rather than merely writing: the vault is gone by
+    /// the time discovery gets to run. Nothing live is carried across that gap,
+    /// so what is left is a lookup that finds nothing.
+    func testDiscoveryDoesNotRunForAVaultThatIsNoLongerStored() async throws {
+        let recorder = DiscoveryRecorder()
+        let service = makeService(discoveringWith: recorder)
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        context.insert(vault)
+        try context.save()
+        service.setDefaultCoinsOnce(vault: vault)
+        try context.save()
+
+        context.delete(vault)
+        try context.save()
+        await service.startTokenDiscovery().value
+
+        XCTAssertTrue(recorder.chains.isEmpty, "a deleted vault must not be written back to")
+    }
+
     // MARK: - Helpers
 
     private func makeService() -> VaultDefaultCoinService {
         VaultDefaultCoinService(context: context)
     }
 
+    private func makeService(discoveringWith recorder: DiscoveryRecorder) -> VaultDefaultCoinService {
+        VaultDefaultCoinService(context: context) { coin, vault in
+            recorder.record(coin, vault)
+        }
+    }
+
     /// Read back through a context that never saw the in-memory objects, so an
     /// unsaved relationship cannot answer for a saved one.
     private func storedChains() throws -> [Chain] {
         try ModelContext(token.container).fetch(FetchDescriptor<Vault>()).flatMap(\.coins).map(\.chain)
+    }
+}
+
+/// Stands in for the discovery that in production goes to the network and
+/// writes what it finds, so the tests can assert on *whether* it was asked to
+/// run rather than on what it found.
+@MainActor
+private final class DiscoveryRecorder {
+    private(set) var calls: [(chain: Chain, vaultName: String)] = []
+
+    var chains: [Chain] { calls.map(\.chain) }
+
+    func record(_ coin: Coin, _ vault: Vault) {
+        calls.append((coin.chain, vault.name))
     }
 }

--- a/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
@@ -12,7 +12,7 @@ import XCTest
 /// prepares one that has already been inserted *and saved*. Those are not the
 /// same thing to SwiftData, and the difference is where a real regression lived
 /// — attaching a coin by appending to `vault.coins` does not register on a vault
-/// that has been through a `save()`, so an import wrote five coin rows belonging
+/// that has been through a `save()`, so an import wrote its coin rows belonging
 /// to nobody and the wallet came up with no chains in it and no error anywhere.
 ///
 /// So both orders are pinned here, not just the one a given caller uses today.
@@ -50,7 +50,7 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
 
         context.insert(vault)
         try context.save()
-        XCTAssertEqual(Set(try storedChains()), Set(makeService().baseDefaultChains))
+        XCTAssertEqual(Set(try storedChains()), Set(TestStore.derivableChains))
     }
 
     /// The import's order: the vault is already on disk when it is prepared.
@@ -63,7 +63,7 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
         XCTAssertTrue(makeService().setDefaultCoinsOnce(vault: vault))
         try context.save()
 
-        XCTAssertEqual(Set(try storedChains()), Set(makeService().baseDefaultChains))
+        XCTAssertEqual(Set(try storedChains()), Set(TestStore.derivableChains))
     }
 
     /// The half that made the failure silent rather than merely wrong: the coin
@@ -94,7 +94,7 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
 
         let fresh = ModelContext(token.container)
         let stored = try XCTUnwrap(try fresh.fetch(FetchDescriptor<Vault>()).first)
-        XCTAssertTrue(stored.defiChains.contains(.thorChain))
+        XCTAssertTrue(stored.defiChains.contains(.tron))
     }
 
     // MARK: - What "prepared" means

--- a/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
@@ -1,0 +1,142 @@
+//
+//  VaultDefaultCoinServiceTests.swift
+//  VultisigAppTests
+//
+
+import SwiftData
+import XCTest
+@testable import VultisigApp
+
+/// The service has two callers, and they hand it a vault in two different
+/// states: keygen prepares one that has never been inserted, the backup import
+/// prepares one that has already been inserted *and saved*. Those are not the
+/// same thing to SwiftData, and the difference is where a real regression lived
+/// — attaching a coin by appending to `vault.coins` does not register on a vault
+/// that has been through a `save()`, so an import wrote five coin rows belonging
+/// to nobody and the wallet came up with no chains in it and no error anywhere.
+///
+/// So both orders are pinned here, not just the one a given caller uses today.
+@MainActor
+final class VaultDefaultCoinServiceTests: XCTestCase {
+
+    private var token: TestContextToken!
+    private var context: ModelContext!
+
+    private let share = "eyJrZXlzaGFyZSI6ImRrbHMifQ=="
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        token = try TestStore.installInMemoryContainer()
+        context = token.container.mainContext
+        // `setDefaultCoins` starts a token-discovery `Task` per coin that
+        // outlives the test method and touches the models it captured.
+        TestStore.retain(token.container)
+    }
+
+    override func tearDown() {
+        context = nil
+        TestStore.restore(token)
+        token = nil
+        super.tearDown()
+    }
+
+    // MARK: - Both orders
+
+    /// Keygen's order: the vault is prepared before it ever reaches the context.
+    func testAVaultThatHasNotBeenInsertedGetsItsDefaultCoins() throws {
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+
+        XCTAssertTrue(makeService().setDefaultCoinsOnce(vault: vault))
+
+        context.insert(vault)
+        try context.save()
+        XCTAssertEqual(Set(try storedChains()), Set(makeService().baseDefaultChains))
+    }
+
+    /// The import's order: the vault is already on disk when it is prepared.
+    /// This is the one that broke.
+    func testAVaultThatHasAlreadyBeenSavedGetsItsDefaultCoins() throws {
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        context.insert(vault)
+        try context.save()
+
+        XCTAssertTrue(makeService().setDefaultCoinsOnce(vault: vault))
+        try context.save()
+
+        XCTAssertEqual(Set(try storedChains()), Set(makeService().baseDefaultChains))
+    }
+
+    /// The half that made the failure silent rather than merely wrong: the coin
+    /// rows were written either way, so counting them proved nothing. What was
+    /// lost was which vault they belonged to.
+    func testNoCoinIsLeftWithNoVaultToBelongTo() throws {
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        context.insert(vault)
+        try context.save()
+
+        makeService().setDefaultCoinsOnce(vault: vault)
+        try context.save()
+
+        let fresh = ModelContext(token.container)
+        let coins = try fresh.fetch(FetchDescriptor<Coin>())
+        XCTAssertFalse(coins.isEmpty)
+        XCTAssertTrue(coins.allSatisfy { $0.vault != nil })
+    }
+
+    /// The DeFi chains are derived in the same pass and have to survive it too.
+    func testTheDefiChainsDerivedAlongsideTheCoinsPersist() throws {
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        context.insert(vault)
+        try context.save()
+
+        makeService().setDefaultCoinsOnce(vault: vault)
+        try context.save()
+
+        let fresh = ModelContext(token.container)
+        let stored = try XCTUnwrap(try fresh.fetch(FetchDescriptor<Vault>()).first)
+        XCTAssertTrue(stored.defiChains.contains(.thorChain))
+    }
+
+    // MARK: - What "prepared" means
+
+    /// Re-runnable by design, and the import relies on that to retry: a vault
+    /// that already has coins is left exactly as it is.
+    func testAVaultThatAlreadyHasCoinsIsLeftAlone() throws {
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        context.insert(vault)
+        try context.save()
+        makeService().setDefaultCoinsOnce(vault: vault)
+        try context.save()
+        let after = try storedChains().count
+
+        XCTAssertTrue(makeService().setDefaultCoinsOnce(vault: vault))
+        try context.save()
+
+        XCTAssertEqual(try storedChains().count, after, "a second run must not duplicate what the first one wrote")
+    }
+
+    /// A legacy key-import vault predates `chainPublicKeys`, so there is nothing
+    /// to derive for it. Nothing to derive is not a failure to derive — reading
+    /// it as one would report every such import as broken.
+    func testAVaultWithNothingToDeriveIsNotReportedAsUnprepared() throws {
+        let vault = Vault(name: "Legacy KeyImport", libType: .KeyImport)
+        vault.chainPublicKeys = []
+        context.insert(vault)
+        try context.save()
+
+        XCTAssertTrue(makeService().setDefaultCoinsOnce(vault: vault))
+        XCTAssertTrue(vault.coins.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func makeService() -> VaultDefaultCoinService {
+        VaultDefaultCoinService(context: context)
+    }
+
+    /// Read back through a context that never saw the in-memory objects, so an
+    /// unsaved relationship cannot answer for a saved one.
+    private func storedChains() throws -> [Chain] {
+        try ModelContext(token.container).fetch(FetchDescriptor<Vault>()).flatMap(\.coins).map(\.chain)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift
@@ -28,8 +28,8 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
         try super.setUpWithError()
         token = try TestStore.installInMemoryContainer()
         context = token.container.mainContext
-        // `setDefaultCoins` starts a token-discovery `Task` per coin that
-        // outlives the test method and touches the models it captured.
+        // `startTokenDiscovery()` hands out a `Task` that can outlive the test
+        // method and touch the models it resolved.
         TestStore.retain(token.container)
     }
 
@@ -168,8 +168,8 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
         XCTAssertEqual(try storedChains(), [.bitcoin], "and a second run must not write a second Bitcoin beside the first")
     }
 
-    /// The expectation is the chains the vault was asked for, so a default
-    /// chain the catalog carries no native asset for could never be satisfied.
+    /// A default chain the catalog carries no native asset for could never be
+    /// satisfied, so the five this app chooses for itself have to be covered.
     /// Nothing else in the app states that correspondence, and the catalog is
     /// edited far more often than this file is.
     func testEveryBaseDefaultChainHasANativeAssetToBuild() {
@@ -177,6 +177,31 @@ final class VaultDefaultCoinServiceTests: XCTestCase {
         for chain in makeService().baseDefaultChains {
             XCTAssertTrue(natives.contains(chain), "\(chain.name) is a default chain with no native asset in the catalog")
         }
+    }
+
+    /// The other half of that, and the reason the expectation is not simply the
+    /// chains asked for. A key-import vault's chains are the user's selection,
+    /// and `ethereumSepolia` is offered in that picker while having no native
+    /// asset in the catalog at all — so this device has nothing to build for it.
+    /// Nothing to build is not a failure to build; counting it as one would
+    /// report every Sepolia import as broken, forever, with no action available.
+    func testAChainWithNothingInTheCatalogToBuildIsNotCountedAsAFailure() throws {
+        let vault = TestStore.makeDerivableVault(keyshare: share)
+        let usable = try XCTUnwrap(vault.chainPublicKeys.first).publicKeyHex
+        vault.chainPublicKeys = [
+            ChainPublicKey(chain: .bitcoin, publicKeyHex: usable, isEddsa: false),
+            ChainPublicKey(chain: .ethereumSepolia, publicKeyHex: usable, isEddsa: false)
+        ]
+        context.insert(vault)
+        try context.save()
+
+        XCTAssertTrue(
+            makeService().setDefaultCoinsOnce(vault: vault),
+            "a chain the catalog cannot build is not a chain this pass failed to build"
+        )
+        try context.save()
+
+        XCTAssertEqual(try storedChains(), [.bitcoin])
     }
 
     /// And the degenerate case the same `allSatisfy` answered `true` for:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# In-repo documentation
+
+Long-form notes for subsystems whose reasoning does not fit in code comments —
+ordering constraints, rejected alternatives, and the failure each guard exists to
+prevent. Written for whoever changes the code next, human or agent.
+
+One folder per subsystem. Code comments stay the source of truth for *what a type
+does*; these pages carry the *why* that spans several types.
+
+| Folder | Subsystem |
+|---|---|
+| [`passcode-keyshare-encryption/`](passcode-keyshare-encryption/overview.md) | The app passcode and at-rest encryption of key shares. Read before touching anything under `Core/Security/Keyshare/` or `Core/Security/Passcode/`. |
+
+These files are outside the XcodeGen source globs in `VultisigApp/project.yml`
+(which scan `VultisigApp/` only), so adding a page here never needs
+`make generate`.

--- a/docs/passcode-keyshare-encryption/concurrency-and-leases.md
+++ b/docs/passcode-keyshare-encryption/concurrency-and-leases.md
@@ -1,0 +1,181 @@
+# Concurrency and the write coordinator
+
+`KeyshareWriteCoordinator` exists because the invariant — *a share is sealed iff
+a passcode is set* — is a statement about the whole store, and a passcode
+transition rewrites the whole store while other code is writing shares into it.
+
+## The two races it closes
+
+### 1. Two transitions interleaving
+
+`PasscodeService` is an `actor`, and **actors are reentrant at every `await`**.
+`setPasscode` suspends inside `keyStore.wrap` for roughly half a second of
+PBKDF2. Two calls can both clear `guard !isSet`, both mint a key, and interleave
+their store / adopt / sweep steps — leaving shares sealed under a key the
+surviving wrapper does not wrap. `changePasscode` and `disablePasscode`
+interleave the same way.
+
+Being an actor is necessary (it serializes the read-modify-write over the
+attempt limiter's Keychain state) but nowhere near sufficient.
+
+### 2. A share computed under one protection state, persisted under another
+
+`LocalStateAccessorImpl.saveLocalState` is a **synchronous callback the TSS layer
+makes from an arbitrary thread**. It seals a share the moment TSS hands it over.
+If the seal and the store are not one indivisible span:
+
+| Interleaving | Result |
+|---|---|
+| seal at `.disabled` → sweep runs → append | plaintext share in a passcode-protected store. Invariant broken, silently |
+| seal under the key during a disable → wrapper deleted → append | **sealed share, key gone, permanently unreadable** |
+
+The second is genuine fund loss. An earlier version of the design claimed "there
+is no window that silently writes an unsealed share" on the grounds that `seal`
+throws in `.locked`. That is false: the `.locked` branch only covers a call that
+*enters* `seal` during the window. It does nothing for a callback that sealed
+earlier and persists later.
+
+There is a third shape of the same race with a much longer lifetime: TSS produces
+a share, and `KeygenViewModel` persists it at `commitVault` — which, on the
+deferred path, is the user tapping "Looks Good" on the review screen, possibly
+minutes later. A passcode set landing in that interval sweeps a store that does
+not yet contain the share, and the share is then inserted in plaintext behind a
+live passcode.
+
+## Why `NSLock` and not `@MainActor`, and not an actor
+
+An earlier revision proposed a `@MainActor` flag plus an in-flight-write counter.
+**Both halves could not work**, and the review that killed them is worth not
+repeating:
+
+- `saveLocalState` is *synchronous*. Reaching a main-actor lease from it needs
+  either a `Task` hop — which puts the seal outside the span that is the entire
+  point — or `DispatchQueue.main.sync`, which **deadlocks** whenever the callback
+  already runs on main.
+- a per-write counter does not cover the TSS-produces → `commitVault`-persists
+  interval at all.
+
+So the coordinator is an `NSLock`-backed class with **no suspension points**,
+callable synchronously from any thread — the same shape `KeyshareKeySession`
+already uses successfully on this exact call path. It is deliberately not
+`@MainActor` and deliberately not an `actor`. Do not "modernize" it.
+
+## The three lease levels
+
+Three hazards, three lifetimes, three levels:
+
+| Lease | Taken by | Span | Prevents |
+|---|---|---|---|
+| `TransitionLease` | `setPasscode`, `changePasscode`, `disablePasscode`, `KeyshareInstallReconciler.reconcile` | one whole transition, claimed **before the first `await`** | two transitions interleaving across key derivation |
+| `WriteLease` (`withWriteLease` / `beginWrite`) | `LocalStateAccessorImpl.saveLocalState`, `KeygenViewModel.commitVault`, `unlockApp`, `unlockWithBiometrics`, `enableBiometricUnlock`, `disableBiometricUnlock` | one seal **and** its persistence | a value sealed under one state being stored under another |
+| `EpisodeLease` | `KeygenViewModel.startKeygen`, `ProtectedVaultImporter.commit` | a whole keygen / reshare / import, start through commit **or** discard | a share produced before a transition and committed after it |
+
+Exclusion matrix — this is the whole semantics:
+
+```
+                    can start while ...
+                    transition   write     episode
+                    held?        in flight? open?
+  transition          NO           NO        NO
+  write               NO           yes       yes
+  episode             NO           yes       yes
+```
+
+A transition is exclusive against everything. Writes and episodes do not exclude
+each other, so ordinary vault creation is never serialized against itself.
+
+Contention is reported as `.busy`, **not queued**. A passcode toggle that waits
+silently for a keygen to finish looks like a hang; "finish creating your vault
+first" is the honest version of the guarantee, and the alternative is a lock-free
+protocol nobody can review.
+
+## Leases release on `deinit`
+
+`KeyshareLease` releases on `deinit` as well as on `end(_:)`, and releasing twice
+is a no-op. That is not tidiness — an episode brackets a flow with a great many
+error and cancellation paths, and **a leaked lease blocks every passcode change
+until the app is relaunched**. Holding the token in a `defer`, or in a property
+that goes away with the flow, is therefore enough.
+
+`NSLock` is not recursive and `release()` reaches back into the coordinator, so
+every coordinator lock is dropped before bodies and release callbacks run, and
+the lease's own lock is dropped before it calls back. There are regression tests
+named for exactly this (a lease deallocated inside a write body; an episode
+deallocated while a write runs). If you refactor the locking, run them.
+
+## The app unlock takes a WRITE lease, not a transition lease
+
+This is the single most important thing on this page to not undo.
+
+`beginTransition()` is refused while an **episode** is open, and
+`KeygenViewModel` deliberately holds one through the deferred "Looks Good"
+commit. If the app unlock took a transition lease, an app that auto-locked while
+sitting on the review screen **could never be opened again**: the keygen flow
+cannot be finished without unlocking, and unlocking could not happen while the
+flow is open. Permanent, user-visible, and it costs the user the vault they just
+created.
+
+`beginWrite()` is the same accounting `withWriteLease` uses, exposed as a token
+an `async` caller can hold across an `await`. It excludes set / change / disable
+— which is all an unlock actually needs — and is refused by no episode. Both
+`unlockApp` and `unlockWithBiometrics` use it, for exactly this reason.
+
+Consequence for copy: on the lock screen, `.busy` means *another unlock or a
+transition*, never "a vault is being created". The string is worded to be true on
+every path rather than actionable on one.
+
+## What the coordinator does NOT protect
+
+`PasscodeService.lock()` is `nonisolated` and stays **outside** the coordinator
+on purpose: a background scene-phase lock must never block on a transition, and
+it must never be undone by one. It is synchronized only through
+`KeyshareKeySession`'s own lock.
+
+Winning is therefore arranged by generation counting, not by mutual exclusion.
+Every operation that will adopt a key captures `session.currentGeneration` as
+close to its **first instruction** as possible, and adopts via
+`adopt(_:ifGeneration:)`. `lock()` bumps the generation, so a lock that landed
+mid-derivation makes the adopt fail and the operation throws `.cancelledByLock`.
+
+That capture placement is a real bug that was caught: reading the generation
+after the first `await` (the sealed-share scan) let a `lock()` landing during the
+scan be silently undone, leaving the key live in memory behind a lock screen.
+**If you add a statement above the generation capture in `setPasscode` or
+`unlock`, you are widening that window.** The residual window — a `lock()`
+between the call and that first instruction — is one instruction wide and is
+accepted, not closed; closing it would require `lock()` to synchronize with the
+actor, which the design rules out.
+
+## What the coordinator also does not cover: overlapping unlocks
+
+Because write leases do not exclude each other, two app unlocks can overlap. Two
+actor-isolated flags close that, each read and set **with no `await` between
+them** (which is what makes them atomic inside the actor):
+
+- `isAppUnlockInFlight`, around `unlockApp` and `unlockWithBiometrics`. Without
+  it, a slower unlock's post-sweep generation check can clear a faster one's
+  perfectly good session.
+- `isVerifyingPasscode`, around `unlock(with:)`. Without it, overlapping attempts
+  all clear the attempt limiter's lockout check *before any of them records a
+  failure* — a burst of guesses collapsing into one counted failure, i.e. the
+  brute-force throttle switching itself off exactly when it is under attack.
+  This one covers every caller, including the change flow's verification.
+
+## Sequence: a TSS write versus a disable
+
+```
+  TSS thread                  coordinator            main actor (disable)
+  ──────────                  ───────────            ────────────────────
+  withWriteLease {                                   beginTransition()
+      seal(share)  ────────►  writesInFlight = 1 ──►  refused: .busy
+      append                                          (user retries)
+  }                ────────►  writesInFlight = 0
+                                                     beginTransition() ✓
+                              transition held  ───►  unseal all, delete wrapper
+  withWriteLease {  ───────►  refused: .busy
+      ...
+```
+
+Either order is safe. What is *not* safe, and is what the lease makes
+unreachable, is the seal landing on one side of the transition and the append on
+the other.

--- a/docs/passcode-keyshare-encryption/concurrency-and-leases.md
+++ b/docs/passcode-keyshare-encryption/concurrency-and-leases.md
@@ -67,8 +67,21 @@ Three hazards, three lifetimes, three levels:
 | Lease | Taken by | Span | Prevents |
 |---|---|---|---|
 | `TransitionLease` | `setPasscode`, `changePasscode`, `disablePasscode`, `KeyshareInstallReconciler.reconcile` | one whole transition, claimed **before the first `await`** | two transitions interleaving across key derivation |
-| `WriteLease` (`withWriteLease` / `beginWrite`) | `LocalStateAccessorImpl.saveLocalState`, `KeygenViewModel.commitVault`, `unlockApp`, `unlockWithBiometrics`, `enableBiometricUnlock`, `disableBiometricUnlock` | one seal **and** its persistence | a value sealed under one state being stored under another |
+| `WriteLease` (`withWriteLease` / `beginWrite`) | see the per-caller table below | one span that a transition must not split | a transition landing in the middle of a multi-step write |
 | `EpisodeLease` | `KeygenViewModel.startKeygen`, `ProtectedVaultImporter.commit` | a whole keygen / reshare / import, start through commit **or** discard | a share produced before a transition and committed after it |
+
+**A write lease does not mean "one seal and its persistence".** That is only the
+`saveLocalState` case. What the lease actually guarantees is narrower and
+uniform: *no passcode transition begins or completes inside this span.* What the
+span contains differs per caller, and conflating them hides which invariant each
+one is buying:
+
+| Caller | What the span actually covers | What a transition splitting it would do |
+|---|---|---|
+| `LocalStateAccessorImpl.saveLocalState` | seal a share **and** append it to the in-memory array | seal under one protection state, persist under another |
+| `KeygenViewModel.commitVault` | insert **and** `save()` shares sealed earlier in the episode | commit shares the sweep never saw |
+| `PasscodeService.unlockApp` / `unlockWithBiometrics` | verify or biometric-match, adopt the key, **and** run the resume sweep | a disable deleting the wrapper mid-unlock, or a sweep racing a transition |
+| `enableBiometricUnlock` / `disableBiometricUnlock` | write or delete the biometric copy only — no share is touched | a copy created just after a disable removed it, i.e. the orphan the binding exists to catch |
 
 Exclusion matrix — this is the whole semantics:
 

--- a/docs/passcode-keyshare-encryption/invariants.md
+++ b/docs/passcode-keyshare-encryption/invariants.md
@@ -236,7 +236,7 @@ in passing without reading the tradeoff.
   another flow's pending work.** SwiftData has no scoped save. The alternatives
   are refusing the import whenever anyone has unsaved work — which the lease
   placement deliberately rejected — or nothing. The *failure* path does preserve
-  foreign work: `context.hasChanges` is sampled on entry, and a save failure
+  foreign work: `context.hasChanges` is sampled before anything is inserted, and a save failure
   rolls back only if the context was clean, otherwise it withdraws just the
   imported vaults one by one.
 

--- a/docs/passcode-keyshare-encryption/invariants.md
+++ b/docs/passcode-keyshare-encryption/invariants.md
@@ -136,6 +136,7 @@ explicitly, and the deliberate collapses all go through the conspicuously named
 | reconciler: store occupancy | **defer the clear**, marker unset (alignment still runs) | set a permanent marker on a guess, keeping a previous install's wrapper forever |
 | reconciler: inherited material | **defer the clear**, marker unset (alignment still runs) | issue launch-time Keychain deletes on a first-ever install whose Keychain stuttered |
 | reconciler: lock-mode alignment | **move nothing** | raise a gate with nothing behind it, or take a real gate down |
+| `isPasscodeGateRequired` — every overlay decision | **gate required** | take a real lock screen down over a Keychain that merely went quiet |
 | `PasscodeAttemptLimiter.loadState` | **no record** ← the one exception | put a permanent, undecayable lockout in front of a passcode the user knows |
 
 That last row is the deliberate exception and it is argued at the call site.
@@ -180,6 +181,8 @@ switch over the cases.
 | let `BiometricKeychain.store` delete-then-add in one place with one query | `SecItemDelete` takes a *search* query; the full add dictionary matches nothing and the add answers `errSecDuplicateItem`, silently breaking rebinding after a passcode change |
 | collapse `BiometricUnlockError.malformedCopy` into `.failed` | `.failed` also covers "the face did not match", which the UI stays silent about — so a *successful* Face ID would appear to do nothing while silently disabling the shortcut |
 | have `KeyshareInstallReconciler` skip taking the transition lease (it only runs at launch) | a launch landing between `setPasscode` verifying its wrapper and adopting the key deletes that wrapper **and marks the container done** |
+| raise or lower the overlay from `AppLockService.mode` instead of `isPasscodeGateRequired` | the mode is `UserDefaults` and the wrapper is Keychain; a completed disable moves them at different moments. Reading the mode leaves a lock screen standing with nothing that can dismiss it — see [transitions](transitions.md#the-gate-is-derived-never-cached) |
+| cache the gate predicate in a `@Published` flag and update it on transitions | the transitions that matter run while the overlay is already up, from a `nonisolated` `lock()` that synchronizes with nothing. Re-deriving is the only shape that cannot go stale |
 | wire the lock screen to `PasscodeService.unlock(with:)` | see below — there is **no compile-time forcing function** for this one |
 
 ### The one with no forcing function

--- a/docs/passcode-keyshare-encryption/invariants.md
+++ b/docs/passcode-keyshare-encryption/invariants.md
@@ -468,9 +468,9 @@ Check that explicitly; a test that passes both ways is documenting nothing.
 3. Ask what a crash immediately after your new statement leaves on disk, and
    which existing repair path finds it.
 4. If you touched ordering, re-read [the table above](#ordering-constraints--do-not-reorder-these).
-5. Run the full `VultisigAppTests/Security/` and `VultisigAppTests/Storage/`
-   suites, not a subset — plus
-   `VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift` if you touched
-   what the import hands to `prepare:`.
+5. Run the full `VultisigApp/VultisigAppTests/Security/` and
+   `VultisigApp/VultisigAppTests/Storage/` suites, not a subset — plus
+   `VultisigApp/VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift` if
+   you touched what the import hands to `prepare:`.
 6. If you added a `PasscodeError` case, follow the exhaustive switch the
    compiler points you at rather than defaulting it.

--- a/docs/passcode-keyshare-encryption/invariants.md
+++ b/docs/passcode-keyshare-encryption/invariants.md
@@ -6,8 +6,15 @@ you are about to change something here, find it below first.
 
 ## Rule zero
 
-> A key share that cannot be opened is a vault that can never sign again. There
-> is no server copy. There is no support ticket that fixes it.
+> A key share that cannot be opened is one this device can never sign with
+> again. There is no server copy and no support ticket that fixes it — recovery
+> depends entirely on the user having a `.vult` backup, or on the vault's other
+> signers still reaching its threshold without this device.
+
+`Vault.getThreshold()` is `ceil(signers × 2/3) − 1`, so a share loss is not
+automatically fatal to the vault — but it is entirely outside this code's
+control whether it is. Treat "the share becomes unopenable" as unrecoverable
+here, because from inside `Core/Security/` it is.
 
 Every guard in `Core/Security/Keyshare/` is there to make a specific unopenable
 state unreachable. "This check looks redundant" is almost always the sound of a
@@ -126,8 +133,8 @@ explicitly, and the deliberate collapses all go through the conspicuously named
 | `unlockWithBiometrics`' wrapper read | `.storageFailure` | leave nothing to check the bound copy against |
 | `storeWrappedDataKey` read-back | **write failed** | record an unverified write as durable, then seal against it |
 | `deleteWrappedDataKey` read-back | **delete failed** | record a removal as done and never retry it |
-| reconciler: store occupancy | **defer the pass** | set a permanent marker on a guess, keeping a previous install's wrapper forever |
-| reconciler: inherited material | **defer the pass** | issue launch-time Keychain deletes on a first-ever install whose Keychain stuttered |
+| reconciler: store occupancy | **defer the clear**, marker unset (alignment still runs) | set a permanent marker on a guess, keeping a previous install's wrapper forever |
+| reconciler: inherited material | **defer the clear**, marker unset (alignment still runs) | issue launch-time Keychain deletes on a first-ever install whose Keychain stuttered |
 | reconciler: lock-mode alignment | **move nothing** | raise a gate with nothing behind it, or take a real gate down |
 | `PasscodeAttemptLimiter.loadState` | **no record** ← the one exception | put a permanent, undecayable lockout in front of a passcode the user knows |
 

--- a/docs/passcode-keyshare-encryption/invariants.md
+++ b/docs/passcode-keyshare-encryption/invariants.md
@@ -114,7 +114,7 @@ Two alternatives were proposed and both rejected:
 | the wrapper is re-stored **before** anything is resealed in the disable rollback | ciphertext whose only key is in memory, destroyed by the next lock |
 | `session.currentGeneration` is captured as the **first instruction** of `setPasscode` and `unlock` | a background `lock()` silently undone; the key stays live behind a lock screen |
 | reconciliation runs **synchronously first** inside `restorePasscodeLockOnLaunch` | the gate chosen from a mode reconciliation is about to change; app sits open all session with a wrapped key and no lock screen |
-| `prepare:` in `ProtectedVaultImporter.commit` runs **after** the save, inside the lease | a preparation whose own save fails could no longer be undone. `rollback()` is safe there *only* because the insert's save has already flushed whatever the context was carrying, so everything still pending is provably `prepare`'s — see [below](#the-write-that-did-not-take). Ahead of that save, undoing a failed preparation either discards another flow's uncommitted work or leaves its rows pending, and pending rows reach disk through the next autosave or any unrelated `save()` |
+| `prepare:` in `ProtectedVaultImporter.commit` runs **after** the save, inside the lease | a preparation whose own save fails could no longer be taken back. `rollback()` undoes it there *only* because the insert's save has already flushed whatever the context was carrying and nothing suspends in between, so everything still pending is provably `prepare`'s — see [below](#the-write-that-did-not-take). Ahead of that save the same call would discard another flow's uncommitted work, `commit` cannot enumerate what an arbitrary `prepare` wrote in order to withdraw it row by row, and leaving it pending reaches disk anyway through the next autosave or any unrelated `save()` |
 
 ---
 
@@ -151,10 +151,13 @@ it is the caller that reaches the trap.
 `prepare` answers `Bool` and `commit` **checks the answer**, in addition to
 catching a throwing save. That is the whole point: in the failure above the save
 *succeeded* and stored nothing, so an error-only guard saw a clean import and
-said nothing. Nothing else rebuilds what the preparation writes — default coins
-are set at keygen and at import and nowhere else — so a vault that leaves
-`commit` unprepared is one the user opens missing chains, with no error, for
-good.
+said nothing. And nothing rebuilds what the preparation writes **automatically**
+— default coins are set at keygen and at import and nowhere else — so a vault
+that leaves `commit` unprepared is one the user opens missing chains, with no
+error, indefinitely. Manage Chains can add one back by hand, but only for a
+vault type that allows it (`Vault.canCustomizeChains` is false for key-import
+vaults) and only by a user who has worked out that something is missing, which
+nothing tells them.
 
 An unprepared vault is put through the idempotent preparation once more, and
 reported if it is still unprepared. It is not thrown: the vault is stored and
@@ -183,10 +186,17 @@ computing it were not:
 case that exists: it suspends on the network and then writes through
 `Storage.shared`, so started from inside the preparation it can come back and
 persist a vault whose save failed and which the caller has already withdrawn.
-The preparation records value identifiers only — a vault's public key and a coin
-id — and every caller starts `startTokenDiscovery()` after **its own** save has
-landed, which re-resolves each coin through its vault and skips the ones the
-store no longer holds that way.
+The preparation therefore records value identifiers only — a vault's public key
+and a coin id — and the caller starts `startTokenDiscovery()` afterwards: keygen
+once its own save has landed, the import once `commit` has returned.
+
+`commit` returning is **not** proof that the preparation's save landed — it
+returns normally after a preparation that failed twice and was rolled back — so
+the identifiers are what makes that safe rather than the ordering. Each coin is
+looked up again through its vault immediately before its own discovery runs, and
+one the store no longer holds that way is skipped. Hand a live `Coin` or `Vault`
+across that gap instead and the rolled-back case is not a skipped lookup but a
+detached model, which traps on the first property read.
 
 ---
 
@@ -349,11 +359,11 @@ in passing without reading the tradeoff.
   blocks every passcode change until relaunch.
 
 - **`ProtectedVaultImporter`'s lease brackets normalize → insert → save →
-  prepare, not decode → insert → save.** Decode and commit are separated by a modal password
-  prompt on the multi-file path, and a lease held across a modal leaks when the
-  user walks away. Re-normalizing at commit under the lease gives the same
-  guarantee. The cost is a narrow liveness case: a decode that seals, followed by
-  a disable, refuses the import until the user retries.
+  prepare, not decode → insert → save.** Decode and commit are separated by a
+  modal password prompt on the multi-file path, and a lease held across a modal
+  leaks when the user walks away. Re-normalizing at commit under the lease gives
+  the same guarantee. The cost is a narrow liveness case: a decode that seals,
+  followed by a disable, refuses the import until the user retries.
 
 - **No recovery path exists for stores sealed by the superseded always-encrypted
   design** (which kept a clear data key in the Keychain). Nothing shipped in that
@@ -370,7 +380,8 @@ in passing without reading the tradeoff.
 
 **Pre-existing. Not introduced by the passcode work, and not fixed by it.** It is
 recorded here because this is where the next person reading the import path will
-be, and because its consequence is the one this whole feature exists to prevent.
+be, and because its end state is the one [rule zero](#rule-zero) is about: a
+share this device can never sign with again.
 
 > An imported vault that collides with a stored one on a **single** unique
 > attribute — or on nothing but its **name** — replaces it, key shares included.
@@ -427,9 +438,9 @@ Each of these is over-specified because the plain version was written first and
   three assertions pass over one vault → fixtures assert their own row count;
 - an assertion on a `@Model` object the test is still holding cannot tell an
   attachment that was persisted from one that was not — which is exactly the
-  failure [above](#the-write-that-did-not-take) → the default-coin and import
-  fixtures read the vault back through a **fresh** `ModelContext` on the same
-  container;
+  failure [above](#the-write-that-did-not-take) → every fixture that asserts
+  coins were attached reads them back through a **fresh** `ModelContext` on the
+  same container;
 - a postcondition computed from what a pass *produced* is satisfied by an empty
   list, so a preparation that built nothing at all passes as complete → the coin
   cases include a vault nothing can be built for, and one where a single chain

--- a/docs/passcode-keyshare-encryption/invariants.md
+++ b/docs/passcode-keyshare-encryption/invariants.md
@@ -72,8 +72,9 @@ is left cannot be opened by anything, ever.
 
 The app cannot construct one — `seal` refuses an already-sealed value — but an
 imported `.vult` or JSON backup can carry whatever bytes it likes. Both the
-sweeper's `openedShare(from:)` and `ProtectedVaultImporter.openedShare(_:pubkey:)`
-open once and **refuse** a result that is still sealed.
+sweeper's `openedShare(from:)` and `KeyshareNormalizer.opened(_:pubkey:)` — the
+route every import takes in, shared with the keygen commit — open once and
+**refuse** a result that is still sealed.
 
 **Do not "fix" this by unwrapping recursively.** Recursion accepts adversarial
 input rather than rejecting it. One layer is the most a legitimate backup can
@@ -113,7 +114,79 @@ Two alternatives were proposed and both rejected:
 | the wrapper is re-stored **before** anything is resealed in the disable rollback | ciphertext whose only key is in memory, destroyed by the next lock |
 | `session.currentGeneration` is captured as the **first instruction** of `setPasscode` and `unlock` | a background `lock()` silently undone; the key stays live behind a lock screen |
 | reconciliation runs **synchronously first** inside `restorePasscodeLockOnLaunch` | the gate chosen from a mode reconciliation is about to change; app sits open all session with a wrapped key and no lock screen |
-| `prepare:` in `ProtectedVaultImporter.commit` runs **after** the save, inside the lease | default-coin derivation starts unstructured `Task`s that outlive `commit`; on a save failure they operate on a vault that was just withdrawn |
+| `prepare:` in `ProtectedVaultImporter.commit` runs **after** the save, inside the lease | a preparation whose own save fails could no longer be undone. `rollback()` is safe there *only* because the insert's save has already flushed whatever the context was carrying, so everything still pending is provably `prepare`'s — see [below](#the-write-that-did-not-take). Ahead of that save, undoing a failed preparation either discards another flow's uncommitted work or leaves its rows pending, and pending rows reach disk through the next autosave or any unrelated `save()` |
+
+---
+
+## The write that did not take
+
+A user reported imported vaults arriving with no chains at all. Every save along
+the way had succeeded. Two rules came out of it, and both are easy to undo by
+accident because neither failure raises anything.
+
+### Attach a coin from the coin's side
+
+`coin.vault = vault`, **never** `vault.coins.append(coin)`.
+
+On a `Vault` that has already been through a `context.save()`, appending a still
+unsaved `Coin` to the to-many side does not register. The relationship re-faults
+to its persisted value, and the next save writes that value back **over** the
+`Coin.vault` inverse the append had just set. What lands on disk is coin rows
+belonging to nobody and a vault with no chains — nothing thrown, nothing logged,
+and a wallet that simply opens empty.
+
+The to-one write is the one that survives, and on a vault that has not been
+inserted yet it does exactly what the append did — which is why it is correct
+for both callers. `VaultDefaultCoinService` also detaches from that side
+(`coin.vault = nil`) before deleting a coin it is taking back, for the same
+reason. `CoinService.addToChain` sidesteps the trap differently, by saving the
+coin before appending; there is no save to hang that on inside the preparation.
+
+Keygen never hit this — `commitVault` prepares a vault it has not inserted yet.
+The import path prepares after insert + save, for the ordering reason above, so
+it is the caller that reaches the trap.
+
+### `prepare`'s success is a postcondition, not a `catch`
+
+`prepare` answers `Bool` and `commit` **checks the answer**, in addition to
+catching a throwing save. That is the whole point: in the failure above the save
+*succeeded* and stored nothing, so an error-only guard saw a clean import and
+said nothing. Nothing else rebuilds what the preparation writes — default coins
+are set at keygen and at import and nowhere else — so a vault that leaves
+`commit` unprepared is one the user opens missing chains, with no error, for
+good.
+
+An unprepared vault is put through the idempotent preparation once more, and
+reported if it is still unprepared. It is not thrown: the vault is stored and
+openable, and refusing an import that already reached disk would leave the user a
+vault they can no longer re-import.
+
+The answer is only worth checking if it stays truthful, and two ways of
+computing it were not:
+
+- **read off what succeeded, the answer holds vacuously.** A postcondition checked
+  against the coins that *built* is satisfied by an empty list — the vault with
+  no chains at all passes as prepared, which is the reported symptom surviving
+  its own fix. It is read off the chains the vault was asked for instead, minus
+  the ones the catalog carries no native asset for at all. That subtraction is
+  logged rather than silently filtered: a chain with nothing to build (there is
+  one, `ethereumSepolia`, offered in the key-import picker) is a gap in this app;
+  a chain that failed to build is a broken key. Only the second is a failure to
+  report, and reporting the first would mark every such import broken forever
+  with nothing a user or a retry could do.
+- **a vault that already holds coins must not be blessed.** Skipping the *work*
+  for one is right; answering `true` for it is not. The retry lands exactly
+  there — first pass a chain short, second pass sees one coin and calls the
+  import clean — so the reporting the postcondition exists for reports nothing.
+
+`prepare` must also **start nothing that outlives it**. Token discovery is the
+case that exists: it suspends on the network and then writes through
+`Storage.shared`, so started from inside the preparation it can come back and
+persist a vault whose save failed and which the caller has already withdrawn.
+The preparation records value identifiers only — a vault's public key and a coin
+id — and every caller starts `startTokenDiscovery()` after **its own** save has
+landed, which re-resolves each coin through its vault and skips the ones the
+store no longer holds that way.
 
 ---
 
@@ -174,6 +247,8 @@ switch over the cases.
 | move the `session.currentGeneration` read below a "cheap" guard | that is exactly the bug that let a `lock()` be undone during the sealed-share scan |
 | unwrap doubly-sealed values recursively instead of refusing them | accepts adversarial input rather than rejecting it |
 | have the sweeper flush or roll back a dirty context so it can proceed | commits or discards another flow's half-finished work because the user toggled a setting |
+| attach a vault's default coins with `vault.coins.append(coin)` instead of `coin.vault = vault` | on a vault that has already been saved the append does not register: the relationship re-faults and the next save writes the empty value back over the inverse, so the coin rows end up belonging to nobody and the vault opens with no chains — silently, and every save reports success. See [above](#attach-a-coin-from-the-coins-side) |
+| let `prepare:` report success by not throwing, now that `commit` catches its save | the failure that shipped was a save that *succeeded* and stored nothing, which no `catch` can see. See [above](#prepares-success-is-a-postcondition-not-a-catch) |
 | replace `KeyshareSweeping`'s per-method `@MainActor` with an attribute on the protocol | attributing the protocol infers main-actor isolation onto the whole conforming type, singleton included — and an `actor` cannot name a main-actor singleton as a default argument. Same reason on `ProtectedVaultImporter` |
 | make `KeyshareSweeping` `Sendable` | cascades into `KeyshareProtecting`, whose implementation holds a non-`@Sendable` closure. A Swift 6 migration item, not a local cleanup |
 | clear `lastMigratedVersion` in the reconciler | re-runs every ordinary migration on a container with no passcode artifact — a launch-time write for people who never touched this feature |
@@ -251,9 +326,20 @@ in passing without reading the tradeoff.
   another flow's pending work.** SwiftData has no scoped save. The alternatives
   are refusing the import whenever anyone has unsaved work — which the lease
   placement deliberately rejected — or nothing. The *failure* path does preserve
-  foreign work: `context.hasChanges` is sampled before anything is inserted, and a save failure
-  rolls back only if the context was clean, otherwise it withdraws just the
-  imported vaults one by one.
+  foreign work: `context.hasChanges` is sampled before anything is inserted, and
+  a failed insert save rolls back only if the context was clean, otherwise it
+  withdraws just the imported vaults one by one. The **preparation's** save is
+  the one that rolls back unconditionally, and it may: it runs after the insert
+  save has already flushed anything foreign, and `commit` suspends nowhere in
+  between, so everything pending at that point was written by `prepare`.
+
+- **A preparation that fails twice is logged and the import still reports
+  success to the user.** The vault is stored and openable but missing at least
+  one of its default chains, and only a log line says so. Throwing instead would
+  refuse an import that has already reached disk, leaving the user a vault they
+  can no longer re-import; telling them properly needs a new error, a new
+  outcome for three import routes to render, and a string in every shipping
+  locale. Unclaimed work, priced the same way as the resume-sweep gap above.
 
 - **The keygen episode lease crosses screens.** `KeygenViewModel` takes it;
   `commitVault` is a `static` function that neither owns nor releases it. Safety
@@ -262,8 +348,8 @@ in passing without reading the tradeoff.
   `deinit`-release. This is the design's own named open question. A leaked lease
   blocks every passcode change until relaunch.
 
-- **`ProtectedVaultImporter`'s lease brackets normalize → insert → save, not
-  decode → insert → save.** Decode and commit are separated by a modal password
+- **`ProtectedVaultImporter`'s lease brackets normalize → insert → save →
+  prepare, not decode → insert → save.** Decode and commit are separated by a modal password
   prompt on the multi-file path, and a lease held across a modal leaks when the
   user walks away. Re-normalizing at commit under the lease gives the same
   guarantee. The cost is a narrow liveness case: a decode that seals, followed by
@@ -277,6 +363,43 @@ in passing without reading the tradeoff.
 - **There is no launch migration, and `KeyshareEncryptionMigration` does not
   exist.** If a document you are reading describes one, a completion marker, or a
   clear `keyshareDataKey` Keychain item, it is stale — stop and re-read the code.
+
+---
+
+## A hazard on the import path that predates this feature
+
+**Pre-existing. Not introduced by the passcode work, and not fixed by it.** It is
+recorded here because this is where the next person reading the import path will
+be, and because its consequence is the one this whole feature exists to prevent.
+
+> An imported vault that collides with a stored one on a **single** unique
+> attribute — or on nothing but its **name** — replaces it, key shares included.
+
+`EncryptedBackupViewModel.isVaultUnique` treats an incoming vault as a duplicate
+only when `pubKeyECDSA` **and** `pubKeyEdDSA` both match one already stored. But
+`Vault` declares `name`, `pubKeyECDSA` and `pubKeyEdDSA` as three *independent*
+`@Attribute(.unique)` properties. So a vault matching on one key, or on neither
+key and only the name, passes the guard, reaches `context.insert`, and SwiftData
+resolves the collision the way it always does — by **upserting** rather than by
+failing, the behaviour the fixtures below are written around. The stored row is
+replaced by the incoming vault's values, and `keyshares` is one of those values:
+a plain stored property on `Vault`, not a related row that could survive on its
+own.
+
+No error, no prompt, nothing written to the log. The displaced share is gone
+from this device, and what is left is whatever `.vult` backup the user happens to
+hold. All three import routes reach it — `restoreVault`, `restoreVaultBack` and
+the multi-file `importVaults` each guard with `isVaultUnique` and then commit
+through `ProtectedVaultImporter`.
+
+It is deliberately left alone rather than repaired in passing.
+`ZipImportDuplicateTests` currently pins the same-`pubKeyECDSA` /
+different-`pubKeyEdDSA` case as *acceptable*, so tightening the guard changes
+shipped behaviour and needs its own review, its own copy and its own decision
+about what a partial collision should mean. **Do not read that test as evidence
+the case is safe** — it pins today's behaviour, not a judgement about it. And
+note what is not covered: no test imports a vault colliding on one key alone, or
+on the name alone, so nothing in the suite would notice the replacement.
 
 ---
 
@@ -302,6 +425,15 @@ Each of these is over-specified because the plain version was written first and
 - SwiftData answers a duplicate `@Attribute(.unique)` with an **upsert rather
   than an error**, so a multi-vault fixture silently collapses to one row and
   three assertions pass over one vault → fixtures assert their own row count;
+- an assertion on a `@Model` object the test is still holding cannot tell an
+  attachment that was persisted from one that was not — which is exactly the
+  failure [above](#the-write-that-did-not-take) → the default-coin and import
+  fixtures read the vault back through a **fresh** `ModelContext` on the same
+  container;
+- a postcondition computed from what a pass *produced* is satisfied by an empty
+  list, so a preparation that built nothing at all passes as complete → the coin
+  cases include a vault nothing can be built for, and one where a single chain
+  fails while the others succeed;
 - test doubles that upsert model semantics production does not provide (the
   `SecItemAdd` case) pass for the wrong reason → the doubles mirror
   `errSecDuplicateItem`;
@@ -326,6 +458,8 @@ Check that explicitly; a test that passes both ways is documenting nothing.
    which existing repair path finds it.
 4. If you touched ordering, re-read [the table above](#ordering-constraints--do-not-reorder-these).
 5. Run the full `VultisigAppTests/Security/` and `VultisigAppTests/Storage/`
-   suites, not a subset.
+   suites, not a subset — plus
+   `VultisigAppTests/Services/VaultDefaultCoinServiceTests.swift` if you touched
+   what the import hands to `prepare:`.
 6. If you added a `PasscodeError` case, follow the exhaustive switch the
    compiler points you at rather than defaulting it.

--- a/docs/passcode-keyshare-encryption/invariants.md
+++ b/docs/passcode-keyshare-encryption/invariants.md
@@ -1,0 +1,316 @@
+# Invariants and traps
+
+Everything on this page exists because a review caught a real fund-loss bug, or
+because a plausible-looking cleanup was proposed and rejected with a reason. If
+you are about to change something here, find it below first.
+
+## Rule zero
+
+> A key share that cannot be opened is a vault that can never sign again. There
+> is no server copy. There is no support ticket that fixes it.
+
+Every guard in `Core/Security/Keyshare/` is there to make a specific unopenable
+state unreachable. "This check looks redundant" is almost always the sound of a
+state you have not thought of yet.
+
+---
+
+## The three sweeper refusals
+
+`KeyshareSweeper` is the only thing in the feature that rewrites key material in
+bulk. It refuses three things, and each refusal is a bug that shipped in a draft.
+
+### 1. Two phases — never apply per vault
+
+Everything is computed and verified in memory before a single model is touched;
+the writes go in together only once every share in every vault has passed.
+
+Applying a vault as soon as it verifies leaves earlier vaults mutated in the
+**live** context when a later one fails — and an unrelated autosave can flush
+that half-swept state to disk. Autosave is on by default, which is why the sweep
+disables it for the duration and restores it after.
+
+Two companions to this rule, equally load-bearing:
+
+- **whole-array assignment.** `vault.keyshares = newArray`, never
+  `keyshares[i] = …`. Assigning into an element is not a dependable way to mark a
+  `@Model` dirty, and a sweep that reports success while persisting nothing
+  leaves plaintext shares sitting behind a passcode.
+- **explicit `save()`, and `rollback()` if it throws**, so the context cannot
+  carry a partial sweep forward.
+
+### 2. Authenticate every already-sealed value
+
+`KeyshareProtector.seal` returns an already-sealed value **unchanged and
+unchecked**. A sweep that takes that on trust reports success over a share sealed
+under a key nobody holds any more — a dead vault, and nothing ever revisits it
+*because the sweep said it was fine*.
+
+So `sealAll` opens every already-sealed value it meets. Symmetrically, it
+**asserts its own output is sealed**: with no key in hand `seal` returns the
+plaintext unchanged, so without that check a sweep with nothing to seal with
+would report success over shares it left in the clear.
+
+This is why the protocol has no `hasPlaintextShares() -> Bool`. A `Bool` cannot
+carry "one of these does not authenticate", and a caller that got `false` would
+proceed.
+
+### 3. Refuse a value that opens to *another* sealed value
+
+Only the outermost envelope used to be opened. A value shaped like
+`seal(seal(share))` authenticates on its outer layer, so `sealAll` accepted it
+unchanged and `unsealAll` wrote the **inner `vlt2:` string** back and reported
+the store fully unsealed. The disable that follows then deletes the key, and what
+is left cannot be opened by anything, ever.
+
+The app cannot construct one — `seal` refuses an already-sealed value — but an
+imported `.vult` or JSON backup can carry whatever bytes it likes. Both the
+sweeper's `openedShare(from:)` and `ProtectedVaultImporter.openedShare(_:pubkey:)`
+open once and **refuse** a result that is still sealed.
+
+**Do not "fix" this by unwrapping recursively.** Recursion accepts adversarial
+input rather than rejecting it. One layer is the most a legitimate backup can
+carry: the export path (`Vault.mapToProtobuff`) writes opened plaintext, and the
+import path will not wrap an already-sealed value.
+
+### And: the context must be clean
+
+A dirty main `ModelContext` is `KeyshareSweeperError.busy`, surfaced as
+`PasscodeError.busy`, and the user retries.
+
+Two alternatives were proposed and both rejected:
+
+- **flush foreign pending changes** (`if hasChanges { save() }`) — commits
+  somebody's half-finished keygen, reshare or import merely because the user
+  enabled a passcode. Some code defers persistence deliberately until a flow is
+  confirmed; rolling them back instead would throw that work away. Neither is the
+  sweeper's to decide.
+- **use a dedicated context off the same container** — the main context would
+  keep stale `Vault` objects holding the old plaintext, and a later edit to one
+  of those writes it back.
+
+`hasSealedShare()` refuses a dirty context too, for a sharper reason — see
+[transitions](transitions.md#step-4-never-mint-over-evidence).
+
+---
+
+## Ordering constraints — do not reorder these
+
+| Constraint | Reordering it produces |
+|---|---|
+| the wrapper is durable **before** anything is sealed | every sealed share orphaned by a crash, key never having left memory |
+| `mode = .passcode` fires **the moment the wrapper verifies**, not after the sweep | a passcode both durable and unreachable: no gate, so no unlock, so no resume, and retry says `.alreadySet` |
+| a failed sweep does **not** delete the wrapper | already-sealed shares stranded; a later set mints a *different* key that opens none of them |
+| disable changes the mode **before** deleting the wrapper | plaintext shares behind a gate with nothing to unlock against |
+| disable removes the biometric copy **before** any share moves | a survivor silently works again next time a passcode is set; and a failure after the shares moved reports an error over a half-gone passcode |
+| the wrapper is re-stored **before** anything is resealed in the disable rollback | ciphertext whose only key is in memory, destroyed by the next lock |
+| `session.currentGeneration` is captured as the **first instruction** of `setPasscode` and `unlock` | a background `lock()` silently undone; the key stays live behind a lock screen |
+| reconciliation runs **synchronously first** inside `restorePasscodeLockOnLaunch` | the gate chosen from a mode reconciliation is about to change; app sits open all session with a wrapped key and no lock screen |
+| `prepare:` in `ProtectedVaultImporter.commit` runs **after** the save, inside the lease | default-coin derivation starts unstructured `Task`s that outlive `commit`; on a save failure they operate on a vault that was just withdrawn |
+
+---
+
+## Fail closed, and which direction that is per site
+
+"Fail closed" is not one direction — it depends on which mistake loses key
+material at that call site. `KeychainReadResult` is three-valued
+(`absent` / `present` / `unavailable`) precisely so each site chooses
+explicitly, and the deliberate collapses all go through the conspicuously named
+`valueTreatingUnavailableAsAbsent` so no consumer collapses invisibly.
+
+| Site | `.unavailable` is read as | Because the opposite would |
+|---|---|---|
+| `PasscodeService.isSet` | **set** | let `setPasscode` mint a fresh key **over** an existing wrapper; the new key opens no share the old one sealed |
+| `KeyshareKeySession.currentState()` | **`.locked`** | make `.disabled` a licence to write plaintext behind a live passcode |
+| `PasscodeService.unlock` | `.storageFailure` | `.notSet` sends the UI off to offer *creating* a passcode over one that exists |
+| `unlockWithBiometrics`' wrapper read | `.storageFailure` | leave nothing to check the bound copy against |
+| `storeWrappedDataKey` read-back | **write failed** | record an unverified write as durable, then seal against it |
+| `deleteWrappedDataKey` read-back | **delete failed** | record a removal as done and never retry it |
+| reconciler: store occupancy | **defer the pass** | set a permanent marker on a guess, keeping a previous install's wrapper forever |
+| reconciler: inherited material | **defer the pass** | issue launch-time Keychain deletes on a first-ever install whose Keychain stuttered |
+| reconciler: lock-mode alignment | **move nothing** | raise a gate with nothing behind it, or take a real gate down |
+| `PasscodeAttemptLimiter.loadState` | **no record** ← the one exception | put a permanent, undecayable lockout in front of a passcode the user knows |
+
+That last row is the deliberate exception and it is argued at the call site.
+`remainingLockout` would answer an unreadable state with a flat maximum delay
+that never decays and that a correct passcode cannot clear — clearing needs a
+write the same Keychain is refusing. The strict reading also buys nothing:
+anyone able to make the item unreadable can **delete** it instead, and a deleted
+item is `.absent`, which is legitimately a fresh start. A *corrupt* record still
+fails closed. If you revisit the limiter, re-read that paragraph before changing
+it.
+
+### The optional-promotion trap
+
+A `KeychainReadResult` is **not** an `Optional`, but Swift will happily compare
+one to `nil` via optional promotion — and the comparison is then always false.
+That shipped once: a guard in `KeyshareInstallReconciler` became permanently
+false, so the destructive clear repeated **on every launch**, silently removing
+any passcode set after the first one. It compiled green and the whole suite
+passed.
+
+If you write `someKeychainRead == nil`, you have written a bug. Use
+`valueTreatingUnavailableAsAbsent == nil` when the collapse is what you mean, or
+switch over the cases.
+
+---
+
+## Things that look like safe cleanups and are not
+
+| Tempting change | Why not |
+|---|---|
+| make `KeyshareWriteCoordinator` an `actor` or `@MainActor` | its hottest caller is a **synchronous** TSS callback on an arbitrary thread. A `Task` hop loses the atomicity that is the entire point; `DispatchQueue.main.sync` deadlocks when the callback is already on main |
+| have the app unlock take a `TransitionLease` like the other operations | transitions are refused while a keygen episode is open, and keygen holds one through the deferred "Looks Good" commit — an app that auto-locked on the review screen could **never be opened again** |
+| add an acquiring `resumeSweep()` for API completeness | a lease is not reentrant; it would throw `.busy` on the one path that must always work |
+| make `lock()` synchronize with the actor to close the last one-instruction race | a background lock must never block on a transition. The window is accepted and documented |
+| move the `session.currentGeneration` read below a "cheap" guard | that is exactly the bug that let a `lock()` be undone during the sealed-share scan |
+| unwrap doubly-sealed values recursively instead of refusing them | accepts adversarial input rather than rejecting it |
+| have the sweeper flush or roll back a dirty context so it can proceed | commits or discards another flow's half-finished work because the user toggled a setting |
+| replace `KeyshareSweeping`'s per-method `@MainActor` with an attribute on the protocol | attributing the protocol infers main-actor isolation onto the whole conforming type, singleton included — and an `actor` cannot name a main-actor singleton as a default argument. Same reason on `ProtectedVaultImporter` |
+| make `KeyshareSweeping` `Sendable` | cascades into `KeyshareProtecting`, whose implementation holds a non-`@Sendable` closure. A Swift 6 migration item, not a local cleanup |
+| clear `lastMigratedVersion` in the reconciler | re-runs every ordinary migration on a container with no passcode artifact — a launch-time write for people who never touched this feature |
+| delete the plaintext passthrough in `open` / `seal` now that encryption exists | `.disabled` is permanent and the majority state. Both passthroughs are forever |
+| let `BiometricKeychain.store` delete-then-add in one place with one query | `SecItemDelete` takes a *search* query; the full add dictionary matches nothing and the add answers `errSecDuplicateItem`, silently breaking rebinding after a passcode change |
+| collapse `BiometricUnlockError.malformedCopy` into `.failed` | `.failed` also covers "the face did not match", which the UI stays silent about — so a *successful* Face ID would appear to do nothing while silently disabling the shortcut |
+| have `KeyshareInstallReconciler` skip taking the transition lease (it only runs at launch) | a launch landing between `setPasscode` verifying its wrapper and adopting the key deletes that wrapper **and marks the container done** |
+| wire the lock screen to `PasscodeService.unlock(with:)` | see below — there is **no compile-time forcing function** for this one |
+
+### The one with no forcing function
+
+`unlock(with:)` and `unlockApp(with:)` take the same argument, throw the same
+errors, and compile identically at the lock screen's call site. `unlock` is
+passcode *verification*: no lease, no resume sweep. Wired to it, the lock screen
+looks and behaves exactly right while **silently never finishing an interrupted
+transition** — so shares an interrupted `setPasscode` did not reach stay in the
+clear behind a live passcode for as long as the app is installed.
+
+This actually happened during a rebase that was textually clean and compiled.
+`PasscodeViewModel.unlock()` carries a doc comment saying it must stay on
+`unlockApp`; the change flow's own `service.unlock(with: current)` is correct and
+must stay as it is.
+
+A protocol seam that would let a test prove which method the lock screen reaches
+was proposed and rejected: `PasscodeService` is an `actor` whose methods carry
+`now: Date = Date()` defaults and `@discardableResult` returns, so the protocol
+needs renamed shim requirements to dodge overload ambiguity — roughly sixty lines
+of indirection plus a mock, to guard one line.
+
+Contrast the forcing function that *does* exist: `PasscodeError` is switched
+exhaustively in the view model's message mapping, so adding or removing a case
+**cannot compile** until every UI surface is addressed. Prefer that shape when
+you add state to this feature.
+
+---
+
+## Things that are deliberately NOT done
+
+Live, known gaps. Do not report them as new findings; do not silently "fix" one
+in passing without reading the tradeoff.
+
+- **A persistently failing resume sweep is logged and surfaced nowhere.**
+  `resumeSweepUnlocked` swallows its errors so a failure cannot leave the lock
+  screen up over an open session. The consequence is plaintext shares behind a
+  live passcode with no user-visible signal. The correct remedy is a
+  degraded-protection indicator in the UI; it is unclaimed work. Rejected three
+  times as "just propagate the error" — see
+  [transitions](transitions.md#it-swallows-its-own-errors-and-that-is-deliberate).
+
+- **`storeWrappedDataKey` cannot distinguish "the write did not land" from "the
+  write landed and the read-back was unavailable".** It reports failure for both.
+  In `changePasscode` that means the **new passcode may be the live one while the
+  UI says the change failed**. Fixing it properly is an error-taxonomy change — a
+  new store error, a new `PasscodeError`, a new string in every shipping locale —
+  which deserves its own review round. It is survivable because the next launch's
+  mode alignment keeps the gate up and the user has just typed the new passcode
+  twice. Note the tension: the read-back fails closed *on purpose*, because
+  callers must never record an unverified write as durable. This gap is the price
+  of that choice, and it was priced.
+
+- **TSS call sites still use the optional-collapsing `Vault.getKeyshare(pubKey:)`
+  rather than the throwing `keyshareValue(for:)`.** So a locked app and a vault
+  with no share for that key are indistinguishable at those sites. That is
+  accessor-layer scope, and `Blockchain/Tss/` is a declared critical boundary
+  requiring maintainer review.
+
+- **`ProtectedVaultImporter` saves a shared `ModelContext` that may be carrying
+  another flow's pending work.** SwiftData has no scoped save. The alternatives
+  are refusing the import whenever anyone has unsaved work — which the lease
+  placement deliberately rejected — or nothing. The *failure* path does preserve
+  foreign work: `context.hasChanges` is sampled on entry, and a save failure
+  rolls back only if the context was clean, otherwise it withdraws just the
+  imported vaults one by one.
+
+- **The keygen episode lease crosses screens.** `KeygenViewModel` takes it;
+  `commitVault` is a `static` function that neither owns nor releases it. Safety
+  rests on SwiftUI retaining the view model (`@StateObject` on `KeygenView`,
+  which stays in the navigation stack under the review screen) plus
+  `deinit`-release. This is the design's own named open question. A leaked lease
+  blocks every passcode change until relaunch.
+
+- **`ProtectedVaultImporter`'s lease brackets normalize → insert → save, not
+  decode → insert → save.** Decode and commit are separated by a modal password
+  prompt on the multi-file path, and a lease held across a modal leaks when the
+  user walks away. Re-normalizing at commit under the lease gives the same
+  guarantee. The cost is a narrow liveness case: a decode that seals, followed by
+  a disable, refuses the import until the user retries.
+
+- **No recovery path exists for stores sealed by the superseded always-encrypted
+  design** (which kept a clear data key in the Keychain). Nothing shipped in that
+  state, so nothing was written for an empty population. If you somehow have one:
+  erase the simulator or delete the app.
+
+- **There is no launch migration, and `KeyshareEncryptionMigration` does not
+  exist.** If a document you are reading describes one, a completion marker, or a
+  clear `keyshareDataKey` Keychain item, it is stale — stop and re-read the code.
+
+---
+
+## Tests that look paranoid and are not
+
+Each of these is over-specified because the plain version was written first and
+**passed against the live bug**:
+
+- a concurrency test that returns early when `beginEpisode()` yields `nil` passes
+  even if every acquisition is spuriously refused → count and assert the
+  acquisitions;
+- a lock-race test that only drives the PBKDF2 window passes against a
+  generation captured too late → the hooked sweeper has to fire inside the
+  **sealed-share scan**;
+- serialization tests that assert only the eventual `.busy` pass against an
+  implementation that takes the lease *late* → also assert no Keychain write, no
+  share rewrite, no mode change;
+- a "reconciliation is retried next launch" test is vacuous without asserting the
+  wrapper **survives** the busy pass;
+- **no assertion on stored values can distinguish a no-op write from no write at
+  all** — `MockKeychainService` records every mutating call in order, and the
+  first-ever-install acceptance test asserts on that list;
+- SwiftData answers a duplicate `@Attribute(.unique)` with an **upsert rather
+  than an error**, so a multi-vault fixture silently collapses to one row and
+  three assertions pass over one vault → fixtures assert their own row count;
+- test doubles that upsert model semantics production does not provide (the
+  `SecItemAdd` case) pass for the wrong reason → the doubles mirror
+  `errSecDuplicateItem`;
+- tests that exercise a unit but not the **route** cannot catch a routing
+  regression, which was exactly the import bug → `BackupImportProtectionTests`
+  drives the real `EncryptedBackupViewModel`;
+- any test that installs `Storage.shared.modelContext` must use
+  `TestStore.installInMemoryContainer()` / `TestStore.restore(token)`, or it
+  crashes every later suite in the process.
+
+New regression tests here are expected to **fail against the parent commit**.
+Check that explicitly; a test that passes both ways is documenting nothing.
+
+---
+
+## Before you change this code
+
+1. Read [the overview](overview.md), then the page for the area you are in.
+2. Ask which of the three states the change is reachable in, and what it does in
+   `.disabled` — that is most users, forever.
+3. Ask what a crash immediately after your new statement leaves on disk, and
+   which existing repair path finds it.
+4. If you touched ordering, re-read [the table above](#ordering-constraints--do-not-reorder-these).
+5. Run the full `VultisigAppTests/Security/` and `VultisigAppTests/Storage/`
+   suites, not a subset.
+6. If you added a `PasscodeError` case, follow the exhaustive switch the
+   compiler points you at rather than defaulting it.

--- a/docs/passcode-keyshare-encryption/invariants.md
+++ b/docs/passcode-keyshare-encryption/invariants.md
@@ -226,11 +226,16 @@ in passing without reading the tradeoff.
   callers must never record an unverified write as durable. This gap is the price
   of that choice, and it was priced.
 
-- **TSS call sites still use the optional-collapsing `Vault.getKeyshare(pubKey:)`
-  rather than the throwing `keyshareValue(for:)`.** So a locked app and a vault
-  with no share for that key are indistinguishable at those sites. That is
-  accessor-layer scope, and `Blockchain/Tss/` is a declared critical boundary
-  requiring maintainer review.
+- **Most TSS call sites still use the optional-collapsing
+  `Vault.getKeyshare(pubKey:)` rather than the throwing `keyshareValue(for:)`.**
+  So a locked app and a vault with no share for that key are indistinguishable at
+  those sites. `Blockchain/Tss/` is *not* one of them —
+  `LocalStateAccessorImpl.getLocalState` already uses the throwing accessor and
+  reports the failure through the TSS error pointer. What is left is
+  `Blockchain/States/Keygen/` (`DKLSKeygen`, `SchnorrKeygen`),
+  `Blockchain/States/Keysign/` (`DKLSKeysign`, `SchnorrKeysign`,
+  `DilithiumKeysign`) and `KeygenViewModel`. Converting them is accessor-layer
+  scope and has not been done.
 
 - **`ProtectedVaultImporter` saves a shared `ModelContext` that may be carrying
   another flow's pending work.** SwiftData has no scoped save. The alternatives

--- a/docs/passcode-keyshare-encryption/key-hierarchy.md
+++ b/docs/passcode-keyshare-encryption/key-hierarchy.md
@@ -13,8 +13,9 @@ cheap and the reason a 5-digit passcode is not the thing protecting the wallet.
            │  AES-GCM seals 32 bytes
            ▼
    ┌───────────────────────────────────────────┐
-   │  wrapped data key   ← the ONLY persisted   │  Keychain item
+   │  wrapped data key — 80 bytes               │  Keychain item, WhenUnlocked
    │  VLT\x02 ‖ salt ‖ nonce ‖ ct ‖ tag         │  (absent when no passcode)
+   │  4    +   16  +  12   + 32 + 16 = 80       │
    └───────────────────────────────────────────┘
            │
            │  unwrap on unlock; held in memory only
@@ -38,8 +39,9 @@ every blob has the same shape.
 
 Three separate reasons, all load-bearing:
 
-1. **Changing a passcode is O(1).** Rewrap 32 bytes, write one Keychain item,
-   done — **no key share is read or written**. The desktop client, which does
+1. **Changing a passcode is O(1).** Rewrap the 32-byte data key into one 80-byte
+   wrapper, write one Keychain item, done — **no key share is read or written**,
+   however many vaults the device holds. The desktop client, which does
    encrypt shares under the passcode directly, has to re-encrypt every share of
    every vault for the same user action, which means it puts key material
    through a rewrite on a routine settings change. `changePasscode` here is
@@ -47,27 +49,56 @@ Three separate reasons, all load-bearing:
    ciphertext on disk is byte-identical before and after. There is a test that
    asserts exactly that.
 
-2. **A 5-digit passcode is ~16.6 bits.** However it is stretched, an attacker
-   holding the Keychain blob can enumerate it. PBKDF2 at 600k iterations does
-   not make the wrap strong — it buys a per-guess cost on the *in-app* path,
-   which is what `PasscodeAttemptLimiter` is really enforcing. The thing
-   actually protecting a share is the 256-bit data key, which is random and
-   derived from nothing the user knows. If shares were sealed under a
-   passcode-derived key, share strength would be passcode strength.
+2. **The shares are never keyed by anything the user typed.** That is what makes
+   a passcode change, and later per-vault keys, possible without re-encrypting a
+   single share.
+
+   **It is not a strength multiplier, and this doc will not pretend otherwise.**
+   An attacker who gets the wrapper *and* the sealed shares out of the Keychain
+   can derive a candidate wrapping key from each of the 100,000 possible
+   passcodes offline, and the GCM tag tells them which one is right. So
+   **resistance to an offline attack is bounded by passcode entropy plus the
+   PBKDF2 cost — roughly 16.6 bits × 600k iterations — not by the data key's 256
+   bits.** The indirection buys structure, not entropy.
+
+   The two mitigations that actually apply are different from each other and are
+   worth keeping straight: PBKDF2 at 600k iterations sets the *per-guess cost* of
+   the offline search, and `PasscodeAttemptLimiter` throttles the *in-app* path,
+   which is a different attacker entirely. Getting to the offline attack at all
+   means first defeating the Keychain, where the wrapper is stored
+   `kSecAttrAccessibleWhenUnlocked` and is therefore unreadable while the device
+   is locked.
 
 3. **Future indirection is free.** Per-vault keys (decoy vaults, say) slot in
    under the data key without touching the passcode layer at all.
 
-## Why there is no unwrapped resting state
+## Where the data key can be found
 
-The Keychain holds the key **only** in passcode-wrapped form. It is in memory
-only while the app is unlocked (`KeyshareKeySession`), and `lock()` forgets it.
-Removing the passcode does not stash a clear key beside the shares — it opens
-every share back to plaintext and deletes the wrapper.
+Exactly three places, and the third is opt-in:
 
-That means there is no third place the key can be found, and no state in which a
-share is sealed but reachable without the passcode. An earlier design did keep a
-clear `keyshareDataKey` item; it is gone, and `PasscodeError.noDataKey` with it.
+| Where | Form | When |
+|---|---|---|
+| Keychain, the wrapper item | passcode-wrapped | whenever a passcode is set |
+| memory (`KeyshareKeySession`) | opened | only while the app is unlocked; `lock()` forgets it |
+| Keychain, the biometric item | **raw**, prefixed by `SHA256(wrapper)` | only if the user turned on the biometric shortcut |
+
+**The third one is a genuine exception and not an oversight.** A shortcut that
+opens the app without the passcode has to hold a key the passcode did not
+unwrap, so `BiometricUnlockStore` persists the data key *unwrapped* — behind
+`.biometryCurrentSet` and `kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly`, so
+reaching it takes a live biometric match on that device. Everything in
+[its section below](#the-biometric-copy) — binding it to the wrapper, destroying
+it when enrolment changes, removing it first in `disablePasscode` — exists
+because that copy is raw.
+
+So the accurate statement is: **there is no copy reachable without either the
+passcode or a biometric match**, and no state in which a sealed share is
+readable with neither. Removing the passcode does not stash a clear key beside
+the shares — it opens every share back to plaintext, removes the biometric copy,
+and deletes the wrapper.
+
+An earlier design did keep a general-purpose clear `keyshareDataKey` item usable
+with no authentication at all; it is gone, and `PasscodeError.noDataKey` with it.
 If you find a source describing one, you are reading a superseded document.
 
 ## Verification, and where it comes from

--- a/docs/passcode-keyshare-encryption/key-hierarchy.md
+++ b/docs/passcode-keyshare-encryption/key-hierarchy.md
@@ -1,10 +1,10 @@
 # The key hierarchy
 
 Two levels, and the separation between them is the reason changing a passcode is
-cheap and the reason a 5-digit passcode is not the thing protecting the wallet.
+cheap and the reason a 6-digit passcode is not the thing protecting the wallet.
 
 ```
-   user types 5 digits
+   user types 6 digits
            │
            │  PBKDF2-SHA256, 600k iterations, 16-byte random salt
            ▼
@@ -55,11 +55,19 @@ Three separate reasons, all load-bearing:
 
    **It is not a strength multiplier, and this doc will not pretend otherwise.**
    An attacker who gets the wrapper *and* the sealed shares out of the Keychain
-   can derive a candidate wrapping key from each of the 100,000 possible
-   passcodes offline, and the GCM tag tells them which one is right. So
+   can derive a candidate wrapping key from each of the 1,000,000 passcodes the
+   keypad can produce, and the GCM tag tells them which one is right. So
    **resistance to an offline attack is bounded by passcode entropy plus the
-   PBKDF2 cost — roughly 16.6 bits × 600k iterations — not by the data key's 256
+   PBKDF2 cost — at most 19.9 bits × 600k iterations — not by the data key's 256
    bits.** The indirection buys structure, not entropy.
+
+   "The keypad can produce" is the honest scope, and the bound is *at most*.
+   Validation accepts any six characters satisfying `Character.isNumber`, which
+   is a larger set than the ten ASCII digits — the macOS field takes a hardware
+   keyboard, so a non-ASCII digit can reach it. That widens the accepted strings
+   without widening what anyone actually types, and an attacker enumerating a
+   keypad-entered passcode still has 10⁶ to try. It is written down because the
+   number below is otherwise the kind of claim that quietly becomes false.
 
    The two mitigations that actually apply are different from each other and are
    worth keeping straight: PBKDF2 at 600k iterations sets the *per-guess cost* of

--- a/docs/passcode-keyshare-encryption/key-hierarchy.md
+++ b/docs/passcode-keyshare-encryption/key-hierarchy.md
@@ -1,0 +1,178 @@
+# The key hierarchy
+
+Two levels, and the separation between them is the reason changing a passcode is
+cheap and the reason a 5-digit passcode is not the thing protecting the wallet.
+
+```
+   user types 5 digits
+           │
+           │  PBKDF2-SHA256, 600k iterations, 16-byte random salt
+           ▼
+   wrapping key (256 bit, never stored)
+           │
+           │  AES-GCM seals 32 bytes
+           ▼
+   ┌───────────────────────────────────────────┐
+   │  wrapped data key   ← the ONLY persisted   │  Keychain item
+   │  VLT\x02 ‖ salt ‖ nonce ‖ ct ‖ tag         │  (absent when no passcode)
+   └───────────────────────────────────────────┘
+           │
+           │  unwrap on unlock; held in memory only
+           ▼
+   data key (256 random bits, CSPRNG, derived from nothing)
+           │
+           │  AES-GCM, one blob per share, fresh nonce each time
+           ▼
+   "vlt2:" + base64(VLT\x02 ‖ salt ‖ nonce ‖ ct ‖ tag)   ← KeyShare.keyshare
+```
+
+Constants live in `VaultCryptoEnvelope`: `keyLengthBytes = 32`,
+`saltLength = 16`, `ivLength = 12`, `gcmTagBytes = 16`,
+`pbkdf2Iterations = 600_000`. The `VLT\x02` blob format is shared with the
+desktop client's vault backup, so one parser covers vault backups, sealed key
+shares and the wrapped data key alike. The salt is meaningful only for the
+password-derived payloads; raw-key callers still fill it with random bytes so
+every blob has the same shape.
+
+## Why the passcode never encrypts shares directly
+
+Three separate reasons, all load-bearing:
+
+1. **Changing a passcode is O(1).** Rewrap 32 bytes, write one Keychain item,
+   done — **no key share is read or written**. The desktop client, which does
+   encrypt shares under the passcode directly, has to re-encrypt every share of
+   every vault for the same user action, which means it puts key material
+   through a rewrite on a routine settings change. `changePasscode` here is
+   `unlock → wrap → storeWrappedDataKey → rebind the biometric copy`, and the
+   ciphertext on disk is byte-identical before and after. There is a test that
+   asserts exactly that.
+
+2. **A 5-digit passcode is ~16.6 bits.** However it is stretched, an attacker
+   holding the Keychain blob can enumerate it. PBKDF2 at 600k iterations does
+   not make the wrap strong — it buys a per-guess cost on the *in-app* path,
+   which is what `PasscodeAttemptLimiter` is really enforcing. The thing
+   actually protecting a share is the 256-bit data key, which is random and
+   derived from nothing the user knows. If shares were sealed under a
+   passcode-derived key, share strength would be passcode strength.
+
+3. **Future indirection is free.** Per-vault keys (decoy vaults, say) slot in
+   under the data key without touching the passcode layer at all.
+
+## Why there is no unwrapped resting state
+
+The Keychain holds the key **only** in passcode-wrapped form. It is in memory
+only while the app is unlocked (`KeyshareKeySession`), and `lock()` forgets it.
+Removing the passcode does not stash a clear key beside the shares — it opens
+every share back to plaintext and deletes the wrapper.
+
+That means there is no third place the key can be found, and no state in which a
+share is sealed but reachable without the passcode. An earlier design did keep a
+clear `keyshareDataKey` item; it is gone, and `PasscodeError.noDataKey` with it.
+If you find a source describing one, you are reading a superseded document.
+
+## Verification, and where it comes from
+
+There is no separate stored "verification sample" to check a passcode against,
+and there must not be — that would be an oracle. Every check is a GCM tag check:
+
+| Question | Answered by |
+|---|---|
+| Is this the right passcode? | `unwrap` fails GCM ⇒ `KeyshareKeyStoreError.wrongPasscode` |
+| Is this blob even a wrapped key? | `VaultCryptoEnvelope.parse` returns nil, or the plaintext is not 32 bytes ⇒ `malformedWrappedKey` (**not** a wrong passcode — see below) |
+| Was this share sealed under the key I hold? | `open` succeeds |
+| Did my seal actually work? | seal, then open, then compare to the original — the sweeper does this per share |
+
+`malformedWrappedKey` is mapped to `PasscodeError.storageFailure` and
+deliberately **not** counted as a failed attempt. Counting it would bury an
+unrecoverable storage problem under a growing lockout and tell the user the
+wrong thing.
+
+## Reading a value tells you which kind it is
+
+`AesGcmKeyshareCipher.sealedPrefix` is `"vlt2:"`. `:` is outside the base64
+alphabet, so a sealed value can never be confused with a plaintext DKLS share
+(base64) or a plaintext GG20 share (JSON). Detection is a pure function of the
+value — nothing else has to be consulted, and re-sealing an already-sealed value
+is a no-op rather than a corruption.
+
+That property is what lets a store be half-swept and still work, and it is also
+the property that makes the sweeper's third refusal necessary: a value that
+`isSealed` says is sealed has *not* thereby been proved openable. See
+[invariants](invariants.md#the-three-sweeper-refusals).
+
+## The wrapped key is the whole of the persisted state
+
+There is no "passcode is enabled" boolean anywhere. `PasscodeService.isSet` is a
+read of the wrapped key, and `AppLockService.mode` (in `UserDefaults`) is a
+*cache* of that fact which `KeyshareInstallReconciler` repairs in both
+directions at launch. Deriving state from one source is what removes the class
+of bug where two flags disagree.
+
+Because the wrapper is that important, both of its mutations are verified:
+
+- `storeWrappedDataKey` writes then reads back and compares bytes; anything
+  other than `.present(sameBytes)` throws `persistenceFailed`. Encrypting
+  against a key we cannot prove is durable is how shares get lost.
+- `deleteWrappedDataKey` deletes then requires a **confirmed** `.absent`;
+  `.unavailable` counts as failure, because a caller records a successful
+  removal as done and never retries it.
+
+The corollary of that second one is a trap in its own right and is written up in
+[transitions](transitions.md#if-the-delete-fails): **a throw from
+`deleteWrappedDataKey` does not prove the item survived.**
+
+## The biometric copy
+
+`BiometricUnlockStore` is an optional shortcut, never a replacement. It holds a
+**second copy of the same data key** behind
+`SecAccessControl(kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, .biometryCurrentSet)`.
+The passcode-wrapped copy is untouched and always works, so the shortcut can be
+removed, invalidated or fail without costing anyone access.
+
+`.biometryCurrentSet` rather than `.biometryAny`: the system destroys the item if
+enrolled biometrics change, so enrolling a new face does not silently inherit
+access to the wallet. `localizedFallbackTitle = ""` hides the fallback button,
+but what actually prevents the *device* passcode from satisfying the read is the
+access control — neither `.devicePasscode` nor `.userPresence` is requested, so a
+biometric lockout fails rather than falling back. Someone who knows only the
+device passcode must not reach a wallet the app passcode exists to protect.
+
+### Why the copy is *bound* rather than *verified*
+
+The stored blob is `SHA256(wrappedDataKey) ‖ dataKey`, and the digest is checked
+before the key is ever adopted.
+
+The direct check is unavailable: nothing in the unlock path can prove a stored
+key opens anything. The wrapper cannot be unwrapped without the passcode — that
+is the whole point — and an interrupted `setPasscode` can leave a store with no
+sealed share to test against either.
+
+The failure this closes is a fund-loss path. A copy surviving from a previous
+install holds key **A** while the durable wrapper holds key **B**. Adopting A
+would let the resume sweep that follows *every* app unlock seal every share
+under a key no wrapper holds — orphaned on the next lock. Binding makes the
+mismatch detectable up front, and the stale copy is removed rather than left to
+fail again.
+
+The digest leaks nothing (it digests a blob that already sits unprotected in the
+same Keychain) and a collision would be cryptographic, since the wrapper carries
+a random salt and nonce. Its one false negative — a crash between
+`storeWrappedDataKey` and the rebind — costs the shortcut, never the passcode.
+
+### Lifecycle
+
+| Event | What happens to the copy |
+|---|---|
+| `setPasscode` | any leftover is deleted first, and a failure to delete **aborts the set** — a copy without a passcode behind it is a leftover, and it would report the shortcut as already enabled for a passcode the user is only now creating |
+| `changePasscode` | rebound to the new wrapper. Writing the item never prompts for a face; only reading does, so this is silent. If it cannot be rebound it is removed, because a stale binding is refused at the next unlock anyway and leaving one advertises a shortcut the app will not honour |
+| `disablePasscode` | removed **first**, before a single share moves — see [transitions](transitions.md#disablepasscode) |
+| new app container | removed by `KeyshareInstallReconciler` along with the rest of the inherited material |
+| enrolment changes | destroyed by the system |
+
+One `Security` gotcha is baked into the type split and is easy to undo:
+`BiometricKeychain.store` is a **pure `SecItemAdd`**, and the delete-first is
+`BiometricUnlockStore.enable`'s job with a **search-only** query.
+`SecItemDelete` takes a search query, so handing it the full add dictionary
+(with `kSecValueData` and `kSecAttrAccessControl` in it) matches nothing, and the
+add that follows answers `errSecDuplicateItem`. That silently broke rebinding
+after a passcode change.

--- a/docs/passcode-keyshare-encryption/overview.md
+++ b/docs/passcode-keyshare-encryption/overview.md
@@ -104,14 +104,18 @@ Nothing. Not "an encrypted store with the key lying around" — nothing:
   import all route through it, so every write is a passthrough;
 - `Vault.mapToProtobuff` opens each share before writing the `.vult`, and `open`
   passes plaintext through, so export is byte-identical;
-- `KeyshareInstallReconciler` reads three items (wrapper, attempt-limiter state,
-  biometric copy) and, on three *confirmed* absences, issues **no Keychain
-  mutation at all** — not even a no-op delete, which still reaches
-  `SecItemDelete` and still counts. Confirmed, not assumed: an `.unavailable`
-  read defers the whole pass to the next launch rather than issuing deletes;
+- `KeyshareInstallReconciler` reads three items and, finding none of them,
+  issues **no Keychain mutation at all** — not even a no-op delete, which still
+  reaches `SecItemDelete` and still counts. Two of the three are tri-state and an
+  `.unavailable` read **defers the whole pass** to the next launch rather than
+  issuing deletes; the biometric copy has no tri-state to report, because
+  presence is checked without authentication, so a `false` there is as close to a
+  confirmed absence as that item gets;
 - the whole feature is additionally behind `PasscodeFeatureFlag`, off by default
   (`SettingsViewModel.passcodeFeatureEnabled`, toggled from Settings →
-  Advanced), so the Settings entry does not even appear.
+  Advanced), so the Settings entry does not appear at all unless the flag is on
+  or a passcode is already set — the second disjunct exists so turning the flag
+  back off cannot strand someone behind a passcode they can no longer remove.
 
 ## Who owns what
 

--- a/docs/passcode-keyshare-encryption/overview.md
+++ b/docs/passcode-keyshare-encryption/overview.md
@@ -72,10 +72,14 @@ and `KeyshareKeySession.currentState()` is the only thing that produces them:
                  .locked                 .disabled                 .locked
         a passcode exists,          no passcode; shares      fail closed — the
         the key is not in hand      are plaintext            Keychain may hold
-        → open throws               → seal is a passthrough   a wrapper we
-        → seal throws               → open passes plaintext   cannot see
-                                       through
+        → open throws on a          → seal is a passthrough   a wrapper we
+          SEALED value              → open passes plaintext   cannot see
+        → seal throws                 through
 ```
+
+A plaintext value passes straight through `open` in **every** state, `.locked`
+included — that is the first thing `open` checks, before it consults the state at
+all. Only a sealed value can throw there.
 
 `.disabled` is the **majority and permanent** state, not a transient one before
 some migration. Most installs are in it and stay in it forever. That is why
@@ -141,9 +145,6 @@ Nothing. Not "an encrypted store with the key lying around" — nothing:
             KeyshareSweeper   ProtectedVaultImporter  KeyShare.sealed
             whole-store        every backup format     every write path
             seal/unseal        normalizes on import
-                    │                 │                 │
-                    └────────► KeyshareWriteCoordinator ◄┘
-                               transition / write / episode leases
 
  KeyshareKeySession     the opened key, in memory, + the lock generation
  KeyshareInstallReconciler  launch: Keychain vs. container vs. lock mode
@@ -151,6 +152,30 @@ Nothing. Not "an encrypted store with the key lying around" — nothing:
  PasscodeAttemptLimiter the in-app guessing throttle
  AppLockService         which gate is in use (off / deviceAuth / passcode)
 ```
+
+**Serialization is a separate axis, and it does not run through the types
+above.** `KeyshareSweeper` and `KeyShare.sealed` contain no reference to
+`KeyshareWriteCoordinator` at all — they are serialized by **whoever calls
+them**, which is why deleting a caller's lease as "redundant" is a live way to
+break this. Exactly five files reach the coordinator:
+
+```
+  KeyshareWriteCoordinator
+        ▲            ▲                    ▲
+   transition      write                episode
+        │            │                      │
+  PasscodeService    ├─ LocalStateAccessorImpl  ├─ KeygenViewModel
+    set/change/      │    (seal + append)       │    .startKeygen
+    disable          ├─ KeygenViewModel         └─ ProtectedVaultImporter
+  KeyshareInstall    │    .commitVault               .commit
+    Reconciler       └─ PasscodeService
+    .reconcile            unlockApp / unlockWithBiometrics
+                          enable/disableBiometricUnlock
+```
+
+So `sealAll` is safe because `setPasscode` holds a transition lease around it;
+`KeyShare.sealed` is safe because `saveLocalState` and `commitVault` hold a write
+lease around it. Neither can protect itself.
 
 Read paths: `Vault.keyshareValue(for:)` throws so a locked app is
 distinguishable from a vault with no share; `Vault.getKeyshare(pubKey:)` is the

--- a/docs/passcode-keyshare-encryption/overview.md
+++ b/docs/passcode-keyshare-encryption/overview.md
@@ -2,10 +2,12 @@
 
 **Read this before changing anything under `Core/Security/Keyshare/` or
 `Core/Security/Passcode/`.** That code holds key material. A mistake there is
-lost funds, not a bad screen: a key share that cannot be opened is a vault that
-can never sign again, and there is no server-side copy to restore from.
+lost funds, not a bad screen: a key share that cannot be opened is one this
+device can no longer sign with, and unless the user has a `.vult` backup or the
+vault's remaining signers still make a quorum, the vault is unspendable. There
+is no server-side copy to restore from.
 
-- [Key hierarchy](key-hierarchy.md) — what encrypts what, and why changing a passcode moves 32 bytes
+- [Key hierarchy](key-hierarchy.md) — what encrypts what, why changing a passcode rewrites one 80-byte wrapper and no shares, and what the indirection does *not* buy
 - [Concurrency and the write coordinator](concurrency-and-leases.md) — the three leases and the races each closes
 - [Transitions](transitions.md) — set / disable / change / resume, step by step, with what survives a crash at each step
 - [Invariants and traps](invariants.md) — the list of things that look like safe cleanups and are not
@@ -24,7 +26,14 @@ writes, reinstalls and app downgrades.
 ## The acceptance test
 
 > **A user who never sets a passcode must be byte-for-byte indistinguishable
-> from an app build without this feature.**
+> from an app build without this feature** — in key shares, exports, and
+> Keychain state.
+
+One deliberate exception, and it is the only one: `KeyshareInstallReconciler`
+writes a `keyshareInstallReconciled` flag to `UserDefaults`. The acceptance test
+does not speak about `UserDefaults`, and the flag has to live there precisely
+*because* it must vanish with the container — its absence is the only evidence
+that a container is new. Nothing else is written.
 
 Concretely, with no passcode set:
 
@@ -101,8 +110,8 @@ would be failing on too.
 
 Nothing. Not "an encrypted store with the key lying around" — nothing:
 
-- no data key exists in any form, wrapped or clear. There is no unwrapped
-  resting state of the key anywhere in the design;
+- no data key exists in any form — no wrapper, and no biometric copy either,
+  since that shortcut requires a passcode to exist first;
 - `KeyShare.sealed(...)` calls `KeyshareProtector.seal`, which returns the
   plaintext unchanged in `.disabled`. Keygen, reshare, key import and backup
   import all route through it, so every write is a passthrough;
@@ -110,11 +119,12 @@ Nothing. Not "an encrypted store with the key lying around" — nothing:
   passes plaintext through, so export is byte-identical;
 - `KeyshareInstallReconciler` reads three items and, finding none of them,
   issues **no Keychain mutation at all** — not even a no-op delete, which still
-  reaches `SecItemDelete` and still counts. Two of the three are tri-state and an
-  `.unavailable` read **defers the whole pass** to the next launch rather than
-  issuing deletes; the biometric copy has no tri-state to report, because
-  presence is checked without authentication, so a `false` there is as close to a
-  confirmed absence as that item gets;
+  reaches `SecItemDelete` and still counts. Two of the three are tri-state, and
+  an `.unavailable` read **defers the inherited-material clear** to the next
+  launch with the marker left unset, rather than issuing deletes — lock-mode
+  alignment still runs afterwards either way. The biometric copy has no tri-state
+  to report, because presence is checked without authentication, so a `false`
+  there is as close to a confirmed absence as that item gets;
 - the whole feature is additionally behind `PasscodeFeatureFlag`, off by default
   (`SettingsViewModel.passcodeFeatureEnabled`, toggled from Settings →
   Advanced), so the Settings entry does not appear at all unless the flag is on
@@ -160,17 +170,19 @@ them**, which is why deleting a caller's lease as "redundant" is a live way to
 break this. Exactly five files reach the coordinator:
 
 ```
-  KeyshareWriteCoordinator
-        ▲            ▲                    ▲
-   transition      write                episode
-        │            │                      │
-  PasscodeService    ├─ LocalStateAccessorImpl  ├─ KeygenViewModel
-    set/change/      │    (seal + append)       │    .startKeygen
-    disable          ├─ KeygenViewModel         └─ ProtectedVaultImporter
-  KeyshareInstall    │    .commitVault               .commit
-    Reconciler       └─ PasscodeService
-    .reconcile            unlockApp / unlockWithBiometrics
-                          enable/disableBiometricUnlock
+  transition (exclusive)      write                       episode
+  ──────────────────────      ─────                       ───────
+  PasscodeService             PasscodeService             KeygenViewModel
+    setPasscode                 unlockApp                   startKeygen
+    changePasscode              unlockWithBiometrics
+    disablePasscode             enableBiometricUnlock     ProtectedVaultImporter
+                                disableBiometricUnlock      commit
+  KeyshareInstallReconciler
+    reconcile                 LocalStateAccessorImpl
+                                saveLocalState
+
+                              KeygenViewModel
+                                commitVault
 ```
 
 So `sealAll` is safe because `setPasscode` holds a transition lease around it;

--- a/docs/passcode-keyshare-encryption/overview.md
+++ b/docs/passcode-keyshare-encryption/overview.md
@@ -1,0 +1,169 @@
+# Passcode and key-share encryption — overview
+
+**Read this before changing anything under `Core/Security/Keyshare/` or
+`Core/Security/Passcode/`.** That code holds key material. A mistake there is
+lost funds, not a bad screen: a key share that cannot be opened is a vault that
+can never sign again, and there is no server-side copy to restore from.
+
+- [Key hierarchy](key-hierarchy.md) — what encrypts what, and why changing a passcode moves 32 bytes
+- [Concurrency and the write coordinator](concurrency-and-leases.md) — the three leases and the races each closes
+- [Transitions](transitions.md) — set / disable / change / resume, step by step, with what survives a crash at each step
+- [Invariants and traps](invariants.md) — the list of things that look like safe cleanups and are not
+
+---
+
+## The invariant
+
+> **A key share is sealed if and only if a passcode is currently set.**
+
+"Currently", not "ever" — which is what forces `disablePasscode` to open every
+share back to plaintext rather than merely removing the gate. Everything else in
+this feature follows from keeping that sentence true across crashes, concurrent
+writes, reinstalls and app downgrades.
+
+## The acceptance test
+
+> **A user who never sets a passcode must be byte-for-byte indistinguishable
+> from an app build without this feature.**
+
+Concretely, with no passcode set:
+
+| Surface | Must be |
+|---|---|
+| `KeyShare.keyshare` on disk | plaintext, byte-identical |
+| Keychain | no wrapped data key, no attempt-limiter record, no biometric copy, no marker of any kind |
+| Launch | no key-material rewrite, **and no other new Keychain mutation** — not even a no-op delete |
+| `.vult` export / import | unchanged bytes, restores on any build, any platform |
+| TSS keygen / keysign / reshare | unchanged values reach `LocalStateAccessorImpl` |
+| Downgrade to an older build | works, forever, with no action required |
+
+That last row is why the feature is opt-in rather than encrypting everyone. An
+older build has no `vlt2:` awareness: it reads a sealed share and hands the
+literal string `"vlt2:…"` into the TSS layer, so signing fails for someone who
+never chose anything, and a `.vult` exported from that build contains ciphertext
+and is dead on every other device. This repo is open source and contributors
+hop between branches constantly — reviewing a PR branch and then running `main`
+is a downgrade in the sense that breaks. Opt-in confines that hazard to people
+who deliberately turned the feature on, and `disablePasscode` is a real inverse
+they can press to get out of it.
+
+The cost is recorded honestly: optional security settings see single-digit
+adoption, so most installs — macOS especially — hold plaintext key material.
+That was decided, not overlooked.
+
+## The three protection states
+
+`KeyshareProtectionState` (in `KeyshareProtector.swift`) has exactly three cases,
+and `KeyshareKeySession.currentState()` is the only thing that produces them:
+
+```
+                        cached key in memory?
+                                 │
+                    ┌────────yes─┴─no────────┐
+                    ▼                        ▼
+             .unlocked(key)        read the wrapped data key
+        seal and open both work     from the Keychain
+                                             │
+                    ┌────────────────────────┼────────────────────────┐
+                    ▼                        ▼                        ▼
+                .present                 .absent                .unavailable
+                    │                        │                        │
+                    ▼                        ▼                        ▼
+                 .locked                 .disabled                 .locked
+        a passcode exists,          no passcode; shares      fail closed — the
+        the key is not in hand      are plaintext            Keychain may hold
+        → open throws               → seal is a passthrough   a wrapper we
+        → seal throws               → open passes plaintext   cannot see
+                                       through
+```
+
+`.disabled` is the **majority and permanent** state, not a transient one before
+some migration. Most installs are in it and stay in it forever. That is why
+`KeyshareProtector.open` checks `isSealed` *before* consulting the state and
+returns a plaintext value unchanged whatever the state is — a store part-way
+through a sweep still signs correctly.
+
+`.unavailable → .locked` is deliberate and was challenged on review. Reading an
+unreadable Keychain as `.disabled` is a licence to write plaintext behind a
+passcode that is still set — silently, and only for the users who opted in.
+Reading it as `.locked` fails a keygen or an import visibly and the user
+retries. The exposure is also narrower than it looks: with no passcode there is
+no wrapped item at all, and a Keychain query matching no item answers
+`errSecItemNotFound` whatever the device's lock state, so reaching that line
+without a passcode takes a Keychain-wide fault that the fast-vault password read
+would be failing on too.
+
+## What a user who never sets a passcode gets
+
+Nothing. Not "an encrypted store with the key lying around" — nothing:
+
+- no data key exists in any form, wrapped or clear. There is no unwrapped
+  resting state of the key anywhere in the design;
+- `KeyShare.sealed(...)` calls `KeyshareProtector.seal`, which returns the
+  plaintext unchanged in `.disabled`. Keygen, reshare, key import and backup
+  import all route through it, so every write is a passthrough;
+- `Vault.mapToProtobuff` opens each share before writing the `.vult`, and `open`
+  passes plaintext through, so export is byte-identical;
+- `KeyshareInstallReconciler` reads three items (wrapper, attempt-limiter state,
+  biometric copy) and, on three *confirmed* absences, issues **no Keychain
+  mutation at all** — not even a no-op delete, which still reaches
+  `SecItemDelete` and still counts. Confirmed, not assumed: an `.unavailable`
+  read defers the whole pass to the next launch rather than issuing deletes;
+- the whole feature is additionally behind `PasscodeFeatureFlag`, off by default
+  (`SettingsViewModel.passcodeFeatureEnabled`, toggled from Settings →
+  Advanced), so the Settings entry does not even appear.
+
+## Who owns what
+
+```
+ Storage                     Cryptography                 Policy / lifecycle
+ ───────                     ────────────                 ──────────────────
+ KeychainReadResult          VaultCryptoEnvelope          PasscodeService (actor)
+   absent/present/             VLT\x02 blob format          set / change / disable
+   unavailable                 AES-GCM + PBKDF2 600k        unlockApp / unlock
+        │                            │                      resumeSweepUnlocked
+        ▼                            ▼                             │
+ DefaultKeyshareKeyStore     AesGcmKeyshareCipher                   │
+   the wrapped data key        the "vlt2:" prefix                   │
+   store/load/delete           seal / open one share                │
+   wrap / unwrap                      │                             │
+        │                             ▼                             │
+        └──────────────────►  KeyshareProtector  ◄──────────────────┘
+                               the ONE place a stored value
+                               becomes a usable one
+                                      ▲
+                    ┌─────────────────┼─────────────────┐
+                    │                 │                 │
+            KeyshareSweeper   ProtectedVaultImporter  KeyShare.sealed
+            whole-store        every backup format     every write path
+            seal/unseal        normalizes on import
+                    │                 │                 │
+                    └────────► KeyshareWriteCoordinator ◄┘
+                               transition / write / episode leases
+
+ KeyshareKeySession     the opened key, in memory, + the lock generation
+ KeyshareInstallReconciler  launch: Keychain vs. container vs. lock mode
+ BiometricUnlockStore   optional shortcut; a second copy of the key, bound
+ PasscodeAttemptLimiter the in-app guessing throttle
+ AppLockService         which gate is in use (off / deviceAuth / passcode)
+```
+
+Read paths: `Vault.keyshareValue(for:)` throws so a locked app is
+distinguishable from a vault with no share; `Vault.getKeyshare(pubKey:)` is the
+`try?` collapse over it and most TSS call sites still use that one — see
+[invariants](invariants.md#things-that-are-deliberately-not-done).
+
+Write paths: `KeyShare.sealed(pubkey:keyshare:keyId:)` for anything that mints a
+share, `ProtectedVaultImporter` for anything that comes in from a file.
+
+## Where the tests are
+
+`VultisigApp/VultisigAppTests/Security/` — one file per type, plus
+`BackupImportProtectionTests` (drives the real `EncryptedBackupViewModel`
+through every import route) and `PasscodeLaunchGateTests`.
+`VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift` covers the
+tri-state read the whole design rests on.
+
+Several of those tests look over-specified. They are: the plain version of each
+was written first and **passed against the live bug**. See
+[invariants](invariants.md#tests-that-look-paranoid-and-are-not).

--- a/docs/passcode-keyshare-encryption/transitions.md
+++ b/docs/passcode-keyshare-encryption/transitions.md
@@ -1,0 +1,376 @@
+# The transitions
+
+Four operations move the store across the invariant or repair it:
+`setPasscode`, `disablePasscode`, `changePasscode` and the resume sweep that
+every app unlock runs. The step order in each is not stylistic — every position
+below closes a specific way of losing key material, and the "what survives a
+crash here" column is the argument.
+
+Two of them are cheap and two are not:
+
+- `changePasscode` moves **32 bytes** and touches no key share at all.
+- `setPasscode` and `disablePasscode` **cross the invariant**, so each rewrites
+  every stored share. Both are transactional, both take the exclusive transition
+  lease, and both are resumable.
+
+---
+
+## `setPasscode(_:)`
+
+```
+ 0  lease = coordinator.beginTransition()            → .busy if a write or episode is open
+ 1  generation = session.currentGeneration           ← FIRST instruction after the lease
+ 2  validate(passcode)
+ 3  guard !isSet                                     → .alreadySet   (fails closed on .unavailable)
+ 4  guard !sweeper.hasSealedShare()                  → .sealedSharesWithoutKey
+ 5  if biometrics.isEnabled { biometrics.disable() } → throws; nothing has changed yet
+ 6  dataKey = keyStore.generateDataKey()             ← in memory only
+ 7  wrapped = await keyStore.wrap(dataKey, passcode) ← ~0.5s of PBKDF2; SUSPENSION POINT
+ 8  keyStore.storeWrappedDataKey(wrapped)            ← writes AND reads back
+ 9  lockService.mode = .passcode                     ← the moment the wrapper is durable
+10  session.adopt(dataKey, ifGeneration: generation) → .cancelledByLock if a lock landed
+11  sweeper.sealAll()                                ← verified per share
+12  limiter.recordSuccess()
+```
+
+### What survives a crash at each step
+
+| Crash after | Store state | Recovery |
+|---|---|---|
+| 1–7 | nothing written anywhere | none needed |
+| **8** | wrapper durable, `mode` still `.deviceAuth`, all shares plaintext | launch reconciliation sees a present wrapper and restores `.passcode`; the next unlock's resume seals |
+| **9** | wrapper durable, gate up, all shares plaintext | unlock → resume seals everything |
+| **10–11 (mid-sweep)** | wrapper durable, gate up, **some shares sealed, some plaintext** — the *pending-passcode* state | unlock → resume seals the rest. A half-swept store still signs, because `open` passes plaintext through |
+| 12 | done | none |
+
+There is no state in that table where a sealed share exists without a durable
+wrapper. That is the property the ordering buys.
+
+### Why step 8 comes before step 11
+
+The tempting order — mint, seal everything, then store the wrapper — orphans
+**every** sealed share if the process dies in between, because the key only ever
+lived in memory. Unrecoverable.
+
+### Why step 9 moved up
+
+With `mode = .passcode` at the *end* (an earlier revision), a failed sweep left a
+durable wrapper while the mode stayed `.deviceAuth`. The consequence chain:
+
+```
+  sweep fails
+    → mode stays .deviceAuth
+    → launch shows no passcode gate
+    → resume only runs on an app-passcode unlock, which never happens
+    → retry fails with .alreadySet (the wrapper IS there)
+    → the passcode is durable and unreachable. Permanently.
+```
+
+Setting `.passcode` the moment the wrapper verifies means the next launch shows
+the gate, the unlock runs resume, and the sweep finishes.
+
+The cost of moving it up is that a throw from `setPasscode` no longer means
+"nothing durable happened", and the UI had to learn that — see
+[the UI note](#a-throw-does-not-mean-nothing-happened) below.
+
+### Why a failed sweep must NOT delete the wrapper
+
+An earlier revision said the failure path should clean up by deleting the
+wrapper. **That is unsafe.** Once sealing may have begun, deleting the wrapper
+strands whatever got sealed. The consoling argument — "a later `setPasscode`
+re-sweeps idempotently" — is false: a newly minted key **cannot open ciphertext
+produced by the discarded one**.
+
+So the app stays in the pending-passcode state and resume completes it. Deleting
+the wrapper is only safe in the window where sealing has *provably* not started,
+i.e. between steps 8 and 9.
+
+That also makes step 4's guard coherent rather than over-broad: a **completed**
+disable leaves nothing sealed, so re-enabling works; an **interrupted** set
+leaves a wrapper, so `guard !isSet` refuses first and resume — not a fresh mint —
+is the recovery.
+
+### Step 4, "never mint over evidence"
+
+A sealed share plus no readable wrapper means a key already exists somewhere,
+and the key generated at step 6 opens none of what that one sealed. So the set is
+refused with `.sealedSharesWithoutKey` rather than completed.
+
+`hasSealedShare()` **refuses a dirty `ModelContext`** (mapped to
+`PasscodeError.busy`), and that is not symmetry for its own sake. A SwiftData
+fetch answers from the context's *pending* state, so an unsaved edit or an
+uncommitted deletion can present a vault as plaintext — or hide it entirely —
+while the durable row is still sealed. Without the refusal the scan returns
+`false`, a wrapper is stored, and *then* the sweep at step 11 fails `.busy`
+because the same dirty context is refused one layer down: the set fails **after**
+the wrapper is durable. With it, the set fails **before a key is minted**, which
+is strictly the better failure.
+
+### Step 5, and why it is before step 6
+
+The biometric copy holds the *same* data key. A copy with no passcode behind it
+is a leftover — a previous install's, or one a reconciliation could not clear —
+bound to a wrapper that no longer exists, so it could never open the app. What it
+*can* do is report biometric unlock as already enabled for a passcode the user is
+only now creating. Failing here is deliberate, and it is clean: nothing has
+changed yet.
+
+---
+
+## `disablePasscode(current:)`
+
+The exact inverse of `setPasscode`: the device is left byte-for-byte in the state
+it would have been in had a passcode never been set.
+
+```
+ 0  lease = coordinator.beginTransition()
+ 1  wrappedBeforeVerification = loadWrappedDataKey().valueTreatingUnavailableAsAbsent
+ 2  await unlock(with: current)                      ← key in memory
+ 3  biometrics.disable()                             ← BEFORE a single share moves
+ 4  wrapped = wrappedBeforeVerification ?? loadWrappedDataKey().value…
+ 5  sweeper.unsealAll()                              ← the GCM open IS the verification
+ 6  lockService.mode = .deviceAuth                   ← BEFORE the wrapper goes
+ 7  keyStore.deleteWrappedDataKey()                  ← on failure: restore, then rethrow
+ 8  session.clear()
+```
+
+### What survives a crash at each step
+
+| Crash after | Store state | Recovery |
+|---|---|---|
+| 1–4 | unchanged; passcode fully working | none needed |
+| **5 (mid-unseal)** | wrapper present, mode `.passcode`, some shares plaintext | resume on the next unlock re-seals them; user presses disable again |
+| **6** | wrapper present, mode `.deviceAuth`, all shares plaintext | reconciliation restores `.passcode`; resume re-seals; user presses disable again |
+| **7** | no wrapper, mode `.deviceAuth`, all shares plaintext | this is the finished state |
+| 8 | done | the key is only in memory; the process died, so it is gone |
+
+### Why the mode changes before the wrapper is deleted
+
+With the reverse order, a crash after the deletion but before the mode change
+leaves plaintext shares behind `mode == .passcode` and **no wrapper to unlock
+against**. `unlock` has nothing to verify a passcode against, so that gate can
+never be opened — on a store that needs no protection at all.
+
+The mode-first order creates its own, smaller window (row 6 above): plaintext
+shares, wrapper present, persisted `.deviceAuth`. `KeyshareInstallReconciler`'s
+*present ⇒ `.passcode`* direction repairs exactly that, and its worst case is a
+disable the user presses twice. The reverse order's failure has no repair at all.
+That asymmetry is the whole argument.
+
+### Why the biometric copy goes first
+
+It holds the same data key, so a survivor would quietly work again the next time
+a passcode is set. And failing to remove it *after* the shares had already been
+opened would report an error over a passcode that is half gone. At step 3 nothing
+has changed, so aborting is clean.
+
+It is called directly rather than through `disableBiometricUnlock()`, because
+that method takes a write lease and this call already holds the transition lease
+the write would be excluded by.
+
+### If the delete fails
+
+One protocol, not a choice: **prove the wrapper is durable, restore
+`.passcode`, reseal transactionally, throw.** The app is back to a working
+passcode and the user retries.
+
+Proving the wrapper first is not belt and braces. `deleteWrappedDataKey` reports
+failure on an **unreadable read-back** too, so "it threw" does not mean "the item
+is still there". Resealing on that assumption produces ciphertext whose only key
+is in memory, until the next `lock()` destroys it. So
+`restorePasscodeAfterFailedRemoval` re-stores the wrapper — and therefore
+read-back-verifies it — *before a single share is resealed*.
+
+If the wrapper cannot be made durable, nothing is resealed **and the session is
+cleared**. Plaintext shares with no key anywhere is precisely the no-passcode
+resting state, and it is the only outcome here that loses nothing. Clearing the
+session matters: leaving the key cached would let a keygen or reshare seal a new
+share against a key nothing on disk wraps, and the first lock after that makes
+that share unreadable forever.
+
+Step 1 and step 4 read the wrapper on **both sides** of the verification for the
+same reason. `unlock` cannot succeed without reading that item, so a read that
+comes back unreadable on one side of it is transient rather than meaningful — and
+without those bytes the rollback has nothing to restore, which is the difference
+between "the passcode is back" and "plaintext shares behind a mode that says
+there is no passcode".
+
+---
+
+## `changePasscode(current:new:)`
+
+```
+ 0  lease = coordinator.beginTransition()
+ 1  validate(new)
+ 2  dataKey = await unlock(with: current)            ← verification; throttled
+ 3  rewrapped = await keyStore.wrap(dataKey, new)
+ 4  keyStore.storeWrappedDataKey(rewrapped)          ← 32 bytes; read-back verified
+ 5  rebindTheBiometricCopy(to: rewrapped, dataKey:)
+```
+
+**No key share is read or written.** The ciphertext on disk is byte-identical
+before and after, and there is a test that asserts it. That is what makes this
+safe to do casually.
+
+It still takes the transition lease, because it rewrites the one item every
+sealed share depends on. Interleaving with a set or a disable is how a wrapper
+ends up holding a key that matches nothing on disk.
+
+Step 5 is required rather than cosmetic: the biometric copy is bound to the exact
+wrapped blob it was made for, and step 4 replaces that blob. Without the rebind
+the shortcut stops working the moment anyone changes their passcode. Rebinding
+costs no prompt — writing the Keychain item never asks for a face, only reading
+does — and the data key has just been verified. If it cannot be rebound the copy
+is **removed** instead; a stale binding is refused at the next unlock anyway, and
+leaving one advertises a shortcut the app will not honour. A failure to remove it
+is logged rather than thrown: the change itself succeeded and the leftover cannot
+open anything.
+
+---
+
+## Resume on unlock
+
+One rule, no persisted marker, nothing that can fall behind:
+
+> **With the data key in hand and a wrapper present, seal any share that is still
+> plaintext.**
+
+That finishes an interrupted `setPasscode`, re-establishes the invariant after an
+interrupted `disablePasscode`, and closes "plaintext introduced by an app
+downgrade stays plaintext forever" as a side effect.
+
+It deliberately does **not** try to tell an interrupted disable from an
+interrupted set. With the wrapper still present there is no way to, and guessing
+"disable" would silently remove protection. Restoring the invariant is
+unambiguous and fails safe — worst case is a disable the user presses twice.
+(An earlier design page says resume should detect the inverse and complete the
+disable. That was rejected; this overrides it.)
+
+### Wiring rules
+
+- invoked from **exactly two places**: `unlockApp(with:)` and
+  `unlockWithBiometrics(reason:)`, before either tells the caller the app is
+  open;
+- **never** from `unlock(with:)`, which is passcode *verification* and is what
+  `changePasscode` and `disablePasscode` also call. Firing it there would run a
+  store-wide sweep in the middle of a change;
+- `resumeSweepUnlocked()` is **non-acquiring, and there is deliberately no
+  acquiring variant.** Both app-unlock paths already hold a lease that excludes
+  transitions. An acquiring `resumeSweep()` would ask the coordinator for a lease
+  from inside a held one — which is exactly what the coordinator refuses — so it
+  would throw `.busy` on the single path that must work every time. The missing
+  API reads like a completeness gap; it is not;
+- the latch is keyed on the **session generation**, not a boolean. `lock()` is
+  `nonisolated` and cannot touch actor state, so bumping the generation *is* the
+  reset. Plaintext introduced after a successful sweep is picked up on the next
+  lock cycle rather than never;
+- the latch is set **only on success**, so a failed resume retries on the next
+  unlock.
+
+### It swallows its own errors, and that is deliberate
+
+`resumeSweepUnlocked` catches everything and logs. `unlockApp` returns success
+regardless. This was raised as a finding three separate times and rejected three
+times, so here is the reasoning in full:
+
+the key is **adopted before** the resume runs, so the session *is* open by then.
+Propagating the error would leave the lock screen up over an unlocked session,
+and a persistent cause — one share that will not open, an unsaved edit somewhere
+in the store — would lock a user out of an app whose passcode they know. That
+trades a partial-protection exposure for a total loss of access.
+
+What *is* true and is not hidden: **a persistently failing resume leaves
+plaintext shares behind a live passcode, logged at error level and surfaced
+nowhere.** The right fix is a degraded-protection indicator in the UI. It is
+unclaimed work, not a solved problem. The doc comment on `unlockApp` says
+"attempts", not "guarantees", for this reason — do not tighten that wording
+without building the indicator.
+
+### The generation check on both sides
+
+Both unlock paths capture the generation before the first suspension point and
+**re-check it after the resume**, clearing the session and throwing
+`.cancelledByLock` on a mismatch. `unlock` only guards the *adoption* against a
+lock; without the second check, a lock landing during the sweep would still be
+followed by a successful return, and the caller would dismiss the lock screen
+over a session that is locked again.
+
+There is one more gap after that, in the UI: `lock()` can land between
+`unlockApp` returning and the overlay flag moving. `PasscodeService.isSessionUnlocked`
+is `nonisolated` precisely so no `await` can open a gap between asking and
+acting, and both `AppViewModel.markPasscodeUnlocked()` and
+`PasscodeViewModel.unlock()` check it immediately before the flag moves, with
+nothing in between.
+
+---
+
+## Launch
+
+```
+  ContentView.onLoad
+        │
+        ▼
+  AppViewModel.restorePasscodeLockOnLaunch()
+        │
+        ├─► KeyshareInstallReconciler().reconcile()      ← SYNCHRONOUSLY, first
+        │        │
+        │        ├─ take the transition lease, or skip entirely and leave
+        │        │  the container unmarked so the next launch retries
+        │        ├─ clear inherited key material if the container is new
+        │        └─ align the lock mode with the wrapped key, both directions
+        │
+        └─► if mode == .passcode: lock() and raise the gate
+```
+
+**The ordering is the point.** `KeyshareInstallReconciler().reconcile()` also
+runs from `VultisigApp`'s `onAppear`, but nothing orders that against
+`ContentView.onLoad` — so the gate could be chosen from a mode reconciliation was
+about to change, after which the app sits open for the whole session with a
+wrapped key and no lock screen. Running it here makes the ordering hold by
+construction rather than by luck. A second pass is a no-op: the destructive half
+is marked once per container, and the alignment only writes when the two
+disagree.
+
+The reconciler takes the **transition lease** around its whole body. Without it,
+a launch landing between `setPasscode` verifying its wrapper and adopting the key
+would delete that wrapper *and mark the container done* — leaving the data key
+live in memory with nothing on disk that wraps it. If the lease cannot be taken
+it skips entirely and leaves the container unmarked.
+
+Its three-valued reads exist for the same reason everything else here is
+three-valued. Store occupancy is `empty` / `occupied` / **`unknown`**, and
+`unknown` **defers the whole pass**: counting an unreadable store as occupied
+would set the permanent marker and retire the clear for good, so a genuinely new
+container whose store stuttered at launch would keep the previous install's
+wrapped data key forever — a passcode gate nobody can open and reinstalling
+cannot remove, which is the exact failure this type exists to prevent. Inherited
+key material is `nothing` / `something` / `unknown` on the same principle, and
+`unknown` defers rather than issuing deletes, because deletes on a first-ever
+install are a launch-time Keychain mutation the acceptance test forbids.
+
+`lastMigratedVersion` is deliberately **not** cleared. It is Keychain-held so it
+survives reinstalls, and clearing it would re-run every ordinary migration on a
+container with no passcode artifact of any kind.
+
+---
+
+## A throw does not mean nothing happened
+
+`setPasscode` stores the wrapper and switches the mode *before* the sweep, so a
+sweep failure leaves a **working passcode** while the screen shows an error and
+offers a retry whose only possible answer is `.alreadySet` — a dead end.
+
+`PasscodeViewModel` closes the set flow on exactly one error: `.cancelledByLock`.
+That error is thrown from a **single guard**, after the wrapper has verified and
+after the mode has moved, so it is the one failure that *proves* the typed
+passcode is durable.
+
+The first attempt at this asked `isSet` instead, and it was wrong twice over:
+`isSet` answers `true` for an **unreadable** wrapper as well as a present one,
+and it cannot tell a wrapper this call wrote from one that was already there. A
+failed read-back, or a transition refused while somebody else's set completed,
+would have dismissed the screen over a passcode the user never set.
+
+A sweep that fails after the wrapper is durable also leaves a working passcode,
+but nothing distinguishes it from a sweep-shaped failure *before* the wrapper, so
+it reports the error and `.alreadySet` explains the retry.

--- a/docs/passcode-keyshare-encryption/transitions.md
+++ b/docs/passcode-keyshare-encryption/transitions.md
@@ -8,7 +8,8 @@ crash here" column is the argument.
 
 Two of them are cheap and two are not:
 
-- `changePasscode` moves **32 bytes** and touches no key share at all.
+- `changePasscode` rewraps the 32-byte data key into **one 80-byte wrapper** and
+  touches no key share at all.
 - `setPasscode` and `disablePasscode` **cross the invariant**, so each rewrites
   every stored share. Both are transactional, both take the exclusive transition
   lease, and both are resumable.
@@ -39,16 +40,18 @@ Two of them are cheap and two are not:
 |---|---|---|
 | 1–4 | nothing written anywhere | none needed |
 | **5–7** | a leftover biometric copy has been deleted; nothing else written | none needed — that copy could never have opened anything |
-| **8** | wrapper durable, `mode` still `.deviceAuth`, all shares plaintext | launch reconciliation sees a present wrapper and restores `.passcode`; the next unlock's resume seals |
+| **8** | wrapper durable, `mode` still whatever it was (`.deviceAuth` **or** `.off` — this step has not touched it), all shares plaintext | launch reconciliation sees a present wrapper and restores `.passcode`; the next unlock's resume seals |
 | **9** | wrapper durable, gate up, all shares plaintext | unlock → resume seals everything |
-| **10–11**, or a sweep that simply *fails* | wrapper durable, gate up, shares **not yet sealed** — the *pending-passcode* state | unlock → resume seals them |
+| **10**, or anywhere inside 11 **before its save lands**, or a sweep that simply *fails* | wrapper durable, gate up, shares **still plaintext** — the *pending-passcode* state | unlock → resume seals them |
+| **11**, after its save returned | wrapper durable, gate up, **all shares sealed** — the finished state bar the throttle reset | none needed |
 | 12 | done | none |
 
-The sweep itself is not a partial-write hazard: `KeyshareSweeper` computes and
-verifies everything first and then commits **one** `context.save()`, so a crash
-inside it leaves the store exactly as row 9 describes rather than half rewritten.
-Pending-passcode is therefore "durable wrapper, gate up, sweep not applied", and
-resume is what applies it.
+The sweep itself is not a partial-write hazard, which is why those two rows have
+a hard edge between them rather than a gradient: `KeyshareSweeper` computes and
+verifies everything first and then commits **one** `context.save()`. Before that
+save the store is untouched; after it, every share is sealed. Pending-passcode is
+therefore exactly "durable wrapper, gate up, sweep not applied", and resume is
+what applies it.
 
 A genuinely **mixed** store — some shares sealed, some plaintext — is still
 reachable, just not from this path: a keygen commits a share sealed under the
@@ -230,7 +233,7 @@ there is no passcode".
  1  validate(new)
  2  dataKey = await unlock(with: current)            ← verification; throttled
  3  rewrapped = await keyStore.wrap(dataKey, new)
- 4  keyStore.storeWrappedDataKey(rewrapped)          ← 32 bytes; read-back verified
+ 4  keyStore.storeWrappedDataKey(rewrapped)          ← one 80-byte wrapper; read-back verified
  5  rebindTheBiometricCopy(to: rewrapped, dataKey:)
 ```
 
@@ -373,14 +376,18 @@ it skips entirely and leaves the container unmarked.
 
 Its three-valued reads exist for the same reason everything else here is
 three-valued. Store occupancy is `empty` / `occupied` / **`unknown`**, and
-`unknown` **defers the whole pass**: counting an unreadable store as occupied
+`unknown` **defers the inherited-material clear and leaves the marker unset**
+ — the lock-mode alignment below still runs, because a gate that disagrees with
+the wrapper has to be repaired whether or not the store could be read. Counting
+an unreadable store as occupied
 would set the permanent marker and retire the clear for good, so a genuinely new
 container whose store stuttered at launch would keep the previous install's
 wrapped data key forever — a passcode gate nobody can open and reinstalling
 cannot remove, which is the exact failure this type exists to prevent. Inherited
 key material is `nothing` / `something` / `unknown` on the same principle, and
-`unknown` defers rather than issuing deletes, because deletes on a first-ever
-install are a launch-time Keychain mutation the acceptance test forbids.
+`unknown` defers that clear rather than issuing deletes, because deletes on a
+first-ever install are a launch-time Keychain mutation the acceptance test
+forbids.
 
 `lastMigratedVersion` is deliberately **not** cleared. It is Keychain-held so it
 survives reinstalls, and clearing it would re-run every ordinary migration on a

--- a/docs/passcode-keyshare-encryption/transitions.md
+++ b/docs/passcode-keyshare-encryption/transitions.md
@@ -137,8 +137,14 @@ changed yet.
 
 ## `disablePasscode(current:)`
 
-The exact inverse of `setPasscode`: the device is left byte-for-byte in the state
-it would have been in had a passcode never been set.
+The exact inverse of `setPasscode` where key material is concerned: no data key
+in any form, and every share byte-identical to what a device that never had a
+passcode would hold.
+
+One thing does not come back. `AppLockMode` has three cases, and this writes
+`.deviceAuth` unconditionally — so someone who was on `.off` before they set a
+passcode lands on `.deviceAuth`, not back on `.off`. That is a `UserDefaults`
+preference they can change again, not key material.
 
 ```
  0  lease = coordinator.beginTransition()
@@ -318,11 +324,16 @@ over a session that is locked again.
 There is one more gap after that, in the UI: `lock()` can land between
 `unlockApp` returning and the overlay flag moving. `PasscodeService.isSessionUnlocked`
 is `nonisolated` precisely so no `await` can open a gap between asking and
-acting. `AppViewModel.markPasscodeUnlocked()` checks it immediately before the
-flag moves, with nothing in between. `PasscodeViewModel.unlock()` cannot do that
-— `perform` sets `didFinish` on success — so it re-checks the instant
-`unlockApp` returns and puts `didFinish` back to `false` if a lock landed,
-clearing the entry so the passcode can be retyped.
+acting. Three callers, three shapes, all of them making a lock win:
+
+- `AppViewModel.markPasscodeUnlocked()` checks it immediately before the flag
+  moves, with nothing in between;
+- `PasscodeViewModel.unlockWithBiometrics(reason:)` derives the flag *from* the
+  check — `didFinish = service.isSessionUnlocked`;
+- `PasscodeViewModel.unlock()` cannot do either, because the shared `perform`
+  helper sets `didFinish` on success. So it re-checks the instant `unlockApp`
+  returns and puts `didFinish` back to `false` if a lock landed, clearing the
+  entry so the passcode can be retyped.
 
 ---
 

--- a/docs/passcode-keyshare-encryption/transitions.md
+++ b/docs/passcode-keyshare-encryption/transitions.md
@@ -37,11 +37,25 @@ Two of them are cheap and two are not:
 
 | Crash after | Store state | Recovery |
 |---|---|---|
-| 1–7 | nothing written anywhere | none needed |
+| 1–4 | nothing written anywhere | none needed |
+| **5–7** | a leftover biometric copy has been deleted; nothing else written | none needed — that copy could never have opened anything |
 | **8** | wrapper durable, `mode` still `.deviceAuth`, all shares plaintext | launch reconciliation sees a present wrapper and restores `.passcode`; the next unlock's resume seals |
 | **9** | wrapper durable, gate up, all shares plaintext | unlock → resume seals everything |
-| **10–11 (mid-sweep)** | wrapper durable, gate up, **some shares sealed, some plaintext** — the *pending-passcode* state | unlock → resume seals the rest. A half-swept store still signs, because `open` passes plaintext through |
+| **10–11**, or a sweep that simply *fails* | wrapper durable, gate up, shares **not yet sealed** — the *pending-passcode* state | unlock → resume seals them |
 | 12 | done | none |
+
+The sweep itself is not a partial-write hazard: `KeyshareSweeper` computes and
+verifies everything first and then commits **one** `context.save()`, so a crash
+inside it leaves the store exactly as row 9 describes rather than half rewritten.
+Pending-passcode is therefore "durable wrapper, gate up, sweep not applied", and
+resume is what applies it.
+
+A genuinely **mixed** store — some shares sealed, some plaintext — is still
+reachable, just not from this path: a keygen commits a share sealed under the
+adopted key while resume has not yet run over the older plaintext ones, or an app
+downgrade writes a plaintext share into a sealed store. That store signs
+correctly regardless, because `open` passes a plaintext value through whatever
+the state, and the next unlock's resume closes it.
 
 There is no state in that table where a sealed share exists without a durable
 wrapper. That is the property the ordering buys.
@@ -76,10 +90,14 @@ The cost of moving it up is that a throw from `setPasscode` no longer means
 ### Why a failed sweep must NOT delete the wrapper
 
 An earlier revision said the failure path should clean up by deleting the
-wrapper. **That is unsafe.** Once sealing may have begun, deleting the wrapper
-strands whatever got sealed. The consoling argument — "a later `setPasscode`
-re-sweeps idempotently" — is false: a newly minted key **cannot open ciphertext
-produced by the discarded one**.
+wrapper. **That is unsafe**, and the reason is not that today's sweeper is
+sloppy — it is that the failure does not tell you whether anything was sealed.
+`KeyshareSweeper` as written is two-phase and rolls back, so a thrown `sealAll`
+happens to leave nothing sealed; that is a property of one implementation, not of
+the contract this ordering has to survive. And the consoling argument that made
+deletion look safe — "a later `setPasscode` re-sweeps idempotently" — is false
+either way: a newly minted key **cannot open ciphertext produced by the discarded
+one**.
 
 So the app stays in the pending-passcode state and resume completes it. Deleting
 the wrapper is only safe in the window where sealing has *provably* not started,
@@ -138,8 +156,10 @@ it would have been in had a passcode never been set.
 
 | Crash after | Store state | Recovery |
 |---|---|---|
-| 1–4 | unchanged; passcode fully working | none needed |
-| **5 (mid-unseal)** | wrapper present, mode `.passcode`, some shares plaintext | resume on the next unlock re-seals them; user presses disable again |
+| 1–2 | unchanged; passcode fully working | none needed |
+| **3–4** | passcode fully working, but the biometric shortcut is gone | none needed; the user re-enables it |
+| **5** (crash inside the unseal, or an unseal that fails) | wrapper present, mode `.passcode`, shares **still sealed** — the unseal is one `save()`, so it is all or nothing | nothing to repair; the passcode still works and the user presses disable again |
+| **5**, after its save landed | wrapper present, mode `.passcode`, all shares plaintext | resume on the next unlock re-seals them; user presses disable again |
 | **6** | wrapper present, mode `.deviceAuth`, all shares plaintext | reconciliation restores `.passcode`; resume re-seals; user presses disable again |
 | **7** | no wrapper, mode `.deviceAuth`, all shares plaintext | this is the finished state |
 | 8 | done | the key is only in memory; the process died, so it is gone |
@@ -298,9 +318,11 @@ over a session that is locked again.
 There is one more gap after that, in the UI: `lock()` can land between
 `unlockApp` returning and the overlay flag moving. `PasscodeService.isSessionUnlocked`
 is `nonisolated` precisely so no `await` can open a gap between asking and
-acting, and both `AppViewModel.markPasscodeUnlocked()` and
-`PasscodeViewModel.unlock()` check it immediately before the flag moves, with
-nothing in between.
+acting. `AppViewModel.markPasscodeUnlocked()` checks it immediately before the
+flag moves, with nothing in between. `PasscodeViewModel.unlock()` cannot do that
+— `perform` sets `didFinish` on success — so it re-checks the instant
+`unlockApp` returns and puts `didFinish` back to `false` if a lock landed,
+clearing the entry so the passcode can be retyped.
 
 ---
 
@@ -331,7 +353,8 @@ construction rather than by luck. A second pass is a no-op: the destructive half
 is marked once per container, and the alignment only writes when the two
 disagree.
 
-The reconciler takes the **transition lease** around its whole body. Without it,
+The reconciler takes the **transition lease** around everything it decides or
+writes; only the store-occupancy read that feeds it sits just outside. Without it,
 a launch landing between `setPasscode` verifying its wrapper and adopting the key
 would delete that wrapper *and mark the container done* — leaving the data key
 live in memory with nothing on disk that wraps it. If the lease cannot be taken

--- a/docs/passcode-keyshare-encryption/transitions.md
+++ b/docs/passcode-keyshare-encryption/transitions.md
@@ -355,7 +355,7 @@ acting. Three callers, three shapes, all of them making a lock win:
         │        ├─ clear inherited key material if the container is new
         │        └─ align the lock mode with the wrapped key, both directions
         │
-        └─► if mode == .passcode: lock() and raise the gate
+        └─► if isPasscodeGateRequired: lock() and raise the gate
 ```
 
 **The ordering is the point.** `KeyshareInstallReconciler().reconcile()` also
@@ -392,6 +392,58 @@ forbids.
 `lastMigratedVersion` is deliberately **not** cleared. It is Keychain-held so it
 survives reinstalls, and clearing it would re-run every ordinary migration on a
 container with no passcode artifact of any kind.
+
+---
+
+## The gate is derived, never cached
+
+`AppViewModel.isPasscodeLocked` is what the user is looking at, and it is a copy
+of `PasscodeService.isPasscodeGateRequired` taken at the moment the overlay went
+up. One transition invalidates that copy in the worst way available. A
+`disablePasscode` **past its abort cut-off** completes even across a background
+`lock()` — stopping there would strand every share in the clear behind a passcode
+still being demanded — and what it completes into is `.deviceAuth`, no wrapper,
+and a screen whose only exit calls `unlockApp`, which can now answer nothing but
+`notSet`. Nothing typed there is ever right; force quitting is the only way out.
+
+So the predicate is asked again rather than remembered:
+
+```swift
+nonisolated var isPasscodeGateRequired: Bool {
+    guard lockService.mode == .passcode else { return false }
+    if case .absent = keyStore.loadWrappedDataKey() { return false }
+    return true
+}
+```
+
+Both halves matter. It is the mode **and** a wrapper that is not *confirmed*
+gone, so an unreadable Keychain leaves a real gate standing while a provably
+removed passcode takes one down. `disablePasscode` guarantees it is `false` by
+the time it returns, and `unlockApp` repairs a mode it finds standing over a
+confirmed absence on the spot, for the person already at the gate.
+
+Every site that raises or lowers the overlay derives it:
+
+| Site | Asks |
+|---|---|
+| `restorePasscodeLockOnLaunch()` — cold start | after reconciliation, never before |
+| `enableAuth()` — foreground | which gate this install has: raise, or lower a stale one and fall through to device auth |
+| `EnterPasscodeScreen`'s failed attempt | reports; `lowerPasscodeGateIfNoLongerRequired()` decides |
+
+Reading `AppLockService.mode` at either of the first two is the bug this
+replaced, and it is a strict narrowing rather than a change of policy — the
+predicate's own first clause is that mode check.
+
+**Each site derives it exactly once and every branch acts on that one answer.**
+`raisePasscodeGate()` deliberately does *not* re-derive: a transition runs on
+`PasscodeService`'s executor rather than the main one, so a second read can
+disagree with the first, and `enableAuth`'s passcode branch returns past the
+device-auth fallback. Split across two reads, a foreground could raise no gate,
+skip the fallback, and put the wallet on screen behind neither.
+
+Not forgetting the data key when no gate is required is deliberate too: with the
+wrapper confirmed gone, the session key is the last copy of something nothing can
+hand back.
 
 ---
 


### PR DESCRIPTION
> **Also carries the in-repo docs.** `docs/passcode-keyshare-encryption/` (5 pages + a `docs/README.md`)
> is the written-down reasoning for this whole stack — the invariant, the key hierarchy, the lease model,
> per-step crash tables for every transition, and a list of things that look like safe cleanups and are
> not. `CLAUDE.md` and `AGENTS.md` route agents to it and add `Core/Security/Keyshare/` as a critical
> boundary. It sits here because this is the only layer where the whole feature exists.

> **Stack 8 of 8** for #4846 — renumbered from /7; a transition-coordinator layer was inserted as 5/8.
> **The stack was reworked to opt-in encryption**: key shares are sealed **if and only if a passcode is
> currently set**, so anyone who never sets one keeps plaintext shares and a safely downgradable build.
> The launch migration that used to sit at 3/8 is deleted. Full rationale in #4991 and #4993.
> Re-derived, not rebased: it touches the reconciler, whose shape changed.
> Base: `feat/passcode-ui-4846-v2`.

## Description

**Stack 7 of 7** for #4846, and the optional one. Adds a biometric unlock shortcut: a **second** wrapped copy of the data key stored under `SecAccessControl(.biometryCurrentSet)`, so Face ID / Touch ID can unlock without retyping the passcode.

Part of #4846. **Base: `feat/passcode-ui-4846-v2` (PR 6)** — review PRs 1–6 first. This one is genuinely droppable if the stack needs to get smaller.

19 files, +674/−3.

### The design constraint

Biometrics are a **shortcut, not a source of truth**. The passcode-wrapped copy of the data key remains the authority; the biometric copy is an additional wrap of the same key. `.biometryCurrentSet` means the copy is invalidated by the OS whenever enrolment changes — adding a fingerprint or re-enrolling a face drops it, and the user falls back to the passcode.

Every failure mode falls through to the passcode screen and **never to unlocked**: biometric success unwraps; biometric failure, cancel, unavailable, and enrolment-changed all land on passcode entry.

### Included review fix

`7e4f7e6aa` — the biometric key copy was not cleared on a **new container**. Same class of bug as the reinstall problem in PR 5: a fresh install inheriting a Keychain item from a previous one. The reconciler now clears the biometric copy too, not just the passcode-wrapped one.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Parity

- Android: `vultisig/vultisig-android#5343`
- Windows + extension: n/a — no biometric equivalent in the desktop client
- SDK: n/a

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — **see the limitation below**

## Additional context

⚠️ **This step cannot be fully tested on a simulator, and that is not a gap in the tests.** A simulator has no device passcode, so a `.biometryCurrentSet` item cannot be stored at all. The observable symptom is the biometric toggle **bouncing back off** when enabled — which is correct fail-closed behaviour, not a bug, and is exactly what you should expect if you try it in a sim.

**Needs a real device to verify:** enable the toggle, background, unlock with Face ID / Touch ID, then re-enrol a face or add a fingerprint and confirm it falls back to the passcode rather than unlocking or bricking.

Because of that, this is the least-verified PR in the stack. If review bandwidth is limited, PRs 1–3 are the ones with standalone value (at-rest encryption, no passcode, no UX) — this one can wait or be dropped.

See PR 1 for design rationale and sign-off status.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4846
- **Confidence**: low — logic is reviewed and fails closed by construction, but the happy path has never executed on real hardware
- **Needs human review for**: on-device biometric behaviour, `.biometryCurrentSet` invalidation, and whether this shortcut is wanted at all


