### PR TITLE
fix(keysign): resolve KeyImport custom-message keys by derivation path

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keysign/ViewModels/KeysignViewModel.swift
@@ -433,6 +433,39 @@ class KeysignViewModel: ObservableObject {
         self.txid = newTxid
     }
 
+    /// Resolves the public key a custom message must be signed with.
+    ///
+    /// A key-import vault holds one pre-derived share per imported chain and signs with an
+    /// empty chain path, so the share handed to the ceremony *is* the signing key — nothing
+    /// derives it further. An exact chain match is preferred; failing that, any share on the
+    /// same derivation path is the very same key (every EVM chain derives from
+    /// `m/44'/60'/0'/0/0`), which is what lets a vault imported with BSC alone sign the
+    /// Ethereum-named messages the app produces.
+    ///
+    /// A path sibling must also be on the same curve as the target, checked two ways: the
+    /// persisted flag, and the curve the candidate's own chain implies. The persisted flag
+    /// alone is not enough — iOS and Android write it differently for the one MLDSA chain
+    /// (QBTC), and QBTC shares Cosmos' derivation path, so a vault restored from an Android
+    /// backup could otherwise resolve a Cosmos message to the QBTC share.
+    ///
+    /// Returns `nil` when nothing matches, leaving the caller's root-key fallback intact.
+    /// Non-import vaults get the exact match only: their root key is the signing key.
+    static func customMessagePublicKey(for chain: Chain,
+                                       in chainPublicKeys: [ChainPublicKey],
+                                       isImport: Bool) -> String? {
+        if let exactMatch = chainPublicKeys.first(where: { $0.chain == chain }) {
+            return exactMatch.publicKeyHex
+        }
+        guard isImport else { return nil }
+        let derivationPath = chain.coinType.derivationPath()
+        let isEddsa = !chain.isECDSA
+        return chainPublicKeys.first {
+            $0.isEddsa == isEddsa
+                && $0.chain.isECDSA == chain.isECDSA
+                && $0.chain.coinType.derivationPath() == derivationPath
+        }?.publicKeyHex
+    }
+
     func startKeysignDKLS(isImport: Bool) async {
         do {
             // Check if we have either keysignPayload or customMessagePayload
@@ -455,7 +488,9 @@ class KeysignViewModel: ObservableObject {
                     // Fallback to Ethereum if chain name cannot be parsed
                     chainPath = TokensStore.Token.ethereum.coinType.derivationPath()
                 }
-                publicKey = self.vault.chainPublicKeys.first(where: { $0.chain == targetChain })?.publicKeyHex
+                publicKey = Self.customMessagePublicKey(for: targetChain,
+                                                        in: self.vault.chainPublicKeys,
+                                                        isImport: isImport)
             } else {
                 throw HelperError.runtimeError("keysign payload is nil")
             }

--- a/VultisigApp/VultisigAppTests/KeyImport/KeyImportCustomMessageKeyResolutionTests.swift
+++ b/VultisigApp/VultisigAppTests/KeyImport/KeyImportCustomMessageKeyResolutionTests.swift
@@ -106,6 +106,31 @@ final class KeyImportCustomMessageKeyResolutionTests: XCTestCase {
         XCTAssertNil(resolved)
     }
 
+    /// The **exact** match deliberately does not filter on the persisted curve flag, unlike
+    /// Android's resolvers. `chain` is the entry's primary identity — it forms the
+    /// `@Attribute(.unique)` id and is written from the same import job as the key itself —
+    /// so a share filed under a chain *is* that chain's key, whatever the flag says. Were
+    /// the flag ever inconsistent, filtering would drop through to the root share at path
+    /// `m`: a signature that verifies against nothing, which is the precise failure this
+    /// fix exists to remove. Trusting `chain` over the flag keeps the safer failure mode.
+    ///
+    /// Neither platform's write path can actually produce this state for a chain that
+    /// reaches this helper: QBTC is the only chain whose `isEddsa` the two platforms
+    /// disagree on, and the `.MLDSA` branch signs with `vault.publicKeyMLDSA44` instead of
+    /// this helper's result. The test pins the intent so the check is not "fixed" later.
+    func testExactMatchWithInconsistentCurveMetadataStillWins() {
+        let vault = makeKeyImportVault(keys: [(.ethereum, ethKey)], isEddsaOverride: true)
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .ethereum,
+            in: vault.chainPublicKeys,
+            isImport: true
+        )
+
+        XCTAssertEqual(resolved, ethKey, "The chain's own share must win over an inconsistent curve flag, never the root key")
+        XCTAssertNotEqual(resolved, vault.pubKeyECDSA)
+    }
+
     // MARK: - The fallback must not cross curves
 
     func testEcdsaTargetDoesNotPickUpAnEddsaShare() {

--- a/VultisigApp/VultisigAppTests/KeyImport/KeyImportCustomMessageKeyResolutionTests.swift
+++ b/VultisigApp/VultisigAppTests/KeyImport/KeyImportCustomMessageKeyResolutionTests.swift
@@ -1,0 +1,212 @@
+//
+//  KeyImportCustomMessageKeyResolutionTests.swift
+//  VultisigAppTests
+//
+//  Covers how a custom message picks its signing key on the key-import path
+//  (`KeysignViewModel.customMessagePublicKey(for:in:isImport:)`).
+//
+//  A key-import vault holds one pre-derived share per imported chain and signs
+//  with an empty chain path, so the share handed to the ceremony is the signing
+//  key outright. The app stamps every custom message it initiates with
+//  chain "Ethereum", but key import never forces Ethereum into the chain set —
+//  so the resolution has to fall back to a share on the same derivation path
+//  before it falls back to the vault's root share.
+//
+
+import WalletCore
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class KeyImportCustomMessageKeyResolutionTests: XCTestCase {
+
+    private let bscKey = "bsc-chain-public-key"
+    private let ethKey = "eth-chain-public-key"
+    private let rootEcdsaKey = "root-ecdsa-public-key"
+
+    // MARK: - The reported bug
+
+    func testBscOnlyImportVaultResolvesBscKeyForEthereumCustomMessage() {
+        let vault = makeKeyImportVault(keys: [(.bscChain, bscKey)])
+
+        // Mirrors the production expression: the resolved key, or the root share.
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .ethereum,
+            in: vault.chainPublicKeys,
+            isImport: true
+        ) ?? vault.pubKeyECDSA
+
+        XCTAssertEqual(resolved, bscKey, "A BSC-only import vault must sign an Ethereum-named custom message with its BSC share")
+        XCTAssertNotEqual(resolved, vault.pubKeyECDSA, "The root share at path m must not be used when the vault holds an EVM share")
+    }
+
+    func testEveryEvmSiblingResolvesForAnEthereumCustomMessage() {
+        for chain in [Chain.bscChain, .base, .arbitrum, .polygon, .optimism, .avalanche, .sei] {
+            let vault = makeKeyImportVault(keys: [(chain, "key-\(chain.name)")])
+
+            let resolved = KeysignViewModel.customMessagePublicKey(
+                for: .ethereum,
+                in: vault.chainPublicKeys,
+                isImport: true
+            )
+
+            XCTAssertEqual(resolved, "key-\(chain.name)", "\(chain.name) shares Ethereum's derivation path and must resolve")
+        }
+    }
+
+    /// Guards the premise the fallback rests on: every EVM chain the app offers
+    /// derives from Ethereum's path, so a sibling share is the very same key.
+    func testEvmSiblingsShareEthereumsDerivationPath() {
+        let ethereumPath = Chain.ethereum.coinType.derivationPath()
+        XCTAssertEqual(ethereumPath, "m/44'/60'/0'/0/0")
+
+        for chain in Chain.allCases where chain.chainType == .EVM {
+            XCTAssertEqual(chain.coinType.derivationPath(), ethereumPath, "\(chain.name) is EVM but does not derive from Ethereum's path")
+        }
+    }
+
+    // MARK: - Unchanged behaviour
+
+    func testExactChainMatchWinsOverADerivationPathSibling() {
+        let vault = makeKeyImportVault(keys: [(.bscChain, bscKey), (.ethereum, ethKey)])
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .ethereum,
+            in: vault.chainPublicKeys,
+            isImport: true
+        )
+
+        XCTAssertEqual(resolved, ethKey, "An exact chain entry must take precedence over a path sibling")
+    }
+
+    func testNoKeyOnThatDerivationPathFallsBackToTheRootKey() {
+        // THORChain derives from m/44'/931'/0'/0/0 — nothing on Ethereum's path.
+        let vault = makeKeyImportVault(keys: [(.thorChain, "thor-chain-public-key")])
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .ethereum,
+            in: vault.chainPublicKeys,
+            isImport: true
+        )
+
+        XCTAssertNil(resolved, "No share on Ethereum's path must leave the caller's root fallback in charge")
+        XCTAssertEqual(resolved ?? vault.pubKeyECDSA, rootEcdsaKey)
+    }
+
+    func testEmptyChainPublicKeysFallsBackToTheRootKey() {
+        // Legacy JSON backups predate `chainPublicKeys` persistence.
+        let vault = makeKeyImportVault(keys: [])
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .ethereum,
+            in: vault.chainPublicKeys,
+            isImport: true
+        )
+
+        XCTAssertNil(resolved)
+    }
+
+    // MARK: - The fallback must not cross curves
+
+    func testEcdsaTargetDoesNotPickUpAnEddsaShare() {
+        let vault = makeKeyImportVault(keys: [(.solana, "solana-chain-public-key")])
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .ethereum,
+            in: vault.chainPublicKeys,
+            isImport: true
+        )
+
+        XCTAssertNil(resolved, "An ECDSA target must never resolve to an EdDSA share")
+    }
+
+    func testEddsaTargetDoesNotPickUpAnEcdsaShare() {
+        let vault = makeKeyImportVault(keys: [(.ethereum, ethKey)])
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .solana,
+            in: vault.chainPublicKeys,
+            isImport: true
+        )
+
+        XCTAssertNil(resolved, "An EdDSA target must never resolve to an ECDSA share")
+    }
+
+    func testEddsaTargetStillResolvesItsExactShare() {
+        let solanaKey = "solana-chain-public-key"
+        let vault = makeKeyImportVault(keys: [(.solana, solanaKey)])
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .solana,
+            in: vault.chainPublicKeys,
+            isImport: true
+        )
+
+        XCTAssertEqual(resolved, solanaKey)
+    }
+
+    /// QBTC signs with MLDSA and shares Cosmos' derivation path, and the two platforms
+    /// persist its `isEddsa` differently — iOS writes `true` (`!chain.isECDSA`), Android
+    /// writes `false` (`TssKeysignType == EDDSA`). A vault restored from an Android backup
+    /// therefore carries a QBTC share that the persisted flag alone would hand to a
+    /// Cosmos-named message.
+    func testAndroidWrittenQbtcShareIsNotUsedForACosmosCustomMessage() {
+        let vault = makeKeyImportVault(keys: [(.qbtc, "qbtc-chain-public-key")], isEddsaOverride: false)
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .gaiaChain,
+            in: vault.chainPublicKeys,
+            isImport: true
+        )
+
+        XCTAssertNil(resolved, "An MLDSA share must never be handed to an ECDSA Cosmos message")
+    }
+
+    // MARK: - Non-import vaults are untouched
+
+    func testNonImportVaultGetsNoDerivationPathFallback() {
+        let vault = makeKeyImportVault(keys: [(.bscChain, bscKey)])
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .ethereum,
+            in: vault.chainPublicKeys,
+            isImport: false
+        )
+
+        XCTAssertNil(resolved, "Only key-import vaults sign with a pre-derived per-chain share")
+    }
+
+    func testNonImportVaultKeepsItsExactMatch() {
+        let vault = makeKeyImportVault(keys: [(.ethereum, ethKey)])
+
+        let resolved = KeysignViewModel.customMessagePublicKey(
+            for: .ethereum,
+            in: vault.chainPublicKeys,
+            isImport: false
+        )
+
+        XCTAssertEqual(resolved, ethKey, "The pre-existing exact match must behave exactly as before")
+    }
+
+    // MARK: - Helpers
+
+    /// - Parameter isEddsaOverride: forces the persisted flag, to model a vault written by
+    ///   another platform. Defaults to the predicate iOS's own import uses.
+    private func makeKeyImportVault(keys: [(chain: Chain, publicKeyHex: String)],
+                                    isEddsaOverride: Bool? = nil) -> Vault {
+        let vault = Vault(name: "KeyImport", libType: .KeyImport)
+        vault.pubKeyECDSA = rootEcdsaKey
+        vault.pubKeyEdDSA = "root-eddsa-public-key"
+        vault.hexChainCode = "00"
+        // `isEddsa` is written at import with the same predicate the resolver
+        // matches on (`KeygenViewModel.buildChainImportJobs`).
+        vault.chainPublicKeys = keys.map { entry in
+            ChainPublicKey(
+                chain: entry.chain,
+                publicKeyHex: entry.publicKeyHex,
+                isEddsa: isEddsaOverride ?? !entry.chain.isECDSA
+            )
+        }
+        return vault
+    }
+}


