### PR TITLE
fix(swap): title the no-pool error properly and stop the raw provider string flash

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapError.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapError.swift
@@ -22,6 +22,14 @@ enum SwapError: Error, LocalizedError, Equatable {
     /// Actionable by the user: raise the slippage setting or reduce the amount.
     case slippageToleranceTooTight
     case lessThenMinSwapAmount(amount: String)
+    /// A THORChain secured-asset swap resolved to a destination that is not a
+    /// THORChain address, so the mint would have no valid settlement target.
+    /// Raised before quoting, with app-authored copy — distinct from
+    /// `serverError`, which carries text we did not write.
+    case securedAssetInvalidDestination(expectedPrefix: String, destination: String)
+    /// An upstream provider rejected the quote with a message this app could not
+    /// classify. The payload is the provider's own wording: it belongs in logs
+    /// (`errorDescription`) and never on screen (`errorMessage`).
     case serverError(message: String)
 
     var errorDescription: String? {
@@ -42,8 +50,59 @@ enum SwapError: Error, LocalizedError, Equatable {
             return "swapSlippageToleranceTooTight".localized
         case .lessThenMinSwapAmount(let amount):
             return String(format: "swapAmountTooSmallRecommended".localized, amount)
+        case let .securedAssetInvalidDestination(expectedPrefix, destination):
+            return String(
+                format: "swapSecuredAssetInvalidDestination".localized,
+                expectedPrefix,
+                destination
+            )
         case .serverError(let msg):
             return msg
+        }
+    }
+}
+
+// MARK: - Tooltip presentation
+
+extension SwapError: SwapErrorPresentable {
+    /// Every case gets a domain title. `SwapError` is the swap flow's own typed
+    /// vocabulary, so a case reaching the tooltip under a generic heading means
+    /// the app knew exactly what went wrong and said "Unexpected Error" anyway.
+    var errorTitle: String {
+        switch self {
+        case .routeUnavailable:
+            return "swapErrorRouteUnavailableTitle".localized
+        case .recipientRouteUnavailable:
+            return "swapErrorRecipientRouteTitle".localized
+        case .recipientVerificationFailed:
+            return "swapErrorRecipientVerificationTitle".localized
+        case .noLiquidityPool:
+            return "swapErrorNoLiquidityPoolTitle".localized
+        case .tradingHalted:
+            return "swapErrorTradingHaltedTitle".localized
+        case .swapAmountTooSmall, .lessThenMinSwapAmount:
+            // Same verdict as `SwapCryptoLogic.Errors.swapAmountTooSmall`, so it
+            // reuses that title rather than adding a second phrasing for it.
+            return "swapErrorAmountTooSmallTitle".localized
+        case .slippageToleranceTooTight:
+            return "swapErrorSlippageTooTightTitle".localized
+        case .securedAssetInvalidDestination:
+            return "swapErrorInvalidDestinationTitle".localized
+        case .serverError:
+            return "swapErrorProviderRejectedTitle".localized
+        }
+    }
+
+    var errorMessage: String {
+        switch self {
+        case .serverError:
+            // The provider's own wording stays in `errorDescription` for the log
+            // and is replaced here: an untranslated node body ("failed to
+            // simulate swap: pool ETH.VULT-0X… doesn't exist") is not something
+            // to put in front of someone deciding whether to trade.
+            return "swapErrorProviderRejectedDescription".localized
+        default:
+            return errorDescription ?? "swapErrorProviderRejectedDescription".localized
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -149,9 +149,26 @@ struct SwapService {
     /// describe the real routing outcome (no route, amount too small, etc.). Fall
     /// back to a SwapKit error only when SwapKit was the sole provider attempted
     /// (e.g. TON/Cardano/Sui pairs), where it's the only signal available.
+    ///
+    /// Within the chosen pool, a *classified* verdict beats an unclassified
+    /// upstream relay. `errors` arrives in task-completion order, so `first` alone
+    /// is a network race: a poolless THORChain↔EVM pair fails on THORChain and
+    /// MAYAChain simultaneously, and whichever node answered first decided whether
+    /// the user saw "No liquidity pool available for this token pair" or the
+    /// losing node's raw body. Same failure, different sentence on every refresh.
     static func surfacedQuoteError(from errors: [Error]) -> Error? {
         let coreProviderErrors = errors.filter { !($0 is SwapKitError) }
-        return coreProviderErrors.first ?? errors.first
+        let pool = coreProviderErrors.isEmpty ? errors : coreProviderErrors
+        return pool.first(where: isClassifiedVerdict) ?? pool.first
+    }
+
+    /// Whether an error is a typed verdict about the swap itself, as opposed to
+    /// `.serverError`, which is only a container for text an upstream provider
+    /// sent and this app could not classify.
+    private static func isClassifiedVerdict(_ error: Error) -> Bool {
+        guard let swapError = error as? SwapError else { return false }
+        if case .serverError = swapError { return false }
+        return true
     }
 
     /// Restrict the candidate provider set so a quote can never be ranked/selected
@@ -686,11 +703,41 @@ extension SwapService {
         tradingHaltedMarkers.contains { message.localizedCaseInsensitiveContains($0) }
     }
 
+    /// Substrings that name the missing asset itself rather than the pool.
+    private static let unknownAssetMarkers = [
+        "invalid symbol",
+        "bad to asset",
+        "bad from asset"
+    ]
+
+    /// Whether a native quote-error body says "this pair has no pool".
+    ///
+    /// The two nodes word the identical verdict differently — THORChain returns
+    /// `…fail to convert dest fee to src asset pool does not exist`, MAYAChain
+    /// returns `failed to simulate swap: pool <ASSET> doesn't exist` — so
+    /// matching only THORChain's phrasing left Maya's verdict unclassified and
+    /// relayed its raw node text instead.
+    ///
+    /// The contraction is only accepted alongside the word "pool". A bare
+    /// `doesn't exist` also appears in THORNode's
+    /// `bad destination address: unable to parse address: THORName doesn't exist: thor1…`,
+    /// which is a destination failure and must not be reported as a missing pool.
+    private static func isMissingPool(_ message: String) -> Bool {
+        if unknownAssetMarkers.contains(where: { message.localizedCaseInsensitiveContains($0) }) {
+            return true
+        }
+        guard message.localizedCaseInsensitiveContains("pool") else { return false }
+        return message.localizedCaseInsensitiveContains("does not exist")
+            || message.localizedCaseInsensitiveContains("doesn't exist")
+            || message.localizedCaseInsensitiveContains("doesn\u{2019}t exist")
+    }
+
     /// Classify a native (THORChain/MAYAChain) quote-error body into a typed
     /// `SwapError`, shared by both branches so Maya stops leaking dust-minimum /
     /// missing-pool errors as a raw `.serverError`. Returns `nil` when the body
     /// matches none of the known classes; the caller then applies its own
-    /// fallback (THORChain relays the server message, Maya relays the raw error).
+    /// fallback (`.serverError`, which carries the upstream text for logs and
+    /// renders as generic copy on screen).
     private static func classifyNativeQuoteError(_ message: String) -> SwapError? {
         if message.contains("not enough asset to pay for fees") ||
             message.localizedCaseInsensitiveContains("zero emit asset") {
@@ -699,11 +746,8 @@ extension SwapService {
             // the retry-with-more message.
             return .swapAmountTooSmall
         }
-        if message.localizedCaseInsensitiveContains("invalid symbol") ||
-            message.localizedCaseInsensitiveContains("bad to asset") ||
-            message.localizedCaseInsensitiveContains("bad from asset") ||
-            message.localizedCaseInsensitiveContains("pool does not exist") {
-            // This typically means no liquidity pool exists for this token pair.
+        if isMissingPool(message) {
+            // No liquidity pool exists for this token pair.
             return .noLiquidityPool
         }
         if message.localizedCaseInsensitiveContains("less than price limit") {
@@ -716,14 +760,16 @@ extension SwapService {
         return nil
     }
 
-    /// Translate a decoded THORChain quote error into the user-facing `SwapError`.
+    /// Translate a decoded THORChain quote error into the typed `SwapError`.
     /// A trading halt is detected on any code so a paused chain surfaces as a
     /// retryable message. Otherwise the known dust/fee/missing-pool classes are
-    /// mapped to their typed errors and anything else relays THORNode's own
-    /// message — so a specific, actionable failure (e.g. code 2 "swap
-    /// destination address is not the same chain as the target asset") is
-    /// diagnosable instead of collapsing into a generic `routeUnavailable`. Only
-    /// a truly empty message falls back to `routeUnavailable`.
+    /// mapped to their typed errors and anything else is carried in
+    /// `.serverError` — so a specific, actionable failure (e.g. code 2 "swap
+    /// destination address is not the same chain as the target asset") stays
+    /// diagnosable in the logs instead of collapsing into a generic
+    /// `routeUnavailable`. The tooltip shows generic copy for `.serverError`
+    /// rather than the node's own wording. Only a truly empty message falls back
+    /// to `routeUnavailable`.
     static func mapThorchainSwapError(_ error: ThorchainSwapError) -> SwapError {
         if isTradingHalted(error.message) {
             return .tradingHalted
@@ -734,11 +780,12 @@ extension SwapService {
         return error.message.isEmpty ? .routeUnavailable : .serverError(message: error.message)
     }
 
-    /// Translate a decoded MAYAChain quote error into the user-facing `SwapError`.
+    /// Translate a decoded MAYAChain quote error into the typed `SwapError`.
     /// A trading halt surfaces as the retryable message; the shared dust-minimum
-    /// / missing-pool classification (previously THORChain-only) now applies here
-    /// too, so those no longer leak as a raw `.serverError`. Anything unrecognised
-    /// keeps the previous behaviour of relaying the raw upstream string.
+    /// / missing-pool classification (previously THORChain-only) applies here too,
+    /// so those no longer leak as a raw `.serverError`. Anything unrecognised is
+    /// carried in `.serverError`, which keeps the raw upstream string for the logs
+    /// and renders as generic copy on screen.
     static func mapMayachainSwapError(_ error: MayachainSwapError) -> SwapError {
         if isTradingHalted(error.error) {
             return .tradingHalted

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -150,24 +150,30 @@ struct SwapService {
     /// back to a SwapKit error only when SwapKit was the sole provider attempted
     /// (e.g. TON/Cardano/Sui pairs), where it's the only signal available.
     ///
-    /// Within the chosen pool, a *classified* verdict beats an unclassified
-    /// upstream relay. `errors` arrives in task-completion order, so `first` alone
-    /// is a network race: a poolless THORChain↔EVM pair fails on THORChain and
-    /// MAYAChain simultaneously, and whichever node answered first decided whether
-    /// the user saw "No liquidity pool available for this token pair" or the
-    /// losing node's raw body. Same failure, different sentence on every refresh.
+    /// Within the chosen pool, `.serverError` sorts last. `errors` arrives in
+    /// task-completion order, so `first` alone is a network race: a poolless
+    /// THORChain↔EVM pair fails on THORChain and MAYAChain simultaneously, and
+    /// whichever node answered first decided whether the user saw "No liquidity
+    /// pool available for this token pair" or the losing node's raw body. Same
+    /// failure, different sentence on every refresh.
+    ///
+    /// Only `.serverError` is demoted, not "everything that isn't a typed
+    /// `SwapError`" — a Kyber/LI.FI/transport failure carries its own specific
+    /// description and must keep its place, or a provider that merely answered
+    /// slower could downgrade "Insufficient funds" to "No Route Available".
     static func surfacedQuoteError(from errors: [Error]) -> Error? {
         let coreProviderErrors = errors.filter { !($0 is SwapKitError) }
         let pool = coreProviderErrors.isEmpty ? errors : coreProviderErrors
-        return pool.first(where: isClassifiedVerdict) ?? pool.first
+        return pool.first(where: { !isUnclassifiedRelay($0) }) ?? pool.first
     }
 
-    /// Whether an error is a typed verdict about the swap itself, as opposed to
-    /// `.serverError`, which is only a container for text an upstream provider
-    /// sent and this app could not classify.
-    private static func isClassifiedVerdict(_ error: Error) -> Bool {
-        guard let swapError = error as? SwapError else { return false }
-        if case .serverError = swapError { return false }
+    /// Whether an error is only a container for text an upstream provider sent
+    /// and this app could not classify — as opposed to any error that carries a
+    /// verdict of its own, typed or described.
+    private static func isUnclassifiedRelay(_ error: Error) -> Bool {
+        guard let swapError = error as? SwapError, case .serverError = swapError else {
+            return false
+        }
         return true
     }
 
@@ -710,6 +716,9 @@ extension SwapService {
         "bad from asset"
     ]
 
+    /// Ways the two nodes spell "… does not exist".
+    private static let missingVerbs = ["does not exist", "doesn't exist", "doesn\u{2019}t exist"]
+
     /// Whether a native quote-error body says "this pair has no pool".
     ///
     /// The two nodes word the identical verdict differently — THORChain returns
@@ -718,18 +727,23 @@ extension SwapService {
     /// matching only THORChain's phrasing left Maya's verdict unclassified and
     /// relayed its raw node text instead.
     ///
-    /// The contraction is only accepted alongside the word "pool". A bare
-    /// `doesn't exist` also appears in THORNode's
-    /// `bad destination address: unable to parse address: THORName doesn't exist: thor1…`,
-    /// which is a destination failure and must not be reported as a missing pool.
+    /// Matched per clause, not per message. Both real bodies name the pool and
+    /// the verb in the same clause; requiring that keeps a body that mentions a
+    /// pool in one clause and something else missing in another from reading as
+    /// a missing pool. THORNode uses the same verb for an unrelated failure —
+    /// `bad destination address: unable to parse address: THORName doesn't exist: thor1…`
+    /// — and reporting that as a missing pool would send the user off to pick a
+    /// different asset when the fault is the address.
     private static func isMissingPool(_ message: String) -> Bool {
         if unknownAssetMarkers.contains(where: { message.localizedCaseInsensitiveContains($0) }) {
             return true
         }
-        guard message.localizedCaseInsensitiveContains("pool") else { return false }
-        return message.localizedCaseInsensitiveContains("does not exist")
-            || message.localizedCaseInsensitiveContains("doesn't exist")
-            || message.localizedCaseInsensitiveContains("doesn\u{2019}t exist")
+        return message
+            .lowercased()
+            .split(whereSeparator: { $0 == ":" || $0 == ";" })
+            .contains { clause in
+                clause.contains("pool") && missingVerbs.contains { clause.contains($0) }
+            }
     }
 
     /// Classify a native (THORChain/MAYAChain) quote-error body into a typed

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -656,12 +656,9 @@ extension SwapService {
         if recipientAddress == nil,
            THORChainHelper.isSecuredAsset(coin: toCoin),
            !THORChainHelper.isValidThorchainAddress(destination, chain: toCoin.chain) {
-            throw SwapError.serverError(
-                message: String(
-                    format: "swapSecuredAssetInvalidDestination".localized,
-                    THORChainHelper.expectedAddressPrefix(for: toCoin.chain),
-                    destination.nilIfEmpty ?? "empty"
-                )
+            throw SwapError.securedAssetInvalidDestination(
+                expectedPrefix: THORChainHelper.expectedAddressPrefix(for: toCoin.chain),
+                destination: destination.nilIfEmpty ?? "empty"
             )
         }
 

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1331,8 +1331,17 @@
 "swapErrorInsufficientFundsTitle" = "Unzureichendes Guthaben";
 "swapErrorInsufficientGasDescription" = "Nicht genügend Gas-Token, um die Netzwerkgebühr zu decken. Bitte fügen Sie Gas zu Ihrem Wallet hinzu.";
 "swapErrorInsufficientGasTitle" = "Unzureichendes Gas";
+"swapErrorInvalidDestinationTitle" = "Ungültiges Ziel";
+"swapErrorNoLiquidityPoolTitle" = "Kein Liquiditätspool";
+"swapErrorProviderRejectedDescription" = "Der Swap-Anbieter konnte für diesen Handel kein Angebot erstellen. Versuche es erneut oder wähle ein anderes Paar.";
+"swapErrorProviderRejectedTitle" = "Swap nicht verfügbar";
+"swapErrorRecipientRouteTitle" = "Keine Empfängerroute";
+"swapErrorRecipientVerificationTitle" = "Empfängerprüfung fehlgeschlagen";
+"swapErrorRouteUnavailableTitle" = "Keine Route verfügbar";
 "swapErrorSameAssetDescription" = "Es ist nicht möglich, dasselbe Asset zu tauschen. Bitte wählen Sie ein anderes Asset.";
 "swapErrorSameAssetTitle" = "Gleiches Asset";
+"swapErrorSlippageTooTightTitle" = "Slippage zu niedrig";
+"swapErrorTradingHaltedTitle" = "Handel ausgesetzt";
 "swapErrorUnexpectedDescription" = "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.";
 "swapErrorUnexpectedTitle" = "Unerwarteter Fehler";
 "swapFee" = "Tauschgebühr";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1340,7 +1340,7 @@
 "swapErrorRouteUnavailableTitle" = "Keine Route verfügbar";
 "swapErrorSameAssetDescription" = "Es ist nicht möglich, dasselbe Asset zu tauschen. Bitte wählen Sie ein anderes Asset.";
 "swapErrorSameAssetTitle" = "Gleiches Asset";
-"swapErrorSlippageTooTightTitle" = "Slippage zu niedrig";
+"swapErrorSlippageTooTightTitle" = "Slippage-Toleranz zu eng";
 "swapErrorTradingHaltedTitle" = "Handel ausgesetzt";
 "swapErrorUnexpectedDescription" = "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.";
 "swapErrorUnexpectedTitle" = "Unerwarteter Fehler";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1329,8 +1329,17 @@
 "swapErrorInsufficientFundsTitle" = "Insufficient Funds";
 "swapErrorInsufficientGasDescription" = "Not enough gas token to cover the network fee. Please add gas to your wallet.";
 "swapErrorInsufficientGasTitle" = "Insufficient Gas";
+"swapErrorInvalidDestinationTitle" = "Invalid Destination";
+"swapErrorNoLiquidityPoolTitle" = "No Liquidity Pool";
+"swapErrorProviderRejectedDescription" = "The swap provider couldn't quote this trade. Try again, or choose a different pair.";
+"swapErrorProviderRejectedTitle" = "Swap Unavailable";
+"swapErrorRecipientRouteTitle" = "No Recipient Route";
+"swapErrorRecipientVerificationTitle" = "Recipient Check Failed";
+"swapErrorRouteUnavailableTitle" = "No Route Available";
 "swapErrorSameAssetDescription" = "Can't swap to the same asset. Please select a different asset.";
 "swapErrorSameAssetTitle" = "Same Asset";
+"swapErrorSlippageTooTightTitle" = "Slippage Too Tight";
+"swapErrorTradingHaltedTitle" = "Trading Halted";
 "swapErrorUnexpectedDescription" = "An unexpected error occurred. Please try again.";
 "swapErrorUnexpectedTitle" = "Unexpected Error";
 "swapFee" = "Swap Fee";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1331,8 +1331,17 @@
 "swapErrorInsufficientFundsTitle" = "Fondos Insuficientes";
 "swapErrorInsufficientGasDescription" = "Token de gas insuficiente para cubrir la tarifa de red. Por favor, agrega gas a tu billetera.";
 "swapErrorInsufficientGasTitle" = "Gas Insuficiente";
+"swapErrorInvalidDestinationTitle" = "Destino Inválido";
+"swapErrorNoLiquidityPoolTitle" = "Sin Pool de Liquidez";
+"swapErrorProviderRejectedDescription" = "El proveedor de intercambio no pudo cotizar esta operación. Inténtalo de nuevo o elige otro par.";
+"swapErrorProviderRejectedTitle" = "Intercambio No Disponible";
+"swapErrorRecipientRouteTitle" = "Sin Ruta al Destinatario";
+"swapErrorRecipientVerificationTitle" = "Verificación de Destinatario Fallida";
+"swapErrorRouteUnavailableTitle" = "Sin Ruta Disponible";
 "swapErrorSameAssetDescription" = "No se puede intercambiar por el mismo activo. Por favor, selecciona un activo diferente.";
 "swapErrorSameAssetTitle" = "Mismo Activo";
+"swapErrorSlippageTooTightTitle" = "Slippage Demasiado Ajustado";
+"swapErrorTradingHaltedTitle" = "Negociación Suspendida";
 "swapErrorUnexpectedDescription" = "Ocurrió un error inesperado. Por favor, inténtalo de nuevo.";
 "swapErrorUnexpectedTitle" = "Error Inesperado";
 "swapFee" = "Tarifa de intercambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1331,8 +1331,17 @@
 "swapErrorInsufficientFundsTitle" = "Nedovoljna Sredstva";
 "swapErrorInsufficientGasDescription" = "Nedovoljno gas tokena za pokrivanje mrežne naknade. Molimo dodajte gas u svoj novčanik.";
 "swapErrorInsufficientGasTitle" = "Nedovoljan Gas";
+"swapErrorInvalidDestinationTitle" = "Nevažeće Odredište";
+"swapErrorNoLiquidityPoolTitle" = "Nema Pool Likvidnosti";
+"swapErrorProviderRejectedDescription" = "Pružatelj zamjene nije mogao dati ponudu za ovu trgovinu. Pokušajte ponovno ili odaberite drugi par.";
+"swapErrorProviderRejectedTitle" = "Zamjena Nije Dostupna";
+"swapErrorRecipientRouteTitle" = "Nema Rute do Primatelja";
+"swapErrorRecipientVerificationTitle" = "Provjera Primatelja Nije Uspjela";
+"swapErrorRouteUnavailableTitle" = "Nema Dostupne Rute";
 "swapErrorSameAssetDescription" = "Ne možete zamijeniti isti asset. Molimo odaberite drugi asset.";
 "swapErrorSameAssetTitle" = "Isti Asset";
+"swapErrorSlippageTooTightTitle" = "Klizanje Preusko";
+"swapErrorTradingHaltedTitle" = "Trgovanje Zaustavljeno";
 "swapErrorUnexpectedDescription" = "Došlo je do neočekivane greške. Molimo pokušajte ponovo.";
 "swapErrorUnexpectedTitle" = "Neočekivana Greška";
 "swapFee" = "Naknada za zamjenu";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1331,8 +1331,17 @@
 "swapErrorInsufficientFundsTitle" = "Fondi Insufficienti";
 "swapErrorInsufficientGasDescription" = "Token gas insufficiente per coprire la commissione di rete. Per favore aggiungi gas al tuo portafoglio.";
 "swapErrorInsufficientGasTitle" = "Gas Insufficiente";
+"swapErrorInvalidDestinationTitle" = "Destinazione Non Valida";
+"swapErrorNoLiquidityPoolTitle" = "Nessun Pool di Liquidità";
+"swapErrorProviderRejectedDescription" = "Il fornitore di scambio non è riuscito a quotare questa operazione. Riprova o scegli un'altra coppia.";
+"swapErrorProviderRejectedTitle" = "Scambio Non Disponibile";
+"swapErrorRecipientRouteTitle" = "Nessun Percorso al Destinatario";
+"swapErrorRecipientVerificationTitle" = "Verifica Destinatario Fallita";
+"swapErrorRouteUnavailableTitle" = "Nessun Percorso Disponibile";
 "swapErrorSameAssetDescription" = "Non è possibile scambiare lo stesso asset. Per favore seleziona un asset diverso.";
 "swapErrorSameAssetTitle" = "Stesso Asset";
+"swapErrorSlippageTooTightTitle" = "Slippage Troppo Stretto";
+"swapErrorTradingHaltedTitle" = "Negoziazione Sospesa";
 "swapErrorUnexpectedDescription" = "Si è verificato un errore imprevisto. Per favore riprova.";
 "swapErrorUnexpectedTitle" = "Errore Imprevisto";
 "swapFee" = "Commissione di scambio";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1303,7 +1303,7 @@
 "swapErrorRouteUnavailableTitle" = "사용 가능한 경로 없음";
 "swapErrorSameAssetDescription" = "동일한 자산으로 스왑할 수 없습니다. 다른 자산을 선택하세요.";
 "swapErrorSameAssetTitle" = "동일한 자산";
-"swapErrorSlippageTooTightTitle" = "슬리피지가 너무 낮음";
+"swapErrorSlippageTooTightTitle" = "슬리피지 허용 범위가 너무 좁음";
 "swapErrorTradingHaltedTitle" = "거래 중단됨";
 "swapErrorUnexpectedDescription" = "예상치 못한 오류가 발생했습니다. 다시 시도하세요.";
 "swapErrorUnexpectedTitle" = "예상치 못한 오류";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1294,8 +1294,17 @@
 "swapErrorInsufficientFundsTitle" = "자금 부족";
 "swapErrorInsufficientGasDescription" = "네트워크 수수료를 충당할 가스 토큰이 부족합니다. 지갑에 가스를 추가하세요.";
 "swapErrorInsufficientGasTitle" = "가스 부족";
+"swapErrorInvalidDestinationTitle" = "유효하지 않은 대상";
+"swapErrorNoLiquidityPoolTitle" = "유동성 풀 없음";
+"swapErrorProviderRejectedDescription" = "스왑 제공자가 이 거래의 견적을 제공하지 못했습니다. 다시 시도하거나 다른 쌍을 선택하세요.";
+"swapErrorProviderRejectedTitle" = "스왑 불가";
+"swapErrorRecipientRouteTitle" = "수신자 경로 없음";
+"swapErrorRecipientVerificationTitle" = "수신자 확인 실패";
+"swapErrorRouteUnavailableTitle" = "사용 가능한 경로 없음";
 "swapErrorSameAssetDescription" = "동일한 자산으로 스왑할 수 없습니다. 다른 자산을 선택하세요.";
 "swapErrorSameAssetTitle" = "동일한 자산";
+"swapErrorSlippageTooTightTitle" = "슬리피지가 너무 낮음";
+"swapErrorTradingHaltedTitle" = "거래 중단됨";
 "swapErrorUnexpectedDescription" = "예상치 못한 오류가 발생했습니다. 다시 시도하세요.";
 "swapErrorUnexpectedTitle" = "예상치 못한 오류";
 "swapFee" = "스왑 수수료";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1331,8 +1331,17 @@
 "swapErrorInsufficientFundsTitle" = "Fundos Insuficientes";
 "swapErrorInsufficientGasDescription" = "Token de gas insuficiente para cobrir a taxa de rede. Por favor, adicione gas à sua carteira.";
 "swapErrorInsufficientGasTitle" = "Gas Insuficiente";
+"swapErrorInvalidDestinationTitle" = "Destino Inválido";
+"swapErrorNoLiquidityPoolTitle" = "Sem Pool de Liquidez";
+"swapErrorProviderRejectedDescription" = "O fornecedor de troca não conseguiu cotar esta operação. Tente novamente ou escolha outro par.";
+"swapErrorProviderRejectedTitle" = "Troca Indisponível";
+"swapErrorRecipientRouteTitle" = "Sem Rota para o Destinatário";
+"swapErrorRecipientVerificationTitle" = "Verificação do Destinatário Falhou";
+"swapErrorRouteUnavailableTitle" = "Sem Rota Disponível";
 "swapErrorSameAssetDescription" = "Não é possível trocar pelo mesmo ativo. Por favor, selecione um ativo diferente.";
 "swapErrorSameAssetTitle" = "Mesmo Ativo";
+"swapErrorSlippageTooTightTitle" = "Slippage Demasiado Baixo";
+"swapErrorTradingHaltedTitle" = "Negociação Suspensa";
 "swapErrorUnexpectedDescription" = "Ocorreu um erro inesperado. Por favor, tente novamente.";
 "swapErrorUnexpectedTitle" = "Erro Inesperado";
 "swapFee" = "Taxa de troca";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1340,7 +1340,7 @@
 "swapErrorRouteUnavailableTitle" = "Sem Rota Disponível";
 "swapErrorSameAssetDescription" = "Não é possível trocar pelo mesmo ativo. Por favor, selecione um ativo diferente.";
 "swapErrorSameAssetTitle" = "Mesmo Ativo";
-"swapErrorSlippageTooTightTitle" = "Slippage Demasiado Baixo";
+"swapErrorSlippageTooTightTitle" = "Tolerância de Slippage Muito Baixa";
 "swapErrorTradingHaltedTitle" = "Negociação Suspensa";
 "swapErrorUnexpectedDescription" = "Ocorreu um erro inesperado. Por favor, tente novamente.";
 "swapErrorUnexpectedTitle" = "Erro Inesperado";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1331,8 +1331,17 @@
 "swapErrorInsufficientFundsTitle" = "余额不足";
 "swapErrorInsufficientGasDescription" = "Gas 代币不足以支付网络费用。请向钱包添加 Gas。";
 "swapErrorInsufficientGasTitle" = "Gas 不足";
+"swapErrorInvalidDestinationTitle" = "目标地址无效";
+"swapErrorNoLiquidityPoolTitle" = "无流动性池";
+"swapErrorProviderRejectedDescription" = "交换服务商无法为此交易报价。请重试或选择其他交易对。";
+"swapErrorProviderRejectedTitle" = "无法交换";
+"swapErrorRecipientRouteTitle" = "无接收方路由";
+"swapErrorRecipientVerificationTitle" = "接收方校验失败";
+"swapErrorRouteUnavailableTitle" = "无可用路由";
 "swapErrorSameAssetDescription" = "无法兑换相同的资产。请选择不同的资产。";
 "swapErrorSameAssetTitle" = "相同资产";
+"swapErrorSlippageTooTightTitle" = "滑点过低";
+"swapErrorTradingHaltedTitle" = "交易已暂停";
 "swapErrorUnexpectedDescription" = "发生意外错误。请重试。";
 "swapErrorUnexpectedTitle" = "意外错误";
 "swapFee" = "交换费用";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1340,7 +1340,7 @@
 "swapErrorRouteUnavailableTitle" = "无可用路由";
 "swapErrorSameAssetDescription" = "无法兑换相同的资产。请选择不同的资产。";
 "swapErrorSameAssetTitle" = "相同资产";
-"swapErrorSlippageTooTightTitle" = "滑点过低";
+"swapErrorSlippageTooTightTitle" = "滑点容忍度过低";
 "swapErrorTradingHaltedTitle" = "交易已暂停";
 "swapErrorUnexpectedDescription" = "发生意外错误。请重试。";
 "swapErrorUnexpectedTitle" = "意外错误";

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapErrorPresentable.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapErrorPresentable.swift
@@ -24,3 +24,47 @@ protocol SwapErrorPresentable: Error {
     /// Tooltip body. Localized app copy, never a raw upstream string.
     var errorMessage: String { get }
 }
+
+/// Resolves any error reaching the swap form into the tooltip's title and body.
+///
+/// Lives outside the view so the resolution is testable on its own: the bug this
+/// replaces was that the view resolved title and body through two independent
+/// `if let` ladders, and an error type present in one ladder but missing from the
+/// other rendered a domain-correct sentence under "Unexpected Error".
+enum SwapErrorPresentation {
+
+    static func title(for error: Error) -> String {
+        presentable(for: error)?.errorTitle ?? SwapCryptoLogic.Errors.unexpectedError.errorTitle
+    }
+
+    static func message(for error: Error) -> String {
+        // Errors outside the swap flow's own vocabulary (fee-path failures,
+        // aggregator bodies, transport errors) still relay their localized
+        // description — it is the only signal available for them.
+        presentable(for: error)?.errorMessage ?? error.localizedDescription
+    }
+
+    /// The single lookup both `title` and `message` go through, so they can never
+    /// disagree about which vocabulary an error belongs to.
+    static func presentable(for error: Error) -> SwapErrorPresentable? {
+        if let presentable = error as? SwapErrorPresentable {
+            return presentable
+        }
+        return normalizedSwapKitError(error)
+    }
+
+    /// Map terminal SwapKit error cases onto the swap flow's user-facing error
+    /// vocabulary so the tooltip shows a domain-appropriate title and description
+    /// instead of the generic "Unexpected Error" fallback. Only covers cases with
+    /// a clear `SwapCryptoLogic.Errors` equivalent — everything else flows
+    /// through `error.localizedDescription` as before.
+    private static func normalizedSwapKitError(_ error: Error) -> SwapCryptoLogic.Errors? {
+        guard let swapKitError = error as? SwapKitError else { return nil }
+        switch swapKitError {
+        case .amountBelowProviderMinimum:
+            return .swapAmountTooSmall
+        default:
+            return nil
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapErrorPresentable.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapErrorPresentable.swift
@@ -1,0 +1,26 @@
+//
+//  SwapErrorPresentable.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// User-facing presentation of a swap-flow error: the title and body the swap
+/// form's error tooltip renders.
+///
+/// Deliberately separate from `LocalizedError.errorDescription`. That stays the
+/// *diagnostic* text and may carry a raw upstream provider string (a node body
+/// with an uppercased contract address, a 500 page, an aggregator's internal
+/// wording) which is useful in a log and hostile on screen. `errorMessage` is
+/// always localized app copy.
+///
+/// Conforming an error type here is what keeps it out of the tooltip's generic
+/// "Unexpected Error" fallback: title and body resolve through this one
+/// protocol, so a type can never end up with a domain-correct body under a
+/// generic title.
+protocol SwapErrorPresentable: Error {
+    /// Tooltip heading — a short domain verdict ("No Liquidity Pool").
+    var errorTitle: String { get }
+    /// Tooltip body. Localized app copy, never a raw upstream string.
+    var errorMessage: String { get }
+}

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -19,7 +19,7 @@ import SwiftUI
 enum SwapCryptoLogic {
     // MARK: - Errors
 
-    enum Errors: String, Error, LocalizedError {
+    enum Errors: String, Error, LocalizedError, SwapErrorPresentable {
         case unexpectedError
         case insufficientFunds
         case insufficientGas
@@ -47,6 +47,12 @@ enum SwapCryptoLogic {
             case .inboundAddress: return "swapErrorInboundAddressDescription".localized
             case .sameAsset: return "swapErrorSameAssetDescription".localized
             }
+        }
+
+        /// Every case has a localized description, so the body is that string;
+        /// the coalesce only satisfies `LocalizedError`'s optional return type.
+        var errorMessage: String {
+            errorDescription ?? Errors.unexpectedError.errorDescription ?? ""
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapErrorTooltipView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapErrorTooltipView.swift
@@ -54,24 +54,26 @@ struct SwapErrorTooltipView: View {
         }
     }
 
+    /// Single resolution path for the tooltip's title AND body. Resolving them
+    /// separately is what let a domain-correct description sit under the generic
+    /// "Unexpected Error" heading: `SwapError` satisfied the description's
+    /// `localizedDescription` fallback but matched none of the title's arms.
+    private var presentableError: SwapErrorPresentable? {
+        if let presentable = error as? SwapErrorPresentable {
+            return presentable
+        }
+        return normalizedSwapKitError
+    }
+
     private var errorTitle: String {
-        if let swapError = error as? SwapCryptoLogic.Errors {
-            return swapError.errorTitle
-        }
-        if let normalized = normalizedSwapKitError {
-            return normalized.errorTitle
-        }
-        return SwapCryptoLogic.Errors.unexpectedError.errorTitle
+        presentableError?.errorTitle ?? SwapCryptoLogic.Errors.unexpectedError.errorTitle
     }
 
     private var errorDescription: String {
-        if let swapError = error as? SwapCryptoLogic.Errors {
-            return swapError.errorDescription ?? error.localizedDescription
-        }
-        if let normalized = normalizedSwapKitError {
-            return normalized.errorDescription ?? error.localizedDescription
-        }
-        return error.localizedDescription
+        // Errors outside the swap flow's own vocabulary (fee-path failures,
+        // aggregator bodies, transport errors) still relay their localized
+        // description — it is the only signal available for them.
+        presentableError?.errorMessage ?? error.localizedDescription
     }
 
     /// Map terminal SwapKit error cases onto the swap-flow's user-facing

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapErrorTooltipView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapErrorTooltipView.swift
@@ -54,41 +54,18 @@ struct SwapErrorTooltipView: View {
         }
     }
 
-    /// Single resolution path for the tooltip's title AND body. Resolving them
-    /// separately is what let a domain-correct description sit under the generic
-    /// "Unexpected Error" heading: `SwapError` satisfied the description's
-    /// `localizedDescription` fallback but matched none of the title's arms.
-    private var presentableError: SwapErrorPresentable? {
-        if let presentable = error as? SwapErrorPresentable {
-            return presentable
-        }
-        return normalizedSwapKitError
-    }
+    // Title and body both come from `SwapErrorPresentation`, which owns the one
+    // lookup they share. Resolving them separately in this view is what let a
+    // domain-correct description sit under the generic "Unexpected Error"
+    // heading: `SwapError` satisfied the description ladder's
+    // `localizedDescription` fallback but matched none of the title ladder's arms.
 
     private var errorTitle: String {
-        presentableError?.errorTitle ?? SwapCryptoLogic.Errors.unexpectedError.errorTitle
+        SwapErrorPresentation.title(for: error)
     }
 
     private var errorDescription: String {
-        // Errors outside the swap flow's own vocabulary (fee-path failures,
-        // aggregator bodies, transport errors) still relay their localized
-        // description — it is the only signal available for them.
-        presentableError?.errorMessage ?? error.localizedDescription
-    }
-
-    /// Map terminal SwapKit error cases onto the swap-flow's user-facing
-    /// error vocabulary so the tooltip shows a domain-appropriate title and
-    /// description instead of the generic "Unexpected Error" fallback. Only
-    /// covers cases that have a clear `SwapCryptoLogic.Errors` equivalent —
-    /// everything else flows through `error.localizedDescription` as before.
-    private var normalizedSwapKitError: SwapCryptoLogic.Errors? {
-        guard let swapKitError = error as? SwapKitError else { return nil }
-        switch swapKitError {
-        case .amountBelowProviderMinimum:
-            return .swapAmountTooSmall
-        default:
-            return nil
-        }
+        SwapErrorPresentation.message(for: error)
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapErrorMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapErrorMappingTests.swift
@@ -162,4 +162,59 @@ final class SwapErrorMappingTests: XCTestCase {
         )
         XCTAssertEqual(SwapService.mapThorchainSwapError(error).errorDescription, "swapTradingHalted".localized)
     }
+
+    // MARK: - Both nodes' wording for the same missing-pool verdict
+
+    func testThorchainMissingPoolVerbatimBodyMapsToNoLiquidityPool() {
+        // Verbatim THORNode body for THOR.RUNE → ETH.VULT (no such pool),
+        // captured from gateway.liquify.com/chain/thorchain_api.
+        let error = ThorchainSwapError(
+            code: 2,
+            message: "failed to calculate min swap amount: fail to convert dest fee to src asset pool does not exist"
+        )
+        XCTAssertEqual(SwapService.mapThorchainSwapError(error), .noLiquidityPool)
+    }
+
+    func testMayachainContractedWordingMapsToNoLiquidityPool() {
+        // Verbatim Mayanode body for the same pair. MAYAChain contracts the verb
+        // where THORChain spells it out, which is why the same verdict used to
+        // classify on one chain and leak the raw node string on the other.
+        let error = MayachainSwapError(
+            code: nil,
+            error: "failed to simulate swap: pool ETH.VULT-0XB788144DF611029C60B859DF47E79B7726C4DEBA doesn't exist"
+        )
+        XCTAssertEqual(SwapService.mapMayachainSwapError(error), .noLiquidityPool)
+    }
+
+    func testMayachainContractedWordingNoLongerLeaksTheRawNodeString() {
+        let raw = "failed to simulate swap: pool ETH.VULT-0XB788144DF611029C60B859DF47E79B7726C4DEBA doesn't exist"
+        let error = MayachainSwapError(code: nil, error: raw)
+        XCTAssertNotEqual(SwapService.mapMayachainSwapError(error).errorDescription, raw)
+    }
+
+    func testTypographicApostropheAlsoClassifies() {
+        let error = MayachainSwapError(code: nil, error: "pool ETH.FOO doesn\u{2019}t exist")
+        XCTAssertEqual(SwapService.mapMayachainSwapError(error), .noLiquidityPool)
+    }
+
+    func testMissingPoolMatchIsCaseInsensitive() {
+        let error = ThorchainSwapError(code: 3, message: "POOL DOES NOT EXIST")
+        XCTAssertEqual(SwapService.mapThorchainSwapError(error), .noLiquidityPool)
+    }
+
+    func testUnknownThornameIsNotAMissingPool() {
+        // The trap the contraction opens up: THORNode uses the same verb for a
+        // bad destination address. Verbatim body, captured live. Classifying it
+        // as a missing pool would tell the user to pick a different asset when
+        // the real fault is the address.
+        let message = "bad destination address: unable to parse address: THORName doesn't exist: thor1zf3gsk7edzwl9syyefvfhle37cjtql35h6k85m"
+        let error = ThorchainSwapError(code: 2, message: message)
+        XCTAssertNotEqual(SwapService.mapThorchainSwapError(error), .noLiquidityPool)
+        XCTAssertEqual(SwapService.mapThorchainSwapError(error), .serverError(message: message))
+    }
+
+    func testUnrelatedMissingThingIsNotAMissingPool() {
+        let error = MayachainSwapError(code: nil, error: "inbound address doesn't exist")
+        XCTAssertNotEqual(SwapService.mapMayachainSwapError(error), .noLiquidityPool)
+    }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapErrorMappingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapErrorMappingTests.swift
@@ -217,4 +217,17 @@ final class SwapErrorMappingTests: XCTestCase {
         let error = MayachainSwapError(code: nil, error: "inbound address doesn't exist")
         XCTAssertNotEqual(SwapService.mapMayachainSwapError(error), .noLiquidityPool)
     }
+
+    func testPoolAndMissingVerbInDifferentClausesIsNotAMissingPool() {
+        // The pool and the verb have to be in the SAME clause. A composite body
+        // that names a pool in one clause and something else missing in another
+        // is not a missing-pool verdict — and this classification is load-bearing
+        // beyond the tooltip: the limit-order form persists `.noRoute` from it
+        // and blocks placement.
+        let error = MayachainSwapError(
+            code: nil,
+            error: "pool ETH.USDC rejected the swap: affiliate THORName doesn't exist"
+        )
+        XCTAssertNotEqual(SwapService.mapMayachainSwapError(error), .noLiquidityPool)
+    }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapErrorPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapErrorPresentationTests.swift
@@ -13,93 +13,174 @@ import XCTest
 
 final class SwapErrorPresentationTests: XCTestCase {
 
-    /// One value per `SwapError` case. Kept honest by `caseName(_:)` below,
-    /// whose exhaustive switch fails to compile when a case is added.
-    private let allCases: [SwapError] = [
-        .routeUnavailable,
-        .recipientRouteUnavailable,
-        .recipientVerificationFailed,
-        .noLiquidityPool,
-        .tradingHalted,
-        .swapAmountTooSmall,
-        .slippageToleranceTooTight,
-        .lessThenMinSwapAmount(amount: "0.01 BTC"),
-        .securedAssetInvalidDestination(expectedPrefix: "thor", destination: "0xabc"),
-        .serverError(message: "some upstream body")
-    ]
+    /// One tag per `SwapError` case. Two exhaustive switches close the loop
+    /// around it: `tag(of:)` fails to compile when a case is added to
+    /// `SwapError`, and `sample(for:)` fails to compile when a tag is added
+    /// here. Adding a case therefore cannot reach `main` without supplying a
+    /// sample, and every sample is in `allCases` by construction.
+    private enum CaseTag: String, CaseIterable {
+        case routeUnavailable
+        case recipientRouteUnavailable
+        case recipientVerificationFailed
+        case noLiquidityPool
+        case tradingHalted
+        case swapAmountTooSmall
+        case slippageToleranceTooTight
+        case lessThenMinSwapAmount
+        case securedAssetInvalidDestination
+        case serverError
+    }
 
-    /// Compile-time exhaustiveness guard. A new `SwapError` case breaks this
-    /// switch, which forces it into `allCases` and therefore into every
-    /// assertion below — including "no case is titled Unexpected Error".
-    private func caseName(_ error: SwapError) -> String {
-        switch error {
-        case .routeUnavailable: return "routeUnavailable"
-        case .recipientRouteUnavailable: return "recipientRouteUnavailable"
-        case .recipientVerificationFailed: return "recipientVerificationFailed"
-        case .noLiquidityPool: return "noLiquidityPool"
-        case .tradingHalted: return "tradingHalted"
-        case .swapAmountTooSmall: return "swapAmountTooSmall"
-        case .slippageToleranceTooTight: return "slippageToleranceTooTight"
-        case .lessThenMinSwapAmount: return "lessThenMinSwapAmount"
-        case .securedAssetInvalidDestination: return "securedAssetInvalidDestination"
-        case .serverError: return "serverError"
+    private func sample(for tag: CaseTag) -> SwapError {
+        switch tag {
+        case .routeUnavailable: return .routeUnavailable
+        case .recipientRouteUnavailable: return .recipientRouteUnavailable
+        case .recipientVerificationFailed: return .recipientVerificationFailed
+        case .noLiquidityPool: return .noLiquidityPool
+        case .tradingHalted: return .tradingHalted
+        case .swapAmountTooSmall: return .swapAmountTooSmall
+        case .slippageToleranceTooTight: return .slippageToleranceTooTight
+        case .lessThenMinSwapAmount: return .lessThenMinSwapAmount(amount: "0.01 BTC")
+        case .securedAssetInvalidDestination:
+            return .securedAssetInvalidDestination(expectedPrefix: "thor", destination: "0xabc")
+        case .serverError: return .serverError(message: "some upstream body")
         }
     }
 
-    // MARK: - The reported bug
+    private func tag(of error: SwapError) -> CaseTag {
+        switch error {
+        case .routeUnavailable: return .routeUnavailable
+        case .recipientRouteUnavailable: return .recipientRouteUnavailable
+        case .recipientVerificationFailed: return .recipientVerificationFailed
+        case .noLiquidityPool: return .noLiquidityPool
+        case .tradingHalted: return .tradingHalted
+        case .swapAmountTooSmall: return .swapAmountTooSmall
+        case .slippageToleranceTooTight: return .slippageToleranceTooTight
+        case .lessThenMinSwapAmount: return .lessThenMinSwapAmount
+        case .securedAssetInvalidDestination: return .securedAssetInvalidDestination
+        case .serverError: return .serverError
+        }
+    }
+
+    private var allCases: [SwapError] { CaseTag.allCases.map(sample) }
+
+    /// Localized value for `key`, or `nil` when the key is missing from the
+    /// bundle. `"key".localized` echoes the key back on a miss, so asserting
+    /// against it proves nothing about the strings file; this does.
+    private func localizedValue(forKey key: String) -> String? {
+        let sentinel = "__missing_localization__"
+        let value = Bundle.main.localizedString(forKey: key, value: sentinel, table: nil)
+        return value == sentinel ? nil : value
+    }
+
+    // MARK: - The reported bug, through the path the view actually uses
 
     func testNoLiquidityPoolIsNotTitledUnexpectedError() {
-        XCTAssertNotEqual(
-            SwapError.noLiquidityPool.errorTitle,
+        let generic = SwapCryptoLogic.Errors.unexpectedError.errorTitle
+        XCTAssertNotEqual(SwapErrorPresentation.title(for: SwapError.noLiquidityPool), generic)
+        XCTAssertEqual(
+            SwapErrorPresentation.title(for: SwapError.noLiquidityPool),
+            "swapErrorNoLiquidityPoolTitle".localized
+        )
+        XCTAssertEqual(
+            SwapErrorPresentation.message(for: SwapError.noLiquidityPool),
+            "noLiquidityPool".localized
+        )
+    }
+
+    func testResolutionCoversTheThreeVocabulariesTheTooltipMeets() {
+        // `SwapError` — the vocabulary that had no title arm at all.
+        XCTAssertNotNil(SwapErrorPresentation.presentable(for: SwapError.tradingHalted))
+        // `SwapCryptoLogic.Errors` — the vocabulary that always worked.
+        XCTAssertNotNil(SwapErrorPresentation.presentable(for: SwapCryptoLogic.Errors.insufficientGas))
+        // `SwapKitError` — normalized for the one case with an equivalent.
+        XCTAssertEqual(
+            SwapErrorPresentation.title(for: SwapKitError.amountBelowProviderMinimum),
+            SwapCryptoLogic.Errors.swapAmountTooSmall.errorTitle
+        )
+    }
+
+    func testUnknownErrorStillFallsBackToItsLocalizedDescription() {
+        // Fee-path and transport failures are outside the swap vocabulary. They
+        // keep the previous behaviour — generic title, real description — because
+        // that description is the only signal they carry.
+        let error = NSError(
+            domain: "test",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "an unclassifiable failure"]
+        )
+        XCTAssertEqual(
+            SwapErrorPresentation.title(for: error),
             SwapCryptoLogic.Errors.unexpectedError.errorTitle
         )
-        XCTAssertEqual(SwapError.noLiquidityPool.errorTitle, "swapErrorNoLiquidityPoolTitle".localized)
-        XCTAssertEqual(SwapError.noLiquidityPool.errorMessage, "noLiquidityPool".localized)
+        XCTAssertEqual(SwapErrorPresentation.message(for: error), "an unclassifiable failure")
     }
 
     // MARK: - Every case, not just the reported one
 
-    func testEveryCaseCoveredExactlyOnce() {
-        let names = allCases.map(caseName)
-        XCTAssertEqual(Set(names).count, names.count, "duplicate sample in allCases")
-        XCTAssertEqual(names.count, 10, "a SwapError case is missing from allCases")
-    }
-
     func testNoCaseFallsBackToUnexpectedErrorTitle() {
         let generic = SwapCryptoLogic.Errors.unexpectedError.errorTitle
         for error in allCases {
-            XCTAssertNotEqual(error.errorTitle, generic, "\(caseName(error)) is still titled generically")
+            XCTAssertNotEqual(
+                SwapErrorPresentation.title(for: error),
+                generic,
+                "\(tag(of: error).rawValue) is still titled generically"
+            )
         }
     }
 
     func testEveryCaseHasNonEmptyTitleAndMessage() {
         for error in allCases {
-            XCTAssertFalse(error.errorTitle.isEmpty, "\(caseName(error)) has an empty title")
-            XCTAssertFalse(error.errorMessage.isEmpty, "\(caseName(error)) has an empty message")
+            XCTAssertFalse(error.errorTitle.isEmpty, "\(tag(of: error).rawValue) has an empty title")
+            XCTAssertFalse(error.errorMessage.isEmpty, "\(tag(of: error).rawValue) has an empty message")
         }
     }
 
     func testTitleKeyPerCase() {
-        let expected: [String: String] = [
-            "routeUnavailable": "swapErrorRouteUnavailableTitle",
-            "recipientRouteUnavailable": "swapErrorRecipientRouteTitle",
-            "recipientVerificationFailed": "swapErrorRecipientVerificationTitle",
-            "noLiquidityPool": "swapErrorNoLiquidityPoolTitle",
-            "tradingHalted": "swapErrorTradingHaltedTitle",
+        let expected: [CaseTag: String] = [
+            .routeUnavailable: "swapErrorRouteUnavailableTitle",
+            .recipientRouteUnavailable: "swapErrorRecipientRouteTitle",
+            .recipientVerificationFailed: "swapErrorRecipientVerificationTitle",
+            .noLiquidityPool: "swapErrorNoLiquidityPoolTitle",
+            .tradingHalted: "swapErrorTradingHaltedTitle",
             // Same verdict as `SwapCryptoLogic.Errors.swapAmountTooSmall`, so the
             // two amount cases deliberately reuse that existing title key.
-            "swapAmountTooSmall": "swapErrorAmountTooSmallTitle",
-            "lessThenMinSwapAmount": "swapErrorAmountTooSmallTitle",
-            "slippageToleranceTooTight": "swapErrorSlippageTooTightTitle",
-            "securedAssetInvalidDestination": "swapErrorInvalidDestinationTitle",
-            "serverError": "swapErrorProviderRejectedTitle"
+            .swapAmountTooSmall: "swapErrorAmountTooSmallTitle",
+            .lessThenMinSwapAmount: "swapErrorAmountTooSmallTitle",
+            .slippageToleranceTooTight: "swapErrorSlippageTooTightTitle",
+            .securedAssetInvalidDestination: "swapErrorInvalidDestinationTitle",
+            .serverError: "swapErrorProviderRejectedTitle"
         ]
         for error in allCases {
-            guard let key = expected[caseName(error)] else {
-                XCTFail("no expected title key for \(caseName(error))")
+            let name = tag(of: error).rawValue
+            guard let key = expected[tag(of: error)] else {
+                XCTFail("no expected title key for \(name)")
                 continue
             }
-            XCTAssertEqual(error.errorTitle, key.localized, "wrong title key for \(caseName(error))")
+            guard let value = localizedValue(forKey: key) else {
+                XCTFail("\(key) is missing from Localizable.strings (\(name))")
+                continue
+            }
+            XCTAssertEqual(error.errorTitle, value, "wrong title key for \(name)")
+        }
+    }
+
+    func testNewCopyKeysExistInTheBundle() {
+        // Guards the "missing key leaks a raw camelCase identifier to the user"
+        // failure mode that a `"key".localized == "key".localized` assertion
+        // cannot see.
+        for key in [
+            "swapErrorRouteUnavailableTitle",
+            "swapErrorRecipientRouteTitle",
+            "swapErrorRecipientVerificationTitle",
+            "swapErrorNoLiquidityPoolTitle",
+            "swapErrorTradingHaltedTitle",
+            "swapErrorSlippageTooTightTitle",
+            "swapErrorInvalidDestinationTitle",
+            "swapErrorProviderRejectedTitle",
+            "swapErrorProviderRejectedDescription"
+        ] {
+            XCTAssertNotNil(localizedValue(forKey: key), "\(key) is missing from Localizable.strings")
         }
     }
 
@@ -117,10 +198,15 @@ final class SwapErrorPresentationTests: XCTestCase {
     // MARK: - Raw upstream text never reaches the tooltip body
 
     func testServerErrorMessageIsGenericNotTheProviderString() {
+        // Verbatim MAYAChain body for RUNE → ETH.VULT, captured from
+        // mayanode.mayachain.info.
         let raw = "failed to simulate swap: pool ETH.VULT-0XB788144DF611029C60B859DF47E79B7726C4DEBA doesn't exist"
         let error = SwapError.serverError(message: raw)
-        XCTAssertNotEqual(error.errorMessage, raw)
-        XCTAssertEqual(error.errorMessage, "swapErrorProviderRejectedDescription".localized)
+        XCTAssertNotEqual(SwapErrorPresentation.message(for: error), raw)
+        XCTAssertEqual(
+            SwapErrorPresentation.message(for: error),
+            "swapErrorProviderRejectedDescription".localized
+        )
     }
 
     func testServerErrorKeepsTheProviderStringForLogs() {
@@ -138,7 +224,7 @@ final class SwapErrorPresentationTests: XCTestCase {
         let expected = String(format: "swapSecuredAssetInvalidDestination".localized, "thor", "0xdead")
         XCTAssertEqual(error.errorDescription, expected)
         // It is app copy, so unlike `serverError` it is shown verbatim.
-        XCTAssertEqual(error.errorMessage, expected)
+        XCTAssertEqual(SwapErrorPresentation.message(for: error), expected)
     }
 
     // MARK: - SwapCryptoLogic.Errors keeps its existing presentation
@@ -152,7 +238,8 @@ final class SwapErrorPresentationTests: XCTestCase {
             .inboundAddress,
             .sameAsset
         ] {
-            XCTAssertEqual(error.errorMessage, error.errorDescription)
+            XCTAssertEqual(SwapErrorPresentation.message(for: error), error.errorDescription)
+            XCTAssertEqual(SwapErrorPresentation.title(for: error), error.errorTitle)
             XCTAssertFalse(error.errorTitle.isEmpty)
         }
     }

--- a/VultisigApp/VultisigAppTests/Swap/SwapErrorPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapErrorPresentationTests.swift
@@ -1,0 +1,159 @@
+//
+//  SwapErrorPresentationTests.swift
+//  VultisigAppTests
+//
+//  Pins the swap tooltip's title/body resolution. `SwapError` carried correct
+//  localized descriptions but no titles, so every one of its cases rendered
+//  under the generic "Unexpected Error" heading — a deterministic "no pool for
+//  this pair" verdict included.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapErrorPresentationTests: XCTestCase {
+
+    /// One value per `SwapError` case. Kept honest by `caseName(_:)` below,
+    /// whose exhaustive switch fails to compile when a case is added.
+    private let allCases: [SwapError] = [
+        .routeUnavailable,
+        .recipientRouteUnavailable,
+        .recipientVerificationFailed,
+        .noLiquidityPool,
+        .tradingHalted,
+        .swapAmountTooSmall,
+        .slippageToleranceTooTight,
+        .lessThenMinSwapAmount(amount: "0.01 BTC"),
+        .securedAssetInvalidDestination(expectedPrefix: "thor", destination: "0xabc"),
+        .serverError(message: "some upstream body")
+    ]
+
+    /// Compile-time exhaustiveness guard. A new `SwapError` case breaks this
+    /// switch, which forces it into `allCases` and therefore into every
+    /// assertion below — including "no case is titled Unexpected Error".
+    private func caseName(_ error: SwapError) -> String {
+        switch error {
+        case .routeUnavailable: return "routeUnavailable"
+        case .recipientRouteUnavailable: return "recipientRouteUnavailable"
+        case .recipientVerificationFailed: return "recipientVerificationFailed"
+        case .noLiquidityPool: return "noLiquidityPool"
+        case .tradingHalted: return "tradingHalted"
+        case .swapAmountTooSmall: return "swapAmountTooSmall"
+        case .slippageToleranceTooTight: return "slippageToleranceTooTight"
+        case .lessThenMinSwapAmount: return "lessThenMinSwapAmount"
+        case .securedAssetInvalidDestination: return "securedAssetInvalidDestination"
+        case .serverError: return "serverError"
+        }
+    }
+
+    // MARK: - The reported bug
+
+    func testNoLiquidityPoolIsNotTitledUnexpectedError() {
+        XCTAssertNotEqual(
+            SwapError.noLiquidityPool.errorTitle,
+            SwapCryptoLogic.Errors.unexpectedError.errorTitle
+        )
+        XCTAssertEqual(SwapError.noLiquidityPool.errorTitle, "swapErrorNoLiquidityPoolTitle".localized)
+        XCTAssertEqual(SwapError.noLiquidityPool.errorMessage, "noLiquidityPool".localized)
+    }
+
+    // MARK: - Every case, not just the reported one
+
+    func testEveryCaseCoveredExactlyOnce() {
+        let names = allCases.map(caseName)
+        XCTAssertEqual(Set(names).count, names.count, "duplicate sample in allCases")
+        XCTAssertEqual(names.count, 10, "a SwapError case is missing from allCases")
+    }
+
+    func testNoCaseFallsBackToUnexpectedErrorTitle() {
+        let generic = SwapCryptoLogic.Errors.unexpectedError.errorTitle
+        for error in allCases {
+            XCTAssertNotEqual(error.errorTitle, generic, "\(caseName(error)) is still titled generically")
+        }
+    }
+
+    func testEveryCaseHasNonEmptyTitleAndMessage() {
+        for error in allCases {
+            XCTAssertFalse(error.errorTitle.isEmpty, "\(caseName(error)) has an empty title")
+            XCTAssertFalse(error.errorMessage.isEmpty, "\(caseName(error)) has an empty message")
+        }
+    }
+
+    func testTitleKeyPerCase() {
+        let expected: [String: String] = [
+            "routeUnavailable": "swapErrorRouteUnavailableTitle",
+            "recipientRouteUnavailable": "swapErrorRecipientRouteTitle",
+            "recipientVerificationFailed": "swapErrorRecipientVerificationTitle",
+            "noLiquidityPool": "swapErrorNoLiquidityPoolTitle",
+            "tradingHalted": "swapErrorTradingHaltedTitle",
+            // Same verdict as `SwapCryptoLogic.Errors.swapAmountTooSmall`, so the
+            // two amount cases deliberately reuse that existing title key.
+            "swapAmountTooSmall": "swapErrorAmountTooSmallTitle",
+            "lessThenMinSwapAmount": "swapErrorAmountTooSmallTitle",
+            "slippageToleranceTooTight": "swapErrorSlippageTooTightTitle",
+            "securedAssetInvalidDestination": "swapErrorInvalidDestinationTitle",
+            "serverError": "swapErrorProviderRejectedTitle"
+        ]
+        for error in allCases {
+            guard let key = expected[caseName(error)] else {
+                XCTFail("no expected title key for \(caseName(error))")
+                continue
+            }
+            XCTAssertEqual(error.errorTitle, key.localized, "wrong title key for \(caseName(error))")
+        }
+    }
+
+    func testAmountCasesShareTheExistingAmountTitle() {
+        XCTAssertEqual(
+            SwapError.swapAmountTooSmall.errorTitle,
+            SwapCryptoLogic.Errors.swapAmountTooSmall.errorTitle
+        )
+        XCTAssertEqual(
+            SwapError.lessThenMinSwapAmount(amount: "0.01 BTC").errorTitle,
+            SwapCryptoLogic.Errors.swapAmountTooSmall.errorTitle
+        )
+    }
+
+    // MARK: - Raw upstream text never reaches the tooltip body
+
+    func testServerErrorMessageIsGenericNotTheProviderString() {
+        let raw = "failed to simulate swap: pool ETH.VULT-0XB788144DF611029C60B859DF47E79B7726C4DEBA doesn't exist"
+        let error = SwapError.serverError(message: raw)
+        XCTAssertNotEqual(error.errorMessage, raw)
+        XCTAssertEqual(error.errorMessage, "swapErrorProviderRejectedDescription".localized)
+    }
+
+    func testServerErrorKeepsTheProviderStringForLogs() {
+        // `errorDescription` is the diagnostic channel (`localizedDescription`,
+        // logger lines). It must keep the provider's own wording so a support
+        // log still explains what upstream actually said.
+        let raw = "failed to simulate swap: pool ETH.VULT-0X… doesn't exist"
+        XCTAssertEqual(SwapError.serverError(message: raw).errorDescription, raw)
+    }
+
+    // MARK: - The secured-asset guard keeps its app-authored copy
+
+    func testSecuredAssetInvalidDestinationKeepsFormattedAppCopy() {
+        let error = SwapError.securedAssetInvalidDestination(expectedPrefix: "thor", destination: "0xdead")
+        let expected = String(format: "swapSecuredAssetInvalidDestination".localized, "thor", "0xdead")
+        XCTAssertEqual(error.errorDescription, expected)
+        // It is app copy, so unlike `serverError` it is shown verbatim.
+        XCTAssertEqual(error.errorMessage, expected)
+    }
+
+    // MARK: - SwapCryptoLogic.Errors keeps its existing presentation
+
+    func testSwapCryptoLogicErrorsMessageMatchesItsDescription() {
+        for error in [
+            SwapCryptoLogic.Errors.unexpectedError,
+            .insufficientFunds,
+            .insufficientGas,
+            .swapAmountTooSmall,
+            .inboundAddress,
+            .sameAsset
+        ] {
+            XCTAssertEqual(error.errorMessage, error.errorDescription)
+            XCTAssertFalse(error.errorTitle.isEmpty)
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapErrorPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapErrorPresentationTests.swift
@@ -64,13 +64,26 @@ final class SwapErrorPresentationTests: XCTestCase {
 
     private var allCases: [SwapError] { CaseTag.allCases.map(sample) }
 
-    /// Localized value for `key`, or `nil` when the key is missing from the
-    /// bundle. `"key".localized` echoes the key back on a miss, so asserting
-    /// against it proves nothing about the strings file; this does.
-    private func localizedValue(forKey key: String) -> String? {
+    /// Every locale the app ships. `ko` is included deliberately: the repo's own
+    /// docs list seven, but Korean is a shipping localization, and a key added to
+    /// the other seven leaks a raw camelCase identifier to Korean users.
+    private static let shippedLocales = ["en", "de", "es", "hr", "it", "ko", "pt", "zh-Hans"]
+
+    /// Localized value for `key` in `bundle`, or `nil` when the key is missing.
+    /// `"key".localized` echoes the key back on a miss, so asserting against it
+    /// proves nothing about the strings file; this does.
+    private func localizedValue(forKey key: String, in bundle: Bundle = .main) -> String? {
         let sentinel = "__missing_localization__"
-        let value = Bundle.main.localizedString(forKey: key, value: sentinel, table: nil)
+        let value = bundle.localizedString(forKey: key, value: sentinel, table: nil)
         return value == sentinel ? nil : value
+    }
+
+    /// The bundle for a single `.lproj`, which resolves keys from that locale
+    /// alone with no fallback. `Bundle.main` answers for the *active*
+    /// localization only, so a key present in `en` and missing from `ko` reads as
+    /// covered when the whole point of the check is that it isn't.
+    private func bundle(forLocale locale: String) -> Bundle? {
+        Bundle.main.path(forResource: locale, ofType: "lproj").flatMap(Bundle.init(path:))
     }
 
     // MARK: - The reported bug, through the path the view actually uses
@@ -165,11 +178,12 @@ final class SwapErrorPresentationTests: XCTestCase {
         }
     }
 
-    func testNewCopyKeysExistInTheBundle() {
+    func testNewCopyKeysExistInEveryShippedLocale() {
         // Guards the "missing key leaks a raw camelCase identifier to the user"
         // failure mode that a `"key".localized == "key".localized` assertion
-        // cannot see.
-        for key in [
+        // cannot see — and checks it per locale, because the active-localization
+        // lookup would pass on `en` alone while a non-English user saw the key.
+        let keys = [
             "swapErrorRouteUnavailableTitle",
             "swapErrorRecipientRouteTitle",
             "swapErrorRecipientVerificationTitle",
@@ -179,8 +193,64 @@ final class SwapErrorPresentationTests: XCTestCase {
             "swapErrorInvalidDestinationTitle",
             "swapErrorProviderRejectedTitle",
             "swapErrorProviderRejectedDescription"
-        ] {
-            XCTAssertNotNil(localizedValue(forKey: key), "\(key) is missing from Localizable.strings")
+        ]
+        for locale in Self.shippedLocales {
+            guard let bundle = bundle(forLocale: locale) else {
+                XCTFail("\(locale).lproj does not ship in the app bundle")
+                continue
+            }
+            for key in keys {
+                XCTAssertNotNil(
+                    localizedValue(forKey: key, in: bundle),
+                    "\(key) is missing from \(locale).lproj/Localizable.strings"
+                )
+            }
+        }
+    }
+
+    func testPerLocaleLookupDoesNotFallBackToEnglish() {
+        // Gives the two per-locale assertions their teeth. If `Bundle(path:)`
+        // resolved through the English table, a key missing from a locale would
+        // still answer and both checks would pass vacuously.
+        // `swapErrorNoLiquidityPoolTitle` is translated in all eight, so every
+        // non-English bundle must answer with something other than the English.
+        guard let english = bundle(forLocale: "en"),
+              let englishValue = localizedValue(forKey: "swapErrorNoLiquidityPoolTitle", in: english) else {
+            XCTFail("en.lproj does not ship in the app bundle")
+            return
+        }
+        for locale in Self.shippedLocales where locale != "en" {
+            guard let bundle = bundle(forLocale: locale) else {
+                XCTFail("\(locale).lproj does not ship in the app bundle")
+                continue
+            }
+            XCTAssertNotEqual(
+                localizedValue(forKey: "swapErrorNoLiquidityPoolTitle", in: bundle),
+                englishValue,
+                "\(locale) answered with the English value — the per-locale lookup is falling back"
+            )
+        }
+    }
+
+    func testSecuredDestinationTemplateSurvivesFormattingInEveryLocale() {
+        // `securedAssetInvalidDestination` is the one case whose copy is built
+        // with `String(format:)`. A locale that drops or mangles a positional
+        // specifier silently loses the prefix or the address from the message —
+        // and both are the whole content of it. Assert on the formatted output
+        // rather than on the literal `%1$@` / `%2$@`, since a translation is free
+        // to reorder them.
+        for locale in Self.shippedLocales {
+            guard let bundle = bundle(forLocale: locale) else {
+                XCTFail("\(locale).lproj does not ship in the app bundle")
+                continue
+            }
+            guard let template = localizedValue(forKey: "swapSecuredAssetInvalidDestination", in: bundle) else {
+                XCTFail("swapSecuredAssetInvalidDestination is missing from \(locale).lproj")
+                continue
+            }
+            let formatted = String(format: template, "thor", "0xdead")
+            XCTAssertTrue(formatted.contains("thor"), "\(locale): expected prefix dropped by the template")
+            XCTAssertTrue(formatted.contains("0xdead"), "\(locale): destination dropped by the template")
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapServiceErrorSurfacingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapServiceErrorSurfacingTests.swift
@@ -100,17 +100,27 @@ final class SwapServiceErrorSurfacingTests: XCTestCase {
         )
     }
 
-    func testNonSwapErrorCoreFailureStillSurfacesInOrder() {
-        // Transport/decode failures are not `SwapError` at all, so they are not
-        // "classified"; with no classified verdict present the first one wins,
-        // exactly as before.
-        let transport = URLError(.timedOut)
-        let errors: [Error] = [transport, SwapError.serverError(message: "body")]
+    func testRelayLosesToAnyOtherCoreError() {
+        // Transport failures are not `SwapError`, but they still carry a verdict
+        // of their own, so they outrank the relay.
+        let errors: [Error] = [SwapError.serverError(message: "body"), URLError(.timedOut)]
         XCTAssertTrue(SwapService.surfacedQuoteError(from: errors) is URLError)
     }
 
-    func testClassifiedVerdictBeatsNonSwapErrorCoreFailure() {
+    func testOnlyTheRelayIsDemoted() {
+        // Guard against over-reach: the rule demotes `.serverError` and nothing
+        // else. A typed aggregator failure with a specific, actionable message
+        // must keep its place in completion order — otherwise a provider that
+        // merely answered slower downgrades "Insufficient funds" to the generic
+        // "No route available".
+        let kyber = KyberSwapError.insufficientFunds(message: "not enough ETH")
+        let errors: [Error] = [kyber, SwapError.routeUnavailable]
+        XCTAssertTrue(SwapService.surfacedQuoteError(from: errors) is KyberSwapError)
+    }
+
+    func testNonSwapErrorCoreFailureStillSurfacesInOrder() {
+        // No relay involved at all: completion order is untouched.
         let errors: [Error] = [URLError(.timedOut), SwapError.tradingHalted]
-        XCTAssertEqual(SwapService.surfacedQuoteError(from: errors) as? SwapError, .tradingHalted)
+        XCTAssertTrue(SwapService.surfacedQuoteError(from: errors) is URLError)
     }
 }

--- a/VultisigApp/VultisigAppTests/Swap/SwapServiceErrorSurfacingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapServiceErrorSurfacingTests.swift
@@ -63,4 +63,54 @@ final class SwapServiceErrorSurfacingTests: XCTestCase {
         ]
         XCTAssertEqual(SwapService.surfacedQuoteError(from: errors) as? SwapKitError, .addressScreeningFailed)
     }
+
+    // MARK: - A classified verdict beats an unclassified upstream relay
+
+    func testClassifiedVerdictWinsOverRawProviderRelayRegardlessOfOrder() {
+        // The reported case: a poolless THORChain↔EVM pair fails on THORChain and
+        // MAYAChain at once. THORChain's body classifies to `.noLiquidityPool`;
+        // an unclassifiable body only reaches `.serverError`. `errors` arrives in
+        // task-completion order, so without this rule the user saw whichever node
+        // happened to answer first — a different sentence on every refresh.
+        let raw = SwapError.serverError(message: "failed to simulate swap: pool ETH.FOO-0XDEAD doesn't exist")
+        let classifiedFirst: [Error] = [SwapError.noLiquidityPool, raw]
+        let classifiedLast: [Error] = [raw, SwapError.noLiquidityPool]
+        XCTAssertEqual(SwapService.surfacedQuoteError(from: classifiedFirst) as? SwapError, .noLiquidityPool)
+        XCTAssertEqual(SwapService.surfacedQuoteError(from: classifiedLast) as? SwapError, .noLiquidityPool)
+    }
+
+    func testRawRelaySurfacesWhenNothingWasClassified() {
+        // Nothing better available — the relay is still the only signal, and its
+        // message is preserved for the logs.
+        let raw = SwapError.serverError(message: "some upstream body")
+        XCTAssertEqual(SwapService.surfacedQuoteError(from: [raw]) as? SwapError, raw)
+    }
+
+    func testCoreProviderPrecedenceOutranksClassification() {
+        // A classified SwapKit error must NOT jump ahead of a core provider's
+        // unclassified relay: the SwapKit-is-optional rule is about which
+        // provider's opinion is trustworthy, and it still comes first.
+        let errors: [Error] = [
+            SwapKitError.noRoutesFound,
+            SwapError.serverError(message: "core provider body")
+        ]
+        XCTAssertEqual(
+            SwapService.surfacedQuoteError(from: errors) as? SwapError,
+            .serverError(message: "core provider body")
+        )
+    }
+
+    func testNonSwapErrorCoreFailureStillSurfacesInOrder() {
+        // Transport/decode failures are not `SwapError` at all, so they are not
+        // "classified"; with no classified verdict present the first one wins,
+        // exactly as before.
+        let transport = URLError(.timedOut)
+        let errors: [Error] = [transport, SwapError.serverError(message: "body")]
+        XCTAssertTrue(SwapService.surfacedQuoteError(from: errors) is URLError)
+    }
+
+    func testClassifiedVerdictBeatsNonSwapErrorCoreFailure() {
+        let errors: [Error] = [URLError(.timedOut), SwapError.tradingHalted]
+        XCTAssertEqual(SwapService.surfacedQuoteError(from: errors) as? SwapError, .tradingHalted)
+    }
 }


### PR DESCRIPTION
## Description

The swap error tooltip titled a deterministic "there is no pool for this pair" verdict **"Unexpected Error"**, and the body alternated between the correct copy and a raw MAYAChain node string with an uppercased contract address.

Fixes #4987

### Why the title was wrong

`SwapErrorTooltipView` resolved the title and the body down two independent `if let` ladders. The body's ladder ended in `error.localizedDescription`, which `SwapError` satisfies correctly. The title's ladder had **no arm for `SwapError` at all** and fell through to `SwapCryptoLogic.Errors.unexpectedError`. So the right sentence rendered under the wrong heading — and not just for `noLiquidityPool`: **all ten `SwapError` cases** were titled generically.

Title and body now resolve through one `SwapErrorPresentable` lookup (`SwapErrorPresentation`), so a type can no longer be present in one and missing from the other.

**Every `SwapError` case and the title it now resolves to:**

| Case | Title | Key |
|---|---|---|
| `routeUnavailable` | No Route Available | `swapErrorRouteUnavailableTitle` (new) |
| `recipientRouteUnavailable` | No Recipient Route | `swapErrorRecipientRouteTitle` (new) |
| `recipientVerificationFailed` | Recipient Check Failed | `swapErrorRecipientVerificationTitle` (new) |
| `noLiquidityPool` | No Liquidity Pool | `swapErrorNoLiquidityPoolTitle` (new) |
| `tradingHalted` | Trading Halted | `swapErrorTradingHaltedTitle` (new) |
| `swapAmountTooSmall` | Amount Too Small | `swapErrorAmountTooSmallTitle` (existing, reused) |
| `slippageToleranceTooTight` | Slippage Too Tight | `swapErrorSlippageTooTightTitle` (new) |
| `lessThenMinSwapAmount` | Amount Too Small | `swapErrorAmountTooSmallTitle` (existing, reused) |
| `securedAssetInvalidDestination` (new case) | Invalid Destination | `swapErrorInvalidDestinationTitle` (new) |
| `serverError` | Swap Unavailable | `swapErrorProviderRejectedTitle` (new) |

9 new keys × 8 locales (en, de, es, hr, it, **ko**, pt, zh-Hans), sorted with `sort_localizable.py`.

### Why the raw string flashed — the issue's diagnosis was wrong here

The issue read it as an intermediate state settling. It isn't. `Coin.swapProviders` resolves RUNE → ETH.VULT to exactly **two** providers, THORChain and MAYAChain, which `SwapService.fetchQuotes` runs **in parallel**. Both fail, and the two nodes word the identical verdict differently — captured live on 2026-07-30:

```
GET gateway.liquify.com/chain/thorchain_api/thorchain/quote/swap?from_asset=THOR.RUNE&to_asset=ETH.VULT-0XB788…EBA&…
→ {"code":2,"message":"failed to calculate min swap amount: fail to convert dest fee to src asset pool does not exist"}

GET mayanode.mayachain.info/mayachain/quote/swap   (same pair)
→ {"error":"failed to simulate swap: pool ETH.VULT-0XB788144DF611029C60B859DF47E79B7726C4DEBA doesn't exist"}
```

`classifyNativeQuoteError` matched only THORChain's spelling, so MAYAChain's fell through to the raw relay. Failures are then collected in **task-completion order** and `surfacedQuoteError` returned the first one — so which sentence the user saw was decided by whichever node answered first, and re-decided on every quote refresh. Two consecutive refresh rounds, two different winners: exactly the "raw string, then the mapped copy" in the report.

Fixed at both points, because either alone leaves a hole:

1. **`isMissingPool`** accepts both spellings of the verb, matched **per clause**. THORNode uses the same contraction in `bad destination address: unable to parse address: THORName doesn't exist: thor1…` (also captured live), and reporting a bad address as a missing pool would send the user off to pick a different asset. Clause-scoping also keeps a composite body that names a pool in one clause and something else missing in another from false-positiving — that matters past the tooltip, since `LimitSwapFormViewModel` persists `.noRoute` from this same classification and blocks order placement.
2. **`surfacedQuoteError`** sorts `.serverError` last within the core-provider pool, so a provider that merely answers faster can't downgrade the message. Only `.serverError` is demoted — a Kyber/LI.FI/transport failure carries its own specific description and keeps its place. The SwapKit-is-optional precedence rule is untouched and still outranks this.

### Raw provider strings

`.serverError` is the only case whose text this app did not write. Its `errorDescription` still returns the provider's wording verbatim (logs, `localizedDescription`, `logger.error` at the throw site); its `errorMessage` — what the tooltip renders — is generic localized copy.

So that this couldn't swallow app-authored text, the one place the app itself built a `.serverError` (the secured-asset destination guard in `resolveThorchainDestination`) is promoted to its own `securedAssetInvalidDestination` case, which is still shown verbatim. Text is byte-identical to before at that throw site.

**Deliberate trade-off, stated plainly:** this also genericizes messages that were arguably worth showing, most notably THORNode's `swap destination address is not the same chain as the target asset`. `SwapErrorMappingTests` previously commented that such a body "must reach the user/logs verbatim" — after this PR it reaches the **logs** verbatim and the **user** generically. The mapping layer and every one of its existing assertions are unchanged; only the tooltip's rendering differs. This is #4987's second acceptance criterion, and it is what Android already does (see Parity).

## Which feature is affected?
- [x] Swap — quote-error presentation only. No change to quote selection, ranking, payload building, signing, or broadcast, so there is no tx link to attach.

## Parity

- **Android:** `n/a` — **already ahead on both halves.** `SwapException.handleSwapException` (`data/.../errors/SwapException.kt:57`) already matches `"failed to simulate swap: pool"` alongside `"pool does not exist"`, so Android never had the Maya-phrasing gap; and `SwapQuoteManager.kt:1105-1125` maps every `SwapException` to an `R.string.*` resource (`UnkownSwapError → swap_error_quote_failed`), so a raw upstream body has never reached an Android user. iOS is catching up, not diverging.
- **SDK:** **gap confirmed, not filed.** `packages/core/chain/swap/native/api/getNativeSwapQuote.ts:104` ends `assertOkQuote` with a bare `throw new Error(result.error)` — the node string is surfaced verbatim, the same defect this PR fixes on iOS. I did not open a sibling issue (unrequested side-action); happy to file one on your word.
- **Windows + extension:** same gap, inherited — they consume the SDK's `getNativeSwapQuote` and have no native-quote error classifier of their own.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings — SwiftLint 36 violations before and after, none in the touched files
- [x] I have added tests that prove my fix is effective

## Testing

`make test` on a dedicated iPhone 17 Pro Max / iOS 26.5 simulator:

```
** TEST SUCCEEDED **
Executed 4379 tests, with 1 test skipped and 0 failures (0 unexpected) in 66.097 seconds
```

New/extended coverage across three suites:

- `SwapErrorPresentationTests` — resolution driven through `SwapErrorPresentation`, i.e. the path the view uses. Case coverage is closed at both ends by a `CaseTag: CaseIterable` plus two exhaustive switches, so a new `SwapError` case cannot compile without a sample and therefore cannot skip the "is not titled Unexpected Error" assertion. Locale keys are asserted present via a sentinel-default lookup against **each shipped `.lproj` bundle individually** (all 9 keys × all 8 locales), not `"key".localized` compared to itself and not via `Bundle.main`, which answers only for the active localization. `swapSecuredAssetInvalidDestination` additionally gets a formatting check — it is the only case built with `String(format:)`, and a locale that drops a positional specifier silently loses the address or the chain prefix; asserted on the formatted output rather than on literal `%1$@` / `%2$@`, since a translation may reorder them. A third test proves the per-locale lookup doesn't fall back to English, without which the other two could pass vacuously.
- `SwapErrorMappingTests` — both nodes' verbatim missing-pool bodies, the typographic apostrophe, case-insensitivity, and two negative guards: the verbatim `THORName doesn't exist` body, and a composite pool/verb-in-different-clauses body.
- `SwapServiceErrorSurfacingTests` — the relay loses regardless of completion order; a typed aggregator error is *not* demoted; SwapKit-vs-core precedence unchanged.

**Limitation — not reproduced live.** I could not hit a real no-pool quote against production: that needs a vault holding RUNE plus the swap form on device. The two node bodies above were captured with `curl` against the app's own hosts and pinned as verbatim fixtures, and the resolution is unit-tested end to end — but **the on-screen title and body were not observed on a device**. Worth an on-device pass on RUNE → VULT before merge.

## Additional context

Cross-model reviewed with `codex exec --sandbox read-only` (per-step + whole-branch): 6 findings, 5 fixed, 1 rejected with reason. Plus 2 CodeRabbit threads, both fixed and resolved — the German slippage title said "slippage too low" when the error is that the *tolerance* is too restrictive, and checking the rest found the same inversion in Korean, Portuguese and Simplified Chinese (Spanish/Croatian/Italian already matched the English idiom and were left alone). The two most valuable were genuine over-reach in my own first cut — the surfacing preference initially demoted every non-`SwapError`, which would have downgraded Kyber's "Insufficient funds" to a generic "No Route Available", and the pool match was whole-message rather than per clause. Full ledger in the wiki plan page.

## Agent Metadata
- **Agent**: Claude Code
- **Issue**: #4987
- **Confidence**: high on the mechanism and the code; medium on copy wording, which is a product call
- **Needs human review for**: the deliberate suppression of unclassified upstream text in the tooltip (Android precedent argues for it, the previous iOS tests argued against it), the ten new title strings, and an on-device pass on the RUNE → VULT repro


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap error handling to show specific, actionable messages instead of generic relay errors.
  * Added clearer detection and messaging for missing liquidity pools and invalid secured-asset destinations.
  * Preserved useful provider details for diagnostics while improving user-facing explanations.

* **Improvements**
  * Added consistent messaging for unavailable routes, rejected providers, verification issues, tight slippage, and trading halts.
  * Expanded localized swap error messaging across supported languages.
  * Added clearer minimum-payout information for supported swaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
