### PR TITLE
fix(import): stop a vault import from silently overwriting a stored vault

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1542,6 +1542,7 @@
 "vaultCreated" = "Tresor erstellt";
 "vaultDetailsDescription" = "Details zu deinem Tresor ansehen";
 "vaultDetailsTitle" = "Tresor-Details";
+"vaultImportWouldOverwriteExisting" = "Dieses Backup kann nicht importiert werden: Es würde einen bereits auf diesem Gerät vorhandenen Tresor überschreiben.";
 "vaultInfo" = "Vault -Info";
 "vaultLibType" = "Tresortyp";
 "vaultManagement" = "Tresorverwaltung";
@@ -1686,3 +1687,4 @@
 "yourVaultSetup" = "Ihre Tresor-Einrichtung";
 "zipImportAllDuplicates" = "Alle %d Tresor(e) existieren bereits und wurden übersprungen: %@.";
 "zipImportPartialSuccess" = "%d Tresor(e) importiert. %d Duplikat(e) übersprungen: %@.";
+"zipImportUnsafeVaults" = "%1$d Tresor(e) importiert. %2$d übersprungen. %3$@ konnte nicht importiert werden: Es würde einen bereits auf diesem Gerät vorhandenen Tresor überschreiben.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1542,6 +1542,7 @@
 "vaultCreated" = "Vault created";
 "vaultDetailsDescription" = "View vault name, part and type";
 "vaultDetailsTitle" = "Details";
+"vaultImportWouldOverwriteExisting" = "This backup can't be imported: it would overwrite a vault already on this device.";
 "vaultInfo" = "Vault Info";
 "vaultLibType" = "Vault Type";
 "vaultManagement" = "Vault";
@@ -1686,3 +1687,4 @@
 "yourVaultSetup" = "Your vault setup";
 "zipImportAllDuplicates" = "All %d vault(s) already exist and were skipped: %@.";
 "zipImportPartialSuccess" = "Imported %d vault(s). Skipped %d duplicate(s): %@.";
+"zipImportUnsafeVaults" = "Imported %1$d vault(s). Skipped %2$d. %3$@ could not be imported: it would overwrite a vault already on this device.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1542,6 +1542,7 @@
 "vaultCreated" = "Bóveda creada";
 "vaultDetailsDescription" = "Ver los detalles de tu caja fuerte";
 "vaultDetailsTitle" = "Detalles";
+"vaultImportWouldOverwriteExisting" = "Esta copia de seguridad no se puede importar: sobrescribiría una bóveda que ya está en este dispositivo.";
 "vaultInfo" = "Información de bóveda";
 "vaultLibType" = "tipo de bóveda";
 "vaultManagement" = "Gestión de bóveda";
@@ -1686,3 +1687,4 @@
 "yourVaultSetup" = "Tu configuración de bóveda";
 "zipImportAllDuplicates" = "Las %d bóveda(s) ya existen y fueron omitidas: %@.";
 "zipImportPartialSuccess" = "Se importaron %d bóveda(s). Se omitieron %d duplicado(s): %@.";
+"zipImportUnsafeVaults" = "Se importaron %1$d bóveda(s). Se omitieron %2$d. %3$@ no se pudo importar: sobrescribiría una bóveda que ya está en este dispositivo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1542,6 +1542,7 @@
 "vaultCreated" = "Trezor stvoren";
 "vaultDetailsDescription" = "Pogledajte detalje vašeg sefa";
 "vaultDetailsTitle" = "Detalji";
+"vaultImportWouldOverwriteExisting" = "Ova sigurnosna kopija ne može se uvesti: prebrisala bi trezor koji već postoji na ovom uređaju.";
 "vaultInfo" = "Informacije o trezorima";
 "vaultLibType" = "Tip trezora";
 "vaultManagement" = "Upravljanje trezorima";
@@ -1686,3 +1687,4 @@
 "yourVaultSetup" = "Vaša postavka trezora";
 "zipImportAllDuplicates" = "Svih %d trezor(a) već postoji i preskočeno je: %@.";
 "zipImportPartialSuccess" = "Uvezeno %d trezor(a). Preskočeno %d duplikat(a): %@.";
+"zipImportUnsafeVaults" = "Uvezeno %1$d trezor(a). Preskočeno %2$d. %3$@ nije moguće uvesti: prebrisalo bi trezor koji već postoji na ovom uređaju.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1542,6 +1542,7 @@
 "vaultCreated" = "Vault creato";
 "vaultDetailsDescription" = "Visualizza i dettagli della tua cassaforte";
 "vaultDetailsTitle" = "Dettagli";
+"vaultImportWouldOverwriteExisting" = "Questo backup non può essere importato: sovrascriverebbe un vault già presente su questo dispositivo.";
 "vaultInfo" = "Informazioni sul Vault";
 "vaultLibType" = "Tipo di cassaforte";
 "vaultManagement" = "Gestione del caveau";
@@ -1686,3 +1687,4 @@
 "yourVaultSetup" = "La tua configurazione del vault";
 "zipImportAllDuplicates" = "Tutti i %d vault esistono già e sono stati saltati: %@.";
 "zipImportPartialSuccess" = "Importati %d vault. Saltati %d duplicati: %@.";
+"zipImportUnsafeVaults" = "Importati %1$d vault. Saltati %2$d. %3$@ non è stato importato: sovrascriverebbe un vault già presente su questo dispositivo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1542,6 +1542,7 @@
 "vaultCreated" = "볼트가 생성되었습니다";
 "vaultDetailsDescription" = "볼트 이름, 공유 및 유형 보기";
 "vaultDetailsTitle" = "세부 정보";
+"vaultImportWouldOverwriteExisting" = "이 백업은 가져올 수 없습니다: 이 기기에 이미 있는 볼트를 덮어쓰게 됩니다.";
 "vaultInfo" = "볼트 정보";
 "vaultLibType" = "볼트 유형";
 "vaultManagement" = "볼트";
@@ -1686,3 +1687,4 @@
 "yourVaultSetup" = "볼트 설정";
 "zipImportAllDuplicates" = "모든 볼트 %d개가 이미 존재하여 건너뛰었습니다: %@.";
 "zipImportPartialSuccess" = "%d개의 볼트를 가져왔습니다. %d개의 중복을 건너뛰었습니다: %@.";
+"zipImportUnsafeVaults" = "%1$d개의 볼트를 가져왔습니다. %2$d개를 건너뛰었습니다. %3$@은(는) 가져올 수 없습니다: 이 기기에 이미 있는 볼트를 덮어쓰게 됩니다.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1542,6 +1542,7 @@
 "vaultCreated" = "Cofre criado";
 "vaultDetailsDescription" = "Ver os detalhes do seu cofre";
 "vaultDetailsTitle" = "Detalhes";
+"vaultImportWouldOverwriteExisting" = "Este backup não pode ser importado: ele substituiria um cofre que já está neste dispositivo.";
 "vaultInfo" = "Informações do cofre";
 "vaultLibType" = "tipo de cofre";
 "vaultManagement" = "Gerenciamento de cofre";
