### PR TITLE
fix(swap): inset the advanced-swap settings card from the sheet's bottom edge

### DIFF
--- a/VultisigApp/VultisigApp/Features/Swap/Views/AdvancedSwapSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/AdvancedSwapSheet.swift
@@ -85,13 +85,62 @@ struct AdvancedSwapSheet: View {
         }
     }
 
-    /// Main-sheet height grows with the optional rows it renders: the Gas Limit
-    /// row (EVM only) and the Select route row (provider selection available).
     private var mainDetentHeight: CGFloat {
-        var height: CGFloat = 260
-        if isGasLimitSupported { height += 70 }
-        if vm.canSelectProvider { height += 70 }
-        return height
+        Self.mainDetentHeight(
+            isGasLimitSupported: isGasLimitSupported,
+            canSelectProvider: vm.canSelectProvider,
+            isSecuredMint: vm.isSecuredMint
+        )
+    }
+
+    /// Fixed heights the main state is built from. The detent sizes the content
+    /// area — the system adds the bottom safe area on top of it — so everything
+    /// the card needs has to be accounted for here, the inset below it included:
+    /// content is top-aligned, so anything that doesn't fit is clipped by the
+    /// sheet edge rather than compressed.
+    enum MainLayout {
+        /// The header, plus headroom. The header itself measures 76pt; the rest
+        /// absorbs a row wrapping onto a second line, which a long title does in
+        /// several locales (and in English once the External Recipient row shows
+        /// an address). Unused headroom only ever becomes extra space below the
+        /// card, so it's cheaper than clipping the card when a row grows.
+        static let chrome: CGFloat = 120
+        /// One `AdvancedSwapMainRow` — 68pt on one line — plus its 1pt separator.
+        static let rowHeight: CGFloat = 70
+        /// Gap below the card, mirroring its horizontal inset so the card reads
+        /// as inset on all four sides instead of clipped by the sheet edge.
+        static let cardInset: CGFloat = 16
+    }
+
+    /// Rows the card renders. Mirrors the conditions in `mainView` and has to
+    /// stay in step with them: Slippage is always shown, Gas Limit is EVM-only,
+    /// Select route needs more than one quote to pick from, and a secured mint
+    /// drops External Recipient.
+    static func mainRowCount(
+        isGasLimitSupported: Bool,
+        canSelectProvider: Bool,
+        isSecuredMint: Bool
+    ) -> Int {
+        var rows = 1
+        if isGasLimitSupported { rows += 1 }
+        if canSelectProvider { rows += 1 }
+        if !isSecuredMint { rows += 1 }
+        return rows
+    }
+
+    /// Main-sheet height: fixed chrome, one row per row the card actually
+    /// renders, and the inset that keeps the card off the sheet's bottom edge.
+    static func mainDetentHeight(
+        isGasLimitSupported: Bool,
+        canSelectProvider: Bool,
+        isSecuredMint: Bool
+    ) -> CGFloat {
+        let rows = mainRowCount(
+            isGasLimitSupported: isGasLimitSupported,
+            canSelectProvider: canSelectProvider,
+            isSecuredMint: isSecuredMint
+        )
+        return MainLayout.chrome + CGFloat(rows) * MainLayout.rowHeight + MainLayout.cardInset
     }
 
     private var mainView: some View {
@@ -152,6 +201,7 @@ struct AdvancedSwapSheet: View {
                     .stroke(Theme.colors.borderLight, lineWidth: 1)
             )
             .padding(.horizontal, 16)
+            .padding(.bottom, MainLayout.cardInset)
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Views/AdvancedSwapSheet.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/AdvancedSwapSheet.swift
@@ -107,8 +107,9 @@ struct AdvancedSwapSheet: View {
         static let chrome: CGFloat = 120
         /// One `AdvancedSwapMainRow` — 68pt on one line — plus its 1pt separator.
         static let rowHeight: CGFloat = 70
-        /// Gap below the card, mirroring its horizontal inset so the card reads
-        /// as inset on all four sides instead of clipped by the sheet edge.
+        /// The card's inset from the sheet's edges — the same value on the sides
+        /// and below, so the card reads as inset rather than clipped by the
+        /// sheet edge.
         static let cardInset: CGFloat = 16
     }
 
@@ -200,7 +201,7 @@ struct AdvancedSwapSheet: View {
                 Theme.radius.xl.shape
                     .stroke(Theme.colors.borderLight, lineWidth: 1)
             )
-            .padding(.horizontal, 16)
+            .padding(.horizontal, MainLayout.cardInset)
             .padding(.bottom, MainLayout.cardInset)
         }
     }

