### PR TITLE
refactor(design-system): tokenise every remaining corner-radius literal (phase 3)

### DIFF
--- a/VultisigApp/VultisigApp/Components/AddressBook/AddressBookTextField.swift
+++ b/VultisigApp/VultisigApp/Components/AddressBook/AddressBookTextField.swift
@@ -47,9 +47,9 @@ struct AddressBookTextField: View {
             Theme.colors.bgButtonPrimary.opacity(0.2)
                 .frame(height: 48)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .cornerRadius(10)
+                .cornerRadius(Theme.radius.md)
 
-            RoundedRectangle(cornerRadius: 10)
+            Theme.radius.md.shape
                 .strokeBorder(Theme.colors.bgButtonPrimary, style: StrokeStyle(lineWidth: 1, dash: [10]))
                 .padding(5)
 

--- a/VultisigApp/VultisigApp/Components/Banners/InfoBannerView.swift
+++ b/VultisigApp/VultisigApp/Components/Banners/InfoBannerView.swift
@@ -53,7 +53,7 @@ struct InfoBannerView: View {
         }
         .padding(16)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .inset(by: 1)
                 .fill(bgColor)
                 .stroke(borderColor, lineWidth: 1)

--- a/VultisigApp/VultisigApp/Components/Buttons/PrimaryButton/PrimaryButtonStyle.swift
+++ b/VultisigApp/VultisigApp/Components/Buttons/PrimaryButton/PrimaryButtonStyle.swift
@@ -42,17 +42,17 @@ struct PrimaryButtonStyle: ButtonStyle {
             )
             .foregroundStyle(foregroundColor(for: type, isEnabled: isEnabled))
             .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius(for: size))
+                    radius(for: size).shape
                         .stroke(borderColor(for: type, isEnabled: isEnabled),
                                 lineWidth: borderWidth(for: type))
             )
             .overlay {
                 if hasBevel(for: type), isEnabled {
-                    InsetBevelOverlay(cornerRadius: cornerRadius(for: size))
+                    InsetBevelOverlay(radius: radius(for: size))
                 }
             }
-            .cornerRadius(cornerRadius(for: size))
-            .contentShape(RoundedRectangle(cornerRadius: cornerRadius(for: size)))
+            .cornerRadius(radius(for: size))
+            .contentShape(radius(for: size).shape)
     }
 }
 
