### PR TITLE
fix(tron): accept compressed public key on cross-device keysign

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/SwapKitTronSigner.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/SwapKitTronSigner.swift
@@ -85,11 +85,9 @@ enum SwapKitTronSigner {
         signatures: [String: TssKeysignResponse],
         pubKeyHex: String
     ) throws -> SignedTransactionResult {
-        guard let pubKeyData = Data(hexString: pubKeyHex),
-              let secp = PublicKey(data: pubKeyData, type: .secp256k1Extended) else {
+        guard let publicKey = try? TronHelper.uncompressedPublicKey(fromHex: pubKeyHex) else {
             throw SwapKitTronSignerError.invalidPublicKey(pubKeyHex)
         }
-        let publicKey = secp.uncompressed
 
         let parsed = try parsePayload(payload.txPayload)
         let rawDataBytes = parsed.rawDataBytes

--- a/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tron/Signing/Tron.swift
@@ -393,15 +393,30 @@ enum TronHelper {
         return [preSigningOutput.dataHash.hexString]
     }
 
+    /// Tron addresses derive from the uncompressed (65-byte, `0x04`-prefixed)
+    /// secp256k1 key, but a peer device's `KeysignPayload.coin.hexPublicKey`
+    /// may legitimately carry the standard compressed (33-byte) form instead
+    /// — that's what every other chain stores, and other platforms' Tron
+    /// implementations aren't guaranteed to special-case it the way this
+    /// app's `CoinFactory` does. Accept either wire format rather than
+    /// rejecting a validly-signed cross-device transaction as "invalid".
+    static func uncompressedPublicKey(fromHex hex: String) throws -> PublicKey {
+        guard let data = Data(hexString: hex) else {
+            throw CoinFactory.Errors.invalidPublicKey(pubKey: hex)
+        }
+        if let extended = PublicKey(data: data, type: .secp256k1Extended) {
+            return extended.uncompressed
+        }
+        guard let compressed = PublicKey(data: data, type: .secp256k1) else {
+            throw CoinFactory.Errors.invalidPublicKey(pubKey: hex)
+        }
+        return compressed.uncompressed
+    }
+
     static func getSignedTransaction(
         keysignPayload: KeysignPayload,
         signatures: [String: TssKeysignResponse]) throws -> SignedTransactionResult {
-        guard
-            let pubKeyData = Data(hexString: keysignPayload.coin.hexPublicKey),
-            let secp256k1PubKey = PublicKey(data: pubKeyData, type: .secp256k1Extended) else {
-            throw CoinFactory.Errors.invalidPublicKey(pubKey: keysignPayload.coin.hexPublicKey)
-        }
-        let publicKey = secp256k1PubKey.uncompressed
+        let publicKey = try uncompressedPublicKey(fromHex: keysignPayload.coin.hexPublicKey)
         let inputData = try getPreSignedInputData(
             keysignPayload: keysignPayload
         )

--- a/VultisigApp/VultisigAppTests/Chains/TronPublicKeyFormatTests.swift
+++ b/VultisigApp/VultisigAppTests/Chains/TronPublicKeyFormatTests.swift
@@ -1,0 +1,44 @@
+//
+//  TronPublicKeyFormatTests.swift
+//  VultisigAppTests
+//
+//  A peer device joining a Tron keysign (e.g. Android initiating a
+//  Freeze/Unfreeze) may send `KeysignPayload.coin.hexPublicKey` in the
+//  standard compressed secp256k1 form rather than this app's
+//  Tron-specific uncompressed one. `TronHelper.uncompressedPublicKey`
+//  must accept both, or a validly cosigned transaction gets rejected
+//  locally as "public key is invalid" even though the peer already
+//  broadcast it successfully.
+//
+
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+final class TronPublicKeyFormatTests: XCTestCase {
+
+    private let compressedHex = "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"
+
+    private var expectedUncompressedData: Data {
+        PublicKey(data: Data(hexString: compressedHex)!, type: .secp256k1)!.uncompressed.data
+    }
+
+    func testAcceptsCompressedPublicKey() throws {
+        let result = try TronHelper.uncompressedPublicKey(fromHex: compressedHex)
+        XCTAssertEqual(result.data, expectedUncompressedData)
+    }
+
+    func testAcceptsUncompressedPublicKey() throws {
+        let extendedHex = expectedUncompressedData.hexString
+        let result = try TronHelper.uncompressedPublicKey(fromHex: extendedHex)
+        XCTAssertEqual(result.data, expectedUncompressedData)
+    }
+
+    func testRejectsNonHexString() {
+        XCTAssertThrowsError(try TronHelper.uncompressedPublicKey(fromHex: "not-hex"))
+    }
+
+    func testRejectsValidHexThatIsNotAPublicKey() {
+        XCTAssertThrowsError(try TronHelper.uncompressedPublicKey(fromHex: "deadbeef"))
+    }
+}


### PR DESCRIPTION
## Description

A device joining a Tron keysign trusted the initiator's `KeysignPayload.coin.hexPublicKey` to already be in the uncompressed secp256k1 format WalletCore's `Tron::Address` requires. When the initiator sent the standard compressed form instead — as observed with Android's Freeze/Unfreeze feature — the joining iOS device rejected an otherwise-valid, already-broadcast transaction with "public key is invalid" (`CoinFactory.Errors.invalidPublicKey`), even though the TSS keysign itself succeeded and the initiator had already broadcast successfully.

`TronHelper.uncompressedPublicKey(fromHex:)` (`Tron.swift`) now accepts either wire format: it tries the extended/uncompressed form first, falling back to parsing as standard compressed secp256k1 and converting. Applied to both `Tron.swift:getSignedTransaction` and `SwapKitTronSigner.swift:compileSignedTransaction` (same assumption existed there for SwapKit-routed Tron swaps).

Reported directly by a maintainer (no tracked issue number) as: Tron Freeze/Unfreeze initiated on Android, paired with iOS — keysign succeeds and Android broadcasts, but iOS fails locally reporting the public key is invalid.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [x] New Chain / Chain related feature  -  Please attach tx link here

## Parity

- Android: n/a — verified in `vultisig-android`'s `TronHelper.kt`: its `getSignedTransaction` never trusts the peer's wire `coin.hexPublicKey` for signing; it re-derives the key locally from the vault's own root key (`PublicKeyHelper.getDerivedPublicKey`), so it isn't exposed to this wire-format mismatch in either direction.
- Windows + extension: not checked — didn't have access to verify.
- SDK: not checked — didn't have access to verify.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

N/A — signing-layer fix, not UI.

## Additional context

Root cause traced from a user report: Android initiates a Tron Freeze/Unfreeze, pairs with iOS, TSS keysign completes and Android broadcasts fine, but iOS locally fails with "public key is invalid" when it independently recompiles the signed transaction. `PublicKey(data:type:.secp256k1Extended)` in WalletCore requires exactly 65 bytes with a `0x04` prefix (`PublicKey::isValid` in `wallet-core/src/PublicKey.cpp`) — a 33-byte compressed key fails that check outright.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: none tracked
- **Confidence**: high
- **Needs human review for**: TSS/keysign-path signing logic (per repo security tier — crypto changes require maintainer review)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TRON transaction signing to support both compressed and uncompressed public keys.
  * Invalid or undecodable public keys continue to be rejected safely.

* **Tests**
  * Added coverage for public-key conversion, including valid compressed and uncompressed keys and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->