### PR TITLE
fix(swap): reserve a constant line box for the swap card amount row

### DIFF
--- a/VultisigApp/VultisigApp/Components/Swap/SwapAssetCard.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapAssetCard.swift
@@ -14,6 +14,27 @@ import SwiftUI
 /// which is also `@ScaledMetric`'s default text style.
 private let swapAmountLineHeight: CGFloat = 30
 
+/// The part of the card's height that is pure chrome and never scales: the 16pt
+/// top and bottom padding plus the 16pt spacing between the header and the
+/// content row.
+private let swapCardChromeHeight: CGFloat = 48
+
+/// The rest of the card's 116pt height — the header row (16) plus the content row
+/// (52). Both are driven by text, so this is the part that has to grow with
+/// Dynamic Type; `swapCardChromeHeight + swapCardTextHeight == swapCardHeight` at
+/// the default text size.
+private let swapCardTextHeight: CGFloat = 68
+
+/// The card's Figma height at the default text size, and its floor.
+///
+/// Dynamic Type scales *down* below `.large` as well as up, but the two tallest
+/// things in the card are images that don't scale at all — the 36pt coin icon
+/// (48pt once padded) and the header's 16pt chain logo. So the card can never be
+/// usefully shorter than `48 chrome + 16 header + 48 content row = 112`, and
+/// letting the scaled height fall below that would push content out of the card at
+/// small text sizes exactly the way a fixed height did at large ones.
+private let swapCardHeight: CGFloat = 116
+
 /// The shared Sell/Buy (a.k.a. From/To) asset card used by BOTH swap forms — the
 /// Market form (`SwapFromToField`) and the Limit form (`LimitAssetRow`). Purely
 /// presentational (no view model): each form is a thin adapter that maps its own
