### PR TITLE
fix(defi): DeFi "Select positions" no longer renders empty while /pools loads

### DIFF
--- a/VultisigApp/VultisigApp/Core/Utils/AsyncTimeout.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AsyncTimeout.swift
@@ -35,7 +35,10 @@ func withTimeout<T: Sendable>(
 
     return try await withTaskCancellationHandler {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
-            race.start(continuation)
+            // A task cancelled before this point already delivered its result to
+            // the race, and `start` consumes it. Bail out before spawning
+            // anything so an abandoned load never fires its request.
+            guard race.start(continuation) else { return }
 
             race.track(Task {
                 do {
@@ -67,11 +70,28 @@ private final class AsyncTimeoutRace<T>: @unchecked Sendable {
     private var continuation: CheckedContinuation<T, Error>?
     private var racers: [Task<Void, Never>] = []
     private var isFinished = false
+    /// A terminal result that arrived before the continuation existed. The
+    /// cancellation handler fires immediately for an already-cancelled task —
+    /// i.e. before the continuation body runs — so without this the cancellation
+    /// would be dropped and the racers would start anyway.
+    private var pendingResult: Result<T, Error>?
 
-    func start(_ continuation: CheckedContinuation<T, Error>) {
+    /// Installs the continuation. Returns `false` when a terminal result had
+    /// already arrived, in which case it is delivered here and the caller must
+    /// not start any racers.
+    func start(_ continuation: CheckedContinuation<T, Error>) -> Bool {
         lock.lock()
-        defer { lock.unlock() }
-        self.continuation = continuation
+        guard let pendingResult else {
+            self.continuation = continuation
+            lock.unlock()
+            return true
+        }
+        isFinished = true
+        self.pendingResult = nil
+        lock.unlock()
+
+        continuation.resume(with: pendingResult)
+        return false
     }
 
     /// Registers a racer. If the race is already decided the task is cancelled
@@ -90,7 +110,15 @@ private final class AsyncTimeoutRace<T>: @unchecked Sendable {
 
     func resume(_ result: Result<T, Error>) {
         lock.lock()
-        guard !isFinished, let continuation else {
+        guard !isFinished else {
+            lock.unlock()
+            return
+        }
+        guard let continuation else {
+            // Nothing to resume yet — hold the first terminal result for `start`.
+            if pendingResult == nil {
+                pendingResult = result
+            }
             lock.unlock()
             return
         }

--- a/VultisigApp/VultisigApp/Core/Utils/AsyncTimeout.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AsyncTimeout.swift
@@ -1,0 +1,42 @@
+//
+//  AsyncTimeout.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Thrown by `withTimeout(seconds:operation:)` when the deadline wins the race.
+struct AsyncTimeoutError: LocalizedError {
+    let seconds: TimeInterval
+
+    var errorDescription: String? {
+        "Operation timed out after \(seconds)s"
+    }
+}
+
+/// Races `operation` against a wall-clock deadline.
+///
+/// A request-level timeout only bounds the gap *between* packets, so a server
+/// that drips bytes indefinitely never trips it. Wrapping a call here bounds the
+/// total elapsed time, which is what a UI waiting on the result actually cares
+/// about.
+///
+/// The losing child task is cancelled before returning.
+func withTimeout<T: Sendable>(
+    seconds: TimeInterval,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { try await operation() }
+        group.addTask {
+            try await Task.sleep(for: .seconds(seconds))
+            throw AsyncTimeoutError(seconds: seconds)
+        }
+
+        defer { group.cancelAll() }
+        guard let result = try await group.next() else {
+            throw AsyncTimeoutError(seconds: seconds)
+        }
+        return result
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Utils/AsyncTimeout.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AsyncTimeout.swift
@@ -14,29 +14,93 @@ struct AsyncTimeoutError: LocalizedError {
     }
 }
 
-/// Races `operation` against a wall-clock deadline.
+/// Runs `operation` with a hard wall-clock bound.
 ///
 /// A request-level timeout only bounds the gap *between* packets, so a server
-/// that drips bytes indefinitely never trips it. Wrapping a call here bounds the
-/// total elapsed time, which is what a UI waiting on the result actually cares
-/// about.
+/// that drips bytes indefinitely never trips it. This bounds total elapsed time,
+/// which is what a UI waiting on the result actually cares about.
 ///
-/// The losing child task is cancelled before returning.
+/// Deliberately *not* built on a task group: a group does not return until every
+/// child has finished, so an operation that ignores cancellation would keep the
+/// call suspended past the deadline — exactly the hang the timeout exists to
+/// prevent. Instead the operation and the timer race to resolve a single
+/// continuation; the first to finish wins and the loser is cancelled. When the
+/// deadline wins, this returns immediately and the operation is abandoned rather
+/// than awaited.
 func withTimeout<T: Sendable>(
     seconds: TimeInterval,
     operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
-    try await withThrowingTaskGroup(of: T.self) { group in
-        group.addTask { try await operation() }
-        group.addTask {
-            try await Task.sleep(for: .seconds(seconds))
-            throw AsyncTimeoutError(seconds: seconds)
-        }
+    let race = AsyncTimeoutRace<T>()
 
-        defer { group.cancelAll() }
-        guard let result = try await group.next() else {
-            throw AsyncTimeoutError(seconds: seconds)
+    return try await withTaskCancellationHandler {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            race.start(continuation)
+
+            race.track(Task {
+                do {
+                    race.resume(.success(try await operation()))
+                } catch {
+                    race.resume(.failure(error))
+                }
+            })
+
+            race.track(Task {
+                do {
+                    try await Task.sleep(for: .seconds(seconds))
+                    race.resume(.failure(AsyncTimeoutError(seconds: seconds)))
+                } catch {
+                    // Cancelled because the operation already won the race.
+                }
+            })
         }
-        return result
+    } onCancel: {
+        race.resume(.failure(CancellationError()))
+    }
+}
+
+/// One-shot continuation guard shared by the operation and the timer. Only the
+/// first `resume` takes effect; it also cancels every racer so the loser stops
+/// as soon as it reaches a suspension point.
+private final class AsyncTimeoutRace<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var racers: [Task<Void, Never>] = []
+    private var isFinished = false
+
+    func start(_ continuation: CheckedContinuation<T, Error>) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.continuation = continuation
+    }
+
+    /// Registers a racer. If the race is already decided the task is cancelled
+    /// straight away, which covers an operation that finishes before its
+    /// competitor has even been registered.
+    func track(_ task: Task<Void, Never>) {
+        lock.lock()
+        guard !isFinished else {
+            lock.unlock()
+            task.cancel()
+            return
+        }
+        racers.append(task)
+        lock.unlock()
+    }
+
+    func resume(_ result: Result<T, Error>) {
+        lock.lock()
+        guard !isFinished, let continuation else {
+            lock.unlock()
+            return
+        }
+        isFinished = true
+        self.continuation = nil
+        let losers = racers
+        racers = []
+        lock.unlock()
+
+        continuation.resume(with: result)
+        losers.forEach { $0.cancel() }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Common/AssetSelection/AssetSelectionContainerSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Common/AssetSelection/AssetSelectionContainerSheet.swift
@@ -7,21 +7,47 @@
 
 import SwiftUI
 
+/// Resolution state of a single section's asset list.
+///
+/// Sections that resolve synchronously stay `.loaded` — the default — so a
+/// section with no assets and no pending work is a genuine empty result. A
+/// section backed by the network reports `.loading` / `.failed` so the picker
+/// can tell "still arriving" and "could not be fetched" apart from "none".
+enum AssetSectionState: Hashable {
+    case loaded
+    case loading
+    /// Carries its own user-facing message so the generic picker stays free of
+    /// any feature's copy.
+    case failed(message: String)
+
+    var isLoading: Bool {
+        self == .loading
+    }
+
+    var isFailed: Bool {
+        if case .failed = self { return true }
+        return false
+    }
+}
+
 struct AssetSection<SectionType: Hashable, Asset: Hashable>: Hashable {
     let title: String?
     let type: SectionType
     let assets: [Asset]
+    let state: AssetSectionState
 
-    init(title: String? = nil, type: SectionType, assets: [Asset]) {
+    init(title: String? = nil, type: SectionType, assets: [Asset], state: AssetSectionState = .loaded) {
         self.title = title
         self.type = type
         self.assets = assets
+        self.state = state
     }
 
-    init(title: String? = nil, assets: [Asset]) where SectionType == Int {
+    init(title: String? = nil, assets: [Asset], state: AssetSectionState = .loaded) where SectionType == Int {
         self.title = title
         self.type = .zero
         self.assets = assets
+        self.state = state
     }
 }
 
@@ -34,8 +60,10 @@ struct AssetSelectionContainerSheet<Asset: Hashable, SectionType: Hashable, Cell
     var onSave: () -> Void
     var cellBuilder: (Asset, SectionType) -> CellView
     var emptyStateBuilder: () -> EmptyStateView
-
-    @State var searchBarFocused: Bool = false
+    /// Invoked with the section type whose fetch failed. Sections never reach
+    /// `.failed` unless the caller puts them there, so this stays `nil` for
+    /// pickers whose catalogs resolve synchronously.
+    var onRetrySection: ((SectionType) -> Void)?
 
     init(
         title: String,
@@ -45,7 +73,8 @@ struct AssetSelectionContainerSheet<Asset: Hashable, SectionType: Hashable, Cell
         elements: [AssetSection<SectionType, Asset>],
         onSave: @escaping () -> Void,
         cellBuilder: @escaping (Asset, SectionType) -> CellView,
-        emptyStateBuilder: @escaping () -> EmptyStateView
+        emptyStateBuilder: @escaping () -> EmptyStateView,
+        onRetrySection: ((SectionType) -> Void)? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -55,6 +84,7 @@ struct AssetSelectionContainerSheet<Asset: Hashable, SectionType: Hashable, Cell
         self.onSave = onSave
         self.cellBuilder = cellBuilder
         self.emptyStateBuilder = emptyStateBuilder
+        self.onRetrySection = onRetrySection
     }
 
     var body: some View {
@@ -69,7 +99,8 @@ struct AssetSelectionContainerSheet<Asset: Hashable, SectionType: Hashable, Cell
             insets: EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 0),
             elements: elements,
             cellBuilder: cellBuilder,
-            emptyStateBuilder: emptyStateBuilder
+            emptyStateBuilder: emptyStateBuilder,
+            onRetrySection: onRetrySection
         )
         .supportsLiquidGlass { view, isSupported in
             view.padding(.bottom, isSupported ? 0 : 16)
@@ -99,71 +130,6 @@ struct AssetSelectionContainerSheet<Asset: Hashable, SectionType: Hashable, Cell
         .presentationBackground(Theme.colors.bgPrimary)
         .presentationDragIndicator(.visible)
         .background(Theme.colors.bgPrimary)
-    }
-
-    var gradientOverlay: some View {
-        LinearGradient(
-            stops: [
-                Gradient.Stop(color: Color(red: 0.01, green: 0.07, blue: 0.17), location: 0.00),
-                Gradient.Stop(color: Color(red: 0.01, green: 0.07, blue: 0.17).opacity(0), location: 1.00)
-            ],
-            startPoint: UnitPoint(x: 0.5, y: 1),
-            endPoint: UnitPoint(x: 0.5, y: 0)
-        )
-        .frame(height: 60)
-    }
-
-    var textfield: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text(title)
-                .foregroundStyle(Theme.colors.textPrimary)
-                .font(Theme.fonts.title2)
-                .multilineTextAlignment(.leading)
-
-            if let subtitle {
-                Text(subtitle)
-                    .foregroundStyle(Theme.colors.textTertiary)
-                    .font(Theme.fonts.bodySMedium)
-                    .multilineTextAlignment(.leading)
-            }
-
-            HStack(spacing: 12) {
-                SearchTextField(value: $searchText, isFocused: $searchBarFocused)
-                Button {
-                    searchText = ""
-                    searchBarFocused.toggle()
-                } label: {
-                    Text("cancel".localized)
-                        .foregroundStyle(Theme.colors.textPrimary)
-                        .font(Theme.fonts.bodySMedium)
-                }
-                .buttonStyle(.plain)
-                .transition(.opacity)
-                .showIf(searchBarFocused)
-            }
-            .animation(.easeInOut, value: searchBarFocused)
-        }
-    }
-
-    @ViewBuilder
-    var grid: some View {
-        let spacing: CGFloat = 16
-        let gridItem = GridItem(.flexible(), spacing: spacing)
-        ForEach(elements, id: \.self) { section in
-            VStack(alignment: .leading, spacing: 8) {
-                if let title = section.title, !section.assets.isEmpty {
-                    Text(title)
-                        .foregroundStyle(Theme.colors.textTertiary)
-                        .font(Theme.fonts.footnote)
-                }
-                LazyVGrid(columns: Array.init(repeating: gridItem, count: 4), spacing: spacing) {
-                    ForEach(section.assets, id: \.self) { element in
-                        cellBuilder(element, section.type)
-                    }
-                }
-            }
-            .padding(.bottom, 16)
-        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Common/AssetSelection/AssetSelectionContainerView.swift
+++ b/VultisigApp/VultisigApp/Features/Common/AssetSelection/AssetSelectionContainerView.swift
@@ -14,6 +14,7 @@ struct AssetSelectionContainerView<Asset: Hashable, SectionType: Hashable, CellV
     let elements: [AssetSection<SectionType, Asset>]
     var cellBuilder: (Asset, SectionType) -> CellView
     var emptyStateBuilder: () -> EmptyStateView
+    var onRetrySection: ((SectionType) -> Void)?
     let insets: EdgeInsets
 
     @State var searchBarFocused: Bool = false
@@ -25,7 +26,8 @@ struct AssetSelectionContainerView<Asset: Hashable, SectionType: Hashable, CellV
         insets: EdgeInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0),
         elements: [AssetSection<SectionType, Asset>],
         cellBuilder: @escaping (Asset, SectionType) -> CellView,
-        emptyStateBuilder: @escaping () -> EmptyStateView
+        emptyStateBuilder: @escaping () -> EmptyStateView,
+        onRetrySection: ((SectionType) -> Void)? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -33,6 +35,7 @@ struct AssetSelectionContainerView<Asset: Hashable, SectionType: Hashable, CellV
         self.elements = elements
         self.cellBuilder = cellBuilder
         self.emptyStateBuilder = emptyStateBuilder
+        self.onRetrySection = onRetrySection
         self.insets = insets
     }
 
@@ -40,8 +43,12 @@ struct AssetSelectionContainerView<Asset: Hashable, SectionType: Hashable, CellV
         content
     }
 
+    /// The empty state means "there is genuinely nothing to pick", so a section
+    /// that is still loading — or that failed and can be retried — suppresses it.
+    /// Sections whose assets resolve synchronously are always `.loaded`, so a
+    /// picker with no pending work still shows the empty state exactly as before.
     var showEmptyState: Bool {
-        elements.isEmpty
+        elements.allSatisfy { $0.state == .loaded && $0.assets.isEmpty }
     }
 
     var content: some View {
@@ -132,19 +139,59 @@ struct AssetSelectionContainerView<Asset: Hashable, SectionType: Hashable, CellV
         // insertions / removals / moves animate.
         ForEach(elements, id: \.type) { section in
             VStack(alignment: .leading, spacing: 8) {
-                if let title = section.title, !section.assets.isEmpty {
+                // A pending or failed section keeps its header so the user can
+                // see *which* group is still resolving rather than watching an
+                // unlabelled placeholder.
+                if let title = section.title, !section.assets.isEmpty || section.state != .loaded {
                     Text(title)
                         .foregroundStyle(Theme.colors.textTertiary)
                         .font(Theme.fonts.footnote)
                 }
-                LazyVGrid(columns: Array.init(repeating: gridItem, count: 4), spacing: spacing) {
-                    ForEach(section.assets, id: \.self) { element in
-                        cellBuilder(element, section.type)
+
+                switch section.state {
+                case .loading:
+                    LazyVGrid(columns: Array.init(repeating: gridItem, count: 4), spacing: spacing) {
+                        ForEach(0..<4, id: \.self) { _ in
+                            AssetSelectionGridCellSkeleton()
+                        }
+                    }
+                case .failed(let message):
+                    sectionFailureView(message: message, type: section.type)
+                case .loaded:
+                    LazyVGrid(columns: Array.init(repeating: gridItem, count: 4), spacing: spacing) {
+                        ForEach(section.assets, id: \.self) { element in
+                            cellBuilder(element, section.type)
+                        }
                     }
                 }
             }
             .padding(.bottom, 16)
         }
+    }
+
+    /// Inline failure row for one section. Deliberately scoped to the section —
+    /// the sections that did resolve stay usable while this one is retried.
+    @ViewBuilder
+    func sectionFailureView(message: String, type: SectionType) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            Icon(.triangleWarning, color: Theme.colors.alertWarning, size: 16)
+
+            Text(message)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .font(Theme.fonts.footnote)
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let onRetrySection {
+                PrimaryButton(title: "retry".localized, size: .mini) {
+                    onRetrySection(type)
+                }
+                .fixedSize()
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Theme.colors.bgSurface1))
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Common/AssetSelection/AssetSelectionGridCellSkeleton.swift
+++ b/VultisigApp/VultisigApp/Features/Common/AssetSelection/AssetSelectionGridCellSkeleton.swift
@@ -1,0 +1,34 @@
+//
+//  AssetSelectionGridCellSkeleton.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Placeholder tile shown while a section's assets are still being fetched.
+/// Mirrors `AssetSelectionGridCell`'s geometry so the grid does not reflow when
+/// the real cells arrive.
+struct AssetSelectionGridCellSkeleton: View {
+    var body: some View {
+        VStack(spacing: 10) {
+            RoundedRectangle(cornerRadius: 24)
+                .fill(Theme.colors.borderLight.opacity(0.3))
+                .frame(width: 74, height: 74)
+
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Theme.colors.borderLight.opacity(0.3))
+                .frame(width: 40, height: 12)
+        }
+        .frame(width: 74, height: 100)
+        .redacted(reason: .placeholder)
+        .accessibilityHidden(true)
+    }
+}
+
+#Preview {
+    HStack(spacing: 16) {
+        ForEach(0..<4, id: \.self) { _ in
+            AssetSelectionGridCellSkeleton()
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
@@ -11,7 +11,11 @@
 /// access; only liquidity pools need a live pool list. Callers rely on that
 /// split to publish the static sections immediately instead of gating the whole
 /// catalog on a network round-trip.
-protocol DefiPositionsProviding {
+///
+/// `Sendable` because the pool fetch is handed to a detached task: the view
+/// model captures its provider into the closure it races against a timeout, so
+/// every conformer has to be safe to use from another isolation domain.
+protocol DefiPositionsProviding: Sendable {
     func bondCoins(for chain: Chain) -> [CoinMeta]
     func stakeCoins(for chain: Chain) -> [CoinMeta]
     /// Whether `lpCoins(for:)` performs a network fetch for this chain. Lets a

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Service/DefiPositionsService.swift
@@ -5,7 +5,25 @@
 //  Created by Gaston Mazzeo on 13/11/2025.
 //
 
-struct DefiPositionsService {
+/// Source of the selectable DeFi position catalog.
+///
+/// Bond and stake are static, in-app lists and resolve without any network
+/// access; only liquidity pools need a live pool list. Callers rely on that
+/// split to publish the static sections immediately instead of gating the whole
+/// catalog on a network round-trip.
+protocol DefiPositionsProviding {
+    func bondCoins(for chain: Chain) -> [CoinMeta]
+    func stakeCoins(for chain: Chain) -> [CoinMeta]
+    /// Whether `lpCoins(for:)` performs a network fetch for this chain. Lets a
+    /// caller tell "this chain has no liquidity pools" apart from "the pool list
+    /// has not arrived yet", so a chain without LPs never shows a loading state.
+    func supportsLiquidityPools(for chain: Chain) -> Bool
+    /// Throws on a failed pool fetch so the caller can surface the failure and
+    /// offer a retry — an empty return means "this chain genuinely has none".
+    func lpCoins(for chain: Chain) async throws -> [CoinMeta]
+}
+
+struct DefiPositionsService: DefiPositionsProviding {
     private let thorchainService = THORChainAPIService()
 
     func bondCoins(for chain: Chain) -> [CoinMeta] {
@@ -66,16 +84,24 @@ struct DefiPositionsService {
     static let nativeSolanaMeta: CoinMeta? = TokensStore.TokenSelectionAssets
         .first { $0.chain == .solana && $0.isNativeToken }
 
-    func lpCoins(for chain: Chain) async -> [CoinMeta] {
+    /// Keep in sync with the network-backed branches of `lpCoins(for:)`.
+    func supportsLiquidityPools(for chain: Chain) -> Bool {
+        switch chain {
+        case .thorChain, .mayaChain:
+            true
+        default:
+            false
+        }
+    }
+
+    func lpCoins(for chain: Chain) async throws -> [CoinMeta] {
         switch chain {
         case .thorChain:
-            let pools = (try? await thorchainService.getPools()) ?? []
-            let coins = pools.compactMap { THORChainAssetFactory.createCoin(from: $0.asset) }
-            return coins
+            let pools = try await thorchainService.getPools()
+            return pools.compactMap { THORChainAssetFactory.createCoin(from: $0.asset) }
         case .mayaChain:
-            let pools = (try? await MayaChainAPIService().getPoolStats(period: SettingsAPRPeriod.current.rawValue)) ?? []
-            let coins = pools.compactMap { THORChainAssetFactory.createCoin(from: $0.asset) }
-            return coins
+            let pools = try await MayaChainAPIService().getPoolStats(period: SettingsAPRPeriod.current.rawValue)
+            return pools.compactMap { THORChainAssetFactory.createCoin(from: $0.asset) }
         default:
             return []
         }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/SelectPosition/DefiChainSelectPositionsScreen.swift
@@ -27,7 +27,8 @@ struct DefiChainSelectPositionsScreen: View {
                 elements: viewModel.filteredAvailablePositions,
                 onSave: onSave,
                 cellBuilder: cellBuilder,
-                emptyStateBuilder: { PositionNotFoundEmptyStateView() }
+                emptyStateBuilder: { PositionNotFoundEmptyStateView() },
+                onRetrySection: { _ in viewModel.loadLiquidityPools() }
             )
             .showIf(!selection.isEmpty)
             .withLoading(isLoading: $isLoading)
@@ -42,14 +43,15 @@ struct DefiChainSelectPositionsScreen: View {
 
     @ViewBuilder
     func cellBuilder(_ asset: CoinMeta, section: DefiChainPositionType) -> some View {
-        let pos = viewModel.availablePositions.firstIndex(where: { $0.type == section }) ?? 0
+        let pos = section.selectionIndex
         TokenSelectionGridCell(
             coin: asset,
             // Prefix for LPs
             name: section == .liquidityPool ? "\(viewModel.chain.ticker)/\(asset.ticker)" : asset.ticker,
             showChainIcon: section == .liquidityPool,
-            isSelected: selection[safe: pos]?.contains(asset) ?? false
+            isSelected: pos.flatMap { selection[safe: $0]?.contains(asset) } ?? false
         ) { selected in
+            guard let pos else { return }
             if selected {
                 add(asset: asset, section: pos)
             } else {
@@ -155,6 +157,27 @@ struct DefiChainSelectPositionsScreen: View {
             } catch {
                 logger.error("Failed to remove LP row for \(removed.ticker, privacy: .public): \(error.localizedDescription, privacy: .private)")
             }
+        }
+    }
+}
+
+private extension DefiChainPositionType {
+    /// Bucket index of this position type inside `selection`, fixed by the shape
+    /// of the persisted `DefiPositions` record. Deliberately independent of the
+    /// catalog's section order, which is presentational: deriving it from the
+    /// catalog would silently file a selection under the wrong position type if
+    /// a section were ever reordered or omitted.
+    var selectionIndex: Int? {
+        switch self {
+        case .bond:
+            0
+        case .stake:
+            1
+        case .liquidityPool:
+            2
+        case .governance:
+            // Not a selectable asset — it has no bucket.
+            nil
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
@@ -6,7 +6,11 @@
 //
 
 import Foundation
+import OSLog
 
+private let logger = Log.defi.viewModel
+
+@MainActor
 final class DefiChainMainViewModel: ObservableObject {
     @Published private(set) var vault: Vault
     @Published var selectedPosition: DefiChainPositionType = .bond
@@ -21,15 +25,29 @@ final class DefiChainMainViewModel: ObservableObject {
             let newPositions = section.assets
                 .filter { $0.ticker.localizedCaseInsensitiveContains(positionsSearchText) || $0.chain.ticker.localizedCaseInsensitiveContains(positionsSearchText) }
             guard !newPositions.isEmpty else { return nil }
-            return AssetSection(title: section.title, type: section.type, assets: newPositions)
+            return AssetSection(title: section.title, type: section.type, assets: newPositions, state: section.state)
         }
     }
 
     let chain: Chain
 
-    init(vault: Vault, chain: Chain) {
+    private let positionsService: DefiPositionsProviding
+    /// Wall-clock cap on the liquidity-pool fetch, so the section cannot sit in
+    /// its loading state indefinitely behind a stalled connection.
+    private let lpLoadTimeout: TimeInterval
+    /// Readable so tests can await the in-flight fetch instead of polling.
+    private(set) var lpLoadTask: Task<Void, Never>?
+
+    init(
+        vault: Vault,
+        chain: Chain,
+        positionsService: DefiPositionsProviding = DefiPositionsService(),
+        lpLoadTimeout: TimeInterval = 15
+    ) {
         self.vault = vault
         self.chain = chain
+        self.positionsService = positionsService
+        self.lpLoadTimeout = lpLoadTimeout
     }
 
     func update(vault: Vault) {
@@ -58,9 +76,7 @@ final class DefiChainMainViewModel: ObservableObject {
             SegmentedControlItem(value: $0, title: $0.segmentedControlTitle)
         }
         selectedPosition = positionTypes.first ?? .bond
-        Task {
-            await setupSelectablePositions()
-        }
+        setupSelectablePositions()
     }
 
     func refresh() async {
@@ -68,19 +84,75 @@ final class DefiChainMainViewModel: ObservableObject {
         await BalanceService.shared.updateBalance(for: nativeCoin)
     }
 
-    func setupSelectablePositions() async {
-        let positionsService = DefiPositionsService()
-        let bond = positionsService.bondCoins(for: chain)
-        let staking = positionsService.stakeCoins(for: chain)
-        let lps = await positionsService.lpCoins(for: chain)
+    /// Publishes the whole catalog synchronously. Bond and stake come from
+    /// static in-app lists and must never wait on the network — gating them on
+    /// the pool fetch left the picker rendering its "no positions" empty state
+    /// for the duration of the request, with nothing to enable.
+    ///
+    /// All three sections are always present and always in this order: the
+    /// picker maps a tapped cell back to a selection bucket by section type, and
+    /// the persisted `DefiPositions` record has one field per type.
+    func setupSelectablePositions() {
+        let supportsLiquidityPools = positionsService.supportsLiquidityPools(for: chain)
+        availablePositions = [
+            AssetSection(
+                title: DefiChainPositionType.bond.sectionTitle,
+                type: .bond,
+                assets: positionsService.bondCoins(for: chain)
+            ),
+            AssetSection(
+                title: DefiChainPositionType.stake.sectionTitle,
+                type: .stake,
+                assets: positionsService.stakeCoins(for: chain)
+            ),
+            AssetSection(
+                title: DefiChainPositionType.liquidityPool.sectionTitle,
+                type: .liquidityPool,
+                assets: [],
+                // A chain without pools resolves to a genuine empty section, not
+                // a spinner that would never finish.
+                state: supportsLiquidityPools ? .loading : .loaded
+            )
+        ]
 
-        await MainActor.run {
-            availablePositions = [
-                AssetSection(title: DefiChainPositionType.bond.sectionTitle, type: DefiChainPositionType.bond, assets: bond),
-                AssetSection(title: DefiChainPositionType.stake.sectionTitle, type: .stake, assets: staking),
-                AssetSection(title: DefiChainPositionType.liquidityPool.sectionTitle, type: .liquidityPool, assets: lps)
-            ]
+        guard supportsLiquidityPools else { return }
+        loadLiquidityPools()
+    }
+
+    /// Fetches the liquidity-pool catalog independently of the static sections.
+    /// A failure or timeout only marks the LP section `.failed` — the bond and
+    /// stake sections stay exactly as they are.
+    func loadLiquidityPools() {
+        lpLoadTask?.cancel()
+        updateLiquidityPoolSection(assets: [], state: .loading)
+
+        lpLoadTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let lps = try await withTimeout(seconds: self.lpLoadTimeout) { [positionsService = self.positionsService, chain = self.chain] in
+                    try await positionsService.lpCoins(for: chain)
+                }
+                guard !Task.isCancelled else { return }
+                self.updateLiquidityPoolSection(assets: lps, state: .loaded)
+            } catch {
+                guard !Task.isCancelled else { return }
+                logger.error("Failed to load \(self.chain.rawValue, privacy: .public) LP catalog: \(error.localizedDescription, privacy: .public)")
+                self.updateLiquidityPoolSection(assets: [], state: .failed(message: "failedToLoadPools".localized))
+            }
         }
+    }
+
+    /// Replaces the LP section in place so the section order — which the picker
+    /// depends on — is never disturbed.
+    private func updateLiquidityPoolSection(assets: [CoinMeta], state: AssetSectionState) {
+        guard let index = availablePositions.firstIndex(where: { $0.type == .liquidityPool }) else { return }
+        let section = availablePositions[index]
+        availablePositions[index] = AssetSection(
+            title: section.title,
+            type: section.type,
+            assets: assets,
+            state: state
+        )
     }
 
     func getDefiPositionTypes() -> [DefiChainPositionType] {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
@@ -22,6 +22,10 @@ final class DefiChainMainViewModel: ObservableObject {
     var filteredAvailablePositions: [AssetSection<DefiChainPositionType, CoinMeta>] {
         guard positionsSearchText.isNotEmpty else { return availablePositions }
         return availablePositions.compactMap { section in
+            // An unresolved section has nothing to match yet. Keep it so a search
+            // run while the pool list is still arriving doesn't claim "no
+            // positions found", and so a failed section keeps its retry action.
+            guard section.state == .loaded else { return section }
             let newPositions = section.assets
                 .filter { $0.ticker.localizedCaseInsensitiveContains(positionsSearchText) || $0.chain.ticker.localizedCaseInsensitiveContains(positionsSearchText) }
             guard !newPositions.isEmpty else { return nil }

--- a/VultisigApp/VultisigAppTests/Core/AsyncTimeoutTests.swift
+++ b/VultisigApp/VultisigAppTests/Core/AsyncTimeoutTests.swift
@@ -11,6 +11,24 @@ final class AsyncTimeoutTests: XCTestCase {
         case boom
     }
 
+    /// Cross-actor flag: the operation closure runs off the main actor.
+    private final class Flag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+
+        func set() {
+            lock.lock()
+            value = true
+            lock.unlock()
+        }
+
+        var isSet: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+    }
+
     func testReturnsTheValueWhenTheOperationBeatsTheDeadline() async throws {
         let value = try await withTimeout(seconds: 5) { 42 }
         XCTAssertEqual(value, 42)
@@ -63,5 +81,30 @@ final class AsyncTimeoutTests: XCTestCase {
             operationDuration,
             "withTimeout must not wait for a non-cooperative operation to finish."
         )
+    }
+
+    /// An already-cancelled task fires its cancellation handler *before* the
+    /// continuation body runs. That result must be held and delivered rather than
+    /// dropped, otherwise an abandoned load would still fire its request.
+    @MainActor
+    func testAlreadyCancelledTaskFailsWithoutRunningTheOperation() async {
+        let didRun = Flag()
+
+        // Inherits the main actor, so it cannot start before `cancel()` below.
+        let task = Task { () -> Int in
+            try await withTimeout(seconds: 5) {
+                didRun.set()
+                return 1
+            }
+        }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation.")
+        } catch {
+            XCTAssertTrue(error is CancellationError, "Got \(error)")
+        }
+        XCTAssertFalse(didRun.isSet, "A cancelled task must not start the operation.")
     }
 }

--- a/VultisigApp/VultisigAppTests/Core/AsyncTimeoutTests.swift
+++ b/VultisigApp/VultisigAppTests/Core/AsyncTimeoutTests.swift
@@ -1,0 +1,67 @@
+//
+//  AsyncTimeoutTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class AsyncTimeoutTests: XCTestCase {
+    private enum StubError: Error {
+        case boom
+    }
+
+    func testReturnsTheValueWhenTheOperationBeatsTheDeadline() async throws {
+        let value = try await withTimeout(seconds: 5) { 42 }
+        XCTAssertEqual(value, 42)
+    }
+
+    func testPropagatesTheOperationErrorRatherThanTheTimeout() async {
+        do {
+            _ = try await withTimeout(seconds: 5) { throw StubError.boom }
+            XCTFail("Expected the operation's own error to propagate.")
+        } catch is AsyncTimeoutError {
+            XCTFail("A fast failure must not be reported as a timeout.")
+        } catch {
+            XCTAssertTrue(error is StubError)
+        }
+    }
+
+    func testThrowsTimeoutWhenTheDeadlineWins() async {
+        do {
+            _ = try await withTimeout(seconds: 0.05) {
+                try await Task.sleep(for: .seconds(30))
+                return 1
+            }
+            XCTFail("Expected a timeout.")
+        } catch {
+            XCTAssertTrue(error is AsyncTimeoutError, "Got \(error)")
+        }
+    }
+
+    /// The point of the utility: it returns on the deadline even when the
+    /// operation refuses to stop, instead of waiting for the operation to finish.
+    func testReturnsOnDeadlineEvenWhenTheOperationIgnoresCancellation() async {
+        let operationDuration: TimeInterval = 3
+        let start = Date()
+
+        do {
+            _ = try await withTimeout(seconds: 0.1) {
+                // Uncancellable on purpose — Thread.sleep never checks for
+                // cancellation, standing in for a wedged non-cooperative call.
+                Thread.sleep(forTimeInterval: operationDuration)
+                return 1
+            }
+            XCTFail("Expected a timeout.")
+        } catch {
+            XCTAssertTrue(error is AsyncTimeoutError, "Got \(error)")
+        }
+
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(
+            elapsed,
+            operationDuration,
+            "withTimeout must not wait for a non-cooperative operation to finish."
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainMainViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainMainViewModelTests.swift
@@ -1,0 +1,219 @@
+//
+//  DefiChainMainViewModelTests.swift
+//  VultisigAppTests
+//
+//  The bond and stake catalogs are static in-app lists; only liquidity pools
+//  need the network. These tests pin that separation: a slow, failing or
+//  timing-out pool fetch must never blank the sections that need no network.
+//
+
+@testable import VultisigApp
+import SwiftData
+import XCTest
+
+@MainActor
+final class DefiChainMainViewModelTests: XCTestCase {
+    private var storeToken: TestContextToken!
+    private var vault: Vault!
+    private var service: MockDefiPositionsProvider!
+
+    private let bondCoin = CoinMeta.make(chain: .thorChain, ticker: "RUNE")
+    private let stakeCoin = CoinMeta.make(chain: .thorChain, ticker: "TCY")
+    private let lpCoin = CoinMeta.make(chain: .thorChain, ticker: "BTC")
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+        vault = TestStore.makeVault()
+        service = MockDefiPositionsProvider()
+        service.bondStub = [bondCoin]
+        service.stakeStub = [stakeCoin]
+        service.lpStub = [lpCoin]
+    }
+
+    override func tearDown() async throws {
+        service = nil
+        vault = nil
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
+    private func makeViewModel(chain: Chain = .thorChain, lpLoadTimeout: TimeInterval = 5) -> DefiChainMainViewModel {
+        DefiChainMainViewModel(
+            vault: vault,
+            chain: chain,
+            positionsService: service,
+            lpLoadTimeout: lpLoadTimeout
+        )
+    }
+
+    private func section(
+        _ type: DefiChainPositionType,
+        in vm: DefiChainMainViewModel
+    ) -> AssetSection<DefiChainPositionType, CoinMeta>? {
+        vm.availablePositions.first { $0.type == type }
+    }
+
+    // MARK: - Static sections are never gated on the network
+
+    func testStaticSectionsArePublishedBeforeLiquidityPoolsResolve() {
+        // A pool fetch that never returns within the test's lifetime.
+        service.lpDelay = .seconds(60)
+        let vm = makeViewModel()
+
+        vm.onLoad()
+
+        // No awaiting: the static catalog must be readable the instant onLoad returns.
+        XCTAssertEqual(vm.availablePositions.count, 3)
+        XCTAssertEqual(section(.bond, in: vm)?.assets, [bondCoin])
+        XCTAssertEqual(section(.stake, in: vm)?.assets, [stakeCoin])
+        XCTAssertTrue(
+            section(.liquidityPool, in: vm)?.state.isLoading ?? false,
+            "LP section must report loading, not an empty result."
+        )
+    }
+
+    func testPickerIsNeverFullyEmptyWhileLiquidityPoolsLoad() {
+        service.lpDelay = .seconds(60)
+        let vm = makeViewModel()
+
+        vm.onLoad()
+
+        // The empty state keys off "every section loaded and empty" — this is the
+        // exact condition that used to render "No positions found" for the whole sheet.
+        let looksEmpty = vm.availablePositions.allSatisfy { $0.state == .loaded && $0.assets.isEmpty }
+        XCTAssertFalse(looksEmpty)
+    }
+
+    // MARK: - Failure isolation
+
+    func testLiquidityPoolFailureLeavesStaticSectionsIntact() async {
+        service.lpError = MockDefiPositionsProvider.StubError.unreachable
+        let vm = makeViewModel()
+
+        vm.onLoad()
+        await vm.lpLoadTask?.value
+
+        XCTAssertEqual(section(.bond, in: vm)?.assets, [bondCoin], "A pools failure must not touch the bond section.")
+        XCTAssertEqual(section(.stake, in: vm)?.assets, [stakeCoin], "A pools failure must not touch the stake section.")
+        XCTAssertTrue(section(.liquidityPool, in: vm)?.state.isFailed ?? false)
+        XCTAssertEqual(section(.liquidityPool, in: vm)?.assets, [])
+    }
+
+    func testLiquidityPoolTimeoutIsSurfacedAsFailure() async {
+        // Fetch outlives the wall-clock budget.
+        service.lpDelay = .seconds(30)
+        let vm = makeViewModel(lpLoadTimeout: 0.05)
+
+        vm.onLoad()
+        await vm.lpLoadTask?.value
+
+        XCTAssertTrue(
+            section(.liquidityPool, in: vm)?.state.isFailed ?? false,
+            "A hung pool fetch must resolve to a retryable failure, not an endless spinner."
+        )
+        XCTAssertEqual(section(.bond, in: vm)?.assets, [bondCoin])
+        XCTAssertEqual(section(.stake, in: vm)?.assets, [stakeCoin])
+    }
+
+    // MARK: - Retry
+
+    func testRetryAfterFailureRepopulatesLiquidityPools() async {
+        service.lpError = MockDefiPositionsProvider.StubError.unreachable
+        let vm = makeViewModel()
+
+        vm.onLoad()
+        await vm.lpLoadTask?.value
+        XCTAssertTrue(section(.liquidityPool, in: vm)?.state.isFailed ?? false)
+        XCTAssertEqual(service.lpCallCount, 1)
+
+        service.lpError = nil
+        vm.loadLiquidityPools()
+        await vm.lpLoadTask?.value
+
+        XCTAssertEqual(service.lpCallCount, 2)
+        XCTAssertEqual(section(.liquidityPool, in: vm)?.state, .loaded)
+        XCTAssertEqual(section(.liquidityPool, in: vm)?.assets, [lpCoin])
+    }
+
+    func testRetryReturnsSectionToLoadingWhileInFlight() async {
+        service.lpError = MockDefiPositionsProvider.StubError.unreachable
+        let vm = makeViewModel()
+        vm.onLoad()
+        await vm.lpLoadTask?.value
+
+        service.lpError = nil
+        service.lpDelay = .seconds(60)
+        vm.loadLiquidityPools()
+
+        XCTAssertTrue(
+            section(.liquidityPool, in: vm)?.state.isLoading ?? false,
+            "Retry must clear the failure so the user sees progress."
+        )
+        vm.lpLoadTask?.cancel()
+    }
+
+    // MARK: - Success
+
+    func testSuccessfulLoadPopulatesAllThreeSections() async {
+        let vm = makeViewModel()
+
+        vm.onLoad()
+        await vm.lpLoadTask?.value
+
+        XCTAssertEqual(section(.bond, in: vm)?.assets, [bondCoin])
+        XCTAssertEqual(section(.stake, in: vm)?.assets, [stakeCoin])
+        XCTAssertEqual(section(.liquidityPool, in: vm)?.assets, [lpCoin])
+        XCTAssertTrue(vm.availablePositions.allSatisfy { $0.state == .loaded })
+    }
+
+    // MARK: - Section ordering (selection buckets depend on it)
+
+    func testSectionOrderIsStableAcrossEveryLoadPhase() async {
+        let expected: [DefiChainPositionType] = [.bond, .stake, .liquidityPool]
+        service.lpDelay = .seconds(60)
+        let vm = makeViewModel(lpLoadTimeout: 0.05)
+
+        vm.onLoad()
+        XCTAssertEqual(vm.availablePositions.map(\.type), expected, "order while loading")
+
+        await vm.lpLoadTask?.value
+        XCTAssertEqual(vm.availablePositions.map(\.type), expected, "order after failure")
+
+        service.lpDelay = nil
+        vm.loadLiquidityPools()
+        await vm.lpLoadTask?.value
+        XCTAssertEqual(vm.availablePositions.map(\.type), expected, "order after success")
+    }
+
+    // MARK: - Chains without liquidity pools
+
+    func testChainWithoutLiquidityPoolsNeverEntersLoadingState() {
+        service.supportsLPs = false
+        service.bondStub = []
+        service.stakeStub = [CoinMeta.make(chain: .ton, ticker: "TON")]
+        let vm = makeViewModel(chain: .ton)
+
+        vm.onLoad()
+
+        XCTAssertEqual(section(.liquidityPool, in: vm)?.state, .loaded)
+        XCTAssertEqual(service.lpCallCount, 0, "A chain with no pools must not hit the network.")
+        XCTAssertNil(vm.lpLoadTask)
+    }
+
+    // MARK: - Search filtering
+
+    func testSearchNarrowsToMatchingSectionsAndKeepsTheirState() async {
+        let vm = makeViewModel()
+        vm.onLoad()
+        await vm.lpLoadTask?.value
+
+        vm.positionsSearchText = "TCY"
+
+        let filtered = vm.filteredAvailablePositions
+        XCTAssertEqual(filtered.map(\.type), [.stake])
+        XCTAssertEqual(filtered.first?.assets, [stakeCoin])
+        XCTAssertEqual(filtered.first?.state, .loaded)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainMainViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainMainViewModelTests.swift
@@ -216,4 +216,33 @@ final class DefiChainMainViewModelTests: XCTestCase {
         XCTAssertEqual(filtered.first?.assets, [stakeCoin])
         XCTAssertEqual(filtered.first?.state, .loaded)
     }
+
+    func testSearchKeepsAnUnresolvedSectionVisible() {
+        service.lpDelay = .seconds(60)
+        let vm = makeViewModel()
+        vm.onLoad()
+
+        // "BTC" only ever matches a pool, which has not arrived yet. Dropping the
+        // loading section here would report "no positions found" for a catalog
+        // that is still on its way.
+        vm.positionsSearchText = "BTC"
+
+        let filtered = vm.filteredAvailablePositions
+        XCTAssertEqual(filtered.map(\.type), [.liquidityPool])
+        XCTAssertTrue(filtered.first?.state.isLoading ?? false)
+        vm.lpLoadTask?.cancel()
+    }
+
+    func testSearchKeepsAFailedSectionVisibleSoRetryStaysReachable() async {
+        service.lpError = MockDefiPositionsProvider.StubError.unreachable
+        let vm = makeViewModel()
+        vm.onLoad()
+        await vm.lpLoadTask?.value
+
+        vm.positionsSearchText = "BTC"
+
+        let filtered = vm.filteredAvailablePositions
+        XCTAssertEqual(filtered.map(\.type), [.liquidityPool])
+        XCTAssertTrue(filtered.first?.state.isFailed ?? false)
+    }
 }

--- a/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
@@ -33,4 +33,38 @@ final class MockLPsInteractor: LPsInteractor, @unchecked Sendable {
     }
 }
 
+/// Test double for the selectable-position catalog. `lpDelay` and `lpError` let
+/// a test hold the pool fetch open, fail it, or make it outlive the view model's
+/// wall-clock budget — the three cases that used to blank the whole picker.
+final class MockDefiPositionsProvider: DefiPositionsProviding, @unchecked Sendable {
+    enum StubError: Error {
+        case unreachable
+    }
+
+    var bondStub: [CoinMeta] = []
+    var stakeStub: [CoinMeta] = []
+    var lpStub: [CoinMeta] = []
+    var supportsLPs = true
+    var lpDelay: Duration?
+    var lpError: Error?
+    private(set) var lpCallCount = 0
+
+    func bondCoins(for chain: Chain) -> [CoinMeta] { bondStub }
+
+    func stakeCoins(for chain: Chain) -> [CoinMeta] { stakeStub }
+
+    func supportsLiquidityPools(for chain: Chain) -> Bool { supportsLPs }
+
+    func lpCoins(for chain: Chain) async throws -> [CoinMeta] {
+        lpCallCount += 1
+        if let lpDelay {
+            try await Task.sleep(for: lpDelay)
+        }
+        if let lpError {
+            throw lpError
+        }
+        return lpStub
+    }
+}
+
 // swiftlint:enable async_without_await unused_parameter

--- a/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Helpers/MockInteractors.swift
@@ -36,18 +36,60 @@ final class MockLPsInteractor: LPsInteractor, @unchecked Sendable {
 /// Test double for the selectable-position catalog. `lpDelay` and `lpError` let
 /// a test hold the pool fetch open, fail it, or make it outlive the view model's
 /// wall-clock budget — the three cases that used to blank the whole picker.
+///
+/// Every property sits behind a lock, which is what backs the `@unchecked
+/// Sendable` here. This is not theoretical: `withTimeout` abandons a timed-out
+/// operation rather than awaiting it, so `lpCoins` can still be running on the
+/// cooperative pool while the test mutates the stubs from the main actor.
+/// `lpCoins` therefore snapshots the stubs once, under the lock, so a single
+/// call cannot observe a half-applied change.
 final class MockDefiPositionsProvider: DefiPositionsProviding, @unchecked Sendable {
     enum StubError: Error {
         case unreachable
     }
 
-    var bondStub: [CoinMeta] = []
-    var stakeStub: [CoinMeta] = []
-    var lpStub: [CoinMeta] = []
-    var supportsLPs = true
-    var lpDelay: Duration?
-    var lpError: Error?
-    private(set) var lpCallCount = 0
+    private let lock = NSLock()
+    private var _bondStub: [CoinMeta] = []
+    private var _stakeStub: [CoinMeta] = []
+    private var _lpStub: [CoinMeta] = []
+    private var _supportsLPs = true
+    private var _lpDelay: Duration?
+    private var _lpError: Error?
+    private var _lpCallCount = 0
+
+    var bondStub: [CoinMeta] {
+        get { lock.withLock { _bondStub } }
+        set { lock.withLock { _bondStub = newValue } }
+    }
+
+    var stakeStub: [CoinMeta] {
+        get { lock.withLock { _stakeStub } }
+        set { lock.withLock { _stakeStub = newValue } }
+    }
+
+    var lpStub: [CoinMeta] {
+        get { lock.withLock { _lpStub } }
+        set { lock.withLock { _lpStub = newValue } }
+    }
+
+    var supportsLPs: Bool {
+        get { lock.withLock { _supportsLPs } }
+        set { lock.withLock { _supportsLPs = newValue } }
+    }
+
+    var lpDelay: Duration? {
+        get { lock.withLock { _lpDelay } }
+        set { lock.withLock { _lpDelay = newValue } }
+    }
+
+    var lpError: Error? {
+        get { lock.withLock { _lpError } }
+        set { lock.withLock { _lpError = newValue } }
+    }
+
+    var lpCallCount: Int {
+        lock.withLock { _lpCallCount }
+    }
 
     func bondCoins(for chain: Chain) -> [CoinMeta] { bondStub }
 
@@ -56,14 +98,18 @@ final class MockDefiPositionsProvider: DefiPositionsProviding, @unchecked Sendab
     func supportsLiquidityPools(for chain: Chain) -> Bool { supportsLPs }
 
     func lpCoins(for chain: Chain) async throws -> [CoinMeta] {
-        lpCallCount += 1
-        if let lpDelay {
-            try await Task.sleep(for: lpDelay)
+        let (delay, error, stub) = lock.withLock {
+            _lpCallCount += 1
+            return (_lpDelay, _lpError, _lpStub)
         }
-        if let lpError {
-            throw lpError
+
+        if let delay {
+            try await Task.sleep(for: delay)
         }
-        return lpStub
+        if let error {
+            throw error
+        }
+        return stub
     }
 }
 


### PR DESCRIPTION
## Problem

The THORChain DeFi **Select positions** sheet could render "No positions found" with nothing to enable — no Bond, no Stake, no LPs. With an empty picker the user cannot turn on a single position, so bond / stake / LP management is unreachable.

For THORChain this should be impossible: Bond (RUNE) and Stake (TCY / sTCY / RUJI / sRUJI / yRUNE / yTCY / ybRUNE) are **static in-app lists**. Only LPs need the network.

## Root cause

`DefiChainMainViewModel.setupSelectablePositions()` computed the static bond and stake lists synchronously, then `await`ed `DefiPositionsService.lpCoins(for:)` → `THORChainAPIService.getPools()`, and assigned `availablePositions` **only after that await** — all three sections in one shot.

`AssetSelectionContainerView` decides its empty state on exactly that value:

```swift
var showEmptyState: Bool { elements.isEmpty }   // before
```

So for the whole duration of the `/pools` round-trip the catalog was `[]` and the sheet rendered its empty state, static sections included. Opening the picker inside that window showed nothing at all.

The window is never short-circuited by caching: `DefiPositionsService` constructs a **fresh** `THORChainAPIService` on every call, and `THORChainAPICache` keeps its entries in *instance* storage — so this path always pays a cold network round-trip.

A second, longer-lived defect sat behind the same code: on a failed fetch `(try? …) ?? []` dropped the error, so the LP section was silently empty with no message and no retry — and it was **never re-attempted**, because `.onLoad` fires once per view identity (`OnLoadModifier` guards on `@State didLoad`) and pull-to-refresh calls `viewModel.refresh()`, which only updates the native-coin balance.

### Corrections to the issue's premises

Worth recording, since the issue asserts otherwise:

- **`/pools` already had a timeout.** `ThorchainMainnetAPI.timeoutInterval` returns `10` for `.pools`. That is a *request-level idle* timeout though — it bounds the gap between packets, not total elapsed time — so a slow-drip response can still outlive it. A wall-clock bound was still worth adding, and this PR adds one at the catalog layer.
- **The silent `try?` alone cannot blank the whole picker.** On failure the assignment still ran, so Bond and Stake *did* populate; only the LP section came back empty. The fully-empty sheet is the loading-window race, not the swallowed error.
- **"The `onLoad` Task dies" is unproven.** The `Task {}` is unstructured and not bound to the view lifecycle; I found no evidence of it being cancelled and did not treat it as a cause.
- The file reference `THORChainAPIService.swift:78+` is right about the line but the path is `Blockchain/THORChain/API/THORChainAPIService.swift`.
- Maya's LP branch had the same silent `try?` (`DefiPositionsService.swift:76`), which the issue did not mention. It is fixed too.

**What I can prove:** the loading-window race and the silent-permanent-LP-failure, both directly from the code. **What I cannot prove:** which of the two the reporter's screenshot actually captured. The fix makes the fully-empty catalog unreachable either way.

## Fix

- **Publish the static sections synchronously.** All three sections are assigned the moment `onLoad()` runs; only the LP section waits on the network.
- **Give the LP section its own state.** `lpCoins` now `throws` (no more silent `try?`); the view model marks the section `.loading` / `.loaded` / `.failed` and exposes `loadLiquidityPools()` as the retry entry point.
- **Distinguish loading from genuinely empty** in the shared picker: redacted skeleton tiles while loading, an inline message + **Retry** on failure, and the empty state only when *every* section is loaded and empty.
- **Bound the fetch with a wall-clock timeout** (`withTimeout`), so a wedged connection cannot pin the section in its loading state.
- **Remove a latent mis-filing bug:** a tapped cell now maps to its selection bucket by position *type* (`DefiChainPositionType.selectionIndex`) instead of by the section's index in the catalog. Previously `firstIndex(where:) ?? 0` meant any reordering or omission would silently file a selection under the wrong position type.
- Deleted `AssetSelectionContainerSheet`'s unused `grid` / `textfield` / `gradientOverlay` members (dead — the sheet delegates rendering to `AssetSelectionContainerView`).

**No new user-facing strings.** Reuses `failedToLoadPools` and `retry`, both already present in all 8 locales (de, en, es, hr, it, ko, pt, zh-Hans).

## Chains and pickers verified

`DefiChainMainViewModel` is shared by every DeFi chain, so the fix is general rather than THORChain-specific. Section order stays `[bond, stake, liquidityPool]` for **every** chain — the persisted `DefiPositions` record has one field per type and `updateVaultDefiPositions()` reads `selection[safe: 0/1/2]`, so a dropped or reordered section would corrupt the saved selection.

| Chain | Behaviour |
|---|---|
| thorChain | Bond + Stake immediate; LP section loads, fails-with-retry, or times out independently |
| mayaChain | Same; its LP fetch had the same silent `try?` and is fixed too |
| terra / terraClassic / ton / solana / qbtc | No LP support → LP section resolves to `.loaded` and empty, never enters a loading state and never hits the network |

`AssetSelectionContainerSheet` / `AssetSelectionContainerView` are shared by **5** pickers. All were checked:

- `TokenSelectionScreen`, `VaultSelectChainScreen`, `DefiSelectChainScreen`, `TransactionHistoryAssetFilterView` — build their sections synchronously, so every section is `.loaded` (the default) and behaviour is unchanged. They additionally *gain* a correct empty state: with `elements.isEmpty` they rendered a blank grid when sections existed but were all empty; now they show the empty state.
- `DefiChainSelectPositionsScreen` — the picker this issue is about.

## Verification

- **Full suite** (not a subset): `make test` — see the checked result below.
- SwiftLint clean on every changed file.
- 16 new tests: 12 in `DefiChainMainViewModelTests`, 4 in `AsyncTimeoutTests`.
- Cross-model review: two Codex (`gpt-5.5-high`, read-only) passes — one per-commit, one whole-branch.

## Manual / on-device steps for a human

These are the parts automated tests cannot cover:

1. **Blocked-THORNode open (the actual regression test).** Put the device in airplane mode — or block `thornode.ninerealms.com` — then open DeFi → THORChain → the manage-positions button. **Bond and Stake must be listed and selectable.** The LP section should show the failure row with a Retry button. Before this change the sheet said "No positions found".
2. **Slow-network open.** With Network Link Conditioner on a poor profile, open the picker *immediately* after the DeFi screen appears. Expect Bond/Stake instantly and skeleton tiles under Liquidity Pools, never a blank sheet.
3. **Retry.** From the failed state, restore connectivity and tap Retry — the LP section should populate in place, without disturbing already-ticked Bond/Stake selections.
4. **Selection integrity.** Enable one position of each type, save, reopen: each must come back ticked under its own heading (guards the `selectionIndex` change). Confirm the rows appear on the DeFi screen.
5. **Search while loading.** Type into the search box while pools are still loading — the Liquidity Pools section should stay visible as loading rather than reporting "no positions found".
6. **Other pickers unaffected.** Open Select chains and the token picker; confirm normal listing and that searching for nonsense still shows the empty state.
7. **macOS.** Repeat step 1 on the macOS target — the sheet is cross-platform.

Closes #5021


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading, error, and retry states to asset and DeFi position selection screens.
  * Added skeleton placeholders while assets or liquidity pools load.
  * Added timeout handling for long-running liquidity-pool requests.
  * Added retry support for failed liquidity-pool loading.

* **Bug Fixes**
  * Network errors now appear as failures instead of empty results.
  * Search and filtering now preserve sections that are still loading or have failed.

* **Tests**
  * Added coverage for timeouts, retries, loading states, failures, cancellation, and successful loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->