--- a/VultisigApp/VultisigAppTests/Swap/AdvancedSwapSheetLayoutTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/AdvancedSwapSheetLayoutTests.swift
@@ -1,0 +1,151 @@
+//
+//  AdvancedSwapSheetLayoutTests.swift
+//  VultisigAppTests
+//
+//  The Advanced Swap sheet's main state is presented at a FIXED detent height,
+//  and its content is top-aligned, so nothing about it is self-sizing: every row
+//  the card can render, and the inset that keeps the card off the sheet's bottom
+//  edge, has to be accounted for in `mainDetentHeight` or the card is either
+//  clipped by the sheet edge or left floating in dead space.
+//
+//  These tests pin that arithmetic for every reachable row combination, and
+//  measure the real header / row views to prove the detent still has room for
+//  the card and its inset once a row wraps.
+//
+
+import SwiftUI
+import UIKit
+import XCTest
+
+@testable import VultisigApp
+
+@MainActor
+final class AdvancedSwapSheetLayoutTests: XCTestCase {
+
+    /// A 375pt-wide phone — the narrowest the app runs on, and so the worst case
+    /// for intrinsic height, since a narrow row is what makes a title wrap onto
+    /// a second line. The card is inset 16pt on each side.
+    private let sheetWidth: CGFloat = 375
+    private var cardWidth: CGFloat { sheetWidth - 32 }
+
+    /// Every reachable row combination, as
+    /// `(isGasLimitSupported, canSelectProvider, isSecuredMint)` with the rows
+    /// the card renders and the detent height that has to hold them. A secured
+    /// mint never has a Gas Limit row — `isGasLimitSupported` is
+    /// `EVM && !isSecuredMint` — so those two are never both true.
+    private static let combinations: [(gasLimit: Bool, provider: Bool, securedMint: Bool, rows: Int, height: CGFloat)] = [
+        // Non-EVM: Slippage + External Recipient.
+        (false, false, false, 2, 276),
+        // Non-EVM with a route to pick: + Select route.
+        (false, true, false, 3, 346),
+        // EVM: + Gas Limit.
+        (true, false, false, 3, 346),
+        // EVM with a route to pick: every row.
+        (true, true, false, 4, 416),
+        // Secured mint: Slippage only.
+        (false, false, true, 1, 206),
+        // Secured mint with a route to pick: + Select route.
+        (false, true, true, 2, 276)
+    ]
+
+    // MARK: - Row count mirrors the rendered rows
+
+    func testMainRowCountMatchesTheRenderedRowCombinations() {
+        for combination in Self.combinations {
+            let rows = AdvancedSwapSheet.mainRowCount(
+                isGasLimitSupported: combination.gasLimit,
+                canSelectProvider: combination.provider,
+                isSecuredMint: combination.securedMint
+            )
+            XCTAssertEqual(rows, combination.rows, "\(combination)")
+        }
+    }
+
+    // MARK: - Detent height
+
+    /// Only the row count moves between combinations: the chrome and the inset
+    /// below the card are the same everywhere, so the card is inset from the
+    /// sheet's bottom edge by the same amount whichever rows it renders.
+    func testMainDetentHeightGrowsOnlyByTheRowsItRenders() {
+        for combination in Self.combinations {
+            let height = AdvancedSwapSheet.mainDetentHeight(
+                isGasLimitSupported: combination.gasLimit,
+                canSelectProvider: combination.provider,
+                isSecuredMint: combination.securedMint
+            )
+            XCTAssertEqual(height, combination.height, accuracy: 0.01, "\(combination)")
+        }
+    }
+
+    /// The gap under the card mirrors the card's own horizontal inset.
+    func testCardInsetMirrorsTheHorizontalInset() {
+        XCTAssertEqual(AdvancedSwapSheet.MainLayout.cardInset, 16)
+    }
+
+    // MARK: - Measured content fits the detent
+
+    /// The header and the rows are measured as SwiftUI actually lays them out,
+    /// so a padding / font change that grows either one fails here instead of
+    /// silently pushing the card back under the sheet edge.
+    ///
+    /// The worst case isn't the tidy one-line row: an External Recipient row
+    /// showing a truncated address wraps its title onto a second line (already
+    /// true in English on a 375pt phone, and in more locales besides). The
+    /// detent has to leave room for the card AND its bottom inset with one of
+    /// the rows in that state.
+    func testDetentLeavesRoomForTheCardAndItsInsetEvenWhenARowWraps() {
+        let headerHeight = measuredHeight(
+            of: AdvancedSwapSheetHeader(title: "advancedSwap".localized) {},
+            width: sheetWidth
+        )
+        let rowHeight = measuredHeight(
+            of: AdvancedSwapMainRow(icon: .bolt, title: "slippageTolerance".localized, value: "auto".localized) {},
+            width: cardWidth
+        )
+        let wrappedRowHeight = measuredHeight(
+            of: AdvancedSwapMainRow(
+                icon: .clone2,
+                title: "useExternalRecipient".localized,
+                value: "0x1234…abcd"
+            ) {},
+            width: cardWidth
+        )
+
+        XCTAssertLessThanOrEqual(
+            rowHeight,
+            AdvancedSwapSheet.MainLayout.rowHeight,
+            "A one-line row no longer fits its per-row allowance (measured \(rowHeight)pt)"
+        )
+
+        for combination in Self.combinations {
+            // Header + the card (rows separated by 1pt hairlines, one of them
+            // wrapped) + the inset below the card. The detent sizes the content
+            // area, so this has to fit inside it or the card is clipped.
+            let separators = CGFloat(combination.rows - 1)
+            let content = headerHeight
+                + CGFloat(combination.rows - 1) * rowHeight
+                + wrappedRowHeight
+                + separators
+                + AdvancedSwapSheet.MainLayout.cardInset
+
+            XCTAssertLessThanOrEqual(
+                content,
+                combination.height,
+                """
+                Content (\(content)pt, one row wrapped) overflows the \(combination.height)pt \
+                detent for \(combination) — the card would be clipped by the sheet edge.
+                """
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func measuredHeight(of view: some View, width: CGFloat) -> CGFloat {
+        let controller = UIHostingController(rootView: view.frame(width: width))
+        controller.view.backgroundColor = .clear
+        return controller.sizeThatFits(
+            in: CGSize(width: width, height: .greatestFiniteMagnitude)
+        ).height
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/AdvancedSwapSheetLayoutTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/AdvancedSwapSheetLayoutTests.swift
@@ -77,11 +77,6 @@ final class AdvancedSwapSheetLayoutTests: XCTestCase {
         }
     }
 
-    /// The gap under the card mirrors the card's own horizontal inset.
-    func testCardInsetMirrorsTheHorizontalInset() {
-        XCTAssertEqual(AdvancedSwapSheet.MainLayout.cardInset, 16)
-    }
-
     // MARK: - Measured content fits the detent
 
     /// The header and the rows are measured as SwiftUI actually lays them out,
@@ -115,6 +110,14 @@ final class AdvancedSwapSheetLayoutTests: XCTestCase {
             rowHeight,
             AdvancedSwapSheet.MainLayout.rowHeight,
             "A one-line row no longer fits its per-row allowance (measured \(rowHeight)pt)"
+        )
+        // Guards the premise: if the External Recipient row stops wrapping at
+        // this width, the loop below is no longer testing the worst case and
+        // this test's name is a lie.
+        XCTAssertGreaterThan(
+            wrappedRowHeight,
+            rowHeight,
+            "The External Recipient row is expected to wrap at \(cardWidth)pt (measured \(wrappedRowHeight)pt)"
         )
 
         for combination in Self.combinations {


### PR DESCRIPTION
## Problem

The rounded settings card in the Advanced Swap sheet was inset 16pt on the sides and nothing at the bottom, so its bottom border ran straight into the sheet edge and the card read as clipped rather than as a card.

## Root cause

Two separate things, one per presentation style:

- **The card had no bottom inset.** `mainView` applied `.padding(.horizontal, 16)` and nothing below. macOS presents this sheet **sized to its content** (`CrossPlatformSheet`, no detents) — which is the presentation in the issue screenshot — so a missing inset shows up directly as a flush edge.
- **The iOS detent is fixed and had to make room for it.** `mainDetentHeight` sizes the sheet's content area and the content is top-aligned, so an inset the height doesn't budget for is clipped by the sheet edge rather than opening a gap. The base is bumped by the same 16pt.

While in that arithmetic: it counted the Gas Limit and Select route rows but not the **External Recipient** row, which a secured mint hides — so the secured-mint sheet was one full row (70pt) taller than the rows it rendered. The height is now derived from the rows the card actually draws, which is also what makes the inset below the card identical in every combination.

## Fix

- `.padding(.bottom, MainLayout.cardInset)` on the card, with the horizontal inset reading the same constant so the two can't drift. **16pt, not 24** — the acceptance criterion is that the gap equals the *side* inset, and the side inset is 16.
- `mainDetentHeight` / `mainRowCount` are now `static` functions of `(isGasLimitSupported, canSelectProvider, isSecuredMint)`: `chrome + rows × rowHeight + cardInset`. Same shape as before, one row per row rendered, secured mint included.
- New `AdvancedSwapSheetLayoutTests` pins the height for every reachable row combination and measures the real header/row views to prove the detent still has room for the card *and* its inset.

Heights: 1 row 206 · 2 rows 276 · 3 rows 346 · 4 rows 416 (was 260 / 260 / 330 / 400, with secured mint mis-sized).

### Why the row and chrome allowances were not tightened

Measured on an iOS 26.5 simulator: header 76pt, one-line row 68pt, separator 1pt. That makes the fixed detent look 30–45pt too generous — but rows are not fixed-height. Measured at a 343pt card width (iPhone SE):

| row | value | height |
|---|---|---|
| Use External Recipient | `Off` | 68 |
| Use External Recipient | `0x1234…abcd` | 81.67 (2 lines) |
| Externen Empfänger verwenden | `0x1234…abcd` | 98.67 (3 lines) |

The spare allowance is what keeps a wrapped row from clipping the card, so it stays. The test asserts the fit with one row wrapped, not with every row on one line.

## Verification

**Rendered.** The sheet needs a live vault + quote to reach in the app, so it was driven directly instead — both presentations, on an iOS 26.5 simulator:

- **Content-sized (macOS-equivalent, the platform in the issue screenshot):** before/after captured via `ImageRenderer` at the sheet's ideal height. Before reproduces the screenshot exactly — the card's bottom corners cut off by the sheet's rounded edge. After shows a 16pt gap matching the side inset.
- **iOS detent:** the real sheet was presented in a `UIWindow` on the simulator and its geometry read back — sheet view height `310` = detent `276` + `safeAreaInsets.bottom` `34`, confirming the detent value sizes the *content* area and the system adds the home-indicator strip below it. So the gap is measured above the safe-area inset and can't collapse into the home indicator. Window screenshot captured.

**Reasoned, not rendered.** The 3- and 4-row combinations and the secured-mint case were verified against the measured header/row/separator heights rather than each being screenshotted; the card is the same `VStack` with one more row in each, and every combination is asserted in `AdvancedSwapSheetLayoutTests` against those measurements. Secured mint additionally requires a THORChain secured-asset pair, which was constructed in-process to confirm `isSecuredMint` gates the row (`BTC.BTC` → `btc-btc`).

Not verified on real macOS — no macOS run in this environment. The macOS path is `CrossPlatformSheet`'s content-sized sheet, which the content-sized render models.

**Gate** (own simulator, iPhone 17 Pro Max / iOS 26.5):
- `make build-check` → `** BUILD SUCCEEDED **`
- `make test` (full suite) → `** TEST SUCCEEDED **`, 0 failed cases
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` → 22 violations, unchanged from `main` (none in the touched files)

Reviewed read-only by `codex exec` before the gate: no production defect; three low-severity test findings, two fixed in the follow-up commit (side/bottom insets tied to one constant, the wrapping test now asserts its own premise), one rejected — `mainRowCount` mirroring `mainView`'s conditions can only be made drift-proof by making the row list data-driven, which is beyond a layout fix; the coupling is called out in the doc comment.

Closes #5016


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Advanced Swap sheet sizing across different row combinations.
  * Ensured layouts correctly accommodate secured mint external-recipient details and wrapped content.
  * Applied consistent bottom spacing within the main card.

* **Tests**
  * Added coverage for rendered rows, sheet heights, content fitting, and dynamic text wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->