### PR TITLE
chore(swap): remove the limitSwapEnabled feature flag

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -751,7 +751,6 @@
 "limitSwap.verify.title" = "Du platzierst eine Limit-Order";
 "limitSwap.warning.priceAtOrBelowMarket" = "Kurs bereits verfügbar, erwäge einen Markt-Swap";
 "limitSwap.warning.priceFarAboveMarket" = "Wird möglicherweise nicht vor Ablauf ausgeführt";
-"limitSwapToggle" = "Limit-Swap";
 "liquidityPools" = "Liquiditätspools";
 "loading" = "Loading...";
 "loadingDetails" = "Lade Details";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -749,7 +749,6 @@
 "limitSwap.verify.title" = "You're placing a limit order";
 "limitSwap.warning.priceAtOrBelowMarket" = "Price already available, consider market swap";
 "limitSwap.warning.priceFarAboveMarket" = "May not fill within expiry";
-"limitSwapToggle" = "Limit Swap";
 "liquidityPools" = "Liquidity Pools";
 "loading" = "Loading...";
 "loadingDetails" = "Loading details";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -751,7 +751,6 @@
 "limitSwap.verify.title" = "Estás colocando una orden límite";
 "limitSwap.warning.priceAtOrBelowMarket" = "Precio ya disponible, considera un swap de mercado";
 "limitSwap.warning.priceFarAboveMarket" = "Puede no ejecutarse antes del vencimiento";
-"limitSwapToggle" = "Swap límite";
 "liquidityPools" = "Pools de liquidez";
 "loading" = "Loading...";
 "loadingDetails" = "Cargando detalles";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -751,7 +751,6 @@
 "limitSwap.verify.title" = "Postavljaš limit nalog";
 "limitSwap.warning.priceAtOrBelowMarket" = "Cijena već dostupna, razmotri tržišnu zamjenu";
 "limitSwap.warning.priceFarAboveMarket" = "Možda se neće izvršiti prije isteka";
-"limitSwapToggle" = "Limit zamjena";
 "liquidityPools" = "Bazeni likvidnosti";
 "loading" = "Učitavanje...";
 "loadingDetails" = "Učitavanje detalja";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -751,7 +751,6 @@
 "limitSwap.verify.title" = "Stai inserendo un ordine limite";
 "limitSwap.warning.priceAtOrBelowMarket" = "Prezzo già disponibile, valuta uno swap di mercato";
 "limitSwap.warning.priceFarAboveMarket" = "Potrebbe non eseguirsi entro la scadenza";
-"limitSwapToggle" = "Swap limite";
 "liquidityPools" = "Pool di liquidità";
 "loading" = "Caricamento...";
 "loadingDetails" = "Caricamento dettagli";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -749,7 +749,6 @@
 "limitSwap.verify.title" = "지정가 주문을 넣고 있습니다";
 "limitSwap.warning.priceAtOrBelowMarket" = "이미 가능한 가격입니다. 시장가 스왑을 고려하세요";
 "limitSwap.warning.priceFarAboveMarket" = "만료 전에 체결되지 않을 수 있습니다";
-"limitSwapToggle" = "지정가 스왑";
 "liquidityPools" = "유동성 풀";
 "loading" = "로딩 중...";
 "loadingDetails" = "세부 정보 로딩 중";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -751,7 +751,6 @@
 "limitSwap.verify.title" = "Você está colocando uma ordem limite";
 "limitSwap.warning.priceAtOrBelowMarket" = "Preço já disponível, considere um swap de mercado";
 "limitSwap.warning.priceFarAboveMarket" = "Pode não ser executada antes da validade";
-"limitSwapToggle" = "Swap limite";
 "liquidityPools" = "Pools de liquidez";
 "loading" = "Loading...";
 "loadingDetails" = "Carregando detalhes";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -751,7 +751,6 @@
 "limitSwap.verify.title" = "您正在下达限价单";
 "limitSwap.warning.priceAtOrBelowMarket" = "价格已可用，建议使用市价兑换";
 "limitSwap.warning.priceFarAboveMarket" = "可能在到期前无法成交";
-"limitSwapToggle" = "限价兑换";
 "liquidityPools" = "流动性池";
 "loading" = "加载中...";
 "loadingDetails" = "正在加载详情";