### PR DESCRIPTION
## Problem

A KeyImport vault holds one pre-derived TSS share **per imported chain** and signs with `chainPath = ""` — no in-ceremony BIP32 derivation — so the share handed to the ceremony *is* the signing key. `KeysignViewModel.startKeysignDKLS(isImport:)` picked that share for a custom message by **exact chain match** against `vault.chainPublicKeys`.

The app stamps every custom message it initiates with `chain: "Ethereum"` (`SettingsCustomMessageView`), but key import never forces Ethereum into the chain set. So a vault imported with BSC, Base or Arbitrum alone matched nothing, `publicKey` stayed `nil`, and `publicKeyECDSA: publicKey ?? vault.pubKeyECDSA` handed the ceremony the **root share at BIP32 path `m`**.

The resulting signature recovers to no address the vault displays and fails `ecrecover`. Cross-device it is worse: Android already resolves this correctly, so the two devices load shares of *different* keys and the DKLS ceremony aborts on `SignError::InvalidFinalSessionID`.

## Root cause

`chainPublicKeys.first(where: { $0.chain == targetChain })` is an identity match, but every EVM chain derives from the same path `m/44'/60'/0'/0/0`. The BSC entry **is** the correct key for an Ethereum-named message — the exact match just couldn't see it.

## Fix

