### PR TITLE
fix(keygen): make commitVault all-or-nothing when the save throws

### DIFF
--- a/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Keygen/ViewModels/KeygenViewModel.swift
@@ -33,6 +33,22 @@ enum KeygenCommitError: Error, Equatable, LocalizedError {
     /// pointing both at the first would make the second one false.
     case unsealableKeyshare(pubkey: String)
 
+    /// The store is carrying uncommitted work from somewhere else, and this
+    /// commit would have to insert a vault it could only take back by
+    /// discarding that work with it.
+    ///
+    /// Refused rather than resolved, and the three ways of resolving it were
+    /// each tried and rejected: flushing the other work commits a half-finished
+    /// flow because the user tapped a button on this one; rolling it back
+    /// discards it; and deleting only this vault's own row strips the caller's
+    /// object of its coins and chain public keys through the cascade, so the
+    /// retry stores a vault that no longer knows which chains it can derive.
+    ///
+    /// Transient: any `save()` from anywhere settles the context — the main
+    /// context autosaves — and the same button then works. It is the same
+    /// answer `KeyshareSweeper` gives to a dirty context, for the same reason.
+    case busy
+
     init(_ failure: KeyshareNormalizationFailure) {
         switch failure {
         case .unreadable(let pubkey):
@@ -56,6 +72,8 @@ enum KeygenCommitError: Error, Equatable, LocalizedError {
             return "keysharesUnreadableVaultNotSaved".localized
         case .unsealableKeyshare:
             return "keysharesUnsealableVaultNotSaved".localized
+        case .busy:
+            return "somethingWentWrongTryAgain".localized
         }
     }
 }
@@ -265,22 +283,95 @@ class KeygenViewModel: ObservableObject {
     /// keygen finishes, so that aborting the review screen discards the vault and
     /// leaves its name reusable. Inserting on the unique `pubKeyECDSA` upserts, so
     /// re-running keygen that reproduces an existing vault replaces it as before.
+    ///
+    /// Not every vault reaching here is new. A secure reshare on a device that
+    /// was already a signer has already had its reshared vault saved by
+    /// `finalizeDKLSKeygen`'s `needsInsert == false` branch and still comes
+    /// through the review screen, so this also runs over vaults that are already
+    /// stored. The insert is then the upsert described above, and the undo below
+    /// must not treat that row as its own.
+    ///
+    /// **All of it or none of it.** A throwing `save()` writes nothing to the
+    /// store, but it leaves the vault and its coins registered in a context the
+    /// whole app shares — and a fetch resolves a pending insert, so the app would
+    /// go on believing in a wallet the user was just told could not be saved,
+    /// until something unrelated flushed it for real. Whatever this put in the
+    /// context is taken back, the vault is handed back in the form it arrived in,
+    /// and the failure is surfaced. Retrying is the caller's to decide: "Looks
+    /// Good" runs the whole thing again under a fresh lease, which is the right
+    /// granularity for the failures a save actually produces here — the container
+    /// unreachable, data protection unavailable, the disk full — none of which a
+    /// second attempt one line later would fix.
+    ///
+    /// - Parameter save: the store write. A seam, and only a seam: SwiftData
+    ///   offers no way to make an in-memory `save()` fail on demand, and the
+    ///   path that matters most here is the one a save failure opens.
     @MainActor
     static func commitVault(
         _ vault: Vault,
         context: ModelContext,
-        protector: KeyshareProtecting = KeyshareProtector.shared
+        protector: KeyshareProtecting = KeyshareProtector.shared,
+        save: @MainActor (ModelContext) throws -> Void = { try $0.save() }
     ) throws {
         let coinService = VaultDefaultCoinService(context: context)
 
         // The insert and the save are one write span. The episode lease already
         // keeps a transition out of the whole review interval, but this is the
         // moment the shares actually reach the store, so it carries its own
-        // guarantee rather than relying on a lease held elsewhere.
+        // guarantee rather than relying on a lease held elsewhere. The undo
+        // below is inside the span for the same reason: a transition must not
+        // land between a failed save and the withdrawal that takes it back.
         try KeyshareWriteCoordinator.shared.withWriteLease {
             // Ahead of everything else, so a refusal leaves the context exactly
             // as it found it — `setDefaultCoinsOnce` builds coins onto the vault.
             let shares = try normalizedKeyshares(of: vault, protector: protector)
+
+            // Whatever the context was already carrying decides how a failure
+            // can be undone, and it has to be sampled before the first mutation.
+            let wasCarryingOtherWork = context.hasChanges
+
+            // Nothing may be committed over a vault the context is on its way to
+            // deleting: the save would remove it and this would report success.
+            // Nothing before the review screen marks one that way, so this is
+            // insurance rather than a live case, and it costs one read.
+            guard !vault.isDeleted else {
+                commitLogger.error("Refusing to persist a vault the context is holding as deleted")
+                throw KeygenCommitError.busy
+            }
+
+            // Whether this call is the one bringing the vault into the store.
+            // Not every vault reaching here is new: a secure reshare on a device
+            // that was already a signer arrives with one that is already stored,
+            // and the two cases have different undos.
+            //
+            // Asked of the *store* and not of `vault.modelContext`, which only
+            // says the object is registered — a pending insert is registered and
+            // is not stored, and reading it as stored would leave that insert
+            // behind on the branch below, which is this whole bug over again. A
+            // context of its own reads durable rows only, so a hit is proof.
+            let isNewToTheStore = !isStored(vault, in: context)
+
+            // A vault this call has to *insert* can only be taken back by a
+            // `rollback()`, and a rollback is only this commit's to run when the
+            // context was clean on the way in. So a context carrying somebody
+            // else's uncommitted work is refused here, before anything is
+            // touched. The alternatives were each tried: flushing that work
+            // commits a half-finished flow because the user tapped a button on
+            // this one, rolling back discards it, and deleting just this
+            // vault's row strips the caller's object through the cascade — see
+            // ``KeygenCommitError.busy``.
+            guard !(isNewToTheStore && wasCarryingOtherWork) else {
+                commitLogger.error("Refusing to persist a vault: the store is carrying work this commit could not take back")
+                throw KeygenCommitError.busy
+            }
+
+            // The shares as they were handed over. A failed save has to give
+            // them back in that form and not in the one this commit computed —
+            // see ``restore(_:to:)``. The coins the vault already held are what
+            // tells the undo which rows are this call's to take back.
+            let previousShares = vault.keyshares
+            let previousCoins = vault.coins
+            let previousDefiChains = vault.defiChains
 
             // Whole-array assignment, never element assignment: assigning into
             // an element is not a dependable way to mark a `@Model` dirty.
@@ -288,12 +379,122 @@ class KeygenViewModel: ObservableObject {
 
             coinService.setDefaultCoinsOnce(vault: vault)
             context.insert(vault)
-            try context.save()
+
+            do {
+                try save(context)
+            } catch {
+                // A throwing save writes nothing, so the *store* is intact — but
+                // the vault and its coins stay pending in a context the whole app
+                // shares, and SwiftData resolves pending inserts in every fetch.
+                // Left alone they would show up as a wallet the user was just
+                // told could not be saved, and the next autosave or any
+                // unrelated `save()` would make that durable *outside* this
+                // lease, where a passcode transition can land between the
+                // normalization and the write.
+                withdraw(
+                    vault,
+                    from: context,
+                    rollingBack: !wasCarryingOtherWork,
+                    coinsItAlreadyHeld: previousCoins,
+                    defiChainsItAlreadyHad: previousDefiChains
+                )
+                restore(vault, to: previousShares)
+                commitLogger.error("Vault commit failed to save: \(error.localizedDescription, privacy: .public)")
+                throw error
+            }
         }
 
         // Past every way this can refuse, so the network work it starts is
         // aimed at a vault that is provably stored and cannot be withdrawn.
         coinService.startTokenDiscovery()
+    }
+
+    /// Takes back what this commit put in the context, without taking anybody
+    /// else's work with it.
+    ///
+    /// Over a context that was clean on the way in, everything pending is
+    /// provably this commit's and `rollback()` is the right primitive: it
+    /// discards the insert and leaves the caller's vault whole and
+    /// re-insertable, which is what makes the next "Looks Good" a real retry.
+    ///
+    /// Over a context that was not clean, the vault is one the store already
+    /// holds — the guard above refuses the other case — so the row is not this
+    /// call's to remove and only the coins it attached come back out. Detached
+    /// from the coin's side before the delete, for the same reason
+    /// `VaultDefaultCoinService` detaches before taking a coin back: on a vault
+    /// that has been through a `save()` the to-one write is the one that takes.
+    ///
+    /// **Do not "simplify" this to `context.delete(vault)` on both branches.**
+    /// The row does go back, and then the `.cascade` on `Vault.coins` and
+    /// `Vault.chainPublicKeys` strips the caller's *object* — so the retry,
+    /// which is the whole point of surfacing rather than swallowing, rebuilds a
+    /// key-import vault that no longer knows which chains it can derive and
+    /// stores it with none. Measured, and not even deterministic run to run.
+    @MainActor
+    private static func withdraw(
+        _ vault: Vault,
+        from context: ModelContext,
+        rollingBack: Bool,
+        coinsItAlreadyHeld previousCoins: [Coin],
+        defiChainsItAlreadyHad previousDefiChains: [Chain]
+    ) {
+        guard !rollingBack else {
+            context.rollback()
+            return
+        }
+
+        for coin in vault.coins where !previousCoins.contains(where: { $0 === coin }) {
+            coin.vault = nil
+            context.delete(coin)
+        }
+
+        // The DeFi chains go back with the coins they were derived from, and
+        // only on this branch. `setDefaultCoins` writes both together, so
+        // taking the coins away and leaving the chains would persist a vault
+        // offering DeFi on chains it holds no coin for. The rollback branch
+        // must *not* do this: it leaves the coin objects attached, and a
+        // preparation that finds coins already there does not recompute the
+        // chains, so reverting them there would drop them for good.
+        vault.defiChains = previousDefiChains
+    }
+
+    /// Whether the store already holds this vault, asked through a context of
+    /// its own so that only durable rows can answer.
+    ///
+    /// `vault.modelContext != nil` is the cheap version and it is wrong: it is
+    /// also true of a pending insert, which is registered and not stored.
+    @MainActor
+    private static func isStored(_ vault: Vault, in context: ModelContext) -> Bool {
+        let pubKeyECDSA = vault.pubKeyECDSA
+        guard !pubKeyECDSA.isEmpty else { return false }
+
+        var descriptor = FetchDescriptor<Vault>(
+            predicate: #Predicate<Vault> { $0.pubKeyECDSA == pubKeyECDSA }
+        )
+        descriptor.fetchLimit = 1
+        return ((try? ModelContext(context.container).fetch(descriptor).first) ?? nil) != nil
+    }
+
+    /// Puts the vault's shares back in the form they were handed over in.
+    ///
+    /// Not tidiness, and not something the rollback does — a rolled-back object
+    /// keeps the property values it was given. Normalizing rewrites the caller's
+    /// vault in place, so a commit that sealed plaintext shares and then failed
+    /// to save leaves the review screen holding sealed ones. Disable the passcode
+    /// before retrying and those shares no longer open under any state: the
+    /// retry refuses, permanently, over a vault that would have committed fine.
+    /// The undo is only total if it reaches the object as well as the context.
+    ///
+    /// The shares and nothing else. `coins` and `defiChains` are the coin
+    /// preparation's own output, it is idempotent over them, and a rollback
+    /// leaves the coin objects attached to the vault — so reverting `defiChains`
+    /// while the coins stay would make the retry store a vault whose DeFi chains
+    /// were silently dropped, because a preparation that finds coins already
+    /// there does not recompute them. They carry no key material; the shares do,
+    /// and the shares are the mismatch nothing can recover from.
+    @MainActor
+    private static func restore(_ vault: Vault, to shares: [KeyShare]) {
+        vault.keyshares = shares
     }
 
     /// The vault's shares in the form the current protection state requires,

--- a/VultisigApp/VultisigAppTests/Keygen/KeygenVaultCommitTests.swift
+++ b/VultisigApp/VultisigAppTests/Keygen/KeygenVaultCommitTests.swift
@@ -724,6 +724,46 @@ final class KeygenVaultCommitTests: XCTestCase {
         )
     }
 
+    /// The other half of the same branch, and the one the reshare case above
+    /// cannot reach: a stored vault that does **not** yet hold its default
+    /// coins. The commit builds and attaches them, the save throws, and the
+    /// coins have to come back out — together with the DeFi chains that were
+    /// derived from them in the same pass, or the vault is left offering DeFi
+    /// on chains it holds no coin for.
+    func testAFailedCommitTakesBackTheCoinsItAttachedToAnAlreadyStoredVault() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let vault = TestStore.makeDerivableVault(keyshare: firstShare)
+
+        // Stored, but with no coins yet — inserted directly rather than through
+        // the commit, which would have attached them.
+        Storage.shared.modelContext.insert(vault)
+        try Storage.shared.modelContext.save()
+        XCTAssertTrue(vault.coins.isEmpty)
+
+        // Dirty, the way the review screen leaves it on the reshare path.
+        vault.isBackedUp = true
+        XCTAssertTrue(Storage.shared.modelContext.hasChanges)
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: protector,
+                save: failingSave
+            )
+        )
+
+        XCTAssertTrue(vault.coins.isEmpty, "the coins this commit attached have to come back out")
+        XCTAssertTrue(vault.defiChains.isEmpty, "and the DeFi chains derived from them in the same pass")
+
+        try Storage.shared.modelContext.save()
+
+        let stored = try XCTUnwrap(try storedVaults().first)
+        XCTAssertTrue(stored.coins.isEmpty, "nothing the failed commit built may reach the store")
+        XCTAssertTrue(stored.defiChains.isEmpty)
+        XCTAssertEqual(stored.keyshares.map(\.keyshare), [firstShare])
+    }
+
     /// The review screen renders `error.localizedDescription`. Without the
     /// `LocalizedError` conformance the user would be shown
     /// "(VultisigApp.KeygenCommitError error 0.)" for a dead vault.

