### PR TITLE
fix(send): read a balance exactly past Int64 so a send can't validate against funds that aren't there

### DIFF
--- a/VultisigApp/VultisigApp/Core/Extensions/CoinExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/CoinExtension.swift
@@ -5,6 +5,7 @@
 //  Created by Johnny Luo on 15/3/2024.
 //
 
+import BigInt
 import Foundation
 import WalletCore
 
@@ -18,6 +19,17 @@ extension Coin {
 
     var isDefiOnly: Bool {
         Coin.defiOnlyTickers.contains(ticker.uppercased())
+    }
+
+    /// The balance in base units.
+    ///
+    /// `rawBalance` is a base-unit integer string, and this is the one reading
+    /// of it that every affordability guard shares — so no guard ever compares
+    /// against a balance that is merely close to the real one. A value that
+    /// isn't a plain integer still goes through the shared parse rather than
+    /// collapsing to a zero balance.
+    var balanceRaw: BigInt {
+        rawBalance.toBigInt(decimals: decimals)
     }
 }
 

--- a/VultisigApp/VultisigApp/Core/Extensions/CoinExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/CoinExtension.swift
@@ -21,13 +21,17 @@ extension Coin {
         Coin.defiOnlyTickers.contains(ticker.uppercased())
     }
 
-    /// The balance in base units.
+    /// The balance in base units, read exactly.
     ///
-    /// `rawBalance` is a base-unit integer string, and this is the one reading
-    /// of it that every affordability guard shares — so no guard ever compares
-    /// against a balance that is merely close to the real one. A value that
-    /// isn't a plain integer still goes through the shared parse rather than
-    /// collapsing to a zero balance.
+    /// `rawBalance` is a base-unit integer string, and this is the reading of it
+    /// that the send affordability guards share, so none of them can drift onto
+    /// a value that is merely close to the real one. A value that isn't a plain
+    /// integer still goes through the shared parse rather than collapsing to a
+    /// zero balance.
+    ///
+    /// Not yet universal: guards outside Send still weigh amounts against
+    /// `balanceDecimal`, which divides through the same `Double`-backed parser
+    /// this exists to avoid.
     var balanceRaw: BigInt {
         rawBalance.toBigInt(decimals: decimals)
     }

--- a/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Extensions/StringExtension.swift
@@ -199,9 +199,27 @@ extension String {
         return valueBigInt
     }
 
