### PR TITLE
fix(tests): un-skip the ChainHelper golden signing-vector suite

### DIFF
--- a/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
@@ -24,17 +24,18 @@ struct ChainHelperTestCase: Codable {
 
 /// The golden signing-vector fixtures bundled under `TestData/`.
 ///
-/// Every fixture is named here and gets its own `test…` method rather than
-/// being discovered by a wildcard walk of the bundle. A wildcard walk is what
-/// let the entire corpus stop executing without anything turning red: the
-/// walk's "is this one of ours?" filter silently matched nothing, so the loop
-/// body never ran and the suite stayed green with zero conformance coverage.
+/// This list — not a wildcard walk of the bundle — is what the suite executes.
+/// A wildcard walk is what let the entire corpus stop running without anything
+/// turning red: the walk's "is this one of ours?" filter silently matched
+/// nothing, so the loop body never ran and the suite stayed green with zero
+/// conformance coverage.
 ///
-/// Explicit registration makes that failure mode impossible to reach silently:
-/// `testEveryBundledFixtureIsRegistered` pins this list against the JSON files
-/// actually present in the bundle and against the number of test methods on
-/// this class, so a fixture can neither be added without a test nor listed
-/// without one.
+/// Two tests keep that from happening again.
+/// `testAllRegisteredFixturesExecute` runs every case in this list in a single
+/// test, so coverage never depends on per-method bookkeeping, and
+/// `testEveryBundledFixtureIsRegistered` pins the list against the JSON files
+/// actually present in the bundle — in both directions — so a fixture can
+/// neither be added without being run nor listed without existing.
 enum ChainHelperFixture: String, CaseIterable {
     case arb
     case bsc
@@ -59,6 +60,18 @@ enum ChainHelperFixture: String, CaseIterable {
     case tron
     case utxo
     case xrp
+
+    /// The per-fixture test method that must exist so a failure is attributable
+    /// to one fixture instead of to the corpus as a whole. Derived from the
+    /// file name, so the guard checks the same name the method has to declare.
+    var testMethodName: String {
+        let camelCased = rawValue
+            .split(separator: "-")
+            .enumerated()
+            .map { $0.offset == 0 ? String($0.element) : $0.element.capitalized }
+            .joined()
+        return "test\(camelCased.prefix(1).uppercased())\(camelCased.dropFirst())Fixture"
+    }
 }
 
 final class ChainHelperTests: XCTestCase {
@@ -96,10 +109,27 @@ final class ChainHelperTests: XCTestCase {
     func testUtxoFixture() throws { try runFixture(.utxo) }
     func testXrpFixture() throws { try runFixture(.xrp) }
 
-    // MARK: - Corpus guard
+    // MARK: - Corpus guards
+
+    /// Authoritative coverage: executes every registered fixture in one test.
+    ///
+    /// The per-fixture methods above exist for attribution, but coverage must
+    /// not depend on someone remembering to add one — that bookkeeping is
+    /// exactly what failed before. This test runs the whole registered corpus
+    /// regardless of how many per-fixture methods survive, so the vectors
+    /// cannot go dark again. Cases therefore run twice; the corpus is small
+    /// enough that this costs a fraction of a second.
+    func testAllRegisteredFixturesExecute() throws {
+        var executedCases = 0
+        for fixture in ChainHelperFixture.allCases {
+            executedCases += try runFixture(fixture)
+        }
+        XCTAssertGreaterThan(executedCases, 0,
+                             "The golden corpus executed zero signing vectors — the suite is vacuous")
+    }
 
     /// Fails if the bundled corpus and the registered fixtures diverge in
-    /// either direction, so no fixture can silently stop being executed.
+    /// either direction, or if a fixture has lost its attributing test method.
     func testEveryBundledFixtureIsRegistered() throws {
         let bundle = Bundle(for: type(of: self))
         guard let urls = bundle.urls(forResourcesWithExtension: "json",
@@ -112,27 +142,31 @@ final class ChainHelperTests: XCTestCase {
         let registered = Set(ChainHelperFixture.allCases.map(\.rawValue))
 
         XCTAssertEqual(bundled.subtracting(registered), [],
-                       "Bundled golden fixtures with no test method — add a case to ChainHelperFixture and a test that runs it")
+                       "Bundled golden fixtures missing from ChainHelperFixture — add the case and its test method")
         XCTAssertEqual(registered.subtracting(bundled), [],
                        "Registered golden fixtures missing from the bundle")
 
-        // One `test…Fixture` method per registered fixture, plus this guard.
-        XCTAssertEqual(Self.defaultTestSuite.testCaseCount, ChainHelperFixture.allCases.count + 1,
-                       "Every ChainHelperFixture case needs its own test method so failures are attributable per fixture")
+        let discoveredTestNames = Self.defaultTestSuite.tests.map(\.name)
+        for fixture in ChainHelperFixture.allCases {
+            XCTAssertTrue(discoveredTestNames.contains { $0.contains(fixture.testMethodName) },
+                          "Golden fixture \(fixture.rawValue).json has no \(fixture.testMethodName)() method, so its failures would not be attributable to it")
+        }
     }
 
     // MARK: - Runner
 
+    /// Runs one fixture and returns the number of cases it executed.
+    @discardableResult
     private func runFixture(_ fixture: ChainHelperFixture,
                             file: StaticString = #filePath,
-                            line: UInt = #line) throws {
+                            line: UInt = #line) throws -> Int {
         let bundle = Bundle(for: type(of: self))
         guard let url = bundle.url(forResource: fixture.rawValue,
                                    withExtension: "json",
                                    subdirectory: Self.fixtureSubdirectory) else {
             XCTFail("Missing golden fixture \(Self.fixtureSubdirectory)/\(fixture.rawValue).json in the test bundle",
                     file: file, line: line)
-            return
+            return 0
         }
 
         let data = try Data(contentsOf: url)
@@ -141,7 +175,7 @@ final class ChainHelperTests: XCTestCase {
             testCases = try JSONDecoder().decode([ChainHelperTestCase].self, from: data)
         } catch {
             XCTFail("Invalid golden fixture \(fixture.rawValue).json: \(error)", file: file, line: line)
-            return
+            return 0
         }
 
         XCTAssertFalse(testCases.isEmpty,
@@ -157,6 +191,8 @@ final class ChainHelperTests: XCTestCase {
                 XCTFail("Test case \(testCase.name) threw: \(error)", file: file, line: line)
             }
         }
+
+        return testCases.count
     }
 
     private func runTestCaseWithSwap(_ testCase: ChainHelperTestCase, keysignPayload: KeysignPayload) throws {

--- a/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
@@ -22,51 +22,143 @@ struct ChainHelperTestCase: Codable {
     }
 }
 
+/// The golden signing-vector fixtures bundled under `TestData/`.
+///
+/// Every fixture is named here and gets its own `test…` method rather than
+/// being discovered by a wildcard walk of the bundle. A wildcard walk is what
+/// let the entire corpus stop executing without anything turning red: the
+/// walk's "is this one of ours?" filter silently matched nothing, so the loop
+/// body never ran and the suite stayed green with zero conformance coverage.
+///
+/// Explicit registration makes that failure mode impossible to reach silently:
+/// `testEveryBundledFixtureIsRegistered` pins this list against the JSON files
+/// actually present in the bundle and against the number of test methods on
+/// this class, so a fixture can neither be added without a test nor listed
+/// without one.
+enum ChainHelperFixture: String, CaseIterable {
+    case arb
+    case bsc
+    case cardano
+    case cosmos
+    case cosmosSdkSignAmino = "cosmos-sdk-sign-amino"
+    case cosmosSdkSignDirect = "cosmos-sdk-sign-direct"
+    case dot
+    case evm
+    case kujira
+    case lifiswap
+    case maya
+    case mayaswap
+    case pol
+    case solana
+    case solanaSignData = "solana-sign-data"
+    case sui
+    case terra
+    case thorchain
+    case thorchainswap
+    case ton
+    case tron
+    case utxo
+    case xrp
+}
+
 final class ChainHelperTests: XCTestCase {
     let hexPublicKey = "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"
     let hexChainCode = "c9b189a8232b872b8d9ccd867d0db316dd10f56e729c310fe072adf5fd204ae7"
 
-    func testChainHelpers() throws {
-        // Get the test bundle
-        let bundle = Bundle(for: type(of: self))
+    /// Fixtures are bundled as a folder reference so they keep their own
+    /// directory inside the test bundle instead of flattening into the
+    /// resource root next to unrelated suites' JSON.
+    private static let fixtureSubdirectory = "TestData"
 
-        // Get all JSON files in the bundle
-        let fileManager = FileManager.default
-        guard let resourcePath = bundle.resourcePath else {
-            XCTFail("Missing resource path")
+    // MARK: - Per-fixture golden vectors
+
+    func testArbFixture() throws { try runFixture(.arb) }
+    func testBscFixture() throws { try runFixture(.bsc) }
+    func testCardanoFixture() throws { try runFixture(.cardano) }
+    func testCosmosFixture() throws { try runFixture(.cosmos) }
+    func testCosmosSdkSignAminoFixture() throws { try runFixture(.cosmosSdkSignAmino) }
+    func testCosmosSdkSignDirectFixture() throws { try runFixture(.cosmosSdkSignDirect) }
+    func testDotFixture() throws { try runFixture(.dot) }
+    func testEvmFixture() throws { try runFixture(.evm) }
+    func testKujiraFixture() throws { try runFixture(.kujira) }
+    func testLifiswapFixture() throws { try runFixture(.lifiswap) }
+    func testMayaFixture() throws { try runFixture(.maya) }
+    func testMayaswapFixture() throws { try runFixture(.mayaswap) }
+    func testPolFixture() throws { try runFixture(.pol) }
+    func testSolanaFixture() throws { try runFixture(.solana) }
+    func testSolanaSignDataFixture() throws { try runFixture(.solanaSignData) }
+    func testSuiFixture() throws { try runFixture(.sui) }
+    func testTerraFixture() throws { try runFixture(.terra) }
+    func testThorchainFixture() throws { try runFixture(.thorchain) }
+    func testThorchainswapFixture() throws { try runFixture(.thorchainswap) }
+    func testTonFixture() throws { try runFixture(.ton) }
+    func testTronFixture() throws { try runFixture(.tron) }
+    func testUtxoFixture() throws { try runFixture(.utxo) }
+    func testXrpFixture() throws { try runFixture(.xrp) }
+
+    // MARK: - Corpus guard
+
+    /// Fails if the bundled corpus and the registered fixtures diverge in
+    /// either direction, so no fixture can silently stop being executed.
+    func testEveryBundledFixtureIsRegistered() throws {
+        let bundle = Bundle(for: type(of: self))
+        guard let urls = bundle.urls(forResourcesWithExtension: "json",
+                                     subdirectory: Self.fixtureSubdirectory) else {
+            XCTFail("No \(Self.fixtureSubdirectory) directory in the test bundle — the golden fixtures are not being copied as resources")
             return
         }
-        let resourceURL = URL(fileURLWithPath: resourcePath)
-        let jsonFiles = try fileManager.contentsOfDirectory(at: resourceURL, includingPropertiesForKeys: nil)
-            .filter { $0.pathExtension == "json" }
 
-        // Iterate through each JSON file
-        for jsonFile in jsonFiles {
-            let data = try Data(contentsOf: jsonFile)
-            let decoder = JSONDecoder()
+        let bundled = Set(urls.map { $0.deletingPathExtension().lastPathComponent })
+        let registered = Set(ChainHelperFixture.allCases.map(\.rawValue))
 
-            // Skip files that aren't ChainHelper fixtures — other suites
-            // may bundle their own JSON (e.g. Fixtures/LimitSwapMemos.json)
-            // that flatten to the same resourcePath at test time. Match by
-            // filename prefix and fail fast if a *named* ChainHelper file
-            // doesn't decode (so genuine schema regressions still surface).
-            let isChainHelperFixture = jsonFile.lastPathComponent.hasPrefix("ChainHelper")
-            guard isChainHelperFixture else { continue }
+        XCTAssertEqual(bundled.subtracting(registered), [],
+                       "Bundled golden fixtures with no test method — add a case to ChainHelperFixture and a test that runs it")
+        XCTAssertEqual(registered.subtracting(bundled), [],
+                       "Registered golden fixtures missing from the bundle")
 
-            let testCases: [ChainHelperTestCase]
-            do {
-                testCases = try decoder.decode([ChainHelperTestCase].self, from: data)
-            } catch {
-                XCTFail("Invalid ChainHelper fixture \(jsonFile.lastPathComponent): \(error)")
-                continue
-            }
+        // One `test…Fixture` method per registered fixture, plus this guard.
+        XCTAssertEqual(Self.defaultTestSuite.testCaseCount, ChainHelperFixture.allCases.count + 1,
+                       "Every ChainHelperFixture case needs its own test method so failures are attributable per fixture")
+    }
 
-            for testCase in testCases {
-                try runTestCase(testCase)
-            }
+    // MARK: - Runner
+
+    private func runFixture(_ fixture: ChainHelperFixture,
+                            file: StaticString = #filePath,
+                            line: UInt = #line) throws {
+        let bundle = Bundle(for: type(of: self))
+        guard let url = bundle.url(forResource: fixture.rawValue,
+                                   withExtension: "json",
+                                   subdirectory: Self.fixtureSubdirectory) else {
+            XCTFail("Missing golden fixture \(Self.fixtureSubdirectory)/\(fixture.rawValue).json in the test bundle",
+                    file: file, line: line)
+            return
         }
 
+        let data = try Data(contentsOf: url)
+        let testCases: [ChainHelperTestCase]
+        do {
+            testCases = try JSONDecoder().decode([ChainHelperTestCase].self, from: data)
+        } catch {
+            XCTFail("Invalid golden fixture \(fixture.rawValue).json: \(error)", file: file, line: line)
+            return
+        }
+
+        XCTAssertFalse(testCases.isEmpty,
+                       "Golden fixture \(fixture.rawValue).json decoded to zero cases",
+                       file: file, line: line)
+
+        // Run every case even if an earlier one throws, so one broken vector
+        // doesn't hide the state of the rest of the file.
+        for testCase in testCases {
+            do {
+                try runTestCase(testCase)
+            } catch {
+                XCTFail("Test case \(testCase.name) threw: \(error)", file: file, line: line)
+            }
+        }
     }
+
     private func runTestCaseWithSwap(_ testCase: ChainHelperTestCase, keysignPayload: KeysignPayload) throws {
         var result: [String] = []
         if keysignPayload.approvePayload != nil {
@@ -110,8 +202,8 @@ final class ChainHelperTests: XCTestCase {
         }
         XCTAssertEqual(result, testCase.expectedImageHash, "Test case \(testCase.name) failed")
     }
+
     private func runTestCase(_ testCase: ChainHelperTestCase) throws {
-        print("Running test case: \(testCase.name)")
         let keysignPayload = try KeysignPayload(proto: testCase.keysignPayload)
         let chain = keysignPayload.coin.chain
         if keysignPayload.swapPayload != nil {

--- a/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/ChainHelperTests.swift
@@ -32,7 +32,8 @@ struct ChainHelperTestCase: Codable {
 ///
 /// Two tests keep that from happening again.
 /// `testAllRegisteredFixturesExecute` runs every case in this list in a single
-/// test, so coverage never depends on per-method bookkeeping, and
+/// test and pins the total vector count, so coverage never depends on
+/// per-method bookkeeping and cannot shrink unnoticed;
 /// `testEveryBundledFixtureIsRegistered` pins the list against the JSON files
 /// actually present in the bundle — in both directions — so a fixture can
 /// neither be added without being run nor listed without existing.
@@ -60,6 +61,41 @@ enum ChainHelperFixture: String, CaseIterable {
     case tron
     case utxo
     case xrp
+
+    /// How many signing vectors this fixture must contain.
+    ///
+    /// Pinning the count is what stops the corpus shrinking quietly: the
+    /// filename checks only prove the file still exists, not that it still
+    /// asserts anything, and a fixture emptied down to one vector would
+    /// otherwise stay green. Adding or removing a vector is a deliberate act,
+    /// so it should show up here as a deliberate edit.
+    var expectedCaseCount: Int {
+        switch self {
+        case .arb: return 1
+        case .bsc: return 2
+        case .cardano: return 2
+        case .cosmos: return 4
+        case .cosmosSdkSignAmino: return 2
+        case .cosmosSdkSignDirect: return 2
+        case .dot: return 1
+        case .evm: return 2
+        case .kujira: return 3
+        case .lifiswap: return 2
+        case .maya: return 3
+        case .mayaswap: return 2
+        case .pol: return 1
+        case .solana: return 4
+        case .solanaSignData: return 1
+        case .sui: return 1
+        case .terra: return 5
+        case .thorchain: return 9
+        case .thorchainswap: return 5
+        case .ton: return 3
+        case .tron: return 4
+        case .utxo: return 5
+        case .xrp: return 3
+        }
+    }
 
     /// The per-fixture test method that must exist so a failure is attributable
     /// to one fixture instead of to the corpus as a whole. Derived from the
@@ -124,8 +160,10 @@ final class ChainHelperTests: XCTestCase {
         for fixture in ChainHelperFixture.allCases {
             executedCases += try runFixture(fixture)
         }
-        XCTAssertGreaterThan(executedCases, 0,
-                             "The golden corpus executed zero signing vectors — the suite is vacuous")
+
+        let expectedCases = ChainHelperFixture.allCases.reduce(0) { $0 + $1.expectedCaseCount }
+        XCTAssertEqual(executedCases, expectedCases,
+                       "The golden corpus executed \(executedCases) signing vectors, expected \(expectedCases) — coverage shrank")
     }
 
     /// Fails if the bundled corpus and the registered fixtures diverge in
@@ -178,8 +216,8 @@ final class ChainHelperTests: XCTestCase {
             return 0
         }
 
-        XCTAssertFalse(testCases.isEmpty,
-                       "Golden fixture \(fixture.rawValue).json decoded to zero cases",
+        XCTAssertEqual(testCases.count, fixture.expectedCaseCount,
+                       "Golden fixture \(fixture.rawValue).json holds \(testCases.count) signing vectors, expected \(fixture.expectedCaseCount) — if a vector was deliberately added or removed, update ChainHelperFixture.expectedCaseCount",
                        file: file, line: line)
 
         // Run every case even if an earlier one throws, so one broken vector

--- a/VultisigApp/VultisigAppTests/TestData/mayaswap.json
+++ b/VultisigApp/VultisigAppTests/TestData/mayaswap.json
@@ -138,5 +138,5 @@
             "lib_type": "DKLS"
         },
         "expected_image_hash": ["8fc58a393062400da51d6f16d97763008ebf807e8a4e03ae530faf94a7d593c7", "5abefbff1d10fc36063e075d2b92e1664129c2c04fc3db7d5bcf1dbcc0737acd"]
-    },
+    }
 ]

--- a/VultisigApp/project.yml
+++ b/VultisigApp/project.yml
@@ -271,29 +271,34 @@ targets:
           # never a test resource, so exclude it wholesale.
           - "**/*.md"
           # Exclude the fixture JSONs from the generic-sources scan; they're
-          # picked up explicitly below as a folder reference so they land at
-          # `__fixtures__/*.json` inside the bundle. Without this exclude,
+          # picked up explicitly below as folder references so each set keeps
+          # its own directory inside the bundle. Without these excludes,
           # XcodeGen treats every `.json` under the tree as a flattened
-          # resource and collides with `ChainHelperTests.testChainHelpers`,
-          # which enumerates every top-level JSON in the bundle root.
+          # resource, so unrelated suites' fixtures all land side by side in
+          # the bundle's resource root with no way to tell them apart.
           - "Swap/SwapKit/__fixtures__/**"
           - "Blockchain/Cosmos/Staking/CosmosStakingFixtures/**"
+          - "TestData/**"
           # The QBTC weighted-vote vector generator is a committed Node/cosmjs
           # tool (generate.mjs + package.json + README + node_modules), not test
           # code or a bundled resource. Excluding it keeps its .js/.ts/.map
           # files from being flattened into the test bundle root (which
           # collides under "Multiple commands produce").
           - "Blockchain/Cosmos/Signing/fixtures/qbtc-voteweighted/**"
-      # Static fixture JSONs bundled with the test target as a *folder
-      # reference* (blue folder in Xcode) so they land at
-      # `__fixtures__/*.json` inside the bundle instead of flattening into
-      # the resource root. Flattening would collide with
-      # `ChainHelperTests.testChainHelpers`, which enumerates every top-level
-      # JSON and decodes it as `[ChainHelperTestCase]`.
+      # Static fixture JSONs bundled with the test target as *folder
+      # references* (blue folders in Xcode) so they keep their directory
+      # inside the bundle instead of flattening into the resource root.
+      # `TestData` in particular is the golden signing-vector corpus: keeping
+      # it addressable as a directory lets `ChainHelperTests` enumerate
+      # exactly its own fixtures and assert every one of them is executed,
+      # instead of guessing which of a flat pile of JSON files belongs to it.
       - path: VultisigAppTests/Swap/SwapKit/__fixtures__
         type: folder
         buildPhase: resources
       - path: VultisigAppTests/Blockchain/Cosmos/Staking/CosmosStakingFixtures
+        type: folder
+        buildPhase: resources
+      - path: VultisigAppTests/TestData
         type: folder
         buildPhase: resources
 


### PR DESCRIPTION
## Description

`ChainHelperTests.testChainHelpers` — the golden signing-vector conformance suite — has been passing **vacuously since 2026-07-15**. It walked the flattened test-bundle resource root and then did:

```swift
let isChainHelperFixture = jsonFile.lastPathComponent.hasPrefix("ChainHelper")
guard isChainHelperFixture else { continue }
```

No fixture is named that way — they are `thorchain.json`, `evm.json`, `utxo.json`, … — so every iteration hit `continue`, the loop body never executed, and the test went green having decoded **zero** cases. Baseline on `main`: `testChainHelpers` **passed in 0.005 s**.

Fixes #4931. Unblocks #4932.

### What changed

1. **`TestData/` is now bundled as a folder reference** (`project.yml`), so the corpus keeps its own directory inside the test bundle instead of flattening into the resource root next to `LimitSwapMemos.json` and `SigningGoldenVectors.json`. The filename heuristic existed *because* of that flat namespace; fixing the namespace removes the need to guess which JSON belongs to which suite. Same pattern already used for `Swap/SwapKit/__fixtures__` and `CosmosStakingFixtures`.
2. **Explicit registration replaces the wildcard walk.** A `ChainHelperFixture` enum names all 23 fixtures, and `testAllRegisteredFixturesExecute` runs every case in the registry in one test — so coverage does not depend on anyone remembering to add a per-fixture method.
3. **Per-fixture test methods for attribution.** Each fixture also gets its own `test…Fixture()`, so a failure names the fixture it came from, and a vector that genuinely needs quarantining can carry its own annotated `XCTSkip` instead of a blanket one. Cases therefore run twice; the whole class takes ~0.1 s.
4. **`testEveryBundledFixtureIsRegistered`** pins the bundled `TestData/*.json` set against the registry *in both directions*, and checks each fixture still has its attributing method. A fixture can no longer stop being executed without something turning red — that is the actual bug class here, not the one bad predicate.
5. **Each fixture pins how many vectors it must hold**, and the aggregate test asserts the corpus total (23 fixtures / 67 vectors). Filenames alone only prove a file still exists, not that it still asserts anything — a fixture emptied down to one vector would otherwise stay green. Adding or removing a vector is a deliberate act, so it now needs a deliberate edit, and the failure message names which fixture changed size and by how much. (#4932 will bump these when it adds vectors; that friction is the point.)
6. **`mayaswap.json` trailing comma fixed.** That file has been invalid JSON since it landed; `JSONDecoder` rejects it outright. It is the standalone proof the runner was inert rather than merely quiet — a live runner would have been red every day since.
7. Each case in a fixture now runs even if an earlier one throws, so one broken vector cannot hide the state of the rest of its file.

### Executed-test count (the evidence)

| | Whole `VultisigAppTests` suite | `ChainHelperTests` | Golden cases actually asserted |
|---|---|---|---|
| Before (`main` @ `a36c03509`) | 4351 executed, 0 failures | 1 (`testChainHelpers`, 0.005 s) | **0** |
| After | 4375 executed, 0 failures | 25 | **67** |

### Proof the suite is not vacuous again

Restoring coverage is easy to *claim* and easy to get wrong, so it was verified by perturbation rather than by trusting the green result:

- Every `expected_image_hash` in all 23 fixtures was flipped in its first hex character, and the suite re-run.
- Result: `Executed 25 tests, with 134 failures` — **134 = 67 × 2**, i.e. every corpus case failed once under its own per-fixture test and once under the aggregate coverage test. 67 distinct case names appeared in the failure messages, exactly matching the corpus.
- The aggregate `testAllRegisteredFixturesExecute` was among the failures, confirming it really is carrying the coverage rather than merely existing.
- The fixtures were then restored (`git checkout`) and the suite is green again.

So every one of the 67 cases genuinely executes and genuinely compares its computed pre-image hash against the committed vector. The perturbation was a local verification step only — no perturbed data is in this branch.

## Per-fixture triage

All 23 fixtures / 67 cases **pass** against the current Swift signers. No fixture needed quarantining; **there are no skips in this PR**.

| Fixture | Cases | Result | Verdict |
|---|---|---|---|
| `arb.json` | 1 | pass | — |
| `bsc.json` | 2 | pass | — |
| `cardano.json` | 2 | pass | — |
| `cosmos.json` | 4 | pass | — |
| `cosmos-sdk-sign-amino.json` | 2 | pass | — |
| `cosmos-sdk-sign-direct.json` | 2 | pass | — |
| `dot.json` | 1 | pass | — |
| `evm.json` | 2 | pass | — |
| `kujira.json` | 3 | pass | — |
| `lifiswap.json` | 2 | pass | — |
| `maya.json` | 3 | pass | — |
| `mayaswap.json` | 2 | pass, after the JSON-syntax repair | file was **undecodable**, not wrong — no hash touched |
| `pol.json` | 1 | pass | — |
| `solana.json` | 4 | pass | — |
| `solana-sign-data.json` | 1 | pass | — |
| `sui.json` | 1 | pass | — |
| `terra.json` | 5 | pass | — |
| `thorchain.json` | 9 | pass | — |
| `thorchainswap.json` | 5 | pass | — |
| `ton.json` | 3 | pass | — |
| `tron.json` | 4 | pass | — |
| `utxo.json` | 5 | pass | — |
| `xrp.json` | 3 | pass | — |

**No signing regression was found.** Every committed pre-image hash still matches what the current Swift signers produce. Given that this corpus has had no pressure keeping it correct since 2026-07-15 and `main` has moved a long way, that is a genuinely good outcome and not a foregone one — and it is worth stating plainly, because a red vector here would have been the same failure class as vultisig/vultisig-windows#4464 (joiner polls a `message_id` derived from a locally rebuilt payload the initiator never uploaded).

## What this PR does NOT verify

- **Only the Swift signer was run.** A green vector proves iOS is self-consistent with the committed hash; it does **not** prove the hash itself is right. If a vector had originally been captured from a buggy signer, iOS agreeing with it would look identical to iOS being correct. Cross-signer corroboration (Kotlin / TS) is out of reach from this repo.
- Consequently **no `expected_image_hash` was added, changed, or re-baselined here** — #4932's ground rule (a hash must be corroborated by at least two of the three real signers) cannot be satisfied from inside vultisig-ios. The only fixture edit in this branch is `mayaswap.json`'s trailing comma; `git diff a36c03509..HEAD -- VultisigApp/VultisigAppTests/TestData/` shows no changed hash string.
- **The 4 cases iOS is missing versus Android and the TS core are deliberately not backfilled** (issue suggestion 3): `cosmos.json` "SignAmino - ATOM transaction with multiple messages" and "SignDirect - ATOM transaction (multi-send)", `solana.json` "Send Solana USDC", `thorchain.json` "SignDirect - THORChain Secure asset: LTC transaction". Each needs a new hash, so they belong to #4932 with two-signer corroboration.
- Chains still unpinned by this corpus are unchanged by this PR — everything listed in #4932: TCY, SEI, the wider EVM chainId matrix, Dash/Zcash, Osmosis/Dydx/Noble/Akash, Bittensor, QBTC, and the THORChain limit-order Place flow.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

Test-only change. No production code and no app behaviour is modified — the diff is one test file, one XcodeGen resource declaration, and one JSON syntax repair.

## Parity

Test-infrastructure fix, not a signing change. The skipped-corpus bug is specific to the iOS runner's filename guard; Android and the TS core carry the same fixture corpus but no equivalent guard.

- Android: n/a — the iOS-only filename guard does not exist there (corpus *expansion* is tracked separately in vultisig/vultisig-android#5421, the sibling of #4932 rather than of this fix)
- Windows + extension: n/a — same, no equivalent guard
- SDK: n/a — same

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

Gate: clean build (DerivedData removed first, so the resource-copy change is exercised the way CI would) + full `make test` on a dedicated simulator → `** TEST SUCCEEDED **`, `Executed 4375 tests, with 1 test skipped and 0 failures`. SwiftLint clean on the changed file.

The corpus guards are the part worth reviewing hardest. The original bug was not "someone wrote a wrong predicate"; it was "a wildcard walk can quietly match nothing and nothing notices". Two cross-model review rounds each caught a second-order version of exactly that in earlier drafts of this fix:

1. the guard first compared only the *number* of test methods to the number of fixtures — satisfied by deleting one fixture's test and adding any unrelated one. Hence coverage now lives in a single test that iterates the registry, not in per-method bookkeeping;
2. the aggregate test then asserted only that it had run *more than zero* vectors — satisfied by deleting vectors out of a fixture down to the last one. Hence the pinned per-fixture counts.

Both are the same shape as the original bug, one level up, which is a decent argument for reviewing this file adversarially rather than by reading it.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #4931
- **Confidence**: high for the runner fix and the executed-case evidence; the *correctness of the vectors themselves* is explicitly unverified — see "What this PR does NOT verify"
- **Needs human review for**: whether the un-skipped corpus should now be treated as authoritative, given that only the Swift signer has ever been run against it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the MayaSwap test fixture format so it loads successfully.

* **Tests**
  * Improved ChainHelper fixture coverage with explicit fixture registration and validation.
  * Added checks to ensure all bundled fixtures are registered and executed.
  * Enhanced test reporting so individual fixture failures do not stop remaining cases.

* **Chores**
  * Updated test resource packaging to preserve the TestData folder structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->