### PR TITLE
fix(passcode): put the lock screen above the presentation layer on both platforms

### DIFF
--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -97,6 +97,13 @@ struct ContentView: View {
                 handleDeeplink(incomingURL)
             }
         }
+        // Below the two overlays, and that is the whole reason it moved. The
+        // banner modifier wraps what it is applied to in a `VStack` rather than
+        // layering over it, so applied *after* the gate it is a sibling of the
+        // gate — it pushed the lock screen down the display and drew a decoded
+        // keysign summary in the space it vacated. Applied before, the overlays
+        // cover it like anything else.
+        .withForegroundNotificationBanner()
         .overlay(appViewModel.showCover ? CoverView() : nil)
         .overlay(passcodeGate.animation(.easeInOut(duration: 0.25), value: appViewModel.isPasscodeLocked))
         .onLoad {
@@ -138,7 +145,6 @@ struct ContentView: View {
             // Retry action - clear error to allow user to try again
             deeplinkError = nil
         }
-        .withForegroundNotificationBanner()
     }
 
     /// Covers the app while the passcode lock is engaged. An overlay rather than

--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -85,6 +85,21 @@ struct ContentView: View {
             guard !isLocked else { return }
             drainPendingDeeplinks()
         }
+        // The document scene's hand-off is owned here rather than by `HomeScreen`,
+        // because `HomeScreen` is not always there: an install with no vaults
+        // routes straight to create-vault, and a `.vult` opened from Files then
+        // had nothing listening at all — the user's backup never opened. This view
+        // is mounted in every scene the app can open, and for the whole of each.
+        //
+        // A trigger rather than a subscription on the flag: `@Published` publishes
+        // from `willSet`, so anything that reacts by *reading* the flag reads the
+        // value from before the hand-off, declines, and leaves it raised with
+        // nobody left to ask. `consumeDocumentImport()` is what keeps a second
+        // mounted scene from pushing the same route twice.
+        .presentsWhenUnlocked(on: vultExtensionViewModel.isDocumentImportPending) {
+            guard vultExtensionViewModel.consumeDocumentImport() else { return }
+            navigationRouter.navigate(to: OnboardingRoute.importVaultShare)
+        }
         .onReceive(
             NotificationCenter.default.publisher(
                 for: NSNotification.Name("HandlePushNotification")

--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
     @EnvironmentObject var deeplinkViewModel: DeeplinkViewModel
     @EnvironmentObject var pushNotificationManager: PushNotificationManager
     @Environment(\.sheetPresentedCounterManager) var sheetPresentedCounterManager
+    @ObservedObject private var appLockHost = AppLockHost.shared
 
     @State private var rootRoute: RootRoute?
     @State private var deeplinkError: Error?
@@ -106,6 +107,14 @@ struct ContentView: View {
         .withForegroundNotificationBanner()
         .overlay(appViewModel.showCover ? CoverView() : nil)
         .overlay(passcodeGate.animation(.easeInOut(duration: 0.25), value: appViewModel.isPasscodeLocked))
+        // Additive to the two overlays above, not a replacement for them. The
+        // overlays are what the app draws; the window is what reaches the layer
+        // sheets and alerts are presented in, which no overlay can.
+        .hostsAppLock(
+            appLockPresentation,
+            onUnlocked: { appViewModel.markPasscodeUnlocked() },
+            onAttemptFailed: { appViewModel.lowerPasscodeGateIfNoLongerRequired() }
+        )
         .onLoad {
             // The cold-start gate is not decided here. It is decided in
             // `VultisigApp.init()`, because this modifier runs *after* the
@@ -147,44 +156,72 @@ struct ContentView: View {
         }
     }
 
+    /// What the app is covering itself with, as one value — see
+    /// ``AppLockPresentation``.
+    private var appLockPresentation: AppLockPresentation {
+        if appViewModel.isPasscodeLocked {
+            return .gate(generation: appViewModel.passcodeGateGeneration)
+        }
+        return appViewModel.showCover ? .cover : .uncovered
+    }
+
     /// Covers the app while the passcode lock is engaged. An overlay rather than
     /// a navigation destination, so no route, deeplink or restored screen can
     /// appear instead of it.
     ///
-    /// Known limitation: SwiftUI presents sheets and full-screen covers in a
-    /// separate layer that an overlay does not reach, so a sheet already on
-    /// screen when the app locks stays visible. What it shows is stale — locking
-    /// forgets the data key, so no key share can be read and nothing can be
-    /// signed — but balances and addresses remain legible. The existing
-    /// `CoverView` privacy screen has the same gap; both want the lock hosted in
-    /// a window above the presentation layer, which is a change to how the app
-    /// presents modals and does not belong in this step.
+    /// **The overlay is the floor, not the lock.** SwiftUI presents sheets and
+    /// full-screen covers in a layer an overlay does not reach, so the lock
+    /// screen itself is hosted in a window above that layer — see
+    /// ``SwiftUI/View/hostsAppLock(_:onUnlocked:onAttemptFailed:)``. The overlay
+    /// stays because the window cannot cover the cold start: a `UIWindow` needs a
+    /// `UIWindowScene`, and the gate is decided in `VultisigApp.init()`, before
+    /// any scene exists. This is what makes the first frame drawn the lock screen
+    /// rather than the wallet.
     @ViewBuilder
     var passcodeGate: some View {
         if appViewModel.isPasscodeLocked {
+            gateContent
+                // No `.ignoresSafeArea()` here, and it has to stay that way: the
+                // keypad's `Screen` already paints its background full-bleed
+                // while keeping content inside the safe area, and ignoring it at
+                // this level pushed the title under the Dynamic Island. The
+                // screen's *other* half — the brand screen shown while biometrics
+                // are tried — ignores it internally, which is what makes that
+                // half line up with the privacy cover rather than sitting twelve
+                // points off it.
+                //
+                // **Asymmetric, and the insertion side is the point.** A lock
+                // that fades in is a lock you can see through while it arrives:
+                // the foreground path raises the gate and drops the privacy cover
+                // in one update, so a 0.25s fade renders the home screen —
+                // balances, addresses — underneath for the whole of it. Going up
+                // is instant. Coming down still fades, because by then the app is
+                // unlocked and there is nothing left to hide.
+                .transition(.asymmetric(insertion: .identity, removal: .opacity))
+                // A raise is a new screen, never a reused one. See
+                // ``AppViewModel/passcodeGateGeneration``.
+                .id(appViewModel.passcodeGateGeneration)
+        }
+    }
+
+    /// Exactly one of these mounts an interactive lock screen, and which one is
+    /// the host's to say.
+    ///
+    /// ``EnterPasscodeScreen`` starts a biometric attempt from its `.task`, so a
+    /// second live copy is a second Face ID prompt. When the window is carrying
+    /// the lock, this draws the brand screen instead — the same pixels the lock
+    /// screen itself shows while that attempt runs, so nothing moves if the two
+    /// are ever seen in sequence — and it is only there to stop the wallet being
+    /// visible underneath.
+    @ViewBuilder
+    private var gateContent: some View {
+        if appLockHost.hostsLockScreen {
+            VultisigBrandScreen()
+        } else {
             EnterPasscodeScreen(
                 onUnlocked: { appViewModel.markPasscodeUnlocked() },
                 onAttemptFailed: { appViewModel.lowerPasscodeGateIfNoLongerRequired() }
             )
-            // No `.ignoresSafeArea()` here, and it has to stay that way: the
-            // keypad's `Screen` already paints its background full-bleed while
-            // keeping content inside the safe area, and ignoring it at this
-            // level pushed the title under the Dynamic Island. The screen's
-            // *other* half — the brand screen shown while biometrics are tried —
-            // ignores it internally, which is what makes that half line up with
-            // the privacy cover rather than sitting twelve points off it.
-            //
-            // **Asymmetric, and the insertion side is the point.** A lock that
-            // fades in is a lock you can see through while it arrives: the
-            // foreground path raises the gate and drops the privacy cover in one
-            // update, so a 0.25s fade renders the home screen — balances,
-            // addresses — underneath for the whole of it. Going up is instant.
-            // Coming down still fades, because by then the app is unlocked and
-            // there is nothing left to hide.
-            .transition(.asymmetric(insertion: .identity, removal: .opacity))
-            // A raise is a new screen, never a reused one. See
-            // ``AppViewModel/passcodeGateGeneration``.
-            .id(appViewModel.passcodeGateGeneration)
         }
     }
 

--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -93,8 +93,13 @@ struct VultisigApp: App {
 
         DocumentGroup(newDocument: VULTFileDocument()) { file in
             content
-                .onAppear {
-                    vultExtensionViewModel.documentData = file
+                // The one file-entry route that does not go through
+                // `ContentView.handleDeeplink`, and so the one that was not
+                // queued behind the lock. A password-protected `.vult` opened
+                // from Files while the app is locked ends in a UIKit password
+                // alert on the key window — over the lock screen, taking input.
+                .presentsWhenUnlocked {
+                    vultExtensionViewModel.handOff(documentData: file)
                 }
         }
         .modelContainer(sharedModelContainer)

--- a/VultisigApp/VultisigApp/Components/AppLock/AppLockHosting.swift
+++ b/VultisigApp/VultisigApp/Components/AppLock/AppLockHosting.swift
@@ -1,0 +1,119 @@
+//
+//  AppLockHosting.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// What the app is covering itself with, as one value.
+///
+/// One value rather than two flags, because the ordering between them is load
+/// bearing: `AppViewModel.enableAuth` raises the lock *before* it drops the
+/// privacy cover, precisely so the home screen is never uncovered for the frames
+/// a lock screen takes to mount. Deriving a single case from both keeps that one
+/// decision instead of two racing ones.
+enum AppLockPresentation: Equatable {
+    /// The app is showing itself.
+    case uncovered
+    /// The logo, while the app is leaving, away, or coming back.
+    case cover
+    /// The lock screen. The generation is the lock screen's identity — see
+    /// ``AppViewModel/passcodeGateGeneration``.
+    case gate(generation: Int)
+
+    var isGate: Bool {
+        if case .gate = self { return true }
+        return false
+    }
+}
+
+/// What the raised window draws.
+///
+/// Two states in one root rather than a window each: see ``AppLockPresentation``
+/// for why the two must not be able to disagree.
+struct AppLockHostedScreen: View {
+
+    let presentation: AppLockPresentation
+    let onUnlocked: () -> Void
+    let onAttemptFailed: () -> Void
+
+    var body: some View {
+        content
+            // The window is outside the app's view hierarchy, so it inherits
+            // none of the environment `ContentView` sets. These two are the ones
+            // the lock screen's appearance depends on.
+            .colorScheme(.dark)
+            .accentColor(.white)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch presentation {
+        case .uncovered, .cover:
+            CoverView()
+        case .gate(let generation):
+            EnterPasscodeScreen(
+                onUnlocked: onUnlocked,
+                onAttemptFailed: onAttemptFailed
+            )
+            // A raise is a new screen, never a reused one. See
+            // ``AppViewModel/passcodeGateGeneration``.
+            .id(generation)
+        }
+    }
+}
+
+/// The platform's implementation of "put this above everything the app can
+/// present". `UIWindow` on iOS, `NSWindow` on the Mac.
+#if os(iOS)
+typealias AppLockHost = AppLockWindowHost
+#elseif os(macOS)
+typealias AppLockHost = AppLockPanelHost
+#endif
+
+private struct HostsAppLockModifier: ViewModifier {
+
+    let presentation: AppLockPresentation
+    let onUnlocked: () -> Void
+    let onAttemptFailed: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onLoad { sync() }
+            .onChange(of: presentation) { _, _ in sync() }
+    }
+
+    private func sync() {
+        AppLockHost.shared.update(
+            to: presentation,
+            onUnlocked: onUnlocked,
+            onAttemptFailed: onAttemptFailed
+        )
+    }
+}
+
+extension View {
+
+    /// Hosts the privacy cover and the lock screen in a window above the app's
+    /// own, so that a sheet, a full-screen cover or an alert already on screen is
+    /// covered rather than left drawn on top.
+    ///
+    /// A sheet is presented in a layer a SwiftUI `.overlay` does not reach, which
+    /// is why the root overlay alone was never enough. Window order is by level
+    /// first and presented sheets live in the key window's hierarchy, so a window
+    /// at a raised level covers them **without dismissing anything** — the user's
+    /// sheet is still there after unlocking.
+    func hostsAppLock(
+        _ presentation: AppLockPresentation,
+        onUnlocked: @escaping () -> Void,
+        onAttemptFailed: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            HostsAppLockModifier(
+                presentation: presentation,
+                onUnlocked: onUnlocked,
+                onAttemptFailed: onAttemptFailed
+            )
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Components/ViewModifiers/PresentsWhenUnlocked.swift
+++ b/VultisigApp/VultisigApp/Components/ViewModifiers/PresentsWhenUnlocked.swift
@@ -1,0 +1,177 @@
+//
+//  PresentsWhenUnlocked.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// The rule behind ``SwiftUI/View/presentsWhenUnlocked(after:perform:)``, kept as
+/// a value rather than living inside the view modifier so a test can drive it.
+///
+/// A **hold**, not a queue. Every caller is an idempotent "do I still owe the
+/// user this sheet?" check, so a caller that asked three times while the gate was
+/// up wants one answer once it comes down, not three.
+struct AppLockPresentationHold {
+
+    private(set) var isHolding = false
+
+    /// A check has come due.
+    /// - Returns: whether it may run now.
+    mutating func requested(whileLocked isLocked: Bool) -> Bool {
+        guard isLocked else {
+            // Clearing here rather than only on the unlock is what stops the
+            // check running twice. SwiftUI delivers the lock's `onChange` after
+            // the flag has already changed, so a request landing in that window
+            // runs immediately — and would then be run a second time by the
+            // drain that is still on its way.
+            isHolding = false
+            return true
+        }
+        isHolding = true
+        return false
+    }
+
+    /// The gate went up or came down.
+    /// - Returns: whether a held check should run now.
+    mutating func lockChanged(isLocked: Bool) -> Bool {
+        guard !isLocked, isHolding else { return false }
+        isHolding = false
+        return true
+    }
+}
+
+/// Nothing. The parameter exists so both `presentsWhenUnlocked` overloads share
+/// one implementation; a value that can never differ from itself is a trigger
+/// that never fires.
+private struct NeverChanges: Equatable {}
+
+private struct PresentsWhenUnlockedModifier<Trigger: Equatable>: ViewModifier {
+
+    /// Read from the shared instance rather than from the environment, and it is
+    /// not a shortcut. The document scene applies this modifier *outside* the
+    /// view that installs the environment objects, and environment flows
+    /// downward — an `@EnvironmentObject` there would find nothing and trap. The
+    /// instance is the same one the environment carries: `VultisigApp` seeds its
+    /// `@StateObject` from `AppViewModel.shared`.
+    @ObservedObject private var appViewModel: AppViewModel = .shared
+
+    let trigger: Trigger
+    let delay: Duration
+    let check: () -> Void
+
+    @State private var hold = AppLockPresentationHold()
+
+    func body(content: Content) -> some View {
+        content
+            .onLoad { request() }
+            .onChange(of: trigger) { _, _ in request() }
+            .onChange(of: appViewModel.isPasscodeLocked) { _, isLocked in
+                guard hold.lockChanged(isLocked: isLocked) else { return }
+                check()
+            }
+    }
+
+    private func request() {
+        guard delay > .zero else {
+            runIfUnlocked()
+            return
+        }
+        Task { @MainActor in
+            try? await Task.sleep(for: delay)
+            runIfUnlocked()
+        }
+    }
+
+    private func runIfUnlocked() {
+        guard hold.requested(whileLocked: appViewModel.isPasscodeLocked) else { return }
+        check()
+    }
+}
+
+private struct HoldsPresentationWhileLockedModifier: ViewModifier {
+
+    /// See ``PresentsWhenUnlockedModifier``.
+    @ObservedObject private var appViewModel: AppViewModel = .shared
+
+    @Binding var isPresented: Bool
+
+    @State private var hold = AppLockPresentationHold()
+
+    func body(content: Content) -> some View {
+        content
+            .onLoad { holdIfLocked() }
+            .onChange(of: isPresented) { _, _ in holdIfLocked() }
+            .onChange(of: appViewModel.isPasscodeLocked) { _, isLocked in
+                guard hold.lockChanged(isLocked: isLocked) else { return }
+                isPresented = true
+            }
+    }
+
+    private func holdIfLocked() {
+        guard isPresented else { return }
+        guard !hold.requested(whileLocked: appViewModel.isPasscodeLocked) else { return }
+        isPresented = false
+    }
+}
+
+extension View {
+
+    /// Holds a presentation whose flag is raised from somewhere the view cannot
+    /// gate — an in-flight lookup that completes after the app relocked, say —
+    /// putting the flag back down while the gate is up and raising it again when
+    /// the gate comes down.
+    ///
+    /// The closure-shaped overloads below cover a screen that asks *itself* a
+    /// question on load, where holding the question is enough. This one covers
+    /// the case where there is no question left to hold, only an answer that has
+    /// already arrived.
+    func presentsWhenUnlocked(_ isPresented: Binding<Bool>) -> some View {
+        modifier(HoldsPresentationWhileLockedModifier(isPresented: isPresented))
+    }
+
+    /// Runs `check` once the view has loaded — but never while the passcode gate
+    /// is up. A check that comes due behind the lock screen is held, and run the
+    /// moment the gate comes down.
+    ///
+    /// The gate covers what the app *shows*. This covers what the app *raises*,
+    /// which is a separate problem and the reason a lock screen is not enough on
+    /// its own: several screens ask themselves on load whether they owe the user
+    /// a sheet, and a sheet is presented in a layer the gate's overlay cannot
+    /// reach. On a gated cold start those answers arrive half a second after the
+    /// lock screen went up, and a fast-vault password prompt then sits above it
+    /// taking input.
+    ///
+    /// - Parameters:
+    ///   - delay: how long after load to ask. The delay runs whether or not the
+    ///     app is locked; the lock is consulted when it expires.
+    ///   - check: the question, asked in full each time — it is re-run on unlock
+    ///     rather than replayed, so a condition that stopped being true in the
+    ///     meantime raises nothing.
+    func presentsWhenUnlocked(
+        after delay: Duration = .zero,
+        perform check: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            PresentsWhenUnlockedModifier(
+                trigger: NeverChanges(),
+                delay: delay,
+                check: check
+            )
+        )
+    }
+
+    /// The same, asked again whenever `trigger` changes.
+    func presentsWhenUnlocked<Trigger: Equatable>(
+        on trigger: Trigger,
+        after delay: Duration = .zero,
+        perform check: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            PresentsWhenUnlockedModifier(
+                trigger: trigger,
+                delay: delay,
+                check: check
+            )
+        )
+    }
+}

--- a/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
+++ b/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
@@ -303,6 +303,15 @@ class PushNotificationManager: ObservableObject {
 
     @discardableResult
     func handleForegroundNotification(_ content: UNNotificationContent) -> Bool {
+        // Asked before anything is fetched or parsed. The banner carries the
+        // vault name and a decoded transaction summary — "Send 1.2 ETH to 0x…" —
+        // for thirty seconds, which is exactly what the lock screen is standing
+        // in front of.
+        guard !ForegroundNotificationPresentationPolicy.isAppLocked else {
+            logger.info("Custom foreground banner declined while the app is locked")
+            return false
+        }
+
         guard canPresentForegroundBanner() else {
             logger.info("Custom foreground banner unavailable while a modal is presented")
             return false
@@ -392,16 +401,12 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
         completion: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         guard let onForegroundNotification else {
-            completion(ForegroundNotificationPresentationPolicy.systemOptions)
+            completion(ForegroundNotificationPresentationPolicy.options(handled: false))
             return
         }
 
         onForegroundNotification(content) { handled in
-            completion(
-                handled
-                    ? ForegroundNotificationPresentationPolicy.customOptions
-                    : ForegroundNotificationPresentationPolicy.systemOptions
-            )
+            completion(ForegroundNotificationPresentationPolicy.options(handled: handled))
         }
     }
 }
@@ -410,14 +415,33 @@ enum ForegroundNotificationPresentationPolicy {
     static let customOptions: UNNotificationPresentationOptions = [.sound]
     static let systemOptions: UNNotificationPresentationOptions = [.banner, .list, .sound]
 
+    /// What a notification arriving behind the lock screen is allowed to do.
+    ///
+    /// Declining the custom banner is not enough on its own, and that is the
+    /// point of this being its own case rather than a fall-through: a decline
+    /// lands on ``systemOptions``, and the system banner is drawn by the OS above
+    /// every window the app owns — including the one the lock screen is hosted
+    /// in — carrying the same vault name and transaction summary the custom
+    /// banner would have. `.list` goes with it, because an entry in Notification
+    /// Center is the same disclosure a swipe later.
+    static let lockedOptions: UNNotificationPresentationOptions = [.sound]
+
+    /// Read off the app's own gate flag rather than
+    /// ``PasscodeService/isPasscodeGateRequired``. The predicate is true for
+    /// every install that *has* a passcode, gate up or not, so using it here
+    /// would silence notifications for those users the entire time they are
+    /// using the app.
+    static var isAppLocked: Bool { AppViewModel.shared.isPasscodeLocked }
+
+    static func options(handled: Bool) -> UNNotificationPresentationOptions {
+        guard !isAppLocked else { return lockedOptions }
+        return handled ? customOptions : systemOptions
+    }
+
     @MainActor
     static var canPresentCustomBanner: Bool {
         #if os(iOS)
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first(where: { $0.activationState == .foregroundActive }),
-              let keyWindow = windowScene.windows.first(where: \.isKeyWindow),
-              let rootViewController = keyWindow.rootViewController else {
+        guard let rootViewController = UIApplication.shared.activeContentWindow?.rootViewController else {
             return false
         }
         return rootViewController.presentedViewController == nil

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Extensions/UIApplicationExtension.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Extensions/UIApplicationExtension.swift
@@ -1,0 +1,38 @@
+//
+//  UIApplicationExtension.swift
+//  VultisigApp
+//
+
+#if os(iOS)
+import UIKit
+
+extension UIApplication {
+
+    /// Every scene the user is actually in front of. More than one on iPad and
+    /// on the Mac, where the app's `WindowGroup` and `DocumentGroup` can both be
+    /// open at once.
+    var activeWindowScenes: [UIWindowScene] {
+        connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState == .foregroundActive }
+    }
+
+    /// The window the app's own content is in: a key window at the normal level,
+    /// in a scene that is in the foreground.
+    ///
+    /// `windows.first` is not this. The array is unordered, so it hands back
+    /// whichever window the app happens to own first — a window the app raised
+    /// over its content included.
+    ///
+    /// The level filter is the part that matters most: a window raised *above*
+    /// the content is raised precisely so that nothing can be drawn over it, and
+    /// presenting a UIKit alert into it would undo that. While such a window is
+    /// key this answers `nil`, which is the right failure — nothing presented
+    /// beats something presented over the lock screen.
+    var activeContentWindow: UIWindow? {
+        activeWindowScenes
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow && $0.windowLevel == .normal }
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
@@ -1,0 +1,308 @@
+//
+//  AppLockWindowHost.swift
+//  VultisigApp
+//
+
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// A window whose only job is to be above everything the app can present.
+///
+/// A subclass rather than a plain `UIWindow` for two reasons: it can be told
+/// apart from the app's own — see ``UIApplication/activeContentWindow`` — and it
+/// keeps a typed handle on its host so the screen inside can be swapped without
+/// casting `rootViewController` back.
+final class AppLockWindow: UIWindow {
+
+    let host: UIHostingController<AppLockHostedScreen>
+
+    init(scene: UIWindowScene, screen: AppLockHostedScreen) {
+        self.host = UIHostingController(rootView: screen)
+        super.init(windowScene: scene)
+        host.view.backgroundColor = UIColor(Theme.colors.bgPrimary)
+        rootViewController = host
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("AppLockWindow is only ever made in code")
+    }
+}
+
+/// Puts the privacy cover and the lock screen in a window of their own, one per
+/// scene, above the layer sheets and alerts are presented in.
+///
+/// Nothing is dismissed to achieve it. Window order is by level first, and a
+/// presented sheet lives in the key window's hierarchy — so a window at a raised
+/// level simply covers it, and the user's sheet is still there after unlocking.
+@MainActor
+final class AppLockWindowHost: ObservableObject {
+
+    static let shared = AppLockWindowHost()
+
+    /// Whether the raised window is the thing carrying the lock screen, so the
+    /// root overlay knows to draw an opaque floor rather than a second copy of
+    /// it.
+    ///
+    /// It starts `true` — **assumed, not observed**, and that is the only
+    /// ordering that works. A raise happens on the view's first appearance, one
+    /// step after its first body; starting `false` would have the overlay mount
+    /// an interactive lock screen for that step, and that screen starts a
+    /// biometric attempt from its `.task`. Two live copies is two Face ID prompts
+    /// racing on every gated cold start. So the window is assumed to work and
+    /// corrected when a raise actually fails, rather than the other way round.
+    @Published private(set) var hostsLockScreen = true
+
+    private var windows: [ObjectIdentifier: AppLockWindow] = [:]
+    /// What was key in each scene before the gate took it, so unlocking gives it
+    /// back. Per scene, because key windows are.
+    private var previousKeyWindows: [ObjectIdentifier: WeakWindow] = [:]
+    private var current: AppLockPresentation = .uncovered
+    private var callbacks: Callbacks?
+    /// Invalidates the completion of a fade that a re-raise has overtaken, so a
+    /// window just put back up is not dismantled underneath itself.
+    private var lowerToken = 0
+
+    private let lowerDuration: TimeInterval = 0.25
+
+    private struct Callbacks {
+        let onUnlocked: () -> Void
+        let onAttemptFailed: () -> Void
+    }
+
+    private final class WeakWindow {
+        weak var window: UIWindow?
+        init(_ window: UIWindow?) { self.window = window }
+    }
+
+    init() {
+        observeScenes()
+    }
+
+    func update(
+        to presentation: AppLockPresentation,
+        onUnlocked: @escaping () -> Void,
+        onAttemptFailed: @escaping () -> Void
+    ) {
+        guard presentation != .uncovered else {
+            // Asymmetric, and the insertion side is the point: a lock that fades
+            // in is a lock you can see through while it arrives. Going up is
+            // instant; coming down fades, because by then the app is unlocked and
+            // there is nothing left to hide. The privacy cover never faded and
+            // still does not, so only a gate animates away.
+            lower(animated: current.isGate)
+            current = .uncovered
+            callbacks = nil
+            return
+        }
+
+        raise(presentation, onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
+    }
+
+    // MARK: - Raising
+
+    private func raise(
+        _ presentation: AppLockPresentation,
+        onUnlocked: @escaping () -> Void,
+        onAttemptFailed: @escaping () -> Void
+    ) {
+        let scenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState != .unattached }
+
+        guard !scenes.isEmpty else {
+            // No scene, so no window is possible — a `UIWindow` needs one, and
+            // the gate is decided in `VultisigApp.init()`, before any exists. The
+            // root overlay carries the lock screen itself, which is what it is
+            // there for.
+            if presentation.isGate {
+                hostsLockScreen = false
+            }
+            return
+        }
+
+        // Overtakes any fade still running, so a window put back up here is not
+        // torn down by the completion of the lowering it interrupted.
+        lowerToken += 1
+
+        if presentation.isGate {
+            // The keyboard is in a window of its own, far above `.alert`, so a
+            // field that was first responder under a sheet would go on drawing
+            // its keyboard over the lock screen.
+            UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder),
+                to: nil,
+                from: nil,
+                for: nil
+            )
+            // Published before the screen below is mounted, so the overlay's copy
+            // is already on its way out rather than being taken down after a
+            // second one has appeared.
+            hostsLockScreen = true
+        }
+
+        // Exactly one scene gets the interactive lock screen. `EnterPasscodeScreen`
+        // starts a biometric attempt from its `.task`, so one per scene would be
+        // one Face ID prompt per scene; the others are covered instead, and the
+        // election is redone whenever a different scene activates.
+        let interactiveScene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+
+        for scene in scenes {
+            show(
+                scene === interactiveScene ? presentation : .cover,
+                in: scene,
+                onUnlocked: onUnlocked,
+                onAttemptFailed: onAttemptFailed
+            )
+        }
+
+        callbacks = Callbacks(onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
+        current = presentation
+    }
+
+    /// Makes the window for `scene` visible — and key, for a gate — **before**
+    /// mounting the real screen into it.
+    ///
+    /// The order matters: ``EnterPasscodeScreen`` starts a biometric attempt from
+    /// its `.task`, so building it into a window that is not on screen yet races
+    /// the Face ID prompt against the window the prompt is supposed to appear
+    /// over. A new window opens on the brand screen instead, which is exactly
+    /// what the lock screen itself draws while that attempt runs, so there is no
+    /// seam between the two.
+    private func show(
+        _ presentation: AppLockPresentation,
+        in scene: UIWindowScene,
+        onUnlocked: @escaping () -> Void,
+        onAttemptFailed: @escaping () -> Void
+    ) {
+        let key = ObjectIdentifier(scene)
+        let window = windows[key] ?? makeWindow(for: scene)
+        windows[key] = window
+
+        if presentation.isGate,
+           previousKeyWindows[key] == nil,
+           let previous = scene.keyWindow,
+           !(previous is AppLockWindow) {
+            previousKeyWindows[key] = WeakWindow(previous)
+        }
+
+        // A fade may still be running on this window, and the value it left
+        // behind is what `alpha` would otherwise keep.
+        window.layer.removeAllAnimations()
+        window.alpha = 1
+        window.isUserInteractionEnabled = true
+
+        if presentation.isGate {
+            window.makeKeyAndVisible()
+        } else {
+            window.isHidden = false
+        }
+
+        window.host.rootView = AppLockHostedScreen(
+            presentation: presentation,
+            onUnlocked: onUnlocked,
+            onAttemptFailed: onAttemptFailed
+        )
+    }
+
+    private func makeWindow(for scene: UIWindowScene) -> AppLockWindow {
+        let window = AppLockWindow(
+            scene: scene,
+            screen: AppLockHostedScreen(presentation: .cover, onUnlocked: {}, onAttemptFailed: {})
+        )
+        window.windowLevel = UIWindow.Level(rawValue: UIWindow.Level.alert.rawValue + 1)
+        window.overrideUserInterfaceStyle = .dark
+        window.backgroundColor = UIColor(Theme.colors.bgPrimary)
+        return window
+    }
+
+    // MARK: - Lowering
+
+    private func lower(animated: Bool) {
+        guard !windows.isEmpty else { return }
+
+        lowerToken += 1
+        let token = lowerToken
+        let lowering = windows
+
+        for (key, window) in lowering {
+            window.isUserInteractionEnabled = false
+            // Key goes back first, so the app underneath is usable for the whole
+            // of the fade rather than only once it has finished.
+            previousKeyWindows[key]?.window?.makeKey()
+        }
+        previousKeyWindows = [:]
+
+        guard animated else {
+            windows = [:]
+            lowering.values.forEach(dismantle)
+            return
+        }
+
+        // The windows stay in `windows` until the fade finishes, so a gate raised
+        // inside that quarter second reuses the one already there rather than
+        // standing a second interactive lock screen up beside it.
+        UIView.animate(
+            withDuration: lowerDuration,
+            animations: { lowering.values.forEach { $0.alpha = 0 } },
+            completion: { [weak self] _ in
+                guard let self, token == self.lowerToken else { return }
+                self.windows = [:]
+                lowering.values.forEach(self.dismantle)
+            }
+        )
+    }
+
+    private func dismantle(_ window: AppLockWindow) {
+        window.isHidden = true
+        window.rootViewController = nil
+        window.windowScene = nil
+    }
+
+    // MARK: - Scenes
+
+    /// The host outlives every scene the app can open, so these are never
+    /// removed.
+    private func observeScenes() {
+        let center = NotificationCenter.default
+
+        center.addObserver(
+            forName: UIScene.didActivateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.reelectInteractiveScene() }
+        }
+
+        center.addObserver(
+            forName: UIScene.didDisconnectNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let scene = notification.object as? UIWindowScene else { return }
+            let key = ObjectIdentifier(scene)
+            Task { @MainActor in self?.discardWindow(for: key) }
+        }
+    }
+
+    /// Hands the interactive lock screen to whichever scene the user just moved
+    /// to. Without it the scene that happened to be active when the gate went up
+    /// keeps the keypad, and every other one is left with a screen that cannot be
+    /// typed into.
+    private func reelectInteractiveScene() {
+        guard current.isGate, let callbacks else { return }
+        raise(
+            current,
+            onUnlocked: callbacks.onUnlocked,
+            onAttemptFailed: callbacks.onAttemptFailed
+        )
+    }
+
+    private func discardWindow(for key: ObjectIdentifier) {
+        previousKeyWindows[key] = nil
+        guard let window = windows.removeValue(forKey: key) else { return }
+        dismantle(window)
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
@@ -58,6 +58,11 @@ final class AppLockWindowHost: ObservableObject {
     /// What was key in each scene before the gate took it, so unlocking gives it
     /// back. Per scene, because key windows are.
     private var previousKeyWindows: [ObjectIdentifier: WeakWindow] = [:]
+    /// The scene whose window carries the keypad. Held so a raise keeps it where
+    /// it is rather than picking again — `connectedScenes` is a `Set`, so with two
+    /// foreground-active scenes (iPad Split View, Stage Manager) "the first
+    /// foreground-active one" is not a stable answer.
+    private weak var interactiveScene: UIWindowScene?
     private var current: AppLockPresentation = .uncovered
     private var callbacks: Callbacks?
     /// Invalidates the completion of a fade that a re-raise has overtaken, so a
@@ -144,13 +149,22 @@ final class AppLockWindowHost: ObservableObject {
 
         // Exactly one scene gets the interactive lock screen. `EnterPasscodeScreen`
         // starts a biometric attempt from its `.task`, so one per scene would be
-        // one Face ID prompt per scene; the others are covered instead, and the
-        // election is redone whenever a different scene activates.
-        let interactiveScene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+        // one Face ID prompt per scene; the others are covered instead.
+        //
+        // The scene already carrying it wins, and that is not an optimisation:
+        // `connectedScenes` is a `Set`, so on an iPad with two foreground-active
+        // scenes "the first foreground-active one" can answer differently from one
+        // raise to the next, and the keypad would move out from under whoever was
+        // typing. Which scene it moves *to* is decided by `elect(_:)`, from the
+        // scene the user actually activated.
+        let elected = scenes.first { $0 === interactiveScene && $0.activationState == .foregroundActive }
+            ?? scenes.first { $0.activationState == .foregroundActive }
+            ?? scenes.first
+        interactiveScene = elected
 
         for scene in scenes {
             show(
-                scene === interactiveScene ? presentation : .cover,
+                scene === elected ? presentation : .cover,
                 in: scene,
                 onUnlocked: onUnlocked,
                 onAttemptFailed: onAttemptFailed
@@ -233,6 +247,10 @@ final class AppLockWindowHost: ObservableObject {
             previousKeyWindows[key]?.window?.makeKey()
         }
         previousKeyWindows = [:]
+        // `interactiveScene` deliberately survives: it is "the scene the user was
+        // last in", which is still the right answer for the next gate. Clearing it
+        // here would throw the only stable election away and send the next raise
+        // back to picking an arbitrary member of an unordered `Set`.
 
         guard animated else {
             windows = [:]
@@ -271,8 +289,9 @@ final class AppLockWindowHost: ObservableObject {
             forName: UIScene.didActivateNotification,
             object: nil,
             queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in self?.reelectInteractiveScene() }
+        ) { [weak self] notification in
+            guard let scene = notification.object as? UIWindowScene else { return }
+            Task { @MainActor in self?.elect(scene) }
         }
 
         center.addObserver(
@@ -286,11 +305,27 @@ final class AppLockWindowHost: ObservableObject {
         }
     }
 
-    /// Hands the interactive lock screen to whichever scene the user just moved
-    /// to. Without it the scene that happened to be active when the gate went up
-    /// keeps the keypad, and every other one is left with a screen that cannot be
-    /// typed into.
-    private func reelectInteractiveScene() {
+    /// Hands the interactive lock screen to the scene the user just moved to, so
+    /// the keypad is in the one being looked at.
+    ///
+    /// It takes the scene from the notification rather than working it out again:
+    /// re-running the election would answer with whichever scene the `Set` happens
+    /// to yield first, which on an iPad with two foreground-active scenes need not
+    /// be the one that just activated — and then this method would do nothing but
+    /// churn.
+    ///
+    /// A no-op when the keypad is already there, which is what keeps the
+    /// `makeKeyAndVisible` inside the re-raise from electing its way round in a
+    /// circle.
+    ///
+    /// The scene is recorded whether or not a gate is up. Only *moving* the
+    /// keypad needs a gate; knowing which scene the user is in is worth having
+    /// ready for the next one, and activations that happen while the app is
+    /// unlocked are most of them.
+    private func elect(_ scene: UIWindowScene) {
+        guard scene !== interactiveScene else { return }
+        interactiveScene = scene
+
         guard current.isGate, let callbacks else { return }
         raise(
             current,
@@ -299,10 +334,30 @@ final class AppLockWindowHost: ObservableObject {
         )
     }
 
+    /// Takes a disconnected scene's window down — and, if that scene was the one
+    /// holding the keypad, finds somewhere else to put it.
+    ///
+    /// Without the re-election the gate survives its own keypad: every remaining
+    /// window is showing the passive cover, `hostsLockScreen` is still `true` so
+    /// the root overlay is drawing the floor rather than the lock screen, and
+    /// there is nothing anywhere to type a passcode into until some other scene
+    /// happens to activate. If no scene is left, the re-raise reports that and the
+    /// overlay takes the lock screen back.
     private func discardWindow(for key: ObjectIdentifier) {
         previousKeyWindows[key] = nil
-        guard let window = windows.removeValue(forKey: key) else { return }
-        dismantle(window)
+        let heldTheKeypad = interactiveScene.map { ObjectIdentifier($0) == key } ?? true
+
+        if let window = windows.removeValue(forKey: key) {
+            dismantle(window)
+        }
+
+        guard current.isGate, heldTheKeypad, let callbacks else { return }
+        interactiveScene = nil
+        raise(
+            current,
+            onUnlocked: callbacks.onUnlocked,
+            onAttemptFailed: callbacks.onAttemptFailed
+        )
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
@@ -270,6 +270,15 @@ final class AppLockPanelHost: ObservableObject {
         })
     }
 
+    /// Detaching and ordering out is the whole teardown: the host drops its only
+    /// reference immediately afterwards, and the panel deallocates then, taking
+    /// its hosting controller and the lock screen inside it along.
+    ///
+    /// No `close()`. `isReleasedWhenClosed` being false does not mean AppKit holds
+    /// the window — measured over repeated cycles, an ordered-out panel is gone
+    /// from `NSApp.windows` and deallocated with or without it. Key has already
+    /// been handed back to the parent by the time this runs, so nothing else is
+    /// holding on either.
     private func dismantle(_ panel: AppLockPanel) {
         panel.parent?.removeChildWindow(panel)
         panel.orderOut(nil)

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
@@ -4,25 +4,343 @@
 //
 
 #if os(macOS)
+import AppKit
 import SwiftUI
 
-/// The Mac's half of ``AppLockHost``.
+/// A borderless window whose only job is to be above everything the app can
+/// present.
+///
+/// `canBecomeKey` is overridden because a borderless window cannot become key by
+/// default, and the Mac's passcode entry is typed on a hardware keyboard — a lock
+/// screen nothing can be typed into is a lock screen with no way out of it.
+final class AppLockPanel: NSWindow {
+
+    let host: NSHostingController<AppLockHostedScreen>
+
+    init(screen: AppLockHostedScreen) {
+        self.host = NSHostingController(rootView: screen)
+        super.init(
+            contentRect: .zero,
+            styleMask: [.borderless, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        // The panel is sized from the window it covers, never from its content —
+        // left to itself a hosting controller resizes the window around its own
+        // fitting size, and a lock screen that fits its keypad is a lock screen
+        // with the wallet showing around it.
+        host.sizingOptions = []
+        contentViewController = host
+        backgroundColor = NSColor(Theme.colors.bgPrimary)
+        isOpaque = true
+        hasShadow = false
+        isReleasedWhenClosed = false
+        // Above the app's own windows, and their attached sheets with them: a
+        // sheet is a child of the window it belongs to, and takes that window's
+        // level.
+        level = .modalPanel
+        // Levels are global on the Mac, so a window this high in an app that is
+        // *not* frontmost would float over whatever is. Hiding on deactivate is
+        // what keeps the lock screen inside its own app. What the app looks like
+        // once it is no longer frontmost is the root overlay's job.
+        hidesOnDeactivate = true
+        collectionBehavior = [.fullScreenAuxiliary]
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+/// The Mac's half of ``AppLockHost``: an elevated panel over each of the app's
+/// windows.
+///
+/// Needed on every macOS version, not only where `CrossPlatformSheet` uses a
+/// native sheet. Below macOS 26 that modifier does draw its sheets inside the
+/// view hierarchy, where the root overlay already covers them — but every
+/// `.alert` and every plain `.sheet` is a window-attached sheet whatever the
+/// version, and no overlay reaches those.
 @MainActor
 final class AppLockPanelHost: ObservableObject {
 
     static let shared = AppLockPanelHost()
 
-    /// `false`, so the root overlay goes on carrying the lock screen itself on
-    /// the Mac. An overlay covers everything `CrossPlatformSheet` draws in the
-    /// view hierarchy, which on macOS below 26 is every sheet the app has; what
-    /// it does not cover is a window-attached sheet, which is what macOS 26 and
-    /// every `.alert` use.
-    @Published private(set) var hostsLockScreen = false
+    /// See ``AppLockWindowHost/hostsLockScreen`` — same property, same reason for
+    /// starting `true`.
+    @Published private(set) var hostsLockScreen = true
+
+    private var panels: [ObjectIdentifier: AppLockPanel] = [:]
+    /// The window whose panel carries the keypad. Held so that clicking a covered
+    /// window moves the keypad there rather than leaving it two windows away.
+    private weak var interactiveWindow: NSWindow?
+    private var current: AppLockPresentation = .uncovered
+    private var callbacks: Callbacks?
+    /// Invalidates the completion of a fade that a re-raise has overtaken, so a
+    /// panel just put back up is not torn down underneath itself.
+    private var lowerToken = 0
+
+    private let lowerDuration: TimeInterval = 0.25
+
+    private struct Callbacks {
+        let onUnlocked: () -> Void
+        let onAttemptFailed: () -> Void
+    }
+
+    init() {
+        observeWindows()
+    }
 
     func update(
-        to _: AppLockPresentation,
-        onUnlocked _: @escaping () -> Void,
-        onAttemptFailed _: @escaping () -> Void
-    ) {}
+        to presentation: AppLockPresentation,
+        onUnlocked: @escaping () -> Void,
+        onAttemptFailed: @escaping () -> Void
+    ) {
+        guard presentation != .uncovered else {
+            lower(animated: current.isGate)
+            current = .uncovered
+            callbacks = nil
+            return
+        }
+
+        raise(presentation, onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
+    }
+
+    // MARK: - Raising
+
+    private func raise(
+        _ presentation: AppLockPresentation,
+        onUnlocked: @escaping () -> Void,
+        onAttemptFailed: @escaping () -> Void
+    ) {
+        let hosts = coverableWindows
+
+        guard !hosts.isEmpty else {
+            if presentation.isGate {
+                hostsLockScreen = false
+            }
+            return
+        }
+
+        // A window that has been closed or minimised since the last raise takes
+        // its panel with it. Left behind, a hidden panel keeps a live lock screen
+        // — and so a second biometric attempt and a second unlock state.
+        discardPanelsNotCovering(hosts)
+
+        // Overtakes any fade still running, so a panel put back up here is not
+        // torn down by the completion of the lowering it interrupted.
+        lowerToken += 1
+
+        if presentation.isGate {
+            hostsLockScreen = true
+        }
+
+        // One interactive lock screen, as on iOS: ``EnterPasscodeScreen`` starts a
+        // biometric attempt from its `.task`, so one per window would be one Touch
+        // ID prompt per window.
+        let interactive = hosts.first { $0 === interactiveWindow }
+            ?? hosts.first { $0.isMainWindow }
+            ?? hosts.first
+        interactiveWindow = interactive
+
+        for window in hosts {
+            show(
+                window === interactive ? presentation : .cover,
+                over: window,
+                onUnlocked: onUnlocked,
+                onAttemptFailed: onAttemptFailed
+            )
+        }
+
+        callbacks = Callbacks(onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
+        current = presentation
+    }
+
+    private func show(
+        _ presentation: AppLockPresentation,
+        over window: NSWindow,
+        onUnlocked: @escaping () -> Void,
+        onAttemptFailed: @escaping () -> Void
+    ) {
+        let key = ObjectIdentifier(window)
+        let panel = panels[key] ?? AppLockPanel(
+            screen: AppLockHostedScreen(presentation: .cover, onUnlocked: {}, onAttemptFailed: {})
+        )
+        panels[key] = panel
+
+        if panel.parent !== window {
+            window.addChildWindow(panel, ordered: .above)
+            // After the attachment, not before: `addChildWindow` gives the child
+            // its parent's level, which is the one thing being escaped here.
+            panel.level = .modalPanel
+        }
+        panel.setFrame(window.frame, display: true)
+        // A fade may still be running on this panel, and assigning `alphaValue`
+        // outside an animation context would give that animation a new target
+        // rather than stopping it — leaving the lock translucent over the wallet.
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0
+            panel.animator().alphaValue = 1
+        }
+        panel.ignoresMouseEvents = false
+        panel.orderFront(nil)
+
+        if presentation.isGate {
+            panel.makeKey()
+        }
+
+        panel.host.rootView = AppLockHostedScreen(
+            presentation: presentation,
+            onUnlocked: onUnlocked,
+            onAttemptFailed: onAttemptFailed
+        )
+    }
+
+    /// The app's own top-level windows. Sheets are excluded because they are
+    /// children of the window they belong to, and covering the parent covers them.
+    private var coverableWindows: [NSWindow] {
+        NSApp.windows.filter { window in
+            !(window is AppLockPanel)
+                && window.isVisible
+                && !window.isSheet
+                && window.parent == nil
+                && window.canBecomeMain
+        }
+    }
+
+    // MARK: - Lowering
+
+    private func lower(animated: Bool) {
+        guard !panels.isEmpty else { return }
+
+        lowerToken += 1
+        let token = lowerToken
+        let lowering = panels
+
+        // Key goes back to the window the keypad was covering — named, not
+        // whichever entry the dictionary happens to yield last — and it goes back
+        // before the fade, so the app is usable for the whole of it.
+        let restored = lowering.values.first(where: \.isKeyWindow)?.parent
+            ?? interactiveWindow
+            ?? coverableWindows.first
+        lowering.values.forEach { $0.ignoresMouseEvents = true }
+        restored?.makeKey()
+        interactiveWindow = nil
+
+        guard animated else {
+            panels = [:]
+            lowering.values.forEach(dismantle)
+            return
+        }
+
+        // The panels stay in `panels` until the fade finishes, so a gate raised
+        // inside that quarter second reuses the one already there rather than
+        // standing a second interactive lock screen up beside it.
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = lowerDuration
+            lowering.values.forEach { $0.animator().alphaValue = 0 }
+        }, completionHandler: { [weak self] in
+            guard let self, token == self.lowerToken else { return }
+            self.panels = [:]
+            lowering.values.forEach(self.dismantle)
+        })
+    }
+
+    private func dismantle(_ panel: AppLockPanel) {
+        panel.parent?.removeChildWindow(panel)
+        panel.orderOut(nil)
+    }
+
+    private func discardPanelsNotCovering(_ hosts: [NSWindow]) {
+        let live = Set(hosts.map(ObjectIdentifier.init))
+        for (key, panel) in panels where !live.contains(key) {
+            panels.removeValue(forKey: key)
+            dismantle(panel)
+        }
+    }
+
+    // MARK: - Windows
+
+    /// The host outlives every window the app can open, so these are never
+    /// removed.
+    ///
+    /// The blocks run on `OperationQueue.main`, which is the main thread, so they
+    /// step straight into the actor rather than hopping — a hop would leave the
+    /// panels a runloop turn behind the windows they are covering.
+    private func observeWindows() {
+        let center = NotificationCenter.default
+
+        center.addObserver(
+            forName: NSWindow.didBecomeMainNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            MainActor.assumeIsolated {
+                guard let window = notification.object as? NSWindow else { return }
+                self?.elect(window)
+            }
+        }
+
+        // A passive panel can still become key, and the keypad is not in it. The
+        // click that made it key is the user saying which window they want to
+        // unlock from.
+        center.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            MainActor.assumeIsolated {
+                guard let panel = notification.object as? AppLockPanel,
+                      let parent = panel.parent else { return }
+                self?.elect(parent)
+            }
+        }
+
+        center.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            MainActor.assumeIsolated {
+                guard let window = notification.object as? NSWindow else { return }
+                self?.discardPanel(for: ObjectIdentifier(window))
+            }
+        }
+
+        // A child window follows its parent when the parent moves, but not when
+        // it resizes — and a panel left at the old size is a lock screen with the
+        // wallet showing down one edge.
+        for name in [NSWindow.didResizeNotification, NSWindow.didMoveNotification] {
+            center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                MainActor.assumeIsolated {
+                    guard let window = notification.object as? NSWindow else { return }
+                    self?.syncPanelFrame(over: window)
+                }
+            }
+        }
+    }
+
+    /// Hands the interactive lock screen to the window the user just moved to, so
+    /// the keypad is in the one being looked at.
+    ///
+    /// A no-op when it is already there, which is what keeps the `makeKey` inside
+    /// the re-raise from electing its way round in a circle.
+    private func elect(_ window: NSWindow) {
+        guard current.isGate, let callbacks, window !== interactiveWindow else { return }
+        interactiveWindow = window
+        raise(
+            current,
+            onUnlocked: callbacks.onUnlocked,
+            onAttemptFailed: callbacks.onAttemptFailed
+        )
+    }
+
+    private func syncPanelFrame(over window: NSWindow) {
+        guard let panel = panels[ObjectIdentifier(window)] else { return }
+        panel.setFrame(window.frame, display: true)
+    }
+
+    private func discardPanel(for key: ObjectIdentifier) {
+        guard let panel = panels.removeValue(forKey: key) else { return }
+        dismantle(panel)
+    }
 }
 #endif

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
@@ -1,0 +1,28 @@
+//
+//  AppLockPanelHost.swift
+//  VultisigApp
+//
+
+#if os(macOS)
+import SwiftUI
+
+/// The Mac's half of ``AppLockHost``.
+@MainActor
+final class AppLockPanelHost: ObservableObject {
+
+    static let shared = AppLockPanelHost()
+
+    /// `false`, so the root overlay goes on carrying the lock screen itself on
+    /// the Mac. An overlay covers everything `CrossPlatformSheet` draws in the
+    /// view hierarchy, which on macOS below 26 is every sheet the app has; what
+    /// it does not cover is a window-attached sheet, which is what macOS 26 and
+    /// every `.alert` use.
+    @Published private(set) var hostsLockScreen = false
+
+    func update(
+        to _: AppLockPresentation,
+        onUnlocked _: @escaping () -> Void,
+        onAttemptFailed _: @escaping () -> Void
+    ) {}
+}
+#endif

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
@@ -35,15 +35,9 @@ final class AppLockPanel: NSWindow {
         isOpaque = true
         hasShadow = false
         isReleasedWhenClosed = false
-        // Above the app's own windows, and their attached sheets with them: a
-        // sheet is a child of the window it belongs to, and takes that window's
-        // level.
-        level = .modalPanel
-        // Levels are global on the Mac, so a window this high in an app that is
-        // *not* frontmost would float over whatever is. Hiding on deactivate is
-        // what keeps the lock screen inside its own app. What the app looks like
-        // once it is no longer frontmost is the root overlay's job.
-        hidesOnDeactivate = true
+        // The level is **not** set here. It belongs to the app's activation state
+        // and is owned by ``AppLockPanelHost/applyPanelLevel()`` — see there for
+        // why it cannot simply be raised once and left.
         collectionBehavior = [.fullScreenAuxiliary]
     }
 
@@ -51,8 +45,9 @@ final class AppLockPanel: NSWindow {
     override var canBecomeMain: Bool { false }
 }
 
-/// The Mac's half of ``AppLockHost``: an elevated panel over each of the app's
-/// windows.
+/// The Mac's half of ``AppLockHost``: a panel attached over each of the app's
+/// windows, above everything that window can present — and never above another
+/// application, which is what ``applyPanelLevel()`` is for.
 ///
 /// Needed on every macOS version, not only where `CrossPlatformSheet` uses a
 /// native sheet. Below macOS 26 that modifier does draw its sheets inside the
@@ -77,6 +72,9 @@ final class AppLockPanelHost: ObservableObject {
     /// Invalidates the completion of a fade that a re-raise has overtaken, so a
     /// panel just put back up is not torn down underneath itself.
     private var lowerToken = 0
+    /// Whether the app is frontmost. The only condition under which a panel may
+    /// be elevated — see ``applyPanelLevel()``.
+    private var isAppActive = NSApp.isActive
 
     private let lowerDuration: TimeInterval = 0.25
 
@@ -150,8 +148,39 @@ final class AppLockPanelHost: ObservableObject {
             )
         }
 
+        applyPanelLevel()
         callbacks = Callbacks(onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
         current = presentation
+    }
+
+    /// Elevates the panels **only while the app is frontmost**.
+    ///
+    /// Both halves of that are load bearing, and the first version of this got the
+    /// second half wrong badly enough to make the app unusable.
+    ///
+    /// **It has to be elevated at all**, because a child window does not beat an
+    /// attached sheet. Measured, not assumed: a borderless child added with
+    /// `ordered: .above` lands *below* the parent's attached sheet at `.normal`,
+    /// whether it was attached before the sheet began or after — and above it at
+    /// `.modalPanel`. Sheet coverage is the whole reason this panel exists, so
+    /// plain child ordering does not do the job.
+    ///
+    /// **It has to stop being elevated when the app is not frontmost**, because
+    /// levels on macOS are *global, not per-app*: anything above `.normal` floats
+    /// over every other application. Raised unconditionally, the lock screen sat
+    /// on top of Finder and everything else — and it did it exactly when the app
+    /// went to the background, which is when the cover goes up. `hidesOnDeactivate`
+    /// did not contain that and could not: the panel is ordered front *after* the
+    /// app has deactivated, so the hide it was meant to trigger had already
+    /// happened.
+    ///
+    /// While the app *is* frontmost, an elevated window of its own costs nothing —
+    /// every other application is behind the active app regardless.
+    private func applyPanelLevel() {
+        let level: NSWindow.Level = isAppActive ? .modalPanel : .normal
+        for panel in panels.values where panel.level != level {
+            panel.level = level
+        }
     }
 
     private func show(
@@ -168,11 +197,8 @@ final class AppLockPanelHost: ObservableObject {
 
         if panel.parent !== window {
             window.addChildWindow(panel, ordered: .above)
-            // After the attachment, not before: `addChildWindow` gives the child
-            // its parent's level, which is the one thing being escaped here.
-            panel.level = .modalPanel
         }
-        panel.setFrame(window.frame, display: true)
+        panel.setFrame(window.appLockCoverFrame, display: true)
         // A fade may still be running on this panel, and assigning `alphaValue`
         // outside an animation context would give that animation a new target
         // rather than stopping it — leaving the lock translucent over the wallet.
@@ -316,6 +342,32 @@ final class AppLockPanelHost: ObservableObject {
                 }
             }
         }
+
+        // The activation state is what decides whether the panels may be
+        // elevated, so it is tracked rather than sampled: `NSApp.isActive` is
+        // still `true` inside `willResignActive`, and that notification is the
+        // very moment the privacy cover goes up.
+        center.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.isAppActive = true
+                self?.applyPanelLevel()
+            }
+        }
+
+        center.addObserver(
+            forName: NSApplication.willResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.isAppActive = false
+                self?.applyPanelLevel()
+            }
+        }
     }
 
     /// Hands the interactive lock screen to the window the user just moved to, so
@@ -335,12 +387,27 @@ final class AppLockPanelHost: ObservableObject {
 
     private func syncPanelFrame(over window: NSWindow) {
         guard let panel = panels[ObjectIdentifier(window)] else { return }
-        panel.setFrame(window.frame, display: true)
+        panel.setFrame(window.appLockCoverFrame, display: true)
     }
 
     private func discardPanel(for key: ObjectIdentifier) {
         guard let panel = panels.removeValue(forKey: key) else { return }
         dismantle(panel)
+    }
+}
+
+private extension NSWindow {
+
+    /// The part of a window the lock has to cover: everything the app draws, and
+    /// nothing else.
+    ///
+    /// Not `frame`. Covering the title bar takes the traffic lights with it, and
+    /// a lock screen behind which the window can be neither closed nor minimised
+    /// is one there is no way out of short of force quitting.
+    /// `contentLayoutRect` stops below the title bar, which shows a window title
+    /// and nothing about a wallet.
+    var appLockCoverFrame: NSRect {
+        convertToScreen(contentLayoutRect)
     }
 }
 #endif

--- a/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
@@ -10,12 +10,31 @@ import LocalAuthentication
 
 class AppViewModel: ObservableObject {
     @AppStorage("showOnboarding") var showOnboarding: Bool = true
-    @AppStorage("showCover") var showCover: Bool = true
+    @AppStorage("showCover") private var storedShowCover: Bool = true
     @AppStorage("isAuthenticationEnabled") var isAuthenticationEnabled: Bool = true
     @AppStorage("didAskForAuthentication") var didAskForAuthentication: Bool = false
     @AppStorage("lastRecordedTime") var lastRecordedTime: String = ""
     @AppStorage("vaultName") var vaultName: String = ""
     @AppStorage("selectedPubKeyECDSA") var selectedPubKeyECDSA: String = ""
+
+    /// Whether the privacy cover is up.
+    ///
+    /// Written through rather than left as bare `@AppStorage`, because
+    /// `@AppStorage` is a `DynamicProperty`: it publishes from a *view*, and from
+    /// inside an `ObservableObject` it writes `UserDefaults` and tells nobody.
+    /// The overlay got away with that by accident — every writer runs off a
+    /// scene-phase change, which re-evaluates the app's body and re-reads the
+    /// value on the way past. Anything that is not a view has no such accident to
+    /// lean on, and a cover raised without being observed is a cover nothing
+    /// takes down.
+    var showCover: Bool {
+        get { storedShowCover }
+        set {
+            guard newValue != storedShowCover else { return }
+            objectWillChange.send()
+            storedShowCover = newValue
+        }
+    }
 
     @Published var isAuthenticated = false
     /// Whether the passcode lock screen should be covering the app.

--- a/VultisigApp/VultisigApp/Core/ViewModels/VultExtensionViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/VultExtensionViewModel.swift
@@ -11,4 +11,27 @@ class VultExtensionViewModel: ObservableObject {
     @Published var documentData: FileDocumentConfiguration<VULTFileDocument>? = nil
     @Published var documentUrl: URL? = nil
     @Published var showImportView: Bool = false
+
+    /// Raised when a document scene hands a file over, and lowered by whoever
+    /// acts on it.
+    ///
+    /// A flag rather than "is `documentData` still set?", because this view model
+    /// is shared by every scene the app can open — a `WindowGroup` and a
+    /// `DocumentGroup` — and the document stays set until the import screen
+    /// reads it. Two screens both seeing it there is two pushes of the same
+    /// import route for one file.
+    @Published private(set) var isDocumentImportPending: Bool = false
+
+    func handOff(documentData: FileDocumentConfiguration<VULTFileDocument>) {
+        self.documentData = documentData
+        isDocumentImportPending = true
+    }
+
+    /// - Returns: whether the caller is the one that should open the import,
+    ///   which is true for exactly one caller per document.
+    func consumeDocumentImport() -> Bool {
+        guard isDocumentImportPending else { return false }
+        isDocumentImportPending = false
+        return true
+    }
 }

--- a/VultisigApp/VultisigApp/Core/ViewModels/VultExtensionViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/VultExtensionViewModel.swift
@@ -20,6 +20,13 @@ class VultExtensionViewModel: ObservableObject {
     /// `DocumentGroup` — and the document stays set until the import screen
     /// reads it. Two screens both seeing it there is two pushes of the same
     /// import route for one file.
+    ///
+    /// **Use it as a trigger, never as a subscription that reads it back.**
+    /// `@Published` publishes from `willSet`, so a `sink`/`onReceive` that then
+    /// asks ``consumeDocumentImport()`` is asking about the value from *before*
+    /// the hand-off: the consume declines, the flag stays raised, and there is
+    /// nobody left to ask — a user's `.vult` backup silently dropped. Read it
+    /// where the view update reads it, by which time it has settled.
     @Published private(set) var isDocumentImportPending: Bool = false
 
     func handOff(documentData: FileDocumentConfiguration<VULTFileDocument>) {

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -90,6 +90,20 @@ struct HomeScreen: View {
             showVaultSelector = showingVaultSelector
             setData()
         }
+        // The flag is gated rather than the lookup, because the lookup is
+        // asynchronous and its answer can land at any moment — including after
+        // the app has relocked, which starting it while unlocked would not
+        // protect against. An alert is presented in a layer the gate's overlay
+        // cannot reach, so one raised then sits on top of the lock screen.
+        .presentsWhenUnlocked($phoneCheckUpdateViewModel.showUpdateAlert)
+        // The document scene's hand-off is held while the app is locked, so it
+        // can land long after `setData()` asked once and found nothing. Only the
+        // screen that consumes it opens the import, which is what keeps a second
+        // mounted scene from pushing the same route again.
+        .onReceive(vultExtensionViewModel.$isDocumentImportPending.filter { $0 }) { _ in
+            guard vultExtensionViewModel.consumeDocumentImport() else { return }
+            navigateToImportBackup()
+        }
         .onReceive(
             NotificationCenter.default.publisher(for: NSNotification.Name("ProcessDeeplink"))
         ) { _ in
@@ -431,7 +445,7 @@ extension HomeScreen {
     }
 
     fileprivate func presetValuesForDeeplink() {
-        if vultExtensionViewModel.documentData != nil {
+        if vultExtensionViewModel.consumeDocumentImport() {
             navigateToImportBackup()
         }
 

--- a/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Home/HomeScreen.swift
@@ -61,7 +61,6 @@ struct HomeScreen: View {
     @EnvironmentObject var deeplinkViewModel: DeeplinkViewModel
     @EnvironmentObject var homeViewModel: HomeViewModel
     @EnvironmentObject var phoneCheckUpdateViewModel: PhoneCheckUpdateViewModel
-    @EnvironmentObject var vultExtensionViewModel: VultExtensionViewModel
     @EnvironmentObject var appViewModel: AppViewModel
     @ObservedObject private var transactionPoller = TransactionStatusPoller.shared
     @Environment(\.modelContext) private var modelContext
@@ -96,14 +95,6 @@ struct HomeScreen: View {
         // protect against. An alert is presented in a layer the gate's overlay
         // cannot reach, so one raised then sits on top of the lock screen.
         .presentsWhenUnlocked($phoneCheckUpdateViewModel.showUpdateAlert)
-        // The document scene's hand-off is held while the app is locked, so it
-        // can land long after `setData()` asked once and found nothing. Only the
-        // screen that consumes it opens the import, which is what keeps a second
-        // mounted scene from pushing the same route again.
-        .onReceive(vultExtensionViewModel.$isDocumentImportPending.filter { $0 }) { _ in
-            guard vultExtensionViewModel.consumeDocumentImport() else { return }
-            navigateToImportBackup()
-        }
         .onReceive(
             NotificationCenter.default.publisher(for: NSNotification.Name("ProcessDeeplink"))
         ) { _ in
@@ -445,9 +436,6 @@ extension HomeScreen {
     }
 
     fileprivate func presetValuesForDeeplink() {
-        if vultExtensionViewModel.consumeDocumentImport() {
-            navigateToImportBackup()
-        }
 
         guard let type = deeplinkViewModel.type else {
             return
@@ -659,9 +647,6 @@ extension HomeScreen {
                 hasPreselectedCoin: true))
     }
 
-    fileprivate func navigateToImportBackup() {
-        router.navigate(to: OnboardingRoute.importVaultShare)
-    }
 }
 
 private extension HomeScreen {

--- a/VultisigApp/VultisigApp/Features/Notifications/Views/SetupPushNotificationsModifier.swift
+++ b/VultisigApp/VultisigApp/Features/Notifications/Views/SetupPushNotificationsModifier.swift
@@ -29,8 +29,11 @@ struct SetupPushNotificationsModifier: ViewModifier {
                     handleDismiss()
                 }
             }
-            .onLoad { checkIfNeeded() }
-            .onChange(of: vault) { _, _ in
+            // Held while the passcode gate is up. `checkIfNeeded` marks the
+            // prompt as seen before it raises anything, so running it behind the
+            // lock screen would spend the one chance this sheet gets on a screen
+            // nobody can see.
+            .presentsWhenUnlocked(on: vault) {
                 checkIfNeeded()
             }
     }

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/Modifiers/BiweeklyPasswordVerificationViewModifier.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/Modifiers/BiweeklyPasswordVerificationViewModifier.swift
@@ -36,10 +36,17 @@ struct BiweeklyPasswordVerificationViewModifier: ViewModifier {
                     .frame(width: 400, height: sheetHeight)
                 #endif
             }
-            .onLoad {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    checkIfNeeded()
-                }
+            // Gated rather than merely delayed. This raises a *credential* sheet
+            // — the fast-vault server password — from the view's own load, so on
+            // a cold start behind the passcode gate it would appear over the lock
+            // screen and take input, in a layer the gate cannot reach.
+            //
+            // The whole second of delay lives here, and the check raises the
+            // sheet the moment it decides to. Split across two waits, the second
+            // one ran ungated: a relock landing inside it put the sheet up
+            // anyway.
+            .presentsWhenUnlocked(after: .seconds(1)) {
+                checkIfNeeded()
             }
     }
 
@@ -57,9 +64,7 @@ struct BiweeklyPasswordVerificationViewModifier: ViewModifier {
         let difference = calendar.dateComponents([.day], from: calendar.startOfDay(for: lastVerifyDate), to: calendar.startOfDay(for: currentDate))
 
         if let days = difference.day, days >= 15 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                shouldShow = true
-            }
+            shouldShow = true
         }
     }
 }

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/Modifiers/MonthlyBackupWarningViewModifier.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Views/Modifiers/MonthlyBackupWarningViewModifier.swift
@@ -28,10 +28,11 @@ struct MonthlyBackupWarningViewModifier: ViewModifier {
                     }
                 ).presentationDetents([.height(224)])
             }
-            .onLoad {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    checkIfNeeded()
-                }
+            // Held while the passcode gate is up: this raises itself from the
+            // view's own load, so a cold start behind the lock screen would put
+            // the sheet above it.
+            .presentsWhenUnlocked(after: .milliseconds(500)) {
+                checkIfNeeded()
             }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -1022,9 +1022,14 @@ extension EncryptedBackupViewModel {
         }))
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
 
-        if let rootViewController = UIApplication.shared.windows.first?.rootViewController {
-            rootViewController.present(alert, animated: true, completion: nil)
+        guard let rootViewController = UIApplication.shared.activeContentWindow?.rootViewController else {
+            // Nothing to present into, so the import stalls here rather than
+            // finding somewhere else to put a password field — the window the
+            // app raises over its content while locked is not a fallback.
+            logger.error("No content window to present the backup password prompt in")
+            return
         }
+        rootViewController.present(alert, animated: true, completion: nil)
     }
 
     func promptForPasswordAndImportMultiple(encryptedVaultData: [(fileName: String, data: Data)], processedVaults: [Vault]) {
@@ -1056,9 +1061,14 @@ extension EncryptedBackupViewModel {
             }
         }))
 
-        if let rootViewController = UIApplication.shared.windows.first?.rootViewController {
-            rootViewController.present(alert, animated: true, completion: nil)
+        guard let rootViewController = UIApplication.shared.activeContentWindow?.rootViewController else {
+            // Nothing to present into, so the import stalls here rather than
+            // finding somewhere else to put a password field — the window the
+            // app raises over its content while locked is not a fallback.
+            logger.error("No content window to present the backup password prompt in")
+            return
         }
+        rootViewController.present(alert, animated: true, completion: nil)
     }
 }
 #endif

--- a/VultisigApp/VultisigAppTests/Notifications/ForegroundNotificationHandlingTests.swift
+++ b/VultisigApp/VultisigAppTests/Notifications/ForegroundNotificationHandlingTests.swift
@@ -11,8 +11,19 @@ import XCTest
 @MainActor
 final class ForegroundNotificationHandlingTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
+    /// The gate flag is on the shared view model, because that is where the rest
+    /// of the app reads it from. Borrowed and put back so a locked test cannot
+    /// leak into whatever runs next in the same process.
+    private var borrowedPasscodeLock = false
+
+    override func setUp() {
+        super.setUp()
+        borrowedPasscodeLock = AppViewModel.shared.isPasscodeLocked
+        AppViewModel.shared.isPasscodeLocked = false
+    }
 
     override func tearDown() {
+        AppViewModel.shared.isPasscodeLocked = borrowedPasscodeLock
         cancellables.removeAll()
         super.tearDown()
     }
@@ -115,6 +126,84 @@ final class ForegroundNotificationHandlingTests: XCTestCase {
 
         XCTAssertEqual(received.count, 2)
         XCTAssertEqual(received[0], received[1])
+    }
+
+    // MARK: - Behind the passcode gate
+
+    /// The banner draws the vault name and a decoded transaction summary —
+    /// "Send 1.2 ETH to 0x…" — and holds it for thirty seconds. Behind the lock
+    /// screen that is precisely the disclosure the lock is there to prevent, and
+    /// the banner's own check cannot see it: it asks whether a UIKit view
+    /// controller is presented, and the gate is a SwiftUI overlay, which is not
+    /// one.
+    ///
+    /// The unlocked assertion comes first on purpose. Every earlier decline in
+    /// this file is also a `false`, so without it a change that broke the banner
+    /// outright would pass this test.
+    func testALockedAppRaisesNoForegroundBanner() {
+        let manager = makeManager()
+        XCTAssertTrue(
+            manager.handleForegroundNotification(makeValidContent()),
+            "precondition: unlocked, this notification does raise a banner"
+        )
+        manager.foregroundNotification = nil
+
+        AppViewModel.shared.isPasscodeLocked = true
+
+        XCTAssertFalse(manager.handleForegroundNotification(makeValidContent()))
+        XCTAssertNil(manager.foregroundNotification)
+    }
+
+    /// Declining the custom banner is only half of it. The decline falls through
+    /// to the *system* presentation, which the OS draws above every window the
+    /// app owns and which carries the same payload — so a lock that only
+    /// suppressed the custom banner would have swapped one banner for another.
+    func testALockedAppSuppressesTheSystemBannerToo() {
+        AppViewModel.shared.isPasscodeLocked = true
+        let delegate = NotificationDelegate()
+        delegate.onForegroundNotification = { _, completion in
+            completion(false)
+        }
+        var receivedOptions: UNNotificationPresentationOptions?
+
+        delegate.presentationOptions(for: makeValidContent()) {
+            receivedOptions = $0
+        }
+
+        // Spelled out rather than compared against the policy's own constant:
+        // asserting `lockedOptions == lockedOptions` would keep passing if that
+        // constant were widened back to include the banner.
+        XCTAssertEqual(receivedOptions, [.sound])
+        XCTAssertFalse(receivedOptions?.contains(.banner) ?? true)
+        XCTAssertFalse(receivedOptions?.contains(.list) ?? true)
+    }
+
+    /// Including the path where no handler is installed at all — the app has not
+    /// finished launching, so nothing has declined anything, and the fall-through
+    /// is the only decision made.
+    func testALockedAppSuppressesTheSystemBannerWithNoHandlerInstalled() {
+        AppViewModel.shared.isPasscodeLocked = true
+        let delegate = NotificationDelegate()
+        var receivedOptions: UNNotificationPresentationOptions?
+
+        delegate.presentationOptions(for: makeValidContent()) {
+            receivedOptions = $0
+        }
+
+        XCTAssertEqual(receivedOptions, [.sound])
+    }
+
+    /// And the gate coming down gives the banner back, so this is a suppression
+    /// while locked rather than a suppression.
+    func testAnUnlockedAppStillRaisesTheForegroundBanner() {
+        AppViewModel.shared.isPasscodeLocked = true
+        let manager = makeManager()
+        XCTAssertFalse(manager.handleForegroundNotification(makeValidContent()))
+
+        AppViewModel.shared.isPasscodeLocked = false
+
+        XCTAssertTrue(manager.handleForegroundNotification(makeValidContent()))
+        XCTAssertNotNil(manager.foregroundNotification)
     }
 
     private func makeManager(

--- a/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
@@ -525,6 +525,88 @@ final class PasscodeGateWiringTests: XCTestCase {
         XCTAssertFalse(viewModel.didFinish, "precondition: the shortcut did not open the app")
         XCTAssertTrue(viewModel.shouldPresentEntry, "the passcode must still be reachable")
     }
+
+    // MARK: - What the app is allowed to raise while the gate is up
+
+    /// The gate has to apply to what the app *does*, not only to what it shows —
+    /// the same rule `handleDeeplink` already follows. These pin the half of it
+    /// that no lock screen can cover for itself: a sheet is presented in a layer
+    /// an overlay does not reach, so a screen that raises one from its own load
+    /// puts it *above* the lock. Three do, with no user action at all: the
+    /// fast-vault password reminder, the monthly backup warning and the
+    /// notifications intro.
+    func testACheckThatComesDueWhileLockedDoesNotRun() {
+        var sut = AppLockPresentationHold()
+
+        XCTAssertFalse(sut.requested(whileLocked: true))
+        XCTAssertTrue(sut.isHolding)
+    }
+
+    /// Held, not dropped. The reminder is owed either way; what the gate decides
+    /// is when it may be asked for.
+    func testAHeldCheckRunsWhenTheGateComesDown() {
+        var sut = AppLockPresentationHold()
+        _ = sut.requested(whileLocked: true)
+
+        XCTAssertTrue(sut.lockChanged(isLocked: false))
+        XCTAssertFalse(sut.isHolding)
+    }
+
+    /// A hold, not a queue. Every caller asks an idempotent "do I still owe this
+    /// sheet?" question, so three asks behind the gate are one answer once it
+    /// comes down — not three sheets.
+    func testRepeatedRequestsBehindTheGateProduceOneRun() {
+        var sut = AppLockPresentationHold()
+        _ = sut.requested(whileLocked: true)
+        _ = sut.requested(whileLocked: true)
+        _ = sut.requested(whileLocked: true)
+
+        XCTAssertTrue(sut.lockChanged(isLocked: false))
+        XCTAssertFalse(sut.lockChanged(isLocked: false), "the hold was already spent")
+    }
+
+    /// The gate going *up* releases nothing. Without this the sequence
+    /// lock → check → unlock → lock would raise the sheet on the second lock,
+    /// which is the bug being fixed rather than the fix.
+    func testTheGateGoingUpReleasesNothing() {
+        var sut = AppLockPresentationHold()
+        _ = sut.requested(whileLocked: true)
+
+        XCTAssertFalse(sut.lockChanged(isLocked: true))
+        XCTAssertTrue(sut.isHolding, "still owed, still held")
+    }
+
+    /// And an unlock with nothing held raises nothing, so the rule is not simply
+    /// "present something whenever the gate comes down".
+    func testAnUnlockWithNothingHeldRunsNothing() {
+        var sut = AppLockPresentationHold()
+
+        XCTAssertFalse(sut.lockChanged(isLocked: false))
+    }
+
+    /// The half that must keep working: with no gate up, a check runs where it
+    /// always did and is never held.
+    func testACheckThatComesDueWithNoGateUpRunsImmediately() {
+        var sut = AppLockPresentationHold()
+
+        XCTAssertTrue(sut.requested(whileLocked: false))
+        XCTAssertFalse(sut.isHolding)
+        XCTAssertFalse(sut.lockChanged(isLocked: false), "nothing was held, so nothing replays")
+    }
+
+    /// The race the hold has to survive. SwiftUI delivers the lock's `onChange`
+    /// *after* the flag has already changed, so a request landing in that window
+    /// sees an unlocked app and runs — and the drain still on its way would then
+    /// run the same check a second time. Accepting a request has to discharge the
+    /// hold, not only the drain.
+    func testARequestThatOvertakesTheDrainRunsOnce() {
+        var sut = AppLockPresentationHold()
+        _ = sut.requested(whileLocked: true)
+
+        XCTAssertTrue(sut.requested(whileLocked: false), "the flag is already down")
+
+        XCTAssertFalse(sut.lockChanged(isLocked: false), "the drain has nothing left to run")
+    }
 }
 
 /// Lands a lock at the far side of the disable's unseal — the point past which


### PR DESCRIPTION
## Description

The passcode gate was a SwiftUI `.overlay` on the root view, and SwiftUI presents sheets and full-screen covers in a layer an overlay does not reach. A sheet already on screen when the app locked stayed drawn above the lock screen — legible, and still taking input. The `passcodeGate` doc comment already admitted this; the same gap applied to the `CoverView` privacy screen.

Beyond the sheet that was already open, **five routes present themselves over a lock that is already up**, three of which need no user action at all. The worst is a fast-vault server password prompt: a credential field, above a lock screen, taking keystrokes.

Fixes #5082

Three layers, one commit each.

**1. Hold self-raising presentations behind the gate.** A reusable `AppLockPresentationHold` + `.presentsWhenUnlocked(...)` modifier expresses the rule once — refuse to raise while locked, re-check on unlock — rather than five hand-written guards that the next author has to remember. Applied to the biweekly password reminder, the monthly backup warning, the notifications intro, the update alert, and the `DocumentGroup` file hand-off. The push policy now answers `false` while locked and degrades to `[.sound]`, because falling through to the system banner still renders a decoded keysign summary. `UIApplication.activeContentWindow` replaces `UIApplication.shared.windows.first`, which is deprecated, unordered, and would have resolved to the gate window once one existed.

**2. iOS: host the gate in a `UIWindow` at `.alert + 1`.** Window z-order is `windowLevel` first and presented sheets live in the key window's hierarchy, so a higher-level window covers them without dismissing anything — the user's sheet is still there after unlocking. One window per `UIWindowScene`, since the app declares both a `WindowGroup` and a `DocumentGroup`. **The existing overlay is kept**, degraded to a passive brand screen: it is what holds the cold-start guarantee, because the gate is decided in `VultisigApp.init()` where no `UIWindowScene` exists yet. The two cover different halves and neither replaces the other.

**3. macOS: an elevated borderless child `NSWindow` per app window.** Sized to `contentLayoutRect` so the title bar and traffic lights stay reachable, and **scoped to activation** — `.modalPanel` while Vultisig is frontmost, `.normal` the moment it is not. macOS window levels are global rather than per-app, so an unscoped elevation floats the lock over every other application; the level is tracked from `didBecomeActive`/`willResignActive` rather than sampled, because `NSApp.isActive` is still `true` inside `willResignActive` — which is exactly when the cover goes up.

### Two things measured rather than reasoned about

A first attempt at layer 3 floated the lock over all of macOS and covered the traffic lights, so the app could not be minimised or closed. It was caught in manual testing, and the fix was then verified by reading window layers and geometry out of `CGWindowListCopyWindowInfo` on the real app — before (`layer=8`, in front of Finder, bounds identical to the parent) and after (`layer=8` frontmost with a 32pt title bar exposed; `layer=0` and ordered behind Finder when not).

The obvious alternative — dropping the level and relying on `addChildWindow(ordered: .above)` — was measured and **does not work**: an attached sheet outranks a sibling child window at the same level, including in this issue's exact scenario. Re-asserting the ordering does not fix it either. Both were implemented, measured, and deleted rather than shipped.

## Which feature is affected?

None of the below. This is app-lock presentation only — no signing, broadcast, fee computation, or stored data is touched.

## Parity

- Android: linked — vultisig/vultisig-android#5551 → #5554, which fixed the identical bug by hosting the lock in its own window. Their windows stack purely in the order they are added, so a window created afterwards still lands on top; a raised `windowLevel` on iOS does not have that weakness.
- Windows + extension: n/a — no passcode app-lock surface.
- SDK: n/a — client presentation only.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Test plan

```
** BUILD SUCCEEDED **   (generic/platform=iOS Simulator)
** BUILD SUCCEEDED **   (platform=macOS,arch=arm64)
** TEST SUCCEEDED **    5318 tests, 1 skipped, 0 failures
```

SwiftLint: 22 violations, all pre-existing, none in a changed file.

New tests confirmed to fail against the parent commit: applying `ForegroundNotificationHandlingTests` alone onto `01e25f4f7` gives `** TEST FAILED **`, 12 executed / 7 failures — all 4 new tests fail (the parent raises the banner while locked and returns `[.banner, .list, .sound]`), the 8 pre-existing ones pass.

**What the suite cannot prove.** The central property — a sheet presented before the lock being neither visible nor touchable — has no unit test, because there is no UIKit window in the test host. Layer 1's guards are testable; layers 2 and 3 are verified by hand.

**Verified by hand:** iOS, all four acceptance criteria. macOS: the window-level and geometry behaviour above, plus minimise/close.

**Not yet verified:** macOS AC1–AC3 with a real sheet in the app, and Mission Control's actual render.

### Known gap, deliberately deferred

While the macOS app is **not** frontmost the panel drops to `.normal`, so an attached sheet outranks it and Mission Control may still show that sheet in the window preview. This is not a regression — `main` has no panel at all and its overlay never covered sheets — and nothing can be typed into it while the app is inactive. Closing it means introducing another window class on the platform that just produced a critical regression, and Mission Control's render could not be measured from here, so it is better done deliberately with a device in hand.

### On severity

This is disclosure and live input, not a signing bypass — but the PR deliberately does **not** claim "signing is blocked while locked". `KeyshareProtector.open` returns a share unchanged when it is not sealed, before consulting lock state, and `resumeSweepUnlocked` swallows sweep failures by design ("shares staying plaintext for another lock cycle is the lesser failure"), so plaintext shares can coexist with a set passcode. The argument for this change stands on the UI gate itself, not on key sealing as a backstop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added coordinated passcode-lock and privacy-cover screens across iOS and macOS.
  * Added lock-aware presentation for alerts, sheets, notifications, and document imports.
  * Added safer handling for multi-window scenes and active content windows.
  * Added deferred document-import handoff between scenes.

* **Bug Fixes**
  * Foreground notifications are suppressed while the app is locked and resume after unlocking.
  * Password prompts and update reminders now appear from the correct active window.
  * Document-based imports wait until the app is unlocked before opening.

* **Tests**
  * Added coverage for lock-state presentation, notification suppression, unlocking, and deferred actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->