@@ -1686,3 +1687,4 @@
 "yourVaultSetup" = "Sua configuração de cofre";
 "zipImportAllDuplicates" = "Todos os %d cofre(s) já existem e foram ignorados: %@.";
 "zipImportPartialSuccess" = "Importados %d cofre(s). Ignorados %d duplicado(s): %@.";
+"zipImportUnsafeVaults" = "Importados %1$d cofre(s). Ignorados %2$d. %3$@ não pôde ser importado: substituiria um cofre que já está neste dispositivo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1542,6 +1542,7 @@
 "vaultCreated" = "保险库已创建";
 "vaultDetailsDescription" = "查看保险库名称、部分和类型";
 "vaultDetailsTitle" = "详情";
+"vaultImportWouldOverwriteExisting" = "无法导入此备份：它会覆盖此设备上已有的保险库。";
 "vaultInfo" = "保险库信息";
 "vaultLibType" = "保险库类型";
 "vaultManagement" = "保险库管理";
@@ -1686,3 +1687,4 @@
 "yourVaultSetup" = "您的保险库设置";
 "zipImportAllDuplicates" = "全部 %d 个保险库已存在，已跳过：%@。";
 "zipImportPartialSuccess" = "已导入 %d 个保险库。跳过 %d 个重复项：%@。";