@@ -62,10 +62,10 @@ struct PrimaryButtonStyle: ButtonStyle {
 /// shadow pair. Currently applied to `.secondary`; kept as a standalone piece so
 /// the other button types can adopt the same treatment.
 private struct InsetBevelOverlay: View {
-    let cornerRadius: CGFloat
+    let radius: CornerRadius
 
     var body: some View {
-        RoundedRectangle(cornerRadius: cornerRadius)
+        radius.shape
             .strokeBorder(
                 LinearGradient(
                     stops: [
@@ -118,10 +118,14 @@ private extension PrimaryButtonStyle {
         }
     }
 
-    func cornerRadius(for size: ButtonSize) -> CGFloat {
+    /// Every size but `.squared` is a capsule. It was written as `99`, which is
+    /// not a radius anyone chose — it is simply larger than half the button's
+    /// height, and that clamp is what rounds the ends. `pill` names the
+    /// intention instead, and renders the same shape at every button size.
+    func radius(for size: ButtonSize) -> CornerRadius {
         switch size {
-        case .medium, .small, .smallFixed, .mini: 99
-        case .squared: 12
+        case .medium, .small, .smallFixed, .mini: Theme.radius.pill
+        case .squared: Theme.radius.md
         }
     }
 

--- a/VultisigApp/VultisigApp/Components/Disclosure/DisclosureSection.swift
+++ b/VultisigApp/VultisigApp/Components/Disclosure/DisclosureSection.swift
@@ -54,7 +54,7 @@ struct DisclosureSection<Content: View>: View {
                     .padding(16)
                 }
                 .frame(maxHeight: 300)
-                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+                .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
             }
         }
     }

--- a/VultisigApp/VultisigApp/Components/FileQRCodeImporterMac.swift
+++ b/VultisigApp/VultisigApp/Components/FileQRCodeImporterMac.swift
@@ -53,7 +53,7 @@ struct FileQRCodeImporterMac: View {
         .frame(height: 250)
         .frame(maxWidth: .infinity)
         .background(Theme.colors.bgButtonPrimary.opacity(0.15))
-        .cornerRadius(10)
+        .cornerRadius(Theme.radius.md)
         .overlay(
             ZStack {
                 getOverlay(isUploading ? 2 : 1)
@@ -93,7 +93,7 @@ struct FileQRCodeImporterMac: View {
     }
 
     private func getOverlay(_ lineWidth: CGFloat) -> some View {
-        RoundedRectangle(cornerRadius: 10)
+        Theme.radius.md.shape
             .strokeBorder(Theme.colors.bgButtonPrimary, style: StrokeStyle(lineWidth: lineWidth, dash: [10]))
     }
 }

--- a/VultisigApp/VultisigApp/Components/Forms/AddressFieldAccessoryStack/AddressFieldAccessoryButton.swift
+++ b/VultisigApp/VultisigApp/Components/Forms/AddressFieldAccessoryStack/AddressFieldAccessoryButton.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 struct AddressFieldAccessoryButton: View {
     let icon: ImageResource
-    /// Per-corner radii. Defaults to a uniform 8; the accessory row overrides
-    /// the outer bottom corners to 16 so the stack echoes the card's rounded
-    /// bottom edge.
+    /// Per-corner radii. Defaults to a uniform `sm`; the accessory row overrides
+    /// the two outer bottom corners to `lg` so the row's outer edge reads as one
+    /// rounded block rather than three separate tiles.
     var cornerRadii = RectangleCornerRadii(
-        topLeading: 8,
-        bottomLeading: 8,
-        bottomTrailing: 8,
-        topTrailing: 8
+        topLeading: Theme.radius.sm.points,
+        bottomLeading: Theme.radius.sm.points,
+        bottomTrailing: Theme.radius.sm.points,
+        topTrailing: Theme.radius.sm.points
     )
     let action: () -> Void
 
@@ -27,7 +27,7 @@ struct AddressFieldAccessoryButton: View {
                 .padding(.vertical, 12)
                 .frame(maxWidth: .infinity)
                 .background(
-                    UnevenRoundedRectangle(cornerRadii: cornerRadii)
+                    UnevenRoundedRectangle(cornerRadii: cornerRadii, style: Theme.radius.sm.style)
                         .inset(by: 0.5)
                         .fill(Theme.colors.bgSurface1)
                         .stroke(Theme.colors.borderLight)

--- a/VultisigApp/VultisigApp/Components/Forms/AddressFieldAccessoryStack/AddressFieldAccessoryStack.swift
+++ b/VultisigApp/VultisigApp/Components/Forms/AddressFieldAccessoryStack/AddressFieldAccessoryStack.swift
@@ -33,10 +33,10 @@ struct AddressFieldAccessoryStack: View {
             AddressFieldAccessoryButton(
                 icon: .copies3Filled,
                 cornerRadii: RectangleCornerRadii(
-                    topLeading: 8,
-                    bottomLeading: 16,
-                    bottomTrailing: 8,
-                    topTrailing: 8
+                    topLeading: Theme.radius.sm.points,
+                    bottomLeading: Theme.radius.lg.points,
+                    bottomTrailing: Theme.radius.sm.points,
+                    topTrailing: Theme.radius.sm.points
                 )
             ) {
                 pasteAddress()
@@ -47,10 +47,10 @@ struct AddressFieldAccessoryStack: View {
             AddressFieldAccessoryButton(
                 icon: .bookmarks,
                 cornerRadii: RectangleCornerRadii(
-                    topLeading: 8,
-                    bottomLeading: 8,
-                    bottomTrailing: 16,
-                    topTrailing: 8
+                    topLeading: Theme.radius.sm.points,
+                    bottomLeading: Theme.radius.sm.points,
+                    bottomTrailing: Theme.radius.lg.points,
+                    topTrailing: Theme.radius.sm.points
                 )
             ) {
                 showAddressBookSheet.toggle()

--- a/VultisigApp/VultisigApp/Components/FunctionCallContractSelectorDropDown.swift
+++ b/VultisigApp/VultisigApp/Components/FunctionCallContractSelectorDropDown.swift
@@ -27,7 +27,7 @@ struct FunctionCallContractSelectorDropDown: View {
         }
         .padding(.horizontal, 12)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(10)
+        .cornerRadius(Theme.radius.md)
         .disabled(!isActive)
     }
 

--- a/VultisigApp/VultisigApp/Components/FunctionCallSelectorDropdown.swift
+++ b/VultisigApp/VultisigApp/Components/FunctionCallSelectorDropdown.swift
@@ -22,7 +22,7 @@ struct FunctionCallSelectorDropdown: View {
         }
         .padding(.horizontal, 12)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(10)
+        .cornerRadius(Theme.radius.md)
     }
 
     var selectedCell: some View {

--- a/VultisigApp/VultisigApp/Components/GenericSelectorDropDown.swift
+++ b/VultisigApp/VultisigApp/Components/GenericSelectorDropDown.swift
@@ -21,7 +21,7 @@ struct GenericSelectorDropDown<T: Identifiable & Equatable>: View {
         }
         .padding(.horizontal, 12)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(10)
+        .cornerRadius(Theme.radius.md)
         .disabled(items.isEmpty)
     }
 

--- a/VultisigApp/VultisigApp/Components/HiddenTextField.swift
+++ b/VultisigApp/VultisigApp/Components/HiddenTextField.swift
@@ -47,9 +47,9 @@ struct HiddenTextField: View {
         .frame(height: 56)
         .padding(.horizontal, 16)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(12)
+        .cornerRadius(Theme.radius.md)
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .stroke(errorMessage.isEmpty ? Theme.colors.border : Theme.colors.alertError, lineWidth: 1)
         )
     }

--- a/VultisigApp/VultisigApp/Components/ImportWalletUploadSection.swift
+++ b/VultisigApp/VultisigApp/Components/ImportWalletUploadSection.swift
@@ -22,7 +22,7 @@ struct ImportWalletUploadSection: View {
             .frame(height: 200)
             .frame(maxWidth: .infinity)
             .background(backgroundColor.opacity(0.15))
-            .cornerRadius(10)
+            .cornerRadius(Theme.radius.md)
             .overlay(
                 ZStack {
                     getOverlay(isUploading ? 2 : 1)
@@ -89,10 +89,10 @@ struct ImportWalletUploadSection: View {
     private func getOverlay(_ lineWidth: CGFloat) -> some View {
         ZStack {
             if backgroundColor == Theme.colors.bgButtonPrimary {
-                RoundedRectangle(cornerRadius: 10)
+                Theme.radius.md.shape
                     .strokeBorder(backgroundColor, lineWidth: 1)
             } else {
-                RoundedRectangle(cornerRadius: 10)
+                Theme.radius.md.shape
                     .strokeBorder(backgroundColor, style: StrokeStyle(lineWidth: lineWidth, dash: [5]))
             }
         }

--- a/VultisigApp/VultisigApp/Components/Loaders/Loader.swift
+++ b/VultisigApp/VultisigApp/Components/Loaders/Loader.swift
@@ -32,7 +32,7 @@ struct Loader: View {
         }
         .frame(width: 180, height: 120)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(10)
+        .cornerRadius(Theme.radius.md)
     }
 }
 

--- a/VultisigApp/VultisigApp/Components/NotificationBanner/ForegroundNotificationBannerView.swift
+++ b/VultisigApp/VultisigApp/Components/NotificationBanner/ForegroundNotificationBannerView.swift
@@ -15,6 +15,11 @@ struct ForegroundNotificationBannerView: View {
     var body: some View {
         ZStack {
             bannerBackground
+                // Off the scale on purpose. This is a full-bleed banner that
+                // drops from under the status bar and ignores the safe area; its
+                // bottom curve is drawn against the device's own screen corners,
+                // not against the app's card geometry, and 24 reads as a card
+                // stuck to the top of the screen.
                 .clipShape(
                     UnevenRoundedRectangle(
                         bottomLeadingRadius: 40,

--- a/VultisigApp/VultisigApp/Components/OutlinedDisclaimer.swift
+++ b/VultisigApp/VultisigApp/Components/OutlinedDisclaimer.swift
@@ -46,7 +46,7 @@ import SwiftUI
 
 extension OutlinedDisclaimer {
     var overlay: some View {
-        RoundedRectangle(cornerRadius: 10)
+        Theme.radius.md.shape
             .stroke(LinearGradient.primaryGradient, lineWidth: 1)
     }
 }
@@ -57,7 +57,7 @@ import SwiftUI
 
 extension OutlinedDisclaimer {
     var overlay: some View {
-        RoundedRectangle(cornerRadius: 10)
+        Theme.radius.md.shape
             .stroke(LinearGradient.primaryGradient, lineWidth: 2)
     }
 }

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAddressFields.swift
@@ -47,9 +47,9 @@ struct SendDetailsAddressFields: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(12)
+        .cornerRadius(Theme.radius.md)
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .stroke(Theme.colors.borderLight, lineWidth: 1)
         )
         .padding(1)

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTab.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTab.swift
@@ -128,7 +128,7 @@ struct SendDetailsAmountTab: View {
         .padding(12)
         .padding(.vertical, 8)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(12)
+        .cornerRadius(Theme.radius.md)
     }
 
     var additionalOptionsSection: some View {

--- a/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTextField.swift
+++ b/VultisigApp/VultisigApp/Components/Send/SendDetailsAmountTextField.swift
@@ -50,7 +50,7 @@ struct SendDetailsAmountTextField: View {
         }
         .padding(3)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(32)
+        .cornerRadius(Theme.radius.pill)
     }
 
     var selectorOvelay: some View {

--- a/VultisigApp/VultisigApp/Components/Sheet/CrossPlatformSheet.swift
+++ b/VultisigApp/VultisigApp/Components/Sheet/CrossPlatformSheet.swift
@@ -74,9 +74,9 @@ private struct CrossPlatformSheet<SheetContent: View>: ViewModifier {
                     }
 
                 sheetContent()
-                    .clipShape(RoundedRectangle(cornerRadius: 24))
+                    .clipShape(Theme.radius.xl.shape)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 24)
+                        Theme.radius.xl.shape
                             .inset(by: 0.5)
                             .strokeBorder(Theme.colors.borderExtraLight)
                     )
@@ -176,9 +176,9 @@ private struct PlatformSheetWithItem<Item: Identifiable & Equatable, SheetConten
                     }
 
                 sheetContent(currentItem)
-                    .clipShape(RoundedRectangle(cornerRadius: 24))
+                    .clipShape(Theme.radius.xl.shape)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 24)
+                        Theme.radius.xl.shape
                             .inset(by: 0.5)
                             .strokeBorder(Theme.colors.borderExtraLight)
                     )

--- a/VultisigApp/VultisigApp/Components/Swap/NotchedRectangle.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/NotchedRectangle.swift
@@ -21,12 +21,18 @@ let swapCardSpacing: CGFloat = 12
 /// a solid page color that page-colored "filler" paint could hide behind.
 ///
 /// Rotate 180° (as `SwapFromToField` already does for the "to"/Buy card) to
-/// mirror it: the 24/12 corners swap and the notch moves to the top edge.
+/// mirror it: the outer and inner corners swap and the notch moves to the top
+/// edge.
+///
+/// The four corners are the container and nested steps of the scale — the card's
+/// outer edge is a container, the edge where the two cards meet is the nested
+/// one. Only the radius travels from the token: the path is hand-built from
+/// `addArc`, which has no corner style.
 struct NotchedRectangle: Shape {
-    var topLeadingRadius: CGFloat = 24
-    var topTrailingRadius: CGFloat = 24
-    var bottomLeadingRadius: CGFloat = 12
-    var bottomTrailingRadius: CGFloat = 12
+    var topLeadingRadius: CGFloat = Theme.radius.xl.points
+    var topTrailingRadius: CGFloat = Theme.radius.xl.points
+    var bottomLeadingRadius: CGFloat = Theme.radius.md.points
+    var bottomTrailingRadius: CGFloat = Theme.radius.md.points
     /// Radius of the notch cavity: `SwapAssetsButton`'s outer radius (~19 — its
     /// 34pt label + 2pt padding) plus the intended 8pt moat between the button's
     /// stroke ring and the cutout, so the coupling to the button size is discoverable.

--- a/VultisigApp/VultisigApp/Components/Swap/SwapFromToChain.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapFromToChain.swift
@@ -34,7 +34,7 @@ struct SwapFromToChain: View {
         Image(systemName: "chevron.down")
             .font(Theme.fonts.caption10)
             .foregroundStyle(Theme.colors.textPrimary)
-            .cornerRadius(32)
+            .cornerRadius(Theme.radius.pill)
             .bold()
     }
 }

--- a/VultisigApp/VultisigApp/Components/Swap/SwapPercentageButtons.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapPercentageButtons.swift
@@ -114,7 +114,7 @@ extension SwapPercentageButtons {
             .padding(.vertical, 8)
             .frame(maxWidth: .infinity)
             .background(isSelected ? Theme.colors.bgPrimary : Theme.colors.bgSurface1)
-            .cornerRadius(32)
+            .cornerRadius(Theme.radius.pill)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/Components/Swap/SwapPercentageButtons.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapPercentageButtons.swift
@@ -63,7 +63,7 @@ extension SwapPercentageButtons {
             .padding(.horizontal, 8)
             .padding(.vertical, 10)
             .background(isSelected ? Theme.colors.bgPrimary : Theme.colors.bgSurface1)
-            .cornerRadius(16)
+            .cornerRadius(Theme.radius.lg)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/Components/Swap/SwapPercentageButtons.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapPercentageButtons.swift
@@ -63,6 +63,12 @@ extension SwapPercentageButtons {
             .padding(.horizontal, 8)
             .padding(.vertical, 10)
             .background(isSelected ? Theme.colors.bgPrimary : Theme.colors.bgSurface1)
+            // Not the macOS twin's `pill`, and not an oversight: this cell is
+            // taller (10pt of vertical padding against macOS's 8), so its 16
+            // stayed just under the clamp and rendered as a real 16 where the
+            // macOS cell's 32 rendered as a capsule. The two have always looked
+            // different; tokenising each at what it draws keeps that true, and
+            // makes the difference a design question instead of two numbers.
             .cornerRadius(Theme.radius.lg)
     }
 }

--- a/VultisigApp/VultisigApp/Components/SwitchToLocalLink.swift
+++ b/VultisigApp/VultisigApp/Components/SwitchToLocalLink.swift
@@ -70,9 +70,9 @@ struct SwitchToLocalLink: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
                 .background(background)
-                .cornerRadius(12)
+                .cornerRadius(Theme.radius.md)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 12)
+                    Theme.radius.md.shape
                         .stroke(borderColor, lineWidth: 1)
                 )
         }

--- a/VultisigApp/VultisigApp/Components/TextEditor/CommonTextEditor.swift
+++ b/VultisigApp/VultisigApp/Components/TextEditor/CommonTextEditor.swift
@@ -86,9 +86,9 @@ struct CommonTextEditor: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
             .background(Theme.colors.bgSurface1)
-            .cornerRadius(12)
+            .cornerRadius(Theme.radius.md)
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .stroke(borderColor, lineWidth: 1)
             )
             .padding(1)

--- a/VultisigApp/VultisigApp/Components/TextField/CommonTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextField/CommonTextField.swift
@@ -117,9 +117,9 @@ struct CommonTextField<TrailingView: View>: View {
                 .font(Theme.fonts.bodyMMedium)
                 .padding(.horizontal, 12)
                 .background(Theme.colors.bgSurface1)
-                .cornerRadius(12)
+                .cornerRadius(Theme.radius.md)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 12)
+                    Theme.radius.md.shape
                         .stroke(borderColor, lineWidth: borderWidth)
                 )
                 .autocorrectionDisabled()

--- a/VultisigApp/VultisigApp/Components/TextFields/DestinationTagTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/DestinationTagTextField.swift
@@ -20,9 +20,9 @@ struct DestinationTagTextField: View {
             .font(Theme.fonts.bodyMMedium)
             .padding(16)
             .background(Theme.colors.bgSurface1)
-            .cornerRadius(12)
+            .cornerRadius(Theme.radius.md)
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .stroke(Theme.colors.bgSurface2, lineWidth: 1)
             )
             .padding(1)

--- a/VultisigApp/VultisigApp/Components/TextFields/MemoTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/MemoTextField.swift
@@ -17,9 +17,9 @@ struct MemoTextField: View {
             .font(Theme.fonts.bodyMMedium)
             .padding(16)
             .background(Theme.colors.bgSurface1)
-            .cornerRadius(12)
+            .cornerRadius(Theme.radius.md)
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .stroke(Theme.colors.bgSurface2, lineWidth: 1)
             )
             .padding(1)

--- a/VultisigApp/VultisigApp/Components/TextFields/StyledFloatingPointField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/StyledFloatingPointField.swift
@@ -48,7 +48,7 @@ struct StyledFloatingPointField: View {
             .submitLabel(.done)
             .padding(12)
             .background(Theme.colors.bgSurface1)
-            .cornerRadius(12)
+            .cornerRadius(Theme.radius.md)
             .borderlessTextFieldStyle()
             .onChange(of: textFieldValue) { _, newValue in
                 updateValue(newValue)

--- a/VultisigApp/VultisigApp/Components/TextFields/StyledNumberField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/StyledNumberField.swift
@@ -42,7 +42,7 @@ struct StyledIntegerField<Value: BinaryInteger & Codable>: View {
             .submitLabel(.done)
             .padding(12)
             .background(Theme.colors.bgSurface1)
-            .cornerRadius(12)
+            .cornerRadius(Theme.radius.md)
             .borderlessTextFieldStyle()
             .onAppear {
                 localIsValid = isValid

--- a/VultisigApp/VultisigApp/Components/TextFields/StyledTextField.swift
+++ b/VultisigApp/VultisigApp/Components/TextFields/StyledTextField.swift
@@ -36,7 +36,7 @@ struct StyledTextField: View {
                 .submitLabel(.done)
                 .padding(12)
                 .background(Theme.colors.bgSurface1)
-                .cornerRadius(12)
+                .cornerRadius(Theme.radius.md)
                 .borderlessTextFieldStyle()
                 .maxLength(customBinding, maxLengthSize)
                 .onAppear {

--- a/VultisigApp/VultisigApp/Components/Tooltip/TooltipShape.swift
+++ b/VultisigApp/VultisigApp/Components/Tooltip/TooltipShape.swift
@@ -11,14 +11,22 @@ enum TooltipArrowDirection {
 }
 
 struct TooltipShape: Shape {
-    let cornerRadius: CGFloat = 16
-    let smallCornerRadius: CGFloat = 4
+    /// The bubble's own corners, read from the scale. The path is drawn with
+    /// `addArc`, so only the radius travels from the token — the corner style
+    /// does not apply to a hand-built path.
+    let cornerRadius: CGFloat = Theme.radius.lg.points
+    let smallCornerRadius: CGFloat = Theme.radius.xs.points
     let arrowWidth: CGFloat = 20
     let arrowHeight: CGFloat = 10
+    /// Fillet at the arrow tip. Part of the arrow's own geometry — sized
+    /// against `arrowWidth`/`arrowHeight`, not against the bubble — so it is
+    /// deliberately not a scale step.
     let arrowCornerRadius: CGFloat = 2
     /// Radius of the rounded junction where the arrow base blends into the
     /// tooltip body, so the triangle joins the bubble with a soft fillet
-    /// instead of a hard kink (matches the design-system tooltip).
+    /// instead of a hard kink (matches the design-system tooltip). Like the tip
+    /// fillet it belongs to the arrow, and is placed along the arrow's diagonal
+    /// rather than on a corner of the bubble.
     let arrowJunctionRadius: CGFloat = 4
     var arrowXFraction: CGFloat = 0.5
     var arrowDirection: TooltipArrowDirection = .up

--- a/VultisigApp/VultisigApp/Components/WarningView.swift
+++ b/VultisigApp/VultisigApp/Components/WarningView.swift
@@ -15,9 +15,9 @@ struct WarningView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 16)
             .background(Theme.colors.alertError.opacity(0.3))
-            .cornerRadius(12)
+            .cornerRadius(Theme.radius.md)
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .stroke(Theme.colors.alertError, lineWidth: 1)
             )
     }

--- a/VultisigApp/VultisigApp/Components/banxa/BanxaDisclaimer.swift
+++ b/VultisigApp/VultisigApp/Components/banxa/BanxaDisclaimer.swift
@@ -48,6 +48,11 @@ struct BanxaDisclaimer: View {
                     .padding(.horizontal, 24)
                     .padding(.vertical, 12)
                     .overlay(
+                        // `32` was already past half this button's height, so it
+                        // drew a capsule. It stays one at every text size now,
+                        // where the literal would have started showing real
+                        // corners once an accessibility size pushed the button
+                        // past 64pt tall — the idiom held, the number did not.
                         Theme.radius.pill.shape
                             .stroke(Color.gray, lineWidth: 2)
                     )

--- a/VultisigApp/VultisigApp/Components/banxa/BanxaDisclaimer.swift
+++ b/VultisigApp/VultisigApp/Components/banxa/BanxaDisclaimer.swift
@@ -48,7 +48,7 @@ struct BanxaDisclaimer: View {
                     .padding(.horizontal, 24)
                     .padding(.vertical, 12)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 32)
+                        Theme.radius.pill.shape
                             .stroke(Color.gray, lineWidth: 2)
                     )
                 }

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/ServerBackupVerificationView.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/ServerBackupVerificationView.swift
@@ -119,9 +119,9 @@ struct ServerBackupVerificationScreen: View {
             .disableAutocorrection(true)
             .frame(width: 58, height: 46)
             .background(Theme.colors.bgSurface1)
-            .clipShape(RoundedRectangle(cornerRadius: 24))
+            .clipShape(Theme.radius.xl.shape)
             .overlay(
-                RoundedRectangle(cornerRadius: 24)
+                Theme.radius.xl.shape
                     .strokeBorder(digitBorderColor(index), lineWidth: 1.5)
             )
             .focused($focusedField, equals: index)
@@ -162,9 +162,9 @@ struct ServerBackupVerificationScreen: View {
                 .frame(height: 46)
                 .frame(maxWidth: 76)
                 .background(Theme.colors.bgSurface2)
-                .clipShape(RoundedRectangle(cornerRadius: 24))
+                .clipShape(Theme.radius.xl.shape)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 24)
+                    Theme.radius.xl.shape
                         .strokeBorder(Theme.colors.borderExtraLight.opacity(0.03), lineWidth: 1)
                 )
         }

--- a/VultisigApp/VultisigApp/Features/Common/Views/Banners/CarouselBannerView.swift
+++ b/VultisigApp/VultisigApp/Features/Common/Views/Banners/CarouselBannerView.swift
@@ -75,9 +75,9 @@ struct CarouselBannerView<Banner: CarouselBannerType>: View {
         Icon(banner.icon, color: banner.iconColor, size: 20)
             .frame(width: 41, height: 41)
             .background(Theme.colors.bgSurface2)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .clipShape(Theme.radius.lg.shape)
             .overlay(
-                RoundedRectangle(cornerRadius: 16)
+                Theme.radius.lg.shape
                     .stroke(Theme.colors.borderExtraLight, lineWidth: 1)
             )
     }

--- a/VultisigApp/VultisigApp/Features/Common/Views/Buttons/CoinActionButton.swift
+++ b/VultisigApp/VultisigApp/Features/Common/Views/Buttons/CoinActionButton.swift
@@ -29,9 +29,9 @@ struct CoinActionButton: View {
                 )
                 .padding(16)
                 .background(bgColor)
-                .cornerRadius(16)
+                .cornerRadius(Theme.radius.lg)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16)
+                    Theme.radius.lg.shape
                         .inset(by: 0.5)
                         .stroke(.white.opacity(0.03), lineWidth: 1)
                 )

--- a/VultisigApp/VultisigApp/Features/CustomRPC/Views/CustomRPCDetailScreen.swift
+++ b/VultisigApp/VultisigApp/Features/CustomRPC/Views/CustomRPCDetailScreen.swift
@@ -65,11 +65,11 @@ struct CustomRPCDetailScreen: View {
             .padding(16)
             .frame(minHeight: 120, alignment: .topLeading)
             .background(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .fill(Theme.colors.bgSurface1)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .stroke(Theme.colors.borderLight, lineWidth: 1)
             )
 
@@ -97,11 +97,11 @@ struct CustomRPCDetailScreen: View {
         }
         .padding(16)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .fill(Theme.colors.bgSurface1)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .stroke(Theme.colors.borderLight, lineWidth: 1)
         )
     }

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Yield/View/YieldDepositScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Yield/View/YieldDepositScreen.swift
@@ -70,7 +70,7 @@ struct YieldDepositScreen: View {
             }
             .padding(16)
             .background(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .fill(Theme.colors.bgSurface1)
             )
         }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Governance/GovernanceWeightedVoteSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Governance/GovernanceWeightedVoteSheet.swift
@@ -83,7 +83,7 @@ struct GovernanceWeightedVoteSheet: View {
         }
         .padding(12)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .fill(Theme.colors.bgSurface1)
         )
     }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/LPs/DefiChainLPPositionSkeletonView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/LPs/DefiChainLPPositionSkeletonView.swift
@@ -58,12 +58,16 @@ struct DefiChainLPPositionSkeletonView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 // Buttons skeleton
+                // The real row draws `DefiButton`s, which style themselves with
+                // `PrimaryButtonStyle` and are therefore capsules. The
+                // placeholder has to be the shape it stands in for, or the
+                // buttons visibly change shape the moment the data lands.
                 HStack(alignment: .top, spacing: 16) {
-                    Theme.radius.lg.shape
+                    Theme.radius.pill.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(height: 44)
 
-                    Theme.radius.lg.shape
+                    Theme.radius.pill.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(height: 44)
                 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/LPs/DefiChainLPPositionSkeletonView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/LPs/DefiChainLPPositionSkeletonView.swift
@@ -18,11 +18,11 @@ struct DefiChainLPPositionSkeletonView: View {
                         .frame(width: 40, height: 40)
 
                     VStack(alignment: .leading, spacing: 4) {
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.borderLight.opacity(0.3))
                             .frame(width: 120, height: 16)
 
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.borderLight.opacity(0.3))
                             .frame(width: 80, height: 24)
                     }
@@ -34,24 +34,24 @@ struct DefiChainLPPositionSkeletonView: View {
 
                 // APR section skeleton
                 HStack(spacing: 4) {
-                    RoundedRectangle(cornerRadius: 4)
+                    Theme.radius.xs.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(width: 60, height: 16)
 
                     Spacer()
 
-                    RoundedRectangle(cornerRadius: 4)
+                    Theme.radius.xs.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(width: 50, height: 16)
                 }
 
                 // Position amount skeleton
                 VStack(alignment: .leading, spacing: 6) {
-                    RoundedRectangle(cornerRadius: 4)
+                    Theme.radius.xs.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(width: 80, height: 16)
 
-                    RoundedRectangle(cornerRadius: 4)
+                    Theme.radius.xs.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(width: 200, height: 16)
                 }
@@ -59,11 +59,11 @@ struct DefiChainLPPositionSkeletonView: View {
 
                 // Buttons skeleton
                 HStack(alignment: .top, spacing: 16) {
-                    RoundedRectangle(cornerRadius: 16)
+                    Theme.radius.lg.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(height: 44)
 
-                    RoundedRectangle(cornerRadius: 16)
+                    Theme.radius.lg.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(height: 44)
                 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionSkeletonView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionSkeletonView.swift
@@ -18,11 +18,11 @@ struct DefiChainStakedPositionSkeletonView: View {
                         .frame(width: 40, height: 40)
 
                     VStack(alignment: .leading, spacing: 4) {
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.borderLight.opacity(0.3))
                             .frame(width: 100, height: 16)
 
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.borderLight.opacity(0.3))
                             .frame(width: 140, height: 24)
                     }
@@ -35,25 +35,25 @@ struct DefiChainStakedPositionSkeletonView: View {
                 // Rewards section skeleton
                 VStack(alignment: .leading, spacing: 12) {
                     HStack(spacing: 4) {
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.borderLight.opacity(0.3))
                             .frame(width: 50, height: 16)
 
                         Spacer()
 
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.borderLight.opacity(0.3))
                             .frame(width: 60, height: 16)
                     }
 
                     HStack(spacing: 4) {
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.borderLight.opacity(0.3))
                             .frame(width: 90, height: 16)
 
                         Spacer()
 
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.borderLight.opacity(0.3))
                             .frame(width: 80, height: 16)
                     }
@@ -63,11 +63,11 @@ struct DefiChainStakedPositionSkeletonView: View {
 
                 // Buttons skeleton
                 HStack(alignment: .top, spacing: 16) {
-                    RoundedRectangle(cornerRadius: 16)
+                    Theme.radius.lg.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(height: 44)
 
-                    RoundedRectangle(cornerRadius: 16)
+                    Theme.radius.lg.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(height: 44)
                 }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionSkeletonView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Staked/DefiChainStakedPositionSkeletonView.swift
@@ -62,12 +62,16 @@ struct DefiChainStakedPositionSkeletonView: View {
                 Separator(color: Theme.colors.border, opacity: 1)
 
                 // Buttons skeleton
+                // The real row draws `DefiButton`s, which style themselves with
+                // `PrimaryButtonStyle` and are therefore capsules. The
+                // placeholder has to be the shape it stands in for, or the
+                // buttons visibly change shape the moment the data lands.
                 HStack(alignment: .top, spacing: 16) {
-                    Theme.radius.lg.shape
+                    Theme.radius.pill.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(height: 44)
 
-                    Theme.radius.lg.shape
+                    Theme.radius.pill.shape
                         .fill(Theme.colors.borderLight.opacity(0.3))
                         .frame(height: 44)
                 }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronDashboardView.swift
@@ -100,7 +100,7 @@ struct TronDashboardView: View {
 
                     if model.isLoadingBalance {
                         // Skeleton placeholder
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.bgSurface1)
                             .frame(width: 120, height: 24)
                             .shimmer()
@@ -157,7 +157,7 @@ struct TronDashboardView: View {
                         .foregroundStyle(Theme.colors.textSecondary)
 
                     if model.isLoadingBalance {
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.bgSurface1)
                             .frame(width: 80, height: 20)
                             .shimmer()
@@ -182,7 +182,7 @@ struct TronDashboardView: View {
                     .foregroundStyle(Theme.colors.textSecondary)
 
                 if model.isLoadingBalance {
-                    RoundedRectangle(cornerRadius: 4)
+                    Theme.radius.xs.shape
                         .fill(Theme.colors.bgSurface1)
                         .frame(width: 100, height: 20)
                         .shimmer()

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronResourcesCardView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronResourcesCardView.swift
@@ -89,7 +89,7 @@ struct TronResourcesCardView: View {
 
             HStack(spacing: 8) {
                 ZStack {
-                    RoundedRectangle(cornerRadius: 8)
+                    Theme.radius.sm.shape
                         .fill(accentColor.opacity(0.15))
                         .frame(width: 36, height: 36)
 
@@ -100,7 +100,7 @@ struct TronResourcesCardView: View {
 
                 VStack(alignment: .leading, spacing: 4) {
                     if isLoading {
-                        RoundedRectangle(cornerRadius: 4)
+                        Theme.radius.xs.shape
                             .fill(Theme.colors.bgSurface1)
                             .frame(width: 60, height: 14)
                             .shimmer()

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronResourcesInfoSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Tron/TronResourcesInfoSheet.swift
@@ -59,7 +59,7 @@ struct TronResourcesInfoSheet: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: 24, height: 24)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .clipShape(Theme.radius.sm.shape)
 
                 Text("TRON")
                     .font(Theme.fonts.footnote)
@@ -166,7 +166,7 @@ struct TronResourcesInfoSheet: View {
             .foregroundStyle(accentColor)
             .padding(8)
             .background(
-                RoundedRectangle(cornerRadius: 8)
+                Theme.radius.sm.shape
                     .fill(accentColor.opacity(0.1))
             )
     }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -424,7 +424,7 @@ struct AddThorLPFormView: View {
                     .padding(.vertical, 12)
                     .padding(.horizontal, 16)
                     .background(Theme.colors.bgSurface1.opacity(0.1))
-                    .cornerRadius(10)
+                    .cornerRadius(Theme.radius.md)
             }
 
             StyledFloatingPointField(
@@ -503,7 +503,7 @@ struct PoolSelectorSection: View {
         .frame(height: 48)
         .padding(.horizontal, 12)
         .background(Theme.colors.bgSurface1)
-        .cornerRadius(10)
+        .cornerRadius(Theme.radius.md)
     }
 
     private var errorView: some View {
@@ -534,7 +534,7 @@ struct PoolSelectorSection: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(Theme.colors.bgSurface1)
-            .cornerRadius(10)
+            .cornerRadius(Theme.radius.md)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
@@ -256,7 +256,7 @@ struct SecuredAssetFormView: View {
                         .font(.footnote)
                         .padding(8)
                         .background(Color.gray.opacity(0.1))
-                        .cornerRadius(8)
+                        .cornerRadius(Theme.radius.sm)
                 }
             }
 
@@ -268,7 +268,7 @@ struct SecuredAssetFormView: View {
                     .font(.footnote)
                     .padding(8)
                     .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
+                    .cornerRadius(Theme.radius.sm)
             }
         }
         .onAppear {

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
@@ -299,6 +299,6 @@ struct SecuredAssetFormView: View {
         .padding(.vertical, 12)
         .padding(.horizontal, 16)
         .background(Color.blue.opacity(0.1))
-        .cornerRadius(10)
+        .cornerRadius(Theme.radius.md)
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallWithdrawSecuredAsset.swift
@@ -387,7 +387,7 @@ struct SecuredAssetSelectorSection: View {
         .frame(height: 48)
         .padding(.horizontal, 12)
         .background(Color.gray.opacity(0.1))
-        .cornerRadius(10)
+        .cornerRadius(Theme.radius.md)
     }
 
     private var errorView: some View {
@@ -416,7 +416,7 @@ struct SecuredAssetSelectorSection: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(Color.gray.opacity(0.1))
-            .cornerRadius(10)
+            .cornerRadius(Theme.radius.md)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/Redelegate/CosmosRedelegateTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/Redelegate/CosmosRedelegateTransactionScreen.swift
@@ -142,7 +142,7 @@ struct CosmosRedelegateTransactionScreen: View {
         }
         .padding(14)
         .background(Theme.colors.bgSurface1)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(Theme.radius.md.shape)
         .padding(.top, 8)
     }
 

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/WithdrawRewards/CosmosWithdrawRewardsTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Cosmos/WithdrawRewards/CosmosWithdrawRewardsTransactionScreen.swift
@@ -67,7 +67,7 @@ struct CosmosWithdrawRewardsTransactionScreen: View {
                 }
                 .padding(10)
                 .background(Theme.colors.bgSurface1)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .clipShape(Theme.radius.sm.shape)
             }
         }
     }
@@ -100,7 +100,7 @@ struct CosmosWithdrawRewardsTransactionScreen: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
             .background(Theme.colors.bgSurface1)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .clipShape(Theme.radius.md.shape)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -109,7 +109,7 @@ struct CosmosWithdrawRewardsTransactionScreen: View {
     @ViewBuilder
     private func checkbox(isSelected: Bool) -> some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 4)
+            Theme.radius.xs.shape
                 .stroke(
                     isSelected
                         ? Theme.colors.primaryAccent3

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/ValidatorSelection/StakingValidatorCard.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/SharedFunctions/ValidatorSelection/StakingValidatorCard.swift
@@ -41,7 +41,7 @@ struct StakingValidatorCard: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
             .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .clipShape(Theme.radius.lg.shape)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -52,7 +52,7 @@ struct StakingValidatorCard: View {
         if isSelected {
             Theme.colors.bgSurface1
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16)
+                    Theme.radius.lg.shape
                         .stroke(Theme.colors.alertSuccess.opacity(0.5), lineWidth: 1)
                 )
         } else {

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Thorchain/AddLP/AddLPTransactionScreen.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Thorchain/AddLP/AddLPTransactionScreen.swift
@@ -53,7 +53,7 @@ struct AddLPTransactionScreen: View {
             }
             .padding(12)
             .background(Theme.colors.bgNeutral)
-            .cornerRadius(8)
+            .cornerRadius(Theme.radius.sm)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/FunctionTransaction/Ton/PoolSelection/TonPoolCard.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionTransaction/Ton/PoolSelection/TonPoolCard.swift
@@ -47,7 +47,7 @@ struct TonPoolCard: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
             .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .clipShape(Theme.radius.lg.shape)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -66,7 +66,7 @@ struct TonPoolCard: View {
         if isSelected {
             Theme.colors.bgSurface1
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16)
+                    Theme.radius.lg.shape
                         .stroke(Theme.colors.alertSuccess.opacity(0.5), lineWidth: 1)
                 )
         } else {

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/Components/BackspaceDetectingTextField.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/Components/BackspaceDetectingTextField.swift
@@ -36,7 +36,7 @@ struct BackspaceDetectingTextField: NSViewRepresentable {
         textField.backgroundColor = NSColor.clear
 
         textField.wantsLayer = true
-        textField.layer?.cornerRadius = 12
+        textField.layer?.cornerRadius = Theme.radius.md.points
         textField.focusRingType = .none
 
         return textField

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/Components/BackspaceDetectingTextField.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/Components/BackspaceDetectingTextField.swift
@@ -36,6 +36,11 @@ struct BackspaceDetectingTextField: NSViewRepresentable {
         textField.backgroundColor = NSColor.clear
 
         textField.wantsLayer = true
+        // Only the radius travels here. `CALayer` states its corner shape as
+        // `cornerCurve`, a separate axis from SwiftUI's `RoundedCornerStyle`,
+        // and this field has always drawn the AppKit default. Adopting the
+        // token's number keeps it in step with the SwiftUI fields it sits
+        // among; changing the curve would be a visual change to the control.
         textField.layer?.cornerRadius = Theme.radius.md.points
         textField.focusRingType = .none
 

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/JoinKeygenView.swift
@@ -75,7 +75,7 @@ struct JoinKeygenView: View {
         .if(viewModel.status != .KeygenStarted) {
             $0
                 .padding()
-                .cornerRadius(10)
+                .cornerRadius(Theme.radius.md)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/PeerDiscoveryScreen.swift
@@ -297,6 +297,12 @@ struct PeerDiscoveryScreen: View {
             .frame(maxWidth: qrCodeSize, maxHeight: qrCodeSize)
             .padding(20)
             .background(Theme.colors.bgSurface1)
+            // Off the scale on purpose. The frame and its 8pt gradient ring are
+            // one drawn object at a size nothing else in the app has, and the
+            // nearest step is 9pt away — enough to reshape the screen the
+            // pairing flow is built around. Both radii are the same number
+            // because they are the same edge, so they move together or not at
+            // all.
             .cornerRadius(33)
             .overlay(
                 RoundedRectangle(cornerRadius: 33)

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/JoinKeysignView.swift
@@ -71,7 +71,7 @@ struct JoinKeysignView: View {
             }
 
         }
-        .if(!isInAnimationState) { $0.padding().cornerRadius(10) }
+        .if(!isInAnimationState) { $0.padding().cornerRadius(Theme.radius.md) }
     }
 
     var keysignStartedView: some View {

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignCustomMessageConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignCustomMessageConfirmView.swift
@@ -118,7 +118,7 @@ struct KeysignCustomMessageConfirmView: View {
                     .frame(maxWidth: .infinity)
                 }
                 .frame(maxWidth: .infinity, maxHeight: 300)
-                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+                .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -183,7 +183,7 @@ struct KeysignCustomMessageConfirmView: View {
                     .padding(16)
                 }
                 .frame(maxHeight: 300)
-                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+                .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignDiscoveryView.swift
@@ -188,11 +188,11 @@ struct KeysignDiscoveryView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .fill(Theme.colors.bgButtonDisabled.opacity(0.5))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .stroke(Theme.colors.borderExtraLight, lineWidth: 1)
             )
         }

--- a/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/Views/KeysignSwapConfirmView.swift
@@ -134,7 +134,7 @@ struct KeysignSwapConfirmView: View {
             .foregroundStyle(Theme.colors.primaryAccent4)
             .padding(6)
             .background(Theme.colors.bgSurface2)
-            .cornerRadius(32)
+            .cornerRadius(Theme.radius.pill)
             .bold()
     }
 

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyView.swift
@@ -825,7 +825,11 @@ private struct LimitPriceToggle: View {
         }
         .padding(3)
         .background(Theme.colors.bgSurface1)
-        .clipShape(RoundedRectangle(cornerRadius: 20))
+        // Track and thumb are one pair and move together. Neither `20` nor the
+        // thumb's `18` was a chosen radius: both already exceeded half of the
+        // 38pt track / 32pt thumb, so both rendered as the clamp. `pill` names
+        // that and keeps them clamping in step if either size changes.
+        .clipShape(Theme.radius.pill.shape)
     }
 
     private func toggleButton(unit: PriceDisplayUnit, systemImage: String) -> some View {
@@ -846,7 +850,7 @@ private struct LimitPriceToggle: View {
                     // The selected indicator is a single matched-geometry thumb, so
                     // it slides between the two chips instead of hard-switching.
                     if isActive {
-                        RoundedRectangle(cornerRadius: 18)
+                        Theme.radius.pill.shape
                             .fill(Theme.colors.primaryAccent3)
                             .matchedGeometryEffect(id: "thumb", in: thumb)
                     }

--- a/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyView.swift
+++ b/VultisigApp/VultisigApp/Features/LimitSwap/Views/LimitSwapBodyView.swift
@@ -21,7 +21,7 @@ private let limitSectionCornerRadius = Theme.radius.xl
 /// radius: these rows are single-line annotations (~39pt tall), and a 24pt radius
 /// exceeds half their height, degenerating the shape into a capsule and making
 /// them read as pills rather than as messages.
-private let limitNoticeCornerRadius: CGFloat = 12
+private let limitNoticeCornerRadius: CornerRadius = Theme.radius.md
 
 /// The limit form's editable fields, as focus identities.
 ///
@@ -1267,10 +1267,10 @@ private struct LimitUnavailableRow: View {
         .padding(12)
         .background(Theme.colors.bgSurface1)
         .overlay(
-            RoundedRectangle(cornerRadius: limitNoticeCornerRadius)
+            limitNoticeCornerRadius.shape
                 .stroke(Theme.colors.borderLight, lineWidth: 1)
         )
-        .clipShape(RoundedRectangle(cornerRadius: limitNoticeCornerRadius))
+        .clipShape(limitNoticeCornerRadius.shape)
     }
 }
 
@@ -1302,10 +1302,10 @@ private struct LimitNoticeRow: View {
         .padding(12)
         .background(Theme.colors.bgSurface1)
         .overlay(
-            RoundedRectangle(cornerRadius: limitNoticeCornerRadius)
+            limitNoticeCornerRadius.shape
                 .stroke(Theme.colors.borderLight, lineWidth: 1)
         )
-        .clipShape(RoundedRectangle(cornerRadius: limitNoticeCornerRadius))
+        .clipShape(limitNoticeCornerRadius.shape)
     }
 }
 
@@ -1331,10 +1331,10 @@ private struct LimitWarningRow: View {
         .padding(12)
         .background(Theme.colors.bgSurface1)
         .overlay(
-            RoundedRectangle(cornerRadius: limitNoticeCornerRadius)
+            limitNoticeCornerRadius.shape
                 .stroke(Theme.colors.borderLight, lineWidth: 1)
         )
-        .clipShape(RoundedRectangle(cornerRadius: limitNoticeCornerRadius))
+        .clipShape(limitNoticeCornerRadius.shape)
     }
 
     private var messageKey: String {

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/ChainsSetup/Views/KeyImportActiveChainsView.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/ChainsSetup/Views/KeyImportActiveChainsView.swift
@@ -61,6 +61,11 @@ struct KeyImportActiveChainsView: View {
                             .padding(12)
                             .padding(.trailing, 16)
                             .background(
+                                // A 20 that is not the tier card's: it is this
+                                // screen's own Figma value, and both 16 and 24
+                                // are the same 4pt away, so there is no reading
+                                // of the scale that picks one. Left for a design
+                                // call rather than rounded to the nearer step.
                                 RoundedRectangle(cornerRadius: 20)
                                     .inset(by: 0.5)
                                     .stroke(Theme.colors.borderLight, lineWidth: 1)

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/OnboardingYourVaultSetupScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/KeyImport/OnboardingYourVaultSetupScreen.swift
@@ -105,7 +105,7 @@ struct OnboardingYourVaultSetupScreen: View {
         .padding(8)
         .padding(.trailing, 20)
         .background(
-            RoundedRectangle(cornerRadius: 16)
+            Theme.radius.lg.shape
                 .inset(by: 0.5)
                 .fill(Theme.colors.bgSurface1)
                 .stroke(

--- a/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/VaultSetup/VaultSetupScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Onboarding/ImportVault/VaultSetup/VaultSetupScreen.swift
@@ -329,7 +329,7 @@ struct VaultSetupScreen: View {
         }
         .buttonStyle(.plain)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .fill(Theme.colors.bgSurface2)
                 .stroke(Theme.colors.borderExtraLight.opacity(0.3), lineWidth: 1)
         )

--- a/VultisigApp/VultisigApp/Features/QBTCClaim/Views/QBTCClaimSelectionView.swift
+++ b/VultisigApp/VultisigApp/Features/QBTCClaim/Views/QBTCClaimSelectionView.swift
@@ -196,7 +196,7 @@ struct QBTCClaimUtxoRow: View {
             }
             .padding(16)
             .background(Theme.colors.bgSurface1)
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .clipShape(Theme.radius.lg.shape)
         }
         .buttonStyle(.plain)
     }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/CreateReferralDetailsView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/CreateReferralDetailsView.swift
@@ -159,7 +159,7 @@ struct CreateReferralDetailsView: View {
         .padding(.vertical, 12)
         .padding(.horizontal, 16)
         .background(Theme.colors.textPrimary)
-        .cornerRadius(8)
+        .cornerRadius(Theme.radius.sm)
         .onTapGesture {
             showTooltip = false
         }

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferralMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferralMainScreen.swift
@@ -99,7 +99,7 @@ struct ReferralMainScreen: View {
         VStack(spacing: 20) {
             Icon(.circleDashed2, color: Theme.colors.primaryAccent4, size: 24)
                 .padding(7)
-                .background(RoundedRectangle(cornerRadius: 8).fill(Theme.colors.bgSurface1))
+                .background(Theme.radius.sm.shape.fill(Theme.colors.bgSurface1))
                 .padding(.top, 24)
 
             VStack(spacing: 8) {

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferredOnboardingView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferredOnboardingView.swift
@@ -104,9 +104,11 @@ struct ReferredOnboardingView: View {
         .background(Theme.colors.bgSurface1)
         // The trailing edge is a capsule end cap: `32` already exceeded half the
         // row's height, so both corners were clamped and the edge rendered fully
-        // round. `pill` says that, and clamps to the same shape. Rounding each
-        // corner separately means this cannot use the token's `shape`, so the
-        // style is carried across by hand — as the list and banner masks do.
+        // round. `pill` says that, and clamps to the same shape — and keeps
+        // saying it at accessibility text sizes, where the literal would have
+        // stopped clamping once the symbol pushed the row past 64pt. Rounding
+        // each corner separately means this cannot use the token's `shape`, so
+        // the style is carried across by hand — as the list and banner masks do.
         .clipShape(
             UnevenRoundedRectangle(
                 topLeadingRadius: 0,

--- a/VultisigApp/VultisigApp/Features/Referral/Views/ReferredOnboardingView.swift
+++ b/VultisigApp/VultisigApp/Features/Referral/Views/ReferredOnboardingView.swift
@@ -102,20 +102,27 @@ struct ReferredOnboardingView: View {
         .padding(.vertical, 8)
         .padding(.horizontal, 12)
         .background(Theme.colors.bgSurface1)
+        // The trailing edge is a capsule end cap: `32` already exceeded half the
+        // row's height, so both corners were clamped and the edge rendered fully
+        // round. `pill` says that, and clamps to the same shape. Rounding each
+        // corner separately means this cannot use the token's `shape`, so the
+        // style is carried across by hand — as the list and banner masks do.
         .clipShape(
             UnevenRoundedRectangle(
                 topLeadingRadius: 0,
                 bottomLeadingRadius: 0,
-                bottomTrailingRadius: 32,
-                topTrailingRadius: 32
+                bottomTrailingRadius: Theme.radius.pill.points,
+                topTrailingRadius: Theme.radius.pill.points,
+                style: Theme.radius.pill.style
             )
         )
         .overlay(
             UnevenRoundedRectangle(
                 topLeadingRadius: 0,
                 bottomLeadingRadius: 0,
-                bottomTrailingRadius: 32,
-                topTrailingRadius: 32
+                bottomTrailingRadius: Theme.radius.pill.points,
+                topTrailingRadius: Theme.radius.pill.points,
+                style: Theme.radius.pill.style
             )
             .inset(by: 1)
             .stroke(Theme.colors.borderLight, lineWidth: 2)

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignAminoDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignAminoDisplayView.swift
@@ -40,7 +40,7 @@ struct SignAminoDisplayView: View {
                     }
                 }
                 .frame(maxHeight: 300)
-                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+                .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignBitcoinDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignBitcoinDisplayView.swift
@@ -48,7 +48,7 @@ struct SignBitcoinDisplayView: View {
                 }
                 .padding(16)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+                .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
             }
         }
     }
@@ -125,7 +125,7 @@ struct SignBitcoinDisplayView: View {
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Theme.colors.bgPrimary))
+        .background(Theme.radius.sm.shape.fill(Theme.colors.bgPrimary))
     }
 
     private func outputRow(index: Int, output: BitcoinOutput) -> some View {
@@ -155,7 +155,7 @@ struct SignBitcoinDisplayView: View {
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Theme.colors.bgPrimary))
+        .background(Theme.radius.sm.shape.fill(Theme.colors.bgPrimary))
     }
 
     // MARK: - Formatting

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignDirectDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignDirectDisplayView.swift
@@ -44,7 +44,7 @@ struct SignDirectDisplayView: View {
                     .padding(16)
                 }
                 .frame(maxHeight: 300)
-                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+                .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignRippleDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignRippleDisplayView.swift
@@ -42,7 +42,7 @@ struct SignRippleDisplayView: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+        .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
     }
 
     @ViewBuilder
@@ -81,11 +81,11 @@ struct SignRippleDisplayView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(12)
                 .background(Theme.colors.bgPrimary)
-                .cornerRadius(8)
+                .cornerRadius(Theme.radius.sm)
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+        .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
     }
 
     // MARK: - Building blocks

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignSolanaDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignSolanaDisplayView.swift
@@ -42,7 +42,7 @@ struct SignSolanaDisplayView: View {
                     .padding(16)
                 }
                 .frame(maxHeight: 400)
-                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+                .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
             }
         }
     }
@@ -86,7 +86,7 @@ struct SignSolanaDisplayView: View {
             .padding(12)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Theme.colors.bgPrimary)
-            .cornerRadius(8)
+            .cornerRadius(Theme.radius.sm)
         }
     }
 
@@ -118,7 +118,7 @@ struct SignSolanaDisplayView: View {
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Theme.colors.bgPrimary)
-        .cornerRadius(8)
+        .cornerRadius(Theme.radius.sm)
     }
 
 }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignSuiDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignSuiDisplayView.swift
@@ -46,7 +46,7 @@ struct SignSuiDisplayView: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+        .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
     }
 
     // MARK: - Commands
@@ -158,7 +158,7 @@ struct SignSuiDisplayView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(12)
                 .background(Theme.colors.bgPrimary)
-                .cornerRadius(8)
+                .cornerRadius(Theme.radius.sm)
         }
     }
 
@@ -194,7 +194,7 @@ struct SignSuiDisplayView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(
-            RoundedRectangle(cornerRadius: 16)
+            Theme.radius.lg.shape
                 .stroke(Theme.colors.border, lineWidth: 1)
         )
     }

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignTonDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignTonDisplayView.swift
@@ -107,7 +107,7 @@ struct SignTonDisplayView: View {
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                Theme.radius.md.shape
                     .stroke(Theme.colors.border, lineWidth: 1)
             )
         }
@@ -225,7 +225,7 @@ struct SignTonDisplayView: View {
         .padding(24)
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(
-            RoundedRectangle(cornerRadius: 16)
+            Theme.radius.lg.shape
                 .stroke(Theme.colors.border, lineWidth: 1)
         )
     }
@@ -285,7 +285,7 @@ struct SignTonDisplayView: View {
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
+            Theme.radius.md.shape
                 .stroke(Theme.colors.border, lineWidth: 1)
         )
     }

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendCryptoVerifySummary/SendCryptoVerifySummaryView.swift
@@ -391,7 +391,7 @@ struct SendCryptoVerifySummaryView<ContentFooter: View>: View {
                     .padding(16)
                 }
                 .frame(maxHeight: 300)
-                .background(RoundedRectangle(cornerRadius: 16).fill(Theme.colors.bgSurface2))
+                .background(Theme.radius.lg.shape.fill(Theme.colors.bgSurface2))
             }
         }
     }

--- a/VultisigApp/VultisigApp/Features/Send/Views/SendGasSettingsView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/SendGasSettingsView.swift
@@ -117,7 +117,10 @@ struct SendGasSettingsView: View {
 
         }
         .background(
-            RoundedRectangle(cornerSize: .init(width: 5, height: 5))
+            // Written as a `cornerSize` rather than a radius, which is why it
+            // stayed a lone `5` while every other field in the app moved to the
+            // form radius. Same control, same step.
+            Theme.radius.md.shape
                 .foregroundStyle(Theme.colors.bgSurface1)
         )
         .frame(maxWidth: .infinity)
@@ -229,7 +232,10 @@ extension SendGasSettingsView {
             .padding(.vertical, 16)
         }
         .background(
-            RoundedRectangle(cornerSize: .init(width: 5, height: 5))
+            // Written as a `cornerSize` rather than a radius, which is why it
+            // stayed a lone `5` while every other field in the app moved to the
+            // form radius. Same control, same step.
+            Theme.radius.md.shape
                 .foregroundStyle(Theme.colors.bgSurface1)
         )
         .padding(.horizontal, 16)
@@ -282,7 +288,10 @@ extension SendGasSettingsView {
             .padding(.vertical, 16)
         }
         .background(
-            RoundedRectangle(cornerSize: .init(width: 5, height: 5))
+            // Written as a `cornerSize` rather than a radius, which is why it
+            // stayed a lone `5` while every other field in the app moved to the
+            // form radius. Same control, same step.
+            Theme.radius.md.shape
                 .foregroundStyle(Theme.colors.bgSurface1)
         )
         .padding(.horizontal, 16)

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsCustomMessageView.swift
@@ -103,7 +103,7 @@ struct SettingsCustomMessageView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
                 .background(
-                    RoundedRectangle(cornerRadius: 12)
+                    Theme.radius.md.shape
                         .fill(Theme.colors.bgSurface2)
                 )
         }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/GasLimitSettingsView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/GasLimitSettingsView.swift
@@ -30,9 +30,9 @@ struct GasLimitSettingsView: View {
                     .foregroundStyle(Theme.colors.textPrimary)
                     .padding(16)
                     .background(Theme.colors.bgSurface1)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(Theme.radius.md.shape)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 12)
+                        Theme.radius.md.shape
                             .stroke(Theme.colors.borderExtraLight, lineWidth: 1)
                     )
                     .onChange(of: text) { _, newValue in apply(newValue) }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/Screens/SwapVerifyScreen.swift
@@ -312,7 +312,7 @@ struct SwapVerifyScreen: View {
             .foregroundStyle(Theme.colors.primaryAccent4)
             .padding(6)
             .background(Theme.colors.bgSurface2)
-            .cornerRadius(32)
+            .cornerRadius(Theme.radius.pill)
             .bold()
     }
 

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/TransactionHistoryScreen.swift
@@ -176,7 +176,7 @@ struct TransactionHistoryScreen: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
         .background(Theme.colors.bgSurface2)
-        .cornerRadius(6)
+        .cornerRadius(Theme.radius.sm)
         .transition(.opacity.combined(with: .scale))
         .onTapGesture {
             withAnimation(.easeInOut(duration: 0.25)) {

--- a/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryDetailSheet.swift
+++ b/VultisigApp/VultisigApp/Features/TransactionHistory/Views/TransactionHistoryDetailSheet.swift
@@ -367,7 +367,7 @@ struct TransactionHistoryDetailSheet: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 3)
                 .background(Theme.colors.bgSurface2)
-                .cornerRadius(8)
+                .cornerRadius(Theme.radius.sm)
 
             if let expiry = expiryChipText(order) {
                 HStack(spacing: 4) {
@@ -381,7 +381,7 @@ struct TransactionHistoryDetailSheet: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 3)
                 .background(Theme.colors.bgSurface2)
-                .cornerRadius(8)
+                .cornerRadius(Theme.radius.sm)
             }
         }
         .font(Theme.fonts.bodySMedium)
@@ -494,7 +494,7 @@ struct TransactionHistoryDetailSheet: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 3)
                 .background(Theme.colors.bgSurface2)
-                .cornerRadius(8)
+                .cornerRadius(Theme.radius.sm)
         }
         .font(Theme.fonts.bodySMedium)
         .padding(.vertical, 16)