-    // We must truncate before converting to bigInt.
+    /// Base-unit integer value of a numeric string, truncated to at most
+    /// `decimals` fraction digits. Anything still fractional after the
+    /// truncation yields zero — this reads an already-scaled value, it does not
+    /// scale one (`"1.5"` with 18 decimals is zero, not 1.5e18).
+    ///
+    /// A string of plain ASCII digits is read exactly. The general path goes
+    /// through `NumberFormatter`, which returns a `Double`-backed `NSNumber`
+    /// once the value no longer fits in `Int64` — about 9.223 on an 18-decimal
+    /// asset — and keeps only 17 significant digits. That commonly rounds the
+    /// value UP, and a balance reported larger than it really is lets an
+    /// affordability guard pass a send the chain then rejects at broadcast,
+    /// after the signing ceremony has already run.
+    ///
+    /// Non-integer input still takes the `NumberFormatter` path, imprecision
+    /// included, rather than collapsing to zero; no caller passes one, because
+    /// a surviving fraction is already the zero case above.
     func toBigInt(decimals: Int) -> BigInt {
-        self.toDecimal().truncated(toPlaces: decimals).description.toBigInt()
+        if decimals >= 0, isNotEmpty, allSatisfy({ $0.isASCII && $0.isNumber }), let exact = BigInt(self) {
+            return exact
+        }
+        return self.toDecimal().truncated(toPlaces: decimals).description.toBigInt()
     }
 
     func isValidDecimal() -> Bool {

--- a/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Logic/SendCryptoLogic.swift
@@ -49,7 +49,7 @@ enum SendCryptoLogic {
         }
 
         let amountRaw = amountInRaw(coin: coin, amount: amount)
-        let balanceRaw = coin.rawBalance.toBigInt(decimals: coin.decimals)
+        let balanceRaw = coin.balanceRaw
 
         if (sendMaxAmount && (coin.chainType == .UTXO || coin.chainType == .Cardano || coin.chainType == .Ton))
             || !coin.isNativeToken {
@@ -224,7 +224,7 @@ enum SendCryptoLogic {
     ///
     /// Every other chain keeps `balance − fee − ED` unchanged.
     static func verifyMaxCandidateRaw(coin: Coin, fee: BigInt, previousAmountRaw: BigInt) -> BigInt {
-        let balance = coin.rawBalance.toBigInt(decimals: coin.decimals)
+        let balance = coin.balanceRaw
         let candidate = balance - fee - existentialDeposit(for: coin)
         guard coin.chain == .terraClassic else { return candidate }
         return Swift.min(candidate, previousAmountRaw)

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendCryptoVerifyLogic.swift
@@ -139,7 +139,7 @@ struct SendCryptoVerifyLogic {
         }
 
         let amount = tx.amountInRaw
-        let balance = tx.coin.rawBalance.toBigInt(decimals: tx.coin.decimals)
+        let balance = tx.coin.balanceRaw
         // TRON staking operations: skip balance validation entirely
         // The balance is already validated in TronFreezeScreen/TronUnfreezeScreen
         // and the user sees the available balance on the screen
@@ -204,7 +204,7 @@ struct SendCryptoVerifyLogic {
             // error when the vault's ADA balance can't cover that.
             if tx.coin.chain == .cardano,
                let nativeToken = tx.vault.coins.nativeCoin(chain: .cardano) {
-                let nativeBalance = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
+                let nativeBalance = nativeToken.balanceRaw
                 let minAdaReserve = CardanoHelper.defaultMinUTXOValue * 2
                 if nativeBalance < tx.fee + minAdaReserve {
                     return BalanceValidationResult(isValid: false, errorMessage: "cardanoOutputBelowMinAda")
@@ -214,7 +214,7 @@ struct SendCryptoVerifyLogic {
             // Validate gas balance for non-native tokens. Decision 2 win:
             // vault is now non-optional, so the singleton fallback is gone.
             if let nativeToken = tx.vault.coins.nativeCoin(chain: tx.coin.chain) {
-                let nativeBalance = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
+                let nativeBalance = nativeToken.balanceRaw
                 if tx.fee > nativeBalance {
                     let errorMessage = String(format: "insufficientGasTokenError".localized, nativeToken.ticker, tx.coin.ticker)
                     return BalanceValidationResult(isValid: false, errorMessage: errorMessage)
@@ -351,7 +351,7 @@ struct SendCryptoVerifyLogic {
         )
         // The XRP balance is already reserve-net, so it is what can actually be
         // locked up and spent.
-        let spendable = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
+        let spendable = nativeToken.balanceRaw
         let required = ownerReserve + tx.fee
         guard spendable >= required else {
             throw HelperError.runtimeError(

--- a/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Send/ViewModels/SendDetailsViewModel.swift
@@ -800,7 +800,7 @@ final class SendDetailsViewModel {
         // WalletCore's `Int64` amount field, where an out-of-range conversion
         // traps rather than failing. Clamp it — an absurd balance must not
         // crash the form.
-        let probeAmount = Swift.min(coin.rawBalance.toBigInt(decimals: coin.decimals), BigInt(Int64.max))
+        let probeAmount = Swift.min(coin.balanceRaw, BigInt(Int64.max))
         // The form plans against the cached UTXO set: Max is tapped repeatedly
         // while editing, and Verify refreshes before the plan that is signed.
         let plan = try await interactor.calculateMaxSendPlan(
@@ -1183,7 +1183,7 @@ final class SendDetailsViewModel {
               let nativeToken = vault.coins.nativeCoin(chain: coin.chain) else {
             return true
         }
-        let nativeBalance = nativeToken.rawBalance.toBigInt(decimals: nativeToken.decimals)
+        let nativeBalance = nativeToken.balanceRaw
         guard fee > nativeBalance else { return true }
 
         setGeneralError(message: String(format: "insufficientGasTokenError".localized, nativeToken.ticker, coin.ticker))

--- a/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/RippleTrustLineActivationViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ChainDetail/ViewModel/RippleTrustLineActivationViewModel.swift
@@ -97,7 +97,7 @@ final class RippleTrustLineActivationViewModel: ObservableObject {
         quote = RippleTrustLineActivationQuote(
             ownerReserveDrops: ownerReserve,
             feeDrops: fee,
-            spendableDrops: nativeCoin.rawBalance.toBigInt(decimals: nativeCoin.decimals),
+            spendableDrops: nativeCoin.balanceRaw,
             limitValue: limitValue,
             currencyCode: currencyCode,
             issuer: issuer

--- a/VultisigApp/VultisigAppTests/Extensions/CoinExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/CoinExtensionTests.swift
@@ -96,10 +96,10 @@ final class CoinExtensionTests: XCTestCase {
     /// A shape the exact integer read declines still reaches the shared parser
     /// rather than collapsing to a zero balance.
     func testBalanceRawFallsBackInsteadOfCollapsingToZero() {
-        XCTAssertNil(BigInt("1e18"), "the exact integer read has to be what declines this shape")
+        XCTAssertNil(BigInt("1e18", radix: 10), "the exact integer read has to be what declines this shape")
         let coin = makeCoin(ticker: "ETH", chain: .ethereum, isNative: true, decimals: 18, rawBalance: "1e18")
 
-        XCTAssertEqual(coin.balanceRaw, BigInt("1000000000000000000")!)
+        XCTAssertEqual(coin.balanceRaw, BigInt(stringLiteral: "1000000000000000000"))
     }
 
     // MARK: - Helpers

--- a/VultisigApp/VultisigAppTests/Extensions/CoinExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/CoinExtensionTests.swift
@@ -6,6 +6,7 @@
 //
 
 @testable import VultisigApp
+import BigInt
 import XCTest
 
 @MainActor
@@ -69,18 +70,58 @@ final class CoinExtensionTests: XCTestCase {
         XCTAssertFalse(filtered.contains(where: { $0.ticker == "STCY" }))
     }
 
+    // MARK: - balanceRaw
+
+    /// Past `Int64` — about 9.223 on an 18-decimal asset — the shared decimal
+    /// parser goes through `Double` and keeps 17 significant digits. Every
+    /// digit of the vault's balance has to survive the read.
+    func testBalanceRawReadsABalanceBeyondInt64Exactly() {
+        // 99.999999999999999999 ETH — the lossy read rounds it to a flat 100.
+        let raw = "99999999999999999999"
+        let coin = makeCoin(ticker: "ETH", chain: .ethereum, isNative: true, decimals: 18, rawBalance: raw)
+
+        XCTAssertEqual(coin.balanceRaw, BigInt(raw)!)
+    }
+
+    /// Reading a balance as LARGER than it is lets an affordability guard pass
+    /// a send the chain then rejects at broadcast — after the signing ceremony
+    /// has already run. The read may never overstate the vault.
+    func testBalanceRawNeverReportsMoreThanTheVaultHolds() {
+        for raw in ["9223372036854775808", "12345678901234567890", "99999999999999999999"] {
+            let coin = makeCoin(ticker: "ETH", chain: .ethereum, isNative: true, decimals: 18, rawBalance: raw)
+            XCTAssertLessThanOrEqual(coin.balanceRaw, BigInt(raw)!, "\(raw) was read as more than it is")
+        }
+    }
+
+    /// A shape the exact integer read declines still reaches the shared parser
+    /// rather than collapsing to a zero balance.
+    func testBalanceRawFallsBackInsteadOfCollapsingToZero() {
+        XCTAssertNil(BigInt("1e18"), "the exact integer read has to be what declines this shape")
+        let coin = makeCoin(ticker: "ETH", chain: .ethereum, isNative: true, decimals: 18, rawBalance: "1e18")
+
+        XCTAssertEqual(coin.balanceRaw, BigInt("1000000000000000000")!)
+    }
+
     // MARK: - Helpers
 
-    private func makeCoin(ticker: String, chain: Chain, isNative: Bool) -> Coin {
+    private func makeCoin(
+        ticker: String,
+        chain: Chain,
+        isNative: Bool,
+        decimals: Int = 8,
+        rawBalance: String = "0"
+    ) -> Coin {
         let meta = CoinMeta(
             chain: chain,
             ticker: ticker,
             logo: "",
-            decimals: 8,
+            decimals: decimals,
             priceProviderId: "",
             contractAddress: "",
             isNativeToken: isNative
         )
-        return Coin(asset: meta, address: "test", hexPublicKey: "test")
+        let coin = Coin(asset: meta, address: "test", hexPublicKey: "test")
+        coin.rawBalance = rawBalance
+        return coin
     }
 }

--- a/VultisigApp/VultisigAppTests/Extensions/StringExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/StringExtensionTests.swift
@@ -144,4 +144,66 @@ final class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("1.234,56".parseInput(locale: locale), Decimal(string: "1234.56"))
         XCTAssertFalse("abc12,5".isDecimalInput(locale: locale))
     }
+
+    // MARK: - toBigInt(decimals:)
+
+    /// The whole point of the exact path: past `Int64` — about 9.223 on an
+    /// 18-decimal asset — `NumberFormatter` hands back a `Double` and keeps 17
+    /// significant digits. Every digit of a base-unit balance has to survive.
+    func testToBigIntReadsValuesBeyondInt64Exactly() {
+        let cases = [
+            "9223372036854775807",      // Int64.max — the last value the old path got right
+            "9223372036854775808",      // Int64.max + 1 — the old path returned …776000
+            "12345678901234567890",     // ~12.35 ETH
+            "99999999999999999999",     // ~100 ETH — the old path rolled it to 1e20
+            "18446744073709551616",     // UInt64.max + 1
+            "123456789012345678901234567890123456789012345" // past Decimal's 3.4e38 ceiling
+        ]
+
+        for raw in cases {
+            XCTAssertEqual(
+                raw.toBigInt(decimals: 18), BigInt(raw)!,
+                "\(raw) must survive the base-unit parse digit for digit"
+            )
+        }
+    }
+
+    /// Reporting MORE funds than exist is the dangerous direction: it lets an
+    /// affordability guard pass a send the chain rejects at broadcast, after the
+    /// signing ceremony has already run. Nothing may ever round a balance up.
+    func testToBigIntNeverReportsMoreThanTheStringHolds() {
+        for exponent in 15...30 {
+            let base = BigInt("1" + String(repeating: "0", count: exponent))!
+            for offset in [BigInt(-1), .zero, BigInt(1), BigInt(7)] {
+                let value = base + offset
+                XCTAssertLessThanOrEqual(
+                    value.description.toBigInt(decimals: 18), value,
+                    "\(value) was parsed as more than it is"
+                )
+            }
+        }
+    }
+
+    /// Every non-digit shape keeps the pre-existing behaviour: the exact path is
+    /// a precision fix, not a semantic one.
+    func testToBigIntKeepsTheGeneralPathForNonIntegerInput() {
+        // A fraction surviving the truncation is zero — this reads an already
+        // scaled value, it does not scale one.
+        XCTAssertEqual("1.5".toBigInt(decimals: 18), .zero)
+        XCTAssertEqual("1.50".toBigInt(decimals: 18), .zero)
+        XCTAssertEqual("0.000000000000000001".toBigInt(decimals: 18), .zero)
+        // …but a fraction that truncates away, or is all zeros, is not.
+        XCTAssertEqual("1.5".toBigInt(decimals: 0), BigInt(1))
+        XCTAssertEqual("1.0001".toBigInt(decimals: 2), BigInt(1))
+        XCTAssertEqual("1.00".toBigInt(decimals: 18), BigInt(1))
+        // Signs, separators and non-numerics all stay on the general path.
+        XCTAssertEqual("-123".toBigInt(decimals: 18), BigInt(-123))
+        XCTAssertEqual("1e18".toBigInt(decimals: 18), BigInt("1000000000000000000")!)
+        XCTAssertEqual("abc".toBigInt(decimals: 18), .zero)
+        XCTAssertEqual("".toBigInt(decimals: 18), .zero)
+        // Leading zeros and a negative `decimals` are the two shapes the fast
+        // path has to get right rather than wrong.
+        XCTAssertEqual("000123".toBigInt(decimals: 18), BigInt(123))
+        XCTAssertEqual("125".toBigInt(decimals: -1), BigInt(120))
+    }
 }

--- a/VultisigApp/VultisigAppTests/Extensions/StringExtensionTests.swift
+++ b/VultisigApp/VultisigAppTests/Extensions/StringExtensionTests.swift
@@ -186,19 +186,23 @@ final class StringExtensionsTests: XCTestCase {
 
     /// Every non-digit shape keeps the pre-existing behaviour: the exact path is
     /// a precision fix, not a semantic one.
+    ///
+    /// The general path is locale-aware, so no fraction here is three, four or
+    /// two digits long — a locale that groups digits with `.` would read those
+    /// as thousands separators and reach a different number.
     func testToBigIntKeepsTheGeneralPathForNonIntegerInput() {
         // A fraction surviving the truncation is zero — this reads an already
         // scaled value, it does not scale one.
-        XCTAssertEqual("1.5".toBigInt(decimals: 18), .zero)
-        XCTAssertEqual("1.50".toBigInt(decimals: 18), .zero)
+        XCTAssertEqual("1.50000".toBigInt(decimals: 18), .zero)
+        XCTAssertEqual("1.99999".toBigInt(decimals: 2), .zero)
         XCTAssertEqual("0.000000000000000001".toBigInt(decimals: 18), .zero)
         // …but a fraction that truncates away, or is all zeros, is not.
-        XCTAssertEqual("1.5".toBigInt(decimals: 0), BigInt(1))
-        XCTAssertEqual("1.0001".toBigInt(decimals: 2), BigInt(1))
-        XCTAssertEqual("1.00".toBigInt(decimals: 18), BigInt(1))
+        XCTAssertEqual("1.50000".toBigInt(decimals: 0), BigInt(1))
+        XCTAssertEqual("1.00001".toBigInt(decimals: 2), BigInt(1))
+        XCTAssertEqual("1.00000".toBigInt(decimals: 18), BigInt(1))
         // Signs, separators and non-numerics all stay on the general path.
         XCTAssertEqual("-123".toBigInt(decimals: 18), BigInt(-123))
-        XCTAssertEqual("1e18".toBigInt(decimals: 18), BigInt("1000000000000000000")!)
+        XCTAssertEqual("1e18".toBigInt(decimals: 18), BigInt(stringLiteral: "1000000000000000000"))
         XCTAssertEqual("abc".toBigInt(decimals: 18), .zero)
         XCTAssertEqual("".toBigInt(decimals: 18), .zero)
         // Leading zeros and a negative `decimals` are the two shapes the fast

--- a/VultisigApp/VultisigAppTests/Send/Mocks/MockSendInteractor.swift
+++ b/VultisigApp/VultisigAppTests/Send/Mocks/MockSendInteractor.swift
@@ -87,7 +87,7 @@ final class MockSendInteractor: SendInteractor {
     /// plan produces. Tests that care about the numbers stub it.
     var calculateMaxSendPlanStub: ((SendChainSpecificRequest, Vault) throws -> SendMaxPlanResult) = { request, _ in
         let fee = BigInt(3_000)
-        let balance = request.coin.rawBalance.toBigInt(decimals: request.coin.decimals)
+        let balance = request.coin.balanceRaw
         return SendMaxPlanResult(amount: max(balance - fee, .zero), fee: fee, byteFee: BigInt(12))
     }
     var validateUtxosIfNeededStub: ((Coin) throws -> Void) = { _ in }

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -170,6 +170,25 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         XCTAssertEqual(vm.errorMessage, "walletBalanceExceededError")
     }
 
+    /// Past `Int64` — about 9.223 on an 18-decimal asset — reading the balance
+    /// through the shared decimal parser rounds it UP, so `amount + fee` is
+    /// weighed against funds the vault does not hold. The send clears Verify
+    /// and is rejected at broadcast, after the signing ceremony has already run
+    /// and been spent.
+    func testValidateBalanceWithFeeReadsABalanceBeyondInt64Exactly() throws {
+        // 99.999999999999999999 ETH — the lossy read rounds it to a flat 100.
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "99999999999999999999")
+        XCTAssertEqual(eth.balanceRaw, BigInt("99999999999999999999")!)
+        let tx = try makeTransaction(coin: eth, amount: "100", fee: .zero)
+        let vm = SendCryptoVerifyViewModel(transaction: tx)
+
+        vm.validateBalanceWithFee()
+
+        XCTAssertTrue(vm.hasBalanceError)
+        XCTAssertEqual(vm.errorMessage, "walletBalanceExceededError")
+    }
+
     func testValidateBalanceWithFeeSetsErrorForSendMaxWhenFeeExceedsBalance() throws {
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
                            rawBalance: "5000000000000000") // 0.005 ETH

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -179,8 +179,12 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         // 99.999999999999999999 ETH — the lossy read rounds it to a flat 100.
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
                            rawBalance: "99999999999999999999")
-        XCTAssertEqual(eth.balanceRaw, BigInt("99999999999999999999")!)
+        XCTAssertEqual(eth.balanceRaw, BigInt(stringLiteral: "99999999999999999999"))
         let tx = try makeTransaction(coin: eth, amount: "100", fee: .zero)
+        XCTAssertEqual(
+            tx.amountInRaw, BigInt(stringLiteral: "100000000000000000000"),
+            "the send is one wei more than the vault holds"
+        )
         let vm = SendCryptoVerifyViewModel(transaction: tx)
 
         vm.validateBalanceWithFee()

--- a/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
@@ -113,6 +113,26 @@ final class SendValidationTests: XCTestCase {
         ))
     }
 
+    /// Past `Int64` — about 9.223 on an 18-decimal asset — reading the balance
+    /// through the shared decimal parser rounds it UP, so the guard compares
+    /// against funds the vault does not hold and waves through a send the chain
+    /// rejects at broadcast, after the signing ceremony has already run.
+    func testIsAmountExceededReadsABalanceBeyondInt64Exactly() {
+        // 99.999999999999999999 ETH — the lossy read rounds it to a flat 100.
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
+                           rawBalance: "99999999999999999999")
+        XCTAssertEqual(eth.balanceRaw, BigInt("99999999999999999999")!)
+
+        XCTAssertTrue(SendCryptoLogic.isAmountExceeded(
+            coin: eth, amount: "100", sendMaxAmount: false,
+            fee: .zero, gas: .zero, isStakingOperation: false
+        ))
+        XCTAssertFalse(SendCryptoLogic.isAmountExceeded(
+            coin: eth, amount: "99", sendMaxAmount: false,
+            fee: .zero, gas: .zero, isStakingOperation: false
+        ))
+    }
+
     // MARK: - canBeReaped
 
     func testCanBeReapedFalseForChainWithoutExistentialDeposit() {

--- a/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendValidationTests.swift
@@ -121,7 +121,12 @@ final class SendValidationTests: XCTestCase {
         // 99.999999999999999999 ETH — the lossy read rounds it to a flat 100.
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
                            rawBalance: "99999999999999999999")
-        XCTAssertEqual(eth.balanceRaw, BigInt("99999999999999999999")!)
+        XCTAssertEqual(eth.balanceRaw, BigInt(stringLiteral: "99999999999999999999"))
+        XCTAssertEqual(
+            SendCryptoLogic.amountInRaw(coin: eth, amount: "100"),
+            BigInt(stringLiteral: "100000000000000000000"),
+            "the send is one wei more than the vault holds"
+        )
 
         XCTAssertTrue(SendCryptoLogic.isAmountExceeded(
             coin: eth, amount: "100", sendMaxAmount: false,


### PR DESCRIPTION
## Problem

Every send affordability guard turns a coin's `rawBalance` into base units with `String.toBigInt(decimals:)`. Past `Int64` — about **9.223 on an 18-decimal asset** — that parse rounds the balance, and on the common inputs it rounds **UP**. The guards then compare the requested amount against funds the vault does not hold.

The concrete failure: a send clears local validation and is rejected at broadcast — **after a completed MPC ceremony**, so the signing round is wasted. Rounding *up* is the dangerous direction; a downward error would merely strand dust.

## Root cause — the exact `Double` hop

`toBigInt(decimals:)` → `toDecimal()` → `parseInput()` → **`NumberFormatter.number(from:)`**.

`NumberFormatter.number(from:)` returns an `Int64`-backed `NSNumber` (`objCType == "q"`) while the value fits in `Int64`, and a **`Double`-backed** one (`objCType == "d"`) once it doesn't. `.decimalValue` then faithfully converts an already-destroyed value. Setting `generatesDecimalNumbers = true` does not help — ICU parses through a double either way; measured, both give the same wrong digits.

Measured (identical in `en_US`, `de_DE`, `pt_BR`):

| input (18-dec base units) | `objCType` | old `toBigInt(decimals: 18)` | delta |
|---|---|---|---|
| `9223372036854775807` (`Int64.max`) | `q` | `9223372036854775807` | exact |
| `9223372036854775808` | `d` | `9223372036854776000` | **+193** |
| `12345678901234567890` (~12.35 ETH) | `d` | `12345678901234570000` | **+2110** |
| `99999999999999999999` (~100 ETH) | `d` | `100000000000000000000` | **+1** |

## Fix strategy — leaf fix **plus** a shared accessor, not a call-site-only sweep

Two options were weighed, per the issue.

**(A) Sweep the call sites onto a shared helper, leave `toBigInt(decimals:)` lossy.** Rejected as the only action: it leaves a loaded gun in a `String` extension with an inviting name, and the next `rawBalance.toBigInt(decimals:)` re-fires the bug. #5034 already demonstrates that instinct — it reached for the idiom and had to work around it locally.

**(B) Make `toBigInt(decimals:)` itself exact.** The issue framed this as the broader blast radius. **On this tree it isn't**: the complete set of `toBigInt(decimals:)` call sites is 11, all in Send plus one Ripple trust-line view model. The widely-used overload is the zero-argument `toBigInt()`, which is already exact (`BigInt(String)`, no `Double`).

Two premise corrections that drove the choice, both verified against the source:

1. **`toBigInt(decimals:)` does not scale a human decimal.** It truncates to at most `decimals` fraction digits and then integer-parses, yielding `0` when anything fractional survives — so `"1.5".toBigInt(decimals: 18) == 0`, not `1.5e18`.
2. **There is therefore no "human-decimal amount" caller to protect.** `SendCryptoLogic.amountInRaw` multiplies by `pow(10, decimals)` *first* and passes `Decimal.description`, an integer string; the `decimals:` argument there is a vestigial no-op guard. Making the leaf exact for integer strings cannot break amount entry.

**Chosen: B, then A on top.**

1. **Leaf** — an exact fast path for a plain ASCII-digit string. Removes the trap permanently, and fixes `amountInRaw` in place, which a call-site-only sweep would have left broken for any typed amount above ~9.22 on an 18-decimal asset.
2. **Accessor** — `Coin.balanceRaw` in `Core/Extensions/CoinExtension.swift`, defined as `rawBalance.toBigInt(decimals: decimals)`. With the leaf fixed this *is* #5034's private `exactRawBalance(of:)`, so that helper has a home to collapse into. It also names the quantity instead of repeating an idiom whose `decimals:` argument does nothing. Placed in the extension file rather than `Model/Coin.swift`, which is SwiftData `@Model` territory.

The fast path triggers only on an all-ASCII-digit string, where the truncation is a provable no-op. **Signs, decimal points, grouping separators, locale forms, exponent notation, whitespace, garbage and empty all fall through to the byte-identical existing path** — the fallback property #5034 established: a non-integer degrades to the shared parse rather than collapsing to zero. Verified by a differential probe across `en_US`/`de_DE`/`pt_BR` over 33 input shapes: every non-digit-only input matches the old implementation exactly; every digit-only input past `Int64` differs by being right.

Deliberately **not** widened to fractional strings — that would also flip `"1.000000000000000001".toBigInt(decimals: 18)` from `1` to `0`, a semantic change no caller asked for. No production call site passes a fractional string; the residual is documented in the doc comment rather than fixed speculatively.

## Call-site sweep

Ten sites moved from `x.rawBalance.toBigInt(decimals: x.decimals)` to `x.balanceRaw`:

| File | Site |
|---|---|
| `SendCryptoLogic.swift` | `:52` `isAmountExceeded`, `:227` `verifyMaxCandidateRaw` |
| `SendCryptoVerifyLogic.swift` | `:142` `validateBalanceWithFee`, `:207` Cardano min-ADA reserve, `:217` ERC-20 gas balance, `:354` XRP trust-line reserve |
| `SendDetailsViewModel.swift` | `:803` UTXO max probe amount, `:1186` `validateERC20GasBalance` |
| `RippleTrustLineActivationViewModel.swift` | `:100` `spendableDrops` |
| `VultisigAppTests/Send/Mocks/MockSendInteractor.swift` | `:90` max-plan stub — the mock modelled the bug, so a test against a large balance would have passed vacuously |

**Left alone — already exact** (plain `BigInt(String)`, no `Double`): `SendCryptoLogic:98` `canBeReaped`, `:196` `terraClassicMaxValue`, `Coin.getMaxValue:351`, `DefiChainScreenModel:53`, `SwapCryptoLogic:94`/`:108`, `LimitSwapFormViewModel:354`, `SolanaStakingVerifyResolver:38`. Migrating these for cosmetic consistency would widen the diff on a fund-safety PR with no behaviour to gain.

**Left alone — in scope but not this idiom**: `SendCryptoLogic:26` `amountInRaw` keeps its call. It is not a balance read, and the leaf fix corrects it in place.

After the sweep the only remaining `rawBalance.toBigInt(decimals:)` in the tree is inside `Coin.balanceRaw` itself.

## Tests

- `StringExtensionTests` — exactness at and past `Int64.max` (including a value past `Decimal`'s 3.4e38 ceiling); a sweep over `10^15…10^30 ± {1, 0, 1, 7}` asserting the parse can **never** report more than the string holds; and the fallback shapes (fractional, signed, exponent, garbage, empty, leading zeros, negative `decimals`) asserted unchanged.
- `CoinExtensionTests` — `balanceRaw` exactness, the one-directional property, and the fallback that keeps `"1e18"` at `1e18` instead of collapsing to zero (`BigInt("1e18")` is `nil`, so a naive exact-only helper would have).
- `SendValidationTests` / `SendCryptoVerifyViewModelTests` — the guards that actually spend funds: a vault holding **99.999999999999999999 ETH** must reject a **100 ETH** send. The old read returned a flat `1e20`, so both `isAmountExceeded` and `validateBalanceWithFee` waved that send through. These fail if the fix is reverted.

## ⚠️ Conflicts with #5034 — recommended merge order

**#5034 (`fix/evm-max-send-clamp-5019`) is open and unmerged.** This branch is cut from `origin/main`; nothing is cherry-picked from it. Both branches edit `SendCryptoLogic.swift` and `SendCryptoVerifyLogic.swift`, so they **will** conflict. That is expected and accepted.

**Merge #5034 first, then rebase this branch onto it.** On the rebase:

- #5034's private `exactRawBalance(of:)` should collapse into `Coin.balanceRaw` so there is exactly one helper, not two.
- #5034's `EvmMaxSendClampTests.testClampReadsBalancesBeyondInt64Exactly` carries an `XCTAssertNotEqual` asserting the *shared* parser is still lossy, with the comment "if this starts passing, the shared balance parser gained full precision and this guard is stale". This branch is exactly that event — invert that assertion on the rebase.

## Verification

- **Full unit-test suite green**: `** TEST SUCCEEDED **` — **4807 tests, 1 skipped, 0 failures**, iOS Simulator (dedicated `gate-5037`, iPhone 16 Pro, `en_US`). All 7 new tests pass.
- `swiftlint --config VultisigApp/.swiftlint.yml` on all 11 touched files: **0 violations**.
- Root cause and every measured figure above reproduced in a standalone Swift probe against `Foundation`, not inferred.
- Cross-model review: three per-step Codex passes plus a whole-branch pass. Two findings raised and both fixed — an over-claiming doc comment on `balanceRaw`, and locale-sensitive fraction literals in the general-path test (widened to five-digit fractions, which no locale groups).
- **Not verified on device.** No manual send was performed against a real >9.22 ETH balance.

## 🔒 Fund safety — please review as such

This changes how the send/signing path decides whether a transfer is affordable. It needs **human review and on-device verification**, not just a green suite. The behaviour to confirm by hand: a vault with more than ~9.22 of an 18-decimal native asset can no longer be talked into a send that exceeds its real balance, and a normal send below that threshold is unchanged.

## Known adjacent gap (not fixed here)

`Coin.balanceDecimal` is the same bug one layer up — `rawBalance.toDecimal() / pow(10, decimals)`, also `Double`-backed. It is mostly display-facing, but two guards outside Send weigh amounts against it:

- `SwapCryptoLogic.balanceError` (`:890-891`) — the **swap** affordability rule, for both the spend and the gas coin.
- `FunctionCallCustom.isFormValid(for:)` (`:110`) — the submit-time gate on custom function calls.

Out of scope for an issue scoped to `toBigInt(decimals:)`, and a different idiom needing a different fix, but the same rounded-up-balance failure is reachable through them. Worth a follow-up issue; `balanceRaw`'s doc comment says so explicitly rather than implying the sweep is universal.

Closes #5037


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance accuracy for assets with very large values and high decimal precision.
  * Prevented rounding and floating-point conversion errors during send validation, maximum-send calculations, fee checks, and reserve checks.
  * Ensured transactions exceeding the available balance by the smallest unit are correctly rejected.
  * Improved handling of balances represented in scientific notation and other non-standard formats.

* **Tests**
  * Added coverage for large balances, exact integer parsing, rounding prevention, invalid inputs, and send-validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->