### PR TITLE
fix(send): auto-adjust the amount to what the balance can fund instead of dead-ending on Verify

### DIFF
--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -257,13 +257,13 @@ enum SendCryptoLogic {
     ///
     /// `rawBalance` is already a base-unit integer string, and the usual
     /// `toBigInt(decimals:)` route parses it with `NumberFormatter` — which
-    /// falls back to `Double` past `Int64`, and can round a large balance UP.
-    /// A max amount derived from a balance that is higher than the real one is
-    /// precisely the rejected broadcast this clamp exists to prevent, so parse
-    /// the integer directly, the way `canBeReaped` already does. A value that
-    /// isn't a plain integer falls back to the shared path rather than
-    /// collapsing to a zero balance.
-    private static func exactRawBalance(of coin: Coin) -> BigInt {
+    /// falls back to `Double` past `Int64`, and can round a large balance UP:
+    /// over ~9.2 units on an 18-decimal chain. Every spending decision made
+    /// against a balance larger than the real one ends the same way — a
+    /// transaction the chain refuses — so parse the integer directly, the way
+    /// `canBeReaped` already does. A value that isn't a plain integer falls
+    /// back to the shared path rather than collapsing to a zero balance.
+    static func exactRawBalance(of coin: Coin) -> BigInt {
         BigInt(coin.rawBalance) ?? coin.rawBalance.toBigInt(decimals: coin.decimals)
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Models/SendTransaction.swift
@@ -143,6 +143,19 @@ struct SendTransaction: Hashable {
     let toAddressLabel: String?
     let amount: String
     let amountInFiat: String
+
+    /// True when `amount` is a value the APP derived from the balance, not one
+    /// the user typed — Verify clamped it down to what the balance can fund
+    /// once the re-fetched fee no longer left room for the typed number.
+    ///
+    /// It rides on the transaction because the two places that must agree about
+    /// it sit on opposite sides of the VM/logic boundary: the payload build
+    /// re-fits such an amount to the fee it is actually signing, and the VM
+    /// republishes the transaction from the payload so the screen keeps showing
+    /// the value being signed. A balance-derived amount is by definition at the
+    /// edge of the balance, so it needs that re-fit for the same reason a MAX
+    /// send does.
+    let amountWasAutoAdjusted: Bool
     let memo: String
 
     /// XRP destination tag (nil elsewhere / when absent). Carried separately
@@ -210,6 +223,7 @@ extension SendTransaction {
             lhs.toAddressLabel == rhs.toAddressLabel &&
             lhs.amount == rhs.amount &&
             lhs.amountInFiat == rhs.amountInFiat &&
+            lhs.amountWasAutoAdjusted == rhs.amountWasAutoAdjusted &&
             lhs.memo == rhs.memo &&
             lhs.destinationTag == rhs.destinationTag &&
             lhs.gas == rhs.gas &&
@@ -237,6 +251,7 @@ extension SendTransaction {
         hasher.combine(toAddressLabel)
         hasher.combine(amount)
         hasher.combine(amountInFiat)
+        hasher.combine(amountWasAutoAdjusted)
         hasher.combine(memo)
         hasher.combine(destinationTag)
         hasher.combine(gas)
@@ -282,7 +297,8 @@ extension SendTransaction {
         feeCoin: Coin,
         cosmosStakingPayload: CosmosStakingPayload? = nil,
         solanaStakingPayload: SolanaStakingPayload? = nil,
-        limitCancelContext: LimitOrderCancelRequest? = nil
+        limitCancelContext: LimitOrderCancelRequest? = nil,
+        amountWasAutoAdjusted: Bool = false
     ) {
         self.coin = coin
         self.vault = vault
@@ -293,6 +309,7 @@ extension SendTransaction {
         self.toAddressLabel = toAddressLabel
         self.amount = amount
         self.amountInFiat = amountInFiat
+        self.amountWasAutoAdjusted = amountWasAutoAdjusted
         self.memo = memo
         self.destinationTag = destinationTag
         self.gas = gas
@@ -365,6 +382,7 @@ extension SendTransaction {
         toAddressLabel: SendTransactionUpdate<String?>? = nil,
         amount: String? = nil,
         amountInFiat: String? = nil,
+        amountWasAutoAdjusted: Bool? = nil,
         memo: String? = nil,
         destinationTag: SendTransactionUpdate<UInt32?>? = nil,
         gas: BigInt? = nil,
@@ -450,7 +468,8 @@ extension SendTransaction {
             // silently dropped `minOutputOverride`, which carries the same doc
             // comment warning. A field-by-field copy is the shape that invites
             // it — every new field is one someone must remember to add here.
-            limitCancelContext: limitCancelContext
+            limitCancelContext: limitCancelContext,
+            amountWasAutoAdjusted: amountWasAutoAdjusted ?? self.amountWasAutoAdjusted
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -337,23 +337,31 @@ struct SendCryptoVerifyLogic {
         }
     }
 
-    // MARK: - EVM max-send clamp
+    // MARK: - EVM balance-derived amount re-fit
 
-    /// True for the one send whose value is derived from the balance rather than
-    /// typed by the user: a native EVM MAX. Its amount is `balance − fee`, so it
-    /// is the only case where a fee that moved between the Verify quote and the
-    /// payload build makes the signed value unaffordable. Token sends move the
-    /// whole token balance and pay gas from the native sibling; a typed amount
-    /// is the user's number and must never be rewritten.
-    static func needsEVMMaxClamp(tx: SendTransaction) -> Bool {
-        tx.sendMaxAmount && tx.coin.isNativeToken && tx.coin.chainType == .EVM
+    /// True for a send whose value the APP derived from the balance rather than
+    /// the user typing it: a native EVM MAX, or a native EVM amount Verify
+    /// adjusted down to what the balance could actually fund. Both settle at
+    /// `balance − fee`, so both stop being affordable the moment the fee moves
+    /// between the Verify quote and the payload build — which is exactly when
+    /// the signed value has to be re-fitted.
+    ///
+    /// Token sends move the whole token balance and pay gas from the native
+    /// sibling, so a native fee that moved cannot underfund them. And a typed
+    /// amount the app never touched is the user's number: it must never be
+    /// rewritten, however close to the balance it sits.
+    static func needsEVMBalanceRefit(tx: SendTransaction) -> Bool {
+        (tx.sendMaxAmount || tx.amountWasAutoAdjusted)
+            && tx.coin.isNativeToken
+            && tx.coin.chainType == .EVM
     }
 
-    /// Headroom a native MAX send has to leave on OP-stack rollups, where
-    /// op-geth checks `value + gasLimit × maxFeePerGas + l1Cost + operatorCost`
-    /// against the balance. `.zero` for token sends, whose gas comes out of the
-    /// native sibling rather than the amount being sent, and for every chain
-    /// that charges neither term.
+    /// Headroom a native send whose amount came from the balance has to leave on
+    /// OP-stack rollups, where op-geth checks
+    /// `value + gasLimit × maxFeePerGas + l1Cost + operatorCost` against the
+    /// balance — a MAX, or an amount Verify adjusted down to fit the fee.
+    /// `.zero` for token sends, whose gas comes out of the native sibling rather
+    /// than the amount being sent, and for every chain that charges neither term.
     func opStackFeeReserve(tx: SendTransaction, gasLimit: BigInt?) async -> BigInt {
         guard tx.coin.isNativeToken else { return .zero }
         return await interactor.fetchOpStackFeeReserve(coin: tx.coin, memo: tx.memo, gasLimit: gasLimit)
@@ -446,12 +454,14 @@ struct SendCryptoVerifyLogic {
                 )
             }
 
-            // A native EVM MAX is `balance − fee`, and the fee it was derived
-            // from is NOT the one in `chainSpecific` above — that is a second,
-            // independent reading of the fee market. Re-fit the value to the
-            // fee the payload actually carries, or the node rejects the send
-            // for the difference once the ceremony has already run.
-            let amount = try await clampedMaxSendAmount(tx: tx, chainSpecific: chainSpecific)
+            // An amount the app derived from the balance — a native EVM MAX, or
+            // one Verify adjusted down to fit the fee — is `balance − fee`, and
+            // the fee it was derived from is NOT the one in `chainSpecific`
+            // above: that is a second, independent reading of the fee market.
+            // Re-fit the value to the fee the payload actually carries, or the
+            // node rejects the send for the difference once the ceremony has
+            // already run.
+            let amount = try await balanceRefittedAmount(tx: tx, chainSpecific: chainSpecific)
 
             let basePayload = try await interactor.buildKeysignPayload(
                 coin: tx.coin,
@@ -518,18 +528,19 @@ struct SendCryptoVerifyLogic {
 
     /// The value to sign, given the chain-specific the payload is being built
     /// from. Passes a typed amount through untouched; re-derives a native EVM
-    /// MAX against `chainSpecific`'s own `gasLimit × maxFeePerGas` plus the
-    /// OP-stack L1 data fee, clamping down only.
+    /// amount the app took from the balance against `chainSpecific`'s own
+    /// `gasLimit × maxFeePerGas` plus the OP-stack L1 data fee, clamping down
+    /// only.
     ///
     /// Throws rather than signing when nothing is left after the fee: a send the
     /// balance cannot fund is a rejected broadcast, and refusing it here costs
     /// the user nothing where discovering it after the ceremony costs a signing
     /// round.
-    private func clampedMaxSendAmount(
+    private func balanceRefittedAmount(
         tx: SendTransaction,
         chainSpecific: BlockChainSpecific
     ) async throws -> BigInt {
-        guard Self.needsEVMMaxClamp(tx: tx) else { return tx.amountInRaw }
+        guard Self.needsEVMBalanceRefit(tx: tx) else { return tx.amountInRaw }
 
         let amount = SendCryptoLogic.evmMaxSendAmountRaw(
             coin: tx.coin,

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -337,6 +337,73 @@ struct SendCryptoVerifyLogic {
         }
     }
 
+    // MARK: - Fee-shortfall amount adjustment
+
+    /// True when the balance covers the amount but not the amount PLUS the fee.
+    /// That is the one shape Verify can rescue by clamping the amount down,
+    /// instead of dead-ending on an error whose only answer is to go back and
+    /// retype a number the user has no way to compute.
+    ///
+    /// Deliberately narrow:
+    /// - **Native coins only.** A token send pays gas out of the native sibling,
+    ///   so the token balance is never what the fee overruns.
+    /// - **Not a MAX send.** That amount is already re-derived from the fee a
+    ///   few lines earlier; clamping it twice would just fight itself.
+    /// - **Plain transfers only.** A stake, a bond, an unbond, an XRPL TrustSet
+    ///   limit or a function call carries an amount that means something other
+    ///   than "how much to move" — quietly reducing it would change the
+    ///   operation rather than make it affordable. A memo is enough to
+    ///   disqualify a send on its own: on EVM the memo IS the calldata, so the
+    ///   amount is a contract call's `msg.value` and not a transfer at all, and
+    ///   elsewhere a memo is what tells a protocol how to interpret the deposit.
+    ///   The send this issue is about carries none of that.
+    /// - **The amount alone has to fit.** If the user asked to send more than
+    ///   they hold, the fee is not what went wrong and the error is the honest
+    ///   answer. Clamping there would silently replace the send they asked for
+    ///   with a different one.
+    static func hasFeeOnlyShortfall(tx: SendTransaction) -> Bool {
+        guard tx.coin.isNativeToken,
+              !tx.sendMaxAmount,
+              !tx.isStakingOperation,
+              tx.transactionType == .unspecified,
+              tx.memo.isEmpty,
+              tx.memoFunctionDictionary.isEmpty,
+              tx.wasmContractPayload == nil,
+              tx.cosmosStakingPayload == nil,
+              tx.solanaStakingPayload == nil else {
+            return false
+        }
+
+        let balance = SendCryptoLogic.exactRawBalance(of: tx.coin)
+        let amount = tx.amountInRaw
+        return amount <= balance && amount + tx.fee > balance
+    }
+
+    /// What to fall back to when the fee is what pushed the send past the
+    /// balance: the very same `balance − fee − ED − extraReserve` the MAX path
+    /// derives. Sharing it is the point — a DOT clamp keeps reserving the
+    /// existential deposit, an OP-stack clamp keeps reserving the L1 data and
+    /// operator fees op-geth bills on top of gas, and the balance is read
+    /// exactly rather than through the rounding parse.
+    ///
+    /// `nil` when there is nothing safe to fall back TO: the clamp landed at or
+    /// below zero (the balance cannot even fund its own fee — a zero-value send
+    /// is not a rescue), or it somehow came out no smaller than what was asked
+    /// for (this only ever adjusts DOWNWARD). Both leave the existing balance
+    /// error standing.
+    static func feeShortfallAdjustedAmountRaw(tx: SendTransaction, extraReserve: BigInt) -> BigInt? {
+        guard hasFeeOnlyShortfall(tx: tx) else { return nil }
+
+        let candidate = SendCryptoLogic.verifyMaxCandidateRaw(
+            coin: tx.coin,
+            fee: tx.fee,
+            previousAmountRaw: tx.amountInRaw,
+            extraReserve: extraReserve
+        )
+        guard candidate > 0, candidate < tx.amountInRaw else { return nil }
+        return candidate
+    }
+
     // MARK: - EVM balance-derived amount re-fit
 
     /// True for a send whose value the APP derived from the balance rather than

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -109,7 +109,11 @@ struct SendCryptoVerifyLogic {
         }
 
         let amount = tx.amountInRaw
-        let balance = tx.coin.rawBalance.toBigInt(decimals: tx.coin.decimals)
+        // Exactly, not via the shared `toBigInt(decimals:)` route: that one
+        // rounds a balance past `Int64` UP, which makes this check LOOSER than
+        // the truth and lets a send the wallet cannot fund walk through to a
+        // rejected broadcast.
+        let balance = SendCryptoLogic.exactRawBalance(of: tx.coin)
         // TRON staking operations: skip balance validation entirely
         // The balance is already validated in TronFreezeScreen/TronUnfreezeScreen
         // and the user sees the available balance on the screen
@@ -174,7 +178,7 @@ struct SendCryptoVerifyLogic {
             // error when the vault's ADA balance can't cover that.
             if tx.coin.chain == .cardano,
                let nativeToken = tx.vault.coins.nativeCoin(chain: .cardano) {
-                let nativeBalance = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
+                let nativeBalance = SendCryptoLogic.exactRawBalance(of: nativeToken)
                 let minAdaReserve = CardanoHelper.defaultMinUTXOValue * 2
                 if nativeBalance < tx.fee + minAdaReserve {
                     return BalanceValidationResult(isValid: false, errorMessage: "cardanoOutputBelowMinAda")
@@ -184,7 +188,7 @@ struct SendCryptoVerifyLogic {
             // Validate gas balance for non-native tokens. Decision 2 win:
             // vault is now non-optional, so the singleton fallback is gone.
             if let nativeToken = tx.vault.coins.nativeCoin(chain: tx.coin.chain) {
-                let nativeBalance = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
+                let nativeBalance = SendCryptoLogic.exactRawBalance(of: nativeToken)
                 if tx.fee > nativeBalance {
                     let errorMessage = String(format: "insufficientGasTokenError".localized, nativeToken.ticker, tx.coin.ticker)
                     return BalanceValidationResult(isValid: false, errorMessage: errorMessage)

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -157,6 +157,8 @@ class SendCryptoVerifyViewModel: ObservableObject {
                 transaction = transaction.copy(amount: newAmount)
             }
 
+            try await adjustAmountForFeeShortfallIfNeeded(gasLimit: feeResult.gasLimit)
+
             isCalculatingFee = false
 
             validateBalanceWithFee()
@@ -182,6 +184,77 @@ class SendCryptoVerifyViewModel: ObservableObject {
             isCalculatingFee = false
             isLoading = false
         }
+    }
+
+    /// Clamp the amount down to what the balance can actually fund, when the
+    /// re-fetched fee — not the amount itself — is what put the send past the
+    /// balance. The alternative is the dead end this replaces: an error whose
+    /// only answer is to go back and retype a number the user cannot compute,
+    /// because it depends on a fee they never see until this screen.
+    ///
+    /// Publishing the clamped value to `transaction` BEFORE
+    /// `validateBalanceWithFee` runs is what makes it safe, and the ordering is
+    /// load-bearing:
+    ///
+    /// - the screen renders both the crypto amount and its fiat from this same
+    ///   `transaction`, so the user reads the clamped number, not the one they
+    ///   typed;
+    /// - the balance check, the existential-deposit guard (DOT) and the
+    ///   minimum-send floor (Cardano) then all run against the clamped value
+    ///   rather than the abandoned one;
+    /// - and they run against it as the screen shows it — rendering raw units to
+    ///   a decimal string and parsing them back is not lossless, so the check
+    ///   has to see the string's value, not the BigInt it came from. If the
+    ///   clamp fails any of those, the error surfaces and Sign stays disabled.
+    ///
+    /// Nothing is ever signed that the screen did not show.
+    private func adjustAmountForFeeShortfallIfNeeded(gasLimit: BigInt?) async throws {
+        // Same skip as `validateBalanceWithFee`: a pre-built payload's
+        // `transaction` is display-only and its balance is not the real source.
+        guard prebuiltKeysignPayload == nil,
+              SendCryptoVerifyLogic.hasFeeOnlyShortfall(tx: transaction) else {
+            return
+        }
+
+        // Read the OP-stack surcharges only now. It is a network call, and it is
+        // owed only by a send that is actually being clamped to the balance.
+        let pending = transaction
+        let extraReserve = await logic.opStackFeeReserve(tx: pending, gasLimit: gasLimit)
+        // The reserve lookup fails open and never throws, so cancellation has to
+        // be asked for explicitly — otherwise a superseded load pass carries on
+        // and rewrites the amount a newer one just published.
+        try Task.checkCancellation()
+        // A `transaction` that moved while this was suspended means a newer load
+        // pass published it, so this one is stale. Abort the whole pass rather
+        // than returning: carrying on would run the balance validation on the
+        // newer pass's transaction and could leave a spurious error standing on
+        // an amount that pass is still about to adjust.
+        guard transaction == pending else { throw CancellationError() }
+
+        guard let adjusted = SendCryptoVerifyLogic.feeShortfallAdjustedAmountRaw(
+            tx: pending,
+            extraReserve: extraReserve
+        ) else {
+            return
+        }
+
+        let amount = SendCryptoLogic.amountString(coin: pending.coin, raw: adjusted)
+        // The fiat figure moves with the amount. The Verify header derives its
+        // own from `amountDecimal` and follows automatically, but the Done screen
+        // reads the stored `amountInFiat` — left alone it would quote the value
+        // the user asked for rather than the one that was signed. With no rate
+        // the conversion yields "0", which is what a priceless coin showed all
+        // along; what matters is that it never keeps the pre-clamp figure.
+        transaction = pending.copy(
+            amount: amount,
+            amountInFiat: SendCryptoLogic.coinAmountToFiat(amount: amount, coin: pending.coin),
+            amountWasAutoAdjusted: true
+        )
+        // The user is confirming a number the app just changed under them. Any
+        // "the amount is correct" tick standing from before — first load racing
+        // the checkbox, or a retry re-pricing an already-confirmed screen —
+        // authorized the old amount, not this one.
+        isAmountCorrect = false
     }
 
     /// Load-time destination-activation guard. XRPL rejects a Payment that

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyViewModel.swift
@@ -274,21 +274,22 @@ class SendCryptoVerifyViewModel: ObservableObject {
         try await logic.validateTrustLineReserveIfNeeded(tx: transaction)
         try await logic.validateUtxosIfNeeded(tx: transaction)
         let keysignPayload = try await logic.buildKeysignPayload(tx: transaction, vault: transaction.vault)
-        syncMaxSendAmount(with: keysignPayload)
+        syncRefittedAmount(with: keysignPayload)
         return keysignPayload
     }
 
     /// Republish `transaction` at the amount the payload carries.
     ///
-    /// A native EVM MAX is re-fitted at build time to the fee the payload
-    /// itself quotes, so the signed value can come out below the one Verify
-    /// displayed (never above — the clamp only reduces). `transaction` is what
-    /// the signing context, the keysign summary and the history entry are built
-    /// from, so it has to follow the payload or the user is shown a number that
-    /// isn't the one being signed. No-op for every other send, whose amount the
-    /// payload build leaves untouched.
-    private func syncMaxSendAmount(with payload: KeysignPayload) {
-        guard SendCryptoVerifyLogic.needsEVMMaxClamp(tx: transaction),
+    /// A native EVM amount the app derived from the balance — a MAX, or one
+    /// Verify adjusted down to fit the fee — is re-fitted at build time to the
+    /// fee the payload itself quotes, so the signed value can come out below the
+    /// one Verify displayed (never above — the clamp only reduces).
+    /// `transaction` is what the signing context, the keysign summary and the
+    /// history entry are built from, so it has to follow the payload or the user
+    /// is shown a number that isn't the one being signed. No-op for every other
+    /// send, whose amount the payload build leaves untouched.
+    private func syncRefittedAmount(with payload: KeysignPayload) {
+        guard SendCryptoVerifyLogic.needsEVMBalanceRefit(tx: transaction),
               payload.toAmount != transaction.amountInRaw else {
             return
         }

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -1103,6 +1103,63 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - needsEVMBalanceRefit
+
+    /// An amount Verify clamped down to what the balance could fund settles at
+    /// `balance − fee`, exactly like a MAX — so it carries the same exposure to
+    /// a fee that moves before the payload is built, and needs the same re-fit.
+    func testBalanceRefitCoversAnAmountTheAppAdjusted() throws {
+        let tx = try makeTransaction(amountWasAutoAdjusted: true)
+        XCTAssertFalse(tx.sendMaxAmount, "the point of this case is that it is NOT a max send")
+        XCTAssertTrue(SendCryptoVerifyLogic.needsEVMBalanceRefit(tx: tx))
+    }
+
+    func testBalanceRefitStillCoversANativeEvmMax() throws {
+        let tx = try makeTransaction(sendMaxAmount: true)
+        XCTAssertTrue(SendCryptoVerifyLogic.needsEVMBalanceRefit(tx: tx))
+    }
+
+    /// The invariant this predicate protects: a number the user typed and the
+    /// app never touched is never rewritten, however close to the balance it is.
+    func testBalanceRefitSkipsATypedAmountTheAppNeverTouched() throws {
+        let tx = try makeTransaction()
+        XCTAssertFalse(SendCryptoVerifyLogic.needsEVMBalanceRefit(tx: tx))
+    }
+
+    /// A token send moves the token balance and pays gas from the native
+    /// sibling, so a native fee that moved cannot underfund it.
+    func testBalanceRefitSkipsATokenSend() throws {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false,
+                            rawBalance: "1000000", contractAddress: "0xA0b8")
+        let tx = try makeTransaction(coin: usdc, amountWasAutoAdjusted: true)
+        XCTAssertFalse(SendCryptoVerifyLogic.needsEVMBalanceRefit(tx: tx))
+    }
+
+    /// The payload-time re-fit is deliberately EVM-only. Other chains do
+    /// re-resolve their fee at build time, but they fail closed on it — a UTXO
+    /// plan that no longer covers amount + fee throws before the ceremony —
+    /// where an EVM node accepts the signature and refuses the broadcast after
+    /// it. Widening the re-fit is a separate decision, not a side effect of this
+    /// predicate.
+    func testBalanceRefitSkipsANonEvmChain() throws {
+        let dot = makeCoin(.polkadot, ticker: "DOT", decimals: 10, isNative: true,
+                           rawBalance: "100000000000")
+        let tx = try makeTransaction(coin: dot, amountWasAutoAdjusted: true)
+        XCTAssertFalse(SendCryptoVerifyLogic.needsEVMBalanceRefit(tx: tx))
+    }
+
+    /// `copy` is a field-by-field builder whose own doc warns that every new
+    /// field is one someone must remember to add. Losing this one silently
+    /// drops the re-fit on the transaction that most needs it.
+    func testCopyCarriesTheAutoAdjustedMarker() throws {
+        let adjusted = try makeTransaction(amountWasAutoAdjusted: true)
+        XCTAssertTrue(adjusted.copy(amount: "0.2").amountWasAutoAdjusted)
+
+        let typed = try makeTransaction()
+        XCTAssertFalse(typed.copy(amount: "0.2").amountWasAutoAdjusted)
+        XCTAssertTrue(typed.copy(amountWasAutoAdjusted: true).amountWasAutoAdjusted)
+    }
+
     // MARK: - Helpers
 
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, rawBalance: String = "0", contractAddress: String? = nil) -> Coin {
@@ -1149,7 +1206,8 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         fee: BigInt = BigInt(stringLiteral: "1000000000000000"),
         feeMode: FeeMode = .default,
         customGasLimit: BigInt? = nil,
-        sendMaxAmount: Bool = false
+        sendMaxAmount: Bool = false,
+        amountWasAutoAdjusted: Bool = false
     ) throws -> SendTransaction {
         let vault = try TestStore.makeVault()
         let coinToUse = coin ?? makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
@@ -1174,7 +1232,8 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
             transactionType: .unspecified,
             memoFunctionDictionary: [:],
             wasmContractPayload: nil,
-            feeCoin: coinToUse
+            feeCoin: coinToUse,
+            amountWasAutoAdjusted: amountWasAutoAdjusted
         )
     }
 }

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -1103,6 +1103,411 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - hasFeeOnlyShortfall / feeShortfallAdjustedAmountRaw
+
+    /// The whole feature turns on this distinction. `amount ≤ balance` and
+    /// `amount + fee > balance` is a send the fee broke — recoverable by
+    /// clamping. Anything else is not.
+    func testFeeOnlyShortfallIsTheGapBetweenTheAmountAndTheAmountPlusFee() throws {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000000000") // 1 ETH
+        let fee = BigInt(stringLiteral: "10000000000000000") // 0.01 ETH
+
+        // The whole balance, which the fee then overruns.
+        XCTAssertTrue(SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+            tx: try makeTransaction(coin: eth, amount: "1", fee: fee)
+        ))
+        // Comfortably affordable — nothing to rescue.
+        XCTAssertFalse(SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+            tx: try makeTransaction(coin: eth, amount: "0.5", fee: fee)
+        ))
+        // Exactly affordable: `amount + fee == balance` is not a shortfall.
+        XCTAssertFalse(SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+            tx: try makeTransaction(coin: eth, amount: "0.99", fee: fee)
+        ))
+    }
+
+    /// The line the issue draws, and the one that keeps this from quietly
+    /// replacing the user's send with a different one: if the amount ALONE is
+    /// more than the wallet holds, the fee is not what went wrong.
+    func testFeeOnlyShortfallExcludesAnAmountThatExceedsTheBalanceByItself() throws {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000000000")
+        let tx = try makeTransaction(coin: eth, amount: "2",
+                                     fee: BigInt(stringLiteral: "10000000000000000"))
+
+        XCTAssertFalse(SendCryptoVerifyLogic.hasFeeOnlyShortfall(tx: tx))
+        XCTAssertNil(SendCryptoVerifyLogic.feeShortfallAdjustedAmountRaw(tx: tx, extraReserve: .zero))
+    }
+
+    func testFeeOnlyShortfallExcludesTokenAndMaxSends() throws {
+        let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false,
+                            rawBalance: "1000000", contractAddress: "0xA0b8")
+        XCTAssertFalse(
+            SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+                tx: try makeTransaction(coin: usdc, amount: "1", fee: BigInt(500_000))
+            ),
+            "a token pays gas from the native sibling — its own balance is not what the fee overruns"
+        )
+
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000000000")
+        XCTAssertFalse(
+            SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+                tx: try makeTransaction(coin: eth, amount: "1",
+                                        fee: BigInt(stringLiteral: "10000000000000000"),
+                                        sendMaxAmount: true)
+            ),
+            "a MAX amount is already re-derived from the fee upstream"
+        )
+    }
+
+    /// A stake / bond / TrustSet / function-call amount is not "how much to
+    /// move", so reducing it would change the operation rather than fund it.
+    func testFeeOnlyShortfallExcludesOperationsWhoseAmountIsNotATransferValue() throws {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000000000")
+        let fee = BigInt(stringLiteral: "10000000000000000")
+        let plain = try makeTransaction(coin: eth, amount: "1", fee: fee)
+        XCTAssertTrue(SendCryptoVerifyLogic.hasFeeOnlyShortfall(tx: plain),
+                      "precondition: the same numbers ARE a shortfall for a plain send")
+
+        XCTAssertFalse(SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+            tx: plain.copy(isStakingOperation: true)
+        ))
+        XCTAssertFalse(SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+            tx: plain.copy(transactionType: .rippleTrustSet)
+        ))
+        XCTAssertFalse(SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+            tx: plain.copy(memoFunctionDictionary: ["function": "bond"])
+        ))
+        // On EVM the memo IS the transaction's calldata, so the amount is a
+        // contract call's `msg.value`, not a transfer — reducing it would
+        // underfund the call the user is making. Elsewhere a memo is what tells
+        // a protocol how to read the deposit. Either way it is not ours to trim.
+        XCTAssertFalse(SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+            tx: plain.copy(memo: "0xa9059cbb")
+        ))
+        XCTAssertFalse(SendCryptoVerifyLogic.hasFeeOnlyShortfall(
+            tx: plain.copy(wasmContractPayload: .set(
+                WasmExecuteContractPayload(
+                    senderAddress: "sender",
+                    contractAddress: "contract",
+                    executeMsg: "{}",
+                    coins: []
+                )
+            ))
+        ))
+    }
+
+    /// A balance the fee swallows whole has nothing to clamp to. Returning a
+    /// zero or negative "adjusted" amount would turn a blocked send into a
+    /// zero-value one; the balance error is the right answer.
+    func testFeeShortfallAdjustmentRefusesToClampToZeroOrBelow() throws {
+        let balanceRaw = BigInt(stringLiteral: "1000000000000000000")
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: balanceRaw.description)
+
+        // Fee exactly equals the balance ⇒ candidate is 0.
+        let exactlyZero = try makeTransaction(coin: eth, amount: "0.5", fee: balanceRaw)
+        XCTAssertTrue(SendCryptoVerifyLogic.hasFeeOnlyShortfall(tx: exactlyZero))
+        XCTAssertNil(SendCryptoVerifyLogic.feeShortfallAdjustedAmountRaw(tx: exactlyZero, extraReserve: .zero))
+
+        // Fee over the balance ⇒ candidate is negative.
+        let negative = try makeTransaction(coin: eth, amount: "0.5", fee: balanceRaw + 1)
+        XCTAssertNil(SendCryptoVerifyLogic.feeShortfallAdjustedAmountRaw(tx: negative, extraReserve: .zero))
+
+        // And an `extraReserve` big enough to swallow the remainder does too.
+        let squeezed = try makeTransaction(coin: eth, amount: "1",
+                                           fee: BigInt(stringLiteral: "10000000000000000"))
+        XCTAssertNil(SendCryptoVerifyLogic.feeShortfallAdjustedAmountRaw(
+            tx: squeezed,
+            extraReserve: balanceRaw
+        ))
+    }
+
+    /// The clamp is the MAX path's, not a second copy of the arithmetic — so it
+    /// reads the balance exactly, and subtracts the reserves the chain bills on
+    /// top of the quoted fee.
+    func testFeeShortfallAdjustmentReservesWhatTheChainBillsOnTopOfTheFee() throws {
+        let balanceRaw = BigInt(stringLiteral: "1000000000000000000")
+        let opEth = makeCoin(.optimism, ticker: "ETH", decimals: 18, isNative: true,
+                             rawBalance: balanceRaw.description)
+        let fee = BigInt(stringLiteral: "10000000000000000")
+        let reserve = BigInt(4_293_564_911)
+        let tx = try makeTransaction(coin: opEth, amount: "1", fee: fee)
+
+        XCTAssertEqual(
+            SendCryptoVerifyLogic.feeShortfallAdjustedAmountRaw(tx: tx, extraReserve: reserve),
+            balanceRaw - fee - reserve,
+            "op-geth checks value + gas + l1Cost + operatorCost, so the clamp has to leave room for all of it"
+        )
+    }
+
+    /// The existential deposit is reserved on top of the fee, so a clamped DOT
+    /// send lands at `balance − fee − ED` and clears `canBeReaped` — where a
+    /// naive `balance − fee` would leave the sender at zero and be refused
+    /// on-chain by `transfer_keep_alive` after the ceremony.
+    func testFeeShortfallAdjustmentReservesTheExistentialDepositOnDot() throws {
+        let balanceRaw = BigInt(10_000_000_000) // 1 DOT, 10 decimals
+        let dot = makeCoin(.polkadot, ticker: "DOT", decimals: 10, isNative: true,
+                           rawBalance: balanceRaw.description)
+        let fee = BigInt(150_000_000)
+        let tx = try makeTransaction(coin: dot, amount: "1", fee: fee)
+
+        let adjusted = SendCryptoVerifyLogic.feeShortfallAdjustedAmountRaw(tx: tx, extraReserve: .zero)
+        XCTAssertEqual(adjusted, balanceRaw - fee - PolkadotHelper.defaultExistentialDeposit)
+        XCTAssertLessThan(adjusted ?? .zero, balanceRaw - fee, "the ED must be reserved, not spent")
+
+        let clamped = SendCryptoLogic.amountString(coin: dot, raw: adjusted ?? .zero)
+        XCTAssertFalse(SendCryptoLogic.canBeReaped(coin: dot, amount: clamped, gas: fee),
+                       "the clamped value must survive the guard it will be re-checked against")
+    }
+
+    // MARK: - loadGasInfoForSending — auto-adjust instead of the balance dead-end
+
+    /// The dead end this replaces: a send the balance covers, that the
+    /// re-fetched fee then pushes over. Instead of an error the user can only
+    /// answer by retyping a number they cannot compute, Verify clamps the amount
+    /// to what the balance funds and shows it.
+    func testLoadGasInfoAdjustsTheAmountWhenOnlyTheFeeOvershootsTheBalance() async throws {
+        let interactor = MockSendInteractor()
+        let balanceRaw = BigInt(stringLiteral: "1000000000000000000") // 1 ETH
+        let fee = BigInt(stringLiteral: "12345000000000000")
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: fee, gas: BigInt(30_000_000_000), gasLimit: BigInt(21_000))
+        }
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: balanceRaw.description)
+        // The user typed the whole balance — the Details screen lets this
+        // through, because on EVM it checks the amount against the gas PRICE.
+        let tx = try makeTransaction(coin: eth, amount: "1", fee: .zero)
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: interactor)
+
+        await vm.loadGasInfoForSending()
+
+        XCTAssertEqual(vm.transaction.amount,
+                       SendCryptoLogic.amountString(coin: eth, raw: balanceRaw - fee),
+                       "the amount on screen must be what the balance can fund")
+        XCTAssertTrue(vm.transaction.amountWasAutoAdjusted)
+        XCTAssertFalse(vm.hasBalanceError, "the whole point is that this no longer dead-ends")
+        XCTAssertFalse(vm.showAlert)
+        XCTAssertEqual(vm.errorMessage, "")
+        // Rendering raw units to a decimal string and parsing them back is not
+        // lossless (`toDecimal` is Double-bounded past ~17 significant digits),
+        // and what gets signed is the string's value — so the property that has
+        // to hold is about the re-parse, not the BigInt the clamp produced.
+        // Re-running the balance check after the adjust is what enforces it.
+        XCTAssertLessThanOrEqual(vm.transaction.amountInRaw + fee, balanceRaw,
+                                 "the value the displayed string parses back to has to be affordable")
+    }
+
+    /// Only the fee-caused shortfall is rescued. Asking to send more than the
+    /// wallet holds still stops, because clamping there would swap the user's
+    /// send for one they never asked for.
+    func testLoadGasInfoKeepsTheErrorWhenTheAmountAloneExceedsTheBalance() async throws {
+        let interactor = MockSendInteractor()
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: BigInt(stringLiteral: "12345000000000000"),
+                                    gas: BigInt(30_000_000_000), gasLimit: BigInt(21_000))
+        }
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000000000")
+        let tx = try makeTransaction(coin: eth, amount: "2", fee: .zero)
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: interactor)
+
+        await vm.loadGasInfoForSending()
+
+        XCTAssertEqual(vm.transaction.amount, "2", "an unaffordable amount must not be rewritten")
+        XCTAssertFalse(vm.transaction.amountWasAutoAdjusted)
+        XCTAssertTrue(vm.hasBalanceError)
+        XCTAssertEqual(vm.errorMessage, "walletBalanceExceededError")
+        XCTAssertTrue(vm.signButtonDisabled)
+    }
+
+    /// A balance that cannot fund its own fee has nothing to clamp to. It must
+    /// keep the error rather than become a zero-value send.
+    func testLoadGasInfoKeepsTheErrorWhenTheFeeSwallowsTheWholeBalance() async throws {
+        let interactor = MockSendInteractor()
+        let balanceRaw = BigInt(stringLiteral: "1000000000000000000")
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: balanceRaw, gas: BigInt(30_000_000_000), gasLimit: BigInt(21_000))
+        }
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: balanceRaw.description)
+        let tx = try makeTransaction(coin: eth, amount: "0.5", fee: .zero)
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: interactor)
+
+        await vm.loadGasInfoForSending()
+
+        XCTAssertEqual(vm.transaction.amount, "0.5")
+        XCTAssertFalse(vm.transaction.amountWasAutoAdjusted)
+        XCTAssertTrue(vm.hasBalanceError)
+        XCTAssertTrue(vm.signButtonDisabled)
+    }
+
+    /// The clamped value has to re-enter the guards that run after the balance
+    /// check, not skip them. Cardano's protocol floor is the sharpest case: 1.6
+    /// ADA clears it, and the 1.3 ADA the clamp produces does not — the node
+    /// would silently drop that output.
+    func testLoadGasInfoSurfacesTheMinimumSendFloorAgainstTheClampedAmount() async throws {
+        let interactor = MockSendInteractor()
+        interactor.fetchChainSpecificStub = { _ in
+            .Cardano(byteFee: BigInt(300_000), sendMaxAmount: false, ttl: 0)
+        }
+        interactor.calculatePlanFeeStub = { _, _ in BigInt(300_000) } // 0.3 ADA
+        let ada = makeCoin(.cardano, ticker: "ADA", decimals: 6, isNative: true,
+                           rawBalance: "1600000") // 1.6 ADA
+        let tx = try makeTransaction(coin: ada, amount: "1.6", fee: .zero)
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: interactor)
+
+        await vm.loadGasInfoForSending()
+
+        XCTAssertEqual(vm.transaction.amount, SendCryptoLogic.amountString(coin: ada, raw: BigInt(1_300_000)),
+                       "precondition: the clamp ran and landed below the 1.4 ADA floor")
+        XCTAssertTrue(vm.hasBalanceError, "the min-send floor must be re-checked against the clamped value")
+        XCTAssertNotEqual(vm.errorMessage, "walletBalanceExceededError",
+                          "the failure is the protocol floor, not the balance")
+        XCTAssertTrue(vm.signButtonDisabled)
+    }
+
+    /// The screen asks the user to tick "the amount is correct". A retry that
+    /// re-prices an already-confirmed screen — or a first load racing the
+    /// checkbox — must not carry that tick over onto a number the app changed
+    /// underneath it: it authorized the old amount.
+    func testLoadGasInfoClearsTheAmountConfirmationWhenItRewritesTheAmount() async throws {
+        let interactor = MockSendInteractor()
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: BigInt(stringLiteral: "12345000000000000"),
+                                    gas: BigInt(30_000_000_000), gasLimit: BigInt(21_000))
+        }
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000000000")
+        let tx = try makeTransaction(coin: eth, amount: "1", fee: .zero)
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: interactor)
+        vm.isAddressCorrect = true
+        vm.isAmountCorrect = true
+
+        await vm.loadGasInfoForSending()
+
+        XCTAssertTrue(vm.transaction.amountWasAutoAdjusted, "precondition: the amount was rewritten")
+        XCTAssertFalse(vm.isAmountCorrect, "a standing confirmation must not survive the rewrite")
+        XCTAssertTrue(vm.signButtonDisabled, "so Sign has to wait for the user to re-confirm")
+    }
+
+    /// A send that is only over the balance because of its memo-bearing intent
+    /// keeps the error: the amount there is a contract call's value or a
+    /// protocol deposit, not a transfer the app may trim.
+    func testLoadGasInfoDoesNotAdjustAMemoBearingSend() async throws {
+        let interactor = MockSendInteractor()
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: BigInt(stringLiteral: "12345000000000000"),
+                                    gas: BigInt(30_000_000_000), gasLimit: BigInt(21_000))
+        }
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "1000000000000000000")
+        let tx = try makeTransaction(coin: eth, amount: "1", fee: .zero).copy(memo: "0xa9059cbb")
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: interactor)
+
+        await vm.loadGasInfoForSending()
+
+        XCTAssertEqual(vm.transaction.amount, "1", "a contract call's value is not ours to reduce")
+        XCTAssertFalse(vm.transaction.amountWasAutoAdjusted)
+        XCTAssertTrue(vm.hasBalanceError)
+    }
+
+    // MARK: - loadGasInfoForSending — an adjusted amount is the amount that gets signed
+
+    /// The hard requirement behind auto-adjusting silently: whatever the screen
+    /// shows — crypto AND fiat — is what the keysign payload carries. Pinned end
+    /// to end, from the load that rewrites the amount through to the built
+    /// payload.
+    func testAnAdjustedAmountIsExactlyWhatGetsSigned() async throws {
+        let interactor = MockSendInteractor()
+        let balanceRaw = BigInt(stringLiteral: "1000000000000000000")
+        let fee = BigInt(stringLiteral: "12345000000000000")
+        let gasLimit = BigInt(21_000)
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: fee, gas: BigInt(30_000_000_000), gasLimit: gasLimit)
+        }
+        // The payload's own fee reading agrees with the quote, so nothing is
+        // re-fitted here and the displayed value is signed verbatim.
+        interactor.fetchChainSpecificStub = { _ in
+            .Ethereum(maxFeePerGasWei: fee / gasLimit, priorityFeeWei: .zero, nonce: 0, gasLimit: gasLimit)
+        }
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: balanceRaw.description)
+        setPrice(2_500, for: eth)
+
+        let tx = try makeTransaction(coin: eth, amount: "1", fee: .zero)
+        let typedFiat = vmFiat(coin: eth, amount: "1")
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: interactor)
+        vm.isAddressCorrect = true
+
+        await vm.loadGasInfoForSending()
+
+        // The user reads the adjusted figures and ticks "the amount is correct".
+        vm.isAmountCorrect = true
+
+        // What the screen shows.
+        let shownAmount = vm.transaction.amount
+        let shownFiat = vm.amountFiat
+        XCTAssertNotEqual(shownAmount, "1", "precondition: the amount really was adjusted")
+        XCTAssertNotEqual(shownFiat, typedFiat, "the fiat must move with the amount, not stay on the typed one")
+        XCTAssertEqual(shownFiat, vmFiat(coin: eth, amount: shownAmount))
+        XCTAssertEqual(vm.transaction.amountInFiat,
+                       SendCryptoLogic.coinAmountToFiat(amount: shownAmount, coin: eth),
+                       "the Done screen reads the stored fiat — it has to follow too")
+
+        // What gets signed.
+        let payload = try await vm.validateForm()
+
+        XCTAssertEqual(payload.toAmount, SendCryptoLogic.amountInRaw(coin: eth, amount: shownAmount),
+                       "the signed value must be the value of the string on screen")
+        XCTAssertEqual(vm.transaction.amount, shownAmount, "and the screen must not have moved under it")
+        XCTAssertEqual(vm.amountFiat, shownFiat)
+        XCTAssertLessThanOrEqual(payload.toAmount + fee, balanceRaw,
+                                 "the signed send has to be affordable — that is the whole point")
+    }
+
+    /// An adjusted amount sits at `balance − fee` exactly like a MAX, so it
+    /// inherits the MAX path's exposure to a fee that moves between the Verify
+    /// quote and the payload build — and must inherit its re-fit too, including
+    /// republishing the screen so the user still sees what is signed.
+    func testAnAdjustedAmountIsRefittedWhenTheSignedFeeGrew() async throws {
+        let interactor = MockSendInteractor()
+        let balanceRaw = BigInt(stringLiteral: "1000000000000000000")
+        let quotedFee = BigInt(stringLiteral: "12345000000000000")
+        let gasLimit = BigInt(21_000)
+        let signedMaxFeePerGas = BigInt(stringLiteral: "1000000000000") // fee market moved up
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: quotedFee, gas: BigInt(30_000_000_000), gasLimit: gasLimit)
+        }
+        interactor.fetchChainSpecificStub = { _ in
+            .Ethereum(maxFeePerGasWei: signedMaxFeePerGas, priorityFeeWei: .zero, nonce: 0, gasLimit: gasLimit)
+        }
+        let arb = makeCoin(.arbitrum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: balanceRaw.description)
+        let tx = try makeTransaction(coin: arb, amount: "1", fee: .zero)
+        let vm = SendCryptoVerifyViewModel(transaction: tx, interactor: interactor)
+        vm.isAddressCorrect = true
+
+        await vm.loadGasInfoForSending()
+        vm.isAmountCorrect = true
+        XCTAssertEqual(vm.transaction.amount,
+                       SendCryptoLogic.amountString(coin: arb, raw: balanceRaw - quotedFee),
+                       "precondition: the screen was adjusted against the quoted fee")
+        let quotedAmount = vm.transaction.amountInRaw
+
+        let payload = try await vm.validateForm()
+
+        let signedFee = gasLimit * signedMaxFeePerGas
+        XCTAssertEqual(payload.toAmount, balanceRaw - signedFee)
+        XCTAssertLessThan(payload.toAmount, quotedAmount, "the fee grew, so the signed value must shrink")
+        XCTAssertEqual(vm.transaction.amount, SendCryptoLogic.amountString(coin: arb, raw: payload.toAmount),
+                       "the screen must be republished at the value that was signed")
+    }
+
     // MARK: - needsEVMBalanceRefit
 
     /// An amount Verify clamped down to what the balance could fund settles at
