### PR TITLE
fix(limit-swap): derive the cancel dust ceiling from a pinned threshold, and make the coverage test structural

### DIFF
--- a/VultisigApp/VultisigApp/Features/LimitSwap/Logic/LimitOrderCancelDust.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Logic/LimitOrderCancelDust.swift
@@ -34,6 +34,17 @@ enum LimitOrderCancelDustError: Error, Equatable {
     /// be honoured verbatim and then doubled. Every other floor in this file is
     /// a lower bound; this is the only upper one.
     case dustAmountExceedsCeiling(chain: String, computed: String, ceiling: String)
+    /// No `dust_threshold` is pinned for this chain, so there is no locally-known
+    /// bound on what a remote value could ask us to donate.
+    ///
+    /// Deliberately fatal, and deliberately not a default. A default is a number
+    /// nobody checked against the chain it is being applied to: the one this
+    /// replaced was 0.001 natural units, which sat three orders of magnitude
+    /// under XRP's real requirement and would have refused every cancel from it.
+    /// Refusing HERE says which chain is unconfigured; a wrong default says only
+    /// that some amount exceeded some ceiling, on a chain where cancelling then
+    /// never works.
+    case dustCeilingUnpinned(chain: String)
     /// The computed dust is too small for THORChain to observe at all.
     ///
     /// ⚠️ The loud failure that the 2026-07-22 ETH rehearsal needed and did not
@@ -191,47 +202,117 @@ func minimumObservableInbound(decimals: Int) -> BigInt {
     return BigInt(10).power(decimals - Coin.thorchainFixedPointExponent)
 }
 
-/// The most a cancel on `chain` could plausibly need to attach, in NATURAL
-/// units. Multiplied out to smallest units by the caller.
+// MARK: - Ceiling
+
+/// How many multiples of a cancel's NORMAL attach the ceiling permits.
 ///
-/// Deliberately an explicit table rather than a formula. The per-chain minima
-/// are known and verified, but they live in wildly different unit systems (wei
-/// vs sats vs uatom), so no single absolute number and no ratio against
-/// WalletCore's floor works across all of them — `getFixedDustThreshold()`
-/// returns 0 for every non-UTXO chain, which would collapse any relative bound.
+/// Equivalently: how far THORChain may legitimately raise a `dust_threshold`
+/// before cancelling on that chain starts failing. Ten is the rule the previous
+/// natural-units table documented for itself — "roughly an order of magnitude
+/// above each chain's live `dust_threshold` doubled" — and the centre of the
+/// spread that table actually implemented, which ranged from 5× the attach
+/// (DOGE, BCH, BSC) to 50× (BTC, ETH) with no rationale attached to any
+/// individual row.
 ///
-/// Set roughly an order of magnitude above each chain's live `dust_threshold`
-/// doubled — the amount a cancel actually attaches. Loose enough that a
-/// legitimate threshold change does not break cancelling, tight enough that a
-/// bad value cannot quietly donate a meaningful sum. If a chain legitimately
-/// raises its threshold past this, cancelling fails loudly with the computed and
-/// permitted values — which is the right way to find out.
+/// Tighter would be a truer bound but a thinner margin; looser would let a bad
+/// remote value donate more. This is the trade the ceiling is, stated once
+/// instead of eight times.
+let limitOrderCancelDustCeilingHeadroom = BigInt(10)
+
+/// The `dust_threshold` THORChain publishes for `chain`, pinned locally, in
+/// THORChain's own 1e8 fixed point — the SAME unit system the live value
+/// arrives in. `nil` for a chain THORChain publishes no inbound row for.
 ///
-/// ⚠️ Sized against the thresholds `inbound_addresses` actually publishes
-/// (captured 2026-07-22, natural units): DOGE 1, LTC 0.001, AVAX 0.001,
-/// GAIA 0.01, BCH/BSC 0.0001, BTC/ETH 0.00001. The earlier table was sized
-/// against the EVM `ConvertAmount` floor (~1e-8) rather than against these, and
-/// so sat BELOW the real attach on both LTC and AVAX — a legitimate cancel on
-/// either would have been refused outright by the ceiling.
-func limitOrderCancelDustCeiling(for chain: Chain) -> Decimal {
+/// ⚠️ **The pin is the point, and it must stay local.** The ceiling this feeds
+/// is the only defence against a wrong or hostile `dust_threshold` deciding how
+/// much of the user's money is irreversibly donated. Deriving it from the value
+/// it is meant to bound would be circular: the attach is `threshold × 2`, so
+/// any ceiling of the form `threshold × K` with `K >= 2` is satisfied by every
+/// possible remote value, however absurd. The guard would still be there and
+/// would never fire again. `min()` against an absolute cap does not rescue it
+/// either — the derived term never binds, so the expression is just the cap.
+///
+/// What a formula CAN remove is the hand-arithmetic, and that is what this
+/// shape does. These are the endpoint's numbers verbatim, so verifying an entry
+/// is a string compare against `/thorchain/inbound_addresses` rather than a
+/// 1e8 → native rescale performed in someone's head. That rescale is exactly
+/// what went wrong before: the table two revisions ago was sized against the
+/// EVM `ConvertAmount` floor instead of the published thresholds and so sat
+/// BELOW the real attach on both LTC and AVAX, refusing cancels the user was
+/// entitled to make. Here `chainSmallestUnits` does the conversion.
+///
+/// ⚠️ Captured 2026-08-03 from `/thorchain/inbound_addresses`. Every chain that
+/// endpoint publishes is listed, including ones `thorchainChainPrefix` does not
+/// yet gate in — pinning ahead of the gate is what stops the next chain
+/// addition from silently breaking cancellation on it.
+///
+/// DASH, ZCASH and NOBLE are deliberately absent, though the natural-units
+/// table this replaces carried entries for them: THORChain publishes no inbound
+/// row for any of the three, so there is no threshold to pin and no cancel to
+/// build. `resolveThorchainInboundVault` refuses them at `isThorchainRoutable`
+/// and would refuse them for want of an inbound row even if that gate opened.
+/// Inventing a number for them would reintroduce the unverified literal this
+/// table exists to remove.
+func limitOrderCancelPinnedDustThreshold(for chain: Chain) -> BigInt? {
     switch chain {
-    case .dogecoin:
-        // The outlier: a 1 DOGE threshold, so 2 DOGE is the normal attach.
-        return 10
-    case .litecoin, .avalanche:
-        // Both publish a 0.001 threshold, so 0.002 is the normal attach — over
-        // the 0.001 these two used to share with BTC.
-        return Decimal(string: "0.02") ?? 0
-    case .bitcoin, .bitcoinCash, .dash, .zcash:
-        return Decimal(string: "0.001") ?? 0
-    case .gaiaChain, .noble:
-        return Decimal(string: "0.5") ?? 0
+    case .bitcoin, .ethereum, .base:
+        return BigInt(1000)
+    case .bitcoinCash, .bscChain:
+        return BigInt(10_000)
+    case .litecoin, .avalanche, .solana:
+        return BigInt(100_000)
+    case .gaiaChain:
+        return BigInt(1_000_000)
+    case .tron:
+        return BigInt(10_000_000)
+    case .dogecoin, .ripple:
+        // The outliers: a whole 1 DOGE / 1 XRP, so 2 of each is the normal
+        // attach. XRP is why the removed `default` was not merely untidy — at
+        // 0.001 XRP it sat 2000× under the amount a cancel there must carry.
+        return BigInt(100_000_000)
     default:
-        // ETH (0.00002 attach), BSC (0.0002) and anything else. Immaterial in
-        // fiat on every supported chain while still leaving room for a
-        // threshold that moves by an order of magnitude.
-        return Decimal(string: "0.001") ?? 0
+        return nil
     }
+}
+
+/// The most a cancel on `chain` could plausibly need to attach, in that chain's
+/// SMALLEST units.
+///
+/// `pinned × safetyMultiple × headroom`: the normal attach at the pinned
+/// threshold, times the headroom. Composed from `limitOrderCancelDustSafetyMultiple`
+/// rather than restating its effect, so raising the safety multiple widens the
+/// ceiling with it instead of silently eating the margin.
+///
+/// Rescaled from THORChain's 1e8 units by the same function the amount goes
+/// through, so the ceiling and the amount cannot end up in different unit
+/// systems — the failure that made a 1e8 threshold read as 2000 wei. The
+/// rescale rounds up, which on a ceiling is the harmless direction: at most one
+/// extra smallest unit of slack.
+///
+/// - Parameter decimals: the SOURCE COIN's own precision, the same value handed
+///   to `limitOrderCancelDustAmount`. A cancel is always signed with the source
+///   chain's gas asset, so this is that asset's precision.
+func limitOrderCancelDustCeiling(
+    for chain: Chain,
+    decimals: Int,
+    chainSymbol: String
+) throws -> BigInt {
+    // ⚠️ Validated HERE, not only in `limitOrderCancelDustAmount`. Swift
+    // evaluates this call as one of that function's arguments, so it runs
+    // BEFORE that guard: a negative precision off malformed persisted metadata
+    // would reach `BigInt(10).power(8 - decimals)` first, which allocates
+    // absurdly and traps outright on `Int.min`. Same error either way, so the
+    // failure a caller sees does not depend on evaluation order.
+    guard decimals >= 0 else {
+        throw LimitOrderCancelDustError.unusableChainPrecision(chain: chainSymbol, decimals: decimals)
+    }
+    guard let pinned = limitOrderCancelPinnedDustThreshold(for: chain), pinned > 0 else {
+        throw LimitOrderCancelDustError.dustCeilingUnpinned(chain: chainSymbol)
+    }
+    let ceilingInThorchainUnits = pinned
+        * limitOrderCancelDustSafetyMultiple
+        * limitOrderCancelDustCeilingHeadroom
+    return chainSmallestUnits(fromThorchainBaseUnits: ceilingInThorchainUnits, decimals: decimals)
 }
 
 // MARK: - Memo length

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Logic/LimitOrderCancelPayloadAssembler.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Logic/LimitOrderCancelPayloadAssembler.swift
@@ -90,13 +90,21 @@ func resolveThorchainInboundVault(for chain: Chain) async throws -> InboundAddre
 /// precision is what turns it into the smallest unit the signer needs.
 @MainActor
 func limitOrderCancelDust(for sourceCoin: Coin, inbound: InboundAddress) throws -> BigInt {
+    let chainSymbol = ThorchainService.getInboundChainName(for: sourceCoin.chain)
     do {
         return try limitOrderCancelDustAmount(
             walletCoreDustFloor: BigInt(sourceCoin.coinType.getFixedDustThreshold()),
             inboundDustThreshold: inbound.dust_threshold,
             decimals: sourceCoin.decimals,
-            ceiling: sourceCoin.raw(for: limitOrderCancelDustCeiling(for: sourceCoin.chain)),
-            chainSymbol: ThorchainService.getInboundChainName(for: sourceCoin.chain)
+            // Built from the coin's own precision rather than from a natural-units
+            // literal, so the ceiling and the amount are rescaled by the same
+            // function out of the same 1e8 source units.
+            ceiling: limitOrderCancelDustCeiling(
+                for: sourceCoin.chain,
+                decimals: sourceCoin.decimals,
+                chainSymbol: chainSymbol
+            ),
+            chainSymbol: chainSymbol
         )
     } catch let error as LimitOrderCancelDustError {
         throw LimitOrderCancelAssemblyError.dust(error)

--- a/VultisigApp/VultisigAppTests/LimitSwap/Logic/LimitOrderCancelDustTests.swift
+++ b/VultisigApp/VultisigAppTests/LimitSwap/Logic/LimitOrderCancelDustTests.swift
@@ -178,6 +178,24 @@ final class LimitOrderCancelDustTests: XCTestCase {
         }
     }
 
+    /// ⚠️ The ceiling has to reject it INDEPENDENTLY, because it is evaluated as
+    /// an argument to the function above and therefore runs before that guard.
+    /// Reaching `BigInt(10).power(8 - decimals)` with a negative precision
+    /// allocates absurdly, and with `Int.min` the subtraction traps outright —
+    /// a crash where the contract says "throw".
+    func testTheCeilingRejectsANegativePrecisionBeforeRaisingAnythingToAPower() {
+        for decimals in [-1, Int.min] {
+            XCTAssertThrowsError(
+                try limitOrderCancelDustCeiling(for: .bitcoin, decimals: decimals, chainSymbol: "BTC")
+            ) { error in
+                XCTAssertEqual(
+                    error as? LimitOrderCancelDustError,
+                    .unusableChainPrecision(chain: "BTC", decimals: decimals)
+                )
+            }
+        }
+    }
+
     /// ⚠️ Fails closed. Guessing low means Bifrost silently ignores the cancel —
     /// fee spent, order untouched, indistinguishable from success.
     func testMissingThresholdThrowsRatherThanDefaulting() {
@@ -211,30 +229,124 @@ final class LimitOrderCancelDustTests: XCTestCase {
         XCTAssertEqual(try dust(walletCore: 0, inbound: "500", ceiling: BigInt(1000)), BigInt(1000))
     }
 
-    /// Every real chain's normal attach must sit comfortably under its ceiling,
-    /// or cancelling would fail on the happy path.
+    // MARK: - The ceiling table, driven by the production predicates
+
+    /// Every chain a cancel can be sent FROM as an L1 dust transfer — i.e.
+    /// every chain that can reach the ceiling at all.
+    ///
+    /// ⚠️ **Composed from the production predicates, never listed.** That is the
+    /// entire point of this section. The THORChain-native cases are excluded
+    /// because `LimitOrderCancelPreparer.prepare` routes them to `MsgDeposit`
+    /// before any dust is computed, and THORChain publishes no inbound row for
+    /// itself.
+    private var l1CancelSourceChains: [Chain] {
+        Chain.allCases.filter {
+            isThorchainRoutable(chain: $0)
+                && !limitOrderCancelIsThorchainSourced(sourceChainRawValue: $0.rawValue)
+        }
+    }
+
+    /// Every chain the ceiling table pins a threshold for. A superset of the
+    /// above: pinning ahead of the routability gate is deliberate.
+    private var pinnedChains: [Chain] {
+        Chain.allCases.filter { limitOrderCancelPinnedDustThreshold(for: $0) != nil }
+    }
+
+    /// The native gas asset's precision, taken from the app's own catalog
+    /// rather than restated here — a cancel is always signed with the source
+    /// chain's gas asset, so this is the number production feeds the rescale.
+    private func nativeDecimals(for chain: Chain) -> Int? {
+        TokensStore.TokenSelectionAssets.first { $0.chain == chain && $0.isNativeToken }?.decimals
+    }
+
+    /// The production ceiling for `chain`, in that chain's smallest units —
+    /// the exact call `limitOrderCancelDust(for:inbound:)` makes, without
+    /// needing a `Coin`.
+    private func ceiling(for chain: Chain, decimals: Int) throws -> BigInt {
+        try limitOrderCancelDustCeiling(for: chain, decimals: decimals, chainSymbol: "\(chain)")
+    }
+
+    /// ⚠️ **The tripwire this file did not have.**
+    ///
+    /// The coverage loop below used to run over a hardcoded array — the same
+    /// captured list the ceiling table itself was sized against — so it could
+    /// not see a chain nobody remembered to add to it. That is structurally why
+    /// XRP, TRON and SOL ended up on a `default` two to three orders of
+    /// magnitude under their real requirement: not an oversight in the table so
+    /// much as a test that could only ever confirm what the table already said.
+    ///
+    /// Driven off the production predicates instead, adding a chain to
+    /// `thorchainChainPrefix` without pinning its threshold fails HERE, in CI,
+    /// rather than shipping a chain whose every cancel its own ceiling refuses.
+    func testEveryChainACancelCanBeSentFromHasAPinnedThreshold() {
+        XCTAssertFalse(l1CancelSourceChains.isEmpty, "the predicates must resolve at least one source chain")
+        for chain in l1CancelSourceChains {
+            guard let pinned = limitOrderCancelPinnedDustThreshold(for: chain) else {
+                XCTFail("""
+                    \(chain) is a limit-swap cancel source with no pinned dust_threshold. \
+                    Read it off /thorchain/inbound_addresses (1e8 units, verbatim) and add it to \
+                    limitOrderCancelPinnedDustThreshold — every cancel from this chain is refused until you do.
+                    """)
+                continue
+            }
+            XCTAssertGreaterThan(pinned, 0, "\(chain) pinned threshold must be positive")
+        }
+    }
+
+    /// The pinned table must be a faithful copy of what THORChain publishes —
+    /// nothing invented, nothing missing.
+    ///
+    /// ⚠️ The second loop is the load-bearing one. Pinning a chain THORChain
+    /// does NOT publish means inventing a bound out of nothing, which is the
+    /// exact defect the natural-units table had: `.dash`, `.zcash` and `.noble`
+    /// carried ceilings derived from no published threshold at all.
+    func testThePinnedThresholdsAreVerbatimWhatThorchainPublishes() {
+        // Captured 2026-08-03 from /thorchain/inbound_addresses, in THORChain's
+        // 1e8 fixed point. Every chain the endpoint lists, and only those.
+        let published: [Chain: BigInt] = [
+            .bitcoin: BigInt(1000),
+            .ethereum: BigInt(1000),
+            .base: BigInt(1000),
+            .bitcoinCash: BigInt(10_000),
+            .bscChain: BigInt(10_000),
+            .litecoin: BigInt(100_000),
+            .avalanche: BigInt(100_000),
+            .solana: BigInt(100_000),
+            .gaiaChain: BigInt(1_000_000),
+            .tron: BigInt(10_000_000),
+            .dogecoin: BigInt(100_000_000),
+            .ripple: BigInt(100_000_000)
+        ]
+        for (chain, threshold) in published {
+            XCTAssertEqual(
+                limitOrderCancelPinnedDustThreshold(for: chain), threshold,
+                "\(chain) must be pinned to the value THORChain publishes"
+            )
+        }
+        for chain in Chain.allCases where published[chain] == nil {
+            XCTAssertNil(
+                limitOrderCancelPinnedDustThreshold(for: chain),
+                "\(chain) has no THORChain inbound row, so pinning it would be inventing a bound"
+            )
+        }
+    }
+
+    /// Every pinned chain's normal attach must sit comfortably under its
+    /// ceiling, or cancelling would fail on the happy path.
     ///
     /// ⚠️ LTC and AVAX both publish a 0.001 threshold, so their normal attach is
-    /// 0.002 — over the 0.001 ceiling they used to be given. A ceiling sized
+    /// 0.002 — over the 0.001 ceiling they were once given. A ceiling sized
     /// against the wrong number does not fail safe: it refuses a cancel the user
     /// is entitled to make.
     func testEveryChainsPublishedThresholdSitsUnderItsCeiling() throws {
-        // (chain, decimals, published 1e8 threshold)
-        let cases: [(Chain, Int, String)] = [
-            (.bitcoin, 8, "1000"),
-            (.dogecoin, 8, "100000000"),
-            (.litecoin, 8, "100000"),
-            (.bitcoinCash, 8, "10000"),
-            (.ethereum, 18, "1000"),
-            (.avalanche, 18, "100000"),
-            (.bscChain, 18, "10000"),
-            (.gaiaChain, 6, "1000000")
-        ]
-        for (chain, decimals, threshold) in cases {
+        for chain in pinnedChains {
+            let decimals = try XCTUnwrap(nativeDecimals(for: chain), "\(chain) has no native asset in the catalog")
+            let pinned = try XCTUnwrap(limitOrderCancelPinnedDustThreshold(for: chain))
+
             XCTAssertNoThrow(
                 try dust(
                     walletCore: 0,
-                    inbound: threshold,
+                    inbound: pinned.description,
                     decimals: decimals,
                     ceiling: try ceiling(for: chain, decimals: decimals),
                     chain: "\(chain)"
@@ -244,11 +356,211 @@ final class LimitOrderCancelDustTests: XCTestCase {
         }
     }
 
-    /// The production ceiling for `chain`, in that chain's smallest units —
-    /// the exact call `limitOrderCancelDust(for:inbound:)` makes, without
-    /// needing a `Coin`.
-    private func ceiling(for chain: Chain, decimals: Int) throws -> BigInt {
-        try limitOrderCancelDustCeiling(for: chain, decimals: decimals, chainSymbol: "\(chain)")
+    /// The ceiling is exactly `headroom` times the normal attach, on every
+    /// chain and in every unit system.
+    ///
+    /// Stated against the ATTACH rather than against the formula, because the
+    /// attach is what a reader cares about: this is how far THORChain may
+    /// legitimately move a threshold before cancelling stops working. It also
+    /// pins the composition — the ceiling is built FROM
+    /// `limitOrderCancelDustSafetyMultiple`, so raising that widens the ceiling
+    /// with it instead of quietly eating the margin.
+    func testTheCeilingIsExactlyTheHeadroomTimesTheNormalAttach() throws {
+        for chain in pinnedChains {
+            let decimals = try XCTUnwrap(nativeDecimals(for: chain), "\(chain) has no native asset in the catalog")
+            let pinned = try XCTUnwrap(limitOrderCancelPinnedDustThreshold(for: chain))
+            let ceilingUnits = try ceiling(for: chain, decimals: decimals)
+            let attach = try dust(
+                walletCore: 0,
+                inbound: pinned.description,
+                decimals: decimals,
+                ceiling: ceilingUnits,
+                chain: "\(chain)"
+            )
+
+            XCTAssertEqual(
+                ceilingUnits, attach * limitOrderCancelDustCeilingHeadroom,
+                "\(chain) ceiling must be exactly the headroom over its normal attach"
+            )
+        }
+    }
+
+    /// ⚠️ **The OTHER floor has to fit under the ceiling too.**
+    ///
+    /// The attach is `max(walletCoreDustFloor, rescaledThreshold) × multiple`,
+    /// and the ceiling is derived from only one of those two. On every chain
+    /// today THORChain's threshold is the larger, so the ceiling is sized by the
+    /// binding floor — but nothing in the types says so. A chain whose local
+    /// signer floor exceeded ten times its published threshold would be refused
+    /// on the happy path by a ceiling that never looked at it.
+    ///
+    /// Uses WalletCore's real per-chain value, the same call production makes.
+    func testTheLocalSignerFloorAlsoFitsUnderEveryCeiling() throws {
+        for chain in pinnedChains {
+            let decimals = try XCTUnwrap(nativeDecimals(for: chain), "\(chain) has no native asset in the catalog")
+            let pinned = try XCTUnwrap(limitOrderCancelPinnedDustThreshold(for: chain))
+            let walletCoreFloor = BigInt(chain.coinType.getFixedDustThreshold())
+
+            XCTAssertNoThrow(
+                try dust(
+                    walletCore: walletCoreFloor,
+                    inbound: pinned.description,
+                    decimals: decimals,
+                    ceiling: try ceiling(for: chain, decimals: decimals),
+                    chain: "\(chain)"
+                ),
+                "\(chain) attach with its real local floor (\(walletCoreFloor)) must fit under its ceiling"
+            )
+        }
+    }
+
+    /// ⚠️ **The headroom is a safety parameter, so its VALUE is pinned here.**
+    ///
+    /// Every other assertion in this section derives its expectations from the
+    /// constant, which is deliberate — they should keep holding if it is ever
+    /// retuned. The cost is that they are all satisfied by any value at all.
+    /// This one is not: the headroom decides how much a wrong or hostile
+    /// `dust_threshold` can cause the app to donate, so changing it has to be a
+    /// conscious edit that lands here rather than a number that drifts.
+    func testTheHeadroomIsTenTimesTheNormalAttach() {
+        XCTAssertEqual(limitOrderCancelDustCeilingHeadroom, BigInt(10))
+        XCTAssertEqual(limitOrderCancelDustSafetyMultiple, BigInt(2))
+    }
+
+    /// The ceilings themselves, spelled out in each chain's own smallest units.
+    ///
+    /// ⚠️ **Hand-computed, deliberately not derived.** Everything else here
+    /// checks the formula against itself; these twelve numbers are the only
+    /// place the formula is checked against arithmetic done independently of
+    /// it. They are also what a reader needs to judge the trade — the natural
+    /// units in the comments are the real answer to "how much could a bad
+    /// remote value cost me on this chain".
+    func testTheCeilingsAreTheExpectedAmountsInEachChainsOwnUnits() throws {
+        // (chain, decimals, ceiling in smallest units, the same in natural units, ticker)
+        let expected: [(Chain, Int, String, String, String)] = [
+            (.bitcoin, 8, "20000", "0.0002", "BTC"),
+            (.bitcoinCash, 8, "200000", "0.002", "BCH"),
+            (.litecoin, 8, "2000000", "0.02", "LTC"),
+            (.dogecoin, 8, "2000000000", "20", "DOGE"),
+            (.ethereum, 18, "200000000000000", "0.0002", "ETH"),
+            (.base, 18, "200000000000000", "0.0002", "ETH"),
+            (.bscChain, 18, "2000000000000000", "0.002", "BNB"),
+            (.avalanche, 18, "20000000000000000", "0.02", "AVAX"),
+            (.gaiaChain, 6, "200000", "0.2", "ATOM"),
+            (.tron, 6, "2000000", "2", "TRX"),
+            (.ripple, 6, "20000000", "20", "XRP"),
+            (.solana, 9, "20000000", "0.02", "SOL")
+        ]
+        XCTAssertEqual(expected.count, pinnedChains.count, "every pinned chain must have an expected ceiling here")
+
+        for (chain, decimals, ceilingUnits, natural, ticker) in expected {
+            let raw = try XCTUnwrap(BigInt(ceilingUnits))
+            XCTAssertEqual(nativeDecimals(for: chain), decimals, "\(chain) native precision")
+            XCTAssertEqual(
+                try ceiling(for: chain, decimals: decimals), raw,
+                "\(chain) ceiling should be \(natural) \(ticker)"
+            )
+            // The smallest-units figure and the natural-units one in the table
+            // above must actually be the same amount, so neither column can be
+            // wrong without the other noticing.
+            XCTAssertEqual(
+                exactNaturalUnitsString(raw, decimals: decimals), natural,
+                "\(chain) ceiling in natural units"
+            )
+        }
+    }
+
+    /// The headroom's boundary, asserted from both sides on every pinned chain:
+    /// a tenfold threshold rise still cancels, an elevenfold one is refused.
+    ///
+    /// This is the trade the ceiling IS. A legitimate protocol change should not
+    /// brick cancelling; a remote value that has gone somewhere absurd must not
+    /// be honoured and then doubled into an irreversible donation.
+    func testATenfoldThresholdRiseStillCancelsAndMoreIsRefused() throws {
+        for chain in pinnedChains {
+            let decimals = try XCTUnwrap(nativeDecimals(for: chain), "\(chain) has no native asset in the catalog")
+            let pinned = try XCTUnwrap(limitOrderCancelPinnedDustThreshold(for: chain))
+            let ceilingUnits = try ceiling(for: chain, decimals: decimals)
+
+            XCTAssertNoThrow(
+                try dust(
+                    walletCore: 0,
+                    inbound: (pinned * limitOrderCancelDustCeilingHeadroom).description,
+                    decimals: decimals,
+                    ceiling: ceilingUnits,
+                    chain: "\(chain)"
+                ),
+                "\(chain) must survive a threshold rise of the full headroom"
+            )
+            XCTAssertThrowsError(
+                try dust(
+                    walletCore: 0,
+                    inbound: (pinned * (limitOrderCancelDustCeilingHeadroom + 1)).description,
+                    decimals: decimals,
+                    ceiling: ceilingUnits,
+                    chain: "\(chain)"
+                ),
+                "\(chain) must refuse a threshold beyond the headroom"
+            )
+        }
+    }
+
+    /// ⚠️ **The regression this change exists for, in its own numbers.**
+    ///
+    /// XRP, TRON and SOL had no ceiling entry and fell to a `default` of 0.001
+    /// natural units. Each row asserts BOTH halves: the attach really did exceed
+    /// that default — so the cancel could never have been built, surfacing only
+    /// as an error message that never resolves — and it fits the pinned ceiling
+    /// now.
+    ///
+    /// BASE is here because it is the one that shows how invisible the trap was:
+    /// THORChain publishes it too, and it survived the same `default` purely
+    /// because its threshold happens to equal Ethereum's.
+    func testTheChainsTheOldDefaultCeilingWouldHaveRefused() throws {
+        // (chain, decimals, published 1e8 threshold, attach, the old 0.001-natural default,
+        //  whether that default refused it)
+        let cases: [(Chain, Int, String, String, BigInt, Bool)] = [
+            (.ripple, 6, "100000000", "2000000", BigInt(1000), true),
+            (.tron, 6, "10000000", "200000", BigInt(1000), true),
+            (.solana, 9, "100000", "2000000", BigInt(1_000_000), true),
+            (.base, 18, "1000", "20000000000000", BigInt(10).power(15), false)
+        ]
+        for (chain, decimals, threshold, expected, oldDefault, wasRefused) in cases {
+            XCTAssertEqual(
+                nativeDecimals(for: chain), decimals,
+                "\(chain) native precision — the entire difference between the right attach and a wrong one"
+            )
+
+            let amount = try dust(
+                walletCore: 0,
+                inbound: threshold,
+                decimals: decimals,
+                ceiling: try ceiling(for: chain, decimals: decimals),
+                chain: "\(chain)"
+            )
+            XCTAssertEqual(amount, BigInt(expected), "\(chain) attach")
+
+            XCTAssertEqual(
+                amount > oldDefault, wasRefused,
+                "\(chain) against the removed default ceiling"
+            )
+        }
+    }
+
+    /// A chain with nothing pinned is refused BY NAME, rather than handed a
+    /// number nobody checked against it.
+    ///
+    /// `.dash` stands in for the general case here: THORChain publishes no
+    /// inbound row for it, so a cancel from it is impossible upstream of this
+    /// anyway — but if the routability gate ever opened, this is the error a
+    /// developer would see, and it says which chain is unconfigured.
+    func testAChainWithNoPinnedThresholdIsRefusedByName() {
+        XCTAssertNil(limitOrderCancelPinnedDustThreshold(for: .dash))
+        XCTAssertThrowsError(
+            try limitOrderCancelDustCeiling(for: .dash, decimals: 8, chainSymbol: "DASH")
+        ) { error in
+            XCTAssertEqual(error as? LimitOrderCancelDustError, .dustCeilingUnpinned(chain: "DASH"))
+        }
     }
 
     func testANegativeLocalFloorFailsClosedRatherThanBeingIgnored() {

--- a/VultisigApp/VultisigAppTests/LimitSwap/Logic/LimitOrderCancelDustTests.swift
+++ b/VultisigApp/VultisigAppTests/LimitSwap/Logic/LimitOrderCancelDustTests.swift
@@ -119,7 +119,7 @@ final class LimitOrderCancelDustTests: XCTestCase {
                 walletCore: 0,
                 inbound: threshold,
                 decimals: decimals,
-                ceiling: ceiling(for: chain, decimals: decimals),
+                ceiling: try ceiling(for: chain, decimals: decimals),
                 chain: "\(chain)"
             )
 
@@ -236,7 +236,7 @@ final class LimitOrderCancelDustTests: XCTestCase {
                     walletCore: 0,
                     inbound: threshold,
                     decimals: decimals,
-                    ceiling: ceiling(for: chain, decimals: decimals),
+                    ceiling: try ceiling(for: chain, decimals: decimals),
                     chain: "\(chain)"
                 ),
                 "\(chain) normal attach must fit under its ceiling"
@@ -245,13 +245,10 @@ final class LimitOrderCancelDustTests: XCTestCase {
     }
 
     /// The production ceiling for `chain`, in that chain's smallest units —
-    /// mirroring what `limitOrderCancelDust(for:inbound:)` does with
-    /// `Coin.raw(for:)`, without needing a `Coin`.
-    private func ceiling(for chain: Chain, decimals: Int) -> BigInt {
-        var natural = limitOrderCancelDustCeiling(for: chain)
-        var raw = Decimal()
-        NSDecimalMultiplyByPowerOf10(&raw, &natural, Int16(decimals), .plain)
-        return BigInt(NSDecimalNumber(decimal: raw).stringValue) ?? 0
+    /// the exact call `limitOrderCancelDust(for:inbound:)` makes, without
+    /// needing a `Coin`.
+    private func ceiling(for chain: Chain, decimals: Int) throws -> BigInt {
+        try limitOrderCancelDustCeiling(for: chain, decimals: decimals, chainSymbol: "\(chain)")
     }
 
     func testANegativeLocalFloorFailsClosedRatherThanBeingIgnored() {


### PR DESCRIPTION
## The trap

`limitOrderCancelDustCeiling(for:)` was a hand-computed per-chain table in **natural** units with a `default: 0.001`. XRP, TRON and SOL had no entry, and that default sits far below the dust THORChain actually requires on all three — so a cancel from any of them would throw `dustAmountExceedsCeiling` and could never be built. The user would see only *"the amount a cancellation must attach could not be determined safely, try again shortly"*, a message that never resolves.

`dust_threshold` is published in THORChain's 1e8 fixed point on **every** chain, whatever precision that chain uses. Re-fetched from `/thorchain/inbound_addresses` on 2026-08-03:

| chain | `dust_threshold` | decimals | attach (×2) | old ceiling | |
|---|---|---|---|---|---|
| XRP | `100000000` | 6 | **2 XRP** | 0.001 XRP | refused, 2000× short |
| TRON | `10000000` | 6 | **0.2 TRX** | 0.001 TRX | refused, 200× short |
| SOL | `100000` | 9 | **0.002 SOL** | 0.001 SOL | refused, 2× short |
| BASE | `1000` | 18 | 0.00002 ETH | 0.001 ETH | passed *by luck* |

**Latent today, not a live bug.** `thorchainChainPrefix(for:)` returns `nil` for those chains and `chainFromThorchainSymbol` is its strict inverse, so `computeSupportedChains(from:)` drops their inbound rows and they can never be selected as a limit-order source. It is worth fixing anyway because adding one to `thorchainChainPrefix` is a two-line change that looks complete and self-contained — placement would work, and **cancel would silently stop working on that chain**. Nothing at that gate points at the dust table. Android is the same table with a wider source set, so there it is live (vultisig-android#5464).

Two things the issue does not state, found while verifying: **BASE is a 12th published chain**, and it survives the same `default` purely because its threshold happens to equal Ethereum's. And **THORChain publishes no inbound row for DASH, ZCASH or NOBLE**, though all three carried ceiling entries.

## Why the ceiling could not simply be derived

The issue's option 2 is `ceiling = rescaled_threshold × K`. **A purely derived ceiling is vacuous and does not ship here.**

The ceiling exists for one reason, stated in `dustAmountExceedsCeiling`'s own doc comment: `dust_threshold` is a **remote** value that decides how much of the user's money is irreversibly `donateToPool`'d, with no refund path. It is the only upper bound in the file; every other floor is a lower bound. The attach is `threshold × 2`, so any ceiling of the form `threshold × K` with `K ≥ 2` is satisfied by *every* possible remote value, however hostile. The guard would still be there and would never fire again.

`min(derived, absoluteCap)` does not rescue it either — the derived term never binds, so the expression collapses to the cap. `max(...)` is worse: it lets the remote value raise its own cap.

**The binding bound has to be local.** What a formula can remove is the hand-arithmetic, and that is what this does.

## What changed

Pin, per chain, the `dust_threshold` THORChain publishes — **in THORChain's own 1e8 fixed point, the same unit system the live value arrives in** — and derive the ceiling from it:

```
ceiling = chainSmallestUnits(pinned × limitOrderCancelDustSafetyMultiple × limitOrderCancelDustCeilingHeadroom)
```

- **The pinned numbers are verbatim copies of the endpoint.** Verifying an entry is a `curl` and a string compare, not a 1e8 → native rescale done in someone's head. That rescale is exactly what went wrong before: the file records that the table two revisions ago was sized against the EVM `ConvertAmount` floor instead and so sat *below* the real attach on both LTC and AVAX, refusing cancels users were entitled to make.
- **The rescale is now done by `chainSmallestUnits`** — the same function the amount goes through, so the ceiling and the amount cannot end up in different unit systems.
- **The ceiling is composed from `limitOrderCancelDustSafetyMultiple`**, so raising the safety multiple widens the ceiling with it instead of silently eating the margin.
- **`headroom = 10`** is the rule the old table documented for itself ("roughly an order of magnitude above each chain's live `dust_threshold` doubled") and the centre of the spread it actually implemented, which ranged 5× (DOGE, BCH, BSC) to 50× (BTC, ETH) with no rationale on any row.
- **No `default:` branch.** An unpinned chain throws `dustCeilingUnpinned` naming itself. It routes through the existing `.dust(...)` mapping, so no new user-facing string.

All 12 published chains are pinned, including BASE/XRP/TRON/SOL which the prefix gate does not yet admit — pinning ahead of the gate is what stops the next chain addition from breaking cancellation. DASH/ZCASH/NOBLE are dropped: no published threshold means nothing honest to pin, and a cancel from them is impossible upstream anyway (`resolveThorchainInboundVault` refuses them at `isThorchainRoutable`). Inventing numbers for them is the defect this removes.

## What the ceiling still guarantees

**Unchanged:** the most a wrong or hostile `dust_threshold` can cause the app to donate is a locally-known, per-chain constant, independent of anything the remote says. After this it is uniformly **10× the normal attach** on every chain.

| | BTC | ETH | GAIA | LTC | AVAX | BCH | BSC | DOGE |
|---|---|---|---|---|---|---|---|---|
| old | 0.001 | 0.001 | 0.5 | 0.02 | 0.02 | 0.001 | 0.001 | 10 |
| new | 0.0002 | 0.0002 | 0.2 | 0.02 | 0.02 | 0.002 | 0.002 | 20 |

BTC and ETH get **5× tighter**, GAIA 2.5× tighter, LTC/AVAX unchanged; BCH/BSC/DOGE 2× looser, which is the price of a uniform rule and still ~$1–4 of exposure.

**Never guaranteed, before or after:** a threshold move *within* the headroom is honoured verbatim. That is the point of headroom — a legitimate protocol change should not brick cancelling. Beyond 10× it fails loudly with both numbers, and the fix is a one-number edit copied from the endpoint.

**Considered and rejected:** a fiat-denominated cap. It is the conceptually right bound — the hazard is "a meaningful sum of money", not "a number of drops" — but rates are themselves remote, the lookup is async, and it would drag `RateProvider` into a function that is currently pure and unit-testable without any of it. Noted as a deliberate choice, not an oversight.

## The structural test

**This is the more important half.** `testEveryChainsPublishedThresholdSitsUnderItsCeiling` already existed — but it looped a hardcoded 8-entry array, *the same captured list the ceiling table itself was sized against*. It could only ever confirm what the table already said, and was blind to a chain nobody remembered to add. That is structurally why XRP/TRON/SOL were missed.

The set is now composed from the production predicates and never listed:

```swift
Chain.allCases.filter { isThorchainRoutable(chain: $0)
                        && !limitOrderCancelIsThorchainSourced(sourceChainRawValue: $0.rawValue) }
```

Add a chain to `thorchainChainPrefix` without pinning its threshold and `testEveryChainACancelCanBeSentFromHasAPinnedThreshold` fails in CI, telling you to read the value off `/thorchain/inbound_addresses`. Native precision comes from the app's own coin catalog rather than a literal, so a chain's decimals cannot be mis-stated here either.

Also asserted: the pinned table is verbatim what the endpoint publishes **and pins nothing it does not**; twelve hand-computed ceilings as literals in both smallest and natural units (the one place the formula is checked against independent arithmetic); the headroom boundary from both sides; that WalletCore's local signer floor — the *other* floor, which the ceiling is not derived from — also fits; and the XRP/TRON/SOL/BASE regression in its own numbers, each row proving the attach really did exceed the removed default before proving it fits now.

## Out of scope

Adding XRP/TRON/SOL/BASE to `thorchainChainPrefix`. That would make them user-selectable limit-swap sources and needs its own memo/routing verification. This only removes the trap that would spring when someone does.

## Verification

- `make test` on a dedicated simulator: **`** TEST SUCCEEDED **`** — 4622 tests executed, 1 skipped, **0 failures**. `LimitOrderCancelDustTests` 40 tests, 0 failures (30 before).
- SwiftLint clean: 39 warnings repo-wide, **none in either touched file** (unchanged from `main`).
- Cross-model review: OpenAI Codex (gpt-5.5, read-only) gated each commit. Step 1 → 1 MINOR (fixed: `decimals >= 0` now guarded in `limitOrderCancelDustCeiling`, since Swift evaluates it as an *argument* to the function whose guard used to cover it — `Int.min` would have trapped on `8 - decimals`). Step 2 → 1 MAJOR (fixed: the headroom boundary derived both sides from the same constant and was tautological). Whole-branch pass: **No findings**. Nothing rejected, nothing deferred.

Closes #5004