+"zipImportUnsafeVaults" = "已导入 %1$d 个保险库。跳过 %2$d 个。无法导入 %3$@：它会覆盖此设备上已有的保险库。";

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -753,9 +753,10 @@ class EncryptedBackupViewModel: ObservableObject {
     /// the names people reuse across devices. Anything still colliding after that
     /// is refused: `pubKeyECDSA`/`pubKeyEdDSA` default to `""`, and `""` is a
     /// real value in the unique index, so two key-less backups would upsert each
-    /// other. The final check is deliberately a raw re-derivation over every
-    /// unique attribute rather than a restatement of the duplicate rule, so a
-    /// unique attribute added later cannot quietly slip past this gate.
+    /// other. The final check restates the raw index semantics — one clause per
+    /// `@Attribute(.unique)` field on `Vault` — rather than reusing the duplicate
+    /// rule, whose empty/`nil` tolerance is exactly what would let those through.
+    /// It is the single place to extend when a unique attribute is added.
     func importDecision(for backupVault: Vault, existing: [Vault]) -> VaultImportDecision {
         guard isVaultUnique(backupVault: backupVault, vaults: existing) else {
             return .duplicate

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -12,8 +12,35 @@ import OSLog
 import VultisigCommonData
 import UniformTypeIdentifiers
 
+/// What to do with an incoming backup vault, decided before it ever reaches
+/// `modelContext.insert`.
+///
+/// `Vault` marks `name`, `pubKeyECDSA`, `pubKeyEdDSA` and `publicKeyMLDSA44` as
+/// `@Attribute(.unique)`. SwiftData turns an insert that collides on any one of
+/// them into an *upsert*: the incoming row replaces the stored one and the
+/// stored vault's key shares go with it, with nothing thrown and nothing logged.
+/// So "is this a duplicate?" and "can this be stored without clobbering
+/// something?" are two separate questions, and both have to be answered.
+enum VaultImportDecision: Equatable {
+    /// Safe to store. `name` is the backup's own name, disambiguated when a
+    /// vault already on the device holds it.
+    case insert(name: String)
+    /// The same vault is already on the device — it shares key material.
+    case duplicate
+    /// The backup would still collide on a unique attribute after its name was
+    /// resolved, and the colliding value carries no identity (an empty public
+    /// key), so it cannot be called a duplicate either. Storing it would
+    /// overwrite a stored vault, so it is refused.
+    case unsafeCollision
+}
+
 @MainActor
 class EncryptedBackupViewModel: ObservableObject {
+    /// Outcome of a multi-vault (zip) import. `unsafeNames` is kept apart from
+    /// `skippedNames` because "already on this device" and "refusing to
+    /// overwrite what is on this device" are different things to tell the user.
+    typealias ImportResults = (imported: [Vault], duplicates: Int, skippedNames: [String], unsafeNames: [String])
+
     @Published var showVaultExporter = false
     @Published var showVaultImporter = false
     @Published var decryptedContent: String?
@@ -493,29 +520,50 @@ class EncryptedBackupViewModel: ObservableObject {
         cleanup()
     }
 
-    private func importVaults(_ vaultsToImport: [Vault], to modelContext: ModelContext, existing: [Vault]) -> (imported: [Vault], duplicates: Int, skippedNames: [String]) {
+    private func importVaults(_ vaultsToImport: [Vault], to modelContext: ModelContext, existing: [Vault]) -> ImportResults {
         var imported: [Vault] = []
         var duplicates = 0
         var skippedNames: [String] = []
+        var unsafeNames: [String] = []
 
         for vault in vaultsToImport {
-            if isVaultUnique(backupVault: vault, vaults: existing + imported) {
-                VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
-                modelContext.insert(vault)
+            // `imported` carries the already-resolved names, so a batch that
+            // contains two vaults called "Savings" disambiguates the second
+            // against the first rather than upserting it.
+            switch insertIfSafe(vault, existing: existing + imported, modelContext: modelContext) {
+            case .insert:
                 imported.append(vault)
-            } else {
+            case .duplicate:
                 duplicates += 1
                 skippedNames.append(vault.name)
                 logger.info("Skipped duplicate vault during zip import: \(vault.name)")
+            case .unsafeCollision:
+                unsafeNames.append(vault.name)
+                logger.error("Refused a vault during zip import: storing it would have overwritten a vault already on this device")
             }
         }
 
-        return (imported, duplicates, skippedNames)
+        return (imported, duplicates, skippedNames, unsafeNames)
     }
 
-    func showImportResults(_ results: (imported: [Vault], duplicates: Int, skippedNames: [String])) {
+    func showImportResults(_ results: ImportResults) {
         let successCount = results.imported.count
         let duplicateCount = results.duplicates
+
+        // A backup refused because storing it would have overwritten a vault on
+        // the device is not "already imported" — it gets its own message rather
+        // than being folded into the duplicate count.
+        if !results.unsafeNames.isEmpty {
+            alertTitle = String(
+                format: NSLocalizedString("zipImportUnsafeVaults", comment: ""),
+                successCount,
+                duplicateCount + results.unsafeNames.count,
+                results.unsafeNames.joined(separator: ", ")
+            )
+            showAlert = true
+            isVaultImported = successCount > 0
+            return
+        }
 
         if successCount > 0 && duplicateCount > 0 {
             // Mixed: some imported, some skipped
@@ -600,21 +648,19 @@ class EncryptedBackupViewModel: ObservableObject {
         do {
             let vsVault = try VSVault(serializedBytes: vaultData)
             let vault = try Vault(proto: vsVault)
-            if !isVaultUnique(backupVault: vault, vaults: vaults) {
-                alertTitle = "vaultAlreadyExists"
-                showAlert = true
-                isVaultImported = false
-                return
-            }
             if isDKLS(filename: self.importedFileName ?? ""), vault.libType != LibType.GG20, vault.libType != LibType.KeyImport {
                 vault.libType = LibType.DKLS
             }
 
-            VaultDefaultCoinService(context: modelContext)
-                .setDefaultCoinsOnce(vault: vault)
-            modelContext.insert(vault)
-            selectedVault = vault
-            isVaultImported = true
+            switch insertIfSafe(vault, existing: vaults, modelContext: modelContext) {
+            case .insert:
+                selectedVault = vault
+                isVaultImported = true
+            case .duplicate:
+                showError("vaultAlreadyExists")
+            case .unsafeCollision:
+                showError("vaultImportWouldOverwriteExisting")
+            }
         } catch {
             logger.error("fail to restore vault: \(error.localizedDescription)")
             alertTitle = "vaultRestoreFailed"
@@ -641,18 +687,16 @@ class EncryptedBackupViewModel: ObservableObject {
             let backupVault = try decoder.decode(BackupVault.self,
                                                  from: vaultData)
             // if version get updated , then we can process the migration here
-            if !isVaultUnique(backupVault: backupVault.vault, vaults: vaults) {
-                alertTitle = "vaultAlreadyExists"
-                showAlert = true
-                isVaultImported = false
-                return
+            switch insertIfSafe(backupVault.vault, existing: vaults, modelContext: modelContext) {
+            case .insert:
+                selectedVault = backupVault.vault
+                showAlert = false
+                isVaultImported = true
+            case .duplicate:
+                showError("vaultAlreadyExists")
+            case .unsafeCollision:
+                showError("vaultImportWouldOverwriteExisting")
             }
-            VaultDefaultCoinService(context: modelContext)
-                .setDefaultCoinsOnce(vault: backupVault.vault)
-            modelContext.insert(backupVault.vault)
-            selectedVault = backupVault.vault
-            showAlert = false
-            isVaultImported = true
         } catch {
             logger.warning("failed to import with new format , fallback to the old format instead. \(error.localizedDescription, privacy: .public)")
 
@@ -660,18 +704,16 @@ class EncryptedBackupViewModel: ObservableObject {
             do {
                 let vault = try decoder.decode(Vault.self, from: vaultData)
 
-                if !isVaultUnique(backupVault: vault, vaults: vaults) {
-                    alertTitle = "vaultAlreadyExists"
-                    showAlert = true
-                    isVaultImported = false
-                    return
+                switch insertIfSafe(vault, existing: vaults, modelContext: modelContext) {
+                case .insert:
+                    selectedVault = vault
+                    showAlert = false
+                    isVaultImported = true
+                case .duplicate:
+                    showError("vaultAlreadyExists")
+                case .unsafeCollision:
+                    showError("vaultImportWouldOverwriteExisting")
                 }
-                VaultDefaultCoinService(context: modelContext)
-                    .setDefaultCoinsOnce(vault: vault)
-                modelContext.insert(vault)
-                selectedVault = vault
-                showAlert = false
-                isVaultImported = true
             } catch {
                 logger.error("fail to restore vault: \(error.localizedDescription)")
                 alertTitle = "vaultRestoreFailed"
@@ -681,15 +723,87 @@ class EncryptedBackupViewModel: ObservableObject {
         }
     }
 
-    func isVaultUnique(backupVault: Vault, vaults: [Vault]) -> Bool {
-        for vault in vaults {
-            if vault.pubKeyECDSA == backupVault.pubKeyECDSA &&
-                vault.pubKeyEdDSA == backupVault.pubKeyEdDSA {
-                return false
-            }
+    // MARK: - Import safety
 
+    /// "Is this the same vault we already have?"
+    ///
+    /// A vault cannot legitimately share a public key with a *different* vault,
+    /// so a match on any single key means the same key material — one shared key
+    /// and one differing key is not a distinct vault, it is a sign something is
+    /// wrong. Empty/absent keys carry no identity and never count as a match;
+    /// whether they are safe to store is the separate question that
+    /// ``importDecision(for:existing:)`` answers.
+    func isVaultUnique(backupVault: Vault, vaults: [Vault]) -> Bool {
+        let ecdsa = backupVault.pubKeyECDSA.nilIfEmpty
+        let eddsa = backupVault.pubKeyEdDSA.nilIfEmpty
+        let mldsa = backupVault.publicKeyMLDSA44?.nilIfEmpty
+
+        for vault in vaults {
+            if let ecdsa, vault.pubKeyECDSA == ecdsa { return false }
+            if let eddsa, vault.pubKeyEdDSA == eddsa { return false }
+            if let mldsa, vault.publicKeyMLDSA44?.nilIfEmpty == mldsa { return false }
         }
         return true
+    }
+
+    /// "Can this vault be stored without overwriting one already on the device?"
+    ///
+    /// A name collision between two genuinely different vaults is resolved, not
+    /// rejected — the name is user-chosen and `Main`/`Savings`/`Test` are exactly
+    /// the names people reuse across devices. Anything still colliding after that
+    /// is refused: `pubKeyECDSA`/`pubKeyEdDSA` default to `""`, and `""` is a
+    /// real value in the unique index, so two key-less backups would upsert each
+    /// other. The final check is deliberately a raw re-derivation over every
+    /// unique attribute rather than a restatement of the duplicate rule, so a
+    /// unique attribute added later cannot quietly slip past this gate.
+    func importDecision(for backupVault: Vault, existing: [Vault]) -> VaultImportDecision {
+        guard isVaultUnique(backupVault: backupVault, vaults: existing) else {
+            return .duplicate
+        }
+
+        let name = availableVaultName(basedOn: backupVault.name, taken: Set(existing.map(\.name)))
+
+        let collides = existing.contains { vault in
+            vault.name == name
+                || vault.pubKeyECDSA == backupVault.pubKeyECDSA
+                || vault.pubKeyEdDSA == backupVault.pubKeyEdDSA
+                || (vault.publicKeyMLDSA44 != nil && vault.publicKeyMLDSA44 == backupVault.publicKeyMLDSA44)
+        }
+        guard !collides else { return .unsafeCollision }
+
+        return .insert(name: name)
+    }
+
+    /// A vault name no stored vault holds, derived from the backup's own name
+    /// (`Savings` → `Savings (2)`) so the user keeps the name they chose rather
+    /// than a generated one. Terminates by pigeonhole: at most `taken.count`
+    /// names are unavailable, and the scan covers `taken.count + 1` candidates.
+    func availableVaultName(basedOn name: String, taken: Set<String>) -> String {
+        guard taken.contains(name) else { return name }
+
+        var suffix = 2
+        var candidate = "\(name) (\(suffix))"
+        while taken.contains(candidate), suffix <= taken.count + 1 {
+            suffix += 1
+            candidate = "\(name) (\(suffix))"
+        }
+        return candidate
+    }
+
+    /// Runs the import gate and stores `vault` when it is safe to store,
+    /// renaming it first if the backup's own name is already taken. Returns the
+    /// decision so the caller can surface the outcome.
+    private func insertIfSafe(_ vault: Vault, existing: [Vault], modelContext: ModelContext) -> VaultImportDecision {
+        let decision = importDecision(for: vault, existing: existing)
+        guard case .insert(let name) = decision else { return decision }
+
+        if vault.name != name {
+            logger.info("Renamed an imported vault to avoid colliding with a stored vault's name")
+            vault.name = name
+        }
+        VaultDefaultCoinService(context: modelContext).setDefaultCoinsOnce(vault: vault)
+        modelContext.insert(vault)
+        return decision
     }
 
     private func isValidFormat(_ url: URL) -> Bool {

--- a/VultisigApp/VultisigAppTests/Utils/ZipImportDuplicateTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ZipImportDuplicateTests.swift
@@ -13,6 +13,7 @@
 
 import XCTest
 import SwiftData
+import VultisigCommonData
 @testable import VultisigApp
 
 @MainActor
@@ -322,6 +323,9 @@ final class ZipImportDuplicateTests: XCTestCase {
         viewModel.multipleVaultsToImport = [incoming]
         viewModel.restoreMultipleVaults(modelContext: context, vaults: [stored])
 
+        // Save so the unique indexes are actually applied by the store, not
+        // just reasoned about in memory.
+        try context.save()
         let all = try context.fetch(FetchDescriptor<Vault>())
         XCTAssertEqual(all.count, 2, "A name-only collision must not replace the stored vault")
         XCTAssertEqual(Set(all.map(\.name)), ["Savings", "Savings (2)"])
@@ -346,6 +350,9 @@ final class ZipImportDuplicateTests: XCTestCase {
         viewModel.multipleVaultsToImport = [incoming]
         viewModel.restoreMultipleVaults(modelContext: context, vaults: [stored])
 
+        // Save so the unique indexes are actually applied by the store, not
+        // just reasoned about in memory.
+        try context.save()
         let all = try context.fetch(FetchDescriptor<Vault>())
         XCTAssertEqual(all.count, 1, "A partial key collision must be skipped, not upserted")
         XCTAssertEqual(all.first?.keyshares.map(\.keyshare), ["stored-share"])
@@ -365,9 +372,77 @@ final class ZipImportDuplicateTests: XCTestCase {
         viewModel.multipleVaultsToImport = [first, second]
         viewModel.restoreMultipleVaults(modelContext: context, vaults: [])
 
+        // Save so the unique indexes are actually applied by the store, not
+        // just reasoned about in memory.
+        try context.save()
         let all = try context.fetch(FetchDescriptor<Vault>())
         XCTAssertEqual(all.count, 2, "Two same-named vaults in one batch must both land")
         XCTAssertEqual(Set(all.map(\.name)), ["Savings", "Savings (2)"])
+    }
+
+    // The three single-vault entry points share `insertIfSafe` with the zip
+    // batch, but each is its own fund-safety call site — an accidental bypass in
+    // any of them would compile and pass a suite that only drove the batch path.
+
+    func testBakRestoreRenamesInsteadOfOverwritingAStoredVault() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let context = token.container.mainContext
+
+        let stored = storeVault(named: "Savings", key: "zzstored", in: context)
+
+        let incoming = makeVault(name: "Savings", ecdsa: "zzincoming-ecdsa", eddsa: "zzincoming-eddsa")
+        let vaultData = try incoming.mapToProtobuff().serializedData()
+
+        viewModel.restoreVaultBack(modelContext: context, vaults: [stored], vaultData: vaultData)
+
+        try context.save()
+        let all = try context.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(Set(all.map(\.name)), ["Savings", "Savings (2)"])
+        XCTAssertEqual(survivingKeyshares(in: all), ["stored-share"])
+        XCTAssertTrue(viewModel.isVaultImported)
+    }
+
+    func testJsonRestoreSkipsAVaultSharingOnlyOnePublicKey() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let context = token.container.mainContext
+
+        let stored = storeVault(named: "Savings", key: "zzstored", in: context)
+
+        let incoming = makeVault(name: "Holidays", ecdsa: "zzstored-ecdsa", eddsa: "zzincoming-eddsa")
+        let backup = BackupVault(version: .v1, vault: incoming)
+        viewModel.decryptedContent = try JSONEncoder().encode(backup).hexString
+
+        viewModel.restoreVault(modelContext: context, vaults: [stored])
+
+        try context.save()
+        let all = try context.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(all.count, 1, "A partial key collision must be skipped, not upserted")
+        XCTAssertEqual(survivingKeyshares(in: all), ["stored-share"])
+        XCTAssertFalse(viewModel.isVaultImported)
+        XCTAssertEqual(viewModel.alertTitle, "vaultAlreadyExists")
+    }
+
+    func testLegacyJsonRestoreRenamesInsteadOfOverwritingAStoredVault() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let context = token.container.mainContext
+
+        let stored = storeVault(named: "Savings", key: "zzstored", in: context)
+
+        // A bare `Vault` payload has no `version` key, so the new-format decode
+        // fails and the legacy fallback branch handles it.
+        let incoming = makeVault(name: "Savings", ecdsa: "zzincoming-ecdsa", eddsa: "zzincoming-eddsa")
+        viewModel.decryptedContent = try JSONEncoder().encode(incoming).hexString
+
+        viewModel.restoreVault(modelContext: context, vaults: [stored])
+
+        try context.save()
+        let all = try context.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(Set(all.map(\.name)), ["Savings", "Savings (2)"])
+        XCTAssertEqual(survivingKeyshares(in: all), ["stored-share"])
+        XCTAssertTrue(viewModel.isVaultImported)
     }
 
     // MARK: - Helpers
@@ -378,6 +453,19 @@ final class ZipImportDuplicateTests: XCTestCase {
         vault.pubKeyEdDSA = eddsa
         vault.publicKeyMLDSA44 = mldsa
         return vault
+    }
+
+    /// A stored vault holding one key share, so a test can assert the share
+    /// survived rather than being upserted away with its owner.
+    private func storeVault(named name: String, key: String, in context: ModelContext) -> Vault {
+        let vault = makeVault(name: name, ecdsa: "\(key)-ecdsa", eddsa: "\(key)-eddsa")
+        vault.keyshares = [KeyShare(pubkey: "\(key)-ecdsa", keyshare: "stored-share")]
+        context.insert(vault)
+        return vault
+    }
+
+    private func survivingKeyshares(in vaults: [Vault]) -> [String] {
+        vaults.flatMap { $0.keyshares.map(\.keyshare) }.filter { $0 == "stored-share" }
     }
 
     /// `VaultDefaultCoinService` only derives default coins for a vault with no

--- a/VultisigApp/VultisigAppTests/Utils/ZipImportDuplicateTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ZipImportDuplicateTests.swift
@@ -2,10 +2,17 @@
 //  ZipImportDuplicateTests.swift
 //  VultisigAppTests
 //
-//  Tests for duplicate vault handling during .zip import (issue #3982)
+//  Duplicate and unique-attribute collision handling during vault import.
+//
+//  `Vault` marks `name`, `pubKeyECDSA`, `pubKeyEdDSA` and `publicKeyMLDSA44`
+//  `@Attribute(.unique)`, and SwiftData turns a colliding insert into an
+//  *upsert* — the incoming vault replaces the stored one and takes its key
+//  shares with it. These tests pin both halves of the gate: "is this a
+//  duplicate?" and "can this be stored without clobbering something?".
 //
 
 import XCTest
+import SwiftData
 @testable import VultisigApp
 
 @MainActor
@@ -42,21 +49,170 @@ final class ZipImportDuplicateTests: XCTestCase {
         XCTAssertFalse(viewModel.isVaultUnique(backupVault: duplicate, vaults: [existing]))
     }
 
-    func testIsVaultUnique_withPartialKeyMatch_returnsTrue() {
+    func testIsVaultUnique_withPartialKeyMatch_returnsFalse() {
         let existing = makeVault(name: "Vault A", ecdsa: "key1", eddsa: "key2")
-        // Same ECDSA but different EdDSA — should be treated as unique
+        // Same ECDSA, different EdDSA. A vault cannot legitimately share one key
+        // with a different vault, and `pubKeyECDSA` is `@Attribute(.unique)` — so
+        // inserting this would upsert the stored vault's key shares away. Treated
+        // as a duplicate and rejected.
         let partial = makeVault(name: "Vault B", ecdsa: "key1", eddsa: "key999")
-        XCTAssertTrue(viewModel.isVaultUnique(backupVault: partial, vaults: [existing]))
+        XCTAssertFalse(viewModel.isVaultUnique(backupVault: partial, vaults: [existing]))
+    }
+
+    func testIsVaultUniqueRejectsEddsaOnlyCollision() {
+        let existing = makeVault(name: "Vault A", ecdsa: "key1", eddsa: "key2")
+        let partial = makeVault(name: "Vault B", ecdsa: "key999", eddsa: "key2")
+        XCTAssertFalse(viewModel.isVaultUnique(backupVault: partial, vaults: [existing]))
+    }
+
+    func testIsVaultUniqueRejectsMldsaOnlyCollision() {
+        let existing = makeVault(name: "Vault A", ecdsa: "key1", eddsa: "key2", mldsa: "quantum1")
+        let partial = makeVault(name: "Vault B", ecdsa: "key3", eddsa: "key4", mldsa: "quantum1")
+        XCTAssertFalse(viewModel.isVaultUnique(backupVault: partial, vaults: [existing]))
+    }
+
+    func testIsVaultUniqueTreatsNilMldsaAsNoIdentity() {
+        // Every non-quantum vault has a nil MLDSA key; that must not make them
+        // all duplicates of each other.
+        let existing = makeVault(name: "Vault A", ecdsa: "key1", eddsa: "key2")
+        let other = makeVault(name: "Vault B", ecdsa: "key3", eddsa: "key4")
+        XCTAssertNil(existing.publicKeyMLDSA44)
+        XCTAssertTrue(viewModel.isVaultUnique(backupVault: other, vaults: [existing]))
+    }
+
+    func testIsVaultUniqueTreatsEmptyPubkeysAsNoIdentity() {
+        // `""` is the default for both keys. It says nothing about identity, so
+        // it is not evidence of duplication — whether it is safe to *store* is a
+        // separate question, answered by `importDecision`.
+        let existing = makeVault(name: "Vault A", ecdsa: "", eddsa: "")
+        let other = makeVault(name: "Vault B", ecdsa: "", eddsa: "")
+        XCTAssertTrue(viewModel.isVaultUnique(backupVault: other, vaults: [existing]))
+    }
+
+    func testIsVaultUniqueTreatsEmptyMldsaAsNoIdentity() {
+        // The JSON backup path decodes `publicKeyMLDSA44` verbatim, so `""` can
+        // reach here where the proto path would have produced `nil`.
+        let existing = makeVault(name: "Vault A", ecdsa: "key1", eddsa: "key2", mldsa: "")
+        let other = makeVault(name: "Vault B", ecdsa: "key3", eddsa: "key4", mldsa: "")
+        XCTAssertTrue(viewModel.isVaultUnique(backupVault: other, vaults: [existing]))
+    }
+
+    // MARK: - importDecision
+
+    func testImportDecisionKeepsTheBackupNameWhenItIsFree() {
+        let existing = makeVault(name: "Savings", ecdsa: "key1", eddsa: "key2")
+        let incoming = makeVault(name: "Holidays", ecdsa: "key3", eddsa: "key4")
+
+        XCTAssertEqual(
+            viewModel.importDecision(for: incoming, existing: [existing]),
+            .insert(name: "Holidays")
+        )
+    }
+
+    func testImportDecisionRenamesOnANameOnlyCollision() {
+        let existing = makeVault(name: "Savings", ecdsa: "key1", eddsa: "key2")
+        let incoming = makeVault(name: "Savings", ecdsa: "key3", eddsa: "key4")
+
+        // Genuinely different key material: admit it under a non-colliding name
+        // rather than let SwiftData replace the stored vault.
+        XCTAssertEqual(
+            viewModel.importDecision(for: incoming, existing: [existing]),
+            .insert(name: "Savings (2)")
+        )
+    }
+
+    func testImportDecisionWalksPastAlreadyTakenSuffixes() {
+        let existing = [
+            makeVault(name: "Savings", ecdsa: "key1", eddsa: "key2"),
+            makeVault(name: "Savings (2)", ecdsa: "key3", eddsa: "key4")
+        ]
+        let incoming = makeVault(name: "Savings", ecdsa: "key5", eddsa: "key6")
+
+        XCTAssertEqual(
+            viewModel.importDecision(for: incoming, existing: existing),
+            .insert(name: "Savings (3)")
+        )
+    }
+
+    func testImportDecisionReportsDuplicateOnBothKeysMatching() {
+        let existing = makeVault(name: "Savings", ecdsa: "key1", eddsa: "key2")
+        let incoming = makeVault(name: "Savings Copy", ecdsa: "key1", eddsa: "key2")
+
+        XCTAssertEqual(viewModel.importDecision(for: incoming, existing: [existing]), .duplicate)
+    }
+
+    func testImportDecisionReportsDuplicateOnEcdsaOnlyMatch() {
+        let existing = makeVault(name: "Savings", ecdsa: "key1", eddsa: "key2")
+        let incoming = makeVault(name: "Holidays", ecdsa: "key1", eddsa: "key999")
+
+        XCTAssertEqual(viewModel.importDecision(for: incoming, existing: [existing]), .duplicate)
+    }
+
+    func testImportDecisionReportsDuplicateOnEddsaOnlyMatch() {
+        let existing = makeVault(name: "Savings", ecdsa: "key1", eddsa: "key2")
+        let incoming = makeVault(name: "Holidays", ecdsa: "key999", eddsa: "key2")
+
+        XCTAssertEqual(viewModel.importDecision(for: incoming, existing: [existing]), .duplicate)
+    }
+
+    func testImportDecisionReportsDuplicateOnMldsaOnlyMatch() {
+        let existing = makeVault(name: "Savings", ecdsa: "key1", eddsa: "key2", mldsa: "quantum1")
+        let incoming = makeVault(name: "Holidays", ecdsa: "key3", eddsa: "key4", mldsa: "quantum1")
+
+        XCTAssertEqual(viewModel.importDecision(for: incoming, existing: [existing]), .duplicate)
+    }
+
+    func testImportDecisionRefusesAnEmptyPubkeyCollision() {
+        // Two key-less backups are not recognisably the same vault, but `""` is a
+        // real value in the unique index, so storing the second would upsert the
+        // first. Refuse rather than overwrite.
+        let existing = makeVault(name: "Broken A", ecdsa: "", eddsa: "")
+        let incoming = makeVault(name: "Broken B", ecdsa: "", eddsa: "")
+
+        XCTAssertEqual(viewModel.importDecision(for: incoming, existing: [existing]), .unsafeCollision)
+    }
+
+    func testImportDecisionRefusesAnEmptyEddsaCollisionAlone() {
+        let existing = makeVault(name: "Vault A", ecdsa: "key1", eddsa: "")
+        let incoming = makeVault(name: "Vault B", ecdsa: "key2", eddsa: "")
+
+        XCTAssertEqual(viewModel.importDecision(for: incoming, existing: [existing]), .unsafeCollision)
+    }
+
+    func testImportDecisionAdmitsAnEmptyPubkeyVaultWhenNothingCollides() {
+        let existing = makeVault(name: "Savings", ecdsa: "key1", eddsa: "key2")
+        let incoming = makeVault(name: "Broken", ecdsa: "", eddsa: "")
+
+        XCTAssertEqual(
+            viewModel.importDecision(for: incoming, existing: [existing]),
+            .insert(name: "Broken")
+        )
+    }
+
+    // MARK: - availableVaultName
+
+    func testAvailableVaultNameReturnsTheNameWhenFree() {
+        XCTAssertEqual(viewModel.availableVaultName(basedOn: "Savings", taken: ["Holidays"]), "Savings")
+    }
+
+    func testAvailableVaultNameTerminatesOnALongCollisionChain() {
+        var taken: Set<String> = ["Savings"]
+        for suffix in 2...50 {
+            taken.insert("Savings (\(suffix))")
+        }
+
+        XCTAssertEqual(viewModel.availableVaultName(basedOn: "Savings", taken: taken), "Savings (51)")
     }
 
     // MARK: - showImportResults
 
     func testShowImportResults_allNew_setsImportedSuccessfully() {
         let vault = makeVault(name: "Vault A", ecdsa: "k1", eddsa: "k2")
-        let results: (imported: [Vault], duplicates: Int, skippedNames: [String]) = (
+        let results: EncryptedBackupViewModel.ImportResults = (
             imported: [vault],
             duplicates: 0,
-            skippedNames: []
+            skippedNames: [],
+            unsafeNames: []
         )
 
         viewModel.showImportResults(results)
@@ -69,10 +225,11 @@ final class ZipImportDuplicateTests: XCTestCase {
     func testShowImportResults_multipleAllNew_setsVaultsImportedSuccessfully() {
         let v1 = makeVault(name: "V1", ecdsa: "k1", eddsa: "k2")
         let v2 = makeVault(name: "V2", ecdsa: "k3", eddsa: "k4")
-        let results: (imported: [Vault], duplicates: Int, skippedNames: [String]) = (
+        let results: EncryptedBackupViewModel.ImportResults = (
             imported: [v1, v2],
             duplicates: 0,
-            skippedNames: []
+            skippedNames: [],
+            unsafeNames: []
         )
 
         viewModel.showImportResults(results)
@@ -84,10 +241,11 @@ final class ZipImportDuplicateTests: XCTestCase {
 
     func testShowImportResults_mixed_showsPartialSuccess() {
         let imported = makeVault(name: "New Vault", ecdsa: "k1", eddsa: "k2")
-        let results: (imported: [Vault], duplicates: Int, skippedNames: [String]) = (
+        let results: EncryptedBackupViewModel.ImportResults = (
             imported: [imported],
             duplicates: 1,
-            skippedNames: ["Old Vault"]
+            skippedNames: ["Old Vault"],
+            unsafeNames: []
         )
 
         viewModel.showImportResults(results)
@@ -98,10 +256,11 @@ final class ZipImportDuplicateTests: XCTestCase {
     }
 
     func testShowImportResults_allDuplicates_showsInfoNotError() {
-        let results: (imported: [Vault], duplicates: Int, skippedNames: [String]) = (
+        let results: EncryptedBackupViewModel.ImportResults = (
             imported: [],
             duplicates: 2,
-            skippedNames: ["Vault A", "Vault B"]
+            skippedNames: ["Vault A", "Vault B"],
+            unsafeNames: []
         )
 
         viewModel.showImportResults(results)
@@ -113,10 +272,11 @@ final class ZipImportDuplicateTests: XCTestCase {
     }
 
     func testShowImportResults_noneImportedNoDuplicates_showsRestoreFailed() {
-        let results: (imported: [Vault], duplicates: Int, skippedNames: [String]) = (
+        let results: EncryptedBackupViewModel.ImportResults = (
             imported: [],
             duplicates: 0,
-            skippedNames: []
+            skippedNames: [],
+            unsafeNames: []
         )
 
         viewModel.showImportResults(results)
@@ -126,12 +286,110 @@ final class ZipImportDuplicateTests: XCTestCase {
         XCTAssertEqual(viewModel.alertTitle, "vaultRestoreFailed")
     }
 
+    func testShowImportResultsNamesTheVaultsItRefusedToStore() {
+        let results: EncryptedBackupViewModel.ImportResults = (
+            imported: [],
+            duplicates: 0,
+            skippedNames: [],
+            unsafeNames: ["Broken Vault"]
+        )
+
+        viewModel.showImportResults(results)
+
+        XCTAssertFalse(viewModel.isVaultImported)
+        XCTAssertTrue(viewModel.showAlert)
+        XCTAssertTrue(
+            viewModel.alertTitle.contains("Broken Vault"),
+            "A refused vault must be named, not folded into the duplicate count"
+        )
+    }
+
+    // MARK: - End-to-end against a real store
+
+    func testZipImportRenamesInsteadOfOverwritingAStoredVault() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let context = token.container.mainContext
+
+        let stored = makeVault(name: "Savings", ecdsa: "zzstored-ecdsa", eddsa: "zzstored-eddsa")
+        stored.keyshares = [KeyShare(pubkey: "zzstored-ecdsa", keyshare: "stored-share")]
+        context.insert(stored)
+
+        let incoming = makeVault(name: "Savings", ecdsa: "zzincoming-ecdsa", eddsa: "zzincoming-eddsa")
+        incoming.keyshares = [KeyShare(pubkey: "zzincoming-ecdsa", keyshare: "incoming-share")]
+        givePlaceholderCoin(to: incoming)
+
+        viewModel.multipleVaultsToImport = [incoming]
+        viewModel.restoreMultipleVaults(modelContext: context, vaults: [stored])
+
+        let all = try context.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(all.count, 2, "A name-only collision must not replace the stored vault")
+        XCTAssertEqual(Set(all.map(\.name)), ["Savings", "Savings (2)"])
+
+        let survivor = try XCTUnwrap(all.first { $0.pubKeyECDSA == "zzstored-ecdsa" })
+        XCTAssertEqual(survivor.keyshares.map(\.keyshare), ["stored-share"], "The stored vault's key shares must survive")
+        XCTAssertTrue(viewModel.isVaultImported)
+    }
+
+    func testZipImportSkipsAVaultThatSharesOnlyOnePublicKey() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let context = token.container.mainContext
+
+        let stored = makeVault(name: "Savings", ecdsa: "zzshared-ecdsa", eddsa: "zzstored-eddsa")
+        stored.keyshares = [KeyShare(pubkey: "zzshared-ecdsa", keyshare: "stored-share")]
+        context.insert(stored)
+
+        let incoming = makeVault(name: "Holidays", ecdsa: "zzshared-ecdsa", eddsa: "zzincoming-eddsa")
+        givePlaceholderCoin(to: incoming)
+
+        viewModel.multipleVaultsToImport = [incoming]
+        viewModel.restoreMultipleVaults(modelContext: context, vaults: [stored])
+
+        let all = try context.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(all.count, 1, "A partial key collision must be skipped, not upserted")
+        XCTAssertEqual(all.first?.keyshares.map(\.keyshare), ["stored-share"])
+        XCTAssertFalse(viewModel.isVaultImported)
+    }
+
+    func testZipImportDisambiguatesTwoIncomingVaultsSharingAName() throws {
+        let token = try TestStore.installInMemoryContainer()
+        defer { TestStore.restore(token) }
+        let context = token.container.mainContext
+
+        let first = makeVault(name: "Savings", ecdsa: "zzfirst-ecdsa", eddsa: "zzfirst-eddsa")
+        let second = makeVault(name: "Savings", ecdsa: "zzsecond-ecdsa", eddsa: "zzsecond-eddsa")
+        givePlaceholderCoin(to: first)
+        givePlaceholderCoin(to: second)
+
+        viewModel.multipleVaultsToImport = [first, second]
+        viewModel.restoreMultipleVaults(modelContext: context, vaults: [])
+
+        let all = try context.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(all.count, 2, "Two same-named vaults in one batch must both land")
+        XCTAssertEqual(Set(all.map(\.name)), ["Savings", "Savings (2)"])
+    }
+
     // MARK: - Helpers
 
-    private func makeVault(name: String, ecdsa: String, eddsa: String) -> Vault {
+    private func makeVault(name: String, ecdsa: String, eddsa: String, mldsa: String? = nil) -> Vault {
         let vault = Vault(name: name)
         vault.pubKeyECDSA = ecdsa
         vault.pubKeyEdDSA = eddsa
+        vault.publicKeyMLDSA44 = mldsa
         return vault
+    }
+
+    /// `VaultDefaultCoinService` only derives default coins for a vault with no
+    /// coins, and that derivation reaches for the network. A placeholder coin
+    /// keeps these tests to the code under test.
+    private func givePlaceholderCoin(to vault: Vault) {
+        vault.coins = [
+            Coin(
+                asset: .make(chain: .bitcoin, ticker: "BTC"),
+                address: "placeholder-\(vault.pubKeyECDSA)",
+                hexPublicKey: vault.pubKeyECDSA
+            )
+        ]
     }
 }


### PR DESCRIPTION
> [!WARNING]
> **Fund-safety change — needs human + on-device review.** This touches the vault import path, where the failure mode is *permanent, silent loss of a vault's key shares*. The unit tests exercise the decision function; the premise (SwiftData upsert-on-unique-collision) deserves a real device/simulator import run before merge.

## Problem

Importing a vault could **silently replace a different, unrelated vault** already on the device and destroy its key shares. The user saw a successful import and no error.

## Root cause

`Vault` marks **four** fields `@Attribute(.unique)` — `name`, `pubKeyECDSA`, `pubKeyEdDSA` and `publicKeyMLDSA44` (`VultisigApp/VultisigApp/Model/Vault.swift:12-15`; the issue says three, `publicKeyMLDSA44` landed later).

`EncryptedBackupViewModel.isVaultUnique` rejected an incoming backup only when **both** pubkeys matched:

```swift
if vault.pubKeyECDSA == backupVault.pubKeyECDSA &&
    vault.pubKeyEdDSA == backupVault.pubKeyEdDSA { return false }
```

So a backup colliding on **one** pubkey — or on **nothing but the name** — passed the guard and reached `modelContext.insert`. SwiftData treats a unique-attribute collision as an **upsert**: the incoming vault replaces the stored row, and the stored vault's key shares go with it. Nothing throws, nothing is logged, the import reports success.

Four call sites fed that guard and then inserted, all in `EncryptedBackupViewModel.swift`: `importVaults` (zip batch), `restoreVaultBack` (`.bak`), and both branches of `restoreVault` (new `BackupVault` format + legacy `Vault` JSON fallback).

## Fix

The guard was answering two questions with one predicate. They are now separate:

**"Is this a duplicate?"** — `isVaultUnique(backupVault:vaults:)`. Any **single** shared public key (`pubKeyECDSA`, `pubKeyEdDSA` *or* `publicKeyMLDSA44`) means the same key material, so any one match rejects. A vault cannot legitimately share one key with a *different* vault — @johnnyluo confirmed on the issue that both pubkeys "should be unique and have no collision at all", so a partial collision means something is wrong, and inserting it would upsert key shares away. Empty/`nil` keys carry no identity and never count as a match.

**"Can this be stored without clobbering something?"** — `importDecision(for:existing:)`, returning:

| | |
|---|---|
| `.duplicate` | same key material — skip, `vaultAlreadyExists` |
| `.insert(name:)` | safe; `name` is the backup's own name, disambiguated (`Savings` → `Savings (2)`) when a stored vault holds it |
| `.unsafeCollision` | still collides on a unique attribute after the name was resolved — refuse rather than upsert |

- **Name collisions are resolved, not rejected.** `availableVaultName(basedOn:taken:)` derives from the incoming vault's own name rather than reusing `Vault.getUniqueVaultName`, which generates `Vault #N` from scratch and would throw away the user's chosen name. It checks the stored vaults *and* everything already renamed earlier in the same zip batch, and terminates by pigeonhole (at most `taken.count` names are unavailable; the scan covers `taken.count + 1` candidates), so there is no arbitrary cap and no unbounded loop.
- **Empty pubkeys.** `pubKeyECDSA`/`pubKeyEdDSA` default to `""`, and `""` is a real value in a SQLite unique index (unlike `NULL`), so two key-less backups would upsert each other. They are *not* treated as duplicates — `""` says nothing about identity — but the final gate refuses them with a clear error rather than letting the insert through. `publicKeyMLDSA44` is normalized with `nilIfEmpty` on both sides, because the proto path already does that (`Vault+ProtoMappable.swift:37`) while the JSON path decodes `""` verbatim.
- The `.unsafeCollision` check deliberately **restates the raw index semantics** — one clause per `@Attribute(.unique)` field — rather than reusing the duplicate rule, whose empty/`nil` tolerance is exactly what would let a key-less backup through. It is the single place to extend if a fifth unique attribute is ever added.
- All four import paths now go through one `insertIfSafe(_:existing:modelContext:)` helper, so there is a single place where a vault becomes stored.

No schema change: `Model/` is untouched.

## Deliberate test-expectation inversion

`ZipImportDuplicateTests.testIsVaultUnique_withPartialKeyMatch_returnsTrue` pinned the same-ECDSA / different-EdDSA case as **acceptable** — i.e. the suite endorsed one of the dangerous paths. It is now `..._returnsFalse`, with a comment explaining why. **This is an intentional behaviour change**: a backup sharing one pubkey with a stored vault is now refused where it previously imported (and destroyed the stored vault).

## `context.insert` audit (the issue asks for it)

Every `@Model` with `@Attribute(.unique)` was checked against every insert site. **No other production insert path is in the same silent-key-material-loss class**, so nothing outside the import path was changed.

<details>
<summary>Full audit — 14 models with unique attributes</summary>

| Model | unique attr(s) | insert sites | verdict |
|---|---|---|---|
| `Vault` | `name`, `pubKeyECDSA`, `pubKeyEdDSA`, `publicKeyMLDSA44` | `EncryptedBackupViewModel` ×4 | **fixed here** |
| `Vault` | ” | `KeygenViewModel.swift:214, 486, 828, 901` | guarded — all behind `confirmDuplicateVaultIfNeeded` + user confirmation; the upsert is *intended* for the reshare/replace case |
| `Vault` | ” | `Core/Extensions/VaultExtension.swift:14-15` | preview/test fixture only (both fixtures share `pubKeyECDSA`, so the "two sample vaults" preview only ever shows one) |
| `CustomRPCOverride` | `chainRaw` | `CustomRPCStore.swift:68, 145` | guarded (fetch-then-update; migration checks membership) |
| `StoredPendingTransaction` | `txHash` | `PendingTransactionStorage.swift:84` | guarded (predicate fetch, update branch) |
| `DatabaseRate` | `id` (`fiat-crypto`) | `RateProvider.swift:185` | guarded (update-else-insert) |
| `CirclePosition` | `id` (`circle_<pubKeyECDSA>`) | `CirclePositionStorageService.swift:22` | guarded; regenerable cache |
| `YieldPosition` | `id` (`<provider>_<pubKeyECDSA>`) | `YieldPositionStorageService.swift:39, 61` | guarded; regenerable cache |
| `YieldRedemptionRecord` | `id` | via relationship, `YieldPositionStorageService.swift:74` | delete-then-replace; unreachable today (Circle emits no redemptions) |
| `LimitOrder` | `id` (`<txHash>_<pubKeyECDSA>`) | `LimitOrderStorageService.swift:64` | guarded (throws `.duplicate`; rejects empty `inboundTxHash`) |
| `StakePosition` | `id` | `DefiPositionsStorageService.swift:114, 161, 181` | guarded |
| `LPPosition` | `id` | `DefiPositionsStorageService.swift:42, 208` | guarded |
| `BondPosition` | `id` | `DefiPositionsStorageService.swift:77` | guarded |
| `ReferralCode` / `ReferredCode` | `id` | `ReferralViewModel.swift:125`, `ReferredViewModel.swift:114` | random `UUID()` keys |
| `ChainPublicKey` | `id` (`<chain>-<publicKeyHex>`) | relationship-driven only | see note below |

Three things worth a maintainer's eye, all filed as observations rather than changed here:

1. **`confirmDuplicateVaultIfNeeded` checks only `pubKeyECDSA`, never `name`** (`KeygenViewModel.swift:178-194`) — yet `name` is unique too. A name collision at any of the four keygen inserts would upsert a *different* vault away. Today that is only prevented at a distance, by `VaultNameValidator` on the initiating device and `isVaultNameAlreadyExist` on the joining device; nothing enforces it at the insert.
2. **`ChainPublicKey.id` is `"<chain.name>-<publicKeyHex>"` with no vault component.** Two vaults derived from the same seed (the same mnemonic key-imported twice, or an import alongside the original) produce identical ids, so the second vault's relationship-driven insert *steals* the row from the first. Not key material — a derived public key, regenerable — but it silently mutates the older vault's `chainPublicKeys`, which `VaultDefaultCoinService` reads to pick derived-vs-root pubkeys.
3. **`YieldRedemptionRecord.id` is provider-supplied and vault-agnostic** — harmless today, but the next windowed yield provider should namespace it by `pubKeyECDSA` the way `YieldPosition.makeID` does.

</details>

## Tests

`VultisigApp/VultisigAppTests/Utils/ZipImportDuplicateTests.swift`, one case per collision shape:

- duplicate detection: name-only, ECDSA-only, EdDSA-only, MLDSA-only, both-pubkeys, empty-pubkeys, empty-MLDSA, nil-MLDSA
- `importDecision`: keeps a free name, renames on a name-only collision, walks past already-taken suffixes, refuses an empty-pubkey collision, admits an empty-pubkey vault when nothing collides
- `availableVaultName` bound over a 50-long collision chain
- three end-to-end cases against a real in-memory `ModelContainer` proving the stored vault and its key shares **survive**: a name-only collision renames, a partial-pubkey collision is skipped, and two same-named vaults in one zip both land

## Localization

Two new keys — `vaultImportWouldOverwriteExisting`, `zipImportUnsafeVaults` — added to all **8** shipping locales (`en de es hr it ko pt zh-Hans`), sorted with `VultisigApp/scripts/sort_localizable.py`.

## Verification

- SwiftLint: no new warnings (22 pre-existing, none in the touched files).
- Build: `xcodebuild build -destination 'generic/platform=iOS Simulator'` — marker: `** BUILD SUCCEEDED **`
- Tests: full suite on a dedicated iPhone 17 Pro Max simulator — marker: `** TEST SUCCEEDED **`, **4893 tests, 1 skipped, 0 failures**

Closes #5066


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved vault backup imports by preventing unsafe overwrites and key collisions.
  * Automatically renames safe imports when vault names conflict.
  * Reports imported, duplicate, skipped, and unsafe vaults during multi-vault imports.
  * Applies the same safety checks to individual vault restores.
* **Localization**
  * Added translated import-safety messages in English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->