### PR TITLE
fix: add foreground notification fallback

### DIFF
--- a/VultisigApp/VultisigApp/Components/NotificationBanner/ForegroundNotificationBannerModifier.swift
+++ b/VultisigApp/VultisigApp/Components/NotificationBanner/ForegroundNotificationBannerModifier.swift
@@ -33,7 +33,7 @@ private struct ForegroundNotificationBannerModifier: ViewModifier {
             content
         }
         .background(showBackground ? Theme.colors.bgPrimary.ignoresSafeArea() : nil)
-        .onChange(of: pushNotificationManager.foregroundNotification) { _, newValue in
+        .onReceive(pushNotificationManager.$foregroundNotification) { newValue in
             guard let newValue else { return }
             show(data: newValue)
         }

--- a/VultisigApp/VultisigApp/Core/Notifications/ForegroundNotificationParser.swift
+++ b/VultisigApp/VultisigApp/Core/Notifications/ForegroundNotificationParser.swift
@@ -9,10 +9,10 @@ import UserNotifications
 enum ForegroundNotificationParser {
 
     static func parse(
-        notification: UNNotification,
+        content: UNNotificationContent,
         vaults: [Vault]
     ) -> ForegroundNotificationData? {
-        let userInfo = notification.request.content.userInfo
+        let userInfo = content.userInfo
 
         guard let deeplinkString = userInfo["deeplink"] as? String,
               let deeplinkURL = URL(string: deeplinkString) else {
@@ -30,7 +30,7 @@ enum ForegroundNotificationParser {
 
         let transactionType = parseTransactionType(
             queryItems: queryItems,
-            notificationBody: notification.request.content.body
+            notificationBody: content.body
         )
 
         return ForegroundNotificationData(

--- a/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
+++ b/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
@@ -25,24 +25,38 @@ class PushNotificationManager: ObservableObject {
 
     private let keychainService: KeychainService
     private let notificationService: NotificationServicing
+    private let fetchVaults: () throws -> [Vault]
+    private let canPresentForegroundBanner: @MainActor () -> Bool
     private let logger = Log.app.other
 
     private let notificationDelegate = NotificationDelegate()
 
     init(
         notificationService: NotificationServicing = NotificationService(),
-        keychainService: KeychainService = DefaultKeychainService.shared
+        keychainService: KeychainService = DefaultKeychainService.shared,
+        fetchVaults: (() throws -> [Vault])? = nil,
+        canPresentForegroundBanner: (@MainActor () -> Bool)? = nil
     ) {
         self.notificationService = notificationService
         self.keychainService = keychainService
+        self.fetchVaults = fetchVaults ?? {
+            try Storage.shared.modelContext.fetch(FetchDescriptor<Vault>())
+        }
+        self.canPresentForegroundBanner = canPresentForegroundBanner ?? {
+            ForegroundNotificationPresentationPolicy.canPresentCustomBanner
+        }
     }
 
     // MARK: - Notification Delegate
 
     func setupNotificationDelegate() {
-        notificationDelegate.onForegroundNotification = { [weak self] notification in
+        notificationDelegate.onForegroundNotification = { [weak self] content, completion in
             Task { @MainActor in
-                self?.handleForegroundNotification(notification)
+                guard let self else {
+                    completion(false)
+                    return
+                }
+                completion(self.handleForegroundNotification(content))
             }
         }
         UNUserNotificationCenter.current().delegate = notificationDelegate
@@ -284,14 +298,31 @@ class PushNotificationManager: ObservableObject {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
-    private func handleForegroundNotification(_ notification: UNNotification) {
-        let descriptor = FetchDescriptor<Vault>()
-        guard let vaults = try? Storage.shared.modelContext.fetch(descriptor) else { return }
+    @discardableResult
+    func handleForegroundNotification(_ content: UNNotificationContent) -> Bool {
+        guard canPresentForegroundBanner() else {
+            logger.info("Custom foreground banner unavailable while a modal is presented")
+            return false
+        }
 
-        foregroundNotification = ForegroundNotificationParser.parse(
-            notification: notification,
+        let vaults: [Vault]
+        do {
+            vaults = try fetchVaults()
+        } catch {
+            logger.error("Failed to fetch vaults for foreground notification: \(error.localizedDescription)")
+            return false
+        }
+
+        guard let parsedNotification = ForegroundNotificationParser.parse(
+            content: content,
             vaults: vaults
-        )
+        ) else {
+            logger.warning("Unable to parse foreground notification; using system presentation")
+            return false
+        }
+
+        foregroundNotification = parsedNotification
+        return true
     }
 
     private func reRegisterOptedInVaults() async {
@@ -318,17 +349,22 @@ class PushNotificationManager: ObservableObject {
 
 // MARK: - UNUserNotificationCenterDelegate
 
-private class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
 
-    var onForegroundNotification: ((UNNotification) -> Void)?
+    var onForegroundNotification: ((
+        UNNotificationContent,
+        @escaping (Bool) -> Void
+    ) -> Void)?
 
     func userNotificationCenter(
         _: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        onForegroundNotification?(notification)
-        completionHandler([.sound])
+        presentationOptions(
+            for: notification.request.content,
+            completion: completionHandler
+        )
     }
 
     func userNotificationCenter(
@@ -346,5 +382,47 @@ private class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
             }
         }
         completionHandler()
+    }
+
+    func presentationOptions(
+        for content: UNNotificationContent,
+        completion: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        guard let onForegroundNotification else {
+            completion(ForegroundNotificationPresentationPolicy.systemOptions)
+            return
+        }
+
+        onForegroundNotification(content) { handled in
+            completion(
+                handled
+                    ? ForegroundNotificationPresentationPolicy.customOptions
+                    : ForegroundNotificationPresentationPolicy.systemOptions
+            )
+        }
+    }
+}
+
+enum ForegroundNotificationPresentationPolicy {
+    static let customOptions: UNNotificationPresentationOptions = [.sound]
+    static let systemOptions: UNNotificationPresentationOptions = [.banner, .list, .sound]
+
+    @MainActor
+    static var canPresentCustomBanner: Bool {
+        #if os(iOS)
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+              let keyWindow = windowScene.windows.first(where: \.isKeyWindow),
+              let rootViewController = keyWindow.rootViewController else {
+            return false
+        }
+        return rootViewController.presentedViewController == nil
+        #elseif os(macOS)
+        guard let window = NSApplication.shared.keyWindow ?? NSApplication.shared.mainWindow else {
+            return false
+        }
+        return window.attachedSheet == nil
+        #endif
     }
 }

--- a/VultisigApp/VultisigAppTests/Notifications/ForegroundNotificationHandlingTests.swift
+++ b/VultisigApp/VultisigAppTests/Notifications/ForegroundNotificationHandlingTests.swift
@@ -1,0 +1,158 @@
+//
+//  ForegroundNotificationHandlingTests.swift
+//  VultisigAppTests
+//
+
+import Combine
+import UserNotifications
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class ForegroundNotificationHandlingTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testDelegateUsesSystemPresentationWhenHandlerIsMissing() {
+        let delegate = NotificationDelegate()
+        var receivedOptions: UNNotificationPresentationOptions?
+
+        delegate.presentationOptions(for: UNMutableNotificationContent()) {
+            receivedOptions = $0
+        }
+
+        XCTAssertEqual(
+            receivedOptions,
+            ForegroundNotificationPresentationPolicy.systemOptions
+        )
+    }
+
+    func testDelegateUsesSoundOnlyWhenCustomBannerHandlesNotification() {
+        let delegate = NotificationDelegate()
+        delegate.onForegroundNotification = { _, completion in
+            completion(true)
+        }
+        var receivedOptions: UNNotificationPresentationOptions?
+
+        delegate.presentationOptions(for: UNMutableNotificationContent()) {
+            receivedOptions = $0
+        }
+
+        XCTAssertEqual(
+            receivedOptions,
+            ForegroundNotificationPresentationPolicy.customOptions
+        )
+    }
+
+    func testDelegateUsesSystemPresentationWhenCustomBannerDeclinesNotification() {
+        let delegate = NotificationDelegate()
+        delegate.onForegroundNotification = { _, completion in
+            completion(false)
+        }
+        var receivedOptions: UNNotificationPresentationOptions?
+
+        delegate.presentationOptions(for: UNMutableNotificationContent()) {
+            receivedOptions = $0
+        }
+
+        XCTAssertEqual(
+            receivedOptions,
+            ForegroundNotificationPresentationPolicy.systemOptions
+        )
+    }
+
+    func testMissingDeeplinkDeclinesCustomPresentation() {
+        let manager = makeManager()
+
+        XCTAssertFalse(
+            manager.handleForegroundNotification(UNMutableNotificationContent())
+        )
+        XCTAssertNil(manager.foregroundNotification)
+    }
+
+    func testVaultFetchFailureDeclinesCustomPresentation() {
+        let manager = makeManager(fetchVaults: { throw TestError.fetchFailed })
+
+        XCTAssertFalse(
+            manager.handleForegroundNotification(makeValidContent())
+        )
+        XCTAssertNil(manager.foregroundNotification)
+    }
+
+    func testPresentedModalDeclinesCustomPresentation() {
+        let manager = makeManager(canPresentForegroundBanner: { false })
+
+        XCTAssertFalse(
+            manager.handleForegroundNotification(makeValidContent())
+        )
+        XCTAssertNil(manager.foregroundNotification)
+    }
+
+    func testValidNotificationUsesCustomPresentation() {
+        let manager = makeManager()
+
+        XCTAssertTrue(
+            manager.handleForegroundNotification(makeValidContent())
+        )
+        XCTAssertNotNil(manager.foregroundNotification)
+    }
+
+    func testIdenticalNotificationsPublishTwice() {
+        let manager = makeManager()
+        var received: [ForegroundNotificationData] = []
+        manager.$foregroundNotification
+            .compactMap { $0 }
+            .sink { received.append($0) }
+            .store(in: &cancellables)
+        let content = makeValidContent()
+
+        XCTAssertTrue(manager.handleForegroundNotification(content))
+        XCTAssertTrue(manager.handleForegroundNotification(content))
+
+        XCTAssertEqual(received.count, 2)
+        XCTAssertEqual(received[0], received[1])
+    }
+
+    private func makeManager(
+        fetchVaults: @escaping () throws -> [Vault] = { [] },
+        canPresentForegroundBanner: @escaping () -> Bool = { true }
+    ) -> PushNotificationManager {
+        PushNotificationManager(
+            notificationService: StubNotificationService(),
+            keychainService: MockKeychainService(),
+            fetchVaults: fetchVaults,
+            canPresentForegroundBanner: canPresentForegroundBanner
+        )
+    }
+
+    private func makeValidContent() -> UNMutableNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.body = "Transaction ready"
+        content.userInfo = [
+            "deeplink": "vultisig://keysign?vault=test-vault"
+        ]
+        return content
+    }
+}
+
+private enum TestError: Error {
+    case fetchFailed
+}
+
+private struct StubNotificationService: NotificationServicing {
+    func registerDevice(request _: DeviceRegistrationRequest) async throws {
+        await Task.yield()
+    }
+
+    func unregisterDevice(vaultId _: String, partyName _: String) async throws {
+        await Task.yield()
+    }
+
+    func sendNotification(request _: NotifyRequest) async throws {
+        await Task.yield()
+    }
+}


### PR DESCRIPTION
## Description

Fix foreground pushes being silently consumed when the custom notification banner cannot be shown:

- Report custom foreground handling success back to `UNUserNotificationCenterDelegate`.
- Fall back to native banner, list, and sound presentation when parsing or vault loading fails, or when a native modal covers the app-level banner.
- Observe every published notification so identical consecutive pushes restart the custom banner.
- Add regression coverage for fallback selection, each failure mode, successful custom presentation, and repeated notifications.

Fixes #4973

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

Not applicable — notification presentation behavior only.

## Additional context

Verification:

- `make test` — 4,581 tests passed, 1 skipped, 0 failures
- `make build-check` — succeeded
- Changed-file SwiftLint — clean
- Full SwiftLint — 39 pre-existing warnings, no new warnings

Native system presentation is intentionally used while a sheet or full-screen modal is active, because it renders above those presentations; the custom in-app banner remains in use when the root surface is available.

## Agent Metadata (if applicable)
- **Agent**: Codex
- **Issue**: #4973
- **Confidence**: high
- **Needs human review for**: foreground notification presentation behavior across iOS and macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved foreground notification handling and presentation.
  * Notifications now fall back to the system presentation when custom banners cannot be shown.
  * Added safeguards for invalid links, vault-loading failures, modal restrictions, and repeated notifications.

* **Tests**
  * Added coverage for custom banners, system alerts, fallback behavior, and notification edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->