### PR TITLE
fix(swap): show the memo-enforced floor as "min. payout", the quote as "expected payout"

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -442,6 +442,7 @@
 "estNetworkFee" = "Geschätzte Netzwerkgebühr";
 "evmChains" = "EVM -Ketten";
 "excessGasRefund" = "Erstattung überschüssiger Gas";
+"expectedPayout" = "Erwartete Auszahlung";
 "expirationDate" = "Ablaufdatum";
 "expiresOn" = "Läuft ab";
 "extendExpiration(inYears)" = "Ausweitung des Ablaufs (in Jahren)";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -440,6 +440,7 @@
 "estNetworkFee" = "Est. network fee";
 "evmChains" = "EVM Chains";
 "excessGasRefund" = "Excess Gas Refund";
+"expectedPayout" = "expected payout";
 "expirationDate" = "Expiration date";
 "expiresOn" = "Expires on";
 "extendExpiration(inYears)" = "Extend Expiration (in years)";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -442,6 +442,7 @@
 "estNetworkFee" = "Comisión estimada de red";
 "evmChains" = "Cadenas EVM";
 "excessGasRefund" = "Reembolso de Gas Excedente";
+"expectedPayout" = "pago esperado";
 "expirationDate" = "Fecha de expiración";
 "expiresOn" = "Vencer";
 "extendExpiration(inYears)" = "Extender el vencimiento (en años)";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -442,6 +442,7 @@
 "estNetworkFee" = "Procijenjena mrežna naknada";
 "evmChains" = "EVM lanci";
 "excessGasRefund" = "Povrat viška goriva";
+"expectedPayout" = "očekivana isplata";
 "expirationDate" = "Datum isteka";
 "expiresOn" = "Ističe na";
 "extendExpiration(inYears)" = "Produžite istek (u godinama)";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -442,6 +442,7 @@
 "estNetworkFee" = "Comm. di rete stimata";
 "evmChains" = "Catene EVM";
 "excessGasRefund" = "Rimborso del Gas in Eccesso";
+"expectedPayout" = "pagamento previsto";
 "expirationDate" = "Data di scadenza";
 "expiresOn" = "Scade";
 "extendExpiration(inYears)" = "Estendere la scadenza (in anni)";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -440,6 +440,7 @@
 "estNetworkFee" = "예상 네트워크 수수료";
 "evmChains" = "EVM 체인";
 "excessGasRefund" = "초과 가스 환불";
+"expectedPayout" = "예상 지급";
 "expirationDate" = "만료 날짜";
 "expiresOn" = "만료 날짜";
 "extendExpiration(inYears)" = "만료 연장 (년 단위)";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -442,6 +442,7 @@
 "estNetworkFee" = "Taxa de rede estimada";
 "evmChains" = "Correntes EVM";
 "excessGasRefund" = "Reembolso de Gás Excedente";
+"expectedPayout" = "pagamento esperado";
 "expirationDate" = "Data de validade";
 "expiresOn" = "Expira em";
 "extendExpiration(inYears)" = "Estender a expiração (em anos)";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -442,6 +442,7 @@
 "estNetworkFee" = "预计网络费用";
 "evmChains" = "EVM 链";
 "excessGasRefund" = "多余 Gas 退款";
+"expectedPayout" = "预期支付";
 "expirationDate" = "到期日期";
 "expiresOn" = "到期于";
 "extendExpiration(inYears)" = "延长到期时间（年）";

--- a/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Services/Swap/SwapPayload.swift
@@ -74,6 +74,21 @@ enum SwapPayload: Codable, Hashable { // TODO: Merge with SwapQuote
         }
     }
 