@@ -80,6 +101,18 @@ struct SwapAssetCard<Focus: Hashable>: View {
     /// it. Reserving the font's own line box collapses all three to one height.
     @ScaledMetric private var amountLineHeight: CGFloat = swapAmountLineHeight
 
+    /// Text-driven share of the card height, scaled by the same Dynamic Type factor
+    /// as `amountLineHeight` and the fonts inside the card.
+    @ScaledMetric private var cardTextHeight: CGFloat = swapCardTextHeight
+
+    /// Card height: fixed chrome plus the text-driven part, floored at the Figma
+    /// height. So the card is exactly 116pt at the default text size, never shrinks
+    /// below it, and grows only as Dynamic Type grows. It stays constant for a given
+    /// text size — content length never moves it.
+    private var cardHeight: CGFloat {
+        max(swapCardHeight, swapCardChromeHeight + cardTextHeight)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             header
@@ -89,8 +122,10 @@ struct SwapAssetCard<Focus: Hashable>: View {
         // Fixed card height (Figma cards are 333×112; 116 is the smallest that fits
         // the Satoshi-22 amount + 36pt coin pill + 16 padding/spacing without
         // clipping — Sell needs 115, Buy 113). Constant regardless of content, with
-        // the content pinned top-leading (header row on top) like the Figma.
-        .frame(maxWidth: .infinity, minHeight: 116, maxHeight: 116, alignment: .topLeading)
+        // the content pinned top-leading (header row on top) like the Figma. The
+        // height has to follow Dynamic Type, though: the amount and fiat lines scale,
+        // and pinning the card to a fixed 116 while they grow pushes them out of it.
+        .frame(maxWidth: .infinity, minHeight: cardHeight, maxHeight: cardHeight, alignment: .topLeading)
         .background(
             NotchedRectangle(notchCenterInset: swapCardSpacing / 2)
                 .strokeBorder(Theme.colors.borderLight, lineWidth: 1)

--- a/VultisigApp/VultisigApp/Components/Swap/SwapAssetCard.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/SwapAssetCard.swift
@@ -5,6 +5,15 @@
 
 import SwiftUI
 
+/// Unscaled line box reserved for the amount row — the full line box of
+/// `Theme.fonts.priceTitle2` (Satoshi-Medium 22) rounded up: ascent 22.22 +
+/// descent 5.28 + leading 2.20 = 29.70.
+///
+/// Scaled through `@ScaledMetric` at the point of use, so it tracks Dynamic Type
+/// the same way the font does — `Font.custom(_:size:)` scales relative to `.body`,
+/// which is also `@ScaledMetric`'s default text style.
+private let swapAmountLineHeight: CGFloat = 30
+
 /// The shared Sell/Buy (a.k.a. From/To) asset card used by BOTH swap forms — the
 /// Market form (`SwapFromToField`) and the Limit form (`LimitAssetRow`). Purely
 /// presentational (no view model): each form is a thin adapter that maps its own
@@ -57,6 +66,19 @@ struct SwapAssetCard<Focus: Hashable>: View {
     /// The Buy/To card is the same shape rotated 180° so its notch sits on the top
     /// edge; both cards' notches then meet as one circle around the shared toggle.
     let isSecondRow: Bool
+
+    /// Height the amount row reserves, so the row is one deterministic size instead
+    /// of whatever its current content happens to measure.
+    ///
+    /// The two amount branches otherwise report three different intrinsic heights
+    /// for the same font. On iOS the editable branch is a `UITextField`-backed
+    /// `TextField` measuring 28.00pt while it shows its placeholder but 29.33pt once
+    /// it holds text, and the read-only branch is a plain `Text` measuring 27.67pt.
+    /// So the row — and the fiat line and coin pill laid out against it — shifted the
+    /// instant the first character was typed, the Sell and Buy cards never shared a
+    /// baseline, and the empty field was shorter than the 29.33pt caret drawn inside
+    /// it. Reserving the font's own line box collapses all three to one height.
+    @ScaledMetric private var amountLineHeight: CGFloat = swapAmountLineHeight
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -127,6 +149,7 @@ struct SwapAssetCard<Focus: Hashable>: View {
                     .font(Theme.fonts.priceTitle2)
                     .foregroundStyle(Theme.colors.textPrimary)
                     .multilineTextAlignment(.trailing)
+                    .frame(height: amountLineHeight)
                 Text(fiat)
                     .font(Theme.fonts.caption12)
                     .foregroundStyle(Theme.colors.textTertiary)


### PR DESCRIPTION
## Problem

On the Swap screen the "From" amount input misbehaves before anything is typed: the placeholder glyph and the caret are laid out against a box smaller than the font needs, and the row jumps as soon as the first character is typed. The "To" card never lines up with it either.

## Root cause

`SwapAssetCard` drops `amountView` straight into the trailing `VStack`, so the amount row's height is whatever the underlying view happens to measure. On iOS that is **three different values for the same font** (`Theme.fonts.priceTitle2` = Satoshi-Medium 22):

| amount view | intrinsic height |
|---|---|
| `TextField` **empty** (placeholder showing) | **28.00pt** |
| `TextField` **filled** | **29.33pt** |
| read-only `Text` (the To / Buy side) | **27.67pt** |

The font's own full line box is **29.70pt** (`UIFont` ascender 22.22 + descender 5.28 + leading 2.20). So:

1. **Empty ≠ filled** — the editable branch is `UITextField`-backed (`PlatformTextFieldAdaptor` → `UITextField`), and it measures differently while it is laying out its placeholder label vs live text. The row, and the fiat line and coin pill laid out against it, shifted **1.33pt** on the first keystroke.
2. **The empty box is smaller than the caret drawn in it** — measured with the field focused, the caret is 29.33pt tall inside a 28.00pt box: `caret 71.33…100.66` vs `field 72.00…100.00`, i.e. **0.67pt out the top and 0.66pt out the bottom of its own frame**. That is the reported "glyph and caret clipped" symptom.
3. **From ≠ To** — the read-only branch is a plain `Text`, a third height again, so the two cards never shared a baseline.
4. **No slack to absorb any of it** — the card is hard-pinned at 116pt (`.frame(minHeight: 116, maxHeight: 116, alignment: .topLeading)`, chosen in #4928 against a ~113–115pt structural floor), so the row's height variance eats essentially all the headroom.

macOS is not affected — AppKit resolves all three to the same 27pt line box (checked with a standalone `NSHostingView` replica).

## Fix

One change, in the shared card: reserve the font's own line box on the amount row, applied **after** the editable/read-only branch so both sides get it.

```swift
@ScaledMetric private var amountLineHeight: CGFloat = swapAmountLineHeight  // 30
...
amountView
    .font(Theme.fonts.priceTitle2)
    .foregroundStyle(Theme.colors.textPrimary)
    .multilineTextAlignment(.trailing)
    .frame(height: amountLineHeight)
```

`30` is the font's full line box rounded up. It goes through `@ScaledMetric` so the reservation scales with Dynamic Type the same way the font does — `Font.custom(_:size:)` scales relative to `.body`, which is also `@ScaledMetric`'s default — rather than freezing the amount at one physical size.

Card arithmetic at the default text size: `16 padding + 16 header + 16 spacing + 50.67 content row + 16 padding = 114.67pt` inside the 116pt card.

No change to amount formatting or number parsing, and no change to the surrounding adapters.

## Verification

**Measured in the iOS simulator** by hosting the real `SwapAssetCard` in a `UIWindow` at real card widths and reading the laid-out `UITextField` frame in card coordinates (card spans y 24…140):

| | before | after |
|---|---|---|
| empty | y 72.00 h 28.00 → centre **86.00** | y 73.00 h 28.00 → centre **87.00** |
| filled | y 72.00 h 29.33 → centre **86.67** | y 72.33 h 29.33 → centre **87.00** |
| caret (empty, focused) | 71.33…100.66 against a 72.00…100.00 box — overflows top and bottom | 72.33…101.66 inside the 72.00…102.00 box — contained, 0.33pt margin |

Empty and filled now resolve to the **same centre**, so nothing below the amount moves when you type.

Dynamic Type after the fix (empty vs filled centre): `.large` 87.00 / 87.00 · `.xxxLarge` 95.17 / 95.33 · `.accessibilityMedium` 102.17 / 102.17 — aligned at every size.

Rendered at both size extremes — iPhone SE 3 class (375pt → 343pt card) and iPhone 16/17 Pro Max (440pt → 408pt card) — in these states: From empty, From filled, To read-only, Limit Buy row (`balance: nil`), the composed two-card stack, and the focused/caret state. All content sits inside the card; the Limit configuration is unchanged.

**Gate:** full suite on a dedicated simulator — `** TEST SUCCEEDED **`, 4799 tests, 1 skipped, 0 failures. SwiftLint clean on the changed file (0 violations).

### What I did NOT verify

- **Not driven end-to-end in the real app.** The Swap screen needs a real vault and there is no mock-vault launch argument in this repo, so verification is of the real shared component hosted in the simulator at the real screen's geometry, not of the running Swap screen. Worth a quick on-device look at Swap and Limit before this leaves draft.
- **macOS was reasoned about and replicated standalone, not run.** The same file compiles for macOS; AppKit already resolved all three branches to one line box, and the reservation is a no-op there at the default size.

### Card height now scales too

Reserving the row made it *scale* with Dynamic Type, which turned the card's flat 116pt pin into a reachable constraint rather than a latent one — both Codex and CodeRabbit flagged it, so it's fixed here rather than deferred. `116 = 48 + 68`: 48pt of chrome that never scales (16pt top padding + 16pt header/content spacing + 16pt bottom padding) and 68pt that is text-driven (header row 16 + content row 52). Only the latter goes through `@ScaledMetric`, floored at 116 — `@ScaledMetric` scales *down* below `.large` too, while the 36pt coin icon and 16pt chain logo don't scale at all, so an unfloored card would fall under its own content at small text sizes.

`maxHeight` deliberately stays: dropping it would let content length move the card at default sizes, which is exactly what the pin exists to prevent.

Measured card height, and the slack between the bottom of the content (amount row box + 6pt spacing + fiat line + 16pt bottom padding) and the card's bottom edge:

| text size | card height | slack (empty / filled) | |
|---|---|---|---|
| `.extraSmall` | 116.00 | +6.00 / +5.83 | contained |
| `.small` | 116.00 | +4.50 / +4.67 | contained |
| `.large` (default) | **116.00** | +1.33 / +1.33 | contained |
| `.extraExtraExtraLarge` | 137.67 | +5.33 / +5.33 | contained |
| `.accessibilityMedium` | 153.00 | +6.67 / +6.67 | contained |
| `.accessibilityExtraExtraExtraLarge` | 239.67 | +19.00 / +19.00 | contained |

Identical at every size for the Market From row, the Market To row and the Limit Buy row (`balance: nil`), so the stacked cards still match and the notch/toggle stays centred in the gap. No default-size regression: exactly 116.00pt at `.large`, amount row centre unchanged between empty and filled at both the 343pt and 408pt card widths.

Closes #5061


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap amount display alignment and stability.
  * Ensured editable and read-only amount layouts remain consistent across Dynamic Type sizes.
  * Improved swap card sizing for larger accessibility text settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->