### PR TITLE
fix: correct notification intro state

### DIFF
--- a/VultisigApp/VultisigApp/Features/Notifications/Views/NotificationsIntroSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Notifications/Views/NotificationsIntroSheet.swift
@@ -8,14 +8,29 @@ import SwiftUI
 
 struct NotificationsIntroSheet: View {
     @Binding var isPresented: Bool
+    let targetVault: Vault?
     @Query var vaults: [Vault]
     @EnvironmentObject var pushNotificationManager: PushNotificationManager
 
     @State private var step: Step = .welcome
 
+    enum PermissionDestination {
+        case dismiss
+        case enableVault(Vault)
+        case vaultSelection
+    }
+
     private enum Step {
         case welcome
         case vaultOptIn
+    }
+
+    init(
+        isPresented: Binding<Bool>,
+        targetVault: Vault? = nil
+    ) {
+        _isPresented = isPresented
+        self.targetVault = targetVault
     }
 
     var allVaultsEnabled: Bool {
@@ -78,15 +93,22 @@ struct NotificationsIntroSheet: View {
                 PrimaryButton(title: "enable") {
                     Task {
                         let granted = await pushNotificationManager.requestPermission()
-                        if granted && vaults.count > 1 {
+                        pushNotificationManager.isNotificationsEnabled = granted
+
+                        switch Self.permissionDestination(
+                            granted: granted,
+                            targetVault: targetVault,
+                            vaults: vaults
+                        ) {
+                        case .dismiss:
+                            dismiss()
+                        case .enableVault(let vault):
+                            pushNotificationManager.setVaultOptIn(vault, enabled: true)
+                            dismiss()
+                        case .vaultSelection:
                             withAnimation(.interpolatingSpring) {
                                 step = .vaultOptIn
                             }
-                        } else {
-                            if let vault = vaults.first {
-                                pushNotificationManager.setVaultOptIn(vault, enabled: true)
-                            }
-                            dismiss()
                         }
                     }
                 }
@@ -158,6 +180,18 @@ struct NotificationsIntroSheet: View {
     private func dismiss() {
         pushNotificationManager.hasSeenNotificationPrompt = true
         isPresented = false
+    }
+
+    static func permissionDestination(
+        granted: Bool,
+        targetVault: Vault?,
+        vaults: [Vault]
+    ) -> PermissionDestination {
+        guard granted else { return .dismiss }
+        if let targetVault { return .enableVault(targetVault) }
+        if vaults.count > 1 { return .vaultSelection }
+        if let vault = vaults.first { return .enableVault(vault) }
+        return .dismiss
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Notifications/Views/SetupPushNotificationsModifier.swift
+++ b/VultisigApp/VultisigApp/Features/Notifications/Views/SetupPushNotificationsModifier.swift
@@ -22,7 +22,7 @@ struct SetupPushNotificationsModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .crossPlatformSheet(isPresented: $shouldShow) {
-                NotificationsIntroSheet(isPresented: $shouldShow)
+                sheetContent
             }
             .onChange(of: shouldShow) { _, newValue in
                 if !newValue {
@@ -33,6 +33,21 @@ struct SetupPushNotificationsModifier: ViewModifier {
             .onChange(of: vault) { _, _ in
                 checkIfNeeded()
             }
+    }
+
+    @ViewBuilder
+    private var sheetContent: some View {
+        switch activeSheetType {
+        case .intro:
+            NotificationsIntroSheet(isPresented: $shouldShow)
+        case .vaultOptIn:
+            NotificationsIntroSheet(
+                isPresented: $shouldShow,
+                targetVault: vault
+            )
+        case nil:
+            EmptyView()
+        }
     }
 
     private func checkIfNeeded() {

--- a/VultisigApp/VultisigAppTests/Notifications/NotificationsIntroSheetTests.swift
+++ b/VultisigApp/VultisigAppTests/Notifications/NotificationsIntroSheetTests.swift
@@ -1,0 +1,67 @@
+//
+//  NotificationsIntroSheetTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class NotificationsIntroSheetTests: XCTestCase {
+    func testDeniedPermissionDismissesWithoutEnablingVault() {
+        let vault = Vault(name: "Vault")
+
+        let destination = NotificationsIntroSheet.permissionDestination(
+            granted: false,
+            targetVault: vault,
+            vaults: [vault]
+        )
+
+        guard case .dismiss = destination else {
+            return XCTFail("Denied permission should dismiss")
+        }
+    }
+
+    func testPerVaultPromptEnablesTriggeringVault() {
+        let firstVault = Vault(name: "First")
+        let triggeringVault = Vault(name: "Triggering")
+
+        let destination = NotificationsIntroSheet.permissionDestination(
+            granted: true,
+            targetVault: triggeringVault,
+            vaults: [firstVault, triggeringVault]
+        )
+
+        guard case .enableVault(let vault) = destination else {
+            return XCTFail("Per-vault prompt should enable its triggering vault")
+        }
+        XCTAssertTrue(vault === triggeringVault)
+    }
+
+    func testGeneralPromptWithOneVaultEnablesThatVault() {
+        let vault = Vault(name: "Vault")
+
+        let destination = NotificationsIntroSheet.permissionDestination(
+            granted: true,
+            targetVault: nil,
+            vaults: [vault]
+        )
+
+        guard case .enableVault(let enabledVault) = destination else {
+            return XCTFail("Single-vault prompt should enable its only vault")
+        }
+        XCTAssertTrue(enabledVault === vault)
+    }
+
+    func testGeneralPromptWithMultipleVaultsShowsSelection() {
+        let destination = NotificationsIntroSheet.permissionDestination(
+            granted: true,
+            targetVault: nil,
+            vaults: [Vault(name: "First"), Vault(name: "Second")]
+        )
+
+        guard case .vaultSelection = destination else {
+            return XCTFail("Multi-vault prompt should show vault selection")
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fix the notification introduction flow so it:

- never opts a vault in when system permission is denied
- routes new/imported-vault prompts to the vault that triggered the prompt
- synchronizes the master notification preference with the permission result
- preserves the all-vault selection step for the general multi-vault introduction

Fixes #4972

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable; existing UI is preserved.

## Additional context

### Test plan

- [x] make test — 4,577 tests passed, 1 skipped, 0 failures
- [x] make build-check — iOS Simulator build succeeded
- [x] Changed files pass SwiftLint with 0 violations
- [x] Full SwiftLint result matches the 39-warning baseline

## Agent Metadata (if applicable)
- **Agent**: Codex
- **Issue**: #4972
- **Confidence**: high
- **Needs human review for**: notification permission UX and preference semantics

Co-Authored-By: Codex <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted notification setup for a selected vault.
  * Notification prompts now guide you to enable a specific vault, select from multiple vaults, or proceed automatically when only one vault is available.
  * Added separate notification opt-in experiences based on the setup context.

* **Bug Fixes**
  * Improved handling of denied notification permissions by dismissing the prompt appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->