### PR TITLE
fix(send): bind the pinned EVM gas limit to the asset it was sized for

### DIFF
--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -792,7 +792,7 @@ final class SendDetailsViewModel {
     /// Background refine for the native-coin Max path. Settles the optimistic
     /// full-balance fill to what can really be sent.
     ///
-    /// Its ordering against the amount fields rests on two guards, re-checked
+    /// Its ordering against the amount fields rests on three guards, re-checked
     /// after the await, which between them cover every writer of the amount:
     ///
     /// - paths that replace the amount while *keeping* the max intent cancel
@@ -801,31 +801,49 @@ final class SendDetailsViewModel {
     /// - every path that replaces it with an *explicit* amount clears
     ///   `sendMaxAmount` as it does so — a keystroke included, which drops the
     ///   intent synchronously in `onAmountFieldEdited` rather than waiting for
-    ///   its debounced commit.
+    ///   its debounced commit;
+    /// - the coin picker replaces the *asset* under an unchanged max intent
+    ///   without cancelling anything, so the refine compares the asset it asked
+    ///   about against the one the form is on now (`isStillOn(_:)`).
     ///
-    /// So a refine settling into either kind of newer write stands down instead
-    /// of clobbering it.
+    /// So a refine settling into any kind of newer state stands down instead of
+    /// clobbering it.
     private func startFeeRefine() {
         isCalculatingFee = true
         feeRefineTask = Task { [weak self] in
             guard let self else { return }
+            // Read once, before the first suspension: everything this task
+            // writes describes this asset and nothing else.
+            let requestedAsset = self.coin.uniqueId
             defer { self.isCalculatingFee = false }
             do {
                 if self.coin.chainType == .UTXO {
-                    try await self.refineMaxFromPlan()
+                    try await self.refineMaxFromPlan(asset: requestedAsset)
                 } else {
-                    try await self.refineMaxFromFee()
+                    try await self.refineMaxFromFee(asset: requestedAsset)
                 }
             } catch is CancellationError {
                 return
             } catch {
                 // Same guards as the success paths: a verdict about a max send
-                // the user has already moved off must not paint an alert on the
-                // amount they typed instead.
-                guard !Task.isCancelled, self.sendMaxAmount else { return }
+                // the user has already moved off — in amount or in asset — must
+                // not paint an alert on what they are looking at instead.
+                guard !Task.isCancelled, self.sendMaxAmount, self.isStillOn(requestedAsset) else { return }
                 self.handleMaxRefineFailure(error)
             }
         }
+    }
+
+    /// Whether the form is still on the asset an in-flight request asked about.
+    ///
+    /// A fee result describes the asset it was requested for, and the coin
+    /// picker can replace that asset mid-flight: it cancels nothing and it
+    /// leaves the max intent alone, so neither of the other two guards catches
+    /// it. Without this, a result for the old asset would be written — and,
+    /// worse, *stamped* — against the new one, which is exactly the leak the
+    /// asset stamp exists to close.
+    private func isStillOn(_ requestedAsset: String) -> Bool {
+        coin.uniqueId == requestedAsset
     }
 
     /// The max-send request for the current form state. `amount` differs by
@@ -858,7 +876,7 @@ final class SendDetailsViewModel {
     /// so the Details figure is the one Verify will confirm rather than
     /// `balance − rate`, which reserves roughly a dozen sats for a fee of a few
     /// thousand.
-    private func refineMaxFromPlan() async throws {
+    private func refineMaxFromPlan(asset requestedAsset: String) async throws {
         // The planner ignores this value in max mode, but it still reaches
         // WalletCore's `Int64` amount field, where an out-of-range conversion
         // traps rather than failing. Clamp it — an absurd balance must not
@@ -871,7 +889,7 @@ final class SendDetailsViewModel {
             vault: vault,
             refreshUtxos: false
         )
-        guard !Task.isCancelled, sendMaxAmount else { return }
+        guard !Task.isCancelled, sendMaxAmount, isStillOn(requestedAsset) else { return }
         // `gas` stays the rate (what the gas sheet edits); `fee` becomes the
         // planned total, so the balance guard compares against a real number
         // and the hand-off transaction carries an honest fee into Verify.
@@ -884,9 +902,9 @@ final class SendDetailsViewModel {
 
     /// Every other native chain: the chain quotes a flat fee, so `balance − fee`
     /// is the max.
-    private func refineMaxFromFee() async throws {
+    private func refineMaxFromFee(asset requestedAsset: String) async throws {
         let result = try await interactor.fetchGasAndFee(SendFeeEstimateRequest(chainSpecific: maxSendRequest(amount: .zero)))
-        guard !Task.isCancelled, sendMaxAmount else { return }
+        guard !Task.isCancelled, sendMaxAmount, isStillOn(requestedAsset) else { return }
         if customGasLimit == nil, let resolvedGasLimit = result.gasLimit {
             estimatedGasLimit = resolvedGasLimit
         }
@@ -937,6 +955,7 @@ final class SendDetailsViewModel {
 
         isCalculatingFee = true
         defer { isCalculatingFee = false }
+        let requestedAsset = coin.uniqueId
 
         do {
             let result = try await interactor.fetchGasAndFee(SendFeeEstimateRequest(chainSpecific: SendChainSpecificRequest(
@@ -953,6 +972,9 @@ final class SendDetailsViewModel {
                 feeMode: feeMode,
                 fromAddress: fromAddress
             )))
+            // The picker can swap the asset while this is in flight; figures
+            // for the one the form has left must not land on the one it is on.
+            guard isStillOn(requestedAsset) else { return }
             gas = result.gas
             fee = result.fee
             // Adopt the real estimate so the displayed fee, and the gas limit
@@ -963,6 +985,7 @@ final class SendDetailsViewModel {
             }
         } catch {
             logger.error("loadGasInfo failed: \(error.localizedDescription, privacy: .public)")
+            guard isStillOn(requestedAsset) else { return }
             errorMessage = error.localizedDescription
         }
     }

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -792,8 +792,8 @@ final class SendDetailsViewModel {
     /// Background refine for the native-coin Max path. Settles the optimistic
     /// full-balance fill to what can really be sent.
     ///
-    /// Its ordering against the amount fields rests on three guards, re-checked
-    /// after the await, which between them cover every writer of the amount:
+    /// Its ordering against the amount fields rests on three guards, which
+    /// between them cover every writer of the amount:
     ///
     /// - paths that replace the amount while *keeping* the max intent cancel
     ///   this task first (`setMaxAmount`, `hydrate`), so `Task.isCancelled`
@@ -803,19 +803,30 @@ final class SendDetailsViewModel {
     ///   intent synchronously in `onAmountFieldEdited` rather than waiting for
     ///   its debounced commit;
     /// - the coin picker replaces the *asset* under an unchanged max intent
-    ///   without cancelling anything, so the refine compares the asset it asked
-    ///   about against the one the form is on now (`isStillOn(_:)`).
+    ///   without cancelling anything, so the asset the user tapped Max on is
+    ///   compared against the one the form is on (`isStillOn(_:)`) — twice:
+    ///   before the request is built, and again before its result is written.
     ///
-    /// So a refine settling into any kind of newer state stands down instead of
-    /// clobbering it.
+    /// The first two are re-checked after the await; the asset is checked on
+    /// both sides of it. So a refine settling into any kind of newer state
+    /// stands down instead of clobbering it.
+    ///
+    /// The asset is read *here*, not in the task body. An unstructured `Task`
+    /// inherits the actor but is scheduled rather than run inline, so the main
+    /// actor gets a turn — enough for the picker to write `coin` — between this
+    /// line and the body's first. Reading it inside would let the task adopt
+    /// the new asset as its own request and refine *that* under a max intent
+    /// the user formed on the old one, which is the same "send everything"
+    /// the user never asked for, arrived at by a scheduling coin flip.
     private func startFeeRefine() {
+        let requestedAsset = coin.uniqueId
         isCalculatingFee = true
         feeRefineTask = Task { [weak self] in
             guard let self else { return }
-            // Read once, before the first suspension: everything this task
-            // writes describes this asset and nothing else.
-            let requestedAsset = self.coin.uniqueId
+            // Installed before the asset check so standing down still takes the
+            // calculating indicator down with it — nothing else would.
             defer { self.isCalculatingFee = false }
+            guard self.isStillOn(requestedAsset) else { return }
             do {
                 if self.coin.chainType == .UTXO {
                     try await self.refineMaxFromPlan(asset: requestedAsset)

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -83,8 +83,66 @@ final class SendDetailsViewModel {
     // MARK: - Fee / gas (derived from interactor calls)
     var gas: BigInt = .zero
     var fee: BigInt = .zero
-    var estimatedGasLimit: BigInt? = nil
-    var customGasLimit: BigInt? = nil
+
+    /// A gas limit together with the asset it was sized for.
+    ///
+    /// Reads are asset-scoped, so a limit self-invalidates the moment the form
+    /// moves to another coin or chain and no view has to remember to clear it.
+    /// The key is `Coin.uniqueId` (chain + ticker + contract): it ignores the
+    /// address, which is right here because the vault is fixed for the life of
+    /// the form, and it is stable across `Coin` instances for the same asset.
+    private struct AssetScopedGasLimit {
+        private var limit: BigInt?
+        private var assetId: String?
+
+        func value(for coin: Coin) -> BigInt? {
+            guard let assetId, assetId == coin.uniqueId else { return nil }
+            return limit
+        }
+
+        mutating func set(_ newValue: BigInt?, for coin: Coin) {
+            limit = newValue
+            assetId = newValue == nil ? nil : coin.uniqueId
+        }
+    }
+
+    private var stampedEstimatedGasLimit = AssetScopedGasLimit()
+    private var stampedCustomGasLimit = AssetScopedGasLimit()
+
+    /// The limit the current fee was estimated against — the real
+    /// `eth_estimateGas` result, adopted whenever the user hasn't pinned one.
+    ///
+    /// Asset-scoped for the same reason as `customGasLimit`, and it has to be:
+    /// `gasLimit` falls back to it, `BlockChainService` treats the requested
+    /// limit as a *floor* rather than a suggestion, and the gas sheet is seeded
+    /// with `gasLimit` and re-pins whatever it displays on Save. A stale
+    /// estimate from another asset would therefore both inflate the reserved
+    /// amount and offer the user a foreign number to confirm — which is how a
+    /// pin scoped to one asset would come back on the next.
+    var estimatedGasLimit: BigInt? {
+        get { stampedEstimatedGasLimit.value(for: coin) }
+        set { stampedEstimatedGasLimit.set(newValue, for: coin) }
+    }
+
+    /// The user-pinned gas limit from the gas settings sheet.
+    ///
+    /// A gas limit prices the execution of one specific call, not a chain: a
+    /// native transfer is sized at 23,000 units where an ERC20 transfer is
+    /// sized at 120,000 (`defaultGasLimit` below already branches on exactly
+    /// that), and a token with transfer hooks costs more again. So the stamp is
+    /// the *asset*, not the chain — a limit pinned for ETH must not size a USDC
+    /// send on the same chain. Too low is the dangerous direction: the
+    /// transaction runs out of gas on-chain, which burns the fee and delivers
+    /// nothing.
+    ///
+    /// The coin picker writes `coin` directly and no view owns clearing this,
+    /// so the binding is enforced here rather than left to a caller to
+    /// remember: the limit is only visible while the form is still on the asset
+    /// it was sized for, and re-pinning re-stamps.
+    var customGasLimit: BigInt? {
+        get { stampedCustomGasLimit.value(for: coin) }
+        set { stampedCustomGasLimit.set(newValue, for: coin) }
+    }
 
     /// Backing storage for `customByteFee`, plus the chain it was pinned for.
     private var pinnedByteFee: BigInt? = nil
@@ -98,6 +156,11 @@ final class SendDetailsViewModel {
     /// view owns clearing this, so the binding is enforced here rather than left
     /// to a caller to remember: the rate is only visible while the form is still
     /// on the chain it was set for, and re-pinning re-stamps the chain.
+    ///
+    /// The chain is the whole identity for a rate: it is a property of that
+    /// chain's fee market and holds for every asset on it. `customGasLimit`
+    /// is deliberately stricter — it prices one specific call, so it is
+    /// stamped with the asset.
     var customByteFee: BigInt? {
         get {
             guard let pinnedByteFeeChain, pinnedByteFeeChain == coin.chain else { return nil }

--- a/VultisigApp/VultisigAppTests/Send/SendGasLimitAssetBindingTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendGasLimitAssetBindingTests.swift
@@ -179,6 +179,35 @@ final class SendGasLimitAssetBindingTests: XCTestCase {
         XCTAssertEqual(vm.gasLimit, BigInt(EVMHelper.defaultERC20TransferGasUnit))
     }
 
+    /// The narrower window on the same race: the switch happens after
+    /// `setMaxAmount()` returns but before the scheduled task body runs, so the
+    /// task has not read anything yet. It must still refine the asset the user
+    /// tapped Max on — which it is no longer on — rather than adopting the new
+    /// one and quietly turning the switch into a max send of it.
+    func testRefineDoesNotAdoptAnAssetSwitchedToBeforeItStarts() async {
+        let interactor = MockSendInteractor()
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH(), interactor: interactor)
+        interactor.calculateEVMFeeStub = { _ in
+            SendInteractorFeeResult(fee: BigInt(1_000), gas: BigInt(7), gasLimit: BigInt(60_000))
+        }
+
+        vm.setMaxAmount(percentage: 100)
+        // No await in between: the picker gets its main-actor turn before the
+        // task body's first line, which is the window this covers.
+        vm.coin = SendFormFixture.makeCoin(.arbitrum, ticker: "ARB", decimals: 18, isNative: true,
+                                           rawBalance: "5000000000000000000")
+
+        await vm.feeRefineTask?.value
+
+        XCTAssertTrue(interactor.calculateEVMFeeCalls.isEmpty,
+                      "a refine that has lost its asset must stand down, not re-aim at the new one")
+        XCTAssertNil(vm.estimatedGasLimit)
+        XCTAssertEqual(vm.gas, .zero)
+        XCTAssertEqual(vm.fee, .zero)
+        XCTAssertFalse(vm.isCalculatingFee,
+                       "standing down must still take the calculating indicator down — nothing else will")
+    }
+
     /// The refresh path carries the same guard. Nothing in the app calls it
     /// today — it is reached only from here — so this test is what holds the
     /// guard in place for whenever the form starts refreshing its fee again.

--- a/VultisigApp/VultisigAppTests/Send/SendGasLimitAssetBindingTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendGasLimitAssetBindingTests.swift
@@ -178,4 +178,26 @@ final class SendGasLimitAssetBindingTests: XCTestCase {
                      "an ETH estimate must not be stamped onto the USDC the form has moved to")
         XCTAssertEqual(vm.gasLimit, BigInt(EVMHelper.defaultERC20TransferGasUnit))
     }
+
+    /// The refresh path carries the same guard. Nothing in the app calls it
+    /// today — it is reached only from here — so this test is what holds the
+    /// guard in place for whenever the form starts refreshing its fee again.
+    func testLoadGasInfoDropsAResultForAnAssetTheFormHasLeft() async {
+        let interactor = MockSendInteractor()
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH(), interactor: interactor)
+        vm.amount = "0.1"
+        let usdc = SendFormFixture.makeUSDC()
+
+        interactor.calculateEVMFeeStub = { _ in
+            vm.coin = usdc
+            return SendInteractorFeeResult(fee: BigInt(1_000), gas: BigInt(7), gasLimit: BigInt(23_000))
+        }
+
+        await vm.loadGasInfo()
+
+        XCTAssertNil(vm.estimatedGasLimit)
+        XCTAssertEqual(vm.gas, .zero,
+                       "figures fetched for the asset the form has left must not be shown against the new one")
+        XCTAssertEqual(vm.fee, .zero)
+    }
 }

--- a/VultisigApp/VultisigAppTests/Send/SendGasLimitAssetBindingTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendGasLimitAssetBindingTests.swift
@@ -1,0 +1,181 @@
+//
+//  SendGasLimitAssetBindingTests.swift
+//  VultisigAppTests
+//
+//  A pinned gas limit belongs to the asset it was sized for.
+//
+//  The coin picker writes `viewModel.coin` directly and no view is responsible
+//  for clearing the gas sheet's override, so a limit pinned for one asset used
+//  to survive a switch and then price the next transaction verbatim —
+//  `BlockChainService` honours a custom limit exactly, by design. Too low is
+//  the dangerous direction: the transaction runs out of gas on-chain, which
+//  burns the fee and delivers nothing.
+//
+//  The stamp is the asset rather than the chain (which is all a byte-fee rate
+//  needs) because a gas limit prices one specific call: a native transfer is
+//  sized at 23,000 units where an ERC20 transfer is sized at 120,000, on the
+//  very same chain. `estimatedGasLimit` carries the same stamp — `gasLimit`
+//  falls back to it, and the gas sheet re-pins whatever it displays.
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class SendGasLimitAssetBindingTests: XCTestCase {
+
+    // MARK: - Visibility of the pin
+
+    func testPinnedLimitAppliesOnTheAssetItWasSetFor() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.customGasLimit = BigInt(500_000)
+
+        XCTAssertEqual(vm.customGasLimit, BigInt(500_000))
+        XCTAssertEqual(vm.gasLimit, BigInt(500_000))
+    }
+
+    func testPinnedLimitIsDroppedAfterSwitchingChain() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.customGasLimit = BigInt(500_000)
+
+        vm.coin = SendFormFixture.makeCoin(.arbitrum, ticker: "ARB", decimals: 18, isNative: true)
+
+        XCTAssertNil(vm.customGasLimit,
+                     "a limit pinned for an Ethereum send must not size an Arbitrum one")
+    }
+
+    /// The case a chain-only stamp would miss, and the reason this one is
+    /// keyed on the asset.
+    func testPinnedLimitIsDroppedAfterSwitchingTokenOnTheSameChain() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.customGasLimit = BigInt(23_000)
+
+        vm.coin = SendFormFixture.makeUSDC()
+
+        XCTAssertNil(vm.customGasLimit,
+                     "a native-transfer limit must not size an ERC20 transfer on the same chain")
+    }
+
+    func testPinnedLimitReturnsWhenSwitchingBack() {
+        let eth = SendFormFixture.makeETH()
+        let vm = SendFormFixture.make(coin: eth)
+        vm.customGasLimit = BigInt(500_000)
+
+        vm.coin = SendFormFixture.makeUSDC()
+        XCTAssertNil(vm.customGasLimit)
+
+        vm.coin = eth
+        XCTAssertEqual(vm.customGasLimit, BigInt(500_000),
+                       "returning to the asset the limit was sized for restores it")
+    }
+
+    func testRepinningOnTheNewAssetStampsThatAsset() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.customGasLimit = BigInt(23_000)
+
+        vm.coin = SendFormFixture.makeUSDC()
+        vm.customGasLimit = BigInt(150_000)
+
+        XCTAssertEqual(vm.customGasLimit, BigInt(150_000))
+
+        vm.coin = SendFormFixture.makeETH()
+        XCTAssertNil(vm.customGasLimit, "the limit now belongs to USDC, not ETH")
+    }
+
+    func testClearingTheLimitAlsoClearsItsStamp() {
+        let eth = SendFormFixture.makeETH()
+        let vm = SendFormFixture.make(coin: eth)
+        vm.customGasLimit = BigInt(500_000)
+        vm.customGasLimit = nil
+
+        vm.coin = eth
+        XCTAssertNil(vm.customGasLimit)
+    }
+
+    // MARK: - What the form falls back to after a switch
+
+    func testGasLimitFallsBackToTheNewAssetsDefault() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.customGasLimit = BigInt(500_000)
+
+        vm.coin = SendFormFixture.makeUSDC()
+
+        XCTAssertEqual(vm.gasLimit, BigInt(EVMHelper.defaultERC20TransferGasUnit),
+                       "with the foreign pin gone the ERC20 default is the floor, not the pinned number")
+    }
+
+    /// `estimatedGasLimit` is `gasLimit`'s fallback, `BlockChainService` treats
+    /// the requested limit as a floor, and the gas sheet re-pins what it shows
+    /// — so a stale estimate would put the old asset's number back in front of
+    /// the user, one Save away from becoming an exact custom limit.
+    func testStaleEstimateIsDroppedAfterSwitchingAsset() {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.estimatedGasLimit = BigInt(23_000)
+
+        vm.coin = SendFormFixture.makeUSDC()
+
+        XCTAssertNil(vm.estimatedGasLimit)
+        XCTAssertEqual(vm.gasLimit, BigInt(EVMHelper.defaultERC20TransferGasUnit))
+    }
+
+    // MARK: - The paths a stale limit could still reach signing through
+
+    /// The hand-off is the last point the stale limit could reach the signer.
+    func testHandOffTransactionDoesNotCarryAForeignAssetLimit() throws {
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH())
+        vm.customGasLimit = BigInt(23_000)
+        vm.estimatedGasLimit = BigInt(23_000)
+
+        vm.coin = SendFormFixture.makeUSDC()
+        vm.toAddress = "0xdeadbeef"
+        vm.amount = "100"
+
+        let tx = try vm.makeTransaction()
+        XCTAssertNil(tx.customGasLimit,
+                     "the signed transaction must not size a USDC transfer at ETH's limit")
+        XCTAssertNil(tx.estimatedGasLimit)
+        XCTAssertEqual(tx.gasLimit, BigInt(EVMHelper.defaultERC20TransferGasUnit))
+    }
+
+    func testFeeRequestDoesNotCarryAForeignAssetLimit() async throws {
+        let interactor = MockSendInteractor()
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH(), interactor: interactor)
+        vm.customGasLimit = BigInt(23_000)
+
+        vm.coin = SendFormFixture.makeCoin(.arbitrum, ticker: "ARB", decimals: 18, isNative: true,
+                                           rawBalance: "1000000000000000000")
+        vm.setMaxAmount(percentage: 100)
+        await vm.feeRefineTask?.value
+
+        // Unwrap first: an absent request would satisfy the nil assertion below
+        // for the wrong reason — the refine never having run at all.
+        let request = try XCTUnwrap(interactor.calculateEVMFeeCalls.last?.request,
+                                    "the refine must have asked for a fee, or there is no request to inspect")
+        XCTAssertNil(request.customGasLimit,
+                     "the fee request must not carry a limit pinned for another asset")
+    }
+
+    /// The race the stamp alone does not close: a refine asks about one asset,
+    /// the user switches while it is in flight, and the result lands — stamping
+    /// the *new* asset with the *old* asset's number.
+    func testInFlightRefineDoesNotStampTheNewAsset() async {
+        let interactor = MockSendInteractor()
+        let vm = SendFormFixture.make(coin: SendFormFixture.makeETH(), interactor: interactor)
+        let usdc = SendFormFixture.makeUSDC()
+
+        interactor.calculateEVMFeeStub = { _ in
+            // Stand in for the user tapping the coin picker while the fetch is
+            // outstanding.
+            vm.coin = usdc
+            return SendInteractorFeeResult(fee: BigInt(1_000), gas: BigInt(1), gasLimit: BigInt(23_000))
+        }
+
+        vm.setMaxAmount(percentage: 100)
+        await vm.feeRefineTask?.value
+
+        XCTAssertNil(vm.estimatedGasLimit,
+                     "an ETH estimate must not be stamped onto the USDC the form has moved to")
+        XCTAssertEqual(vm.gasLimit, BigInt(EVMHelper.defaultERC20TransferGasUnit))
+    }
+}


### PR DESCRIPTION
## Problem

A gas limit the user pins in the Send form's gas-settings sheet survives a switch to a different coin **or** chain and is then applied verbatim to the new transaction. Pin a limit while sending on one asset, switch the form without leaving the screen, and the old asset's limit is what gets used.

A wrong gas **limit** fails worse than a wrong fee rate. Too low and the transaction runs out of gas on-chain: it fails **and still burns the gas**, so the fee is lost with nothing sent. Too high and it inflates the reserved amount, which on a max send eats into the amount.

## Root cause

`SendDetailsViewModel.customGasLimit` was plain stored state. Its only invalidation point is `reset(to:)`, whose only caller is `SendDetailsScreen.setMainData()`. Both pickers write `viewModel.coin` directly through a `Binding` and never go through it; the coin-change handler clears the memo and the XRP destination tag, but nothing fee-related. So nothing invalidated the pin.

The pinned value then won all the way down: `gasLimit` (`customGasLimit ?? estimatedGasLimit ?? default`) → `makeTransaction()` / the fee requests → `BlockChainService.resolveEVMSendGasLimit`, which honours a custom limit **exactly**, by design.

## Fix

Both gas limits are now stored stamped with the asset they were sized for, and reads are scoped to it — the value is only visible while the form is still on that asset. Same shape as the chain-stamped `customByteFee` in the same file (#5032): no view has to remember to clear anything, re-pinning re-stamps, and switching back restores.

### The judgement call: asset, not chain

`#5032` stamped the byte fee with the **chain**. That is right for a byte rate — sat/vB is a property of a chain's fee market and holds for every asset on it.

A gas limit is not a rate. It prices **the execution of one specific call**, so the stamp here is the **asset** (`Coin.uniqueId` = chain + ticker + contract):

- a native transfer is sized at 23,000 units, an ERC20 transfer at 120,000 — on the *same* chain. `SendDetailsViewModel.defaultGasLimit` already branches on `coin.isNativeToken`, so the codebase already treats that distinction as gas-limit-relevant.
- a chain-only stamp would therefore still let a limit pinned for ETH size a USDC send on Ethereum — the "too low, burns the fee" failure, not a merely suboptimal one.
- tokens are not interchangeable either (transfer hooks, blacklists, rebasing), so the contract is part of the identity rather than just native-vs-token.

The asymmetry with `customByteFee` is deliberate and is written into both doc comments so the next reader doesn't have to guess.

### `estimatedGasLimit` gets the same stamp

Stamping only `customGasLimit` would have left the leak in place through the back door:

- `gasLimit` falls back to `estimatedGasLimit`, and `resolveEVMSendGasLimit` uses the requested limit as a **floor**, so a stale foreign estimate inflates the new asset's limit;
- the gas sheet is seeded with `viewModel.gasLimit` and `SendGasSettingsView.save()` re-pins **whatever it displays**, unconditionally (unlike `byteFee`, which requires an explicit edit). So after a switch the sheet would still show the old asset's number, one Save away from becoming an exact custom limit for the new one.

### One HIGH finding, found in review and fixed here

The first Codex review pass on the stamping commit caught a hole in it: `startFeeRefine` documents two guards covering "every writer of the amount" — task cancellation and the max intent — and the coin picker is a third kind of writer that neither guard sees. It cancels nothing and leaves `sendMaxAmount` alone. A refine started on asset A and landing after a switch to B wrote A's figures against B, and with the stamp applied at write time it would have stamped **B** with **A's** estimate, re-opening the leak the stamp had just closed.

Second commit: read the asset once before the first suspension and re-check it after, on every path that writes a fetched figure — both max refines, their shared failure handler, and `loadGasInfo`.

## Part 3 of the issue: sweep for other pinned state with the same exposure

The root cause is structural: `reset(to:)` is the sole invalidation point and the pickers bypass it, so anything cleared only there is suspect. Everything below is **out of scope here and not fixed** — reported for triage, no issues filed.

| State | Exposure on a coin/chain switch | Severity |
|---|---|---|
| `sendMaxAmount` | Sticky by design since #5032, cleared only in `reset(to:)`. Survives a switch, so the form still carries "send everything" with the *previous* asset's amount string in the field. At Verify, `loadGasInfoForSending` re-derives the max from the **new** coin's balance — so the amount sent is not the amount Details displayed. | **Highest of the leftovers** — fund-relevant, worth its own issue |
| `amount` / `amountInFiat` | Carried verbatim; the fiat figure was converted at the old asset's price. Visible in the field, so self-evident to the user — unless `sendMaxAmount` is set, per the row above. | Medium |
| `gas` / `fee` | Stale figures from the previous asset stay on screen. Nothing refetches on a coin switch: `setData()` only refreshes the balance, and `SendDetailsViewModel.loadGasInfo()` has **no production caller at all** (only tests, and the Referral/FunctionCall screens' own same-named methods). | Medium |
| `toAddress` + `addressSetupDone` | An address for the old chain stays in the field with the step still marked done. `validateForm()` re-runs `validateAddressResolved()` on Continue, so this is fail-closed — but the form looks valid until then. | Low |
| `feeMode` | Not cleared, but a relative priority (slow/normal/fast) ports across chains meaningfully. | Low, arguably correct |
| `memo` | Cleared only when the *new* chain lacks memo support. A memo typed for one memo-supporting chain rides to another. Visible in the field. | Low |
| `isStakingOperation`, `transactionType`, `memoFunctionDictionary`, `wasmContractPayload` | Cleared only in `reset(to:)`, and chain-specific in nature. Inert today: the only production seed builder (`SendDetailsSeed.fromAction`) sets them all to defaults and nothing else writes them on this screen. Latent rather than live. | Low / latent |
| `rippleTag` | Already handled — the screen clears it when the new chain lacks destination-tag support. | — |
| `customByteFee` | Fixed by #5032 (chain-stamped). | — |

Also noted, pre-existing: `SendDetailsViewModel.loadGasInfo()` is dead in-app. It is still covered by tests (including a new one here for its guard), so it is left alone rather than deleted in a fund-path PR.

## Verification

- **Full unit-test gate at HEAD, green:** `xcodebuild test` on a dedicated `iPhone 16 Pro` / iOS 26.5 simulator, worktree-local derived data — `** TEST SUCCEEDED **`, **4809 test cases passed, 0 failed**.
- **12 new tests**, all passing (`SendGasLimitAssetBindingTests`, 12/12) — pin applies on its own asset; dropped after a chain switch; dropped after a token switch **on the same chain** (the case a chain-only stamp would miss); restored on switching back; re-pinning re-stamps; clearing clears the stamp; `gasLimit` falls back to the new asset's default; a stale estimate is dropped; and the three paths a stale limit could still reach the signer through — the hand-off `SendTransaction`, the fee request, and a refine that lands after the switch (plus the same race on `loadGasInfo`).
- **SwiftLint:** clean, zero new warnings.
- **Cross-model review:** three read-only Codex passes (per-commit + whole-branch). One HIGH (the in-flight refine race — fixed, second commit), one LOW (the `loadGasInfo` guard was untested — fixed by adding that test). No findings rejected.
- **Not verified on device.** No transaction has been signed or broadcast against this build; the behaviour is asserted at the view-model and hand-off seams only.
- **Non-vacuity of the new tests** was established by reading the diff (every "dropped" assertion targets state that was a plain stored `var` before) and by the whole-branch Codex pass, which was asked to look for tests that pass vacuously. A mutation run — reverting the fix and watching the suite go red — was **not** performed.

## Fund safety

This touches the send/signing path. The change is strictly *subtractive* on what reaches the signer: a gas limit is only ever visible for the asset it was sized for, so the worst case introduced is falling back to the chain's default limit and letting `eth_estimateGas` size the send — which is what an untouched form does. No new value is ever invented, and no path can now carry a **larger** limit than before. Non-EVM chains are unaffected: they have no gas limit and `customByteFee` keeps its existing chain stamp.

Conflict risk with #5034 (`fix/evm-max-send-clamp-5019`) is nil — that branch does not touch `SendDetailsViewModel.swift`, and this one touches nothing else.

Closes #5045


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gas limits and fee estimates now remain correctly associated with the selected asset.
  * Switching assets clears outdated values and restores previously configured values when returning.
  * Prevented delayed fee and gas updates from overwriting details after switching assets.
  * Improved handling of asset-specific defaults and removed estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->