### PR TITLE
fix(limit-swap): block Place Order when the sell amount is unaffordable

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -727,6 +727,8 @@
 "limitSwap.done.status.restingDetail" = "Ruht, bis dein Preis erreicht ist";
 "limitSwap.done.status.submitted" = "Order übermittelt";
 "limitSwap.error.advancedSwapQueueDisabled" = "Limit-Orders sind auf THORChain vorübergehend nicht verfügbar. Versuche es später erneut oder nutze einen Markt-Swap.";
+"limitSwap.error.insufficientFunds" = "Nicht genug %@ für diese Order. Gib einen Betrag innerhalb deines Guthabens ein.";
+"limitSwap.error.insufficientGas" = "Nicht genug %@, um die Netzwerkgebühr für diese Order zu decken.";
 "limitSwap.error.invalidInputs" = "Einige Auftragsdetails sind ungültig. Prüfe Betrag, Preis und Ablauf und versuche es erneut.";
 "limitSwap.error.limitAmountTooSmall" = "Diese Order ist zu klein für einen Limit-Preis. Erhöhe den Betrag oder passe den Preis an und versuche es erneut.";
 "limitSwap.error.pairNotRoutable" = "Dieses Paar kann derzeit nicht auf THORChain gehandelt werden. Wähle ein anderes Asset.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -725,6 +725,8 @@
 "limitSwap.done.status.restingDetail" = "Resting until your price is met";
 "limitSwap.done.status.submitted" = "Order submitted";
 "limitSwap.error.advancedSwapQueueDisabled" = "Limit orders are temporarily unavailable on THORChain. Try again later or use a market swap.";
+"limitSwap.error.insufficientFunds" = "Not enough %@ to place this order. Enter an amount within your balance.";
+"limitSwap.error.insufficientGas" = "Not enough %@ to cover the network fee for this order.";
 "limitSwap.error.invalidInputs" = "Some order details are invalid. Check the amount, price and expiry, then try again.";
 "limitSwap.error.limitAmountTooSmall" = "This order is too small to place at a limit price. Increase the amount or adjust the price and try again.";
 "limitSwap.error.pairNotRoutable" = "This pair can't be traded on THORChain right now. Pick a different asset.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -727,6 +727,8 @@
 "limitSwap.done.status.restingDetail" = "En espera hasta alcanzar tu precio";
 "limitSwap.done.status.submitted" = "Orden enviada";
 "limitSwap.error.advancedSwapQueueDisabled" = "Las órdenes límite no están disponibles temporalmente en THORChain. Inténtalo más tarde o usa un swap de mercado.";
+"limitSwap.error.insufficientFunds" = "No tienes suficiente %@ para colocar esta orden. Introduce un importe dentro de tu saldo.";
+"limitSwap.error.insufficientGas" = "No tienes suficiente %@ para cubrir la comisión de red de esta orden.";
 "limitSwap.error.invalidInputs" = "Algunos datos de la orden no son válidos. Revisa el importe, el precio y la caducidad e inténtalo de nuevo.";
 "limitSwap.error.limitAmountTooSmall" = "Esta orden es demasiado pequeña para un precio límite. Aumenta el importe o ajusta el precio e inténtalo de nuevo.";
 "limitSwap.error.pairNotRoutable" = "Este par no se puede negociar en THORChain en este momento. Elige otro activo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -727,6 +727,8 @@
 "limitSwap.done.status.restingDetail" = "Čeka dok se ne dosegne tvoja cijena";
 "limitSwap.done.status.submitted" = "Nalog poslan";
 "limitSwap.error.advancedSwapQueueDisabled" = "Limit nalozi trenutačno nisu dostupni na THORChainu. Pokušajte kasnije ili upotrijebite tržišni swap.";
+"limitSwap.error.insufficientFunds" = "Nemaš dovoljno %@ za ovaj nalog. Unesi iznos unutar svojeg stanja.";
+"limitSwap.error.insufficientGas" = "Nemaš dovoljno %@ za pokrivanje mrežne naknade ovog naloga.";
 "limitSwap.error.invalidInputs" = "Neki podaci naloga nisu valjani. Provjerite iznos, cijenu i istek pa pokušajte ponovno.";
 "limitSwap.error.limitAmountTooSmall" = "Ovaj nalog je premalen za limitiranu cijenu. Povećaj iznos ili prilagodi cijenu i pokušaj ponovno.";
 "limitSwap.error.pairNotRoutable" = "Ovaj se par trenutačno ne može trgovati na THORChainu. Odaberite drugu imovinu.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -727,6 +727,8 @@
 "limitSwap.done.status.restingDetail" = "In attesa finché il tuo prezzo non viene raggiunto";
 "limitSwap.done.status.submitted" = "Ordine inviato";
 "limitSwap.error.advancedSwapQueueDisabled" = "Gli ordini limite non sono temporaneamente disponibili su THORChain. Riprova più tardi o usa uno swap di mercato.";
+"limitSwap.error.insufficientFunds" = "%@ non sufficiente per inserire questo ordine. Inserisci un importo entro il tuo saldo.";
+"limitSwap.error.insufficientGas" = "%@ non sufficiente per coprire la commissione di rete di questo ordine.";
 "limitSwap.error.invalidInputs" = "Alcuni dettagli dell'ordine non sono validi. Controlla importo, prezzo e scadenza e riprova.";
 "limitSwap.error.limitAmountTooSmall" = "Questo ordine è troppo piccolo per un prezzo limite. Aumenta l'importo o modifica il prezzo e riprova.";
 "limitSwap.error.pairNotRoutable" = "Questa coppia non può essere scambiata su THORChain al momento. Scegli un altro asset.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -725,6 +725,8 @@
 "limitSwap.done.status.restingDetail" = "지정한 가격에 도달할 때까지 대기 중";
 "limitSwap.done.status.submitted" = "주문 제출됨";
 "limitSwap.error.advancedSwapQueueDisabled" = "THORChain에서 지정가 주문을 일시적으로 사용할 수 없습니다. 나중에 다시 시도하거나 시장가 스왑을 사용하세요.";
