### PR TITLE
fix(passcode): apply hardware-key edits after the update that delivered them

### DIFF
--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
@@ -38,6 +38,19 @@ struct PasscodeEntryView: View {
     /// only on appearance — otherwise one click ends typing for the rest of the
     /// flow.
     @FocusState private var isKeypadFocused: Bool
+    /// Bookkeeping for keys accepted but not yet applied — see ``enqueue(_:)``.
+    ///
+    /// A reference type rather than `@State` of a value: it is not something the
+    /// view draws, and writing to it must not invalidate the view. The write
+    /// happens while a key is being delivered, which on this screen is inside a
+    /// view update — invalidating from there is the very thing being fixed.
+    @State private var keyboard = KeyboardEntry()
+
+    /// The entry as it will stand once every accepted key has been applied, or
+    /// `nil` when nothing is queued and the binding is the truth.
+    private final class KeyboardEntry {
+        var expected: String?
+    }
     #endif
 
     private var digitCount: Int { PasscodeService.passcodeLength }
@@ -180,9 +193,29 @@ struct PasscodeEntryView: View {
         #endif
     }
 
-    private func append(_ digit: String) {
-        guard passcode.count < digitCount, !isBusy else { return }
-        passcode.append(digit)
+    /// What a digit key does to an entry, as a value rather than a statement.
+    ///
+    /// The rule is returned rather than applied because the two inputs reach the
+    /// entry differently — a click edits it now, a hardware key edits it a turn
+    /// later — and the one thing that must not differ between them is *whether*
+    /// a key applies at all. `nil` means it does not: the entry is already full.
+    private func appending(_ digit: String) -> (String) -> String? {
+        { entry in entry.count < digitCount ? entry + digit : nil }
+    }
+
+    /// As ``appending(_:)``. `nil` when there is nothing left to delete.
+    private var deletingLast: (String) -> String? {
+        { entry in entry.isEmpty ? nil : String(entry.dropLast()) }
+    }
+
+    /// Edits the entry now. What the on-screen keys do, on both platforms.
+    private func apply(_ edit: (String) -> String?) {
+        guard !isBusy, let next = edit(passcode) else { return }
+        passcode = next
+        confirmEntry()
+    }
+
+    private func confirmEntry() {
         #if os(iOS)
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
         #else
@@ -190,14 +223,12 @@ struct PasscodeEntryView: View {
         #endif
     }
 
+    private func append(_ digit: String) {
+        apply(appending(digit))
+    }
+
     private func deleteLast() {
-        guard !passcode.isEmpty, !isBusy else { return }
-        passcode.removeLast()
-        #if os(iOS)
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-        #else
-        isKeypadFocused = true
-        #endif
+        apply(deletingLast)
     }
 
     #if os(macOS)
@@ -229,8 +260,8 @@ struct PasscodeEntryView: View {
             guard modifiers == .command, press.phase == .down, press.characters == "v" else {
                 return .ignored
             }
-            paste()
-            return .handled
+            guard let pasted = clipboardPasscode() else { return .handled }
+            return enqueue { _ in pasted }
         }
 
         // Every remaining path is a bare key. Checked before the actions rather
@@ -244,8 +275,7 @@ struct PasscodeEntryView: View {
         guard press.phase == .down || isDelete else { return .ignored }
 
         if isDelete {
-            deleteLast()
-            return .handled
+            return enqueue(deletingLast)
         }
 
         guard press.characters.count == 1,
@@ -254,31 +284,77 @@ struct PasscodeEntryView: View {
             return .ignored
         }
 
-        append(String(digit))
+        return enqueue(appending(String(digit)))
+    }
+
+    /// Accepts a key now and applies its edit a turn later.
+    ///
+    /// **Why it cannot be applied now.** The lock screen is hosted in a panel
+    /// over the app rather than in the app's own view hierarchy, and a hardware
+    /// key arrives there while SwiftUI is mid-update. `passcode` is a binding
+    /// onto a published property, so editing it inline publishes a change from
+    /// within that update — undefined behaviour, and logged as such. One hop to
+    /// the next main-queue turn puts the edit after the update instead.
+    ///
+    /// **Why the queue and not a `Task`.** `DispatchQueue.main` is FIFO and an
+    /// unstructured task's ordering is not guaranteed. Digits have to land in
+    /// the order they were pressed, or the entry that submits is not the one the
+    /// user typed — and a wrong entry spends one of the throttled attempts.
+    ///
+    /// **Why `expected` exists.** A key is judged against the entry as it will
+    /// stand once the keys already accepted have been applied, never against the
+    /// binding. Two keys can arrive in one turn, before any of their edits have
+    /// run: judged against the binding, the second one reads an entry the first
+    /// has not reached yet, and a digit followed by a delete leaves the digit.
+    ///
+    /// **Why the applied edit re-checks.** Between accepting a key and applying
+    /// it the entry can be taken away — a stage advancing, an attempt failing,
+    /// both of which clear it. Such a key was typed into an entry that no longer
+    /// exists, and applying it would seed the next one with a digit nobody typed
+    /// there: seven digits into "choose a passcode" would silently start the
+    /// confirmation, and a pasted six would submit it.
+    private func enqueue(_ edit: (String) -> String?) -> KeyPress.Result {
+        let base = keyboard.expected ?? passcode
+        guard !isBusy, let next = edit(base) else { return .handled }
+        keyboard.expected = next
+
+        DispatchQueue.main.async {
+            guard passcode == base else {
+                keyboard.expected = nil
+                return
+            }
+            passcode = next
+            if keyboard.expected == next {
+                keyboard.expected = nil
+            }
+            confirmEntry()
+        }
         return .handled
     }
 
-    /// ⌘V, which the text field this replaced got for free.
+    /// The clipboard, if it is already a passcode. ⌘V, which the text field this
+    /// replaced got for free.
     ///
-    /// The clipboard has to already *be* a passcode — surrounding whitespace is
-    /// forgiven, nothing else is. Sieving the digits out of arbitrary text turns
-    /// "Order 12-34-56 shipped" into a complete entry, and reaching six digits
-    /// submits, so a stray paste would spend one of the throttled attempts on a
-    /// value the user never saw. Over-long is refused rather than truncated for
-    /// the same reason: silently keeping the first six of seven submits
-    /// something nobody typed.
-    private func paste() {
-        guard !isBusy, let pasted = ClipboardManager.pasteFromClipboard() else { return }
+    /// Surrounding whitespace is forgiven, nothing else is. Sieving the digits
+    /// out of arbitrary text turns "Order 12-34-56 shipped" into a complete
+    /// entry, and reaching six digits submits, so a stray paste would spend one
+    /// of the throttled attempts on a value the user never saw. Over-long is
+    /// refused rather than truncated for the same reason: silently keeping the
+    /// first six of seven submits something nobody typed.
+    ///
+    /// Read when ⌘V is pressed rather than when the edit runs, so what lands is
+    /// what was on the clipboard at the moment the user asked for it.
+    private func clipboardPasscode() -> String? {
+        guard let pasted = ClipboardManager.pasteFromClipboard() else { return nil }
 
         let candidate = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !candidate.isEmpty,
               candidate.count <= PasscodeService.passcodeLength,
               candidate.allSatisfy({ $0.isASCII && $0.isNumber }) else {
-            return
+            return nil
         }
 
-        passcode = candidate
-        isKeypadFocused = true
+        return candidate
     }
     #endif
 }

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/PasscodeEntryView.swift
@@ -313,9 +313,19 @@ struct PasscodeEntryView: View {
     /// exists, and applying it would seed the next one with a digit nobody typed
     /// there: seven digits into "choose a passcode" would silently start the
     /// confirmation, and a pasted six would submit it.
+    ///
+    /// **Why a complete entry takes no keys at all.** An entry submits the moment
+    /// it fills, so once it is complete what is waiting on it is a verification
+    /// that reads `entry` when it runs. An edit applied a turn later — a delete,
+    /// a paste — would have that verification check a passcode the user never
+    /// submitted, and spend one of the throttled attempts on it. `isBusy` covers
+    /// the verification itself but is only set once the submitting task has
+    /// started; this covers the gap between the entry filling and that happening.
+    /// It has to be judged on `base` rather than the binding, for the same reason
+    /// everything else here is.
     private func enqueue(_ edit: (String) -> String?) -> KeyPress.Result {
         let base = keyboard.expected ?? passcode
-        guard !isBusy, let next = edit(base) else { return .handled }
+        guard !isBusy, base.count < digitCount, let next = edit(base) else { return .handled }
         keyboard.expected = next
 
         DispatchQueue.main.async {


### PR DESCRIPTION
## Description

Fixes #5102

Typing a digit on the **macOS lock screen** with a hardware keyboard logged:

```
Publishing changes from within view updates is not allowed, this will cause undefined behavior.
```

`PasscodeEntryView.passcode` is a `@Binding` onto `PasscodeViewModel`'s `@Published var entry`. The lock screen is hosted in an `AppLockPanel` over the app rather than in the app's own view hierarchy, and a hardware key reaches `.onKeyPress` there while SwiftUI is mid-update — so editing the entry inline published a change from inside that update.

Hardware keys are now **accepted synchronously and applied one main-queue turn later**, which puts the edit after the update instead of inside it. The on-screen keypad is untouched: a button action is not delivered inside an update, so those edits were always legal, and hopping them would only make a tap land a turn late.

`DispatchQueue.main` rather than a `Task`: the queue is FIFO and an unstructured task's ordering is not. Digits have to land in the order they were pressed — a reordered entry is a wrong entry, and a wrong entry spends one of the throttled attempts.

### Deferring is not free, and the two gaps it opens are handled

Both of these were found by review, not by luck, and each has a concrete repro:

1. **Keys accepted but not yet applied.** A key is judged against the entry as it will stand once those have landed (`keyboard.expected`), never against the binding. Judged against the binding, two keys arriving in one runloop turn would have the second read an entry the first has not reached yet — press a digit then Delete in one turn and you would be left with the digit.

2. **The entry being taken away.** A stage advancing (`advance(to:)`) or an attempt failing (`fail(with:)`) clears `entry`, and `submitForSet()` at the `.new` stage does it with no suspension point at all. So an accepted key can belong to an entry that no longer exists. Applying it would seed the next one with something nobody typed there: type seven digits quickly into "choose a passcode" and the seventh would silently become the first digit of the *confirmation*; a ⌘V landing across the same boundary would fill — possibly submit — it. The applied edit re-checks that the entry is still the one the key was typed into.

3. **A complete entry taking further keys.** An entry submits the moment it fills, so what is waiting on it is a verification that reads `entry` when it runs. A delete or a ⌘V accepted in the gap between the entry filling and the submitting task setting `isBusy` would apply a turn later, mid-verification, and have the service check a passcode the user never submitted — spending one of the throttled attempts on it. A complete entry now takes no keys at all.

Each operation's rule (a digit past the last place does not apply; a delete on an empty entry does not apply) now exists once, as a transform shared by the keyboard and the on-screen keys, so the two cannot drift apart.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

macOS passcode entry only — no chain, keysign, broadcast or fee code is touched.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

**On tests:** none added, and I do not think they are reachable here. The behaviour lives in `handleKeyPress`, which is `private` and takes a `KeyPress` — a type with no public initialiser, so the key path cannot be driven from a unit test. The orderings that matter are runloop-scheduling orderings, which a test would have to fake rather than exercise. Called out rather than papered over.

## Verification

- `swiftlint` — 0 violations.
- **macOS** `xcodebuild build` — `** BUILD SUCCEEDED **`, no warnings on the changed file. This is the build that matters: the changed code is inside `#if os(macOS)` and the iOS build never compiles it.
- **iOS** `make test` — `Executed 5465 tests, with 1 test skipped and 0 failures` / `** TEST SUCCEEDED **`.
- Three rounds of read-only cross-model (Codex) review. Round 1 found the seven-digit cross-reset defect, round 2 found the paste equivalent plus the stale-guard ordering bug; both were fixed rather than argued down. The final whole-branch pass reports no findings.
- CodeRabbit's review then found the third gap above, which is fixed in the follow-up commit; both gates were re-run green after it. Its two proposed remedies were not taken as written, and both threads carry the reasoning: re-reading `isBusy` inside the deferred closure is a no-op, because `isBusy` is a plain stored property of a `View` struct and the escaping closure holds a by-value copy from the render that handled the key press; and replacing the main-queue hop with a serial async/await queue would hand-roll the FIFO guarantee the main queue already gives by contract, which is the one property this change depends on.

**What I could not verify myself:** I could not reproduce the original warning in isolation. I built a standalone macOS SwiftUI harness mirroring this view — `@Published` behind a `@Binding`, `.focusable/.focused/.onKeyPress`, the `entry` `didSet`, the completion `Task`, the error/shake path — with a known-positive control that publishes from inside `body`. The control was correctly detected as running inside the view update (51 `AttributeGraph` frames); the key-press path was not, under both paced and burst typing. So `.onKeyPress` alone does not do it, and the trigger involves the panel hosting that the harness cannot model. The warning itself is an Xcode runtime issue and is not emitted to the console, so it cannot be asserted on from a script.

**Confirmed on a Mac by the author** — the behaviour this fixes is the part a script could not reach, so that run is the verification that the warning is gone.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5102
- **Confidence**: high — gates green, three cross-model review rounds plus CodeRabbit's, and the fix confirmed on a Mac
- **Needs human review for**: the deferral itself, since it changes when passcode input reaches the view model; and the two CodeRabbit remedies declined above, if you disagree with the reasoning
