### PR TITLE
fix(thorchain): stop the LP-actions pause flag blocking Secured Assets deposits

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapHaltGate.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapHaltGate.swift
@@ -20,6 +20,6 @@ enum SwapHaltGate {
         guard let entry = inbound.first(where: { $0.chain.caseInsensitiveCompare(chainName) == .orderedSame }) else {
             return false
         }
-        return entry.halted || (entry.global_trading_paused ?? false) || (entry.chain_trading_paused ?? false)
+        return entry.isTradingHalted
     }
 }

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/Service/InboundAddress.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/Service/InboundAddress.swift
@@ -37,3 +37,28 @@ struct InboundAddress: Codable {
     let outbound_fee: String? // Outbound fee for the chain
     let outbound_tx_size: String? // Outbound transaction size
 }
+
+extension InboundAddress {
+
+    /// The chain cannot process an inbound transfer at all: it is halted, or
+    /// THORChain has paused trading globally or for this chain. Any transfer to
+    /// the inbound vault while this is true risks being stranded, so it gates
+    /// swaps and secured-asset deposits alike.
+    ///
+    /// Deliberately excludes `chain_lp_actions_paused`. That flag is the
+    /// `PauseLP<CHAIN>` mimir, which suspends only liquidity-provider add and
+    /// withdraw — swaps and every other transaction keep processing while it is
+    /// set, and THORChain leaves it set on healthy chains for long stretches.
+    /// Folding it in here would block operations the chain is happily accepting.
+    var isTradingHalted: Bool {
+        halted || (global_trading_paused ?? false) || (chain_trading_paused ?? false)
+    }
+
+    /// Liquidity-provider add/withdraw is unavailable: either the chain cannot
+    /// transact at all, or THORChain has paused LP actions specifically. Only
+    /// LP flows may gate on this — it is strictly broader than
+    /// `isTradingHalted`.
+    var isLPActionsHalted: Bool {
+        isTradingHalted || (chain_lp_actions_paused ?? false)
+    }
+}