+"limitSwap.error.insufficientFunds" = "%@ 잔액이 부족하여 이 주문을 넣을 수 없습니다. 잔액 범위 내의 수량을 입력하세요.";
+"limitSwap.error.insufficientGas" = "이 주문의 네트워크 수수료를 지불할 %@이(가) 부족합니다.";
 "limitSwap.error.invalidInputs" = "일부 주문 정보가 잘못되었습니다. 수량, 가격, 만료를 확인한 후 다시 시도하세요.";
 "limitSwap.error.limitAmountTooSmall" = "이 주문은 지정가로 설정하기에 너무 작습니다. 수량을 늘리거나 가격을 조정한 후 다시 시도하세요.";
 "limitSwap.error.pairNotRoutable" = "현재 이 페어는 THORChain에서 거래할 수 없습니다. 다른 자산을 선택하세요.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -727,6 +727,8 @@
 "limitSwap.done.status.restingDetail" = "Aguardando até atingir seu preço";
 "limitSwap.done.status.submitted" = "Ordem enviada";
 "limitSwap.error.advancedSwapQueueDisabled" = "As ordens limite estão temporariamente indisponíveis na THORChain. Tente novamente mais tarde ou use uma troca de mercado.";
+"limitSwap.error.insufficientFunds" = "Não há %@ suficiente para colocar esta ordem. Insira um valor dentro do seu saldo.";
+"limitSwap.error.insufficientGas" = "Não há %@ suficiente para cobrir a taxa de rede desta ordem.";
 "limitSwap.error.invalidInputs" = "Alguns detalhes da ordem são inválidos. Verifique o valor, o preço e a validade e tente novamente.";
 "limitSwap.error.limitAmountTooSmall" = "Esta ordem é pequena demais para um preço limite. Aumente o valor ou ajuste o preço e tente novamente.";
 "limitSwap.error.pairNotRoutable" = "Este par não pode ser negociado na THORChain no momento. Escolha outro ativo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -727,6 +727,8 @@
 "limitSwap.done.status.restingDetail" = "挂单等待，直至达到您的价格";
 "limitSwap.done.status.submitted" = "订单已提交";
 "limitSwap.error.advancedSwapQueueDisabled" = "THORChain 暂时无法使用限价单。请稍后重试或使用市价兑换。";
+"limitSwap.error.insufficientFunds" = "%@ 余额不足，无法下此订单。请输入不超过余额的数量。";
+"limitSwap.error.insufficientGas" = "%@ 不足，无法支付此订单的网络手续费。";
 "limitSwap.error.invalidInputs" = "部分订单信息无效。请检查数量、价格和有效期后重试。";
 "limitSwap.error.limitAmountTooSmall" = "此订单金额过小，无法设置限价。请增加数量或调整价格后重试。";
 "limitSwap.error.pairNotRoutable" = "该交易对目前无法在 THORChain 上交易。请选择其他资产。";

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Models/LimitSwapErrors.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Models/LimitSwapErrors.swift
@@ -77,6 +77,49 @@ enum LimitSwapPairUnroutableReason: Equatable {
     }
 }
 
+/// Whether the vault can afford the sell amount the limit form currently holds.
+///
+/// Derived from the SAME rule the market swap gates Continue on
+/// (`SwapCryptoLogic.balanceError`), so the two swap tabs can never disagree for
+/// identical input. This type only names the verdict and the asset it is about;
+/// the affordability arithmetic lives entirely in `SwapCryptoLogic`.
+enum LimitSwapBalanceState: Equatable {
+    /// The sell amount, and the network fee on top of it, both fit.
+    case sufficient
+    /// The sell amount alone exceeds the source balance. Knowable WITHOUT a
+    /// resolved network fee, so it is shown the moment the amount is typed.
+    case insufficientFunds(sourceTicker: String)
+    /// The sell amount fits, but the network fee does not — either it no longer
+    /// fits alongside the amount (source coin pays its own gas) or the native
+    /// fee sibling can't cover it (an ERC20 source pays ETH). Only ever produced
+    /// from a RESOLVED fee estimate.
+    case insufficientGas(feeTicker: String)
+    /// Nothing can be concluded yet: the network-fee estimate is still in flight
+    /// (so gas coverage is unjudgeable), or the selected coin and the draft's
+    /// source asset have not re-synced after a pair change. Renders NO row and
+    /// blocks placement — the form never shows a gas error it would have to take
+    /// back one frame later.
+    case indeterminate
+
+    /// Whether this verdict must keep the Place Order button disabled. Only an
+    /// affirmative `sufficient` unblocks it, so both failure modes and the
+    /// not-yet-known state all fail closed.
+    var blocksPlacement: Bool { self != .sufficient }
+
+    /// Message for the inline notice row, or `nil` when there is nothing honest
+    /// to say — the order is affordable, or the verdict isn't in yet.
+    var noticeMessage: String? {
+        switch self {
+        case .sufficient, .indeterminate:
+            return nil
+        case let .insufficientFunds(sourceTicker):
+            return String(format: "limitSwap.error.insufficientFunds".localized, sourceTicker)
+        case let .insufficientGas(feeTicker):
+            return String(format: "limitSwap.error.insufficientGas".localized, feeTicker)
+        }
+    }
+}
+
 /// User-facing failure surfaced when "Place Order" cannot assemble a valid
 /// order. Carries a localized message so the entry view can show an alert
 /// instead of silently doing nothing. `Identifiable` so it can back a SwiftUI

