### PR TITLE
fix(coin-detail): open the sheet at a partial detent with a faded bottom edge

### DIFF
--- a/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
@@ -18,6 +18,10 @@ struct CoinDetailScreen: View {
     @State var showContractCopiedBanner: Bool = false
     @State var size: CGFloat?
 
+    /// Where the sheet is resting. Purely presentation state — it never leaves
+    /// the view, so it stays here rather than in the view model.
+    @State private var detent: PresentationDetent = CoinDetailScreen.initialDetent
+
     @StateObject var viewModel: CoinDetailViewModel
 
     @Environment(\.openURL) var openURL
@@ -54,10 +58,86 @@ struct CoinDetailScreen: View {
 #endif
     }
 
+    /// Resting height of the sheet on iPhone, as a fraction of its full height.
+    ///
+    /// Measured against a rendered sheet rather than picked as a ratio: 0.50
+    /// puts the sheet at ~405pt on an iPhone 16 Pro, the shortest height that
+    /// still clears the balance, the whole action row and the top of the price
+    /// chart — what the sheet is opened for. A third of the screen, the first
+    /// guess, cuts through the action labels and shows no chart at all.
+    private static let partialFraction: CGFloat = 0.50
+
+    /// iPad presents this as a large sheet and macOS sizes it with
+    /// `applySheetSize`; only iPhone has a partial resting height.
+    private static var supportsPartialDetent: Bool {
+        !isIPadOS && !isMacOS
+    }
+
+    /// `.large` stays in the set alongside the partial height so one drag still
+    /// reveals the chart and the market sections.
+    private static var detents: Set<PresentationDetent> {
+        supportsPartialDetent ? [.fraction(partialFraction), .large] : [.large]
+    }
+
+    private static var initialDetent: PresentationDetent {
+        supportsPartialDetent ? .fraction(partialFraction) : .large
+    }
+
+    /// Whether the sheet is resting below its full height.
+    private var isPartial: Bool {
+        Self.supportsPartialDetent && detent != .large
+    }
+
+    /// Scroll target for the top of the content, used to rewind the scroll
+    /// view when the sheet returns to its resting height.
+    private static let topAnchor = "coinDetailTop"
+
+    /// At the partial detent the content is cut mid-chart. Left hard, that edge
+    /// reads as a clipped view; dissolving the last strip into the sheet
+    /// surface makes it read as "there is more below" instead — the same
+    /// bottom-anchored surface gradient `ModalBackgroundView` and
+    /// `ListBottomSection` already use. Gone once the sheet is expanded, since
+    /// then the edge is the actual end of the content.
+    @ViewBuilder
+    private var bottomFade: some View {
+        if Self.supportsPartialDetent {
+            LinearGradient(
+                stops: [
+                    Gradient.Stop(color: Theme.colors.bgSurface1, location: 0.0),
+                    Gradient.Stop(color: Theme.colors.bgSurface1.opacity(0.55), location: 0.40),
+                    Gradient.Stop(color: Theme.colors.bgSurface1.opacity(0), location: 1.0)
+                ],
+                startPoint: .bottom,
+                endPoint: .top
+            )
+            .frame(height: 64)
+            .frame(maxHeight: .infinity, alignment: .bottom)
+            .allowsHitTesting(false)
+            .opacity(isPartial ? 1 : 0)
+            .animation(.easeInOut(duration: 0.2), value: isPartial)
+        }
+    }
+
     var content: some View {
+        ScrollViewReader { proxy in
+            scrollView
+                // Collapsing while scrolled would otherwise strand the user
+                // mid-content with scrolling switched off — and the actions,
+                // which are what the sheet is opened for, off the top of it.
+                .onChange(of: isPartial) { _, isNowPartial in
+                    guard isNowPartial else { return }
+                    proxy.scrollTo(Self.topAnchor, anchor: .top)
+                }
+        }
+    }
+
+    /// The sheet's scrolling body. Split out of `content` so the
+    /// `ScrollViewReader` that rewinds it stays a thin wrapper.
+    private var scrollView: some View {
         ScrollView {
             VStack(spacing: 24) {
                 CoinDetailHeaderView(coin: coin)
+                    .id(Self.topAnchor)
                 CoinActionsView(
                     actions: viewModel.availableActions,
                     onAction: onAction
@@ -80,7 +160,9 @@ struct CoinDetailScreen: View {
             .padding(.top, isMacOS ? 40 : 0)
             .padding(.bottom, 24)
         }
+        .scrollDisabled(isPartial)
         .background(ModalBackgroundView(width: size ?? 0))
+        .overlay(bottomFade)
         .task {
             viewModel.setup()
         }
@@ -98,11 +180,7 @@ struct CoinDetailScreen: View {
         .refreshable {
             await refresh()
         }
-        // Large only. `.medium` was kept while this sheet held four rows; with
-        // the chart and the stats/extremes/info sections it now opens below the
-        // fold on every asset, so a medium detent only ever costs the user a
-        // drag before they can see what they came for.
-        .presentationDetents([.large])
+        .presentationDetents(Self.detents, selection: $detent)
         .presentationBackground(Theme.colors.bgSurface1)
         .presentationDragIndicator(.visible)
         .background(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/CoinDetail/CoinDetailScreen.swift
@@ -16,7 +16,6 @@ struct CoinDetailScreen: View {
     @State var showReceiveSheet: Bool = false
     @State var addressToCopy: Coin?
     @State var showContractCopiedBanner: Bool = false
-    @State var size: CGFloat?
 
     /// Where the sheet is resting. Purely presentation state — it never leaves
     /// the view, so it stays here rather than in the view model.
@@ -92,12 +91,6 @@ struct CoinDetailScreen: View {
     /// view when the sheet returns to its resting height.
     private static let topAnchor = "coinDetailTop"
 
-    /// At the partial detent the content is cut mid-chart. Left hard, that edge
-    /// reads as a clipped view; dissolving the last strip into the sheet
-    /// surface makes it read as "there is more below" instead — the same
-    /// bottom-anchored surface gradient `ModalBackgroundView` and
-    /// `ListBottomSection` already use. Gone once the sheet is expanded, since
-    /// then the edge is the actual end of the content.
     @ViewBuilder
     private var bottomFade: some View {
         if Self.supportsPartialDetent {
@@ -115,6 +108,7 @@ struct CoinDetailScreen: View {
             .allowsHitTesting(false)
             .opacity(isPartial ? 1 : 0)
             .animation(.easeInOut(duration: 0.2), value: isPartial)
+            .ignoresSafeArea(edges: .bottom)
         }
     }
 
@@ -161,7 +155,6 @@ struct CoinDetailScreen: View {
             .padding(.bottom, 24)
         }
         .scrollDisabled(isPartial)
-        .background(ModalBackgroundView(width: size ?? 0))
         .overlay(bottomFade)
         .task {
             viewModel.setup()
@@ -184,7 +177,6 @@ struct CoinDetailScreen: View {
         .presentationBackground(Theme.colors.bgSurface1)
         .presentationDragIndicator(.visible)
         .background(Theme.colors.bgSurface1)
-        .readSize { size = $0.width }
         .crossPlatformSheet(isPresented: $showReceiveSheet) {
             ReceiveQRCodeBottomSheet(
                 coin: coin,


### PR DESCRIPTION
## The regression

Since #4981 (price chart, market stats, extremes, token info — merged 2026-07-29, `f4a8b01e0`) the coin-detail sheet opens **full height** on iPhone. That commit changed

```swift
.presentationDetents([isIPadOS ? .large : .medium])   // before
.presentationDetents([.large])                        // after
```

Full height costs two things: the sheet is slower to scan, and — the bigger one — swipe-to-dismiss goes from a flick to a full screen-height throw.

Worth recording that this was a deliberate reversal at implementation time, not an oversight: the plan of record said the sheet stays a sheet at `[.medium, .large]`, and the post-implementation note reversed it because a partial detent "guarantees opening below the fold, so it only ever costs a drag". This PR reverses it back **and answers that objection** — a partial detent only reads as "below the fold" if the cut edge looks clipped. Faded, it reads as an affordance, and `.large` stays one drag away.

## The fix

`CoinDetailScreen.swift` only.

- **iPhone rests at `.fraction(0.50)`, with `.large` still in the set** and a `selection:` binding. iPad and macOS keep `[.large]` and their `applySheetSize` path untouched (`supportsPartialDetent` is `!isIPadOS && !isMacOS`).
- **Bottom fade while partial** — a bottom-anchored `bgSurface1 → .clear` gradient over the last 64pt, `allowsHitTesting(false)`, cross-fading out when the sheet reaches `.large`. It reuses the shape `ModalBackgroundView` and `ListBottomSection` already use rather than introducing a new mask helper (searched; there is no generic fade-edge modifier in the codebase).
- **Detent state lives in the screen** (`@State private var detent`), not the view model — it is pure presentation state that never crosses a boundary, and `CoinDetailViewModel` is about market data.

### Why 0.50 and not the ~1/3 the issue suggested

`.fraction` is relative to the sheet's full height, not the screen. Measured on a rendered sheet (iPhone 16 Pro, 402×874pt):

| | sheet top edge | sheet height |
|---|---|---|
| partial (`0.50`) | 469pt | **405pt** (~46% of the screen) |
| `.large` | 66pt | 808pt |

The content above the chart card is ~301pt (nav bar + balance header + action row). A third of the screen is ~276pt — it cuts through the **action labels** and shows no chart at all. 0.50 is the shortest height I measured that clears the balance, the whole action row **and** the chart card's price + change chip, with the plot itself starting to dissolve into the fade. Dismiss is still a 405pt throw instead of 808pt.

### The `ScrollView` swallowed the drag — and `.refreshable` is why

The classic multi-detent trap, and it was real here. With the partial detent in place, dragging **up from inside the content** scrolled the content under a sheet that never moved; `.large` was only reachable by grabbing the drag indicator.

- `.presentationContentInteraction(.resizes)` did **not** fix it — tried both inside and outside the `NavigationStack`, no effect. That line is not in the final diff.
- Removing `.refreshable` *did* fix it. So the blocker is the refresh control attached to the scroll view.

Rather than delete pull-to-refresh, scrolling is switched off while the sheet is at its resting height (`.scrollDisabled(isPartial)`). The partial detent then behaves like a card: drag up expands the sheet, and once it is at `.large` the content scrolls normally and `.refreshable` is exactly as it is on `main` today. Collapsing while scrolled would strand the user mid-content with scrolling off — and the actions off the top — so returning to the resting height rewinds the scroll view via a `ScrollViewReader`.

## Verification

Runtime, in the simulator (iPhone 16 Pro, iOS 26.5) — not code-only. Reaching this screen in the real app needs an imported vault and there is no test-mode vault seeding, so I drove it through a **throwaway, uncommitted harness root** that presented `CoinDetailScreen(coin: .example, vault: .example, …)`, plus a throwaway XCUITest that performed the drags and captured screenshots. Both were reverted before committing; the diff is the one file.

Screenshots captured (they can't be embedded from an automated run — the numbers below are measured off the PNGs):

| state | what it shows | sheet top edge |
|---|---|---|
| partial | BTC + balance + all five actions + the chart card's `$62,591.00` / `-0.87%`, plot dissolving into the faded edge | 469pt |
| drag up from content | expands to `.large`, full chart visible, fade gone | 66pt |
| drag down | back to partial, scroll rewound to the header | 469pt |
| flick down from `.large` | dismissed (screen empty) | — |

Also confirmed: content scrolls normally at `.large`; swipe-down dismisses from the partial detent.

**What a human should still check**, since the harness is not the real navigation:
- Opening the sheet from `ChainDetailScreen` for a real coin with a balance and a pending-balance row (a taller header shifts the cut a little).
- A Tron coin (extra resources card) and a pool-priced asset with **no** chart section (shorter content) at the partial detent.
- iPad and macOS — unchanged by construction (`[.large]`, no fade, no `scrollDisabled`), but not re-run here.
- Whether pull-to-refresh at `.large` behaves as before. I could not get the refresh spinner to fire in this sheet either before or after the change, but I did not chase it — it is out of scope and unchanged by this diff.
- iPhone SE / large Dynamic Type: one fraction for every size means SE shows proportionally less; the fade is what keeps that reading as "more below" rather than broken.

## Gate

- `make test` on a dedicated simulator: **`** TEST SUCCEEDED **`** — 4612 tests executed, 1 skipped, 0 failures.
- SwiftLint: 0 violations in `Features/Wallet/CoinDetail/` (the repo's 39 pre-existing violations elsewhere are untouched).
- Cross-model review: two `codex exec --sandbox read-only` passes (per-commit and whole-branch, including the call site and the nested sheets/overlays) — **No findings** on both.

No new user-facing strings, so no locale changes.

Closes #5014


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Coin detail sheets now support half-height and full-height views on iPhone, with full-height presentation on iPad and macOS.
  * Improved expansion and collapse behavior, including automatic scroll positioning.
  * Added a bottom fade when viewing the partially expanded sheet for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->