### PR TITLE
fix(settings): make the passcode screens behave on macOS (#5075)

### DIFF
--- a/VultisigApp/VultisigApp/Components/Cells/SettingToggleCell.swift
+++ b/VultisigApp/VultisigApp/Components/Cells/SettingToggleCell.swift
@@ -39,9 +39,7 @@ struct SettingToggleCell: View {
     }
 
     var toggle: some View {
-        Toggle(isOn: $isEnabled) { EmptyView() }
-            .scaleEffect(0.8)
-            .frame(width: 48, height: 24)
+        VultiToggle(isOn: $isEnabled)
     }
 }
 

--- a/VultisigApp/VultisigApp/Components/Sheet/CrossPlatformSheet.swift
+++ b/VultisigApp/VultisigApp/Components/Sheet/CrossPlatformSheet.swift
@@ -192,6 +192,13 @@ private struct PlatformSheetWithItem<Item: Identifiable & Equatable, SheetConten
             }
         }
         .onChange(of: item) { _, newValue in
+            // A new item cancels the pending close, as in the boolean sheet
+            // above — and here the stale task carries `onDismiss` with it, so
+            // letting it run would hand the incoming sheet the outgoing one's
+            // dismissal callback as well as closing it.
+            if newValue != nil {
+                dismissTask?.cancel()
+            }
             withAnimation(.interpolatingSpring(duration: 0.2)) {
                 internalItem = newValue
             }

--- a/VultisigApp/VultisigApp/Components/Sheet/CrossPlatformSheet.swift
+++ b/VultisigApp/VultisigApp/Components/Sheet/CrossPlatformSheet.swift
@@ -83,6 +83,13 @@ private struct CrossPlatformSheet<SheetContent: View>: ViewModifier {
             }
         }
         .onChange(of: isPresented) { _, newValue in
+            // A reopen cancels the pending close. Dismissing arms a task that
+            // lowers `isPresented` 300ms later so the animation can finish; if
+            // the sheet is presented again inside that window, the old task is
+            // still holding an order to close and would shut the new one.
+            if newValue {
+                dismissTask?.cancel()
+            }
             withAnimation(.interpolatingSpring(duration: 0.2)) {
                 internalIsPresented = newValue
             }

--- a/VultisigApp/VultisigApp/Components/Toolbar/CrossPlatformToolbar/MacOSToolbarView.swift
+++ b/VultisigApp/VultisigApp/Components/Toolbar/CrossPlatformToolbar/MacOSToolbarView.swift
@@ -16,6 +16,7 @@ struct MacOSToolbarView<Content: View>: View {
     let content: Content
 
     @Environment(\.dismiss) var dismiss
+    @Environment(\.screenBackgroundType) private var screenBackgroundType
 
     init(
         items: [CustomToolbarItem],
@@ -42,11 +43,28 @@ struct MacOSToolbarView<Content: View>: View {
             VStack(spacing: 0) {
                 // macOS toolbar
                 toolbarContent
-                    .background(Theme.colors.bgPrimary)
+                    .background(barBackground)
 
                 // Content below toolbar
                 content
             }
+        }
+    }
+
+    /// The bar fills itself only over a screen that is a flat colour anyway.
+    ///
+    /// `bgPrimary` behind the bar is invisible on a `.plain` screen and a seam on
+    /// any other: over a gradient it cuts an opaque band across the top sixty
+    /// points, and over `.clear` it paints a background the caller asked not to
+    /// have. The screen already draws its own background edge to edge, so
+    /// stepping out of the way is all this has to do.
+    @ViewBuilder
+    private var barBackground: some View {
+        switch screenBackgroundType {
+        case .plain:
+            Theme.colors.bgPrimary
+        case .gradient, .clear:
+            Color.clear
         }
     }
 

--- a/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
@@ -32,7 +32,6 @@ enum AccessibilityID {
     enum Passcode {
         static let dots = "passcode.dots"
         static let deleteKey = "passcode.deleteKey"
-        static let macField = "passcode.macField"
         static let enterScreen = "passcode.enterScreen"
         static let awaitingBiometrics = "passcode.awaitingBiometrics"
 

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/DisablePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/DisablePasscodeScreen.swift
@@ -25,6 +25,16 @@ struct DisablePasscodeScreen: View {
     /// one thing both sheet implementations agree on.
     @Binding var isPresented: Bool
 
+    /// Mirrors the removal being in flight up to the presenter, which is the
+    /// only place that can refuse the swipe and the backdrop tap.
+    ///
+    /// Removal rewrites every stored key share. Walking out of it does not
+    /// cancel it — the work is an unstructured task that outlives this screen —
+    /// it only means the settings list refreshes while the passcode is still
+    /// there and never hears that it went, so it goes on offering to change a
+    /// passcode that no longer exists.
+    @Binding var isRemoving: Bool
+
     var body: some View {
         Screen {
             PasscodeEntryView(
@@ -55,7 +65,11 @@ struct DisablePasscodeScreen: View {
                 ToolbarButton(image: .xmark) {
                     isPresented = false
                 }
+                .disabled(viewModel.isBusy)
             }
+        }
+        .onChange(of: viewModel.isBusy) { _, isBusy in
+            isRemoving = isBusy
         }
         .onChange(of: viewModel.didFinish) { _, finished in
             guard finished else { return }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/DisablePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/DisablePasscodeScreen.swift
@@ -15,7 +15,15 @@ import SwiftUI
 struct DisablePasscodeScreen: View {
 
     @StateObject private var viewModel = PasscodeViewModel(stage: .current)
-    @Environment(\.dismiss) private var dismiss
+
+    /// Closing is done by the presenter's flag rather than `@Environment(\.dismiss)`.
+    ///
+    /// Below macOS 26 `crossPlatformSheet` is not a presentation at all — it
+    /// renders this view as a sibling inside the presenter's own `ZStack` — so
+    /// there is nothing there for `dismiss()` to close, and it would reach past
+    /// this screen to the enclosing navigation stack instead. The flag is the
+    /// one thing both sheet implementations agree on.
+    @Binding var isPresented: Bool
 
     var body: some View {
         Screen {
@@ -32,9 +40,26 @@ struct DisablePasscodeScreen: View {
         }
         .screenTitle("passcodeDisableNavTitle".localized)
         .screenBackground(.gradient)
+        // A sheet is not a place you go back from. macOS would otherwise draw
+        // `Screen`'s own back chevron here, which offers to return to a screen
+        // that is still sitting behind this one; iOS has only the swipe, which
+        // is invisible. Both get the close instead.
+        //
+        // It goes through `Screen`'s toolbar rather than a second
+        // `.crossPlatformToolbar`, because `Screen` already renders one on
+        // macOS and an outer toolbar stacks another row above it rather than
+        // replacing it.
+        .screenBackButtonHidden()
+        .screenToolbar {
+            CustomToolbarItem(placement: .leading) {
+                ToolbarButton(image: .xmark) {
+                    isPresented = false
+                }
+            }
+        }
         .onChange(of: viewModel.didFinish) { _, finished in
             guard finished else { return }
-            dismiss()
+            isPresented = false
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -56,7 +56,6 @@ struct ManagePasscodeScreen: View {
             }
         }
         .screenTitle("passcodeManageTitle".localized)
-        .screenBackground(.gradient)
         .screenEdgeInsets(ScreenEdgeInsets(bottom: 0))
         .crossPlatformSheet(isPresented: $showDisable) {
             DisablePasscodeScreen()

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -65,16 +65,24 @@ struct ManagePasscodeScreen: View {
         // offering "Set passcode" after one had just been set.
         .task { await refresh() }
         .onAppear { Task { await refresh() } }
-        // And the navigation path on top of both, because on macOS neither
-        // lifecycle callback fires when a pushed screen pops: this view is never
-        // torn down, so it keeps the `isSet` it was built with and goes on
-        // offering "Set passcode" over a passcode that now exists. The path is
-        // the one thing that provably changes when the set or change screen
-        // dismisses itself, and it is published, so a live subscription hears it
-        // whether or not the view is told it reappeared.
+        // And the navigation path on top of both, but only where the two above
+        // are not enough: on macOS neither lifecycle callback fires when a
+        // pushed screen pops, and this view is not torn down either, so it keeps
+        // the `isSet` it was built with and goes on offering "Set passcode" over
+        // a passcode that now exists. The path is the one thing that provably
+        // changes when the set or change screen dismisses itself, and it is
+        // published, so a live subscription hears the return whether or not the
+        // view is told it reappeared.
+        //
+        // Confined to macOS because it is not free: `Published` replays on
+        // subscribe and fires again for every push and pop anywhere in the
+        // stack, so on iOS — where `.onAppear` already works — it would only add
+        // Keychain and biometry reads for a screen that is often not on top.
+        #if os(macOS)
         .onReceive(router.$navPath) { _ in
             Task { await refresh() }
         }
+        #endif
         .onChange(of: showDisable) { _, isShowing in
             guard !isShowing else { return }
             Task { await refresh() }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -15,6 +15,9 @@ struct ManagePasscodeScreen: View {
     @State private var biometricAvailability: BiometricAvailability = .available
     @State private var biometricError: String?
     @State private var showDisable = false
+    /// Raised while the remove flow is actually rewriting key material, which is
+    /// the one stretch the sheet must not be dismissable over.
+    @State private var isRemoving = false
 
     private let service: PasscodeService
 
@@ -57,8 +60,12 @@ struct ManagePasscodeScreen: View {
         }
         .screenTitle("passcodeManageTitle".localized)
         .screenEdgeInsets(ScreenEdgeInsets(bottom: 0))
-        .crossPlatformSheet(isPresented: $showDisable) {
-            DisablePasscodeScreen(isPresented: $showDisable)
+        // Not dismissable mid-removal. The swipe and the backdrop tap are
+        // refused for the same reason the close button is disabled: leaving does
+        // not stop the transition, it only means this list re-reads the passcode
+        // while it is still there and never hears that it went.
+        .crossPlatformSheet(isPresented: $showDisable, isDismissable: !isRemoving) {
+            DisablePasscodeScreen(isPresented: $showDisable, isRemoving: $isRemoving)
                 .presentationDragIndicator(.visible)
         }
         // `.onAppear` as well as `.task`: returning from the pushed set/change

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -58,7 +58,7 @@ struct ManagePasscodeScreen: View {
         .screenTitle("passcodeManageTitle".localized)
         .screenEdgeInsets(ScreenEdgeInsets(bottom: 0))
         .crossPlatformSheet(isPresented: $showDisable) {
-            DisablePasscodeScreen()
+            DisablePasscodeScreen(isPresented: $showDisable)
         }
         // `.onAppear` as well as `.task`: returning from the pushed set/change
         // screens does not re-run `.task`, and a stale `isSet` would keep

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -65,6 +65,16 @@ struct ManagePasscodeScreen: View {
         // offering "Set passcode" after one had just been set.
         .task { await refresh() }
         .onAppear { Task { await refresh() } }
+        // And the navigation path on top of both, because on macOS neither
+        // lifecycle callback fires when a pushed screen pops: this view is never
+        // torn down, so it keeps the `isSet` it was built with and goes on
+        // offering "Set passcode" over a passcode that now exists. The path is
+        // the one thing that provably changes when the set or change screen
+        // dismisses itself, and it is published, so a live subscription hears it
+        // whether or not the view is told it reappeared.
+        .onReceive(router.$navPath) { _ in
+            Task { await refresh() }
+        }
         .onChange(of: showDisable) { _, isShowing in
             guard !isShowing else { return }
             Task { await refresh() }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -59,6 +59,7 @@ struct ManagePasscodeScreen: View {
         .screenEdgeInsets(ScreenEdgeInsets(bottom: 0))
         .crossPlatformSheet(isPresented: $showDisable) {
             DisablePasscodeScreen(isPresented: $showDisable)
+                .presentationDragIndicator(.visible)
         }
         // `.onAppear` as well as `.task`: returning from the pushed set/change
         // screens does not re-run `.task`, and a stale `isSet` would keep

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
@@ -216,11 +216,27 @@ struct PasscodeEntryView: View {
     /// themselves, so rejecting it would reject the one keyboard someone is most
     /// likely to type six digits on.
     private func handleKeyPress(_ press: KeyPress) -> KeyPress.Result {
-        if press.modifiers.contains(.command) {
-            guard press.characters == "v" else { return .ignored }
+        // Neither of these two is intent. Caps lock says nothing about a digit,
+        // and macOS sets `.numericPad` on the keypad keys themselves — treating
+        // that as a modifier would reject the one keyboard someone is most
+        // likely to type six digits on.
+        let modifiers = press.modifiers.subtracting([.capsLock, .numericPad])
+
+        // Exactly ⌘V, and only on the way down. Anything else carrying command
+        // is a shortcut aimed at the app, not at this field — and a held ⌘V must
+        // not paste once per repeat.
+        if modifiers.contains(.command) {
+            guard modifiers == .command, press.phase == .down, press.characters == "v" else {
+                return .ignored
+            }
             paste()
             return .handled
         }
+
+        // Every remaining path is a bare key. Checked before the actions rather
+        // than inside one of them, so ⌥⌫ and ⌃⌫ cannot reach the delete branch
+        // by being handled ahead of the test.
+        guard modifiers.isEmpty else { return .ignored }
 
         let isDelete = press.key == .delete || press.key == .deleteForward
         // Held keys repeat for delete only. A held digit would fill all six
@@ -232,8 +248,7 @@ struct PasscodeEntryView: View {
             return .handled
         }
 
-        guard press.modifiers.subtracting([.shift, .capsLock, .numericPad]).isEmpty,
-              press.characters.count == 1,
+        guard press.characters.count == 1,
               let digit = press.characters.first,
               digit.isASCII, digit.isNumber else {
             return .ignored
@@ -245,17 +260,24 @@ struct PasscodeEntryView: View {
 
     /// ⌘V, which the text field this replaced got for free.
     ///
-    /// Filtered exactly as a typed digit is, and truncated rather than refused —
-    /// a six-digit code copied with a trailing newline is still the code the
-    /// user meant. Landing a full-length value here completes the entry through
-    /// the same `onChange` a typed sixth digit does.
+    /// The clipboard has to already *be* a passcode — surrounding whitespace is
+    /// forgiven, nothing else is. Sieving the digits out of arbitrary text turns
+    /// "Order 12-34-56 shipped" into a complete entry, and reaching six digits
+    /// submits, so a stray paste would spend one of the throttled attempts on a
+    /// value the user never saw. Over-long is refused rather than truncated for
+    /// the same reason: silently keeping the first six of seven submits
+    /// something nobody typed.
     private func paste() {
         guard !isBusy, let pasted = ClipboardManager.pasteFromClipboard() else { return }
 
-        let digits = pasted.filter { $0.isASCII && $0.isNumber }
-        guard !digits.isEmpty else { return }
+        let candidate = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty,
+              candidate.count <= PasscodeService.passcodeLength,
+              candidate.allSatisfy({ $0.isASCII && $0.isNumber }) else {
+            return
+        }
 
-        passcode = String(digits.prefix(PasscodeService.passcodeLength))
+        passcode = candidate
         isKeypadFocused = true
     }
     #endif

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
@@ -91,16 +91,24 @@ struct PasscodeEntryView: View {
         .focusEffectDisabled()
         .focused($isKeypadFocused)
         .onAppear { isKeypadFocused = true }
-        .onKeyPress(phases: .down) { handleKeyPress($0) }
+        .onKeyPress(phases: [.down, .repeat]) { handleKeyPress($0) }
         #endif
     }
 
+    /// Both labels are fixed vertically so they wrap to whatever height they
+    /// need instead of being compressed into one truncated line. The keypad is
+    /// tall and the spacers around it are greedy, so on a short window — the
+    /// remove-passcode sheet on macOS is the shortest — the layout will
+    /// otherwise take the height back out of the text, and the sentence
+    /// explaining what removing a passcode costs is the last thing that should
+    /// end in an ellipsis.
     private var header: some View {
         VStack(spacing: 8) {
             Text(title)
                 .font(Theme.fonts.title2)
                 .foregroundStyle(Theme.colors.textPrimary)
                 .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
                 .id(title)
                 .transition(.opacity.combined(with: .move(edge: .top)))
 
@@ -109,6 +117,7 @@ struct PasscodeEntryView: View {
                     .font(Theme.fonts.bodySMedium)
                     .foregroundStyle(Theme.colors.textTertiary)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
                     .id(subtitle)
                     .transition(.opacity)
             }
@@ -192,20 +201,39 @@ struct PasscodeEntryView: View {
     }
 
     #if os(macOS)
-    /// Routes a hardware key to the same two operations the on-screen keys call,
-    /// so typing and clicking cannot diverge.
+    /// Routes a hardware key to the same operations the on-screen keys call, so
+    /// typing and clicking cannot diverge.
     ///
-    /// ASCII digits only, which is what ``PasscodeService/validate(_:)`` accepts
-    /// and what the pad can produce. A keyboard laid out for Arabic-Indic digits
-    /// would otherwise enter a passcode that could never be typed on the phone
-    /// this vault is also on.
+    /// ASCII digits only, which is what `PasscodeService` accepts and what the
+    /// pad can produce. A keyboard laid out for Arabic-Indic digits would
+    /// otherwise enter a passcode that could never be typed on the phone this
+    /// vault is also on.
+    ///
+    /// Modifiers have to be inspected because `characters` reports the key with
+    /// them stripped. Without that check ⌘1 — a window shortcut nobody aims at a
+    /// passcode — enters a digit and spends one of the throttled attempts.
+    /// `.numericPad` is deliberately allowed: macOS sets it on the keypad keys
+    /// themselves, so rejecting it would reject the one keyboard someone is most
+    /// likely to type six digits on.
     private func handleKeyPress(_ press: KeyPress) -> KeyPress.Result {
-        if press.key == .delete || press.key == .deleteForward {
+        if press.modifiers.contains(.command) {
+            guard press.characters == "v" else { return .ignored }
+            paste()
+            return .handled
+        }
+
+        let isDelete = press.key == .delete || press.key == .deleteForward
+        // Held keys repeat for delete only. A held digit would fill all six
+        // places and submit an entry the user never finished typing.
+        guard press.phase == .down || isDelete else { return .ignored }
+
+        if isDelete {
             deleteLast()
             return .handled
         }
 
-        guard press.characters.count == 1,
+        guard press.modifiers.subtracting([.shift, .capsLock, .numericPad]).isEmpty,
+              press.characters.count == 1,
               let digit = press.characters.first,
               digit.isASCII, digit.isNumber else {
             return .ignored
@@ -213,6 +241,22 @@ struct PasscodeEntryView: View {
 
         append(String(digit))
         return .handled
+    }
+
+    /// ⌘V, which the text field this replaced got for free.
+    ///
+    /// Filtered exactly as a typed digit is, and truncated rather than refused —
+    /// a six-digit code copied with a trailing newline is still the code the
+    /// user meant. Landing a full-length value here completes the entry through
+    /// the same `onChange` a typed sixth digit does.
+    private func paste() {
+        guard !isBusy, let pasted = ClipboardManager.pasteFromClipboard() else { return }
+
+        let digits = pasted.filter { $0.isASCII && $0.isNumber }
+        guard !digits.isEmpty else { return }
+
+        passcode = String(digits.prefix(PasscodeService.passcodeLength))
+        isKeypadFocused = true
     }
     #endif
 }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
@@ -5,12 +5,18 @@
 
 import SwiftUI
 
-/// Fixed-length entry: filled dots plus a keypad on iOS, hardware keyboard on
-/// macOS. The number of dots comes from ``PasscodeService/passcodeLength``, so
-/// nothing here has the length written into it.
+/// Fixed-length entry: filled dots over a keypad, on both platforms. The number
+/// of dots comes from ``PasscodeService/passcodeLength``, so nothing here has the
+/// length written into it.
 ///
 /// One component for every flow — lock screen, set, confirm, change, disable — so
 /// entering a passcode looks and behaves the same everywhere it is asked for.
+///
+/// macOS shows the same keypad rather than a text field. A passcode is six digits
+/// on a numeric pad, and rendering it as a bordered `SecureField` made it look
+/// like a password box on one platform and a passcode on the other. The hardware
+/// keyboard still types into it — see ``handleKeyPress(_:)`` — so the pad is an
+/// addition on the Mac, not a replacement for the keys under the user's hands.
 struct PasscodeEntryView: View {
 
     let title: String
@@ -27,7 +33,11 @@ struct PasscodeEntryView: View {
     /// Bumped on each error to drive the shake; the value itself is meaningless.
     @State private var shakeTravel: CGFloat = 0
     #if os(macOS)
-    @FocusState private var isFieldFocused: Bool
+    /// Held by the keypad so hardware key presses reach it. Clicking a key takes
+    /// focus away to the button, so it is taken back on every entry rather than
+    /// only on appearance — otherwise one click ends typing for the rest of the
+    /// flow.
+    @FocusState private var isKeypadFocused: Bool
     #endif
 
     private var digitCount: Int { PasscodeService.passcodeLength }
@@ -71,6 +81,18 @@ struct PasscodeEntryView: View {
             guard message?.isEmpty == false else { return }
             reactToError()
         }
+        #if os(macOS)
+        // Focused rather than merely focusable: whoever opened this screen came
+        // here to type six digits, and a first keystroke that goes nowhere
+        // because nothing claimed focus reads as a screen that is not listening.
+        // The focus ring is suppressed because the dots already show where the
+        // input is going.
+        .focusable()
+        .focusEffectDisabled()
+        .focused($isKeypadFocused)
+        .onAppear { isKeypadFocused = true }
+        .onKeyPress(phases: .down) { handleKeyPress($0) }
+        #endif
     }
 
     private var header: some View {
@@ -154,6 +176,8 @@ struct PasscodeEntryView: View {
         passcode.append(digit)
         #if os(iOS)
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        #else
+        isKeypadFocused = true
         #endif
     }
 
@@ -162,8 +186,35 @@ struct PasscodeEntryView: View {
         passcode.removeLast()
         #if os(iOS)
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        #else
+        isKeypadFocused = true
         #endif
     }
+
+    #if os(macOS)
+    /// Routes a hardware key to the same two operations the on-screen keys call,
+    /// so typing and clicking cannot diverge.
+    ///
+    /// ASCII digits only, which is what ``PasscodeService/validate(_:)`` accepts
+    /// and what the pad can produce. A keyboard laid out for Arabic-Indic digits
+    /// would otherwise enter a passcode that could never be typed on the phone
+    /// this vault is also on.
+    private func handleKeyPress(_ press: KeyPress) -> KeyPress.Result {
+        if press.key == .delete || press.key == .deleteForward {
+            deleteLast()
+            return .handled
+        }
+
+        guard press.characters.count == 1,
+              let digit = press.characters.first,
+              digit.isASCII, digit.isNumber else {
+            return .ignored
+        }
+
+        append(String(digit))
+        return .handled
+    }
+    #endif
 }
 
 /// Horizontal shake driven by one animatable value, so the whole wiggle is a
@@ -185,7 +236,6 @@ private struct ShakeEffect: GeometryEffect {
     }
 }
 
-#if os(iOS)
 extension PasscodeEntryView {
 
     private static let keys = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "⌫"]
@@ -251,90 +301,62 @@ extension PasscodeEntryView {
 /// Uses the same treatment as `ToolbarButton` / `VultiTabBar` — `.glassEffect`
 /// on iOS 26, with their gradient-stroke fallback below it — rather than
 /// `.ultraThinMaterial`, which renders as flat opaque grey over a dark
-/// background and loses the translucency entirely.
+/// background and loses the translucency entirely. macOS takes the same
+/// fallback: `glassEffect` is iOS-only, and the stroke is what carries the shape
+/// there.
 private struct PasscodeKeyButtonStyle: ButtonStyle {
     let hasFill: Bool
 
     func makeBody(configuration: Configuration) -> some View {
-        Group {
+        configuration.label
+            .background { fill }
+            .overlay {
+                if configuration.isPressed {
+                    Circle().fill(Theme.colors.textPrimary.opacity(0.22))
+                }
+            }
+            .clipShape(Circle())
+            // Press compresses hard and fast; release overshoots slightly before
+            // settling. A single symmetric spring reads as mushy next to the
+            // platform keypad, which snaps down and bounces back.
+            .scaleEffect(configuration.isPressed ? 0.88 : 1)
+            .animation(
+                configuration.isPressed
+                    ? .spring(response: 0.12, dampingFraction: 0.55)
+                    : .spring(response: 0.34, dampingFraction: 0.42),
+                value: configuration.isPressed
+            )
+    }
+
+    @ViewBuilder
+    private var fill: some View {
+        if hasFill {
+            #if os(iOS)
             if #available(iOS 26.0, *) {
-                configuration.label
-                    .background {
-                        if hasFill {
-                            Circle()
-                                .fill(.clear)
-                                .glassEffect(.clear.interactive(), in: Circle())
-                        }
-                    }
+                Circle()
+                    .fill(.clear)
+                    .glassEffect(.clear.interactive(), in: Circle())
             } else {
-                configuration.label
-                    .background {
-                        if hasFill {
-                            Circle()
-                                .fill(Theme.colors.bgSurface1.opacity(0.35))
-                                .overlay(
-                                    Circle().stroke(
-                                        LinearGradient(
-                                            colors: [.white.opacity(0.6), .clear, .clear, .white.opacity(0.4)],
-                                            startPoint: .topLeading,
-                                            endPoint: .bottomTrailing
-                                        ),
-                                        lineWidth: 1
-                                    )
-                                )
-                        }
-                    }
+                strokedFill
             }
+            #else
+            strokedFill
+            #endif
         }
-        .overlay {
-            if configuration.isPressed {
-                Circle().fill(Theme.colors.textPrimary.opacity(0.22))
-            }
-        }
-        .clipShape(Circle())
-        // Press compresses hard and fast; release overshoots slightly before
-        // settling. A single symmetric spring reads as mushy next to the
-        // platform keypad, which snaps down and bounces back.
-        .scaleEffect(configuration.isPressed ? 0.88 : 1)
-        .animation(
-            configuration.isPressed
-                ? .spring(response: 0.12, dampingFraction: 0.55)
-                : .spring(response: 0.34, dampingFraction: 0.42),
-            value: configuration.isPressed
-        )
+    }
+
+    private var strokedFill: some View {
+        Circle()
+            .fill(Theme.colors.bgSurface1.opacity(0.35))
+            .overlay(
+                Circle().stroke(
+                    LinearGradient(
+                        colors: [.white.opacity(0.6), .clear, .clear, .white.opacity(0.4)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: 1
+                )
+            )
     }
 }
-#endif
-
-#if os(macOS)
-extension PasscodeEntryView {
-
-    /// No on-screen keypad on macOS — the hardware keyboard drives entry and the
-    /// dots above render the state.
-    ///
-    /// The field is visible and focused on appearance rather than hidden at one
-    /// pixel: an invisible field gives the user nothing to click when focus is
-    /// lost, which makes entry unreliable and occasionally impossible.
-    var keypad: some View {
-        SecureField("passcodeEnterTitle".localized, text: Binding(
-            get: { passcode },
-            set: { newValue in
-                // ASCII only, matching what the iOS keypad can produce and what
-                // `PasscodeService.validate` accepts. `isNumber` alone lets a
-                // paste put Arabic-Indic digits into a passcode that could then
-                // never be typed on the phone.
-                let digits = newValue.filter { $0.isASCII && $0.isNumber }
-                passcode = String(digits.prefix(PasscodeService.passcodeLength))
-            }
-        ))
-        .textFieldStyle(.roundedBorder)
-        .font(Theme.fonts.bodyMMedium)
-        .frame(maxWidth: 220)
-        .padding(.bottom, 24)
-        .focused($isFieldFocused)
-        .disabled(isBusy)
-        .onAppear { isFieldFocused = true }
-        .accessibilityIdentifier(AccessibilityID.Passcode.macField)
-    }
-}
-#endif


### PR DESCRIPTION
Closes #5075.

Follow-up to #5070 (passcode app-lock, #4846). Every fix lands in the shared component rather than behind a new platform branch, because in each case macOS is revealing a defect that is merely invisible on iOS rather than a place the platforms should differ.

## What changed

| # | Fix | Commit |
|---|---|---|
| 1 | `ManagePasscodeScreen` drops `.screenBackground(.gradient)` | `20d57e99a` |
| 2 | Re-read the passcode state when a pushed screen pops | `b9283d993` |
| 3 | The Mac gets the same keypad as the phone | `b062815c2` |
| 4 | The macOS toolbar stops painting over the screen's own background | `27b1d76c9` |
| 5 | The settings toggle row becomes the app's switch | `d8149627b` |
| 6 | The remove sheet cannot be abandoned mid-removal | `e8653f0bf` |
| 7 | The remove sheet closes with a close button, not a back chevron | `9fab7df82` |
| 8 | A reopened sheet cancels the previous dismissal | `e8653f0bf` |

Plus the drag indicator on the remove sheet (`f1a93b700`).

### The one that matters

**6** is the reason to read this diff carefully. Removing a passcode rewrites every stored key share, and leaving the sheet mid-flight does not cancel it — the work is an unstructured task that outlives the screen. What it does instead is worse than a cancellation: the settings list refreshes as the sheet closes, reads a passcode that is still there, and never hears that it went. It then offers to change and remove a passcode that no longer exists, over key shares that are no longer encrypted.

So no dismissal path is open while the removal runs: the close button is disabled, and the swipe and backdrop tap are refused through the sheet's own `isDismissable`.

### Notes for review

- **`MacOSToolbarView` now fills only over a `.plain` screen**, read from the same environment value `Screen` uses to draw it. This also reaches `PeerDiscoveryScreen`, the only other screen declaring `.gradient` — it had the same band. Non-`Screen` callers keep the default `.plain` environment and are unchanged.
- **`SettingToggleCell` → `VultiToggle` changes iOS too.** The old bare `Toggle` inherited the app's white accent, so this is not only a macOS checkbox→switch fix: it also turns the five rows in Advanced Settings blue on iOS. Intended — `VultiToggle` is the standard and `NotificationsSettingsScreen` is already blue — but say so if you'd rather it were scoped to the passcode row.
- **The gradient comes off `ManagePasscodeScreen` on both platforms**, deliberately. `AutoLockScreen` and the branded entry screens keep theirs.
- **Nothing under `Core/Security/Passcode/` is touched.** Item 2 is a screen reading stale state, not reading it wrongly, so the fix is in the view layer.
- **Hardware entry on macOS** goes through `.onKeyPress` rather than a hidden field: modifiers are inspected (⌘1 must not enter a digit), `.numericPad` is deliberately allowed since macOS sets it on the keypad keys themselves, repeat is accepted for delete only, and ⌘V requires the clipboard to already be a passcode rather than sieving digits out of arbitrary text.
- **Known limitation:** on layouts where top-row digits require Shift (AZERTY), `KeyPress.characters` reports the unshifted glyph and hardware digits will not register. The numeric keypad and the on-screen pad both work. Restoring layout-aware input would mean bringing back the text field this PR removes.

## Testing

- macOS: `** BUILD SUCCEEDED **`
- iOS unit suite: passes except `ZipImportDuplicateTests.testZipImportRenamesInsteadOfOverwritingAStoredVault`, which **fails identically on `main`** — confirmed by running it in a detached worktree at pristine `origin/main`. Unrelated to this branch, which touches five view files and cannot reach zip import. Worth its own issue if it is not already covered.
- SwiftLint: no new warnings.
- Two `codex exec --sandbox read-only` review passes; findings triaged and fixed in `eb69ddc11` and `e8653f0bf`.

⚠️ Items 1–5 are macOS rendering and lifecycle defects and the unit-test target is iOS-only, so **no automated test in this repo can see them**. They need a look on a Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS keypad experience for passcode entry, including hardware keyboard input, deletion, and validated paste support.
  * Added clearer passcode removal controls and progress handling, preventing accidental dismissal during removal.
* **Bug Fixes**
  * Fixed sheets unexpectedly closing or dismissing newly presented content after being reopened.
  * Improved macOS toolbar backgrounds across plain, gradient, and transparent screens.
* **UI Improvements**
  * Updated settings toggles and keypad styling with consistent visual feedback across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->