### PR TITLE
fix(keychain): distinguish an absent item from an unreadable Keychain

### DIFF
--- a/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
+++ b/VultisigApp/VultisigApp/Core/Migration/AppMigrationService.swift
@@ -33,11 +33,7 @@ struct AppMigrationService {
             return
         }
 
-        // Get the last migrated version from Keychain
-        // there is no way to figure out whether it is a new installation , or an update from a version without AppMigrationService
-        // So when the last migrated version is nil , we need to do the migration
-        // thus we need to make sure the migration is idempotent
-         let lastVersion = keychainService.getLastMigratedVersion() ?? -1
+        let lastVersion = lastMigratedVersion()
 
         // If already migrated to the latest version, skip
         if lastVersion >= latestMigrationVersion {
@@ -51,6 +47,31 @@ struct AppMigrationService {
         executeMigrations(from: lastVersion, migrations: migrations)
 
         logger.info("✅ [Migration] Completed all migrations")
+    }
+
+    /// The version below every registered migration, so that all of them are eligible.
+    private static let noVersionRecorded = -1
+
+    /// The last recorded migration version, or ``noVersionRecorded`` when there
+    /// is none to be had.
+    ///
+    /// A stored version cannot say whether this is a fresh install or an update
+    /// from a build that predates this service, so an absent record has always
+    /// meant "run everything" and the migrations are written to be idempotent.
+    /// An unreadable Keychain is folded into the same answer deliberately: the
+    /// cost is repeating idempotent work, whereas skipping migrations on a
+    /// transient read failure would leave the store half-converted. Nothing here
+    /// writes a secret, so `unavailable` carries no risk of overwriting one.
+    private func lastMigratedVersion() -> Int {
+        switch keychainService.getLastMigratedVersion() {
+        case .present(let version):
+            return version
+        case .absent:
+            return Self.noVersionRecorded
+        case .unavailable(let status):
+            logger.error("⚠️ [Migration] Could not read the last migrated version (status \(status, privacy: .public)) - re-running the idempotent migrations")
+            return Self.noVersionRecorded
+        }
     }
 
     /// Executes all necessary migrations after the last migrated version

--- a/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
+++ b/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
@@ -93,7 +93,10 @@ class PushNotificationManager: ObservableObject {
 
     func setDeviceToken(_ token: Data) {
         let tokenString = token.map { String(format: "%02x", $0) }.joined()
-        let previousToken = keychainService.getDeviceToken()
+        // An unreadable Keychain counts as "no previous token", which re-registers
+        // every opted-in vault. Re-registering an unchanged token is harmless;
+        // skipping a registration for a token that really did change is not.
+        let previousToken = keychainService.getDeviceToken().valueTreatingUnavailableAsAbsent
         deviceToken = tokenString
         keychainService.setDeviceToken(tokenString)
 

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/Keychain.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/Keychain.swift
@@ -6,11 +6,15 @@
 //
 
 import Foundation
+import OSLog
 import Security
+
+private let logger = Log.app.store
 
 struct Keychain {
 
     private let serviceName: String
+    private let itemStore: KeychainItemStore
 
     private let kSecClassGenericPasswordValue = String(kSecClassGenericPassword)
     private let kSecClassValue = String(kSecClass)
@@ -22,18 +26,29 @@ struct Keychain {
     private let kSecAttrAccountValue = String(kSecAttrAccount)
     private let kSecAttrAccessibleValue = String(kSecAttrAccessible)
 
-    init(serviceName: String) {
+    init(serviceName: String, itemStore: KeychainItemStore = SecItemStore()) {
         self.serviceName = serviceName
+        self.itemStore = itemStore
     }
 
     // MARK: - String
 
-    func getString(for key: KeychainIdentifier) -> String? {
-        guard let data = get(for: key),
-              let value = String(data: data, encoding: .utf8) else {
-            return nil
+    /// - Returns: ``KeychainReadResult/unavailable(_:)`` with `errSecDecode` when
+    ///   an item exists but its bytes are not UTF-8. The item is present, so
+    ///   reporting it as absent would invite a caller to overwrite it.
+    func getString(for key: KeychainIdentifier) -> KeychainReadResult<String> {
+        switch get(for: key) {
+        case .absent:
+            return .absent
+        case .unavailable(let status):
+            return .unavailable(status)
+        case .present(let data):
+            guard let value = String(data: data, encoding: .utf8) else {
+                logger.error("Keychain item is not valid UTF-8 for \(key.identifier, privacy: .public)")
+                return .unavailable(errSecDecode)
+            }
+            return .present(value)
         }
-        return value
     }
 
     func setString(_ value: String?, for key: KeychainIdentifier) {
@@ -43,12 +58,22 @@ struct Keychain {
 
     // MARK: - Int
 
-    func getInt(for key: KeychainIdentifier) -> Int? {
-        guard let string = getString(for: key),
-              let value = Int(string) else {
-            return nil
+    /// - Returns: ``KeychainReadResult/unavailable(_:)`` with `errSecDecode` when
+    ///   an item exists but does not parse as an integer, for the same reason
+    ///   ``getString(for:)`` does.
+    func getInt(for key: KeychainIdentifier) -> KeychainReadResult<Int> {
+        switch getString(for: key) {
+        case .absent:
+            return .absent
+        case .unavailable(let status):
+            return .unavailable(status)
+        case .present(let string):
+            guard let value = Int(string) else {
+                logger.error("Keychain item is not an integer for \(key.identifier, privacy: .public)")
+                return .unavailable(errSecDecode)
+            }
+            return .present(value)
         }
-        return value
     }
 
     func setInt(_ value: Int?, for key: KeychainIdentifier) {
@@ -60,7 +85,7 @@ struct Keychain {
 
     func delete(for key: KeychainIdentifier) {
         let query = generateQuery(for: key)
-        SecItemDelete(query as CFDictionary)
+        _ = itemStore.delete(query)
     }
 
 }
@@ -78,30 +103,45 @@ private extension Keychain {
 
         var query = generateQuery(for: key)
 
-        SecItemDelete(query as CFDictionary)
+        _ = itemStore.delete(query)
 
         query.removeValue(forKey: kSecReturnDataValue)
         query.updateValue(data, forKey: kSecValueDataValue)
         query.updateValue(kSecAttrAccessibleWhenUnlockedThisDeviceOnly, forKey: kSecAttrAccessibleValue)
 
-        let status = SecItemAdd(query as CFDictionary, nil)
+        let status = itemStore.add(query)
         guard status == errSecSuccess else {
             return
         }
     }
 
-    func get(for key: KeychainIdentifier) -> Data? {
+    /// Reads one item, keeping apart the three outcomes the Security framework
+    /// actually reports.
+    ///
+    /// Only `errSecItemNotFound` means the key has no item. Every other failing
+    /// status means the answer is unknown — the device is locked, the process
+    /// lacks the entitlement, the keychain is unusable — and is reported as
+    /// ``KeychainReadResult/unavailable(_:)`` so a caller can never mistake a
+    /// failed read for permission to write.
+    func get(for key: KeychainIdentifier) -> KeychainReadResult<Data> {
 
         let query = generateQuery(for: key)
 
-        var dataTypeRef: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        let (status, data) = itemStore.copyMatching(query)
 
-        guard status == errSecSuccess, let data = dataTypeRef as? Data else {
-            return nil
+        switch status {
+        case errSecSuccess:
+            guard let data else {
+                logger.error("Keychain returned success with no data for \(key.identifier, privacy: .public)")
+                return .unavailable(errSecDecode)
+            }
+            return .present(data)
+        case errSecItemNotFound:
+            return .absent
+        default:
+            logger.error("Keychain read failed for \(key.identifier, privacy: .public): status=\(status, privacy: .public)")
+            return .unavailable(status)
         }
-
-        return data
     }
 
     func generateQuery(for key: KeychainIdentifier) -> [String: Any] {

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainItemStore.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainItemStore.swift
@@ -1,0 +1,37 @@
+//
+//  KeychainItemStore.swift
+//  VultisigApp
+//
+
+import Foundation
+import Security
+
+/// The `SecItem` calls ``Keychain`` makes, behind a seam.
+///
+/// The seam exists so the read path can be tested. A unit-test bundle has no
+/// keychain entitlement, so every real `SecItem` call answers
+/// `errSecMissingEntitlement` — one of the very statuses the read path has to
+/// tell apart from "no such item", and one it cannot be shown to tell apart if
+/// it is the only status a test can ever produce.
+protocol KeychainItemStore {
+    func copyMatching(_ query: [String: Any]) -> (status: OSStatus, data: Data?)
+    func add(_ attributes: [String: Any]) -> OSStatus
+    func delete(_ query: [String: Any]) -> OSStatus
+}
+
+struct SecItemStore: KeychainItemStore {
+
+    func copyMatching(_ query: [String: Any]) -> (status: OSStatus, data: Data?) {
+        var dataTypeRef: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        return (status, dataTypeRef as? Data)
+    }
+
+    func add(_ attributes: [String: Any]) -> OSStatus {
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    func delete(_ query: [String: Any]) -> OSStatus {
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainReadResult.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainReadResult.swift
@@ -1,0 +1,57 @@
+//
+//  KeychainReadResult.swift
+//  VultisigApp
+//
+
+import Foundation
+import Security
+
+/// The outcome of a single Keychain read.
+///
+/// `SecItemCopyMatching` already distinguishes "there is no item for this key"
+/// (`errSecItemNotFound`) from "the item could not be read" — a locked device,
+/// a missing entitlement, a keychain the system refused to open. Returning
+/// `Data?` throws that distinction away, and the two license opposite decisions:
+/// absence says a value may safely be written, while an unreadable keychain says
+/// a value may already be there. Where the stored item is key material, that is
+/// the difference between saving a secret and destroying one.
+///
+/// Callers that genuinely do not need the distinction still have to say so, via
+/// ``valueTreatingUnavailableAsAbsent``.
+enum KeychainReadResult<Value> {
+
+    /// The Keychain answered, and holds no item for this key.
+    case absent
+
+    /// The Keychain answered with the stored value.
+    case present(Value)
+
+    /// The Keychain could not answer. Whether an item exists is unknown.
+    ///
+    /// - Parameter status: the `OSStatus` the Security framework reported, or
+    ///   `errSecDecode` when an item was returned but could not be interpreted
+    ///   as the requested type.
+    case unavailable(OSStatus)
+}
+
+extension KeychainReadResult {
+
+    /// The stored value, treating an unreadable Keychain exactly like an absent
+    /// item.
+    ///
+    /// Correct wherever the value is a cache or a convenience the caller can
+    /// obtain again — a fast-vault password that cannot be read just means the
+    /// user types it in. Wrong wherever `nil` would authorise a write, because
+    /// a transient failure would then overwrite a value that is still there.
+    /// Spelled out at the call site so that choice is visible in review.
+    var valueTreatingUnavailableAsAbsent: Value? {
+        switch self {
+        case .present(let value):
+            return value
+        case .absent, .unavailable:
+            return nil
+        }
+    }
+}
+
+extension KeychainReadResult: Equatable where Value: Equatable {}

--- a/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
+++ b/VultisigApp/VultisigApp/Core/Storage/Keychain/KeychainService.swift
@@ -7,14 +7,18 @@
 
 import Foundation
 
+/// Every read answers with a ``KeychainReadResult`` rather than an optional, so
+/// "there is no such item" and "the Keychain could not be read" stay apart all
+/// the way to the call site. Callers that want to treat them alike say so with
+/// ``KeychainReadResult/valueTreatingUnavailableAsAbsent``.
 protocol KeychainService: AnyObject {
-    func getFastPassword(pubKeyECDSA: String) -> String?
+    func getFastPassword(pubKeyECDSA: String) -> KeychainReadResult<String>
     func setFastPassword(_ fastPassword: String?, pubKeyECDSA: String)
-    func getFastHint(pubKeyECDSA: String) -> String?
+    func getFastHint(pubKeyECDSA: String) -> KeychainReadResult<String>
     func setFastHint(_ fastHint: String?, pubKeyECDSA: String)
-    func getLastMigratedVersion() -> Int?
+    func getLastMigratedVersion() -> KeychainReadResult<Int>
     func setLastMigratedVersion(_ version: Int?)
-    func getDeviceToken() -> String?
+    func getDeviceToken() -> KeychainReadResult<String>
     func setDeviceToken(_ token: String?)
 }
 
@@ -33,7 +37,7 @@ final class DefaultKeychainService: KeychainService {
         self.keychain = keychain
     }
 
-    func getFastPassword(pubKeyECDSA: String) -> String? {
+    func getFastPassword(pubKeyECDSA: String) -> KeychainReadResult<String> {
         return keychain.getString(for: Keys.fastPassword(pubKeyECDSA: pubKeyECDSA))
     }
 
@@ -41,7 +45,7 @@ final class DefaultKeychainService: KeychainService {
         keychain.setString(fastPassword, for: Keys.fastPassword(pubKeyECDSA: pubKeyECDSA))
     }
 
-    func getFastHint(pubKeyECDSA: String) -> String? {
+    func getFastHint(pubKeyECDSA: String) -> KeychainReadResult<String> {
         return keychain.getString(for: Keys.fastHint(pubKeyECDSA: pubKeyECDSA))
     }
 
@@ -49,7 +53,7 @@ final class DefaultKeychainService: KeychainService {
         keychain.setString(fastHint, for: Keys.fastHint(pubKeyECDSA: pubKeyECDSA))
     }
 
-    func getLastMigratedVersion() -> Int? {
+    func getLastMigratedVersion() -> KeychainReadResult<Int> {
         return keychain.getInt(for: Keys.lastMigratedVersion)
     }
 
@@ -57,7 +61,7 @@ final class DefaultKeychainService: KeychainService {
         keychain.setInt(version, for: Keys.lastMigratedVersion)
     }
 
-    func getDeviceToken() -> String? {
+    func getDeviceToken() -> KeychainReadResult<String> {
         return keychain.getString(for: Keys.deviceToken)
     }
 

--- a/VultisigApp/VultisigApp/Features/Keygen/Views/FastVaultEnterPasswordView.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/Views/FastVaultEnterPasswordView.swift
@@ -26,7 +26,9 @@ struct FastVaultEnterPasswordView: View {
     private let biometryService = BiometryService.shared
 
     var hint: String? {
-        keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA)
+        // Display only: an unreadable Keychain hides the hint, exactly as an
+        // unsaved one does.
+        keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA).valueTreatingUnavailableAsAbsent
     }
 
     var body: some View {
@@ -136,7 +138,11 @@ struct FastVaultEnterPasswordView: View {
     }
 
     func tryAuthenticate() {
-        guard let fastPassword = keychain.getFastPassword(pubKeyECDSA: vault.pubKeyECDSA) else {
+        // No saved password and an unreadable Keychain lead to the same place —
+        // the user types the password in. This path writes nothing, so the two
+        // need not be told apart.
+        let saved = keychain.getFastPassword(pubKeyECDSA: vault.pubKeyECDSA)
+        guard let fastPassword = saved.valueTreatingUnavailableAsAbsent else {
             return
         }
 

--- a/VultisigApp/VultisigApp/Features/Settings/Views/SettingsBiometryViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/SettingsBiometryViewModel.swift
@@ -33,7 +33,9 @@ final class SettingsBiometryViewModel: ObservableObject {
     }
 
     func resetHintData(vault: Vault) {
-        if let hint = keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA) {
+        // The hint is a convenience the user can retype, so an unreadable
+        // Keychain leaves the field exactly where a never-saved hint would.
+        if let hint = keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA).valueTreatingUnavailableAsAbsent {
            self.hint = hint
            self.initialHint = hint
        }

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/Modifiers/BiweeklyPasswordVerificationViewModifier.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/Modifiers/BiweeklyPasswordVerificationViewModifier.swift
@@ -16,7 +16,10 @@ struct BiweeklyPasswordVerificationViewModifier: ViewModifier {
     private let keychain = DefaultKeychainService.shared
 
     private var hasHint: Bool {
-        guard let hint = keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA) else { return false }
+        // Only decides the sheet's height, so an unreadable Keychain sizes it as
+        // if no hint were stored.
+        let saved = keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA)
+        guard let hint = saved.valueTreatingUnavailableAsAbsent else { return false }
         return !hint.isEmpty
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -64,7 +64,11 @@ class EncryptedBackupViewModel: ObservableObject {
     }
 
     func exportFileWithVaultPassword(_ backupType: VaultBackupType) async -> FileExporterModel<EncryptedDataFile>? {
-        guard let vaultPassword = keychain.getFastPassword(pubKeyECDSA: backupType.vault.pubKeyECDSA) else {
+        // Either way there is no password to encrypt with, and the export is
+        // abandoned rather than written unprotected — so an unreadable Keychain
+        // takes the same branch as an absent password.
+        let saved = keychain.getFastPassword(pubKeyECDSA: backupType.vault.pubKeyECDSA)
+        guard let vaultPassword = saved.valueTreatingUnavailableAsAbsent else {
             logger.warning("Couldn't fetch password for vault")
             return nil
         }

--- a/VultisigApp/VultisigApp/Features/Wallet/Views/PasswordVerifyReminderView.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/Views/PasswordVerifyReminderView.swift
@@ -25,7 +25,9 @@ struct PasswordVerifyReminderView: View {
     private let keychain = DefaultKeychainService.shared
 
     private var hint: String? {
-        keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA)
+        // Display only: an unreadable Keychain hides the hint, exactly as an
+        // unsaved one does.
+        keychain.getFastHint(pubKeyECDSA: vault.pubKeyECDSA).valueTreatingUnavailableAsAbsent
     }
 
     var body: some View {

--- a/VultisigApp/VultisigAppTests/Migration/AppMigrationServiceKeychainReadTests.swift
+++ b/VultisigApp/VultisigAppTests/Migration/AppMigrationServiceKeychainReadTests.swift
@@ -1,0 +1,90 @@
+//
+//  AppMigrationServiceKeychainReadTests.swift
+//  VultisigAppTests
+//
+//  The migration service is the one shipping consumer that reads a Keychain
+//  item on every launch and acts on its absence. It folds an unreadable
+//  Keychain into "nothing has been migrated" on purpose — the migrations are
+//  idempotent, so repeating them costs a little work while skipping them would
+//  leave the store half-converted. These pin that choice so it stays a decision
+//  rather than a side effect of an optional.
+//
+
+import Security
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class AppMigrationServiceKeychainReadTests: XCTestCase {
+
+    /// The two `UserDefaults` keys the real migration list reads and writes.
+    /// These tests drive every registered migration, and the promo-banner one
+    /// seeds a process-wide store from app-wide defaults — so both are cleared
+    /// for the duration and put back afterwards, or this class would leak state
+    /// into whatever runs next in the same host.
+    private static let legacyBannersKey = "appClosedBanners"
+    private static let bannerDismissalsKey = "promoBannerDismissals"
+
+    private var token: TestContextToken?
+    private var savedDefaults: [String: Any] = [:]
+
+    override func setUpWithError() throws {
+        token = try TestStore.installInMemoryContainer()
+        savedDefaults = [:]
+        for key in [Self.legacyBannersKey, Self.bannerDismissalsKey] {
+            if let value = UserDefaults.standard.object(forKey: key) {
+                savedDefaults[key] = value
+            }
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    override func tearDownWithError() throws {
+        for key in [Self.legacyBannersKey, Self.bannerDismissalsKey] {
+            if let value = savedDefaults[key] {
+                UserDefaults.standard.set(value, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+        savedDefaults = [:]
+        TestStore.restore(token)
+        token = nil
+    }
+
+    func testAnAbsentRecordRunsTheMigrations() {
+        let keychain = MockKeychainService()
+        keychain.lastMigratedVersionResult = .absent
+
+        AppMigrationService(keychainService: keychain).performMigrationsIfNeeded()
+
+        XCTAssertNotNil(
+            keychain.lastMigratedVersion,
+            "a fresh install has no record, so every migration should run and ratchet the version forward"
+        )
+    }
+
+    func testAnUnreadableKeychainRunsTheMigrationsInsteadOfSkippingThem() {
+        let keychain = MockKeychainService()
+        keychain.lastMigratedVersionResult = .unavailable(errSecInteractionNotAllowed)
+
+        AppMigrationService(keychainService: keychain).performMigrationsIfNeeded()
+
+        XCTAssertNotNil(
+            keychain.lastMigratedVersion,
+            "a failed read must not be mistaken for 'already migrated' - the migrations are idempotent, so re-running them is the safe answer"
+        )
+    }
+
+    func testARecordAtOrBeyondTheLatestVersionSkipsTheMigrations() {
+        let keychain = MockKeychainService(lastMigratedVersion: .max)
+
+        AppMigrationService(keychainService: keychain).performMigrationsIfNeeded()
+
+        XCTAssertEqual(
+            keychain.lastMigratedVersion,
+            .max,
+            "nothing should run, and nothing should be written back"
+        )
+    }
+}

--- a/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockKeychainService.swift
@@ -9,34 +9,56 @@ import Foundation
 /// In-memory `KeychainService` so migration-ordering behaviour can be driven
 /// without touching the real Keychain (which persists across test runs and
 /// across app reinstalls).
+///
+/// Values are held as `KeychainReadResult`s rather than optionals so a test can
+/// stage an unreadable Keychain as easily as a stored value — the two are
+/// different answers and the consumers have to be pinned against both.
 final class MockKeychainService: KeychainService {
-    var lastMigratedVersion: Int?
 
-    private var fastPasswords: [String: String] = [:]
-    private var fastHints: [String: String] = [:]
-    private var deviceToken: String?
+    /// The answer ``getLastMigratedVersion()`` gives. Settable directly so a
+    /// test can stage `.unavailable`.
+    var lastMigratedVersionResult: KeychainReadResult<Int>
+
+    private var fastPasswords: [String: KeychainReadResult<String>] = [:]
+    private var fastHints: [String: KeychainReadResult<String>] = [:]
+    private var deviceTokenResult: KeychainReadResult<String> = .absent
+
+    /// The recorded version, for tests that only care about the stored value.
+    var lastMigratedVersion: Int? {
+        get { lastMigratedVersionResult.valueTreatingUnavailableAsAbsent }
+        set { lastMigratedVersionResult = Self.result(newValue) }
+    }
 
     init(lastMigratedVersion: Int? = nil) {
-        self.lastMigratedVersion = lastMigratedVersion
+        self.lastMigratedVersionResult = Self.result(lastMigratedVersion)
     }
 
-    func getFastPassword(pubKeyECDSA: String) -> String? { fastPasswords[pubKeyECDSA] }
+    func getFastPassword(pubKeyECDSA: String) -> KeychainReadResult<String> {
+        fastPasswords[pubKeyECDSA] ?? .absent
+    }
 
     func setFastPassword(_ fastPassword: String?, pubKeyECDSA: String) {
-        fastPasswords[pubKeyECDSA] = fastPassword
+        fastPasswords[pubKeyECDSA] = Self.result(fastPassword)
     }
 
-    func getFastHint(pubKeyECDSA: String) -> String? { fastHints[pubKeyECDSA] }
+    func getFastHint(pubKeyECDSA: String) -> KeychainReadResult<String> {
+        fastHints[pubKeyECDSA] ?? .absent
+    }
 
     func setFastHint(_ fastHint: String?, pubKeyECDSA: String) {
-        fastHints[pubKeyECDSA] = fastHint
+        fastHints[pubKeyECDSA] = Self.result(fastHint)
     }
 
-    func getLastMigratedVersion() -> Int? { lastMigratedVersion }
+    func getLastMigratedVersion() -> KeychainReadResult<Int> { lastMigratedVersionResult }
 
-    func setLastMigratedVersion(_ version: Int?) { lastMigratedVersion = version }
+    func setLastMigratedVersion(_ version: Int?) { lastMigratedVersionResult = Self.result(version) }
 
-    func getDeviceToken() -> String? { deviceToken }
+    func getDeviceToken() -> KeychainReadResult<String> { deviceTokenResult }
 
-    func setDeviceToken(_ token: String?) { deviceToken = token }
+    func setDeviceToken(_ token: String?) { deviceTokenResult = Self.result(token) }
+
+    private static func result<Value>(_ value: Value?) -> KeychainReadResult<Value> {
+        guard let value else { return .absent }
+        return .present(value)
+    }
 }

--- a/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
+++ b/VultisigApp/VultisigAppTests/Storage/KeychainTriStateReadTests.swift
@@ -1,0 +1,183 @@
+//
+//  KeychainTriStateReadTests.swift
+//  VultisigAppTests
+//
+//  `SecItemCopyMatching` reports "no such item" and "could not read the item"
+//  as different statuses, and the two license opposite decisions: absence says
+//  a value may safely be written, an unreadable keychain says one may already
+//  be there. These pin that the distinction survives every layer between
+//  `SecItem` and the call site, for every failure a device can actually hand
+//  back — because the moment it collapses, a transient failure looks exactly
+//  like permission to overwrite whatever is stored.
+//
+
+import Security
+import XCTest
+@testable import VultisigApp
+
+final class KeychainTriStateReadTests: XCTestCase {
+
+    private static let serviceName = "com.vultisig.tests.keychain"
+
+    /// Failures a real device hands back, none of which mean "no such item".
+    /// `errSecInteractionNotAllowed` is the everyday one — a read while the
+    /// device is locked — and `errSecMissingEntitlement` is what this very test
+    /// bundle would get from the real Keychain.
+    private static let failureStatuses: [OSStatus] = [
+        errSecInteractionNotAllowed,
+        errSecNotAvailable,
+        errSecAuthFailed,
+        errSecMissingEntitlement,
+        errSecUserCanceled,
+        errSecDecode,
+        errSecParam,
+        errSecIO
+    ]
+
+    // MARK: - Keychain
+
+    func testReadsAStoredStringAsPresent() {
+        let keychain = makeKeychain(status: errSecSuccess, data: Data("hunter2".utf8))
+
+        XCTAssertEqual(keychain.getString(for: TestKey()), .present("hunter2"))
+    }
+
+    func testReadsAStoredIntegerAsPresent() {
+        let keychain = makeKeychain(status: errSecSuccess, data: Data("42".utf8))
+
+        XCTAssertEqual(keychain.getInt(for: TestKey()), .present(42))
+    }
+
+    func testReportsAbsentOnlyWhenTheItemIsNotFound() {
+        let keychain = makeKeychain(status: errSecItemNotFound, data: nil)
+
+        XCTAssertEqual(keychain.getString(for: TestKey()), .absent)
+        XCTAssertEqual(keychain.getInt(for: TestKey()), .absent)
+    }
+
+    func testReportsUnavailableForEveryOtherFailingStatus() {
+        for status in Self.failureStatuses {
+            let keychain = makeKeychain(status: status, data: nil)
+
+            XCTAssertEqual(
+                keychain.getString(for: TestKey()),
+                .unavailable(status),
+                "status \(status) is a failed read, not an absent item"
+            )
+            XCTAssertEqual(
+                keychain.getInt(for: TestKey()),
+                .unavailable(status),
+                "status \(status) is a failed read, not an absent item"
+            )
+        }
+    }
+
+    func testReportsUnavailableWhenTheKeychainSucceedsWithoutData() {
+        let keychain = makeKeychain(status: errSecSuccess, data: nil)
+
+        XCTAssertEqual(keychain.getString(for: TestKey()), .unavailable(errSecDecode))
+    }
+
+    /// An item that exists but cannot be decoded is still an item. Reporting it
+    /// as absent would invite the caller to write over it.
+    func testReportsUnavailableWhenTheStoredBytesAreNotUTF8() {
+        let keychain = makeKeychain(status: errSecSuccess, data: Data([0xFF, 0xFE, 0xFD]))
+
+        XCTAssertEqual(keychain.getString(for: TestKey()), .unavailable(errSecDecode))
+    }
+
+    func testReportsUnavailableWhenTheStoredStringIsNotAnInteger() {
+        let keychain = makeKeychain(status: errSecSuccess, data: Data("not-a-number".utf8))
+
+        XCTAssertEqual(keychain.getInt(for: TestKey()), .unavailable(errSecDecode))
+    }
+
+    // MARK: - KeychainService
+
+    func testEveryServiceReadReportsUnavailableRatherThanAbsent() {
+        for status in Self.failureStatuses {
+            let service = makeService(status: status, data: nil)
+
+            XCTAssertEqual(
+                service.getFastPassword(pubKeyECDSA: "pub"),
+                .unavailable(status),
+                "the fast-vault password read must not pass a failure off as an absent item (status \(status))"
+            )
+            XCTAssertEqual(
+                service.getFastHint(pubKeyECDSA: "pub"),
+                .unavailable(status),
+                "the fast-vault hint read must not pass a failure off as an absent item (status \(status))"
+            )
+            XCTAssertEqual(
+                service.getDeviceToken(),
+                .unavailable(status),
+                "the device-token read must not pass a failure off as an absent item (status \(status))"
+            )
+            XCTAssertEqual(
+                service.getLastMigratedVersion(),
+                .unavailable(status),
+                "the migration-version read must not pass a failure off as an absent item (status \(status))"
+            )
+        }
+    }
+
+    func testEveryServiceReadReportsAbsentWhenTheItemIsNotFound() {
+        let service = makeService(status: errSecItemNotFound, data: nil)
+
+        XCTAssertEqual(service.getFastPassword(pubKeyECDSA: "pub"), .absent)
+        XCTAssertEqual(service.getFastHint(pubKeyECDSA: "pub"), .absent)
+        XCTAssertEqual(service.getDeviceToken(), .absent)
+        XCTAssertEqual(service.getLastMigratedVersion(), .absent)
+    }
+
+    func testEveryServiceReadReturnsTheStoredValue() {
+        let service = makeService(status: errSecSuccess, data: Data("7".utf8))
+
+        XCTAssertEqual(service.getFastPassword(pubKeyECDSA: "pub"), .present("7"))
+        XCTAssertEqual(service.getFastHint(pubKeyECDSA: "pub"), .present("7"))
+        XCTAssertEqual(service.getDeviceToken(), .present("7"))
+        XCTAssertEqual(service.getLastMigratedVersion(), .present(7))
+    }
+
+    // MARK: - The deliberate collapse
+
+    func testCollapsingToAnOptionalKeepsOnlyThePresentValue() {
+        XCTAssertEqual(KeychainReadResult.present("value").valueTreatingUnavailableAsAbsent, "value")
+        XCTAssertNil(KeychainReadResult<String>.absent.valueTreatingUnavailableAsAbsent)
+
+        for status in Self.failureStatuses {
+            XCTAssertNil(KeychainReadResult<String>.unavailable(status).valueTreatingUnavailableAsAbsent)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeKeychain(status: OSStatus, data: Data?) -> Keychain {
+        Keychain(serviceName: Self.serviceName, itemStore: FakeItemStore(status: status, data: data))
+    }
+
+    private func makeService(status: OSStatus, data: Data?) -> KeychainService {
+        DefaultKeychainService(keychain: makeKeychain(status: status, data: data))
+    }
+}
+
+/// Answers every read with the status and payload the test asked for, so a
+/// failure the test host could never provoke against the real Keychain can be
+/// injected directly.
+private struct FakeItemStore: KeychainItemStore {
+
+    let status: OSStatus
+    let data: Data?
+
+    func copyMatching(_: [String: Any]) -> (status: OSStatus, data: Data?) {
+        (status, data)
+    }
+
+    func add(_: [String: Any]) -> OSStatus { errSecSuccess }
+
+    func delete(_: [String: Any]) -> OSStatus { errSecSuccess }
+}
+
+private struct TestKey: KeychainIdentifier {
+    let identifier = "com.vultisig.tests.keychain.item"
+}

--- a/VultisigApp/VultisigAppTests/Storage/KeychainWriteSeamTests.swift
+++ b/VultisigApp/VultisigAppTests/Storage/KeychainWriteSeamTests.swift
@@ -1,0 +1,131 @@
+//
+//  KeychainWriteSeamTests.swift
+//  VultisigAppTests
+//
+//  Making reads tri-state moved `Keychain`'s `SecItem` calls behind
+//  `KeychainItemStore`. The write path is supposed to come through that move
+//  untouched — precisely the sort of claim nothing was checking, since a unit
+//  test bundle has no keychain entitlement and could never observe a real
+//  write. These pin the query, the attributes and the delete-then-add order the
+//  Keychain has always used.
+//
+
+import Security
+import XCTest
+@testable import VultisigApp
+
+final class KeychainWriteSeamTests: XCTestCase {
+
+    private static let serviceName = "com.vultisig.tests.keychain"
+
+    func testWritingAValueDeletesTheExistingItemBeforeAddingTheNewOne() {
+        let store = RecordingItemStore()
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
+
+        XCTAssertEqual(store.calls, ["delete", "add"])
+    }
+
+    func testTheDeleteCarriesTheGeneratedQuery() throws {
+        let store = RecordingItemStore()
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
+
+        let query = try XCTUnwrap(store.deletedQueries.first)
+        XCTAssertEqual(query[kSecClass as String] as? String, kSecClassGenericPassword as String)
+        XCTAssertEqual(query[kSecAttrService as String] as? String, Self.serviceName)
+        XCTAssertEqual(query[kSecAttrAccount as String] as? String, TestKey().identifier)
+        XCTAssertNotNil(query[kSecReturnData as String])
+    }
+
+    func testTheAddCarriesTheValueAndAccessibilityWithoutTheReturnFlag() throws {
+        let store = RecordingItemStore()
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
+
+        let attributes = try XCTUnwrap(store.addedAttributes.first)
+        XCTAssertEqual(
+            attributes[kSecClass as String] as? String,
+            kSecClassGenericPassword as String,
+            "the class survives the query being reused as the added item's attributes"
+        )
+        XCTAssertEqual(attributes[kSecValueData as String] as? Data, Data("hunter2".utf8))
+        XCTAssertEqual(
+            attributes[kSecAttrAccessible as String] as? String,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String
+        )
+        XCTAssertEqual(attributes[kSecAttrService as String] as? String, Self.serviceName)
+        XCTAssertEqual(attributes[kSecAttrAccount as String] as? String, TestKey().identifier)
+        XCTAssertNil(attributes[kSecReturnData as String], "the return flag belongs to reads, not to the added item")
+    }
+
+    func testWritingAnIntegerStoresItsDecimalText() throws {
+        let store = RecordingItemStore()
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).setInt(42, for: TestKey())
+
+        let attributes = try XCTUnwrap(store.addedAttributes.first)
+        XCTAssertEqual(attributes[kSecValueData as String] as? Data, Data("42".utf8))
+    }
+
+    func testWritingNilDeletesWithoutAdding() {
+        let store = RecordingItemStore()
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).setString(nil, for: TestKey())
+
+        XCTAssertEqual(store.calls, ["delete"])
+    }
+
+    func testDeletingIssuesASingleDelete() {
+        let store = RecordingItemStore()
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).delete(for: TestKey())
+
+        XCTAssertEqual(store.calls, ["delete"])
+    }
+
+    /// A failing write has always been swallowed here. Pinned so the seam is not
+    /// blamed if that ever needs to change.
+    func testAFailedAddIsIgnoredWithoutRetrying() {
+        let store = RecordingItemStore(addStatus: errSecDuplicateItem)
+
+        Keychain(serviceName: Self.serviceName, itemStore: store).setString("hunter2", for: TestKey())
+
+        XCTAssertEqual(store.calls, ["delete", "add"])
+    }
+}
+
+/// Records what the write path hands to `SecItem`, and answers reads as if the
+/// item were absent.
+private final class RecordingItemStore: KeychainItemStore {
+
+    private(set) var calls: [String] = []
+    private(set) var deletedQueries: [[String: Any]] = []
+    private(set) var addedAttributes: [[String: Any]] = []
+
+    private let addStatus: OSStatus
+
+    init(addStatus: OSStatus = errSecSuccess) {
+        self.addStatus = addStatus
+    }
+
+    func copyMatching(_: [String: Any]) -> (status: OSStatus, data: Data?) {
+        (errSecItemNotFound, nil)
+    }
+
+    func add(_ attributes: [String: Any]) -> OSStatus {
+        calls.append("add")
+        addedAttributes.append(attributes)
+        return addStatus
+    }
+
+    func delete(_ query: [String: Any]) -> OSStatus {
+        calls.append("delete")
+        deletedQueries.append(query)
+        return errSecSuccess
+    }
+}
+
+private struct TestKey: KeychainIdentifier {
+    let identifier = "com.vultisig.tests.keychain.item"
+}


### PR DESCRIPTION
## The bug, which predates the passcode work

`Keychain.get` returned `nil` for **every** `SecItemCopyMatching` failure, not only for
`errSecItemNotFound`. A caller could therefore not tell these apart:

- **there is no item for this key** — the Keychain answered, and the answer was "nothing"
- **the item could not be read** — a locked device (`errSecInteractionNotAllowed`), a missing
  entitlement, an IO error. The Keychain did not answer at all

They license opposite decisions. Absence says a value may safely be written. An unreadable
Keychain says one may already be there. Collapsed into `nil`, a transient read failure looks
exactly like permission to overwrite whatever is stored — and where the stored item is key
material, that is the difference between saving a secret and destroying one.

This is not hypothetical or new: it already sits under the fast-vault password path on `main`
today. It is also the foundation the passcode/at-rest-encryption work builds on, where the same
collapse would let a failed read mint a fresh data key over an existing wrapper and orphan every
encrypted key share on disk. Fixing it separately, on its own merits, keeps that review honest.

## What changed

- **`KeychainReadResult<Value>`** — `absent` / `present(Value)` / `unavailable(OSStatus)`,
  returned by `Keychain.getString` / `getInt` and by every `KeychainService` read.
  `errSecItemNotFound` is the only status that maps to `absent`.
- An item that exists but cannot be decoded — bytes that are not UTF-8, a version string that is
  not an integer, a success with no data — reports `unavailable(errSecDecode)`. It is present, so
  calling it absent would invite a caller to write over it.
- **`KeychainItemStore`** puts the three `SecItem` calls behind a seam. A unit-test bundle has no
  keychain entitlement, so every real `SecItem` call answers `errSecMissingEntitlement` — one of
  the very statuses that must not be mistaken for an absent item, and one that cannot be *shown*
  to be told apart if it is the only status a test can produce.
- Every existing consumer now **states** its choice instead of inheriting it from a collapsed
  `nil`: the display-only and re-obtainable reads (fast-vault hint and password, device token)
  call `valueTreatingUnavailableAsAbsent` with a comment saying why that is safe there, and
  `AppMigrationService` folds `unavailable` into "nothing migrated" in a named method that
  records the reasoning — the migrations are idempotent, so repeating them is cheaper than
  skipping them, and nothing on that path writes a secret.

## No behaviour changes

This is an API-shape change plus explicitness, nothing more. Every call site takes the same
branch it took before, for every combination of present / absent / read-failed / undecodable.
Nothing about passcodes, key shares, encryption or migration is touched.

## Tests

- `KeychainTriStateReadTests` — fault-injects eight `OSStatus` values a real device hands back
  (`errSecInteractionNotAllowed`, `errSecNotAvailable`, `errSecAuthFailed`,
  `errSecMissingEntitlement`, `errSecUserCanceled`, `errSecDecode`, `errSecParam`, `errSecIO`)
  and asserts that **not one of them reaches a caller as `absent`**, through `Keychain` and
  through all four `KeychainService` reads. Plus the decode-failure and success-without-data paths.
- `KeychainWriteSeamTests` — pins the write path across its move behind the seam: delete-then-add
  order, the generated query, `kSecClass`, the value bytes, the accessibility attribute, the
  dropped `kSecReturnData` flag, `nil` meaning delete, and a failing add still being ignored.
- `AppMigrationServiceKeychainReadTests` — pins the one shipping consumer that acts on absence:
  `unavailable` runs the migrations rather than skipping them, and a recorded latest version still
  skips them.

The seven remaining consumers are SwiftUI views and view models that reach
`DefaultKeychainService.shared` directly with no injection point; giving them one is a refactor
this PR deliberately does not do. Their collapse is expressed through the named
`valueTreatingUnavailableAsAbsent` affordance, which is itself covered.

## Verification

- `make test` — **`** TEST SUCCEEDED **`**, 4704 tests, 1 skipped, 0 failures
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 39 warnings, unchanged from
  the base commit, none in any touched file
- Reviewed by `codex exec --sandbox read-only` over two rounds: no CRITICAL or MAJOR findings;
  three MINOR findings (test-only global-state leak, unpinned write path, a missing `kSecClass`
  assertion) all fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable or unreadable secure storage.
  * Prevented inaccessible saved passwords and hints from appearing or triggering autofill.
  * Ensured device registration and migrations retry when stored values cannot be read.
  * Improved backup export behavior when saved credentials are unavailable.

* **Tests**
  * Added coverage for missing, available, invalid, and inaccessible secure-storage values.
  * Added tests for secure-storage writes, deletions, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->