--- a/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -31,7 +31,6 @@ class SettingsViewModel: ObservableObject {
     @AppStorage("thorchainChainnet") var enableThorchainChainnet: Bool = false
     @AppStorage("SellEnabled") var sellEnabled: Bool = false
     @AppStorage("tssBatchEnabled") var tssBatchEnabled: Bool = false
-    @AppStorage("limitSwapEnabled") var limitSwapEnabled: Bool = false
     /// Debug-only: force every swap quote through a single provider so a
     /// tester can verify a specific signing path in isolation. Empty string
     /// = no force (production ranking across all providers). Otherwise one

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsAdvancedView.swift
@@ -36,7 +36,6 @@ struct SettingsAdvancedView: View {
         case thorchainStagenet
         case sell
         case tssBatching
-        case limitSwap
         case forcedSwapProvider
         case clearSwapKitTokensCache
         case resetTransactionHistory
@@ -78,12 +77,6 @@ struct SettingsAdvancedView: View {
                 title: "TSS Batching",
                 icon: "bolt.horizontal",
                 isEnabled: $settingsViewModel.tssBatchEnabled
-            )
-        case .limitSwap:
-            SettingToggleCell(
-                title: "limitSwapToggle".localized,
-                icon: "arrow.up.right.square",
-                isEnabled: $settingsViewModel.limitSwapEnabled
             )
         case .forcedSwapProvider:
             SettingPickerCell(

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapDetailsScreen.swift
@@ -15,17 +15,15 @@ struct SwapDetailsScreen: View {
     @StateObject private var keyboardObserver = KeyboardObserver()
 
     @State private var showErrorTooltip = false
-    /// Local Market/Limit tab state. The Limit branch lives entirely
-    /// inside `LimitSwapModeBody` (which owns its own form view model and
-    /// drives the limit-swap pipeline via `SwapRoute.limitPair`) — flag-off
-    /// renders the existing Market layout pixel-identical to pre-feature.
+    /// Local Market/Limit tab state. The Limit branch lives entirely inside
+    /// `LimitSwapEntryView`, which owns its own `LimitSwapFormViewModel` and
+    /// drives the limit-swap pipeline independently of `detailsViewModel`.
     @State private var selectedSwapMode: SwapFormMode = .market
     @State private var showAdvancedLockedSheet = false
 
     private let tierService = VultTierService()
 
     @EnvironmentObject var coinSelectionViewModel: CoinSelectionViewModel
-    @EnvironmentObject var settingsViewModel: SettingsViewModel
     @Environment(\.router) var router
 
     var body: some View {
@@ -40,7 +38,6 @@ struct SwapDetailsScreen: View {
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 8)
-                .showIf(settingsViewModel.limitSwapEnabled)
 
                 switch selectedSwapMode {
                 case .market:
@@ -69,15 +66,8 @@ struct SwapDetailsScreen: View {
             )
         }
         .screenToolbar {
-            // Glass button (shared toolbar background) first, then the custom
-            // countdown pill (own background → shared hidden). The toolbar
-            // renders the glass group ahead of the plain group, so this order
-            // shows the advanced-settings button left of the countdown.
             CustomToolbarItem(placement: .trailing) {
                 advancedSettingsButton
-            }
-            CustomToolbarItem(placement: .trailing, hideSharedBackground: true) {
-                refreshCounter
             }
         }
         .crossPlatformSheet(isPresented: $showAdvancedLockedSheet) {
@@ -298,16 +288,6 @@ struct SwapDetailsScreen: View {
             return String(format: "swapInsufficientTokenBalance".localized, detailsViewModel.fromCoin.ticker)
         }
         return "continue"
-    }
-
-    @ViewBuilder
-    var refreshCounter: some View {
-        // When the Market/Limit tab row is visible (limit swap enabled) the
-        // countdown lives in that row via `tabRowCountdown`; keep the toolbar
-        // counter only for the flag-off market layout, which has no tab row.
-        if !settingsViewModel.limitSwapEnabled, detailsViewModel.showRefreshCounter {
-            SwapRefreshQuoteCounter(timer: detailsViewModel.timer)
-        }
     }
 
     /// Source coin the **limit** entry seeds with. Limit-entry only — the shared


### PR DESCRIPTION
## Description

Removes the `limitSwapEnabled` feature flag so THORChain limit swaps ship unconditionally.

The feature has been complete and landing fixes for weeks, but it sat behind an Advanced-settings toggle that defaulted to `false` — so unless a user went digging in Settings → Advanced, the Market/Limit tab row on the swap details screen never appeared at all. The flag was a **local `@AppStorage` value, not a server-driven `FeatureFlagService` flag**, so there was no remote kill-switch to coordinate; removing the property is the whole of the change.

Fixes #5000

### What was deleted

**The flag itself**
- `SettingsViewModel.swift` — the `@AppStorage("limitSwapEnabled")` property.
- `SettingsAdvancedView.swift` — the `SettingToggleCell` that wrote it, **and** the `Row.limitSwap` enum case that placed it in the list. `Row` is `CaseIterable` and drives the screen's `ForEach`, so the case had to go with the cell; the issue's call-site map missed this one.
- `Localizable.strings` — the `"limitSwapToggle"` key, removed from **all 8** shipping locales (en, de, es, hr, it, **ko**, pt, zh-Hans) and re-sorted with `sort_localizable.py`.

**The gate**
- `SwapDetailsScreen.swift` — `.showIf(settingsViewModel.limitSwapEnabled)` on the Market/Limit tab row.

### What became dead as a consequence, and was removed

- **`SwapDetailsScreen.refreshCounter` and its toolbar item.** Its own comment said it existed *only* for the flag-off market layout, "which has no tab row". With the row always present, `!limitSwapEnabled` can never be true — the view was unreachable, not merely redundant. `tabRowCountdown` is now the single quote countdown on this screen.
- **The toolbar-ordering comment** explaining how the glass advanced-settings button and the countdown pill sequenced. Only one toolbar item remains, so there is no ordering left to explain.
- **`SwapDetailsScreen`'s `@EnvironmentObject var settingsViewModel`.** The two flag reads were its only uses anywhere on the screen. Safe to drop: `@EnvironmentObject` *reads* from the environment, it does not inject into it, and nothing here fed a descendant via `.environmentObject(settingsViewModel)`.
- **The `selectedSwapMode` doc comment**, which described "flag-off renders the existing Market layout pixel-identical to pre-feature" — and, separately, named two symbols that no longer exist in the codebase at all (`LimitSwapModeBody`, `SwapRoute.limitPair`). Rewritten against the real types.

### Deliberately kept — each still has a live consumer

| Symbol | Why it stays |
|---|---|
| `SwapDetailsViewModel.showRefreshCounter` | Still read by `tabRowCountdown`, and by `updateTimer` as the timer's park guard |
| `SwapRefreshQuoteCounter` | Still the countdown on `SwapVerifyScreen` — only the *details*-screen usage went |
| `SwapQuoteCountdownBadge` | It is what `tabRowCountdown` renders |
| `CustomToolbarItem(hideSharedBackground:)` | Still used by `SwapVerifyScreen` and `VaultSetupScreen` |
| `"swap.tab.market"` / `"swap.tab.limit"` | Label the tab row, which is now always visible |
| `SwapVerifyScreen.refreshCounter` | **Identically named but unrelated** — it gates on `currentTransaction.isLimit`. Untouched. |

### Behaviour worth a reviewer's eye

The tab row now renders for **every** vault, including one with zero THORChain-routable chains. That is not new behaviour introduced here — `canCurrentPairUseLimitSwap` already *disabled* (rather than hid) the Limit segment in that case, which is what flag-on users have been seeing all along. Flagging it because removing `.showIf` is what makes that path reachable for everyone.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

> No swap tx link: this PR changes only which UI is visible. It touches no keysign, broadcast, quote, memo or fee-computation code — the limit-swap pipeline itself is byte-for-byte unchanged.

## Parity

- Android: `n/a` — already unconditional. `SwapScreen.kt` renders `SwapModeTabs` with no flag gate; its Limit tab shows a `swap_limit_coming_soon` placeholder because the feature isn't implemented there yet, but the row itself was never hidden.
- Windows + extension: `n/a` — already unconditional. `core/ui/vault/swap/form/SwapForm.tsx` registers the `market` / `limit` tab set with no feature-flag check.
- SDK: `n/a` — no UI-level flag exists. `packages/core/chain/swap/native/limitSwapMemo.ts` is memo construction only.

iOS was the only platform hiding the tab row, so this closes a divergence rather than opening one.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

> No tests added, and none removed. Grepped: **no test in `VultisigAppTests` or `VultisigAppUITests` referenced `limitSwapEnabled` or `limitSwapToggle`**, `VultisigAppUITests` has no limit-swap coverage at all, and no snapshot test covers `SwapDetailsScreen` — so nothing asserted flag-off behaviour and there was nothing to rewrite. The change is a deletion of a visibility gate; there is no new logic to assert.

## Screenshots (if applicable):

_None._ See "Not verified" below — the reviewer's device pass is the right place for this.

## Additional context

**Not verified here, and worth a manual pass:** that an existing install whose stored `limitSwapEnabled` is `false` renders the tab row correctly on device. The reasoning is sound — nothing reads the key any more, so the stored value is inert — but that is reasoning, not an observation, and this was not run on a device that previously had the toggle off.

Per the issue, the orphaned `limitSwapEnabled` value left in `UserDefaults` on existing installs is **out of scope**: it is inert once unread, and a cleanup migration is not worth adding a keyshare-adjacent code path.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5000
- **Confidence**: high
- **Needs human review for**: on-device confirmation that the tab row appears for a user who previously had the toggle off; the "tab row now shows for vaults with no THORChain-routable chains" note above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Limit Swap toggle from Advanced Settings.
  * Limit Swap availability in Swap Details is now determined by supported trading pairs rather than the removed setting.
  * Simplified the Swap Details toolbar; refresh and countdown information now appears within the tab interface.
* **Localization**
  * Removed obsolete Limit Swap toggle translations across supported languages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->