@@ -511,7 +511,7 @@ struct TransactionHistoryDetailSheet: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 3)
                 .background(Theme.colors.bgSurface2)
-                .cornerRadius(8)
+                .cornerRadius(Theme.radius.sm)
         }
         .font(Theme.fonts.bodySMedium)
         .padding(.vertical, 16)

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Views/FolderCellView.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Views/FolderCellView.swift
@@ -84,7 +84,7 @@ struct FolderCellView: View {
     }
 
     var selectedBackground: some View {
-        RoundedRectangle(cornerRadius: 12)
+        Theme.radius.md.shape
             .fill(Theme.colors.bgSurface1)
     }
 }

--- a/VultisigApp/VultisigApp/Features/VaultSelector/Views/VaultCellView.swift
+++ b/VultisigApp/VultisigApp/Features/VaultSelector/Views/VaultCellView.swift
@@ -76,7 +76,7 @@ struct VaultCellView<TrailingView: View>: View {
                         .font(Theme.fonts.caption12)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 3)
-                        .background(RoundedRectangle(cornerRadius: 8).stroke(isEditing ? Theme.colors.textTertiary : Theme.colors.borderLight))
+                        .background(Theme.radius.sm.shape.stroke(isEditing ? Theme.colors.textTertiary : Theme.colors.borderLight))
                         .fixedSize()
                 }
                 .showIf(showTrailingDetails && !isEditing)
