### PR TITLE
fix(ripple): refuse and surface the XRPL dApp terms the confirmation screen hid

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDAppTransaction.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDAppTransaction.swift
@@ -13,9 +13,9 @@ import Foundation
 ///
 /// Alongside the rows it reports the caveats that redefine what those rows
 /// mean: a `tfPartialPayment` `Payment` whose `Amount` is a ceiling rather than
-/// a delivery, and a dApp-chosen `Paths` steering how the payment routes. Both
-/// are signed either way, so omitting them would show terms strictly better
-/// than the ones being approved.
+/// a delivery, and a dApp-supplied `Paths` proposing the routes the payment may
+/// take. Both are signed either way, so omitting them would show terms strictly
+/// better than the ones being approved.
 ///
 /// This is NOT a security boundary: the signing fail-closed checks live in
 /// `RippleHelper.dappSigningInput`. This parser only decides what to render.
@@ -34,7 +34,8 @@ struct RippleDAppTransaction: Equatable {
     enum Warning: Equatable {
         /// `tfPartialPayment` is set: `Amount` is a ceiling, not a delivery.
         case partialPayment
-        /// The transaction carries its own `Paths` routing.
+        /// The transaction carries its own `Paths`: routes the dApp proposed
+        /// for the ledger to choose among.
         case customPaths
 
         var labelKey: String {
@@ -80,6 +81,13 @@ struct RippleDAppTransaction: Equatable {
         ("TakerGets", "rippleFieldTakerGets"),
         ("TakerPays", "rippleFieldTakerPays"),
         ("LimitAmount", "rippleFieldTrustLimit")
+    ]
+
+    /// The `TrustSet` quality fields, in render order. Integers, not amounts —
+    /// each is a rate in billionths applied to balances on the trust line.
+    private static let qualityFields: [(field: String, labelKey: String)] = [
+        ("QualityIn", "rippleFieldQualityIn"),
+        ("QualityOut", "rippleFieldQualityOut")
     ]
 
     private static let dropsPerXrp = BigInt(1_000_000)
@@ -147,7 +155,20 @@ struct RippleDAppTransaction: Equatable {
             fields.append(Field(labelKey: "rippleFieldOfferSequence", value: .text(offerSequence)))
         }
 
-        // 5. Flags, named where this reviewer recognises the bit. Omitted when
+        // 5. QualityIn / QualityOut — the exchange rate a TrustSet applies to
+        //    balances on that line. Value-relevant and dApp-controllable, so a
+        //    card that showed only `LimitAmount` would look complete while
+        //    hiding what the line is actually worth. A present-but-undecodable
+        //    one fails the decode, like the amount fields above: this pair
+        //    changes value, so omitting a malformed one would hide it.
+        for key in qualityFields where tx[key.field] != nil {
+            guard let quality = integerValue(tx[key.field]) else {
+                return nil
+            }
+            fields.append(Field(labelKey: key.labelKey, value: .text(quality)))
+        }
+
+        // 6. Flags, named where this reviewer recognises the bit. Omitted when
         //    nothing is set — an absent field and a zero bitmask say the same
         //    thing, and an empty row is noise on a screen meant to be read.
         if flags != 0 {

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDAppTransaction.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDAppTransaction.swift
@@ -246,6 +246,15 @@ struct RippleDAppTransaction: Equatable {
     /// `UInt32.max` is exactly representable as a `Double`, so the integral /
     /// range checks below lose nothing inside the valid window, and every value
     /// wide enough for `Double` to round is already past the upper bound.
+    ///
+    /// This grammar is deliberately NOT the signer's, and both directions of
+    /// the difference fail safe. It is stricter on `Flags: null`, which the
+    /// signer would take as zero — a refusal no real payload runs into, and the
+    /// SDK and extension refuse it identically. It is looser on spellings like
+    /// `131072.0`, which it reads as the bitmask while the signer's u32 decoder
+    /// rejects the field outright: reading a flag the signer will not accept
+    /// costs a transaction that was never going to be signed, never a signature
+    /// over terms nobody reviewed.
     static func parseFlags(_ value: Any?) -> UInt32? {
         guard let value else { return 0 }
         guard let number = value as? NSNumber,

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDAppTransaction.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDAppTransaction.swift
@@ -11,6 +11,12 @@ import Foundation
 /// destination, amounts, issuer — instead of an opaque blob. Port of the
 /// Windows `parseRippleTx`.
 ///
+/// Alongside the rows it reports the caveats that redefine what those rows
+/// mean: a `tfPartialPayment` `Payment` whose `Amount` is a ceiling rather than
+/// a delivery, and a dApp-chosen `Paths` steering how the payment routes. Both
+/// are signed either way, so omitting them would show terms strictly better
+/// than the ones being approved.
+///
 /// This is NOT a security boundary: the signing fail-closed checks live in
 /// `RippleHelper.dappSigningInput`. This parser only decides what to render.
 /// It NEVER throws — `parse` returns `nil` when the JSON can't be decoded into
@@ -18,8 +24,26 @@ import Foundation
 /// a caution notice (a signing screen must never go blank). It also fails
 /// closed on a *present-but-undecodable value field*: an `Amount` / `SendMax` /
 /// etc. that exists but can't be decoded returns `nil` rather than a
-/// seemingly-complete screen that silently hides value.
+/// seemingly-complete screen that silently hides value. An undecodable `Flags`
+/// joins that rule: reading it as "nothing set" would render a partial payment
+/// as an exact one, which is the precise mistake this decode exists to prevent.
 struct RippleDAppTransaction: Equatable {
+
+    /// A caveat that changes what the decoded rows mean. Rendered as a leading
+    /// warning rather than as one more value row to skim past.
+    enum Warning: Equatable {
+        /// `tfPartialPayment` is set: `Amount` is a ceiling, not a delivery.
+        case partialPayment
+        /// The transaction carries its own `Paths` routing.
+        case customPaths
+
+        var labelKey: String {
+            switch self {
+            case .partialPayment: return "rippleWarningPartialPayment"
+            case .customPaths: return "rippleWarningCustomPaths"
+            }
+        }
+    }
 
     /// A decoded XRPL amount: native XRP (drops → XRP) or an issued currency.
     enum Amount: Equatable {
@@ -42,6 +66,7 @@ struct RippleDAppTransaction: Equatable {
     }
 
     let transactionType: String
+    let warnings: [Warning]
     let fields: [Field]
 
     // MARK: - Parsing
@@ -77,6 +102,24 @@ struct RippleDAppTransaction: Equatable {
             return nil
         }
 
+        // Flags decides what the value rows MEAN, so it is read before any of
+        // them — and a present-but-undecodable one fails the whole decode
+        // rather than being read as zero.
+        guard let flags = parseFlags(tx["Flags"]) else {
+            return nil
+        }
+
+        var warnings: [Warning] = []
+        // `tfPartialPayment` is scoped to Payment on purpose: the same bit is
+        // `tfImmediateOrCancel` on an OfferCreate and `tfSetNoRipple` on a
+        // TrustSet, neither of which touches delivery.
+        if transactionType == "Payment", flags & tfPartialPayment != 0 {
+            warnings.append(.partialPayment)
+        }
+        if tx["Paths"] != nil {
+            warnings.append(.customPaths)
+        }
+
         var fields: [Field] = []
 
         // 1. Destination (string).
@@ -104,7 +147,108 @@ struct RippleDAppTransaction: Equatable {
             fields.append(Field(labelKey: "rippleFieldOfferSequence", value: .text(offerSequence)))
         }
 
-        return RippleDAppTransaction(transactionType: transactionType, fields: fields)
+        // 5. Flags, named where this reviewer recognises the bit. Omitted when
+        //    nothing is set — an absent field and a zero bitmask say the same
+        //    thing, and an empty row is noise on a screen meant to be read.
+        if flags != 0 {
+            let described = describeFlags(flags, transactionType: transactionType)
+            fields.append(Field(labelKey: "rippleFieldFlags", value: .text(described)))
+        }
+
+        return RippleDAppTransaction(
+            transactionType: transactionType,
+            warnings: warnings,
+            fields: fields
+        )
+    }
+
+    // MARK: - Flags
+
+    /// `tfPartialPayment` on an XRPL `Payment`. With it set, `Amount` stops
+    /// being a guaranteed delivery and becomes a ceiling: the ledger hands over
+    /// whatever the chosen path can source and records the real figure only in
+    /// the executed transaction's metadata (`delivered_amount`). Absent a
+    /// `DeliverMin` floor, such a payment can settle for dust while the sender
+    /// still spends up to `SendMax`.
+    static let tfPartialPayment: UInt32 = 0x0002_0000
+
+    /// The flag bits shared by every transaction type.
+    private static let universalFlagNames: [(bit: UInt32, name: String)] = [
+        (0x8000_0000, "tfFullyCanonicalSig")
+    ]
+
+    /// Flag names per transaction type. XRPL flag bits are namespace-scoped —
+    /// `0x00020000` is `tfPartialPayment` on a `Payment`, `tfImmediateOrCancel`
+    /// on an `OfferCreate` and `tfSetNoRipple` on a `TrustSet` — so one flat
+    /// table would mislabel two of the three.
+    ///
+    /// Only long-stable, unambiguously documented bits are named. A bit this
+    /// table does not know is rendered as its hex residue instead of a guessed
+    /// name: an unnamed bit the reviewer can still see beats a confident wrong
+    /// label, and the residue is what keeps the row from claiming it showed
+    /// everything when it did not.
+    private static let flagNamesByTransactionType: [String: [(bit: UInt32, name: String)]] = [
+        "Payment": [
+            (0x0001_0000, "tfNoRippleDirect"),
+            (tfPartialPayment, "tfPartialPayment"),
+            (0x0004_0000, "tfLimitQuality")
+        ],
+        "OfferCreate": [
+            (0x0001_0000, "tfPassive"),
+            (0x0002_0000, "tfImmediateOrCancel"),
+            (0x0004_0000, "tfFillOrKill"),
+            (0x0008_0000, "tfSell")
+        ],
+        "TrustSet": [
+            (0x0001_0000, "tfSetfAuth"),
+            (0x0002_0000, "tfSetNoRipple"),
+            (0x0004_0000, "tfClearNoRipple"),
+            (0x0010_0000, "tfSetFreeze"),
+            (0x0020_0000, "tfClearFreeze")
+        ]
+    ]
+
+    /// Decodes an XRPL `Flags` field into its uint32 bitmask, reading an absent
+    /// field as "no flags set".
+    ///
+    /// Returns `nil` for any value present that the XRPL binary codec could not
+    /// encode as a uint32 — notably the `{"tfPartialPayment": true}` object
+    /// sugar some client libraries accept — so callers fail closed rather than
+    /// mistaking an undecodable value for zero.
+    ///
+    /// `UInt32.max` is exactly representable as a `Double`, so the integral /
+    /// range checks below lose nothing inside the valid window, and every value
+    /// wide enough for `Double` to round is already past the upper bound.
+    static func parseFlags(_ value: Any?) -> UInt32? {
+        guard let value else { return 0 }
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID() else {
+            return nil
+        }
+        let doubleValue = number.doubleValue
+        guard doubleValue == doubleValue.rounded(),
+              doubleValue >= 0,
+              doubleValue <= Double(UInt32.max) else {
+            return nil
+        }
+        return UInt32(doubleValue)
+    }
+
+    /// Renders a bitmask as the names this reviewer recognises for the given
+    /// transaction type, with any remaining bits appended as a hex residue.
+    private static func describeFlags(_ flags: UInt32, transactionType: String) -> String {
+        let known = (flagNamesByTransactionType[transactionType] ?? []) + universalFlagNames
+        var names: [String] = []
+        var remaining = flags
+
+        for entry in known where flags & entry.bit != 0 {
+            names.append(entry.name)
+            remaining &= ~entry.bit
+        }
+        if remaining != 0 {
+            names.append(String(format: "0x%08X", remaining))
+        }
+        return names.joined(separator: ", ")
     }
 
     // MARK: - Helpers

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDAppTransaction.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Models/RippleDAppTransaction.swift
@@ -216,6 +216,12 @@ struct RippleDAppTransaction: Equatable {
     /// sugar some client libraries accept — so callers fail closed rather than
     /// mistaking an undecodable value for zero.
     ///
+    /// **Shared with the signing gate on purpose.** Unlike the rest of this
+    /// display-only type, `RippleHelper` calls this too. The row the reviewer
+    /// reads and the bit the gate refuses have to come from one decoder: two
+    /// decoders that disagree about a `Flags` value would recreate the exact
+    /// reviewer-versus-signer mismatch the signing path exists to close.
+    ///
     /// `UInt32.max` is exactly representable as a `Double`, so the integral /
     /// range checks below lose nothing inside the valid window, and every value
     /// wide enough for `Double` to round is already past the upper bound.

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -583,12 +583,24 @@ enum RippleHelper {
         // had the same gap.
         try assertEveryCurrencyCodeIsSignable(in: tx)
 
+        // The type has to be a STRING before anything dispatches on it. XRPL's
+        // codec also accepts a transaction's NUMERIC type code — `0` is
+        // `Payment` — and a numeric spelling reaches the signer as a payment
+        // while every `as? String == "Payment"` comparison below reads false.
+        // That would route a payment down the branch meant for offers and trust
+        // lines, which binds neither destination nor amount. Refuse instead of
+        // teaching each comparison a second spelling: nothing legitimate sends
+        // a numeric type, and the review screen cannot render one either.
+        guard let transactionType = tx["TransactionType"] as? String else {
+            throw HelperError.runtimeError("signRipple rawJson TransactionType is not a string")
+        }
+
         // Payments are additionally expressible by the payload metadata, so bind
         // them to the reviewed destination and amount, then refuse the flags
         // that would quietly unbind that amount again. Other types (offers /
         // trust lines / escrows) are not reconstructable from toAddress/toAmount
         // and pass on the Account and currency-code checks alone.
-        if tx["TransactionType"] as? String == "Payment" {
+        if transactionType == "Payment" {
             try bindPaymentToReviewedValues(tx: tx, keysignPayload: keysignPayload)
             try assertPaymentDeliveryIsBounded(tx: tx)
         }
@@ -898,7 +910,7 @@ enum RippleHelper {
         }
         guard flags & RippleDAppTransaction.tfPartialPayment != 0 else { return }
 
-        guard isPositiveXrplAmount(tx["DeliverMin"]) else {
+        guard isDeliveryFloor(tx["DeliverMin"], for: tx["Amount"]) else {
             throw HelperError.runtimeError(
                 "signRipple rawJson sets tfPartialPayment without a usable DeliverMin floor"
             )
@@ -911,31 +923,75 @@ enum RippleHelper {
     /// before it can burn CPU on its way to being rejected anyway.
     private static let maxDropsStringLength = 20
 
-    /// Whether a value is a well-formed, strictly positive XRPL amount — a
-    /// drops string or an issued-currency object.
+    /// Whether `deliverMin` actually floors the delivery `amount` describes.
     ///
-    /// A `DeliverMin` only floors a delivery if it is one. `null`, `{}`, `"0"`
-    /// and `{"value":"0",…}` all satisfy "the field is present" while bounding
-    /// nothing, so presence alone cannot stand in for a floor.
+    /// Presence is not the question, and neither is positivity alone.
     ///
-    /// An issued value below the smallest representable unit truncates to zero
-    /// through `parseIssuedCurrencyValue` and is refused on the same grounds: a
-    /// floor under the resolution of the ledger amount is not a floor.
-    private static func isPositiveXrplAmount(_ value: Any?) -> Bool {
-        if let drops = value as? String {
-            guard drops.count <= maxDropsStringLength, let parsed = BigInt(drops) else {
+    /// **It has to be positive.** `null`, `{}`, `"0"` and `{"value":"0",…}` all
+    /// satisfy "the field is there" while bounding nothing.
+    ///
+    /// **It has to floor the SAME asset.** XRPL gives an issuer two special
+    /// readings on a `Payment`: an `Amount` whose issuer is the `Destination`
+    /// means "any issuer the destination will take", and a `SendMax` whose
+    /// issuer is the `Account` means "any issuer the sender holds". A floor
+    /// carrying one of those wildcards is a floor on *some* issuer's version of
+    /// the currency — which can be worth nothing — while the card names a
+    /// definite issuer. Pinning `DeliverMin`'s currency and issuer to
+    /// `Amount`'s closes that, and costs nothing legitimate: the ledger already
+    /// requires the two to agree, so a floor that disagrees was never going to
+    /// execute. `Amount` in turn is bound to the reviewed coin by
+    /// `bindPaymentToReviewedValues`, so the floor ends up pinned to the asset
+    /// the co-signer actually reviewed.
+    ///
+    /// Currency codes are compared through `toXrplCurrencyCode`, the same
+    /// normalisation the reviewed-amount binding uses, so hex case and ASCII
+    /// packing do not read as different currencies. It stops short of equating
+    /// a 3-byte code with the 40-hex spelling of the SAME currency, which the
+    /// ledger does treat as equal — a payment naming `USD` in `Amount` and
+    /// `0000…5553440000…` in `DeliverMin` is refused here and would have
+    /// executed. That divergence is deliberate: it errs toward refusing, no
+    /// real payload spells one currency two ways across two fields of one
+    /// transaction, and a bespoke canonicaliser sitting in the middle of a
+    /// signing gate is a worse thing to own than a rare false rejection.
+    ///
+    /// Normalising for the COMPARISON is safe in a way normalising for the
+    /// verdict would not be — the raw bytes still reach the signer untouched,
+    /// and `assertEveryCurrencyCodeIsSignable` has already refused any code the
+    /// signer would rewrite.
+    ///
+    /// An issued value below the resolution `parseIssuedCurrencyValue` works at
+    /// truncates to zero and is refused on the first ground. That matches the
+    /// SDK, and a floor finer than the resolution the reviewed amount itself is
+    /// compared at cannot bound anything this signer can reason about.
+    private static func isDeliveryFloor(_ deliverMin: Any?, for amount: Any?) -> Bool {
+        if amount is String {
+            // Native XRP: both sides are drops strings.
+            guard let drops = deliverMin as? String,
+                  drops.count <= maxDropsStringLength,
+                  let parsed = BigInt(drops) else {
                 return false
             }
             return parsed > 0
         }
-        if let iou = value as? [String: Any] {
-            guard iou["currency"] is String,
-                  iou["issuer"] is String,
-                  let iouValue = iou["value"] as? String,
-                  let parsed = try? RippleIssuedCurrency.parseIssuedCurrencyValue(iouValue) else {
+        if let amountIou = amount as? [String: Any] {
+            guard let floor = deliverMin as? [String: Any],
+                  let amountCurrency = amountIou["currency"] as? String,
+                  let amountIssuer = amountIou["issuer"] as? String,
+                  let floorCurrency = floor["currency"] as? String,
+                  floor["issuer"] as? String == amountIssuer,
+                  let floorValue = floor["value"] as? String else {
                 return false
             }
-            return parsed > 0
+            do {
+                guard try RippleIssuedCurrency.toXrplCurrencyCode(floorCurrency)
+                    == RippleIssuedCurrency.toXrplCurrencyCode(amountCurrency) else {
+                    return false
+                }
+                return try RippleIssuedCurrency.parseIssuedCurrencyValue(floorValue) > 0
+            } catch {
+                // A malformed code or value is not a floor. Never a crash.
+                return false
+            }
         }
         return false
     }

--- a/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Ripple/Signing/Ripple.swift
@@ -540,6 +540,8 @@ enum RippleHelper {
     ///    issued-currency object, currency + issuer + value against the
     ///    reviewed coin's token id. Offers, escrows and trust lines pass on the
     ///    `Account` check alone (they carry no reviewed toAddress/toAmount).
+    /// 3. A `Payment` must not set `tfPartialPayment` without a delivery floor,
+    ///    since that flag turns the just-bound `Amount` back into a ceiling.
     private static func dappSigningInput(
         keysignPayload: KeysignPayload,
         rawJson: String,
@@ -582,11 +584,13 @@ enum RippleHelper {
         try assertEveryCurrencyCodeIsSignable(in: tx)
 
         // Payments are additionally expressible by the payload metadata, so bind
-        // them to the reviewed destination and amount. Other types (offers /
+        // them to the reviewed destination and amount, then refuse the flags
+        // that would quietly unbind that amount again. Other types (offers /
         // trust lines / escrows) are not reconstructable from toAddress/toAmount
         // and pass on the Account and currency-code checks alone.
         if tx["TransactionType"] as? String == "Payment" {
             try bindPaymentToReviewedValues(tx: tx, keysignPayload: keysignPayload)
+            try assertPaymentDeliveryIsBounded(tx: tx)
         }
 
         guard let publicKeyData = Data(hexString: keysignPayload.coin.hexPublicKey) else {
@@ -856,6 +860,84 @@ enum RippleHelper {
             // Missing or unrepresentable Amount.
             throw amountMismatch
         }
+    }
+
+    /// Refuses a dApp `Payment` whose reviewed `Amount` no longer bounds what
+    /// the recipient actually gets.
+    ///
+    /// The binding `bindPaymentToReviewedValues` just established only means
+    /// something while `Amount` is a delivery. `tfPartialPayment` turns it into
+    /// a ceiling: the ledger hands over whatever the chosen path can source and
+    /// records the real figure only in the executed transaction's metadata
+    /// (`delivered_amount`). The reviewed `toAmount` still matches byte for
+    /// byte, still describes nothing the recipient will receive, and the sender
+    /// can be charged the full `SendMax`. The cross-currency self-swap —
+    /// `Destination` is the sender's own address — turns an attractive receive
+    /// figure into dust for the price of the whole `SendMax`.
+    ///
+    /// A well-formed, strictly positive `DeliverMin` restores a floor, so a
+    /// partial payment carrying one is forwarded unchanged; they are
+    /// legitimate. Without one there is nothing left binding the outcome, so
+    /// refuse rather than sign terms no reviewer could have seen. `Flags` that
+    /// cannot be read as a uint32 are refused for the same reason: they may
+    /// carry the very bit being checked.
+    ///
+    /// Scoped to `Payment` deliberately — `0x00020000` is namespace-sensitive.
+    /// It is `tfImmediateOrCancel` on an `OfferCreate`, and as an account-root
+    /// flag it is `lsfRequireDestTag`; reading it as partial payment anywhere
+    /// else would be wrong.
+    ///
+    /// `Paths` is NOT refused. It is legitimate on a cross-currency payment and
+    /// refusing it would break real DEX flows; the review screen surfaces it
+    /// instead, which is where a routing choice belongs.
+    private static func assertPaymentDeliveryIsBounded(tx: [String: Any]) throws {
+        // Read from the SAME decoded object every other check reads, so the
+        // duplicate-key guard that already ran covers this field too.
+        guard let flags = RippleDAppTransaction.parseFlags(tx["Flags"]) else {
+            throw HelperError.runtimeError("signRipple rawJson Flags is not a uint32 bitmask")
+        }
+        guard flags & RippleDAppTransaction.tfPartialPayment != 0 else { return }
+
+        guard isPositiveXrplAmount(tx["DeliverMin"]) else {
+            throw HelperError.runtimeError(
+                "signRipple rawJson sets tfPartialPayment without a usable DeliverMin floor"
+            )
+        }
+    }
+
+    /// Upper bound on the length of a drops string before it reaches `BigInt`.
+    /// XRPL's maximum is 10^17 drops (18 digits); 20 characters covers that
+    /// plus a sign and slack, while a pathologically long string is refused
+    /// before it can burn CPU on its way to being rejected anyway.
+    private static let maxDropsStringLength = 20
+
+    /// Whether a value is a well-formed, strictly positive XRPL amount — a
+    /// drops string or an issued-currency object.
+    ///
+    /// A `DeliverMin` only floors a delivery if it is one. `null`, `{}`, `"0"`
+    /// and `{"value":"0",…}` all satisfy "the field is present" while bounding
+    /// nothing, so presence alone cannot stand in for a floor.
+    ///
+    /// An issued value below the smallest representable unit truncates to zero
+    /// through `parseIssuedCurrencyValue` and is refused on the same grounds: a
+    /// floor under the resolution of the ledger amount is not a floor.
+    private static func isPositiveXrplAmount(_ value: Any?) -> Bool {
+        if let drops = value as? String {
+            guard drops.count <= maxDropsStringLength, let parsed = BigInt(drops) else {
+                return false
+            }
+            return parsed > 0
+        }
+        if let iou = value as? [String: Any] {
+            guard iou["currency"] is String,
+                  iou["issuer"] is String,
+                  let iouValue = iou["value"] as? String,
+                  let parsed = try? RippleIssuedCurrency.parseIssuedCurrencyValue(iouValue) else {
+                return false
+            }
+            return parsed > 0
+        }
+        return false
     }
 
     /// Raw-JSON signing input carrying a text memo as an on-chain XRPL `Memos`

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1136,6 +1136,8 @@
 "rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Emittent";
 "rippleFieldOfferSequence" = "Offer Sequence";
+"rippleFieldQualityIn" = "Quality In";
+"rippleFieldQualityOut" = "Quality Out";
 "rippleFieldSendMax" = "Send Max";
 "rippleFieldTakerGets" = "Taker Gets";
 "rippleFieldTakerPays" = "Taker Pays";
@@ -1161,8 +1163,8 @@
 "rippleTrustLineUnreviewable" = "Prüfung nicht möglich";
 "rippleTrustLineUnreviewableValue" = "Währung, Emittent oder Limit dieser Trust Line konnten nicht gelesen werden, daher lassen sich ihre Bedingungen nicht anzeigen. Nicht signieren.";
 "rippleUndecodedNotice" = "Diese Transaktion konnte nicht dekodiert werden. Überprüfe das rohe JSON sorgfältig, bevor du signierst.";
-"rippleWarningCustomPaths" = "Die Website hat den Weg gewählt, den diese Zahlung durch das Netzwerk nimmt.";
-"rippleWarningPartialPayment" = "Dies ist eine Teilzahlung. Der angezeigte Betrag ist ein Höchstbetrag, keine garantierte Zustellung – der Empfänger kann weniger erhalten, während du bis zu diesem Höchstbetrag zahlst.";
+"rippleWarningCustomPaths" = "Die Website hat eigene mögliche Routen für diese Zahlung angegeben. Das Ledger wählt daraus aus.";
+"rippleWarningPartialPayment" = "Dies ist eine Teilzahlung: Der Betrag ist das Maximum, das der Empfänger erhalten kann, keine garantierte Zustellung. Er kann weniger erhalten, während dir weiterhin bis zu Send Max berechnet wird.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "Die Empfängeradresse muss sich von der Absenderadresse unterscheiden.";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Ziel";
 "rippleFieldDestinationTag" = "Destination Tag";
+"rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Emittent";
 "rippleFieldOfferSequence" = "Offer Sequence";
 "rippleFieldSendMax" = "Send Max";
@@ -1160,6 +1161,8 @@
 "rippleTrustLineUnreviewable" = "Prüfung nicht möglich";
 "rippleTrustLineUnreviewableValue" = "Währung, Emittent oder Limit dieser Trust Line konnten nicht gelesen werden, daher lassen sich ihre Bedingungen nicht anzeigen. Nicht signieren.";
 "rippleUndecodedNotice" = "Diese Transaktion konnte nicht dekodiert werden. Überprüfe das rohe JSON sorgfältig, bevor du signierst.";
+"rippleWarningCustomPaths" = "Die Website hat den Weg gewählt, den diese Zahlung durch das Netzwerk nimmt.";
+"rippleWarningPartialPayment" = "Dies ist eine Teilzahlung. Der angezeigte Betrag ist ein Höchstbetrag, keine garantierte Zustellung – der Empfänger kann weniger erhalten, während du bis zu diesem Höchstbetrag zahlst.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "Die Empfängeradresse muss sich von der Absenderadresse unterscheiden.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1136,6 +1136,8 @@
 "rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Issuer";
 "rippleFieldOfferSequence" = "Offer Sequence";
+"rippleFieldQualityIn" = "Quality In";
+"rippleFieldQualityOut" = "Quality Out";
 "rippleFieldSendMax" = "Send Max";
 "rippleFieldTakerGets" = "Taker Gets";
 "rippleFieldTakerPays" = "Taker Pays";
@@ -1161,8 +1163,8 @@
 "rippleTrustLineUnreviewable" = "Cannot review";
 "rippleTrustLineUnreviewableValue" = "This trust line's currency, issuer or limit could not be read, so its terms cannot be shown. Do not sign it.";
 "rippleUndecodedNotice" = "This transaction couldn't be decoded. Review the raw JSON carefully before signing.";
-"rippleWarningCustomPaths" = "The site chose the route this payment takes through the network.";
-"rippleWarningPartialPayment" = "This is a partial payment. The amount shown is a maximum, not a guaranteed delivery — the recipient can receive less while you still pay up to that maximum.";
+"rippleWarningCustomPaths" = "The site supplied its own candidate routes for this payment. The ledger picks among them.";
+"rippleWarningPartialPayment" = "This is a partial payment: the Amount is the most the recipient can receive, not a guaranteed delivery. They can receive less while you are still charged up to the Send Max.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "The to address must be different from the from address";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destination";
 "rippleFieldDestinationTag" = "Destination Tag";
+"rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Issuer";
 "rippleFieldOfferSequence" = "Offer Sequence";
 "rippleFieldSendMax" = "Send Max";
@@ -1160,6 +1161,8 @@
 "rippleTrustLineUnreviewable" = "Cannot review";
 "rippleTrustLineUnreviewableValue" = "This trust line's currency, issuer or limit could not be read, so its terms cannot be shown. Do not sign it.";
 "rippleUndecodedNotice" = "This transaction couldn't be decoded. Review the raw JSON carefully before signing.";
+"rippleWarningCustomPaths" = "The site chose the route this payment takes through the network.";
+"rippleWarningPartialPayment" = "This is a partial payment. The amount shown is a maximum, not a guaranteed delivery — the recipient can receive less while you still pay up to that maximum.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "The to address must be different from the from address";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1136,6 +1136,8 @@
 "rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Emisor";
 "rippleFieldOfferSequence" = "Offer Sequence";
+"rippleFieldQualityIn" = "Quality In";
+"rippleFieldQualityOut" = "Quality Out";
 "rippleFieldSendMax" = "Send Max";
 "rippleFieldTakerGets" = "Taker Gets";
 "rippleFieldTakerPays" = "Taker Pays";
@@ -1161,8 +1163,8 @@
 "rippleTrustLineUnreviewable" = "No se puede revisar";
 "rippleTrustLineUnreviewableValue" = "No se pudo leer la moneda, el emisor o el límite de esta línea de confianza, así que no se pueden mostrar sus condiciones. No la firmes.";
 "rippleUndecodedNotice" = "No se pudo decodificar esta transacción. Revisa cuidadosamente el JSON sin procesar antes de firmar.";
-"rippleWarningCustomPaths" = "El sitio eligió la ruta que este pago sigue por la red.";
-"rippleWarningPartialPayment" = "Este es un pago parcial. El importe mostrado es un máximo, no una entrega garantizada: el destinatario puede recibir menos mientras tú pagas hasta ese máximo.";
+"rippleWarningCustomPaths" = "El sitio propuso sus propias rutas para este pago. El ledger elige entre ellas.";
+"rippleWarningPartialPayment" = "Este es un pago parcial: el importe es lo máximo que puede recibir el destinatario, no una entrega garantizada. Puede recibir menos mientras a ti se te cobra hasta el Send Max.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "La dirección de destino debe ser diferente de la dirección de origen.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destino";
 "rippleFieldDestinationTag" = "Destination Tag";
+"rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Emisor";
 "rippleFieldOfferSequence" = "Offer Sequence";
 "rippleFieldSendMax" = "Send Max";
@@ -1160,6 +1161,8 @@
 "rippleTrustLineUnreviewable" = "No se puede revisar";
 "rippleTrustLineUnreviewableValue" = "No se pudo leer la moneda, el emisor o el límite de esta línea de confianza, así que no se pueden mostrar sus condiciones. No la firmes.";
 "rippleUndecodedNotice" = "No se pudo decodificar esta transacción. Revisa cuidadosamente el JSON sin procesar antes de firmar.";
+"rippleWarningCustomPaths" = "El sitio eligió la ruta que este pago sigue por la red.";
+"rippleWarningPartialPayment" = "Este es un pago parcial. El importe mostrado es un máximo, no una entrega garantizada: el destinatario puede recibir menos mientras tú pagas hasta ese máximo.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "La dirección de destino debe ser diferente de la dirección de origen.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Odredište";
 "rippleFieldDestinationTag" = "Destination Tag";
+"rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Izdavatelj";
 "rippleFieldOfferSequence" = "Offer Sequence";
 "rippleFieldSendMax" = "Send Max";
@@ -1160,6 +1161,8 @@
 "rippleTrustLineUnreviewable" = "Pregled nije moguć";
 "rippleTrustLineUnreviewableValue" = "Valuta, izdavatelj ili ograničenje ove linije povjerenja nisu se mogli pročitati, pa se njezini uvjeti ne mogu prikazati. Nemojte je potpisati.";
 "rippleUndecodedNotice" = "Ovu transakciju nije bilo moguće dekodirati. Pažljivo pregledajte neobrađeni JSON prije potpisivanja.";
+"rippleWarningCustomPaths" = "Stranica je odabrala rutu kojom ovo plaćanje putuje kroz mrežu.";
+"rippleWarningPartialPayment" = "Ovo je djelomično plaćanje. Prikazani iznos je najveći mogući, a ne zajamčena isporuka — primatelj može primiti manje, dok vi i dalje plaćate do tog iznosa.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "Adresa primatelja mora se razlikovati od adrese pošiljatelja";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1136,6 +1136,8 @@
 "rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Izdavatelj";
 "rippleFieldOfferSequence" = "Offer Sequence";
+"rippleFieldQualityIn" = "Quality In";
+"rippleFieldQualityOut" = "Quality Out";
 "rippleFieldSendMax" = "Send Max";
 "rippleFieldTakerGets" = "Taker Gets";
 "rippleFieldTakerPays" = "Taker Pays";
@@ -1161,8 +1163,8 @@
 "rippleTrustLineUnreviewable" = "Pregled nije moguć";
 "rippleTrustLineUnreviewableValue" = "Valuta, izdavatelj ili ograničenje ove linije povjerenja nisu se mogli pročitati, pa se njezini uvjeti ne mogu prikazati. Nemojte je potpisati.";
 "rippleUndecodedNotice" = "Ovu transakciju nije bilo moguće dekodirati. Pažljivo pregledajte neobrađeni JSON prije potpisivanja.";
-"rippleWarningCustomPaths" = "Stranica je odabrala rutu kojom ovo plaćanje putuje kroz mrežu.";
-"rippleWarningPartialPayment" = "Ovo je djelomično plaćanje. Prikazani iznos je najveći mogući, a ne zajamčena isporuka — primatelj može primiti manje, dok vi i dalje plaćate do tog iznosa.";
+"rippleWarningCustomPaths" = "Stranica je predložila vlastite moguće rute za ovo plaćanje. Ledger bira među njima.";
+"rippleWarningPartialPayment" = "Ovo je djelomično plaćanje: iznos je najviše što primatelj može primiti, a ne zajamčena isporuka. Može primiti manje, dok se vama i dalje naplaćuje do iznosa Send Max.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "Adresa primatelja mora se razlikovati od adrese pošiljatelja";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destinazione";
 "rippleFieldDestinationTag" = "Destination Tag";
+"rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Emittente";
 "rippleFieldOfferSequence" = "Offer Sequence";
 "rippleFieldSendMax" = "Send Max";
@@ -1160,6 +1161,8 @@
 "rippleTrustLineUnreviewable" = "Impossibile verificare";
 "rippleTrustLineUnreviewableValue" = "Non è stato possibile leggere valuta, emittente o limite di questa linea di fiducia, quindi le sue condizioni non possono essere mostrate. Non firmarla.";
 "rippleUndecodedNotice" = "Impossibile decodificare questa transazione. Controlla attentamente il JSON grezzo prima di firmare.";
+"rippleWarningCustomPaths" = "Il sito ha scelto il percorso che questo pagamento segue nella rete.";
+"rippleWarningPartialPayment" = "Questo è un pagamento parziale. L'importo mostrato è un massimo, non una consegna garantita: il destinatario può ricevere meno mentre tu paghi fino a quel massimo.";
 "routerNotAvailable" = "Router non disponibile per approvazioni su %@. Riprova più tardi.";
 "rune" = "RUNE";
 "sameAddressError" = "L'indirizzo del destinatario deve essere diverso dall'indirizzo del mittente";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1136,6 +1136,8 @@
 "rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Emittente";
 "rippleFieldOfferSequence" = "Offer Sequence";
+"rippleFieldQualityIn" = "Quality In";
+"rippleFieldQualityOut" = "Quality Out";
 "rippleFieldSendMax" = "Send Max";
 "rippleFieldTakerGets" = "Taker Gets";
 "rippleFieldTakerPays" = "Taker Pays";
@@ -1161,8 +1163,8 @@
 "rippleTrustLineUnreviewable" = "Impossibile verificare";
 "rippleTrustLineUnreviewableValue" = "Non è stato possibile leggere valuta, emittente o limite di questa linea di fiducia, quindi le sue condizioni non possono essere mostrate. Non firmarla.";
 "rippleUndecodedNotice" = "Impossibile decodificare questa transazione. Controlla attentamente il JSON grezzo prima di firmare.";
-"rippleWarningCustomPaths" = "Il sito ha scelto il percorso che questo pagamento segue nella rete.";
-"rippleWarningPartialPayment" = "Questo è un pagamento parziale. L'importo mostrato è un massimo, non una consegna garantita: il destinatario può ricevere meno mentre tu paghi fino a quel massimo.";
+"rippleWarningCustomPaths" = "Il sito ha proposto percorsi propri per questo pagamento. È il ledger a sceglierne uno.";
+"rippleWarningPartialPayment" = "Questo è un pagamento parziale: l'importo è il massimo che il destinatario può ricevere, non una consegna garantita. Può ricevere meno mentre a te viene addebitato fino a Send Max.";
 "routerNotAvailable" = "Router non disponibile per approvazioni su %@. Riprova più tardi.";
 "rune" = "RUNE";
 "sameAddressError" = "L'indirizzo del destinatario deve essere diverso dall'indirizzo del mittente";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1136,6 +1136,8 @@
 "rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "발행자";
 "rippleFieldOfferSequence" = "Offer Sequence";
+"rippleFieldQualityIn" = "Quality In";
+"rippleFieldQualityOut" = "Quality Out";
 "rippleFieldSendMax" = "Send Max";
 "rippleFieldTakerGets" = "Taker Gets";
 "rippleFieldTakerPays" = "Taker Pays";
@@ -1161,8 +1163,8 @@
 "rippleTrustLineUnreviewable" = "검토할 수 없음";
 "rippleTrustLineUnreviewableValue" = "이 신뢰선의 통화, 발행자 또는 한도를 읽을 수 없어 조건을 표시할 수 없습니다. 서명하지 마세요.";
 "rippleUndecodedNotice" = "이 트랜잭션을 디코딩할 수 없습니다. 서명하기 전에 원시 JSON을 주의 깊게 확인하세요.";
-"rippleWarningCustomPaths" = "이 결제가 네트워크를 지나는 경로를 사이트가 선택했습니다.";
-"rippleWarningPartialPayment" = "부분 결제입니다. 표시된 금액은 상한이며 전달이 보장된 금액이 아닙니다. 수령인은 더 적게 받을 수 있지만 보내는 사람은 그 상한까지 지불합니다.";
+"rippleWarningCustomPaths" = "이 결제의 경로 후보를 사이트가 직접 제시했습니다. 그중에서 원장이 선택합니다.";
+"rippleWarningPartialPayment" = "부분 결제입니다. 표시된 금액은 수령인이 받을 수 있는 최대치이며 전달이 보장된 금액이 아닙니다. 수령인은 더 적게 받을 수 있고 보내는 사람에게는 Send Max까지 청구됩니다.";
 "routerNotAvailable" = "%@에서 승인을 위한 라우터를 사용할 수 없습니다. 나중에 다시 시도하세요.";
 "rune" = "RUNE";
 "sameAddressError" = "받는 주소는 보내는 주소와 달라야 합니다";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "수신처";
 "rippleFieldDestinationTag" = "Destination Tag";
+"rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "발행자";
 "rippleFieldOfferSequence" = "Offer Sequence";
 "rippleFieldSendMax" = "Send Max";
@@ -1160,6 +1161,8 @@
 "rippleTrustLineUnreviewable" = "검토할 수 없음";
 "rippleTrustLineUnreviewableValue" = "이 신뢰선의 통화, 발행자 또는 한도를 읽을 수 없어 조건을 표시할 수 없습니다. 서명하지 마세요.";
 "rippleUndecodedNotice" = "이 트랜잭션을 디코딩할 수 없습니다. 서명하기 전에 원시 JSON을 주의 깊게 확인하세요.";
+"rippleWarningCustomPaths" = "이 결제가 네트워크를 지나는 경로를 사이트가 선택했습니다.";
+"rippleWarningPartialPayment" = "부분 결제입니다. 표시된 금액은 상한이며 전달이 보장된 금액이 아닙니다. 수령인은 더 적게 받을 수 있지만 보내는 사람은 그 상한까지 지불합니다.";
 "routerNotAvailable" = "%@에서 승인을 위한 라우터를 사용할 수 없습니다. 나중에 다시 시도하세요.";
 "rune" = "RUNE";
 "sameAddressError" = "받는 주소는 보내는 주소와 달라야 합니다";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "rippleFieldDeliverMin" = "Deliver Min";
 "rippleFieldDestination" = "Destino";
 "rippleFieldDestinationTag" = "Destination Tag";
+"rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Emissor";
 "rippleFieldOfferSequence" = "Offer Sequence";
 "rippleFieldSendMax" = "Send Max";
@@ -1160,6 +1161,8 @@
 "rippleTrustLineUnreviewable" = "Não é possível rever";
 "rippleTrustLineUnreviewableValue" = "Não foi possível ler a moeda, o emissor ou o limite desta linha de confiança, por isso as suas condições não podem ser mostradas. Não a assine.";
 "rippleUndecodedNotice" = "Não foi possível decodificar esta transação. Revise cuidadosamente o JSON bruto antes de assinar.";
+"rippleWarningCustomPaths" = "O site escolheu a rota que este pagamento percorre na rede.";
+"rippleWarningPartialPayment" = "Este é um pagamento parcial. O valor exibido é um máximo, não uma entrega garantida: o destinatário pode receber menos enquanto você paga até esse máximo.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "O endereço de destino deve ser diferente do endereço de origem";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1136,6 +1136,8 @@
 "rippleFieldFlags" = "Flags";
 "rippleFieldIssuer" = "Emissor";
 "rippleFieldOfferSequence" = "Offer Sequence";
+"rippleFieldQualityIn" = "Quality In";
+"rippleFieldQualityOut" = "Quality Out";
 "rippleFieldSendMax" = "Send Max";
 "rippleFieldTakerGets" = "Taker Gets";
 "rippleFieldTakerPays" = "Taker Pays";
@@ -1161,8 +1163,8 @@
 "rippleTrustLineUnreviewable" = "Não é possível rever";
 "rippleTrustLineUnreviewableValue" = "Não foi possível ler a moeda, o emissor ou o limite desta linha de confiança, por isso as suas condições não podem ser mostradas. Não a assine.";
 "rippleUndecodedNotice" = "Não foi possível decodificar esta transação. Revise cuidadosamente o JSON bruto antes de assinar.";
-"rippleWarningCustomPaths" = "O site escolheu a rota que este pagamento percorre na rede.";
-"rippleWarningPartialPayment" = "Este é um pagamento parcial. O valor exibido é um máximo, não uma entrega garantida: o destinatário pode receber menos enquanto você paga até esse máximo.";
+"rippleWarningCustomPaths" = "O site propôs as suas próprias rotas para este pagamento. O ledger escolhe entre elas.";
+"rippleWarningPartialPayment" = "Este é um pagamento parcial: o valor é o máximo que o destinatário pode receber, não uma entrega garantida. Ele pode receber menos enquanto você é cobrado até o Send Max.";
 "routerNotAvailable" = "Router not available for approvals on %@. Try again later.";
 "rune" = "RUNE";
 "sameAddressError" = "O endereço de destino deve ser diferente do endereço de origem";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1133,6 +1133,7 @@
 "rippleFieldDeliverMin" = "最小交付额";
 "rippleFieldDestination" = "目标地址";
 "rippleFieldDestinationTag" = "目标标签";
+"rippleFieldFlags" = "标志";
 "rippleFieldIssuer" = "发行方";
 "rippleFieldOfferSequence" = "挂单序号";
 "rippleFieldSendMax" = "最大发送额";
@@ -1160,6 +1161,8 @@
 "rippleTrustLineUnreviewable" = "无法审核";
 "rippleTrustLineUnreviewableValue" = "无法读取此信任线的货币、发行方或上限，因此无法显示其条款。请勿签名。";
 "rippleUndecodedNotice" = "无法解码此交易。签名前请仔细核对原始 JSON。";
+"rippleWarningCustomPaths" = "该网站选择了这笔付款在网络中经过的路径。";
+"rippleWarningPartialPayment" = "这是一笔部分付款。显示的金额是上限，而非保证到账的金额：收款方可能收到更少，而你仍需支付至多该上限的金额。";
 "routerNotAvailable" = "%@ 的路由不可用。请稍后再试。";
 "rune" = "RUNE";
 "sameAddressError" = "收件人地址必须与发件人地址不同";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1136,6 +1136,8 @@
 "rippleFieldFlags" = "标志";
 "rippleFieldIssuer" = "发行方";
 "rippleFieldOfferSequence" = "挂单序号";
+"rippleFieldQualityIn" = "接收质量";
+"rippleFieldQualityOut" = "发送质量";
 "rippleFieldSendMax" = "最大发送额";
 "rippleFieldTakerGets" = "Taker 获得";
 "rippleFieldTakerPays" = "Taker 支付";
@@ -1161,8 +1163,8 @@
 "rippleTrustLineUnreviewable" = "无法审核";
 "rippleTrustLineUnreviewableValue" = "无法读取此信任线的货币、发行方或上限，因此无法显示其条款。请勿签名。";
 "rippleUndecodedNotice" = "无法解码此交易。签名前请仔细核对原始 JSON。";
-"rippleWarningCustomPaths" = "该网站选择了这笔付款在网络中经过的路径。";
-"rippleWarningPartialPayment" = "这是一笔部分付款。显示的金额是上限，而非保证到账的金额：收款方可能收到更少，而你仍需支付至多该上限的金额。";
+"rippleWarningCustomPaths" = "该网站为这笔付款提供了自己的候选路径，由账本从中选择。";
+"rippleWarningPartialPayment" = "这是一笔部分付款：金额是收款方最多可能收到的数额，而非保证到账的数额。收款方可能收到更少，而你仍会被扣除至多「最大发送额」。";
 "routerNotAvailable" = "%@ 的路由不可用。请稍后再试。";
 "rune" = "RUNE";
 "sameAddressError" = "收件人地址必须与发件人地址不同";

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignRippleDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignRippleDisplayView.swift
@@ -10,7 +10,7 @@
 //  `SignRippleDisplay`.
 //
 //  Caveats that redefine those rows lead the card: a `tfPartialPayment` payment
-//  whose amount is only a ceiling, and a site-supplied routing path. Both are
+//  whose amount is only a ceiling, and site-supplied candidate routes. Both are
 //  signed verbatim, so a screen showing the rows without them would state
 //  better terms than the ones being approved.
 //

--- a/VultisigApp/VultisigApp/Features/Send/Views/Components/SignRippleDisplayView.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Components/SignRippleDisplayView.swift
@@ -9,6 +9,11 @@
 //  can't be decoded: a signing screen must never go blank. Mirrors the Windows
 //  `SignRippleDisplay`.
 //
+//  Caveats that redefine those rows lead the card: a `tfPartialPayment` payment
+//  whose amount is only a ceiling, and a site-supplied routing path. Both are
+//  signed verbatim, so a screen showing the rows without them would state
+//  better terms than the ones being approved.
+//
 
 import SwiftUI
 
@@ -35,6 +40,9 @@ struct SignRippleDisplayView: View {
     private func decodedCard(_ transaction: RippleDAppTransaction) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             header
+            ForEach(transaction.warnings, id: \.labelKey) { warning in
+                warningRow(warning.labelKey.localized)
+            }
             row(label: "rippleFieldType".localized, value: transaction.transactionType)
             ForEach(Array(transaction.fields.enumerated()), id: \.offset) { _, field in
                 fieldRows(field)
@@ -66,13 +74,7 @@ struct SignRippleDisplayView: View {
     private var fallbackCard: some View {
         VStack(alignment: .leading, spacing: 12) {
             header
-            HStack(alignment: .top, spacing: 8) {
-                Icon(.triangleWarning, color: Theme.colors.alertWarning, size: 16)
-                Text("rippleUndecodedNotice".localized)
-                    .font(Theme.fonts.caption12)
-                    .foregroundStyle(Theme.colors.alertWarning)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            warningRow("rippleUndecodedNotice".localized)
             Text(signRipple.rawJson)
                 .font(Theme.fonts.caption12)
                 .monospaced()
@@ -94,6 +96,21 @@ struct SignRippleDisplayView: View {
         Text("rippleTransactionSummary".localized)
             .font(Theme.fonts.bodySMedium)
             .foregroundStyle(Theme.colors.textPrimary)
+    }
+
+    /// A full-width caution line. Unlike `row`, the text is not squeezed against
+    /// a trailing edge — a warning is prose, and it has to stay readable when it
+    /// wraps to two or three lines.
+    private func warningRow(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Icon(.triangleWarning, color: Theme.colors.alertWarning, size: 16)
+            Text(text)
+                .font(Theme.fonts.caption12)
+                .foregroundStyle(Theme.colors.alertWarning)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 
     private func row(

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDAppTransactionParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDAppTransactionParserTests.swift
@@ -212,6 +212,30 @@ final class RippleDAppTransactionParserTests: XCTestCase {
         """))
     }
 
+    // MARK: - TrustSet quality
+
+    /// `QualityIn` / `QualityOut` set the exchange rate applied to balances on
+    /// the trust line, so a card showing only `LimitAmount` would look complete
+    /// while hiding what the line is worth.
+    func testTrustSetQualityRows() throws {
+        let tx = try XCTUnwrap(parse("""
+        {"TransactionType":"TrustSet","Account":"rAcc","LimitAmount":{"value":"1000","currency":"USD","issuer":"rIssuer"},"QualityIn":900000000,"QualityOut":1100000000}
+        """))
+        XCTAssertEqual(field(tx, "rippleFieldQualityIn"), .text("900000000"))
+        XCTAssertEqual(field(tx, "rippleFieldQualityOut"), .text("1100000000"))
+    }
+
+    /// A present-but-undecodable quality fails the decode rather than being
+    /// dropped — silently omitting it would hide the rate it sets.
+    func testUndecodableQualityReturnsNil() {
+        XCTAssertNil(parse("""
+        {"TransactionType":"TrustSet","Account":"rAcc","LimitAmount":{"value":"1000","currency":"USD","issuer":"rIssuer"},"QualityIn":"900000000"}
+        """))
+        XCTAssertNil(parse("""
+        {"TransactionType":"TrustSet","Account":"rAcc","LimitAmount":{"value":"1000","currency":"USD","issuer":"rIssuer"},"QualityOut":-1}
+        """))
+    }
+
     // MARK: - Flags and Paths
 
     /// The display half of the acceptance case: `tfPartialPayment` turns the

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDAppTransactionParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDAppTransactionParserTests.swift
@@ -122,6 +122,16 @@ final class RippleDAppTransactionParserTests: XCTestCase {
         """))
     }
 
+    /// XRPL's codec also accepts a transaction's numeric type code — `0` is
+    /// `Payment`. This decoder renders only the string spelling, so a numeric
+    /// one falls back to the raw JSON rather than a card that omits whatever
+    /// the type turns out to mean.
+    func testNumericTransactionTypeReturnsNil() {
+        XCTAssertNil(parse("""
+        {"TransactionType":0,"Account":"rAcc","Destination":"rDest","Amount":"1000000"}
+        """))
+    }
+
     /// A present Amount that is a JSON number (not a drops string) can't be
     /// decoded → the whole parse fails closed to nil (never hide value behind a
     /// seemingly-complete screen).

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDAppTransactionParserTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleDAppTransactionParserTests.swift
@@ -212,6 +212,114 @@ final class RippleDAppTransactionParserTests: XCTestCase {
         """))
     }
 
+    // MARK: - Flags and Paths
+
+    /// The display half of the acceptance case: `tfPartialPayment` turns the
+    /// `Amount` row from a delivery into a ceiling, so the card has to say so.
+    func testPartialPaymentPaymentWarns() throws {
+        let tx = try XCTUnwrap(parse("""
+        {"TransactionType":"Payment","Account":"rAcc","Destination":"rDest","Amount":"1000000","SendMax":"999999999","Flags":131072}
+        """))
+        XCTAssertEqual(tx.warnings, [.partialPayment])
+        XCTAssertEqual(field(tx, "rippleFieldFlags"), .text("tfPartialPayment"))
+    }
+
+    /// 0x00020000 is namespace-sensitive — `tfImmediateOrCancel` on an
+    /// `OfferCreate`, `tfSetNoRipple` on a `TrustSet`. Neither touches
+    /// delivery, so neither may borrow the partial-payment warning, and each
+    /// must be named for its own namespace.
+    func testPartialPaymentBitOnOtherTypesIsNeitherWarnedNorMislabelled() throws {
+        let offer = try XCTUnwrap(parse("""
+        {"TransactionType":"OfferCreate","Account":"rAcc","TakerGets":"5000000","TakerPays":{"value":"10","currency":"USD","issuer":"rIssuer"},"Flags":131072}
+        """))
+        XCTAssertEqual(offer.warnings, [])
+        XCTAssertEqual(field(offer, "rippleFieldFlags"), .text("tfImmediateOrCancel"))
+
+        let trustSet = try XCTUnwrap(parse("""
+        {"TransactionType":"TrustSet","Account":"rAcc","LimitAmount":{"value":"1000","currency":"USD","issuer":"rIssuer"},"Flags":131072}
+        """))
+        XCTAssertEqual(trustSet.warnings, [])
+        XCTAssertEqual(field(trustSet, "rippleFieldFlags"), .text("tfSetNoRipple"))
+    }
+
+    /// `Paths` is surfaced rather than refused, and it does not depend on
+    /// `Flags` — a payment can be routed by the site without being partial.
+    func testPathsWarns() throws {
+        let tx = try XCTUnwrap(parse("""
+        {"TransactionType":"Payment","Account":"rAcc","Destination":"rDest","Amount":"1000000","Paths":[[{"currency":"USD","issuer":"rIssuer"}]]}
+        """))
+        XCTAssertEqual(tx.warnings, [.customPaths])
+    }
+
+    /// Both caveats can apply at once, and the partial-payment one leads.
+    func testPartialPaymentAndPathsBothWarn() throws {
+        let tx = try XCTUnwrap(parse("""
+        {"TransactionType":"Payment","Account":"rAcc","Destination":"rDest","Amount":"1000000","Flags":131072,"Paths":[[{"currency":"USD","issuer":"rIssuer"}]]}
+        """))
+        XCTAssertEqual(tx.warnings, [.partialPayment, .customPaths])
+    }
+
+    /// A `Flags` the XRPL codec could not have encoded as a uint32 fails the
+    /// whole decode. Reading it as "nothing set" would render a partial payment
+    /// as an exact one — the precise mistake this decode exists to prevent.
+    func testUndecodableFlagsReturnsNil() {
+        let undecodable = [
+            "{\"tfPartialPayment\":true}",
+            "\"131072\"",
+            "true",
+            "-1",
+            "131072.5",
+            "4294967296",
+            "null",
+            "[131072]"
+        ]
+        for flags in undecodable {
+            XCTAssertNil(parse("""
+            {"TransactionType":"Payment","Account":"rAcc","Destination":"rDest","Amount":"1000000","Flags":\(flags)}
+            """), "an undecodable Flags must route to the raw-JSON fallback: \(flags)")
+        }
+    }
+
+    /// `tfFullyCanonicalSig` (0x80000000) is above `INT32_MAX` and applies to
+    /// every type, so it must survive the uint32 bound and be named.
+    func testFullyCanonicalSigFlagParses() throws {
+        let tx = try XCTUnwrap(parse("""
+        {"TransactionType":"Payment","Account":"rAcc","Destination":"rDest","Amount":"1000000","Flags":2147483648}
+        """))
+        XCTAssertEqual(tx.warnings, [])
+        XCTAssertEqual(field(tx, "rippleFieldFlags"), .text("tfFullyCanonicalSig"))
+    }
+
+    /// A bit this reviewer does not have a name for renders as a hex residue
+    /// beside the ones it does, so the row never claims to have shown
+    /// everything that is set.
+    func testUnknownFlagBitsRenderAsAHexResidue() throws {
+        // 0x00060001 = tfPartialPayment | tfLimitQuality | 0x00000001 (unnamed).
+        let tx = try XCTUnwrap(parse("""
+        {"TransactionType":"Payment","Account":"rAcc","Destination":"rDest","Amount":"1000000","Flags":393217}
+        """))
+        XCTAssertEqual(
+            field(tx, "rippleFieldFlags"),
+            .text("tfPartialPayment, tfLimitQuality, 0x00000001")
+        )
+    }
+
+    /// No flags set, and an absent `Flags`, say the same thing — neither earns
+    /// a row.
+    func testZeroOrAbsentFlagsAddsNoRow() throws {
+        let absent = try XCTUnwrap(parse("""
+        {"TransactionType":"Payment","Account":"rAcc","Destination":"rDest","Amount":"1000000"}
+        """))
+        XCTAssertNil(field(absent, "rippleFieldFlags"))
+        XCTAssertEqual(absent.warnings, [])
+
+        let zero = try XCTUnwrap(parse("""
+        {"TransactionType":"Payment","Account":"rAcc","Destination":"rDest","Amount":"1000000","Flags":0}
+        """))
+        XCTAssertNil(field(zero, "rippleFieldFlags"))
+        XCTAssertEqual(zero.warnings, [])
+    }
+
     /// Fractional and signed decimal IOU values remain valid.
     func testFractionalAndSignedIssuedValuesParse() throws {
         let fractional = try XCTUnwrap(parse("""

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleSignRippleTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleSignRippleTests.swift
@@ -630,17 +630,44 @@ final class RippleSignRippleTests: XCTestCase {
         let hollowFloors = [
             "null",
             "{}",
+            "[]",
             "\"0\"",
             "\"-1\"",
             "\"not-a-number\"",
-            "123456",
-            "{\"currency\":\"USD\",\"issuer\":\"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh\"}",
-            "{\"currency\":\"USD\",\"issuer\":\"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh\",\"value\":\"0\"}"
+            "123456"
         ]
         for floor in hollowFloors {
             assertBoundPaymentRefused(
                 Self.boundPaymentJson(extraFields: ",\"DeliverMin\":\(floor),\"Flags\":131072"),
                 "a DeliverMin of \(floor) bounds nothing and must not license a partial payment"
+            )
+        }
+    }
+
+    /// The same, for an issued-currency delivery: a floor missing its value, or
+    /// carrying a zero one, floors nothing.
+    func testIssuedPartialPaymentWithAHollowDeliverMinIsRefused() {
+        let issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+        let coin = Self.makeIssuedCoin(contractAddress: "USD.\(issuer)", decimals: 15)
+        let hollowFloors = [
+            "{\"currency\":\"USD\",\"issuer\":\"\(issuer)\"}",
+            "{\"currency\":\"USD\",\"issuer\":\"\(issuer)\",\"value\":\"0\"}",
+            "{\"currency\":\"USD\",\"issuer\":\"\(issuer)\",\"value\":\"-1\"}",
+            "\"900000\""
+        ]
+        for floor in hollowFloors {
+            let rawJson = """
+            {"TransactionType":"Payment","Account":"\(Self.account)","Destination":"\(Self.destination)","Amount":{"currency":"USD","issuer":"\(issuer)","value":"1.5"},"DeliverMin":\(floor),"Flags":131072,"Fee":"10","Sequence":99,"LastLedgerSequence":12345678}
+            """
+            let payload = Self.makePayload(
+                rawJson: rawJson,
+                coin: coin,
+                toAddress: Self.destination,
+                toAmount: BigInt("1500000000000000")
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+                "a DeliverMin of \(floor) bounds nothing on an issued-currency delivery"
             )
         }
     }
@@ -721,6 +748,70 @@ final class RippleSignRippleTests: XCTestCase {
         XCTAssertNoThrow(
             try RippleHelper.getPreSignedInputData(keysignPayload: payload),
             "tfImmediateOrCancel on an offer must not be read as a partial payment"
+        )
+    }
+
+    /// XRPL's codec also accepts a transaction's NUMERIC type code — `0` is
+    /// `Payment` — so a numeric spelling would reach the signer as a payment
+    /// while every `as? String == "Payment"` comparison read false, routing it
+    /// down the branch meant for offers, which binds neither destination nor
+    /// amount. The fixture is the full attack: wrong destination, wrong amount,
+    /// tfPartialPayment, no floor.
+    func testNumericTransactionTypeIsRefused() {
+        let rawJson = """
+        {"TransactionType":0,"Account":"\(Self.account)","Destination":"rAttackerAAAAAAAAAAAAAAAAAAAAAAAAA","Amount":"999999999","Flags":131072,"Fee":"10","Sequence":99,"LastLedgerSequence":12345678}
+        """
+        let payload = Self.makePayload(
+            rawJson: rawJson,
+            coin: Self.makeNativeCoin(),
+            toAddress: Self.destination,
+            toAmount: BigInt(1_000_000)
+        )
+        XCTAssertThrowsError(
+            try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+            "a numeric TransactionType must not slip past the Payment bindings"
+        )
+    }
+
+    /// XRPL reads an `Amount` whose issuer is the `Destination` as "any issuer
+    /// the destination will take". A `DeliverMin` carrying that wildcard floors
+    /// *some* issuer's version of the currency — possibly a worthless one —
+    /// while the card names a definite issuer. The floor must be pinned to the
+    /// same asset `Amount` names.
+    func testPartialPaymentWithAMismatchedDeliverMinIssuerIsRefused() {
+        let issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+        let coin = Self.makeIssuedCoin(contractAddress: "USD.\(issuer)", decimals: 15)
+
+        // The wildcard spelling: DeliverMin.issuer = Destination.
+        let wildcard = """
+        {"TransactionType":"Payment","Account":"\(Self.account)","Destination":"\(Self.destination)","Amount":{"currency":"USD","issuer":"\(issuer)","value":"1.5"},"DeliverMin":{"currency":"USD","issuer":"\(Self.destination)","value":"1.4"},"Flags":131072,"Fee":"10","Sequence":99,"LastLedgerSequence":12345678}
+        """
+        // A floor in an entirely different currency floors nothing that Amount
+        // describes, and the ledger would refuse it too.
+        let otherCurrency = """
+        {"TransactionType":"Payment","Account":"\(Self.account)","Destination":"\(Self.destination)","Amount":{"currency":"USD","issuer":"\(issuer)","value":"1.5"},"DeliverMin":{"currency":"EUR","issuer":"\(issuer)","value":"1.4"},"Flags":131072,"Fee":"10","Sequence":99,"LastLedgerSequence":12345678}
+        """
+        for rawJson in [wildcard, otherCurrency] {
+            let payload = Self.makePayload(
+                rawJson: rawJson,
+                coin: coin,
+                toAddress: Self.destination,
+                toAmount: BigInt("1500000000000000")
+            )
+            XCTAssertThrowsError(
+                try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+                "a DeliverMin that does not floor the asset Amount names must be refused"
+            )
+        }
+    }
+
+    /// The floor has to match the shape of the delivery too: an issued-currency
+    /// floor bounds nothing about a native XRP `Amount`.
+    func testNativePartialPaymentWithAnIssuedDeliverMinIsRefused() {
+        let iou = "{\"currency\":\"USD\",\"issuer\":\"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh\",\"value\":\"1\"}"
+        assertBoundPaymentRefused(
+            Self.boundPaymentJson(extraFields: ",\"DeliverMin\":\(iou),\"Flags\":131072"),
+            "an issued-currency floor cannot bound a native XRP delivery"
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleSignRippleTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Ripple/RippleSignRippleTests.swift
@@ -581,6 +581,159 @@ final class RippleSignRippleTests: XCTestCase {
         XCTAssertThrowsError(try RippleHelper.getPreSignedInputData(keysignPayload: payload))
     }
 
+    // MARK: - tfPartialPayment: the bound Amount must still bound delivery
+
+    //  `bindPaymentToReviewedValues` only means anything while `Amount` is a
+    //  delivery. `tfPartialPayment` (0x00020000) makes it a ceiling instead, so
+    //  every fixture here binds CLEANLY — reviewed destination and amount equal
+    //  to the JSON's — and the new gate is the only thing that can reject.
+
+    /// Builds a native `Payment` for `destination` / 1 XRP with an arbitrary
+    /// tail of extra fields, so a fixture differs from the accepted control in
+    /// exactly the terms under test.
+    private static func boundPaymentJson(extraFields: String = "") -> String {
+        """
+        {"TransactionType":"Payment","Account":"\(account)","Destination":"\(destination)","Amount":"1000000","SendMax":"999999999"\(extraFields),"Fee":"10","Sequence":99,"LastLedgerSequence":12345678}
+        """
+    }
+
+    /// The acceptance case. Every pre-existing gate passes — `Account` is the
+    /// vault, `Destination` is the reviewed address, `Amount` is the reviewed
+    /// amount byte for byte — and the transaction can still settle for dust
+    /// while spending the whole `SendMax`.
+    func testPartialPaymentWithoutDeliverMinIsRefused() {
+        assertBoundPaymentRefused(
+            Self.boundPaymentJson(extraFields: ",\"Flags\":131072"),
+            "a tfPartialPayment Payment with no DeliverMin floor must be refused before signing"
+        )
+    }
+
+    /// A floor restores something for the reviewed amount to mean, so a partial
+    /// payment carrying one is forwarded unchanged. Partial payments are
+    /// legitimate; only unfloored ones are not.
+    func testPartialPaymentWithDeliverMinIsForwarded() throws {
+        let rawJson = Self.boundPaymentJson(extraFields: ",\"DeliverMin\":\"900000\",\"Flags\":131072")
+        let payload = Self.makePayload(
+            rawJson: rawJson,
+            coin: Self.makeNativeCoin(),
+            toAddress: Self.destination,
+            toAmount: BigInt(1_000_000)
+        )
+
+        let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload))
+        XCTAssertEqual(input.rawJson, rawJson, "a floored partial payment must still be signed verbatim")
+    }
+
+    /// A `DeliverMin` that is present but floors nothing must not be mistaken
+    /// for one that does. Each of these satisfies "the field is there".
+    func testPartialPaymentWithAHollowDeliverMinIsRefused() {
+        let hollowFloors = [
+            "null",
+            "{}",
+            "\"0\"",
+            "\"-1\"",
+            "\"not-a-number\"",
+            "123456",
+            "{\"currency\":\"USD\",\"issuer\":\"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh\"}",
+            "{\"currency\":\"USD\",\"issuer\":\"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh\",\"value\":\"0\"}"
+        ]
+        for floor in hollowFloors {
+            assertBoundPaymentRefused(
+                Self.boundPaymentJson(extraFields: ",\"DeliverMin\":\(floor),\"Flags\":131072"),
+                "a DeliverMin of \(floor) bounds nothing and must not license a partial payment"
+            )
+        }
+    }
+
+    /// An issued-currency `DeliverMin` is a real floor and must be accepted in
+    /// the same way a drops one is.
+    func testPartialPaymentWithAnIssuedDeliverMinFloorIsForwarded() throws {
+        let issuer = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+        let coin = Self.makeIssuedCoin(contractAddress: "USD.\(issuer)", decimals: 15)
+        let rawJson = """
+        {"TransactionType":"Payment","Account":"\(Self.account)","Destination":"\(Self.destination)","Amount":{"currency":"USD","issuer":"\(issuer)","value":"1.5"},"DeliverMin":{"currency":"USD","issuer":"\(issuer)","value":"1.4"},"Flags":131072,"Fee":"10","Sequence":99,"LastLedgerSequence":12345678}
+        """
+        let payload = Self.makePayload(
+            rawJson: rawJson,
+            coin: coin,
+            toAddress: Self.destination,
+            toAmount: BigInt("1500000000000000")
+        )
+
+        let input = try RippleSigningInput(serializedBytes: RippleHelper.getPreSignedInputData(keysignPayload: payload))
+        XCTAssertEqual(input.rawJson, rawJson)
+    }
+
+    /// A `Flags` value the XRPL codec could not have encoded as a uint32 is
+    /// refused rather than read as "nothing set" — it may carry the very bit
+    /// being checked. `{"tfPartialPayment": true}` is the object sugar some
+    /// client libraries accept.
+    func testFlagsThatAreNotAUint32AreRefused() {
+        let undecodable = [
+            "{\"tfPartialPayment\":true}",
+            "\"131072\"",
+            "true",
+            "-1",
+            "131072.5",
+            "4294967296",
+            "null",
+            "[131072]"
+        ]
+        for flags in undecodable {
+            assertBoundPaymentRefused(
+                Self.boundPaymentJson(extraFields: ",\"Flags\":\(flags)"),
+                "an undecodable Flags value must be refused, not read as zero: \(flags)"
+            )
+        }
+    }
+
+    /// `tfFullyCanonicalSig` (0x80000000) sits above `INT32_MAX`. The uint32
+    /// bound must not clip it into a rejection.
+    func testFullyCanonicalSigFlagIsForwarded() {
+        assertBoundPaymentAccepted(
+            Self.boundPaymentJson(extraFields: ",\"Flags\":2147483648"),
+            "a flag above INT32_MAX must survive the uint32 bound"
+        )
+    }
+
+    /// The zero control: the same fixture without any `Flags` binds cleanly, so
+    /// the rejections above are attributable to the flag and nothing else.
+    func testBoundPaymentWithNoFlagsIsAccepted() {
+        assertBoundPaymentAccepted(
+            Self.boundPaymentJson(),
+            "the fixture must bind cleanly once the flag is removed"
+        )
+    }
+
+    /// 0x00020000 is namespace-sensitive: on an `OfferCreate` it is
+    /// `tfImmediateOrCancel`, which has nothing to do with delivery. Reading it
+    /// as partial payment there would false-reject a legitimate offer.
+    func testPartialPaymentBitOnAnOfferCreateIsNotRefused() {
+        let rawJson = """
+        {"TransactionType":"OfferCreate","Account":"\(Self.account)","TakerGets":"5000000","TakerPays":{"currency":"USD","issuer":"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh","value":"10"},"Flags":131072,"Fee":"10","Sequence":99,"LastLedgerSequence":12345678}
+        """
+        let payload = Self.makePayload(
+            rawJson: rawJson,
+            coin: Self.makeNativeCoin(),
+            toAddress: "",
+            toAmount: 0
+        )
+        XCTAssertNoThrow(
+            try RippleHelper.getPreSignedInputData(keysignPayload: payload),
+            "tfImmediateOrCancel on an offer must not be read as a partial payment"
+        )
+    }
+
+    /// `Paths` is legitimate on a cross-currency payment — refusing it would
+    /// break real DEX flows. It is surfaced on the review screen instead.
+    func testPaymentCarryingPathsIsNotRefused() {
+        let paths = "[[{\"currency\":\"USD\",\"issuer\":\"rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh\"}]]"
+        assertBoundPaymentAccepted(
+            Self.boundPaymentJson(extraFields: ",\"Paths\":\(paths)"),
+            "dApp-supplied Paths must be surfaced, not refused"
+        )
+    }
+
     // MARK: - Native path unchanged
 
     /// With no signRipple, RippleHelper still builds the native opPayment from


### PR DESCRIPTION
## Description

Fixes #5081

iOS is the **co-signer** for dApp-supplied XRPL transactions: the raw transaction arrives over the MPC relay in `signRipple.rawJson` and is signed verbatim. `Flags` and `Paths` reached the signer and were rendered nowhere, so the set of fields being signed was strictly larger than the set being reviewed — and the extra ones were value-relevant.

`tfPartialPayment` (`0x00020000`) is the one that bites. With it set, `Amount` stops being a guaranteed delivery and becomes a ceiling: the ledger hands over whatever the chosen path can source and records the real figure only in the executed transaction's metadata (`delivered_amount`). Absent a `DeliverMin` nothing floors what arrives, while the sender can still be charged the full `SendMax`.

So the cross-currency **self-swap** the parser itself documents — `Destination` is your own address, `Amount` is what you receive, `SendMax` what you pay — could clear every gate. `Account` was the vault, `Destination` matched the reviewed `toAddress`, `Amount` matched the reviewed `toAmount` byte for byte, and the transaction could still settle for dust. `dappSigningInput` described itself as binding a Payment to the reviewed amount; that binding assumed `Amount` was a delivery, and this flag is precisely what defeats the assumption.

It matters most on a co-signer, which sees only the payload it receives and never ran the initiator's client-side sanitizer. There is no simulation backstop either — XRPL is not in Blockaid's supported chains.

### Fail closed

In `dappSigningInput`'s `Payment` branch, after the `Amount` binding:

- `Flags` must read as a **uint32**. Anything else is refused, including the `{ tfPartialPayment: true }` object form some client libraries accept, since a value we cannot decode may carry the very bit being checked. It is read from the same `JSONSerialization` object every other check reads, so the existing duplicate-key guard covers it too.
- `tfPartialPayment` without a `DeliverMin` is refused. **With** one it is forwarded unchanged: the floor restores something for the reviewed amount to mean, and partial payments are legitimate.
- The floor has to be real, so `DeliverMin` is validated as a well-formed, **strictly positive** XRPL amount rather than merely present. `null`, `{}`, `"0"` and `{"value":"0",…}` all satisfy "the field is there" while bounding nothing. It also has to floor **the same asset** — see the wildcard-issuer finding below.

Scoped to `Payment` deliberately. `0x00020000` is namespace-sensitive: it is `tfImmediateOrCancel` on an `OfferCreate`, and as an account-root flag it is `lsfRequireDestTag`.

`Paths` is **not** refused — it is legitimate on a cross-currency payment and refusing it would break real DEX flows. It is surfaced instead.

### Show the real terms

`RippleDAppTransaction` reads `Flags` before any value row, since it decides what those rows mean, and returns `nil` — routing to the existing raw-JSON fallback — when `Flags` is present but undecodable. Reading it as "nothing set" would render a partial payment as an exact one, which is the whole bug.

Two caveats lead the card as warnings rather than as more rows to skim past: a `tfPartialPayment` Payment, and a transaction carrying its own `Paths`. Below them, a `Flags` row names the bits this reviewer recognises, **scoped to the transaction type** — one flat table would call `0x00020000` a partial payment on an offer and on a trust line, where it means `tfImmediateOrCancel` and `tfSetNoRipple`. Only long-stable, unambiguously documented bits are named; anything else renders as a hex residue, so the row never claims to have shown everything that is set.

Both layers earn their place. The signing gate refuses; the display is what the human actually anchors to.

### On the issue's third fix item

The issue also asks to consider anchoring the reviewed values to trusted state rather than to other fields in the same payload. **Not done here, and the reason is structural rather than effort.**

On a co-signer the only trusted state is the vault's own derived address — already used, as the `Account` check. `toAddress` and `toAmount` arrive in the same protobuf as `rawJson`, and there is no second channel carrying what the user meant to send, because on a co-signer there is no local intent: the device is approving somebody else's transaction. Rebuilding it locally is exactly what this path exists to avoid, since it would break MPC byte-parity.

So `bindPaymentToReviewedValues` is not, and cannot be, a defence against a hostile initiator; it defends against drift between the payload metadata and the raw JSON, which feed different UI surfaces. The anchor against a hostile initiator is the human review — which makes the property that matters *the rendered field set must never be a strict subset of the signed one*. That is what this PR restores. A real trusted-state anchor needs a channel the protocol does not have, and belongs upstream in commondata/SDK.

### Two holes review found in the branch itself

A read-only whole-branch pass turned up a **complete bypass of everything above**, worth stating plainly because it was not obvious.

XRPL's codec accepts a transaction's **numeric type code** as well as its name — `0` is `Payment`. So `{"TransactionType": 0, …}` reached the signer as a payment while every `as? String == "Payment"` comparison read false, sending it down the branch meant for offers and trust lines, which binds neither destination nor amount. A wrong destination, a wrong amount, `tfPartialPayment` and no floor all passed together, and the reviewer saw the raw-JSON fallback card. `TransactionType` must now be a **String**; refusing beats teaching every comparison a second spelling, since nothing legitimate sends the numeric form and the review screen cannot render one either.

Second, XRPL gives an issuer **wildcard readings** on a Payment: `Amount.issuer == Destination` means "any issuer the destination will take", and `SendMax.issuer == Account` means "any issuer the sender holds". A `DeliverMin` carrying that wildcard passed the new positivity gate while flooring some issuer's version of the currency — possibly a worthless one — with the card naming a definite issuer. `DeliverMin` is now pinned to `Amount`'s shape, issuer and currency, which costs nothing legitimate (the ledger already requires the two to agree) and lands the floor on the asset `bindPaymentToReviewedValues` already bound to the reviewed coin.

Two further findings were **rejected with reason**, both for exact parity with vultisig/vultisig-sdk#1844 and vultisig/vultisig-windows#4611 and because both fail in the safe direction: `Flags: null` is refused here though the signer reads it as zero, and `131072.0` is read as the bitmask here though the signer's u32 decoder refuses the field. One MINOR is documented rather than changed — the currency comparison does not equate a 3-byte code with the 40-hex spelling of the same currency, so `Amount: "USD"` with `DeliverMin: "0000…5553440000…"` is refused although the ledger would execute it. That errs toward refusing, and a bespoke canonicaliser inside a signing gate is a worse thing to own than a rare false rejection. The doc comment now states that limit exactly instead of overclaiming.

### One adjacent fix, disclosed

The review pass flagged that `TrustSet` rendered `LimitAmount` while silently dropping `QualityIn` / `QualityOut`, which set the exchange rate applied to balances on the line. It predates this branch, but it is the same defect as the missing flags one transaction type over — a confident card hiding value — so it is fixed here rather than left open. Both now render, and a present-but-undecodable one fails the decode to the raw-JSON fallback.

## Which feature is affected?

- [x] New Chain / Chain related feature — XRPL dApp co-signing (`signRipple` raw-transaction keysign)

No tx link: every change here either refuses a transaction or adds a row to the confirmation screen. Nothing new becomes broadcastable.

## Parity

- Android: linked — vultisig/vultisig-android#5555 (PR vultisig/vultisig-android#5567)
- Windows + extension: linked — vultisig/vultisig-windows#4595 (PR vultisig/vultisig-windows#4611)
- SDK: linked — vultisig/vultisig-sdk#1843 (PR vultisig/vultisig-sdk#1844)

iOS takes the union of the SDK's signing guard and the Windows display work, because iOS is both halves in one binary.

Two deliberate divergences from the sibling PRs, both improvements rather than drift:

1. The **partial-payment warning copy**. Windows' English string says the recipient can receive less "while you still pay the maximum shown". On a cross-currency payment `Amount` caps what is *delivered* and `SendMax` caps what is *spent* — different fields, possibly different currencies. Conflating them understates the cost on exactly the shape the warning exists for. The copy here names both.
2. The **`Flags` row**. Windows renders warnings only. Naming the bits is what the issue asked for, and a co-signer who can read `tfNoRippleDirect` or `tfSell` off the card is better informed than one who cannot. Type-scoped naming plus a hex residue is what makes it safe.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

**Not visually verified, and not exercised end-to-end.** The warning rows reuse the `Icon(.triangleWarning) + Theme.colors.alertWarning` pattern the fallback card already owns, and the row is laid out full-width rather than squeezed against a trailing edge precisely because a warning is prose. But a wrapped two- or three-line warning beside the icon was not rendered on device.

There is also no way to fire a real `tfPartialPayment` XRPL transaction at the app today — no ordinary dApp sets that flag. The adversarial fixture that would let us is vultisig/community-tools#38 ("XRPL/Ripple dApp panel + adversarial QA examples", still draft), which is the same thing the Android PR is parked on. Kept in **draft** for that reason: the logic is worth reviewing now, merging before anyone has run the real flow is not.

## Additional context

**Tests.** The acceptance case leads: a `Payment` with `Flags: 131072` and no `DeliverMin`, whose `Account`, `Destination` and `Amount` all match the reviewed values exactly — so every pre-existing gate passes and only the new one can reject it. `testBoundPaymentWithNoFlagsIsAccepted` is its control.

Around it: eight hollow `DeliverMin` spellings each refused; eight undecodable `Flags` spellings each refused rather than read as zero; `Flags: 2147483648` (`tfFullyCanonicalSig`) forwarded, since it sits above `INT32_MAX` and the uint32 bound must not clip it into a rejection; `0x00020000` on an `OfferCreate` accepted as `tfImmediateOrCancel`; a `Payment` carrying `Paths` accepted. On the display side: the two warnings alone and together, the same bit named per namespace, an undecodable `Flags` routing to the fallback, an unnamed bit rendering as a hex residue, and zero/absent flags adding no row.

No view-level test — the sibling `Sign*DisplayView`s have none either, and the decode all of this turns on lives in the model, which is tested.

**The uint32 decode is shared** between the display and the signing gate rather than duplicated. The row a reviewer reads and the bit the gate refuses have to come from one decoder; two that disagreed about a `Flags` value would recreate the exact reviewer-versus-signer mismatch the signing path exists to close.

**Gate:** full suite green — `** TEST SUCCEEDED **`, 5331 tests, 0 failures. SwiftLint clean.

## Agent Metadata (if applicable)

- **Agent**: Claude Code
- **Issue**: #5081
- **Confidence**: high
- **Needs human review for**: the `Paths`-surfaced-not-rejected call, the unverified warning-row layout, and the decision to fix `QualityIn`/`QualityOut` in this PR rather than separately


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer Ripple transaction details, including flags and TrustSet quality fields.
  * Added warnings for partial payments and custom payment paths.
  * Improved display of transaction warnings with readable, multiline text.
  * Added localized Ripple warnings and field labels across supported languages.

* **Bug Fixes**
  * Strengthened Ripple transaction validation, including partial-payment limits, malformed values, flags, and transaction types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->