--- a/VultisigApp/VultisigApp/Features/LimitSwap/ViewModel/LimitSwapFormViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/ViewModel/LimitSwapFormViewModel.swift
@@ -88,11 +88,20 @@ final class LimitSwapFormViewModel {
     /// before it resolves and sign an order whose Verify / Done screens show a
     /// blank network-fee row — never seeing the real source-chain gas that is
     /// derived at sign time. While the fee recomputes the button stays disabled.
-    var canPlaceOrder: Bool {
+    ///
+    /// `sourceCoin` is the vault coin the picker currently has selected — the
+    /// same object the Sell row prints a balance for, so the gate can never
+    /// judge a different balance from the one on screen. It is passed in rather
+    /// than mirrored into a stored property precisely so there is no second copy
+    /// to drift from `draft.fromAsset`.
+    func canPlaceOrder(sourceCoin: Coin) -> Bool {
         draft.targetPrice > 0
             && draft.sourceAmount > 0
             && isAdvancedSwapQueueEnabled
             && networkFeeEstimate > 0
+            // Affordability: the vault must hold the sell amount, and the fee on
+            // top of it. Same rule as the market tab's Continue gate.
+            && !balanceState(sourceCoin: sourceCoin).blocksPlacement
             // POSITIVE routability proof: a resolved market reference means the
             // market-price probe got a quote back, which proves the pair has a
             // THORChain pool (the picker only filters per-CHAIN, so a poolless
@@ -112,6 +121,76 @@ final class LimitSwapFormViewModel {
             && draft.fromAsset.memoSymbol != nil
             && draft.toAsset.memoSymbol != nil
             && destinationAddress() != nil
+    }
+
+    /// Whether the vault can afford the current draft, judged against the SAME
+    /// coin the Sell row prints a balance for.
+    ///
+    /// The arithmetic is `SwapCryptoLogic.balanceError` — the market swap's rule,
+    /// reused rather than reimplemented, so an identical input can never produce
+    /// two different verdicts across the two tabs. The fee coin is resolved with
+    /// `SwapCryptoLogic.feeCoin`, the same helper `LimitSwapEntryView` uses to
+    /// build the `SwapTransaction`: gas is paid in the source chain's NATIVE coin,
+    /// so an ERC20 source's fee has to be read against ETH's 18 decimals and not
+    /// the token's (reading wei against a token's decimals once produced a false
+    /// `insufficientGas`).
+    ///
+    /// **The fee-in-flight window.** `networkFeeEstimate` is dropped to `0` on
+    /// every input change and refetched after a debounce, so for a moment there
+    /// is no fee to judge against. The two questions are split by what is
+    /// knowable without one:
+    ///
+    /// - *Does the amount alone exceed the balance?* Fee-independent, so it is
+    ///   answered immediately. The first call passes `fee: .zero`, which makes
+    ///   `balanceError`'s gas arm unreachable by construction (the same-coin arm
+    ///   needs `fromFee > 0`, the split-coin arm needs `fromFee > feeCoinBalance`)
+    ///   — so a zero fee can only ever yield the funds verdict, never a gas one.
+    /// - *Does the fee fit on top?* Not knowable, so it is not guessed at:
+    ///   `.indeterminate` shows no row and keeps the CTA disabled. A gas error is
+    ///   therefore never displayed and then withdrawn a frame later.
+    func balanceState(sourceCoin: Coin) -> LimitSwapBalanceState {
+        // The view can render one frame with a newly-picked coin and the previous
+        // draft asset (the two are synced in an `onChange`). Comparing a BTC
+        // amount against an ETH balance for that frame would flash a bogus row,
+        // so refuse to judge until they agree. Fail-closed: `.indeterminate`
+        // blocks placement.
+        guard sourceCoin.chain == draft.fromAsset.chain,
+              sourceCoin.ticker == draft.fromAsset.ticker,
+              sourceCoin.contractAddress == draft.fromAsset.contractAddress else {
+            return .indeterminate
+        }
+
+        let feeCoin = SwapCryptoLogic.feeCoin(fromCoin: sourceCoin, fromCoins: vault.coins)
+        let amount = sourceCoin.decimal(for: draft.sourceAmount)
+
+        // Fee-independent leg — a zero fee cannot reach the gas arm.
+        if SwapCryptoLogic.balanceError(
+            fromCoin: sourceCoin,
+            feeCoin: feeCoin,
+            amount: amount,
+            fee: .zero
+        ) != nil {
+            return .insufficientFunds(sourceTicker: sourceCoin.ticker)
+        }
+
+        guard networkFeeEstimate > 0 else { return .indeterminate }
+
+        switch SwapCryptoLogic.balanceError(
+            fromCoin: sourceCoin,
+            feeCoin: feeCoin,
+            amount: amount,
+            fee: networkFeeEstimate
+        ) {
+        case .none:
+            return .sufficient
+        case .some(.insufficientGas):
+            return .insufficientGas(feeTicker: feeCoin.ticker)
+        case .some:
+            // The amount cleared the fee-free leg, so this can only be the
+            // same-coin `amount + fee > balance` case that the gas arm didn't
+            // claim. Report it as the funds problem the shared rule called it.
+            return .insufficientFunds(sourceTicker: sourceCoin.ticker)
+        }
     }
 
     /// User-facing error raised while assembling / pre-flighting the order in

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyView.swift
@@ -91,6 +91,10 @@ struct LimitSwapBodyView: View {
     let onPlaceOrder: () -> Void
 
     var body: some View {
+        // Evaluated once and threaded through both consumers — the inline notice
+        // and the CTA's disabled state have to agree, and re-deriving it per read
+        // would run the affordability math twice on every body pass.
+        let balance = vm.balanceState(sourceCoin: fromCoin)
         VStack(spacing: 12) {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 12) {
@@ -130,6 +134,14 @@ struct LimitSwapBodyView: View {
                         LimitNoticeRow(message: unroutable.message)
                     }
 
+                    // Says which asset is short — funds or gas — instead of
+                    // letting the user find out one screen later at Verify.
+                    // Silent while the fee estimate is in flight, so a gas error
+                    // is never shown and then withdrawn.
+                    if let balanceMessage = balance.noticeMessage {
+                        LimitNoticeRow(message: balanceMessage)
+                    }
+
                     if let warning = vm.displayedWarning {
                         LimitWarningRow(warning: warning)
                     }
@@ -140,7 +152,7 @@ struct LimitSwapBodyView: View {
                 title: "limitSwap.placeOrder".localized,
                 action: onPlaceOrder
             )
-            .disabled(!vm.canPlaceOrder)
+            .disabled(!vm.canPlaceOrder(sourceCoin: fromCoin))
             .padding(.bottom, 16)
         }
         #if os(iOS)

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCryptoLogic.swift
@@ -869,10 +869,20 @@ enum SwapCryptoLogic {
     /// Returns the specific balance error, or nil if balance is sufficient.
     /// Differentiates between insufficient token balance and insufficient gas.
     static func balanceError(fromCoin: Coin, feeCoin: Coin, fromAmount: String, fee: BigInt) -> Errors? {
+        balanceError(fromCoin: fromCoin, feeCoin: feeCoin, amount: fromAmount.toDecimal(), fee: fee)
+    }
+
+    /// The same rule, entered with an amount that is already a `Decimal`.
+    ///
+    /// The limit form holds its sell amount as a `BigInt` in the source coin's
+    /// base units, so routing it through the `String` entry point above would
+    /// format it and immediately re-parse it through a locale-aware parser for
+    /// nothing. Both swap tabs therefore share ONE affordability rule — there is
+    /// no second implementation to drift.
+    static func balanceError(fromCoin: Coin, feeCoin: Coin, amount: Decimal, fee: BigInt) -> Errors? {
         let fromFee = feeCoin.decimal(for: fee)
         let fromBalance = fromCoin.balanceDecimal
         let feeCoinBalance = feeCoin.balanceDecimal
-        let amount = fromAmount.toDecimal()
 
         if feeCoin == fromCoin {
             // Same coin pays for amount + gas.

--- a/VultisigApp/VultisigAppTests/LimitSwap/ViewModel/LimitSwapFormViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/LimitSwap/ViewModel/LimitSwapFormViewModelTests.swift
@@ -22,16 +22,23 @@ final class LimitSwapFormViewModelTests: XCTestCase {
 
         // Vault holds matching coins for source (BTC) + target (ETH) so
         // destinationAddress() can resolve.
-        vault.coins.append(Coin(
+        let btc = Coin(
             asset: CoinMeta.make(chain: .bitcoin, ticker: "BTC", decimals: 8),
             address: "bc1qsourceaddress0000000000000000000000000",
             hexPublicKey: "btc-pubkey"
-        ))
-        vault.coins.append(Coin(
+        )
+        // Funded well above every fixture amount so tests that are about a
+        // DIFFERENT `canPlaceOrder` term aren't silently blocked by the balance
+        // gate. The balance-specific tests set their own balances.
+        btc.rawBalance = "1000000000"  // 10 BTC
+        vault.coins.append(btc)
+        let eth = Coin(
             asset: CoinMeta.make(chain: .ethereum, ticker: "ETH", decimals: 18),
             address: "0xethdestaddress00000000000000000000000000",
             hexPublicKey: "eth-pubkey"
-        ))
+        )
+        eth.rawBalance = "1000000000000000000"  // 1 ETH
+        vault.coins.append(eth)
 
         quoteService = MockLimitSwapQuoteService()
         interactor = DefaultLimitSwapInteractor(quoteService: quoteService)
@@ -592,7 +599,7 @@ final class LimitSwapFormViewModelTests: XCTestCase {
             chain: .solana, ticker: "SOL", decimals: 9,
             contractAddress: "", isNativeToken: true
         )
-        XCTAssertFalse(vm.canPlaceOrder, "An unencodable target must disable the CTA")
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btcCoin()), "An unencodable target must disable the CTA")
     }
 
     func testCanPlaceOrderBlockedWhenNoDestinationAddress() {
@@ -602,7 +609,7 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         vm.draft.targetPrice = 16
         vm.networkFeeEstimate = BigInt(4_200)
         vm.marketPriceRef = 16  // isolate the destination cause from the probe gate
-        XCTAssertFalse(vm.canPlaceOrder, "No destination address must disable the CTA")
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btcCoin()), "No destination address must disable the CTA")
     }
 
     func testRuneToTcyIsPlaceable() {
@@ -755,10 +762,10 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         vm.draft.targetPrice = 16
         vm.marketPriceRef = 16  // positive routability proof (a resolved quote)
         vm.networkFeeEstimate = .zero
-        XCTAssertFalse(vm.canPlaceOrder, "Must be blocked while the network fee is unresolved")
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btcCoin()), "Must be blocked while the network fee is unresolved")
 
         vm.networkFeeEstimate = BigInt(4_200)
-        XCTAssertTrue(vm.canPlaceOrder, "Placeable once amount, price, queue gate, fee and market ref are all resolved")
+        XCTAssertTrue(vm.canPlaceOrder(sourceCoin: btcCoin()), "Placeable once amount, price, queue gate, fee and market ref are all resolved")
     }
 
     func testCanPlaceOrderRequiresSuccessfulMarketProbe() {
@@ -770,10 +777,10 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         vm.draft.targetPrice = 16
         vm.networkFeeEstimate = BigInt(4_200)
         vm.marketPriceRef = nil
-        XCTAssertFalse(vm.canPlaceOrder, "Not placeable until the market probe proves the pair routable")
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btcCoin()), "Not placeable until the market probe proves the pair routable")
 
         vm.marketPriceRef = 16
-        XCTAssertTrue(vm.canPlaceOrder)
+        XCTAssertTrue(vm.canPlaceOrder(sourceCoin: btcCoin()))
     }
 
     func testCanPlaceOrderFalseWhenQueueDisabled() {
@@ -781,7 +788,7 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         vm.advancedSwapQueueEnabled = false
         vm.draft.targetPrice = 16
         vm.networkFeeEstimate = BigInt(4_200)
-        XCTAssertFalse(vm.canPlaceOrder)
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btcCoin()))
     }
 
     func testCanPlaceOrderFalseWhenAmountOrPriceMissing() {
@@ -789,12 +796,148 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         vm.advancedSwapQueueEnabled = true
         vm.draft.targetPrice = 16
         vm.networkFeeEstimate = BigInt(4_200)
-        XCTAssertFalse(vm.canPlaceOrder, "Zero amount is not placeable")
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btcCoin()), "Zero amount is not placeable")
 
         vm.amountChanged(BigInt(100_000_000))
         vm.networkFeeEstimate = BigInt(4_200)  // amountChanged clears it; restore
         vm.draft.targetPrice = 0
