### PR TITLE
fix(ton): finish the GRAM rebrand — display sites read coin.ticker, and migrate persisted DeFi positions

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/SwapKit/SwapKitService.swift
@@ -272,29 +272,53 @@ extension SwapKitService {
 }
 
 extension SwapKitService {
-    /// The protocol symbol SwapKit knows an asset by, which can differ from the
-    /// app's display ticker. The Toncoin → GRAM rebrand renamed only the
-    /// *display* ticker of the native TON coin; SwapKit still lists it as "TON"
-    /// (and doesn't support "GRAM"), so a GRAM-ticker'd native must swap as TON.
-    static func swapSymbol(chain: Chain, ticker: String, isNativeToken: Bool) -> String {
-        if chain == .ton, isNativeToken {
-            return "TON"
-        }
-        return ticker
-    }
-}
-
-private extension SwapKitService {
     /// SwapKit asset identifier format: `Chain.Ticker` for native tokens,
     /// `Chain.Ticker-Contract` for tokens with an on-chain contract address.
     /// See `api-contract.md` for the canonical chain prefix table.
+    ///
+    /// SwapKit tracks display renames, so there is no new-to-old mapping to
+    /// apply here. The native TON coin is `TON.GRAM`, not `TON.TON`: the
+    /// Toncoin → Gram rename has landed on their side too, and quoting the
+    /// pre-rename identifier now fails with `tokenPriceUnavailable`. Re-check
+    /// the exact identifier before assuming otherwise — the list is public and
+    /// unauthenticated:
+    ///
+    ///     GET https://api.vultisig.com/swapkit/tokens?provider=NEAR
+    ///
+    /// (bare host, no `/v3` — see `SwapKitAPI.baseURL`). Match on `identifier`;
+    /// `price` is null for every entry on that endpoint, so a null price says
+    /// nothing about whether an asset is quotable.
     func assetIdentifier(for coin: Coin) -> String {
         let prefix = chainPrefix(for: coin.chain, fallback: coin.ticker)
-        let symbol = SwapKitService.swapSymbol(chain: coin.chain, ticker: coin.ticker, isNativeToken: coin.isNativeToken)
+        let symbol = canonicalSymbol(for: coin)
         if coin.isNativeToken || coin.contractAddress.isEmpty {
             return "\(prefix).\(symbol)"
         }
         return "\(prefix).\(symbol)-\(coin.contractAddress)"
+    }
+}
+
+private extension SwapKitService {
+    /// The symbol to quote the coin under: its own ticker, except that a NATIVE
+    /// coin defers to the curated `TokensStore` entry for its chain.
+    ///
+    /// That normalises a *stale persisted* ticker forward to the name the asset
+    /// trades under today. The launch migration rewrites `vault.coins`, but a
+    /// vault restored from a pre-rebrand backup lands after it has already run
+    /// and still holds a `TON`-ticker'd native, which would quote as the dead
+    /// `TON.TON`.
+    ///
+    /// Note the direction — this maps stale local data onto the CURRENT
+    /// canonical symbol, and reads that symbol from the store rather than
+    /// hardcoding it, so a future rename needs no change here. The reverse
+    /// (rewriting a current ticker back to a legacy one to accommodate a
+    /// lagging counterparty) is exactly what broke TON swaps and must not be
+    /// reintroduced without re-checking the live list first.
+    func canonicalSymbol(for coin: Coin) -> String {
+        guard coin.isNativeToken else { return coin.ticker }
+        let curated = TokensStore.TokenSelectionAssets
+            .first { $0.chain == coin.chain && $0.isNativeToken }
+        return curated?.ticker ?? coin.ticker
     }
 
     func chainPrefix(for chain: Chain, fallback: String) -> String {

--- a/VultisigApp/VultisigApp/Blockchain/Ton/Signing/Ton.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ton/Signing/Ton.swift
@@ -24,7 +24,10 @@ enum TonHelper {
 
     static func getPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
 
-        guard keysignPayload.coin.chain.ticker == "TON" else {
+        // Keyed on the chain case, not on a ticker string: `chain.ticker` is a
+        // protocol identifier that a rebrand could move, and this guard failing
+        // open or closed on a renamed ticker would take out every TON send.
+        guard keysignPayload.coin.chain == .ton else {
             throw HelperError.runtimeError("coin is not TON")
         }
 

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -496,7 +496,7 @@
 "foregroundNotificationSwap" = "%@ → %@ 스왑";
 "formInvalid" = "폼이 유효하지 않음";
 "formInvalidDefaultMessage" = "폼이 유효하지 않습니다. 빨간 별표로 표시된 필드를 수정해 주세요.";
-"forwardTonAmount" = "전달된 TON 금액";
+"forwardTonAmount" = "전달된 GRAM 금액";
 "foundActiveChainsSubtitle" = "추가 체인마다 볼트 생성 시간이 늘어나고 타임아웃 가능성이 높아집니다.";
 "foundActiveChainsTitle" = "%d개의 활성 체인을 찾았습니다";
 "from" = "출처";

--- a/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
@@ -79,7 +79,8 @@ struct AppMigrationService {
             THORChainDuplicateTokensMigration(),
             TonGramRebrandMigration(),
             PromoBannerDismissalMigration(),
-            RujiAutoCompoundPositionMigration()
+            RujiAutoCompoundPositionMigration(),
+            TonGramDefiPositionsMigration()
         ]
     }
 }

--- a/VultisigApp/VultisigApp/Core/Migration/Migrations/TonGramDefiPositionsMigration.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/Migrations/TonGramDefiPositionsMigration.swift
@@ -1,0 +1,96 @@
+//
+//  TonGramDefiPositionsMigration.swift
+//  VultisigApp
+//
+
+import SwiftData
+
+/// Extends the Toncoin → Gram rebrand to the persisted DeFi position records.
+///
+/// The first rebrand migration rewrote `vault.coins`, but a `CoinMeta` is stored
+/// in two further places that outlive it: `DefiPositions.bonds/staking/lps` (the
+/// per-vault position opt-in, read back by the position picker) and
+/// `StakePosition.coin`/`.rewardCoin` (what the staked card paints). Neither is
+/// refreshed on load — the position upsert keys existing rows by `CoinMeta` and
+/// `StakePosition.apply(_:)` never rewrites the stored meta — so a vault that
+/// selected its TON staking position before the rebrand keeps showing "TON"
+/// indefinitely.
+///
+/// Display-only, like the rebrand itself: only `ticker` and `logo` change, and
+/// every identifying field (chain, contract address, decimals, price provider)
+/// is preserved. In particular `StakePosition.id` is derived from
+/// `coin.chain.ticker` — the chain's protocol identifier, still "TON" — so no
+/// unique key moves and no row is merged or orphaned.
+struct TonGramDefiPositionsMigration: @MainActor AppMigration {
+    /// Surfaced when the store cannot be read. Throwing leaves the migration
+    /// version un-bumped so `AppMigrationService` retries on the next launch
+    /// rather than marking the rebrand as done with no data.
+    private enum MigrationError: Error {
+        case missingModelContext
+    }
+
+    let version: Int = 4
+
+    let description: String = "Rebranding persisted TON DeFi positions to GRAM (ticker + logo)"
+
+    @MainActor
+    func migrate() throws {
+        guard let modelContext = Storage.shared.modelContext else {
+            throw MigrationError.missingModelContext
+        }
+
+        var descriptor = FetchDescriptor<Vault>()
+        descriptor.relationshipKeyPathsForPrefetching = [\.defiPositions, \.stakePositions]
+
+        for vault in try modelContext.fetch(descriptor) {
+            for positions in vault.defiPositions {
+                if let bonds = Self.rebranded(positions.bonds) {
+                    positions.bonds = bonds
+                }
+                if let staking = Self.rebranded(positions.staking) {
+                    positions.staking = staking
+                }
+                if let lps = Self.rebranded(positions.lps) {
+                    positions.lps = lps
+                }
+            }
+
+            for position in vault.stakePositions {
+                if let coin = Self.rebranded(position.coin) {
+                    position.coin = coin
+                }
+                if let rewardCoin = position.rewardCoin, let rebranded = Self.rebranded(rewardCoin) {
+                    position.rewardCoin = rebranded
+                }
+            }
+        }
+
+        try Storage.shared.save()
+    }
+
+    /// The rebranded meta, or `nil` when `meta` is not a pre-rebrand native TON
+    /// and must be left exactly as it is. Matching on the *pre*-rebrand ticker is
+    /// what makes the migration idempotent: after one pass nothing matches, so a
+    /// re-run writes nothing.
+    private static func rebranded(_ meta: CoinMeta) -> CoinMeta? {
+        guard meta.chain == .ton, meta.isNativeToken, meta.ticker == "TON" else {
+            return nil
+        }
+        return CoinMeta(
+            chain: meta.chain,
+            ticker: "GRAM",
+            logo: "gram",
+            decimals: meta.decimals,
+            priceProviderId: meta.priceProviderId,
+            contractAddress: meta.contractAddress,
+            isNativeToken: meta.isNativeToken
+        )
+    }
+
+    /// The array with every pre-rebrand native TON entry rewritten, or `nil` when
+    /// none matched — so a vault with no TON position is never marked dirty.
+    private static func rebranded(_ metas: [CoinMeta]) -> [CoinMeta]? {
+        guard metas.contains(where: { rebranded($0) != nil }) else { return nil }
+        return metas.map { rebranded($0) ?? $0 }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/TonStake/TonStakeTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/TonStake/TonStakeTransactionScreen.swift
@@ -33,7 +33,7 @@ struct TonStakeTransactionScreen: View {
 
     var body: some View {
         FormScreen(
-            title: String(format: "stakeCoin".localized, viewModel.coin.chain.ticker),
+            title: String(format: "stakeCoin".localized, viewModel.coin.ticker),
             validForm: $viewModel.validForm,
             isContinueDisabled: !viewModel.hasSufficientBalanceForFee,
             onContinue: onContinue
@@ -51,7 +51,7 @@ struct TonStakeTransactionScreen: View {
                 AmountTextField(
                     amount: $viewModel.amountField.value,
                     error: $viewModel.amountField.error,
-                    ticker: viewModel.coin.chain.ticker,
+                    ticker: viewModel.coin.ticker,
                     type: .button,
                     availableAmount: viewModel.maxStakeableAmount,
                     decimals: viewModel.coin.decimals,
@@ -70,14 +70,14 @@ struct TonStakeTransactionScreen: View {
             }
 
             if !viewModel.hasSufficientBalanceForFee {
-                InsufficientFeeNotice(ticker: viewModel.coin.chain.ticker)
+                InsufficientFeeNotice(ticker: viewModel.coin.ticker)
             }
         }
         .crossPlatformSheet(isPresented: $showPoolPicker) {
             TonPoolSelectionScreen(
                 isPresented: $showPoolPicker,
                 selectedPool: $viewModel.selectedPool,
-                ticker: viewModel.coin.chain.ticker,
+                ticker: viewModel.coin.ticker,
                 decimals: viewModel.coin.decimals
             )
         }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/TonStake/TonStakeTransactionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/TonStake/TonStakeTransactionViewModel.swift
@@ -97,7 +97,7 @@ final class TonStakeTransactionViewModel: ObservableObject, Form {
                 guard let self else { return }
                 let amount = value.toDecimal()
                 if amount < self.requiredMinStake {
-                    throw MinStakeError.belowMinimum(self.requiredMinStake, self.coin.chain.ticker)
+                    throw MinStakeError.belowMinimum(self.requiredMinStake, self.coin.ticker)
                 }
             }
         )

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/TonUnstake/TonUnstakeTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/TonUnstake/TonUnstakeTransactionScreen.swift
@@ -29,7 +29,7 @@ struct TonUnstakeTransactionScreen: View {
 
     var body: some View {
         FormScreen(
-            title: String(format: "unstakeCoin".localized, viewModel.coin.chain.ticker),
+            title: String(format: "unstakeCoin".localized, viewModel.coin.ticker),
             fixedHeight: false,
             validForm: $validForm,
             isContinueDisabled: !viewModel.hasSufficientBalance,
@@ -39,7 +39,7 @@ struct TonUnstakeTransactionScreen: View {
                 ContainerView {
                     VStack(alignment: .leading, spacing: 12) {
                         infoRow(
-                            title: String(format: "stakedCoin".localized, viewModel.coin.chain.ticker),
+                            title: String(format: "stakedCoin".localized, viewModel.coin.ticker),
                             value: stakedAmountText
                         )
                         Separator(color: Theme.colors.border, opacity: 1)
@@ -56,7 +56,7 @@ struct TonUnstakeTransactionScreen: View {
                     .foregroundStyle(Theme.colors.textSecondary)
 
                 if !viewModel.hasSufficientBalance {
-                    InsufficientFeeNotice(ticker: viewModel.coin.chain.ticker)
+                    InsufficientFeeNotice(ticker: viewModel.coin.ticker)
                 }
 
                 Spacer()

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapCoinSelectionViewModel.swift
@@ -335,9 +335,9 @@ struct SwapCoinSelectionLogic {
     }
 
     /// A chain has exactly one native asset, so the picker must show it once.
-    /// External providers (e.g. SwapKit's token list) and legacy persisted
-    /// coins can surface that native under a stale ticker — after the Toncoin
-    /// rebrand the curated native is `GRAM` while SwapKit still lists `TON`,
+    /// External providers and legacy persisted coins can surface that native
+    /// under a stale ticker — a vault that predates the Toncoin → Gram rebrand
+    /// still holds a `TON`-ticker'd native alongside the curated `GRAM` one,
     /// which the `uniqueId` dedup treats as distinct and would show as a second
     /// native row (and let it be re-added as a duplicate coin). Keep the first
     /// native — the curated `TokensStore` entry, prepended in `fetchCoins` — and

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/TokenCellView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/TokenCellView.swift
@@ -28,7 +28,7 @@ struct TokenCellView: View {
                 AsyncImageView(
                     logo: coin.logo,
                     size: CGSize(width: 36, height: 36),
-                    ticker: coin.chain.ticker,
+                    ticker: coin.ticker,
                     tokenChainLogo: coin.tokenChainLogo
                 )
 

--- a/VultisigApp/VultisigAppTests/Chains/TonSendTransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TonSendTransactionTests.swift
@@ -18,11 +18,11 @@ final class TonSendTransactionTests: XCTestCase {
     private let destB = "EQCIcjES4cQET0z6nRixZ0MdvTB4u3_8triztLSrIIrDkpgJ"
     private let destC = "Ef8t6cZkqFuHjJ_a_ydEK_tu3LHWRA4JZXRyewLY4j8FZ6B5"
 
-    private func makeCoin() -> Coin {
+    private func makeCoin(chain: Chain = .ton, ticker: String = "GRAM") -> Coin {
         let meta = CoinMeta(
-            chain: .ton,
-            ticker: "GRAM",
-            logo: "gram",
+            chain: chain,
+            ticker: ticker,
+            logo: ticker.lowercased(),
             decimals: 9,
             priceProviderId: "the-open-network",
             contractAddress: "",
@@ -35,10 +35,11 @@ final class TonSendTransactionTests: XCTestCase {
         toAddress: String,
         toAmount: BigInt,
         chainSpecific: BlockChainSpecific,
-        signData: SignData?
+        signData: SignData?,
+        coin: Coin? = nil
     ) -> KeysignPayload {
         KeysignPayload(
-            coin: makeCoin(),
+            coin: coin ?? makeCoin(),
             toAddress: toAddress,
             toAmount: toAmount,
             chainSpecific: chainSpecific,
@@ -67,6 +68,41 @@ final class TonSendTransactionTests: XCTestCase {
             bounceable: bounceable,
             sendMaxAmount: false
         )
+    }
+
+    // MARK: - Pre-sign chain guard
+
+    /// The guard keys on the chain case, not on a ticker string. Ticker strings
+    /// move: the native TON coin already reads "GRAM" after the Toncoin rebrand,
+    /// and `chain.ticker` is only still "TON" because it is the protocol
+    /// identifier the swap asset notation is built from. A guard that compares
+    /// either one is a rename away from rejecting every TON send.
+    func testPreSignAcceptsTheRebrandedNativeCoin() throws {
+        let payload = makePayload(
+            toAddress: destA,
+            toAmount: 50_000_000,
+            chainSpecific: tonSpecific(),
+            signData: nil
+        )
+
+        XCTAssertEqual(payload.coin.ticker, "GRAM")
+        XCTAssertNoThrow(try TonHelper.getPreSignedInputData(keysignPayload: payload))
+    }
+
+    /// Still fail-closed: a coin from another chain must never reach the TON
+    /// signing input builder.
+    func testPreSignRejectsACoinFromAnotherChain() {
+        let payload = makePayload(
+            toAddress: destA,
+            toAmount: 50_000_000,
+            chainSpecific: tonSpecific(),
+            signData: nil,
+            coin: makeCoin(chain: .ethereum, ticker: "ETH")
+        )
+
+        XCTAssertThrowsError(try TonHelper.getPreSignedInputData(keysignPayload: payload)) { error in
+            XCTAssertEqual((error as? HelperError)?.errorDescription, "coin is not TON")
+        }
     }
 
     // MARK: - Regression: native single transfer

--- a/VultisigApp/VultisigAppTests/FunctionTransaction/TonStakeTransactionViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/FunctionTransaction/TonStakeTransactionViewModelTests.swift
@@ -66,6 +66,28 @@ final class TonStakeTransactionViewModelTests: XCTestCase {
         XCTAssertTrue(vm.hasDestinationPool)
     }
 
+    /// The min-stake message must name the COIN's ticker. `chain.ticker` stays
+    /// "TON" because it is the protocol identifier the signer and the swap asset
+    /// notation are keyed on, so a screen that reads it shows the pre-rebrand
+    /// name to a GRAM holder.
+    func testMinStakeErrorUsesCoinTickerNotChainTicker() {
+        let vm = TonStakeTransactionViewModel(
+            coin: makeTonCoin(),
+            vault: .example,
+            existingPoolAddress: Self.poolAddress
+        )
+        vm.onLoad()
+        // Below `defaultMinStake` (1) + `depositFeeBuffer` (1), and well within
+        // the fixture balance, so the min-stake validator is the one that trips.
+        vm.amountField.value = "0.5"
+
+        XCTAssertThrowsError(try vm.amountField.validateErrors(showing: true)) { error in
+            let message = error.localizedDescription
+            XCTAssertTrue(message.contains("GRAM"), "expected the coin ticker in \(message)")
+            XCTAssertFalse(message.contains("TON"), "expected no chain ticker in \(message)")
+        }
+    }
+
     func testFirstTimeStakeUsesPickedPoolAddress() {
         let vm = TonStakeTransactionViewModel(
             coin: makeTonCoin(),

--- a/VultisigApp/VultisigAppTests/Migration/RujiAutoCompoundPositionMigrationTests.swift
+++ b/VultisigApp/VultisigAppTests/Migration/RujiAutoCompoundPositionMigrationTests.swift
@@ -138,8 +138,11 @@ final class RujiAutoCompoundPositionMigrationTests: XCTestCase {
         AppMigrationService(keychainService: keychain).performMigrationsIfNeeded()
 
         XCTAssertEqual(stakingTickers(vault), ["RUJI", "SRUJI"])
-        XCTAssertEqual(
-            keychain.lastMigratedVersion,
+        // At least this migration's version, not exactly it: the service runs
+        // every migration newer than the seed, so pinning the equality here makes
+        // the next migration anyone registers fail this test for no reason.
+        XCTAssertGreaterThanOrEqual(
+            keychain.lastMigratedVersion ?? -1,
             RujiAutoCompoundPositionMigration().version,
             "the migration version must ratchet forward so it does not re-run"
         )

--- a/VultisigApp/VultisigAppTests/Migration/TonGramDefiPositionsMigrationTests.swift
+++ b/VultisigApp/VultisigAppTests/Migration/TonGramDefiPositionsMigrationTests.swift
@@ -1,0 +1,268 @@
+//
+//  TonGramDefiPositionsMigrationTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+import SwiftData
+@testable import VultisigApp
+
+@MainActor
+final class TonGramDefiPositionsMigrationTests: XCTestCase {
+    private var token: TestContextToken?
+
+    override func setUpWithError() throws {
+        token = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDownWithError() throws {
+        TestStore.restore(token)
+        token = nil
+    }
+
+    // MARK: - Fixtures
+
+    /// A pre-rebrand native TON meta, exactly as vaults persisted it before the
+    /// Toncoin → Gram rename.
+    private func legacyTonMeta() -> CoinMeta {
+        CoinMeta(
+            chain: .ton,
+            ticker: "TON",
+            logo: "ton",
+            decimals: 9,
+            priceProviderId: "the-open-network",
+            contractAddress: "",
+            isNativeToken: true
+        )
+    }
+
+    /// Builds a vault with unique values for EVERY `@Attribute(.unique)` field.
+    /// `TestStore.makeVault` varies only `pubKeyECDSA`, so two of its vaults in
+    /// one test collapse into a single row via the unique `pubKeyEdDSA` — and a
+    /// migration that walks every vault has to be exercised across more than one.
+    private func makeVault() -> Vault {
+        let id = UUID().uuidString
+        let vault = Vault(
+            name: "Test Vault \(id)",
+            signers: [],
+            pubKeyECDSA: "ecdsa-\(id)",
+            pubKeyEdDSA: "eddsa-\(id)",
+            keyshares: [],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        Storage.shared.modelContext.insert(vault)
+        return vault
+    }
+
+    @discardableResult
+    private func makeDefiPositions(
+        for vault: Vault,
+        chain: Chain = .ton,
+        bonds: [CoinMeta] = [],
+        staking: [CoinMeta] = [],
+        lps: [CoinMeta] = []
+    ) -> DefiPositions {
+        let positions = DefiPositions(chain: chain, bonds: bonds, staking: staking, lps: lps)
+        vault.defiPositions.append(positions)
+        return positions
+    }
+
+    @discardableResult
+    private func makeStakePosition(
+        for vault: Vault,
+        coin: CoinMeta,
+        rewardCoin: CoinMeta? = nil
+    ) -> StakePosition {
+        let position = StakePosition(
+            coin: coin,
+            type: .stake,
+            amount: 42,
+            rewardCoin: rewardCoin,
+            vault: vault
+        )
+        Storage.shared.modelContext.insert(position)
+        return position
+    }
+
+    // MARK: - Rewrites
+
+    func testMigratesNativeTonMetaInEveryDefiPositionArray() throws {
+        let vault = makeVault()
+        let positions = makeDefiPositions(
+            for: vault,
+            bonds: [legacyTonMeta()],
+            staking: [legacyTonMeta()],
+            lps: [legacyTonMeta()]
+        )
+        try Storage.shared.save()
+
+        try TonGramDefiPositionsMigration().migrate()
+
+        for array in [positions.bonds, positions.staking, positions.lps] {
+            XCTAssertEqual(array.first?.ticker, "GRAM")
+            XCTAssertEqual(array.first?.logo, "gram")
+        }
+    }
+
+    /// Everything that identifies the coin must survive the rebrand — only the
+    /// two display fields move.
+    func testPreservesEveryIdentifyingField() throws {
+        let vault = makeVault()
+        let positions = makeDefiPositions(for: vault, staking: [legacyTonMeta()])
+        try Storage.shared.save()
+
+        try TonGramDefiPositionsMigration().migrate()
+
+        let migrated = try XCTUnwrap(positions.staking.first)
+        XCTAssertEqual(migrated.chain, .ton)
+        XCTAssertEqual(migrated.decimals, 9)
+        XCTAssertEqual(migrated.priceProviderId, "the-open-network")
+        XCTAssertEqual(migrated.contractAddress, "")
+        XCTAssertTrue(migrated.isNativeToken)
+    }
+
+    func testMigratesStakePositionCoinAndRewardCoin() throws {
+        let vault = makeVault()
+        let position = makeStakePosition(
+            for: vault,
+            coin: legacyTonMeta(),
+            rewardCoin: legacyTonMeta()
+        )
+        try Storage.shared.save()
+
+        try TonGramDefiPositionsMigration().migrate()
+
+        XCTAssertEqual(position.coin.ticker, "GRAM")
+        XCTAssertEqual(position.coin.logo, "gram")
+        XCTAssertEqual(position.rewardCoin?.ticker, "GRAM")
+        XCTAssertEqual(position.rewardCoin?.logo, "gram")
+    }
+
+    /// `StakePosition.id` is `@Attribute(.unique)` and is built from
+    /// `coin.chain.ticker` — the chain's protocol identifier, which stays "TON".
+    /// If the migration ever moved it, SwiftData would silently merge or orphan
+    /// the row instead of rebranding it.
+    func testLeavesTheUniqueStakePositionIDUntouched() throws {
+        let vault = makeVault()
+        let position = makeStakePosition(for: vault, coin: legacyTonMeta())
+        try Storage.shared.save()
+        let idBefore = position.id
+
+        try TonGramDefiPositionsMigration().migrate()
+
+        XCTAssertEqual(position.id, idBefore)
+        XCTAssertEqual(
+            position.id,
+            StakePosition.makeID(coin: position.coin, vault: vault, stakeAccountPubkey: nil)
+        )
+    }
+
+    func testMigratesEveryVault() throws {
+        let first = makeVault()
+        let second = makeVault()
+        let firstPositions = makeDefiPositions(for: first, staking: [legacyTonMeta()])
+        let secondPositions = makeDefiPositions(for: second, staking: [legacyTonMeta()])
+        try Storage.shared.save()
+
+        // Proves the two fixtures did not collapse through a shared unique
+        // attribute — otherwise the assertions below would pass having exercised
+        // a single vault.
+        let stored = try Storage.shared.modelContext.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(stored.count, 2)
+
+        try TonGramDefiPositionsMigration().migrate()
+
+        XCTAssertEqual(firstPositions.staking.first?.ticker, "GRAM")
+        XCTAssertEqual(secondPositions.staking.first?.ticker, "GRAM")
+    }
+
+    // MARK: - Leaves alone
+
+    func testLeavesJettonsAndOtherChainsUntouched() throws {
+        let vault = makeVault()
+        // A TON-chain jetton is not the native coin and keeps its own identity.
+        let jetton = CoinMeta(
+            chain: .ton,
+            ticker: "USDT",
+            logo: "usdt",
+            decimals: 6,
+            priceProviderId: "tether",
+            contractAddress: "EQjetton",
+            isNativeToken: false
+        )
+        // A native coin on another chain is unaffected.
+        let rune = CoinMeta(
+            chain: .thorChain,
+            ticker: "RUNE",
+            logo: "rune",
+            decimals: 8,
+            priceProviderId: "thorchain",
+            contractAddress: "",
+            isNativeToken: true
+        )
+        let positions = makeDefiPositions(for: vault, chain: .thorChain, staking: [jetton, rune])
+        let stake = makeStakePosition(for: vault, coin: rune)
+        try Storage.shared.save()
+
+        try TonGramDefiPositionsMigration().migrate()
+
+        XCTAssertEqual(positions.staking.first?.ticker, "USDT")
+        XCTAssertEqual(positions.staking.first?.logo, "usdt")
+        XCTAssertEqual(positions.staking.last?.ticker, "RUNE")
+        XCTAssertEqual(positions.staking.last?.logo, "rune")
+        XCTAssertEqual(stake.coin.ticker, "RUNE")
+    }
+
+    /// A vault that never opted into a DeFi position must be a no-op, not a
+    /// throw — the migration runs on every install at launch.
+    func testVaultWithoutAnyPositionsIsUntouched() throws {
+        let vault = makeVault()
+        try Storage.shared.save()
+
+        XCTAssertNoThrow(try TonGramDefiPositionsMigration().migrate())
+
+        XCTAssertTrue(vault.defiPositions.isEmpty)
+        XCTAssertTrue(vault.stakePositions.isEmpty)
+    }
+
+    /// An already-migrated vault (or a fresh install that never held "TON") must
+    /// survive a second pass unchanged.
+    func testIsIdempotent() throws {
+        let vault = makeVault()
+        let positions = makeDefiPositions(for: vault, staking: [legacyTonMeta()])
+        let stake = makeStakePosition(for: vault, coin: legacyTonMeta(), rewardCoin: legacyTonMeta())
+        try Storage.shared.save()
+
+        try TonGramDefiPositionsMigration().migrate()
+        let idAfterFirstPass = stake.id
+        try TonGramDefiPositionsMigration().migrate()
+
+        XCTAssertEqual(positions.staking.count, 1)
+        XCTAssertEqual(positions.staking.first?.ticker, "GRAM")
+        XCTAssertEqual(positions.staking.first?.logo, "gram")
+        XCTAssertEqual(stake.coin.ticker, "GRAM")
+        XCTAssertEqual(stake.rewardCoin?.ticker, "GRAM")
+        XCTAssertEqual(stake.id, idAfterFirstPass)
+    }
+
+    // MARK: - Registration
+
+    /// The version must be unique and ordered after the migrations already
+    /// shipped, otherwise `AppMigrationService`'s Keychain watermark either skips
+    /// it or re-runs an unrelated migration.
+    func testVersionIsUniqueAndHighest() throws {
+        let migration = TonGramDefiPositionsMigration()
+        let others = [
+            THORChainDuplicateTokensMigration().version,
+            TonGramRebrandMigration().version,
+            PromoBannerDismissalMigration().version,
+            RujiAutoCompoundPositionMigration().version
+        ]
+
+        XCTAssertFalse(others.contains(migration.version))
+        XCTAssertGreaterThan(migration.version, try XCTUnwrap(others.max()))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapKit/SwapKitTokensPickerFlagTests.swift
@@ -70,19 +70,69 @@ final class SwapKitTokensPickerFlagTests: XCTestCase {
         XCTAssertEqual(collapsed.map { $0.ticker }, ["ETH", "USDC"], "No duplicate native → list unchanged")
     }
 
-    func testSwapSymbolMapsNativeTonToTON() {
-        // The Toncoin → GRAM rebrand renamed only the display ticker; SwapKit
-        // still lists the native as "TON" and doesn't support "GRAM", so a
-        // GRAM-ticker'd native must swap as TON.
-        XCTAssertEqual(SwapKitService.swapSymbol(chain: .ton, ticker: "GRAM", isNativeToken: true), "TON")
-        XCTAssertEqual(SwapKitService.swapSymbol(chain: .ton, ticker: "TON", isNativeToken: true), "TON")
+    private func makeCoin(
+        chain: Chain,
+        ticker: String,
+        contractAddress: String = "",
+        isNativeToken: Bool
+    ) -> Coin {
+        let meta = CoinMeta(
+            chain: chain,
+            ticker: ticker,
+            logo: ticker.lowercased(),
+            decimals: 9,
+            priceProviderId: "",
+            contractAddress: contractAddress,
+            isNativeToken: isNativeToken
+        )
+        return Coin(asset: meta, address: "addr", hexPublicKey: "pub")
     }
 
-    func testSwapSymbolLeavesOtherAssetsUnchanged() {
-        XCTAssertEqual(SwapKitService.swapSymbol(chain: .ethereum, ticker: "ETH", isNativeToken: true), "ETH")
-        XCTAssertEqual(SwapKitService.swapSymbol(chain: .bitcoin, ticker: "BTC", isNativeToken: true), "BTC")
-        // TON-chain jetton (non-native) keeps its own ticker.
-        XCTAssertEqual(SwapKitService.swapSymbol(chain: .ton, ticker: "USDT", isNativeToken: false), "USDT")
+    /// The native TON asset is `TON.GRAM` on the wire. SwapKit tracked the
+    /// Toncoin → Gram rename, so the pre-rename `TON.TON` no longer resolves —
+    /// quoting it fails with `tokenPriceUnavailable`. Verifiable against
+    /// `GET https://api.vultisig.com/swapkit/tokens?provider=NEAR` (bare host,
+    /// no `/v3`), which lists `TON.GRAM` and no `TON.TON` at all.
+    func testAssetIdentifierUsesGramForTheNativeTonCoin() {
+        let gram = makeCoin(chain: .ton, ticker: "GRAM", isNativeToken: true)
+
+        XCTAssertEqual(SwapKitService().assetIdentifier(for: gram), "TON.GRAM")
+    }
+
+    /// A jetton keeps its own ticker and appends its contract — the native case
+    /// must not bleed into it. Matches SwapKit's listed
+    /// `TON.USDT-EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs`.
+    func testAssetIdentifierKeepsTheJettonTickerAndContract() {
+        let contract = "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs"
+        let usdt = makeCoin(chain: .ton, ticker: "USDT", contractAddress: contract, isNativeToken: false)
+
+        XCTAssertEqual(SwapKitService().assetIdentifier(for: usdt), "TON.USDT-\(contract)")
+    }
+
+    /// A vault restored from a pre-rebrand backup still holds a `TON`-ticker'd
+    /// native: the launch migration rewrites `vault.coins`, but an import lands
+    /// after it has already run. Canonicalising against the curated store keeps
+    /// that vault quotable instead of sending the dead `TON.TON`.
+    func testAssetIdentifierCanonicalisesAnUnmigratedNativeTonCoin() {
+        let legacy = makeCoin(chain: .ton, ticker: "TON", isNativeToken: true)
+
+        XCTAssertEqual(SwapKitService().assetIdentifier(for: legacy), "TON.GRAM")
+    }
+
+    /// Canonicalisation is scoped to natives — a jetton that happens to carry a
+    /// ticker matching nothing curated must still quote under its own.
+    func testAssetIdentifierDoesNotCanonicaliseNonNativeTokens() {
+        let jetton = makeCoin(chain: .ton, ticker: "TON", contractAddress: "EQjetton", isNativeToken: false)
+
+        XCTAssertEqual(SwapKitService().assetIdentifier(for: jetton), "TON.TON-EQjetton")
+    }
+
+    func testAssetIdentifierLeavesOtherChainsUnchanged() {
+        let eth = makeCoin(chain: .ethereum, ticker: "ETH", isNativeToken: true)
+        let btc = makeCoin(chain: .bitcoin, ticker: "BTC", isNativeToken: true)
+
+        XCTAssertEqual(SwapKitService().assetIdentifier(for: eth), "ETH.ETH")
+        XCTAssertEqual(SwapKitService().assetIdentifier(for: btc), "BTC.BTC")
     }
 
     @MainActor


### PR DESCRIPTION
Finishes the Toncoin → GRAM rebrand on iOS. The original rebrand (#4629) landed the coin store, the `gram` asset and `TonGramRebrandMigration` v1 over `vault.coins`; this covers what was left behind.

> ### ⚠️ Read before testing: selling TON is still broken, and that is not this PR
>
> This fixes **our** SwapKit asset identifier (`TON.TON` → `TON.GRAM`), which unblocks **quoting**. Selling native TON still fails at the **build** step with `core_swap_contract_not_found`, because SwapKit's build engine hasn't adopted the rename their own token list already publishes.
>
> **No client-side change can fix that** — `TON.TON` now fails at quote, `TON.GRAM` fails at build. Merging is still correct: `TON.GRAM` is what their published list specifies, so TON swaps start working the moment SwapKit ships their fix. Buying TON is unaffected.

## What changed

1. **Display sites read the coin's ticker, not the chain's.** The native TON coin's `coin.ticker` is already `"GRAM"`; these screens were asking the wrong object while holding a `Coin` whose ticker was already right.
   `TonStakeTransactionScreen` (:36, :54, :73, :80), `TonStakeTransactionViewModel:100`, `TonUnstakeTransactionScreen` (:32, :42, :59), and `TokenCellView:31` — where a TON **jetton**'s logo-failure fallback rendered "TON" instead of the jetton's own ticker.

2. **Migration v4** rebrands the persisted `CoinMeta`s v1 missed.

3. **Pre-sign guard hardened.** `Ton.swift` gated on `coin.chain.ticker == "TON"`, coupling the entire TON send path to the spelling of a display-adjacent string. Now `coin.chain == .ton` — exactly equivalent today, but it can't re-arm on the next rename.

4. **SwapKit identifier fixed** (see below).

5. **`ko` locale** — the original rebrand skipped Korean.

## ⚠️ `ChainConfig.ticker` for `.ton` stays `"TON"` — do not "finish the job"

The issue suggests flipping it to GRAM. **That breaks TON sends.** `Ton.swift`'s pre-sign guard string-compared this value, so every TON send would have thrown `"coin is not TON"`. (This PR removes that particular landmine, but the field is still a protocol identifier by design — it's what `Coin.swapAsset` builds THORChain/Maya notation from, live the moment TON is routed by THORChain.)

`feeUnit` also stays `"TON"`. Its three consumers are each gated to Cosmos / THORChain / EVM chain types, so **none is reachable for TON** — changing it would fix nothing. It's also not display-only in general: across the Cosmos family it's the on-chain denom (`uatom`, `adydx`).

## Migration — new version 4, not a bump of v1

A `CoinMeta` is persisted in two places v1 didn't touch: `DefiPositions.bonds/staking/lps` (the position opt-in) and `StakePosition.coin`/`.rewardCoin` (what the staked card paints). `upsert(stake:)` keys rows by `CoinMeta` and `StakePosition.apply(_:)` never rewrites the stored meta, so a stale row never self-heals.

Versions 0–3 are taken and `AppMigrationService` only runs migrations above a Keychain watermark, so renumbering v1 would collide and re-run unrelated work.

The predicate is on the **meta itself**, not the owning row's chain, so a TON meta parked elsewhere is still caught. Each safety property has a test:

- **Idempotent** — matches the *pre*-rebrand ticker, so a second pass writes nothing.
- **Unique keys don't move** — `StakePosition.id` is `@Attribute(.unique)` and derives from `chain.ticker` (still "TON"), so no constraint collision, no silently merged row.
- **Non-destructive** — only `ticker` and `logo` change; nothing inserted or deleted.

## SwapKit: native TON quoted as a dead identifier

`SwapKitService.swapSymbol` rewrote a GRAM-ticker'd native back to `"TON"`, compensating for SwapKit not having adopted the rename. **SwapKit has since adopted it, so the compensation became the divergence.** The function's own comment ("SwapKit still lists it as TON and doesn't support GRAM") was true when written and is now backwards — which is how it survived.

Verified against their published list (`GET …/swapkit/tokens?provider=NEAR`, bare host, no `/v3`): `TON.GRAM` and `TON.USDT-EQCx…` are listed; **`TON.TON` appears in no provider's list**. Note `price` is `null` for every entry there, so a null price proves nothing — the evidence is that the identifier is absent.

`swapSymbol` is **removed** rather than kept as a seam: with its only special case gone it was an identity function ignoring two of its three parameters, and its existence is precisely what made the stale case look intentional. Replaced by `canonicalSymbol(for:)`, which resolves a native coin's symbol from the curated `TokensStore` entry — so an **unmigrated** vault (ticker still "TON") also emits `TON.GRAM`, and a future rename needs no change here. Deliberately not hardcoded to `"GRAM"`: that's the same bug's shape, inverted.

**Not affected:** the inbound fee. SwapKit still denominates it `"asset":"TON.TON"`, but `inboundFeeFromWire` matches on `fees[].chain`, not the asset identifier.

## Tests

5 `assetIdentifier` tests (replacing 2 on `swapSymbol`, and made `internal` so they pin the real wire value rather than a fragment): native → `TON.GRAM`; unmigrated `TON`-ticker'd native → `TON.GRAM`; jetton → `TON.USDT-EQCx…`; canonicalisation doesn't touch non-natives; other chains unchanged. Plus migration tests for each safety property above.

**Gate:** `** TEST SUCCEEDED **`, 4627 tests / 1 skipped / 0 failures. SwiftLint at the repo baseline, none added.

## Manual verification

1. **TON send still broadcasts** — the guard change is on the pre-sign path.
2. **TON swap quotes** — sell asset on the wire reads `TON.GRAM` and the `tokenPriceUnavailable` error is gone. ⚠️ The swap will still fail at **build** — expected, see the banner above.
3. **Staking screens read GRAM** — stake/unstake titles, amount suffix, fee notices.
4. **A pre-rebrand vault upgrades cleanly** — DeFi positions and staked cards show GRAM.
5. **Relaunch is a no-op** — the migration doesn't run twice.

Nothing was exercised on device — no funded TON vault. The migration mutates persisted user data, so step 4 is the important one.

## Follow-ups filed, deliberately not in this PR

- #5039 — the same ticker-string guard pattern on Solana, Sui and Tron.
- #5038 — vault **import** bypasses watermark-gated migrations, so restoring an old backup reintroduces stale metadata. Pre-existing and equally true of the shipped v1; this PR neither introduces nor widens it. The `AppMigrationService` actor-isolation gap raised in review is tracked there too.