+    /// True for the native-protocol routes (THORChain on any network, MayaChain)
+    /// whose signed memo carries a `LIM` output floor. Mirrors
+    /// `SwapQuote.isNativeProtocolRoute` for the co-signer, which sees only the
+    /// serialized payload. Aggregator routes (1inch / LI.FI / KyberSwap /
+    /// Jupiter / SwapKit) sign opaque calldata or a pre-built transaction, so
+    /// whatever floor they enforce is not readable here.
+    var isNativeProtocolRoute: Bool {
+        switch self {
+        case .thorchain, .thorchainChainnet, .thorchainStagenet, .mayachain:
+            return true
+        case .generic, .swapkit:
+            return false
+        }
+    }
+
     var isDeposit: Bool {
         switch self {
         case .mayachain(let payload):

--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/JoinKeysignViewModel.swift
@@ -720,6 +720,36 @@ class JoinKeysignViewModel: ObservableObject {
 
     }
 
+    /// Caption over the destination amount on the swap confirm screen. A market
+    /// swap's amount is the quote's *expected* output; the enforced floor is a
+    /// separate, lower number (`getMinPayoutCaption`). A resting limit order is
+    /// the opposite case — the assembler puts the order's LIM floor in
+    /// `toAmountDecimal` precisely so the co-signer sees the guarantee — so it
+    /// keeps the "min. payout" wording.
+    var toAmountCaptionKey: String {
+        isLimitSwapMemo(keysignPayload?.memo) ? "minPayout" : "expectedPayout"
+    }
+
+    /// "min. payout: …" line under a market swap's destination amount, or `nil`
+    /// when this transaction enforces no output floor and the screen must
+    /// therefore promise none.
+    ///
+    /// Read out of `keysignPayload.memo` — the literal bytes THIS device is
+    /// about to sign — rather than the payload's `toAmountLimit`, which the
+    /// initiator derived from the quote's memo before any `OP_RETURN`
+    /// compression. Confirming what it signs is the co-signer's entire job.
+    func getMinPayoutCaption() -> String? {
+        guard let payload = keysignPayload,
+              let swapPayload = payload.swapPayload,
+              swapPayload.isNativeProtocolRoute,
+              let memo = payload.memo,
+              let limit = ThorchainMemoLimit.assertedLimit(in: memo) else {
+            return nil
+        }
+        let amount = Decimal(limit) / swapPayload.toCoin.thorswapMultiplier
+        return SwapCryptoLogic.minPayoutCaption(amount: amount, ticker: swapPayload.toCoin.ticker)
+    }
+
     func getCalculatedNetworkFee() -> (feeCrypto: String, feeFiat: String) {
         guard let keysignPayload else { return (.empty, .empty) }
         return gasViewModel.getCalculatedNetworkFee(payload: keysignPayload)

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -205,7 +205,7 @@ struct KeysignSwapConfirmView: View {
             getCoinIcon(for: coin)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("minPayout".localized)
+                Text(viewModel.toAmountCaptionKey.localized)
                     .font(Theme.fonts.caption12)
                     .foregroundStyle(Theme.colors.textTertiary)
                     .opacity(isTo ? 1 : 0)
@@ -237,6 +237,16 @@ struct KeysignSwapConfirmView: View {
                         .font(Theme.fonts.caption10)
                         .offset(x: 2)
                     }
+                }
+
+                // The floor the memo this device is about to sign enforces —
+                // the whole point of a co-signer's confirm screen is that the
+                // guarantee it approves is the guarantee it signs. Absent on
+                // routes that enforce none.
+                if isTo, let minPayout = viewModel.getMinPayoutCaption() {
+                    Text(minPayout)
+                        .font(Theme.fonts.priceCaption)
+                        .foregroundStyle(Theme.colors.textTertiary)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -170,9 +170,11 @@ extension SwapCryptoLogic {
     /// of the output floor and streaming plan — neither is derivable from the
     /// quote's other fields, because the node applies its tolerance parameter to
     /// a feeless price we never see and bakes its own streaming choice into the
-    /// memo. All three are inert on this device (nothing renders them, no signer
-    /// reads them); they ride the proto so the co-signer sees exactly what the
-    /// memo commits to.
+    /// memo. All three stay inert: no signer reads them, and no screen renders
+    /// them either — the minimum shown on the verify and co-sign screens is read
+    /// from the signed memo itself, because for a UTXO source
+    /// `ThorchainMemoLimit.compressed` lowers that memo's LIM *after* this
+    /// payload is built. They ride the proto for cross-device transit only.
     static func buildThorchainSwapPayload(
         fromCoin: Coin,
         toCoin: Coin,

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/SwapPayloadBuilder.swift
@@ -138,7 +138,7 @@ extension SwapCryptoLogic {
     /// term that isn't already canonical is a term we should not vouch for.
     static func thorchainMemoSwapTerms(from memo: String) -> ThorchainMemoSwapTerms {
         let fields = memo.split(separator: ":", omittingEmptySubsequences: false)
-        guard fields.count >= 4, isThorchainSwapAction(fields[0]) else { return .unspecified }
+        guard fields.count >= 4, ThorchainMemoLimit.isSwapAction(fields[0]) else { return .unspecified }
 
         let terms = fields[3].split(separator: "/", omittingEmptySubsequences: false)
         guard !terms.isEmpty, terms.count <= 3 else { return .unspecified }
@@ -159,19 +159,6 @@ extension SwapCryptoLogic {
             streamingInterval: parsed[1],
             streamingQuantity: parsed[2]
         )
-    }
-
-    /// THORChain and MayaChain both spell the swap action `SWAP`, `=` or `s`,
-    /// case-insensitively. Every other action (`ADD`, `WITHDRAW`, `DONATE`,
-    /// `LOAN+`, …) lays its fields out differently, so its 4th field is not a
-    /// `LIM/INTERVAL/QUANTITY` triple and must not be read as one.
-    private static func isThorchainSwapAction(_ field: Substring) -> Bool {
-        switch field.lowercased() {
-        case "swap", "=", "s":
-            return true
-        default:
-            return false
-        }
     }
 
     /// Build the THORChain/MayaChain swap payload from primitives + selected quote.
@@ -247,10 +234,7 @@ extension SwapCryptoLogic {
                 coin: fromCoin,
                 toAddress: toAddress ?? fromCoin.address,
                 amount: amountInCoin,
-                memo: ThorchainMemoLimit.compressed(
-                    quote.memo,
-                    maxBytes: ThorchainMemoLimit.memoByteLimit(for: fromCoin.chain)
-                ),
+                memo: ThorchainMemoLimit.signedMemo(quote.memo, sourceChain: fromCoin.chain),
                 chainSpecific: chainSpecific,
                 swapPayload: .mayachain(buildThorchainSwapPayload(
                     fromCoin: fromCoin,
@@ -270,10 +254,7 @@ extension SwapCryptoLogic {
                 coin: fromCoin,
                 toAddress: toAddress,
                 amount: amountInCoin,
-                memo: ThorchainMemoLimit.compressed(
-                    quote.memo,
-                    maxBytes: ThorchainMemoLimit.memoByteLimit(for: fromCoin.chain)
-                ),
+                memo: ThorchainMemoLimit.signedMemo(quote.memo, sourceChain: fromCoin.chain),
                 chainSpecific: chainSpecific,
                 swapPayload: .thorchain(buildThorchainSwapPayload(
                     fromCoin: fromCoin,
@@ -293,10 +274,7 @@ extension SwapCryptoLogic {
                 coin: fromCoin,
                 toAddress: toAddress,
                 amount: amountInCoin,
-                memo: ThorchainMemoLimit.compressed(
-                    quote.memo,
-                    maxBytes: ThorchainMemoLimit.memoByteLimit(for: fromCoin.chain)
-                ),
+                memo: ThorchainMemoLimit.signedMemo(quote.memo, sourceChain: fromCoin.chain),
                 chainSpecific: chainSpecific,
                 swapPayload: .thorchainChainnet(buildThorchainSwapPayload(
                     fromCoin: fromCoin,
@@ -316,10 +294,7 @@ extension SwapCryptoLogic {
                 coin: fromCoin,
                 toAddress: toAddress,
                 amount: amountInCoin,
-                memo: ThorchainMemoLimit.compressed(
-                    quote.memo,
-                    maxBytes: ThorchainMemoLimit.memoByteLimit(for: fromCoin.chain)
-                ),
+                memo: ThorchainMemoLimit.signedMemo(quote.memo, sourceChain: fromCoin.chain),
                 chainSpecific: chainSpecific,
                 swapPayload: .thorchainStagenet(buildThorchainSwapPayload(
                     fromCoin: fromCoin,

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
@@ -181,20 +181,25 @@ enum ThorchainMemoLimit {
         guard let limTerm = terms.first, terms.count <= 3 else { return nil }
         // Only the LIM is ever rewritten into scientific notation; the streaming
         // terms are plain integers in both the node's spelling and our own.
-        guard terms.dropFirst().allSatisfy({ isCanonicalDigits($0) }) else { return nil }
+        guard terms.dropFirst().allSatisfy({ isPlainDecimalDigits($0) }) else { return nil }
 
         guard let limit = parseLimitTerm(limTerm), limit > 0 else { return nil }
         return limit
     }
 
     /// `1234` or `1234e5` (mantissa followed by `exponent` trailing zeros) — the
-    /// only two spellings a LIM we are willing to vouch for can take. ASCII
-    /// digits only: `Character.isNumber` alone also accepts non-ASCII numerals
-    /// and fractions, which `BigInt` would then read as something the node never
+    /// two spellings a LIM we are willing to vouch for can take. ASCII digits
+    /// only: `Character.isNumber` alone also accepts non-ASCII numerals and
+    /// fractions, which `BigInt` would then read as something the node never
     /// wrote. Values wider than the node's own `cosmos.Uint` are refused too.
+    ///
+    /// The exponent ceiling is deliberately below the node's own (77): the only
+    /// scientific LIM this app ever has to read is one `compressed(_:maxBytes:)`
+    /// wrote, whose exponent cannot exceed the digit count of a base-1e8 amount.
+    /// A memo past that is one we did not produce and the node did not return.
     private static func parseLimitTerm(_ term: some StringProtocol) -> BigInt? {
         let parts = term.split(separator: "e", omittingEmptySubsequences: false)
-        guard let mantissaText = parts.first, isCanonicalDigits(mantissaText),
+        guard let mantissaText = parts.first, isPlainDecimalDigits(mantissaText),
               let mantissa = BigInt(String(mantissaText)) else {
             return nil
         }
@@ -204,7 +209,7 @@ enum ThorchainMemoLimit {
         case 1:
             value = mantissa
         case 2:
-            guard isCanonicalDigits(parts[1]),
+            guard isPlainDecimalDigits(parts[1]),
                   let exponent = Int(parts[1]), exponent <= maxLimitExponent else {
                 return nil
             }
@@ -217,7 +222,20 @@ enum ThorchainMemoLimit {
         return value
     }
 
-    private static func isCanonicalDigits(_ text: some StringProtocol) -> Bool {
+    /// A non-empty run of ASCII decimal digits, read at its numeric value.
+    ///
+    /// Leading zeros pass and mean what they say — `01` is one. That matches
+    /// THORNode, which reads every numeric memo term through `big.Int.SetString`
+    /// / `big.ParseFloat` / `strconv.ParseUint` at base 10, all of which accept
+    /// zero-padding. Rejecting `01` here would hide a floor the network would
+    /// have enforced, which is the same failure as showing one it would not.
+    ///
+    /// Where this parser IS stricter than the node — an empty term (the node
+    /// substitutes `0`), a fractional LIM (the node truncates) — the difference
+    /// is only reachable through a memo neither the node's own memo builder nor
+    /// `compressed(_:maxBytes:)` can emit, and it fails toward showing no
+    /// minimum, which is the safe direction for a number labelled "minimum".
+    private static func isPlainDecimalDigits(_ text: some StringProtocol) -> Bool {
         !text.isEmpty && text.allSatisfy { $0.isASCII && $0.isNumber }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
@@ -37,6 +37,12 @@ enum ThorchainMemoLimit {
     /// attacker-chosen power.
     private static let maxLimitExponent = 64
 
+    /// THORNode parses the LIM as a `cosmos.Uint` and rejects a memo whose value
+    /// does not fit 256 bits. A wider number is therefore a memo the chain will
+    /// refuse outright — no swap, no floor — so we must not read a guarantee out
+    /// of it. Exclusive upper bound.
+    private static let limitUpperBound = BigInt(2).power(256)
+
     /// The UTF-8 byte budget a chain's THORChain / Maya swap memo must fit, or
     /// `nil` when the source chain carries no such cap.
     ///
@@ -152,18 +158,26 @@ enum ThorchainMemoLimit {
     /// for that reason — the plain integer the node returns, and the scientific
     /// form we may have substituted.
     ///
-    /// Returns `nil` — never a guess — when the memo is not a swap memo, when the
-    /// LIM term is anything other than one of those two canonical spellings, or
-    /// when the floor is `0` (a swap that asserts no minimum, which is what a
+    /// Returns `nil` — never a guess — when the memo is not a swap memo, when any
+    /// term of the `LIM/INTERVAL/QUANTITY` triple is not something we can read,
+    /// or when the floor is `0` (a swap that asserts no minimum, which is what a
     /// user-set 0% slippage produces). Callers must then show no minimum at all
     /// rather than a number the signed transaction does not back.
     static func assertedLimit(in memo: String) -> BigInt? {
         let fields = memo.split(separator: ":", omittingEmptySubsequences: false)
         guard fields.count >= 4, isSwapAction(fields[0]) else { return nil }
 
-        // The LIM is the amount before the first `/` in `LIM/INTERVAL/QUANTITY`.
-        let limField = fields[3]
-        let limTerm = limField.prefix { $0 != "/" }
+        // All-or-nothing on the whole triple, matching the sibling parser that
+        // feeds the proto. THORNode reads `LIM/INTERVAL/QUANTITY` as one field
+        // and rejects the memo outright if any term is malformed — so a LIM
+        // salvaged from a triple we could not fully read is a floor the chain
+        // would never get as far as enforcing.
+        let terms = fields[3].split(separator: "/", omittingEmptySubsequences: false)
+        guard let limTerm = terms.first, terms.count <= 3 else { return nil }
+        // Only the LIM is ever rewritten into scientific notation; the streaming
+        // terms are plain integers in both the node's spelling and our own.
+        guard terms.dropFirst().allSatisfy({ isCanonicalDigits($0) }) else { return nil }
+
         guard let limit = parseLimitTerm(limTerm), limit > 0 else { return nil }
         return limit
     }
@@ -172,7 +186,7 @@ enum ThorchainMemoLimit {
     /// only two spellings a LIM we are willing to vouch for can take. ASCII
     /// digits only: `Character.isNumber` alone also accepts non-ASCII numerals
     /// and fractions, which `BigInt` would then read as something the node never
-    /// wrote.
+    /// wrote. Values wider than the node's own `cosmos.Uint` are refused too.
     private static func parseLimitTerm(_ term: some StringProtocol) -> BigInt? {
         let parts = term.split(separator: "e", omittingEmptySubsequences: false)
         guard let mantissaText = parts.first, isCanonicalDigits(mantissaText),
@@ -180,18 +194,22 @@ enum ThorchainMemoLimit {
             return nil
         }
 
+        let value: BigInt
         switch parts.count {
         case 1:
-            return mantissa
+            value = mantissa
         case 2:
             guard isCanonicalDigits(parts[1]),
                   let exponent = Int(parts[1]), exponent <= maxLimitExponent else {
                 return nil
             }
-            return mantissa * BigInt(10).power(exponent)
+            value = mantissa * BigInt(10).power(exponent)
         default:
             return nil
         }
+
+        guard value < limitUpperBound else { return nil }
+        return value
     }
 
     private static func isCanonicalDigits(_ text: some StringProtocol) -> Bool {

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
@@ -6,8 +6,8 @@
 //  Maya swap memo into scientific notation so a large UTXO swap's memo fits its
 //  source chain's `OP_RETURN` byte cap. THORChain and Maya both parse
 //  `<mantissa>e<exponent>` (mantissa followed by `exponent` trailing zeros) in
-//  the LIM field at execution, so rewriting the memo before signing keeps the
-//  floor on every route without changing what the chain reads.
+//  the LIM field at execution, so rewriting the memo before signing keeps a real
+//  floor on routes the byte cap would otherwise force to no floor at all.
 //
 //  Rounding is always DOWN. For a market swap a lower floor is strictly more
 //  permissive: it can never wrongfully reject a fillable swap, only accept one
@@ -15,6 +15,11 @@
 //  `LimitSwapMemoBuilder`, which rounds a limit order's LIM UP — there raising
 //  the floor is the safe direction because the user must never receive less
 //  than their resting target.)
+//
+//  Because rounding moves the floor, the rewritten memo — not `quote.memo` — is
+//  the one that states what the chain will enforce. `assertedLimit(in:)` reads
+//  a floor back out of it, so the number the swap screens label "minimum" is
+//  the number the signature actually backs.
 //
 
 import BigInt

--- a/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Logic/ThorchainMemoLimit.swift
@@ -30,6 +30,13 @@ enum ThorchainMemoLimit {
     /// liquidity tolerance the floor already carries.
     private static let minSignificantDigits = 5
 
+    /// Largest `e<exponent>` a LIM may carry before it is treated as unreadable.
+    /// `compressed` never emits more than the digit count of a base-1e8 amount,
+    /// and a node-returned LIM is a plain integer, so anything beyond this is a
+    /// memo we don't understand — and expanding it would mean raising 10 to an
+    /// attacker-chosen power.
+    private static let maxLimitExponent = 64
+
     /// The UTF-8 byte budget a chain's THORChain / Maya swap memo must fit, or
     /// `nil` when the source chain carries no such cap.
     ///
@@ -39,6 +46,14 @@ enum ThorchainMemoLimit {
     /// 80-byte constraint, so no compression is applied there.
     static func memoByteLimit(for chain: Chain) -> Int? {
         chain.chainType == .UTXO ? 80 : nil
+    }
+
+    /// The memo a THORChain / Maya swap out of `sourceChain` is actually signed
+    /// with: the node's memo after whatever `OP_RETURN` compression this app
+    /// applies on the way to the signer. One definition so the payload builder
+    /// and the verify/co-sign display can never disagree about what gets signed.
+    static func signedMemo(_ memo: String, sourceChain: Chain) -> String {
+        compressed(memo, maxBytes: memoByteLimit(for: sourceChain))
     }
 
     /// Rewrites the LIM field of a THORChain / Maya swap memo into scientific
@@ -112,5 +127,74 @@ enum ThorchainMemoLimit {
         // emit one we know is over the cap.
         logger.debug("THORChain swap memo LIM could not be compressed within \(maxBytes) bytes; leaving memo unchanged")
         return memo
+    }
+
+    /// THORChain and MayaChain both spell the swap action `SWAP`, `=` or `s`,
+    /// case-insensitively. Every other action (`ADD`, `WITHDRAW`, `DONATE`,
+    /// `LOAN+`, …) lays its fields out differently, so its 4th field is not a
+    /// `LIM/INTERVAL/QUANTITY` triple and must not be read as one.
+    static func isSwapAction(_ field: some StringProtocol) -> Bool {
+        switch field.lowercased() {
+        case "swap", "=", "s":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// The minimum output a THORChain / Maya swap memo asserts (`LIM`), in the
+    /// node's own base units — the same units as `expected_amount_out`.
+    ///
+    /// Read this off the memo that will actually be **signed**, not off
+    /// `quote.memo`: for a UTXO source `compressed(_:maxBytes:)` rewrites the
+    /// floor into `<mantissa>e<exponent>` and rounds it DOWN, so the quote's memo
+    /// overstates what the chain will enforce. Both spellings are accepted here
+    /// for that reason — the plain integer the node returns, and the scientific
+    /// form we may have substituted.
+    ///
+    /// Returns `nil` — never a guess — when the memo is not a swap memo, when the
+    /// LIM term is anything other than one of those two canonical spellings, or
+    /// when the floor is `0` (a swap that asserts no minimum, which is what a
+    /// user-set 0% slippage produces). Callers must then show no minimum at all
+    /// rather than a number the signed transaction does not back.
+    static func assertedLimit(in memo: String) -> BigInt? {
+        let fields = memo.split(separator: ":", omittingEmptySubsequences: false)
+        guard fields.count >= 4, isSwapAction(fields[0]) else { return nil }
+
+        // The LIM is the amount before the first `/` in `LIM/INTERVAL/QUANTITY`.
+        let limField = fields[3]
+        let limTerm = limField.prefix { $0 != "/" }
+        guard let limit = parseLimitTerm(limTerm), limit > 0 else { return nil }
+        return limit
+    }
+
+    /// `1234` or `1234e5` (mantissa followed by `exponent` trailing zeros) — the
+    /// only two spellings a LIM we are willing to vouch for can take. ASCII
+    /// digits only: `Character.isNumber` alone also accepts non-ASCII numerals
+    /// and fractions, which `BigInt` would then read as something the node never
+    /// wrote.
+    private static func parseLimitTerm(_ term: some StringProtocol) -> BigInt? {
+        let parts = term.split(separator: "e", omittingEmptySubsequences: false)
+        guard let mantissaText = parts.first, isCanonicalDigits(mantissaText),
+              let mantissa = BigInt(String(mantissaText)) else {
+            return nil
+        }
+
+        switch parts.count {
+        case 1:
+            return mantissa
+        case 2:
+            guard isCanonicalDigits(parts[1]),
+                  let exponent = Int(parts[1]), exponent <= maxLimitExponent else {
+                return nil
+            }
+            return mantissa * BigInt(10).power(exponent)
+        default:
+            return nil
+        }
+    }
+
+    private static func isCanonicalDigits(_ text: some StringProtocol) -> Bool {
+        !text.isEmpty && text.allSatisfy { $0.isASCII && $0.isNumber }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Models/SwapTransaction.swift
@@ -235,6 +235,23 @@ extension SwapTransaction {
         return SwapCryptoLogic.toAmountDecimal(quote: quote, toCoin: toCoin)
     }
 
+    /// Memo-enforced minimum output for the destination cell, or `nil` when this
+    /// swap signs no floor and the screen must therefore claim none.
+    ///
+    /// `nil` for a limit order by construction: its `toAmountDecimal` already IS
+    /// the floor, so the cell's own amount is the minimum and a second line
+    /// restating it would only be noise. Market swaps show the expected output as
+    /// the amount, which is why they need the floor spelled out separately.
+    var minPayoutDecimal: Decimal? {
+        guard !isLimit else { return nil }
+        return SwapCryptoLogic.signedMinimumOutput(quote: quote, fromCoin: fromCoin, toCoin: toCoin)
+    }
+
+    /// Pre-formatted "min. payout: …" caption, `nil` when there is no floor.
+    var minPayoutCaption: String? {
+        minPayoutDecimal.map { SwapCryptoLogic.minPayoutCaption(amount: $0, ticker: toCoin.ticker) }
+    }
+
     var router: String? {
         SwapCryptoLogic.router(quote: quote)
     }

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -194,6 +194,49 @@ enum SwapCryptoLogic {
         }
     }
 
+    /// The minimum destination amount the transaction this swap will sign
+    /// actually enforces, in `toCoin` units — or `nil` when the route enforces
+    /// nothing this app can see.
+    ///
+    /// Only the native routes assert a floor: THORChain / MayaChain bake
+    /// `LIM = expected_amount_out × (10_000 − liquidity_tolerance_bps) / 10_000`
+    /// into the memo they return, and that memo is signed verbatim. So the floor
+    /// is read back out of the memo — after the same `OP_RETURN` compression the
+    /// payload builder applies — rather than re-derived from the tolerance we
+    /// sent. The node owns the rounding and the streaming split; a client-side
+    /// re-derivation would drift from it, which is the whole reason the displayed
+    /// "minimum" was wrong to begin with.
+    ///
+    /// `nil` for every aggregator route (1inch / KyberSwap / LI.FI / Jupiter /
+    /// SwapKit): they return opaque calldata or a pre-built transaction, so
+    /// whatever floor their own router enforces is not exposed here. `nil` too
+    /// when the memo asserts `LIM 0` — what a user-set 0% slippage produces —
+    /// because that swap genuinely has no floor. Callers must render no minimum
+    /// in those cases, never a stand-in.
+    static func signedMinimumOutput(quote: SwapQuote?, fromCoin: Coin, toCoin: Coin) -> Decimal? {
+        guard let quote else { return nil }
+        switch quote {
+        case let .mayachain(quote),
+             let .thorchain(quote),
+             let .thorchainChainnet(quote),
+             let .thorchainStagenet(quote):
+            let signedMemo = ThorchainMemoLimit.signedMemo(quote.memo, sourceChain: fromCoin.chain)
+            guard let limit = ThorchainMemoLimit.assertedLimit(in: signedMemo) else { return nil }
+            return Decimal(limit) / toCoin.thorswapMultiplier
+        case .oneinch, .kyberswap, .lifi, .jupiter, .swapkit:
+            return nil
+        }
+    }
+
+    /// The "min. payout: 0.00032334 ETH" line that sits under a swap's
+    /// destination amount. Built here rather than at each call site so the
+    /// initiator's verify screen and the co-signer's confirm screen render the
+    /// identical string for the identical swap — the point of showing it at all
+    /// is that both devices consent to the same number.
+    static func minPayoutCaption(amount: Decimal, ticker: String) -> String {
+        "\("minPayout".localized): \(amount.formatForDisplay()) \(ticker)"
+    }
+
     static func router(quote: SwapQuote?) -> String? {
         quote?.router
     }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -297,6 +297,15 @@ struct SwapVerifyScreen: View {
         }
     }
 
+    /// Caption over the destination amount. A market swap's amount is the quote's
+    /// *expected* output — the memo's floor sits ~1% below it and gets its own
+    /// line — so calling it the minimum overstates what the signature guarantees.
+    /// A placed limit order is the opposite case: its amount IS the signed floor,
+    /// so "min. payout" is exactly right there and stays.
+    private var destinationCaptionKey: String {
+        currentTransaction.isLimit ? "minPayout" : "expectedPayout"
+    }
+
     var chevronIcon: some View {
         Image(systemName: "arrow.down")
             .font(Theme.fonts.caption12)
@@ -575,7 +584,7 @@ struct SwapVerifyScreen: View {
             getCoinIcon(for: coin)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("minPayout".localized)
+                Text(destinationCaptionKey.localized)
                     .font(Theme.fonts.caption12)
                     .foregroundStyle(Theme.colors.textTertiary)
                     .opacity(isTo ? 1 : 0)
@@ -611,6 +620,15 @@ struct SwapVerifyScreen: View {
                         .font(Theme.fonts.caption10)
                         .offset(x: 2)
                     }
+                }
+
+                // The floor the signed memo actually enforces. Absent — not
+                // zeroed, not substituted — on routes that enforce none, so the
+                // screen never asserts a guarantee the signature doesn't back.
+                if isTo, let minPayout = currentTransaction.minPayoutCaption {
+                    Text(minPayout)
+                        .font(Theme.fonts.priceCaption)
+                        .foregroundStyle(Theme.colors.textTertiary)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
@@ -305,9 +305,9 @@ struct TransactionHistoryCardView: View {
 
     @ViewBuilder
     private var toRow: some View {
-        // A limit order shows the same from -> to pair as a swap, and the
-        // existing "min. payout" label on the to-side happens to be exactly
-        // right for one: the order's LIM *is* a guaranteed minimum output.
+        // A limit order shows the same from -> to pair as a swap; only the
+        // to-side caption differs, since the order's LIM *is* a guaranteed
+        // minimum output while a market swap's recorded amount is not.
         if transaction.type == .swap || transaction.type == .limit {
             swapToRow
         } else {
@@ -327,7 +327,10 @@ struct TransactionHistoryCardView: View {
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("minPayout".localized)
+                // A market swap persists the quote's EXPECTED output, so it can
+                // only be labelled that. Only a limit order's recorded amount is
+                // a guaranteed minimum.
+                Text((transaction.type == .limit ? "minPayout" : "expectedPayout").localized)
                     .font(Theme.fonts.caption10)
                     .foregroundStyle(Theme.colors.textTertiary)
 

--- a/VultisigApp/VultisigAppTests/Swap/SwapMinPayoutTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapMinPayoutTests.swift
@@ -237,11 +237,30 @@ final class SwapMinPayoutTests: XCTestCase {
             "=:e:0xabc:e5/1/0",                // empty mantissa
             "=:e:0xabc:12e5e5/1/0",            // two exponents
             "=:e:0xabc:1e999999/1/0",          // exponent beyond what we will expand
-            "=:e:0xabc: 12345/1/0"             // leading whitespace — not canonical
+            "=:e:0xabc: 12345/1/0",            // leading whitespace — not canonical
+            // The node reads LIM/INTERVAL/QUANTITY as ONE field and refuses the
+            // whole memo if any term is malformed, so the swap never executes —
+            // salvaging the LIM would advertise a floor nothing ever enforces.
+            "=:e:0xabc:12345/notanumber",
+            "=:e:0xabc:12345/1/notanumber",
+            "=:e:0xabc:12345/1/2/3",           // four terms — not this grammar
+            "=:e:0xabc:12345/1/2e2"            // only the LIM is ever scientific
         ]
         for memo in cases {
             XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: memo), "Must refuse to read a floor from: \(memo)")
         }
+    }
+
+    func testAssertedLimitRefusesValuesWiderThanTheNodesOwnUint() {
+        // THORNode parses the LIM as a `cosmos.Uint`; anything past 256 bits is a
+        // memo it rejects outright, so there is no floor to report.
+        let maxUint = BigInt(2).power(256) - 1
+
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:\(maxUint)/1/0"), maxUint)
+        XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:\(maxUint + 1)/1/0"))
+        // The exponent cap alone does not bound the product — a wide mantissa
+        // inside the cap still has to be range-checked.
+        XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:999999999999999999999999999999e60/1/0"))
     }
 
     // MARK: - Co-signer

--- a/VultisigApp/VultisigAppTests/Swap/SwapMinPayoutTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapMinPayoutTests.swift
@@ -263,6 +263,39 @@ final class SwapMinPayoutTests: XCTestCase {
         XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:999999999999999999999999999999e60/1/0"))
     }
 
+    /// Zero-padded terms are read at their value, because that is what the
+    /// network does with them: every numeric memo term reaches THORNode through
+    /// `big.Int.SetString` / `big.ParseFloat` / `strconv.ParseUint` at base 10,
+    /// and all three accept zero-padding. A padded LIM therefore names a floor
+    /// the chain WOULD enforce — refusing to read it would hide a real
+    /// guarantee, which is the same disservice as inventing one.
+    func testAssertedLimitReadsZeroPaddedTermsAtTheirValueLikeTheNode() {
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:01/1/0"), BigInt(1))
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:001/1/0"), BigInt(1))
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:032334:vi:0"), BigInt(32_334))
+        // `1e00` is one, exactly as the node's own mantissa/exponent split reads it.
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:1e00/1/0"), BigInt(1))
+        // Padding in the streaming terms is the node's reading too.
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:32334/01/003"), BigInt(32_334))
+        // A padded value that IS zero still asserts no floor.
+        XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:00/1/0"))
+    }
+
+    /// The three shapes THORNode accepts that this reader deliberately refuses.
+    /// None is reachable from a real memo — the node's own memo builder emits
+    /// none of them and `compressed(_:maxBytes:)` preserves its input's spelling
+    /// — and refusing them hides a floor rather than inventing one, which is the
+    /// safe direction for a number the UI labels "minimum".
+    func testAssertedLimitIsStricterThanTheNodeOnlyWhereThatFailsSafe() {
+        // The node substitutes "0" for an empty streaming term.
+        XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:32334//"))
+        // The node truncates a fractional LIM (to 32334).
+        XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:32334.9/1/0"))
+        // The node's exponent ceiling is 77; ours is lower, because the only
+        // scientific LIM we ever have to read is one `compressed` wrote.
+        XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:1e70/1/0"))
+    }
+
     // MARK: - Co-signer
 
     /// The WYSIWYS half: the peer approving the swap must see the floor that the

--- a/VultisigApp/VultisigAppTests/Swap/SwapMinPayoutTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapMinPayoutTests.swift
@@ -1,0 +1,527 @@
+//
+//  SwapMinPayoutTests.swift
+//  VultisigAppTests
+//
+//  Pins the "min. payout" the swap screens show to the `LIM` inside the memo
+//  the swap is actually SIGNED with. The invariant under test is one sentence:
+//  a number labelled *minimum* must be a number the broadcast transaction
+//  enforces — never the quote's expected output, and never a client-side
+//  re-derivation from the slippage tolerance we sent.
+//
+//  Routes that enforce no floor this app can read (every aggregator, a memo
+//  whose LIM is 0) must surface `nil` so the caller renders no minimum at all.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class SwapMinPayoutTests: XCTestCase {
+
+    private let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// The exact memo signed by the broadcast in the bug report: RUNE → ETH,
+    /// 2 RUNE, THORChain, `liquidity_tolerance_bps` at its 100 bps default.
+    private let reportedMemo = "=:e:0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF:32334:vi:0"
+    /// `expected_amount_out` from the same quote — 1.0% above the memo's floor,
+    /// and the value the screen used to render under the "min. payout" label.
+    private let reportedExpectedAmountOut = "32658"
+
+    // MARK: - Displayed minimum == LIM in the signed memo
+
+    func testDisplayedMinimumEqualsLimitInTheSignedMemo() async throws {
+        let transaction = makeRuneToEthTransaction(
+            quote: makeThorQuote(memo: reportedMemo, expectedAmountOut: reportedExpectedAmountOut)
+        )
+
+        let payload = try await SwapCryptoLogic.buildSwapKeysignPayload(
+            transaction: transaction,
+            chainSpecific: cosmosChainSpecific(),
+            vault: makeVault(),
+            now: fixedNow
+        )
+
+        // The memo that will be signed, byte-for-byte.
+        XCTAssertEqual(payload.memo, reportedMemo)
+
+        let signedLimit = try XCTUnwrap(ThorchainMemoLimit.assertedLimit(in: try XCTUnwrap(payload.memo)))
+        XCTAssertEqual(signedLimit, BigInt(32_334))
+
+        // What the destination cell renders under "min. payout", scaled back into
+        // the node's base units, is that same LIM — not an approximation of it.
+        let displayed = try XCTUnwrap(transaction.minPayoutDecimal)
+        XCTAssertEqual(displayed * transaction.toCoin.thorswapMultiplier, baseUnits(signedLimit))
+        XCTAssertEqual(displayed, Decimal(string: "0.00032334"))
+    }
+
+    func testDisplayedMinimumIsBelowTheExpectedOutputItUsedToDuplicate() throws {
+        let transaction = makeRuneToEthTransaction(
+            quote: makeThorQuote(memo: reportedMemo, expectedAmountOut: reportedExpectedAmountOut)
+        )
+
+        // The regression this fixes: the cell showed the expected output under a
+        // "minimum" label. The two must now be distinct values.
+        XCTAssertEqual(transaction.toAmountDecimal, Decimal(string: "0.00032658"))
+        let minimum = try XCTUnwrap(transaction.minPayoutDecimal)
+        XCTAssertEqual(minimum, Decimal(string: "0.00032334"))
+        XCTAssertLessThan(minimum, transaction.toAmountDecimal)
+    }
+
+    // MARK: - Custom slippage
+
+    func testCustomSlippageMinimumTracksTheMemoNotTheDefaultTolerance() {
+        // A 3% `liquidity_tolerance_bps` produces a lower node-chosen LIM in the
+        // same-shaped memo. Nothing in the app re-derives it, so the displayed
+        // floor moves with the memo alone — which is the only way it can stay
+        // equal to what is signed on a non-default slippage.
+        let customSlippageMemo = "=:e:0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF:31678:vi:0"
+        let transaction = makeRuneToEthTransaction(
+            quote: makeThorQuote(memo: customSlippageMemo, expectedAmountOut: reportedExpectedAmountOut)
+        )
+
+        XCTAssertEqual(transaction.minPayoutDecimal, Decimal(string: "0.00031678"))
+        // Same quote, same expected output — only the memo changed.
+        XCTAssertEqual(transaction.toAmountDecimal, Decimal(string: "0.00032658"))
+    }
+
+    func testZeroSlippageMemoAssertsNoFloorSoNoMinimumIsShown() {
+        // A user-set 0% slippage omits `liquidity_tolerance_bps` entirely, and
+        // the node then returns `LIM 0` — a swap with genuinely no floor. The
+        // screen must show no minimum rather than fall back to the expected out.
+        let transaction = makeRuneToEthTransaction(
+            quote: makeThorQuote(
+                memo: "=:e:0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF:0/1/0:vi:0",
+                expectedAmountOut: reportedExpectedAmountOut
+            )
+        )
+
+        XCTAssertNil(transaction.minPayoutDecimal)
+        XCTAssertNil(transaction.minPayoutCaption)
+    }
+
+    // MARK: - UTXO source: the signed memo is the compressed one
+
+    func testUtxoSourceMinimumFollowsTheCompressedMemoNotTheQuoteMemo() throws {
+        // 81 bytes — over the 80-byte OP_RETURN cap, so the payload builder
+        // rewrites the LIM into scientific notation, rounding DOWN, before it is
+        // signed. The proto's `toAmountLimit` is read from the *quote* memo and
+        // therefore overstates the real floor; the display must not.
+        let overflowMemo = "=:ETH.USDC:0x742d35Cc6634C0532925a3b844Bc454e4438f44e:653422929721250/0/224:vi:50"
+        XCTAssertEqual(overflowMemo.utf8.count, 81, "Precondition: memo overflows the OP_RETURN cap")
+
+        let quote = makeThorQuote(memo: overflowMemo, expectedAmountOut: "660000000000000")
+        let transaction = makeBtcToUsdcTransaction(quote: quote)
+
+        let signedMemo = ThorchainMemoLimit.signedMemo(overflowMemo, sourceChain: .bitcoin)
+        XCTAssertNotEqual(signedMemo, overflowMemo, "Precondition: compression fired")
+        let signedLimit = try XCTUnwrap(ThorchainMemoLimit.assertedLimit(in: signedMemo))
+
+        let displayed = try XCTUnwrap(transaction.minPayoutDecimal)
+        XCTAssertEqual(displayed * transaction.toCoin.thorswapMultiplier, baseUnits(signedLimit))
+
+        // And it is strictly below the floor the proto field claims.
+        let protoLimit = SwapCryptoLogic.buildThorchainSwapPayload(
+            fromCoin: transaction.fromCoin,
+            toCoin: transaction.toCoin,
+            fromAmountInCoin: BigInt(20_000_000_000),
+            toAmountDecimal: transaction.toAmountDecimal,
+            quote: quote,
+            now: fixedNow
+        ).toAmountLimit
+        XCTAssertEqual(protoLimit, "653422929721250")
+        XCTAssertLessThan(
+            displayed * transaction.toCoin.thorswapMultiplier,
+            try XCTUnwrap(Decimal(string: protoLimit))
+        )
+    }
+
+    // MARK: - Routes that enforce no readable floor
+
+    func testAggregatorRoutesShowNoMinimum() {
+        let evmQuote = EVMQuote(
+            dstAmount: "1000000000000000000",
+            tx: EVMQuote.Transaction(from: "0xFrom", to: "0xRouter", data: "0x", value: "0", gasPrice: "0", gas: 0)
+        )
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+
+        // 1inch / KyberSwap / LI.FI / Jupiter hand back opaque calldata or a
+        // pre-built transaction; SwapKit settles off the source chain. None of
+        // them exposes a floor the signed transaction enforces, so none may
+        // claim one.
+        let quotes: [SwapQuote] = [
+            .oneinch(evmQuote, fee: nil),
+            .kyberswap(evmQuote, fee: nil),
+            .lifi(evmQuote, fee: nil, integratorFee: nil),
+            .jupiter(evmQuote, fee: nil, platformFee: 0, feeOnInput: false),
+            .swapkit(makeSwapKitResponse(), fee: nil, subProvider: "Chainflip")
+        ]
+        for quote in quotes {
+            XCTAssertNil(
+                SwapCryptoLogic.signedMinimumOutput(quote: quote, fromCoin: eth, toCoin: usdc),
+                "Aggregator route \(quote.kind) must not claim a minimum"
+            )
+        }
+    }
+
+    func testSecuredMintShowsNoMinimum() {
+        // The synthetic ~1:1 mint quote carries no memo — nothing is enforced,
+        // the mint settles at the on-chain share ratio.
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
+        let securedBtc = makeCoin(.thorChain, ticker: "BTC-BTC", decimals: 8, isNative: false)
+        let quote = SwapCryptoLogic.securedMintQuote(fromAmount: 1, toCoin: securedBtc)
+
+        XCTAssertNil(SwapCryptoLogic.signedMinimumOutput(quote: quote, fromCoin: btc, toCoin: securedBtc))
+    }
+
+    func testLimitOrderShowsNoSeparateMinimumBecauseItsAmountAlreadyIsOne() {
+        // A placed `=<` order's own destination amount IS the floor, so the
+        // "min. payout" caption already tells the truth and a second line
+        // restating it would be noise.
+        let transaction = makeLimitTransaction()
+
+        XCTAssertTrue(transaction.isLimit)
+        XCTAssertNil(transaction.minPayoutDecimal)
+    }
+
+    func testNilQuoteShowsNoMinimum() {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        XCTAssertNil(SwapCryptoLogic.signedMinimumOutput(quote: nil, fromCoin: eth, toCoin: eth))
+    }
+
+    // MARK: - MayaChain scaling
+
+    func testMayachainMinimumUsesTheDestinationCoinsOwnPrecision() {
+        // Maya quotes CACAO in its native 10 decimals, not THORChain's 1e8, so
+        // the floor must be scaled by the same multiplier the expected amount is.
+        let cacao = makeCoin(.mayaChain, ticker: "CACAO", decimals: 10, isNative: true)
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
+        let quote = SwapQuote.mayachain(makeThorQuote(
+            memo: "=:MAYA.CACAO:maya1qz8p9dxq4l7wg2m4vtn5xq6r3jf0h8u2vk9c7d:12345678901/0/0",
+            expectedAmountOut: "12469372627"
+        ))
+
+        XCTAssertEqual(
+            SwapCryptoLogic.signedMinimumOutput(quote: quote, fromCoin: btc, toCoin: cacao),
+            Decimal(string: "1.2345678901")
+        )
+    }
+
+    // MARK: - Memo parsing
+
+    func testAssertedLimitReadsBothCanonicalSpellings() {
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:32334:vi:0"), BigInt(32_334))
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:32334/1/3:vi:0"), BigInt(32_334))
+        // Scientific notation is what `compressed(_:maxBytes:)` substitutes for a
+        // UTXO source; the chain reads it as `mantissa` + `exponent` zeros.
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "=:e:0xabc:653422929721e3/0/224:vi:50"), BigInt("653422929721000"))
+        // Both other spellings of the swap action, case-insensitively.
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "SWAP:e:0xabc:500"), BigInt(500))
+        XCTAssertEqual(ThorchainMemoLimit.assertedLimit(in: "s:e:0xabc:500"), BigInt(500))
+    }
+
+    func testAssertedLimitRefusesAnythingItCannotVouchFor() {
+        let cases = [
+            "=:e:0xabc:0/1/0",                 // no floor asserted
+            "=:e:0xabc:0",                     // no floor, short memo
+            "=:e:0xabc",                       // fewer than four fields
+            "",                                // empty
+            "ADD:BTC.BTC:0xabc:12345",         // not a swap action — 4th field is not a LIM
+            "LOAN+:BTC.BTC:0xabc:12345",       // ditto
+            "=:e:0xabc:notanumber/1/0",        // unreadable term
+            "=:e:0xabc:-500/1/0",              // signed
+            "=:e:0xabc:1.5/1/0",               // fractional
+            "=:e:0xabc:١٢٣/1/0",               // non-ASCII numerals
+            "=:e:0xabc:12e/1/0",               // empty exponent
+            "=:e:0xabc:e5/1/0",                // empty mantissa
+            "=:e:0xabc:12e5e5/1/0",            // two exponents
+            "=:e:0xabc:1e999999/1/0",          // exponent beyond what we will expand
+            "=:e:0xabc: 12345/1/0"             // leading whitespace — not canonical
+        ]
+        for memo in cases {
+            XCTAssertNil(ThorchainMemoLimit.assertedLimit(in: memo), "Must refuse to read a floor from: \(memo)")
+        }
+    }
+
+    // MARK: - Co-signer
+
+    /// The WYSIWYS half: the peer approving the swap must see the floor that the
+    /// memo IT is about to sign carries, not the initiator's expected output.
+    func testCosignerMinimumEqualsTheLimitInTheMemoItSigns() throws {
+        let viewModel = makeJoinViewModel(
+            memo: reportedMemo,
+            swapPayload: .thorchain(makeThorchainSwapPayload())
+        )
+
+        XCTAssertEqual(viewModel.toAmountCaptionKey, "expectedPayout")
+        XCTAssertEqual(
+            viewModel.getMinPayoutCaption(),
+            SwapCryptoLogic.minPayoutCaption(amount: try XCTUnwrap(Decimal(string: "0.00032334")), ticker: "ETH")
+        )
+    }
+
+    func testCosignerShowsNoMinimumForAnAggregatorRoute() {
+        // A generic payload signs opaque calldata and carries no memo at all.
+        let viewModel = makeJoinViewModel(memo: nil, swapPayload: .generic(makeGenericSwapPayload()))
+
+        XCTAssertEqual(viewModel.toAmountCaptionKey, "expectedPayout")
+        XCTAssertNil(viewModel.getMinPayoutCaption())
+    }
+
+    /// An ERC20-source limit order reaches the co-signer as a swap payload whose
+    /// `toAmountDecimal` the assembler already set to the order's LIM. Its
+    /// caption must stay "min. payout", and a second line restating the same
+    /// number would be noise.
+    func testCosignerKeepsTheMinimumCaptionForALimitOrder() {
+        let viewModel = makeJoinViewModel(
+            memo: "=<:ETH.ETH:0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF:32000/1/0:vi:50",
+            swapPayload: .thorchain(makeThorchainSwapPayload())
+        )
+
+        XCTAssertEqual(viewModel.toAmountCaptionKey, "minPayout")
+        XCTAssertNil(viewModel.getMinPayoutCaption())
+    }
+
+    func testNativeProtocolRouteIsTheOnlyPayloadKindThatCanCarryAFloor() {
+        let native = makeThorchainSwapPayload()
+        for payload in [
+            SwapPayload.thorchain(native),
+            .thorchainChainnet(native),
+            .thorchainStagenet(native),
+            .mayachain(native)
+        ] {
+            XCTAssertTrue(payload.isNativeProtocolRoute)
+        }
+        XCTAssertFalse(SwapPayload.generic(makeGenericSwapPayload()).isNativeProtocolRoute)
+    }
+
+    // MARK: - Caption
+
+    func testMinPayoutCaptionCarriesTheAmountAndTicker() throws {
+        let transaction = makeRuneToEthTransaction(
+            quote: makeThorQuote(memo: reportedMemo, expectedAmountOut: reportedExpectedAmountOut)
+        )
+        let caption = try XCTUnwrap(transaction.minPayoutCaption)
+
+        XCTAssertTrue(caption.hasSuffix("0.00032334 ETH"), "Got: \(caption)")
+        XCTAssertEqual(
+            caption,
+            SwapCryptoLogic.minPayoutCaption(amount: try XCTUnwrap(Decimal(string: "0.00032334")), ticker: "ETH"),
+            "Initiator and co-signer must render one identical string"
+        )
+    }
+
+    // MARK: - Fixtures
+
+    private func makeVault() -> Vault {
+        Vault(
+            name: "Test Vault",
+            signers: [],
+            pubKeyECDSA: "test-pub-ecdsa",
+            pubKeyEdDSA: "test-pub-eddsa",
+            keyshares: [],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool) -> Coin {
+        let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: isNative)
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+
+    private func makeRuneToEthTransaction(quote: ThorchainSwapQuote) -> SwapTransaction {
+        let rune = makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        return SwapTransaction(
+            fromCoin: rune,
+            toCoin: eth,
+            fromAmount: 2.0,
+            kind: .market(.thorchain(quote)),
+            gas: 0,
+            gasLimit: 0,
+            thorchainFee: BigInt(2_000),
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: rune,
+            advancedSettings: .default
+        )
+    }
+
+    private func makeBtcToUsdcTransaction(quote: ThorchainSwapQuote) -> SwapTransaction {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+        return SwapTransaction(
+            fromCoin: btc,
+            toCoin: usdc,
+            fromAmount: 200,
+            kind: .market(.thorchain(quote)),
+            gas: 0,
+            gasLimit: 0,
+            thorchainFee: 0,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: btc,
+            advancedSettings: .default
+        )
+    }
+
+    private func makeLimitTransaction() -> SwapTransaction {
+        let rune = makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true)
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+        let record = LimitOrderRecord(
+            inboundTxHash: "",
+            sourceAsset: "THOR.RUNE",
+            sourceAmount: "200000000",
+            sourceDecimals: 8,
+            targetAsset: "ETH.ETH",
+            destAddress: "0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF",
+            targetPrice: Decimal(string: "0.00016") ?? 0,
+            expiryBlocks: 14_400,
+            createdAt: fixedNow,
+            memo: "=<:ETH.ETH:0x15E9eBd862E8d7cd571062D0fBd41D695A9575AF:32000",
+            expiryHours: 24
+        )
+        return SwapTransaction(
+            fromCoin: rune,
+            toCoin: eth,
+            fromAmount: 2.0,
+            kind: .limit(record),
+            gas: 0,
+            gasLimit: 0,
+            thorchainFee: 0,
+            vultDiscountBps: 0,
+            referralDiscountBps: 0,
+            feeCoin: rune,
+            advancedSettings: .default
+        )
+    }
+
+    private func makeThorQuote(memo: String, expectedAmountOut: String) -> ThorchainSwapQuote {
+        ThorchainSwapQuote(
+            dustThreshold: nil,
+            expectedAmountOut: expectedAmountOut,
+            expiry: 0,
+            fees: Fees(affiliate: "0", asset: "ETH", outbound: "0", total: "0", liquidity: nil, slippageBps: nil, totalBps: nil),
+            inboundAddress: "thor-vault",
+            inboundConfirmationBlocks: nil,
+            inboundConfirmationSeconds: nil,
+            memo: memo,
+            notes: "",
+            outboundDelayBlocks: 0,
+            outboundDelaySeconds: 0,
+            recommendedMinAmountIn: "0",
+            slippageBps: nil,
+            totalSwapSeconds: nil,
+            warning: "",
+            router: nil,
+            maxStreamingQuantity: nil
+        )
+    }
+
+    /// `Decimal(_: BigInt)` is ambiguous from the test target, so spell the
+    /// base-unit conversion out once.
+    private func baseUnits(_ limit: BigInt) -> Decimal {
+        Decimal(string: String(limit)) ?? .nan
+    }
+
+    private func makeJoinViewModel(memo: String?, swapPayload: SwapPayload) -> JoinKeysignViewModel {
+        let viewModel = JoinKeysignViewModel()
+        viewModel.keysignPayload = KeysignPayload(
+            coin: makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true),
+            toAddress: "thor-vault",
+            toAmount: BigInt(200_000_000),
+            chainSpecific: cosmosChainSpecific(),
+            utxos: [],
+            memo: memo,
+            swapPayload: swapPayload,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "",
+            vaultLocalPartyID: "",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+        return viewModel
+    }
+
+    private func makeThorchainSwapPayload() -> THORChainSwapPayload {
+        THORChainSwapPayload(
+            fromAddress: "test-address-RUNE",
+            fromCoin: makeCoin(.thorChain, ticker: "RUNE", decimals: 8, isNative: true),
+            toCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            vaultAddress: "thor-vault",
+            routerAddress: nil,
+            fromAmount: BigInt(200_000_000),
+            toAmountDecimal: Decimal(string: "0.00032658") ?? 0,
+            toAmountLimit: "32334",
+            streamingInterval: "0",
+            streamingQuantity: "0",
+            expirationTime: 0,
+            isAffiliate: true
+        )
+    }
+
+    private func makeGenericSwapPayload() -> GenericSwapPayload {
+        GenericSwapPayload(
+            fromCoin: makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false),
+            toCoin: makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true),
+            fromAmount: BigInt(100_000_000),
+            toAmountDecimal: 1,
+            quote: EVMQuote(
+                dstAmount: "1000000000000000000",
+                tx: EVMQuote.Transaction(from: "0xFrom", to: "0xRouter", data: "0x", value: "0", gasPrice: "0", gas: 0)
+            ),
+            provider: .oneInch
+        )
+    }
+
+    private func cosmosChainSpecific() -> BlockChainSpecific {
+        .Cosmos(accountNumber: 1, sequence: 0, gas: 200_000, transactionType: 0, ibcDenomTrace: nil, gasLimit: nil)
+    }
+
+    /// `SwapKitSwapResponse` is `Decodable`-only, so build it from JSON.
+    /// `expectedBuyAmountMaxSlippage` is populated on purpose: SwapKit DOES
+    /// publish a worst-case figure, and this pins that we still refuse to call
+    /// it a minimum — it is the provider's estimate for a route that settles
+    /// off the source chain, not something the transaction we sign enforces.
+    private func makeSwapKitResponse() -> SwapKitSwapResponse {
+        let json = """
+        {
+          "swapId": "swap-1",
+          "routeId": "route-1",
+          "providers": ["Chainflip"],
+          "sellAsset": "ETH.USDC",
+          "buyAsset": "ETH.ETH",
+          "sellAmount": "10",
+          "expectedBuyAmount": "1.0",
+          "expectedBuyAmountMaxSlippage": "0.97",
+          "sourceAddress": "0xfrom",
+          "destinationAddress": "0xto",
+          "targetAddress": "0xtarget",
+          "meta": { "txType": "EVM" },
+          "tx": {
+            "from": "0xfrom",
+            "to": "0xto",
+            "value": "0",
+            "data": "0x",
+            "gas": "200000",
+            "gasPrice": "20000000000"
+          },
+          "fees": []
+        }
+        """
+        // Test fixture: a decode failure here is a test bug, so force-try is acceptable.
+        // swiftlint:disable:next force_try
+        return try! JSONDecoder().decode(SwapKitSwapResponse.self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## Description

The swap Verify screen captions the destination amount **"min. payout"** and renders the quote's **expected output**. The minimum the signed transaction actually enforces is ~1% lower — the `LIM` THORChain/MayaChain bakes into the memo we sign verbatim, from the `liquidity_tolerance_bps` we send. Same caption, same defect, on the **co-signer's** confirm screen and the transaction-history card.

Evidence from the issue (v1.43.68, RUNE→ETH, 2 RUNE): UI read `min. payout 0.00032658 ETH`; the signed memo of `106175393EF21DC90EA9E0F31840891DCF0A83F6BD7434BB6226C6255A390FDA` was `=:e:0x15E9…:32334:vi:0` → floor `0.00032334 ETH`. No funds were lost. The defect is that the number labelled *minimum* is the *expected* one, on the screens where the user consents and a peer approves.

Fixes #4985

### The fix, and why this one

The issue offered **(a)** render the memo limit under `min. payout`, or **(b)** relabel the expected amount and give the floor its own row. **This PR takes (b)**, because that is what vultisig-windows shipped (#4396, closing vultisig-windows#4392) and matching it is an explicit acceptance criterion. Two more reasons (a) loses:

- It would delete information the rest of the screen depends on. The expected output is what the fiat sub-line and the price-impact row are computed against; replacing it with the floor makes the destination cell disagree with everything below it.
- **It has no honest answer for most routes.** Only 4 of the 9 quote cases sign a floor this app can read. Under (a), aggregator swaps would keep showing expected output under a `min. payout` label — the bug would simply survive for 1inch/Kyber/LI.FI/Jupiter/SwapKit.

So: the big number is captioned **"expected payout"**, and a separate **"min. payout: X"** line renders the enforced floor — present only where one exists, absent everywhere else. No route is left claiming a guarantee it doesn't have.

### The number is read out of the memo, not re-derived

`SwapPayloadBuilder` already populates `toAmountLimit` (#4851), but it reads `quote.memo` while the payload is signed with `ThorchainMemoLimit.compressed(quote.memo, …)` — which, on a UTXO source whose memo overflows the 80-byte `OP_RETURN` cap, rewrites the LIM into `<mantissa>e<exponent>` **rounded down**. Displaying the proto field would show a floor fractionally *above* the enforced one: a smaller copy of the same defect. So:

- **Initiator** runs the same `ThorchainMemoLimit.signedMemo(_:sourceChain:)` the builder runs (extracted from its four existing call sites — no signed byte changes) and reads the LIM back out.
- **Co-signer** reads `keysignPayload.memo` — the literal bytes that device is about to sign. Confirming what it signs is its entire job.

Both compose the line through one formatter, so the two devices render byte-identical strings for the same swap.

### Per-provider behaviour

| Route | Floor visible to iOS? | Renders |
|---|---|---|
| THORChain (mainnet / chainnet / stagenet) | **Yes** — memo `LIM`, signed verbatim | expected payout **+ min. payout** |
| MayaChain | **Yes** — same grammar, destination-coin precision | expected payout **+ min. payout** |
| 1inch / KyberSwap / LI.FI | No — `dstAmount` is expected; any `minReturn` is inside opaque `tx.data` | expected payout only |
| Jupiter | No — floor lives in the pre-built Solana wire tx | expected payout only |
| SwapKit | No — see below | expected payout only |
| Secured mint (`.securedMint`) | No — synthetic quote, `memo: ""`, mints at the share ratio | expected payout only |
| THORChain limit order | **Yes, already correct** — its amount *is* the LIM | keeps `min. payout` |
| `LIM 0` (user-set 0% slippage omits the tolerance param) | No floor exists | expected payout only |

**SwapKit deliberately excluded.** `SwapKitSwapResponse` does carry `expectedBuyAmountMaxSlippage`. It is the provider's worst-case estimate for a route that settles *off* the source chain (NEAR Intents / Chainflip / Garden); nothing in the transaction Vultisig signs enforces it. Surfacing it under a "minimum" label would be this exact bug one layer down. A test pins that we refuse it even though the field is populated.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [x] Swap — **display-only; no transaction was broadcast for this PR** (see Limitations)
- [ ] New Chain / Chain related feature

## Parity

- **Android:** `not filed` — **same defect confirmed in code, no sibling issue exists.** Android sends `tolerance_bps` (default 100, `data/…/repositories/swap/ThorChainQuoteSource.kt:40`) so its memos carry a real LIM, hardcodes `toAmountLimit = "0"` (`ui/models/swap/SwapTransactionBuilder.kt:111,185`), and shows `swap_form_min_pay` / `transaction_history_min_payout_label` = "min. payout" over the expected amount. I did not open the ticket — creating issues was not authorized for this task — so this needs one raising.
- **Windows + extension:** `linked: vultisig-windows#4392` (fixed by vultisig-windows#4396, `2dccfd662`). This PR matches its UX shape exactly. **One divergence worth flagging:** Windows/SDK re-derive the floor client-side (`getNativeSwapToAmountLimit` = `expected × (10_000 − bps)/10_000`) instead of reading the memo. The node computes its LIM against a feeless price with its own rounding, so the two can differ — this repo's own fixture is a real memo with `LIM 340077095` where the naive derivation gives `338179686`. iOS matches the Windows *shape* with a strictly more faithful *value*.
- **SDK:** `n/a` for the display (it renders nothing), but the derivation above lives in `packages/core/mpc/swap/native/utils/nativeSwapQuoteToSwapPayload.ts:42` and is the root of the Windows divergence. Related: vultisig-sdk#1392.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (SwiftLint clean on every touched file)
- [x] I have added tests that prove my fix is effective

**Gate:** `make test` on a dedicated simulator → `** TEST SUCCEEDED **`, **4369 tests, 1 skipped, 0 failures**.

New `SwapMinPayoutTests` (17 cases) pins, among others:
- displayed minimum == the LIM in the memo `buildSwapKeysignPayload` actually returns, on the issue's real memo;
- the same on a **custom-slippage** memo, and `nil` on a `LIM 0` memo;
- on a UTXO source, the displayed floor follows the **compressed** memo and is strictly below the proto's `toAmountLimit`;
- `nil` for every aggregator, secured mints, and limit orders;
- the co-signer's caption and floor for market / limit / aggregator payloads;
- memo-parser refusals: non-swap actions, malformed streaming terms, non-ASCII numerals, and values past the node's own 256-bit `cosmos.Uint`.

## Limitations

- **Nothing here was verified on-chain.** No swap was broadcast for this PR. Correctness is pinned against the memo string, which *is* the signed artifact — the tests assert the displayed number against the memo the payload builder returns — but the end-to-end "UI number == LIM in a broadcast tx" loop was closed only by the reporter's original evidence, not by me.
- **Screenshots not attached** — no simulator run of the swap flow with a live quote.
- **History shows no floor.** `TransactionHistoryItem` is a SwiftData `@Model`; persisting `toAmountLimit` is a schema migration, which is not worth it for a post-broadcast, non-consent surface. The card is relabelled so it stops claiming a minimum. Windows persisted it; iOS defers.
- **The proto's `toAmountLimit` is left as-is** — still derived from the un-compressed `quote.memo`. It stays inert (nothing renders it, no signer reads it), and changing what crosses the keysign wire was not worth doing for a field nothing consumes. Worth a follow-up.

## Additional context

Design notes and the full review ledger: `wiki/pages/projects/vultisig/thorchain-swap-limit/swap-min-payout-4985-plan.md`.

Two **High** findings from a cross-model review of the first commit were fixed in `cc1bafacf`, both about the memo reader vouching for a floor the node itself would reject: a malformed streaming term (`LIM/INTERVAL/QUANTITY` is one field to THORNode — it refuses the whole memo, so the swap never executes), and a LIM wider than `cosmos.Uint`. Neither is reachable from a well-formed node response; the point is that the reader must never be the component that invents a guarantee.

## Agent Metadata (if applicable)
- **Agent**: Claude Code (Opus 5)
- **Issue**: #4985
- **Confidence**: high on the logic and the parity verdict; medium on the visual result, which was not rendered on a simulator
- **Needs human review for**: the product call that a market swap's headline number stays the *expected* output (matching Windows) rather than the floor; and whether the Android sibling ticket should be filed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized “Expected payout” labels across supported languages.
  * Swap screens now distinguish between expected payout and minimum payout.
  * Displays the minimum payout enforced by the signed swap memo when available.
  * Updated transaction history to show clearer payout labels for market swaps and limit orders.

* **Bug Fixes**
  * Improved validation and handling of swap memo payout limits, including compressed memos and native protocol routes.
  * Ensured payout calculations respect asset precision and signed transaction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->