-        XCTAssertFalse(vm.canPlaceOrder, "Zero price is not placeable")
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btcCoin()), "Zero price is not placeable")
+    }
+
+    // MARK: - balance gate (the sell amount must be affordable, on THIS screen)
+
+    func testCanPlaceOrderBlockedWhenAmountExceedsBalance() {
+        // The whole point of the gate: an order for more than the vault holds
+        // must be refused on the FORM, not one screen later at Verify.
+        let btc = btcCoin()
+        btc.rawBalance = "100000000"  // 1 BTC
+        let vm = makeReadyToPlace(sourceAmount: BigInt(200_000_000))  // 2 BTC
+
+        XCTAssertEqual(vm.balanceState(sourceCoin: btc), .insufficientFunds(sourceTicker: "BTC"))
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btc), "An over-balance amount must disable Place Order")
+
+        // Both directions, so deleting the term fails this test either way.
+        vm.amountChanged(BigInt(50_000_000))  // 0.5 BTC
+        vm.networkFeeEstimate = BigInt(4_200)  // amountChanged clears it; restore
+        XCTAssertEqual(vm.balanceState(sourceCoin: btc), .sufficient)
+        XCTAssertTrue(vm.canPlaceOrder(sourceCoin: btc), "An affordable amount must re-enable Place Order")
+    }
+
+    func testAmountThatFitsButLeavesNothingForGasIsReportedAsGasNotFunds() {
+        // Market parity: the source coin pays its own gas, the amount alone fits,
+        // so this is a GAS problem. Collapsing the two into one message — or
+        // calling it insufficient funds — is the failure this pins.
+        let btc = btcCoin()
+        btc.rawBalance = "100000000"  // exactly 1 BTC
+        let vm = makeReadyToPlace(sourceAmount: BigInt(100_000_000))  // exactly 1 BTC
+        vm.networkFeeEstimate = BigInt(10_000)
+
+        XCTAssertEqual(vm.balanceState(sourceCoin: btc), .insufficientGas(feeTicker: "BTC"))
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btc))
+    }
+
+    func testNoGasErrorIsShownWhileTheFeeEstimateIsInFlight() {
+        // `networkFeeEstimate` is dropped to 0 on every input change. A gas
+        // verdict is not knowable in that window, so none is shown — the form
+        // must never display a gas error it would have to withdraw a frame later.
+        let btc = btcCoin()
+        btc.rawBalance = "100000000"
+        let vm = makeReadyToPlace(sourceAmount: BigInt(100_000_000))
+        vm.networkFeeEstimate = .zero
+
+        let inFlight = vm.balanceState(sourceCoin: btc)
+        XCTAssertEqual(inFlight, .indeterminate)
+        XCTAssertNil(inFlight.noticeMessage, "No notice may be rendered from an unresolved fee")
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btc), "Placement stays blocked until the fee resolves")
+
+        // …and the moment the estimate lands, the real verdict appears.
+        vm.networkFeeEstimate = BigInt(10_000)
+        XCTAssertEqual(vm.balanceState(sourceCoin: btc), .insufficientGas(feeTicker: "BTC"))
+    }
+
+    func testInsufficientFundsIsStillReportedWhileTheFeeEstimateIsInFlight() {
+        // The funds question is fee-independent, so suppressing it during the
+        // in-flight window would withhold an answer that cannot change.
+        let btc = btcCoin()
+        btc.rawBalance = "100000000"  // 1 BTC
+        let vm = makeReadyToPlace(sourceAmount: BigInt(200_000_000))  // 2 BTC
+        vm.networkFeeEstimate = .zero
+
+        let state = vm.balanceState(sourceCoin: btc)
+        XCTAssertEqual(state, .insufficientFunds(sourceTicker: "BTC"))
+        XCTAssertNotNil(state.noticeMessage)
+    }
+
+    func testErc20SourceJudgesGasAgainstTheNativeSiblingNotTheToken() {
+        // Gas is paid in the chain's NATIVE coin: an ERC20 source pays ETH. The
+        // fee is in wei, so reading it against the token's 6 decimals would make
+        // it look like ~1e9 tokens and report a false `insufficientGas` even with
+        // a funded ETH sibling — the exact bug `SwapCryptoLogic.feeCoin` exists
+        // to prevent. The second assertion is what catches that.
+        let usdc = Coin(
+            asset: CoinMeta.make(chain: .ethereum, ticker: "USDC", decimals: 6, isNativeToken: false),
+            address: "0xethdestaddress00000000000000000000000000",
+            hexPublicKey: "usdc-pubkey"
+        )
+        usdc.rawBalance = "1000000000"  // 1,000 USDC — the amount itself is covered
+        vault.coins.append(usdc)
+        let eth = ethCoin()
+        eth.rawBalance = "0"  // no gas at all
+
+        let vm = makeReadyToPlace(sourceAmount: BigInt(100_000_000), fromAsset: LimitSwapAsset(coin: usdc))
+        vm.networkFeeEstimate = BigInt(1_050_000_000_000_000)  // 0.00105 ETH in wei
+
+        XCTAssertEqual(vm.balanceState(sourceCoin: usdc), .insufficientGas(feeTicker: "ETH"))
+
+        eth.rawBalance = "1000000000000000000"  // 1 ETH
+        XCTAssertEqual(
+            vm.balanceState(sourceCoin: usdc),
+            .sufficient,
+            "A wei fee must be judged in ETH's 18 decimals, not the token's 6"
+        )
+    }
+
+    func testBalanceStateAgreesWithTheMarketSwapRuleForTheSameInput() {
+        // Anti-drift: the limit form must not grow a second affordability rule.
+        // Same coins, same amount, same fee ⇒ same verdict as the market tab.
+        let btc = btcCoin()
+        btc.rawBalance = "100000000"  // 1 BTC
+        let vm = makeReadyToPlace(sourceAmount: BigInt(99_999_000))  // 0.99999 BTC
+        vm.networkFeeEstimate = BigInt(10_000)
+
+        let marketVerdict = SwapCryptoLogic.balanceError(
+            fromCoin: btc,
+            feeCoin: btc,
+            fromAmount: "0.99999",
+            fee: BigInt(10_000)
+        )
+        XCTAssertEqual(marketVerdict, .insufficientGas)
+        XCTAssertEqual(vm.balanceState(sourceCoin: btc), .insufficientGas(feeTicker: "BTC"))
+    }
+
+    func testBalanceStateIsIndeterminateWhenTheCoinIsNotTheDraftSource() {
+        // SwiftUI can render one frame with a newly-picked coin and the previous
+        // draft asset. Judging a BTC amount against an ETH balance for that frame
+        // would flash a bogus row, so the verdict is withheld and placement fails
+        // closed.
+        let vm = makeReadyToPlace(sourceAmount: BigInt(100_000_000))  // draft source is BTC
+
+        XCTAssertEqual(vm.balanceState(sourceCoin: ethCoin()), .indeterminate)
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: ethCoin()))
+    }
+
+    func testBalanceNoticesNameTheAssetAndDistinguishFundsFromGas() {
+        let funds = LimitSwapBalanceState.insufficientFunds(sourceTicker: "BTC").noticeMessage
+        let gas = LimitSwapBalanceState.insufficientGas(feeTicker: "ETH").noticeMessage
+
+        XCTAssertEqual(funds?.contains("BTC"), true, "The funds notice must name the source asset")
+        XCTAssertEqual(gas?.contains("ETH"), true, "The gas notice must name the fee asset")
+        XCTAssertNotEqual(funds, gas, "The two cases must not collapse into one message")
+
+        XCTAssertNil(LimitSwapBalanceState.sufficient.noticeMessage)
+        XCTAssertNil(LimitSwapBalanceState.indeterminate.noticeMessage)
+        XCTAssertFalse(LimitSwapBalanceState.sufficient.blocksPlacement)
+        XCTAssertTrue(LimitSwapBalanceState.indeterminate.blocksPlacement, "Unknown must fail closed")
     }
 
     // MARK: - pair routability gate (poolless pairs must not be placeable)
