### PR TITLE
fix(ripple): record an XRPL trust-line activation as an activation, not a quadrillion-token transfer

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustSetPresentation.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleTrustSetPresentation.swift
@@ -148,9 +148,17 @@ enum RippleTrustSetPresentation {
     }
 
     private static func heroContent(for display: Display) -> HeroContent {
-        .title(
-            text: String(format: "rippleTrustLineHeroTitle".localized, display.ticker),
-            caption: display.issuer
-        )
+        .title(text: activationTitle(ticker: display.ticker), caption: display.issuer)
+    }
+
+    /// The one sentence that names what a TrustSet did, given the trusted
+    /// currency's ticker.
+    ///
+    /// Shared by the done-screen hero and the transaction-history row on
+    /// purpose. History used to record an activation as a token transfer of the
+    /// limit, contradicting the receipt the user had just been shown; the two
+    /// surfaces now read from the same string so they cannot drift apart again.
+    static func activationTitle(ticker: String) -> String {
+        String(format: "rippleTrustLineHeroTitle".localized, ticker)
     }
 }

--- a/VultisigApp/VultisigApp/Components/TransactionDone/TransactionHistoryRecording.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/TransactionHistoryRecording.swift
@@ -21,23 +21,38 @@ private let logger = Log.wallet.other
 
 enum TransactionHistoryRecording {
 
-    /// Records the send-style transaction reflected in `payload` to tx
-    /// history. No-op when the payload doesn't carry a vault
-    /// `pubKeyECDSA` (e.g. previews), when the hash is empty, or when
-    /// the verb is `.claim` (QBTC has no tx-history schema yet).
+    /// What `record` will do with a payload.
     ///
-    /// Swap-side flows pre-record via `recordSwap` + `recordApprove`
-    /// from their screen layer (they carry from/to coin pairs we don't
-    /// surface on the unified payload) — those payloads ship with
-    /// `isSend == false` and no `keysignPayload`, so this helper skips
-    /// them to avoid double-counting. Cosigner paths with a
-    /// `KeysignPayload` are dispatched here via
-    /// `recordFromKeysignPayload` so the cosigner's swap-branch gets
-    /// captured too.
-    @MainActor
-    static func record(payload: TransactionDonePayload) {
-        guard payload.pubKeyECDSA.isNotEmpty else { return }
-        guard payload.hash.isNotEmpty else { return }
+    /// Split out from `record` so the DISPATCH ORDER is testable, not just the
+    /// individual predicates. The predicates were already pure; the precedence
+    /// between them was not, and precedence is where this dispatch has actually
+    /// gone wrong — a TrustSet reaching `recordSend` is a branch that exists but
+    /// sits in the wrong place, and a suite that only asserts "the payload IS a
+    /// TrustSet" stays green through exactly that mistake.
+    enum Route: Equatable {
+        /// No row. Previews and un-broadcast payloads, QBTC claims, limit-order
+        /// cancels, and the swap initiator (which pre-records in its own screen
+        /// layer, so recording here would double-count).
+        case skip
+        /// An XRPL trust-line activation.
+        case trustLineActivation
+        /// Delegated to `recordFromKeysignPayload`, which reads the swap-or-order
+        /// discriminator off the payload itself.
+        case keysignPayload
+        /// The plain send row.
+        case send
+    }
+
+    /// Which row `payload` earns, and — the part that matters — in which order
+    /// the question is asked.
+    ///
+    /// Pure and `static` so the whole precedence chain can be pinned by tests:
+    /// the recorder it drives is a `private init()` singleton that writes to
+    /// SwiftData, so `record` itself isn't reachable from a unit test.
+    static func route(for payload: TransactionDonePayload) -> Route {
+        guard payload.pubKeyECDSA.isNotEmpty else { return .skip }
+        guard payload.hash.isNotEmpty else { return .skip }
+
         // A limit-order CANCEL gets no row of its own. It is a step in an
         // order's life, not a transfer the user made, and recording it produces
         // a standalone "Send 0 RUNE" — or, on the L1 route, a send of dust —
@@ -49,9 +64,9 @@ enum TransactionHistoryRecording {
         // auditable: its hash is persisted on the `LimitOrder` and the order's
         // detail sheet links it to the block explorer, so the fee and the
         // transaction itself remain one tap away.
-        guard !isLimitOrderCancel(payload) else { return }
+        guard !isLimitOrderCancel(payload) else { return .skip }
 
-        // An XRPL trust-line activation is not a transfer. Branched BEFORE
+        // An XRPL trust-line activation is not a transfer. Asked BEFORE
         // everything below it, because every route beneath this line ends in a
         // `recordSend` that would persist the trust-line LIMIT as an amount sent
         // — 1,000,000,000,000,000 USDC for a USDC activation.
@@ -67,45 +82,70 @@ enum TransactionHistoryRecording {
         // neither routes through `recordFromKeysignPayload` (a TrustSet has no
         // swap payload and no limit memo) — so they share this one fallback, and
         // fixing it here fixes it everywhere.
-        if isTrustLineActivation(payload) {
-            recordTrustLineActivation(payload: payload)
-            return
-        }
+        if isTrustLineActivation(payload) { return .trustLineActivation }
 
         // Cosigner: the full `KeysignPayload` carries the swap-or-send
         // discriminator + amounts. Delegate to the recorder helper.
         if let keysignPayload = payload.keysignPayload,
-           Self.routesThroughKeysignRecorder(keysignPayload) {
-            guard let vault = lookupVault(pubKeyECDSA: payload.pubKeyECDSA) else { return }
+           routesThroughKeysignRecorder(keysignPayload) {
+            return .keysignPayload
+        }
+
+        // QBTC claim opts out — no tx-history schema for claims today.
+        guard payload.verb != .claim else { return .skip }
+
+        // Swap initiator: records via `recordSwap` + `recordApprove`
+        // in its own screen layer. Skip here to avoid double-counting.
+        guard payload.isSend || payload.keysignPayload != nil else { return .skip }
+
+        return .send
+    }
+
+    /// Records the transaction reflected in `payload` to tx history, along the
+    /// route `route(for:)` chose.
+    ///
+    /// Swap-side flows pre-record via `recordSwap` + `recordApprove`
+    /// from their screen layer (they carry from/to coin pairs we don't
+    /// surface on the unified payload) — those payloads ship with
+    /// `isSend == false` and no `keysignPayload`, so this helper skips
+    /// them to avoid double-counting. Cosigner paths with a
+    /// `KeysignPayload` are dispatched here via
+    /// `recordFromKeysignPayload` so the cosigner's swap-branch gets
+    /// captured too.
+    @MainActor
+    static func record(payload: TransactionDonePayload) {
+        switch route(for: payload) {
+        case .skip:
+            return
+
+        case .trustLineActivation:
+            recordTrustLineActivation(payload: payload)
+
+        case .keysignPayload:
+            guard let keysignPayload = payload.keysignPayload,
+                  let vault = lookupVault(pubKeyECDSA: payload.pubKeyECDSA) else { return }
             TransactionHistoryRecorder.shared.recordFromKeysignPayload(
                 txHash: payload.hash,
                 approveTxHash: nil,
                 vault: vault,
                 keysignPayload: keysignPayload
             )
-            return
+
+        case .send:
+            TransactionHistoryRecorder.shared.recordSend(
+                txHash: payload.hash,
+                pubKeyECDSA: payload.pubKeyECDSA,
+                coin: payload.coin,
+                amountCrypto: payload.amountCrypto,
+                amountFiat: payload.amountFiat,
+                fromAddress: payload.fromAddress,
+                toAddress: payload.toAddress,
+                feeCrypto: payload.fee.crypto,
+                feeFiat: payload.fee.fiat,
+                chain: payload.coin.chain,
+                explorerLink: payload.explorerLink
+            )
         }
-
-        // QBTC claim opts out — no tx-history schema for claims today.
-        guard payload.verb != .claim else { return }
-
-        // Swap initiator: records via `recordSwap` + `recordApprove`
-        // in its own screen layer. Skip here to avoid double-counting.
-        guard payload.isSend || payload.keysignPayload != nil else { return }
-
-        TransactionHistoryRecorder.shared.recordSend(
-            txHash: payload.hash,
-            pubKeyECDSA: payload.pubKeyECDSA,
-            coin: payload.coin,
-            amountCrypto: payload.amountCrypto,
-            amountFiat: payload.amountFiat,
-            fromAddress: payload.fromAddress,
-            toAddress: payload.toAddress,
-            feeCrypto: payload.fee.crypto,
-            feeFiat: payload.fee.fiat,
-            chain: payload.coin.chain,
-            explorerLink: payload.explorerLink
-        )
     }
 
     /// Whether this payload opened an XRPL trust line, judged by the WIRE

--- a/VultisigApp/VultisigApp/Components/TransactionDone/TransactionHistoryRecording.swift
+++ b/VultisigApp/VultisigApp/Components/TransactionDone/TransactionHistoryRecording.swift
@@ -51,6 +51,27 @@ enum TransactionHistoryRecording {
         // transaction itself remain one tap away.
         guard !isLimitOrderCancel(payload) else { return }
 
+        // An XRPL trust-line activation is not a transfer. Branched BEFORE
+        // everything below it, because every route beneath this line ends in a
+        // `recordSend` that would persist the trust-line LIMIT as an amount sent
+        // — 1,000,000,000,000,000 USDC for a USDC activation.
+        //
+        // ⚠️ Recorded, not suppressed. A limit-order cancel above can be dropped
+        // because the ORDER's row narrates its lifecycle and keeps the hash
+        // linked; a TrustSet has no parent row, so dropping it would erase the
+        // fee the user paid and the XRP owner reserve they locked.
+        //
+        // One branch covers BOTH devices. The initiator's `SendDoneScreen` and
+        // the cosigner's `JoinKeysignDoneView.sendBranch` build different
+        // `amountCrypto` strings but both carry the `KeysignPayload`, and
+        // neither routes through `recordFromKeysignPayload` (a TrustSet has no
+        // swap payload and no limit memo) — so they share this one fallback, and
+        // fixing it here fixes it everywhere.
+        if isTrustLineActivation(payload) {
+            recordTrustLineActivation(payload: payload)
+            return
+        }
+
         // Cosigner: the full `KeysignPayload` carries the swap-or-send
         // discriminator + amounts. Delegate to the recorder helper.
         if let keysignPayload = payload.keysignPayload,
@@ -83,6 +104,44 @@ enum TransactionHistoryRecording {
             feeCrypto: payload.fee.crypto,
             feeFiat: payload.fee.fiat,
             chain: payload.coin.chain,
+            explorerLink: payload.explorerLink
+        )
+    }
+
+    /// Whether this payload opened an XRPL trust line, judged by the WIRE
+    /// discriminator alone — the same rule `RippleTrustSetPresentation` uses to
+    /// decide what a co-signer is shown.
+    ///
+    /// Deliberately not judged from the amount, the coin or the hero. Whether
+    /// something IS a TrustSet is decided by the field that says so; keying it
+    /// off anything derived would let an unrenderable TrustSet fall back into
+    /// the Payment framing, which is exactly the false record this closes.
+    ///
+    /// Pure and `static` so the routing can be pinned by tests: the recorder it
+    /// guards is a `private init()` singleton that writes to SwiftData.
+    static func isTrustLineActivation(_ payload: TransactionDonePayload) -> Bool {
+        RippleTrustSetPresentation.isTrustSet(payload: payload.keysignPayload)
+    }
+
+    /// Persists the activation row.
+    ///
+    /// The ticker and issuer come from the payload's own trust-line terms —
+    /// the resolved currency (so a hex currency code shows as `RLUSD`, not its
+    /// hex) and the account the line is with. When those cannot be read the row
+    /// still records, degrading to the coin's own ticker and the payload's
+    /// address: the transaction happened and cost a fee either way, and the one
+    /// thing that must never happen is falling back to a transfer row.
+    @MainActor
+    private static func recordTrustLineActivation(payload: TransactionDonePayload) {
+        let display = RippleTrustSetPresentation.display(for: payload.keysignPayload)
+        TransactionHistoryRecorder.shared.recordTrustLineActivation(
+            txHash: payload.hash,
+            pubKeyECDSA: payload.pubKeyECDSA,
+            coin: payload.coin,
+            ticker: display?.ticker ?? payload.coin.ticker,
+            issuer: display?.issuer ?? payload.toAddress,
+            feeCrypto: payload.fee.crypto,
+            feeFiat: payload.fee.fiat,
             explorerLink: payload.explorerLink
         )
     }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1104,6 +1104,7 @@
 "rippleTrustLineNoXrpAccountError" = "Eine Trust Line benötigt ein XRP-Konto als Eigentümer. Fügen Sie diesem Vault zuerst XRP hinzu.";
 "rippleTrustLineOwnerReserve" = "Gesperrte Reserve";
 "rippleTrustLineSpendableAfter" = "Verfügbare XRP danach";
+"rippleTrustLineTypePill" = "Trust-Line";
 "rippleTrustLineUnreviewable" = "Prüfung nicht möglich";
 "rippleTrustLineUnreviewableValue" = "Währung, Emittent oder Limit dieser Trust Line konnten nicht gelesen werden, daher lassen sich ihre Bedingungen nicht anzeigen. Nicht signieren.";
 "rippleUndecodedNotice" = "Diese Transaktion konnte nicht dekodiert werden. Überprüfe das rohe JSON sorgfältig, bevor du signierst.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1102,6 +1102,7 @@
 "rippleTrustLineNoXrpAccountError" = "A trust line needs an XRP account to own it. Add XRP to this vault first.";
 "rippleTrustLineOwnerReserve" = "Reserve locked";
 "rippleTrustLineSpendableAfter" = "Spendable XRP after";
+"rippleTrustLineTypePill" = "Trust line";
 "rippleTrustLineUnreviewable" = "Cannot review";
 "rippleTrustLineUnreviewableValue" = "This trust line's currency, issuer or limit could not be read, so its terms cannot be shown. Do not sign it.";
 "rippleUndecodedNotice" = "This transaction couldn't be decoded. Review the raw JSON carefully before signing.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1104,6 +1104,7 @@
 "rippleTrustLineNoXrpAccountError" = "Una línea de confianza necesita una cuenta XRP que la posea. Añade XRP a esta bóveda primero.";
 "rippleTrustLineOwnerReserve" = "Reserva bloqueada";
 "rippleTrustLineSpendableAfter" = "XRP disponibles después";
+"rippleTrustLineTypePill" = "Línea de confianza";
 "rippleTrustLineUnreviewable" = "No se puede revisar";
 "rippleTrustLineUnreviewableValue" = "No se pudo leer la moneda, el emisor o el límite de esta línea de confianza, así que no se pueden mostrar sus condiciones. No la firmes.";
 "rippleUndecodedNotice" = "No se pudo decodificar esta transacción. Revisa cuidadosamente el JSON sin procesar antes de firmar.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1104,6 +1104,7 @@
 "rippleTrustLineNoXrpAccountError" = "Liniju povjerenja mora posjedovati XRP račun. Najprije dodajte XRP u ovaj trezor.";
 "rippleTrustLineOwnerReserve" = "Zaključana rezerva";
 "rippleTrustLineSpendableAfter" = "Raspoloživi XRP nakon";
+"rippleTrustLineTypePill" = "Linija povjerenja";
 "rippleTrustLineUnreviewable" = "Pregled nije moguć";
 "rippleTrustLineUnreviewableValue" = "Valuta, izdavatelj ili ograničenje ove linije povjerenja nisu se mogli pročitati, pa se njezini uvjeti ne mogu prikazati. Nemojte je potpisati.";
 "rippleUndecodedNotice" = "Ovu transakciju nije bilo moguće dekodirati. Pažljivo pregledajte neobrađeni JSON prije potpisivanja.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1104,6 +1104,7 @@
 "rippleTrustLineNoXrpAccountError" = "Una linea di fiducia deve essere posseduta da un account XRP. Aggiungi prima XRP a questo vault.";
 "rippleTrustLineOwnerReserve" = "Riserva bloccata";
 "rippleTrustLineSpendableAfter" = "XRP disponibili dopo";
+"rippleTrustLineTypePill" = "Linea di fiducia";
 "rippleTrustLineUnreviewable" = "Impossibile verificare";
 "rippleTrustLineUnreviewableValue" = "Non è stato possibile leggere valuta, emittente o limite di questa linea di fiducia, quindi le sue condizioni non possono essere mostrate. Non firmarla.";
 "rippleUndecodedNotice" = "Impossibile decodificare questa transazione. Controlla attentamente il JSON grezzo prima di firmare.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1102,6 +1102,7 @@
 "rippleTrustLineNoXrpAccountError" = "신뢰선을 보유하려면 XRP 계정이 필요합니다. 먼저 이 볼트에 XRP를 추가하세요.";
 "rippleTrustLineOwnerReserve" = "잠긴 준비금";
 "rippleTrustLineSpendableAfter" = "이후 사용 가능한 XRP";
+"rippleTrustLineTypePill" = "신뢰선";
 "rippleTrustLineUnreviewable" = "검토할 수 없음";
 "rippleTrustLineUnreviewableValue" = "이 신뢰선의 통화, 발행자 또는 한도를 읽을 수 없어 조건을 표시할 수 없습니다. 서명하지 마세요.";
 "rippleUndecodedNotice" = "이 트랜잭션을 디코딩할 수 없습니다. 서명하기 전에 원시 JSON을 주의 깊게 확인하세요.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1104,6 +1104,7 @@
 "rippleTrustLineNoXrpAccountError" = "Uma linha de confiança precisa de uma conta XRP que a detenha. Adicione XRP a este cofre primeiro.";
 "rippleTrustLineOwnerReserve" = "Reserva bloqueada";
 "rippleTrustLineSpendableAfter" = "XRP disponíveis depois";
+"rippleTrustLineTypePill" = "Linha de confiança";
 "rippleTrustLineUnreviewable" = "Não é possível rever";
 "rippleTrustLineUnreviewableValue" = "Não foi possível ler a moeda, o emissor ou o limite desta linha de confiança, por isso as suas condições não podem ser mostradas. Não a assine.";
 "rippleUndecodedNotice" = "Não foi possível decodificar esta transação. Revise cuidadosamente o JSON bruto antes de assinar.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1104,6 +1104,7 @@
 "rippleTrustLineNoXrpAccountError" = "信任线需要由一个 XRP 账户持有。请先向此保险库添加 XRP。";
 "rippleTrustLineOwnerReserve" = "锁定的准备金";
 "rippleTrustLineSpendableAfter" = "之后可用的 XRP";
+"rippleTrustLineTypePill" = "信任线";
 "rippleTrustLineUnreviewable" = "无法审核";
 "rippleTrustLineUnreviewableValue" = "无法读取此信任线的货币、发行方或上限，因此无法显示其条款。请勿签名。";
 "rippleUndecodedNotice" = "无法解码此交易。签名前请仔细核对原始 JSON。";

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryData.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Models/TransactionHistoryData.swift
@@ -24,6 +24,19 @@ enum TransactionHistoryType: String, Codable, Sendable, Hashable {
     /// they carry no swap payload and so used to be recorded as plain `send`
     /// rows.
     case limit
+    /// An XRPL `TrustSet` that opened a trust line.
+    ///
+    /// The same category as `.approve`, and typed for the same reason: it is a
+    /// PERMISSIONING transaction. It costs a fee and locks an owner reserve, but
+    /// it moves nothing — its amount is the line's LIMIT, and a TrustSet routed
+    /// to `.send` renders that limit as a transferred quantity (a USDC
+    /// activation reads as a send of 1,000,000,000,000,000 USDC).
+    ///
+    /// ⚠️ Typed rather than suppressed. A limit-order CANCEL gets no row because
+    /// the order's own row narrates its lifecycle and keeps the hash linked; a
+    /// TrustSet has no parent row, so hiding it would erase the fee the user paid
+    /// and the XRP reserve they locked.
+    case trustLineActivation
 }
 
 // MARK: - Status Enum

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Services/TransactionHistoryRecorder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Services/TransactionHistoryRecorder.swift
@@ -328,8 +328,8 @@ final class TransactionHistoryRecorder {
     ///
     /// Pure and `static` so the row's CONTENT can be pinned by tests — the
     /// recorder is a `private init()` singleton writing to SwiftData, so the
-    /// wired path isn't reachable from a unit test. The routing that reaches it
-    /// is pinned separately by `TransactionHistoryRecording.isTrustLineActivation`.
+    /// wired path isn't reachable from a unit test. The precedence that reaches
+    /// it is pinned separately by `TransactionHistoryRecording.route(for:)`.
     static func trustLineActivationRow(
         txHash: String,
         pubKeyECDSA: String,
@@ -392,7 +392,36 @@ final class TransactionHistoryRecorder {
     ) {
         let isSwap = keysignPayload.swapPayload != nil
 
-        if isSwap, let swapPayload = keysignPayload.swapPayload {
+        if RippleTrustSetPresentation.isTrustSet(payload: keysignPayload) {
+            // An XRPL TrustSet never reaches here today — the unified recording
+            // entry point intercepts it first. The gate is duplicated anyway,
+            // for the reason `TransactionStatusPoller` duplicates its tracker
+            // gate: this method is the choke point every payload-driven row
+            // funnels through, and its `else` arm below is an unconditional
+            // `recordSend` whose amount would be the trust-line LIMIT. A caller
+            // added later must not be able to reintroduce a quadrillion-token
+            // row by routing here.
+            //
+            // Gated on the wire discriminator, not on whether the terms could be
+            // rendered — an unreadable TrustSet must degrade to a vaguer
+            // activation row, never to a transfer. The fee is empty because this
+            // path has none to hand, the same reason every branch below passes
+            // empty fees.
+            let display = RippleTrustSetPresentation.display(for: keysignPayload)
+            recordTrustLineActivation(
+                txHash: txHash,
+                pubKeyECDSA: vault.pubKeyECDSA,
+                coin: keysignPayload.coin,
+                ticker: display?.ticker ?? keysignPayload.coin.ticker,
+                issuer: display?.issuer ?? keysignPayload.toAddress,
+                feeCrypto: .empty,
+                feeFiat: .empty,
+                explorerLink: ExplorerLinkBuilder.getExplorerURL(
+                    chain: keysignPayload.coin.chain,
+                    txid: txHash
+                )
+            )
+        } else if isSwap, let swapPayload = keysignPayload.swapPayload {
             recordSwap(
                 txHash: txHash,
                 approveTxHash: approveTxHash,

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Services/TransactionHistoryRecorder.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Services/TransactionHistoryRecorder.swift
@@ -274,6 +274,114 @@ final class TransactionHistoryRecorder {
         }
     }
 
+    // MARK: - Record an XRPL trust-line activation
+
+    /// Records an XRPL `TrustSet` — the transaction that opens a trust line.
+    ///
+    /// Modelled on `recordApprove`, because the two are the same kind of
+    /// transaction: permissioning, not transfer. The difference from an approve
+    /// is that this row carries NO amount at all. A TrustSet's signed amount is
+    /// the line's LIMIT, so any value in `amountCrypto` would be read as a
+    /// quantity that moved — which is the entire bug this exists to close.
+    ///
+    /// The fee IS recorded, unlike an approve (whose call site has none to
+    /// hand). A trust line costs a fee and locks an owner reserve, and that cost
+    /// is the main thing history still owes the user for a transaction that
+    /// moved nothing.
+    ///
+    /// - Parameters:
+    ///   - ticker: the trusted currency as a human reads it — resolved from the
+    ///     on-ledger currency code, so a 40-character hex currency shows as
+    ///     `RLUSD` rather than its hex.
+    ///   - issuer: the account the line is with. Stored in `toAddress` because
+    ///     the row schema has nowhere else, and relabelled by the detail sheet:
+    ///     a TrustSet has no XRPL destination, so the issuer must never be
+    ///     presented as a recipient.
+    func recordTrustLineActivation(
+        txHash: String,
+        pubKeyECDSA: String,
+        coin: Coin,
+        ticker: String,
+        issuer: String,
+        feeCrypto: String,
+        feeFiat: String,
+        explorerLink: String
+    ) {
+        let data = Self.trustLineActivationRow(
+            txHash: txHash,
+            pubKeyECDSA: pubKeyECDSA,
+            coin: coin,
+            ticker: ticker,
+            issuer: issuer,
+            feeCrypto: feeCrypto,
+            feeFiat: feeFiat,
+            explorerLink: explorerLink
+        )
+        do {
+            try storage.save(data)
+        } catch {
+            logger.error("Save failed for txHash=\(txHash): \(error)")
+        }
+    }
+
+    /// The row a trust-line activation persists.
+    ///
+    /// Pure and `static` so the row's CONTENT can be pinned by tests — the
+    /// recorder is a `private init()` singleton writing to SwiftData, so the
+    /// wired path isn't reachable from a unit test. The routing that reaches it
+    /// is pinned separately by `TransactionHistoryRecording.isTrustLineActivation`.
+    static func trustLineActivationRow(
+        txHash: String,
+        pubKeyECDSA: String,
+        coin: Coin,
+        ticker: String,
+        issuer: String,
+        feeCrypto: String,
+        feeFiat: String,
+        explorerLink: String
+    ) -> TransactionHistoryData {
+        TransactionHistoryData(
+            id: UUID(),
+            txHash: txHash,
+            approveTxHash: nil,
+            pubKeyECDSA: pubKeyECDSA,
+            type: .trustLineActivation,
+            status: .inProgress,
+            // Taken from the coin rather than pinned to `.ripple`, even though a
+            // TrustSet is XRPL-only: the explorer link and the native poller
+            // both resolve their chain from this field, and a value that could
+            // disagree with the coin the row shows is a link pointing at the
+            // wrong ledger.
+            chainRawValue: coin.chain.rawValue,
+            coinTicker: ticker,
+            coinLogo: coin.logo,
+            coinChainLogo: coin.tokenChainLogo,
+            // ⚠️ Deliberately empty, both of them. The only number a TrustSet
+            // carries is the trust-line limit, and the whole point of this row
+            // type is that the limit is not a quantity that moved. The card and
+            // the detail sheet branch away from their amount slots for this
+            // type, so nothing formats these.
+            amountCrypto: .empty,
+            amountFiat: .empty,
+            fromAddress: coin.address,
+            toAddress: issuer,
+            toCoinTicker: nil,
+            toCoinLogo: nil,
+            toCoinChainLogo: nil,
+            toAmountCrypto: nil,
+            toAmountFiat: nil,
+            swapProvider: nil,
+            feeCrypto: feeCrypto,
+            feeFiat: feeFiat,
+            network: coin.chain.name,
+            explorerLink: explorerLink,
+            createdAt: Date(),
+            completedAt: nil,
+            estimatedTime: ChainStatusConfig.config(for: coin.chain).estimatedTime,
+            errorMessage: nil
+        )
+    }
+
     // MARK: - Record from KeysignPayload (co-signer path)
 
     func recordFromKeysignPayload(

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryViewModel.swift
@@ -302,7 +302,13 @@ class TransactionHistoryViewModel: ObservableObject {
             // carries the status.
             result = result.filter { $0.type == .limit }
         case .send:
-            result = result.filter { $0.type == .send || $0.type == .approve }
+            // Everything that isn't a trade. An approve and a trust-line
+            // activation both belong here for the same reason: they are what the
+            // user did from the Send/asset flows, they cost a fee, and there is
+            // no other tab that would ever show them.
+            result = result.filter {
+                $0.type == .send || $0.type == .approve || $0.type == .trustLineActivation
+            }
         }
 
         // Asset filter

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryCardView.swift
@@ -60,8 +60,13 @@ struct TransactionHistoryCardView: View {
         }
     }
 
+    /// The expanded layout is a `from -> to` transfer diagram: an amount at the
+    /// top, an arrow, a recipient at the bottom. Only types that MOVED something
+    /// earn it — an approve grants an allowance, and a trust-line activation
+    /// opens a line and locks a reserve. Neither has an amount or a recipient to
+    /// put in those slots.
     static func shouldExpand(status: TransactionHistoryStatus, type: TransactionHistoryType) -> Bool {
-        status == .inProgress && type != .approve
+        status == .inProgress && type != .approve && type != .trustLineActivation
     }
 
     // MARK: - Top Row
@@ -404,13 +409,39 @@ struct TransactionHistoryCardView: View {
     private var collapsedContent: some View {
         HStack(spacing: 12) {
             coinIcon
-            amountColumn
+
+            if transaction.type == .trustLineActivation {
+                trustLineColumn
+            } else {
+                amountColumn
+            }
 
             Spacer()
 
             if transaction.type == .send {
                 addressPill
             }
+        }
+    }
+
+    /// What a trust-line activation says instead of an amount.
+    ///
+    /// The same sentence the done screen showed when the line was opened, over
+    /// the issuer that identifies WHICH line — deliberately the hero's two
+    /// lines, so history and the receipt tell one story. The amount column is
+    /// bypassed rather than fed an empty string: a TrustSet's only number is the
+    /// line's limit, and there is no honest way to render that here.
+    private var trustLineColumn: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(RippleTrustSetPresentation.activationTitle(ticker: transaction.coinTicker))
+                .font(Theme.fonts.priceFootnote)
+                .foregroundStyle(Theme.colors.textPrimary)
+                .lineLimit(1)
+
+            Text(truncatedAddress(transaction.toAddress))
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .lineLimit(1)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryDetailSheet.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryDetailSheet.swift
@@ -45,6 +45,8 @@ struct TransactionHistoryDetailSheet: View {
 
     private var isLimit: Bool { transaction.type == .limit }
 
+    private var isTrustLineActivation: Bool { transaction.type == .trustLineActivation }
+
     /// A limit order and a swap share the from/to header pair: both express an
     /// intent to trade one asset for another.
     private var showsFromToCards: Bool {
@@ -123,16 +125,36 @@ struct TransactionHistoryDetailSheet: View {
                     tokenChainLogo: transaction.coinChainLogo
                 )
 
-                Text(transaction.amountCrypto)
-                    .font(Theme.fonts.priceTitle1)
-                    .foregroundStyle(Theme.colors.textPrimary)
+                if isTrustLineActivation {
+                    trustLineHeadline
+                } else {
+                    Text(transaction.amountCrypto)
+                        .font(Theme.fonts.priceTitle1)
+                        .foregroundStyle(Theme.colors.textPrimary)
 
-                Text(transaction.amountFiat.formatToFiat(includeCurrencySymbol: true))
-                    .font(Theme.fonts.priceBodyS)
-                    .foregroundStyle(Theme.colors.textTertiary)
+                    Text(transaction.amountFiat.formatToFiat(includeCurrencySymbol: true))
+                        .font(Theme.fonts.priceBodyS)
+                        .foregroundStyle(Theme.colors.textTertiary)
+                }
             }
             .padding(.vertical, 8)
         }
+    }
+
+    /// The done screen's hero, restated. A TrustSet has no amount and no fiat
+    /// value — its only number is the trust line's limit, which is a ceiling the
+    /// account accepted, not a sum that moved. Rendering it in the amount slot
+    /// is the bug this row type exists to close.
+    @ViewBuilder
+    private var trustLineHeadline: some View {
+        Text(RippleTrustSetPresentation.activationTitle(ticker: transaction.coinTicker))
+            .font(Theme.fonts.bodyLMedium)
+            .foregroundStyle(Theme.colors.textPrimary)
+            .multilineTextAlignment(.center)
+
+        Text(truncatedAddress(transaction.toAddress))
+            .font(Theme.fonts.priceBodyS)
+            .foregroundStyle(Theme.colors.textTertiary)
     }
 
     // MARK: - From/To Cards (Swap only)
@@ -238,7 +260,15 @@ struct TransactionHistoryDetailSheet: View {
             Separator().opacity(0.2)
             detailRow(title: "from".localized, value: truncatedAddress(transaction.fromAddress))
             Separator().opacity(0.2)
-            detailRow(title: "to".localized, value: truncatedAddress(transaction.toAddress))
+            // ⚠️ A TrustSet has no XRPL destination field at all. The row stores
+            // the ISSUER here because the schema has nowhere else to put it, so
+            // it has to be labelled as the issuer — under a "To" label it reads
+            // as a recipient the transaction paid, which is the same false
+            // framing the verify summary suppresses this row to avoid.
+            detailRow(
+                title: (isTrustLineActivation ? "rippleTrustLineIssuer" : "to").localized,
+                value: truncatedAddress(transaction.toAddress)
+            )
             Separator().opacity(0.2)
             detailRow(title: "date".localized, value: formattedDate)
             Separator().opacity(0.2)

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryTypePill.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryTypePill.swift
@@ -44,6 +44,13 @@ struct TransactionHistoryTypePill: View {
             Image("clock-rotate-clockwise-3")
                 .resizable()
                 .frame(width: 12, height: 12)
+        case .trustLineActivation:
+            // A trust line is a link between an account and an issuer, which is
+            // what this row records — not a check mark, which is the approve
+            // pill and would make two different permissions look alike.
+            Image(.chainLink3)
+                .resizable()
+                .frame(width: 12, height: 12)
         }
     }
 
@@ -57,6 +64,8 @@ struct TransactionHistoryTypePill: View {
             return "approve".localized
         case .limit:
             return "limitSwap.typePill".localized
+        case .trustLineActivation:
+            return "rippleTrustLineTypePill".localized
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TrustLineActivationRecordingTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TrustLineActivationRecordingTests.swift
@@ -1,0 +1,353 @@
+//
+//  TrustLineActivationRecordingTests.swift
+//  VultisigAppTests
+//
+//  Pins how an XRPL trust-line activation reaches transaction history, and what
+//  the row it produces contains.
+//
+//  Regression: `TransactionHistoryRecording.record()` had no TrustSet branch, so
+//  an activation fell through to `recordSend` carrying the transaction's amount
+//  — which for a TrustSet is the trust-line LIMIT. Activating USDC recorded as a
+//  send of 1,000,000,000,000,000 USDC, contradicting the verify summary and the
+//  done screen, both of which already special-case the same value.
+//
+//  Two seams, tested separately because they fail in different ways:
+//    - ROUTING (`isTrustLineActivation`) — a payload that isn't recognised falls
+//      back to the send row.
+//    - CONTENT (`trustLineActivationRow`) — a recognised payload whose row still
+//      carries the limit somewhere would be the same lie in a new type.
+//
+
+@testable import VultisigApp
+import BigInt
+import VultisigCommonData
+import XCTest
+
+@MainActor
+final class TrustLineActivationRecordingTests: XCTestCase {
+
+    private static let account = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+    private static let issuer = "rMxCKbEDwqr76QuheSUMdEGf4B9xJ8m5De"
+    /// 160-bit hex form of `RLUSD` — the on-ledger code for a >3-character ticker.
+    private static let rlusdHex = "524C555344000000000000000000000000000000"
+    /// The limit `RippleTrustLineLimit.defaultLimit` signs, as it renders.
+    private static let limitDisplayValue = "1000000000000000"
+
+    // MARK: - Routing
+
+    /// The INITIATOR's shape: `SendDoneScreen` builds `amountCrypto` from the
+    /// `SendTransaction`, so the string it hands over already reads as a
+    /// quadrillion-token send.
+    func testAnInitiatorsTrustSetIsRoutedToTheActivationRecorder() {
+        let payload = makeDonePayload(
+            amountCrypto: "\(Self.limitDisplayValue) RLUSD",
+            keysignPayload: makeTrustSetPayload()
+        )
+
+        XCTAssertTrue(TransactionHistoryRecording.isTrustLineActivation(payload))
+    }
+
+    /// The CO-SIGNER's shape: `JoinKeysignDoneView.sendBranch` builds
+    /// `amountCrypto` from the payload's `toAmount` instead. Different string,
+    /// same lie — and a bug that only bites the non-initiating device is worse,
+    /// not better.
+    func testACosignersTrustSetIsRoutedToTheActivationRecorder() {
+        let payload = makeDonePayload(
+            amountCrypto: "\(Self.limitDisplayValue) RLUSD",
+            keysignPayload: makeTrustSetPayload(),
+            fromAddress: Self.account
+        )
+
+        XCTAssertTrue(TransactionHistoryRecording.isTrustLineActivation(payload))
+    }
+
+    /// Why ONE branch fixes both devices: a TrustSet carries no swap payload and
+    /// no limit-swap memo, so it never reaches `recordFromKeysignPayload` — both
+    /// the initiator and the co-signer share the `recordSend` fallback at the
+    /// bottom of `record()`, and the activation branch sits above it.
+    func testATrustSetIsInterceptedBeforeTheKeysignRecorderDispatch() {
+        let keysignPayload = makeTrustSetPayload()
+        let payload = makeDonePayload(amountCrypto: "0 RLUSD", keysignPayload: keysignPayload)
+
+        XCTAssertTrue(TransactionHistoryRecording.isTrustLineActivation(payload))
+        XCTAssertFalse(
+            TransactionHistoryRecording.routesThroughKeysignRecorder(keysignPayload),
+            "a TrustSet has no swap payload and no limit memo — it shares the recordSend fallback"
+        )
+    }
+
+    /// ⚠️ Decided by the WIRE discriminator, never by whether the terms could be
+    /// rendered. An unreadable token id must still record as an activation: if
+    /// it collapsed to "not a TrustSet" it would fall back into the send row,
+    /// which is the exact false record this closes.
+    func testAnUnreadableTrustSetIsStillAnActivation() {
+        for tokenId in ["not-a-token-id", "", "USD.", ".rIssuer"] {
+            let payload = makeDonePayload(
+                amountCrypto: "\(Self.limitDisplayValue) TEST",
+                keysignPayload: makeTrustSetPayload(tokenId: tokenId)
+            )
+            XCTAssertTrue(
+                TransactionHistoryRecording.isTrustLineActivation(payload),
+                "'\(tokenId)': the discriminator alone decides the operation"
+            )
+        }
+    }
+
+    /// An ordinary XRPL token Payment genuinely moves tokens and keeps its send
+    /// row — the fix must not swallow transactions that DO have an amount.
+    func testATokenPaymentIsNotAnActivation() {
+        let payload = makeDonePayload(
+            amountCrypto: "12.5 RLUSD",
+            keysignPayload: makeTrustSetPayload(transactionType: .unspecified)
+        )
+
+        XCTAssertFalse(TransactionHistoryRecording.isTrustLineActivation(payload))
+    }
+
+    /// Nothing on another chain, and nothing without a payload at all, can be
+    /// mistaken for a trust-line activation.
+    func testNonRipplePayloadsAreNotActivations() {
+        XCTAssertFalse(
+            TransactionHistoryRecording.isTrustLineActivation(
+                makeDonePayload(amountCrypto: "1 BTC", keysignPayload: nil)
+            ),
+            "a payload with no keysign payload carries no discriminator"
+        )
+        XCTAssertFalse(
+            TransactionHistoryRecording.isTrustLineActivation(
+                makeDonePayload(amountCrypto: "1 RUNE", keysignPayload: makeThorchainPayload())
+            ),
+            "a THORChain payload has no XRPL operation to discriminate"
+        )
+    }
+
+    // MARK: - Row content
+
+    /// The row a recognised activation persists. Asserted field by field rather
+    /// than as a whole, so a regression names which field went wrong.
+    func testTheActivationRowCarriesNoAmountAndKeepsTheFeeAndExplorerLink() throws {
+        let row = makeRow()
+
+        XCTAssertEqual(row.type, .trustLineActivation)
+        XCTAssertEqual(row.txHash, "TRUSTSETHASH")
+        XCTAssertEqual(row.pubKeyECDSA, "pubkey-ecdsa")
+        XCTAssertEqual(row.status, .inProgress)
+        XCTAssertEqual(row.chainRawValue, Chain.ripple.rawValue)
+
+        // The whole point: no amount, and no fiat price for one.
+        XCTAssertTrue(row.amountCrypto.isEmpty, "a TrustSet transferred nothing")
+        XCTAssertTrue(row.amountFiat.isEmpty, "and so it has no fiat value")
+        XCTAssertNil(row.toAmountCrypto)
+        XCTAssertNil(row.toAmountFiat)
+
+        // The fee the user really paid, and the transaction itself, stay
+        // reachable — that is why this row is recorded rather than suppressed.
+        XCTAssertEqual(row.feeCrypto, "0.000012 XRP")
+        XCTAssertEqual(row.feeFiat, "$0.00003")
+        XCTAssertEqual(row.explorerLink, "https://xrpscan.com/tx/TRUSTSETHASH")
+
+        // Who the line is with, and which currency it trusts.
+        XCTAssertEqual(row.coinTicker, "RLUSD", "the resolved ticker, not the hex currency code")
+        XCTAssertEqual(row.toAddress, Self.issuer)
+        XCTAssertEqual(row.fromAddress, Self.account)
+
+        // Not a swap in any disguise — nothing must put it in the Swaps or
+        // Limit Orders tab, or hand it to a tracking service.
+        XCTAssertNil(row.swapProvider)
+        XCTAssertNil(row.swapTracking)
+        XCTAssertFalse(row.isSwapRouted)
+    }
+
+    /// The regression, stated as the thing that must never appear: the
+    /// trust-line limit, in ANY field of the row, in any form.
+    ///
+    /// Written as a sweep rather than one assertion per field so a new field
+    /// added to `TransactionHistoryData` cannot quietly become the next place
+    /// the limit leaks into.
+    func testTheTrustLineLimitAppearsInNoFieldOfTheRow() {
+        let row = makeRow()
+
+        let fields: [String?] = [
+            row.txHash, row.approveTxHash, row.coinTicker, row.coinLogo, row.coinChainLogo,
+            row.amountCrypto, row.amountFiat, row.fromAddress, row.toAddress,
+            row.toCoinTicker, row.toCoinLogo, row.toCoinChainLogo,
+            row.toAmountCrypto, row.toAmountFiat, row.swapProvider,
+            row.feeCrypto, row.feeFiat, row.network, row.explorerLink,
+            row.estimatedTime, row.errorMessage
+        ]
+
+        for field in fields.compactMap({ $0 }) {
+            XCTAssertFalse(
+                field.contains(Self.limitDisplayValue),
+                "the trust-line limit must not be persisted anywhere on the row — found in '\(field)'"
+            )
+        }
+    }
+
+    /// Guards the sweep above against passing vacuously. If the fixture ever
+    /// stops producing the limit string, the sweep would pass no matter what the
+    /// recorder does.
+    func testTheFixtureReallyCarriesTheLimitTheSweepLooksFor() {
+        let payload = makeDonePayload(
+            amountCrypto: "\(Self.limitDisplayValue) RLUSD",
+            keysignPayload: makeTrustSetPayload()
+        )
+
+        XCTAssertTrue(payload.amountCrypto.contains(Self.limitDisplayValue))
+        XCTAssertEqual(
+            RippleTrustLineLimit.defaultLimitDisplayValue(),
+            Self.limitDisplayValue,
+            "the limit this suite asserts against is the one the app actually signs"
+        )
+    }
+
+    /// A trust-line row must render as an activation, not as a transfer: the
+    /// expanded card layout is an amount → recipient diagram, and it has
+    /// neither.
+    func testTheActivationRowNeverUsesTheTransferLayout() {
+        XCTAssertFalse(
+            TransactionHistoryCardView.shouldExpand(status: .inProgress, type: .trustLineActivation)
+        )
+        XCTAssertFalse(
+            TransactionHistoryCardView.shouldExpand(status: .successful, type: .trustLineActivation)
+        )
+        // Unchanged for the types that DO move something.
+        XCTAssertTrue(TransactionHistoryCardView.shouldExpand(status: .inProgress, type: .send))
+        XCTAssertTrue(TransactionHistoryCardView.shouldExpand(status: .inProgress, type: .swap))
+    }
+
+    /// History and the done screen read from one string, so the receipt and the
+    /// row cannot describe the same transaction differently.
+    func testHistoryAndTheDoneScreenShareTheActivationCopy() throws {
+        let hero = try XCTUnwrap(RippleTrustSetPresentation.hero(for: makeTrustSetPayload()))
+        guard case .title(let text, let caption) = hero else {
+            return XCTFail("a TrustSet receipt must not use an amount hero")
+        }
+
+        let row = makeRow()
+        XCTAssertEqual(RippleTrustSetPresentation.activationTitle(ticker: row.coinTicker), text)
+        XCTAssertEqual(row.toAddress, caption)
+        XCTAssertFalse(text.contains(Self.limitDisplayValue))
+    }
+
+    /// The row's persisted `type` survives the SwiftData round trip. A raw value
+    /// the reader doesn't recognise falls back to `.send` — silently restoring
+    /// the transfer framing this whole type exists to escape.
+    func testTheActivationTypeRoundTripsThroughItsRawValue() {
+        XCTAssertEqual(
+            TransactionHistoryType(rawValue: TransactionHistoryType.trustLineActivation.rawValue),
+            .trustLineActivation
+        )
+        XCTAssertEqual(TransactionHistoryType.trustLineActivation.rawValue, "trustLineActivation")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeRow() -> TransactionHistoryData {
+        TransactionHistoryRecorder.trustLineActivationRow(
+            txHash: "TRUSTSETHASH",
+            pubKeyECDSA: "pubkey-ecdsa",
+            coin: makeCoin(tokenId: "\(Self.rlusdHex).\(Self.issuer)"),
+            ticker: "RLUSD",
+            issuer: Self.issuer,
+            feeCrypto: "0.000012 XRP",
+            feeFiat: "$0.00003",
+            explorerLink: "https://xrpscan.com/tx/TRUSTSETHASH"
+        )
+    }
+
+    private func makeCoin(tokenId: String) -> Coin {
+        Coin(
+            asset: CoinMeta(
+                chain: .ripple,
+                ticker: "TEST",
+                logo: .empty,
+                decimals: RippleIssuedCurrency.issuedCurrencyDecimals,
+                priceProviderId: .empty,
+                contractAddress: tokenId,
+                isNativeToken: false
+            ),
+            address: Self.account,
+            hexPublicKey: "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+    }
+
+    private func makeDonePayload(
+        amountCrypto: String,
+        keysignPayload: KeysignPayload?,
+        fromAddress: String = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+    ) -> TransactionDonePayload {
+        TransactionDonePayload(
+            coin: keysignPayload?.coin ?? .example,
+            amountCrypto: amountCrypto,
+            amountFiat: "",
+            hash: "TRUSTSETHASH",
+            explorerLink: "https://xrpscan.com/tx/TRUSTSETHASH",
+            memo: "",
+            isSend: true,
+            fromAddress: fromAddress,
+            toAddress: Self.issuer,
+            fee: FeeDisplay(crypto: "0.000012 XRP", fiat: "$0.00003"),
+            keysignPayload: keysignPayload,
+            pubKeyECDSA: "pubkey-ecdsa"
+        )
+    }
+
+    private func makeTrustSetPayload(
+        tokenId: String? = nil,
+        transactionType: VSTransactionType = .rippleTrustSet
+    ) -> KeysignPayload {
+        makePayload(
+            coin: makeCoin(tokenId: tokenId ?? "\(Self.rlusdHex).\(Self.issuer)"),
+            toAmount: RippleTrustLineLimit.defaultLimit,
+            chainSpecific: .Ripple(
+                sequence: 1,
+                gas: 10,
+                lastLedgerSequence: 100,
+                transactionType: transactionType.rawValue
+            )
+        )
+    }
+
+    private func makeThorchainPayload() -> KeysignPayload {
+        makePayload(
+            coin: .example,
+            toAmount: BigInt(1000),
+            chainSpecific: .THORChain(
+                accountNumber: 1,
+                sequence: 1,
+                fee: 0,
+                isDeposit: true,
+                transactionType: 0
+            )
+        )
+    }
+
+    private func makePayload(
+        coin: Coin,
+        toAmount: BigInt,
+        chainSpecific: BlockChainSpecific
+    ) -> KeysignPayload {
+        KeysignPayload(
+            coin: coin,
+            toAddress: Self.issuer,
+            toAmount: toAmount,
+            chainSpecific: chainSpecific,
+            utxos: [],
+            memo: nil,
+            swapPayload: nil,
+            approvePayload: nil,
+            vaultPubKeyECDSA: "pubkey-ecdsa",
+            vaultLocalPartyID: "iPhone-test",
+            libType: LibType.DKLS.toString(),
+            wasmExecuteContractPayload: nil,
+            tronTransferContractPayload: nil,
+            tronTriggerSmartContractPayload: nil,
+            tronTransferAssetContractPayload: nil,
+            qbtcClaimPayload: nil,
+            isQbtcClaim: false,
+            skipBroadcast: false,
+            signData: nil
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TrustLineActivationRecordingTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TrustLineActivationRecordingTests.swift
@@ -35,6 +35,12 @@ final class TrustLineActivationRecordingTests: XCTestCase {
 
     // MARK: - Routing
 
+    /// ⚠️ The assertion that actually holds the fix up. The predicate being true
+    /// is not enough — the bug was never a missing predicate, it was a dispatch
+    /// that asked the wrong question first. `route(for:)` answers the whole
+    /// precedence chain, so deleting the activation branch or demoting it below
+    /// the send fallback turns this red.
+    ///
     /// The INITIATOR's shape: `SendDoneScreen` builds `amountCrypto` from the
     /// `SendTransaction`, so the string it hands over already reads as a
     /// quadrillion-token send.
@@ -44,6 +50,7 @@ final class TrustLineActivationRecordingTests: XCTestCase {
             keysignPayload: makeTrustSetPayload()
         )
 
+        XCTAssertEqual(TransactionHistoryRecording.route(for: payload), .trustLineActivation)
         XCTAssertTrue(TransactionHistoryRecording.isTrustLineActivation(payload))
     }
 
@@ -58,22 +65,94 @@ final class TrustLineActivationRecordingTests: XCTestCase {
             fromAddress: Self.account
         )
 
-        XCTAssertTrue(TransactionHistoryRecording.isTrustLineActivation(payload))
+        XCTAssertEqual(TransactionHistoryRecording.route(for: payload), .trustLineActivation)
     }
 
     /// Why ONE branch fixes both devices: a TrustSet carries no swap payload and
     /// no limit-swap memo, so it never reaches `recordFromKeysignPayload` — both
     /// the initiator and the co-signer share the `recordSend` fallback at the
-    /// bottom of `record()`, and the activation branch sits above it.
+    /// bottom of the chain, and the activation branch sits above it.
     func testATrustSetIsInterceptedBeforeTheKeysignRecorderDispatch() {
         let keysignPayload = makeTrustSetPayload()
         let payload = makeDonePayload(amountCrypto: "0 RLUSD", keysignPayload: keysignPayload)
 
-        XCTAssertTrue(TransactionHistoryRecording.isTrustLineActivation(payload))
+        XCTAssertEqual(TransactionHistoryRecording.route(for: payload), .trustLineActivation)
         XCTAssertFalse(
             TransactionHistoryRecording.routesThroughKeysignRecorder(keysignPayload),
             "a TrustSet has no swap payload and no limit memo — it shares the recordSend fallback"
         )
+    }
+
+    /// The new branch must not have displaced anything that was already routed.
+    /// Each of these is a precedence the chain had before the activation case
+    /// was inserted, re-asserted from above and below it.
+    func testTheActivationBranchDoesNotDisplaceTheExistingRoutes() {
+        // Above it: a payload with nothing to record still records nothing.
+        XCTAssertEqual(
+            TransactionHistoryRecording.route(
+                for: makeDonePayload(amountCrypto: "1 XRP", keysignPayload: nil, hash: "")
+            ),
+            .skip,
+            "an un-broadcast payload has no row to write"
+        )
+        XCTAssertEqual(
+            TransactionHistoryRecording.route(
+                for: makeDonePayload(amountCrypto: "1 XRP", keysignPayload: nil, pubKeyECDSA: "")
+            ),
+            .skip,
+            "a preview payload carries no vault"
+        )
+        // Still above it: a limit-order cancel is suppressed even though the
+        // order's own row keeps its hash reachable.
+        XCTAssertEqual(
+            TransactionHistoryRecording.route(
+                for: makeDonePayload(
+                    amountCrypto: "0 RUNE",
+                    keysignPayload: nil,
+                    memo: "m=<:100000000THOR.RUNE:15979057441BTC.BTC:0"
+                )
+            ),
+            .skip
+        )
+        // Below it: the co-signer's swap dispatch and the plain send fallback.
+        XCTAssertEqual(
+            TransactionHistoryRecording.route(
+                for: makeDonePayload(
+                    amountCrypto: "1 RUNE",
+                    keysignPayload: makeThorchainPayload(memo: "=<:BTC.BTC:bc1qexample:1e6:va:50")
+                )
+            ),
+            .keysignPayload
+        )
+        XCTAssertEqual(
+            TransactionHistoryRecording.route(
+                for: makeDonePayload(amountCrypto: "1 RUNE", keysignPayload: makeThorchainPayload())
+            ),
+            .send
+        )
+        XCTAssertEqual(
+            TransactionHistoryRecording.route(
+                for: makeDonePayload(amountCrypto: "1 XRP", keysignPayload: nil, verb: .claim)
+            ),
+            .skip,
+            "QBTC claims have no tx-history schema"
+        )
+    }
+
+    /// ⚠️ The exact regression, stated as a route: an XRPL TrustSet must never
+    /// come back `.send`. That is the single assertion that would have caught
+    /// the shipped bug.
+    func testATrustSetIsNeverRoutedToTheSendRow() {
+        for tokenId in ["\(Self.rlusdHex).\(Self.issuer)", "USD.\(Self.issuer)", "not-a-token-id"] {
+            let route = TransactionHistoryRecording.route(
+                for: makeDonePayload(
+                    amountCrypto: "\(Self.limitDisplayValue) RLUSD",
+                    keysignPayload: makeTrustSetPayload(tokenId: tokenId)
+                )
+            )
+            XCTAssertNotEqual(route, .send, "'\(tokenId)' would persist the trust-line limit as a transfer")
+            XCTAssertEqual(route, .trustLineActivation, "'\(tokenId)'")
+        }
     }
 
     /// ⚠️ Decided by the WIRE discriminator, never by whether the terms could be
@@ -102,6 +181,7 @@ final class TrustLineActivationRecordingTests: XCTestCase {
         )
 
         XCTAssertFalse(TransactionHistoryRecording.isTrustLineActivation(payload))
+        XCTAssertEqual(TransactionHistoryRecording.route(for: payload), .send)
     }
 
     /// Nothing on another chain, and nothing without a payload at all, can be
@@ -275,21 +355,26 @@ final class TrustLineActivationRecordingTests: XCTestCase {
     private func makeDonePayload(
         amountCrypto: String,
         keysignPayload: KeysignPayload?,
-        fromAddress: String = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+        fromAddress: String = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+        hash: String = "TRUSTSETHASH",
+        pubKeyECDSA: String = "pubkey-ecdsa",
+        memo: String = "",
+        verb: TransactionActionVerb = .send
     ) -> TransactionDonePayload {
         TransactionDonePayload(
             coin: keysignPayload?.coin ?? .example,
             amountCrypto: amountCrypto,
             amountFiat: "",
-            hash: "TRUSTSETHASH",
+            hash: hash,
             explorerLink: "https://xrpscan.com/tx/TRUSTSETHASH",
-            memo: "",
+            memo: memo,
             isSend: true,
             fromAddress: fromAddress,
             toAddress: Self.issuer,
             fee: FeeDisplay(crypto: "0.000012 XRP", fiat: "$0.00003"),
             keysignPayload: keysignPayload,
-            pubKeyECDSA: "pubkey-ecdsa"
+            pubKeyECDSA: pubKeyECDSA,
+            verb: verb
         )
     }
 
@@ -309,7 +394,7 @@ final class TrustLineActivationRecordingTests: XCTestCase {
         )
     }
 
-    private func makeThorchainPayload() -> KeysignPayload {
+    private func makeThorchainPayload(memo: String? = nil) -> KeysignPayload {
         makePayload(
             coin: .example,
             toAmount: BigInt(1000),
@@ -319,14 +404,16 @@ final class TrustLineActivationRecordingTests: XCTestCase {
                 fee: 0,
                 isDeposit: true,
                 transactionType: 0
-            )
+            ),
+            memo: memo
         )
     }
 
     private func makePayload(
         coin: Coin,
         toAmount: BigInt,
-        chainSpecific: BlockChainSpecific
+        chainSpecific: BlockChainSpecific,
+        memo: String? = nil
     ) -> KeysignPayload {
         KeysignPayload(
             coin: coin,
@@ -334,7 +421,7 @@ final class TrustLineActivationRecordingTests: XCTestCase {
             toAmount: toAmount,
             chainSpecific: chainSpecific,
             utxos: [],
-            memo: nil,
+            memo: memo,
             swapPayload: nil,
             approvePayload: nil,
             vaultPubKeyECDSA: "pubkey-ecdsa",

--- a/VultisigApp/VultisigAppTests/Features/TransactionHistory/TrustLineActivationRecordingTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/TransactionHistory/TrustLineActivationRecordingTests.swift
@@ -155,6 +155,45 @@ final class TrustLineActivationRecordingTests: XCTestCase {
         }
     }
 
+    /// Pins WHERE in the chain the branch sits, not merely that it exists.
+    ///
+    /// Every other TrustSet fixture here carries no swap payload, no limit memo
+    /// and the `.send` verb — so it would still route correctly if the branch
+    /// were demoted below the keysign dispatch or the `.claim` guard, and those
+    /// reorderings would go unnoticed. These two payloads are deliberately
+    /// impossible (a TrustSet cannot carry a limit-order memo, and no XRPL
+    /// operation is a QBTC claim); their only job is to make each of those
+    /// positions distinguishable. Move the branch down past either guard and one
+    /// of these turns red.
+    func testTheActivationBranchOutranksTheKeysignDispatchAndTheClaimGuard() {
+        let withLimitMemo = makeDonePayload(
+            amountCrypto: "\(Self.limitDisplayValue) RLUSD",
+            keysignPayload: makeTrustSetPayload(memo: "=<:BTC.BTC:bc1qexample:1e6:va:50")
+        )
+        XCTAssertTrue(
+            TransactionHistoryRecording.routesThroughKeysignRecorder(
+                makeTrustSetPayload(memo: "=<:BTC.BTC:bc1qexample:1e6:va:50")
+            ),
+            "the fixture must genuinely qualify for the keysign dispatch, or this pins nothing"
+        )
+        XCTAssertEqual(
+            TransactionHistoryRecording.route(for: withLimitMemo),
+            .trustLineActivation,
+            "the activation branch is asked before the keysign dispatch"
+        )
+
+        let claimVerb = makeDonePayload(
+            amountCrypto: "\(Self.limitDisplayValue) RLUSD",
+            keysignPayload: makeTrustSetPayload(),
+            verb: .claim
+        )
+        XCTAssertEqual(
+            TransactionHistoryRecording.route(for: claimVerb),
+            .trustLineActivation,
+            "the activation branch is asked before the claim opt-out"
+        )
+    }
+
     /// ⚠️ Decided by the WIRE discriminator, never by whether the terms could be
     /// rendered. An unreadable token id must still record as an activation: if
     /// it collapsed to "not a TrustSet" it would fall back into the send row,
@@ -380,7 +419,8 @@ final class TrustLineActivationRecordingTests: XCTestCase {
 
     private func makeTrustSetPayload(
         tokenId: String? = nil,
-        transactionType: VSTransactionType = .rippleTrustSet
+        transactionType: VSTransactionType = .rippleTrustSet,
+        memo: String? = nil
     ) -> KeysignPayload {
         makePayload(
             coin: makeCoin(tokenId: tokenId ?? "\(Self.rlusdHex).\(Self.issuer)"),
@@ -390,7 +430,8 @@ final class TrustLineActivationRecordingTests: XCTestCase {
                 gas: 10,
                 lastLedgerSequence: 100,
                 transactionType: transactionType.rawValue
-            )
+            ),
+            memo: memo
         )
     }
 


### PR DESCRIPTION
## Description

Fixes #5005

An XRPL trust-line activation (`TrustSet`) was persisted to local transaction history as a **token transfer of the trust-line limit**. Activating USDC recorded as a send of **1,000,000,000,000,000 USDC**. The transaction is real and the user paid for it — but it moved nothing. It opened a line and locked an owner reserve.

The codebase already knew a TrustSet's amount is not a transfer. `SendCryptoVerifyLogic.validateBalanceWithFee` skips the balance check for one, `SendCryptoVerifySummaryView` renders labelled issuer / currency / limit rows instead of Payment rows, and both done screens route it through `RippleTrustSetPresentation.hero`. Only the *recording* path did not — it fell through to `recordSend` — so history contradicted the receipt the user had just been shown.

### What the row shows now

A typed `.trustLineActivation` row, modelled on `recordApprove`: an ERC-20 approve and a TrustSet are the same category, a permissioning transaction that grants an allowance rather than moving funds.

| | Before | After |
|---|---|---|
| Type pill | `Send` | `Trust line` |
| Body | `1000000000000000 USDC` + a fiat price for it | `Activating the USDC trust line`, over the issuer |
| Card layout | expanded amount → recipient diagram | collapsed; it has neither |
| Detail sheet header | `1000000000000000` in the amount slot + fiat | the same sentence + issuer, matching the done screen |
| Detail sheet address row | `To  rMxCK…m5De` | `Issuer  rMxCK…m5De` |
| Fee row | fee | fee (unchanged) |
| Explorer link | works | works (unchanged) |
| Amount fields on the persisted row | the limit | **empty** |

The copy is not new wording invented for history — `RippleTrustSetPresentation.activationTitle` is extracted from the existing done-screen hero and used by both, so the receipt and the row cannot drift apart again.

**Recorded, not suppressed.** A limit-order cancel gets no row because the *order's* row narrates its lifecycle and keeps the hash linked, so nothing is lost. A TrustSet has no parent row — suppressing it would erase the fee the user paid and the ~0.2 XRP owner reserve they locked. It stays visible and is labelled honestly.

### Paths verified

- **Initiator** (`SendDoneScreen` → `DoneScreen.onAppear` → `TransactionHistoryRecording.record`) — **was affected, fixed.** `amountCrypto` was `"\(tx.amount) \(ticker)"`, i.e. the limit.
- **Co-signer** (`JoinKeysignDoneView.sendBranch` → the same `DoneScreen` → the same `record`) — **was affected, fixed by the same branch.** It builds a different `amountCrypto` (`keysignPayload.toAmountWithTickerString`) but hits the identical fallback.
- **`recordFromKeysignPayload`** — **checked, not affected.** A TrustSet never reaches it: that dispatch requires `swapPayload != nil` or a limit-swap memo, and a TrustSet has neither. Both devices therefore shared *one* defect at *one* line. A defensive gate was still added at the top of that method, because its `else` arm is an unconditional `recordSend` and it is the choke point every payload-driven row funnels through (same rationale `TransactionStatusPoller` gives for duplicating its tracker gate).
- **Downstream `type` consumers** — every switch and filter over `TransactionHistoryType` was checked: type pill (both switches), card expansion + collapsed content + address pill, detail sheet header / from-to cards / address label, the Swaps / Limit Orders / Send tab filters, `SwapTrackingRegistry` (metadata-driven, not type-driven), `TransactionStatusPoller` (chain-driven — the row still polls and still reaches successful/error), the history reset service. No exhaustive switch was left with a silent fall-through.
- **Empty amount fields** — the card and the detail sheet both branch away from the amount/fiat slots for this type, so nothing formats them; no service parses `amountCrypto`/`amountFiat`.

### What I could not verify

**I did not broadcast a real TrustSet.** That needs a funded XRP account and a live signing ceremony, neither of which is available here. The fix is verified by unit tests over the pure routing and row-construction seams and by reading every render path end to end — **not** by observing a row on a device. The rendering in particular (pill, card, sheet) is verified by code inspection and by the routing tests, not by a screenshot.

### Out of scope

- **Rows already written by 1.43.69 keep their `.send` type. No migration** — the app is not in production, so there is no data worth migrating (confirmed on the issue).
- **This bug class is not unique to XRPL.** The Codex review pass turned up several non-transfer operations still recorded as `.send`, the closest siblings being Cosmos **withdraw-rewards** (`.send` with an empty amount and the first validator as the destination), Solana **deactivate/unstake** (`.send 0 SOL` to a stake-account pubkey), THORChain **unbond/leave** (`.send 0`, real quantity in the memo), **governance vote** (`.send 0`), and the **dApp raw-sign paths** (`signRipple` / `signSui` / `signSolana`, whose rows are built from generic `toAmount`/`toAddress` fields that need not describe the opaque signed bytes). Root cause: `TransactionBuilder` turns every function transaction into a `SendTransaction` and the done screen persists its generic fields verbatim. Deliberately not folded in here — it wants its own issue, and this PR establishes the shape of the fix.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [x] New Chain / Chain related feature  -  Please attach tx link here

No tx link: this changes how an already-broadcast transaction is *recorded locally*, and broadcasting a real TrustSet is not possible from this environment. Nothing on the signing, broadcast or fee path is touched.

## Parity

- Android: `first: XRPL trust-line activation` — no other platform can originate a TrustSet yet (iOS is the first to build XRPL token payloads at all), so the defect cannot exist there. Raise the sibling ticket when XRPL token support lands.
- Windows + extension: `first: XRPL trust-line activation` — same reason.
- SDK: `n/a: local transaction-history presentation, no SDK surface`

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings — SwiftLint 36 violations before and after (0 new)
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional context

`TrustLineActivationRecordingTests` covers two seams, because they fail in different ways:

- **Routing.** The precedence chain in `TransactionHistoryRecording` was extracted into a pure `route(for:) -> Route`, so the *order* of the dispatch is testable, not only the individual predicates. That matters: the bug was never a missing predicate, it was a branch in the wrong place — and a suite that only asserts "this payload IS a TrustSet" stays green through exactly that mistake. Tests assert a TrustSet routes `.trustLineActivation` and is never `.send` (readable, plain and *unreadable* token ids), on both the initiator's and the co-signer's payload shape, and that the new branch displaced none of the pre-existing routes (empty hash, preview payload, limit-order cancel, swap dispatch, plain send, `.claim`).
- **Row content.** Asserted field by field, then swept: no field of the persisted row may contain the limit string, written as a sweep so a field added later cannot quietly become the next place it leaks. A companion test proves the fixture really carries that string *and* that it is the value `RippleTrustLineLimit` actually signs — without it the sweep could pass vacuously.

Two further payloads pin the branch's *position*, not just its existence — a TrustSet carrying a limit-order memo (which genuinely qualifies for the keysign dispatch) and one with the `.claim` verb. Both are impossible on-chain; their only job is to make a demotion past either guard observable.

**Verified by mutation, not by assertion alone.** Deleting `if isTrustLineActivation(payload) { return .trustLineActivation }` and re-running the suite turns **9 of 14 tests red**, including all four route tests. Restored afterwards; the committed tree is the unmutated one.

One new user-facing string (`rippleTrustLineTypePill`), added to all **8** locales including `ko`, sorted with `sort_localizable.py`. Everything else reuses keys the trust-line flow already ships.

Full suite: **4390 tests, 1 skipped, 0 failures** (`** TEST SUCCEEDED **`), verified by the log marker.

## Agent Metadata (if applicable)
- **Agent**: Claude Code (Opus 5)
- **Issue**: #5005
- **Confidence**: high on the recording path (unit-tested end to end through the dispatch); medium on the rendering, which is verified by code inspection rather than by running the screen
- **Needs human review for**: the visual treatment of the new row — the pill icon (`chain-link-3`), the card's two-line activation column and the detail-sheet header are design choices made without a Figma reference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated XRPL trust-line activation entries to transaction history.
  * Trust-line records display the activation title, issuer address, chain-link icon, and localized type label.
  * Trust-line transactions are included in the Send history tab and support localized presentation in multiple languages.

* **Bug Fixes**
  * Improved transaction routing so trust-line activations are not incorrectly recorded as sends.
  * Added fallback handling when ticker or issuer details are unavailable.

* **Tests**
  * Added comprehensive coverage for recording, routing, persistence, and display of trust-line activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->