@@ -1161,6 +1566,29 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// Seeds a live rate so fiat assertions mean something. Without one every
+    /// fiat figure is the empty string and a "the fiat followed the amount"
+    /// assertion passes for the wrong reason.
+    private func setPrice(_ value: Double, for coin: Coin) {
+        let cryptoId = RateProvider.cryptoId(for: coin.toCoinMeta()).id
+        do {
+            try RateProvider.shared.save(rates: [
+                Rate(fiat: SettingsCurrency.current.rawValue, crypto: cryptoId, value: value)
+            ])
+        } catch {
+            XCTFail("Failed to seed rate for \(coin.ticker): \(error)")
+        }
+        XCTAssertEqual(coin.price, value, accuracy: 0.0001, "rate for \(coin.ticker) did not take effect")
+    }
+
+    /// The fiat figure the Verify header renders, for a given amount string.
+    private func vmFiat(coin: Coin, amount: String) -> String {
+        CryptoAmountFormatter.amountInFiat(
+            coin: coin,
+            amount: SendCryptoLogic.amountDecimal(coin: coin, amount: amount)
+        )
+    }
 
     private func makeCoin(_ chain: Chain, ticker: String, decimals: Int, isNative: Bool, rawBalance: String = "0", contractAddress: String? = nil) -> Coin {
         let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: isNative)

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -194,6 +194,45 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         XCTAssertEqual(vm.errorMessage, "walletBalanceExceededError")
     }
 