Mirror Android's resolution (`Vault.getEcdsaSigningKey` / `getEddsaSigningKey`, ported in vultisig/vultisig-android#5525) in the custom-message branch of the import path only: **exact chain match → same-curve derivation-path match → the existing root fallback**, which stays as the last resort. The single resolved key feeds both the DKLS and Schnorr branches, so ECDSA and EdDSA pick consistently.

Deliberately unchanged: the transaction branch (the chain always comes from the vault's own enabled chains, so the exact match always hits), the `?? vault.pubKeyECDSA` / `?? vault.pubKeyEdDSA` last-resort fallbacks, the non-import path, and `VultisigApp/Blockchain/Tss/`.

### Worth a reviewer's eye #1: the fallback's curve check is doubled, on purpose

The two platforms persist `ChainPublicKey.isEddsa` **differently** for QBTC, the one MLDSA chain:

| | predicate | stored `isEddsa` for QBTC |
|---|---|---|
| iOS | `!chain.isECDSA` (`signingKeyType` returns `.MLDSA`) | `true` |
| Android | `chain.TssKeysignType == TssKeyType.EDDSA` (QBTC is `MLDSA`) | `false` |

`Vault+ProtoMappable` maps the flag straight through from the shared proto backup, and QBTC shares Cosmos' derivation path (both `coinType: .cosmos`). So the fallback matches the curve twice — the persisted flag *and* the candidate chain's own `isECDSA`, the latter computed from iOS's own `Chain` table on both sides and therefore immune to the divergence. Without it, a vault restored from an Android backup could hand an MLDSA share to a Cosmos-named message.

### Worth a reviewer's eye #2: the *exact* match is deliberately left unchecked

Android's resolvers curve-filter the exact match too. This PR does not, and the reasoning is worth stating because it looks like a parity gap:

1. **It's unreachable.** QBTC is the only chain whose `isEddsa` the platforms disagree on, and QBTC never reaches this helper — the `.MLDSA` branch signs with `vault.publicKeyMLDSA44`. For every chain that *does* reach it, both write paths produce identical metadata.
2. **The unfiltered failure mode is the safer one.** `chain` is the entry's primary identity (it forms the `@Attribute(.unique)` id and is written from the same import job as the key), so a share filed under a chain *is* that chain's key. If the flag were ever inconsistent, filtering would fall through to the root share at path `m` — a signature that verifies against nothing, i.e. exactly the bug this PR removes.

`testExactMatchWithInconsistentCurveMetadataStillWins` pins this so it isn't "fixed" later by someone chasing parity.

## Tests

`KeyImportCustomMessageKeyResolutionTests` — 13 cases pinning the reported bug (a BSC-only import vault resolves the BSC share, not `pubKeyECDSA`), every EVM sibling, exact-match precedence, the preserved root fallback, curve isolation in both directions, non-import behaviour, and both cross-platform cases above. Codex confirmed the BSC-only test fails under exact-only resolution, i.e. it would catch a revert.

`testEvmSiblingsShareEthereumsDerivationPath` asserts at runtime over `Chain.allCases where chainType == .EVM` that all 16 EVM chains really do derive from `m/44'/60'/0'/0/0` — the premise the whole fallback rests on is now a guard, not a comment, so a future chain whose coin type carries a different path fails loudly here.

## Verification

- `make build-check` → `** BUILD SUCCEEDED **`
- `make test` (full suite, dedicated simulator) → `** TEST SUCCEEDED **` — 4881 tests, 1 skipped, 0 failures
- SwiftLint: 0 violations on both changed files
- Cross-model review: a read-only Codex pass per commit plus a whole-branch pass. No blocker-level findings. The one should-fix that survived was resolved test-only, after the whole-branch pass correctly refuted my first rejection rationale for it.

## ⚠️ Needs human + on-device review

This is signing-path code in a HIGH-security-tier wallet, so please review accordingly.

**Two acceptance criteria from the issue were NOT verified and cannot be by automated tests** — both need a real seed import and a second device:

- [ ] the resulting `personal_sign` signature recovers to the vault's EVM address
- [ ] the same message co-signs successfully with an Android device

I am explicitly **not** claiming either. The unit tests prove the *selection* logic picks the imported EVM share instead of the root share; they do not prove the end-to-end ceremony or the cross-device handshake.

Closes #5067
