### PR TITLE
fix(dkls): strip redundant leading zero bytes before DER-encoding r

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/States/Keysign/DERSignature.swift
+++ b/VultisigApp/VultisigApp/Blockchain/States/Keysign/DERSignature.swift
@@ -13,6 +13,16 @@ func encodeCanonicalDERSignature(r: [UInt8], s: [UInt8]) -> Data {
     func derInteger(_ value: Data) -> Data {
         var value = value
 
+        // Strip non-essential leading zero bytes first. `r` arrives as a
+        // fixed 32-byte scalar straight from the raw signature, not a
+        // minimal-length big-endian value like `s` (which is already minimal
+        // via BigUInt.serialize() below) — encoding it verbatim adds padding
+        // a strict node's DER check rejects as non-canonical whenever the
+        // true value needs fewer than 32 bytes.
+        while value.count > 1 && value.first == 0x00 && value[value.index(after: value.startIndex)] < 0x80 {
+            value.removeFirst()
+        }
+
         // Ensure the value is positive (prefix with 0x00 if highest bit is set)
         if value.first! >= 0x80 {
             value.insert(0x00, at: 0)

--- a/VultisigApp/VultisigAppTests/Keysign/DERSignatureTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/DERSignatureTests.swift
@@ -1,0 +1,81 @@
+//
+//  DERSignatureTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+/// Pins `encodeCanonicalDERSignature` against the non-canonical-DER broadcast
+/// rejection this fix addresses: DKLS returns `r` as a fixed 32-byte scalar,
+/// not a minimal-length big-endian value, so a leading `0x00` byte must be
+/// stripped before encoding — otherwise the signature carries excess padding
+/// a strict node's DER check rejects (BIP66 rule 3).
+final class DERSignatureTests: XCTestCase {
+
+    /// A single leading zero followed by a byte whose high bit is clear must
+    /// be stripped entirely: it is not needed to keep the integer positive.
+    func testStripsALeadingZeroByteWhenTheNextByteIsNotHigh() {
+        var r = [UInt8](repeating: 0x11, count: 32)
+        r[0] = 0x00
+        r[1] = 0x01
+        let s = [UInt8](repeating: 0x22, count: 32) // 0x22.. is far below the curve's half-order
+
+        let der = encodeCanonicalDERSignature(r: r, s: s)
+        let rEncoded = rIntegerBytes(from: der)
+
+        XCTAssertEqual(rEncoded, Data(r.dropFirst()), "the redundant leading zero must not appear in the DER integer")
+    }
+
+    /// Two leading zero bytes followed by a high-bit byte must collapse to
+    /// exactly one zero byte of padding, not two.
+    func testCollapsesMultipleLeadingZerosToExactlyOneWhenTheNextByteIsHigh() {
+        var r = [UInt8](repeating: 0x11, count: 32)
+        r[0] = 0x00
+        r[1] = 0x00
+        r[2] = 0x80
+        let s = [UInt8](repeating: 0x22, count: 32)
+
+        let der = encodeCanonicalDERSignature(r: r, s: s)
+        let rEncoded = rIntegerBytes(from: der)
+
+        XCTAssertEqual(rEncoded, Data(r.dropFirst()), "exactly one 0x00 must remain ahead of the high-bit byte")
+        XCTAssertEqual(rEncoded.first, 0x00)
+    }
+
+    /// A value with no leading zero byte and a high bit set still needs the
+    /// sign-safety padding added, same as before this fix.
+    func testStillPadsAHighBitLeadingByteWithNoExistingZero() {
+        var r = [UInt8](repeating: 0x11, count: 32)
+        r[0] = 0x80
+        let s = [UInt8](repeating: 0x22, count: 32)
+
+        let der = encodeCanonicalDERSignature(r: r, s: s)
+        let rEncoded = rIntegerBytes(from: der)
+
+        XCTAssertEqual(rEncoded, Data([0x00] + r), "a high-bit leading byte with no pre-existing zero still needs one added")
+    }
+
+    /// A value that is already minimal (no leading zero, no high bit) is
+    /// untouched — this is the common case and must stay a no-op.
+    func testLeavesAnAlreadyMinimalValueUnchanged() {
+        var r = [UInt8](repeating: 0x11, count: 32)
+        r[0] = 0x7f
+        let s = [UInt8](repeating: 0x22, count: 32)
+
+        let der = encodeCanonicalDERSignature(r: r, s: s)
+        let rEncoded = rIntegerBytes(from: der)
+
+        XCTAssertEqual(rEncoded, Data(r))
+    }
+
+    /// Extracts the bytes of the first (`r`) INTEGER from a DER
+    /// `SEQUENCE { INTEGER, INTEGER }` produced by `encodeCanonicalDERSignature`.
+    private func rIntegerBytes(from der: Data) -> Data {
+        let bytes = [UInt8](der)
+        precondition(bytes[0] == 0x30, "expected a DER SEQUENCE")
+        precondition(bytes[2] == 0x02, "expected the first element to be an INTEGER")
+        let rLen = Int(bytes[3])
+        return Data(bytes[4..<(4 + rLen)])
+    }
+}


### PR DESCRIPTION
## Description

A DOGE self-send using a DKLS (Secure) vault intermittently failed to broadcast with:

```
Invalid transaction. Error: 64: non-mandatory-script-verify-flag (Non-canonical DER signature)
```

**Root cause:** `encodeCanonicalDERSignature` (`DERSignature.swift`) builds the DER `SEQUENCE { INTEGER r, INTEGER s }` from the raw DKLS signature. `s` is run through `BigUInt(...).serialize()` first, which always returns the minimal-length big-endian representation — no leading zero bytes. `r`, however, is passed straight from `DKLSKeysign.swift`'s `Array(sig.prefix(32))`: a **fixed 32-byte** slice of the raw signature, never minimized.

`derInteger` only ever checked whether the leading byte needed a `0x00` sign-safety prefix (`>= 0x80`) — it never checked whether the value already carried *non-essential* leading zero bytes. So whenever `r`'s true value needed fewer than 32 bytes (i.e. its leading byte happened to be `0x00` — roughly a 1-in-256 chance per signature), the DER integer kept the extra padding, producing a signature with excess padding that strict nodes reject under BIP66 rule 3 ("no unnecessary leading 0x00 bytes"). That matches the intermittent nature of the report exactly.

**Fix:** `derInteger` now strips redundant leading zero bytes down to the minimum before deciding whether to re-add the single sign-safety byte, so the encoding is correct regardless of whether the input arrives already-minimal (`s`) or not (`r`).

This is a pure serialization fix — same `r`/`s` scalar values, correctly re-encoded. No change to any cryptographic logic.

## Which feature is affected?
- [x] Sending — UTXO chains signed via a DKLS (Secure) vault

## Checklist
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Test plan
- `DERSignatureTests` (new): pins the fix directly — a leading zero with a following non-high byte is stripped entirely; two leading zeros followed by a high-bit byte collapse to exactly one; a high-bit leading byte with no existing zero still gets padded; an already-minimal value is untouched.
- Ran the new suite directly: `xcodebuild test -only-testing:VultisigAppTests/DERSignatureTests` — 4/4 passing.
- `swiftlint lint` — 0 violations on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved digital signature encoding to remove unnecessary leading padding while preserving valid positive values.
  * Ensured signatures follow canonical DER formatting for better compatibility and validation.

* **Tests**
  * Added coverage for minimal encoding, sign-safe padding, redundant zeros, and high-bit-leading values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->