+    /// The balance this check runs against has to be the balance the wallet
+    /// actually holds. `rawBalance.toBigInt(decimals:)` parses through
+    /// `NumberFormatter`, which falls back to `Double` past `Int64` and rounds
+    /// UP over ~9.2 units on an 18-decimal chain — making the check LOOSER than
+    /// the truth, so a send the wallet cannot fund clears Verify and dies at
+    /// broadcast instead.
+    ///
+    /// 9999999999999999999 wei is one wei under 10 ETH, and the nearest `Double`
+    /// to it is 1e19 — exactly the amount + fee below. Read lossily the send
+    /// "fits"; read exactly it is one wei short.
+    func testValidateBalanceWithFeeReadsABalancePastInt64Exactly() throws {
+        let oneWeiUnderTenEth = "9999999999999999999"
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: oneWeiUnderTenEth)
+        XCTAssertGreaterThan(
+            eth.rawBalance.toBigInt(decimals: eth.decimals),
+            BigInt(stringLiteral: oneWeiUnderTenEth),
+            "precondition: the shared parse must be the one that rounds this balance up"
+        )
+
+        // 9.9 ETH + 0.1 ETH fee = 10 ETH exactly, one wei more than the balance.
+        let tx = try makeTransaction(coin: eth, amount: "9.9",
+                                     fee: BigInt(stringLiteral: "100000000000000000"))
+        // Pin the total rather than trusting it: the amount parse is locale
+        // sensitive, and a "9.9" that scaled differently would make this test
+        // pass against the old lossy read too — for the wrong reason.
+        XCTAssertEqual(
+            tx.amountInRaw + tx.fee,
+            eth.rawBalance.toBigInt(decimals: eth.decimals),
+            "the send has to land exactly on the rounded-up balance for this to test anything"
+        )
+        let vm = SendCryptoVerifyViewModel(transaction: tx)
+
+        vm.validateBalanceWithFee()
+
+        XCTAssertTrue(vm.hasBalanceError, "a send one wei past the real balance must not clear Verify")
+        XCTAssertEqual(vm.errorMessage, "walletBalanceExceededError")
+    }
+
     // MARK: - validateBalanceWithFee — Terra Classic bank denom vs CW20/IBC
 
     func testValidateBalanceUSTCBankDenomSubtractsFeeFromTokenBalance() throws {


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #5034 — do not merge before it.** The base of this PR is `fix/evm-max-send-clamp-5019`, not `main`. It reuses the clamp #5034 corrected; merging this first would land it against the pre-#5034 clamp and reintroduce the bug that PR fixes.
>
> **`Closes #5020` does not register while this PR is stacked.** Verified after opening: `closingIssuesReferences` on this PR is **empty**, even though the body ends with `Closes #5020`. That is GitHub's documented behaviour — a closing reference is only created for PRs targeting the repository's **default branch**, and this one targets `fix/evm-max-send-clamp-5019`. Control: #5034, same body convention but based on `main`, links #5019 correctly.
>
> Consequence: merging this will **not** auto-close #5020. Retargeting the base to `main` once #5034 merges makes the link register with no body change; otherwise close #5020 by hand. No other issue is linked — the reference set is empty, not wrong.

## The dead end

On Verify, a native send whose amount the balance covers — but whose amount **plus the re-fetched fee** does not — hit a hard error dialog:

> The total amount and fee exceed your wallet's balance. Try again.

`Try again` meant going back and retyping a number the user cannot compute, because it depends on a fee they never see until this screen. There is no affordance that gets them to a valid amount.

It is easy to reach, and not a rare edge. The Details screen's pre-flight (`SendCryptoLogic.isAmountExceeded`) compares a non-UTXO amount against **`gas`, not `fee`** — on EVM `gas` is the per-unit gas *price* in gwei, not `gasLimit × maxFeePerGas`. So Details effectively waves through `amount ≈ balance`, and Verify is the first screen that refuses it.

## The rule

Adjust down to what the balance can fund, and show it — strictly when

```
amount ≤ balance  <  amount + fee
```

i.e. only when the **fee** is what caused the shortfall. If the amount alone exceeds the balance, the fee is not the problem and the error stands: clamping there would quietly substitute a different send for the one the user asked for.

The clamped value is the max-send path's arithmetic, not a second copy — `SendCryptoLogic.verifyMaxCandidateRaw`, i.e. `balance − fee − existentialDeposit − extraReserve`. Reusing it means DOT keeps reserving its existential deposit, OP-stack rollups keep reserving the L1-data and operator fees op-geth adds to its own balance check, and the balance is read exactly (below).

Deliberately narrow. Native coins only (a token pays gas from its native sibling, so the token balance is never what the fee overruns — token behaviour is untouched); not a MAX send (already re-derived upstream); and **plain transfers only** — no memo, no wasm payload, no staking / function-call intent, no non-`unspecified` transaction type. On EVM the memo *is* the calldata, so the amount there is a contract call's `msg.value`; elsewhere a memo is what tells a protocol how to read the deposit. Those amounts are not "how much to move" and reducing them would change the operation rather than fund it.

A clamp landing at or below zero adjusts nothing. A balance that cannot fund its own fee keeps the error rather than becoming a zero-value send.

## The display/sign invariant

Auto-adjusting on a send-money screen only works if the user signs what they see. How that is guaranteed:

1. **One source.** The Verify screen renders `tx.amount` verbatim and derives its fiat live from `transaction.amountDecimal`; the Done screen reads the stored `amountInFiat`, which the adjust rewrites alongside the amount. There is no second amount to drift.
2. **Ordering.** The clamped value is published to `transaction` **before** `validateBalanceWithFee()` runs. So the balance check, the DOT existential-deposit guard (`canBeReaped`) and the Cardano minimum-send floor all re-run against the clamped value — and against it *as the screen shows it*. If the clamp fails any of them the error surfaces and Sign stays disabled; nothing is signed.
3. **The confirmation is cleared.** The adjust resets `isAmountCorrect`. A tick standing from before — a first load racing the checkbox, or a retry re-pricing an already-confirmed screen — authorized the previous amount, not this one.
4. **Fee drift.** An adjusted amount sits at `balance − fee` exactly like a MAX, so it inherits #5034's payload-build re-fit via a new `SendTransaction.amountWasAutoAdjusted` marker (predicate widened and renamed `needsEVMMaxClamp` → `needsEVMBalanceRefit`). Without it, the feature meant to rescue users at the edge of their balance would have put them straight onto the rejected-broadcast path #5034 just fixed.

### Precisely what is and is not guaranteed

**The signed value is the value of the string on screen, produced by `SendTransaction.amountInRaw` — the app's single string→raw conversion, the same one every send uses.** There is no second path and no divergence introduced here.

That conversion is `NumberFormatter`/`Double`-backed and cannot carry an 18-decimal value past ~17 significant digits (a pre-existing, app-wide property #5034 already documents and test-pins). So the signed raw value can differ from the *exact decimal the displayed string denotes* by ~1e-16 of a coin — e.g. screen `0.987655`, signed `987654999999999900` wei. A typed `0.987655` signs the same number. Making that exact means replacing `String.toDecimal()` / `toBigInt(decimals:)` app-wide, which changes the signed amount of every send in the wallet — its own issue, not this PR.

What protects funds is that re-validating **after** the adjust checks the re-parsed value, so a round-trip that no longer fits raises the error rather than signing. Pinned by `XCTAssertLessThanOrEqual(vm.transaction.amountInRaw + fee, balanceRaw)`.

## The exact-balance parse

`rawBalance.toBigInt(decimals:)` routes through `NumberFormatter`, which falls back to `Double` past `Int64` and **rounds a balance over ~9.2 units UP** on an 18-decimal chain. #5034 fixed this inside its own clamp only; `validateBalanceWithFee` still used the lossy idiom.

That mattered twice: deriving `balance − fee` from an inflated balance hands back an "adjusted" amount larger than the wallet holds, and the inflated balance also makes the *error* check looser than the truth — sends where `amount + fee ≤ balance_lossy` but `> balance_exact` raised no error and would never have triggered the adjust either. Detection and adjustment have to agree on one balance, and it has to be the exact one, so `SendCryptoLogic.exactRawBalance(of:)` is now used for the balance reads in `validateBalanceWithFee`. Strictly more accurate, never a regression — anything that isn't a plain integer still falls back to the shared parse.

## Known limitations (inherited from #5034, flagged not fixed)

Both were raised by the cross-model review and deliberately **not** changed here, because both live on the base branch's code paths and apply identically to every native EVM MAX send today. Fixing either means changing #5034's shipped design, which a stacked PR should not do unilaterally. Maintainer call:

1. **Post-Sign re-fit without reconfirmation.** If the fee rose between the Verify quote and the payload build, `syncRefittedAmount` republishes the transaction at the lower signed value *after* the user pressed Sign. The screen and keysign summary then show the signed value, but the user was not asked to re-confirm it. The alternative #5034 was fixing is a rejected broadcast after a completed MPC ceremony.
2. **No generation token on `loadGasInfoForSending`.** A superseded load pass can still finalize the loading flags. Pre-existing (the base already has three awaits with none). The incremental interleaving this change would have added is removed — the adjust throws `CancellationError` when the transaction moved under it, so a stale pass aborts instead of running the balance validation.

## No new user-facing string

Per the shape chosen for this issue: auto-adjust, no confirmation button, no undo affordance. The screen already forces an explicit acknowledgement of the displayed number — the `correctAmountCheck` checkbox gates Sign, and this change now clears it when the amount is rewritten. A banner would also collide with the screen's single `withBanner` slot (owned by the retry banner). So no new key and no 8-locale change. Recorded as a deliberate choice.

## Tests

`SendCryptoVerifyViewModelTests` (+ existing `EvmMaxSendClampTests` unchanged):

- the adjust path — amount rewritten to `balance − fee`, no error, marker set;
- `amount alone > balance` keeps `walletBalanceExceededError` and a disabled Sign;
- fee ≥ balance keeps the error rather than producing a zero-value send;
- display == signed, end to end: crypto **and** fiat, through `validateForm()` to `payload.toAmount`, including that the fiat moved off the typed value (with a seeded rate, so the assertion isn't vacuous);
- the payload-build re-fit applies to an adjusted amount when the signed fee grew, and the screen is republished at the signed value;
- Cardano's minimum-send floor re-raised against the *clamped* value (1.6 ADA clears it, the 1.3 ADA clamp does not);
- DOT's existential deposit reserved by the clamp, and the clamped value clears `canBeReaped`;
- OP-stack `extraReserve` subtracted;
- the confirmation checkbox cleared on rewrite;
- exclusions: token sends, MAX sends, staking, TrustSet, function-call, memo-bearing (EVM calldata), wasm payload;
- the exact-balance read: a balance one wei under 10 ETH no longer rounds up, so a send one wei past it is rejected;
- `needsEVMBalanceRefit` on both flags, and `copy` carrying the marker.

## Gate

- `xcodebuild test` (full suite, iPhone 16 Pro / iOS 26.5): **`** TEST SUCCEEDED **` — 4668 tests, 0 failures, 1 skipped.**
- SwiftLint: **39 violations, exactly the repo baseline** — zero added, zero in any touched file.
- Cross-model review: `codex exec --sandbox read-only` per commit + a whole-branch pass. All findings triaged; three MAJORs and one MINOR fixed, two rejected/deferred with the reasons recorded above.

## On-device steps for a human

No broadcast was run — the arithmetic is covered by unit tests only. Worth checking on device:

1. **The main path.** On an EVM L2 (Arbitrum / Optimism), send a native amount equal to the full balance. Details accepts it; Verify should show a reduced amount rather than the error dialog, with the fiat sub-line reduced to match, and the "amount is correct" checkbox **unticked**.
2. **Sign it** and confirm the broadcast succeeds and the Done screen quotes the same amount and fiat the Verify screen showed.
3. **The error is preserved.** Type more than the balance — the dialog must still appear, with the amount untouched.
4. **OP-stack reserve.** Repeat (1) on Optimism/Base and confirm the send is not rejected for the L1 data fee.
5. **DOT.** Full-balance native DOT send — the adjusted amount should leave the existential deposit behind, and `transfer_keep_alive` should not fail on-chain.
6. **Cardano.** A balance just above the ~1.4 ADA floor where `balance − fee` falls below it — Verify should surface the minimum-send error, not sign.
7. **Memo.** A native EVM send carrying calldata in the memo must still show the error, not a reduced value.

Closes #5020
