### PR TITLE
fix(tss): snapshot the vault's key shares before the TSS ceremony starts

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Tss/LocalStateAccessorImp.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/LocalStateAccessorImp.swift
@@ -58,15 +58,36 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol {
     /// episode lease; keysign holds no lease, and there the two directions are
     /// not symmetric:
     ///
-    /// - snapshot plaintext, store then sealed: a later lock no longer stops
-    ///   this read, where re-reading the model would have. The value is already
-    ///   in this process's memory and only a ceremony this app is itself driving
-    ///   can ask for it again, so this is recorded rather than closed;
-    /// - snapshot sealed, store then unsealed by a disable: this read fails
+    /// - snapshot **plaintext**, store then sealed: `open` passes a plaintext
+    ///   value through in every state, so on its own it could not notice, and a
+    ///   later lock would go on handing this share to the signing layer where
+    ///   re-reading the model would have refused. That is the one way a snapshot
+    ///   could be weaker than the read it replaced, so it is closed below rather
+    ///   than accepted — see ``lockGeneration``;
+    /// - snapshot **sealed**, store then unsealed by a disable: this read fails
     ///   closed where re-reading would have succeeded, so the ceremony fails
-    ///   visibly and the user retries.
+    ///   visibly and the user retries. Availability, never safety, and there is
+    ///   no way to see the unsealed value without reading the model.
     private let vaultShares: [String: String]
     private let protector: KeyshareProtecting
+    private let session: KeyshareKeySession
+
+    /// The session generation at the moment the snapshot was taken.
+    ///
+    /// `KeyshareKeySession.clear()` — which is all `PasscodeService.lock()`
+    /// does — bumps this counter, so a value different from the one captured
+    /// here means *the app has locked since the shares were copied*. That is the
+    /// signal a plaintext snapshot has no other way to get: the store may have
+    /// been sealed behind it, and the key that would open the sealed form is
+    /// gone.
+    ///
+    /// It is the **cheap** half of the test, deliberately. Reading it costs one
+    /// `NSLock`-guarded integer, so the ordinary read pays nothing; only once a
+    /// lock has actually landed is the protection state consulted, which is
+    /// where a Keychain round trip could otherwise appear in the middle of
+    /// signing — the exact cost `KeyshareKeySession` is documented as existing
+    /// to keep off this path.
+    private let lockGeneration: Int
 
     /// Snapshots the vault on the MainActor.
     ///
@@ -75,14 +96,18 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol {
     /// inside the ceremony instead of ahead of it. Both call sites — the GG20
     /// keygen and the GG20 keysign view models — are already main-actor bound.
     @MainActor
-    convenience init(vault: Vault, protector: KeyshareProtecting = KeyshareProtector.shared) {
+    convenience init(
+        vault: Vault,
+        protector: KeyshareProtecting = KeyshareProtector.shared,
+        session: KeyshareKeySession = .shared
+    ) {
         // `first` wins on a duplicate public key, matching the `first(where:)`
         // the vault accessor used to do.
         let shares = Dictionary(
             vault.keyshares.map { ($0.pubkey, $0.keyshare) },
             uniquingKeysWith: { first, _ in first }
         )
-        self.init(vaultShares: shares, protector: protector)
+        self.init(vaultShares: shares, protector: protector, session: session)
     }
 
     /// Private on purpose: a module-visible dictionary initializer would let a
@@ -90,14 +115,29 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol {
     /// result in, which is the exact thing the main-actor initializer exists to
     /// stop. Every construction — production and test — goes through
     /// `init(vault:)`.
-    private init(vaultShares: [String: String], protector: KeyshareProtecting) {
+    private init(
+        vaultShares: [String: String],
+        protector: KeyshareProtecting,
+        session: KeyshareKeySession
+    ) {
         self.vaultShares = vaultShares
         self.protector = protector
+        self.session = session
+        // Captured with the shares, not later: it is only meaningful as "the
+        // generation those values were copied at".
+        self.lockGeneration = session.currentGeneration
         super.init()
     }
 
     func getLocalState(_ pubKey: String?, error: NSErrorPointer) -> String {
         guard let pubKey, let stored = vaultShares[pubKey] else {
+            return ""
+        }
+
+        if isRefusedByALockTakenAfterTheSnapshot(stored) {
+            let lockedError = KeyshareProtectionError.locked
+            logger.error("Refusing a snapshotted key share: the app locked after the ceremony started")
+            error?.pointee = lockedError as NSError
             return ""
         }
 
@@ -112,6 +152,39 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol {
             error?.pointee = openError as NSError
             return ""
         }
+    }
+
+    /// Whether a lock landed after the snapshot was taken and left this value
+    /// one the app must no longer hand over.
+    ///
+    /// Only a value that is **plaintext in the snapshot** can be answered wrongly
+    /// without this: `open` already refuses a sealed value with no key in hand,
+    /// and passes a plaintext one through in every state — a passthrough that is
+    /// deliberate and permanent, because most installs never set a passcode and
+    /// their shares stay plaintext forever. So it cannot tell "plaintext because
+    /// there is no passcode" from "plaintext because the passcode arrived after
+    /// this was copied", and that second case is the whole hazard.
+    ///
+    /// Three conditions, cheapest first, all required:
+    ///
+    /// 1. the snapshotted value is not sealed — otherwise `open` decides and
+    ///    this must not second-guess it;
+    /// 2. the session generation moved, i.e. a `lock()` ran since the snapshot.
+    ///    One integer read, and it is false on every ordinary call;
+    /// 3. the protection state is now `.locked` — a wrapper exists and its key is
+    ///    not in hand. An install with no passcode answers `.disabled` here and
+    ///    is served exactly as before; an app that locked and was then unlocked
+    ///    answers `.unlocked` and is served too, which is what re-reading the
+    ///    model would have done.
+    private func isRefusedByALockTakenAfterTheSnapshot(_ stored: String) -> Bool {
+        guard !protector.isSealed(stored), session.currentGeneration != lockGeneration else {
+            return false
+        }
+
+        if case .locked = session.currentState() {
+            return true
+        }
+        return false
     }
 
     func saveLocalState(_ pubkey: String?, localState: String?) throws {

--- a/VultisigApp/VultisigApp/Blockchain/Tss/LocalStateAccessorImp.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/LocalStateAccessorImp.swift
@@ -47,9 +47,24 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol {
     /// hand back a torn value on a build with a different scheduler.
     ///
     /// Values are kept **as stored** — sealed if a passcode is set, plaintext
-    /// otherwise — and opened per call, so the snapshot never extends the
-    /// lifetime of plaintext key material and a `lock()` mid-ceremony still
-    /// makes a sealed share unreadable, exactly as before.
+    /// otherwise — and opened per read rather than at construction, so no
+    /// plaintext key material is parked in memory for the length of a ceremony,
+    /// and a share that was sealed when the snapshot was taken stays unreadable
+    /// once the key is gone.
+    ///
+    /// What the snapshot does change is a share whose stored *representation*
+    /// moves while a ceremony is live — which only a passcode transition or the
+    /// resume sweep does. Keygen and reshare are excluded from that by their
+    /// episode lease; keysign holds no lease, and there the two directions are
+    /// not symmetric:
+    ///
+    /// - snapshot plaintext, store then sealed: a later lock no longer stops
+    ///   this read, where re-reading the model would have. The value is already
+    ///   in this process's memory and only a ceremony this app is itself driving
+    ///   can ask for it again, so this is recorded rather than closed;
+    /// - snapshot sealed, store then unsealed by a disable: this read fails
+    ///   closed where re-reading would have succeeded, so the ceremony fails
+    ///   visibly and the user retries.
     private let vaultShares: [String: String]
     private let protector: KeyshareProtecting
 
@@ -70,7 +85,12 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol {
         self.init(vaultShares: shares, protector: protector)
     }
 
-    init(vaultShares: [String: String], protector: KeyshareProtecting = KeyshareProtector.shared) {
+    /// Private on purpose: a module-visible dictionary initializer would let a
+    /// caller read `vault.keyshares` off the MainActor themselves and hand the
+    /// result in, which is the exact thing the main-actor initializer exists to
+    /// stop. Every construction — production and test — goes through
+    /// `init(vault:)`.
+    private init(vaultShares: [String: String], protector: KeyshareProtecting) {
         self.vaultShares = vaultShares
         self.protector = protector
         super.init()

--- a/VultisigApp/VultisigApp/Blockchain/Tss/LocalStateAccessorImp.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Tss/LocalStateAccessorImp.swift
@@ -36,17 +36,53 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol {
         return storedKeyshares
     }
 
-    private var vault: Vault
-    init(vault: Vault) {
-        self.vault = vault
+    /// The vault's stored key-share values, keyed by public key, copied out of
+    /// the `@Model` once on the MainActor before the ceremony starts.
+    ///
+    /// `getLocalState` is a synchronous callback the TSS binding makes on
+    /// whichever thread entered it — in this app always a
+    /// `Task.detached(priority: .high)` worker, never main. Reading a SwiftData
+    /// `@Model` from there is undefined behaviour, and undefined behaviour that
+    /// happens to work is the worst kind here: it can hold for years and then
+    /// hand back a torn value on a build with a different scheduler.
+    ///
+    /// Values are kept **as stored** — sealed if a passcode is set, plaintext
+    /// otherwise — and opened per call, so the snapshot never extends the
+    /// lifetime of plaintext key material and a `lock()` mid-ceremony still
+    /// makes a sealed share unreadable, exactly as before.
+    private let vaultShares: [String: String]
+    private let protector: KeyshareProtecting
+
+    /// Snapshots the vault on the MainActor.
+    ///
+    /// `@MainActor` is the forcing function: it is what stops a future caller
+    /// re-introducing the off-MainActor `@Model` read by constructing this from
+    /// inside the ceremony instead of ahead of it. Both call sites — the GG20
+    /// keygen and the GG20 keysign view models — are already main-actor bound.
+    @MainActor
+    convenience init(vault: Vault, protector: KeyshareProtecting = KeyshareProtector.shared) {
+        // `first` wins on a duplicate public key, matching the `first(where:)`
+        // the vault accessor used to do.
+        let shares = Dictionary(
+            vault.keyshares.map { ($0.pubkey, $0.keyshare) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        self.init(vaultShares: shares, protector: protector)
     }
+
+    init(vaultShares: [String: String], protector: KeyshareProtecting = KeyshareProtector.shared) {
+        self.vaultShares = vaultShares
+        self.protector = protector
+        super.init()
+    }
+
     func getLocalState(_ pubKey: String?, error: NSErrorPointer) -> String {
-        guard let pubKey else {
+        guard let pubKey, let stored = vaultShares[pubKey] else {
             return ""
         }
 
         do {
-            return try vault.keyshareValue(for: pubKey) ?? ""
+            return try protector.open(stored)
         } catch let openError {
             // Only reachable once shares are stored sealed: the share exists but
             // cannot be opened. Reported through the error pointer so the TSS
@@ -75,7 +111,7 @@ final class LocalStateAccessorImpl: NSObject, TssLocalStateAccessorProtocol {
         // synchronously, because this is a callback the TSS layer makes from an
         // arbitrary thread and cannot await.
         try KeyshareWriteCoordinator.shared.withWriteLease {
-            let share = try KeyShare.sealed(pubkey: pubkey, keyshare: localState)
+            let share = try KeyShare.sealed(pubkey: pubkey, keyshare: localState, protector: protector)
             sharesLock.lock()
             storedKeyshares.append(share)
             sharesLock.unlock()

--- a/VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift
+++ b/VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift
@@ -18,6 +18,11 @@ import XCTest
 /// that the callback answers out of a value snapshot rather than out of the
 /// model, which is checkable, fails against the previous implementation, and is
 /// the only thing a future change could quietly undo.
+///
+/// Everything here constructs through `init(vault:)`, the one initializer
+/// production uses, so a test cannot pass through a seam production does not
+/// have.
+@MainActor
 final class LocalStateAccessorImpTests: XCTestCase {
 
     private let ecdsaPubKey = "02aaa"
@@ -30,7 +35,6 @@ final class LocalStateAccessorImpTests: XCTestCase {
         return KeyshareProtector(state: { .unlocked(key) })
     }
 
-    @MainActor
     private func makeVault(protector: KeyshareProtecting) throws -> Vault {
         let vault = Vault(name: "Test Vault")
         vault.pubKeyECDSA = ecdsaPubKey
@@ -42,13 +46,18 @@ final class LocalStateAccessorImpTests: XCTestCase {
         return vault
     }
 
+    private func makeEmptyVault() -> Vault {
+        let vault = Vault(name: "Empty Vault")
+        vault.pubKeyECDSA = ecdsaPubKey
+        return vault
+    }
+
     // MARK: - The snapshot seam
 
     /// The regression this change exists for: after construction the callback
     /// must answer without reaching the `@Model` again. Emptying the vault is
     /// the observable stand-in for "the model is touched" — the previous
     /// implementation read `vault.keyshares` on every call and answered `""`.
-    @MainActor
     func testTheShareSnapshotIsNotReReadFromTheModel() throws {
         let protector = KeyshareProtector(state: { .disabled })
         let vault = try makeVault(protector: protector)
@@ -62,7 +71,6 @@ final class LocalStateAccessorImpTests: XCTestCase {
     }
 
     /// The same property from the thread the TSS binding actually uses.
-    @MainActor
     func testABackgroundCallbackAnswersFromTheSnapshot() throws {
         let protector = KeyshareProtector(state: { .disabled })
         let vault = try makeVault(protector: protector)
@@ -85,12 +93,10 @@ final class LocalStateAccessorImpTests: XCTestCase {
 
     /// Reached concurrently during a ceremony, so the snapshot has to be
     /// readable from many threads at once without a lock.
-    func testConcurrentReadsAllAnswerFromTheSnapshot() {
+    func testConcurrentReadsAllAnswerFromTheSnapshot() throws {
         let protector = KeyshareProtector(state: { .disabled })
-        let sut = LocalStateAccessorImpl(
-            vaultShares: [ecdsaPubKey: ecdsaShare, eddsaPubKey: eddsaShare],
-            protector: protector
-        )
+        let vault = try makeVault(protector: protector)
+        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
         let expected = ecdsaShare
         let pubKey = ecdsaPubKey
 
@@ -103,7 +109,6 @@ final class LocalStateAccessorImpTests: XCTestCase {
 
     /// `Vault.keyshareValue(for:)` resolved duplicates with `first(where:)`;
     /// the snapshot has to resolve them the same way.
-    @MainActor
     func testADuplicatePublicKeyKeepsTheFirstShare() {
         let protector = KeyshareProtector(state: { .disabled })
         let vault = Vault(name: "Duplicate Vault")
@@ -120,22 +125,18 @@ final class LocalStateAccessorImpTests: XCTestCase {
 
     // MARK: - The read contract the TSS layer depends on
 
-    func testAnUnknownPublicKeyAnswersEmptyWithNoError() {
-        let sut = LocalStateAccessorImpl(
-            vaultShares: [ecdsaPubKey: ecdsaShare],
-            protector: KeyshareProtector(state: { .disabled })
-        )
+    func testAnUnknownPublicKeyAnswersEmptyWithNoError() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let sut = LocalStateAccessorImpl(vault: try makeVault(protector: protector), protector: protector)
 
         var error: NSError?
         XCTAssertEqual(sut.getLocalState("not-a-key", error: &error), "")
         XCTAssertNil(error, "A vault with no share for this key is not an error")
     }
 
-    func testANilPublicKeyAnswersEmptyWithNoError() {
-        let sut = LocalStateAccessorImpl(
-            vaultShares: [ecdsaPubKey: ecdsaShare],
-            protector: KeyshareProtector(state: { .disabled })
-        )
+    func testANilPublicKeyAnswersEmptyWithNoError() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let sut = LocalStateAccessorImpl(vault: try makeVault(protector: protector), protector: protector)
 
         var error: NSError?
         XCTAssertEqual(sut.getLocalState(nil, error: &error), "")
@@ -146,7 +147,6 @@ final class LocalStateAccessorImpTests: XCTestCase {
     /// per read rather than at construction. Keeping it that way is what stops
     /// the snapshot from parking plaintext key material in memory for the whole
     /// ceremony.
-    @MainActor
     func testASealedShareIsOpenedOnRead() throws {
         let protector = try makeUnlockedProtector()
         let vault = try makeVault(protector: protector)
@@ -163,7 +163,6 @@ final class LocalStateAccessorImpTests: XCTestCase {
     /// A locked app and a vault with no share for this key must stay
     /// distinguishable to the TSS layer — they need different handling and both
     /// used to look like `""`.
-    @MainActor
     func testALockedShareIsReportedThroughTheErrorPointer() throws {
         let unlocked = try makeUnlockedProtector()
         let vault = try makeVault(protector: unlocked)
@@ -176,9 +175,9 @@ final class LocalStateAccessorImpTests: XCTestCase {
         XCTAssertEqual(error as? KeyshareProtectionError, .locked)
     }
 
-    /// A locking `lock()` landing mid-ceremony has to still make a sealed share
-    /// unreadable. Opening at construction instead would defeat that.
-    @MainActor
+    /// A `lock()` landing mid-ceremony has to still make a share that was sealed
+    /// when the snapshot was taken unreadable. Opening at construction instead
+    /// would defeat that.
     func testAShareSealedAtConstructionBecomesUnreadableOnceTheKeyIsGone() throws {
         let key = try VaultCryptoEnvelope.randomKey()
         var state: KeyshareProtectionState = .unlocked(key)
@@ -198,11 +197,61 @@ final class LocalStateAccessorImpTests: XCTestCase {
         XCTAssertEqual(afterLock as? KeyshareProtectionError, .locked)
     }
 
+    // MARK: - What the snapshot costs when the store moves under it
+
+    /// A disable unseals the store and destroys the key. A ceremony holding a
+    /// snapshot taken before it fails closed rather than signing — worse
+    /// availability than re-reading the model, never worse safety. Recorded so
+    /// the trade is visible rather than discovered.
+    func testASnapshotTakenBeforeADisableFailsClosed() throws {
+        let key = try VaultCryptoEnvelope.randomKey()
+        var state: KeyshareProtectionState = .unlocked(key)
+        let protector = KeyshareProtector(state: { state })
+        let vault = try makeVault(protector: protector)
+
+        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+
+        // The disable unseals every stored share and then deletes the wrapper,
+        // so the model holds plaintext and the session holds nothing.
+        vault.keyshares = [KeyShare(pubkey: ecdsaPubKey, keyshare: ecdsaShare)]
+        state = .disabled
+
+        var error: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), "")
+        XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+    }
+
+    /// The other direction, and the one that is genuinely weaker than the old
+    /// re-read: a snapshot taken while shares were plaintext keeps answering
+    /// after a sweep has sealed the store and a lock has taken the key away.
+    /// Pinned deliberately — if someone later decides to close it, this test is
+    /// where the decision is recorded.
+    func testASnapshotTakenBeforeASweepStillAnswersAfterALock() throws {
+        var state: KeyshareProtectionState = .disabled
+        let protector = KeyshareProtector(state: { state })
+        let vault = try makeVault(protector: protector)
+
+        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+
+        // A resume sweep seals the store behind the ceremony, then the app locks.
+        let unlocked = try makeUnlockedProtector()
+        vault.keyshares = [try KeyShare.sealed(pubkey: ecdsaPubKey, keyshare: ecdsaShare, protector: unlocked)]
+        state = .locked
+
+        var error: NSError?
+        XCTAssertEqual(
+            sut.getLocalState(ecdsaPubKey, error: &error),
+            ecdsaShare,
+            "A plaintext snapshot keeps answering; the model being sealed behind it is not observed"
+        )
+        XCTAssertNil(error)
+    }
+
     // MARK: - The write path is unchanged
 
     func testSaveLocalStateSealsThroughTheInjectedProtector() throws {
         let protector = try makeUnlockedProtector()
-        let sut = LocalStateAccessorImpl(vaultShares: [:], protector: protector)
+        let sut = LocalStateAccessorImpl(vault: makeEmptyVault(), protector: protector)
 
         try sut.saveLocalState(ecdsaPubKey, localState: ecdsaShare)
 
@@ -215,7 +264,7 @@ final class LocalStateAccessorImpTests: XCTestCase {
 
     func testSaveLocalStateStoresPlaintextWhileProtectionIsDisabled() throws {
         let protector = KeyshareProtector(state: { .disabled })
-        let sut = LocalStateAccessorImpl(vaultShares: [:], protector: protector)
+        let sut = LocalStateAccessorImpl(vault: makeEmptyVault(), protector: protector)
 
         try sut.saveLocalState(ecdsaPubKey, localState: ecdsaShare)
 
@@ -224,7 +273,7 @@ final class LocalStateAccessorImpTests: XCTestCase {
 
     func testSaveLocalStateRejectsMissingArguments() {
         let sut = LocalStateAccessorImpl(
-            vaultShares: [:],
+            vault: makeEmptyVault(),
             protector: KeyshareProtector(state: { .disabled })
         )
 

--- a/VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift
+++ b/VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift
@@ -1,0 +1,235 @@
+//
+//  LocalStateAccessorImpTests.swift
+//  VultisigAppTests
+//
+
+import XCTest
+
+@testable import VultisigApp
+
+/// The TSS binding calls `getLocalState` synchronously on whichever thread
+/// entered it — in this app a `Task.detached(priority: .high)` worker, never the
+/// main one. Reading a SwiftData `@Model` from there is undefined behaviour, so
+/// the vault's shares are snapshotted on the MainActor at construction instead.
+///
+/// What these tests can and cannot prove is worth stating plainly: a data race
+/// on a `@Model` is undefined behaviour, not a deterministic failure, so no test
+/// can make the old code trap on demand. What they pin instead is the **seam** —
+/// that the callback answers out of a value snapshot rather than out of the
+/// model, which is checkable, fails against the previous implementation, and is
+/// the only thing a future change could quietly undo.
+final class LocalStateAccessorImpTests: XCTestCase {
+
+    private let ecdsaPubKey = "02aaa"
+    private let eddsaPubKey = "03bbb"
+    private let ecdsaShare = "eyJrZXlzaGFyZSI6ImVjZHNhIn0="
+    private let eddsaShare = #"{"PubKey":"03bbb","ShareID":{"value":"9"}}"#
+
+    private func makeUnlockedProtector() throws -> KeyshareProtector {
+        let key = try VaultCryptoEnvelope.randomKey()
+        return KeyshareProtector(state: { .unlocked(key) })
+    }
+
+    @MainActor
+    private func makeVault(protector: KeyshareProtecting) throws -> Vault {
+        let vault = Vault(name: "Test Vault")
+        vault.pubKeyECDSA = ecdsaPubKey
+        vault.pubKeyEdDSA = eddsaPubKey
+        vault.keyshares = [
+            try KeyShare.sealed(pubkey: ecdsaPubKey, keyshare: ecdsaShare, protector: protector),
+            try KeyShare.sealed(pubkey: eddsaPubKey, keyshare: eddsaShare, protector: protector)
+        ]
+        return vault
+    }
+
+    // MARK: - The snapshot seam
+
+    /// The regression this change exists for: after construction the callback
+    /// must answer without reaching the `@Model` again. Emptying the vault is
+    /// the observable stand-in for "the model is touched" — the previous
+    /// implementation read `vault.keyshares` on every call and answered `""`.
+    @MainActor
+    func testTheShareSnapshotIsNotReReadFromTheModel() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let vault = try makeVault(protector: protector)
+        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+
+        vault.keyshares = []
+
+        var error: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), ecdsaShare)
+        XCTAssertNil(error)
+    }
+
+    /// The same property from the thread the TSS binding actually uses.
+    @MainActor
+    func testABackgroundCallbackAnswersFromTheSnapshot() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let vault = try makeVault(protector: protector)
+        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+
+        vault.keyshares = []
+
+        let expected = ecdsaShare
+        let pubKey = ecdsaPubKey
+        let answered = expectation(description: "callback answered off the main thread")
+        DispatchQueue.global(qos: .userInitiated).async {
+            XCTAssertFalse(Thread.isMainThread, "This test is only meaningful off the main thread")
+            var error: NSError?
+            XCTAssertEqual(sut.getLocalState(pubKey, error: &error), expected)
+            XCTAssertNil(error)
+            answered.fulfill()
+        }
+        wait(for: [answered], timeout: 5)
+    }
+
+    /// Reached concurrently during a ceremony, so the snapshot has to be
+    /// readable from many threads at once without a lock.
+    func testConcurrentReadsAllAnswerFromTheSnapshot() {
+        let protector = KeyshareProtector(state: { .disabled })
+        let sut = LocalStateAccessorImpl(
+            vaultShares: [ecdsaPubKey: ecdsaShare, eddsaPubKey: eddsaShare],
+            protector: protector
+        )
+        let expected = ecdsaShare
+        let pubKey = ecdsaPubKey
+
+        DispatchQueue.concurrentPerform(iterations: 200) { _ in
+            var error: NSError?
+            XCTAssertEqual(sut.getLocalState(pubKey, error: &error), expected)
+            XCTAssertNil(error)
+        }
+    }
+
+    /// `Vault.keyshareValue(for:)` resolved duplicates with `first(where:)`;
+    /// the snapshot has to resolve them the same way.
+    @MainActor
+    func testADuplicatePublicKeyKeepsTheFirstShare() {
+        let protector = KeyshareProtector(state: { .disabled })
+        let vault = Vault(name: "Duplicate Vault")
+        vault.keyshares = [
+            KeyShare(pubkey: ecdsaPubKey, keyshare: ecdsaShare),
+            KeyShare(pubkey: ecdsaPubKey, keyshare: "second-share-for-the-same-key")
+        ]
+        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+
+        var error: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), ecdsaShare)
+        XCTAssertNil(error)
+    }
+
+    // MARK: - The read contract the TSS layer depends on
+
+    func testAnUnknownPublicKeyAnswersEmptyWithNoError() {
+        let sut = LocalStateAccessorImpl(
+            vaultShares: [ecdsaPubKey: ecdsaShare],
+            protector: KeyshareProtector(state: { .disabled })
+        )
+
+        var error: NSError?
+        XCTAssertEqual(sut.getLocalState("not-a-key", error: &error), "")
+        XCTAssertNil(error, "A vault with no share for this key is not an error")
+    }
+
+    func testANilPublicKeyAnswersEmptyWithNoError() {
+        let sut = LocalStateAccessorImpl(
+            vaultShares: [ecdsaPubKey: ecdsaShare],
+            protector: KeyshareProtector(state: { .disabled })
+        )
+
+        var error: NSError?
+        XCTAssertEqual(sut.getLocalState(nil, error: &error), "")
+        XCTAssertNil(error)
+    }
+
+    /// The snapshot holds shares **as stored**, so a sealed one is still opened
+    /// per read rather than at construction. Keeping it that way is what stops
+    /// the snapshot from parking plaintext key material in memory for the whole
+    /// ceremony.
+    @MainActor
+    func testASealedShareIsOpenedOnRead() throws {
+        let protector = try makeUnlockedProtector()
+        let vault = try makeVault(protector: protector)
+        XCTAssertTrue(vault.keyshares[0].keyshare.hasPrefix(AesGcmKeyshareCipher.sealedPrefix))
+
+        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+
+        var error: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), ecdsaShare)
+        XCTAssertEqual(sut.getLocalState(eddsaPubKey, error: &error), eddsaShare)
+        XCTAssertNil(error)
+    }
+
+    /// A locked app and a vault with no share for this key must stay
+    /// distinguishable to the TSS layer — they need different handling and both
+    /// used to look like `""`.
+    @MainActor
+    func testALockedShareIsReportedThroughTheErrorPointer() throws {
+        let unlocked = try makeUnlockedProtector()
+        let vault = try makeVault(protector: unlocked)
+        let locked = KeyshareProtector(state: { .locked })
+
+        let sut = LocalStateAccessorImpl(vault: vault, protector: locked)
+
+        var error: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), "")
+        XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+    }
+
+    /// A locking `lock()` landing mid-ceremony has to still make a sealed share
+    /// unreadable. Opening at construction instead would defeat that.
+    @MainActor
+    func testAShareSealedAtConstructionBecomesUnreadableOnceTheKeyIsGone() throws {
+        let key = try VaultCryptoEnvelope.randomKey()
+        var state: KeyshareProtectionState = .unlocked(key)
+        let protector = KeyshareProtector(state: { state })
+        let vault = try makeVault(protector: protector)
+
+        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+
+        var beforeLock: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &beforeLock), ecdsaShare)
+        XCTAssertNil(beforeLock)
+
+        state = .locked
+
+        var afterLock: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &afterLock), "")
+        XCTAssertEqual(afterLock as? KeyshareProtectionError, .locked)
+    }
+
+    // MARK: - The write path is unchanged
+
+    func testSaveLocalStateSealsThroughTheInjectedProtector() throws {
+        let protector = try makeUnlockedProtector()
+        let sut = LocalStateAccessorImpl(vaultShares: [:], protector: protector)
+
+        try sut.saveLocalState(ecdsaPubKey, localState: ecdsaShare)
+
+        XCTAssertEqual(sut.keyshares.count, 1)
+        let stored = try XCTUnwrap(sut.keyshares.first)
+        XCTAssertEqual(stored.pubkey, ecdsaPubKey)
+        XCTAssertTrue(stored.keyshare.hasPrefix(AesGcmKeyshareCipher.sealedPrefix))
+        XCTAssertEqual(try protector.open(stored.keyshare), ecdsaShare)
+    }
+
+    func testSaveLocalStateStoresPlaintextWhileProtectionIsDisabled() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let sut = LocalStateAccessorImpl(vaultShares: [:], protector: protector)
+
+        try sut.saveLocalState(ecdsaPubKey, localState: ecdsaShare)
+
+        XCTAssertEqual(sut.keyshares.first?.keyshare, ecdsaShare)
+    }
+
+    func testSaveLocalStateRejectsMissingArguments() {
+        let sut = LocalStateAccessorImpl(
+            vaultShares: [:],
+            protector: KeyshareProtector(state: { .disabled })
+        )
+
+        XCTAssertThrowsError(try sut.saveLocalState(nil, localState: ecdsaShare))
+        XCTAssertThrowsError(try sut.saveLocalState(ecdsaPubKey, localState: nil))
+        XCTAssertTrue(sut.keyshares.isEmpty)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift
+++ b/VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift
@@ -3,6 +3,7 @@
 //  VultisigAppTests
 //
 
+import CryptoKit
 import XCTest
 
 // The type under test is handed to a Go binding that calls it from arbitrary
@@ -21,12 +22,15 @@ import XCTest
 /// on a `@Model` is undefined behaviour, not a deterministic failure, so no test
 /// can make the old code trap on demand. What they pin instead is the **seam** —
 /// that the callback answers out of a value snapshot rather than out of the
-/// model, which is checkable, fails against the previous implementation, and is
-/// the only thing a future change could quietly undo.
+/// model, and that the snapshot cannot outlive the protection state it was taken
+/// under.
 ///
-/// Everything here constructs through `init(vault:)`, the one initializer
-/// production uses, so a test cannot pass through a seam production does not
-/// have.
+/// Two things keep them from passing for the wrong reason. Everything
+/// constructs through `init(vault:)`, the one initializer production uses. And
+/// the protection state is driven through the **real** `KeyshareKeySession` and
+/// `KeyshareProtector` over a mock Keychain, rather than a hand-held state
+/// closure — so "set a passcode", "lock" and "unlock" are the state transitions
+/// production performs, not a test's idea of them.
 @MainActor
 final class LocalStateAccessorImpTests: XCTestCase {
 
@@ -35,9 +39,51 @@ final class LocalStateAccessorImpTests: XCTestCase {
     private let ecdsaShare = "eyJrZXlzaGFyZSI6ImVjZHNhIn0="
     private let eddsaShare = #"{"PubKey":"03bbb","ShareID":{"value":"9"}}"#
 
-    private func makeUnlockedProtector() throws -> KeyshareProtector {
-        let key = try VaultCryptoEnvelope.randomKey()
-        return KeyshareProtector(state: { .unlocked(key) })
+    /// A real session and protector over a mock Keychain, wired the way
+    /// production wires them: the protector reads its state from the session.
+    private struct Environment {
+        let keychain: MockKeychainService
+        let session: KeyshareKeySession
+        let protector: KeyshareProtector
+
+        /// Models `setPasscode`: the wrapper becomes durable and the key is
+        /// adopted, so the session reports `.unlocked`.
+        @discardableResult
+        func setPasscode() throws -> SymmetricKey {
+            let key = try VaultCryptoEnvelope.randomKey()
+            keychain.wrappedKeyshareDataKeyResult = .present(Data([0x01]))
+            session.adopt(key)
+            return key
+        }
+
+        /// Models `PasscodeService.lock()` — the only thing it does is forget
+        /// the key, which bumps the session generation.
+        func lock() {
+            session.clear()
+        }
+
+        /// Models the unlock that follows: the key comes back without the
+        /// generation moving again.
+        func unlock(_ key: SymmetricKey) {
+            session.adopt(key)
+        }
+
+        /// Models `disablePasscode`: every share is opened back to plaintext and
+        /// the wrapper is deleted, so the session reports `.disabled`.
+        func disablePasscode() {
+            keychain.wrappedKeyshareDataKeyResult = .absent
+            session.clear()
+        }
+    }
+
+    private func makeEnvironment() -> Environment {
+        let keychain = MockKeychainService()
+        let session = KeyshareKeySession(store: DefaultKeyshareKeyStore(keychain: keychain))
+        return Environment(
+            keychain: keychain,
+            session: session,
+            protector: KeyshareProtector(state: { session.currentState() })
+        )
     }
 
     private func makeVault(protector: KeyshareProtecting) throws -> Vault {
@@ -57,6 +103,10 @@ final class LocalStateAccessorImpTests: XCTestCase {
         return vault
     }
 
+    private func makeAccessor(vault: Vault, env: Environment) -> LocalStateAccessorImpl {
+        LocalStateAccessorImpl(vault: vault, protector: env.protector, session: env.session)
+    }
+
     // MARK: - The snapshot seam
 
     /// The regression this change exists for: after construction the callback
@@ -64,9 +114,9 @@ final class LocalStateAccessorImpTests: XCTestCase {
     /// the observable stand-in for "the model is touched" — the previous
     /// implementation read `vault.keyshares` on every call and answered `""`.
     func testTheShareSnapshotIsNotReReadFromTheModel() throws {
-        let protector = KeyshareProtector(state: { .disabled })
-        let vault = try makeVault(protector: protector)
-        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+        let env = makeEnvironment()
+        let vault = try makeVault(protector: env.protector)
+        let sut = makeAccessor(vault: vault, env: env)
 
         vault.keyshares = []
 
@@ -77,9 +127,9 @@ final class LocalStateAccessorImpTests: XCTestCase {
 
     /// The same property from the thread the TSS binding actually uses.
     func testABackgroundCallbackAnswersFromTheSnapshot() throws {
-        let protector = KeyshareProtector(state: { .disabled })
-        let vault = try makeVault(protector: protector)
-        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+        let env = makeEnvironment()
+        let vault = try makeVault(protector: env.protector)
+        let sut = makeAccessor(vault: vault, env: env)
 
         vault.keyshares = []
 
@@ -99,9 +149,9 @@ final class LocalStateAccessorImpTests: XCTestCase {
     /// Reached concurrently during a ceremony, so the snapshot has to be
     /// readable from many threads at once without a lock.
     func testConcurrentReadsAllAnswerFromTheSnapshot() throws {
-        let protector = KeyshareProtector(state: { .disabled })
-        let vault = try makeVault(protector: protector)
-        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+        let env = makeEnvironment()
+        let vault = try makeVault(protector: env.protector)
+        let sut = makeAccessor(vault: vault, env: env)
         let expected = ecdsaShare
         let pubKey = ecdsaPubKey
 
@@ -115,13 +165,13 @@ final class LocalStateAccessorImpTests: XCTestCase {
     /// `Vault.keyshareValue(for:)` resolved duplicates with `first(where:)`;
     /// the snapshot has to resolve them the same way.
     func testADuplicatePublicKeyKeepsTheFirstShare() {
-        let protector = KeyshareProtector(state: { .disabled })
+        let env = makeEnvironment()
         let vault = Vault(name: "Duplicate Vault")
         vault.keyshares = [
             KeyShare(pubkey: ecdsaPubKey, keyshare: ecdsaShare),
             KeyShare(pubkey: ecdsaPubKey, keyshare: "second-share-for-the-same-key")
         ]
-        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+        let sut = makeAccessor(vault: vault, env: env)
 
         var error: NSError?
         XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), ecdsaShare)
@@ -131,8 +181,8 @@ final class LocalStateAccessorImpTests: XCTestCase {
     // MARK: - The read contract the TSS layer depends on
 
     func testAnUnknownPublicKeyAnswersEmptyWithNoError() throws {
-        let protector = KeyshareProtector(state: { .disabled })
-        let sut = LocalStateAccessorImpl(vault: try makeVault(protector: protector), protector: protector)
+        let env = makeEnvironment()
+        let sut = makeAccessor(vault: try makeVault(protector: env.protector), env: env)
 
         var error: NSError?
         XCTAssertEqual(sut.getLocalState("not-a-key", error: &error), "")
@@ -140,8 +190,8 @@ final class LocalStateAccessorImpTests: XCTestCase {
     }
 
     func testANilPublicKeyAnswersEmptyWithNoError() throws {
-        let protector = KeyshareProtector(state: { .disabled })
-        let sut = LocalStateAccessorImpl(vault: try makeVault(protector: protector), protector: protector)
+        let env = makeEnvironment()
+        let sut = makeAccessor(vault: try makeVault(protector: env.protector), env: env)
 
         var error: NSError?
         XCTAssertEqual(sut.getLocalState(nil, error: &error), "")
@@ -153,11 +203,12 @@ final class LocalStateAccessorImpTests: XCTestCase {
     /// the snapshot from parking plaintext key material in memory for the whole
     /// ceremony.
     func testASealedShareIsOpenedOnRead() throws {
-        let protector = try makeUnlockedProtector()
-        let vault = try makeVault(protector: protector)
+        let env = makeEnvironment()
+        try env.setPasscode()
+        let vault = try makeVault(protector: env.protector)
         XCTAssertTrue(vault.keyshares[0].keyshare.hasPrefix(AesGcmKeyshareCipher.sealedPrefix))
 
-        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+        let sut = makeAccessor(vault: vault, env: env)
 
         var error: NSError?
         XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), ecdsaShare)
@@ -169,11 +220,12 @@ final class LocalStateAccessorImpTests: XCTestCase {
     /// distinguishable to the TSS layer — they need different handling and both
     /// used to look like `""`.
     func testALockedShareIsReportedThroughTheErrorPointer() throws {
-        let unlocked = try makeUnlockedProtector()
-        let vault = try makeVault(protector: unlocked)
-        let locked = KeyshareProtector(state: { .locked })
+        let env = makeEnvironment()
+        try env.setPasscode()
+        let vault = try makeVault(protector: env.protector)
+        env.lock()
 
-        let sut = LocalStateAccessorImpl(vault: vault, protector: locked)
+        let sut = makeAccessor(vault: vault, env: env)
 
         var error: NSError?
         XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), "")
@@ -184,79 +236,130 @@ final class LocalStateAccessorImpTests: XCTestCase {
     /// when the snapshot was taken unreadable. Opening at construction instead
     /// would defeat that.
     func testAShareSealedAtConstructionBecomesUnreadableOnceTheKeyIsGone() throws {
-        let key = try VaultCryptoEnvelope.randomKey()
-        var state: KeyshareProtectionState = .unlocked(key)
-        let protector = KeyshareProtector(state: { state })
-        let vault = try makeVault(protector: protector)
+        let env = makeEnvironment()
+        try env.setPasscode()
+        let vault = try makeVault(protector: env.protector)
 
-        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+        let sut = makeAccessor(vault: vault, env: env)
 
         var beforeLock: NSError?
         XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &beforeLock), ecdsaShare)
         XCTAssertNil(beforeLock)
 
-        state = .locked
+        env.lock()
 
         var afterLock: NSError?
         XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &afterLock), "")
         XCTAssertEqual(afterLock as? KeyshareProtectionError, .locked)
     }
 
-    // MARK: - What the snapshot costs when the store moves under it
+    // MARK: - The snapshot cannot outlive the protection state it was taken under
 
-    /// A disable unseals the store and destroys the key. A ceremony holding a
-    /// snapshot taken before it fails closed rather than signing — worse
-    /// availability than re-reading the model, never worse safety. Recorded so
-    /// the trade is visible rather than discovered.
+    /// The window a snapshot opens that a per-call re-read did not, driven
+    /// end-to-end through the real session: no passcode, ceremony starts, a
+    /// passcode is set and the store is swept, then the app locks.
+    ///
+    /// Without the generation check `open` would hand the plaintext over
+    /// forever, because a plaintext value passes through in **every** state —
+    /// so a locked app would go on signing. That is the one direction in which
+    /// snapshotting could be weaker than the read it replaced.
+    func testAPlaintextSnapshotIsRefusedOnceAPasscodeIsSetAndTheAppLocks() throws {
+        let env = makeEnvironment()
+        let vault = try makeVault(protector: env.protector)
+        XCTAssertEqual(vault.keyshares[0].keyshare, ecdsaShare, "No passcode: shares are stored in the clear")
+
+        let sut = makeAccessor(vault: vault, env: env)
+
+        var beforeTransition: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &beforeTransition), ecdsaShare)
+        XCTAssertNil(beforeTransition)
+
+        // setPasscode: the wrapper lands, the key is adopted, the sweep seals
+        // the store behind the live ceremony.
+        try env.setPasscode()
+        vault.keyshares = [try KeyShare.sealed(pubkey: ecdsaPubKey, keyshare: ecdsaShare, protector: env.protector)]
+
+        // Still unlocked, so signing continues — exactly what re-reading the
+        // model and opening with the live key would have done.
+        var whileUnlocked: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &whileUnlocked), ecdsaShare)
+        XCTAssertNil(whileUnlocked)
+
+        env.lock()
+
+        var afterLock: NSError?
+        XCTAssertEqual(
+            sut.getLocalState(ecdsaPubKey, error: &afterLock),
+            "",
+            "A locked app must not keep handing a snapshotted plaintext share to the TSS layer"
+        )
+        XCTAssertEqual(afterLock as? KeyshareProtectionError, .locked)
+    }
+
+    /// The unlock that follows has to give the ceremony its share back, or the
+    /// refusal above would turn a lock into a permanently broken keysign.
+    func testAPlaintextSnapshotIsServedAgainOnceTheAppIsUnlocked() throws {
+        let env = makeEnvironment()
+        let vault = try makeVault(protector: env.protector)
+        let sut = makeAccessor(vault: vault, env: env)
+
+        let key = try env.setPasscode()
+        env.lock()
+
+        var afterLock: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &afterLock), "")
+        XCTAssertEqual(afterLock as? KeyshareProtectionError, .locked)
+
+        env.unlock(key)
+
+        var afterUnlock: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &afterUnlock), ecdsaShare)
+        XCTAssertNil(afterUnlock)
+    }
+
+    /// The guard that matters most: an install with **no passcode** is the
+    /// permanent majority, and nothing about the refusal above may reach it. A
+    /// generation bump with no wrapper in the Keychain still reads `.disabled`,
+    /// so the share is served exactly as before.
+    func testALockWithNoPasscodeSetStillServesThePlaintextSnapshot() throws {
+        let env = makeEnvironment()
+        let vault = try makeVault(protector: env.protector)
+        let sut = makeAccessor(vault: vault, env: env)
+
+        env.lock()
+
+        var error: NSError?
+        XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), ecdsaShare)
+        XCTAssertNil(error)
+    }
+
+    /// The other direction, unchanged and deliberately so: a disable unseals the
+    /// store and destroys the key, and a ceremony holding a snapshot taken
+    /// before it fails closed rather than signing. Worse availability than
+    /// re-reading the model, never worse safety — and there is no way to see the
+    /// unsealed value without reading the model this cannot touch.
     func testASnapshotTakenBeforeADisableFailsClosed() throws {
-        let key = try VaultCryptoEnvelope.randomKey()
-        var state: KeyshareProtectionState = .unlocked(key)
-        let protector = KeyshareProtector(state: { state })
-        let vault = try makeVault(protector: protector)
+        let env = makeEnvironment()
+        try env.setPasscode()
+        let vault = try makeVault(protector: env.protector)
 
-        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
+        let sut = makeAccessor(vault: vault, env: env)
 
-        // The disable unseals every stored share and then deletes the wrapper,
-        // so the model holds plaintext and the session holds nothing.
+        // The disable opens every stored share and then deletes the wrapper.
         vault.keyshares = [KeyShare(pubkey: ecdsaPubKey, keyshare: ecdsaShare)]
-        state = .disabled
+        env.disablePasscode()
 
         var error: NSError?
         XCTAssertEqual(sut.getLocalState(ecdsaPubKey, error: &error), "")
         XCTAssertEqual(error as? KeyshareProtectionError, .locked)
     }
 
-    /// The other direction, and the one that is genuinely weaker than the old
-    /// re-read: a snapshot taken while shares were plaintext keeps answering
-    /// after a sweep has sealed the store and a lock has taken the key away.
-    /// Pinned deliberately — if someone later decides to close it, this test is
-    /// where the decision is recorded.
-    func testASnapshotTakenBeforeASweepStillAnswersAfterALock() throws {
-        var state: KeyshareProtectionState = .disabled
-        let protector = KeyshareProtector(state: { state })
-        let vault = try makeVault(protector: protector)
-
-        let sut = LocalStateAccessorImpl(vault: vault, protector: protector)
-
-        // A resume sweep seals the store behind the ceremony, then the app locks.
-        let unlocked = try makeUnlockedProtector()
-        vault.keyshares = [try KeyShare.sealed(pubkey: ecdsaPubKey, keyshare: ecdsaShare, protector: unlocked)]
-        state = .locked
-
-        var error: NSError?
-        XCTAssertEqual(
-            sut.getLocalState(ecdsaPubKey, error: &error),
-            ecdsaShare,
-            "A plaintext snapshot keeps answering; the model being sealed behind it is not observed"
-        )
-        XCTAssertNil(error)
-    }
-
     // MARK: - The write path is unchanged
 
     func testSaveLocalStateSealsThroughTheInjectedProtector() throws {
-        let protector = try makeUnlockedProtector()
-        let sut = LocalStateAccessorImpl(vault: makeEmptyVault(), protector: protector)
+        let env = makeEnvironment()
+        try env.setPasscode()
+        let sut = makeAccessor(vault: makeEmptyVault(), env: env)
 
         try sut.saveLocalState(ecdsaPubKey, localState: ecdsaShare)
 
@@ -264,12 +367,12 @@ final class LocalStateAccessorImpTests: XCTestCase {
         let stored = try XCTUnwrap(sut.keyshares.first)
         XCTAssertEqual(stored.pubkey, ecdsaPubKey)
         XCTAssertTrue(stored.keyshare.hasPrefix(AesGcmKeyshareCipher.sealedPrefix))
-        XCTAssertEqual(try protector.open(stored.keyshare), ecdsaShare)
+        XCTAssertEqual(try env.protector.open(stored.keyshare), ecdsaShare)
     }
 
     func testSaveLocalStateStoresPlaintextWhileProtectionIsDisabled() throws {
-        let protector = KeyshareProtector(state: { .disabled })
-        let sut = LocalStateAccessorImpl(vault: makeEmptyVault(), protector: protector)
+        let env = makeEnvironment()
+        let sut = makeAccessor(vault: makeEmptyVault(), env: env)
 
         try sut.saveLocalState(ecdsaPubKey, localState: ecdsaShare)
 
@@ -277,10 +380,8 @@ final class LocalStateAccessorImpTests: XCTestCase {
     }
 
     func testSaveLocalStateRejectsMissingArguments() {
-        let sut = LocalStateAccessorImpl(
-            vault: makeEmptyVault(),
-            protector: KeyshareProtector(state: { .disabled })
-        )
+        let env = makeEnvironment()
+        let sut = makeAccessor(vault: makeEmptyVault(), env: env)
 
         XCTAssertThrowsError(try sut.saveLocalState(nil, localState: ecdsaShare))
         XCTAssertThrowsError(try sut.saveLocalState(ecdsaPubKey, localState: nil))

--- a/VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift
+++ b/VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift
@@ -5,7 +5,12 @@
 
 import XCTest
 
-@testable import VultisigApp
+// The type under test is handed to a Go binding that calls it from arbitrary
+// threads, so these tests deliberately reach it from off the main actor. That is
+// the behaviour being pinned, not an oversight, and the module is not built
+// under Swift 6 checking — so the `Sendable` diagnostics it would raise here
+// would be noise around the one place they are least informative.
+@preconcurrency @testable import VultisigApp
 
 /// The TSS binding calls `getLocalState` synchronously on whichever thread
 /// entered it — in this app a `Task.detached(priority: .high)` worker, never the


### PR DESCRIPTION
Fixes #5072

## ⚠️ This touches a declared critical boundary

`VultisigApp/Blockchain/Tss/` is marked in `VultisigApp/CLAUDE.md` as *"TSS keygen/keysign bindings. Do not modify without explicit review."* One file in it changes. Nothing else in the directory is touched, and no call site of the changed type changes.

The evidence that the change is safe, up front:

- **The read contract is byte-for-byte preserved.** `getLocalState` stays synchronous, non-throwing and O(1). Same four outcomes as before: `""` for a nil key; `""` and *no* error for a key the vault has no share for; `""` **and** the error pointer set for a share that exists but cannot be opened; the opened plaintext otherwise. Duplicate public keys still resolve to the first entry.
- **`saveLocalState` is untouched in substance** — it never read the model. Its `KeyshareWriteCoordinator` write lease still brackets seal *and* record as one span, which `docs/passcode-keyshare-encryption/concurrency-and-leases.md` calls the whole point of that lease.
- **A user with no passcode set sees nothing change.** Values are copied out of the vault as stored, and with protection `.disabled` they are plaintext and `KeyshareProtector.open` passes them through unchanged — the `overview.md` acceptance-test row *"TSS keygen / keysign / reshare — unchanged values reach `LocalStateAccessorImpl`"* still holds literally.
- **Three rounds of independent cross-model review** (`codex exec --sandbox read-only`). Round 1: no critical/high, one medium and two low, all fixed. Round 2: no findings at any severity. Round 3, on the lock-generation fix below: **no findings at any severity**, including a twelve-row enumeration of (snapshot representation × protection state × generation moved) confirming every combination matches what the pre-change re-read would have answered, bar the one documented availability case.
- **Full suite green**, not a subset: `Executed 5321 tests, with 1 test skipped and 0 failures (0 unexpected)` / `** TEST SUCCEEDED **`, on a clean build so nothing came from stale products.

## The bug

`LocalStateAccessorImpl` held a `Vault` — a SwiftData `@Model` — and read it inside `getLocalState`, the synchronous callback the TSS binding makes to fetch this device's key share. `CLAUDE.md` rule 2 is *"never access `@Model` classes off MainActor"*. Off-MainActor `@Model` access is undefined behaviour rather than a crash, so it works right up until a different scheduler or a different load makes it not.

## Which thread it actually runs on — measured, not assumed

The issue asked for this to be confirmed empirically. A throwaway XCTest drove the **real** `Tss.xcframework` — `TssNewService` with a recording `TssLocalStateAccessorProtocol` and a silent messenger — and called `keysignECDSA` / `reshareECDSA`, logging the thread from inside the callback. Run on a simulator, `** TEST SUCCEEDED **`:

| Caller | Observed inside `getLocalState` |
|---|---|
| main thread | `isMainThread=true`, `<_NSMainThread …>{number = 1, name = main}`, queue `com.apple.main-thread` |
| `Task.detached(priority: .high)` | `isMainThread=false`, `<NSThread …>{number = 5, name = (null)}`, queue `com.apple.root.user-initiated-qos.cooperative` |

So the binding calls back **synchronously on whichever thread entered it**, and promises nothing beyond that. What settles it is the production entry shape: every call into the binding goes through `Task.detached(priority: .high)` — `createTssInstance`, `tssKeygen`, `tssReshare` (`KeygenViewModel`) and `tssKeysign` (`KeysignViewModel`). The `@Model` read was therefore on a Swift-concurrency cooperative-pool worker on **every** real keygen, reshare and keysign — never on main.

The probe was deleted before committing; nothing here ships it.

This is not a dormant path: `KeysignViewModel` routes `case .GG20, .none` through this accessor, so every legacy pre-DKLS vault signs through it, and reshare/migrate of those vaults does too.

## The change

The vault's shares are copied into a `[String: String]` on the MainActor at construction, and the callback answers out of that. It never touches a `@Model`.

Three decisions worth reviewing, each with the alternative that was rejected:

**Snapshot the values as *stored*, not opened.** Opening every share at construction would have been simpler and would have made the ceremony immune to everything below — but it parks plaintext key material in memory for the length of a ceremony and survives a `lock()`, defeating the property that a background lock makes sealed shares unreadable. Keeping them stored is also what makes the no-passcode path byte-identical, and what keeps `.locked` reaching the TSS layer through the error pointer so a locked app stays distinguishable from a vault with no share.

**`@MainActor` on `init(vault:)`, and the dictionary initializer is `private`.** `invariants.md` argues for compile-time forcing functions over doc comments. Marking the initializer main-actor bound is one: the off-MainActor read cannot be reintroduced by moving construction into the ceremony without a compile error. Review round 1 pointed out that a module-visible dictionary initializer would have been a silent way around it, so it is private and *every* construction — production and test — goes through `init(vault:)`.

**Nothing about `saveLocalState`'s span moves.** The only edit there threads the injected protector into `KeyShare.sealed`; the default is the same singleton, so production behaviour is identical and the injection is honest for tests.

## The window review found, and how it is closed

The first version of this PR **documented** a cost it should have removed. CodeRabbit raised it as Major / Security & Privacy, and it was right:

> An unprotected vault snapshot keeps plaintext key-share material in `vaultShares`. After `setPasscode` seals the vault and `lock()` clears the session key, `KeyshareProtector.open()` still returns that plaintext, so an active keysign can continue after locking.

The mechanism is one line of `KeyshareProtector`: `open` checks `isSealed` **before** it consults the protection state, so a plaintext value passes through in *every* state. That passthrough is deliberate and permanent — `.disabled` is the majority state forever — but it means a snapshot cannot tell *"plaintext because there is no passcode"* from *"plaintext because the passcode arrived after these values were copied"*. A locked app that keeps signing is the one shape that is **worse than the per-call re-read this replaced**, and that is not a cost worth accepting.

Both remedies the review suggested were rejected, with reasons:

- **"hold a ceremony lease until keysign completes"** — it would not work. An `EpisodeLease` excludes *transitions*, but the unlock-time resume sweep runs under a **write** lease, and per the exclusion matrix in `concurrency-and-leases.md` episodes do not exclude writes. It would also block every passcode change for the length of a signature, and a leaked keysign episode blocks them until relaunch — the hazard `invariants.md` already names for the keygen episode.
- **"invalidate the snapshot during protection transitions"** — needs a registry of live accessors reachable from `PasscodeService`, inside a critical boundary, to carry a signal the codebase already publishes.

It already publishes the **session generation**. `KeyshareKeySession.clear()` — all that `PasscodeService.lock()` does — bumps a counter, and `concurrency-and-leases.md` describes generation counting as precisely the mechanism for *"an operation that began before a lock must not complete after it"*. So the generation is captured with the shares, and a read is refused when three things hold together:

1. the snapshotted value is **not sealed** — otherwise `open` decides and this must not second-guess it;
2. the generation has **moved** — one `NSLock`-guarded integer, false on every ordinary call;
3. the state is now **`.locked`**.

Ordered cheapest-first deliberately, so the protection state is consulted **only** once a lock has actually landed and no Keychain round trip appears in the middle of signing — the cost `KeyshareKeySession`'s own doc comment says it exists to keep off this path.

**Nothing changes for an install with no passcode**, which is the permanent majority: the predicate short-circuits on the generation before any Keychain read, and `AppViewModel` only calls `lock()` after `isPasscodeGateRequired` confirms a gate exists. Even a bumped generation with no wrapper reads `.disabled` and is served. There is a test that pins exactly this. An app that locks and is then unlocked mid-keysign reads `.unlocked` and is served again, so the refusal is not a latch.

The one asymmetry that remains, unchanged and deliberate: a `disablePasscode` mid-keysign leaves the snapshot holding a sealed value whose wrapper is gone, so the read fails **closed** where the old code would have re-read the freshly unsealed plaintext. Availability, never safety — and there is no way to see the unsealed value without reading the model this cannot touch.

## Tests

`VultisigApp/VultisigAppTests/Tss/LocalStateAccessorImpTests.swift`, 16 cases, all constructing the way production does, and all driven through the **real** `KeyshareKeySession` + `KeyshareProtector` over a mock Keychain rather than a hand-held state closure — so "set a passcode", "lock", "unlock" and "disable" are the transitions production performs.

The honest limit is stated in the file: **a data race on a `@Model` is undefined behaviour and cannot be made to trap on demand**, so no test here reproduces the race. What they pin is the seam — that the callback answers out of a value snapshot rather than out of the model — which is checkable and is the only thing a future change could quietly undo. `invariants.md` warns that this area has a history of tests that passed identically with and without the bug, so **four of the sixteen were verified to fail against the parent read path**, by restoring `vault.keyshareValue(for:)` behind the new initializers and re-running (`** TEST FAILED **`, exit 65):

```
testTheShareSnapshotIsNotReReadFromTheModel           ("") is not equal to ("eyJrZXlzaGFyZSI6ImVjZHNhIn0=")
testABackgroundCallbackAnswersFromTheSnapshot         ("") is not equal to ("eyJrZXlzaGFyZSI6ImVjZHNhIn0=")
testASnapshotTakenBeforeADisableFailsClosed           ("eyJrZXlzaGFyZSI6ImVjZHNhIn0=") is not equal to ("")
testASnapshotTakenBeforeASweepStillAnswersAfterALock  ("") is not equal to ("eyJrZXlzaGFyZSI6ImVjZHNhIn0=")
```

The first two are the regression. The last two are transition cases, and they fail in *both* directions — which is the point: they pin exactly where the new behaviour differs from the old rather than pretending it does not.

The two tests covering the lock window were separately verified to fail with the guard neutered to `return false`:

```
testAPlaintextSnapshotIsRefusedOnceAPasscodeIsSetAndTheAppLocks
  ("eyJrZXlzaGFyZSI6ImVjZHNhIn0=") is not equal to ("") - A locked app must not
  keep handing a snapshotted plaintext share to the TSS layer
testAPlaintextSnapshotIsServedAgainOnceTheAppIsUnlocked
  ("eyJrZXlzaGFyZSI6ImVjZHNhIn0=") is not equal to ("")
```

The remainder pin the read/write contract and pass either way by design.

## Verification

- Full suite on a dedicated en_US iPhone 16 / iOS 26.5 simulator, **clean build**: `Executed 5323 tests, with 1 test skipped and 0 failures (0 unexpected)`, `** TEST SUCCEEDED **`. Both changed files appear as `SwiftCompile` lines in that same run, so it is not a stale-products pass.
- `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/`: 22 violations before and 22 after, none in either changed file.
- Compiler warnings: the first version of the suite added three `capture of … non-Sendable` warnings; they are gone — a clean build emits no warning from either changed file.

## Still worth doing before merge

**No live two-party ceremony was run.** The probe exercised the real binding but not an end-to-end keygen or keysign. A **GG20 keysign against a legacy vault** and a **GG20 reshare** on device are the runtime checks this change deserves, since that is the only path the accessor is on.

Out of scope, and recorded rather than fixed: the other TSS call sites still using the optional-collapsing `Vault.getKeyshare(pubKey:)` (`Blockchain/States/Keygen/`, `Blockchain/States/Keysign/`, `KeygenViewModel`), already listed under *things that are deliberately not done* in `invariants.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection and retrieval of locally stored vault keyshares.
  * Preserved the correct keyshare when duplicate entries are encountered.
  * Added clearer handling for unknown keys, locked storage, unavailable protection, and invalid data.
  * Ensured saved keyshares are securely sealed when protection is enabled.

* **Reliability**
  * Improved local-state access during background and concurrent operations.
  * Added coverage for state changes after locking or disabling protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->