### PR TITLE
feat(defi): Kamino Earn plumbing — REST client, Solana v0 message editor, transaction validator

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaAddressLookupTable.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaAddressLookupTable.swift
@@ -16,15 +16,15 @@ enum SolanaAddressLookupTableError: Error, LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .accountNotFound(let table):
-            return "Address lookup table \(table) does not exist on chain"
+            return String(format: "solanaAddressLookupTableErrorAccountNotFound".localized, table)
         case .wrongOwner(let table, let owner):
-            return "Account \(table) is owned by \(owner), not the Address Lookup Table program"
+            return String(format: "solanaAddressLookupTableErrorWrongOwner".localized, table, owner)
         case .unsupportedEncoding(let table):
-            return "Address lookup table \(table) was returned in an unexpected encoding"
+            return String(format: "solanaAddressLookupTableErrorUnsupportedEncoding".localized, table)
         case .malformedAccountData(let table):
-            return "Address lookup table \(table) has malformed account data"
+            return String(format: "solanaAddressLookupTableErrorMalformedData".localized, table)
         case .uninitialized(let table):
-            return "Address lookup table \(table) is not initialized"
+            return String(format: "solanaAddressLookupTableErrorUninitialized".localized, table)
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaAddressLookupTable.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaAddressLookupTable.swift
@@ -1,0 +1,105 @@
+//
+//  SolanaAddressLookupTable.swift
+//  VultisigApp
+//
+
+import Foundation
+import WalletCore
+
+enum SolanaAddressLookupTableError: Error, LocalizedError, Equatable {
+    case accountNotFound(String)
+    case wrongOwner(table: String, owner: String)
+    case unsupportedEncoding(table: String)
+    case malformedAccountData(table: String)
+    case uninitialized(table: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .accountNotFound(let table):
+            return "Address lookup table \(table) does not exist on chain"
+        case .wrongOwner(let table, let owner):
+            return "Account \(table) is owned by \(owner), not the Address Lookup Table program"
+        case .unsupportedEncoding(let table):
+            return "Address lookup table \(table) was returned in an unexpected encoding"
+        case .malformedAccountData(let table):
+            return "Address lookup table \(table) has malformed account data"
+        case .uninitialized(let table):
+            return "Address lookup table \(table) is not initialized"
+        }
+    }
+}
+
+/// Supplies the contents of Address Lookup Tables. Injected so a validator can be
+/// exercised against pinned table contents instead of the network.
+protocol SolanaAddressLookupTableFetching {
+    /// - Returns: table address to that table's full address list. Every
+    ///   requested address must be present in the result.
+    func fetchAddressLookupTables(addresses: [String]) async throws -> [String: [String]]
+}
+
+/// Decoder for an on-chain Address Lookup Table account.
+///
+/// A v0 transaction addresses lookup-table-loaded accounts by *position*, so an
+/// index on its own says nothing about which account is being touched. Anything
+/// that reasons about what a transaction actually does — which is the whole point
+/// of validating one before signing it — has to resolve those positions against
+/// the table's real contents, which means reading the account.
+///
+/// The account is read as raw `base64` rather than `jsonParsed`. `jsonParsed`
+/// would hand the decode to whichever RPC node answered, and the addresses it
+/// returns are what the app then compares its safety checks against; decoding the
+/// bytes here keeps that step deterministic and testable.
+enum SolanaAddressLookupTable {
+
+    /// Owner every lookup-table account must have.
+    static let programId = "AddressLookupTab1e1111111111111111111111111"
+
+    /// `LookupTableMeta` occupies a fixed 56-byte prefix — the 4-byte bincode
+    /// enum discriminant, `deactivation_slot` (u64), `last_extended_slot` (u64),
+    /// `last_extended_slot_start_index` (u8), an `Option<Pubkey>` authority
+    /// (1 + 32) and 2 bytes of padding. The address list starts immediately after.
+    static let metadataSize = 56
+
+    /// `ProgramState::LookupTable`. `0` is `Uninitialized`, which carries no
+    /// addresses at all.
+    static let lookupTableDiscriminant: UInt32 = 1
+
+    /// Decodes the address list from a `getAccountInfo` result.
+    ///
+    /// - Parameters:
+    ///   - table: the table's own address, used only for error messages.
+    ///   - owner: the account's owner as reported by the RPC.
+    ///   - data: the `data` array, `[payload, encoding]`.
+    static func addresses(table: String, owner: String, data: [String]) throws -> [String] {
+        guard owner == programId else {
+            throw SolanaAddressLookupTableError.wrongOwner(table: table, owner: owner)
+        }
+        guard data.count >= 2, data[1] == "base64", let payload = Data(base64Encoded: data[0]) else {
+            throw SolanaAddressLookupTableError.unsupportedEncoding(table: table)
+        }
+        return try addresses(table: table, accountData: [UInt8](payload))
+    }
+
+    static func addresses(table: String, accountData: [UInt8]) throws -> [String] {
+        guard accountData.count >= metadataSize else {
+            throw SolanaAddressLookupTableError.malformedAccountData(table: table)
+        }
+
+        let discriminant = accountData[0..<4].reversed().reduce(UInt32(0)) { $0 << 8 | UInt32($1) }
+        guard discriminant == lookupTableDiscriminant else {
+            throw SolanaAddressLookupTableError.uninitialized(table: table)
+        }
+
+        let body = accountData.count - metadataSize
+        // A trailing partial key would mean the table was decoded at the wrong
+        // offset, and every address after that point would be wrong by some
+        // number of bytes rather than obviously invalid.
+        guard body % 32 == 0 else {
+            throw SolanaAddressLookupTableError.malformedAccountData(table: table)
+        }
+
+        return stride(from: metadataSize, to: accountData.count, by: 32).map { offset in
+            Base58.encodeNoCheck(data: Data(accountData[offset..<(offset + 32)]))
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaAssociatedTokenAccount.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Models/SolanaAssociatedTokenAccount.swift
@@ -1,0 +1,54 @@
+//
+//  SolanaAssociatedTokenAccount.swift
+//  VultisigApp
+//
+
+import Foundation
+import WalletCore
+
+/// The two SPL token programs an associated token account can belong to. The
+/// program is part of the ATA's derivation seeds, so the same owner and mint
+/// produce two different addresses under the two programs.
+enum SolanaTokenProgram: String, CaseIterable {
+    case token = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    case token2022 = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+
+    init?(programId: String) {
+        self.init(rawValue: programId)
+    }
+}
+
+/// Derivation of associated token account addresses.
+///
+/// This is how "did the funds go to an account the user controls?" is answered
+/// without trusting anything the transaction builder said: the ATA is a program
+/// address derived from the owner, the token program and the mint, so it can be
+/// recomputed locally and compared.
+enum SolanaAssociatedTokenAccount {
+
+    static let programId = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+
+    static func derive(owner: String, mint: String, tokenProgram: SolanaTokenProgram) -> String? {
+        guard let address = WalletCore.SolanaAddress(string: owner) else { return nil }
+        let derived: String?
+        switch tokenProgram {
+        case .token:
+            derived = address.defaultTokenAddress(tokenMintAddress: mint)
+        case .token2022:
+            derived = address.token2022Address(tokenMintAddress: mint)
+        }
+        guard let derived, !derived.isEmpty else { return nil }
+        return derived
+    }
+
+    /// Every associated token account `owner` can hold for `mint`, one per token
+    /// program.
+    ///
+    /// A mint belongs to exactly one token program on chain, but which one is not
+    /// known from the mint address alone. Both derivations are the user's own
+    /// account, so treating the pair as the answer stays fail-closed against a
+    /// third party's address while never rejecting the user's own.
+    static func ownedAccounts(owner: String, mint: String) -> Set<String> {
+        Set(SolanaTokenProgram.allCases.compactMap { derive(owner: owner, mint: mint, tokenProgram: $0) })
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
@@ -36,6 +36,15 @@ struct SolanaAPI: TargetType {
 
     enum Method {
         case sendTransaction(encodedTransaction: String)
+        /// Dry-runs a transaction against the current bank without broadcasting.
+        /// Used to prove a third-party-built transaction actually executes — and
+        /// to measure its compute usage — before it is put in front of a signer.
+        ///
+        /// `replaceRecentBlockhash` lets the node substitute its own blockhash so
+        /// a transaction can be simulated before the pre-keysign refresh
+        /// installs a fresh one; passing `false` simulates the exact bytes,
+        /// which is what proves a spliced blockhash is live.
+        case simulateTransaction(encodedTransaction: String, replaceRecentBlockhash: Bool)
         case getBalance(address: String)
         case getRecentPrioritizationFees
         case getLatestBlockhash
@@ -104,6 +113,27 @@ struct SolanaAPI: TargetType {
                 rpcEnvelope(
                     method: "sendTransaction",
                     params: [encodedTransaction, ["encoding": "base64", "preflightCommitment": "confirmed"]]
+                ),
+                .jsonEncoding
+            )
+        case .simulateTransaction(let encodedTransaction, let replaceRecentBlockhash):
+            // `sigVerify` is pinned off: the transactions this simulates still
+            // carry an all-zero placeholder signature, and the RPC rejects the
+            // combination of signature verification with blockhash replacement
+            // outright. Commitment matches the blockhash fetch so the simulation
+            // runs against the same bank the broadcast preflight will.
+            return .requestParameters(
+                rpcEnvelope(
+                    method: "simulateTransaction",
+                    params: [
+                        encodedTransaction,
+                        [
+                            "encoding": "base64",
+                            "commitment": "confirmed",
+                            "sigVerify": false,
+                            "replaceRecentBlockhash": replaceRecentBlockhash
+                        ]
+                    ]
                 ),
                 .jsonEncoding
             )
@@ -228,6 +258,91 @@ struct SolanaSendTransactionResponse: Decodable {
                 stringValue = try? container.decode(String.self)
             }
         }
+    }
+}
+
+/// A JSON value of unknown shape, decoded far enough to be rendered.
+///
+/// `simulateTransaction`'s `err` is polymorphic: `null` on success, a bare string
+/// (`"BlockhashNotFound"`) for transaction-level failures, and an object
+/// (`{"InstructionError":[3,{"Custom":6003}]}`) for program failures. The
+/// interesting part — which instruction failed and with what code — lives inside
+/// the object form, so it cannot be flattened to a `String?`.
+indirect enum SolanaRPCJSONValue: Decodable, Equatable {
+    case null
+    case bool(Bool)
+    case number(String)
+    case string(String)
+    case array([SolanaRPCJSONValue])
+    case object([String: SolanaRPCJSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int64.self) {
+            self = .number(String(value))
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(String(value))
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([SolanaRPCJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: SolanaRPCJSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported JSON value in Solana RPC response"
+            )
+        }
+    }
+
+    /// Stable rendering for logs and error messages. Object keys are sorted so
+    /// the same failure always reads the same way.
+    var text: String {
+        switch self {
+        case .null:
+            return "null"
+        case .bool(let value):
+            return value ? "true" : "false"
+        case .number(let value):
+            return value
+        case .string(let value):
+            return value
+        case .array(let values):
+            return "[" + values.map(\.text).joined(separator: ", ") + "]"
+        case .object(let values):
+            let body = values.sorted { $0.key < $1.key }
+                .map { "\($0.key): \($0.value.text)" }
+                .joined(separator: ", ")
+            return "{" + body + "}"
+        }
+    }
+}
+
+/// `simulateTransaction` payload. `result` and `error` are mutually exclusive:
+/// `error` is a transport-level JSON-RPC failure, while a transaction that ran
+/// and failed comes back as a successful `result` with a non-null `value.err`.
+struct SolanaSimulateTransactionResponse: Decodable {
+    let result: Result?
+    let error: RPCError?
+
+    struct Result: Decodable {
+        let value: Value
+
+        struct Value: Decodable {
+            let err: SolanaRPCJSONValue?
+            let logs: [String]?
+            let unitsConsumed: UInt64?
+        }
+    }
+
+    struct RPCError: Decodable {
+        let code: Int
+        let message: String
     }
 }
 

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaAPI.swift
@@ -58,6 +58,13 @@ struct SolanaAPI: TargetType {
         case getLatestBlockhashFinalized
         case getTokenAccountsByOwner(walletAddress: String, filter: TokenAccountFilter)
         case getAccountInfo(address: String)
+        /// Raw (`base64`) account data for an Address Lookup Table.
+        ///
+        /// Deliberately not `jsonParsed`: the addresses in a lookup table are
+        /// what a v0 transaction's account indices actually resolve to, so they
+        /// are the ground truth every pre-signing safety check compares against.
+        /// `jsonParsed` would delegate that decode to whichever node answered.
+        case getAddressLookupTable(address: String)
         /// All validators (vote accounts), `current` + `delinquent`.
         case getVoteAccounts
         /// Stake-program accounts owned by `staker`. `dataSize:200` excludes
@@ -164,6 +171,11 @@ struct SolanaAPI: TargetType {
         case .getAccountInfo(let address):
             return .requestParameters(
                 rpcEnvelope(method: "getAccountInfo", params: [address, ["encoding": "jsonParsed"]]),
+                .jsonEncoding
+            )
+        case .getAddressLookupTable(let address):
+            return .requestParameters(
+                rpcEnvelope(method: "getAccountInfo", params: [address, ["encoding": "base64", "commitment": "confirmed"]]),
                 .jsonEncoding
             )
         case .getVoteAccounts:
@@ -382,6 +394,24 @@ struct SolanaGetAccountInfoResponse: Decodable {
 
         struct Value: Decodable {
             let owner: String
+        }
+    }
+}
+
+/// `getAccountInfo` with `encoding: base64`. A missing `value` means the account
+/// does not exist, which for a lookup table is a refusal rather than an empty
+/// table — an unresolvable index cannot be checked.
+struct SolanaGetAccountInfoBase64Response: Decodable {
+    let result: Result
+
+    struct Result: Decodable {
+        let value: Value?
+
+        struct Value: Decodable {
+            let owner: String
+            /// `[payload, encoding]` — the RPC returns the encoding it used
+            /// alongside the data, and it is asserted rather than assumed.
+            let data: [String]
         }
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -32,6 +32,17 @@ enum SolanaRetryableError: Error, LocalizedError, RetryableBroadcastError {
     }
 }
 
+/// Outcome of a `simulateTransaction` dry run.
+struct SolanaSimulationResult: Equatable {
+    /// `nil` when the transaction executed cleanly. Otherwise the rendered
+    /// `err`, e.g. `BlockhashNotFound` or `{InstructionError: [3, {Custom: 6003}]}`.
+    let failure: String?
+    let unitsConsumed: UInt64?
+    let logs: [String]
+
+    var succeeded: Bool { failure == nil }
+}
+
 class SolanaService {
     static let shared = SolanaService()
 
@@ -144,6 +155,47 @@ class SolanaService {
         // Unreachable: the loop either returns a result or throws on the final
         // attempt. Present to satisfy the non-optional control-flow analysis.
         return nil
+    }
+
+    /// Dry-runs a transaction against the current bank. Returns the outcome
+    /// rather than throwing on an on-chain failure — "this transaction would
+    /// fail, and here is why" is a result the caller acts on, not a transport
+    /// error. A JSON-RPC transport failure still throws.
+    ///
+    /// - Parameter replaceRecentBlockhash: `true` lets the node substitute its
+    ///   own blockhash, so a transaction can be checked before the pre-keysign
+    ///   refresh gives it a live one. `false` simulates the exact bytes.
+    func simulateTransaction(
+        base64Transaction: String,
+        replaceRecentBlockhash: Bool
+    ) async throws -> SolanaSimulationResult {
+        let response = try await httpClient.request(
+            api(.simulateTransaction(
+                encodedTransaction: base64Transaction,
+                replaceRecentBlockhash: replaceRecentBlockhash
+            )),
+            responseType: SolanaSimulateTransactionResponse.self
+        )
+
+        if let error = response.data.error {
+            throw SolanaServiceError.rpcError(message: error.message, code: error.code)
+        }
+        guard let value = response.data.result?.value else {
+            throw SolanaServiceError.rpcError(message: "simulateTransaction returned no result", code: -1)
+        }
+
+        let logs = value.logs ?? []
+        if let failure = value.err {
+            logger.warning(
+                "solana simulation failed: \(failure.text, privacy: .public)\nlogs:\n\(logs.suffix(8).joined(separator: "\n"), privacy: .public)"
+            )
+        }
+
+        return SolanaSimulationResult(
+            failure: value.err?.text,
+            unitsConsumed: value.unitsConsumed,
+            logs: logs
+        )
     }
 
     func getSolanaBalance(coin: CoinMeta, address: String) async throws -> String {

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaService.swift
@@ -43,7 +43,7 @@ struct SolanaSimulationResult: Equatable {
     var succeeded: Bool { failure == nil }
 }
 
-class SolanaService {
+class SolanaService: SolanaAddressLookupTableFetching {
     static let shared = SolanaService()
 
     private let logger = Log.chain.service
@@ -195,6 +195,44 @@ class SolanaService {
             failure: value.err?.text,
             unitsConsumed: value.unitsConsumed,
             logs: logs
+        )
+    }
+
+    /// Reads the contents of the given Address Lookup Tables, keyed by table
+    /// address.
+    ///
+    /// A v0 transaction names most of its accounts by position inside a table, so
+    /// nothing can say what such a transaction touches without these. Every
+    /// requested table must resolve: a partial map would let an unverifiable
+    /// account index be treated as absent.
+    func fetchAddressLookupTables(addresses: [String]) async throws -> [String: [String]] {
+        let unique = Array(Set(addresses))
+        guard !unique.isEmpty else { return [:] }
+
+        return try await withThrowingTaskGroup(of: (String, [String]).self) { group in
+            for address in unique {
+                group.addTask { (address, try await self.fetchAddressLookupTable(address: address)) }
+            }
+            var tables: [String: [String]] = [:]
+            for try await (address, contents) in group {
+                tables[address] = contents
+            }
+            return tables
+        }
+    }
+
+    func fetchAddressLookupTable(address: String) async throws -> [String] {
+        let response = try await httpClient.request(
+            api(.getAddressLookupTable(address: address)),
+            responseType: SolanaGetAccountInfoBase64Response.self
+        )
+        guard let value = response.data.result.value else {
+            throw SolanaAddressLookupTableError.accountNotFound(address)
+        }
+        return try SolanaAddressLookupTable.addresses(
+            table: address,
+            owner: value.owner,
+            data: value.data
         )
     }
 

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaTransactionParser.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Service/SolanaTransactionParser.swift
@@ -28,7 +28,13 @@ enum SolanaTransactionParser {
         "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA": "Token Program",
         "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb": "Token-2022 Program",
         "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL": "Associated Token Program",
-        "ComputeBudget111111111111111111111111111111": "Compute Budget Program"
+        "ComputeBudget111111111111111111111111111111": "Compute Budget Program",
+        // Kamino Earn: the vaults program the app invokes, and the farms program
+        // its deposits auto-stake into. Without these two the verify screen shows
+        // a bare base58 program id for the instructions that actually move the
+        // user's money.
+        "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd": "Kamino Vaults Program",
+        "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr": "Kamino Farms Program"
     ]
 
     static func parse(base64Transaction: String) throws -> ParsedSolanaTransaction {
@@ -138,12 +144,16 @@ enum SolanaTransactionParser {
             return "Create Associated Token Account"
         }
 
-        // Compute Budget Program
+        // Compute Budget Program. Discriminant 0 is the deprecated `RequestUnits`
+        // instruction, so the limit and price instructions are 2 and 3 — not 1
+        // and 2. Getting this wrong mislabels every priority-fee instruction the
+        // app injects, which is what a co-signer reads on the verify screen.
         if programId == "ComputeBudget111111111111111111111111111111" {
             switch discriminator {
-            case 0: return "Request Heap Frame"
-            case 1: return "Set Compute Unit Limit"
-            case 2: return "Set Compute Unit Price"
+            case ComputeBudgetInstruction.requestUnitsDeprecated: return "Request Units (Deprecated)"
+            case ComputeBudgetInstruction.requestHeapFrame: return "Request Heap Frame"
+            case ComputeBudgetInstruction.setUnitLimit: return "Set Compute Unit Limit"
+            case ComputeBudgetInstruction.setUnitPrice: return "Set Compute Unit Price"
             default: return "Compute Budget (\(discriminator))"
             }
         }

--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/SolanaV0Transaction.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/SolanaV0Transaction.swift
@@ -1,0 +1,678 @@
+//
+//  SolanaV0Transaction.swift
+//  VultisigApp
+//
+
+import Foundation
+import WalletCore
+
+/// Structural failures of a serialized Solana v0 transaction, and of the two
+/// edits this type performs on one. Every case is a refusal to proceed — nothing
+/// here degrades to a best-effort result, because the output is signed verbatim.
+enum SolanaV0TransactionError: Error, LocalizedError, Equatable {
+    case invalidBase64
+    case truncated(needed: Int, available: Int)
+    case trailingBytes(Int)
+    case malformedLengthPrefix
+    case legacyMessageUnsupported
+    case unsupportedMessageVersion(Int)
+    case malformedHeader
+    case signatureCountMismatch(header: Int, encoded: Int)
+    case notSingleSigner(Int)
+    case signaturePlaceholderNotEmpty
+    case feePayerMismatch(expected: String, actual: String)
+    case invalidBlockhash
+    case programIdFromLookupTable(instruction: Int)
+    case programIdIsFeePayer(instruction: Int)
+    case accountIndexOutOfRange(instruction: Int, index: Int, accountCount: Int)
+    case emptyAddressTableLookup
+    case tooManyAccounts(Int)
+    case oversizedTransaction(Int)
+    case computeBudgetAlreadyPresent
+    case computeUnitLimitOutOfRange(UInt32)
+    case unknownLookupTable(String)
+    case lookupIndexOutOfRange(table: String, index: Int, tableSize: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidBase64:
+            return "Transaction is not valid base64"
+        case .truncated(let needed, let available):
+            return "Transaction truncated: needed \(needed) more bytes, \(available) available"
+        case .trailingBytes(let count):
+            return "Transaction has \(count) unparsed trailing bytes"
+        case .malformedLengthPrefix:
+            return "Transaction contains a malformed compact-u16 length"
+        case .legacyMessageUnsupported:
+            return "Transaction uses a legacy message; only versioned (v0) messages are supported"
+        case .unsupportedMessageVersion(let version):
+            return "Unsupported message version \(version)"
+        case .malformedHeader:
+            return "Transaction message header is inconsistent with its account keys"
+        case .signatureCountMismatch(let header, let encoded):
+            return "Header requires \(header) signatures but \(encoded) signature slots are encoded"
+        case .notSingleSigner(let count):
+            return "Expected exactly one required signature, found \(count)"
+        case .signaturePlaceholderNotEmpty:
+            return "Transaction already carries a signature; expected an unsigned placeholder"
+        case .feePayerMismatch(let expected, let actual):
+            return "Transaction fee payer is \(actual), expected \(expected)"
+        case .invalidBlockhash:
+            return "Blockhash is not 32 bytes of base58"
+        case .programIdFromLookupTable(let index):
+            return "Instruction \(index) invokes a program that is not a static account key"
+        case .programIdIsFeePayer(let index):
+            return "Instruction \(index) invokes the fee payer as a program"
+        case .accountIndexOutOfRange(let instruction, let index, let count):
+            return "Instruction \(instruction) references account index \(index) of \(count)"
+        case .emptyAddressTableLookup:
+            return "Transaction contains an address lookup that loads no accounts"
+        case .tooManyAccounts(let count):
+            return "Transaction resolves \(count) accounts, above the 256 an 8-bit index can address"
+        case .oversizedTransaction(let size):
+            return "Transaction is \(size) bytes, above the 1232-byte packet limit"
+        case .computeBudgetAlreadyPresent:
+            return "Transaction already carries a Compute Budget instruction"
+        case .computeUnitLimitOutOfRange(let limit):
+            return "Compute unit limit \(limit) is outside the range the network accepts"
+        case .unknownLookupTable(let address):
+            return "No contents supplied for address lookup table \(address)"
+        case .lookupIndexOutOfRange(let table, let index, let size):
+            return "Lookup table \(table) has \(size) addresses; index \(index) is out of range"
+        }
+    }
+}
+
+/// A span-indexed, byte-level view of a serialized Solana **v0 (versioned)**
+/// transaction.
+///
+/// This exists because third-party-built Solana transactions are signed
+/// *verbatim*: the bytes the builder returned are what
+/// `SolanaHelper.getPreSignedImageHashForRaw` hashes, and every co-signer hashes
+/// the same bytes independently. Feeding them through WalletCore's signing proto
+/// and re-serializing produces a message that differs by a byte, which breaks
+/// Secure Vault co-signing before any TSS message is emitted. So both edits here
+/// work on the bytes directly: the blockhash is spliced in place, and the
+/// ComputeBudget injection re-serializes the message field by field from the
+/// values it parsed, leaving every other field byte-identical.
+///
+/// Parsing is deliberately strict — non-canonical length prefixes, trailing
+/// bytes, out-of-range account indices and inconsistent headers are all refusals
+/// rather than tolerated quirks.
+struct SolanaV0Transaction: Equatable {
+
+    /// Maximum size of a Solana transaction packet.
+    static let maxWireSize = 1232
+    /// An account index is a single byte, so 256 is the ceiling on static keys
+    /// plus lookup-table-loaded keys combined.
+    static let maxAccountCount = 256
+    /// Network ceiling on a `SetComputeUnitLimit` request.
+    static let maxComputeUnitLimit: UInt32 = 1_400_000
+
+    static let computeBudgetProgramId = "ComputeBudget111111111111111111111111111111"
+
+    /// The 32 raw bytes of `computeBudgetProgramId`, decoded once. The input is
+    /// a compile-time constant, so a decode failure would mean the base58
+    /// decoder itself is broken rather than that the data is bad — hence the
+    /// trap rather than a thrown error. `SolanaV0TransactionTests` pins the
+    /// decoded bytes so the trap is unreachable in a passing build.
+    static let computeBudgetProgramKey: [UInt8] = {
+        guard let data = Base58.decodeNoCheck(string: computeBudgetProgramId), data.count == 32 else {
+            preconditionFailure("ComputeBudget program id must decode to 32 bytes")
+        }
+        return [UInt8](data)
+    }()
+
+    struct Instruction: Equatable {
+        /// Index into the **static** account keys. Versioned messages forbid
+        /// invoking a program loaded from a lookup table, so this is never a
+        /// lookup-derived index — which is exactly why injection leaves it alone.
+        let programIdIndex: UInt8
+        let accountIndexes: [UInt8]
+        let data: [UInt8]
+    }
+
+    struct AddressTableLookup: Equatable {
+        let tableKey: [UInt8]
+        let writableIndexes: [UInt8]
+        let readonlyIndexes: [UInt8]
+
+        var tableAddress: String { Base58.encodeNoCheck(data: Data(tableKey)) }
+        var loadedAccountCount: Int { writableIndexes.count + readonlyIndexes.count }
+    }
+
+    /// The complete wire transaction: the signature vector followed by the
+    /// serialized message.
+    private let wire: [UInt8]
+
+    /// Byte range of the signature slots, i.e. past the count prefix and up to
+    /// the first message byte.
+    let signaturesRange: Range<Int>
+    /// Offset of the first message byte, i.e. just past the signature vector.
+    let messageOffset: Int
+    let numRequiredSignatures: UInt8
+    let numReadonlySignedAccounts: UInt8
+    let numReadonlyUnsignedAccounts: UInt8
+    let staticAccountKeys: [[UInt8]]
+    /// Byte range of the 32-byte recent-blockhash field within `wire`.
+    let blockhashRange: Range<Int>
+    let instructions: [Instruction]
+    let addressTableLookups: [AddressTableLookup]
+
+    // MARK: - Derived
+
+    var wireSize: Int { wire.count }
+
+    var base64EncodedTransaction: String { Data(wire).base64EncodedString() }
+
+    var staticAccountAddresses: [String] {
+        staticAccountKeys.map { Base58.encodeNoCheck(data: Data($0)) }
+    }
+
+    /// Signer index 0 — the account that pays the fee.
+    var feePayer: String { Base58.encodeNoCheck(data: Data(staticAccountKeys[0])) }
+
+    var recentBlockhash: String { Base58.encodeNoCheck(data: Data(wire[blockhashRange])) }
+
+    /// Static keys plus every account the lookup tables load. This is the space
+    /// instruction account indexes address.
+    var totalAccountCount: Int {
+        staticAccountKeys.count + addressTableLookups.reduce(0) { $0 + $1.loadedAccountCount }
+    }
+
+    var hasComputeBudgetInstruction: Bool {
+        instructions.contains { staticAccountKeys[Int($0.programIdIndex)] == Self.computeBudgetProgramKey }
+    }
+
+    // MARK: - Parsing
+
+    init(base64Transaction: String) throws {
+        guard let data = Data(base64Encoded: base64Transaction) else {
+            throw SolanaV0TransactionError.invalidBase64
+        }
+        try self.init(wireBytes: [UInt8](data))
+    }
+
+    init(wireBytes: [UInt8]) throws {
+        guard wireBytes.count <= Self.maxWireSize else {
+            throw SolanaV0TransactionError.oversizedTransaction(wireBytes.count)
+        }
+
+        var cursor = Cursor(bytes: wireBytes)
+
+        let signatureCount = try cursor.compactLength()
+        let signaturesStart = cursor.offset
+        _ = try cursor.take(64 * signatureCount)
+        let messageOffset = cursor.offset
+
+        // The high bit of the first message byte marks a versioned message; the
+        // low seven carry the version. A legacy message starts with the header's
+        // `numRequiredSignatures`, which is always < 128, so the bit is an
+        // unambiguous discriminator.
+        let versionByte = try cursor.byte()
+        guard versionByte & 0x80 != 0 else { throw SolanaV0TransactionError.legacyMessageUnsupported }
+        guard versionByte & 0x7F == 0 else {
+            throw SolanaV0TransactionError.unsupportedMessageVersion(Int(versionByte & 0x7F))
+        }
+
+        let numRequiredSignatures = try cursor.byte()
+        let numReadonlySigned = try cursor.byte()
+        let numReadonlyUnsigned = try cursor.byte()
+
+        let keyCount = try cursor.compactLength()
+        var keys: [[UInt8]] = []
+        keys.reserveCapacity(keyCount)
+        for _ in 0..<keyCount {
+            keys.append(Array(try cursor.take(32)))
+        }
+
+        let blockhashStart = cursor.offset
+        _ = try cursor.take(32)
+
+        let instructionCount = try cursor.compactLength()
+        var instructions: [Instruction] = []
+        instructions.reserveCapacity(instructionCount)
+        for _ in 0..<instructionCount {
+            let programIdIndex = try cursor.byte()
+            let accountCount = try cursor.compactLength()
+            let accountIndexes = Array(try cursor.take(accountCount))
+            let dataLength = try cursor.compactLength()
+            let data = Array(try cursor.take(dataLength))
+            instructions.append(
+                Instruction(programIdIndex: programIdIndex, accountIndexes: accountIndexes, data: data)
+            )
+        }
+
+        let lookupCount = try cursor.compactLength()
+        var lookups: [AddressTableLookup] = []
+        lookups.reserveCapacity(lookupCount)
+        for _ in 0..<lookupCount {
+            let tableKey = Array(try cursor.take(32))
+            let writableCount = try cursor.compactLength()
+            let writableIndexes = Array(try cursor.take(writableCount))
+            let readonlyCount = try cursor.compactLength()
+            let readonlyIndexes = Array(try cursor.take(readonlyCount))
+            lookups.append(
+                AddressTableLookup(
+                    tableKey: tableKey,
+                    writableIndexes: writableIndexes,
+                    readonlyIndexes: readonlyIndexes
+                )
+            )
+        }
+
+        guard cursor.offset == wireBytes.count else {
+            throw SolanaV0TransactionError.trailingBytes(wireBytes.count - cursor.offset)
+        }
+
+        self.wire = wireBytes
+        self.signaturesRange = signaturesStart..<messageOffset
+        self.messageOffset = messageOffset
+        self.numRequiredSignatures = numRequiredSignatures
+        self.numReadonlySignedAccounts = numReadonlySigned
+        self.numReadonlyUnsignedAccounts = numReadonlyUnsigned
+        self.staticAccountKeys = keys
+        self.blockhashRange = blockhashStart..<(blockhashStart + 32)
+        self.instructions = instructions
+        self.addressTableLookups = lookups
+
+        try validateStructure(encodedSignatureCount: signatureCount)
+    }
+
+    /// Invariants Solana itself enforces when it sanitizes a message. Checked at
+    /// parse time so a malformed transaction is rejected before any edit, rather
+    /// than producing edited bytes that only fail at the RPC node.
+    private func validateStructure(encodedSignatureCount: Int) throws {
+        guard encodedSignatureCount == Int(numRequiredSignatures) else {
+            throw SolanaV0TransactionError.signatureCountMismatch(
+                header: Int(numRequiredSignatures),
+                encoded: encodedSignatureCount
+            )
+        }
+        // The fee payer is signer 0 and must be writable, so the read-only
+        // signer block can never cover every signer.
+        guard numRequiredSignatures > 0,
+              numReadonlySignedAccounts < numRequiredSignatures,
+              Int(numRequiredSignatures) + Int(numReadonlyUnsignedAccounts) <= staticAccountKeys.count
+        else {
+            throw SolanaV0TransactionError.malformedHeader
+        }
+        // A lookup that loads nothing is a wasted 32-byte reference and is
+        // rejected by the runtime.
+        guard !addressTableLookups.contains(where: { $0.loadedAccountCount == 0 }) else {
+            throw SolanaV0TransactionError.emptyAddressTableLookup
+        }
+
+        let accountCount = totalAccountCount
+        guard accountCount <= Self.maxAccountCount else {
+            throw SolanaV0TransactionError.tooManyAccounts(accountCount)
+        }
+
+        for (position, instruction) in instructions.enumerated() {
+            guard Int(instruction.programIdIndex) < staticAccountKeys.count else {
+                throw SolanaV0TransactionError.programIdFromLookupTable(instruction: position)
+            }
+            // Solana refuses to invoke the fee payer as a program, so a message
+            // that does is one the network would drop after we had signed it.
+            guard instruction.programIdIndex != 0 else {
+                throw SolanaV0TransactionError.programIdIsFeePayer(instruction: position)
+            }
+            for index in instruction.accountIndexes where Int(index) >= accountCount {
+                throw SolanaV0TransactionError.accountIndexOutOfRange(
+                    instruction: position,
+                    index: Int(index),
+                    accountCount: accountCount
+                )
+            }
+        }
+    }
+
+    // MARK: - Fail-closed preconditions
+
+    /// Asserts the shape the app is willing to sign: a single required signature
+    /// whose slot is still an all-zero placeholder, paid for by `feePayer`.
+    ///
+    /// The zero-placeholder check is what makes the signature splice at index 0
+    /// safe, and the fee-payer check is what stops a builder from handing back a
+    /// transaction that another account pays for — or that pays out of an
+    /// account the user does not control.
+    func validateUnsignedSingleSigner(feePayer expected: String) throws {
+        guard numRequiredSignatures == 1 else {
+            throw SolanaV0TransactionError.notSingleSigner(Int(numRequiredSignatures))
+        }
+        guard wire[signaturesRange].allSatisfy({ $0 == 0 }) else {
+            throw SolanaV0TransactionError.signaturePlaceholderNotEmpty
+        }
+        guard feePayer == expected else {
+            throw SolanaV0TransactionError.feePayerMismatch(expected: expected, actual: feePayer)
+        }
+    }
+
+    // MARK: - Edits
+
+    /// Replaces the 32-byte recent blockhash **in place**.
+    ///
+    /// Nothing else in the transaction moves: the length of the field is fixed,
+    /// so the surrounding bytes — including the signature slots — stay exactly
+    /// where they were. The result is re-parsed only to re-derive the spans and
+    /// re-run the structural guards.
+    func replacingBlockhash(_ blockhash: String) throws -> SolanaV0Transaction {
+        guard let decoded = Base58.decodeNoCheck(string: blockhash), decoded.count == 32 else {
+            throw SolanaV0TransactionError.invalidBlockhash
+        }
+        var bytes = wire
+        bytes.replaceSubrange(blockhashRange, with: [UInt8](decoded))
+        return try SolanaV0Transaction(wireBytes: bytes)
+    }
+
+    /// Prepends `SetComputeUnitLimit` + `SetComputeUnitPrice`, appending the
+    /// ComputeBudget program as a new **static, read-only, unsigned** account key.
+    ///
+    /// Static keys are ordered by privilege — writable signers, read-only
+    /// signers, writable non-signers, read-only non-signers — so the read-only
+    /// unsigned block is the tail, and appending there plus incrementing
+    /// `numReadonlyUnsignedAccounts` preserves the ordering without moving any
+    /// existing key.
+    ///
+    /// The one consequence is index drift: indexes at or above the old static
+    /// count addressed lookup-table-loaded accounts, which now begin one slot
+    /// later, so each is shifted by one. `programIdIndex` values are untouched —
+    /// a versioned message may not invoke a program loaded from a lookup table,
+    /// so every program is already a static key below the insertion point. The
+    /// indexes *inside* each `AddressTableLookup` are positions in the table
+    /// itself, not in this message, so they are untouched too.
+    func injectingComputeBudget(price: UInt64, limit: UInt32) throws -> SolanaV0Transaction {
+        guard limit > 0, limit <= Self.maxComputeUnitLimit else {
+            throw SolanaV0TransactionError.computeUnitLimitOutOfRange(limit)
+        }
+        // Both checks matter. A stray ComputeBudget key with no instruction would
+        // make the append a duplicate account; an instruction with no static key
+        // is impossible, but checking it keeps the guard honest if the key ever
+        // arrives through a lookup table.
+        guard !staticAccountKeys.contains(Self.computeBudgetProgramKey), !hasComputeBudgetInstruction else {
+            throw SolanaV0TransactionError.computeBudgetAlreadyPresent
+        }
+
+        // Checked before any index arithmetic: with the new key the message must
+        // still address at most 256 accounts, which bounds both the appended
+        // key's own index and every shifted index below `UInt8.max`.
+        let newAccountCount = totalAccountCount + 1
+        guard newAccountCount <= Self.maxAccountCount else {
+            throw SolanaV0TransactionError.tooManyAccounts(newAccountCount)
+        }
+
+        let oldStaticCount = staticAccountKeys.count
+        let programIdIndex = UInt8(oldStaticCount)
+        let keys = staticAccountKeys + [Self.computeBudgetProgramKey]
+
+        let shifted = instructions.map { instruction in
+            Instruction(
+                programIdIndex: instruction.programIdIndex,
+                accountIndexes: instruction.accountIndexes.map {
+                    Int($0) >= oldStaticCount ? $0 + 1 : $0
+                },
+                data: instruction.data
+            )
+        }
+
+        let budgetInstructions = [
+            Instruction(
+                programIdIndex: programIdIndex,
+                accountIndexes: [],
+                data: [ComputeBudgetInstruction.setUnitLimit] + Self.littleEndianBytes(limit)
+            ),
+            Instruction(
+                programIdIndex: programIdIndex,
+                accountIndexes: [],
+                data: [ComputeBudgetInstruction.setUnitPrice] + Self.littleEndianBytes(price)
+            )
+        ]
+
+        var message: [UInt8] = [0x80, numRequiredSignatures, numReadonlySignedAccounts]
+        message.append(numReadonlyUnsignedAccounts + 1)
+        message += try Self.encodeCompactLength(keys.count)
+        for key in keys { message += key }
+        message += wire[blockhashRange]
+
+        let allInstructions = budgetInstructions + shifted
+        message += try Self.encodeCompactLength(allInstructions.count)
+        for instruction in allInstructions {
+            message.append(instruction.programIdIndex)
+            message += try Self.encodeCompactLength(instruction.accountIndexes.count)
+            message += instruction.accountIndexes
+            message += try Self.encodeCompactLength(instruction.data.count)
+            message += instruction.data
+        }
+
+        message += try Self.encodeCompactLength(addressTableLookups.count)
+        for lookup in addressTableLookups {
+            message += lookup.tableKey
+            message += try Self.encodeCompactLength(lookup.writableIndexes.count)
+            message += lookup.writableIndexes
+            message += try Self.encodeCompactLength(lookup.readonlyIndexes.count)
+            message += lookup.readonlyIndexes
+        }
+
+        // Re-checked by the parse below, but checking here names the injection as
+        // the cause instead of reporting a generic malformed transaction.
+        let bytes = Array(wire[0..<messageOffset]) + message
+        guard bytes.count <= Self.maxWireSize else {
+            throw SolanaV0TransactionError.oversizedTransaction(bytes.count)
+        }
+
+        return try SolanaV0Transaction(wireBytes: bytes)
+    }
+
+    // MARK: - Address resolution
+
+    /// Every account key the message addresses, in index order: the static keys,
+    /// then the writable accounts each lookup loads, then the read-only ones —
+    /// the same order the runtime builds.
+    ///
+    /// - Parameter lookupTables: table address to that table's full address list.
+    func resolvedAccountAddresses(lookupTables: [String: [String]]) throws -> [String] {
+        var writable: [String] = []
+        var readonly: [String] = []
+
+        for lookup in addressTableLookups {
+            let address = lookup.tableAddress
+            guard let table = lookupTables[address] else {
+                throw SolanaV0TransactionError.unknownLookupTable(address)
+            }
+            writable += try lookup.writableIndexes.map { try Self.entry($0, in: table, at: address) }
+            readonly += try lookup.readonlyIndexes.map { try Self.entry($0, in: table, at: address) }
+        }
+
+        return staticAccountAddresses + writable + readonly
+    }
+
+    /// The account addresses an instruction passes, resolved through the lookup
+    /// tables. Duplicates are preserved — an instruction may legitimately pass
+    /// the same account twice.
+    func resolvedAccountAddresses(
+        forInstructionAt position: Int,
+        lookupTables: [String: [String]]
+    ) throws -> [String] {
+        guard instructions.indices.contains(position) else {
+            throw SolanaV0TransactionError.accountIndexOutOfRange(
+                instruction: position,
+                index: position,
+                accountCount: instructions.count
+            )
+        }
+        let resolved = try resolvedAccountAddresses(lookupTables: lookupTables)
+        return try instructions[position].accountIndexes.map { index in
+            guard Int(index) < resolved.count else {
+                throw SolanaV0TransactionError.accountIndexOutOfRange(
+                    instruction: position,
+                    index: Int(index),
+                    accountCount: resolved.count
+                )
+            }
+            return resolved[Int(index)]
+        }
+    }
+
+    /// Whether the account at `index` has to sign. Signers occupy the first
+    /// `numRequiredSignatures` static slots and can never come from a lookup
+    /// table.
+    func isSigner(accountIndex index: Int) -> Bool {
+        guard (0..<totalAccountCount).contains(index) else { return false }
+        return index < Int(numRequiredSignatures)
+    }
+
+    /// Whether the account at `index` is loaded writable.
+    ///
+    /// Writability is positional, not stored per account: within the static keys
+    /// the read-only accounts are the tail of each of the signer and non-signer
+    /// blocks, and among lookup-loaded accounts the writable ones all precede
+    /// the read-only ones. That is exactly why injecting a key into the wrong
+    /// block — or forgetting to bump `numReadonlyUnsignedAccounts` — would
+    /// silently re-privilege unrelated accounts rather than fail to parse.
+    func isWritable(accountIndex index: Int) -> Bool {
+        // Out of range fails closed: an index nothing addresses is not something
+        // the transaction may write to.
+        guard (0..<totalAccountCount).contains(index) else { return false }
+        let staticCount = staticAccountKeys.count
+        if index < Int(numRequiredSignatures) {
+            return index < Int(numRequiredSignatures) - Int(numReadonlySignedAccounts)
+        }
+        if index < staticCount {
+            return index < staticCount - Int(numReadonlyUnsignedAccounts)
+        }
+        let writableLoaded = addressTableLookups.reduce(0) { $0 + $1.writableIndexes.count }
+        return index - staticCount < writableLoaded
+    }
+
+    private static func entry(_ index: UInt8, in table: [String], at address: String) throws -> String {
+        guard Int(index) < table.count else {
+            throw SolanaV0TransactionError.lookupIndexOutOfRange(
+                table: address,
+                index: Int(index),
+                tableSize: table.count
+            )
+        }
+        return table[Int(index)]
+    }
+
+    // MARK: - compact-u16
+
+    /// The widest value compact-u16 can express.
+    static let maxCompactLength = 0xFFFF
+
+    /// Serializes a length in Solana's compact-u16 ("short vec") form, always in
+    /// its shortest encoding.
+    ///
+    /// Throws outside `0...65535` rather than emitting something: a negative
+    /// value has no encoding at all, and a value past `UInt16` would be
+    /// serialized as a truncated one that silently means a different length.
+    static func encodeCompactLength(_ value: Int) throws -> [UInt8] {
+        guard (0...maxCompactLength).contains(value) else {
+            throw SolanaV0TransactionError.malformedLengthPrefix
+        }
+        var remaining = value
+        var out: [UInt8] = []
+        while true {
+            let chunk = UInt8(remaining & 0x7F)
+            remaining >>= 7
+            if remaining == 0 {
+                out.append(chunk)
+                return out
+            }
+            out.append(chunk | 0x80)
+        }
+    }
+
+    /// Reads a compact-u16 length, rejecting anything but its shortest encoding.
+    ///
+    /// The strictness matters: a padded encoding of the same number would let two
+    /// different byte strings describe the same transaction, and the app hashes
+    /// bytes rather than a decoded structure. Solana's own decoder rejects them
+    /// too, so accepting one would mean signing something the network won't.
+    ///
+    /// What is *not* padding is a zero payload chunk in a continuing byte —
+    /// 16,384 encodes as `80 80 01`, whose first two bytes carry no value bits at
+    /// all yet is the only encoding of that number. The rule is a zero **byte**
+    /// past the first, which is what Solana checks.
+    ///
+    /// - Returns: the value and how many bytes it consumed.
+    static func decodeCompactLength(_ bytes: ArraySlice<UInt8>) throws -> (value: Int, byteCount: Int) {
+        var value = 0
+        var shift = 0
+        var consumed = 0
+
+        for index in bytes.indices.prefix(3) {
+            let byte = bytes[index]
+            consumed += 1
+            guard consumed == 1 || byte != 0 else {
+                throw SolanaV0TransactionError.malformedLengthPrefix
+            }
+            value |= Int(byte & 0x7F) << shift
+            if byte & 0x80 == 0 {
+                guard value <= maxCompactLength else {
+                    throw SolanaV0TransactionError.malformedLengthPrefix
+                }
+                return (value, consumed)
+            }
+            shift += 7
+        }
+
+        // Ran out of input mid-length is truncation; three continuing bytes is a
+        // value compact-u16 cannot hold.
+        guard consumed == 3 else {
+            throw SolanaV0TransactionError.truncated(needed: consumed + 1, available: consumed)
+        }
+        throw SolanaV0TransactionError.malformedLengthPrefix
+    }
+
+    private static func littleEndianBytes(_ value: UInt32) -> [UInt8] {
+        withUnsafeBytes(of: value.littleEndian) { [UInt8]($0) }
+    }
+
+    private static func littleEndianBytes(_ value: UInt64) -> [UInt8] {
+        withUnsafeBytes(of: value.littleEndian) { [UInt8]($0) }
+    }
+}
+
+/// ComputeBudget program instruction discriminants.
+///
+/// Note the offset: `RequestUnits` (deprecated) occupies 0, so the limit and
+/// price instructions are 2 and 3 — not 1 and 2.
+enum ComputeBudgetInstruction {
+    static let requestUnitsDeprecated: UInt8 = 0
+    static let requestHeapFrame: UInt8 = 1
+    static let setUnitLimit: UInt8 = 2
+    static let setUnitPrice: UInt8 = 3
+}
+
+/// Bounds-checked forward-only reader over the wire bytes.
+private struct Cursor {
+    let bytes: [UInt8]
+    private(set) var offset = 0
+
+    init(bytes: [UInt8]) {
+        self.bytes = bytes
+    }
+
+    mutating func byte() throws -> UInt8 {
+        guard offset < bytes.count else {
+            throw SolanaV0TransactionError.truncated(needed: 1, available: 0)
+        }
+        defer { offset += 1 }
+        return bytes[offset]
+    }
+
+    mutating func take(_ count: Int) throws -> ArraySlice<UInt8> {
+        guard count >= 0, bytes.count - offset >= count else {
+            throw SolanaV0TransactionError.truncated(needed: count, available: bytes.count - offset)
+        }
+        defer { offset += count }
+        return bytes[offset..<(offset + count)]
+    }
+
+    mutating func compactLength() throws -> Int {
+        let (value, byteCount) = try SolanaV0Transaction.decodeCompactLength(bytes[offset...])
+        offset += byteCount
+        return value
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -626,7 +626,7 @@
 "joinSend" = "Senden beitreten";
 "joinSwap" = "Tausch beitreten";
 "joinTransactionSigning" = "Verbinden Sie die Transaktionsunterzeichnung";
-"kaminoErrorVaultMetadataMismatch" = "Kamino meldet %1$@ als %2$@; dieser Vault hat %3$@";
+"kaminoErrorVaultMetadataMismatch" = "Kamino meldet für %1$@ den Wert %2$@; dieser Vault erwartet %3$@";
 "kaminoErrorVaultNotInRegistry" = "Vault %@ ist keiner, mit dem diese App Transaktionen durchführt";
 "keyCopied" = "Schlüssel kopiert";
 "keygen" = "Schlüsselerzeugung";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -626,6 +626,8 @@
 "joinSend" = "Senden beitreten";
 "joinSwap" = "Tausch beitreten";
 "joinTransactionSigning" = "Verbinden Sie die Transaktionsunterzeichnung";
+"kaminoErrorVaultMetadataMismatch" = "Kamino meldet %1$@ als %2$@; dieser Vault hat %3$@";
+"kaminoErrorVaultNotInRegistry" = "Vault %@ ist keiner, mit dem diese App Transaktionen durchführt";
 "keyCopied" = "Schlüssel kopiert";
 "keygen" = "Schlüsselerzeugung";
 "keygenFailed" = "Schlüsselgenerierung fehlgeschlagen";
@@ -1309,6 +1311,11 @@
 "slippageHelperText" = "Begrenzt, wie stark sich der Preis ändern darf, bevor die Ausführung abgebrochen wird.";
 "slippageMaxNote" = "Slippage ist auf %@ begrenzt.";
 "slippageTolerance" = "Slippage-Toleranz";
+"solanaAddressLookupTableErrorAccountNotFound" = "Die Address Lookup Table %@ existiert nicht auf der Chain";
+"solanaAddressLookupTableErrorMalformedData" = "Die Address Lookup Table %@ hat fehlerhafte Kontodaten";
+"solanaAddressLookupTableErrorUninitialized" = "Die Address Lookup Table %@ ist nicht initialisiert";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "Die Address Lookup Table %@ wurde in einer unerwarteten Kodierung zurückgegeben";
+"solanaAddressLookupTableErrorWrongOwner" = "Konto %1$@ gehört %2$@, nicht dem Address-Lookup-Table-Programm";
 "solanaBatchSigningNotSupported" = "Das Signieren mehrerer Solana-Transaktionen auf einmal wird noch nicht unterstützt.";
 "solanaStakingActionDelegate" = "Einsatz";
 "solanaStakingActionUnstake" = "Entstaken";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -626,6 +626,8 @@
 "joinSend" = "Join Send";
 "joinSwap" = "Join Swap";
 "joinTransactionSigning" = "Join transaction signing";
+"kaminoErrorVaultMetadataMismatch" = "Kamino reported %1$@ as %2$@; this vault's is %3$@";
+"kaminoErrorVaultNotInRegistry" = "Vault %@ is not one this app transacts with";
 "keyCopied" = "Key copied";
 "keygen" = "Keygen";
 "keygenFailed" = "Key generation failed";
@@ -1309,6 +1311,11 @@
 "slippageHelperText" = "Limits how much the price can change before execution is canceled.";
 "slippageMaxNote" = "Slippage is capped at %@.";
 "slippageTolerance" = "Slippage Tolerance";
+"solanaAddressLookupTableErrorAccountNotFound" = "Address lookup table %@ does not exist on chain";
+"solanaAddressLookupTableErrorMalformedData" = "Address lookup table %@ has malformed account data";
+"solanaAddressLookupTableErrorUninitialized" = "Address lookup table %@ is not initialized";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "Address lookup table %@ was returned in an unexpected encoding";
+"solanaAddressLookupTableErrorWrongOwner" = "Account %1$@ is owned by %2$@, not the Address Lookup Table program";
 "solanaBatchSigningNotSupported" = "Signing multiple Solana transactions at once isn't supported yet.";
 "solanaStakingActionDelegate" = "Stake";
 "solanaStakingActionUnstake" = "Unstake";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -626,7 +626,7 @@
 "joinSend" = "Join Send";
 "joinSwap" = "Join Swap";
 "joinTransactionSigning" = "Join transaction signing";
-"kaminoErrorVaultMetadataMismatch" = "Kamino reported %1$@ as %2$@; this vault's is %3$@";
+"kaminoErrorVaultMetadataMismatch" = "Kamino reported %1$@ as %2$@; this vault expects %3$@";
 "kaminoErrorVaultNotInRegistry" = "Vault %@ is not one this app transacts with";
 "keyCopied" = "Key copied";
 "keygen" = "Keygen";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -626,6 +626,8 @@
 "joinSend" = "Unirse a Enviar";
 "joinSwap" = "Unirse al intercambio";
 "joinTransactionSigning" = "Unir firma de transacciones";
+"kaminoErrorVaultMetadataMismatch" = "Kamino informó %1$@ como %2$@; el de este vault es %3$@";
+"kaminoErrorVaultNotInRegistry" = "El vault %@ no es uno con el que esta app opera";
 "keyCopied" = "Clave copiada";
 "keygen" = "Generación de claves";
 "keygenFailed" = "La generación de clave falló";
@@ -1309,6 +1311,11 @@
 "slippageHelperText" = "Limita cuánto puede cambiar el precio antes de cancelar la ejecución.";
 "slippageMaxNote" = "El deslizamiento está limitado a %@.";
 "slippageTolerance" = "Tolerancia de deslizamiento";
+"solanaAddressLookupTableErrorAccountNotFound" = "La address lookup table %@ no existe en la cadena";
+"solanaAddressLookupTableErrorMalformedData" = "La address lookup table %@ tiene datos de cuenta con formato incorrecto";
+"solanaAddressLookupTableErrorUninitialized" = "La address lookup table %@ no está inicializada";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "La address lookup table %@ se devolvió en una codificación inesperada";
+"solanaAddressLookupTableErrorWrongOwner" = "La cuenta %1$@ pertenece a %2$@, no al programa Address Lookup Table";
 "solanaBatchSigningNotSupported" = "Aún no se admite firmar varias transacciones de Solana a la vez.";
 "solanaStakingActionDelegate" = "Apostar";
 "solanaStakingActionUnstake" = "Cancelar staking";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -626,7 +626,7 @@
 "joinSend" = "Unirse a Enviar";
 "joinSwap" = "Unirse al intercambio";
 "joinTransactionSigning" = "Unir firma de transacciones";
-"kaminoErrorVaultMetadataMismatch" = "Kamino informó %1$@ como %2$@; el de este vault es %3$@";
+"kaminoErrorVaultMetadataMismatch" = "Kamino informó %1$@ como %2$@; este vault espera %3$@";
 "kaminoErrorVaultNotInRegistry" = "El vault %@ no es uno con el que esta app opera";
 "keyCopied" = "Clave copiada";
 "keygen" = "Generación de claves";
@@ -1311,10 +1311,10 @@
 "slippageHelperText" = "Limita cuánto puede cambiar el precio antes de cancelar la ejecución.";
 "slippageMaxNote" = "El deslizamiento está limitado a %@.";
 "slippageTolerance" = "Tolerancia de deslizamiento";
-"solanaAddressLookupTableErrorAccountNotFound" = "La address lookup table %@ no existe en la cadena";
-"solanaAddressLookupTableErrorMalformedData" = "La address lookup table %@ tiene datos de cuenta con formato incorrecto";
-"solanaAddressLookupTableErrorUninitialized" = "La address lookup table %@ no está inicializada";
-"solanaAddressLookupTableErrorUnsupportedEncoding" = "La address lookup table %@ se devolvió en una codificación inesperada";
+"solanaAddressLookupTableErrorAccountNotFound" = "La tabla de búsqueda de direcciones %@ no existe en la cadena";
+"solanaAddressLookupTableErrorMalformedData" = "La tabla de búsqueda de direcciones %@ tiene datos de cuenta con formato incorrecto";
+"solanaAddressLookupTableErrorUninitialized" = "La tabla de búsqueda de direcciones %@ no está inicializada";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "La tabla de búsqueda de direcciones %@ se devolvió en una codificación inesperada";
 "solanaAddressLookupTableErrorWrongOwner" = "La cuenta %1$@ pertenece a %2$@, no al programa Address Lookup Table";
 "solanaBatchSigningNotSupported" = "Aún no se admite firmar varias transacciones de Solana a la vez.";
 "solanaStakingActionDelegate" = "Apostar";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -626,6 +626,8 @@
 "joinSend" = "Pridruži se Slanju";
 "joinSwap" = "Pridruži se Zamjeni";
 "joinTransactionSigning" = "Pridružite se potpisivanju transakcija";
+"kaminoErrorVaultMetadataMismatch" = "Kamino je prijavio %1$@ kao %2$@; ovaj vault ima %3$@";
+"kaminoErrorVaultNotInRegistry" = "Vault %@ nije onaj s kojim ova aplikacija posluje";
 "keyCopied" = "Ključ kopiran";
 "keygen" = "Generiranje ključeva";
 "keygenFailed" = "Generiranje ključa nije uspjelo";
@@ -1309,6 +1311,11 @@
 "slippageHelperText" = "Ograničava koliko se cijena može promijeniti prije nego se izvršenje otkaže.";
 "slippageMaxNote" = "Klizanje je ograničeno na %@.";
 "slippageTolerance" = "Tolerancija klizanja";
+"solanaAddressLookupTableErrorAccountNotFound" = "Address lookup table %@ ne postoji na lancu";
+"solanaAddressLookupTableErrorMalformedData" = "Address lookup table %@ ima neispravne podatke računa";
+"solanaAddressLookupTableErrorUninitialized" = "Address lookup table %@ nije inicijalizirana";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "Address lookup table %@ vraćena je u neočekivanom kodiranju";
+"solanaAddressLookupTableErrorWrongOwner" = "Račun %1$@ u vlasništvu je %2$@, a ne programa Address Lookup Table";
 "solanaBatchSigningNotSupported" = "Potpisivanje više Solana transakcija odjednom još nije podržano.";
 "solanaStakingActionDelegate" = "Ulog";
 "solanaStakingActionUnstake" = "Skidanje stake-a";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -626,7 +626,7 @@
 "joinSend" = "Unisciti a Invia";
 "joinSwap" = "Partecipa a Swap";
 "joinTransactionSigning" = "Unisciti alla firma delle transazioni";
-"kaminoErrorVaultMetadataMismatch" = "Kamino ha riportato %1$@ come %2$@; quello di questo vault è %3$@";
+"kaminoErrorVaultMetadataMismatch" = "Kamino ha riportato %1$@ come %2$@; questo vault si aspetta %3$@";
 "kaminoErrorVaultNotInRegistry" = "Il vault %@ non è uno di quelli con cui questa app opera";
 "keyCopied" = "Chiave copiata";
 "keygen" = "Generazione chiavi";
@@ -1311,10 +1311,10 @@
 "slippageHelperText" = "Limita quanto il prezzo può cambiare prima che l'esecuzione venga annullata.";
 "slippageMaxNote" = "Lo slippage è limitato a %@.";
 "slippageTolerance" = "Tolleranza di slippage";
-"solanaAddressLookupTableErrorAccountNotFound" = "La address lookup table %@ non esiste sulla chain";
-"solanaAddressLookupTableErrorMalformedData" = "La address lookup table %@ ha dati dell'account non validi";
-"solanaAddressLookupTableErrorUninitialized" = "La address lookup table %@ non è inizializzata";
-"solanaAddressLookupTableErrorUnsupportedEncoding" = "La address lookup table %@ è stata restituita in una codifica inattesa";
+"solanaAddressLookupTableErrorAccountNotFound" = "L'Address Lookup Table %@ non esiste sulla chain";
+"solanaAddressLookupTableErrorMalformedData" = "L'Address Lookup Table %@ ha dati dell'account non validi";
+"solanaAddressLookupTableErrorUninitialized" = "L'Address Lookup Table %@ non è inizializzata";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "L'Address Lookup Table %@ è stata restituita in una codifica inattesa";
 "solanaAddressLookupTableErrorWrongOwner" = "L'account %1$@ appartiene a %2$@, non al programma Address Lookup Table";
 "solanaBatchSigningNotSupported" = "La firma di più transazioni Solana contemporaneamente non è ancora supportata.";
 "solanaStakingActionDelegate" = "Palo";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -626,6 +626,8 @@
 "joinSend" = "Unisciti a Invia";
 "joinSwap" = "Partecipa a Swap";
 "joinTransactionSigning" = "Unisciti alla firma delle transazioni";
+"kaminoErrorVaultMetadataMismatch" = "Kamino ha riportato %1$@ come %2$@; quello di questo vault è %3$@";
+"kaminoErrorVaultNotInRegistry" = "Il vault %@ non è uno di quelli con cui questa app opera";
 "keyCopied" = "Chiave copiata";
 "keygen" = "Generazione chiavi";
 "keygenFailed" = "Generazione della chiave fallita";
@@ -1309,6 +1311,11 @@
 "slippageHelperText" = "Limita quanto il prezzo può cambiare prima che l'esecuzione venga annullata.";
 "slippageMaxNote" = "Lo slippage è limitato a %@.";
 "slippageTolerance" = "Tolleranza di slippage";
+"solanaAddressLookupTableErrorAccountNotFound" = "La address lookup table %@ non esiste sulla chain";
+"solanaAddressLookupTableErrorMalformedData" = "La address lookup table %@ ha dati dell'account non validi";
+"solanaAddressLookupTableErrorUninitialized" = "La address lookup table %@ non è inizializzata";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "La address lookup table %@ è stata restituita in una codifica inattesa";
+"solanaAddressLookupTableErrorWrongOwner" = "L'account %1$@ appartiene a %2$@, non al programma Address Lookup Table";
 "solanaBatchSigningNotSupported" = "La firma di più transazioni Solana contemporaneamente non è ancora supportata.";
 "solanaStakingActionDelegate" = "Palo";
 "solanaStakingActionUnstake" = "Ritira stake";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -627,7 +627,7 @@
 "joinSwap" = "스왑 참여";
 "joinTransactionSigning" = "트랜잭션 서명 참여";
 "kaminoErrorVaultMetadataMismatch" = "Kamino가 %1$@을(를) %2$@(으)로 보고했습니다. 이 볼트의 값은 %3$@입니다";
-"kaminoErrorVaultNotInRegistry" = "볼트 %@은(는) 이 앱이 거래하는 볼트가 아닙니다";
+"kaminoErrorVaultNotInRegistry" = "볼트 %@은(는) 이 앱이 지원하는 볼트가 아닙니다";
 "keyCopied" = "키 복사됨";
 "keygen" = "키젠";
 "keygenFailed" = "키 생성 실패";
@@ -1312,7 +1312,7 @@
 "slippageMaxNote" = "슬리피지는 %@로 제한됩니다.";
 "slippageTolerance" = "슬리피지 허용치";
 "solanaAddressLookupTableErrorAccountNotFound" = "주소 조회 테이블 %@이(가) 체인에 존재하지 않습니다";
-"solanaAddressLookupTableErrorMalformedData" = "주소 조회 테이블 %@의 계정 데이터가 손상되었습니다";
+"solanaAddressLookupTableErrorMalformedData" = "주소 조회 테이블 %@의 계정 데이터 형식이 잘못되었습니다";
 "solanaAddressLookupTableErrorUninitialized" = "주소 조회 테이블 %@이(가) 초기화되지 않았습니다";
 "solanaAddressLookupTableErrorUnsupportedEncoding" = "주소 조회 테이블 %@이(가) 예기치 않은 인코딩으로 반환되었습니다";
 "solanaAddressLookupTableErrorWrongOwner" = "계정 %1$@의 소유자는 %2$@이며, 주소 조회 테이블 프로그램이 아닙니다";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -626,6 +626,8 @@
 "joinSend" = "전송 참여";
 "joinSwap" = "스왑 참여";
 "joinTransactionSigning" = "트랜잭션 서명 참여";
+"kaminoErrorVaultMetadataMismatch" = "Kamino가 %1$@을(를) %2$@(으)로 보고했습니다. 이 볼트의 값은 %3$@입니다";
+"kaminoErrorVaultNotInRegistry" = "볼트 %@은(는) 이 앱이 거래하는 볼트가 아닙니다";
 "keyCopied" = "키 복사됨";
 "keygen" = "키젠";
 "keygenFailed" = "키 생성 실패";
@@ -1309,6 +1311,11 @@
 "slippageHelperText" = "실행이 취소되기 전에 가격이 변동할 수 있는 한도를 제한합니다.";
 "slippageMaxNote" = "슬리피지는 %@로 제한됩니다.";
 "slippageTolerance" = "슬리피지 허용치";
+"solanaAddressLookupTableErrorAccountNotFound" = "주소 조회 테이블 %@이(가) 체인에 존재하지 않습니다";
+"solanaAddressLookupTableErrorMalformedData" = "주소 조회 테이블 %@의 계정 데이터가 손상되었습니다";
+"solanaAddressLookupTableErrorUninitialized" = "주소 조회 테이블 %@이(가) 초기화되지 않았습니다";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "주소 조회 테이블 %@이(가) 예기치 않은 인코딩으로 반환되었습니다";
+"solanaAddressLookupTableErrorWrongOwner" = "계정 %1$@의 소유자는 %2$@이며, 주소 조회 테이블 프로그램이 아닙니다";
 "solanaBatchSigningNotSupported" = "여러 Solana 트랜잭션에 한 번에 서명하는 기능은 아직 지원되지 않습니다.";
 "solanaStakingActionDelegate" = "스테이킹";
 "solanaStakingActionUnstake" = "언스테이킹";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -626,6 +626,8 @@
 "joinSend" = "Juntar-se ao Envio";
 "joinSwap" = "Participar da troca";
 "joinTransactionSigning" = "Junte -se à assinatura da transação";
+"kaminoErrorVaultMetadataMismatch" = "A Kamino informou %1$@ como %2$@; o deste vault é %3$@";
+"kaminoErrorVaultNotInRegistry" = "O vault %@ não é um com o qual esta app transaciona";
 "keyCopied" = "Chave copiada";
 "keygen" = "Geração de chaves";
 "keygenFailed" = "A geração de chave falhou";
@@ -1309,6 +1311,11 @@
 "slippageHelperText" = "Limita quanto o preço pode mudar antes que a execução seja cancelada.";
 "slippageMaxNote" = "O slippage é limitado a %@.";
 "slippageTolerance" = "Tolerância de slippage";
+"solanaAddressLookupTableErrorAccountNotFound" = "A address lookup table %@ não existe na chain";
+"solanaAddressLookupTableErrorMalformedData" = "A address lookup table %@ tem dados de conta malformados";
+"solanaAddressLookupTableErrorUninitialized" = "A address lookup table %@ não está inicializada";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "A address lookup table %@ foi devolvida numa codificação inesperada";
+"solanaAddressLookupTableErrorWrongOwner" = "A conta %1$@ pertence a %2$@, não ao programa Address Lookup Table";
 "solanaBatchSigningNotSupported" = "Assinar várias transações Solana de uma vez ainda não é suportado.";
 "solanaStakingActionDelegate" = "Estaca";
 "solanaStakingActionUnstake" = "Cancelar stake";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -626,8 +626,8 @@
 "joinSend" = "Juntar-se ao Envio";
 "joinSwap" = "Participar da troca";
 "joinTransactionSigning" = "Junte -se à assinatura da transação";
-"kaminoErrorVaultMetadataMismatch" = "A Kamino informou %1$@ como %2$@; o deste vault é %3$@";
-"kaminoErrorVaultNotInRegistry" = "O vault %@ não é um com o qual esta app transaciona";
+"kaminoErrorVaultMetadataMismatch" = "A Kamino informou %1$@ como %2$@; o valor deste vault é %3$@";
+"kaminoErrorVaultNotInRegistry" = "O vault %@ não está no registro de vaults suportados por este aplicativo";
 "keyCopied" = "Chave copiada";
 "keygen" = "Geração de chaves";
 "keygenFailed" = "A geração de chave falhou";
@@ -1311,10 +1311,10 @@
 "slippageHelperText" = "Limita quanto o preço pode mudar antes que a execução seja cancelada.";
 "slippageMaxNote" = "O slippage é limitado a %@.";
 "slippageTolerance" = "Tolerância de slippage";
-"solanaAddressLookupTableErrorAccountNotFound" = "A address lookup table %@ não existe na chain";
-"solanaAddressLookupTableErrorMalformedData" = "A address lookup table %@ tem dados de conta malformados";
-"solanaAddressLookupTableErrorUninitialized" = "A address lookup table %@ não está inicializada";
-"solanaAddressLookupTableErrorUnsupportedEncoding" = "A address lookup table %@ foi devolvida numa codificação inesperada";
+"solanaAddressLookupTableErrorAccountNotFound" = "A tabela de consulta de endereços %@ não existe na chain";
+"solanaAddressLookupTableErrorMalformedData" = "A tabela de consulta de endereços %@ tem dados de conta malformados";
+"solanaAddressLookupTableErrorUninitialized" = "A tabela de consulta de endereços %@ não está inicializada";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "A tabela de consulta de endereços %@ foi devolvida numa codificação inesperada";
 "solanaAddressLookupTableErrorWrongOwner" = "A conta %1$@ pertence a %2$@, não ao programa Address Lookup Table";
 "solanaBatchSigningNotSupported" = "Assinar várias transações Solana de uma vez ainda não é suportado.";
 "solanaStakingActionDelegate" = "Estaca";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -626,6 +626,8 @@
 "joinSend" = "加入发送";
 "joinSwap" = "加入交换";
 "joinTransactionSigning" = "加入交易签名";
+"kaminoErrorVaultMetadataMismatch" = "Kamino 报告 %1$@ 为 %2$@；此金库的值为 %3$@";
+"kaminoErrorVaultNotInRegistry" = "金库 %@ 不是此应用会进行交易的金库";
 "keyCopied" = "密钥已复制";
 "keygen" = "密钥生成";
 "keygenFailed" = "密钥生成失败";
@@ -1309,6 +1311,11 @@
 "slippageHelperText" = "限制价格在执行被取消前可以变动的幅度。";
 "slippageMaxNote" = "滑点上限为 %@。";
 "slippageTolerance" = "滑点容差";
+"solanaAddressLookupTableErrorAccountNotFound" = "地址查找表 %@ 在链上不存在";
+"solanaAddressLookupTableErrorMalformedData" = "地址查找表 %@ 的账户数据格式错误";
+"solanaAddressLookupTableErrorUninitialized" = "地址查找表 %@ 尚未初始化";
+"solanaAddressLookupTableErrorUnsupportedEncoding" = "地址查找表 %@ 以意外的编码返回";
+"solanaAddressLookupTableErrorWrongOwner" = "账户 %1$@ 的所有者是 %2$@，而非地址查找表程序";
 "solanaBatchSigningNotSupported" = "暂不支持一次性签署多笔 Solana 交易。";
 "solanaStakingActionDelegate" = "质押";
 "solanaStakingActionUnstake" = "取消质押";

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoAPI.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoAPI.swift
@@ -1,0 +1,58 @@
+//
+//  KaminoAPI.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Kamino's public REST API. No key, no auth header — the action endpoints build
+/// an unsigned Solana transaction from the caller's wallet address alone, which
+/// is why every built transaction is validated on-device before it is signed.
+enum KaminoAPI: TargetType {
+
+    case vaultState(address: String)
+    case vaultMetrics(address: String)
+    case userPositions(owner: String)
+    case positionPnl(owner: String, vault: String)
+    case deposit(request: KaminoActionRequest)
+    case withdraw(request: KaminoActionRequest)
+
+    private static let apiBaseURL = URL(staticString: "https://api.kamino.finance")
+
+    var baseURL: URL { Self.apiBaseURL }
+
+    var path: String {
+        switch self {
+        case .vaultState(let address):
+            return "/kvaults/vaults/\(address)"
+        case .vaultMetrics(let address):
+            return "/kvaults/vaults/\(address)/metrics"
+        case .userPositions(let owner):
+            return "/kvaults/users/\(owner)/positions"
+        case .positionPnl(let owner, let vault):
+            return "/kvaults/users/\(owner)/vaults/\(vault)/pnl"
+        case .deposit:
+            return "/ktx/kvault/deposit"
+        case .withdraw:
+            return "/ktx/kvault/withdraw"
+        }
+    }
+
+    var method: HTTPMethod {
+        switch self {
+        case .vaultState, .vaultMetrics, .userPositions, .positionPnl:
+            return .get
+        case .deposit, .withdraw:
+            return .post
+        }
+    }
+
+    var task: HTTPTask {
+        switch self {
+        case .vaultState, .vaultMetrics, .userPositions, .positionPnl:
+            return .requestPlain
+        case .deposit(let request), .withdraw(let request):
+            return .requestCodable(request, .jsonEncoding)
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoAmount.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoAmount.swift
@@ -1,0 +1,284 @@
+//
+//  KaminoAmount.swift
+//  VultisigApp
+//
+
+import BigInt
+import Foundation
+
+/// Locale-independent parsing for Kamino's numeric JSON, which arrives as decimal
+/// strings (`"0.03994268764493801732"`, `"1.0536041812651029025"`).
+///
+/// `String.toDecimal()` is deliberately NOT used on these. It routes through
+/// `NumberFormatter`, which is Double-backed — so a 20-significant-digit rate
+/// truncates to ~16 — and locale-sensitive: on a `de_DE` device `"1.0536"` parses
+/// as one thousand and change, because `.` reads as a grouping separator. Both
+/// failure modes are silent and both mis-price a position.
+///
+/// What this guarantees: the *format* is validated, so grouping separators,
+/// exponents and whitespace are rejected rather than coerced. What it does not
+/// guarantee is exactness — `Decimal` holds 38 significant digits and Kamino
+/// publishes longer values (`prevAum` runs past 50). That is acceptable for the
+/// display values this is used on (APY, PnL, prices). Anything that sizes a
+/// transaction must use `KaminoRate`, which is exact.
+enum KaminoDecimal {
+
+    private static let posix = Locale(identifier: "en_US_POSIX")
+
+    static func parse(_ raw: String) -> Decimal? {
+        guard isPlainDecimal(raw) else { return nil }
+        return Decimal(string: raw, locale: posix)
+    }
+
+    /// Validates the character set and shape: optional leading `-`, digits, at
+    /// most one `.`, at least one digit.
+    static func isPlainDecimal(_ raw: String) -> Bool {
+        guard !raw.isEmpty else { return false }
+
+        var hasDigit = false
+        var hasSeparator = false
+        for (index, character) in raw.enumerated() {
+            switch character {
+            case "-":
+                guard index == 0 else { return false }
+            case ".":
+                guard !hasSeparator else { return false }
+                hasSeparator = true
+            default:
+                guard character.isASCII, character.isNumber else { return false }
+                hasDigit = true
+            }
+        }
+        return hasDigit
+    }
+
+    /// Renders an integral `Decimal` as plain digits under a fixed POSIX locale,
+    /// so the separator can never follow the device locale.
+    static func integralString(_ value: Decimal) -> String {
+        var copy = value
+        return NSDecimalString(&copy, posix)
+    }
+}
+
+/// An exact decimal value from the API, held as `numerator / 10^scale`.
+///
+/// This exists because `Decimal` arithmetic rounds. A share rate drives how many
+/// shares a withdraw burns, and the API does not validate amounts — it rewrites
+/// an over-sized withdraw to `u64::MAX`, meaning *withdraw everything*. A
+/// division that rounded up at the 38th significant digit could therefore turn a
+/// partial withdraw into a full exit. Integer arithmetic removes the question.
+struct KaminoRate: Hashable {
+    let numerator: BigInt
+    /// Denominator exponent: the value is `numerator / 10^scale`.
+    let scale: Int
+
+    /// Parses Kamino's decimal-string form exactly, with no intermediate binary
+    /// or `Decimal` representation.
+    init?(apiString raw: String) {
+        guard KaminoDecimal.isPlainDecimal(raw) else { return nil }
+
+        let parts = raw.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+        let whole = String(parts[0])
+        let fraction = parts.count > 1 ? String(parts[1]) : ""
+
+        guard let numerator = BigInt(whole + fraction) else { return nil }
+        self.numerator = numerator
+        self.scale = fraction.count
+    }
+
+    var isPositive: Bool { numerator > 0 }
+
+    /// Display-only projection. Loses precision past 38 significant digits, which
+    /// is why conversions never go through it.
+    var decimalValue: Decimal? {
+        KaminoDecimal.parse(apiStringValue)
+    }
+
+    private var apiStringValue: String {
+        KaminoBaseUnits.render(baseUnits: numerator, decimals: scale)
+    }
+}
+
+/// Rendering and scaling helpers shared by the amount types.
+enum KaminoBaseUnits {
+
+    /// Solana instruction arguments are `u64`; anything above that cannot be
+    /// expressed on-chain regardless of what the API would accept.
+    static let maxBaseUnits = BigInt(UInt64.max)
+
+    /// Widest decimal scale we are willing to handle. SPL mints are a `u8`, but
+    /// nothing legitimate approaches this, and an absurd scale would make the
+    /// `10^decimals` factors below unbounded.
+    static let maxDecimals = 18
+
+    /// Renders base units as a plain human-units decimal string: no grouping, no
+    /// trailing zeros, no exponent.
+    static func render(baseUnits: BigInt, decimals: Int) -> String {
+        let isNegative = baseUnits.sign == .minus
+        let digits = String(baseUnits.magnitude)
+        guard decimals > 0 else { return isNegative ? "-" + digits : digits }
+
+        let padded = String(repeating: "0", count: max(0, decimals + 1 - digits.count)) + digits
+        let splitIndex = padded.index(padded.endIndex, offsetBy: -decimals)
+        let whole = String(padded[padded.startIndex..<splitIndex])
+
+        var fraction = String(padded[splitIndex...])
+        while fraction.hasSuffix("0") { fraction.removeLast() }
+
+        let magnitude = fraction.isEmpty ? whole : whole + "." + fraction
+        return isNegative ? "-" + magnitude : magnitude
+    }
+}
+
+/// Shared behaviour for the two Kamino amount units. Base units are the exact
+/// on-chain integer; every other form is derived from it, so no value round-trips
+/// through a binary float.
+protocol KaminoBaseUnitAmount: Hashable {
+    var baseUnits: BigInt { get }
+    var decimals: Int { get }
+}
+
+extension KaminoBaseUnitAmount {
+
+    var isZero: Bool { baseUnits.isZero }
+
+    /// Whether this amount may be sent to Kamino. A request amount must be
+    /// strictly positive, expressible as a `u64`, and carry a sane scale.
+    var isValidRequestAmount: Bool {
+        baseUnits > 0
+            && baseUnits <= KaminoBaseUnits.maxBaseUnits
+            && (0...KaminoBaseUnits.maxDecimals).contains(decimals)
+    }
+
+    var decimalValue: Decimal {
+        KaminoDecimal.parse(apiString) ?? .zero
+    }
+
+    /// The value as Kamino's request bodies want it.
+    var apiString: String {
+        KaminoBaseUnits.render(baseUnits: baseUnits, decimals: decimals)
+    }
+}
+
+/// An amount denominated in a vault's **underlying token** (USDC, SOL).
+///
+/// This is what `POST /ktx/kvault/deposit` expects. Deposit and withdraw take the
+/// same `amount` JSON field with inverted units — deposit in tokens, withdraw in
+/// shares — so the two are separate types on purpose: passing one where the other
+/// belongs is a compile error rather than a silently mis-sized transaction.
+struct KaminoTokenAmount: KaminoBaseUnitAmount {
+    let baseUnits: BigInt
+    let decimals: Int
+
+    init(baseUnits: BigInt, decimals: Int) {
+        self.baseUnits = baseUnits
+        self.decimals = decimals
+    }
+
+    /// Parses a base-unit string as it appears in `VaultState` (e.g.
+    /// `minDepositAmount = "100000"` for 0.1 USDC).
+    init?(baseUnitString: String, decimals: Int) {
+        guard let baseUnits = BigInt(baseUnitString) else { return nil }
+        self.init(baseUnits: baseUnits, decimals: decimals)
+    }
+}
+
+/// An amount denominated in a vault's **share token** (kTokens).
+///
+/// This is what `POST /ktx/kvault/withdraw` expects — see `KaminoTokenAmount` for
+/// why the units are two distinct types.
+struct KaminoShareAmount: KaminoBaseUnitAmount {
+    let baseUnits: BigInt
+    let decimals: Int
+
+    init(baseUnits: BigInt, decimals: Int) {
+        self.baseUnits = baseUnits
+        self.decimals = decimals
+    }
+
+    /// Parses a base-unit string as it appears in `VaultState` (e.g.
+    /// `minWithdrawAmount = "1000"`, which is in SHARE base units, not token ones).
+    init?(baseUnitString: String, decimals: Int) {
+        guard let baseUnits = BigInt(baseUnitString) else { return nil }
+        self.init(baseUnits: baseUnits, decimals: decimals)
+    }
+
+    /// Parses a human-units share string as returned by
+    /// `GET /kvaults/users/{owner}/positions` (e.g. `"517536.857982"`), exactly.
+    init?(decimalString: String, decimals: Int) {
+        guard let rate = KaminoRate(apiString: decimalString),
+              let baseUnits = KaminoAmountMath.scale(rate: rate, toDecimals: decimals)
+        else { return nil }
+        self.init(baseUnits: baseUnits, decimals: decimals)
+    }
+}
+
+enum KaminoAmountMath {
+
+    /// Rescales an exact rate to base units at `decimals`, truncating toward zero.
+    static func scale(rate: KaminoRate, toDecimals decimals: Int) -> BigInt? {
+        guard (0...KaminoBaseUnits.maxDecimals).contains(decimals),
+              (0...KaminoBaseUnits.maxDecimals * 4).contains(rate.scale),
+              rate.numerator >= 0
+        else { return nil }
+
+        if decimals >= rate.scale {
+            return rate.numerator * BigInt(10).power(decimals - rate.scale)
+        }
+        return rate.numerator / BigInt(10).power(rate.scale - decimals)
+    }
+}
+
+extension KaminoShareAmount {
+
+    /// The position's value in the underlying token: `shares × tokensPerShare`,
+    /// computed in exact integer arithmetic and truncated.
+    ///
+    /// `tokensPerShare` is the correct rate — `metrics.sharePrice` is
+    /// USD-denominated and only coincides with it on dollar-pegged vaults (Allez
+    /// SOL: `sharePrice` 0.0794 vs `tokensPerShare` 0.0010749).
+    func tokenValue(tokensPerShare rate: KaminoRate, tokenDecimals: Int) -> KaminoTokenAmount? {
+        guard rate.isPositive,
+              baseUnits >= 0,
+              (0...KaminoBaseUnits.maxDecimals).contains(tokenDecimals),
+              (0...KaminoBaseUnits.maxDecimals).contains(decimals),
+              (0...KaminoBaseUnits.maxDecimals * 4).contains(rate.scale)
+        else { return nil }
+
+        // tokens = shares × rate, in base units:
+        //   tokensBase = sharesBase × numerator × 10^tokenDecimals
+        //                ÷ (10^shareDecimals × 10^rateScale)
+        let numerator = baseUnits * rate.numerator * BigInt(10).power(tokenDecimals)
+        let denominator = BigInt(10).power(decimals + rate.scale)
+        return KaminoTokenAmount(baseUnits: numerator / denominator, decimals: tokenDecimals)
+    }
+}
+
+extension KaminoTokenAmount {
+
+    /// Converts a user-entered token amount into the share amount a withdraw
+    /// actually burns: `shares = tokens / tokensPerShare`, truncated.
+    ///
+    /// Exact integer arithmetic, never `Decimal` division. Rounding down is a
+    /// safety property, not a preference: the API does not validate the amount,
+    /// and a withdraw larger than the user's share balance is silently rewritten
+    /// to `u64::MAX` — "withdraw everything". A division that rounded up, even by
+    /// one base unit at the far end of the mantissa, could turn a partial
+    /// withdraw into a full exit. For the same reason a 100% withdraw must send
+    /// the held share balance directly and never a number derived from here.
+    func shareAmount(tokensPerShare rate: KaminoRate, shareDecimals: Int) -> KaminoShareAmount? {
+        guard rate.isPositive,
+              baseUnits >= 0,
+              (0...KaminoBaseUnits.maxDecimals).contains(shareDecimals),
+              (0...KaminoBaseUnits.maxDecimals).contains(decimals),
+              (0...KaminoBaseUnits.maxDecimals * 4).contains(rate.scale)
+        else { return nil }
+
+        // shares = tokens ÷ rate, in base units:
+        //   sharesBase = tokensBase × 10^rateScale × 10^shareDecimals
+        //                ÷ (10^tokenDecimals × numerator)
+        let numerator = baseUnits * BigInt(10).power(rate.scale + shareDecimals)
+        let denominator = BigInt(10).power(decimals) * rate.numerator
+        return KaminoShareAmount(baseUnits: numerator / denominator, decimals: shareDecimals)
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoComputeBudget.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoComputeBudget.swift
@@ -1,0 +1,43 @@
+//
+//  KaminoComputeBudget.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Compute-budget parameters for the ComputeBudget instructions the app injects
+/// into Kamino's transactions.
+///
+/// Kamino builds its transactions with **no** ComputeBudget instruction at all,
+/// and ignores `priorityFeeLamports` / `computeUnitPriceMicroLamports` in the
+/// request body — the response is byte-identical with or without them. So the
+/// only way a Kamino transaction carries a priority fee is for the app to inject
+/// one, and injecting a price without a limit would price the fee off the
+/// runtime's default limit rather than the units the transaction actually needs.
+enum KaminoComputeBudget {
+
+    /// Compute units measured on mainnet with `simulateTransaction`
+    /// (`err: null`): USDC deposit 252,146 · SOL deposit 287,029 · withdraw
+    /// 174,566. Each limit below carries roughly a quarter more, which absorbs
+    /// the drift a different account-existence mix causes — a deposit whose
+    /// share ATA or farm user account still has to be created does strictly more
+    /// work than one whose accounts already exist.
+    ///
+    /// These are deliberately NOT `SolanaHelper.priorityFeeLimit`. That constant
+    /// is 100,000 CU, which sits below what every one of the three transactions
+    /// consumes, so reusing it would abort each of them on compute exhaustion.
+    static let tokenDepositUnitLimit: UInt32 = 320_000
+    /// A SOL-vault deposit additionally creates the wSOL account, transfers into
+    /// it and syncs it, so it costs more than a token deposit.
+    static let nativeDepositUnitLimit: UInt32 = 350_000
+    static let withdrawUnitLimit: UInt32 = 220_000
+
+    /// Price used when the network's recent-fee sample is unavailable, in
+    /// micro-lamports per compute unit. The live median from
+    /// `getRecentPrioritizationFees` is preferred; this is the floor beneath it.
+    ///
+    /// The priority fee is `price × limit`, so the limits above bound the cost
+    /// as well as the compute: at 320,000 units this price is 6,400 lamports
+    /// (0.0000064 SOL) on top of the base fee.
+    static let fallbackUnitPriceMicroLamports: UInt64 = 20_000
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoModels.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoModels.swift
@@ -1,0 +1,166 @@
+//
+//  KaminoModels.swift
+//  VultisigApp
+//
+
+import Foundation
+
+// MARK: - Reads
+
+/// `GET /kvaults/vaults/{address}`.
+struct KaminoVaultStateResponse: Decodable {
+    let address: String
+    let programId: String
+    let state: State
+
+    struct State: Decodable {
+        let name: String
+        let tokenMint: String
+        let tokenMintDecimals: Int
+        let sharesMint: String
+        /// Share decimals are independent of token decimals — across the live
+        /// vault set the pairs include (6,6), (6,9), (8,8) and (9,9). Never
+        /// assume they match.
+        let sharesMintDecimals: Int
+        /// Base units of the **underlying token**.
+        let minDepositAmount: String
+        /// Base units of **shares**, not of the token. A user-entered token
+        /// amount must be converted before it is compared against this.
+        let minWithdrawAmount: String
+        /// Address lookup table the built transactions reference.
+        let vaultLookupTable: String
+        /// When set, deposits auto-stake the shares into this farm and they never
+        /// appear in the user's associated token account.
+        let vaultFarm: String
+        let performanceFeeBps: Int
+        let managementFeeBps: Int
+    }
+}
+
+/// `GET /kvaults/vaults/{address}/metrics`. Every numeric field is a decimal
+/// string; APYs are fractions (`"0.0391"` = 3.91%), not percentages.
+struct KaminoVaultMetricsResponse: Decodable {
+    let apy30d: String
+    /// Underlying tokens per share — the rate for valuing a position.
+    let tokensPerShare: String
+    /// USD per share. NOT interchangeable with `tokensPerShare`.
+    let sharePrice: String
+    let tokenPrice: String
+    let tokensAvailable: String
+    let tokensInvested: String
+}
+
+/// One element of `GET /kvaults/users/{owner}/positions`. Shares only — the
+/// endpoint returns no token or fiat value.
+struct KaminoUserPositionResponse: Decodable {
+    let vaultAddress: String
+    /// Shares held inside the vault's farm. For a farmed vault this is where a
+    /// deposit lands, so it is normally the whole position.
+    let stakedShares: String
+    /// Shares sitting in the user's associated token account.
+    let unstakedShares: String
+    let totalShares: String
+}
+
+/// `GET /kvaults/users/{owner}/vaults/{vault}/pnl`.
+struct KaminoPnlResponse: Decodable {
+    let totalCostBasis: Amounts
+    let totalPnl: Amounts
+
+    struct Amounts: Decodable {
+        let token: String
+        let sol: String
+        let usd: String
+    }
+}
+
+// MARK: - Actions
+
+/// Body for `POST /ktx/kvault/{deposit,withdraw}`. `amount` is a human-units
+/// decimal string whose unit depends on the action: tokens for deposit, shares
+/// for withdraw. The typed builders on `KaminoService` are the only intended way
+/// to construct this.
+struct KaminoActionRequest: Encodable {
+    let wallet: String
+    let kvault: String
+    let amount: String
+}
+
+struct KaminoActionResponse: Decodable {
+    /// Base64 unsigned transaction, ready to validate, budget and keysign.
+    let transaction: String
+}
+
+/// Error body the API returns with a 400.
+struct KaminoErrorResponse: Decodable {
+    let statusCode: Int
+    let message: String
+    let error: String
+    let code: String?
+}
+
+// MARK: - Errors
+
+enum KaminoServiceError: Error, LocalizedError, Equatable {
+    /// A structured error from the API. `status` is retained alongside the
+    /// machine-readable `code` (`KVAULT_NOT_FOUND`, `TRANSACTION_SIZE_ERROR`, …)
+    /// so callers can still tell a permanent 400 from a retryable 429/5xx that
+    /// happened to carry the same body shape.
+    case api(status: Int, code: String?, message: String)
+    /// A numeric field did not parse under the strict decimal rules.
+    case malformedNumber(field: String, value: String)
+    /// An amount could not be sent: non-positive, beyond the `u64` an on-chain
+    /// instruction can carry, or at an implausible decimal scale.
+    case invalidAmount(String)
+    /// A share/token conversion could not be performed (non-positive rate).
+    case conversionFailed
+
+    /// Whether retrying the same request could plausibly succeed.
+    var isRetryable: Bool {
+        guard case .api(let status, _, _) = self else { return false }
+        return status == 429 || (500...599).contains(status)
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .api(_, let code, let message):
+            return code.map { "\($0): \(message)" } ?? message
+        case .malformedNumber(let field, let value):
+            return "Malformed Kamino number for \(field): \(value)"
+        case .invalidAmount(let detail):
+            return "Invalid Kamino amount: \(detail)"
+        case .conversionFailed:
+            return "Kamino share conversion failed"
+        }
+    }
+}
+
+// MARK: - Hydrated vault
+
+/// A launch vault after its registry entry has been merged with live API state
+/// and metrics. This is what the feature layer consumes; the raw responses stay
+/// at the service boundary.
+struct KaminoVaultInfo: Hashable, Identifiable {
+    let descriptor: KaminoVaultDescriptor
+    /// On-chain vault name (`"Steakhouse USDC"`).
+    let name: String
+    let tokenMint: String
+    let tokenDecimals: Int
+    let sharesMint: String
+    let shareDecimals: Int
+    let minDeposit: KaminoTokenAmount
+    let minWithdraw: KaminoShareAmount
+    let lookupTable: String
+    /// `true` when deposits auto-stake into a farm, so the shares are not visible
+    /// as a wallet token.
+    let hasFarm: Bool
+    /// 30-day APY as a fraction (0.0391 = 3.91%). Display-only, so `Decimal` is
+    /// fine here.
+    let apy30d: Decimal
+    /// Underlying tokens per share, kept exact: this rate sizes a withdraw, and
+    /// a rounding error in it can over-request shares.
+    let tokensPerShare: KaminoRate
+    let tokenPriceUsd: Decimal
+
+    var id: String { descriptor.address }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoModels.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoModels.swift
@@ -112,6 +112,15 @@ enum KaminoServiceError: Error, LocalizedError, Equatable {
     /// An amount could not be sent: non-positive, beyond the `u64` an on-chain
     /// instruction can carry, or at an implausible decimal scale.
     case invalidAmount(String)
+    /// A vault was described to the service in terms the registry does not
+    /// recognise. The curated entry is the app's record of a vault's identity;
+    /// anything else cannot be used to size or target a transaction.
+    case vaultNotInRegistry(String)
+    /// The API described a vault differently from the registry. Mints, their
+    /// decimals and the farm are immutable properties of a kVault, so a
+    /// disagreement is either the wrong vault or a response that cannot be
+    /// trusted to size or target a transaction.
+    case vaultMetadataMismatch(field: String, expected: String, actual: String)
     /// A share/token conversion could not be performed (non-positive rate).
     case conversionFailed
 
@@ -129,6 +138,10 @@ enum KaminoServiceError: Error, LocalizedError, Equatable {
             return "Malformed Kamino number for \(field): \(value)"
         case .invalidAmount(let detail):
             return "Invalid Kamino amount: \(detail)"
+        case .vaultNotInRegistry(let address):
+            return "Vault \(address) is not one this app transacts with"
+        case .vaultMetadataMismatch(let field, let expected, let actual):
+            return "Kamino reported \(field) as \(actual); this vault's is \(expected)"
         case .conversionFailed:
             return "Kamino share conversion failed"
         }
@@ -144,16 +157,17 @@ struct KaminoVaultInfo: Hashable, Identifiable {
     let descriptor: KaminoVaultDescriptor
     /// On-chain vault name (`"Steakhouse USDC"`).
     let name: String
-    let tokenMint: String
-    let tokenDecimals: Int
-    let sharesMint: String
-    let shareDecimals: Int
     let minDeposit: KaminoTokenAmount
     let minWithdraw: KaminoShareAmount
+    /// The address lookup table the built transactions reference.
+    ///
+    /// Live rather than pinned: unlike the mints and the farm, Kamino can
+    /// legitimately repoint a vault at a new table. It is also the one live
+    /// field a transaction check does not rest on — a table only decides which
+    /// pubkey an account index *names*, and every account that matters is
+    /// compared against a locally derived value, so a substituted table renames
+    /// an account into a mismatch rather than out of one.
     let lookupTable: String
-    /// `true` when deposits auto-stake into a farm, so the shares are not visible
-    /// as a wallet token.
-    let hasFarm: Bool
     /// 30-day APY as a fraction (0.0391 = 3.91%). Display-only, so `Decimal` is
     /// fine here.
     let apy30d: Decimal
@@ -163,4 +177,22 @@ struct KaminoVaultInfo: Hashable, Identifiable {
     let tokenPriceUsd: Decimal
 
     var id: String { descriptor.address }
+
+    // The vault's identity is read from the registry, never from the response.
+    // A transaction built by the API cannot be validated against values the same
+    // API supplied.
+    var tokenMint: String { descriptor.tokenMint }
+    var tokenDecimals: Int { descriptor.tokenDecimals }
+    var sharesMint: String { descriptor.sharesMint }
+    var shareDecimals: Int { descriptor.sharesDecimals }
+    var farm: String? { descriptor.farm }
+
+    /// `true` when deposits auto-stake into a farm, so the shares are not visible
+    /// as a wallet token.
+    var hasFarm: Bool { farm != nil }
+
+    /// A vault whose underlying token is wrapped SOL. Its deposits carry a
+    /// wrap prefix — create the wSOL account, transfer lamports, sync — that no
+    /// other vault emits.
+    var isWrappedSolVault: Bool { tokenMint == KaminoVaultRegistry.wrappedSolMint }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoModels.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoModels.swift
@@ -139,9 +139,9 @@ enum KaminoServiceError: Error, LocalizedError, Equatable {
         case .invalidAmount(let detail):
             return "Invalid Kamino amount: \(detail)"
         case .vaultNotInRegistry(let address):
-            return "Vault \(address) is not one this app transacts with"
+            return String(format: "kaminoErrorVaultNotInRegistry".localized, address)
         case .vaultMetadataMismatch(let field, let expected, let actual):
-            return "Kamino reported \(field) as \(actual); this vault's is \(expected)"
+            return String(format: "kaminoErrorVaultMetadataMismatch".localized, field, actual, expected)
         case .conversionFailed:
             return "Kamino share conversion failed"
         }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoService.swift
@@ -16,9 +16,12 @@ protocol KaminoServiceProtocol: Sendable {
 
     /// Builds an unsigned deposit transaction. The amount is in the vault's
     /// **underlying token**.
+    ///
+    /// Takes a descriptor rather than an address so the curated set is enforced
+    /// by the type: an arbitrary vault string cannot reach Kamino through here.
     func buildDepositTransaction(
         owner: String,
-        vault: String,
+        vault: KaminoVaultDescriptor,
         amount: KaminoTokenAmount
     ) async throws -> String
 
@@ -26,7 +29,7 @@ protocol KaminoServiceProtocol: Sendable {
     /// the inverse of deposit. This asymmetry is the API's, not ours.
     func buildWithdrawTransaction(
         owner: String,
-        vault: String,
+        vault: KaminoVaultDescriptor,
         shares: KaminoShareAmount
     ) async throws -> String
 }
@@ -164,24 +167,39 @@ struct KaminoService: KaminoServiceProtocol {
 
     func buildDepositTransaction(
         owner: String,
-        vault: String,
+        vault: KaminoVaultDescriptor,
         amount: KaminoTokenAmount
     ) async throws -> String {
+        try Self.assertCurated(vault)
         try Self.validate(amount, label: "deposit")
-        let request = KaminoActionRequest(wallet: owner, kvault: vault, amount: amount.apiString)
+        let request = KaminoActionRequest(wallet: owner, kvault: vault.address, amount: amount.apiString)
         let response = try await self.request(.deposit(request: request), as: KaminoActionResponse.self)
         return response.transaction
     }
 
     func buildWithdrawTransaction(
         owner: String,
-        vault: String,
+        vault: KaminoVaultDescriptor,
         shares: KaminoShareAmount
     ) async throws -> String {
+        try Self.assertCurated(vault)
         try Self.validate(shares, label: "withdraw")
-        let request = KaminoActionRequest(wallet: owner, kvault: vault, amount: shares.apiString)
+        let request = KaminoActionRequest(wallet: owner, kvault: vault.address, amount: shares.apiString)
         let response = try await self.request(.withdraw(request: request), as: KaminoActionResponse.self)
         return response.transaction
+    }
+
+    /// Refuses to build against anything but the registry's own entry.
+    ///
+    /// The descriptor type narrows the parameter, but it is a struct with a
+    /// memberwise initialiser — a caller can still assemble one that merely
+    /// looks curated. Comparing against the registry entry is what makes the
+    /// invariant hold, and it is the same check `fetchVaultInfo` runs: identity
+    /// is decided here, not by whatever the API is willing to build.
+    private static func assertCurated(_ descriptor: KaminoVaultDescriptor) throws {
+        guard KaminoVaultRegistry.descriptor(for: descriptor.address) == descriptor else {
+            throw KaminoServiceError.vaultNotInRegistry(descriptor.address)
+        }
     }
 
     // MARK: - Plumbing

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoService.swift
@@ -1,0 +1,217 @@
+//
+//  KaminoService.swift
+//  VultisigApp
+//
+
+import Foundation
+import OSLog
+
+protocol KaminoServiceProtocol: Sendable {
+    func fetchVaultState(address: String) async throws -> KaminoVaultStateResponse
+    func fetchVaultMetrics(address: String) async throws -> KaminoVaultMetricsResponse
+    /// Hydrates a curated vault with live state and metrics.
+    func fetchVaultInfo(descriptor: KaminoVaultDescriptor) async throws -> KaminoVaultInfo
+    func fetchPositions(owner: String) async throws -> [KaminoUserPositionResponse]
+    func fetchPnl(owner: String, vault: String) async throws -> KaminoPnlResponse
+
+    /// Builds an unsigned deposit transaction. The amount is in the vault's
+    /// **underlying token**.
+    func buildDepositTransaction(
+        owner: String,
+        vault: String,
+        amount: KaminoTokenAmount
+    ) async throws -> String
+
+    /// Builds an unsigned withdraw transaction. The amount is in **shares** —
+    /// the inverse of deposit. This asymmetry is the API's, not ours.
+    func buildWithdrawTransaction(
+        owner: String,
+        vault: String,
+        shares: KaminoShareAmount
+    ) async throws -> String
+}
+
+/// REST client for Kamino Earn vaults.
+///
+/// The service owns the boundary between Kamino's decimal-string JSON and the
+/// app's typed amounts: nothing above it sees a raw numeric string, and a value
+/// that fails the strict decimal rules throws rather than defaulting to zero.
+struct KaminoService: KaminoServiceProtocol {
+
+    private let httpClient: HTTPClientProtocol
+    private let logger = Log.defi.service
+
+    init(httpClient: HTTPClientProtocol = HTTPClient()) {
+        self.httpClient = httpClient
+    }
+
+    // MARK: - Reads
+
+    func fetchVaultState(address: String) async throws -> KaminoVaultStateResponse {
+        try await request(.vaultState(address: address), as: KaminoVaultStateResponse.self)
+    }
+
+    func fetchVaultMetrics(address: String) async throws -> KaminoVaultMetricsResponse {
+        try await request(.vaultMetrics(address: address), as: KaminoVaultMetricsResponse.self)
+    }
+
+    func fetchPositions(owner: String) async throws -> [KaminoUserPositionResponse] {
+        try await request(.userPositions(owner: owner), as: [KaminoUserPositionResponse].self)
+    }
+
+    func fetchPnl(owner: String, vault: String) async throws -> KaminoPnlResponse {
+        try await request(.positionPnl(owner: owner, vault: vault), as: KaminoPnlResponse.self)
+    }
+
+    func fetchVaultInfo(descriptor: KaminoVaultDescriptor) async throws -> KaminoVaultInfo {
+        async let stateTask = fetchVaultState(address: descriptor.address)
+        async let metricsTask = fetchVaultMetrics(address: descriptor.address)
+        let state = try await stateTask.state
+        let metrics = try await metricsTask
+
+        // Decimal scales come from the API and index the 10^n factors every
+        // conversion uses, so they are bounds-checked before anything derives
+        // from them.
+        guard Self.isPlausibleScale(state.tokenMintDecimals) else {
+            throw KaminoServiceError.malformedNumber(
+                field: "tokenMintDecimals",
+                value: String(state.tokenMintDecimals)
+            )
+        }
+        guard Self.isPlausibleScale(state.sharesMintDecimals) else {
+            throw KaminoServiceError.malformedNumber(
+                field: "sharesMintDecimals",
+                value: String(state.sharesMintDecimals)
+            )
+        }
+
+        guard let minDeposit = KaminoTokenAmount(
+            baseUnitString: state.minDepositAmount,
+            decimals: state.tokenMintDecimals
+        ) else {
+            throw KaminoServiceError.malformedNumber(
+                field: "minDepositAmount",
+                value: state.minDepositAmount
+            )
+        }
+
+        // Share base units, not token base units — the two decimal scales differ
+        // on the SOL vault (9 vs 6).
+        guard let minWithdraw = KaminoShareAmount(
+            baseUnitString: state.minWithdrawAmount,
+            decimals: state.sharesMintDecimals
+        ) else {
+            throw KaminoServiceError.malformedNumber(
+                field: "minWithdrawAmount",
+                value: state.minWithdrawAmount
+            )
+        }
+
+        let apy30d = try Self.decimal(metrics.apy30d, field: "apy30d")
+        let tokenPriceUsd = try Self.decimal(metrics.tokenPrice, field: "tokenPrice")
+
+        // Parsed exactly rather than through `Decimal`: this rate converts a
+        // user's token amount into the shares a withdraw burns.
+        guard let tokensPerShare = KaminoRate(apiString: metrics.tokensPerShare),
+              tokensPerShare.isPositive
+        else {
+            throw KaminoServiceError.malformedNumber(
+                field: "tokensPerShare",
+                value: metrics.tokensPerShare
+            )
+        }
+
+        return KaminoVaultInfo(
+            descriptor: descriptor,
+            name: state.name,
+            tokenMint: state.tokenMint,
+            tokenDecimals: state.tokenMintDecimals,
+            sharesMint: state.sharesMint,
+            shareDecimals: state.sharesMintDecimals,
+            minDeposit: minDeposit,
+            minWithdraw: minWithdraw,
+            lookupTable: state.vaultLookupTable,
+            hasFarm: Self.hasFarm(state.vaultFarm),
+            apy30d: apy30d,
+            tokensPerShare: tokensPerShare,
+            tokenPriceUsd: tokenPriceUsd
+        )
+    }
+
+    // MARK: - Actions
+
+    func buildDepositTransaction(
+        owner: String,
+        vault: String,
+        amount: KaminoTokenAmount
+    ) async throws -> String {
+        try Self.validate(amount, label: "deposit")
+        let request = KaminoActionRequest(wallet: owner, kvault: vault, amount: amount.apiString)
+        let response = try await self.request(.deposit(request: request), as: KaminoActionResponse.self)
+        return response.transaction
+    }
+
+    func buildWithdrawTransaction(
+        owner: String,
+        vault: String,
+        shares: KaminoShareAmount
+    ) async throws -> String {
+        try Self.validate(shares, label: "withdraw")
+        let request = KaminoActionRequest(wallet: owner, kvault: vault, amount: shares.apiString)
+        let response = try await self.request(.withdraw(request: request), as: KaminoActionResponse.self)
+        return response.transaction
+    }
+
+    // MARK: - Plumbing
+
+    /// Issues the request and converts Kamino's structured 400 body into a typed
+    /// error, so callers can branch on `code` (`KVAULT_NOT_FOUND`,
+    /// `TRANSACTION_SIZE_ERROR`, …) instead of matching on message text.
+    private func request<T: Decodable>(_ target: KaminoAPI, as type: T.Type) async throws -> T {
+        do {
+            return try await httpClient.request(target, responseType: type).data
+        } catch let error as HTTPError {
+            guard case .statusCode(let status, let data) = error,
+                  let data,
+                  let decoded = try? JSONDecoder().decode(KaminoErrorResponse.self, from: data)
+            else { throw error }
+
+            logger.error(
+                "kamino \(target.path, privacy: .public) failed \(status, privacy: .public): \(decoded.code ?? "-", privacy: .public)"
+            )
+            throw KaminoServiceError.api(status: status, code: decoded.code, message: decoded.message)
+        }
+    }
+
+    private static func decimal(_ raw: String, field: String) throws -> Decimal {
+        guard let value = KaminoDecimal.parse(raw) else {
+            throw KaminoServiceError.malformedNumber(field: field, value: raw)
+        }
+        return value
+    }
+
+    /// Last gate before an amount becomes a request body. The API accepts
+    /// anything it can parse — a below-minimum deposit builds a transaction that
+    /// fails on-chain, and an over-sized withdraw is rewritten to `u64::MAX`,
+    /// meaning withdraw everything — so bounds are enforced here.
+    private static func validate(_ amount: some KaminoBaseUnitAmount, label: String) throws {
+        guard amount.isValidRequestAmount else {
+            throw KaminoServiceError.invalidAmount(
+                "\(label) amount \(amount.baseUnits) at \(amount.decimals) decimals is out of range"
+            )
+        }
+    }
+
+    /// SPL mints are a `u8`, but nothing legitimate exceeds 18 and the scale
+    /// indexes a `10^n` factor in every conversion.
+    private static func isPlausibleScale(_ decimals: Int) -> Bool {
+        (0...KaminoBaseUnits.maxDecimals).contains(decimals)
+    }
+
+    /// The Solana default/system address doubles as "no farm attached".
+    private static func hasFarm(_ address: String) -> Bool {
+        !address.isEmpty && address != Self.systemProgramAddress
+    }
+
+    private static let systemProgramAddress = "11111111111111111111111111111111"
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoService.swift
@@ -64,30 +64,23 @@ struct KaminoService: KaminoServiceProtocol {
     }
 
     func fetchVaultInfo(descriptor: KaminoVaultDescriptor) async throws -> KaminoVaultInfo {
+        // The descriptor is what every later safety check is measured against, so
+        // it has to be the registry's own entry and not merely something carrying
+        // one of its addresses.
+        guard KaminoVaultRegistry.descriptor(for: descriptor.address) == descriptor else {
+            throw KaminoServiceError.vaultNotInRegistry(descriptor.address)
+        }
+
         async let stateTask = fetchVaultState(address: descriptor.address)
         async let metricsTask = fetchVaultMetrics(address: descriptor.address)
         let state = try await stateTask.state
         let metrics = try await metricsTask
 
-        // Decimal scales come from the API and index the 10^n factors every
-        // conversion uses, so they are bounds-checked before anything derives
-        // from them.
-        guard Self.isPlausibleScale(state.tokenMintDecimals) else {
-            throw KaminoServiceError.malformedNumber(
-                field: "tokenMintDecimals",
-                value: String(state.tokenMintDecimals)
-            )
-        }
-        guard Self.isPlausibleScale(state.sharesMintDecimals) else {
-            throw KaminoServiceError.malformedNumber(
-                field: "sharesMintDecimals",
-                value: String(state.sharesMintDecimals)
-            )
-        }
+        try Self.assertMatchesRegistry(state: state, descriptor: descriptor)
 
         guard let minDeposit = KaminoTokenAmount(
             baseUnitString: state.minDepositAmount,
-            decimals: state.tokenMintDecimals
+            decimals: descriptor.tokenDecimals
         ) else {
             throw KaminoServiceError.malformedNumber(
                 field: "minDepositAmount",
@@ -99,7 +92,7 @@ struct KaminoService: KaminoServiceProtocol {
         // on the SOL vault (9 vs 6).
         guard let minWithdraw = KaminoShareAmount(
             baseUnitString: state.minWithdrawAmount,
-            decimals: state.sharesMintDecimals
+            decimals: descriptor.sharesDecimals
         ) else {
             throw KaminoServiceError.malformedNumber(
                 field: "minWithdrawAmount",
@@ -124,18 +117,47 @@ struct KaminoService: KaminoServiceProtocol {
         return KaminoVaultInfo(
             descriptor: descriptor,
             name: state.name,
-            tokenMint: state.tokenMint,
-            tokenDecimals: state.tokenMintDecimals,
-            sharesMint: state.sharesMint,
-            shareDecimals: state.sharesMintDecimals,
             minDeposit: minDeposit,
             minWithdraw: minWithdraw,
             lookupTable: state.vaultLookupTable,
-            hasFarm: Self.hasFarm(state.vaultFarm),
             apy30d: apy30d,
             tokensPerShare: tokensPerShare,
             tokenPriceUsd: tokenPriceUsd
         )
+    }
+
+    /// Refuses a response whose account of the vault differs from the registry's.
+    ///
+    /// The mints, their decimals and the farm are immutable properties of a
+    /// kVault, so this can never fire on a legitimate change. It exists because
+    /// those values decide where funds go and how amounts are scaled: taking
+    /// them from the API would mean validating a transaction the API built
+    /// against values the same API supplied, and the pair could be made
+    /// consistent. Checking here means the whole feature — not just the
+    /// transaction validator — works from a vault identity the app already knew.
+    private static func assertMatchesRegistry(
+        state: KaminoVaultStateResponse.State,
+        descriptor: KaminoVaultDescriptor
+    ) throws {
+        try assertEqual(state.tokenMint, descriptor.tokenMint, field: "tokenMint")
+        try assertEqual(state.sharesMint, descriptor.sharesMint, field: "sharesMint")
+        try assertEqual(
+            String(state.tokenMintDecimals),
+            String(descriptor.tokenDecimals),
+            field: "tokenMintDecimals"
+        )
+        try assertEqual(
+            String(state.sharesMintDecimals),
+            String(descriptor.sharesDecimals),
+            field: "sharesMintDecimals"
+        )
+        try assertEqual(farm(state.vaultFarm) ?? "", descriptor.farm ?? "", field: "vaultFarm")
+    }
+
+    private static func assertEqual(_ actual: String, _ expected: String, field: String) throws {
+        guard actual == expected else {
+            throw KaminoServiceError.vaultMetadataMismatch(field: field, expected: expected, actual: actual)
+        }
     }
 
     // MARK: - Actions
@@ -202,15 +224,15 @@ struct KaminoService: KaminoServiceProtocol {
         }
     }
 
-    /// SPL mints are a `u8`, but nothing legitimate exceeds 18 and the scale
-    /// indexes a `10^n` factor in every conversion.
-    private static func isPlausibleScale(_ decimals: Int) -> Bool {
-        (0...KaminoBaseUnits.maxDecimals).contains(decimals)
-    }
+    // The decimal scales index a `10^n` factor in every conversion, so they have
+    // to be sane. They no longer need a runtime bound check here because they
+    // come from the registry rather than the response — `KaminoVaultRegistryTests`
+    // pins each one inside `0...KaminoBaseUnits.maxDecimals`.
 
     /// The Solana default/system address doubles as "no farm attached".
-    private static func hasFarm(_ address: String) -> Bool {
-        !address.isEmpty && address != Self.systemProgramAddress
+    private static func farm(_ address: String) -> String? {
+        guard !address.isEmpty, address != Self.systemProgramAddress else { return nil }
+        return address
     }
 
     private static let systemProgramAddress = "11111111111111111111111111111111"

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoSolanaInstructions.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoSolanaInstructions.swift
@@ -1,0 +1,113 @@
+//
+//  KaminoSolanaInstructions.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Every program a Kamino Earn transaction is allowed to invoke.
+///
+/// This is an allow-list, not a catalogue: an instruction whose program is not
+/// one of these is a refusal. That matters because the transaction is built by
+/// Kamino and signed verbatim, so the program set is the outer boundary on what
+/// the user's single signature can authorise. Anything outside it is code we
+/// never agreed to run.
+enum KaminoSolanaProgram: String, CaseIterable {
+    case system = "11111111111111111111111111111111"
+    case token = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    case token2022 = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+    case associatedToken = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+    case computeBudget = "ComputeBudget111111111111111111111111111111"
+    case kvault = "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd"
+    case farms = "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+
+    init?(programId: String) {
+        self.init(rawValue: programId)
+    }
+
+    /// Programs whose instructions Kamino's builder composes itself, rather than
+    /// reaching them through a CPI from its own programs.
+    ///
+    /// The distinction is the crux of the writable-account check. What `kvault`
+    /// and `farms` do with the accounts they are handed is the protocol we chose
+    /// to trust; what appears at the *top level* of the transaction is whatever
+    /// the builder decided to put there, so every account those instructions can
+    /// write to has to be one we can name.
+    var isBuilderComposed: Bool {
+        switch self {
+        case .system, .token, .token2022, .associatedToken:
+            return true
+        case .computeBudget, .kvault, .farms:
+            return false
+        }
+    }
+
+    var isTokenProgram: Bool {
+        self == .token || self == .token2022
+    }
+}
+
+/// Instruction discriminators for the programs a Kamino Earn transaction uses.
+///
+/// The four Anchor ones are `sha256("global:<name>")[0..<8]`, and each was also
+/// read back out of a mainnet-simulated transaction built by the Kamino API, so
+/// the constant and the observation agree.
+enum KaminoInstructionDiscriminator {
+
+    /// `kvault::deposit(u64 tokenAmount)`.
+    static let kvaultDeposit: [UInt8] = [0xf2, 0x23, 0xc6, 0x89, 0x52, 0xe1, 0xf2, 0xb6]
+    /// `kvault::withdraw(u64 shareAmount)` — the argument is in SHARES, the
+    /// inverse of deposit's unit.
+    static let kvaultWithdraw: [UInt8] = [0xb7, 0x12, 0x46, 0x9c, 0x94, 0x6d, 0xa1, 0x22]
+    /// `farms::initialize_user` — creates the user's farm state. Absent when it
+    /// already exists.
+    static let farmsInitializeUser: [UInt8] = [0x6f, 0x11, 0xb9, 0xfa, 0x3c, 0x7a, 0x26, 0xfe]
+    /// `farms::stake(u64 amount)`. Kamino always passes `u64::MAX`, meaning
+    /// "stake the whole share balance".
+    static let farmsStake: [UInt8] = [0xce, 0xb0, 0xca, 0x12, 0xc8, 0xd1, 0xb3, 0x6c]
+
+    /// Associated Token Program `CreateIdempotent`.
+    static let createIdempotentAssociatedTokenAccount: UInt8 = 1
+
+    /// SPL Token `SyncNative` — reconciles a wSOL account's token balance with
+    /// the lamports that were just transferred into it.
+    static let tokenSyncNative: UInt8 = 17
+    /// SPL Token `CloseAccount` — on the Kamino path this unwraps wSOL back to
+    /// native SOL, or reclaims the rent of an emptied token account.
+    static let tokenCloseAccount: UInt8 = 9
+
+    /// System Program `Transfer`, whose discriminant is a 4-byte little-endian
+    /// enum index rather than a single byte.
+    static let systemTransfer: [UInt8] = [2, 0, 0, 0]
+    /// `Transfer` payload: the 4-byte discriminant plus a `u64` lamport amount.
+    static let systemTransferDataLength = 12
+
+    /// An Anchor instruction's `u64` argument: the 8 bytes after the
+    /// discriminator, little-endian.
+    static func anchorArgument(_ data: [UInt8]) -> UInt64? {
+        guard data.count == 16 else { return nil }
+        return littleEndianUInt64(data[8..<16])
+    }
+
+    static func systemTransferLamports(_ data: [UInt8]) -> UInt64? {
+        guard data.count == systemTransferDataLength else { return nil }
+        return littleEndianUInt64(data[4..<12])
+    }
+
+    /// `SetComputeUnitLimit`'s `u32` argument.
+    static func computeUnitLimit(_ data: [UInt8]) -> UInt32? {
+        guard data.count == 5, data[0] == ComputeBudgetInstruction.setUnitLimit else { return nil }
+        return UInt32(truncatingIfNeeded: littleEndianUInt64(data[1..<5]))
+    }
+
+    /// `SetComputeUnitPrice`'s `u64` argument, in micro-lamports per compute
+    /// unit. The fee it produces is `price × limit`, so this is a spend.
+    static func computeUnitPrice(_ data: [UInt8]) -> UInt64? {
+        guard data.count == 9, data[0] == ComputeBudgetInstruction.setUnitPrice else { return nil }
+        return littleEndianUInt64(data[1..<9])
+    }
+
+    private static func littleEndianUInt64(_ bytes: ArraySlice<UInt8>) -> UInt64 {
+        bytes.reversed().reduce(UInt64(0)) { $0 << 8 | UInt64($1) }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoTransactionValidator.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoTransactionValidator.swift
@@ -1,0 +1,941 @@
+//
+//  KaminoTransactionValidator.swift
+//  VultisigApp
+//
+
+import BigInt
+import Foundation
+import OSLog
+
+private let logger = Log.defi.other
+
+/// What the user asked for. The amount carries its unit in its type, so the
+/// deposit/withdraw asymmetry — token base units one way, SHARE base units the
+/// other — cannot be confused at the point where it is checked against the bytes.
+enum KaminoOperation {
+    case deposit(KaminoTokenAmount)
+    case withdraw(KaminoShareAmount)
+}
+
+/// The priority fee the app injected: a compute unit limit and a price per unit.
+///
+/// The fee the network charges is `limit × price`, paid in SOL by the fee payer,
+/// so both halves are a spend and both are checked against the values the app
+/// chose rather than accepted from the transaction.
+struct KaminoPriorityFee: Equatable {
+    let limit: UInt32
+    /// Micro-lamports per compute unit.
+    let price: UInt64
+}
+
+/// The request a built transaction is supposed to be the answer to.
+struct KaminoTransactionIntent {
+    let operation: KaminoOperation
+    let vault: KaminoVaultInfo
+    /// The user's Solana address: fee payer, sole signer, and the account every
+    /// destination must belong to.
+    let owner: String
+    /// The priority fee the app injected, or `nil` before injection — in which
+    /// case any ComputeBudget instruction at all is a refusal, because Kamino's
+    /// builder emits none and a fee we did not choose is SOL leaving the wallet.
+    let priorityFee: KaminoPriorityFee?
+
+    init(
+        operation: KaminoOperation,
+        vault: KaminoVaultInfo,
+        owner: String,
+        priorityFee: KaminoPriorityFee? = nil
+    ) {
+        self.operation = operation
+        self.vault = vault
+        self.owner = owner
+        self.priorityFee = priorityFee
+    }
+}
+
+enum KaminoValidationError: Error, LocalizedError, Equatable {
+    case vaultNotAllowed(String)
+    /// The vault carries an allow-listed address but describes itself
+    /// differently from the registry entry for that address.
+    case vaultDescriptorMismatch(String)
+    case unexpectedLookupTable(expected: String, actual: String)
+    case tooManyLookupTables(Int)
+    case accountResolutionMismatch(resolved: Int, expected: Int)
+    case programNotAllowed(instruction: Int, program: String)
+    case unexpectedInstruction(index: Int, program: String)
+    /// An instruction that is well formed but belongs to the other operation, or
+    /// to a vault configuration this one does not have.
+    case instructionNotForOperation(index: Int, detail: String)
+    case missingInstruction(String)
+    case malformedInstruction(index: Int, detail: String)
+    case accountMismatch(role: String, expected: String, actual: String)
+    case accountNotOwnedByUser(role: String, actual: String)
+    case amountMismatch(role: String, expected: String, actual: String)
+    case amountOutOfRange(String)
+    case unexpectedPriorityFee(index: Int)
+    case unattributableWritableAccount(program: String, account: String)
+    case unreferencedWritableAccount(String)
+    case addressDerivationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .vaultNotAllowed(let address):
+            return "Vault \(address) is not one this app transacts with"
+        case .vaultDescriptorMismatch(let address):
+            return "Vault \(address) does not match this app's record of it"
+        case .unexpectedLookupTable(let expected, let actual):
+            return "Transaction uses address lookup table \(actual); the vault's is \(expected)"
+        case .tooManyLookupTables(let count):
+            return "Transaction uses \(count) address lookup tables; at most one is expected"
+        case .accountResolutionMismatch(let resolved, let expected):
+            return "Resolved \(resolved) accounts for a transaction addressing \(expected)"
+        case .programNotAllowed(let index, let program):
+            return "Instruction \(index) invokes \(program), which is not an allowed program"
+        case .unexpectedInstruction(let index, let program):
+            return "Instruction \(index) (\(program)) is not part of this operation"
+        case .instructionNotForOperation(let index, let detail):
+            return "Instruction \(index) is a \(detail) instruction, which this operation does not perform"
+        case .missingInstruction(let name):
+            return "Transaction is missing its \(name) instruction"
+        case .malformedInstruction(let index, let detail):
+            return "Instruction \(index) is malformed: \(detail)"
+        case .accountMismatch(let role, let expected, let actual):
+            return "Transaction's \(role) is \(actual), expected \(expected)"
+        case .accountNotOwnedByUser(let role, let actual):
+            return "Transaction's \(role) is \(actual), which is not an account of yours"
+        case .amountMismatch(let role, let expected, let actual):
+            return "Transaction's \(role) is \(actual), expected \(expected)"
+        case .amountOutOfRange(let detail):
+            return "Amount cannot be expressed on chain: \(detail)"
+        case .unexpectedPriorityFee(let index):
+            return "Instruction \(index) sets a priority fee this app did not choose"
+        case .unattributableWritableAccount(let program, let account):
+            return "Instruction from \(program) writes to \(account), which this operation does not explain"
+        case .unreferencedWritableAccount(let account):
+            return "Transaction loads \(account) as writable but no instruction uses it"
+        case .addressDerivationFailed(let detail):
+            return "Could not derive \(detail)"
+        }
+    }
+}
+
+/// Fail-closed validation of a Kamino-built Solana transaction, in the
+/// `SwapRecipientVerifier` mould.
+///
+/// Kamino builds the transaction, the app signs the bytes verbatim, and Blockaid
+/// is advisory. So between an API response and a signature over it there is only
+/// this. It runs before simulation and before keysign, and every finding is a
+/// refusal — nothing here downgrades to a warning.
+///
+/// What it establishes, in layers:
+///
+/// 1. **Shape.** One required signature, still an unsigned placeholder, paid for
+///    by the user. Every lookup table is the vault's own, so no account can be
+///    named through a table we did not expect.
+/// 2. **Programs.** Every `programIdIndex` resolves to an allow-listed program.
+///    That is the outer bound on what the user's signature can authorise.
+/// 3. **Sequence.** The instruction list must match the shape this operation
+///    produces, in order. An instruction that is not in the template is a refusal
+///    rather than something skipped — so a new one fails closed.
+/// 4. **Identity.** Inside each instruction, the accounts that decide where money
+///    goes are compared against values the app already had: the vault, its mints
+///    and its farm come from the registry, and the user's token accounts from the
+///    ATA derivation. None of them is read from the response — checking a
+///    transaction the API built against metadata the same API supplied would be
+///    circular, and a compromised response could make the pair agree.
+/// 5. **Amount.** The `u64` the kvault instruction carries equals the amount the
+///    user was shown — in tokens for a deposit, in shares for a withdraw. The
+///    priority fee is an amount too: `limit × price` is SOL, so both halves must
+///    equal the values the app injected, and before injection a ComputeBudget
+///    instruction may not be there at all.
+/// 6. **Writable accounts.** Every writable account is used by some instruction,
+///    and any account a *builder-composed* instruction can write to must be one
+///    of the accounts this operation explains. This is the layer that catches a
+///    drain hidden in an otherwise plausible transaction.
+///
+/// What it does not establish is what the `kvault` and `farms` programs do with
+/// the accounts they are handed. That is the protocol, and choosing to trust it
+/// is what the registry allow-list expresses.
+struct KaminoTransactionValidator {
+
+    private let lookupTableSource: SolanaAddressLookupTableFetching
+
+    init(lookupTableSource: SolanaAddressLookupTableFetching = SolanaService.shared) {
+        self.lookupTableSource = lookupTableSource
+    }
+
+    /// Resolves the transaction's address lookup tables from the RPC, then
+    /// validates it against `intent`.
+    func validate(transaction: SolanaV0Transaction, intent: KaminoTransactionIntent) async throws {
+        let tables = try await lookupTableSource.fetchAddressLookupTables(
+            addresses: transaction.addressTableLookups.map(\.tableAddress)
+        )
+        do {
+            try Self.validate(transaction: transaction, intent: intent, lookupTables: tables)
+        } catch {
+            logger.error("[kamino-validate] refused: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+
+    /// Pure core, exposed so it can be driven against pinned lookup-table
+    /// contents rather than the network.
+    ///
+    /// - Parameter lookupTables: table address to that table's full address list.
+    static func validate(
+        transaction: SolanaV0Transaction,
+        intent: KaminoTransactionIntent,
+        lookupTables: [String: [String]]
+    ) throws {
+        let vaultAddress = intent.vault.descriptor.address
+        guard let registered = KaminoVaultRegistry.descriptor(for: vaultAddress) else {
+            throw KaminoValidationError.vaultNotAllowed(vaultAddress)
+        }
+        // Not just the address. Every value the checks below rest on — the mints,
+        // their decimals, the farm — lives on this descriptor, so accepting one
+        // that merely *claims* an allow-listed address would hand an attacker the
+        // pinning itself. Comparing the whole descriptor makes the registry the
+        // only possible source of a vault's identity, structurally rather than by
+        // convention.
+        guard registered == intent.vault.descriptor else {
+            throw KaminoValidationError.vaultDescriptorMismatch(vaultAddress)
+        }
+
+        try transaction.validateUnsignedSingleSigner(feePayer: intent.owner)
+        try validateLookupTables(transaction: transaction, expected: intent.vault.lookupTable)
+
+        let accounts = try transaction.resolvedAccountAddresses(lookupTables: lookupTables)
+        guard accounts.count == transaction.totalAccountCount else {
+            throw KaminoValidationError.accountResolutionMismatch(
+                resolved: accounts.count,
+                expected: transaction.totalAccountCount
+            )
+        }
+
+        let context = try Context(intent: intent, accounts: accounts, transaction: transaction)
+        try validatePrograms(context)
+        try validatePriorityFeePresence(context)
+        try validateSequence(context)
+        try validateWritableAccounts(context)
+    }
+
+    // MARK: - Lookup tables
+
+    /// Every table the transaction reads from must be the vault's own.
+    ///
+    /// A table decides which pubkey an account index names, so a foreign one is
+    /// how an account substitution would be hidden. Zero tables is allowed — then
+    /// every account is a static key and there is nothing to hide behind.
+    private static func validateLookupTables(transaction: SolanaV0Transaction, expected: String) throws {
+        guard transaction.addressTableLookups.count <= 1 else {
+            throw KaminoValidationError.tooManyLookupTables(transaction.addressTableLookups.count)
+        }
+        for lookup in transaction.addressTableLookups where lookup.tableAddress != expected {
+            throw KaminoValidationError.unexpectedLookupTable(expected: expected, actual: lookup.tableAddress)
+        }
+    }
+
+    // MARK: - Programs
+
+    private static func validatePrograms(_ context: Context) throws {
+        for (position, program) in context.programs.enumerated() where program == nil {
+            throw KaminoValidationError.programNotAllowed(
+                instruction: position,
+                program: context.programId(at: position)
+            )
+        }
+    }
+
+    /// Before injection the app has chosen no fee, so a ComputeBudget
+    /// instruction can only have come from the response.
+    ///
+    /// Checked separately from the sequence so the refusal names the real
+    /// problem: a priority fee is `limit × price` lamports out of the user's
+    /// balance, and an unrecognised one would otherwise read as a sequencing
+    /// error.
+    private static func validatePriorityFeePresence(_ context: Context) throws {
+        guard context.intent.priorityFee == nil else { return }
+        for (position, program) in context.programs.enumerated() where program == .computeBudget {
+            throw KaminoValidationError.unexpectedPriorityFee(index: position)
+        }
+    }
+
+    // MARK: - Instruction sequence
+
+    /// Walks the expected sequence and the actual instructions together. A step
+    /// that does not match is skipped only when it is optional; an instruction
+    /// left over at the end has no place in this operation at all.
+    private static func validateSequence(_ context: Context) throws {
+        var cursor = 0
+        for step in expectedSequence(for: context.intent) {
+            if step.isRepeatable {
+                while cursor < context.instructionCount, context.matches(step.kind, at: cursor) {
+                    try validateInstruction(step.kind, at: cursor, context)
+                    cursor += 1
+                }
+                continue
+            }
+            if cursor < context.instructionCount, context.matches(step.kind, at: cursor) {
+                try validateInstruction(step.kind, at: cursor, context)
+                cursor += 1
+            } else if step.isRequired {
+                throw KaminoValidationError.missingInstruction(step.kind.name)
+            }
+        }
+        guard cursor == context.instructionCount else {
+            throw KaminoValidationError.unexpectedInstruction(
+                index: cursor,
+                program: context.programId(at: cursor)
+            )
+        }
+    }
+
+    /// The instruction shapes each operation produces, verified by decoding
+    /// transactions the Kamino API built and simulating them on mainnet.
+    ///
+    /// Optional steps are the ones whose absence cannot cost the user anything —
+    /// an idempotent account creation that was already done, a farm user that
+    /// already exists, a token account that stays open. Everything that decides
+    /// where money moves is required, and anything not listed at all is refused.
+    ///
+    /// The withdraw sequence is the one that is not yet complete: every observed
+    /// withdraw spent unstaked shares, while every deposit auto-stakes, so the
+    /// farm-staked withdraw has never been seen. If it carries a farm unstake,
+    /// this refuses it — deliberately, until the real shape has been observed
+    /// rather than guessed.
+    private static func expectedSequence(for intent: KaminoTransactionIntent) -> [Step] {
+        // The API emits no ComputeBudget instructions. The two below are the
+        // ones the app injects, so they are expected exactly when a fee was
+        // injected and pinned to its values when they are.
+        var steps: [Step] = []
+        if intent.priorityFee != nil {
+            steps.append(Step(.computeUnitLimit, required: true, repeatable: false))
+            steps.append(Step(.computeUnitPrice, required: true, repeatable: false))
+        }
+
+        switch intent.operation {
+        case .deposit:
+            steps.append(Step(.createTokenAccount, required: false, repeatable: true))
+            if intent.vault.isWrappedSolVault {
+                steps.append(Step(.wrapSolTransfer, required: true, repeatable: false))
+                steps.append(Step(.syncNative, required: true, repeatable: false))
+                steps.append(Step(.createTokenAccount, required: false, repeatable: true))
+            }
+            steps.append(Step(.kvaultDeposit, required: true, repeatable: false))
+            if intent.vault.hasFarm {
+                // Only the user's farm state may already exist. The stake itself
+                // is what makes the shares the position the app then reads, so a
+                // deposit that omits it is not the deposit that was requested.
+                steps.append(Step(.farmsInitializeUser, required: false, repeatable: false))
+                steps.append(Step(.farmsStake, required: true, repeatable: false))
+            }
+
+        case .withdraw:
+            steps.append(Step(.createTokenAccount, required: false, repeatable: true))
+            steps.append(Step(.kvaultWithdraw, required: true, repeatable: false))
+            steps.append(Step(.closeTokenAccount, required: false, repeatable: false))
+        }
+
+        return steps
+    }
+
+    // MARK: - Per-instruction checks
+
+    private static func validateInstruction(_ kind: Step.Kind, at position: Int, _ context: Context) throws {
+        let data = context.transaction.instructions[position].data
+        let accounts = context.accountAddresses(at: position)
+
+        switch kind {
+        case .computeUnitLimit:
+            try validateComputeUnitLimit(data: data, accounts: accounts, position: position, context)
+
+        case .computeUnitPrice:
+            try validateComputeUnitPrice(data: data, accounts: accounts, position: position, context)
+
+        case .createTokenAccount:
+            try validateCreateTokenAccount(accounts: accounts, position: position, context)
+
+        case .wrapSolTransfer:
+            try validateWrapSolTransfer(data: data, accounts: accounts, position: position, context)
+
+        case .syncNative:
+            guard let account = accounts.first else {
+                throw KaminoValidationError.malformedInstruction(index: position, detail: "syncNative takes an account")
+            }
+            try context.requireUserTokenAccount(account, role: "wrapped SOL account")
+
+        case .closeTokenAccount:
+            try validateCloseTokenAccount(accounts: accounts, position: position, context)
+
+        case .kvaultDeposit:
+            try validateKvaultDeposit(data: data, accounts: accounts, position: position, context)
+
+        case .kvaultWithdraw:
+            try validateKvaultWithdraw(data: data, accounts: accounts, position: position, context)
+
+        case .farmsInitializeUser:
+            try validateFarmsInitializeUser(accounts: accounts, position: position, context)
+
+        case .farmsStake:
+            try validateFarmsStake(data: data, accounts: accounts, position: position, context)
+        }
+    }
+
+    /// The compute unit limit, pinned to the value the app injected.
+    ///
+    /// A limit is half of the fee: the network charges `limit × price`, so a
+    /// limit raised beyond what the transaction needs is SOL spent for nothing.
+    private static func validateComputeUnitLimit(
+        data: [UInt8],
+        accounts: [String],
+        position: Int,
+        _ context: Context
+    ) throws {
+        try requireNoAccounts(accounts, position: position)
+        guard let fee = context.intent.priorityFee,
+              let limit = KaminoInstructionDiscriminator.computeUnitLimit(data) else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "compute unit limit")
+        }
+        guard limit == fee.limit else {
+            throw KaminoValidationError.amountMismatch(
+                role: "compute unit limit",
+                expected: String(fee.limit),
+                actual: String(limit)
+            )
+        }
+    }
+
+    /// The price per compute unit, pinned to the value the app injected. This is
+    /// the half an attacker would inflate: it is a `u64` of micro-lamports and
+    /// nothing on chain caps the resulting fee below the payer's balance.
+    private static func validateComputeUnitPrice(
+        data: [UInt8],
+        accounts: [String],
+        position: Int,
+        _ context: Context
+    ) throws {
+        try requireNoAccounts(accounts, position: position)
+        guard let fee = context.intent.priorityFee,
+              let price = KaminoInstructionDiscriminator.computeUnitPrice(data) else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "compute unit price")
+        }
+        guard price == fee.price else {
+            throw KaminoValidationError.amountMismatch(
+                role: "compute unit price",
+                expected: String(fee.price),
+                actual: String(price)
+            )
+        }
+    }
+
+    private static func requireNoAccounts(_ accounts: [String], position: Int) throws {
+        guard accounts.isEmpty else {
+            throw KaminoValidationError.malformedInstruction(
+                index: position,
+                detail: "compute budget instructions take no accounts"
+            )
+        }
+    }
+
+    /// A `CreateIdempotent` may only create one of the vault's two mints'
+    /// accounts, for the user, at the address that derivation says it must have.
+    /// Creating an account is harmless in itself, but it is also where a
+    /// third-party destination would first appear.
+    private static func validateCreateTokenAccount(accounts: [String], position: Int, _ context: Context) throws {
+        guard accounts.count >= AssociatedTokenAccounts.count else {
+            throw KaminoValidationError.malformedInstruction(
+                index: position,
+                detail: "createIdempotent needs \(AssociatedTokenAccounts.count) accounts"
+            )
+        }
+        try context.requireOwner(accounts[AssociatedTokenAccounts.payer], role: "token account funder")
+        try context.requireOwner(accounts[AssociatedTokenAccounts.wallet], role: "token account owner")
+
+        let mint = accounts[AssociatedTokenAccounts.mint]
+        guard mint == context.intent.vault.tokenMint || mint == context.intent.vault.sharesMint else {
+            throw KaminoValidationError.accountMismatch(
+                role: "created token account mint",
+                expected: "\(context.intent.vault.tokenMint) or \(context.intent.vault.sharesMint)",
+                actual: mint
+            )
+        }
+
+        let programId = accounts[AssociatedTokenAccounts.tokenProgram]
+        guard let tokenProgram = SolanaTokenProgram(programId: programId) else {
+            throw KaminoValidationError.programNotAllowed(instruction: position, program: programId)
+        }
+        guard let derived = SolanaAssociatedTokenAccount.derive(
+            owner: context.intent.owner,
+            mint: mint,
+            tokenProgram: tokenProgram
+        ) else {
+            throw KaminoValidationError.addressDerivationFailed("the associated token account for \(mint)")
+        }
+        guard accounts[AssociatedTokenAccounts.account] == derived else {
+            throw KaminoValidationError.accountMismatch(
+                role: "created token account",
+                expected: derived,
+                actual: accounts[AssociatedTokenAccounts.account]
+            )
+        }
+    }
+
+    /// The lamports that fund the wSOL account. This is the only native SOL
+    /// movement the operation performs, so both its endpoints and its amount are
+    /// pinned: out of the user's own account, into the user's own wSOL account,
+    /// for exactly the deposit.
+    private static func validateWrapSolTransfer(
+        data: [UInt8],
+        accounts: [String],
+        position: Int,
+        _ context: Context
+    ) throws {
+        guard accounts.count >= SystemTransferAccounts.count,
+              let lamports = KaminoInstructionDiscriminator.systemTransferLamports(data) else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "system transfer")
+        }
+        try context.requireOwner(accounts[SystemTransferAccounts.source], role: "SOL transfer source")
+        try context.requireUserTokenAccount(
+            accounts[SystemTransferAccounts.destination],
+            role: "SOL transfer destination"
+        )
+
+        guard case .deposit(let amount) = context.intent.operation else {
+            throw KaminoValidationError.instructionNotForOperation(index: position, detail: "SOL wrap")
+        }
+        let expected = try requireUInt64(amount.baseUnits, role: "deposit amount")
+        guard lamports == expected else {
+            throw KaminoValidationError.amountMismatch(
+                role: "wrapped SOL amount",
+                expected: String(expected),
+                actual: String(lamports)
+            )
+        }
+    }
+
+    /// Closing a token account sends its remaining lamports somewhere. Both the
+    /// account being closed and where its rent lands have to be the user's.
+    private static func validateCloseTokenAccount(accounts: [String], position: Int, _ context: Context) throws {
+        guard accounts.count >= CloseAccountAccounts.count else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "closeAccount")
+        }
+        let closed = accounts[CloseAccountAccounts.account]
+        guard context.userTokenAccounts.contains(closed) || context.userShareAccounts.contains(closed) else {
+            throw KaminoValidationError.accountNotOwnedByUser(role: "closed token account", actual: closed)
+        }
+        try context.requireOwner(accounts[CloseAccountAccounts.destination], role: "closed account rent destination")
+        try context.requireOwner(accounts[CloseAccountAccounts.authority], role: "closed account authority")
+    }
+
+    private static func validateKvaultDeposit(
+        data: [UInt8],
+        accounts: [String],
+        position: Int,
+        _ context: Context
+    ) throws {
+        guard accounts.count >= KvaultDepositAccounts.minimumCount else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "kvault deposit accounts")
+        }
+        guard case .deposit(let amount) = context.intent.operation else {
+            throw KaminoValidationError.instructionNotForOperation(index: position, detail: "vault deposit")
+        }
+
+        try context.requireOwner(accounts[KvaultDepositAccounts.user], role: "deposit authority")
+        try context.requireVault(accounts[KvaultDepositAccounts.vault])
+        try context.requireMint(accounts[KvaultDepositAccounts.tokenMint], expected: context.intent.vault.tokenMint, role: "deposit token mint")
+        try context.requireMint(accounts[KvaultDepositAccounts.sharesMint], expected: context.intent.vault.sharesMint, role: "deposit shares mint")
+        try context.requireUserTokenAccount(accounts[KvaultDepositAccounts.userTokenAccount], role: "deposit source")
+        try context.requireUserShareAccount(accounts[KvaultDepositAccounts.userShareAccount], role: "deposit share destination")
+
+        try requireAnchorAmount(
+            data: data,
+            position: position,
+            expected: amount.baseUnits,
+            role: "deposit amount"
+        )
+    }
+
+    private static func validateKvaultWithdraw(
+        data: [UInt8],
+        accounts: [String],
+        position: Int,
+        _ context: Context
+    ) throws {
+        guard accounts.count >= KvaultWithdrawAccounts.minimumCount else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "kvault withdraw accounts")
+        }
+        guard case .withdraw(let shares) = context.intent.operation else {
+            throw KaminoValidationError.instructionNotForOperation(index: position, detail: "vault withdraw")
+        }
+
+        try context.requireOwner(accounts[KvaultWithdrawAccounts.user], role: "withdraw authority")
+        try context.requireVault(accounts[KvaultWithdrawAccounts.vault])
+        try context.requireMint(accounts[KvaultWithdrawAccounts.tokenMint], expected: context.intent.vault.tokenMint, role: "withdraw token mint")
+        try context.requireMint(accounts[KvaultWithdrawAccounts.sharesMint], expected: context.intent.vault.sharesMint, role: "withdraw shares mint")
+        try context.requireUserTokenAccount(accounts[KvaultWithdrawAccounts.userTokenAccount], role: "withdraw destination")
+        try context.requireUserShareAccount(accounts[KvaultWithdrawAccounts.userShareAccount], role: "withdraw share source")
+
+        // Shares, not tokens. The API takes the same `amount` field for both
+        // actions with inverted units, and an amount above the user's balance is
+        // silently rewritten to u64::MAX — withdraw everything — so this is the
+        // check that stands between a partial exit and a full one.
+        try requireAnchorAmount(
+            data: data,
+            position: position,
+            expected: shares.baseUnits,
+            role: "withdraw share amount"
+        )
+    }
+
+    private static func validateFarmsInitializeUser(accounts: [String], position: Int, _ context: Context) throws {
+        guard accounts.count >= FarmsInitializeUserAccounts.minimumCount else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "farms initializeUser accounts")
+        }
+        try context.requireOwner(accounts[FarmsInitializeUserAccounts.authority], role: "farm user authority")
+        try context.requireFarm(accounts[FarmsInitializeUserAccounts.farm], position: position)
+    }
+
+    /// The stake that makes the deposit's shares invisible in the wallet. It must
+    /// move the user's own shares into this vault's own farm — a farm belonging
+    /// to another vault would park the position somewhere the app never reads.
+    private static func validateFarmsStake(
+        data: [UInt8],
+        accounts: [String],
+        position: Int,
+        _ context: Context
+    ) throws {
+        guard accounts.count >= FarmsStakeAccounts.minimumCount else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "farms stake accounts")
+        }
+        try context.requireOwner(accounts[FarmsStakeAccounts.owner], role: "stake authority")
+        try context.requireFarm(accounts[FarmsStakeAccounts.farm], position: position)
+        try context.requireUserShareAccount(accounts[FarmsStakeAccounts.userShareAccount], role: "stake source")
+        try context.requireMint(accounts[FarmsStakeAccounts.sharesMint], expected: context.intent.vault.sharesMint, role: "stake shares mint")
+
+        // Kamino stakes the whole share balance rather than the freshly minted
+        // amount, so the argument is the u64 sentinel. A different value is a
+        // behaviour change, not a variation, and is worth stopping on.
+        guard let argument = KaminoInstructionDiscriminator.anchorArgument(data) else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "farms stake argument")
+        }
+        guard argument == UInt64.max else {
+            throw KaminoValidationError.amountMismatch(
+                role: "staked share amount",
+                expected: String(UInt64.max),
+                actual: String(argument)
+            )
+        }
+    }
+
+    // MARK: - Writable accounts
+
+    /// Two rules, together covering "no unexplained writes".
+    ///
+    /// A writable account nothing references is a loaded write privilege with no
+    /// purpose, which is not a shape any legitimate builder emits. And an account
+    /// that a builder-composed instruction can write to has to be one this
+    /// operation can name — the user, the vault, its two mints, or the user's own
+    /// token accounts for them. A drain has to write somewhere, and outside the
+    /// `kvault`/`farms` programs there is nowhere left for it to write.
+    private static func validateWritableAccounts(_ context: Context) throws {
+        var referenced = Set<Int>()
+        for instruction in context.transaction.instructions {
+            referenced.formUnion(instruction.accountIndexes.map(Int.init))
+        }
+        for index in context.accounts.indices
+        where context.transaction.isWritable(accountIndex: index) && !referenced.contains(index) {
+            throw KaminoValidationError.unreferencedWritableAccount(context.accounts[index])
+        }
+
+        for (position, program) in context.programs.enumerated() {
+            guard let program, program.isBuilderComposed else { continue }
+            for index in context.transaction.instructions[position].accountIndexes
+            where context.transaction.isWritable(accountIndex: Int(index)) {
+                let account = context.accounts[Int(index)]
+                guard context.explainedAccounts.contains(account) else {
+                    throw KaminoValidationError.unattributableWritableAccount(
+                        program: program.rawValue,
+                        account: account
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Amount helpers
+
+    private static func requireAnchorAmount(
+        data: [UInt8],
+        position: Int,
+        expected: BigInt,
+        role: String
+    ) throws {
+        guard let argument = KaminoInstructionDiscriminator.anchorArgument(data) else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "\(role) argument")
+        }
+        let bounded = try requireUInt64(expected, role: role)
+        guard argument == bounded else {
+            throw KaminoValidationError.amountMismatch(
+                role: role,
+                expected: String(bounded),
+                actual: String(argument)
+            )
+        }
+    }
+
+    private static func requireUInt64(_ value: BigInt, role: String) throws -> UInt64 {
+        guard let bounded = UInt64(exactly: value) else {
+            throw KaminoValidationError.amountOutOfRange("\(role) \(value)")
+        }
+        return bounded
+    }
+}
+
+// MARK: - Sequence model
+
+private extension KaminoTransactionValidator {
+
+    struct Step {
+        enum Kind {
+            case computeUnitLimit
+            case computeUnitPrice
+            case createTokenAccount
+            case wrapSolTransfer
+            case syncNative
+            case closeTokenAccount
+            case kvaultDeposit
+            case kvaultWithdraw
+            case farmsInitializeUser
+            case farmsStake
+
+            var name: String {
+                switch self {
+                case .computeUnitLimit: return "compute unit limit"
+                case .computeUnitPrice: return "compute unit price"
+                case .createTokenAccount: return "create associated token account"
+                case .wrapSolTransfer: return "SOL wrap transfer"
+                case .syncNative: return "wrapped SOL sync"
+                case .closeTokenAccount: return "close token account"
+                case .kvaultDeposit: return "vault deposit"
+                case .kvaultWithdraw: return "vault withdraw"
+                case .farmsInitializeUser: return "farm user initialization"
+                case .farmsStake: return "farm stake"
+                }
+            }
+        }
+
+        let kind: Kind
+        let isRequired: Bool
+        let isRepeatable: Bool
+
+        init(_ kind: Kind, required: Bool, repeatable: Bool) {
+            self.kind = kind
+            self.isRequired = required
+            self.isRepeatable = repeatable
+        }
+    }
+}
+
+// MARK: - Account layouts
+
+/// Positions of the accounts each instruction is checked on.
+///
+/// An Anchor instruction's account list is fixed by its IDL — only the trailing
+/// `remaining_accounts` vary, which is why the observed lists differ in length
+/// between vaults while these prefixes do not. Each index below was read out of
+/// transactions the Kamino API built for all three launch vaults.
+private enum KvaultDepositAccounts {
+    static let user = 0
+    static let vault = 1
+    static let tokenMint = 3
+    static let sharesMint = 5
+    static let userTokenAccount = 6
+    static let userShareAccount = 7
+    static let minimumCount = 8
+}
+
+private enum KvaultWithdrawAccounts {
+    static let user = 0
+    static let vault = 1
+    static let userTokenAccount = 5
+    static let tokenMint = 6
+    static let userShareAccount = 7
+    static let sharesMint = 8
+    static let minimumCount = 9
+}
+
+private enum FarmsInitializeUserAccounts {
+    static let authority = 0
+    static let farm = 5
+    static let minimumCount = 6
+}
+
+private enum FarmsStakeAccounts {
+    static let owner = 0
+    static let farm = 2
+    static let userShareAccount = 4
+    static let sharesMint = 5
+    static let minimumCount = 6
+}
+
+private enum AssociatedTokenAccounts {
+    static let payer = 0
+    static let account = 1
+    static let wallet = 2
+    static let mint = 3
+    static let tokenProgram = 5
+    static let count = 6
+}
+
+private enum SystemTransferAccounts {
+    static let source = 0
+    static let destination = 1
+    static let count = 2
+}
+
+private enum CloseAccountAccounts {
+    static let account = 0
+    static let destination = 1
+    static let authority = 2
+    static let count = 3
+}
+
+// MARK: - Context
+
+private extension KaminoTransactionValidator {
+
+    /// Everything the per-instruction checks compare against, resolved once.
+    struct Context {
+        let intent: KaminoTransactionIntent
+        let transaction: SolanaV0Transaction
+        /// Every account the message addresses, in index order.
+        let accounts: [String]
+        /// The program each instruction invokes, `nil` when it is not allow-listed.
+        let programs: [KaminoSolanaProgram?]
+        /// The user's associated token accounts for the vault's underlying token,
+        /// one per token program.
+        let userTokenAccounts: Set<String>
+        /// The same for the vault's share mint.
+        let userShareAccounts: Set<String>
+        /// Every account this operation can name — the set a builder-composed
+        /// instruction's writes must fall inside.
+        let explainedAccounts: Set<String>
+
+        init(intent: KaminoTransactionIntent, accounts: [String], transaction: SolanaV0Transaction) throws {
+            self.intent = intent
+            self.transaction = transaction
+            self.accounts = accounts
+            self.programs = transaction.instructions.map {
+                KaminoSolanaProgram(programId: accounts[Int($0.programIdIndex)])
+            }
+
+            let owner = intent.owner
+            let tokenAccounts = SolanaAssociatedTokenAccount.ownedAccounts(
+                owner: owner,
+                mint: intent.vault.tokenMint
+            )
+            let shareAccounts = SolanaAssociatedTokenAccount.ownedAccounts(
+                owner: owner,
+                mint: intent.vault.sharesMint
+            )
+            guard !tokenAccounts.isEmpty, !shareAccounts.isEmpty else {
+                throw KaminoValidationError.addressDerivationFailed("the user's associated token accounts")
+            }
+
+            self.userTokenAccounts = tokenAccounts
+            self.userShareAccounts = shareAccounts
+            self.explainedAccounts = tokenAccounts
+                .union(shareAccounts)
+                .union([owner, intent.vault.descriptor.address, intent.vault.tokenMint, intent.vault.sharesMint])
+        }
+
+        var instructionCount: Int { transaction.instructions.count }
+
+        func programId(at position: Int) -> String {
+            guard transaction.instructions.indices.contains(position) else { return "unknown" }
+            return accounts[Int(transaction.instructions[position].programIdIndex)]
+        }
+
+        func accountAddresses(at position: Int) -> [String] {
+            transaction.instructions[position].accountIndexes.map { accounts[Int($0)] }
+        }
+
+        /// Whether the instruction at `position` is the kind a template step is
+        /// looking for. Program and discriminator only: everything else about the
+        /// instruction is checked once it has been matched, so a wrong account
+        /// refuses rather than silently failing to match.
+        func matches(_ kind: Step.Kind, at position: Int) -> Bool {
+            guard let program = programs[position] else { return false }
+            let data = transaction.instructions[position].data
+
+            switch kind {
+            case .computeUnitLimit:
+                return program == .computeBudget && data.first == ComputeBudgetInstruction.setUnitLimit
+            case .computeUnitPrice:
+                return program == .computeBudget && data.first == ComputeBudgetInstruction.setUnitPrice
+            case .createTokenAccount:
+                return program == .associatedToken
+                    && data.first == KaminoInstructionDiscriminator.createIdempotentAssociatedTokenAccount
+            case .wrapSolTransfer:
+                return program == .system
+                    && Array(data.prefix(4)) == KaminoInstructionDiscriminator.systemTransfer
+            case .syncNative:
+                return program.isTokenProgram && data == [KaminoInstructionDiscriminator.tokenSyncNative]
+            case .closeTokenAccount:
+                return program.isTokenProgram && data == [KaminoInstructionDiscriminator.tokenCloseAccount]
+            case .kvaultDeposit:
+                return program == .kvault
+                    && Array(data.prefix(8)) == KaminoInstructionDiscriminator.kvaultDeposit
+            case .kvaultWithdraw:
+                return program == .kvault
+                    && Array(data.prefix(8)) == KaminoInstructionDiscriminator.kvaultWithdraw
+            case .farmsInitializeUser:
+                return program == .farms
+                    && Array(data.prefix(8)) == KaminoInstructionDiscriminator.farmsInitializeUser
+            case .farmsStake:
+                return program == .farms
+                    && Array(data.prefix(8)) == KaminoInstructionDiscriminator.farmsStake
+            }
+        }
+
+        func requireOwner(_ account: String, role: String) throws {
+            guard account == intent.owner else {
+                throw KaminoValidationError.accountMismatch(role: role, expected: intent.owner, actual: account)
+            }
+        }
+
+        func requireVault(_ account: String) throws {
+            let expected = intent.vault.descriptor.address
+            guard account == expected else {
+                throw KaminoValidationError.accountMismatch(role: "vault", expected: expected, actual: account)
+            }
+        }
+
+        func requireMint(_ account: String, expected: String, role: String) throws {
+            guard account == expected else {
+                throw KaminoValidationError.accountMismatch(role: role, expected: expected, actual: account)
+            }
+        }
+
+        func requireFarm(_ account: String, position: Int) throws {
+            guard let farm = intent.vault.farm else {
+                throw KaminoValidationError.instructionNotForOperation(index: position, detail: "farm")
+            }
+            guard account == farm else {
+                throw KaminoValidationError.accountMismatch(role: "farm", expected: farm, actual: account)
+            }
+        }
+
+        func requireUserTokenAccount(_ account: String, role: String) throws {
+            guard userTokenAccounts.contains(account) else {
+                throw KaminoValidationError.accountNotOwnedByUser(role: role, actual: account)
+            }
+        }
+
+        func requireUserShareAccount(_ account: String, role: String) throws {
+            guard userShareAccounts.contains(account) else {
+                throw KaminoValidationError.accountNotOwnedByUser(role: role, actual: account)
+            }
+        }
+    }
+}

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoVaultRegistry.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoVaultRegistry.swift
@@ -38,6 +38,14 @@ struct KaminoVaultDescriptor: Hashable, Identifiable {
 /// three entries are hydrated with three ~2.8 KB per-vault requests instead.
 enum KaminoVaultRegistry {
 
+    /// The kVaults program every deposit and withdraw invokes.
+    static let programId = "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd"
+
+    /// Kamino's farms program. Every launch vault has a farm attached, so a
+    /// deposit ends with `initializeUser` + `stake` against this program and the
+    /// shares never land in the user's wallet.
+    static let farmsProgramId = "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+
     static let steakhouseUSDC = KaminoVaultDescriptor(
         address: "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",
         fallbackName: "Steakhouse USDC",

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoVaultRegistry.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoVaultRegistry.swift
@@ -18,11 +18,29 @@ enum KaminoRiskTier: Int, Hashable, CaseIterable {
     case privateCredit = 1
 }
 
-/// A curated vault the app offers. The address is the allow-list; everything the
-/// API can tell us (name, mints, decimals, minimums, APY) is fetched live, and
-/// everything it cannot (curator, risk tier) is carried here.
+/// A curated vault the app offers.
+///
+/// This carries everything a transaction is checked against, because a value
+/// fetched from the API cannot be used to validate a transaction built by the
+/// same API — the check would be circular, and a compromised response could
+/// supply a matching pair. The fields below are all immutable properties of the
+/// vault: a kVault's mints, their decimals and its farm are fixed at creation.
+/// Everything that legitimately moves — name, minimums, APY, rates, the lookup
+/// table — stays live, and `KaminoService` refuses a response that disagrees
+/// with the pinned identity.
 struct KaminoVaultDescriptor: Hashable, Identifiable {
     let address: String
+    /// The vault's underlying token mint. Pinned: the deposit source and the
+    /// withdraw destination are derived from it.
+    let tokenMint: String
+    /// Pinned because it scales every amount. A wrong scale mis-sizes the
+    /// transfer by a power of ten while every other check still passes.
+    let tokenDecimals: Int
+    let sharesMint: String
+    let sharesDecimals: Int
+    /// The farm a deposit stakes into, or `nil` when the vault has none. Pinned
+    /// because `farms::stake` moves the whole share balance into it.
+    let farm: String?
     /// Shown until live state arrives, and as the fallback if it never does.
     let fallbackName: String
     let curator: String
@@ -46,8 +64,20 @@ enum KaminoVaultRegistry {
     /// shares never land in the user's wallet.
     static let farmsProgramId = "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
 
+    /// Wrapped SOL. The SOL vault's underlying token is this mint, not native
+    /// SOL, which is why its deposits carry a wrap prefix.
+    static let wrappedSolMint = "So11111111111111111111111111111111111111112"
+
+    /// Circle's USDC — the underlying token of both dollar vaults.
+    static let usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
     static let steakhouseUSDC = KaminoVaultDescriptor(
         address: "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",
+        tokenMint: usdcMint,
+        tokenDecimals: 6,
+        sharesMint: "7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS",
+        sharesDecimals: 6,
+        farm: "9FVjHqduhDPMVqvu3cXiEBjU6nvxvGdCCLRwd9WpVRZj",
         fallbackName: "Steakhouse USDC",
         curator: "Steakhouse Financial",
         riskTier: .conservative
@@ -55,13 +85,25 @@ enum KaminoVaultRegistry {
 
     static let rwaUSDC = KaminoVaultDescriptor(
         address: "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",
+        tokenMint: usdcMint,
+        tokenDecimals: 6,
+        sharesMint: "DgHN3q3dSYAchNX7V3D4aYiTWMx8RHTgHbfPiwiqBkE9",
+        sharesDecimals: 6,
+        farm: "ArwyAHmnFmbKbUxC2fnK5VUEpspHrnoFtJ22bvEyriKk",
         fallbackName: "RWA USDC",
         curator: "RockawayX",
         riskTier: .privateCredit
     )
 
+    /// The share scale differs from the token scale here — 9 against 6. Nothing
+    /// may assume the two match.
     static let allezSOL = KaminoVaultDescriptor(
         address: "A1so1bPD3W1TfeFwboDh8yfAAVaVtcdAYBYCjhg2mJQ",
+        tokenMint: wrappedSolMint,
+        tokenDecimals: 9,
+        sharesMint: "FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN",
+        sharesDecimals: 6,
+        farm: "H6kauPaHmNqpdKtD5U2zw3Eb28ZB7iMeBdHVfLq1i4Kh",
         fallbackName: "Allez SOL",
         curator: "Allez Labs",
         riskTier: .conservative

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoVaultRegistry.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoVaultRegistry.swift
@@ -1,0 +1,73 @@
+//
+//  KaminoVaultRegistry.swift
+//  VultisigApp
+//
+
+import Foundation
+
+/// Relative risk of a launch vault, used to order and label them.
+///
+/// This is curation, not API data — Kamino exposes no risk or curator field
+/// anywhere, so both live here and travel with the allow-list.
+enum KaminoRiskTier: Int, Hashable, CaseIterable {
+    /// Plain over-collateralised lending against liquid crypto collateral.
+    case conservative = 0
+    /// Lending against tokenized private credit — reinsurance, receivables and
+    /// corporate bonds. Materially different risk from the conservative tier and
+    /// must not be presented as government-backed.
+    case privateCredit = 1
+}
+
+/// A curated vault the app offers. The address is the allow-list; everything the
+/// API can tell us (name, mints, decimals, minimums, APY) is fetched live, and
+/// everything it cannot (curator, risk tier) is carried here.
+struct KaminoVaultDescriptor: Hashable, Identifiable {
+    let address: String
+    /// Shown until live state arrives, and as the fallback if it never does.
+    let fallbackName: String
+    let curator: String
+    let riskTier: KaminoRiskTier
+
+    var id: String { address }
+}
+
+/// The curated set of Kamino Earn vaults the app exposes.
+///
+/// Kamino runs 166 vaults; `GET /kvaults/vaults` returns all of them as a single
+/// 339 KB payload. The allow-list both curates and keeps the fetch small — the
+/// three entries are hydrated with three ~2.8 KB per-vault requests instead.
+enum KaminoVaultRegistry {
+
+    static let steakhouseUSDC = KaminoVaultDescriptor(
+        address: "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",
+        fallbackName: "Steakhouse USDC",
+        curator: "Steakhouse Financial",
+        riskTier: .conservative
+    )
+
+    static let rwaUSDC = KaminoVaultDescriptor(
+        address: "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",
+        fallbackName: "RWA USDC",
+        curator: "RockawayX",
+        riskTier: .privateCredit
+    )
+
+    static let allezSOL = KaminoVaultDescriptor(
+        address: "A1so1bPD3W1TfeFwboDh8yfAAVaVtcdAYBYCjhg2mJQ",
+        fallbackName: "Allez SOL",
+        curator: "Allez Labs",
+        riskTier: .conservative
+    )
+
+    static let allowList: [KaminoVaultDescriptor] = [steakhouseUSDC, rwaUSDC, allezSOL]
+
+    static func descriptor(for address: String) -> KaminoVaultDescriptor? {
+        allowList.first { $0.address == address }
+    }
+
+    /// Whether an address is one the app is willing to transact against. Used to
+    /// reject any vault a response mentions that we did not ask about.
+    static func isAllowed(_ address: String) -> Bool {
+        descriptor(for: address) != nil
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/KaminoTransactionFixtures.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/KaminoTransactionFixtures.swift
@@ -1,0 +1,298 @@
+//
+//  KaminoTransactionFixtures.swift
+//  VultisigAppTests
+//
+//  Golden vectors captured from `api.kamino.finance` on 2026-08-04, plus the
+//  contents of the address lookup tables they reference, read from mainnet the
+//  same day.
+//
+//  The `injected` payloads are not expectations invented here: each was produced
+//  by the reference implementation before any Swift was written, and each was
+//  simulated on mainnet through `simulateTransaction` with `err: null` and the
+//  ComputeBudget program visible in the logs. So a Swift result that differs from
+//  one of these is wrong about a transaction that is known to execute.
+//
+
+import Foundation
+
+enum KaminoTransactionFixtures {
+
+    /// Every vector was injected at this price, in micro-lamports per compute
+    /// unit.
+    static let unitPriceMicroLamports: UInt64 = 20_000
+
+    struct Vector {
+        let name: String
+        /// The transaction exactly as the Kamino API returned it.
+        let source: String
+        /// The same transaction with the two ComputeBudget instructions injected.
+        let injected: String
+        let unitLimit: UInt32
+        let feePayer: String
+        let lookupTable: String
+    }
+
+    static let usdcDeposit = Vector(
+        name: "Steakhouse USDC deposit",
+        source: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAFCX6M\
+            CIdgv94d3c8ywX8gm4JC7lKq8TH6zYjQ6ixtCwbyi2G+J7TtwhmmIGAksFHWHBRuD3RE+zBbFhbNlyaHUS/T6oz1rKyozQUg\
+            dRIXXEPO9Upd2Z7eIKFrVSU3OPOX3AwoNIw0S/83XKQnpefdOo4z5yPOpkC2dDdTPAbIHsm7AAAAAAAAAAAAAAAAAAAAAAAA\
+            AAAAAAAAAAAAAAAAAAAP2mzp9mGY3YcNiphvMGdcRvg+L1KDSHlS9dUFY+PveoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASO\
+            e9jb6fhZ2LAQF2PT5R8SbmFW3oXejGEwWbhEaNDaP+iioiUcxwEE2Qrx24k57DX/lNlkDVfcwyeUuz4btm/TroSahNzblN76\
+            Ws6qir7XRG1XkeCtBuHFqihTJrTDGrQlDXGSFqA+BAYGAAMACQQaAQEIFQARDRYUCQIDGBoaBQgQDwoMFRMXEhDyI8aJUuHy\
+            toCWmAAAAAAABwgAAAAAAQsEGQhvEbn6PHom/gcIAAELDgMJBxoQzrDKEsjRs2z//////////wGC6dRmw0Z9LrKw2cy+tHvb\
+            9JXuHBu0d9Dar60DX6fr5AkFNTElLzITCQEJJxUECwI3BwYD
+            """,
+        injected: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAGCn6M\
+            CIdgv94d3c8ywX8gm4JC7lKq8TH6zYjQ6ixtCwbyi2G+J7TtwhmmIGAksFHWHBRuD3RE+zBbFhbNlyaHUS/T6oz1rKyozQUg\
+            dRIXXEPO9Upd2Z7eIKFrVSU3OPOX3AwoNIw0S/83XKQnpefdOo4z5yPOpkC2dDdTPAbIHsm7AAAAAAAAAAAAAAAAAAAAAAAA\
+            AAAAAAAAAAAAAAAAAAAP2mzp9mGY3YcNiphvMGdcRvg+L1KDSHlS9dUFY+PveoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASO\
+            e9jb6fhZ2LAQF2PT5R8SbmFW3oXejGEwWbhEaNDaP+iioiUcxwEE2Qrx24k57DX/lNlkDVfcwyeUuz4btm/TroSahNzblAMG\
+            Rm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAA3vpazqqKvtdEbVeR4K0G4cWqKFMmtMMatCUNcZIWoD4GCQAFAgDiBAAJ\
+            AAkDIE4AAAAAAAAGBgADAAoEGwEBCBUAEg4XFQoCAxkbGwUIERALDRYUGBMQ8iPGiVLh8raAlpgAAAAAAAcIAAAAAAEMBBoI\
+            bxG5+jx6Jv4HCAABDA8DCgcbEM6wyhLI0bNs//////////8BgunUZsNGfS6ysNnMvrR72/SV7hwbtHfQ2q+tA1+n6+QJBTUx\
+            JS8yEwkBCScVBAsCNwcGAw==
+            """,
+        unitLimit: 320000,
+        feePayer: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+        lookupTable: "9p2oT9J6BojHigd3V5qXzrwsQf4dtgMgLxtrzLVR3rwu"
+    )
+
+    static let solDeposit = Vector(
+        name: "Allez SOL deposit",
+        source: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAGDH6M\
+            CIdgv94d3c8ywX8gm4JC7lKq8TH6zYjQ6ixtCwbyJnd9pKyNWm8rX5WMWlaRpEuaYsAMd/0uKk2HNuILqFNNvPvC4A7dhX1Z\
+            Jyo29DiuibPP/uANSC1jj19qJzEK31tWVuPJV5ITcuOIn1fHs4hHodajEBxE75fcJD2QevvWbQ/ffN89KMzS1moKr3xD+eaL\
+            jFLD93Uu7/6fCChoRW/6HoLYlf5IbdNEuFQby9p5byRMsWwK5OpCzyixXzveqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+            AAAAAAAAD9ps6fZhmN2HDYqYbzBnXEb4Pi9Sg0h5UvXVBWPj73qMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4Wdiw\
+            EBdj0+UfEm5hVt6F3oxhMFm4RGjQ2j/ooqIlHMcBBNkK8duJOew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25QG3fbh12Whk9nL\
+            4UbO63msHLSF7V9bN5E6jPWFfv8AqQratdTZskh3RX3JYgwHZm2POqig2u19lkObE1kyFxBnBwgGAAQAHQYLAQEGAgAEDAIA\
+            AAAAZc0dAAAAAAsBBAERCAYAAwASBgsBAQoZAA8FHRYSBAMcCwsHCg4QDRQRDBsVFxgaGRDyI8aJUuHytgBlzR0AAAAACQgA\
+            AAAAAhMGHghvEbn6PHom/gkIAAITAQMSCQsQzrDKEsjRs2z//////////wFcvAkvUgYmlpRjmt1MX98IzA/9elzQ9ld+Vs/y\
+            AHeYyAlbGwkBEjwFUDEKFAQdM0g+CwcCBg==
+            """,
+        injected: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAHDX6M\
+            CIdgv94d3c8ywX8gm4JC7lKq8TH6zYjQ6ixtCwbyJnd9pKyNWm8rX5WMWlaRpEuaYsAMd/0uKk2HNuILqFNNvPvC4A7dhX1Z\
+            Jyo29DiuibPP/uANSC1jj19qJzEK31tWVuPJV5ITcuOIn1fHs4hHodajEBxE75fcJD2QevvWbQ/ffN89KMzS1moKr3xD+eaL\
+            jFLD93Uu7/6fCChoRW/6HoLYlf5IbdNEuFQby9p5byRMsWwK5OpCzyixXzveqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
+            AAAAAAAAD9ps6fZhmN2HDYqYbzBnXEb4Pi9Sg0h5UvXVBWPj73qMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4Wdiw\
+            EBdj0+UfEm5hVt6F3oxhMFm4RGjQ2j/ooqIlHMcBBNkK8duJOew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25QG3fbh12Whk9nL\
+            4UbO63msHLSF7V9bN5E6jPWFfv8AqQMGRm/lIRcy/+ytunLDm+e8jOW7xfcSayxDmzpAAAAACtq11NmySHdFfcliDAdmbY86\
+            qKDa7X2WQ5sTWTIXEGcJDAAFAjBXBQAMAAkDIE4AAAAAAAAIBgAEAB4GCwEBBgIABAwCAAAAAGXNHQAAAAALAQQBEQgGAAMA\
+            EwYLAQEKGQAQBR4XEwQDHQsLBwoPEQ4VEg0cFhgZGxoQ8iPGiVLh8rYAZc0dAAAAAAkIAAAAAAIUBh8IbxG5+jx6Jv4JCAAC\
+            FAEDEwkLEM6wyhLI0bNs//////////8BXLwJL1IGJpaUY5rdTF/fCMwP/Xpc0PZXflbP8gB3mMgJWxsJARI8BVAxChQEHTNI\
+            PgsHAgY=
+            """,
+        unitLimit: 350000,
+        feePayer: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+        lookupTable: "7EzosNioQ6FDNvMKLfg6om5wTVHiJo9vVx7DZNGYBKU3"
+    )
+
+    static let usdcWithdraw = Vector(
+        name: "Steakhouse USDC withdraw",
+        source: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAFCKsw\
+            rRIFkBysDdnNhubzrF66vbPjTv/3hcdPJbSgz1/GXJg1uByBqO1HgaECiZNKznnWBakBK4T2pvqREYQQsSqo9yTugQEFGbmp\
+            LOPs4I/yp0MfoHZrmM1es+rkznnAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9ps6fZhmN2HDYqYbzBnXEb4\
+            Pi9Sg0h5UvXVBWPj73qMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZlxKXooAEJJPkJxkMd7ZH6G99GZch/RVimW\
+            XJ1rZZT4BNkK8duJOew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25QYczzLRpmklaFtCSar20CU1Xpecg0pHCVyFOEC5dShbAIF\
+            BgABAA8DGwEBByEAEgYNFQEPAgobGxkEBxIQCRcWEQgbGgQHEA4LDBcUGBMQtxJGnJRtoSJg7FMAAAAAAAGC6dRmw0Z9LrKw\
+            2cy+tHvb9JXuHBu0d9Dar60DX6fr5AsQCgU1JS8TAgkOAQknFQQSCzcHCAM=
+            """,
+        injected: """
+            AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQAGCasw\
+            rRIFkBysDdnNhubzrF66vbPjTv/3hcdPJbSgz1/GXJg1uByBqO1HgaECiZNKznnWBakBK4T2pvqREYQQsSqo9yTugQEFGbmp\
+            LOPs4I/yp0MfoHZrmM1es+rkznnAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9ps6fZhmN2HDYqYbzBnXEb4\
+            Pi9Sg0h5UvXVBWPj73qMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZlxKXooAEJJPkJxkMd7ZH6G99GZch/RVimW\
+            XJ1rZZT4BNkK8duJOew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25QDBkZv5SEXMv/srbpyw5vnvIzlu8X3EmssQ5s6QAAAABhz\
+            PMtGmaSVoW0JJqvbQJTVel5yDSkcJXIU4QLl1KFsBAgABQJgWwMACAAJAyBOAAAAAAAABQYAAQAQAxwBAQchABMGDhYBEAIL\
+            HBwaBAcTEQoYFxIJHBsEBxEPDA0YFRkUELcSRpyUbaEiYOxTAAAAAAABgunUZsNGfS6ysNnMvrR72/SV7hwbtHfQ2q+tA1+n\
+            6+QLEAoFNSUvEwIJDgEJJxUEEgs3BwgD
+            """,
+        unitLimit: 220000,
+        feePayer: "CXFmQi2eM4Jzt9HZwm9A5JAzGvNpKwRuxo52ua3Jyceh",
+        lookupTable: "9p2oT9J6BojHigd3V5qXzrwsQf4dtgMgLxtrzLVR3rwu"
+    )
+
+    static let all: [Vector] = [usdcDeposit, solDeposit, usdcWithdraw]
+
+    /// Address lookup table contents, keyed by table address — read from mainnet
+    /// with `getAccountInfo` on 2026-08-04. A lookup table is append-only unless
+    /// it is deactivated wholesale, so the prefix these transactions index into
+    /// is stable.
+    ///
+    /// These are what make the golden tests mean something. An account index is
+    /// only a position, so showing that an edit preserved the *indices* shows
+    /// nothing; resolving both sides through the real table shows the edit
+    /// preserved the account *pubkeys* every instruction receives.
+    static let lookupTables: [String: [String]] = [
+        "9p2oT9J6BojHigd3V5qXzrwsQf4dtgMgLxtrzLVR3rwu": [
+            "sadmBTQm5HJsyzWHEjV4YwG9CiahZKVDVqAyS4Wx1zH",
+            "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8",
+            "7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS",
+            "SysvarRent111111111111111111111111111111111",
+            "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+            "Sysvar1nstructions1111111111111111111111111",
+            "Ga4rZytCpq1unD4DbEJ5bkHeUz9g3oh9AAFEi6vSauXp",
+            "5rGkiF4Jf1rPTJ6nazBgcjewVktXhagwcw5Nux7GccRi",
+            "DxXdAyU3kCjnyggvHmY5nAwg5cRbbmdyX3npfDMjjMek",
+            "EGDhupegCXLtonYDSY67c4dzw86S9eMxsntQ1yxWSoHv",
+            "B7nzBEuViVtaQN8iEhhtBY4gQSxBY38ms31DUWUx1bza",
+            "GENey8es3EgGiNTM8H8gzA3vf98haQF8LHiYFyErjgrv",
+            "rywFxeqHfCWL5iGq9cDxutwiiR2TabZgzv8aRM1Lceq",
+            "32XLsweyeQwWgLKRVAzS72nxHGU1JmmNQQZ3C3q6fBjJ",
+            "6WnymZBTAekuHf9DgsaDKJ397oEZ3qMApNMHg9qjqhgm",
+            "B9spsrMK6pJicYtukaZzDyzsUQLgc3jbx5gHVwdDxb6y",
+            "D6q6wuQSrifJKZYpR1M8R4YawnLDtDsMmWM1NbBmgJ59",
+            "CZg8x8oqB7FYUfURq15F5AcjRTymcXsc8ann76CrpJrf",
+            "7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF",
+            "JAvnB9AKtgPsTEoKmn24Bq64UMoYcrtWtq42HHBdsPkh",
+            "Bgq7trRgVMeq33yt235zM2onQ4bRDBsY5EWiTetF4qw6",
+            "BbDUrk1bVtSixgQsPLBJFZEF7mwGstnD5joA1WzYvYFX",
+            "B8V6WVjPxW1UGwVDfxH2d2r8SyT4cqn7dQRK6XneVa7D",
+            "3DzjXRfxRm6iejfyyMynR4tScddaanrePJ1NJU2XnPPL",
+            "9DrvZvyWh1HuAoZxvYWMvkf2XCzryCpGgHqrMjyDWpmo",
+            "9TD2TSv4pENb8VwfbVYg25jvym7HN6iuAR6pFNSrKjqQ",
+            "DNcUGqKJ8SD2uEmmWmzsTiZ8xbNc6UBYM8yzdTex9kgE",
+            "ByYiZxp8QrdN9qbdtaAiePN8AAr3qvTPppNJDpf5DVJ5",
+            "23UsLhyeuZBCRJNVFkPrmMCfXuka8hQa8S6spXwTEHcc",
+            "HTyrXvSvBbD7WstvU3oqFTBZM1fPZJPxVRvwLAmCTDyJ",
+            "9CvpyHx3FHJfrMcdCYMS5CaCucov5VSzJ3pyzs7RJ8r6",
+            "A2mcvn3kQXwG9XPUPgjghXJDqvYHTpkCJE3wtKqU1VRn",
+            "8bGWMt65Y7RV2DV5sxNRxFM5jsUhBMSo8u24pbRPjQLY",
+            "81BgcfZuZf9bESLvw3zDkh7cZmMtDwTPgkCvYu7zx26o",
+            "Atj6UREVWa7WxbF2EMKNyfmYUY1U1txughe2gjhcPDCo",
+            "Hq8LJAn7scQSBCNysRtrRXuZYNvZ5MRpbqK7T3JyLYqc",
+            "6WEGfej9B9wjxRs6t4BYpb9iCXd8CpTpJ8fVSNzHCC5y",
+            "6Y9fzrWzGZaxdAJ2eWRg9UZpL3kqPDiVXAb67KJpWdUg",
+            "BBcwMNSMyhhBnYE9pevEvkxKHGzTafMP9v3j7Kk7nAWM",
+            "HH7GLnRcGHJrdkEueVVj7mccNUjnSeWobDmtu9cHLkJV",
+            "6M89FWrQaqcy3domy85J1a1wVMnviL86WeUqbqTXf1qb",
+            "25x4aEFoJE3bk4sdNLgHrrmchyop1JvcmGA4ccA6tWWT",
+            "6QbtpY2jDNcncRFmVf343NThnCdaY8gCAsYATPnYQR9g",
+            "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF",
+            "CKTEDx5z19CntAB9B66AxuS98S1NuCgMvfpsew7TQwi",
+            "87gUNr8LwYJCT25HjPEHnrfBBjwEMAjfqCfnKcJNqy9Y",
+            "9FVjHqduhDPMVqvu3cXiEBjU6nvxvGdCCLRwd9WpVRZj",
+            "CRsf9nPkGBUT1HDytxfoYe3PBa5CZc9Nsh9a5aoBbGnb",
+            "45AYN1NotDSbptLmfPrV31nrbZktJ6DLJKBxQbJMBxYg",
+            "6UodrBjL2ZreDy7QdR4YV1oxqMBjVYSEyrFpctqqwGwL",
+            "9FRZvAsjDJ6WM8BJ2S45h9PoDCLAq8DNY9zZDX7MyGzT",
+            "Dc2gueqz9FkChnKNEwBFf5enu7hhuiFWFjGCkUaXawR5",
+            "GMqmFygF5iSm5nkckYU6tieggFcR42SyjkkhK5rswFRs",
+            "BtKurxqKCCpL6bgvpfPskT2F5pjynnwgTJKF8REAQm1T",
+            "6sHZvPZLVPqG5HPguW13UbfoGvqb3VRsa5NkBBdj7gjw",
+            "5J8om3Mwx8FGuu3GaD29ibRLtjX9z1ZK3oX112ruUheG",
+            "5zUFYbpFbapqWSuTpGS7X2PD1cs1pDaoFtqm4UK4fRV9",
+            "5Qb9RJCA1ZNTjLK4TNTNm3L2YtpbxQajtkqg6vWDdB2T"
+        ],
+        "7EzosNioQ6FDNvMKLfg6om5wTVHiJo9vVx7DZNGYBKU3": [
+            "FU76ac2Hm2mo4hoyckhAKDrbKTFwxyDPHnrrERfMXusE",
+            "A1so1bPD3W1TfeFwboDh8yfAAVaVtcdAYBYCjhg2mJQ",
+            "So11111111111111111111111111111111111111112",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "89icm3xw75kZV9Cu7UkbkXj1F1iZeJdQeF1cxtkfHYUr",
+            "FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN",
+            "SysvarRent111111111111111111111111111111111",
+            "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+            "Sysvar1nstructions1111111111111111111111111",
+            "6gTJfuPHEg6uRAijRkMqNc9kan4sVZejKMxmvx2grT1p",
+            "Dcna6zQFf4BzBWK8nnDAcgjBPPAe5Mj4LZ7TvtqnzWpT",
+            "H6rHXmXoCQvq8Ue81MqNh7ow5ysPa1dSozwW3PU1dDH6",
+            "BgMEUzcjkJxEH1PdPkZyv3NbUynwbkPiNJ7X2x7G1JmH",
+            "ywaaLvG7t1vXJo8sT3UzE8yzzZtxLM7Fmev64Jbooye",
+            "EQ7hw63aBS7aPQqXsoxaaBxiwbEzaAiY9Js6tCekkqxf",
+            "DxzDt5kPdFkMy9AANiZh4zuoitobqsn1G6bdoNyjePC2",
+            "8qnXfbaLbY6Y4xiCP6SZ3RK8ccjVa8DhALzDGifBPeNx",
+            "Dx8iy2o46sK1DzWbEcznqSKeLbLVeu7otkibA3WohGAj",
+            "d4A2prbA2whesmvHaL88BH6Ewn5N4bTSU2Ze8P6Bc4Q",
+            "BpjUkkRUfEoHNz6ghe2ETwKZtRvy3E6RBuYehjYiwxds",
+            "7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF",
+            "955xWFhSDcDiUgUr4sBRtCpTLiMd4H5uZLAmgtP3R3sX",
+            "GafNuUXj9rxGLn4y79dPu6MHSuPWeJR6UtTWuexpGh3U",
+            "3JNof8s453bwG5UqiXBLJc77NRQXezYYEBbk3fqnoKph",
+            "2UywZrUdyqs5vDchy7fKQJKau2RVyuzBev2XKGPDSiX1",
+            "8NXMyRD91p3nof61BTkJvrfpGTASHygz1cUvc3HvwyGS",
+            "9DrvZvyWh1HuAoZxvYWMvkf2XCzryCpGgHqrMjyDWpmo",
+            "4oigbthMAgjTMPyw8dBxhxU59YMtvNDHqhpR3W4HAzBM",
+            "3kJUKfsaYZZ4LpuRxw47FKemey8TwpMJkDGFNbfSwMYj",
+            "C7h9YnjPrDvNhe2cWWDhCu4CZEB1XTTH4RzjmsHuengV",
+            "11111111111111111111111111111111",
+            "11111111111111111111111111111111",
+            "So11111111111111111111111111111111111111112",
+            "3SdrFTt4Ye5yppzpT9axNMj8W1x71nDYXdjv7vDuBpnR",
+            "DW718KwF5d9URykynv8dcmHSQNXKTv7V5VxW5ozckbGS",
+            "BDvpFVD23XCRUCoznyeUHFRU4HfNuAn2KEnMoj7PDGsd",
+            "2yD1e9jGqwnQ4BXasTdL2Y3eGbmsmzeBtfX9yNL2kTXv",
+            "69rYv5ucrCvhL3k8MnaSaySa2Eqivv6ee8FjcpUvviRK",
+            "4RcnUDXjrr4Fj36ZfwhqJ32s14ziXWHLBjorMrdkDcfV",
+            "49SoZGy2gJ5U3EN8rumKhGVXmoTT42eozySajgyENKGm",
+            "CuSNbDHVEXGfptpnbDRW5VxTRhGsz7BrudK95cJhH8uV",
+            "11111111111111111111111111111111",
+            "11111111111111111111111111111111",
+            "So11111111111111111111111111111111111111112",
+            "2qYqGguuNMruP3wZ5xHRYkpom6Ha4hSMYQQFCBpTAVck",
+            "Acpag5AsMAqmd1zS8qKrb2xMvKsUAZQ3JeyBg93aHAd6",
+            "CQZ3NWdDpADRPjgLP281Qq34E7sQCHfCjkkXemxKnsju",
+            "7VLjLyJe6GrdvGJNyDS5nPTCptLT9Uy4pFJjP7hxskpt",
+            "8gUWLhFzxh6b22poaUhbm5GkZp6j4Q2eXsGiuDnMvFNx",
+            "HaVsdBb4mMoYQ3vnS7wCdvhixg5xFQALmFwyL9QJm3fn",
+            "Dr1V9swXjxY9xa3hQnMVu5CpLV1fMQenWf6io8cJfBA7",
+            "eNLm5e5KVDX2vEcCkt75PpZ2GMfXcZES3QrFshgpVzp",
+            "11111111111111111111111111111111",
+            "11111111111111111111111111111111",
+            "So11111111111111111111111111111111111111112",
+            "5CKcCjoNrcwegdLFuBxa3HJBaJsnHHhTYaJPwcEwh69u",
+            "HT7Z98Y6FgiDet1QCQPPQr8at72hnDC1hUSdQhhjhVdg",
+            "C558WZD2BMrZikgoDbs9GMHNaMVournUnxyySxGmL8w9",
+            "AS7jFm5TVMu1y2t9YoyXmcBNMkTBeXmDETVu1t8Siixs",
+            "3DiGQ4cKL1NLVh2VG7LrhqGw5PsoLXJsYawzkwFUkW8d",
+            "DQ126djx5db6SMCbejHLNxoosonVes3qW5eVVUQuT93v",
+            "E4ajZm5WVE6kU4z4YWhQvMQXZhB3r91ga5Hf88mNDAzU",
+            "GVDUXFwS8uvBG35RjZv6Y8S1AkV5uASiMJ9qTUKqb5PL",
+            "9C3ZmYzfkYLfUDyCoRR4sxYYUNSQJFEXK8FtJuomnQk9",
+            "3VP8AjMBLmRNJ199QP6iaBG9LZYCkukXpV5ePm8ov66i",
+            "So11111111111111111111111111111111111111112",
+            "BSqBirnJMQnRFCq8EEhx4z2nJTMKHxgVLqchwyzSdESL",
+            "6uDSbrsGiUnsCDubqsXAQA3Zs4tAii2v3P52M3WuYpeQ",
+            "3EDSt29jGSz69ZQmxuWrsvHJqmztr8wyUjvn9x41uAca",
+            "BmesT6HkmXWHuLDf7CkdMt81rx5GSgy4JFLyMezwSJ1Z",
+            "Gi2fcYkNMP4Gv88oaZt7D27mkeMW6wv8E5GZnN1eSQgt",
+            "A11EznxnJM3JrjUvAq16wqoVyPRNz522mdQm6mSmzMeR",
+            "F4Pn9mAvbUazDmWET5yYATTiyLHLaCRTWgGex4tiMXAs",
+            "CJVpkUjja7dvgavxsH66KFrUrNCfEqW2tL1sPrYcc3jt",
+            "5dLLmbTgxZg6eSmvvrmE7JqtoXGnPGKbB4qRCmrbbYBK",
+            "5WkWedGR2eeSSTSzHivdYoHNuz9Rv1tMxmaFdDBJGvzz",
+            "FwWtRufokc1U2q8mcLLnW3k2TvguQ4z8bAkdzG155ohJ",
+            "HTpShnvV8hwaaLuJygzXqGEz45g22fGJxmdxpuy7XGi5",
+            "96QTa6oKGwwvg9fRuy5knVqLfhHDAqxYzEGLzLVe7Dzu",
+            "2N7x2mPkJKuSuVwTSSY8pwba7EGZLfPF8thUsJY6xU8v",
+            "H6kauPaHmNqpdKtD5U2zw3Eb28ZB7iMeBdHVfLq1i4Kh",
+            "BZC1zqPDiBDF3aRWk4cQqiLhJ6wYeeWu2eZr7MoztoyG",
+            "GNDisPNo6MUHvSavZYqnUD8rsC9B2FaHzchk1TnLaQKo",
+            "3j5Sy3LUrEgXHNtnsstKrk54F9WxQmNvbY7w8UTrztWe",
+            "6vSidHXvxYEZL53wVZioSys9r8WAjh9KoH7T9K3satrw",
+            "DyP2zKye4AZ8gKeUexFqa3niHUNusUhh4TmKZJfd1YWh",
+            "BLYBTU5L5wuENyFX1m7rBChRzNELxRpskq4U4YYkd46i",
+            "8GWJgq9wks1KERyXtpJ6fJLPuVkBwKuRN2LCnJCGeu4J",
+            "9wgvjvrk2Ru3w5getmMA9YEgXrdDFirMsrU2EoSU2DYh",
+            "BgoNQ9hKXbhvWdQqVZYEr2QAkhyPN7XwoT38pw1m4DnS",
+            "Cj1SVEpEi4tsZqmR8AguXRUkWWv1C22scPu4QxTGSxhN",
+            "3Mf2mmocNbNAc7KS9QmANGEv9BcgwbT1tLRBuruGCdu5",
+            "t2VnpiTyoahHuB8ibJj986DmkURxjSKtUqbtqstzEQi",
+            "BZC1zqPDiBDF3aRWk4cQqiLhJ6wYeeWu2eZr7MoztoyG",
+            "GNDisPNo6MUHvSavZYqnUD8rsC9B2FaHzchk1TnLaQKo",
+            "3j5Sy3LUrEgXHNtnsstKrk54F9WxQmNvbY7w8UTrztWe",
+            "6vSidHXvxYEZL53wVZioSys9r8WAjh9KoH7T9K3satrw",
+            "DyP2zKye4AZ8gKeUexFqa3niHUNusUhh4TmKZJfd1YWh",
+            "BLYBTU5L5wuENyFX1m7rBChRzNELxRpskq4U4YYkd46i"
+        ]
+    ]
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaAddressLookupTableTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaAddressLookupTableTests.swift
@@ -1,0 +1,154 @@
+//
+//  SolanaAddressLookupTableTests.swift
+//  VultisigAppTests
+//
+//  A v0 transaction names most of its accounts by position inside a lookup
+//  table, so these bytes decide which account every one of those indices refers
+//  to. A decode that is off by a field, or that trusts an account the lookup
+//  table program does not own, renames accounts silently — and the app then
+//  validates a transaction it has misread.
+//
+
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+final class SolanaAddressLookupTableTests: XCTestCase {
+
+    private static let tableAddress = "9p2oT9J6BojHigd3V5qXzrwsQf4dtgMgLxtrzLVR3rwu"
+
+    // MARK: - Decoding
+
+    func testDecodesTheAddressListAfterTheMetadata() throws {
+        let addresses = [
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "11111111111111111111111111111111"
+        ]
+
+        let decoded = try SolanaAddressLookupTable.addresses(
+            table: Self.tableAddress,
+            accountData: Self.account(addresses: addresses)
+        )
+
+        XCTAssertEqual(decoded, addresses)
+    }
+
+    func testDecodesAnEmptyTable() throws {
+        let decoded = try SolanaAddressLookupTable.addresses(
+            table: Self.tableAddress,
+            accountData: Self.account(addresses: [])
+        )
+        XCTAssertEqual(decoded, [])
+    }
+
+    /// The whole point of the fixed 56-byte prefix: the first address starts
+    /// there, not at the start of the account. Decoding from the wrong offset
+    /// yields addresses that are all plausible base58 and all wrong.
+    func testFirstAddressStartsAtTheMetadataBoundary() throws {
+        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+        var data = Self.account(addresses: [mint])
+        // Fill the metadata with a recognisable pattern; the decode must ignore
+        // every byte of it except the discriminant.
+        for index in 4..<SolanaAddressLookupTable.metadataSize { data[index] = 0xAB }
+
+        let decoded = try SolanaAddressLookupTable.addresses(table: Self.tableAddress, accountData: data)
+        XCTAssertEqual(decoded, [mint])
+    }
+
+    // MARK: - Guards
+
+    func testRejectsAnAccountOwnedByAnotherProgram() throws {
+        XCTAssertThrowsError(
+            try SolanaAddressLookupTable.addresses(
+                table: Self.tableAddress,
+                owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                data: [Data(Self.account(addresses: [])).base64EncodedString(), "base64"]
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SolanaAddressLookupTableError,
+                .wrongOwner(table: Self.tableAddress, owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+            )
+        }
+    }
+
+    /// `jsonParsed` would hand the decode to the RPC node. Asserting the encoding
+    /// the node reports keeps that from happening silently.
+    func testRejectsANonBase64Encoding() throws {
+        XCTAssertThrowsError(
+            try SolanaAddressLookupTable.addresses(
+                table: Self.tableAddress,
+                owner: SolanaAddressLookupTable.programId,
+                data: ["{}", "jsonParsed"]
+            )
+        ) { error in
+            XCTAssertEqual(error as? SolanaAddressLookupTableError, .unsupportedEncoding(table: Self.tableAddress))
+        }
+    }
+
+    func testRejectsAnUninitializedTable() throws {
+        var data = Self.account(addresses: [])
+        data[0] = 0
+
+        XCTAssertThrowsError(
+            try SolanaAddressLookupTable.addresses(table: Self.tableAddress, accountData: data)
+        ) { error in
+            XCTAssertEqual(error as? SolanaAddressLookupTableError, .uninitialized(table: Self.tableAddress))
+        }
+    }
+
+    func testRejectsAnAccountShorterThanItsMetadata() throws {
+        XCTAssertThrowsError(
+            try SolanaAddressLookupTable.addresses(
+                table: Self.tableAddress,
+                accountData: [UInt8](repeating: 0, count: SolanaAddressLookupTable.metadataSize - 1)
+            )
+        ) { error in
+            XCTAssertEqual(error as? SolanaAddressLookupTableError, .malformedAccountData(table: Self.tableAddress))
+        }
+    }
+
+    /// A trailing partial key means the address list was read at the wrong
+    /// offset. Every address after that point would be shifted rather than
+    /// obviously invalid, so this has to be a refusal rather than a truncation.
+    func testRejectsATrailingPartialAddress() throws {
+        var data = Self.account(addresses: ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"])
+        data += [0x01, 0x02, 0x03]
+
+        XCTAssertThrowsError(
+            try SolanaAddressLookupTable.addresses(table: Self.tableAddress, accountData: data)
+        ) { error in
+            XCTAssertEqual(error as? SolanaAddressLookupTableError, .malformedAccountData(table: Self.tableAddress))
+        }
+    }
+
+    func testRejectsMalformedBase64Payload() throws {
+        XCTAssertThrowsError(
+            try SolanaAddressLookupTable.addresses(
+                table: Self.tableAddress,
+                owner: SolanaAddressLookupTable.programId,
+                data: ["not base64 !!", "base64"]
+            )
+        ) { error in
+            XCTAssertEqual(error as? SolanaAddressLookupTableError, .unsupportedEncoding(table: Self.tableAddress))
+        }
+    }
+
+    // MARK: - Fixture
+
+    /// A `ProgramState::LookupTable` account: the 4-byte bincode discriminant,
+    /// 52 further bytes of `LookupTableMeta`, then the packed 32-byte addresses.
+    private static func account(addresses: [String]) -> [UInt8] {
+        var data = [UInt8](repeating: 0, count: SolanaAddressLookupTable.metadataSize)
+        data[0] = UInt8(SolanaAddressLookupTable.lookupTableDiscriminant)
+        for address in addresses {
+            guard let decoded = Base58.decodeNoCheck(string: address), decoded.count == 32 else {
+                XCTFail("fixture address \(address) is not 32 bytes")
+                return data
+            }
+            data += [UInt8](decoded)
+        }
+        return data
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaSimulateTransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaSimulateTransactionTests.swift
@@ -1,0 +1,171 @@
+//
+//  SolanaSimulateTransactionTests.swift
+//  VultisigAppTests
+//
+//  `simulateTransaction` is the only thing that can tell us a third-party-built
+//  transaction will actually execute before a signer is asked to approve it, so
+//  both halves are pinned: the request options the RPC node needs, and the
+//  polymorphic `err` shape that says whether it ran.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class SolanaSimulateTransactionTests: XCTestCase {
+
+    // MARK: - Request shape
+
+    private func params(for method: SolanaAPI.Method) throws -> [String: Any] {
+        let api = SolanaAPI(baseURL: SolanaAPI.rpcBaseURL, usesProxyPath: true, rpcMethod: method)
+        guard case .requestParameters(let envelope, _) = api.task else {
+            XCTFail("expected requestParameters task")
+            return [:]
+        }
+        return envelope
+    }
+
+    func testSimulateRequestPinsBase64EncodingAndSkipsSignatureVerification() throws {
+        let envelope = try params(
+            for: .simulateTransaction(encodedTransaction: "dHg=", replaceRecentBlockhash: false)
+        )
+
+        XCTAssertEqual(envelope["method"] as? String, "simulateTransaction")
+        let rpcParams = try XCTUnwrap(envelope["params"] as? [Any])
+        XCTAssertEqual(rpcParams.first as? String, "dHg=")
+
+        let config = try XCTUnwrap(rpcParams[1] as? [String: Any])
+        XCTAssertEqual(config["encoding"] as? String, "base64")
+        XCTAssertEqual(config["commitment"] as? String, "confirmed")
+        // The transactions being simulated still carry an all-zero placeholder
+        // signature; verifying it would fail every simulation.
+        XCTAssertEqual(config["sigVerify"] as? Bool, false)
+        XCTAssertEqual(config["replaceRecentBlockhash"] as? Bool, false)
+    }
+
+    func testSimulateRequestCarriesTheBlockhashReplacementFlag() throws {
+        let envelope = try params(
+            for: .simulateTransaction(encodedTransaction: "dHg=", replaceRecentBlockhash: true)
+        )
+        let rpcParams = try XCTUnwrap(envelope["params"] as? [Any])
+        let config = try XCTUnwrap(rpcParams[1] as? [String: Any])
+
+        XCTAssertEqual(config["replaceRecentBlockhash"] as? Bool, true)
+        XCTAssertEqual(config["sigVerify"] as? Bool, false)
+    }
+
+    // MARK: - Response decoding
+
+    private func makeService(_ json: String) -> SolanaService {
+        SolanaService(resolver: SimulationResolver(), httpClient: SimulationStubHTTPClient(json: json))
+    }
+
+    func testCleanSimulationReportsSuccessAndComputeUsage() async throws {
+        let service = makeService("""
+        {"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":
+        {"err":null,"logs":["Program ComputeBudget111111111111111111111111111111 invoke [1]"],
+        "unitsConsumed":252146,"returnData":null}}}
+        """)
+
+        let result = try await service.simulateTransaction(base64Transaction: "dHg=", replaceRecentBlockhash: false)
+
+        XCTAssertTrue(result.succeeded)
+        XCTAssertNil(result.failure)
+        XCTAssertEqual(result.unitsConsumed, 252_146)
+        XCTAssertEqual(result.logs.count, 1)
+    }
+
+    /// A stale blockhash comes back as a bare string, which is what the control
+    /// run of the blockhash splice produced.
+    func testStringErrorIsSurfacedVerbatim() async throws {
+        let service = makeService("""
+        {"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":
+        {"err":"BlockhashNotFound","logs":[],"unitsConsumed":0}}}
+        """)
+
+        let result = try await service.simulateTransaction(base64Transaction: "dHg=", replaceRecentBlockhash: false)
+
+        XCTAssertFalse(result.succeeded)
+        XCTAssertEqual(result.failure, "BlockhashNotFound")
+        XCTAssertEqual(result.unitsConsumed, 0)
+    }
+
+    /// A program failure is an object, and the interesting part — which
+    /// instruction failed, with which custom code — lives inside it. Flattening
+    /// `err` to a `String?` would throw exactly that away.
+    func testInstructionErrorObjectKeepsTheInstructionIndexAndCode() async throws {
+        let service = makeService("""
+        {"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":
+        {"err":{"InstructionError":[3,{"Custom":6003}]},"logs":["Program log: deposit below minimum"],
+        "unitsConsumed":18000}}}
+        """)
+
+        let result = try await service.simulateTransaction(base64Transaction: "dHg=", replaceRecentBlockhash: false)
+
+        XCTAssertFalse(result.succeeded)
+        let failure = try XCTUnwrap(result.failure)
+        XCTAssertTrue(failure.contains("InstructionError"), failure)
+        XCTAssertTrue(failure.contains("3"), failure)
+        XCTAssertTrue(failure.contains("Custom"), failure)
+        XCTAssertTrue(failure.contains("6003"), failure)
+        XCTAssertEqual(result.logs, ["Program log: deposit below minimum"])
+    }
+
+    /// A transport-level JSON-RPC error is not a simulation verdict — the
+    /// transaction was never run, so it must not read as "would fail".
+    func testTransportErrorThrowsRatherThanReportingFailure() async {
+        let service = makeService("""
+        {"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}
+        """)
+
+        do {
+            _ = try await service.simulateTransaction(base64Transaction: "dHg=", replaceRecentBlockhash: false)
+            XCTFail("expected an rpcError")
+        } catch let error as SolanaServiceError {
+            guard case .rpcError(let message, let code) = error else {
+                return XCTFail("unexpected error \(error)")
+            }
+            XCTAssertEqual(code, -32601)
+            XCTAssertEqual(message, "Method not found")
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+
+    func testMissingResultThrows() async {
+        let service = makeService(#"{"jsonrpc":"2.0","id":1}"#)
+
+        do {
+            _ = try await service.simulateTransaction(base64Transaction: "dHg=", replaceRecentBlockhash: false)
+            XCTFail("expected an rpcError")
+        } catch is SolanaServiceError {
+            // expected
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+    }
+}
+
+private struct SimulationResolver: RPCEndpointResolving {
+    // swiftlint:disable:next unused_parameter
+    func url(for chain: Chain) -> String? { nil }
+}
+
+private final class SimulationStubHTTPClient: HTTPClientProtocol {
+
+    private let json: String
+
+    init(json: String) {
+        self.json = json
+    }
+
+    // Protocol requires `async`; the body is synchronous.
+    // swiftlint:disable:next async_without_await unused_parameter
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        guard let url = URL(string: "https://test.local"),
+              let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+        else {
+            throw HTTPError.invalidResponse
+        }
+        return HTTPResponse(data: Data(json.utf8), response: response)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaTransactionParserComputeBudgetTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaTransactionParserComputeBudgetTests.swift
@@ -1,0 +1,109 @@
+//
+//  SolanaTransactionParserComputeBudgetTests.swift
+//  VultisigAppTests
+//
+//  `SolanaTransactionParser` feeds the keysign verify screen, so a mislabelled
+//  instruction is a co-signer approving something other than what they read.
+//  Its ComputeBudget decoder was off by one — discriminant 0 is the deprecated
+//  `RequestUnits`, so the limit and price instructions are 2 and 3, not 1 and 2 —
+//  which mislabelled every priority-fee instruction, including the ones the app
+//  injects itself.
+//
+
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+final class SolanaTransactionParserComputeBudgetTests: XCTestCase {
+
+    private static let computeBudgetProgramId = "ComputeBudget111111111111111111111111111111"
+
+    func testComputeBudgetDiscriminantsMatchTheOnChainEncoding() throws {
+        let parsed = try SolanaTransactionParser.parse(base64Transaction: try Self.computeBudgetSample())
+
+        XCTAssertEqual(parsed.instructions.count, 4)
+        XCTAssertTrue(parsed.instructions.allSatisfy { $0.programId == Self.computeBudgetProgramId })
+        XCTAssertTrue(parsed.instructions.allSatisfy { $0.programName == "Compute Budget Program" })
+
+        XCTAssertEqual(parsed.instructions[0].instructionType, "Request Units (Deprecated)")
+        XCTAssertEqual(parsed.instructions[1].instructionType, "Request Heap Frame")
+        XCTAssertEqual(parsed.instructions[2].instructionType, "Set Compute Unit Limit")
+        XCTAssertEqual(parsed.instructions[3].instructionType, "Set Compute Unit Price")
+    }
+
+    func testKaminoProgramsAreNamed() {
+        XCTAssertEqual(
+            SolanaTransactionParser.getKnownProgramName(programId: KaminoVaultRegistry.programId),
+            "Kamino Vaults Program"
+        )
+        XCTAssertEqual(
+            SolanaTransactionParser.getKnownProgramName(programId: KaminoVaultRegistry.farmsProgramId),
+            "Kamino Farms Program"
+        )
+    }
+
+    /// The discriminants the app writes have to be the ones the app reads back.
+    func testInjectedInstructionsDecodeAsLimitAndPrice() throws {
+        let injected = try SolanaV0Transaction(base64Transaction: KaminoTransactionFixtures.usdcDeposit.source)
+            .injectingComputeBudget(
+                price: KaminoTransactionFixtures.unitPriceMicroLamports,
+                limit: KaminoComputeBudget.tokenDepositUnitLimit
+            )
+
+        XCTAssertEqual(injected.instructions[0].data.first, ComputeBudgetInstruction.setUnitLimit)
+        XCTAssertEqual(injected.instructions[1].data.first, ComputeBudgetInstruction.setUnitPrice)
+
+        let limit = try Self.singleInstructionSample(data: injected.instructions[0].data)
+        let price = try Self.singleInstructionSample(data: injected.instructions[1].data)
+
+        XCTAssertEqual(
+            try SolanaTransactionParser.parse(base64Transaction: limit).instructions.first?.instructionType,
+            "Set Compute Unit Limit"
+        )
+        XCTAssertEqual(
+            try SolanaTransactionParser.parse(base64Transaction: price).instructions.first?.instructionType,
+            "Set Compute Unit Price"
+        )
+    }
+
+    // MARK: - Sample transactions
+
+    /// A v0 transaction carrying one ComputeBudget instruction per discriminant,
+    /// with no lookup tables — the parser only needs the program id and the first
+    /// data byte, so this isolates the mapping under test.
+    private static func computeBudgetSample() throws -> String {
+        try sample(instructionData: [
+            [ComputeBudgetInstruction.requestUnitsDeprecated, 0x40, 0x42, 0x0F, 0x00],
+            [ComputeBudgetInstruction.requestHeapFrame, 0x00, 0x00, 0x04, 0x00],
+            [ComputeBudgetInstruction.setUnitLimit, 0x00, 0xE2, 0x04, 0x00],
+            [ComputeBudgetInstruction.setUnitPrice, 0x20, 0x4E, 0, 0, 0, 0, 0, 0]
+        ])
+    }
+
+    private static func singleInstructionSample(data: [UInt8]) throws -> String {
+        try sample(instructionData: [data])
+    }
+
+    private static func sample(instructionData: [[UInt8]]) throws -> String {
+        var payer = [UInt8](repeating: 0, count: 32)
+        payer[0] = 1
+        let program = SolanaV0Transaction.computeBudgetProgramKey
+
+        var bytes = try SolanaV0Transaction.encodeCompactLength(1)
+        bytes += [UInt8](repeating: 0, count: 64)
+        bytes += [0x80, 1, 0, 1]
+        bytes += try SolanaV0Transaction.encodeCompactLength(2)
+        bytes += payer
+        bytes += program
+        bytes += [UInt8](repeating: 9, count: 32)
+        bytes += try SolanaV0Transaction.encodeCompactLength(instructionData.count)
+        for data in instructionData {
+            bytes.append(1)
+            bytes += try SolanaV0Transaction.encodeCompactLength(0)
+            bytes += try SolanaV0Transaction.encodeCompactLength(data.count)
+            bytes += data
+        }
+        bytes += try SolanaV0Transaction.encodeCompactLength(0)
+        return Data(bytes).base64EncodedString()
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaV0TransactionGoldenTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaV0TransactionGoldenTests.swift
@@ -1,0 +1,344 @@
+//
+//  SolanaV0TransactionGoldenTests.swift
+//  VultisigAppTests
+//
+//  The Swift ComputeBudget injection against transactions that are known to
+//  execute: every `injected` fixture here was simulated on mainnet with
+//  `err: null`, so a byte that differs is a byte that is wrong.
+//
+//  Byte equality alone would not be enough, though. The injection shifts account
+//  indices, and an index is only a position — a transaction whose indices all
+//  shifted consistently still parses, still re-serializes, and still names a
+//  completely different set of accounts. So the load-bearing test resolves both
+//  sides through the real address lookup tables and compares the account
+//  *pubkeys*, together with their signer and writable privileges, that every
+//  instruction actually receives.
+//
+
+@testable import VultisigApp
+import BigInt
+import XCTest
+
+final class SolanaV0TransactionGoldenTests: XCTestCase {
+
+    private let tables = KaminoTransactionFixtures.lookupTables
+
+    // MARK: - Byte-level parity with the mainnet-verified vectors
+
+    func testInjectingComputeBudgetReproducesTheVerifiedBytes() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let source = try SolanaV0Transaction(base64Transaction: vector.source)
+
+            let injected = try source.injectingComputeBudget(
+                price: KaminoTransactionFixtures.unitPriceMicroLamports,
+                limit: vector.unitLimit
+            )
+
+            XCTAssertEqual(injected.base64EncodedTransaction, vector.injected, vector.name)
+        }
+    }
+
+    func testSourceVectorsCarryNoPriorityFee() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let source = try SolanaV0Transaction(base64Transaction: vector.source)
+            XCTAssertFalse(source.hasComputeBudgetInstruction, vector.name)
+        }
+    }
+
+    func testInjectedVectorsStayInsideThePacketLimit() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let injected = try SolanaV0Transaction(base64Transaction: vector.injected)
+            XCTAssertLessThanOrEqual(injected.wireSize, SolanaV0Transaction.maxWireSize, vector.name)
+            XCTAssertLessThanOrEqual(injected.totalAccountCount, SolanaV0Transaction.maxAccountCount, vector.name)
+        }
+    }
+
+    // MARK: - Resolved-account equivalence
+
+    /// The real assertion: after injection every original instruction still
+    /// receives the same accounts, with the same privileges, as before.
+    func testInjectionPreservesResolvedAccountsForEveryInstruction() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let source = try SolanaV0Transaction(base64Transaction: vector.source)
+            let injected = try source.injectingComputeBudget(
+                price: KaminoTransactionFixtures.unitPriceMicroLamports,
+                limit: vector.unitLimit
+            )
+
+            // The two ComputeBudget instructions are prepended, so instruction
+            // `i` of the source is instruction `i + 2` of the result.
+            XCTAssertEqual(injected.instructions.count, source.instructions.count + 2, vector.name)
+
+            for position in source.instructions.indices {
+                let before = try describe(source, instructionAt: position)
+                let after = try describe(injected, instructionAt: position + 2)
+                XCTAssertEqual(before, after, "\(vector.name): instruction \(position)")
+            }
+        }
+    }
+
+    /// The keys that were already static must keep their exact index, so the
+    /// shift never touches an account that did not move.
+    func testInjectionAppendsOnlyTheComputeBudgetKey() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let source = try SolanaV0Transaction(base64Transaction: vector.source)
+            let injected = try source.injectingComputeBudget(
+                price: KaminoTransactionFixtures.unitPriceMicroLamports,
+                limit: vector.unitLimit
+            )
+
+            XCTAssertEqual(
+                injected.staticAccountAddresses,
+                source.staticAccountAddresses + [SolanaV0Transaction.computeBudgetProgramId],
+                vector.name
+            )
+            XCTAssertEqual(
+                injected.numReadonlyUnsignedAccounts,
+                source.numReadonlyUnsignedAccounts + 1,
+                vector.name
+            )
+            XCTAssertEqual(injected.numRequiredSignatures, source.numRequiredSignatures, vector.name)
+            XCTAssertEqual(injected.numReadonlySignedAccounts, source.numReadonlySignedAccounts, vector.name)
+            XCTAssertEqual(injected.addressTableLookups, source.addressTableLookups, vector.name)
+            XCTAssertEqual(injected.recentBlockhash, source.recentBlockhash, vector.name)
+        }
+    }
+
+    /// The appended key must land in the read-only unsigned block. If it were
+    /// treated as writable, the accounts either side of the boundary would be
+    /// re-privileged even though their indices look untouched.
+    func testInjectedComputeBudgetKeyIsReadOnlyAndUnsigned() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let injected = try SolanaV0Transaction(base64Transaction: vector.injected)
+            let index = injected.staticAccountKeys.count - 1
+
+            XCTAssertEqual(injected.staticAccountAddresses[index], SolanaV0Transaction.computeBudgetProgramId)
+            XCTAssertFalse(injected.isSigner(accountIndex: index), vector.name)
+            XCTAssertFalse(injected.isWritable(accountIndex: index), vector.name)
+        }
+    }
+
+    /// Independent of the injection: the lookup-table resolution itself has to be
+    /// right, or the equivalence test above would compare two identically wrong
+    /// answers. These are the accounts the Steakhouse USDC deposit really names.
+    func testLookupResolutionNamesTheExpectedAccounts() throws {
+        let vector = KaminoTransactionFixtures.usdcDeposit
+        let source = try SolanaV0Transaction(base64Transaction: vector.source)
+
+        let resolved = try source.resolvedAccountAddresses(lookupTables: tables)
+        XCTAssertEqual(source.staticAccountKeys.count, 9)
+        XCTAssertEqual(resolved.count, 27)
+        XCTAssertEqual(resolved[0], vector.feePayer)
+
+        // The vault the deposit pays into, reached through the lookup table.
+        XCTAssertEqual(resolved[17], KaminoVaultRegistry.steakhouseUSDC.address)
+        XCTAssertTrue(source.isWritable(accountIndex: 17))
+        XCTAssertEqual(resolved[26], "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+        XCTAssertFalse(source.isWritable(accountIndex: 26))
+
+        // Instruction 0 creates the *shares* ATA, not the token one — the shares
+        // mint is the fourth account of an Associated Token Program create.
+        let createAta = try source.resolvedAccountAddresses(forInstructionAt: 0, lookupTables: tables)
+        XCTAssertEqual(createAta[0], vector.feePayer)
+        XCTAssertEqual(createAta[3], "7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS")
+
+        // The kvault deposit is invoked against the Kamino program with the vault
+        // as its second account.
+        let deposit = try source.resolvedAccountAddresses(forInstructionAt: 1, lookupTables: tables)
+        XCTAssertEqual(
+            source.staticAccountAddresses[Int(source.instructions[1].programIdIndex)],
+            KaminoVaultRegistry.programId
+        )
+        XCTAssertEqual(deposit[0], vector.feePayer)
+        XCTAssertEqual(deposit[1], KaminoVaultRegistry.steakhouseUSDC.address)
+    }
+
+    func testResolutionFailsClosedWithoutTheLookupTable() throws {
+        let source = try SolanaV0Transaction(base64Transaction: KaminoTransactionFixtures.usdcDeposit.source)
+
+        XCTAssertThrowsError(try source.resolvedAccountAddresses(lookupTables: [:])) { error in
+            XCTAssertEqual(
+                error as? SolanaV0TransactionError,
+                .unknownLookupTable(KaminoTransactionFixtures.usdcDeposit.lookupTable)
+            )
+        }
+    }
+
+    func testResolutionFailsClosedOnATruncatedLookupTable() throws {
+        let vector = KaminoTransactionFixtures.usdcDeposit
+        let source = try SolanaV0Transaction(base64Transaction: vector.source)
+        let truncated = [vector.lookupTable: Array(tables[vector.lookupTable]?.prefix(4) ?? [])]
+
+        XCTAssertThrowsError(try source.resolvedAccountAddresses(lookupTables: truncated)) { error in
+            guard case .lookupIndexOutOfRange(let table, _, let size)? = error as? SolanaV0TransactionError else {
+                return XCTFail("expected lookupIndexOutOfRange, got \(error)")
+            }
+            XCTAssertEqual(table, vector.lookupTable)
+            XCTAssertEqual(size, 4)
+        }
+    }
+
+    // MARK: - ComputeBudget instruction contents
+
+    func testInjectedInstructionsCarryTheRequestedLimitAndPrice() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let injected = try SolanaV0Transaction(base64Transaction: vector.injected)
+
+            let limitInstruction = injected.instructions[0]
+            let priceInstruction = injected.instructions[1]
+            let programIndex = Int(limitInstruction.programIdIndex)
+
+            XCTAssertEqual(
+                injected.staticAccountAddresses[programIndex],
+                SolanaV0Transaction.computeBudgetProgramId,
+                vector.name
+            )
+            XCTAssertTrue(limitInstruction.accountIndexes.isEmpty, vector.name)
+            XCTAssertTrue(priceInstruction.accountIndexes.isEmpty, vector.name)
+
+            XCTAssertEqual(limitInstruction.data.first, ComputeBudgetInstruction.setUnitLimit, vector.name)
+            XCTAssertEqual(littleEndianUInt32(limitInstruction.data.dropFirst()), vector.unitLimit, vector.name)
+
+            XCTAssertEqual(priceInstruction.data.first, ComputeBudgetInstruction.setUnitPrice, vector.name)
+            XCTAssertEqual(
+                littleEndianUInt64(priceInstruction.data.dropFirst()),
+                KaminoTransactionFixtures.unitPriceMicroLamports,
+                vector.name
+            )
+        }
+    }
+
+    /// The limits the app ships must clear what the transactions were measured to
+    /// consume, and must not be the 100,000 CU transfer constant.
+    func testKaminoUnitLimitsClearMeasuredUsage() {
+        XCTAssertGreaterThan(KaminoComputeBudget.tokenDepositUnitLimit, 252_146)
+        XCTAssertGreaterThan(KaminoComputeBudget.nativeDepositUnitLimit, 287_029)
+        XCTAssertGreaterThan(KaminoComputeBudget.withdrawUnitLimit, 174_566)
+
+        // `SolanaHelper.priorityFeeLimit` is the transfer-path constant; every
+        // Kamino limit has to sit above it, or the transaction aborts on compute
+        // exhaustion before it does anything.
+        for limit in [
+            KaminoComputeBudget.tokenDepositUnitLimit,
+            KaminoComputeBudget.nativeDepositUnitLimit,
+            KaminoComputeBudget.withdrawUnitLimit
+        ] {
+            XCTAssertGreaterThan(BigInt(limit), SolanaHelper.priorityFeeLimit)
+            XCTAssertLessThanOrEqual(limit, SolanaV0Transaction.maxComputeUnitLimit)
+        }
+    }
+
+    // MARK: - Blockhash splice
+
+    func testBlockhashSpliceTouchesOnlyTheBlockhashBytes() throws {
+        let vector = KaminoTransactionFixtures.usdcDeposit
+        let source = try SolanaV0Transaction(base64Transaction: vector.source)
+        let fresh = KaminoTransactionFixtures.usdcWithdraw
+        let freshBlockhash = try SolanaV0Transaction(base64Transaction: fresh.source).recentBlockhash
+
+        let spliced = try source.replacingBlockhash(freshBlockhash)
+
+        XCTAssertEqual(spliced.recentBlockhash, freshBlockhash)
+        XCTAssertNotEqual(source.recentBlockhash, freshBlockhash)
+        XCTAssertEqual(spliced.wireSize, source.wireSize)
+        XCTAssertEqual(spliced.blockhashRange, source.blockhashRange)
+
+        let before = try XCTUnwrap(Data(base64Encoded: source.base64EncodedTransaction))
+        let after = try XCTUnwrap(Data(base64Encoded: spliced.base64EncodedTransaction))
+        let differing = zip(before, after).enumerated().filter { $0.element.0 != $0.element.1 }.map(\.offset)
+        XCTAssertFalse(differing.isEmpty)
+        XCTAssertTrue(Set(differing).isSubset(of: Set(source.blockhashRange)))
+    }
+
+    /// Splicing and injecting have to commute: the pre-keysign blockhash refresh
+    /// runs after the transaction is built, but a re-simulation may happen either
+    /// side of it.
+    func testSpliceAndInjectionCommute() throws {
+        let fresh = try SolanaV0Transaction(base64Transaction: KaminoTransactionFixtures.usdcWithdraw.source)
+            .recentBlockhash
+
+        for vector in KaminoTransactionFixtures.all {
+            let source = try SolanaV0Transaction(base64Transaction: vector.source)
+
+            let injectFirst = try source
+                .injectingComputeBudget(price: KaminoTransactionFixtures.unitPriceMicroLamports, limit: vector.unitLimit)
+                .replacingBlockhash(fresh)
+            let spliceFirst = try source
+                .replacingBlockhash(fresh)
+                .injectingComputeBudget(price: KaminoTransactionFixtures.unitPriceMicroLamports, limit: vector.unitLimit)
+
+            XCTAssertEqual(injectFirst.base64EncodedTransaction, spliceFirst.base64EncodedTransaction, vector.name)
+        }
+    }
+
+    func testInjectingTwiceIsRefused() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let injected = try SolanaV0Transaction(base64Transaction: vector.injected)
+
+            XCTAssertThrowsError(
+                try injected.injectingComputeBudget(
+                    price: KaminoTransactionFixtures.unitPriceMicroLamports,
+                    limit: vector.unitLimit
+                )
+            ) { error in
+                XCTAssertEqual(error as? SolanaV0TransactionError, .computeBudgetAlreadyPresent, vector.name)
+            }
+        }
+    }
+
+    // MARK: - Fee payer
+
+    func testGoldenVectorsAreUnsignedSingleSignerTransactionsForTheirOwner() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let source = try SolanaV0Transaction(base64Transaction: vector.source)
+            XCTAssertEqual(source.feePayer, vector.feePayer, vector.name)
+            XCTAssertNoThrow(try source.validateUnsignedSingleSigner(feePayer: vector.feePayer), vector.name)
+        }
+    }
+
+    func testFeePayerGuardRejectsAnotherWallet() throws {
+        let vector = KaminoTransactionFixtures.usdcDeposit
+        let source = try SolanaV0Transaction(base64Transaction: vector.source)
+        let other = KaminoTransactionFixtures.usdcWithdraw.feePayer
+
+        XCTAssertThrowsError(try source.validateUnsignedSingleSigner(feePayer: other)) { error in
+            XCTAssertEqual(
+                error as? SolanaV0TransactionError,
+                .feePayerMismatch(expected: other, actual: vector.feePayer)
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Everything an instruction actually does, in resolved terms: which program
+    /// runs, which accounts it receives with which privileges, and its data.
+    private func describe(
+        _ transaction: SolanaV0Transaction,
+        instructionAt position: Int
+    ) throws -> String {
+        let instruction = transaction.instructions[position]
+        let resolved = try transaction.resolvedAccountAddresses(
+            forInstructionAt: position,
+            lookupTables: tables
+        )
+        let program = transaction.staticAccountAddresses[Int(instruction.programIdIndex)]
+        let accounts = zip(instruction.accountIndexes, resolved).map { index, address in
+            let signer = transaction.isSigner(accountIndex: Int(index)) ? "s" : "-"
+            let writable = transaction.isWritable(accountIndex: Int(index)) ? "w" : "r"
+            return "\(address)/\(signer)\(writable)"
+        }
+        let data = instruction.data.map { String(format: "%02x", $0) }.joined()
+        return "\(program)(\(accounts.joined(separator: ","))) data=\(data)"
+    }
+
+    private func littleEndianUInt32(_ bytes: ArraySlice<UInt8>) -> UInt32? {
+        guard bytes.count == 4 else { return nil }
+        return bytes.reversed().reduce(UInt32(0)) { ($0 << 8) | UInt32($1) }
+    }
+
+    private func littleEndianUInt64(_ bytes: ArraySlice<UInt8>) -> UInt64? {
+        guard bytes.count == 8 else { return nil }
+        return bytes.reversed().reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaV0TransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaV0TransactionTests.swift
@@ -1,0 +1,482 @@
+//
+//  SolanaV0TransactionTests.swift
+//  VultisigAppTests
+//
+//  The structural guards on `SolanaV0Transaction`. These matter more than usual:
+//  the bytes this type parses come from a third party and are signed verbatim, so
+//  anything it tolerates is something the app is willing to sign without
+//  understanding.
+//
+
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+final class SolanaV0TransactionTests: XCTestCase {
+
+    // MARK: - Well-formed baseline
+
+    func testParsesAMinimalVersionedTransaction() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
+
+        XCTAssertEqual(transaction.numRequiredSignatures, 1)
+        XCTAssertEqual(transaction.numReadonlySignedAccounts, 0)
+        XCTAssertEqual(transaction.numReadonlyUnsignedAccounts, 1)
+        XCTAssertEqual(transaction.staticAccountKeys.count, 2)
+        XCTAssertEqual(transaction.instructions.count, 1)
+        XCTAssertEqual(transaction.totalAccountCount, 2)
+        XCTAssertEqual(transaction.signaturesRange, 1..<65)
+        XCTAssertEqual(transaction.messageOffset, 65)
+        XCTAssertNoThrow(try transaction.validateUnsignedSingleSigner(feePayer: transaction.feePayer))
+    }
+
+    func testRoundTripsThroughBase64() throws {
+        let bytes = try Builder().bytes()
+        let transaction = try SolanaV0Transaction(base64Transaction: Data(bytes).base64EncodedString())
+        XCTAssertEqual(transaction.wireSize, bytes.count)
+    }
+
+    // MARK: - Parse guards
+
+    func testRejectsInvalidBase64() throws {
+        XCTAssertThrowsError(try SolanaV0Transaction(base64Transaction: "not base64 !!")) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .invalidBase64)
+        }
+    }
+
+    /// A legacy message has no version byte; its first byte is
+    /// `numRequiredSignatures`, which never has the high bit set. Accepting one
+    /// would mean reading the header at the wrong offset.
+    func testRejectsLegacyMessage() throws {
+        var builder = Builder()
+        builder.versionByte = nil
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .legacyMessageUnsupported)
+        }
+    }
+
+    func testRejectsAFutureMessageVersion() throws {
+        var builder = Builder()
+        builder.versionByte = 0x81
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .unsupportedMessageVersion(1))
+        }
+    }
+
+    func testRejectsTrailingBytes() throws {
+        var builder = Builder()
+        builder.trailing = [0x00]
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .trailingBytes(1))
+        }
+    }
+
+    func testRejectsTruncatedInput() throws {
+        let bytes = try Builder().bytes()
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: Array(bytes.dropLast(3)))) { error in
+            guard case .truncated? = error as? SolanaV0TransactionError else {
+                return XCTFail("expected truncated, got \(error)")
+            }
+        }
+    }
+
+    /// `0x81 0x00` and `0x01` both decode to 1. Accepting the padded form would
+    /// mean two different byte strings describe the same transaction — and the
+    /// app hashes bytes, not the decoded structure, so a co-signer given the
+    /// other form would produce a different pre-image.
+    func testRejectsNonCanonicalLengthPrefix() throws {
+        var builder = Builder()
+        builder.keyCountPrefix = [0x81, 0x00]
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .malformedLengthPrefix)
+        }
+    }
+
+    /// Two signature slots for a header that requires one. Solana derives the
+    /// number of slots from the header, so the extra slot would shift where the
+    /// signature splice writes.
+    func testRejectsSignatureCountThatDisagreesWithTheHeader() throws {
+        var builder = Builder()
+        builder.encodedSignatureCount = 2
+        builder.signatureBytes = Array(repeating: 0, count: 128)
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(
+                error as? SolanaV0TransactionError,
+                .signatureCountMismatch(header: 1, encoded: 2)
+            )
+        }
+    }
+
+    /// The read-only signer block can never cover every signer: the fee payer is
+    /// signer 0 and has to be writable.
+    func testRejectsHeaderWithNoWritableSigner() throws {
+        var builder = Builder()
+        builder.header = [1, 1, 1]
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .malformedHeader)
+        }
+    }
+
+    func testRejectsHeaderWithOverlappingSignerAndReadonlyBlocks() throws {
+        var builder = Builder()
+        builder.header = [1, 0, 2]
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .malformedHeader)
+        }
+    }
+
+    func testRejectsAnAccountIndexBeyondTheAccountSpace() throws {
+        var builder = Builder()
+        builder.instructions = [(programIdIndex: 1, accounts: [7], data: [9])]
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(
+                error as? SolanaV0TransactionError,
+                .accountIndexOutOfRange(instruction: 0, index: 7, accountCount: 2)
+            )
+        }
+    }
+
+    /// A versioned message may not invoke a program loaded from a lookup table,
+    /// which is precisely why the injection can leave `programIdIndex` alone.
+    func testRejectsAProgramIdOutsideTheStaticKeys() throws {
+        var builder = Builder()
+        builder.lookups = [(table: Self.key(9), writable: [0], readonly: [])]
+        builder.instructions = [(programIdIndex: 2, accounts: [0], data: [9])]
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .programIdFromLookupTable(instruction: 0))
+        }
+    }
+
+    /// Solana refuses to invoke the fee payer as a program, so a message that
+    /// does is one we would have signed and the network would then drop.
+    func testRejectsAnInstructionThatInvokesTheFeePayer() throws {
+        var builder = Builder()
+        builder.instructions = [(programIdIndex: 0, accounts: [1], data: [9])]
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .programIdIsFeePayer(instruction: 0))
+        }
+    }
+
+    func testRejectsALookupThatLoadsNothing() throws {
+        var builder = Builder()
+        builder.lookups = [(table: Self.key(9), writable: [], readonly: [])]
+
+        XCTAssertThrowsError(try SolanaV0Transaction(wireBytes: try builder.bytes())) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .emptyAddressTableLookup)
+        }
+    }
+
+    func testRejectsATransactionAboveThePacketLimit() throws {
+        XCTAssertThrowsError(
+            try SolanaV0Transaction(wireBytes: Array(repeating: 0, count: 1233))
+        ) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .oversizedTransaction(1233))
+        }
+    }
+
+    // MARK: - Signing preconditions
+
+    func testRejectsATransactionThatIsAlreadySigned() throws {
+        var builder = Builder()
+        builder.signatureBytes = Array(repeating: 0xAB, count: 64)
+        let transaction = try SolanaV0Transaction(wireBytes: try builder.bytes())
+
+        XCTAssertThrowsError(
+            try transaction.validateUnsignedSingleSigner(feePayer: transaction.feePayer)
+        ) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .signaturePlaceholderNotEmpty)
+        }
+    }
+
+    func testRejectsAMultiSignerTransaction() throws {
+        var builder = Builder()
+        builder.header = [2, 0, 1]
+        builder.encodedSignatureCount = 2
+        builder.signatureBytes = Array(repeating: 0, count: 128)
+        builder.keys = [Self.key(1), Self.key(2), Self.key(3)]
+        let transaction = try SolanaV0Transaction(wireBytes: try builder.bytes())
+
+        XCTAssertThrowsError(
+            try transaction.validateUnsignedSingleSigner(feePayer: transaction.feePayer)
+        ) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .notSingleSigner(2))
+        }
+    }
+
+    // MARK: - Blockhash
+
+    func testReplacingBlockhashRejectsAWrongLengthValue() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
+        let short = Base58.encodeNoCheck(data: Data(repeating: 3, count: 31))
+
+        XCTAssertThrowsError(try transaction.replacingBlockhash(short)) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .invalidBlockhash)
+        }
+    }
+
+    func testReplacingBlockhashRejectsNonBase58() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
+
+        XCTAssertThrowsError(try transaction.replacingBlockhash("0OIl-not-base58")) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .invalidBlockhash)
+        }
+    }
+
+    // MARK: - Compute budget
+
+    func testInjectionRejectsAZeroUnitLimit() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
+
+        XCTAssertThrowsError(try transaction.injectingComputeBudget(price: 1, limit: 0)) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .computeUnitLimitOutOfRange(0))
+        }
+    }
+
+    func testInjectionRejectsAUnitLimitAboveTheNetworkCeiling() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
+        let limit = SolanaV0Transaction.maxComputeUnitLimit + 1
+
+        XCTAssertThrowsError(try transaction.injectingComputeBudget(price: 1, limit: limit)) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .computeUnitLimitOutOfRange(limit))
+        }
+    }
+
+    /// A ComputeBudget key that is present but unused would still make the append
+    /// a duplicate account key.
+    func testInjectionRejectsATransactionThatAlreadyCarriesTheProgramKey() throws {
+        var builder = Builder()
+        builder.header = [1, 0, 2]
+        builder.keys = [Self.key(1), Self.key(2), SolanaV0Transaction.computeBudgetProgramKey]
+        let transaction = try SolanaV0Transaction(wireBytes: try builder.bytes())
+
+        XCTAssertThrowsError(try transaction.injectingComputeBudget(price: 1, limit: 1000)) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .computeBudgetAlreadyPresent)
+        }
+    }
+
+    func testInjectionRefusesWhenTheAccountSpaceIsFull() throws {
+        // Two static keys plus 254 lookup-loaded ones is exactly the 256 an 8-bit
+        // index can address; a 257th account could not be referenced at all.
+        var builder = Builder()
+        builder.lookups = [(
+            table: Self.key(255),
+            writable: (0..<127).map { UInt8($0) },
+            readonly: (0..<127).map { UInt8($0) }
+        )]
+        let transaction = try SolanaV0Transaction(wireBytes: try builder.bytes())
+        XCTAssertEqual(transaction.totalAccountCount, 256)
+
+        XCTAssertThrowsError(try transaction.injectingComputeBudget(price: 1, limit: 1000)) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .tooManyAccounts(257))
+        }
+    }
+
+    /// The synthetic path: a transaction with no lookup tables at all still has
+    /// to come out right, since nothing then needs shifting.
+    func testInjectionWithoutLookupTablesShiftsNothing() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
+
+        let injected = try transaction.injectingComputeBudget(price: 7, limit: 1234)
+
+        XCTAssertEqual(injected.instructions.count, 3)
+        XCTAssertEqual(injected.instructions[2].accountIndexes, transaction.instructions[0].accountIndexes)
+        XCTAssertEqual(injected.instructions[2].programIdIndex, transaction.instructions[0].programIdIndex)
+        XCTAssertEqual(injected.staticAccountKeys.count, transaction.staticAccountKeys.count + 1)
+        XCTAssertEqual(injected.numReadonlyUnsignedAccounts, transaction.numReadonlyUnsignedAccounts + 1)
+    }
+
+    // MARK: - Multiple address lookup tables
+
+    /// Two tables, each contributing writable and read-only entries. The runtime
+    /// concatenates every table's writable accounts first and only then every
+    /// table's read-only ones, so with more than one table the loaded accounts do
+    /// not appear table by table — a resolver that walked them in table order
+    /// would name the wrong account for the same index, silently.
+    func testResolutionInterleavesMultipleLookupTablesWritableFirst() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Self.twoTableBuilder().bytes())
+
+        let resolved = try transaction.resolvedAccountAddresses(lookupTables: Self.twoTables)
+
+        XCTAssertEqual(resolved.count, 8)
+        XCTAssertEqual(Array(resolved[0..<2]), transaction.staticAccountAddresses)
+        XCTAssertEqual(
+            Array(resolved[2...]),
+            ["A-w0", "A-w1", "B-w0", "B-w1", "A-r0", "B-r0"]
+        )
+        // Writability is positional, so the boundary between the two blocks has
+        // to fall in the right place.
+        XCTAssertTrue((2..<6).allSatisfy { transaction.isWritable(accountIndex: $0) })
+        XCTAssertFalse((6..<8).contains { transaction.isWritable(accountIndex: $0) })
+    }
+
+    func testInjectionPreservesResolvedAccountsAcrossMultipleLookupTables() throws {
+        let source = try SolanaV0Transaction(wireBytes: try Self.twoTableBuilder().bytes())
+        let injected = try source.injectingComputeBudget(price: 20_000, limit: 200_000)
+
+        let before = try source.resolvedAccountAddresses(forInstructionAt: 0, lookupTables: Self.twoTables)
+        let after = try injected.resolvedAccountAddresses(forInstructionAt: 2, lookupTables: Self.twoTables)
+
+        XCTAssertEqual(before, after)
+        XCTAssertEqual(before.count, 8)
+        // Every lookup-derived index moved by exactly one; the static ones did not.
+        XCTAssertEqual(source.instructions[0].accountIndexes, [0, 1, 2, 3, 4, 5, 6, 7])
+        XCTAssertEqual(injected.instructions[2].accountIndexes, [0, 1, 3, 4, 5, 6, 7, 8])
+        XCTAssertEqual(injected.addressTableLookups, source.addressTableLookups)
+
+        // Index 2 of the result is the newly appended ComputeBudget key; every
+        // other account keeps the privileges it had.
+        let privilegesBefore = (0..<8).map { Self.privilege(source, at: $0) }
+        let privilegesAfter = (0..<9).filter { $0 != 2 }.map { Self.privilege(injected, at: $0) }
+        XCTAssertEqual(privilegesBefore, privilegesAfter)
+    }
+
+    // MARK: - Encoding primitives
+
+    func testCompactLengthUsesTheShortestEncoding() throws {
+        XCTAssertEqual(try SolanaV0Transaction.encodeCompactLength(0), [0x00])
+        XCTAssertEqual(try SolanaV0Transaction.encodeCompactLength(127), [0x7F])
+        XCTAssertEqual(try SolanaV0Transaction.encodeCompactLength(128), [0x80, 0x01])
+        XCTAssertEqual(try SolanaV0Transaction.encodeCompactLength(16_383), [0xFF, 0x7F])
+        XCTAssertEqual(try SolanaV0Transaction.encodeCompactLength(16_384), [0x80, 0x80, 0x01])
+        XCTAssertEqual(try SolanaV0Transaction.encodeCompactLength(65_535), [0xFF, 0xFF, 0x03])
+    }
+
+    /// Values compact-u16 cannot express have no encoding, so emitting one would
+    /// mean writing a length that silently means something else. A negative value
+    /// would also never terminate a shift loop.
+    func testCompactLengthRefusesValuesOutsideItsDomain() {
+        for value in [-1, 65_536, Int.max] {
+            XCTAssertThrowsError(try SolanaV0Transaction.encodeCompactLength(value)) { error in
+                XCTAssertEqual(error as? SolanaV0TransactionError, .malformedLengthPrefix)
+            }
+        }
+    }
+
+    /// Every value round-trips, including the three-byte encodings whose leading
+    /// bytes carry no value bits at all — `80 80 01` is the *only* encoding of
+    /// 16,384, so rejecting it as padded would reject a canonical length.
+    func testCompactLengthRoundTripsAcrossTheWholeDomain() throws {
+        for value in 0...SolanaV0Transaction.maxCompactLength {
+            let encoded = try SolanaV0Transaction.encodeCompactLength(value)
+            let decoded = try SolanaV0Transaction.decodeCompactLength(encoded[...])
+            XCTAssertEqual(decoded.value, value)
+            XCTAssertEqual(decoded.byteCount, encoded.count)
+        }
+    }
+
+    func testCompactLengthRejectsPaddedEncodings() {
+        // `81 00` and `01` both mean 1; `80 80 80 …` never terminates.
+        for encoding: [UInt8] in [[0x81, 0x00], [0x80, 0x00], [0x81, 0x80, 0x00], [0x80, 0x80, 0x80]] {
+            XCTAssertThrowsError(try SolanaV0Transaction.decodeCompactLength(encoding[...])) { error in
+                XCTAssertEqual(error as? SolanaV0TransactionError, .malformedLengthPrefix, "\(encoding)")
+            }
+        }
+    }
+
+    func testCompactLengthReportsTruncationSeparatelyFromMalformedInput() {
+        XCTAssertThrowsError(try SolanaV0Transaction.decodeCompactLength([0x80][...])) { error in
+            guard case .truncated? = error as? SolanaV0TransactionError else {
+                return XCTFail("expected truncated, got \(error)")
+            }
+        }
+    }
+
+    func testComputeBudgetProgramKeyIsTheDecodedProgramId() {
+        XCTAssertEqual(SolanaV0Transaction.computeBudgetProgramKey.count, 32)
+        XCTAssertEqual(
+            Base58.encodeNoCheck(data: Data(SolanaV0Transaction.computeBudgetProgramKey)),
+            SolanaV0Transaction.computeBudgetProgramId
+        )
+    }
+
+    // MARK: - Builder
+
+    private static let tableAKey = key(200)
+    private static let tableBKey = key(201)
+
+    /// Two lookup tables that each load writable *and* read-only accounts, so the
+    /// resolution order is only right if writables are gathered across all tables
+    /// before any read-only one.
+    private static let twoTables: [String: [String]] = [
+        Base58.encodeNoCheck(data: Data(tableAKey)): ["A-w0", "A-w1", "A-r0"],
+        Base58.encodeNoCheck(data: Data(tableBKey)): ["B-w0", "B-w1", "B-r0"]
+    ]
+
+    private static func twoTableBuilder() -> Builder {
+        var builder = Builder()
+        builder.lookups = [
+            (table: tableAKey, writable: [0, 1], readonly: [2]),
+            (table: tableBKey, writable: [0, 1], readonly: [2])
+        ]
+        builder.instructions = [(programIdIndex: 1, accounts: [0, 1, 2, 3, 4, 5, 6, 7], data: [9])]
+        return builder
+    }
+
+    private static func privilege(_ transaction: SolanaV0Transaction, at index: Int) -> String {
+        let signer = transaction.isSigner(accountIndex: index) ? "s" : "-"
+        let writable = transaction.isWritable(accountIndex: index) ? "w" : "r"
+        return signer + writable
+    }
+
+    private static func key(_ seed: UInt8) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        bytes[31] = seed
+        bytes[0] = seed &+ 1
+        return bytes
+    }
+
+    /// Assembles a v0 transaction byte by byte so individual fields can be made
+    /// invalid in isolation.
+    private struct Builder {
+        var encodedSignatureCount = 1
+        var signatureBytes: [UInt8] = Array(repeating: 0, count: 64)
+        var versionByte: UInt8? = 0x80
+        var header: [UInt8] = [1, 0, 1]
+        var keys: [[UInt8]] = [SolanaV0TransactionTests.key(1), SolanaV0TransactionTests.key(2)]
+        var keyCountPrefix: [UInt8]?
+        var blockhash: [UInt8] = Array(repeating: 7, count: 32)
+        var instructions: [(programIdIndex: UInt8, accounts: [UInt8], data: [UInt8])] = [
+            (programIdIndex: 1, accounts: [0], data: [9])
+        ]
+        var lookups: [(table: [UInt8], writable: [UInt8], readonly: [UInt8])] = []
+        var trailing: [UInt8] = []
+
+        func bytes() throws -> [UInt8] {
+            var out = try SolanaV0Transaction.encodeCompactLength(encodedSignatureCount)
+            out += signatureBytes
+            if let versionByte { out.append(versionByte) }
+            out += header
+            out += try keyCountPrefix ?? SolanaV0Transaction.encodeCompactLength(keys.count)
+            for key in keys { out += key }
+            out += blockhash
+            out += try SolanaV0Transaction.encodeCompactLength(instructions.count)
+            for instruction in instructions {
+                out.append(instruction.programIdIndex)
+                out += try SolanaV0Transaction.encodeCompactLength(instruction.accounts.count)
+                out += instruction.accounts
+                out += try SolanaV0Transaction.encodeCompactLength(instruction.data.count)
+                out += instruction.data
+            }
+            out += try SolanaV0Transaction.encodeCompactLength(lookups.count)
+            for lookup in lookups {
+                out += lookup.table
+                out += try SolanaV0Transaction.encodeCompactLength(lookup.writable.count)
+                out += lookup.writable
+                out += try SolanaV0Transaction.encodeCompactLength(lookup.readonly.count)
+                out += lookup.readonly
+            }
+            return out + trailing
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoAmountTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoAmountTests.swift
@@ -1,0 +1,197 @@
+//
+//  KaminoAmountTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import BigInt
+import XCTest
+
+/// Pins the unit discipline the Kamino integration depends on: exact decimal
+/// parsing, exact base-unit ↔ human-units rendering, and share/token conversion
+/// that always rounds in the safe direction.
+final class KaminoAmountTests: XCTestCase {
+
+    // MARK: - Strict decimal parsing
+
+    func test_parse_keepsFullPrecisionBeyondDoubleRange() {
+        // A real `tokensPerShare` from the Steakhouse USDC vault: 20 significant
+        // digits. Anything Double-backed loses the tail, which silently mis-prices
+        // every position that uses this rate.
+        let raw = "1.0536041812651029025"
+        let parsed = KaminoDecimal.parse(raw)
+
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed.map { KaminoDecimal.integralString($0 * pow(Decimal(10), 19)) },
+                       "10536041812651029025")
+    }
+
+    func test_parse_isNotLocaleSensitive() {
+        // The bug this guards: a `NumberFormatter` on a grouping-separator locale
+        // reads "1.0536" as 10536. The parser must be locale-independent.
+        let parsed = KaminoDecimal.parse("1.0536")
+        XCTAssertEqual(parsed, Decimal(string: "1.0536", locale: Locale(identifier: "en_US_POSIX")))
+    }
+
+    func test_parse_rejectsFormattingRatherThanCoercingIt() {
+        XCTAssertNil(KaminoDecimal.parse("1,053.60"), "grouping separators must be rejected")
+        XCTAssertNil(KaminoDecimal.parse("1e-5"), "exponent notation must be rejected")
+        XCTAssertNil(KaminoDecimal.parse(" 1.5"), "whitespace must be rejected")
+        XCTAssertNil(KaminoDecimal.parse("1.5.5"), "a second separator must be rejected")
+        XCTAssertNil(KaminoDecimal.parse("."), "a bare separator has no digits")
+        XCTAssertNil(KaminoDecimal.parse("abc"))
+        XCTAssertNil(KaminoDecimal.parse(""))
+    }
+
+    func test_parse_acceptsPlainAndNegativeValues() {
+        XCTAssertEqual(KaminoDecimal.parse("0"), 0)
+        XCTAssertEqual(KaminoDecimal.parse("100000"), 100_000)
+        XCTAssertEqual(KaminoDecimal.parse("-17064.57"),
+                       Decimal(string: "-17064.57", locale: Locale(identifier: "en_US_POSIX")))
+    }
+
+    // MARK: - Base units ↔ API string
+
+    func test_apiString_rendersHumanUnitsWithoutTrailingZeros() {
+        XCTAssertEqual(KaminoTokenAmount(baseUnits: 10_000_000, decimals: 6).apiString, "10")
+        XCTAssertEqual(KaminoTokenAmount(baseUnits: 10_500_000, decimals: 6).apiString, "10.5")
+        XCTAssertEqual(KaminoTokenAmount(baseUnits: 500_000_000, decimals: 9).apiString, "0.5")
+        XCTAssertEqual(KaminoTokenAmount(baseUnits: 100_000, decimals: 6).apiString, "0.1")
+        XCTAssertEqual(KaminoTokenAmount(baseUnits: 1, decimals: 9).apiString, "0.000000001")
+        XCTAssertEqual(KaminoTokenAmount(baseUnits: 0, decimals: 6).apiString, "0")
+    }
+
+    func test_apiString_zeroDecimalsIsPlainInteger() {
+        XCTAssertEqual(KaminoTokenAmount(baseUnits: 42, decimals: 0).apiString, "42")
+    }
+
+    func test_baseUnitStringInit_matchesLiveVaultMinimums() {
+        // Steakhouse USDC `minDepositAmount` and `minWithdrawAmount`, verbatim.
+        let minDeposit = KaminoTokenAmount(baseUnitString: "100000", decimals: 6)
+        XCTAssertEqual(minDeposit?.apiString, "0.1")
+
+        // The withdraw minimum is in SHARE base units — a distinct type so it can
+        // never be compared against a token amount by accident.
+        let minWithdraw = KaminoShareAmount(baseUnitString: "1000", decimals: 6)
+        XCTAssertEqual(minWithdraw?.apiString, "0.001")
+    }
+
+    func test_shareAmountFromDecimalString_parsesLivePositionShares() {
+        let shares = KaminoShareAmount(decimalString: "517536.857982", decimals: 6)
+        XCTAssertEqual(shares?.baseUnits, BigInt(517_536_857_982))
+        XCTAssertEqual(shares?.apiString, "517536.857982")
+    }
+
+    // MARK: - Share ↔ token conversion
+
+    // MARK: - Exact rate
+
+    func test_rate_parsesExactlyWithoutGoingThroughDecimal() throws {
+        let rate = try XCTUnwrap(KaminoRate(apiString: "1.0536041812651029025"))
+        XCTAssertEqual(rate.numerator, BigInt("10536041812651029025"))
+        XCTAssertEqual(rate.scale, 19)
+
+        // Past Decimal's 38 significant digits, where a Decimal-backed rate would
+        // silently round.
+        let long = try XCTUnwrap(
+            KaminoRate(apiString: "19929400626900.66071158913974817848691057")
+        )
+        XCTAssertEqual(long.numerator, BigInt("1992940062690066071158913974817848691057"))
+        XCTAssertEqual(long.scale, 26)
+    }
+
+    func test_rate_rejectsTheSameFormattingTheParserDoes() {
+        XCTAssertNil(KaminoRate(apiString: "1,053.60"))
+        XCTAssertNil(KaminoRate(apiString: "1e-5"))
+        XCTAssertNil(KaminoRate(apiString: ""))
+    }
+
+    // MARK: - Share ↔ token conversion
+
+    func test_tokenValue_usesTokensPerShareNotSharePrice() throws {
+        // Allez SOL: tokensPerShare 0.0010749299151180878396 (SOL per share) vs
+        // sharePrice 0.079437779653781828774 (USD per share). Using the wrong one
+        // overstates the position by ~74x.
+        let rate = try XCTUnwrap(KaminoRate(apiString: "0.0010749299151180878396"))
+        let shares = KaminoShareAmount(baseUnits: 1_000_000, decimals: 6) // 1 share
+
+        let tokens = try XCTUnwrap(shares.tokenValue(tokensPerShare: rate, tokenDecimals: 9))
+        XCTAssertEqual(tokens.apiString, "0.001074929")
+    }
+
+    func test_shareAmount_truncatesSoAWithdrawCanNeverExceedTheBalance() throws {
+        // 1 USDC at a share rate above parity is less than 1 share. Rounding up
+        // would ask for more shares than the amount is worth, and the API rewrites
+        // an over-sized withdraw to u64::MAX — a full exit.
+        let rate = try XCTUnwrap(KaminoRate(apiString: "1.0536041812651029025"))
+        let oneUsdc = KaminoTokenAmount(baseUnits: 1_000_000, decimals: 6)
+
+        let shares = try XCTUnwrap(oneUsdc.shareAmount(tokensPerShare: rate, shareDecimals: 6))
+        XCTAssertEqual(shares.apiString, "0.949123")
+
+        // Round-tripping back must never exceed what the user asked to withdraw.
+        let backToTokens = try XCTUnwrap(shares.tokenValue(tokensPerShare: rate, tokenDecimals: 6))
+        XCTAssertEqual(backToTokens.baseUnits, BigInt(999_999))
+        XCTAssertLessThanOrEqual(backToTokens.baseUnits, oneUsdc.baseUnits)
+    }
+
+    func test_shareAmount_truncatesExactlyAtABaseUnitBoundary() throws {
+        // The case Decimal division could get wrong: an exact quotient of one
+        // half a base unit must floor to zero, never round up to one.
+        let rate = try XCTUnwrap(KaminoRate(apiString: "2"))
+        let oneBaseUnit = KaminoTokenAmount(baseUnits: 1, decimals: 6)
+
+        let shares = try XCTUnwrap(oneBaseUnit.shareAmount(tokensPerShare: rate, shareDecimals: 6))
+        XCTAssertEqual(shares.baseUnits, 0)
+    }
+
+    func test_shareAmount_honoursDifferingShareAndTokenDecimals() throws {
+        // Allez SOL is the (token 9, share 6) case: scaling with the wrong
+        // decimals here is a 1000x error.
+        let rate = try XCTUnwrap(KaminoRate(apiString: "0.0010749299151180878396"))
+        let oneSol = KaminoTokenAmount(baseUnits: 1_000_000_000, decimals: 9)
+
+        let shares = try XCTUnwrap(oneSol.shareAmount(tokensPerShare: rate, shareDecimals: 6))
+        XCTAssertEqual(shares.apiString, "930.293208")
+    }
+
+    func test_conversions_rejectNonPositiveRate() throws {
+        let tokens = KaminoTokenAmount(baseUnits: 1_000_000, decimals: 6)
+        let shares = KaminoShareAmount(baseUnits: 1_000_000, decimals: 6)
+        let zero = try XCTUnwrap(KaminoRate(apiString: "0"))
+        let negative = try XCTUnwrap(KaminoRate(apiString: "-1"))
+
+        XCTAssertNil(tokens.shareAmount(tokensPerShare: zero, shareDecimals: 6))
+        XCTAssertNil(shares.tokenValue(tokensPerShare: zero, tokenDecimals: 6))
+        XCTAssertNil(tokens.shareAmount(tokensPerShare: negative, shareDecimals: 6))
+    }
+
+    func test_conversions_rejectImplausibleDecimalScales() throws {
+        let rate = try XCTUnwrap(KaminoRate(apiString: "1.5"))
+        let tokens = KaminoTokenAmount(baseUnits: 1_000_000, decimals: 6)
+
+        XCTAssertNil(tokens.shareAmount(tokensPerShare: rate, shareDecimals: 64))
+        XCTAssertNil(tokens.shareAmount(tokensPerShare: rate, shareDecimals: -1))
+        XCTAssertNil(
+            KaminoTokenAmount(baseUnits: 1, decimals: 99).shareAmount(
+                tokensPerShare: rate,
+                shareDecimals: 6
+            )
+        )
+    }
+
+    // MARK: - Request-amount bounds
+
+    func test_isValidRequestAmount_rejectsWhatCannotBeSent() {
+        // Solana instruction arguments are u64; anything larger cannot be
+        // expressed on-chain no matter what the API accepts.
+        let overU64 = KaminoTokenAmount(baseUnits: BigInt(UInt64.max) + 1, decimals: 6)
+        XCTAssertFalse(overU64.isValidRequestAmount)
+        XCTAssertTrue(KaminoTokenAmount(baseUnits: BigInt(UInt64.max), decimals: 6).isValidRequestAmount)
+
+        XCTAssertFalse(KaminoTokenAmount(baseUnits: 0, decimals: 6).isValidRequestAmount)
+        XCTAssertFalse(KaminoTokenAmount(baseUnits: -1, decimals: 6).isValidRequestAmount)
+        XCTAssertFalse(KaminoTokenAmount(baseUnits: 1, decimals: 64).isValidRequestAmount)
+        XCTAssertTrue(KaminoTokenAmount(baseUnits: 1, decimals: 6).isValidRequestAmount)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoServiceTests.swift
@@ -1,0 +1,419 @@
+//
+//  KaminoServiceTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import BigInt
+import XCTest
+
+/// Decoding and request-shaping for the Kamino REST client, against response
+/// bodies captured verbatim from `api.kamino.finance`.
+///
+/// The load-bearing assertion is `test_deposit_sendsTokenUnits_withdraw_sendsShareUnits`:
+/// the two endpoints take the same `amount` field with inverted units, and the
+/// whole typed-amount design exists to make that impossible to get wrong.
+final class KaminoServiceTests: XCTestCase {
+
+    private var http: StubKaminoHTTPClient!
+    private var service: KaminoService!
+
+    override func setUp() {
+        super.setUp()
+        http = StubKaminoHTTPClient()
+        service = KaminoService(httpClient: http)
+    }
+
+    override func tearDown() {
+        http = nil
+        service = nil
+        super.tearDown()
+    }
+
+    // MARK: - Reads
+
+    func test_fetchVaultState_decodesLiveBody() async throws {
+        http.queueJSON(Fixtures.steakhouseState, for: .state)
+
+        let response = try await service.fetchVaultState(address: Fixtures.steakhouseAddress)
+
+        XCTAssertEqual(response.address, Fixtures.steakhouseAddress)
+        XCTAssertEqual(response.state.name, "Steakhouse USDC")
+        XCTAssertEqual(response.state.tokenMintDecimals, 6)
+        XCTAssertEqual(response.state.sharesMintDecimals, 6)
+        XCTAssertEqual(response.state.minDepositAmount, "100000")
+        XCTAssertEqual(response.state.minWithdrawAmount, "1000")
+        XCTAssertEqual(response.state.performanceFeeBps, 500)
+    }
+
+    func test_fetchVaultInfo_mergesRegistryWithLiveStateAndMetrics() async throws {
+        http.queueJSON(Fixtures.allezState, for: .state)
+        http.queueJSON(Fixtures.allezMetrics, for: .metrics)
+
+        let info = try await service.fetchVaultInfo(descriptor: KaminoVaultRegistry.allezSOL)
+
+        XCTAssertEqual(info.name, "Allez SOL")
+        XCTAssertEqual(info.descriptor.curator, "Allez Labs")
+        // The (token 9, share 6) vault — the case that breaks any code assuming
+        // the two decimal scales match.
+        XCTAssertEqual(info.tokenDecimals, 9)
+        XCTAssertEqual(info.shareDecimals, 6)
+        XCTAssertEqual(info.minDeposit.apiString, "0.01")
+        XCTAssertEqual(info.minWithdraw.apiString, "0.001")
+        XCTAssertTrue(info.hasFarm, "all three launch vaults auto-stake shares into a farm")
+        XCTAssertEqual(info.apy30d, KaminoDecimal.parse("0.066908831669281033201"))
+        XCTAssertEqual(info.tokensPerShare, KaminoRate(apiString: "0.0010749299151180878396"))
+    }
+
+    func test_fetchPositions_decodesSharesOnly() async throws {
+        http.queueJSON(Fixtures.positions, for: .positions)
+
+        let positions = try await service.fetchPositions(owner: Fixtures.owner)
+
+        XCTAssertEqual(positions.count, 1)
+        XCTAssertEqual(positions.first?.vaultAddress, Fixtures.steakhouseAddress)
+        XCTAssertEqual(positions.first?.totalShares, "517536.857982")
+    }
+
+    func test_fetchPnl_decodesNegativeAndPositiveLegs() async throws {
+        http.queueJSON(Fixtures.pnl, for: .pnl)
+
+        let pnl = try await service.fetchPnl(owner: Fixtures.owner, vault: Fixtures.steakhouseAddress)
+
+        XCTAssertEqual(pnl.totalCostBasis.usd, "528083.63695495184445")
+        XCTAssertEqual(pnl.totalPnl.token, "17064.57109480498919")
+    }
+
+    // MARK: - Actions
+
+    func test_deposit_sendsTokenUnits_withdraw_sendsShareUnits() async throws {
+        http.queueJSON(Fixtures.actionResponse, for: .deposit)
+        _ = try await service.buildDepositTransaction(
+            owner: Fixtures.owner,
+            vault: Fixtures.steakhouseAddress,
+            amount: KaminoTokenAmount(baseUnits: 10_000_000, decimals: 6)
+        )
+        XCTAssertEqual(http.lastRequestBody()?.amount, "10", "deposit amount is in token units")
+
+        http.queueJSON(Fixtures.actionResponse, for: .withdraw)
+        _ = try await service.buildWithdrawTransaction(
+            owner: Fixtures.owner,
+            vault: Fixtures.steakhouseAddress,
+            shares: KaminoShareAmount(baseUnits: 5_500_000, decimals: 6)
+        )
+        XCTAssertEqual(http.lastRequestBody()?.amount, "5.5", "withdraw amount is in SHARE units")
+    }
+
+    func test_deposit_returnsRawBase64Transaction() async throws {
+        http.queueJSON(Fixtures.actionResponse, for: .deposit)
+
+        let transaction = try await service.buildDepositTransaction(
+            owner: Fixtures.owner,
+            vault: Fixtures.steakhouseAddress,
+            amount: KaminoTokenAmount(baseUnits: 10_000_000, decimals: 6)
+        )
+
+        XCTAssertEqual(transaction, "AQAAdGVzdA==")
+    }
+
+    // MARK: - Errors
+
+    func test_structuredApiError_surfacesMachineReadableCode() async {
+        http.queueError(.statusCode(400, Data(Fixtures.vaultNotFound.utf8)), for: .state)
+
+        do {
+            _ = try await service.fetchVaultState(address: "not-a-vault")
+            XCTFail("Expected a Kamino API error")
+        } catch let error as KaminoServiceError {
+            XCTAssertEqual(
+                error,
+                .api(status: 400, code: "KVAULT_NOT_FOUND", message: "Kamino Earn Vault does not exist")
+            )
+            XCTAssertFalse(error.isRetryable)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_serverErrorWithTheSameBodyShapeStaysRetryable() async {
+        // Kamino's error envelope carries its own `statusCode`, so a 503 can
+        // arrive in the identical shape as a permanent 400. Losing the HTTP
+        // status would make a transient outage indistinguishable from a bad
+        // request and suppress any retry.
+        http.queueError(.statusCode(503, Data(Fixtures.serviceUnavailable.utf8)), for: .state)
+
+        do {
+            _ = try await service.fetchVaultState(address: Fixtures.steakhouseAddress)
+            XCTFail("Expected a Kamino API error")
+        } catch let error as KaminoServiceError {
+            guard case .api(let status, _, _) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(status, 503)
+            XCTAssertTrue(error.isRetryable)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Amount gating
+
+    func test_outOfRangeAmountsNeverReachTheNetwork() async {
+        // The API validates nothing, so the client is the only gate. A zero or
+        // above-u64 amount must fail before a request is issued.
+        await assertInvalidAmount {
+            try await self.service.buildDepositTransaction(
+                owner: Fixtures.owner,
+                vault: Fixtures.steakhouseAddress,
+                amount: KaminoTokenAmount(baseUnits: 0, decimals: 6)
+            )
+        }
+        await assertInvalidAmount {
+            try await self.service.buildWithdrawTransaction(
+                owner: Fixtures.owner,
+                vault: Fixtures.steakhouseAddress,
+                shares: KaminoShareAmount(baseUnits: BigInt(UInt64.max) + 1, decimals: 6)
+            )
+        }
+        await assertInvalidAmount {
+            try await self.service.buildWithdrawTransaction(
+                owner: Fixtures.owner,
+                vault: Fixtures.steakhouseAddress,
+                shares: KaminoShareAmount(baseUnits: -1, decimals: 6)
+            )
+        }
+        XCTAssertNil(http.lastRequestBody(), "no request should have been issued")
+    }
+
+    func test_implausibleDecimalScaleFromTheApiIsRejected() async {
+        http.queueJSON(Fixtures.stateWithAbsurdDecimals, for: .state)
+        http.queueJSON(Fixtures.allezMetrics, for: .metrics)
+
+        do {
+            _ = try await service.fetchVaultInfo(descriptor: KaminoVaultRegistry.allezSOL)
+            XCTFail("Expected a malformed-number error")
+        } catch let error as KaminoServiceError {
+            XCTAssertEqual(error, .malformedNumber(field: "tokenMintDecimals", value: "64"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    private func assertInvalidAmount(
+        _ operation: () async throws -> String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await operation()
+            XCTFail("Expected an invalid-amount error", file: file, line: line)
+        } catch let error as KaminoServiceError {
+            guard case .invalidAmount = error else {
+                return XCTFail("Unexpected error: \(error)", file: file, line: line)
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+
+    func test_unstructuredHTTPError_propagatesUnchanged() async {
+        http.queueError(.statusCode(503, Data("gateway".utf8)), for: .state)
+
+        do {
+            _ = try await service.fetchVaultState(address: Fixtures.steakhouseAddress)
+            XCTFail("Expected the HTTP error to propagate")
+        } catch let error as HTTPError {
+            guard case .statusCode(let code, _) = error else {
+                return XCTFail("Unexpected HTTPError variant: \(error)")
+            }
+            XCTAssertEqual(code, 503)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_malformedMetricNumber_throwsRatherThanDefaultingToZero() async {
+        http.queueJSON(Fixtures.allezState, for: .state)
+        http.queueJSON(Fixtures.metricsWithGroupedApy, for: .metrics)
+
+        do {
+            _ = try await service.fetchVaultInfo(descriptor: KaminoVaultRegistry.allezSOL)
+            XCTFail("Expected a malformed-number error")
+        } catch let error as KaminoServiceError {
+            XCTAssertEqual(error, .malformedNumber(field: "apy30d", value: "1,234.5"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}
+
+// MARK: - Fixtures
+
+private enum Fixtures {
+    static let steakhouseAddress = "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E"
+    static let allezAddress = "A1so1bPD3W1TfeFwboDh8yfAAVaVtcdAYBYCjhg2mJQ"
+    static let owner = "CXFmQi2eM4Jzt9HZwm9A5JAzGvNpKwRuxo52ua3Jyceh"
+
+    static let steakhouseState = """
+    {"address":"\(steakhouseAddress)","programId":"KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd",
+     "state":{"name":"Steakhouse USDC","tokenMint":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+     "tokenMintDecimals":6,"sharesMint":"7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS",
+     "sharesMintDecimals":6,"minDepositAmount":"100000","minWithdrawAmount":"1000",
+     "vaultLookupTable":"9p2oT9J6BojHigd3V5qXzrwsQf4dtgMgLxtrzLVR3rwu",
+     "vaultFarm":"9FVjHqduhDPMVqvu3cXiEBjU6nvxvGdCCLRwd9WpVRZj",
+     "performanceFeeBps":500,"managementFeeBps":0}}
+    """
+
+    static let allezState = """
+    {"address":"\(allezAddress)","programId":"KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd",
+     "state":{"name":"Allez SOL","tokenMint":"So11111111111111111111111111111111111111112",
+     "tokenMintDecimals":9,"sharesMint":"FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN",
+     "sharesMintDecimals":6,"minDepositAmount":"10000000","minWithdrawAmount":"1000",
+     "vaultLookupTable":"7EzosNioQ6FDNvMKLfg6om5wTVHiJo9vVx7DZNGYBKU3",
+     "vaultFarm":"H6kauPaHmNqpdKtD5U2zw3Eb28ZB7iMeBdHVfLq1i4Kh",
+     "performanceFeeBps":500,"managementFeeBps":0}}
+    """
+
+    static let allezMetrics = """
+    {"apy30d":"0.066908831669281033201","tokensPerShare":"0.0010749299151180878396",
+     "sharePrice":"0.079437779653781828774","tokenPrice":"73.900426936257595",
+     "tokensAvailable":"34.19551574","tokensInvested":"85886.966434150043482"}
+    """
+
+    /// Same shape, but with a grouped APY the strict parser must reject.
+    static let metricsWithGroupedApy = """
+    {"apy30d":"1,234.5","tokensPerShare":"0.0010749299151180878396",
+     "sharePrice":"0.079437779653781828774","tokenPrice":"73.900426936257595",
+     "tokensAvailable":"34.19551574","tokensInvested":"85886.966434150043482"}
+    """
+
+    static let positions = """
+    [{"vaultAddress":"\(steakhouseAddress)","stakedShares":"0",
+      "unstakedShares":"517536.857982","totalShares":"517536.857982"}]
+    """
+
+    static let pnl = """
+    {"totalCostBasis":{"token":"528214.9564752811641","sol":"2205.9506713821705758",
+      "usd":"528083.63695495184445"},
+     "totalPnl":{"token":"17064.57109480498919","sol":"5199.4589620796208721",
+      "usd":"17065.96140930490871"}}
+    """
+
+    static let actionResponse = #"{"transaction":"AQAAdGVzdA=="}"#
+
+    static let vaultNotFound = """
+    {"statusCode":400,"message":"Kamino Earn Vault does not exist",
+     "error":"Bad Request","code":"KVAULT_NOT_FOUND"}
+    """
+
+    /// Same envelope shape as the 400 above — the reason the HTTP status has to
+    /// survive the mapping.
+    static let serviceUnavailable = """
+    {"statusCode":503,"message":"Service temporarily unavailable",
+     "error":"Service Unavailable","code":null}
+    """
+
+    static let stateWithAbsurdDecimals = """
+    {"address":"\(allezAddress)","programId":"KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd",
+     "state":{"name":"Allez SOL","tokenMint":"So11111111111111111111111111111111111111112",
+     "tokenMintDecimals":64,"sharesMint":"FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN",
+     "sharesMintDecimals":6,"minDepositAmount":"10000000","minWithdrawAmount":"1000",
+     "vaultLookupTable":"7EzosNioQ6FDNvMKLfg6om5wTVHiJo9vVx7DZNGYBKU3",
+     "vaultFarm":"H6kauPaHmNqpdKtD5U2zw3Eb28ZB7iMeBdHVfLq1i4Kh",
+     "performanceFeeBps":500,"managementFeeBps":0}}
+    """
+}
+
+// MARK: - Test double
+
+/// Serves raw JSON so the tests exercise the real decoding path (the typed
+/// `request<T>` overload is a protocol-extension default over this one).
+///
+/// Responses are keyed by endpoint, not by call order. `fetchVaultInfo` issues
+/// its state and metrics requests concurrently with `async let`, so a FIFO queue
+/// resolves them in nondeterministic order and hands each request the other's
+/// body — which decodes as a `keyNotFound` failure rather than anything
+/// resembling the real defect. Access is locked because those calls genuinely
+/// arrive on different threads.
+private final class StubKaminoHTTPClient: HTTPClientProtocol, @unchecked Sendable {
+
+    enum Route: Hashable {
+        case state, metrics, positions, pnl, deposit, withdraw
+    }
+
+    private enum Queued {
+        case json(String)
+        case error(HTTPError)
+    }
+
+    private let lock = NSLock()
+    private var routes: [Route: Queued] = [:]
+    private var targets: [KaminoAPI] = []
+
+    func queueJSON(_ json: String, for route: Route) {
+        lock.withLock { routes[route] = .json(json) }
+    }
+
+    func queueError(_ error: HTTPError, for route: Route) {
+        lock.withLock { routes[route] = .error(error) }
+    }
+
+    /// The body of the most recent action request, read back off the target.
+    func lastRequestBody() -> KaminoActionRequest? {
+        lock.withLock {
+            guard let target = targets.last else { return nil }
+            switch target {
+            case .deposit(let request), .withdraw(let request):
+                return request
+            default:
+                return nil
+            }
+        }
+    }
+
+    // swiftlint:disable:next async_without_await
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        guard let kamino = target as? KaminoAPI else {
+            XCTFail("StubKaminoHTTPClient received a non-Kamino target")
+            throw HTTPError.invalidResponse
+        }
+
+        let queued: Queued? = lock.withLock {
+            targets.append(kamino)
+            return routes[Self.route(for: kamino)]
+        }
+
+        guard let queued else {
+            XCTFail("No stubbed response for \(kamino.path)")
+            throw HTTPError.invalidResponse
+        }
+
+        switch queued {
+        case .error(let error):
+            throw error
+        case .json(let json):
+            guard let url = URL(string: "https://test.local"),
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: nil
+                  )
+            else {
+                throw HTTPError.invalidResponse
+            }
+            return HTTPResponse(data: Data(json.utf8), response: response)
+        }
+    }
+
+    private static func route(for target: KaminoAPI) -> Route {
+        switch target {
+        case .vaultState: return .state
+        case .vaultMetrics: return .metrics
+        case .userPositions: return .positions
+        case .positionPnl: return .pnl
+        case .deposit: return .deposit
+        case .withdraw: return .withdraw
+        }
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoServiceTests.swift
@@ -86,19 +86,23 @@ final class KaminoServiceTests: XCTestCase {
 
     // MARK: - Actions
 
+    /// Deliberately the Allez SOL vault, whose token scale (9) differs from its
+    /// share scale (6). On a vault where the two match, a deposit serialized with
+    /// share decimals — or a withdraw serialized with token decimals — produces
+    /// the identical string and the regression goes unseen.
     func test_deposit_sendsTokenUnits_withdraw_sendsShareUnits() async throws {
         http.queueJSON(Fixtures.actionResponse, for: .deposit)
         _ = try await service.buildDepositTransaction(
             owner: Fixtures.owner,
-            vault: Fixtures.steakhouseAddress,
-            amount: KaminoTokenAmount(baseUnits: 10_000_000, decimals: 6)
+            vault: KaminoVaultRegistry.allezSOL,
+            amount: KaminoTokenAmount(baseUnits: 10_000_000_000, decimals: 9)
         )
         XCTAssertEqual(http.lastRequestBody()?.amount, "10", "deposit amount is in token units")
 
         http.queueJSON(Fixtures.actionResponse, for: .withdraw)
         _ = try await service.buildWithdrawTransaction(
             owner: Fixtures.owner,
-            vault: Fixtures.steakhouseAddress,
+            vault: KaminoVaultRegistry.allezSOL,
             shares: KaminoShareAmount(baseUnits: 5_500_000, decimals: 6)
         )
         XCTAssertEqual(http.lastRequestBody()?.amount, "5.5", "withdraw amount is in SHARE units")
@@ -109,7 +113,7 @@ final class KaminoServiceTests: XCTestCase {
 
         let transaction = try await service.buildDepositTransaction(
             owner: Fixtures.owner,
-            vault: Fixtures.steakhouseAddress,
+            vault: KaminoVaultRegistry.steakhouseUSDC,
             amount: KaminoTokenAmount(baseUnits: 10_000_000, decimals: 6)
         )
 
@@ -164,21 +168,21 @@ final class KaminoServiceTests: XCTestCase {
         await assertInvalidAmount {
             try await self.service.buildDepositTransaction(
                 owner: Fixtures.owner,
-                vault: Fixtures.steakhouseAddress,
+                vault: KaminoVaultRegistry.steakhouseUSDC,
                 amount: KaminoTokenAmount(baseUnits: 0, decimals: 6)
             )
         }
         await assertInvalidAmount {
             try await self.service.buildWithdrawTransaction(
                 owner: Fixtures.owner,
-                vault: Fixtures.steakhouseAddress,
+                vault: KaminoVaultRegistry.steakhouseUSDC,
                 shares: KaminoShareAmount(baseUnits: BigInt(UInt64.max) + 1, decimals: 6)
             )
         }
         await assertInvalidAmount {
             try await self.service.buildWithdrawTransaction(
                 owner: Fixtures.owner,
-                vault: Fixtures.steakhouseAddress,
+                vault: KaminoVaultRegistry.steakhouseUSDC,
                 shares: KaminoShareAmount(baseUnits: -1, decimals: 6)
             )
         }
@@ -229,6 +233,50 @@ final class KaminoServiceTests: XCTestCase {
             XCTAssertEqual(error, .vaultNotInRegistry(impostor.address))
         } catch {
             XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertNil(http.lastRequestBody(), "no request should have been issued")
+    }
+
+    /// The same refusal, at the transaction boundary.
+    ///
+    /// Hydration is not the only way into the service: the builders send a vault
+    /// straight to Kamino. Narrowing them to `KaminoVaultDescriptor` stops a bare
+    /// address, but the struct has a memberwise initialiser, so the type alone
+    /// proves nothing — only the registry comparison does. Nothing may be built
+    /// against a vault the app did not curate.
+    func test_buildersRefuseAVaultTheRegistryDoesNotRecognise() async {
+        let impostor = KaminoVaultDescriptor(
+            address: "5YxwKgsvyTdT8q2CBgwA4L9BKbnKNrB66K9wUzij5wH",
+            tokenMint: KaminoVaultRegistry.wrappedSolMint,
+            tokenDecimals: 9,
+            sharesMint: KaminoVaultRegistry.allezSOL.sharesMint,
+            sharesDecimals: 6,
+            farm: nil,
+            fallbackName: "Not A Real Vault",
+            curator: "Nobody",
+            riskTier: .conservative
+        )
+
+        for build in [
+            { try await self.service.buildDepositTransaction(
+                owner: Fixtures.owner,
+                vault: impostor,
+                amount: KaminoTokenAmount(baseUnits: 10_000_000_000, decimals: 9)
+            ) },
+            { try await self.service.buildWithdrawTransaction(
+                owner: Fixtures.owner,
+                vault: impostor,
+                shares: KaminoShareAmount(baseUnits: 5_500_000, decimals: 6)
+            ) }
+        ] {
+            do {
+                _ = try await build()
+                XCTFail("Expected an unregistered-vault error")
+            } catch let error as KaminoServiceError {
+                XCTAssertEqual(error, .vaultNotInRegistry(impostor.address))
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
         }
         XCTAssertNil(http.lastRequestBody(), "no request should have been issued")
     }

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoServiceTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoServiceTests.swift
@@ -185,15 +185,74 @@ final class KaminoServiceTests: XCTestCase {
         XCTAssertNil(http.lastRequestBody(), "no request should have been issued")
     }
 
-    func test_implausibleDecimalScaleFromTheApiIsRejected() async {
+    /// A decimal scale is not something the API gets to change: it is a property
+    /// of the mint, it scales every amount, and a wrong one mis-sizes the actual
+    /// transfer by a power of ten while every other check still passes.
+    func test_decimalScaleDisagreeingWithTheRegistryIsRejected() async {
         http.queueJSON(Fixtures.stateWithAbsurdDecimals, for: .state)
         http.queueJSON(Fixtures.allezMetrics, for: .metrics)
 
         do {
             _ = try await service.fetchVaultInfo(descriptor: KaminoVaultRegistry.allezSOL)
-            XCTFail("Expected a malformed-number error")
+            XCTFail("Expected a vault-metadata mismatch")
         } catch let error as KaminoServiceError {
-            XCTAssertEqual(error, .malformedNumber(field: "tokenMintDecimals", value: "64"))
+            XCTAssertEqual(
+                error,
+                .vaultMetadataMismatch(field: "tokenMintDecimals", expected: "9", actual: "64")
+            )
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    /// A descriptor is the app's record of a vault's identity. One that merely
+    /// carries a curated address while describing itself differently is not that
+    /// record, and hydrating it would put fabricated mints in front of every
+    /// later check.
+    func test_aDescriptorTheRegistryDoesNotRecogniseIsRejected() async {
+        let impostor = KaminoVaultDescriptor(
+            address: KaminoVaultRegistry.allezSOL.address,
+            tokenMint: KaminoVaultRegistry.allezSOL.tokenMint,
+            tokenDecimals: 9,
+            sharesMint: KaminoVaultRegistry.steakhouseUSDC.sharesMint,
+            sharesDecimals: 6,
+            farm: KaminoVaultRegistry.allezSOL.farm,
+            fallbackName: "Allez SOL",
+            curator: "Allez Labs",
+            riskTier: .conservative
+        )
+
+        do {
+            _ = try await service.fetchVaultInfo(descriptor: impostor)
+            XCTFail("Expected an unregistered-vault error")
+        } catch let error as KaminoServiceError {
+            XCTAssertEqual(error, .vaultNotInRegistry(impostor.address))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertNil(http.lastRequestBody(), "no request should have been issued")
+    }
+
+    /// The mints and the farm decide where funds go, so they are pinned in the
+    /// registry and a response that disagrees is refused rather than merged. A
+    /// transaction built by the API cannot be validated against metadata the same
+    /// API supplied.
+    func test_vaultMetadataDisagreeingWithTheRegistryIsRejected() async {
+        http.queueJSON(Fixtures.stateWithSubstitutedFarm, for: .state)
+        http.queueJSON(Fixtures.allezMetrics, for: .metrics)
+
+        do {
+            _ = try await service.fetchVaultInfo(descriptor: KaminoVaultRegistry.allezSOL)
+            XCTFail("Expected a vault-metadata mismatch")
+        } catch let error as KaminoServiceError {
+            XCTAssertEqual(
+                error,
+                .vaultMetadataMismatch(
+                    field: "vaultFarm",
+                    expected: "H6kauPaHmNqpdKtD5U2zw3Eb28ZB7iMeBdHVfLq1i4Kh",
+                    actual: "9FVjHqduhDPMVqvu3cXiEBjU6nvxvGdCCLRwd9WpVRZj"
+                )
+            )
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -320,6 +379,19 @@ private enum Fixtures {
      "sharesMintDecimals":6,"minDepositAmount":"10000000","minWithdrawAmount":"1000",
      "vaultLookupTable":"7EzosNioQ6FDNvMKLfg6om5wTVHiJo9vVx7DZNGYBKU3",
      "vaultFarm":"H6kauPaHmNqpdKtD5U2zw3Eb28ZB7iMeBdHVfLq1i4Kh",
+     "performanceFeeBps":500,"managementFeeBps":0}}
+    """
+
+    /// The Allez vault as the API would describe it if it named another vault's
+    /// farm — the shape a response would take to stake the user's shares
+    /// somewhere the app never reads.
+    static let stateWithSubstitutedFarm = """
+    {"address":"\(allezAddress)","programId":"KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd",
+     "state":{"name":"Allez SOL","tokenMint":"So11111111111111111111111111111111111111112",
+     "tokenMintDecimals":9,"sharesMint":"FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN",
+     "sharesMintDecimals":6,"minDepositAmount":"10000000","minWithdrawAmount":"1000",
+     "vaultLookupTable":"7EzosNioQ6FDNvMKLfg6om5wTVHiJo9vVx7DZNGYBKU3",
+     "vaultFarm":"9FVjHqduhDPMVqvu3cXiEBjU6nvxvGdCCLRwd9WpVRZj",
      "performanceFeeBps":500,"managementFeeBps":0}}
     """
 }

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
@@ -935,6 +935,14 @@ private struct MutableTransaction {
         instructions = instructions.map { instruction in
             var shifted = instruction
             shifted.accounts = instruction.accounts.map { Int($0) >= oldStaticCount ? $0 + 1 : $0 }
+            // The program is addressed by the same index space as the accounts.
+            // No current vector invokes a program that lives in a lookup table —
+            // every fixture's programIdIndex is static — so this shift is inert
+            // today. It is here so that a vector which does will exercise the
+            // mutation under test rather than a refusal caused by the insertion.
+            if Int(instruction.programIdIndex) >= oldStaticCount {
+                shifted.programIdIndex = instruction.programIdIndex + 1
+            }
             return shifted
         }
         return UInt8(oldStaticCount)

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
@@ -1,0 +1,972 @@
+//
+//  KaminoTransactionValidatorTests.swift
+//  VultisigAppTests
+//
+//  Kamino builds the transaction, the app signs the bytes verbatim, and Blockaid
+//  is advisory — so this validator is the only thing between a compromised or
+//  buggy API response and a signature over it. A test suite that only proved the
+//  happy paths pass would prove nothing about that, so most of what follows takes
+//  a transaction that is known to execute on mainnet, changes exactly one thing an
+//  attacker would want changed, and asserts a refusal.
+//
+
+import BigInt
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+final class KaminoTransactionValidatorTests: XCTestCase {
+
+    // MARK: - Happy paths
+
+    func testAcceptsTheUsdcDepositAsBuilt() throws {
+        try assertValid(KaminoTransactionFixtures.usdcDeposit.source, intent: Self.usdcDepositIntent)
+    }
+
+    func testAcceptsTheSolDepositAsBuilt() throws {
+        try assertValid(KaminoTransactionFixtures.solDeposit.source, intent: Self.solDepositIntent)
+    }
+
+    func testAcceptsTheUsdcWithdrawAsBuilt() throws {
+        try assertValid(KaminoTransactionFixtures.usdcWithdraw.source, intent: Self.usdcWithdrawIntent)
+    }
+
+    /// The priority fee is injected after validation and the transaction is
+    /// re-simulated, so the validator has to accept its own output too — otherwise
+    /// it could not be re-run as a final gate before keysign.
+    func testAcceptsTheComputeBudgetInjectedTransactions() throws {
+        try assertValid(
+            KaminoTransactionFixtures.usdcDeposit.injected,
+            intent: Self.usdcDepositIntent.replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit))
+        )
+        try assertValid(
+            KaminoTransactionFixtures.solDeposit.injected,
+            intent: Self.solDepositIntent.replacing(priorityFee: Self.fee(KaminoTransactionFixtures.solDeposit))
+        )
+        try assertValid(
+            KaminoTransactionFixtures.usdcWithdraw.injected,
+            intent: Self.usdcWithdrawIntent.replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcWithdraw))
+        )
+    }
+
+    /// A full withdraw closes the emptied token account. The sampled vector is a
+    /// partial withdraw, so the closing instruction is appended here — its rent
+    /// destination is the user, which is what makes it acceptable.
+    func testAcceptsAWithdrawThatClosesTheUserTokenAccount() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcWithdraw.source)
+        let tokenProgram = mutable.appendStaticReadonlyKey(Self.tokenProgramKey)
+        mutable.instructions.append(
+            .init(
+                programIdIndex: tokenProgram,
+                accounts: [Self.withdrawUserTokenAccountIndex, Self.ownerIndex, Self.ownerIndex],
+                data: [KaminoInstructionDiscriminator.tokenCloseAccount]
+            )
+        )
+
+        try assertValid(try mutable.base64(), intent: Self.usdcWithdrawIntent)
+    }
+
+    /// The mutations below are only meaningful if re-serialising an unmodified
+    /// transaction reproduces it byte for byte — otherwise a refusal could come
+    /// from the rebuild rather than from the change under test.
+    func testRebuildingAnUnmodifiedTransactionIsByteIdentical() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let original = try XCTUnwrap(Data(base64Encoded: vector.source))
+            let rebuilt = try MutableTransaction(base64: vector.source).bytes()
+            XCTAssertEqual(rebuilt, [UInt8](original), vector.name)
+        }
+    }
+
+    // MARK: - Operation, vault and amount
+
+    func testRejectsAWithdrawTransactionOfferedAsADeposit() throws {
+        assertRefused(
+            KaminoTransactionFixtures.usdcWithdraw.source,
+            intent: Self.usdcWithdrawIntent.replacing(operation: .deposit(Self.usdcDepositAmount)),
+            expected: .missingInstruction("vault deposit")
+        )
+    }
+
+    func testRejectsADepositTransactionOfferedAsAWithdraw() throws {
+        assertRefused(
+            KaminoTransactionFixtures.usdcDeposit.source,
+            intent: Self.usdcDepositIntent.replacing(operation: .withdraw(Self.usdcWithdrawShares)),
+            expected: .missingInstruction("vault withdraw")
+        )
+    }
+
+    /// The vault the instruction targets, not the vault the caller said it asked
+    /// about. Everything else here is untouched and correct, so only the kvault
+    /// instruction's own account can tell the two apart.
+    func testRejectsAVaultAccountOtherThanTheOneRequested() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions[Self.usdcDepositKvaultIndex].accounts[1] = Self.foreignWritableIndex
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .accountMismatch(
+                role: "vault",
+                expected: KaminoVaultRegistry.steakhouseUSDC.address,
+                actual: Self.foreignWritableAddress
+            )
+        )
+    }
+
+    /// The two USDC vaults share an underlying token but nothing else. Because
+    /// the mints and the farm are pinned in the registry rather than read from
+    /// the response, asking about one and being handed the other's transaction
+    /// diverges at the first account either one names.
+    func testRejectsATransactionBuiltForTheOtherUsdcVault() throws {
+        let intent = Self.usdcDepositIntent.replacing(descriptor: KaminoVaultRegistry.rwaUSDC)
+        assertRefused(
+            KaminoTransactionFixtures.usdcDeposit.source,
+            intent: intent,
+            expected: .accountMismatch(
+                role: "created token account mint",
+                expected: "\(KaminoVaultRegistry.rwaUSDC.tokenMint) or \(KaminoVaultRegistry.rwaUSDC.sharesMint)",
+                actual: KaminoVaultRegistry.steakhouseUSDC.sharesMint
+            )
+        )
+    }
+
+    func testRejectsAVaultOutsideTheRegistryAllowList() throws {
+        let unknown = KaminoVaultDescriptor(
+            address: "5rGkiF4Jf1rPTJ6nazBgcjewVktXhagwcw5Nux7GccRi",
+            tokenMint: KaminoVaultRegistry.usdcMint,
+            tokenDecimals: 6,
+            sharesMint: "7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS",
+            sharesDecimals: 6,
+            farm: nil,
+            fallbackName: "Not ours",
+            curator: "Unknown",
+            riskTier: .conservative
+        )
+        assertRefused(
+            KaminoTransactionFixtures.usdcDeposit.source,
+            intent: Self.usdcDepositIntent.replacing(descriptor: unknown),
+            expected: .vaultNotAllowed(unknown.address)
+        )
+    }
+
+    func testRejectsAnAlteredDepositAmount() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions[Self.usdcDepositKvaultIndex].data = Self.anchorData(
+            discriminator: KaminoInstructionDiscriminator.kvaultDeposit,
+            argument: 20_000_000
+        )
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .amountMismatch(role: "deposit amount", expected: "10000000", actual: "20000000")
+        )
+    }
+
+    /// One base unit over is the whole attack: the API rewrites a withdraw above
+    /// the user's share balance to `u64::MAX`, which means withdraw everything.
+    func testRejectsAWithdrawAmountOffByOneShare() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcWithdraw.source)
+        mutable.instructions[Self.usdcWithdrawKvaultIndex].data = Self.anchorData(
+            discriminator: KaminoInstructionDiscriminator.kvaultWithdraw,
+            argument: 5_500_001
+        )
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcWithdrawIntent,
+            expected: .amountMismatch(role: "withdraw share amount", expected: "5500000", actual: "5500001")
+        )
+    }
+
+    /// Deposit takes token base units, withdraw takes SHARE base units. The typed
+    /// amounts make confusing them a compile error at the call site; this is the
+    /// same confusion arriving from the API side instead.
+    func testRejectsAWithdrawSizedInTokensRatherThanShares() throws {
+        let tokens = KaminoTokenAmount(baseUnits: BigInt(5_500_000), decimals: 6)
+        guard let asShares = tokens.shareAmount(
+            tokensPerShare: Self.steakhouseTokensPerShare,
+            shareDecimals: 6
+        ) else {
+            return XCTFail("conversion failed")
+        }
+        XCTAssertNotEqual(asShares.baseUnits, BigInt(5_500_000), "the rate must actually move the number")
+
+        assertRefused(
+            KaminoTransactionFixtures.usdcWithdraw.source,
+            intent: Self.usdcWithdrawIntent.replacing(operation: .withdraw(asShares)),
+            expected: .amountMismatch(
+                role: "withdraw share amount",
+                expected: String(describing: asShares.baseUnits),
+                actual: "5500000"
+            )
+        )
+    }
+
+    func testRejectsASolWrapForADifferentAmountThanTheDeposit() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.solDeposit.source)
+        mutable.instructions[Self.solDepositTransferIndex].data =
+            KaminoInstructionDiscriminator.systemTransfer + Self.littleEndian(1_500_000_000)
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.solDepositIntent,
+            expected: .amountMismatch(
+                role: "wrapped SOL amount",
+                expected: "500000000",
+                actual: "1500000000"
+            )
+        )
+    }
+
+    // MARK: - Destination
+
+    /// The share account the deposit mints into, replaced with an address the
+    /// user does not control. Derivation is what catches it: the ATA is a
+    /// function of owner, mint and token program, so it can be recomputed.
+    func testRejectsSharesDeliveredToAThirdPartyAccount() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.keys[Self.usdcDepositShareAccountKeyIndex] = Self.attackerKey
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .accountMismatch(
+                role: "created token account",
+                expected: Self.usdcDepositShareAccount,
+                actual: Self.attackerAddress
+            )
+        )
+    }
+
+    /// The same substitution done only inside the kvault instruction, so the
+    /// account-creation instruction still looks correct. Caught by the deposit's
+    /// own destination check rather than by the creation's.
+    func testRejectsAShareDestinationRepointedInsideTheVaultInstruction() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions[Self.usdcDepositKvaultIndex].accounts[7] = Self.foreignWritableIndex
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .accountNotOwnedByUser(
+                role: "deposit share destination",
+                actual: Self.foreignWritableAddress
+            )
+        )
+    }
+
+    func testRejectsWrappedSolSentSomewhereOtherThanTheUsersOwnAccount() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.solDeposit.source)
+        mutable.instructions[Self.solDepositTransferIndex].accounts[1] = Self.solForeignWritableIndex
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.solDepositIntent,
+            expected: .accountNotOwnedByUser(
+                role: "SOL transfer destination",
+                actual: Self.solForeignWritableAddress
+            )
+        )
+    }
+
+    /// Closing a token account sweeps its lamports. A close whose rent lands
+    /// somewhere other than the user is a drain wearing a housekeeping costume.
+    func testRejectsACloseWhoseRentGoesToAThirdParty() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcWithdraw.source)
+        let tokenProgram = mutable.appendStaticReadonlyKey(Self.tokenProgramKey)
+        mutable.instructions.append(
+            .init(
+                programIdIndex: tokenProgram,
+                accounts: [
+                    Self.withdrawUserTokenAccountIndex,
+                    Self.withdrawForeignWritableIndex,
+                    Self.ownerIndex
+                ],
+                data: [KaminoInstructionDiscriminator.tokenCloseAccount]
+            )
+        )
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcWithdrawIntent,
+            expected: .accountMismatch(
+                role: "closed account rent destination",
+                expected: Self.withdrawOwner,
+                actual: Self.foreignWritableAddress
+            )
+        )
+    }
+
+    /// The stake moves the user's whole share balance into whatever farm the
+    /// instruction names. A farm that is not this vault's own would park the
+    /// position somewhere the app never looks.
+    func testRejectsAStakeIntoAFarmThatIsNotTheVaultsOwn() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions[Self.farmsStakeIndex].accounts[Self.farmsStakeFarmPosition] =
+            Self.foreignWritableIndex
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .accountMismatch(
+                role: "farm",
+                expected: Self.steakhouseFarm,
+                actual: Self.foreignWritableAddress
+            )
+        )
+    }
+
+    /// The mints and the farm are only trustworthy because they come from the
+    /// registry, so a vault that carries an allow-listed address while describing
+    /// itself differently would hand back the pinning it is supposed to provide.
+    func testRejectsAVaultDescriptorTheRegistryDoesNotRecognise() throws {
+        assertRefused(
+            KaminoTransactionFixtures.usdcDeposit.source,
+            intent: Self.usdcDepositIntent.replacing(farm: Self.allezFarm),
+            expected: .vaultDescriptorMismatch(KaminoVaultRegistry.steakhouseUSDC.address)
+        )
+    }
+
+    // MARK: - Programs
+
+    func testRejectsAnInstructionFromAProgramOutsideTheAllowList() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.keys[Self.usdcDepositKvaultProgramKeyIndex] = Self.attackerKey
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .programNotAllowed(instruction: Self.usdcDepositKvaultIndex, program: Self.attackerAddress)
+        )
+    }
+
+    // MARK: - Extra instructions
+
+    func testRejectsAnInjectedTransferAppendedToADeposit() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions.append(
+            .init(
+                programIdIndex: Self.usdcDepositSystemProgramIndex,
+                accounts: [Self.ownerIndex, Self.foreignWritableIndex],
+                data: KaminoInstructionDiscriminator.systemTransfer + Self.littleEndian(900_000_000)
+            )
+        )
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .unexpectedInstruction(index: 4, program: KaminoSolanaProgram.system.rawValue)
+        )
+    }
+
+    /// An instruction spliced into the middle rather than appended. It cannot
+    /// match the step the walk is on, and nothing downstream re-syncs — so the
+    /// sequence fails rather than skipping past it.
+    func testRejectsAnInjectedTransferSplicedBeforeTheDeposit() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions.insert(
+            .init(
+                programIdIndex: Self.usdcDepositSystemProgramIndex,
+                accounts: [Self.ownerIndex, Self.foreignWritableIndex],
+                data: KaminoInstructionDiscriminator.systemTransfer + Self.littleEndian(900_000_000)
+            ),
+            at: Self.usdcDepositKvaultIndex
+        )
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .missingInstruction("vault deposit")
+        )
+    }
+
+    // MARK: - Priority fee
+
+    /// The fee is `limit × price` lamports out of the user's balance and Kamino
+    /// emits no ComputeBudget instruction at all, so one arriving with the
+    /// response is a spend nobody asked for.
+    func testRejectsAPriorityFeeTheAppDidNotChoose() throws {
+        assertRefused(
+            KaminoTransactionFixtures.usdcDeposit.injected,
+            intent: Self.usdcDepositIntent,
+            expected: .unexpectedPriorityFee(index: 0)
+        )
+    }
+
+    /// The price is the half worth inflating: a `u64` of micro-lamports with
+    /// nothing on chain capping the resulting fee below the payer's balance.
+    func testRejectsAnInflatedComputeUnitPrice() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.injected)
+        mutable.instructions[Self.computeUnitPriceIndex].data =
+            [ComputeBudgetInstruction.setUnitPrice] + Self.littleEndian(50_000_000_000)
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent.replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit)),
+            expected: .amountMismatch(
+                role: "compute unit price",
+                expected: String(KaminoTransactionFixtures.unitPriceMicroLamports),
+                actual: "50000000000"
+            )
+        )
+    }
+
+    func testRejectsAComputeUnitLimitOtherThanTheOneInjected() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.injected)
+        mutable.instructions[Self.computeUnitLimitIndex].data =
+            [ComputeBudgetInstruction.setUnitLimit] + Self.littleEndianUInt32(1_400_000)
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent.replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit)),
+            expected: .amountMismatch(
+                role: "compute unit limit",
+                expected: String(KaminoTransactionFixtures.usdcDeposit.unitLimit),
+                actual: "1400000"
+            )
+        )
+    }
+
+    /// A ComputeBudget instruction that is neither of the two priority-fee ones.
+    /// A heap-frame request would raise the fee-payer's cost without ever
+    /// matching a template step.
+    func testRejectsAnUnrecognisedComputeBudgetInstruction() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.injected)
+        mutable.instructions[Self.computeUnitLimitIndex].data =
+            [ComputeBudgetInstruction.requestHeapFrame, 0, 0, 0, 0]
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent.replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit)),
+            expected: .missingInstruction("compute unit limit")
+        )
+    }
+
+    /// A fee was injected, so both instructions have to be there. One alone
+    /// would mean a limit priced off the runtime default, or a price applied to
+    /// a limit nobody bounded.
+    func testRejectsAnInjectedTransactionMissingItsPriceInstruction() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.injected)
+        mutable.instructions.remove(at: Self.computeUnitPriceIndex)
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent.replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit)),
+            expected: .missingInstruction("compute unit price")
+        )
+    }
+
+    // MARK: - Writable accounts
+
+    /// An extra account handed to an otherwise correct `createIdempotent`. Every
+    /// positional check still passes; what refuses it is that a builder-composed
+    /// instruction can now write to an account this operation cannot name.
+    func testRejectsAnUnexplainedWritableAccountOnABuilderInstruction() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions[0].accounts.append(Self.foreignWritableIndex)
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .unattributableWritableAccount(
+                program: KaminoSolanaProgram.associatedToken.rawValue,
+                account: Self.foreignWritableAddress
+            )
+        )
+    }
+
+    /// The farm's own share vault is written by exactly one instruction. Point
+    /// that one slot at an account already in use and the vault stays loaded
+    /// writable with nothing touching it — a write privilege no instruction
+    /// explains, which is not a shape any honest builder emits.
+    func testRejectsAWritableAccountNoInstructionUses() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions[Self.farmsStakeIndex].accounts[Self.farmsStakeFarmVaultPosition] =
+            Self.foreignWritableIndex
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .unreferencedWritableAccount(Self.steakhouseFarmVault)
+        )
+    }
+
+    /// The stake is what turns the minted shares into the position the app reads.
+    /// A farm-backed deposit that omits it is not the deposit that was requested,
+    /// so it cannot be waved through as an optional step.
+    func testRejectsAFarmBackedDepositThatDoesNotStake() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        mutable.instructions.removeLast()
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent,
+            expected: .missingInstruction("farm stake")
+        )
+    }
+
+    // MARK: - Shape and lookup tables
+
+    func testRejectsATransactionPaidForBySomeoneElse() throws {
+        let intent = Self.usdcDepositIntent.replacing(owner: Self.withdrawOwner)
+        XCTAssertThrowsError(
+            try KaminoTransactionValidator.validate(
+                transaction: try SolanaV0Transaction(base64Transaction: KaminoTransactionFixtures.usdcDeposit.source),
+                intent: intent,
+                lookupTables: KaminoTransactionFixtures.lookupTables
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SolanaV0TransactionError,
+                .feePayerMismatch(expected: Self.withdrawOwner, actual: Self.depositOwner)
+            )
+        }
+    }
+
+    /// A lookup table decides which pubkey an index names, so a foreign one is
+    /// where an account substitution would hide.
+    func testRejectsAForeignAddressLookupTable() throws {
+        var mutable = try MutableTransaction(base64: KaminoTransactionFixtures.usdcDeposit.source)
+        let foreign = try XCTUnwrap(Base58.decodeNoCheck(string: KaminoTransactionFixtures.solDeposit.lookupTable))
+        mutable.lookups[0].table = [UInt8](foreign)
+
+        XCTAssertThrowsError(
+            try KaminoTransactionValidator.validate(
+                transaction: try SolanaV0Transaction(base64Transaction: try mutable.base64()),
+                intent: Self.usdcDepositIntent,
+                lookupTables: KaminoTransactionFixtures.lookupTables
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? KaminoValidationError,
+                .unexpectedLookupTable(
+                    expected: KaminoTransactionFixtures.usdcDeposit.lookupTable,
+                    actual: KaminoTransactionFixtures.solDeposit.lookupTable
+                )
+            )
+        }
+    }
+
+    /// The table contents are the transaction's meaning. Same bytes, one entry
+    /// swapped, and every index that pointed at the vault now points elsewhere.
+    func testRejectsWhenTheLookupTableResolvesTheVaultToAnotherAccount() throws {
+        var tables = KaminoTransactionFixtures.lookupTables
+        let table = KaminoTransactionFixtures.usdcDeposit.lookupTable
+        var contents = try XCTUnwrap(tables[table])
+        XCTAssertEqual(contents[1], KaminoVaultRegistry.steakhouseUSDC.address)
+        contents[1] = Self.attackerAddress
+        tables[table] = contents
+
+        XCTAssertThrowsError(
+            try KaminoTransactionValidator.validate(
+                transaction: try SolanaV0Transaction(base64Transaction: KaminoTransactionFixtures.usdcDeposit.source),
+                intent: Self.usdcDepositIntent,
+                lookupTables: tables
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? KaminoValidationError,
+                .accountMismatch(
+                    role: "vault",
+                    expected: KaminoVaultRegistry.steakhouseUSDC.address,
+                    actual: Self.attackerAddress
+                )
+            )
+        }
+    }
+
+    func testRefusesWhenALookupTableCannotBeResolved() throws {
+        XCTAssertThrowsError(
+            try KaminoTransactionValidator.validate(
+                transaction: try SolanaV0Transaction(base64Transaction: KaminoTransactionFixtures.usdcDeposit.source),
+                intent: Self.usdcDepositIntent,
+                lookupTables: [:]
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SolanaV0TransactionError,
+                .unknownLookupTable(KaminoTransactionFixtures.usdcDeposit.lookupTable)
+            )
+        }
+    }
+
+    // MARK: - Resolution through the fetcher
+
+    func testResolvesLookupTablesThroughTheFetcher() async throws {
+        let validator = KaminoTransactionValidator(
+            lookupTableSource: StubLookupTables(tables: KaminoTransactionFixtures.lookupTables)
+        )
+        let transaction = try SolanaV0Transaction(
+            base64Transaction: KaminoTransactionFixtures.usdcDeposit.source
+        )
+
+        try await validator.validate(transaction: transaction, intent: Self.usdcDepositIntent)
+    }
+
+    func testPropagatesALookupTableFetchFailure() async throws {
+        let validator = KaminoTransactionValidator(lookupTableSource: StubLookupTables(tables: [:], fails: true))
+        let transaction = try SolanaV0Transaction(
+            base64Transaction: KaminoTransactionFixtures.usdcDeposit.source
+        )
+
+        do {
+            try await validator.validate(transaction: transaction, intent: Self.usdcDepositIntent)
+            XCTFail("expected the fetch failure to propagate")
+        } catch {
+            XCTAssertEqual(
+                error as? SolanaAddressLookupTableError,
+                .accountNotFound(KaminoTransactionFixtures.usdcDeposit.lookupTable)
+            )
+        }
+    }
+
+    // MARK: - Discriminator provenance
+
+    /// The four Anchor discriminators are `sha256("global:<name>")[0..<8]`. Pinning
+    /// them against the hash rather than against the bytes that were observed
+    /// means a typo in a constant that sizes or targets a transaction cannot
+    /// survive to runtime.
+    func testAnchorDiscriminatorsMatchTheirInstructionNames() throws {
+        let expectations: [(String, [UInt8])] = [
+            ("global:deposit", KaminoInstructionDiscriminator.kvaultDeposit),
+            ("global:withdraw", KaminoInstructionDiscriminator.kvaultWithdraw),
+            ("global:initialize_user", KaminoInstructionDiscriminator.farmsInitializeUser),
+            ("global:stake", KaminoInstructionDiscriminator.farmsStake)
+        ]
+        for (name, discriminator) in expectations {
+            let digest = Hash.sha256(data: Data(name.utf8))
+            XCTAssertEqual([UInt8](digest.prefix(8)), discriminator, name)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func assertValid(
+        _ base64: String,
+        intent: KaminoTransactionIntent,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let transaction = try SolanaV0Transaction(base64Transaction: base64)
+        do {
+            try KaminoTransactionValidator.validate(
+                transaction: transaction,
+                intent: intent,
+                lookupTables: KaminoTransactionFixtures.lookupTables
+            )
+        } catch {
+            XCTFail("expected the transaction to validate, refused with: \(error)", file: file, line: line)
+        }
+    }
+
+    private func assertRefused(
+        _ base64: @autoclosure () throws -> String,
+        intent: KaminoTransactionIntent,
+        expected: KaminoValidationError,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        do {
+            let transaction = try SolanaV0Transaction(base64Transaction: try base64())
+            try KaminoTransactionValidator.validate(
+                transaction: transaction,
+                intent: intent,
+                lookupTables: KaminoTransactionFixtures.lookupTables
+            )
+            XCTFail("expected \(expected)", file: file, line: line)
+        } catch let error as KaminoValidationError {
+            XCTAssertEqual(error, expected, file: file, line: line)
+        } catch {
+            XCTFail("expected \(expected), got \(error)", file: file, line: line)
+        }
+    }
+
+    private static func anchorData(discriminator: [UInt8], argument: UInt64) -> [UInt8] {
+        discriminator + littleEndian(argument)
+    }
+
+    private static func littleEndian(_ value: UInt64) -> [UInt8] {
+        withUnsafeBytes(of: value.littleEndian) { [UInt8]($0) }
+    }
+
+    private static func littleEndianUInt32(_ value: UInt32) -> [UInt8] {
+        withUnsafeBytes(of: value.littleEndian) { [UInt8]($0) }
+    }
+
+    /// The priority fee the golden vectors were injected with.
+    private static func fee(_ vector: KaminoTransactionFixtures.Vector) -> KaminoPriorityFee {
+        KaminoPriorityFee(limit: vector.unitLimit, price: KaminoTransactionFixtures.unitPriceMicroLamports)
+    }
+}
+
+// MARK: - Fixtures
+
+private extension KaminoTransactionValidatorTests {
+
+    // Owners and accounts, read out of the decoded golden vectors.
+    static let depositOwner = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+    static let withdrawOwner = "CXFmQi2eM4Jzt9HZwm9A5JAzGvNpKwRuxo52ua3Jyceh"
+
+    static let ownerIndex: UInt8 = 0
+
+    /// Static key 3 of the USDC deposit: the user's share account.
+    static let usdcDepositShareAccountKeyIndex = 3
+    static let usdcDepositShareAccount = "pTT7BQ26zy2YkBzNk3m7ywK4E4h4XD6oL2ns5SiJTnA"
+    /// Static key 8 of the USDC deposit: the kvault program itself.
+    static let usdcDepositKvaultProgramKeyIndex = 8
+    static let usdcDepositSystemProgramIndex: UInt8 = 4
+    static let usdcDepositKvaultIndex = 1
+    static let usdcWithdrawKvaultIndex = 1
+    static let solDepositTransferIndex = 1
+    static let farmsStakeIndex = 3
+    /// Positions inside `farms::stake`: the farm itself, and its share vault.
+    static let farmsStakeFarmPosition = 2
+    static let farmsStakeFarmVaultPosition = 3
+    /// The injected payloads carry the limit then the price, ahead of everything
+    /// the API built.
+    static let computeUnitLimitIndex = 0
+    static let computeUnitPriceIndex = 1
+
+    /// A writable account belonging to the vault, not to the user — the shape an
+    /// attacker's account would have if it were substituted in.
+    static let foreignWritableIndex: UInt8 = 13
+    static let foreignWritableAddress = "CKTEDx5z19CntAB9B66AxuS98S1NuCgMvfpsew7TQwi"
+    static let solForeignWritableIndex: UInt8 = 5
+    static let solForeignWritableAddress = "HqMuhd4cKWNFbLHc7zMZrThnh1cP39JwqczdBueK1bxj"
+
+    static let withdrawUserTokenAccountIndex: UInt8 = 1
+    /// `foreignWritableIndex` as it reads in the withdraw vector after a static
+    /// key has been appended, which shifts every lookup-derived index by one.
+    static let withdrawForeignWritableIndex: UInt8 = foreignWritableIndex + 1
+
+    static let steakhouseFarm = "9FVjHqduhDPMVqvu3cXiEBjU6nvxvGdCCLRwd9WpVRZj"
+    static let steakhouseFarmVault = "CRsf9nPkGBUT1HDytxfoYe3PBa5CZc9Nsh9a5aoBbGnb"
+    static let allezFarm = "H6kauPaHmNqpdKtD5U2zw3Eb28ZB7iMeBdHVfLq1i4Kh"
+
+    static let attackerKey = [UInt8](repeating: 0x11, count: 32)
+    static var attackerAddress: String { Base58.encodeNoCheck(data: Data(attackerKey)) }
+
+    static var tokenProgramKey: [UInt8] {
+        guard let data = Base58.decodeNoCheck(string: SolanaTokenProgram.token.rawValue) else { return [] }
+        return [UInt8](data)
+    }
+
+    static let steakhouseTokensPerShare = KaminoRate(apiString: "1.0536041812651029025") ?? KaminoRate(apiString: "1")!
+
+    static let usdcDepositAmount = KaminoTokenAmount(baseUnits: BigInt(10_000_000), decimals: 6)
+    static let solDepositAmount = KaminoTokenAmount(baseUnits: BigInt(500_000_000), decimals: 9)
+    static let usdcWithdrawShares = KaminoShareAmount(baseUnits: BigInt(5_500_000), decimals: 6)
+
+    static var steakhouseVault: KaminoVaultInfo {
+        vaultInfo(descriptor: KaminoVaultRegistry.steakhouseUSDC, lookupTable: KaminoTransactionFixtures.usdcDeposit.lookupTable)
+    }
+
+    static var allezVault: KaminoVaultInfo {
+        vaultInfo(descriptor: KaminoVaultRegistry.allezSOL, lookupTable: KaminoTransactionFixtures.solDeposit.lookupTable)
+    }
+
+    /// Only the live fields are supplied here — the mints, their decimals and the
+    /// farm come from the registry, which is the point of pinning them.
+    static func vaultInfo(descriptor: KaminoVaultDescriptor, lookupTable: String) -> KaminoVaultInfo {
+        KaminoVaultInfo(
+            descriptor: descriptor,
+            name: descriptor.fallbackName,
+            minDeposit: KaminoTokenAmount(baseUnits: BigInt(100_000), decimals: descriptor.tokenDecimals),
+            minWithdraw: KaminoShareAmount(baseUnits: BigInt(1_000), decimals: descriptor.sharesDecimals),
+            lookupTable: lookupTable,
+            apy30d: Decimal(string: "0.0391") ?? .zero,
+            tokensPerShare: steakhouseTokensPerShare,
+            tokenPriceUsd: 1
+        )
+    }
+
+    static var usdcDepositIntent: KaminoTransactionIntent {
+        KaminoTransactionIntent(operation: .deposit(usdcDepositAmount), vault: steakhouseVault, owner: depositOwner)
+    }
+
+    static var solDepositIntent: KaminoTransactionIntent {
+        KaminoTransactionIntent(operation: .deposit(solDepositAmount), vault: allezVault, owner: depositOwner)
+    }
+
+    static var usdcWithdrawIntent: KaminoTransactionIntent {
+        KaminoTransactionIntent(operation: .withdraw(usdcWithdrawShares), vault: steakhouseVault, owner: withdrawOwner)
+    }
+}
+
+// MARK: - Intent editing
+
+private extension KaminoTransactionIntent {
+
+    func replacing(operation: KaminoOperation) -> KaminoTransactionIntent {
+        KaminoTransactionIntent(operation: operation, vault: vault, owner: owner, priorityFee: priorityFee)
+    }
+
+    func replacing(owner: String) -> KaminoTransactionIntent {
+        KaminoTransactionIntent(operation: operation, vault: vault, owner: owner, priorityFee: priorityFee)
+    }
+
+    func replacing(priorityFee: KaminoPriorityFee?) -> KaminoTransactionIntent {
+        KaminoTransactionIntent(operation: operation, vault: vault, owner: owner, priorityFee: priorityFee)
+    }
+
+    func replacing(descriptor: KaminoVaultDescriptor) -> KaminoTransactionIntent {
+        KaminoTransactionIntent(
+            operation: operation,
+            vault: vault.replacing(descriptor: descriptor),
+            owner: owner,
+            priorityFee: priorityFee
+        )
+    }
+
+    func replacing(farm: String?) -> KaminoTransactionIntent {
+        replacing(descriptor: vault.descriptor.replacing(farm: farm))
+    }
+}
+
+private extension KaminoVaultDescriptor {
+
+    func replacing(farm: String?) -> KaminoVaultDescriptor {
+        KaminoVaultDescriptor(
+            address: address,
+            tokenMint: tokenMint,
+            tokenDecimals: tokenDecimals,
+            sharesMint: sharesMint,
+            sharesDecimals: sharesDecimals,
+            farm: farm,
+            fallbackName: fallbackName,
+            curator: curator,
+            riskTier: riskTier
+        )
+    }
+}
+
+private extension KaminoVaultInfo {
+
+    func replacing(descriptor: KaminoVaultDescriptor) -> KaminoVaultInfo {
+        KaminoVaultInfo(
+            descriptor: descriptor,
+            name: name,
+            minDeposit: minDeposit,
+            minWithdraw: minWithdraw,
+            lookupTable: lookupTable,
+            apy30d: apy30d,
+            tokensPerShare: tokensPerShare,
+            tokenPriceUsd: tokenPriceUsd
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+private struct StubLookupTables: SolanaAddressLookupTableFetching {
+    let tables: [String: [String]]
+    var fails = false
+
+    func fetchAddressLookupTables(addresses: [String]) async throws -> [String: [String]] {
+        // A real fetch suspends; yielding keeps the stub from resolving
+        // synchronously and hiding an ordering bug in the caller.
+        await Task.yield()
+        if fails, let first = addresses.first {
+            throw SolanaAddressLookupTableError.accountNotFound(first)
+        }
+        return tables
+    }
+}
+
+// MARK: - Mutation
+
+/// A decoded v0 transaction that can be edited and re-serialized.
+///
+/// `SolanaV0Transaction` deliberately offers only the two edits production needs,
+/// so the adversarial cases build their bytes here instead. Round-tripping an
+/// untouched transaction is asserted byte-for-byte above, which is what makes a
+/// refusal in these tests attributable to the mutation rather than to the rebuild.
+private struct MutableTransaction {
+
+    struct Instruction {
+        var programIdIndex: UInt8
+        var accounts: [UInt8]
+        var data: [UInt8]
+    }
+
+    struct Lookup {
+        var table: [UInt8]
+        var writable: [UInt8]
+        var readonly: [UInt8]
+    }
+
+    var numRequiredSignatures: UInt8
+    var numReadonlySignedAccounts: UInt8
+    var numReadonlyUnsignedAccounts: UInt8
+    var keys: [[UInt8]]
+    var blockhash: [UInt8]
+    var instructions: [Instruction]
+    var lookups: [Lookup]
+
+    init(base64: String) throws {
+        let transaction = try SolanaV0Transaction(base64Transaction: base64)
+        guard let blockhash = Base58.decodeNoCheck(string: transaction.recentBlockhash) else {
+            throw SolanaV0TransactionError.invalidBlockhash
+        }
+        self.numRequiredSignatures = transaction.numRequiredSignatures
+        self.numReadonlySignedAccounts = transaction.numReadonlySignedAccounts
+        self.numReadonlyUnsignedAccounts = transaction.numReadonlyUnsignedAccounts
+        self.keys = transaction.staticAccountKeys
+        self.blockhash = [UInt8](blockhash)
+        self.instructions = transaction.instructions.map {
+            Instruction(programIdIndex: $0.programIdIndex, accounts: $0.accountIndexes, data: $0.data)
+        }
+        self.lookups = transaction.addressTableLookups.map {
+            Lookup(table: $0.tableKey, writable: $0.writableIndexes, readonly: $0.readonlyIndexes)
+        }
+    }
+
+    /// Appends a static read-only unsigned key, shifting every account index that
+    /// addressed a lookup-loaded account. This is the same insertion the compute
+    /// budget injection performs, reused so a Token instruction can be added to a
+    /// transaction whose token program only exists inside a lookup table.
+    ///
+    /// - Returns: the new key's index.
+    mutating func appendStaticReadonlyKey(_ key: [UInt8]) -> UInt8 {
+        let oldStaticCount = keys.count
+        keys.append(key)
+        numReadonlyUnsignedAccounts += 1
+        instructions = instructions.map { instruction in
+            var shifted = instruction
+            shifted.accounts = instruction.accounts.map { Int($0) >= oldStaticCount ? $0 + 1 : $0 }
+            return shifted
+        }
+        return UInt8(oldStaticCount)
+    }
+
+    func bytes() throws -> [UInt8] {
+        var out = try SolanaV0Transaction.encodeCompactLength(Int(numRequiredSignatures))
+        out += [UInt8](repeating: 0, count: 64 * Int(numRequiredSignatures))
+        out += [0x80, numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts]
+        out += try SolanaV0Transaction.encodeCompactLength(keys.count)
+        for key in keys { out += key }
+        out += blockhash
+        out += try SolanaV0Transaction.encodeCompactLength(instructions.count)
+        for instruction in instructions {
+            out.append(instruction.programIdIndex)
+            out += try SolanaV0Transaction.encodeCompactLength(instruction.accounts.count)
+            out += instruction.accounts
+            out += try SolanaV0Transaction.encodeCompactLength(instruction.data.count)
+            out += instruction.data
+        }
+        out += try SolanaV0Transaction.encodeCompactLength(lookups.count)
+        for lookup in lookups {
+            out += lookup.table
+            out += try SolanaV0Transaction.encodeCompactLength(lookup.writable.count)
+            out += lookup.writable
+            out += try SolanaV0Transaction.encodeCompactLength(lookup.readonly.count)
+            out += lookup.readonly
+        }
+        return out
+    }
+
+    func base64() throws -> String {
+        Data(try bytes()).base64EncodedString()
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoVaultRegistryTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoVaultRegistryTests.swift
@@ -1,0 +1,65 @@
+//
+//  KaminoVaultRegistryTests.swift
+//  VultisigAppTests
+//
+
+@testable import VultisigApp
+import WalletCore
+import XCTest
+
+/// The allow-list is money-critical: a mistyped address is a transaction built
+/// against the wrong vault, and the API happily builds one for any vault that
+/// exists. These tests pin the constants and prove each is a real Solana address.
+final class KaminoVaultRegistryTests: XCTestCase {
+
+    func test_allowList_addressesAreValidSolanaAddresses() {
+        for descriptor in KaminoVaultRegistry.allowList {
+            XCTAssertNotNil(
+                AnyAddress(string: descriptor.address, coin: .solana),
+                "\(descriptor.fallbackName) has an invalid Solana address"
+            )
+        }
+    }
+
+    func test_allowList_pinsTheLaunchSet() {
+        XCTAssertEqual(
+            KaminoVaultRegistry.allowList.map(\.address),
+            [
+                "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",
+                "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",
+                "A1so1bPD3W1TfeFwboDh8yfAAVaVtcdAYBYCjhg2mJQ"
+            ]
+        )
+    }
+
+    func test_allowList_addressesAreUnique() {
+        let addresses = KaminoVaultRegistry.allowList.map(\.address)
+        XCTAssertEqual(Set(addresses).count, addresses.count)
+    }
+
+    func test_rwaVaultIsRankedAboveTheConservativeTier() {
+        // The RWA vault lends against tokenized private credit, not liquid
+        // crypto collateral. It must never be presented at the same risk tier as
+        // the plain lending vaults.
+        XCTAssertEqual(KaminoVaultRegistry.rwaUSDC.riskTier, .privateCredit)
+        XCTAssertEqual(KaminoVaultRegistry.steakhouseUSDC.riskTier, .conservative)
+        XCTAssertEqual(KaminoVaultRegistry.allezSOL.riskTier, .conservative)
+        XCTAssertGreaterThan(
+            KaminoVaultRegistry.rwaUSDC.riskTier.rawValue,
+            KaminoVaultRegistry.steakhouseUSDC.riskTier.rawValue
+        )
+    }
+
+    func test_isAllowed_rejectsAnythingOutsideTheCuratedSet() {
+        XCTAssertTrue(KaminoVaultRegistry.isAllowed(KaminoVaultRegistry.steakhouseUSDC.address))
+        // A real Kamino vault, but not one we curate.
+        XCTAssertFalse(KaminoVaultRegistry.isAllowed("5YxwKgsvyTdT8q2CBgwA4L9BKbnKNrB66K9wUzij5wH"))
+        XCTAssertFalse(KaminoVaultRegistry.isAllowed(""))
+    }
+
+    func test_descriptorLookup_isAddressKeyed() {
+        let descriptor = KaminoVaultRegistry.descriptor(for: KaminoVaultRegistry.allezSOL.address)
+        XCTAssertEqual(descriptor?.curator, "Allez Labs")
+        XCTAssertNil(KaminoVaultRegistry.descriptor(for: "nope"))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoVaultRegistryTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoVaultRegistryTests.swift
@@ -57,6 +57,58 @@ final class KaminoVaultRegistryTests: XCTestCase {
         XCTAssertFalse(KaminoVaultRegistry.isAllowed(""))
     }
 
+    /// Mints and farms are pinned here rather than read from the API, because a
+    /// transaction the API built cannot be validated against metadata the same
+    /// API supplied. That only helps if the pinned values are themselves real
+    /// Solana addresses.
+    func test_allowList_pinnedMintsAndFarmsAreValidSolanaAddresses() {
+        for descriptor in KaminoVaultRegistry.allowList {
+            for (label, address) in [
+                ("tokenMint", descriptor.tokenMint),
+                ("sharesMint", descriptor.sharesMint)
+            ] + (descriptor.farm.map { [("farm", $0)] } ?? []) {
+                XCTAssertNotNil(
+                    AnyAddress(string: address, coin: .solana),
+                    "\(descriptor.fallbackName) has an invalid \(label)"
+                )
+            }
+        }
+    }
+
+    /// Every launch vault stakes deposits into a farm, so the shares never reach
+    /// the user's wallet and the position cannot be read from an ATA.
+    func test_allowList_everyLaunchVaultHasAFarm() {
+        for descriptor in KaminoVaultRegistry.allowList {
+            XCTAssertNotNil(descriptor.farm, "\(descriptor.fallbackName) has no farm")
+        }
+    }
+
+    /// The decimal scales index a `10^n` factor in every conversion. They used to
+    /// be bounds-checked at the service boundary; now they are constants, so this
+    /// is where that guarantee lives.
+    func test_allowList_decimalScalesAreSane() {
+        for descriptor in KaminoVaultRegistry.allowList {
+            XCTAssertTrue((0...KaminoBaseUnits.maxDecimals).contains(descriptor.tokenDecimals))
+            XCTAssertTrue((0...KaminoBaseUnits.maxDecimals).contains(descriptor.sharesDecimals))
+        }
+    }
+
+    /// The SOL vault is the counterexample to any code that assumes a vault's two
+    /// decimal scales match.
+    func test_allezSol_pinsMismatchedDecimalScales() {
+        XCTAssertEqual(KaminoVaultRegistry.allezSOL.tokenMint, KaminoVaultRegistry.wrappedSolMint)
+        XCTAssertEqual(KaminoVaultRegistry.allezSOL.tokenDecimals, 9)
+        XCTAssertEqual(KaminoVaultRegistry.allezSOL.sharesDecimals, 6)
+    }
+
+    /// Two vaults over the same token, with different share mints and different
+    /// farms — a mix-up between them would deposit into the wrong curator's book.
+    func test_usdcVaults_shareATokenButNotAShareMintOrFarm() {
+        XCTAssertEqual(KaminoVaultRegistry.steakhouseUSDC.tokenMint, KaminoVaultRegistry.rwaUSDC.tokenMint)
+        XCTAssertNotEqual(KaminoVaultRegistry.steakhouseUSDC.sharesMint, KaminoVaultRegistry.rwaUSDC.sharesMint)
+        XCTAssertNotEqual(KaminoVaultRegistry.steakhouseUSDC.farm, KaminoVaultRegistry.rwaUSDC.farm)
+    }
+
     func test_descriptorLookup_isAddressKeyed() {
         let descriptor = KaminoVaultRegistry.descriptor(for: KaminoVaultRegistry.allezSOL.address)
         XCTAssertEqual(descriptor?.curator, "Allez Labs")


### PR DESCRIPTION
## Description

Layer 1 of a 4-layer stacked change adding **Kamino Earn vaults (kVaults)** to the Solana DeFi surface. This layer is plumbing only — no UI, nothing user-reachable, nothing that can move funds yet.

Part of #5017. Deliberately not `Fixes` — the issue closes with the final layer.

**Stack**

| Layer | Branch | Contents |
|---|---|---|
| **1 (this PR)** | `feat/kamino-plumbing-5017` | REST client, Solana v0 message editor, transaction validator |
| 2 | `feat/kamino-earn-view-5017` | `KaminoPosition` model + read-only Earn segment |
| 3 | `feat/kamino-flows-5017` | Deposit + withdraw |
| 4 | `feat/kamino-verify-5017` | Verify-screen decoding, locales, polish |

Each layer targets the branch below it, so this PR's diff is the whole review surface.

### What's here

**Kamino REST client** (`KaminoAPI`, `KaminoService`, `KaminoVaultRegistry`) over `api.kamino.finance`, no API key. Three curated launch vaults; curator and risk tier live in our registry because the API exposes neither.

**Typed amounts.** The deposit and withdraw endpoints take the same `amount` JSON field with **inverted units** — deposit in underlying tokens, withdraw in vault *shares*. `KaminoTokenAmount` and `KaminoShareAmount` are separate types over exact `BigInt` base units, so passing one where the other belongs is a compile error rather than a silently mis-sized transaction. Conversion is exact integer arithmetic, not `Decimal`: the API does not validate amounts, and a withdraw above the user's share balance is silently rewritten to `u64::MAX` — *withdraw everything* — so a one-base-unit rounding error can turn a partial withdraw into a full exit.

**Byte-level v0 message editor** (`SolanaV0Transaction`). Kamino builds the transactions and the app signs them verbatim: `SolanaHelper.getPreSignedImageHashForRaw` hashes the wire bytes the builder returned, and every co-signer hashes the same bytes independently. Feeding them through WalletCore's signing proto and re-serializing produces a message differing by a byte, which breaks Secure Vault co-signing before any TSS message is emitted. So we edit bytes:

- `replacingBlockhash(_:)` splices in place — fixed 32-byte field, nothing else moves.
- `injectingComputeBudget(price:limit:)` appends ComputeBudget as a static readonly-unsigned key, increments `numReadonlyUnsignedAccounts`, and shifts instruction account indices at or above the old static count by one. `programIdIndex` values are untouched: a versioned message may not invoke a program loaded from a lookup table, so every program is already static and below the insertion point.

Parsing is strict, because anything it tolerates is something the app signs without understanding — non-canonical compact-u16 lengths, trailing bytes, inconsistent headers, out-of-range account indices, empty lookups and invoking the fee payer as a program are all refusals.

**Kamino compute limits are deliberately not `SolanaHelper.priorityFeeLimit`.** That constant is 100,000 CU; the three transactions were measured on mainnet consuming 252,146 / 287,029 / 174,566, so reusing it would abort every one of them on compute exhaustion.

**Pre-existing bug fix:** `SolanaTransactionParser` mapped ComputeBudget discriminants `0/1/2` to heap/limit/price, but `0` is the deprecated `RequestUnits`, so limit and price are `2` and `3`. The parser feeds the keysign verify screen, so the effect was a co-signer reading a different instruction from the one being approved.

**Fail-closed validator** (`KaminoTransactionValidator`). We sign an unauthenticated third-party transaction verbatim and Blockaid is advisory only, so before simulation or signing the transaction runs six checks in order: program allow-list → instruction sequence → account identity → amount → priority fee → writable-account attribution.

The last is what catches a drain: every writable account must be used by some instruction, and any account a *builder-composed* instruction (System / Token / Token-2022 / AssociatedToken) can write to must be one the operation can name. What `kvault` and `farms` do with the accounts they're handed is the protocol we chose to trust; the top-level instructions are not.

Two properties are load-bearing and easy to lose:

- **The priority fee is an amount.** The network charges `limit × price` in SOL, bounded only by the payer's balance. Validation before injection refuses *any* ComputeBudget instruction; validation after requires both, pinned to the locally chosen values.
- **Vault metadata is pinned locally, not taken from the API.** The farm and mints previously came from the same source as the transaction, which made the farm check compare an API value against an API value — a poisoned `vaultFarm` plus a matching transaction would stake the user's whole share balance into an attacker's farm. `tokenMint`, `tokenDecimals`, `sharesMint`, `sharesDecimals` and `farm` are now registry constants (all immutable kVault properties, so pinning cannot break on a legitimate change), and the validator requires the *complete* descriptor to equal the registry's — not just the address.

The address lookup table is deliberately still API-supplied: a table only decides which pubkey an index *names*, and every account that matters is compared against a locally derived value, so a substituted table renames an account into a mismatch, never out of one.

### Verification

The golden vectors are not expectations invented in this PR. Each injected payload was produced by a reference implementation and simulated on mainnet with `err: null` before any Swift was written, so a byte that differs is a byte that is wrong.

Byte equality alone would not be enough: an index is only a position, and a transaction whose indices all shifted consistently still parses and still names a completely different set of accounts. The load-bearing test therefore resolves both sides through the **real address lookup tables** and compares the account pubkeys — with signer and writable privileges — that every instruction receives.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None ticked, and no tx link: this layer ships no user-reachable path and broadcasts nothing. Transaction links arrive with layer 3, which is where deposit and withdraw become reachable.

## Parity

Required here because this touches keysign — `SolanaTransactionParser` feeds the verify screen.

- Android: `linked: vultisig-android#5485`
- Windows + extension: `linked: vultisig-windows#4541`
- SDK: **unfiled gap.** `sdk.defi.*` has eight providers (river, pendle, stakekit, osmosis, balancer, threeJane, arkis, glif) but all are EVM/Cosmos, and `chains/solana/` carries only `spl` and `staking`. Kamino Earn would be the SDK's first Solana DeFi provider, so this is a genuine new surface rather than `n/a` — it needs a ticket raised deliberately, not as a side effect of this PR.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

SwiftLint unchanged: 39 pre-existing violations, 0 serious, none in the touched files.

## Screenshots (if applicable):

N/A — no UI in this layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kamino vault support, including vault details, positions, performance metrics, deposits, and withdrawals.
  * Added curated vault listings with risk classifications.
  * Added Solana transaction simulation, address lookup tables, associated token accounts, and improved transaction preparation.
  * Added support for recognizing and validating Kamino programs and transaction details.
  * Added localized validation messages for Kamino and Solana errors.

* **Bug Fixes**
  * Improved validation of transaction data, amounts, fees, lookup tables, and malformed responses.

* **Tests**
  * Added comprehensive coverage for Solana transaction flows and Kamino vault operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->