--- a/VultisigApp/VultisigAppTests/Keygen/KeygenVaultCommitTests.swift
+++ b/VultisigApp/VultisigAppTests/Keygen/KeygenVaultCommitTests.swift
@@ -24,6 +24,9 @@ final class KeygenVaultCommitTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         token = try TestStore.installInMemoryContainer()
+        // A successful commit hands out a token-discovery `Task` that can
+        // outlive the test method and touch the models it resolved.
+        TestStore.retain(try XCTUnwrap(token).container)
     }
 
     override func tearDown() async throws {
@@ -76,6 +79,30 @@ final class KeygenVaultCommitTests: XCTestCase {
             .fetch(FetchDescriptor<Vault>())
             .flatMap(\.keyshares)
             .map(\.keyshare)
+    }
+
+    /// Read through a context that never saw the in-memory objects, so a
+    /// pending insert cannot answer for a stored row. `Storage.shared`'s own
+    /// context resolves pending inserts in every fetch, which is exactly the
+    /// confusion the tests below are about.
+    private func storedVaults() throws -> [Vault] {
+        try ModelContext(try XCTUnwrap(token).container).fetch(FetchDescriptor<Vault>())
+    }
+
+    /// A store write that fails the way a real one does — the container
+    /// unreachable, data protection unavailable, the disk full. SwiftData
+    /// offers no way to make an in-memory `save()` fail on demand, which is why
+    /// `commitVault` takes the write as a seam.
+    private struct StoreUnavailable: Error {}
+
+    private func failingSave(_: ModelContext) throws {
+        throw StoreUnavailable()
+    }
+
+    /// Read through a context that never saw the in-memory objects, for the
+    /// same reason as ``storedVaults()``.
+    private func storedShares() throws -> [String] {
+        try storedVaults().flatMap(\.keyshares).map(\.keyshare)
     }
 
     // MARK: - Tests
@@ -465,13 +492,246 @@ final class KeygenVaultCommitTests: XCTestCase {
         XCTAssertEqual(try persistedVaultCount(), 0)
     }
 
+    // MARK: - All of it or none of it, when the save throws
+
+    /// **The regression.** A throwing `save()` writes nothing to the store, so
+    /// nothing is half-written *there* — but the vault and its coins stay
+    /// registered in a context the whole app shares, and SwiftData resolves a
+    /// pending insert in every fetch. The review screen said the vault could not
+    /// be saved and the app went on answering that it existed.
+    func testAFailedSaveLeavesNothingFetchableAndNothingPending() throws {
+        let vault = makeVault(name: "Treasury", shares: [firstShare])
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: KeyshareProtector(state: { .disabled }),
+                save: failingSave
+            )
+        ) { error in
+            XCTAssertTrue(error is StoreUnavailable, "the store's own failure has to reach the caller unchanged")
+        }
+
+        XCTAssertEqual(try persistedVaultCount(), 0, "a vault whose save threw must not answer a fetch")
+        XCTAssertFalse(
+            Storage.shared.modelContext.hasChanges,
+            "and must not be left pending for something else to flush"
+        )
+    }
+
+    /// The half that makes it durable. Nothing about the failure stops the next
+    /// unrelated `save()` anywhere in the app — or the main context's autosave —
+    /// from writing the pending insert for real, minutes later and *outside* the
+    /// write lease this commit holds.
+    func testAFailedSaveDoesNotBecomeDurableOnTheNextUnrelatedSave() throws {
+        let vault = makeVault(name: "Treasury", shares: [firstShare])
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: KeyshareProtector(state: { .disabled }),
+                save: failingSave
+            )
+        )
+
+        // Something else in the app saves the shared context.
+        try Storage.shared.modelContext.save()
+
+        XCTAssertEqual(try storedVaults().count, 0, "a refused vault must not reach disk on somebody else's save")
+    }
+
+    /// The vault is handed back in the form it arrived in, not the form the
+    /// commit computed. Keygen produced plaintext shares, the user set a
+    /// passcode during the review, so the commit sealed them — and then the save
+    /// threw. Left sealed, disabling the passcode before retrying would make
+    /// them unopenable under every state and the vault uncommittable for good.
+    func testAFailedSaveGivesTheSharesBackInTheFormTheyArrivedIn() throws {
+        var state: KeyshareProtectionState = .disabled
+        let protector = KeyshareProtector(state: { state })
+        let vault = makeVault(name: "Treasury", shares: [firstShare])
+
+        // A passcode set while the review screen was up.
+        state = .unlocked(SymmetricKey(size: .bits256))
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: protector,
+                save: failingSave
+            )
+        )
+
+        XCTAssertEqual(
+            vault.keyshares.map(\.keyshare),
+            [firstShare],
+            "a failed commit must not leave the caller holding shares it sealed"
+        )
+
+        // The user disables the passcode and taps again. Against a commit that
+        // kept its own seal this throws `.unreadableKeyshare`, permanently.
+        state = .disabled
+        try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+        XCTAssertEqual(try storedShares(), [firstShare], "read back from the store, not from a pending insert")
+    }
+
+    /// "Looks Good" is the retry, so it has to work — and it has to bring the
+    /// default coins with it, not just the vault.
+    func testARetryAfterAFailedSaveStoresTheVaultAndItsCoins() throws {
+        let vault = TestStore.makeDerivableVault(keyshare: firstShare)
+        let protector = KeyshareProtector(state: { .disabled })
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: protector,
+                save: failingSave
+            )
+        )
+
+        try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+
+        let stored = try storedVaults()
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(
+            Set(stored.first?.coins.map(\.chain) ?? []),
+            Set(TestStore.derivableChains),
+            "the retry has to attach the default coins, not only store the vault"
+        )
+        // The undo deliberately leaves the coin preparation's own output alone.
+        // Reverting `defiChains` while the rollback leaves the coin objects
+        // attached would drop them for good: a preparation that finds coins
+        // already there does not recompute the DeFi chains.
+        XCTAssertTrue(
+            stored.first?.defiChains.contains(.tron) ?? false,
+            "the DeFi chains derived alongside the coins have to survive the retry too"
+        )
+    }
+
+    /// The undo for a vault this commit has to insert is a `rollback()`, and
+    /// `rollback()` discards *every* pending change in the context — measured:
+    /// a foreign pending insert is destroyed outright and a foreign pending
+    /// edit is reverted. `Storage.shared.modelContext` is the app-wide context
+    /// and episodes overlap by design, so a commit that could not take its own
+    /// work back without taking somebody else's is refused before it starts.
+    func testACommitIsRefusedWhileTheStoreIsCarryingWorkItCouldNotTakeBack() throws {
+        let foreign = makeVault(name: "Savings", shares: [secondShare])
+        Storage.shared.modelContext.insert(foreign)   // never saved
+
+        let vault = makeVault(name: "Treasury", shares: [firstShare])
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: KeyshareProtector(state: { .disabled }),
+                save: failingSave
+            )
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .busy)
+        }
+
+        XCTAssertEqual(
+            try Storage.shared.modelContext.fetch(FetchDescriptor<Vault>()).map(\.name),
+            ["Savings"],
+            "the refused vault must not even be registered — a pending insert answers every fetch in the app"
+        )
+        XCTAssertTrue(vault.coins.isEmpty, "and no coins may have been built for it")
+        XCTAssertTrue(
+            Storage.shared.modelContext.hasChanges,
+            "while the work the context was carrying is left exactly where it was"
+        )
+    }
+
+    /// And the refusal is the transient thing it claims to be: any save settles
+    /// the context and the same button then works, completely — coins included.
+    func testTheRefusalClearsOnceTheStoreSettles() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        Storage.shared.modelContext.insert(makeVault(name: "Savings", shares: [secondShare]))
+
+        let vault = TestStore.makeDerivableVault(keyshare: firstShare)
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+        ) { error in
+            XCTAssertEqual(error as? KeygenCommitError, .busy)
+        }
+
+        // Anything at all saves the shared context — the main one autosaves.
+        try Storage.shared.modelContext.save()
+
+        try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+
+        let stored = try storedVaults()
+        XCTAssertEqual(Set(stored.map(\.name)), ["Savings", vault.name])
+        XCTAssertEqual(
+            Set(stored.first { $0.name == vault.name }?.coins.map(\.chain) ?? []),
+            Set(TestStore.derivableChains),
+            "a retry that stores the vault without its chains is the failure this undo exists to avoid"
+        )
+    }
+
+    /// **Not every vault reaching the commit is new.** A secure reshare on a
+    /// device that was already a signer has its reshared vault saved outright by
+    /// `finalizeDKLSKeygen`, and still routes through the review screen — where
+    /// the screen's own `isBackedUp = false` leaves the context dirty, which is
+    /// precisely the branch that withdraws row by row.
+    ///
+    /// Deleting the vault there does not remove the row — a delete that follows
+    /// this call's own no-op `insert` of an already-registered object leaves it
+    /// in place — but the `.cascade` on `Vault.coins` runs anyway, so the
+    /// reshared wallet comes back with **no chains in it**, silently, because a
+    /// re-save failed. Which is why the fixture has to be a vault whose coins
+    /// actually build: a placeholder-key vault attaches none, and the cascade
+    /// then has nothing to take.
+    func testAFailedCommitDoesNotWithdrawAVaultItDidNotInsert() throws {
+        let protector = KeyshareProtector(state: { .disabled })
+        let vault = TestStore.makeDerivableVault(keyshare: firstShare)
+
+        // The reshare's own save, before the review screen is shown.
+        try KeygenViewModel.commitVault(vault, context: Storage.shared.modelContext, protector: protector)
+        vault.isBackedUp = true
+        try Storage.shared.modelContext.save()
+        XCTAssertEqual(try storedVaults().first?.coins.count, TestStore.derivableChains.count)
+
+        // What the review screen does on the way in, leaving the context dirty.
+        vault.isBackedUp = false
+        XCTAssertTrue(Storage.shared.modelContext.hasChanges, "the fixture has to reach the coins-only undo")
+
+        XCTAssertThrowsError(
+            try KeygenViewModel.commitVault(
+                vault,
+                context: Storage.shared.modelContext,
+                protector: protector,
+                save: failingSave
+            )
+        )
+
+        try Storage.shared.modelContext.save()
+
+        let stored = try storedVaults()
+        XCTAssertEqual(stored.count, 1, "an already-stored vault must survive a failed re-commit")
+        XCTAssertEqual(
+            Set(stored.first?.coins.map(\.chain) ?? []),
+            Set(TestStore.derivableChains),
+            "and must keep its chains — nothing rebuilds default coins after keygen and import"
+        )
+        XCTAssertEqual(
+            stored.first?.keyshares.map(\.keyshare),
+            [firstShare],
+            "and its key shares"
+        )
+    }
+
     /// The review screen renders `error.localizedDescription`. Without the
     /// `LocalizedError` conformance the user would be shown
     /// "(VultisigApp.KeygenCommitError error 0.)" for a dead vault.
     func testEveryRefusalIsReportedInWordsRatherThanAsAnNSError() {
         let cases: [(KeygenCommitError, String)] = [
             (.unreadableKeyshare(pubkey: "treasury-share-0"), "keysharesUnreadableVaultNotSaved"),
-            (.unsealableKeyshare(pubkey: "treasury-share-0"), "keysharesUnsealableVaultNotSaved")
+            (.unsealableKeyshare(pubkey: "treasury-share-0"), "keysharesUnsealableVaultNotSaved"),
+            (.busy, "somethingWentWrongTryAgain")
         ]
 
         for (error, key) in cases {


### PR DESCRIPTION
Fixes #5073

## What was actually wrong

`KeygenViewModel.commitVault` inserts a freshly generated vault and its default coins into the app-wide `ModelContext` and then saves. The issue's premise holds, but the mechanism is the reverse of the natural reading, and it is worse than "the store and the object graph disagree":

- **The store is never half-written.** A throwing `save()` writes nothing.
- **The disagreement is that the app already believes the vault exists.** Measured on an in-memory container: with the vault and two coins inserted and no save, `FetchDescriptor<Vault>` returns **1** and `FetchDescriptor<Coin>` returns **2**. SwiftData resolves pending inserts in every fetch, so the vault list, `VaultNameValidator` and every other read see the vault the moment the alert says it could not be saved.
- **A later save makes it durable.** The main context autosaves and every service in the app saves it, so the pending insert lands with no further user action — and *outside* the write lease, where a passcode transition can land between the normalization and the write, putting the shares on the wrong side of the sealed-iff-a-passcode-is-set invariant.
- **The abort guarantee is lost.** `deferVaultPersistence` exists so that abandoning the review leaves the vault's name reusable; a failed commit took the name anyway.

### The mutation inventory

| # | Statement | Observable if `save()` throws? |
|---|---|---|
| 1 | `normalizedKeyshares(of:protector:)` | no — pure, and it throws before anything else |
| 2 | `vault.keyshares = shares` | **yes**, on the caller's object — see the share-form trap |
| 3 | `setDefaultCoinsOnce(vault:)` — `context.insert(coin)`, `coin.vault = vault`, `vault.defiChains = …` | **yes** — pending inserts in the shared context |
| 4 | `context.insert(vault)` | **yes** — pending insert in the shared context |
| 5 | `try context.save()` | the store is untouched |
| 6 | `startTokenDiscovery()` | no — outside and after the lease block; already correct on `main` |

### The share-form trap

`vault.keyshares = shares` rewrites the caller's vault *before* a save that can fail, and `main` never puts it back. Plaintext keygen → the user sets a passcode during the review → the commit seals the shares onto the object → the save throws → the user disables the passcode and retries → the retry cannot open shares sealed under a key that no longer exists, and the vault is **permanently uncommittable**. So the undo has to reach the object, not only the context.

## Rollback, retry, or surface

**Surface**, and undo. The screen already renders the error and stays put, so "Looks Good" *is* the retry, at the right granularity for the failures a save actually produces here — the container unreachable, data protection unavailable, the disk full — none of which a second attempt one line later would fix. `ProtectedVaultImporter` sets the same precedent: it retries `prepare` and never the insert's save.

`context.rollback()` is **not** safe unconditionally, measured: it destroys a foreign pending insert outright and reverts a foreign pending edit. And `commitVault` does not always receive a new vault — a secure reshare on a device that was already a signer has its vault saved by `finalizeDKLSKeygen`'s `needsInsert == false` branch and *still* routes through the review screen. So:

| Shape | Undo |
|---|---|
| the store does not hold the vault yet | `rollback()`, and the commit is **refused up front** with `.busy` if the context was carrying other work |
| the store already holds it (secure reshare) | delete only the coins this call attached, plus the DeFi chains derived with them; never touch the row |

Which shape it is, is asked of the **store** through a `ModelContext` of its own, not of `vault.modelContext` — that answers "registered", which a pending insert also is.

### Two designs that were tried and measured away

- **`context.delete(vault)` as the universal undo.** The row does go back, and the `.cascade` on `Vault.coins` and `Vault.chainPublicKeys` then strips the caller's *object* — so the retry rebuilds a key-import vault that no longer knows which chains it can derive and stores it with none. Not deterministic run to run. On the reshare shape the same delete cascaded an existing wallet's coins away silently.
- **Flushing the context first**, so the rollback is always safe. Rejected: a reshare that has set `vault.signers` and is suspended before its completion check is exactly the half-finished flow `KeyshareSweeper` refuses to flush.

### Interaction with the sealing already done under the lease

None that can strand key material. The seal `commitVault` performs is purely in-memory — `KeyshareNormalizer` returns a new `[KeyShare]`, mints no data key and deletes none — so there is no durable half to leave behind. The undo has exactly two places to reach, the context and the object, and both run inside `withWriteLease`.

### `@Attribute(.unique)` upsert

Reachable at this call site and deliberately untouched. `Vault` carries four independent unique attributes and `keyshares` is a plain stored property, so an upsert replaces a stored vault's shares; the `pubKeyECDSA` case is documented and prompted for, a `name`-only or `pubKeyEdDSA`-only collision is not. But an upsert makes `save()` **succeed**, so it is not on this issue's path — and the one thing the fix must not do is remove a row it did not insert, which is why the shape is decided by a fetch against the store. Same call as the pre-existing import hazard in `invariants.md`; it deserves its own issue.

## Tests

Eight cases in `KeygenVaultCommitTests`. Five fail against `main`'s `commitVault`, verified by running them against it. Three pass against `main` and are kept deliberately because they guard the fix rather than the bug — each fails against a rejected variant, verified the same way.

## Gate

`** BUILD SUCCEEDED **` and `** TEST SUCCEEDED **` in the same run — 5315 tests, 1 skipped, 0 failures. SwiftLint: 22 violations, all pre-existing, none in the touched files.

## Needs a device pass

The `.busy` refusal is new user-visible behaviour on a path that is hard to reach deliberately. A secure keygen + a secure reshare on device would confirm it does not fire in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault commit reliability when saving fails or conflicting changes are detected.
  * Prevented incomplete or rejected vaults from being retained after failed commits.
  * Restored original key shares when processing cannot be completed safely.
  * Preserved or removed associated coins and DeFi chains correctly during rollback.
  * Added clearer localized messaging for temporarily unavailable commit actions.
  * Enabled safer retries after transient commit failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->