### PR TITLE
test(import): state the protection state the import tests are written for (#5078)

### DIFF
--- a/VultisigApp/VultisigAppTests/Security/BackupImportProtectionTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/BackupImportProtectionTests.swift
@@ -105,6 +105,37 @@ final class BackupImportProtectionTests: XCTestCase {
         XCTAssertEqual(try context.fetchCount(FetchDescriptor<Coin>()), 0, "default coins must not outlive a refused import")
     }
 
+    /// The third protection state, which nothing pinned until an import test
+    /// started failing for a reason no assertion named.
+    ///
+    /// `.locked` is not only "a passcode is set and not yet entered". A Keychain
+    /// that cannot be read resolves here too, deliberately — `.disabled` is a
+    /// licence to write plaintext, and taking it wrongly stores an unprotected
+    /// share behind a passcode that is still set. So the refusal is the intended
+    /// behaviour and this states it: a backup carrying key shares does not
+    /// import, and nothing of it is left behind.
+    ///
+    /// It also records the shape of the surprise. Normalization runs over the
+    /// *incoming* shares, so a vault with none imports perfectly well in this
+    /// state — which is why a suite full of share-less fixtures can look healthy
+    /// while every real vault, all of which carry shares, is refused.
+    func testAnImportIsRefusedWhileTheKeyIsOutOfReach() throws {
+        let sut = makeViewModel(state: .locked)
+        sut.decryptedContent = try backupVaultJSONHex()
+
+        sut.restoreVault(modelContext: context, vaults: [])
+
+        XCTAssertFalse(sut.isVaultImported)
+        XCTAssertEqual(
+            try context.fetchCount(FetchDescriptor<Vault>()), 0,
+            "a share that cannot be sealed must not reach the store"
+        )
+        XCTAssertEqual(
+            try context.fetchCount(FetchDescriptor<Coin>()), 0,
+            "default coins must not outlive a refused import"
+        )
+    }
+
     // MARK: - What the restored vault opens on
 
     /// The reported regression, through the batch entry point and with no

--- a/VultisigApp/VultisigAppTests/Utils/ZipImportDuplicateTests.swift
+++ b/VultisigApp/VultisigAppTests/Utils/ZipImportDuplicateTests.swift
@@ -23,7 +23,21 @@ final class ZipImportDuplicateTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        viewModel = EncryptedBackupViewModel()
+        // "No passcode set" has to be stated, not inherited. The default
+        // protector reads the real Keychain, which the test host cannot read, and
+        // an unreadable Keychain deliberately fails closed to `.locked` — under
+        // which `seal` throws and *any* import carrying key shares is refused.
+        // Left to the default, these tests would be asserting collision handling
+        // against an import that never got as far as the collision.
+        //
+        // The coordinator is fresh for the same reason: the shared one carries
+        // whatever lease state another test left behind.
+        viewModel = EncryptedBackupViewModel(
+            importer: ProtectedVaultImporter(
+                protector: KeyshareProtector(state: { .disabled }),
+                coordinator: KeyshareWriteCoordinator()
+            )
+        )
     }
 
     override func tearDown() {


### PR DESCRIPTION
Closes #5078.

Unblocks `main`, whose iOS job has been red since #5070 merged. Every PR that re-runs CI inherits the failure.

**No production code changes, and no production bug.** The refusal the test hit is correct behaviour reached in a configuration the test never meant to be in.

## What was happening

#5070 routed imports through `ProtectedVaultImporter.commit`, which normalizes the **incoming** vault's key shares via `KeyshareProtector.shared`. That protector reads the real Keychain: `.absent` → `.disabled`, `.present` → `.locked`, and `.unavailable` → `.locked`, failing closed on purpose. The test bundle has no Keychain entitlement (`KeychainWriteTests.swift:11`), so the state is `.locked`, `seal` throws, and any import carrying key shares is refused — the view model catches it, reports `vaultRestoreFailed`, and stores nothing.

Verified by probe, not inferred: calling `commit` directly with a share-bearing vault throws `locked`. Confirmed by bisect: green at `c861dae3d` (#5068, where the test landed), red from `322ddd625` (#5070).

**Only one test fell** because normalization runs over the *incoming* shares, and it is the only zip test whose incoming vault has any. Its three siblings use share-less fixtures. That is the part worth remembering: a suite full of share-less fixtures looks healthy while every real vault, all of which carry shares, would be refused.

## The change

- `ZipImportDuplicateTests.setUp` now states the protection state instead of inheriting it — `KeyshareProtector(state: { .disabled })`, which is what "no passcode set" means, plus a fresh `KeyshareWriteCoordinator()` rather than the shared one carrying another test's lease residue. Same shape as the existing `makeViewModel(state:)` helper in `BackupImportProtectionTests`.
- A regression test for `.locked`, which had **no coverage**. `.unlocked` and `.disabled` were both well covered, which is exactly why this surfaced as a mystery instead of a named assertion.

## Testing

- iOS full suite: `** TEST SUCCEEDED **`, 5307 tests, **0 failures** — first clean run since #5070.
- macOS: `** BUILD SUCCEEDED **`.
- SwiftLint: no new warnings.
- `codex exec --sandbox read-only` reviewed the diagnosis as well as the diff, and was asked specifically whether this papers over a production bug. Four categories clean; it independently located the entitlement evidence.

## Known, not fixed here

The same latent coupling survives where fixtures happen to be share-less, and would produce the same mystery if shares were ever added:

- `ZipImportDuplicateTests`' BAK path → `restoreVaultBack` → `Vault(proto:)` uses `KeyshareProtector.shared` **before** the injected importer is reached (`EncryptedBackupViewModel.swift:744`).
- `KeygenVaultCommitTests`, three sites.

Left out deliberately: this PR's job is to get `main` green, and that cleanup is a wider test refactor. Recorded in #5078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup imports are now verified to fail safely when the required key is locked or unavailable, without creating incomplete vault or coin records.

* **Tests**
  * Expanded automated coverage for protected backup imports and duplicate archive handling to help prevent regressions in import security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->