@@ -89,7 +89,7 @@ struct VaultCellView<TrailingView: View>: View {
     }
 
     var selectedBackground: some View {
-        RoundedRectangle(cornerRadius: 12)
+        Theme.radius.md.shape
             .fill(Theme.colors.bgSurface1)
     }
 }

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/LockedFeatureSheet.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/LockedFeatureSheet.swift
@@ -17,7 +17,9 @@ struct LockedFeatureSheet: View {
     @StateObject private var viewModel: LockedFeatureSheetViewModel
 
     private let footerHeight: CGFloat = 48
-    private let footerCornerRadius: CGFloat = 24
+    private let footerCornerRadius: CGFloat = Theme.radius.xl.points
+    /// Deliberately off the scale — mirrors `VultDiscountTierView`'s card, whose
+    /// 20pt bottom is a Figma value the footer bar is drawn to sit under.
     private let cardCornerRadius: CGFloat = 20
 
     init(

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/LockedFeatureSheet.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/LockedFeatureSheet.swift
@@ -17,7 +17,7 @@ struct LockedFeatureSheet: View {
     @StateObject private var viewModel: LockedFeatureSheetViewModel
 
     private let footerHeight: CGFloat = 48
-    private let footerCornerRadius: CGFloat = Theme.radius.xl.points
+    private let footerRadius: CornerRadius = Theme.radius.xl
     /// Deliberately off the scale — mirrors `VultDiscountTierView`'s card, whose
     /// 20pt bottom is a Figma value the footer bar is drawn to sit under.
     private let cardCornerRadius: CGFloat = 20
@@ -198,11 +198,11 @@ struct LockedFeatureSheet: View {
     /// Soft top highlight on the footer, matching
     /// `VultDiscountTierView.footerInnerShadow`.
     private var footerInnerShadow: some View {
-        RoundedRectangle(cornerRadius: footerCornerRadius)
+        footerRadius.shape
             .stroke(Color.white.opacity(0.1), lineWidth: 1)
             .blur(radius: 1)
             .mask(
-                RoundedRectangle(cornerRadius: footerCornerRadius)
+                footerRadius.shape
                     .fill(
                         LinearGradient(
                             colors: [.white, .clear],

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/LockedFeatureSheet.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/LockedFeatureSheet.swift
@@ -151,11 +151,11 @@ struct LockedFeatureSheet: View {
         }
         .padding(16)
         .background(
-            RoundedRectangle(cornerRadius: 14)
+            Theme.radius.md.shape
                 .fill(Theme.colors.bgSurface12)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 14)
+            Theme.radius.md.shape
                 .stroke(Theme.colors.borderLight, lineWidth: 1)
         )
     }

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/VultDiscountTierView.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/VultDiscountTierView.swift
@@ -135,9 +135,22 @@ private extension VultDiscountTierView {
             .padding(.bottom, 14)
             .background(footerGradient)
             .overlay(footerInnerShadow)
-            .clipShape(UnevenRoundedRectangle(bottomLeadingRadius: 20, bottomTrailingRadius: 20))
+            // Both radii below are the CARD's bottom radius, not the footer's
+            // own: the bar sits behind `cardBody` and peeks out from under it,
+            // so its bottom edge has to trace the edge it emerges from. Written
+            // as a literal `20` they were a silent copy — move the card and the
+            // footer would have cut across the corner it is meant to follow.
+            .clipShape(
+                UnevenRoundedRectangle(
+                    bottomLeadingRadius: bottomCornerRadius,
+                    bottomTrailingRadius: bottomCornerRadius
+                )
+            )
             .offset(y: isExpanded ? 48 : 2)
-            .overlay(RoundedRectangle(cornerRadius: 20).stroke(Theme.colors.borderLight, lineWidth: 1))
+            .overlay(
+                RoundedRectangle(cornerRadius: bottomCornerRadius)
+                    .stroke(Theme.colors.borderLight, lineWidth: 1)
+            )
             .onTapGesture {
                 if isUnlockTappable {
                     onUnlock()

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/VultDiscountTierView.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/VultDiscountTierView.swift
@@ -17,12 +17,12 @@ struct VultDiscountTierView: View {
     @State var isExpanded: Bool = false
     @State var isActiveInternal: Bool = false
 
-    private let topCornerRadius: CGFloat = Theme.radius.xl.points
+    private let topRadius: CornerRadius = Theme.radius.xl
     /// Deliberately off the scale. The card's 24-top / 20-bottom asymmetry is a
     /// Figma value, not a rounding of one: the footer bar peeks out from under
     /// the bottom edge and the two radii are drawn to sit together.
     private let bottomCornerRadius: CGFloat = 20
-    private let footerCornerRadius: CGFloat = Theme.radius.xl.points
+    private let footerRadius: CornerRadius = Theme.radius.xl
     private let footerHeight: CGFloat = 48
 
     var holdAmountText: String {
@@ -195,11 +195,11 @@ private extension VultDiscountTierView {
     }
 
     var footerInnerShadow: some View {
-        RoundedRectangle(cornerRadius: footerCornerRadius)
+        footerRadius.shape
             .stroke(Color.white.opacity(0.1), lineWidth: 1)
             .blur(radius: 1)
             .mask(
-                RoundedRectangle(cornerRadius: footerCornerRadius)
+                footerRadius.shape
                     .fill(
                         LinearGradient(
                             colors: [.white, .clear],
@@ -214,11 +214,16 @@ private extension VultDiscountTierView {
     var cardShape: some Shape {
         UnevenRoundedRectangle(
             cornerRadii: .init(
-                topLeading: topCornerRadius,
+                topLeading: topRadius.points,
                 bottomLeading: bottomCornerRadius,
                 bottomTrailing: bottomCornerRadius,
-                topTrailing: topCornerRadius
-            )
+                topTrailing: topRadius.points
+            ),
+            // The top corners come from the token, so the style has to come
+            // from it too — a radius on the scale drawn with whatever style the
+            // SDK happens to default to is the one pairing that silently stops
+            // tracking the design system.
+            style: topRadius.style
         )
     }
 

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/VultDiscountTierView.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/View/VultDiscountTierView.swift
@@ -17,9 +17,12 @@ struct VultDiscountTierView: View {
     @State var isExpanded: Bool = false
     @State var isActiveInternal: Bool = false
 
-    private let topCornerRadius: CGFloat = 24
+    private let topCornerRadius: CGFloat = Theme.radius.xl.points
+    /// Deliberately off the scale. The card's 24-top / 20-bottom asymmetry is a
+    /// Figma value, not a rounding of one: the footer bar peeks out from under
+    /// the bottom edge and the two radii are drawn to sit together.
     private let bottomCornerRadius: CGFloat = 20
-    private let footerCornerRadius: CGFloat = 24
+    private let footerCornerRadius: CGFloat = Theme.radius.xl.points
     private let footerHeight: CGFloat = 48
 
     var holdAmountText: String {
@@ -83,9 +86,9 @@ private extension VultDiscountTierView {
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .background(Theme.colors.bgSurface1)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .clipShape(Theme.radius.lg.shape)
             .overlay(
-                RoundedRectangle(cornerRadius: 16)
+                Theme.radius.lg.shape
                     .stroke(Theme.colors.borderLight, lineWidth: 1)
             )
             .fixedSize(horizontal: true, vertical: true)

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/ChainDetailHeaderView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/ChainDetailHeaderView.swift
@@ -61,7 +61,7 @@ struct ChainDetailHeaderView: View {
             }
             .padding(.vertical, 4)
             .padding(.horizontal, 6)
-            .background(RoundedRectangle(cornerRadius: 8).fill(Color(hex: "5180FC").opacity(0.12)))
+            .background(Theme.radius.sm.shape.fill(Color(hex: "5180FC").opacity(0.12)))
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/RippleTrustLineActivationSheet.swift
@@ -115,7 +115,7 @@ struct RippleTrustLineActivationSheet: View {
             row("rippleTrustLineIssuer", value: viewModel.quote?.issuer, ticker: nil, truncatesInMiddle: true)
         }
         .padding(16)
-        .background(RoundedRectangle(cornerRadius: 12).fill(Theme.colors.bgSurface2))
+        .background(Theme.radius.md.shape.fill(Theme.colors.bgSurface2))
     }
 
     @ViewBuilder

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/TokenCellView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/View/TokenCellView.swift
@@ -41,7 +41,7 @@ struct TokenCellView: View {
                         .foregroundStyle(Theme.colors.textSecondary)
                         .padding(.vertical, 3)
                         .padding(.horizontal, 8)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(Theme.colors.bgSurface2))
+                        .background(Theme.radius.sm.shape.fill(Theme.colors.bgSurface2))
                         .fixedSize()
                         .contentTransition(.numericText())
                         .animation(.interpolatingSpring, value: coin.price)

--- a/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ModalBackgroundView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Receive/Screens/ModalBackgroundView.swift
@@ -11,6 +11,11 @@ struct ModalBackgroundView: View {
     let width: CGFloat
 
     var body: some View {
+        // Not a scale step, and deliberately not tokenised: this pattern is the
+        // backdrop of a presented sheet and its corner traces the sheet's, which
+        // the platform owns. The scale stops at 24 for the same reason it has no
+        // sheet step — a number that has to match a platform default is not ours
+        // to standardise.
         let cornerRadius: CGFloat = 34
         ZStack(alignment: .bottom) {
             magicPattern

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainBalanceView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/VaultMainBalanceView.swift
@@ -56,7 +56,7 @@ struct VaultMainBalanceView: View {
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 6)
-        .background(RoundedRectangle(cornerRadius: 8).fill(Color(hex: "5180FC").opacity(0.12)))
+        .background(Theme.radius.sm.shape.fill(Color(hex: "5180FC").opacity(0.12)))
         .frame(width: 120)
         .animation(.interactiveSpring(duration: 0.3), value: homeViewModel.hideVaultBalance)
     }

--- a/VultisigApp/VultisigAppTests/DesignSystem/CornerRadiusTokenTests.swift
+++ b/VultisigApp/VultisigAppTests/DesignSystem/CornerRadiusTokenTests.swift
@@ -110,6 +110,81 @@ final class CornerRadiusTokenTests: XCTestCase {
         }
     }
 
+    /// Several surfaces round only some of their corners — a badge's end cap, a
+    /// docked banner's top edge, a list's first and last row. Those take
+    /// `UnevenRoundedRectangle`, which cannot accept the token's `shape`, so the
+    /// call site passes `points` and `style` by hand. `pill` has to survive that
+    /// route too: its bound is far larger than any of these surfaces, and the
+    /// per-corner clamp is a different code path from the uniform one.
+    func testPillClampsTheSameWayOnIndividualCorners() {
+        let capRow = CGRect(x: 0, y: 0, width: 140, height: 32)
+
+        func endCap(_ radius: CGFloat) -> String {
+            UnevenRoundedRectangle(
+                topLeadingRadius: 0,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: radius,
+                topTrailingRadius: radius,
+                style: Theme.radius.pill.style
+            ).path(in: capRow).description
+        }
+
+        XCTAssertEqual(
+            endCap(Theme.radius.pill.points),
+            endCap(32),
+            "pill does not clamp to what the 32 literal it replaces clamps to"
+        )
+    }
+
+    /// `strokeBorder` insets the shape by half the line width before building
+    /// the path, and `inset(by:)` is used directly by several borders. `pill` is
+    /// a bound rather than a drawn number, so an inset has to leave it above the
+    /// clamp — otherwise a bordered capsule would quietly stop being one.
+    func testPillStaysFullyRoundAfterAnInset() {
+        let button = CGRect(x: 0, y: 0, width: 320, height: 44)
+        let inset = CGRect(x: 0.5, y: 0.5, width: 319, height: 43)
+
+        XCTAssertEqual(
+            Theme.radius.pill.shape.inset(by: 0.5).path(in: button).description,
+            Capsule(style: Theme.radius.pill.style).path(in: inset).description,
+            "pill stops clamping to a capsule once a border insets it"
+        )
+    }
+
+    /// `RoundedRectangle` and `UnevenRoundedRectangle` both default their corner
+    /// style, and the app leans on those defaults matching the token's — every
+    /// per-corner call site that was migrated passed the style in for the first
+    /// time. If the two ever disagree, that migration was a restyle rather than
+    /// a rename, and this is where it shows.
+    func testTheImplicitCornerStyleMatchesTheToken() {
+        let rect = CGRect(x: 0, y: 0, width: 200, height: 80)
+        let radius = Theme.radius.lg.points
+
+        func corners(style: RoundedCornerStyle?) -> String {
+            if let style {
+                return UnevenRoundedRectangle(
+                    topLeadingRadius: radius,
+                    bottomLeadingRadius: 0,
+                    bottomTrailingRadius: radius,
+                    topTrailingRadius: 0,
+                    style: style
+                ).path(in: rect).description
+            }
+            return UnevenRoundedRectangle(
+                topLeadingRadius: radius,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: radius,
+                topTrailingRadius: 0
+            ).path(in: rect).description
+        }
+
+        XCTAssertEqual(
+            corners(style: nil),
+            corners(style: Theme.radius.lg.style),
+            "UnevenRoundedRectangle's implicit style is not the token's"
+        )
+    }
+
     func testPillIsNotOnTheNumericScale() {
         let numericScale = allTokens.dropLast().map(\.points)
         XCTAssertFalse(numericScale.contains(Theme.radius.pill.points))


### PR DESCRIPTION
Part of #5024. **Phase 3 of 4** — the phase that makes the token layer universal.

Stacked: #5040 (token layer) → #5046 (containers) → **this**. Base is `feat/radius-containers-5024`, not `main`.

---

## The census — deliberately not a `cornerRadius(`-shaped grep

Phase 2 closed saying **181 raw literals remain**. That number came from a search shaped like the obvious form, and phase 2 had already been bitten once by exactly that: the iOS scanner's stroke was tokenised while its punch-out mask, written as `RoundedRectangle(cornerSize: CGSize(width: 24, height: 24))`, stayed a literal — a line containing no `cornerRadius` token at all.

So this phase started by scanning every *form* a radius can take:

```python
BINDERS = [
 ("cornerRadius(n)",      r"cornerRadius\s*\(\s*(\d+(?:\.\d+)?)\s*[,)]"),
 ("cornerRadius: n",      r"cornerRadius\s*:\s*(\d+(?:\.\d+)?)\b"),
 ("cornerRadius = n",     r"cornerRadius\s*=\s*(\d+(?:\.\d+)?)\b"),          # AppKit/UIKit layer
 ("cornerSize:",          r"cornerSize\s*:\s*(?:CGSize|\.init)\s*\(\s*width:\s*(\d+(?:\.\d+)?)"),
 ("perCorner",            r"\b(?:topLeading|topTrailing|bottomLeading|bottomTrailing)Radius\s*:\s*(\d+(?:\.\d+)?)\b"),
 ("RectangleCornerRadii", r"^\s*(?:topLeading|topTrailing|bottomLeading|bottomTrailing)\s*:\s*(\d+(?:\.\d+)?)\s*,?\s*$"),
 ("namedConst",           r"\b(?:let|var)\s+\w*(?:cornerRadius|Radius)\w*\s*:\s*CGFloat\s*=\s*(\d+(?:\.\d+)?)\b"),
 ("funcReturn",           r"^\s*case\s+[^:]+:\s*(\d+(?:\.\d+)?)\s*$"),        # inside a `-> CGFloat` radius func
]
```

Python walk over every `.swift` file in the repo, comments stripped, `Theme.radius.*` lines excluded.

**Total: 216 radius literal bindings, 202 of them non-zero.** That is 21 more than 181, and none of it is new code — it is the forms the earlier search could not see:

| Form | Bindings | Why a `cornerRadius` grep misses it |
|---|---|---|
| `cornerRadius(N)` / `cornerRadius: N` | 176 | — (the obvious form) |
| per-corner `…Radius:` on `UnevenRoundedRectangle` | 23 | corner *names*, not `cornerRadius` |
| `let/var …Radius: CGFloat = N` | 16 | one hop of indirection |
| `RectangleCornerRadii(topLeading: N, …)` | 12 | no radius keyword on the line at all |
| `cornerSize: CGSize(width: N, height: N)` | 3 | number lives inside a `CGSize` |
| `func …(for:) -> CGFloat { case …: 99 }` | 2 | **number returned from a `switch`** |
| `layer?.cornerRadius = N` | 1 | assignment, not a modifier |

The `funcReturn` row is the one worth remembering. `PrimaryButtonStyle.cornerRadius(for:)` returned `99` for four of its five button sizes — **the most-rendered radius in the app** — and no literal-shaped census can see it, because every call site reads `cornerRadius(for: size)`. Phase 1's plan even cites this function as the prior art for the token API's shape, and still did not count it.

The three `cornerSize` sites the brief predicted (`SendGasSettingsView` 120 / 232 / 285) were there. There were no others of that form outside the scanner viewports phase 2 already fixed.

---

## What changed on screen

Everything below is the whole of the visual change. It is in **one commit** (`fold the four off-scale small radii onto the scale`) so the ~150 pixel-identical conversions can be reviewed without reading a diff for movement.

| Value | Δ | Sites | Where | Why |
|---|---|---|---|---|
| **10 → `md` (12)** | **+2pt** | 21 | `GenericSelectorDropDown`, `FunctionCallSelectorDropdown`, `FunctionCallContractSelectorDropDown`, `FunctionCallAddThorLP` ×3, `FunctionCallWithdrawSecuredAsset` ×2, `FunctionCallSecuredAsset`, `ImportWalletUploadSection` ×3, `FileQRCodeImporterMac` ×2, `AddressBookTextField` ×2, `OutlinedDisclaimer` ×2, `Loader`, `JoinKeygenView`, `JoinKeysignView` | 10 was an unofficial step between `sm` and `md`. Nothing distinguishes these surfaces from the ones already at 12. Every site's pair (fill + dashed stroke overlay, or fill + border) moves together. |
| **5 → `md` (12)** | **+7pt** | 3 | `SendGasSettingsView` (iOS label, iOS field, macOS field) | Written as `cornerSize`, which is why it stayed a lone `5`. These are the sheet's own text fields plus a read-only label styled to match them — the same control as `GasLimitSettingsView`'s field one screen over, which is 12. Largest move in the PR. |
| **6 → `sm` (8)** | **+2pt** | 1 | `TransactionHistoryScreen` asset-filter chip | Alone at 6; `sm` is documented as the step for a small inline tag. |
| **14 → `md` (12)** | **−2pt** | 2 | `LockedFeatureSheet.balanceRow` (fill + border) | A nested surface inside the card; `md` is the app's nested step and 12 still reads as nested inside the card's 20. |

Nothing else moves. **27 sites total.**

---

## Outliers judged, with reasoning

### `32` (10 sites) — splits by geometry, not by value

Seven are surfaces under ~64pt on their smaller dimension, so `32` was *already clamped* by SwiftUI to half the smaller side and the rendered radius was the clamp. They become `pill` and are pixel-identical: the swap and keysign direction chevrons (~25pt), the swap chain chip glyph, the macOS percentage cell (~31pt), the send amount unit selector (~38pt wide), the Banxa CTA border (~46pt), and the referral-onboarding badge's end cap (~31pt, per-corner).

The instructive counter-example is in the same file as one of them. `SwapPercentageButtons` has an **iOS** cell at `16` on a ~35pt-tall box — just under the clamp, so it renders a real 16 and is a mechanical `lg` — and a **macOS** cell at `32` on a ~31pt box, which is a `pill`. Same component, two platform extensions, two different answers, and only the frame tells you which.

### `99` (1 site, 4 button sizes) — `pill`

`PrimaryButtonStyle` — not a radius anyone chose, just a number bigger than half a button's height. `radius(for:)` now vends a `CornerRadius`, so the border, the bevel overlay, the clip and the hit-test shape read one token instead of one number passed four ways. Its `.squared` case (12) becomes `md`.

### `20` (7 sites) — three different answers

- `VultDiscountTierView`'s `bottomCornerRadius` and `LockedFeatureSheet`'s `cardCornerRadius`: **left**, per the ruling. The 24-top / 20-bottom asymmetry is deliberate.
- `VultDiscountTierView`'s footer clip + border (2 sites, both bare `20`): **left at 20, but rewired** — see the pairing fix below.
- `LimitSwapBodyView`'s price toggle track: `20` on a 38pt-tall control, i.e. already clamped → **`pill`**, pixel-identical.
- `KeyImportActiveChainsView`'s chain row: **left**, and now commented. It is a 20 that is *not* the tier card's, and it is equidistant from 16 and 24 — no reading of the scale picks one.

### `18` (1 site) — `pill`

`LimitSwapBodyView`'s toggle *thumb*: 18 on a 32×32 frame, already clamped. It is one control with the 20pt track above — **the pair moves together or the two desync**.

### `33` (2 sites) — left

`PeerDiscoveryScreen`'s QR frame and its 8pt gradient ring. One drawn object at a size nothing else in the app uses; the nearest step is 9pt away, on the screen the pairing flow is built around. Both radii are the same number because they are the same edge, so they move together or not at all. This was phase 2's open question 3 and stays open.

### `14` → `md`, `6` → `sm`, `5` → `md`

See the table above.

### `34`, `40`, `27` — found by this census, not on the brief's list; all left

- `ModalBackgroundView` (34): the backdrop pattern of a **presented sheet**, clipped to the sheet's corner. Sheets take the platform radius — the same reason the scale has no sheet step.
- `ForegroundNotificationBannerView` (40): full-bleed, `ignoresSafeArea`, bottom curve drawn against the *device's* screen corners. 24 reads as a card stuck to the top of the screen.
- `NotchedRectangle.notchRadius` (27): documented in-place as `SwapAssetsButton`'s outer radius plus an 8pt moat. A restatement of a neighbour's *size*, not a corner of a surface.

### `1` and `2` — left, per the ruling

16×1 step connectors and 3pt Tron progress bars. Worth recording: both are technically **above** half their own thickness, so they already render fully round and `pill` would be pixel-identical. Left because the ruling says leave them.

### `TooltipShape` — split

The bubble's own corners (16 → `lg`, 4 → `xs`) are tokenised. Its `arrowCornerRadius` (2) and `arrowJunctionRadius` (4) are **not**: they are placed along the arrow's diagonal and sized against `arrowWidth`/`arrowHeight`, so they belong to the arrow's geometry, not to the scale. Both now say so.

---

## Input fields — the phase-2 deferral, closed

Phase 2 deliberately left them, and the effect was that the app's **most repeated radius** stayed a magic number: 12, on every text field, text editor and number field.

They are tokenised **at their current value**. `CommonTextField`, `CommonTextEditor`, `MemoTextField`, `DestinationTagTextField`, `StyledTextField`, `StyledNumberField`, `StyledFloatingPointField`, `HiddenTextField`, `SendDetailsAddressFields`, `GasLimitSettingsView`, `CustomRPCDetailScreen` and `BackspaceDetectingTextField`'s AppKit `layer?.cornerRadius` all still render 12. `AddressBookTextField` (10) and `SendGasSettingsView` (5) join them at 12 as part of the value-changing commit.

Nothing about an input's appearance changes. The point is that *"should inputs be 16 or 24?"* is now **one line in `CornerRadiusSystem`** instead of another 16-file sweep.

---

## The pairing fix

Phase 2's four review rounds all found the same defect, and this phase's review was pointed at it explicitly:

> A radius literal is either a surface's **own** geometry, or a **restatement of a neighbour's** — and only the call site tells you which.

One live instance was found and fixed. `VultDiscountTierView`'s gradient footer wrote its bottom corners as a bare `20` twice — once in its clip, once in its border. That is the **card's** radius, not the bar's: the bar sits behind the card and peeks out from under its bottom edge, so its curve has to be the curve it emerges from. As two literals, moving the card would have left the footer cutting across the corner it traces. Both now read `bottomCornerRadius`.

Pairs checked and kept in step: every fill + stroke/overlay drawing the same edge (including the ones with `.inset(by:)` / `.strokeBorder`), the limit-swap toggle's track and thumb, the address-field accessory row's per-corner radii, the referral badge's clip + inset stroke, and the scanner masks phase 2 fixed.

---

## Tests

Three added to `CornerRadiusTokenTests`, each backing a claim this PR makes rather than restating the scale:

- **`testPillClampsTheSameWayOnIndividualCorners`** — `UnevenRoundedRectangle` clamps per-corner, which is a different code path from the uniform clamp. The referral badge's end cap goes through it, so `pill` has to produce the same path as the `32` it replaces.
- **`testPillStaysFullyRoundAfterAnInset`** — `strokeBorder` and `inset(by:)` shrink the shape before the path is built. `pill` is a *bound*, not a drawn number, so an inset has to leave it above the clamp.
- **`testTheImplicitCornerStyleMatchesTheToken`** — every per-corner site migrated here passes the corner style **explicitly for the first time**. That is only a rename rather than a restyle if the SDK's implicit style is the token's. This is the tripwire if it is not.

---

## Verification

- **iOS**: `make test` on a dedicated en_US iPhone 16 Pro — `** TEST SUCCEEDED **`, **4624 tests, 1 skipped, 0 failures**
- **macOS**: `xcodebuild build -destination platform=macOS` — `** BUILD SUCCEEDED **` (the iOS gate does not compile macOS-only code, and this PR touches `FileQRCodeImporterMac`, `BackspaceDetectingTextField`, `ServerBackupVerificationView` and both platform extensions of `SwapPercentageButtons` and `SendGasSettingsView`)
- **SwiftLint**: 39 violations, unchanged from baseline
- **Codex** (`gpt-5.5-high`, read-only, whole-branch): round 1 raised **8 MINOR**, 0 BLOCKER/MAJOR; round 2 returned **No findings**. Triage below.

---

## Final literal count

Re-running the same census on the finished branch: **202 non-zero → 17.** Every one is a deliberate keep, and each says why in place.

| Value | Sites | Kept because |
|---|---|---|
| 1 | 2 | 16×1 step connectors — hairlines |
| 2 | 4 | 3pt Tron progress bars (3) and `TooltipShape`'s arrow tip |
| 4 | 1 | `TooltipShape`'s arrow/body junction fillet |
| 10 | 1 | `FigmaParitySelfTests`' fixture — deliberately fixed geometry, not a design surface |
| 20 | 3 | tier card bottom, locked-feature card, key-import chain row |
| 27 | 1 | `NotchedRectangle`'s notch cavity — the toggle's size plus its moat |
| 33 | 2 | QR frame and its 8pt ring |
| 34 | 1 | sheet backdrop, tracing a platform corner |
| 40 | 2 | full-bleed notification banner |

Nothing remains except the deliberate `20` / `1` / `2` keeps the brief called for, plus five one-off surfaces this census surfaced and documented (`4` arrow fillet, `10` test fixture, `27`, `33`, `34`, `40`).

**Phase 4's lint rule is now unblocked.** Its stated blocker was "181 literals remain, and the human-call list is why". Seventeen documented exceptions is an allowlist, not a backlog.

---

## Cross-model review

`codex exec --sandbox read-only` (gpt-5.5-high), whole-branch, pointed explicitly at the paired-radius class.

**Round 1 — 8 MINOR, 0 BLOCKER/MAJOR:**

| Finding | Disposition |
|---|---|
| DeFi skeletons draw 16pt button placeholders, but the real `DefiButton` uses `PrimaryButtonStyle` → capsule | **Fixed.** This is the paired-radius bug, found in the predicted shape. See below. |
| `VultDiscountTierView` / `LockedFeatureSheet` extract `.points` into a `CGFloat`, then build shapes whose style falls back to the SDK | **Fixed.** Both hold a `CornerRadius` and use `.shape`; the tier card's mixed radii pass `style:` across by hand. This is the exact pairing `CornerRadius`'s own doc comment warns about. |
| `BackspaceDetectingTextField` takes the token's points but `CALayer`'s `cornerCurve` stays the AppKit default | **Accepted as documented, not changed.** `cornerCurve` is a different axis from SwiftUI's `RoundedCornerStyle`; changing it would be an unrequested visual change to that macOS control. Stated in place so it does not read as a half-migration. |
| `SwapPercentageButtons` iOS is `lg` while macOS is `pill` | **Rejected with reason, now commented.** The two genuinely render differently: the iOS cell has 2pt more vertical padding per side, which kept its 16 *under* the clamp while macOS's 32 went over. Unifying them is a visual change on one platform, and a design question. |
| The clamp claim can break under Dynamic Type — `.headline` / a scaling SF Symbol can push the Banxa CTA and the referral badge past 64pt tall, where `32` would stop clamping but `pill` does not (×2) | **Accepted as a narrowed claim, now commented.** Judged the *intent* of the idiom rather than a regression. The general lesson is worth stating: a clamp argument is a claim about a rendered frame, and a frame that scales with text is not a constant. |

**Round 2 — `No findings.`**

### The bug it found

Phase 2 closed by naming the one defect it kept hitting. The reviewer found a sixth instance, in the shape the brief predicted: **a skeleton that no longer traces what it replaces.** The two DeFi position skeletons drew their button placeholders at 16 while the real rows draw `DefiButton`, i.e. capsules — so the buttons visibly changed shape the moment data landed.

The mismatch predates this branch. What made it *findable* is this PR: replacing the `99` buried inside `PrimaryButtonStyle.cornerRadius(for:)` with the word `pill` is what made the two sides comparable. Fixed in the last commit.

---

## Left for a human

1. **`PeerDiscoveryScreen`'s QR frame (33)** — carried over from phase 2, still open. A container by the rule, but 33 looks matched to the 8pt border it is drawn with.
2. **The `1`s and `2`s are technically capsules.** The 16×1 step connectors and the 3pt Tron progress bars have radii above half their own thickness, so they already render fully round and `pill` would be pixel-identical. Left because the ruling says leave them — but one word collapses six more sites at zero risk.
3. **`VultDiscountTierView.footerInnerShadow` draws at `xl` while the footer is clipped to 20.** Pre-existing and invisible (the highlight is blurred and masked to a fading gradient). Untouched, because "fixing" it means deciding which of the two is wrong.
4. **`SwapPercentageButtons` renders differently on iOS and macOS** — now legible as a design question rather than two arbitrary numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