@@ -875,13 +1018,13 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         vm.draft.targetPrice = 16
         vm.networkFeeEstimate = BigInt(4_200)
         vm.marketPriceRef = 16
-        XCTAssertTrue(vm.canPlaceOrder)
+        XCTAssertTrue(vm.canPlaceOrder(sourceCoin: btcCoin()))
 
         vm.pairUnroutableReason = .noRoute
-        XCTAssertFalse(vm.canPlaceOrder, "A pair THORChain can't route must not be placeable")
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btcCoin()), "A pair THORChain can't route must not be placeable")
 
         vm.pairUnroutableReason = nil
-        XCTAssertTrue(vm.canPlaceOrder)
+        XCTAssertTrue(vm.canPlaceOrder(sourceCoin: btcCoin()))
     }
 
     func testSelectFromAssetClearsUnroutableReason() {
@@ -952,6 +1095,29 @@ final class LimitSwapFormViewModelTests: XCTestCase {
             vault: vault,
             interactor: interactor
         )
+    }
+
+    /// A draft with every NON-balance `canPlaceOrder` term already satisfied, so
+    /// a `false` verdict in the balance tests can only come from the balance gate.
+    private func makeReadyToPlace(
+        sourceAmount: BigInt,
+        fromAsset: LimitSwapAsset? = nil
+    ) -> LimitSwapFormViewModel {
+        let draft = LimitSwapDraft(
+            fromAsset: fromAsset ?? btcAsset(),
+            toAsset: ethAsset(),
+            sourceAmount: sourceAmount
+        )
+        let vm = LimitSwapFormViewModel(
+            initialDraft: draft,
+            vault: vault,
+            interactor: interactor
+        )
+        vm.advancedSwapQueueEnabled = true
+        vm.draft.targetPrice = 16
+        vm.marketPriceRef = 16
+        vm.networkFeeEstimate = BigInt(4_200)
+        return vm
     }
 
     /// The vault's BTC / ETH coins (installed in `setUp`) — for VM methods that

