### PR TITLE
fix(signing): guard Solana/Sui/Tron pre-sign on chain, not ticker

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/Solana.swift
@@ -18,7 +18,7 @@ enum SolanaHelper {
     static let ataRentLamports: BigInt = 2_039_280
 
     static func getPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
-        guard keysignPayload.coin.chain.ticker == "SOL" else {
+        guard keysignPayload.coin.chain == .solana else {
             throw HelperError.runtimeError("coin is not SOL")
         }
         guard case .Solana(let recentBlockHash, let priorityFee, let priorityLimit, let fromAddressPubKey, let toAddressPubKey, let tokenProgramId) = keysignPayload.chainSpecific else {

--- a/VultisigApp/VultisigApp/Blockchain/Sui/Signing/Sui.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Sui/Signing/Sui.swift
@@ -13,7 +13,7 @@ import BigInt
 enum SuiHelper {
 
     static func getPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
-        guard keysignPayload.coin.chain.ticker == "SUI" else {
+        guard keysignPayload.coin.chain == .sui else {
             throw HelperError.runtimeError("coin is not SUI")
         }
 

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -20,7 +20,7 @@ enum TronHelper {
 
     static func getPreSignedInputData(keysignPayload: KeysignPayload) throws -> Data {
 
-        guard keysignPayload.coin.chain.ticker == "TRX" else {
+        guard keysignPayload.coin.chain == .tron else {
             throw HelperError.runtimeError("coin is not TRX")
         }
 


### PR DESCRIPTION
## Summary
- `SolanaHelper.getPreSignedInputData` guarded on `chain.ticker == "SOL"`, `SuiHelper.getPreSignedInputData` on `chain.ticker == "SUI"`, and `TronHelper.getPreSignedInputData` on `chain.ticker == "TRX"`. Ticker is a display-adjacent value that can change on rebrand or config edit, so a ticker guard silently breaks sending for the whole chain if the ticker ever changes (this already happened for TON, fixed in #5022/#5035).
- Changed all three guards to compare chain identity (`chain == .solana` / `.sui` / `.tron`) instead, preserving existing fail-closed behavior and error messages.
- Swept the rest of the codebase for `ticker ==` comparisons used as identity checks on signing/validation paths — the remaining matches are legitimate ticker lookups (e.g. matching USDC/RUNE across chains) or historical one-off migrations, not chain-identity guards, so no further changes were needed.

## Issue
Closes #5039

## Test Plan
- [x] SwiftLint passes on changed files (0 violations)
- [ ] Manual: send SOL/SUI/TRX from the app and confirm pre-sign succeeds

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction validation for Solana, Sui, and Tron.
  * Ensured signing checks use the selected blockchain rather than ticker symbols.
  * Preserved existing error handling for invalid blockchain selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->