--- a/VultisigApp/VultisigApp/Blockchain/THORChain/ThorchainRouterDepositBuilder.swift
+++ b/VultisigApp/VultisigApp/Blockchain/THORChain/ThorchainRouterDepositBuilder.swift
@@ -116,7 +116,7 @@ enum ThorchainRouterDepositBuilder {
 
     /// Resolves the L1 deposit destination for a SECURE+ mint: the THORChain
     /// inbound vault (native sources) or the ERC20 router (approve sources).
-    /// Throws on a halted/paused or missing inbound so a mint never signs to an
+    /// Throws on a trading-halted or missing inbound so a mint never signs to an
     /// empty/stranded destination. Mirrors
     /// `FunctionCallSecuredAsset.fetchInboundAddressAndSetupApproval`.
     @MainActor
@@ -133,7 +133,9 @@ enum ThorchainRouterDepositBuilder {
         guard let inbound = addresses.first(where: { $0.chain.uppercased() == chainName.uppercased() }) else {
             throw HelperError.runtimeError(String(format: "inboundAddressNotFound".localized, chainName))
         }
-        if inbound.halted || inbound.global_trading_paused ?? false || inbound.chain_trading_paused ?? false || inbound.chain_lp_actions_paused ?? false {
+        // A mint is a plain transfer to the inbound vault, not a liquidity-provider
+        // action, so it gates on the trading flags only — see `isTradingHalted`.
+        if inbound.isTradingHalted {
             throw HelperError.runtimeError(String(format: "inboundPaused".localized, inbound.chain))
         }
 

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallAddThorLP.swift
@@ -141,7 +141,13 @@ final class FunctionCallAddThorLP {
         // `toAddress` empty so `isTheFormValid` blocks submission — otherwise
         // signing proceeds with an empty destination and wallet-core rejects
         // it with the raw `Error_invalid_address` enum.
-        if inbound.halted || inbound.global_trading_paused ?? false || inbound.chain_trading_paused ?? false || inbound.chain_lp_actions_paused ?? false {
+        //
+        // This is an LP add, so it must also honour `chain_lp_actions_paused`
+        // (the `PauseLP<CHAIN>` mimir) — hence `isLPActionsHalted`, which is
+        // strictly stricter than the `isTradingHalted` gate the non-LP flows
+        // use. Do not relax this one to `isTradingHalted`: THORChain rejects an
+        // LP add while LP actions are paused, and the funds would be stranded.
+        if inbound.isLPActionsHalted {
             customErrorMessage = String(format: "inboundPaused".localized, inbound.chain)
             return
         }

--- a/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
+++ b/VultisigApp/VultisigApp/Features/FunctionCall/Models/FunctionCallSecuredAsset.swift
@@ -94,10 +94,12 @@ final class FunctionCallSecuredAsset {
             return
         }
 
-        // A halted/paused source chain has no usable inbound vault; leave
+        // A trading-halted source chain has no usable inbound vault; leave
         // `toAddress` empty so the form blocks submission instead of signing
         // with an empty destination (raw `Error_invalid_address` at sign time).
-        if inbound.halted || inbound.global_trading_paused ?? false || inbound.chain_trading_paused ?? false || inbound.chain_lp_actions_paused ?? false {
+        // A mint is a plain transfer to the inbound vault, not a liquidity-provider
+        // action, so it gates on the trading flags only — see `isTradingHalted`.
+        if inbound.isTradingHalted {
             inboundStateError = String(format: "inboundPaused".localized, inbound.chain)
             updateErrorMessage()
             return

--- a/VultisigApp/VultisigAppTests/Blockchain/THORChain/SecuredAssetDepositHaltGateTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/THORChain/SecuredAssetDepositHaltGateTests.swift
@@ -1,0 +1,310 @@
+//
+//  SecuredAssetDepositHaltGateTests.swift
+//  VultisigAppTests
+//
+//  Fund-safety gate for SECURE+ mints (`ThorchainRouterDepositBuilder
+//  .resolveInboundDestination`). The gate exists so a mint never signs to an
+//  empty or stranded destination, so these tests pin BOTH directions: which
+//  inbound states must still block, and which must not.
+//
+//  The regression they guard: `chain_lp_actions_paused` (THORChain's
+//  `PauseLP<CHAIN>` mimir) suspends liquidity-provider add/withdraw only —
+//  swaps and every other transaction keep processing — yet it was folded into
+//  the deposit gate. THORChain leaves it set on healthy chains for long
+//  stretches, which blocked every secured-asset deposit network-wide.
+//
+
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class SecuredAssetDepositHaltGateTests: XCTestCase {
+
+    // MARK: - Inbound-state predicates
+
+    func testLPActionsPausedAloneIsNotATradingHalt() {
+        XCTAssertFalse(entry(lpActionsPaused: true).isTradingHalted)
+    }
+
+    func testHaltedIsATradingHalt() {
+        XCTAssertTrue(entry(halted: true).isTradingHalted)
+    }
+
+    func testGlobalTradingPausedIsATradingHalt() {
+        XCTAssertTrue(entry(globalTradingPaused: true).isTradingHalted)
+    }
+
+    func testChainTradingPausedIsATradingHalt() {
+        XCTAssertTrue(entry(chainTradingPaused: true).isTradingHalted)
+    }
+
+    func testAllFlagsClearIsNotATradingHalt() {
+        XCTAssertFalse(entry().isTradingHalted)
+    }
+
+    /// MayaChain serves no pause flags at all; nil must read as not-paused so
+    /// `halted` stays the only halt signal there.
+    func testNilPauseFlagsAreNotATradingHalt() {
+        XCTAssertFalse(
+            InboundAddress(
+                chain: "ZEC",
+                address: "t1zec",
+                router: nil,
+                halted: false,
+                global_trading_paused: nil,
+                chain_trading_paused: nil,
+                chain_lp_actions_paused: nil,
+                gas_rate: "20",
+                gas_rate_units: "satsperbyte",
+                dust_threshold: nil,
+                outbound_fee: nil,
+                outbound_tx_size: nil
+            ).isTradingHalted
+        )
+    }
+
+    // MARK: - The LP predicate must stay strict
+
+    /// The LP-add path (`FunctionCallAddThorLP`) gates on `isLPActionsHalted`,
+    /// which — unlike the deposit gate — MUST keep honouring
+    /// `chain_lp_actions_paused`. THORChain rejects an LP add while LP actions
+    /// are paused, so relaxing this the way the deposit gate was relaxed would
+    /// strand funds.
+    func testLPActionsPausedAloneIsAnLPHalt() {
+        XCTAssertTrue(entry(lpActionsPaused: true).isLPActionsHalted)
+    }
+
+    func testEveryTradingHaltIsAlsoAnLPHalt() {
+        XCTAssertTrue(entry(halted: true).isLPActionsHalted)
+        XCTAssertTrue(entry(globalTradingPaused: true).isLPActionsHalted)
+        XCTAssertTrue(entry(chainTradingPaused: true).isLPActionsHalted)
+    }
+
+    func testAllFlagsClearIsNotAnLPHalt() {
+        XCTAssertFalse(entry().isLPActionsHalted)
+    }
+
+    // MARK: - Deposit destination resolution: allowed
+
+    /// The reported bug: Ethereum is online on every trading flag and only has
+    /// LP actions paused, so the mint must resolve the inbound vault.
+    func testNativeDepositAllowedWhenOnlyLPActionsPaused() async throws {
+        let service = makeService(inboundJSON(chain: "ETH", address: "0xvault", lpActionsPaused: true))
+        let destination = try await ThorchainRouterDepositBuilder.resolveInboundDestination(
+            coin: nativeETH(),
+            thorchainService: service
+        )
+        XCTAssertEqual(destination, "0xvault")
+    }
+
+    /// The ERC20 mint routes through the router, not the vault — and that is
+    /// equally unaffected by an LP-actions pause.
+    func testERC20DepositResolvesRouterWhenOnlyLPActionsPaused() async throws {
+        let service = makeService(
+            inboundJSON(chain: "ETH", address: "0xvault", router: "0xrouter", lpActionsPaused: true)
+        )
+        let destination = try await ThorchainRouterDepositBuilder.resolveInboundDestination(
+            coin: erc20USDC(),
+            thorchainService: service
+        )
+        XCTAssertEqual(destination, "0xrouter")
+    }
+
+    /// A RUNE-source mint is a THORChain-native deposit: no inbound to resolve,
+    /// so no inbound state can block it.
+    func testThorchainSourceResolvesToOwnAddressWithoutFetchingInbound() async throws {
+        let service = makeService("[]")
+        let rune = FunctionCallFixture.makeRUNE()
+        let destination = try await ThorchainRouterDepositBuilder.resolveInboundDestination(
+            coin: rune,
+            thorchainService: service
+        )
+        XCTAssertEqual(destination, rune.address)
+    }
+
+    // MARK: - Deposit destination resolution: still blocked
+
+    func testDepositBlockedWhenChainHalted() async {
+        await assertBlocked(
+            json: inboundJSON(chain: "ETH", address: "0xvault", halted: true, lpActionsPaused: true),
+            coin: nativeETH(),
+            expected: String(format: "inboundPaused".localized, "ETH")
+        )
+    }
+
+    func testDepositBlockedWhenGlobalTradingPaused() async {
+        await assertBlocked(
+            json: inboundJSON(chain: "ETH", address: "0xvault", globalTradingPaused: true),
+            coin: nativeETH(),
+            expected: String(format: "inboundPaused".localized, "ETH")
+        )
+    }
+
+    func testDepositBlockedWhenChainTradingPaused() async {
+        await assertBlocked(
+            json: inboundJSON(chain: "ETH", address: "0xvault", chainTradingPaused: true),
+            coin: nativeETH(),
+            expected: String(format: "inboundPaused".localized, "ETH")
+        )
+    }
+
+    func testDepositBlockedWhenInboundMissing() async {
+        await assertBlocked(
+            json: inboundJSON(chain: "BTC", address: "bc1vault"),
+            coin: nativeETH(),
+            expected: String(format: "inboundAddressNotFound".localized, "ETH")
+        )
+    }
+
+    /// A transport/decode failure yields an empty list, which must read as
+    /// "no inbound" and block — never as "nothing is halted".
+    func testDepositBlockedWhenInboundFetchFails() async {
+        await assertBlocked(
+            json: "not json",
+            coin: nativeETH(),
+            expected: String(format: "inboundAddressNotFound".localized, "ETH")
+        )
+    }
+
+    func testERC20DepositBlockedWhenRouterAbsent() async {
+        await assertBlocked(
+            json: inboundJSON(chain: "ETH", address: "0xvault", lpActionsPaused: true),
+            coin: erc20USDC(),
+            expected: String(format: "routerNotAvailable".localized, "ETH")
+        )
+    }
+
+    func testERC20DepositBlockedWhenRouterEmpty() async {
+        await assertBlocked(
+            json: inboundJSON(chain: "ETH", address: "0xvault", router: "", lpActionsPaused: true),
+            coin: erc20USDC(),
+            expected: String(format: "routerNotAvailable".localized, "ETH")
+        )
+    }
+
+    // MARK: - Live-shape regression
+
+    /// The verbatim shape THORChain served on 2026-08-05: every chain carried
+    /// `chain_lp_actions_paused: true`, while only BASE/BSC/SOL were genuinely
+    /// halted. ETH must deposit; BSC must not.
+    func testLiveInboundSnapshotAllowsEthereumAndBlocksHaltedChain() async throws {
+        let snapshot = """
+        [
+          {"chain":"ETH","address":"0xethvault","router":"0xethrouter","halted":false,
+           "global_trading_paused":false,"chain_trading_paused":false,
+           "chain_lp_actions_paused":true,"gas_rate":"1","gas_rate_units":"gwei"},
+          {"chain":"BSC","address":"0xbscvault","router":"0xbscrouter","halted":true,
+           "global_trading_paused":false,"chain_trading_paused":true,
+           "chain_lp_actions_paused":true,"gas_rate":"1","gas_rate_units":"gwei"}
+        ]
+        """
+        let destination = try await ThorchainRouterDepositBuilder.resolveInboundDestination(
+            coin: nativeETH(),
+            thorchainService: makeService(snapshot)
+        )
+        XCTAssertEqual(destination, "0xethvault")
+
+        await assertBlocked(
+            json: snapshot,
+            coin: FunctionCallFixture.makeCoin(.bscChain, ticker: "BNB", decimals: 18, isNative: true),
+            expected: String(format: "inboundPaused".localized, "BSC")
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func assertBlocked(
+        json: String,
+        coin: Coin,
+        expected: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            let destination = try await ThorchainRouterDepositBuilder.resolveInboundDestination(
+                coin: coin,
+                thorchainService: makeService(json)
+            )
+            XCTFail("Expected the deposit to be blocked, resolved \(destination) instead", file: file, line: line)
+        } catch {
+            XCTAssertEqual(error.localizedDescription, expected, file: file, line: line)
+        }
+    }
+
+    private func makeService(_ json: String) -> ThorchainService {
+        ThorchainService(
+            httpClient: InboundStubClient(inboundBody: Data(json.utf8))
+        )
+    }
+
+    private func nativeETH() -> Coin {
+        FunctionCallFixture.makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
+    }
+
+    private func erc20USDC() -> Coin {
+        FunctionCallFixture.makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
+    }
+
+    private func entry(
+        halted: Bool = false,
+        globalTradingPaused: Bool = false,
+        chainTradingPaused: Bool = false,
+        lpActionsPaused: Bool = false
+    ) -> InboundAddress {
+        InboundAddress(
+            chain: "ETH",
+            address: "0xvault",
+            router: "0xrouter",
+            halted: halted,
+            global_trading_paused: globalTradingPaused,
+            chain_trading_paused: chainTradingPaused,
+            chain_lp_actions_paused: lpActionsPaused,
+            gas_rate: "1",
+            gas_rate_units: "gwei",
+            dust_threshold: nil,
+            outbound_fee: nil,
+            outbound_tx_size: nil
+        )
+    }
+
+    private func inboundJSON(
+        chain: String,
+        address: String,
+        router: String? = nil,
+        halted: Bool = false,
+        globalTradingPaused: Bool = false,
+        chainTradingPaused: Bool = false,
+        lpActionsPaused: Bool = false
+    ) -> String {
+        let routerField = router.map { "\"router\":\"\($0)\"," } ?? ""
+        return """
+        [{"chain":"\(chain)","address":"\(address)",\(routerField)"halted":\(halted),
+          "global_trading_paused":\(globalTradingPaused),
+          "chain_trading_paused":\(chainTradingPaused),
+          "chain_lp_actions_paused":\(lpActionsPaused),
+          "gas_rate":"1","gas_rate_units":"gwei"}]
+        """
+    }
+}
+
+/// Serves one canned body on `/thorchain/inbound_addresses` and 501s everything
+/// else, so a test that accidentally hits another endpoint fails loudly.
+private actor InboundStubClient: HTTPClientProtocol {
+    private let inboundBody: Data
+
+    init(inboundBody: Data) {
+        self.inboundBody = inboundBody
+    }
+
+    func request(_ target: TargetType) async throws -> HTTPResponse<Data> {
+        await Task.yield()
+        guard target.path == "/thorchain/inbound_addresses" else {
+            throw HTTPError.statusCode(501, nil)
+        }
+        let url = target.baseURL.appendingPathComponent(target.path)
+        guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil) else {
+            throw HTTPError.invalidResponse
+        }
+        return HTTPResponse(data: inboundBody, response: response)
+    }
+}


### PR DESCRIPTION
## Description

Secured Assets (SECURE+ mint) deposits were blocked on every chain, including healthy ones — reported on Ethereum, iOS v1.43.69.

**Root cause.** The mint pre-flight gate folded THORChain's `chain_lp_actions_paused` into its halt condition:

```swift
if inbound.halted || inbound.global_trading_paused ?? false
   || inbound.chain_trading_paused ?? false
   || inbound.chain_lp_actions_paused ?? false { throw … }
```

`chain_lp_actions_paused` is the `PauseLP<CHAIN>` mimir. Per THORChain's network-halts docs it "suspends addition and withdrawal of liquidity, but swaps and other transactions are processed" — it says nothing about whether the chain will observe an inbound transfer. A SECURE+ mint is a plain transfer to the inbound vault (or ERC20 router), not a liquidity-provider action.

And THORChain currently has that flag set **on every single chain**. Live `/thorchain/inbound_addresses`, fetched 2026-08-05:

| Chain | halted | global_trading_paused | chain_trading_paused | chain_lp_actions_paused |
|-------|--------|----------------------|----------------------|------------------------|
| AVAX | false | false | false | **true** |
| BASE | **true** | false | **true** | **true** |
| BCH  | false | false | false | **true** |
| BSC  | **true** | false | **true** | **true** |
| BTC  | false | false | false | **true** |
| DOGE | false | false | false | **true** |
| ETH  | false | false | false | **true** |
| GAIA | false | false | false | **true** |
| LTC  | false | false | false | **true** |
| SOL  | **true** | false | **true** | **true** |
| TRON | false | false | false | **true** |
| XRP  | false | false | false | **true** |

So the gate was blocking 100% of secured-asset deposits, network-wide, permanently. Ethereum is clean on all three trading flags and was still refused.

**Fix.** Split the halt semantics into two named predicates on `InboundAddress`, so each call site gates on what it's actually doing:

```swift
var isTradingHalted:   halted || global_trading_paused || chain_trading_paused
var isLPActionsHalted: isTradingHalted || chain_lp_actions_paused
```

| Path | Before | After |
|---|---|---|
| `ThorchainRouterDepositBuilder.resolveInboundDestination` (SECURE+ mint) | all 4 flags | `isTradingHalted` |
| `FunctionCallSecuredAsset.fetchInboundAddressAndSetupApproval` (SECURE+ mint form) | all 4 flags | `isTradingHalted` |
| `FunctionCallAddThorLP.fetchInboundAddressAndSetupApproval` (LP add) | all 4 flags | `isLPActionsHalted` — **unchanged behaviour**, now self-documenting |
| `SwapHaltGate.isHalted` | 3 trading flags | `isTradingHalted` — exact no-op |

Net behavioural change: **exactly one condition, on the two secured-asset deposit paths only** — `chain_lp_actions_paused` no longer blocks a mint.

### What is still blocked (fund safety)

This loosens a gate on a *signing destination*, so the guards that matter are deliberately untouched:

- `halted`, `global_trading_paused`, `chain_trading_paused` all still block a mint.
- Missing inbound entry still throws `inboundAddressNotFound` — unchanged.
- An empty list from a failed/undecodable fetch still reads as "no inbound" and blocks — unchanged.
- The ERC20 path still requires a non-empty `router` or throws `routerNotAvailable` — unchanged.
- The LP-add path did not get loosened, and its comment now says explicitly why it must stay strict.

`chain_trading_paused` is arguably stricter than THORChain requires for a mint (a mint is not a swap), and it's left strict on purpose: over-blocking is recoverable, mis-signing to a stranded vault is not.

## Which feature is affected?
- [x] Sending — Secured Assets (SECURE+) deposit / mint destination resolution
- [ ] Create vault ( Secure / Fast)
- [ ] Swap
- [ ] New Chain / Chain related feature

## Parity

- **Android:** ⚠️ **has the identical bug.** `SecuredAssetLoader.fetchThorChainInboundForChain` returns `InboundAddressResult.Halted` when `inboundAddress.chainLPActionsPaused` is set (`app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/SecuredAssetLoader.kt:110`). Needs a sibling ticket — not filed from this PR.
- **Windows + extension:** n/a — `core/ui/vault/deposit/keysignPayload/build.ts:177` only applies the LP flag on the `isNonThorChainLp` branch, which is the LP path where it is correct.
- **SDK:** n/a — `packages/core/chain/swap/native/halts/getNativeSwapTradingHalt.ts:99` already documents "Intentionally ignore chain_lp_actions_paused; LP action pauses do not block swaps", and the LP-specific gate lives separately in `chain/chains/cosmos/thor/lp/halts.ts`. The SDK already has this split right.

## Verification

- **Full unit-test suite, green.** `xcodebuild test -scheme VultisigApp -destination 'platform=iOS Simulator,id=<gate-5058 iPhone 16 Pro>' -derivedDataPath .build-dd`:

  ```
  Executed 4819 tests, with 1 test skipped and 0 failures (0 unexpected) in 71.834 seconds
  ** TEST SUCCEEDED **
  ```

  Of those, the new `SecuredAssetDepositHaltGateTests` suite: `Executed 20 tests, with 0 failures (0 unexpected)`.
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — no new violations (22 pre-existing, none in any of the six changed files).
- Two read-only cross-model review passes (per-commit + whole-branch) found no production defect; both confirmed no remaining non-LP gate folds `chain_lp_actions_paused`, and that the LP-add gate correctly retains it.
- New `SecuredAssetDepositHaltGateTests` pins both directions of the gate:
  - deposit **allowed** when only `chain_lp_actions_paused` is set (native + ERC20-via-router);
  - deposit **still blocked** for each of `halted`, `global_trading_paused`, `chain_trading_paused`;
  - missing inbound still throws; failed fetch still blocks; ERC20 with absent/empty router still throws;
  - THORChain-native source short-circuits to its own address;
  - the LP predicate stays strict (`chain_lp_actions_paused` alone is an LP halt) so nobody "fixes" the LP path the same way;
  - a verbatim replay of the live 2026-08-05 inbound snapshot: ETH resolves, BSC is refused.

**Not verified, and cannot be locally:** the blocked paths are exercised against stubbed inbound responses, not a real halted chain. The live snapshot above at least confirms the allow-path (ETH) and block-path (BSC/BASE/SOL) resolve correctly against real production data, but an end-to-end deposit on a genuinely halted chain has not been performed.

## ⚠️ Requires human + on-device review

This is fund-safety-adjacent: it relaxes the check that keeps a SECURE+ mint from signing to a destination THORChain will never observe. Please review the predicate split on its merits and confirm on-device that a real Ethereum secured-asset deposit now completes, and that a genuinely halted chain (BASE/BSC/SOL at time of writing) is still refused.

## Follow-up (not in this PR)

THORChain's *precise* switch for this operation is the `HaltSecuredDeposit-<CHAIN>` / `HaltSecuredGlobal` mimir, which is not carried on `/inbound_addresses`. Wiring it in needs a separate `/thorchain/mimir/key/<KEY>` fetch on the form's critical path with its own fail-open/fail-closed decision. The plumbing already exists (`ThorchainMainnetAPI.mimir(key:)` + `ThorchainService.parseMimirEnabled`, from the advanced-swap-queue work).

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective

Closes #5058


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of THORChain trading halts and paused inbound transfers.
  * Blocked secured-asset deposits and LP actions more consistently when relevant operations are paused.
  * Preserved appropriate handling for RUNE transfers and malformed or incomplete inbound data.

* **Tests**
  * Added comprehensive coverage for halted deposits, LP-action pauses, destination resolution, router requirements, and inbound-address responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->