--- a/VultisigApp/VultisigAppTests/LimitSwap/ViewModel/LimitSwapFormViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/LimitSwap/ViewModel/LimitSwapFormViewModelTests.swift
@@ -850,9 +850,11 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         XCTAssertNil(inFlight.noticeMessage, "No notice may be rendered from an unresolved fee")
         XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btc), "Placement stays blocked until the fee resolves")
 
-        // …and the moment the estimate lands, the real verdict appears.
+        // …and the moment the estimate lands, the real verdict appears — and it
+        // is the ONLY term still blocking the CTA, so this pins the wiring too.
         vm.networkFeeEstimate = BigInt(10_000)
         XCTAssertEqual(vm.balanceState(sourceCoin: btc), .insufficientGas(feeTicker: "BTC"))
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btc))
     }
 
     func testInsufficientFundsIsStillReportedWhileTheFeeEstimateIsInFlight() {
@@ -888,6 +890,7 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         vm.networkFeeEstimate = BigInt(1_050_000_000_000_000)  // 0.00105 ETH in wei
 
         XCTAssertEqual(vm.balanceState(sourceCoin: usdc), .insufficientGas(feeTicker: "ETH"))
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: usdc))
 
         eth.rawBalance = "1000000000000000000"  // 1 ETH
         XCTAssertEqual(
@@ -895,6 +898,10 @@ final class LimitSwapFormViewModelTests: XCTestCase {
             .sufficient,
             "A wei fee must be judged in ETH's 18 decimals, not the token's 6"
         )
+        // Funding the sibling is the ONLY thing that changed, so the CTA coming
+        // back proves the split-fee-coin path is wired through `canPlaceOrder`
+        // and not merely classified correctly in isolation.
+        XCTAssertTrue(vm.canPlaceOrder(sourceCoin: usdc))
     }
 
     func testBalanceStateAgreesWithTheMarketSwapRuleForTheSameInput() {
@@ -913,6 +920,9 @@ final class LimitSwapFormViewModelTests: XCTestCase {
         )
         XCTAssertEqual(marketVerdict, .insufficientGas)
         XCTAssertEqual(vm.balanceState(sourceCoin: btc), .insufficientGas(feeTicker: "BTC"))
+        // Every other `canPlaceOrder` term is satisfied here, so the disabled CTA
+        // can only come from the shared rule's verdict.
+        XCTAssertFalse(vm.canPlaceOrder(sourceCoin: btc))
     }
 
     func testBalanceStateIsIndeterminateWhenTheCoinIsNotTheDraftSource() {


### PR DESCRIPTION
## Description

The limit-order form let you place an order for more than the vault holds. `LimitSwapFormViewModel.canPlaceOrder` had **no balance term at all** — `draft.sourceAmount > 0` was the only amount check. The market swap tab blocks the same mistake inline, gating Continue on `SwapCryptoLogic.balanceError`. On the limit tab you could type the amount, tap **Place Order**, land on Verify, and only find out when you tapped Sign.

This adds the balance gate to the **first** screen, reusing the market's rule rather than writing a second one.

Fixes #5008

### What the user now sees

| Situation | Before | After |
|---|---|---|
| Sell amount exceeds the balance | Place Order enabled → Verify → error at Sign | Place Order **disabled**, inline row: *"Not enough BTC to place this order. Enter an amount within your balance."* |
| Amount fits but leaves nothing for gas | same as above | Place Order **disabled**, inline row: *"Not enough ETH to cover the network fee for this order."* — named as a **gas** problem, and naming the coin that actually pays gas |
| Network-fee estimate still in flight | — | **No error row at all**, button disabled (see below) |

The reason renders in the form's existing `LimitNoticeRow`, the same component already used for `pairUnroutableReason` — no new component.

### The fee-in-flight window, deliberately

`networkFeeEstimate` is dropped to `0` on every input change and re-fetched after a 300 ms debounce, so for a moment there is no fee to judge against. The two questions are split by what is knowable without one:

- **Amount vs. balance is fee-independent**, so it is answered immediately. The first `balanceError` call passes `fee: .zero`, which makes that function's gas arm unreachable *by construction* — the same-coin arm requires `fromFee > 0`, the split-coin arm requires `fromFee > feeCoinBalance` — so a zero fee can only ever produce the funds verdict.
- **Amount + fee is not knowable**, so it is not guessed at. The state is `.indeterminate`: no row, and the CTA stays disabled (the pre-existing `networkFeeEstimate > 0` term already did the latter).

**So in that window the user sees: nothing new, and a disabled button.** A gas error is never displayed and then withdrawn a frame later. An insufficient-funds row *is* shown immediately, because the arrival of a fee cannot change that answer.

`.indeterminate` also covers the frame where SwiftUI has the newly-picked coin but not yet the re-synced `draft.fromAsset`, which would otherwise compare a BTC amount against an ETH balance.

### Reuse, not a second rule

- The arithmetic is `SwapCryptoLogic.balanceError` — the market's own function. It gained a `Decimal`-amount overload (the `String` one now delegates to it) because the limit form holds its amount as a `BigInt` in base units; routing that through the `String` entry point would format and immediately re-parse it through a locale-aware parser for nothing. Pure extraction: the market path's behaviour is unchanged.
- The fee coin is resolved with `SwapCryptoLogic.feeCoin(fromCoin:fromCoins:)`, the same helper `LimitSwapEntryView` already uses to build the `SwapTransaction`. Gas is paid in the chain's **native** coin, so an ERC20 source's wei fee is read against ETH's 18 decimals, not the token's — reading wei against a token's decimals once produced a false `insufficientGas`, and there is a test that fails if that regresses.
- The source coin is passed in from the view rather than mirrored into a stored property: it is the object whose balance the Sell row prints, so the gate can never judge a balance other than the one on screen, and there is no second copy to drift from `draft.fromAsset`.

### Severity: a validation-*timing* defect, not funds loss

An over-balance limit order still could not be signed before this change, and cannot now. Worth stating so the severity isn't misjudged.

**One correction to the issue text.** The issue credits `SwapVerifyViewModel:152` with the limit sign-time gate. That call lives in `refreshData(vault:referredCode:)`, which **early-returns for limit orders** (`guard !transaction.isLimit else { return }`) precisely because a limit transaction has no market quote to refresh — so line 152 never runs for a limit order. The real limit gates are the two `SwapCryptoLogic.balanceError` calls inside `buildSwapKeysignPayload` (one against the entry-screen fee estimate, one against the freshly-derived sign-time fee), both preceded by `refreshBalanceOrThrow`. The conclusion is unchanged — the order cannot be signed over-balance — but the user was being told at **Sign**, one tap later than even Verify's arrival.

### Verdict on the secondary ask: the minimum-amount check — **deferred to its own PR**

The issue also notes the limit form has no minimum-amount check, and that a below-minimum order signs, costs a real fee, and rests forever. That is real, and it is deliberately **not** fixed here:

- The limit form's only quote call, `LimitSwapQuoteServiceProtocol.fetchCurrentMarketPrice`, returns a bare `Decimal`. THORChain's `recommended_min_amount_in` and `dust_threshold` are in the quote envelope that call **discards**. A correct floor means changing the protocol, the interactor, the mock, and the form's state — a different PR's worth of surface area.
- A local constant would be wrong on purpose: the minimum is per-pool and moves with the outbound fee, so a fixed number is either too low (useless) or too high, and **blocking a legitimate order is worse than today's behaviour**.
- The market quote's minimum is not even the right floor for a *resting* order: it sizes the outbound fee at today's price, whereas a limit order fills later, at a better price, against whatever the fee is then.
- Dust is not wholly unguarded today — `buildFittedLimitSwapMemo` throws `limitAmountTooSmall` when the LIM truncates to zero, surfaced as an alert. That catches the extreme, not "above LIM-zero but below THORChain's outbound-fee minimum".

### What I could **not** verify

**I did not place a real limit order.** No on-device or testnet run, no broadcast, no tx hash — this is verified by unit tests and by reading the shared sign path, not by exercising the form against a live vault. Specifically unverified by execution: the inline row's appearance on a real screen (layout/wrapping of the two new strings), and the exact frame-timing of `.indeterminate` during a picker change, which is reasoned about rather than observed.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

> No tx link: this change only *prevents* a transaction from being started. Its whole effect is a disabled button and an inline message — there is no successful transaction it could produce.

## Parity

- Android: `n/a` — limit orders are not implemented on Android at all.
- Windows + extension: `first` — THORChain limit-order form. `LimitSwapForm.tsx` is a "coming soon" placeholder today; when the real form lands it must carry this gate.
- SDK: `n/a` — this is form-level validation. The SDK's `limitSwapMemo.ts` builds memos and holds no balance state.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

### Tests, and the mutation check

Nine assertions over `balanceState` / `canPlaceOrder`, written to pin *identity* (`XCTAssertEqual(state, .insufficientGas(feeTicker: "ETH"))`) rather than shape, so none can pass vacuously:

- over-balance disables Place Order **and** an affordable amount re-enables it (both directions in one test, so deleting the term fails it either way)
- an amount that fits exactly but leaves nothing for gas is `.insufficientGas`, **not** `.insufficientFunds`
- with the fee in flight: no gas notice, no placement — then the real verdict the moment it lands
- the fee-independent funds verdict is **not** suppressed while the fee is in flight
- an ERC20 source judges gas against the native ETH sibling: funding the sibling is the only change, and it must flip the verdict to `.sufficient` and re-enable the CTA — precisely what a wei fee misread against the token's 6 decimals would fail
- the limit verdict agrees with `SwapCryptoLogic.balanceError` for the same input (anti-drift)
- a coin that is not the draft's source yields `.indeterminate`
- the two notices name their asset and are distinct

**Mutation-tested.** Deleting the balance term from `canPlaceOrder` reddens **6 of the 8** new tests; inverting it reddens **9 test cases** (12 failing assertions). Full suite green: `** TEST SUCCEEDED **`, 4553 tests. SwiftLint: 0 new warnings.

## Additional context

Reviewed by OpenAI Codex (`codex exec --sandbox read-only`) before the gate — verdict *"no branch-blocking correctness or fund-safety defect found"*. Its one actionable finding was that five of the new tests exercised the classification without pinning the CTA wiring; that is fixed in the final commit. Two findings were accepted-as-correct rather than changed and are worth recording so they are not later mistaken for drift:

1. **The two tabs can legitimately differ near the gas boundary** — market validates `displayedNetworkFeeWei` (including the reconciled EVM signed bond), limit validates its own THORChain limit-deposit estimate. The shared thing is the *rule*, not the *fee*; the fee differs because the transactions differ.
2. **Decimal handling differs** — market judges the user's typed string (`0.123456789`), limit judges the already-truncated base-unit amount (`0.12345678`). Limit is judging the amount it will actually place, so this is not an overspend; changing it would make the form judge an amount it never places.

Plan and full review ledger: `wiki/pages/projects/vultisig/thorchain-limit-swap/limit-balance-validation-5008-plan.md`.

Two new strings in all **8** shipping locales (en, de, es, hr, it, ko, pt, zh-Hans — `CLAUDE.md` lists 7 and omits Korean, but Korean ships), sorted with `sort_localizable.py`.

## Agent Metadata (if applicable)
- **Agent**: Claude Code (Opus 5)
- **Issue**: #5008
- **Confidence**: high
- **Needs human review for**: the two new strings' wording and their layout in the inline row on a real screen — no on-device pass was made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Limit orders now verify available funds and network gas before placement.
  * The Place Order button is disabled when balances are insufficient or cannot be confirmed.
  * Clear notices distinguish insufficient funds from insufficient gas.
* **Localization**
  * Added error messages in English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.
* **Bug Fixes**
  * Improved balance validation for token swaps, including transactions requiring native-asset gas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->