### PR TITLE
fix(home): crossfade the portfolio balance into the top bar as the header collapses

### DIFF
--- a/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiMain/DefiMainScreen.swift
@@ -10,7 +10,10 @@ import SwiftUI
 
 struct DefiMainScreen: View {
     @ObservedObject var vault: Vault
-    @Binding var showBalanceInHeader: Bool
+    /// Shared with the top bar and written from this screen's scroll offset.
+    /// Held as a plain `let`, deliberately un-observed: this screen must not be
+    /// invalidated by a scroll, only the leaf that renders the balance is.
+    let collapse: HomeHeaderCollapse
 
     @Environment(\.modelContext) var modelContext
     @EnvironmentObject var settingsViewModel: SettingsViewModel
@@ -19,7 +22,6 @@ struct DefiMainScreen: View {
     @State var scrollProxy: ScrollViewProxy?
     @State var showSearchHeader: Bool = false
     @State var focusSearch: Bool = false
-    @State var scrollOffset: CGFloat = 0
     @State var showChainSelection: Bool = false
     @State private var searchScrollTask: Task<Void, Never>?
     @State private var clearSearchTask: Task<Void, Never>?
@@ -38,10 +40,11 @@ struct DefiMainScreen: View {
                     showsIndicators: false,
                     topInset: contentInset,
                     bottomInset: 0,
-                    scrollOffset: $scrollOffset
+                    onOffsetChange: onScrollOffsetChange
                 ) {
                     LazyVStack(spacing: 20) {
                         DefiMainBalanceView(vault: vault)
+                            .headerCollapseFade(collapse, tab: .defi)
                         Separator(color: Theme.colors.borderLight, opacity: 1)
                         bottomContentSection
                     }
@@ -76,9 +79,6 @@ struct DefiMainScreen: View {
             .refreshable { refresh() }
             .onChange(of: settingsViewModel.selectedCurrency) {
                 refresh()
-            }
-            .onChange(of: scrollOffset) { _, newValue in
-                onScrollOffsetChange(newValue)
             }
         }
         .throttledOnAppear(interval: 15.0, action: refresh)
@@ -188,16 +188,14 @@ struct DefiMainScreen: View {
     }
 
     func onScrollOffsetChange(_ offset: CGFloat) {
-        let showBalanceInHeader: Bool = offset < contentInset
-        guard showBalanceInHeader != self.showBalanceInHeader else { return }
-        self.showBalanceInHeader = showBalanceInHeader
+        collapse.update(tab: .defi, offset: offset, restingOffset: contentInset)
     }
 }
 
 #Preview {
     DefiMainScreen(
         vault: .example,
-        showBalanceInHeader: .constant(false)
+        collapse: HomeHeaderCollapse()
     )
     .environmentObject(HomeViewModel())
     .environmentObject(VaultDetailViewModel())

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -26,10 +26,13 @@ struct HomeScreen: View {
     @State var showBackupNow = false
     @State var selectedChain: Chain? = nil
 
-    @State var walletShowPortfolioHeader: Bool = false
-    @State var defiShowPortfolioHeader: Bool = false
-    @State var showPortfolioHeader: Bool = false
     @State var shouldRefresh: Bool = false
+    /// Per-tab collapse progress for the top bar, written by each tab's scroll
+    /// view and read by the bar and by the two large balances. Held in a plain
+    /// `@State` rather than a `@StateObject` on purpose: this screen owns it but
+    /// must not observe it, or every frame of a collapse would rebuild the whole
+    /// tab content.
+    @State private var headerCollapse = HomeHeaderCollapse()
     @State private var deeplinkError: Error?
 
     @State private var capturedGeometryHeight: CGFloat = 600
@@ -172,14 +175,14 @@ struct HomeScreen: View {
                             addressToCopy: $addressToCopy,
                             showUpgradeVaultSheet: $showUpgradeVaultSheet,
                             showBackupNow: $showBackupNow,
-                            showBalanceInHeader: $walletShowPortfolioHeader,
+                            collapse: headerCollapse,
                             shouldRefresh: $shouldRefresh,
                             onCamera: onCamera
                         )
                     case .defi:
                         DefiMainScreen(
                             vault: selectedVault,
-                            showBalanceInHeader: $defiShowPortfolioHeader
+                            collapse: headerCollapse
                         )
                     case .camera:
                         EmptyView()
@@ -221,10 +224,7 @@ struct HomeScreen: View {
             .onLoad {
                 onVaultLoaded(vault: selectedVault)
             }
-            .onChange(of: walletShowPortfolioHeader) { _, _ in updateHeader() }
-            .onChange(of: defiShowPortfolioHeader) { _, _ in updateHeader() }
             .onChange(of: selectedTab) { _, newValue in
-                updateHeader()
                 if newValue == .camera {
                     onCamera()
                 }
@@ -352,7 +352,7 @@ struct HomeScreen: View {
         HomeMainHeaderView(
             vault: vault,
             activeTab: $selectedTab,
-            showBalance: $showPortfolioHeader,
+            collapse: headerCollapse,
             vaultSelectorAction: { showVaultSelector.toggle() },
             historyAction: { vaultRoute = .transactionHistory },
             settingsAction: { vaultRoute = .settings },
@@ -362,20 +362,6 @@ struct HomeScreen: View {
 }
 
 extension HomeScreen {
-    fileprivate func updateHeader() {
-        let showOpaqueHeader: Bool
-        switch selectedTab {
-        case .defi:
-            showOpaqueHeader = defiShowPortfolioHeader
-        case .wallet:
-            showOpaqueHeader = walletShowPortfolioHeader
-        case .camera:
-            return
-        }
-
-        self.showPortfolioHeader = showOpaqueHeader
-    }
-
     fileprivate func moveToVaultsView() {
         guard let vault = deeplinkViewModel.selectedVault else {
             return

--- a/VultisigApp/VultisigApp/Features/Home/Model/HeaderCollapseProgress.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Model/HeaderCollapseProgress.swift
@@ -1,0 +1,79 @@
+//
+//  HeaderCollapseProgress.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 03/08/2025.
+//
+
+import Foundation
+
+/// How far the vault-home top bar has collapsed, as a 0…1 value derived from
+/// the scroll offset, plus the two fade ramps that value drives.
+///
+/// The large balance in the scroll content and the balance in the top bar are
+/// faded over **non-overlapping** halves of the progress: everything belonging
+/// to the expanded state fades out over `0…0.5`, everything belonging to the
+/// collapsed state fades in over `0.5…1`. `expandedOpacity` and
+/// `collapsedOpacity` are therefore never both greater than zero, so the two
+/// balances can never be legible at the same time — and because the whole
+/// transition is a function of the scroll offset it scrubs with the drag and
+/// reverses with it, instead of running on its own wall-clock timeline.
+struct HeaderCollapseProgress: Equatable {
+    /// Where the expanded state has finished fading out and the collapsed state
+    /// starts fading in. The top bar swaps its contents exactly here, which is
+    /// the one point where both ramps are zero.
+    private static let midpoint: Double = 0.5
+
+    /// Scroll distance, in points, over which the whole collapse plays out. The
+    /// first half of it fades the large balance away as it travels towards the
+    /// header edge; the second half brings the header balance in.
+    static let defaultDistance: CGFloat = 110
+
+    static let expanded = HeaderCollapseProgress(value: 0)
+
+    /// `0` = fully expanded (large balance in the content), `1` = fully
+    /// collapsed (balance in the top bar).
+    let value: Double
+
+    private init(value: Double) {
+        self.value = value
+    }
+
+    /// - Parameters:
+    ///   - offset: the scroll content's `minY` in the scroll view's coordinate
+    ///     space. Equal to `restingOffset` at scroll position zero, decreasing
+    ///     as the user scrolls down, larger than it during a rubber-band
+    ///     overscroll.
+    ///   - restingOffset: that same value at scroll position zero — i.e. the
+    ///     scroll view's top inset.
+    ///   - distance: how far the user has to scroll for the collapse to
+    ///     complete.
+    init(offset: CGFloat, restingOffset: CGFloat, distance: CGFloat = Self.defaultDistance) {
+        guard distance > 0 else {
+            self.init(value: offset < restingOffset ? 1 : 0)
+            return
+        }
+        let scrolled = restingOffset - offset
+        self.init(value: Double(min(max(scrolled / distance, 0), 1)))
+    }
+
+    /// Opacity of everything that belongs to the expanded state — the large
+    /// balance in the content, and the top bar's toolbar buttons. `1 → 0` over
+    /// the first half of the collapse.
+    var expandedOpacity: Double {
+        max(1 - value / Self.midpoint, 0)
+    }
+
+    /// Opacity of everything that belongs to the collapsed state — the balance
+    /// in the top bar and the bar's own opaque background. `0 → 1` over the
+    /// second half of the collapse.
+    var collapsedOpacity: Double {
+        max((value - Self.midpoint) / (1 - Self.midpoint), 0)
+    }
+
+    /// Whether the top bar shows the balance instead of the toolbar buttons.
+    /// Flips where both ramps are zero, so the swap itself is invisible.
+    var isCollapsed: Bool {
+        value >= Self.midpoint
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Home/Model/HomeHeaderCollapse.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Model/HomeHeaderCollapse.swift
@@ -1,0 +1,54 @@
+//
+//  HomeHeaderCollapse.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 03/08/2025.
+//
+
+import Foundation
+
+/// Shared collapse progress for the vault-home top bar, one value per tab.
+///
+/// Written from the scroll views' geometry reader on **every layout pass**, and
+/// read by exactly two leaves: the top bar itself, and the `headerCollapseFade`
+/// modifier wrapped around the large balance inside the scroll content.
+/// `HomeScreen` owns it in a plain `@State` and never reads it, so a scroll
+/// never invalidates the tab content.
+///
+/// Two properties keep that per-frame write cheap:
+/// - `update` compares before it publishes, and
+/// - the progress saturates at `0`/`1` outside a
+///   `HeaderCollapseProgress.defaultDistance`-point window, so all but that
+///   window of a scroll publishes nothing at all.
+///
+/// Both tabs are stored separately because both screens stay alive inside the
+/// tab view — each one keeps its own scroll position, and the top bar reads
+/// whichever tab is active.
+@MainActor
+final class HomeHeaderCollapse: ObservableObject {
+    @Published private(set) var wallet: HeaderCollapseProgress = .expanded
+    @Published private(set) var defi: HeaderCollapseProgress = .expanded
+
+    func progress(for tab: HomeTab) -> HeaderCollapseProgress {
+        switch tab {
+        case .wallet: wallet
+        case .defi: defi
+        case .camera: .expanded
+        }
+    }
+
+    /// - Parameters:
+    ///   - tab: the tab whose scroll view produced the offset.
+    ///   - offset: the scroll content's `minY` in the scroll view's space.
+    ///   - restingOffset: that value at scroll position zero (the top inset).
+    func update(tab: HomeTab, offset: CGFloat, restingOffset: CGFloat) {
+        let progress = HeaderCollapseProgress(offset: offset, restingOffset: restingOffset)
+        guard progress != self.progress(for: tab) else { return }
+
+        switch tab {
+        case .wallet: wallet = progress
+        case .defi: defi = progress
+        case .camera: break
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Home/Model/HomeHeaderCollapse.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Model/HomeHeaderCollapse.swift
@@ -10,12 +10,16 @@ import Foundation
 /// Shared collapse progress for the vault-home top bar, one value per tab.
 ///
 /// Written from the scroll views' geometry reader on **every layout pass**, and
-/// read by exactly two leaves: the top bar itself, and the `headerCollapseFade`
-/// modifier wrapped around the large balance inside the scroll content.
-/// `HomeScreen` owns it in a plain `@State` and never reads it, so a scroll
-/// never invalidates the tab content.
+/// read only by leaves: the top bar's trailing slot and background, and the
+/// `headerCollapseFade` modifier wrapped around each large balance inside the
+/// scroll content. `HomeScreen` owns it in a plain `@State` and never reads it,
+/// and neither tab screen reads it either, so a scroll never invalidates a
+/// content tree — every observer re-applies an opacity to an already-built
+/// subtree. (Being one `ObservableObject`, a change on one tab does wake the
+/// other tab's fade modifier as well; that is one redundant opacity write per
+/// transition frame, not a rebuild.)
 ///
-/// Two properties keep that per-frame write cheap:
+/// Two properties keep the per-frame write cheap:
 /// - `update` compares before it publishes, and
 /// - the progress saturates at `0`/`1` outside a
 ///   `HeaderCollapseProgress.defaultDistance`-point window, so all but that

--- a/VultisigApp/VultisigApp/Features/Home/Views/HeaderCollapseModifiers.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Views/HeaderCollapseModifiers.swift
@@ -1,0 +1,66 @@
+//
+//  HeaderCollapseModifiers.swift
+//  VultisigApp
+//
+//  Created by Gaston Mazzeo on 03/08/2025.
+//
+
+import SwiftUI
+
+/// Fades the large balance out as the vault-home top bar collapses over it.
+///
+/// Deliberately its own `ViewModifier`, and the only thing inside the scroll
+/// content that reads `HomeHeaderCollapse`: when the progress moves, SwiftUI
+/// re-evaluates this one node and re-applies an opacity to an already-built
+/// subtree. Reading the progress directly in the screen's body instead would
+/// rebuild the entire content tree on every frame of the transition — the exact
+/// cost the scroll-performance work on this screen went to some trouble to
+/// remove.
+struct HeaderCollapseFade: ViewModifier {
+    @ObservedObject var collapse: HomeHeaderCollapse
+    let tab: HomeTab
+
+    func body(content: Content) -> some View {
+        let opacity = collapse.progress(for: tab).expandedOpacity
+        content
+            .opacity(opacity)
+            // Faded out it is still laid out, sitting behind the top bar —
+            // don't let it take taps or be read out.
+            .allowsHitTesting(opacity > 0)
+            .accessibilityHidden(opacity == 0)
+    }
+}
+
+/// The mirror of `HeaderCollapseFade`, for chrome that belongs to the collapsed
+/// state — today the top bar's opaque background. Same observation isolation,
+/// same reason: the bar itself must not re-evaluate per frame.
+///
+/// It is removed rather than left at zero opacity while the home is expanded,
+/// so a transparent full-width background can't swallow taps meant for the
+/// content scrolling underneath.
+struct HeaderCollapseReveal: ViewModifier {
+    @ObservedObject var collapse: HomeHeaderCollapse
+    let tab: HomeTab
+
+    func body(content: Content) -> some View {
+        let progress = collapse.progress(for: tab)
+        content
+            .opacity(progress.collapsedOpacity)
+            .showIf(progress.isCollapsed)
+    }
+}
+
+extension View {
+    /// Fades the receiver out over the first half of `tab`'s header collapse,
+    /// leaving the second half to the top bar's own balance. See
+    /// `HeaderCollapseFade`.
+    func headerCollapseFade(_ collapse: HomeHeaderCollapse, tab: HomeTab) -> some View {
+        modifier(HeaderCollapseFade(collapse: collapse, tab: tab))
+    }
+
+    /// Fades the receiver in over the second half of `tab`'s header collapse.
+    /// See `HeaderCollapseReveal`.
+    func headerCollapseReveal(_ collapse: HomeHeaderCollapse, tab: HomeTab) -> some View {
+        modifier(HeaderCollapseReveal(collapse: collapse, tab: tab))
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Home/Views/HeaderCollapseModifiers.swift
+++ b/VultisigApp/VultisigApp/Features/Home/Views/HeaderCollapseModifiers.swift
@@ -21,13 +21,7 @@ struct HeaderCollapseFade: ViewModifier {
     let tab: HomeTab
 
     func body(content: Content) -> some View {
-        let opacity = collapse.progress(for: tab).expandedOpacity
-        content
-            .opacity(opacity)
-            // Faded out it is still laid out, sitting behind the top bar —
-            // don't let it take taps or be read out.
-            .allowsHitTesting(opacity > 0)
-            .accessibilityHidden(opacity == 0)
+        content.headerCollapseOpacity(collapse.progress(for: tab).expandedOpacity)
     }
 }
 
@@ -37,7 +31,9 @@ struct HeaderCollapseFade: ViewModifier {
 ///
 /// It is removed rather than left at zero opacity while the home is expanded,
 /// so a transparent full-width background can't swallow taps meant for the
-/// content scrolling underneath.
+/// content scrolling underneath. `headerCollapseOpacity` covers the one point
+/// that removal doesn't: the swap itself, where the background is present but
+/// still at zero.
 struct HeaderCollapseReveal: ViewModifier {
     @ObservedObject var collapse: HomeHeaderCollapse
     let tab: HomeTab
@@ -45,12 +41,28 @@ struct HeaderCollapseReveal: ViewModifier {
     func body(content: Content) -> some View {
         let progress = collapse.progress(for: tab)
         content
-            .opacity(progress.collapsedOpacity)
+            .headerCollapseOpacity(progress.collapsedOpacity)
             .showIf(progress.isCollapsed)
     }
 }
 
 extension View {
+    /// Applies one end of the collapse crossfade, and makes the view inert for
+    /// as long as that ramp holds it at zero.
+    ///
+    /// Fading something out does not remove it: it stays laid out, keeps taking
+    /// taps and is still read out by VoiceOver. Everything the crossfade ramps
+    /// goes through here, so that neither side of the swap can leave a control
+    /// live while it is invisible — without it the top bar's buttons stay fully
+    /// tappable through the last sliver of their fade, and its balance is
+    /// exposed from the instant it appears at zero opacity.
+    func headerCollapseOpacity(_ opacity: Double) -> some View {
+        self
+            .opacity(opacity)
+            .allowsHitTesting(opacity > 0)
+            .accessibilityHidden(opacity == 0)
+    }
+
     /// Fades the receiver out over the first half of `tab`'s header collapse,
     /// leaving the second half to the top bar's own balance. See
     /// `HeaderCollapseFade`.

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -14,7 +14,10 @@ struct VaultMainScreen: View {
     @Binding var addressToCopy: Coin?
     @Binding var showUpgradeVaultSheet: Bool
     @Binding var showBackupNow: Bool
-    @Binding var showBalanceInHeader: Bool
+    /// Shared with the top bar and written from this screen's scroll offset.
+    /// Held as a plain `let`, deliberately un-observed: this screen must not be
+    /// invalidated by a scroll, only the two leaves that render a balance are.
+    let collapse: HomeHeaderCollapse
     @Binding var shouldRefresh: Bool
     var onCamera: () -> Void
 
@@ -26,7 +29,6 @@ struct VaultMainScreen: View {
     @EnvironmentObject var settingsViewModel: SettingsViewModel
     @Environment(\.openURL) var openURL
 
-    @State private var scrollOffset: CGFloat = 0
     @State var showChainSelection: Bool = false
     @State var showSearchHeader: Bool = false
     @State var showReceiveList: Bool = false
@@ -53,7 +55,7 @@ struct VaultMainScreen: View {
                         showsIndicators: false,
                         topInset: contentInset,
                         bottomInset: 0,
-                        scrollOffset: $scrollOffset
+                        onOffsetChange: onScrollOffsetChange
                     ) {
                         LazyVStack(spacing: 20) {
                             topContentSection(width: capturedGeometryWidth)
@@ -80,9 +82,6 @@ struct VaultMainScreen: View {
                     if !showChainSelection && !showReceiveList {
                         capturedGeometryWidth = newWidth
                     }
-                }
-                .onChange(of: scrollOffset) { _, newValue in
-                    onScrollOffsetChange(newValue)
                 }
                 .onChange(of: showSearchHeader) { _, showSearchHeader in
                     if showSearchHeader {
@@ -163,6 +162,7 @@ struct VaultMainScreen: View {
                     balanceToShow: totalBalanceToShow,
                     style: .wallet
                 )
+                    .headerCollapseFade(collapse, tab: .wallet)
                     .padding(.bottom, 32)
                 CoinActionsView(
                     actions: viewModel.availableActions,
@@ -276,9 +276,7 @@ struct VaultMainScreen: View {
     }
 
     func onScrollOffsetChange(_ offset: CGFloat) {
-        let showBalanceInHeader: Bool = offset < contentInset
-        guard showBalanceInHeader != self.showBalanceInHeader else { return }
-        self.showBalanceInHeader = showBalanceInHeader
+        collapse.update(tab: .wallet, offset: offset, restingOffset: contentInset)
     }
 
     func clearSearch() {
@@ -389,7 +387,7 @@ struct VaultMainScreen: View {
         addressToCopy: .constant(nil),
         showUpgradeVaultSheet: .constant(false),
         showBackupNow: .constant(false),
-        showBalanceInHeader: .constant(false),
+        collapse: HomeHeaderCollapse(),
         shouldRefresh: .constant(false),
         onCamera: {}
     )

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift
@@ -13,13 +13,15 @@ struct HomeMainHeaderView: View {
 
     let vault: Vault
     @Binding var activeTab: HomeTab
-    @Binding var showBalance: Bool
+    /// Held as a plain `let`: this view must not re-evaluate when the collapse
+    /// progress moves, because `balanceText` below is not free. The two things
+    /// that do move with the scroll — the trailing slot and the bar's opaque
+    /// background — observe it themselves.
+    let collapse: HomeHeaderCollapse
     var vaultSelectorAction: () -> Void
     var historyAction: () -> Void
     var settingsAction: () -> Void
     var onRefresh: () -> Void
-
-    @State private var showBalanceInternal = false
 
     /// Wallet total: the same guard-and-fallback shape as
     /// `VaultMainScreen.totalBalanceToShow`. `VaultDetailViewModel` publishes it
@@ -35,7 +37,9 @@ struct HomeMainHeaderView: View {
     /// `VaultDetailViewModel` has no trigger tied to a DeFi balance refresh — a
     /// value published there would go stale on exactly the tab that shows it.
     /// The walk is also far cheaper: it is filtered to the vault's DeFi chains
-    /// and only runs while the DeFi tab is active.
+    /// and only runs while the DeFi tab is active. It is still a walk, though,
+    /// which is why it is computed here and handed down as a plain `String`
+    /// rather than being re-derived on every frame of a collapse.
     var balanceText: String {
         guard !homeViewModel.hideVaultBalance else { return String.hideBalanceText }
         guard activeTab != .defi else { return homeViewModel.defiBalanceText(for: vault) }
@@ -56,27 +60,66 @@ struct HomeMainHeaderView: View {
 
             HStack {
                 Spacer()
-                trailingView
-                    .transition(.opacity)
+                HomeMainHeaderTrailingView(
+                    collapse: collapse,
+                    tab: activeTab,
+                    balanceText: balanceText,
+                    historyAction: historyAction,
+                    settingsAction: settingsAction,
+                    onRefresh: onRefresh
+                )
             }
         }
         .padding(.top, isMacOS ? 16 : 0)
         .padding(.bottom, 16)
         .padding(.horizontal, 16)
         .background(backgroundView)
-        .onChange(of: showBalance) { _, newValue in
-            withAnimation(.interpolatingSpring) {
-                showBalanceInternal = newValue
-            }
-        }
+        // Nothing here animates on a timeline: every opacity is a function of
+        // the scroll offset. Switching tabs steps straight to the other tab's
+        // stored progress rather than easing into it — easing would fade this
+        // bar's balance out while the tab being switched to already has its
+        // large balance on screen, which is the very overlap this is fixing.
     }
 
-    @ViewBuilder
-    var trailingView: some View {
-        if showBalanceInternal {
+    var backgroundView: some View {
+        VStack(spacing: 0) {
+            Theme.colors.bgPrimary
+            Separator(color: Theme.colors.borderLight, opacity: 1)
+        }
+        .ignoresSafeArea(.all)
+        .headerCollapseReveal(collapse, tab: activeTab)
+    }
+}
+
+/// The bar's trailing slot: toolbar buttons while the home is expanded, the
+/// portfolio balance once it has collapsed.
+///
+/// Split out of `HomeMainHeaderView` so that it, and not the whole bar, is what
+/// SwiftUI re-evaluates as the collapse progress moves — the bar's `balanceText`
+/// walks the vault's DeFi coins on the DeFi tab, and that must not be redone on
+/// every frame of a transition.
+private struct HomeMainHeaderTrailingView: View {
+    @ObservedObject var collapse: HomeHeaderCollapse
+    let tab: HomeTab
+    let balanceText: String
+    let historyAction: () -> Void
+    let settingsAction: () -> Void
+    let onRefresh: () -> Void
+
+    private var progress: HeaderCollapseProgress {
+        collapse.progress(for: tab)
+    }
+
+    /// The buttons and the balance never overlap: the buttons have faded out by
+    /// the time the swap happens, and the balance starts fading in from there,
+    /// so the swap lands on the one point where both are invisible.
+    var body: some View {
+        if progress.isCollapsed {
             balanceView
+                .opacity(progress.collapsedOpacity)
         } else {
             buttonsStack
+                .opacity(progress.expandedOpacity)
         }
     }
 
@@ -110,16 +153,6 @@ struct HomeMainHeaderView: View {
                 .accessibilityIdentifier(AccessibilityID.Home.settingsButton)
         }
     }
-
-    var backgroundView: some View {
-        VStack(spacing: 0) {
-            Theme.colors.bgPrimary
-            Separator(color: Theme.colors.borderLight, opacity: 1)
-        }
-        .ignoresSafeArea(.all)
-        .transition(.opacity)
-        .showIf(showBalanceInternal)
-    }
 }
 
 #Preview {
@@ -127,7 +160,7 @@ struct HomeMainHeaderView: View {
         HomeMainHeaderView(
             vault: .example,
             activeTab: .constant(.wallet),
-            showBalance: .constant(true)
+            collapse: HomeHeaderCollapse()
         ) {
             print("Vault Selector Action")
         } historyAction: {

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/HomeMainHeaderView.swift
@@ -112,14 +112,16 @@ private struct HomeMainHeaderTrailingView: View {
 
     /// The buttons and the balance never overlap: the buttons have faded out by
     /// the time the swap happens, and the balance starts fading in from there,
-    /// so the swap lands on the one point where both are invisible.
+    /// so the swap lands on the one point where both are invisible. Each side
+    /// is ramped through `headerCollapseOpacity`, which is also what stops the
+    /// buttons taking taps once they are no longer legible.
     var body: some View {
         if progress.isCollapsed {
             balanceView
-                .opacity(progress.collapsedOpacity)
+                .headerCollapseOpacity(progress.collapsedOpacity)
         } else {
             buttonsStack
-                .opacity(progress.expandedOpacity)
+                .headerCollapseOpacity(progress.expandedOpacity)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainScreenScrollView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainScreenScrollView.swift
@@ -13,32 +13,32 @@ struct VaultMainScreenScrollView<Content: View>: View {
     var showsIndicators = true
     var topInset: CGFloat
     var bottomInset: CGFloat
-    @Binding var scrollOffset: CGFloat
+    /// Called with the content's `minY` in the scroll view's coordinate space
+    /// once per layout pass — i.e. every frame while the user drags.
+    ///
+    /// It has to stay cheap, and it must not write view state: a `@State` write
+    /// here invalidates this view's body, which re-invokes `content()` — the
+    /// entire screen's content tree — at display rate. The offset used to be
+    /// published through a `@Binding` and needed a throttle in front of it for
+    /// exactly that reason; its only consumer now is the header-collapse
+    /// progress, which compares before it publishes and publishes to leaf
+    /// views only, so the raw per-frame value can be handed over as-is.
+    var onOffsetChange: (CGFloat) -> Void
     @ViewBuilder var content: () -> Content
-
-    /// Throttle bookkeeping lives in a reference box rather than in `@State`
-    /// scalars. The offset reader below fires once per layout pass — i.e. every
-    /// frame while the user drags — and writing `@State` there would invalidate
-    /// this view's body, re-invoking `content()` (the entire wallet content
-    /// tree) at display rate. That defeated the whole point of the throttle:
-    /// only the `scrollOffset` binding was rate-limited, the expensive rebuild
-    /// was not. Mutating the box's properties is invisible to SwiftUI, so the
-    /// only re-render left is the throttled binding write itself.
-    @State private var throttle = ScrollOffsetThrottle(interval: 1.0 / 5.0)
 
     init(
         axes: Axis.Set = .vertical,
         showsIndicators: Bool = true,
         topInset: CGFloat = 0,
         bottomInset: CGFloat = 0,
-        scrollOffset: Binding<CGFloat>,
+        onOffsetChange: @escaping (CGFloat) -> Void,
         content: @escaping () -> Content
     ) {
         self.axes = axes
         self.showsIndicators = showsIndicators
         self.topInset = topInset
         self.bottomInset = bottomInset
-        self._scrollOffset = scrollOffset
+        self.onOffsetChange = onOffsetChange
         self.content = content
     }
 
@@ -51,15 +51,12 @@ struct VaultMainScreenScrollView<Content: View>: View {
                         GeometryReader { proxy in
                             Color.clear
                                 .onChange(of: preferenceValue(proxy: proxy)) { _, newValue in
-                                    throttle.submit(newValue) { scrollOffset = $0 }
+                                    onOffsetChange(newValue)
                                 }
                         }
                     )
                 insetView(length: bottomInset)
             }
-        }
-        .onDisappear {
-            throttle.cancel()
         }
     }
 }
@@ -86,60 +83,5 @@ private extension VaultMainScreenScrollView {
     func preferenceValue(proxy: GeometryProxy) -> CGFloat {
         let frame = proxy.frame(in: .scrollView)
         return axes == .vertical ? frame.minY : frame.minX
-    }
-}
-
-/// Leading-edge throttle for the scroll offset, with a trailing emission so the
-/// last value of a burst is never dropped.
-///
-/// Deliberately a class: it is held in a single `@State` so the per-frame
-/// bookkeeping never invalidates the owning view's body.
-private final class ScrollOffsetThrottle {
-    private let interval: TimeInterval
-    private var lastEmitTime: CFTimeInterval = 0
-    private var pendingValue: CGFloat?
-    private var timer: Timer?
-
-    init(interval: TimeInterval) {
-        self.interval = interval
-    }
-
-    /// Emits `value` immediately when `interval` has elapsed since the last
-    /// emission, otherwise schedules a single trailing emission of the newest
-    /// value seen in the meantime.
-    func submit(_ value: CGFloat, emit: @escaping (CGFloat) -> Void) {
-        let now = CACurrentMediaTime()
-        pendingValue = value
-
-        if now - lastEmitTime >= interval {
-            flush(now: now, emit: emit)
-            return
-        }
-
-        guard timer == nil else { return }
-
-        let trailing = Timer(timeInterval: interval - (now - lastEmitTime), repeats: false) { [weak self] _ in
-            guard let self else { return }
-            self.timer = nil
-            self.flush(now: CACurrentMediaTime(), emit: emit)
-        }
-        timer = trailing
-        // `.common` mode, not the default one: the default run loop mode is
-        // suspended for the whole duration of a scroll drag, so a timer
-        // scheduled there never fires while the finger is down — exactly when
-        // the trailing update is needed.
-        RunLoop.main.add(trailing, forMode: .common)
-    }
-
-    func cancel() {
-        timer?.invalidate()
-        timer = nil
-    }
-
-    private func flush(now: CFTimeInterval, emit: (CGFloat) -> Void) {
-        guard let value = pendingValue else { return }
-        pendingValue = nil
-        lastEmitTime = now
-        emit(value)
     }
 }

--- a/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
@@ -111,6 +111,58 @@ final class HeaderCollapseProgressTests: XCTestCase {
         }
     }
 
+    // MARK: - The guards the ramps drive
+
+    /// A faded-out view is still laid out: it keeps taking taps and is still
+    /// read out by VoiceOver unless something says otherwise. `headerCollapseOpacity`
+    /// says otherwise by comparing the ramp against zero *exactly* — so a ramp
+    /// that merely approached zero, or landed on a float residue, would leave an
+    /// invisible balance or an invisible History/Settings button live. Pin the
+    /// hard zeros at both ends of both ramps.
+    func testBothRampsReachExactlyZero() {
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.5).expandedOpacity, 0)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.75).expandedOpacity, 0)
+        XCTAssertEqual(makeProgress(scrolled: distance).expandedOpacity, 0)
+
+        XCTAssertEqual(makeProgress(scrolled: 0).collapsedOpacity, 0)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.25).collapsedOpacity, 0)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.5).collapsedOpacity, 0)
+    }
+
+    /// The two guards are complementary predicates over the same value —
+    /// `allowsHitTesting(opacity > 0)` and `accessibilityHidden(opacity == 0)` —
+    /// so every scroll position must satisfy exactly one of them. A ramp that
+    /// went negative (or NaN) would satisfy neither, which is precisely the
+    /// defect the guards exist to prevent: invisible, and still exposed.
+    func testTheGuardPredicatesPartitionTheWholeSweep() {
+        for step in stride(from: CGFloat(-40), through: distance + 40, by: 0.25) {
+            let progress = makeProgress(scrolled: step)
+            for opacity in [progress.expandedOpacity, progress.collapsedOpacity] {
+                XCTAssertTrue(
+                    (opacity > 0) != (opacity == 0),
+                    "opacity \(opacity) at \(step)pt is neither legible nor a hard zero"
+                )
+            }
+        }
+    }
+
+    /// The top bar's trailing slot draws whichever side `isCollapsed` selects,
+    /// and ramps it with the matching opacity. Swept across the transition, the
+    /// side that is *not* drawn is always at a hard zero, so the side that is
+    /// drawn is the only thing the guards ever have to keep alive — the swap
+    /// can never hand over while the outgoing side is still legible.
+    func testTheDrawnSideOfTheSwapIsAlwaysTheOnlyLiveOne() {
+        for step in stride(from: CGFloat(-40), through: distance + 40, by: 0.25) {
+            let progress = makeProgress(scrolled: step)
+            let shownOpacity = progress.isCollapsed ? progress.collapsedOpacity : progress.expandedOpacity
+            let hiddenOpacity = progress.isCollapsed ? progress.expandedOpacity : progress.collapsedOpacity
+
+            XCTAssertEqual(hiddenOpacity, 0, "the slot that is not drawn must be at a hard zero at \(step)pt")
+            XCTAssertGreaterThanOrEqual(shownOpacity, 0, "a ramp went negative at \(step)pt")
+            XCTAssertLessThanOrEqual(shownOpacity, 1, "a ramp overshot at \(step)pt")
+        }
+    }
+
     // MARK: - Per-tab store
 
     @MainActor

--- a/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/Home/HeaderCollapseProgressTests.swift
@@ -1,0 +1,163 @@
+//
+//  HeaderCollapseProgressTests.swift
+//  VultisigAppTests
+//
+
+import Combine
+import XCTest
+
+@testable import VultisigApp
+
+/// The vault-home top bar collapses as the user scrolls. The acceptance
+/// criterion for that transition is that the large balance in the content and
+/// the balance in the top bar are *never legible at the same time* — these
+/// tests pin that as an algebraic property of the two fade ramps rather than
+/// something that has to be eyeballed.
+final class HeaderCollapseProgressTests: XCTestCase {
+
+    /// The scroll views' top inset: the offset reported at scroll position zero.
+    private let resting: CGFloat = 78
+    private let distance = HeaderCollapseProgress.defaultDistance
+
+    private func makeProgress(scrolled: CGFloat) -> HeaderCollapseProgress {
+        HeaderCollapseProgress(offset: resting - scrolled, restingOffset: resting)
+    }
+
+    // MARK: - Progress
+
+    func testRestingOffsetIsFullyExpanded() {
+        let progress = makeProgress(scrolled: 0)
+        XCTAssertEqual(progress.value, 0)
+        XCTAssertEqual(progress, .expanded)
+        XCTAssertEqual(progress.expandedOpacity, 1)
+        XCTAssertEqual(progress.collapsedOpacity, 0)
+        XCTAssertFalse(progress.isCollapsed)
+    }
+
+    func testScrollingTheFullDistanceIsFullyCollapsed() {
+        let progress = makeProgress(scrolled: distance)
+        XCTAssertEqual(progress.value, 1)
+        XCTAssertEqual(progress.expandedOpacity, 0)
+        XCTAssertEqual(progress.collapsedOpacity, 1)
+        XCTAssertTrue(progress.isCollapsed)
+    }
+
+    func testScrollingPastTheDistanceStaysCollapsed() {
+        XCTAssertEqual(makeProgress(scrolled: distance * 10).value, 1)
+    }
+
+    /// Pulling down past the top (rubber band, pull-to-refresh) reports an
+    /// offset *larger* than the resting one. It must not drive the progress
+    /// negative or fade anything.
+    func testOverscrollStaysFullyExpanded() {
+        let progress = makeProgress(scrolled: -200)
+        XCTAssertEqual(progress.value, 0)
+        XCTAssertEqual(progress.expandedOpacity, 1)
+        XCTAssertEqual(progress.collapsedOpacity, 0)
+    }
+
+    func testProgressIsMonotonicInScrollDistance() {
+        var previous = makeProgress(scrolled: -20).value
+        for step in stride(from: CGFloat(-20), through: distance + 40, by: 1) {
+            let current = makeProgress(scrolled: step).value
+            XCTAssertGreaterThanOrEqual(current, previous, "progress went backwards at \(step)pt")
+            previous = current
+        }
+    }
+
+    func testADegenerateDistanceFallsBackToAThreshold() {
+        let expanded = HeaderCollapseProgress(offset: resting, restingOffset: resting, distance: 0)
+        let collapsed = HeaderCollapseProgress(offset: resting - 1, restingOffset: resting, distance: 0)
+        XCTAssertEqual(expanded.value, 0)
+        XCTAssertEqual(collapsed.value, 1)
+    }
+
+    // MARK: - The two ramps
+
+    func testExpandedContentFadesOutOverTheFirstHalf() {
+        XCTAssertEqual(makeProgress(scrolled: 0).expandedOpacity, 1)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.25).expandedOpacity, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.5).expandedOpacity, 0, accuracy: 0.0001)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.75).expandedOpacity, 0)
+    }
+
+    func testCollapsedContentFadesInOverTheSecondHalf() {
+        XCTAssertEqual(makeProgress(scrolled: 0).collapsedOpacity, 0)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.25).collapsedOpacity, 0)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.5).collapsedOpacity, 0, accuracy: 0.0001)
+        XCTAssertEqual(makeProgress(scrolled: distance * 0.75).collapsedOpacity, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(makeProgress(scrolled: distance).collapsedOpacity, 1)
+    }
+
+    /// The top bar swaps its toolbar buttons for the balance at the midpoint —
+    /// the single point where both ramps are zero, so nothing pops.
+    func testTheSwapHappensWhereBothRampsAreZero() {
+        let progress = makeProgress(scrolled: distance * 0.5)
+        XCTAssertTrue(progress.isCollapsed)
+        XCTAssertEqual(progress.expandedOpacity, 0, accuracy: 0.0001)
+        XCTAssertEqual(progress.collapsedOpacity, 0, accuracy: 0.0001)
+    }
+
+    /// The whole point of the change: swept across the transition (and well
+    /// past both ends of it) at sub-point resolution, at most one of the two
+    /// balances is ever drawn.
+    func testTheTwoBalancesAreNeverBothVisible() {
+        for step in stride(from: CGFloat(-40), through: distance + 40, by: 0.25) {
+            let progress = makeProgress(scrolled: step)
+            XCTAssertTrue(
+                progress.expandedOpacity == 0 || progress.collapsedOpacity == 0,
+                "both legible at \(step)pt: expanded \(progress.expandedOpacity), collapsed \(progress.collapsedOpacity)"
+            )
+        }
+    }
+
+    // MARK: - Per-tab store
+
+    @MainActor
+    func testStoreStartsExpandedForEveryTab() {
+        let collapse = HomeHeaderCollapse()
+        XCTAssertEqual(collapse.progress(for: .wallet), .expanded)
+        XCTAssertEqual(collapse.progress(for: .defi), .expanded)
+        XCTAssertEqual(collapse.progress(for: .camera), .expanded)
+    }
+
+    @MainActor
+    func testStoreKeepsTheTabsIndependent() {
+        let collapse = HomeHeaderCollapse()
+        collapse.update(tab: .wallet, offset: resting - distance, restingOffset: resting)
+
+        XCTAssertEqual(collapse.progress(for: .wallet).value, 1)
+        XCTAssertEqual(collapse.progress(for: .defi), .expanded)
+
+        collapse.update(tab: .defi, offset: resting - distance * 0.25, restingOffset: resting)
+        XCTAssertEqual(collapse.progress(for: .defi).value, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(collapse.progress(for: .wallet).value, 1, "the wallet tab must not move")
+    }
+
+    /// The offset arrives on every layout pass, so the store has to stay quiet
+    /// unless the progress actually moved — which, outside the transition
+    /// window, it never does.
+    @MainActor
+    func testStoreOnlyPublishesWhenTheProgressChanges() {
+        let collapse = HomeHeaderCollapse()
+        var publishes = 0
+        let cancellable = collapse.objectWillChange.sink { _ in publishes += 1 }
+        defer { cancellable.cancel() }
+
+        // Well past the end of the transition: 200 frames, saturated at 1.
+        for step in 0..<200 {
+            let offset = resting - distance * 2 - CGFloat(step)
+            collapse.update(tab: .wallet, offset: offset, restingOffset: resting)
+        }
+
+        XCTAssertEqual(publishes, 1, "a saturated progress must publish once, not once per frame")
+        XCTAssertEqual(collapse.progress(for: .wallet).value, 1)
+    }
+
+    @MainActor
+    func testStoreIgnoresTheAccessoryTab() {
+        let collapse = HomeHeaderCollapse()
+        collapse.update(tab: .camera, offset: resting - distance, restingOffset: resting)
+        XCTAssertEqual(collapse.progress(for: .camera), .expanded)
+    }
+}


### PR DESCRIPTION
## Cause

Three things, all confirmed against `main`:

- **The threshold is binary and fires almost immediately.** `showBalanceInHeader = offset < contentInset` — and `contentInset` (78) is the scroll view's *own top inset*, which is what the geometry reader reports **at rest**. So the condition became true after ~1pt of scroll: the top bar started bringing its balance in while the large one had barely moved.
- **The top bar animated its own swap on a wall-clock spring** (`withAnimation(.interpolatingSpring)` inside `.onChange(of: showBalance)`). A 0.3s spring cannot stay in sync with a finger-driven translation, by construction.
- **The large balance had no scroll-driven opacity at all.** Nothing ever told `VaultMainBalanceView` to fade.

Result: mid-transition both balances are fully drawn — it reads as a duplicate, not a transition. `VaultMainScreen` and `DefiMainScreen` had the threshold **byte-identical**, so the Wallet and DeFi tabs had the same bug twice.

## The fix

A `HeaderCollapseProgress` value derived from the scroll offset, split into two **non-overlapping** fade ramps:

```
d       = restingOffset − offset            // points scrolled, 0 at rest
value   = clamp(d / 110, 0, 1)
expandedOpacity  = max(1 − value / 0.5, 0)          // 1 → 0 over value 0…0.5
collapsedOpacity = max((value − 0.5) / 0.5, 0)      // 0 → 1 over value 0.5…1
isCollapsed      = value >= 0.5
```

- The **large balance** and the **top bar's toolbar buttons** fade out over the first half.
- The **top bar's balance** and its opaque background fade in over the second half.
- The structural buttons ↔ balance swap happens at `value == 0.5` — the single point where *both* ramps are zero — so nothing pops in or out at the switch.

`expandedOpacity` and `collapsedOpacity` are never both non-zero. That is not a tuning outcome, it's an algebraic property of the split, and it's pinned by a test that sweeps the whole transition (plus 40pt past each end) at 0.25pt resolution. Overscroll, reverse scrolling and re-entry all fall out of it for free, because the whole thing is a pure function of the offset with no timeline anywhere.

## The shared extraction

Rather than fixing the threshold twice:

| New | |
|---|---|
| `HeaderCollapseProgress` | the pure value type above, `Equatable`, no SwiftUI |
| `HomeHeaderCollapse` | per-tab store, written by the scroll views, read by leaves |
| `headerCollapseFade` / `headerCollapseReveal` | the two `ViewModifier`s that apply the ramps |

Wallet and DeFi now share one implementation. `VaultMainScreen`, `DefiMainScreen`, `HomeScreen` and `HomeMainHeaderView` all drop the `showBalanceInHeader` boolean path, and `HomeScreen` loses `walletShowPortfolioHeader` / `defiShowPortfolioHeader` / `showPortfolioHeader` / `updateHeader()` entirely.

## Scroll performance — this screen was profiled, and this change is a net reduction

This is cosmetic polish landing on the screen [#4974](https://github.com/vultisig/vultisig-ios/issues/4974) took from **114 → 4.4 ms/s** hitch time (PRs #4975 / #4976), so "does it cost anything" was the design constraint, not an afterthought.

**It removes more work than it adds:**

- **Removed:** the scroll offset no longer travels through a `@Binding`. That binding wrote `@State` on `VaultMainScreen` / `DefiMainScreen` at 5 Hz for the *entire duration of every scroll*, re-running the screen body — the documented whole-content-tree invalidation. `ScrollOffsetThrottle` existed only to rate-limit that binding; with the binding gone it has nothing left to protect, so it goes with it. (Explicitly flagging this so it doesn't read as a silent revert of #4975's step 1 — it is the same defect being removed one level further up.)
- **Added, and it is bounded:** `HomeHeaderCollapse.update` compares before it publishes, and the progress is saturated at 0 or 1 everywhere outside a 110pt window. **The overwhelming majority of any scroll publishes nothing at all** — the per-layout-pass callback costs one subtraction, one divide, one clamp and one comparison, with zero view invalidations.
- **Inside the window,** the observers are leaves only: `HeaderCollapseFade` / `HeaderCollapseReveal` (each re-applies an `.opacity` to an already-built subtree — the balance view's own body does not re-run) and the bar's trailing slot. `HomeScreen` holds the store in a plain `@State` and never reads it; `VaultMainScreen` and `DefiMainScreen` hold it as a plain `let`. **No screen body, and no chain-list row, is re-evaluated by a collapse.**
- The top bar itself was deliberately kept *out* of the observation: `HomeMainHeaderView.balanceText` walks the vault's DeFi coins on the DeFi tab, so the trailing slot was split into its own view that receives the balance as a plain `String`. Otherwise every frame of a DeFi collapse would have redone that walk. (Caught by the cross-model review, not by me.)

**Honest limits:** this reasoning is static. The change was **not** re-profiled on-device with Instruments — that needs a real device and a large vault, per the protocol in the #4974 write-up. What I can say is that it deletes a continuous 5 Hz whole-tree invalidation and replaces it with something that is silent outside a 110pt window and touches only leaves inside it. If a reviewer disagrees with that analysis, the fix is not worth shipping unmeasured and I'd rather it be held.

## Verification

**Visual — recorded renders of the real views.** I composited the real `HomeMainHeaderView` over the real balance content exactly as `HomeScreen` stacks them, translated the content by a scroll distance and derived the progress from that same distance, then rendered a filmstrip at 0 / 25 / 50 / 75 / 100 % of the transition for **Wallet**, **Wallet with the balance hidden**, and **DeFi**. All 15 frames inspected:

| progress | what's on screen |
|---|---|
| 0 % | large balance at full opacity, toolbar buttons at full opacity, no bar background |
| 25 % | large balance ~50 %, buttons ~50 %, bar still shows no balance |
| 50 % | large balance gone, buttons gone, bar balance not yet in — the swap point, nothing drawn twice |
| 75 % | bar balance ~50 % with its background half in, large balance gone |
| 100 % | bar balance and background fully in, large balance gone |

The balance-hidden run behaves identically — the dots crossfade on the same ramps. The DeFi run fades the whole `DefiMainBalanceView` card the same way.

The harness that recorded these is **not committed** — reference PNGs in CI are a maintenance cost I didn't think this earned, and the non-overlap property is already covered deterministically by the unit tests.

**What I could not verify.** I have no vault with balances to drive the app, so I did not scrub this with a finger on a device or a simulator. Specifically unverified and worth a human minute:

1. **The feel of the 110pt distance** — it's a tuned constant, judged from static renders, not from dragging.
2. **Reversal and fling behaviour.** The maths reverses exactly (it's a pure function of the offset), but the *feel* of a fast fling through the window is not something a still frame shows.
3. **macOS.** The same views build for macOS and there is no platform branch in any of this beyond the header's existing `isMacOS` padding and `RefreshToolbarButton`, but it was rendered on iOS only.
4. **Switching between a scrolled tab and an unscrolled one** still overlaps briefly, because `TabView` cross-fades the two pages and the outgoing page's balance is still on screen. That is the tab-switch transition rather than the scroll-driven collapse, it predates this change, and I left it alone deliberately — the top bar's own animation was removed so it no longer contributes.

**Gate.** `xcodebuild test` (full suite, iOS Simulator, dedicated en_US sim): `** TEST SUCCEEDED **`, **4626 tests, 1 skipped, 0 failures**. SwiftLint: 39 warnings / 0 errors repo-wide, **none in any file this touches** (all pre-existing). `make generate` clean.

**Cross-model review.** Every commit reviewed by `codex exec --sandbox read-only` before the next one started, plus a whole-branch pass. Two MAJORs found and fixed (the tab-switch animation re-creating the overlap; the DeFi balance walk running per transition frame), one MINOR rejected with reason.

## Coverage

- **Wallet tab** ✅ — `VaultMainBalanceView` fades, bar balance crossfades.
- **DeFi tab** ✅ — same modifier, same progress, `DefiMainBalanceView` fades as a card.
- **iOS** ✅ rendered · **macOS** ⚠️ builds and shares the code path, not rendered.
- **Balance hidden** ✅ — `String.hideBalanceText` dots ride the identical ramps.

Closes #5013


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated header collapse behavior across wallet and DeFi screens.
  * Header content now smoothly fades between expanded and collapsed states as users scroll.
  * Wallet and DeFi tabs retain independent header positions.
  * Collapsed header controls and balance information transition more consistently.

* **Bug Fixes**
  * Improved scroll-based header updates and reduced unnecessary visual updates.
  * Camera tab behavior remains unaffected by header collapse changes.

* **Tests**
  * Added coverage for collapse progress, opacity transitions, tab independence, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->