### PR TITLE
feat(design-system): corner-radius token scale in Theme (phase 1 of 4)

### DIFF
--- a/VultisigApp/VultisigApp/Components/CounterView.swift
+++ b/VultisigApp/VultisigApp/Components/CounterView.swift
@@ -58,9 +58,9 @@ struct CounterView: View {
             content()
         }
         .foregroundStyle(Theme.colors.textPrimary)
-        .cornerRadius(12)
+        .cornerRadius(Theme.radius.md)
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .stroke(Theme.colors.border, lineWidth: 1)
         )
         .padding(1)

--- a/VultisigApp/VultisigApp/Components/Forms/PercentageSliderView.swift
+++ b/VultisigApp/VultisigApp/Components/Forms/PercentageSliderView.swift
@@ -31,7 +31,7 @@ struct PercentageSliderView: View {
 
             ZStack(alignment: .leading) {
                 // Background track
-                RoundedRectangle(cornerRadius: 4)
+                Theme.radius.xs.shape
                     .fill(Color.gray.opacity(0.3))
                     .frame(height: 4)
 

--- a/VultisigApp/VultisigApp/Components/InformationNote.swift
+++ b/VultisigApp/VultisigApp/Components/InformationNote.swift
@@ -18,7 +18,7 @@ struct InformationNote: View {
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Theme.colors.bgAlert.opacity(0.35))
-        .cornerRadius(12)
+        .cornerRadius(Theme.radius.md)
         .overlay(
             overlay
         )
@@ -59,7 +59,7 @@ import SwiftUI
 
 extension InformationNote {
     var overlay: some View {
-        RoundedRectangle(cornerRadius: 12)
+        Theme.radius.md.shape
             .stroke(Theme.colors.bgAlert, lineWidth: 1)
     }
 }
@@ -70,7 +70,7 @@ import SwiftUI
 
 extension InformationNote {
     var overlay: some View {
-        RoundedRectangle(cornerRadius: 12)
+        Theme.radius.md.shape
             .stroke(Theme.colors.bgAlert, lineWidth: 2)
     }
 }

--- a/VultisigApp/VultisigApp/Components/List/CommonListItemContainer.swift
+++ b/VultisigApp/VultisigApp/Components/List/CommonListItemContainer.swift
@@ -38,10 +38,17 @@ struct CommonListItemContainer: ViewModifier {
             row(content)
                 .clipShape(
                     .rect(
-                        topLeadingRadius: isFirst ? CommonListContainer.cornerRadius : 0,
-                        bottomLeadingRadius: isLast ? CommonListContainer.cornerRadius : 0,
-                        bottomTrailingRadius: isLast ? CommonListContainer.cornerRadius : 0,
-                        topTrailingRadius: isFirst ? CommonListContainer.cornerRadius : 0
+                        topLeadingRadius: isFirst ? CommonListContainer.cornerRadius.points : 0,
+                        bottomLeadingRadius: isLast ? CommonListContainer.cornerRadius.points : 0,
+                        bottomTrailingRadius: isLast ? CommonListContainer.cornerRadius.points : 0,
+                        topTrailingRadius: isFirst ? CommonListContainer.cornerRadius.points : 0,
+                        // Rounding each corner separately means this cannot use
+                        // the token's `shape`, so the style has to be carried
+                        // across by hand — otherwise these row masks would keep
+                        // the SDK's default while the container follows the
+                        // token, and the two would diverge the moment the
+                        // token's style changes.
+                        style: CommonListContainer.cornerRadius.style
                     )
                 )
         } else {
@@ -61,16 +68,16 @@ struct CommonListItemContainer: ViewModifier {
 /// Wrapping container for a group of `commonListItemContainer` rows: a single
 /// rounded surface with a hairline border, matching the Figma list style.
 struct CommonListContainer: ViewModifier {
-    static let cornerRadius: CGFloat = 24
+    static let cornerRadius = Theme.radius.xl
 
     func body(content: Content) -> some View {
         content
             .background(
-                RoundedRectangle(cornerRadius: Self.cornerRadius)
+                Self.cornerRadius.shape
                     .fill(Theme.colors.bgSurface1)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: Self.cornerRadius)
+                Self.cornerRadius.shape
                     .strokeBorder(Theme.colors.borderLight, lineWidth: 1)
                     .allowsHitTesting(false)
             )

--- a/VultisigApp/VultisigApp/Components/Loaders/LoadingOverlay/LoadingOverlayViewModifier.swift
+++ b/VultisigApp/VultisigApp/Components/Loaders/LoadingOverlay/LoadingOverlayViewModifier.swift
@@ -66,7 +66,7 @@ private struct LoadingBanner: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
-            .background(RoundedRectangle(cornerRadius: 24)
+            .background(Theme.radius.xl.shape
                 .inset(by: 0.5)
                 .stroke(Theme.colors.border, lineWidth: 1)
                 .fill(Theme.colors.bgSurface1)

--- a/VultisigApp/VultisigApp/Components/SegmentedControls/SegmentedControl.swift
+++ b/VultisigApp/VultisigApp/Components/SegmentedControls/SegmentedControl.swift
@@ -53,7 +53,7 @@ struct SegmentedControl<T: Hashable>: View {
                                     .foregroundStyle(Theme.colors.alertInfo)
                                     .padding(6)
                                     .background(Theme.colors.alertInfo.opacity(0.12))
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                                    .clipShape(Theme.radius.sm.shape)
                             }
                         }
                         .fixedSize(horizontal: true, vertical: false)

--- a/VultisigApp/VultisigApp/Components/StepsAnimationView.swift
+++ b/VultisigApp/VultisigApp/Components/StepsAnimationView.swift
@@ -122,9 +122,9 @@ struct StepsAnimationView<Header: View, CellContent: View>: View {
                 .padding(16)
                 .frame(height: cellHeight)
                 .background(Theme.colors.bgSurface1)
-                .cornerRadius(16)
+                .cornerRadius(Theme.radius.lg)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16)
+                    Theme.radius.lg.shape
                         .inset(by: 1)
                         .stroke(Theme.colors.borderLight, lineWidth: 1)
                 )

--- a/VultisigApp/VultisigApp/Components/TextField/SearchTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextField/SearchTextField.swift
@@ -60,7 +60,7 @@ struct SearchTextField: View {
         .frame(height: 44)
         .padding(.horizontal, 12)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(99)
+        .cornerRadius(Theme.radius.pill)
         .onChange(of: focusedState) { _, newValue in
             isFocused = newValue
         }

--- a/VultisigApp/VultisigApp/Core/DesignSystem/CornerRadius/CornerRadius.swift
+++ b/VultisigApp/VultisigApp/Core/DesignSystem/CornerRadius/CornerRadius.swift
@@ -1,0 +1,54 @@
+//
+//  CornerRadius.swift
+//  DesignSystem
+//
+
+import SwiftUI
+
+/// One step of the app's corner-radius scale.
+///
+/// A token carries both the radius **and** the corner style, so a call site
+/// never names either one: it asks for `Theme.radius.lg` and gets whatever
+/// geometry the design system currently defines. That makes a change of corner
+/// shape an edit inside `CornerRadiusSystem` rather than a sweep across every
+/// rounded surface — and it stops the shape being decided by the SDK, which
+/// defaults the style of `RoundedRectangle(cornerRadius:)` and can change what
+/// that default is.
+///
+/// Values live in `CornerRadiusSystem`; this type is only the primitive, the
+/// same way `FontStyle` is the primitive behind `FontSystem`.
+public struct CornerRadius: Equatable {
+    /// Radius in points.
+    ///
+    /// Use this only where a raw `CGFloat` is unavoidable — for example
+    /// `UnevenRoundedRectangle` / `.rect(topLeadingRadius:…)`, which rounds
+    /// corners individually and so cannot take a `shape`. Everywhere else,
+    /// prefer `shape` or the `cornerRadius(_:)` view modifier so the corner
+    /// style travels with the radius.
+    public let points: CGFloat
+
+    /// How the corner is drawn. Set once, for the whole scale, by
+    /// `CornerRadiusSystem`.
+    public let style: RoundedCornerStyle
+
+    /// The rounded rectangle this token describes.
+    ///
+    /// Deliberately a concrete `RoundedRectangle` rather than `AnyShape`:
+    /// `RoundedRectangle` is an `InsettableShape`, which keeps `.strokeBorder`
+    /// and `.inset(by:)` available at the call sites that already use them.
+    public var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: points, style: style)
+    }
+}
+
+extension View {
+    /// Clips the view to the given radius token.
+    ///
+    /// Overloads SwiftUI's deprecated `cornerRadius(_:antialiased:)` on the
+    /// token type, so a tokenised call site reads the same as the literal one
+    /// it replaces while routing through `clipShape` — the replacement Apple's
+    /// deprecation points at.
+    func cornerRadius(_ radius: CornerRadius) -> some View {
+        clipShape(radius.shape)
+    }
+}

--- a/VultisigApp/VultisigApp/Core/DesignSystem/CornerRadius/CornerRadius.swift
+++ b/VultisigApp/VultisigApp/Core/DesignSystem/CornerRadius/CornerRadius.swift
@@ -25,6 +25,10 @@ public struct CornerRadius: Equatable {
     /// corners individually and so cannot take a `shape`. Everywhere else,
     /// prefer `shape` or the `cornerRadius(_:)` view modifier so the corner
     /// style travels with the radius.
+    ///
+    /// Where you do reach for it, pass `style` alongside. A radius taken from a
+    /// token and a style left to the SDK is the one combination that quietly
+    /// stops tracking the design system.
     public let points: CGFloat
 
     /// How the corner is drawn. Set once, for the whole scale, by

--- a/VultisigApp/VultisigApp/Core/DesignSystem/DefaultTheme/CornerRadiusSystem.swift
+++ b/VultisigApp/VultisigApp/Core/DesignSystem/DefaultTheme/CornerRadiusSystem.swift
@@ -1,0 +1,44 @@
+//
+//  CornerRadiusSystem.swift
+//  DesignSystem
+//
+
+import SwiftUI
+
+struct CornerRadiusSystem: CornerRadiusSystemProtocol {
+    /// The one place the app's corner geometry is decided. Every token below is
+    /// built with this style, so changing the app's corner shape is this single
+    /// line — no call site names a style.
+    ///
+    /// `.continuous` is the app's current geometry, not a new choice.
+    /// `RoundedRectangle(cornerRadius:)`, `Shape.rect(cornerRadius:)` and the
+    /// deprecated `View.cornerRadius(_:)` all default their style, and the SDK
+    /// the app builds against defaults it to `.continuous`. Every rounded
+    /// surface therefore already renders continuous, whether or not it says so.
+    ///
+    /// Naming it here is the point: that default is Apple's to change, and it
+    /// has changed. Sites that spell it out are pinned; sites that leave it
+    /// implicit restyle themselves under a new SDK. The token pins it for every
+    /// surface that adopts a token.
+    private static let cornerStyle: RoundedCornerStyle = .continuous
+
+    /// `pill` has to stay above half of the surface it is applied to: SwiftUI
+    /// clamps a corner radius to half the smaller dimension, and that clamp is
+    /// what produces a capsule. So the number is not "big enough to look
+    /// round", it is a bound — a surface 200,000pt across would out-run it,
+    /// which is an order of magnitude beyond a 5K display. Kept private so no
+    /// call site ever writes one of the "fully round" magic numbers.
+    private static let pillPoints: CGFloat = 100_000
+
+    var xs: CornerRadius { radius(4) }
+    var sm: CornerRadius { radius(8) }
+    var md: CornerRadius { radius(12) }
+    var lg: CornerRadius { radius(16) }
+    var xl: CornerRadius { radius(24) }
+    var xxl: CornerRadius { radius(38) }
+    var pill: CornerRadius { radius(Self.pillPoints) }
+
+    private func radius(_ points: CGFloat) -> CornerRadius {
+        CornerRadius(points: points, style: Self.cornerStyle)
+    }
+}

--- a/VultisigApp/VultisigApp/Core/DesignSystem/DefaultTheme/CornerRadiusSystem.swift
+++ b/VultisigApp/VultisigApp/Core/DesignSystem/DefaultTheme/CornerRadiusSystem.swift
@@ -35,7 +35,6 @@ struct CornerRadiusSystem: CornerRadiusSystemProtocol {
     var md: CornerRadius { radius(12) }
     var lg: CornerRadius { radius(16) }
     var xl: CornerRadius { radius(24) }
-    var xxl: CornerRadius { radius(38) }
     var pill: CornerRadius { radius(Self.pillPoints) }
 
     private func radius(_ points: CGFloat) -> CornerRadius {

--- a/VultisigApp/VultisigApp/Core/DesignSystem/DefaultTheme/Theme.swift
+++ b/VultisigApp/VultisigApp/Core/DesignSystem/DefaultTheme/Theme.swift
@@ -8,4 +8,5 @@
 enum Theme {
     static let fonts: FontSystemProtocol = FontSystem()
     static let colors: ColorSystemProtocol = ColorSystem()
+    static let radius: CornerRadiusSystemProtocol = CornerRadiusSystem()
 }

--- a/VultisigApp/VultisigApp/Core/DesignSystem/Theme/CornerRadiusSystemProtocol.swift
+++ b/VultisigApp/VultisigApp/Core/DesignSystem/Theme/CornerRadiusSystemProtocol.swift
@@ -17,6 +17,14 @@ import SwiftUI
 /// The design file expresses it as 50, 77 or 99 depending on the component and
 /// the app has 50, 60, 99 and 100 in use; all four mean the same thing, and the
 /// token collapses them so no call site imports another magic number.
+///
+/// **There is deliberately no sheet token, and the scale stops at 24.** The two
+/// sheet frames in the design file measure 38 and 28, but both are stock
+/// design-kit components dropped into the file rather than authored Vultisig
+/// surfaces — the 38 one is Apple's iOS 26 sheet, the 28 one is Material 3.
+/// Neither number is ours to own, and sheets already get the right radius from
+/// native presentation. Adding a step for them would encode a platform default
+/// as a design decision and invite a real sheet to diverge from the platform.
 public protocol CornerRadiusSystemProtocol {
     /// 4 — progress tracks, skeleton bars, hairline chips.
     var xs: CornerRadius { get }
@@ -28,8 +36,6 @@ public protocol CornerRadiusSystemProtocol {
     var lg: CornerRadius { get }
     /// 24 — cards, banners, list containers.
     var xl: CornerRadius { get }
-    /// 38 — sheets and modals.
-    var xxl: CornerRadius { get }
     /// Fully rounded, at every surface size the app can render.
     var pill: CornerRadius { get }
 }

--- a/VultisigApp/VultisigApp/Core/DesignSystem/Theme/CornerRadiusSystemProtocol.swift
+++ b/VultisigApp/VultisigApp/Core/DesignSystem/Theme/CornerRadiusSystemProtocol.swift
@@ -1,0 +1,35 @@
+//
+//  CornerRadiusSystemProtocol.swift
+//  DesignSystem
+//
+
+import SwiftUI
+
+/// The app's corner-radius scale.
+///
+/// The numeric steps are named by size, not by surface: `md` means "12 from the
+/// scale", nothing more. Which surface class should use which step is
+/// documentation (see the comments below), not a contract — that mapping is
+/// still being reconciled against the design file, and encoding it in the token
+/// names would freeze a half-verified answer.
+///
+/// `pill` is the one semantic token, because "fully rounded" is not a number.
+/// The design file expresses it as 50, 77 or 99 depending on the component and
+/// the app has 50, 60, 99 and 100 in use; all four mean the same thing, and the
+/// token collapses them so no call site imports another magic number.
+public protocol CornerRadiusSystemProtocol {
+    /// 4 — progress tracks, skeleton bars, hairline chips.
+    var xs: CornerRadius { get }
+    /// 8 — small inline tags.
+    var sm: CornerRadius { get }
+    /// 12 — list rows, compact containers.
+    var md: CornerRadius { get }
+    /// 16 — input fields, inner icon tiles.
+    var lg: CornerRadius { get }
+    /// 24 — cards, banners, list containers.
+    var xl: CornerRadius { get }
+    /// 38 — sheets and modals.
+    var xxl: CornerRadius { get }
+    /// Fully rounded, at every surface size the app can render.
+    var pill: CornerRadius { get }
+}

--- a/VultisigApp/VultisigAppTests/DesignSystem/CornerRadiusTokenTests.swift
+++ b/VultisigApp/VultisigAppTests/DesignSystem/CornerRadiusTokenTests.swift
@@ -1,0 +1,156 @@
+//
+//  CornerRadiusTokenTests.swift
+//  VultisigAppTests
+//
+//  Pins the corner-radius scale, and pins the geometry the tokens produce
+//  against the numeric literals they replace. A change to either is then a
+//  deliberate, visible edit rather than a silent restyle of every surface that
+//  reads a token.
+//
+
+import SwiftUI
+import XCTest
+@testable import VultisigApp
+
+final class CornerRadiusTokenTests: XCTestCase {
+
+    /// A rect wide and tall enough that no token on the numeric scale is
+    /// clamped by it, so path comparisons below compare the corner shape rather
+    /// than SwiftUI's clamping.
+    private let rect = CGRect(x: 0, y: 0, width: 320, height: 120)
+
+    // MARK: - The scale
+
+    func testScaleValuesMatchTheDesignScale() {
+        XCTAssertEqual(Theme.radius.xs.points, 4)
+        XCTAssertEqual(Theme.radius.sm.points, 8)
+        XCTAssertEqual(Theme.radius.md.points, 12)
+        XCTAssertEqual(Theme.radius.lg.points, 16)
+        XCTAssertEqual(Theme.radius.xl.points, 24)
+        XCTAssertEqual(Theme.radius.xxl.points, 38)
+    }
+
+    func testScaleIsStrictlyIncreasing() {
+        let scale = allTokens.map(\.points)
+        XCTAssertEqual(scale, scale.sorted())
+        XCTAssertEqual(Set(scale).count, scale.count)
+    }
+
+    // MARK: - Geometry parity with the literals the tokens replace
+
+    /// The tokens have to render exactly what the untokenised call sites render,
+    /// or migrating a site is a visual change. Every literal in the app spells
+    /// the radius out and leaves the corner style to the SDK's default, so this
+    /// compares each token's path against exactly that.
+    ///
+    /// This is also a tripwire. The default belongs to Apple — it was
+    /// `.circular` before the corners-are-continuous SDK and is `.continuous`
+    /// now — so if it moves again this test fails, which is the signal that
+    /// every *untokenised* surface in the app just restyled itself.
+    func testTokenShapesMatchTheImplicitlyStyledLiteralsTheyReplace() {
+        let migrated: [(name: String, token: CornerRadius, literal: CGFloat)] = [
+            ("xs", Theme.radius.xs, 4),
+            ("sm", Theme.radius.sm, 8),
+            ("md", Theme.radius.md, 12),
+            ("lg", Theme.radius.lg, 16),
+            ("xl", Theme.radius.xl, 24),
+            ("xxl", Theme.radius.xxl, 38)
+        ]
+
+        for (name, token, literal) in migrated {
+            XCTAssertEqual(
+                token.shape.path(in: rect).description,
+                RoundedRectangle(cornerRadius: literal).path(in: rect).description,
+                "\(name) does not render what RoundedRectangle(cornerRadius: \(literal)) renders"
+            )
+        }
+    }
+
+    // MARK: - pill
+
+    /// SwiftUI clamps a corner radius to half the surface's smaller dimension,
+    /// which is what turns a large radius into a capsule. `pill` is therefore
+    /// only fully round while it stays above half of the surface it is applied
+    /// to — a large-enough surface out-runs it and the corners come back. The
+    /// sizes below bracket everything the app can render, up to a full 5K
+    /// display, so the token's promise holds by measurement rather than by
+    /// "that number looks big".
+    func testPillIsFullyRoundAtEverySizeTheAppCanRender() {
+        let sizes = [
+            CGSize(width: 320, height: 44),     // search field
+            CGSize(width: 100, height: 52),     // chip / counter row
+            CGSize(width: 1_366, height: 1_024), // iPad landscape
+            CGSize(width: 5_120, height: 2_880)  // 5K display
+        ]
+
+        for size in sizes {
+            let bounds = CGRect(origin: .zero, size: size)
+            XCTAssertEqual(
+                Theme.radius.pill.shape.path(in: bounds).description,
+                Capsule(style: Theme.radius.pill.style).path(in: bounds).description,
+                "pill stops clamping to a capsule at \(size)"
+            )
+        }
+    }
+
+    /// The app expresses "fully round" as 50, 60, 99 and 100, and the design
+    /// file as 50, 77 and 99. All of them clamp to the same capsule, which is
+    /// what lets one semantic token replace all seven numbers without moving a
+    /// pixel.
+    func testPillRendersTheSameCapsuleAsEveryFullyRoundLiteralInUse() {
+        let searchFieldSized = CGRect(x: 0, y: 0, width: 320, height: 44)
+        let capsule = Capsule(style: Theme.radius.pill.style).path(in: searchFieldSized).description
+
+        XCTAssertEqual(Theme.radius.pill.shape.path(in: searchFieldSized).description, capsule)
+
+        for literal in [50, 60, 77, 99, 100] as [CGFloat] {
+            XCTAssertEqual(
+                RoundedRectangle(cornerRadius: literal).path(in: searchFieldSized).description,
+                capsule,
+                "the fully-round literal \(literal) is not what pill renders at this size"
+            )
+        }
+    }
+
+    func testPillIsNotOnTheNumericScale() {
+        let numericScale = allTokens.dropLast().map(\.points)
+        XCTAssertFalse(numericScale.contains(Theme.radius.pill.points))
+    }
+
+    // MARK: - Corner style
+
+    /// The corner style is the app's single shape switch. If a token ever
+    /// carries a different style from its siblings, changing that switch stops
+    /// being a one-line edit — which is the whole point of the token layer.
+    func testEveryTokenSharesTheSameCornerStyle() {
+        XCTAssertEqual(Set(allTokens.map(\.style)).count, 1)
+    }
+
+    /// The app's current corner geometry, stated once so a change to it has to
+    /// be deliberate and screenshot-reviewed rather than incidental.
+    func testCornersAreContinuous() {
+        XCTAssertEqual(Theme.radius.xl.style, .continuous)
+    }
+
+    // MARK: - Shape
+
+    func testShapeCarriesThePointsAndStyleOfItsToken() {
+        let token = Theme.radius.lg
+        XCTAssertEqual(token.shape.cornerSize, CGSize(width: token.points, height: token.points))
+        XCTAssertEqual(token.shape.style, token.style)
+    }
+
+    // MARK: - Helpers
+
+    private var allTokens: [CornerRadius] {
+        [
+            Theme.radius.xs,
+            Theme.radius.sm,
+            Theme.radius.md,
+            Theme.radius.lg,
+            Theme.radius.xl,
+            Theme.radius.xxl,
+            Theme.radius.pill
+        ]
+    }
+}

--- a/VultisigApp/VultisigAppTests/DesignSystem/CornerRadiusTokenTests.swift
+++ b/VultisigApp/VultisigAppTests/DesignSystem/CornerRadiusTokenTests.swift
@@ -27,7 +27,6 @@ final class CornerRadiusTokenTests: XCTestCase {
         XCTAssertEqual(Theme.radius.md.points, 12)
         XCTAssertEqual(Theme.radius.lg.points, 16)
         XCTAssertEqual(Theme.radius.xl.points, 24)
-        XCTAssertEqual(Theme.radius.xxl.points, 38)
     }
 
     func testScaleIsStrictlyIncreasing() {
@@ -53,8 +52,7 @@ final class CornerRadiusTokenTests: XCTestCase {
             ("sm", Theme.radius.sm, 8),
             ("md", Theme.radius.md, 12),
             ("lg", Theme.radius.lg, 16),
-            ("xl", Theme.radius.xl, 24),
-            ("xxl", Theme.radius.xxl, 38)
+            ("xl", Theme.radius.xl, 24)
         ]
 
         for (name, token, literal) in migrated {
@@ -149,7 +147,6 @@ final class CornerRadiusTokenTests: XCTestCase {
             Theme.radius.md,
             Theme.radius.lg,
             Theme.radius.xl,
-            Theme.radius.xxl,
             Theme.radius.pill
         ]
     }


### PR DESCRIPTION
Part of #5024 — **phase 1 of 4.** This PR defines the token layer only. It does not close the issue.

`Core/DesignSystem/` has `Colors`, `Fonts` and `Theme` and **no radius concept at all**, so every rounded surface in the app spells its geometry out as a numeric literal: ~324 of them across 16 distinct values, plus four different "fully round" magic numbers. This adds the missing layer and migrates a small, deliberately-chosen slice of call sites to prove the API works end to end.

**Zero visual change is the acceptance criterion for this phase**, and it is proven rather than asserted — see below.

---

## The scale

| Token | Points | Surface class | Source |
|---|---|---|---|
| `xs` | 4 | progress tracks, skeleton bars | inferred |
| `sm` | 8 | small inline tags | inferred |
| `md` | 12 | list rows, compact containers | Figma — asset list row |
| `lg` | 16 | input fields, inner icon tiles | Figma — input, inner tile |
| `xl` | 24 | cards, banners, list containers | Figma — banner |
| `pill` | — | chips, search fields, capsules | Figma — 50 / 77 / 99 |

**There is deliberately no sheet token, and the scale stops at 24.** The two sheet frames in the design file measure 38 and 28, but both turn out to be **stock design-kit components pasted into the file rather than authored Vultisig surfaces**: the 38 one (`48948:109326`) carries Apple *iOS and iPadOS 26 component* Code Connect snippets (`Grabber`, `ButtonsTopSheets`, `TitleBody`), and the 28 one (`49518:129622`) is a Material 3 `BuildingBlocksBottomSheetsContent`. So 38 is Apple's native sheet radius and 28 is Material's default — neither is ours, and sheets already get the right radius from native presentation. Tokenising 38 would encode a platform default as a design decision and hand someone a token to diverge a real sheet with. A comment at the scale declaration records this so nobody "completes" the scale later.

### Where these came from, and how far to trust them

Read off rendered frames in Figma file `puB2fsVpPrBx3Sup7gaa3v`, canvas `3:1510`, section **"Main View (Mobile) - iOS 26"** (`48948:108982`) — sheet `48948:109326`, banner `79204:94027`, inner tile `68734:97489`, input `48948:113223`, asset row `51141:203613`, plus three fully-round components.

Two caveats worth stating plainly:

1. **Radii are not Figma variables.** `get_variable_defs` on that section returns colours, fonts, `dimensions/3 = 8` and a stroke width — there is no authored radius scale to import. These values were measured off rendered frames.
2. **This is a sample of 5 surfaces out of 22,304 nodes in that section.** Enough to define a credible scale, not enough to call it complete. Any outlier found during phase 2 should go back to the designer rather than be rounded to the nearest token.

**`4` and `8` are lower-confidence than the rest** — they are inferred from existing code usage and the `dimensions/3 = 8` variable, not read off a frame.

`24` is confirmed and agrees with the shipped UI-redesign-2026 work, which already standardised 24pt list containers. Every token in the scale has at least one call site in this PR — nothing ships unused.

---

## The token API

```swift
Theme.radius.md            // the token — reads like Theme.colors.* / Theme.fonts.*
Theme.radius.md.shape      // RoundedRectangle, for background/overlay/clipShape/stroke/fill
Theme.radius.md.points     // CGFloat, only where a raw number is unavoidable (.rect(topLeadingRadius:))
.cornerRadius(Theme.radius.md)  // View modifier, overloaded on the token type
```

Structured to mirror what is already there — `CornerRadius` is the primitive the way `FontStyle` is, `CornerRadiusSystem` holds the scale the way `FontSystem` holds the sizes, and `Theme.radius` sits next to `Theme.colors` and `Theme.fonts`.

**The token vends the *shape*, not just a number.** That is the one design decision everything else follows from: it means a call site names neither a radius nor a corner style, so changing the app's corner geometry is one line inside `CornerRadiusSystem` instead of another 324-site sweep.

`shape` is deliberately a concrete `RoundedRectangle` rather than `AnyShape`: `AnyShape` is not an `InsettableShape`, and the app uses `.strokeBorder` / `.inset(by:)` on rounded rects in 24+ places that phase 2 has to migrate.

`pill` is semantic because "fully rounded" is not a number. The design file says 50, 77 or 99 depending on the component; the app says 50, 60, 99 and 100. All seven mean the same thing, and a literal port would have imported three more magic numbers. Its internal radius is a *clamping bound*, not a big-looking value — SwiftUI clamps a corner radius to half the smaller dimension, and 999 measurably stops clamping at 2000×2000, so the token uses 100,000 and the tests measure that it still produces a capsule at 5120×2880.

---

## ⚠️ Finding: the app already renders continuous corners

The plan for this work assumed the app is `.circular` today, because only 7 sites in the whole codebase pass `style: .continuous` explicitly. **That reading is wrong, and it is worth knowing before anyone plans a "switch to squircles" task.**

Apple changed the default of `RoundedRectangle(cornerRadius:style:)` — and of `Shape.rect(…)` and `UnevenRoundedRectangle` — from `.circular` to `.continuous` in the iOS 26 / macOS 26 SDK. `View.cornerRadius(_:antialiased:)` is `@inlinable` and forwards to `RoundedRectangle(cornerRadius:)`, so it picks the new default up at *our* compile time too. Measured against Xcode 26.6 locally (CI pins Xcode 26.2, same SDK generation):

```
RoundedRectangle(cornerRadius: 30).style              = continuous
Shape.rect(cornerRadius: 30).style                    = continuous
.cornerRadius(24) == clipShape(…, style: .continuous) : true
.cornerRadius(24) == clipShape(…, style: .circular)   : false
```

So: every rounded surface in the app already renders continuous, there is no explicit `style: .circular` anywhere, and the 7 explicit `.continuous` sites are redundant no-ops.

Three consequences:

1. **The token style is seeded at `.continuous`** — that is what already ships. Seeding it at `.circular`, as originally planned, would have made every migrated site a visual regression in the one phase whose whole point is not to change anything.
2. **The later "adopt `.continuous`" phase inverts.** It happened already, via an Xcode upgrade. What is left is deciding whether to keep it.
3. **This strengthens the case for the token layer.** The app's corner shape is currently decided by an Apple default that has already moved once, silently. A tokenised surface pins its style; a literal one floats. That is arguably a better argument for #5024 than the drift argument the issue opens with.

---

## Migrated sites — every one pixel-neutral

15 expressions across 8 files in `Components/`, chosen so each site's current literal **already equals** the token's value and left its corner style implicit. Nothing was re-valued.

| File | Before | After | Radius |
|---|---|---|---|
| `Forms/PercentageSliderView.swift` | `RoundedRectangle(cornerRadius: 4)` | `Theme.radius.xs.shape` | 4 → 4 |
| `SegmentedControls/SegmentedControl.swift` | `.clipShape(RoundedRectangle(cornerRadius: 8))` | `.clipShape(Theme.radius.sm.shape)` | 8 → 8 |
| `CounterView.swift` | `.cornerRadius(12)` | `.cornerRadius(Theme.radius.md)` | 12 → 12 |
| `CounterView.swift` | `RoundedRectangle(cornerRadius: 12)` | `Theme.radius.md.shape` | 12 → 12 |
| `InformationNote.swift` | `.cornerRadius(12)` | `.cornerRadius(Theme.radius.md)` | 12 → 12 |
| `InformationNote.swift` *(iOS)* | `RoundedRectangle(cornerRadius: 12)` | `Theme.radius.md.shape` | 12 → 12 |
| `InformationNote.swift` *(macOS)* | `RoundedRectangle(cornerRadius: 12)` | `Theme.radius.md.shape` | 12 → 12 |
| `StepsAnimationView.swift` | `.cornerRadius(16)` | `.cornerRadius(Theme.radius.lg)` | 16 → 16 |
| `StepsAnimationView.swift` | `RoundedRectangle(cornerRadius: 16)` | `Theme.radius.lg.shape` | 16 → 16 |
| `List/CommonListItemContainer.swift` | `static let cornerRadius: CGFloat = 24` | `static let cornerRadius = Theme.radius.xl` | 24 → 24 |
| `List/CommonListItemContainer.swift` ×4 | `.rect(…Radius: CommonListContainer.cornerRadius)` | `… .cornerRadius.points` | 24 → 24 |
| `List/CommonListItemContainer.swift` ×2 | `RoundedRectangle(cornerRadius: Self.cornerRadius)` | `Self.cornerRadius.shape` | 24 → 24 |
| `Loaders/LoadingOverlay/LoadingOverlayViewModifier.swift` | `RoundedRectangle(cornerRadius: 24)` | `Theme.radius.xl.shape` | 24 → 24 |
| `TextField/SearchTextField.swift` | `.cornerRadius(99)` | `.cornerRadius(Theme.radius.pill)` | capsule → capsule |

Between them these cover both literal forms, every scale step the app actually uses, `.fill` / `.stroke` / `.strokeBorder` / `.inset(by:)` / `.clipShape` / `.overlay` / `.background` / `.contentShape`, the `.rect(topLeadingRadius:)` uneven form, and a cross-platform `#if os(iOS)` / `#if os(macOS)` pair.

### How pixel-neutrality is proven

Not by eyeballing screenshots — by comparing the geometry directly. `CornerRadiusTokenTests` asserts that each token's `shape.path(in:)` is **identical** to the path of the exact literal expression it replaced:

- every numeric token vs `RoundedRectangle(cornerRadius: <the old literal>)` with its style left implicit, i.e. what the untouched sites still render;
- `pill` vs `Capsule`, and vs each of 50 / 60 / 77 / 99 / 100, at a `SearchTextField`-sized 320×44 — the app's fully-round literals all clamp to the same capsule;
- `pill` vs `Capsule` again at 320×44, 100×52, 1366×1024 and 5120×2880, so the clamping bound is measured rather than assumed.

`SearchTextField` in particular has an explicit `.frame(height: 44)`, so both the old `99` and the token clamp to the same 22pt corner. That test file is also a tripwire: if a future SDK moves the default style again, the parity test fails — which is the only signal you would otherwise get that every *untokenised* surface in the app just restyled itself.

### Deliberately not migrated

- **Sheets.** Out of scope entirely, not just out of phase 1 — they keep the native platform radius and the scale has no step for them.
- **Text inputs.** Figma says 16; `CommonTextField` is at 12. Real drift — needs a designer call, not a silent rounding.

---

## What phases 2–4 cover

**Phase 2 — migrate by surface class**, one PR per batch, each with before/after screenshots, ordered by descending confidence:

| Batch | Surface class | Sites (approx) | Value change? |
|---|---|---|---|
| 2a | List containers + list rows | ~90 | no |
| 2b | Cards / banners / summary panels | ~50 | outliers only |
| 2c | Buttons, chips, capsules → `pill` | ~30 | no |
| 2d | Inner tiles / icon containers | ~65 | no |
| 2e | Inputs and text fields | ~25 | **yes, 12 → 16** — designer call |
| ~~2f~~ | ~~Sheets and modals~~ | — | **cancelled** — native radius, no token |
| 2g | Skeletons, progress tracks, dividers | ~40 | no |
| 2h | Outliers matching no step (10, 14, 18, 20, 30, 32, 33, 34) | ~55 | **yes** — reconcile one by one |

**Phase 3 — the lint rule** banning new numeric radius literals, which is the only mechanism that makes the issue's "drift can't re-accumulate" actually true. It can only land after 2h, because until then there are legitimately untokenised values, and it will need an exemption for sheet presentation so the native radius is not lint-forced onto a token.

**Phase 4 — corner style**, now reframed by the finding above: decide whether to keep `.continuous`, and delete the 7 redundant explicit `style: .continuous` arguments.

Cross-platform: vultisig-android#5503 and vultisig-windows#4550 are "values identical, units per platform". iOS defines the scale first; the t-shirt names port to Kotlin and TypeScript without renegotiation.

---

## Gate

- `xcodebuild test` (full suite, iPhone 16 Pro / iOS 26.5 sim): **`** TEST SUCCEEDED **`** — 4620 passed, 0 failed. Includes 9 new `CornerRadiusTokenTests`.
- SwiftLint: **39 violations, unchanged from the `main` baseline** — none in any touched file.
- `make generate` run after adding sources; `project.pbxproj` untouched (it is generated and gitignored).
- Reviewed commit-by-commit and whole-branch by Codex (gpt-5.5, read-only), 3 findings, all fixed before this PR was opened:
  - it independently found the `.continuous` SDK-default issue above;
  - a real bug in the first `pill` implementation — 999 stops clamping to a capsule at 2000×2000, so the bound is now 100,000 and measured;
  - the `.rect(topLeadingRadius:)` clip in `CommonListItemContainer` took the token's radius but left its *style* to the SDK, which would have silently split that one container off from the token on a future style change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized corner-radius system for consistent rounded surfaces across the app.
  * Introduced semantic radius options, including extra-small, small, medium, large, extra-large, and pill-shaped corners.
  * Updated controls, lists, notes, loading banners, fields, and animated cells to use shared styling.

* **Tests**
  * Added coverage validating radius values, ordering, shapes, styles, and pill behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->