### PR TITLE
feat(defi): bring the Kamino Earn UI to the design

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -634,8 +634,8 @@
 "kaminoEarnApy30d" = "APY (30 T.)";
 "kaminoEarnCuratedBy" = "Kuratiert von %@";
 "kaminoEarnDeposit" = "Einzahlen";
-"kaminoEarnDeposited" = "Eingezahlt";
-"kaminoEarnPnl" = "Gewinn & Verlust";
+"kaminoEarnDeposited" = "Eingezahlt: %@";
+"kaminoEarnEarned" = "Verdient: %@";
 "kaminoEarnRiskConservative" = "Konservativ";
 "kaminoEarnRiskPrivateCredit" = "Private Credit";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "joinSend" = "Senden beitreten";
 "joinSwap" = "Tausch beitreten";
 "joinTransactionSigning" = "Verbinden Sie die Transaktionsunterzeichnung";
+"kaminoBannerSubtitle" = "Verdiene jetzt mit Kamino";
+"kaminoBannerTitle" = "Neu auf Solana";
 "kaminoDepositMinimum" = "Mindesteinzahlung ist %@ %@.";
 "kaminoDepositMissingCoin" = "Füge %@ auf Solana zu deinem Vault hinzu, bevor du einzahlst.";
 "kaminoDepositTitle" = "Einzahlen";

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -636,6 +636,7 @@
 "kaminoEarnDeposit" = "Einzahlen";
 "kaminoEarnDeposited" = "Eingezahlt: %@";
 "kaminoEarnEarned" = "Verdient: %@";
+"kaminoEarnLost" = "Verlust: %@";
 "kaminoEarnRiskConservative" = "Konservativ";
 "kaminoEarnRiskPrivateCredit" = "Private Credit";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -634,8 +634,8 @@
 "kaminoEarnApy30d" = "APY (30d)";
 "kaminoEarnCuratedBy" = "Curated by %@";
 "kaminoEarnDeposit" = "Deposit";
-"kaminoEarnDeposited" = "Deposited";
-"kaminoEarnPnl" = "Profit & Loss";
+"kaminoEarnDeposited" = "Deposited: %@";
+"kaminoEarnEarned" = "Earned: %@";
 "kaminoEarnRiskConservative" = "Conservative";
 "kaminoEarnRiskPrivateCredit" = "Private Credit";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -636,6 +636,7 @@
 "kaminoEarnDeposit" = "Deposit";
 "kaminoEarnDeposited" = "Deposited: %@";
 "kaminoEarnEarned" = "Earned: %@";
+"kaminoEarnLost" = "Lost: %@";
 "kaminoEarnRiskConservative" = "Conservative";
 "kaminoEarnRiskPrivateCredit" = "Private Credit";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "joinSend" = "Join Send";
 "joinSwap" = "Join Swap";
 "joinTransactionSigning" = "Join transaction signing";
+"kaminoBannerSubtitle" = "Start earning with Kamino";
+"kaminoBannerTitle" = "New on Solana";
 "kaminoDepositMinimum" = "Minimum deposit is %@ %@.";
 "kaminoDepositMissingCoin" = "Add %@ on Solana to your vault before depositing.";
 "kaminoDepositTitle" = "Deposit";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "joinSend" = "Unirse a Enviar";
 "joinSwap" = "Unirse al intercambio";
 "joinTransactionSigning" = "Unir firma de transacciones";
+"kaminoBannerSubtitle" = "Empieza a ganar con Kamino";
+"kaminoBannerTitle" = "Nuevo en Solana";
 "kaminoDepositMinimum" = "El depósito mínimo es %@ %@.";
 "kaminoDepositMissingCoin" = "Añade %@ en Solana a tu vault antes de depositar.";
 "kaminoDepositTitle" = "Depositar";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -634,8 +634,8 @@
 "kaminoEarnApy30d" = "APY (30 d)";
 "kaminoEarnCuratedBy" = "Gestionado por %@";
 "kaminoEarnDeposit" = "Depositar";
-"kaminoEarnDeposited" = "Depositado";
-"kaminoEarnPnl" = "Ganancias y pérdidas";
+"kaminoEarnDeposited" = "Depositado: %@";
+"kaminoEarnEarned" = "Ganado: %@";
 "kaminoEarnRiskConservative" = "Conservador";
 "kaminoEarnRiskPrivateCredit" = "Crédito privado";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -636,6 +636,7 @@
 "kaminoEarnDeposit" = "Depositar";
 "kaminoEarnDeposited" = "Depositado: %@";
 "kaminoEarnEarned" = "Ganado: %@";
+"kaminoEarnLost" = "Perdido: %@";
 "kaminoEarnRiskConservative" = "Conservador";
 "kaminoEarnRiskPrivateCredit" = "Crédito privado";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -636,6 +636,7 @@
 "kaminoEarnDeposit" = "Položi";
 "kaminoEarnDeposited" = "Položeno: %@";
 "kaminoEarnEarned" = "Zarađeno: %@";
+"kaminoEarnLost" = "Izgubljeno: %@";
 "kaminoEarnRiskConservative" = "Konzervativno";
 "kaminoEarnRiskPrivateCredit" = "Privatni kredit";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -634,8 +634,8 @@
 "kaminoEarnApy30d" = "APY (30 d)";
 "kaminoEarnCuratedBy" = "Kurira %@";
 "kaminoEarnDeposit" = "Položi";
-"kaminoEarnDeposited" = "Položeno";
-"kaminoEarnPnl" = "Dobit i gubitak";
+"kaminoEarnDeposited" = "Položeno: %@";
+"kaminoEarnEarned" = "Zarađeno: %@";
 "kaminoEarnRiskConservative" = "Konzervativno";
 "kaminoEarnRiskPrivateCredit" = "Privatni kredit";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "joinSend" = "Pridruži se Slanju";
 "joinSwap" = "Pridruži se Zamjeni";
 "joinTransactionSigning" = "Pridružite se potpisivanju transakcija";
+"kaminoBannerSubtitle" = "Počnite zarađivati uz Kamino";
+"kaminoBannerTitle" = "Novo na Solani";
 "kaminoDepositMinimum" = "Minimalni polog je %@ %@.";
 "kaminoDepositMissingCoin" = "Dodaj %@ na Solani u svoj vault prije polaganja.";
 "kaminoDepositTitle" = "Položi";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -636,6 +636,7 @@
 "kaminoEarnDeposit" = "Deposita";
 "kaminoEarnDeposited" = "Depositato: %@";
 "kaminoEarnEarned" = "Guadagnato: %@";
+"kaminoEarnLost" = "Perso: %@";
 "kaminoEarnRiskConservative" = "Conservativo";
 "kaminoEarnRiskPrivateCredit" = "Credito privato";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "joinSend" = "Unisciti a Invia";
 "joinSwap" = "Partecipa a Swap";
 "joinTransactionSigning" = "Unisciti alla firma delle transazioni";
+"kaminoBannerSubtitle" = "Inizia a guadagnare con Kamino";
+"kaminoBannerTitle" = "Novità su Solana";
 "kaminoDepositMinimum" = "Il deposito minimo è %@ %@.";
 "kaminoDepositMissingCoin" = "Aggiungi %@ su Solana al tuo vault prima di depositare.";
 "kaminoDepositTitle" = "Deposita";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -634,8 +634,8 @@
 "kaminoEarnApy30d" = "APY (30 gg)";
 "kaminoEarnCuratedBy" = "Gestito da %@";
 "kaminoEarnDeposit" = "Deposita";
-"kaminoEarnDeposited" = "Depositato";
-"kaminoEarnPnl" = "Profitti e perdite";
+"kaminoEarnDeposited" = "Depositato: %@";
+"kaminoEarnEarned" = "Guadagnato: %@";
 "kaminoEarnRiskConservative" = "Conservativo";
 "kaminoEarnRiskPrivateCredit" = "Credito privato";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "joinSend" = "전송 참여";
 "joinSwap" = "스왑 참여";
 "joinTransactionSigning" = "트랜잭션 서명 참여";
+"kaminoBannerSubtitle" = "Kamino로 수익을 시작하세요";
+"kaminoBannerTitle" = "솔라나 신규";
 "kaminoDepositMinimum" = "최소 예치 금액은 %@ %@입니다.";
 "kaminoDepositMissingCoin" = "예치하기 전에 Solana의 %@을(를) 볼트에 추가하세요.";
 "kaminoDepositTitle" = "예치";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -634,8 +634,8 @@
 "kaminoEarnApy30d" = "APY (30일)";
 "kaminoEarnCuratedBy" = "%@ 운영";
 "kaminoEarnDeposit" = "예치";
-"kaminoEarnDeposited" = "예치됨";
-"kaminoEarnPnl" = "손익";
+"kaminoEarnDeposited" = "예치됨: %@";
+"kaminoEarnEarned" = "수익: %@";
 "kaminoEarnRiskConservative" = "보수적";
 "kaminoEarnRiskPrivateCredit" = "사모 대출";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -636,6 +636,7 @@
 "kaminoEarnDeposit" = "예치";
 "kaminoEarnDeposited" = "예치됨: %@";
 "kaminoEarnEarned" = "수익: %@";
+"kaminoEarnLost" = "손실: %@";
 "kaminoEarnRiskConservative" = "보수적";
 "kaminoEarnRiskPrivateCredit" = "사모 대출";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -634,8 +634,8 @@
 "kaminoEarnApy30d" = "APY (30 d)";
 "kaminoEarnCuratedBy" = "Gerido por %@";
 "kaminoEarnDeposit" = "Depositar";
-"kaminoEarnDeposited" = "Depositado";
-"kaminoEarnPnl" = "Lucros e perdas";
+"kaminoEarnDeposited" = "Depositado: %@";
+"kaminoEarnEarned" = "Ganho: %@";
 "kaminoEarnRiskConservative" = "Conservador";
 "kaminoEarnRiskPrivateCredit" = "Crédito privado";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -636,6 +636,7 @@
 "kaminoEarnDeposit" = "Depositar";
 "kaminoEarnDeposited" = "Depositado: %@";
 "kaminoEarnEarned" = "Ganho: %@";
+"kaminoEarnLost" = "Perdido: %@";
 "kaminoEarnRiskConservative" = "Conservador";
 "kaminoEarnRiskPrivateCredit" = "Crédito privado";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "joinSend" = "Juntar-se ao Envio";
 "joinSwap" = "Participar da troca";
 "joinTransactionSigning" = "Junte -se à assinatura da transação";
+"kaminoBannerSubtitle" = "Comece a ganhar com a Kamino";
+"kaminoBannerTitle" = "Novo na Solana";
 "kaminoDepositMinimum" = "O depósito mínimo é %@ %@.";
 "kaminoDepositMissingCoin" = "Adicione %@ na Solana ao seu vault antes de depositar.";
 "kaminoDepositTitle" = "Depositar";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -636,6 +636,7 @@
 "kaminoEarnDeposit" = "存入";
 "kaminoEarnDeposited" = "已存入：%@";
 "kaminoEarnEarned" = "已赚取：%@";
+"kaminoEarnLost" = "已亏损：%@";
 "kaminoEarnRiskConservative" = "保守型";
 "kaminoEarnRiskPrivateCredit" = "私募信贷";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -634,8 +634,8 @@
 "kaminoEarnApy30d" = "年化收益率（30天）";
 "kaminoEarnCuratedBy" = "由 %@ 管理";
 "kaminoEarnDeposit" = "存入";
-"kaminoEarnDeposited" = "已存入";
-"kaminoEarnPnl" = "盈亏";
+"kaminoEarnDeposited" = "已存入：%@";
+"kaminoEarnEarned" = "已赚取：%@";
 "kaminoEarnRiskConservative" = "保守型";
 "kaminoEarnRiskPrivateCredit" = "私募信贷";
 "kaminoEarnTitle" = "Kamino Earn";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -627,6 +627,8 @@
 "joinSend" = "加入发送";
 "joinSwap" = "加入交换";
 "joinTransactionSigning" = "加入交易签名";
+"kaminoBannerSubtitle" = "通过 Kamino 开始赚取收益";
+"kaminoBannerTitle" = "Solana 新功能";
 "kaminoDepositMinimum" = "最低存入金额为 %@ %@。";
 "kaminoDepositMissingCoin" = "存入前请先将 Solana 上的 %@ 添加到你的保险库。";
 "kaminoDepositTitle" = "存入";

--- a/VultisigApp/VultisigApp/Core/Stores/PromoBannerDismissalStore.swift
+++ b/VultisigApp/VultisigApp/Core/Stores/PromoBannerDismissalStore.swift
@@ -85,6 +85,10 @@ final class PromoBannerDismissalStore: PromoBannerDismissalStoring, @unchecked S
                 legacySources = legacyVaultBanners
             case .backupVault:
                 continue
+            case .kaminoEarn:
+                // Newer than the legacy stores, so it has nothing to carry
+                // over: a user who never saw it has never dismissed it.
+                continue
             }
             guard legacySources.contains(banner.rawValue) else { continue }
             seedDismissedIfAbsent(banner, now: now)

--- a/VultisigApp/VultisigApp/Features/Common/Views/Banners/BannersCarousel.swift
+++ b/VultisigApp/VultisigApp/Features/Common/Views/Banners/BannersCarousel.swift
@@ -103,6 +103,14 @@ struct BannersCarousel<Banner: CarouselBannerType>: View {
         }
         .onChange(of: internalBanners) { _, newValue in
             updateBannersCount(newValue.count)
+            // The array can shrink from outside — a promo the user has just
+            // satisfied stops being eligible — and that can drop the page they
+            // are on. Both indices are pulled back inside the new bounds; the
+            // timer cannot do it, because it declines to advance at all once
+            // one banner is left.
+            let clamped = BannersCarouselIndex.clamped(currentIndex, count: newValue.count)
+            if currentIndex != clamped { currentIndex = clamped }
+            if scrollPosition != clamped { scrollPosition = clamped }
         }
         .onAppear {
             startTimer()
@@ -249,6 +257,20 @@ enum BannersCarouselIndex {
 
         // Removing a banner after the current one leaves the index unchanged.
         return currentIndex
+    }
+
+    /// Index that stays valid when the banner array is replaced from OUTSIDE
+    /// the carousel — a promo becoming ineligible while the user is looking at
+    /// it, rather than them closing it.
+    ///
+    /// `afterRemoval` cannot answer this: it needs the position that went away,
+    /// and an external replacement only says what is left. So the index is
+    /// clamped instead. Without it, dropping the page the carousel is currently
+    /// on leaves `currentIndex` past the end — and `next(after:count:)` no-ops
+    /// at one banner, so the auto-advance never corrects it either.
+    static func clamped(_ current: Int, count: Int) -> Int {
+        guard count > 0 else { return 0 }
+        return min(max(current, 0), count - 1)
     }
 }
 

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Earn/KaminoEarnView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Earn/KaminoEarnView.swift
@@ -76,25 +76,31 @@ struct KaminoEarnView<EmptyState: View>: View {
         .overlay(cardBorder)
     }
 
+    /// Two states, as the design draws them: a vault the user holds nothing in
+    /// is its identity, its rate and one full-width Deposit — there is no
+    /// position to describe, and rows of zeros describe nothing. A vault they
+    /// hold something in gains the deposited and earned figures, and the
+    /// separator that sets its two actions apart.
     @ViewBuilder
     private func vaultCard(for row: KaminoEarnRow) -> some View {
         VStack(spacing: 14) {
             vaultIdentityRow(for: row)
-            Separator(color: Theme.colors.borderLight, opacity: 1)
-            depositedRow(for: row)
-            // Kept on screen while the value is still being fetched, rather than
-            // appearing once it lands. A row that pops into existence reads as a
-            // layout jump; a labelled row with a shimmering value says which
-            // figure the screen is waiting on. Both are genuinely absent until
-            // the API answers — unlike the deposited amount, whose zero is a
-            // real value, so nothing there is placeheld.
+            if row.hasPosition {
+                depositedRow(for: row)
+                // Kept on screen while the value is still being fetched, rather
+                // than appearing once it lands. A row that pops into existence
+                // reads as a layout jump; a labelled row with a shimmering value
+                // says which figure the screen is waiting on.
+                if row.pnlToken != nil || viewModel.isLoading {
+                    earnedRow(for: row)
+                }
+            }
             if row.apy30d != nil || viewModel.isLoading {
                 apyRow(for: row)
             }
-            if row.pnlToken != nil || viewModel.isLoading {
-                pnlRow(for: row)
+            if row.hasPosition {
+                Separator(color: Theme.colors.borderLight, opacity: 1)
             }
-            Separator(color: Theme.colors.borderLight, opacity: 1)
             actionRow(for: row)
         }
         .padding(16)
@@ -102,20 +108,27 @@ struct KaminoEarnView<EmptyState: View>: View {
         .overlay(cardBorder)
     }
 
-    /// The withdraw button appears only once the vault holds something. Whether
-    /// that position can actually be withdrawn is the withdraw form's answer —
-    /// it depends on whether the shares are staked in the vault's farm, which
-    /// this row does not know and must not guess.
+    /// The withdraw button appears only once the vault holds something, and
+    /// deposit takes the whole width until it does — there is nothing to put
+    /// beside it, and a half-width button next to empty space reads as a missing
+    /// control rather than an absent one.
+    ///
+    /// Whether the position can actually be withdrawn is the withdraw form's
+    /// answer — it depends on whether the shares are staked in the vault's farm,
+    /// which this row does not know and must not guess.
     @ViewBuilder
     private func actionRow(for row: KaminoEarnRow) -> some View {
-        HStack(spacing: 12) {
-            PrimaryButton(title: "kaminoEarnDeposit".localized, size: .smallFixed) {
-                onDeposit(row.descriptor)
-            }
-            if row.tokenAmount > 0 {
+        // `.smallFixed` has no horizontal padding of its own, so each button
+        // takes an equal share of the row: two side by side when there is a
+        // position, one across the full width when there is not.
+        HStack(spacing: 16) {
+            if row.hasPosition {
                 PrimaryButton(title: "kaminoEarnWithdraw".localized, type: .secondary, size: .smallFixed) {
                     onWithdraw(row.descriptor)
                 }
+            }
+            PrimaryButton(title: "kaminoEarnDeposit".localized, size: .smallFixed) {
+                onDeposit(row.descriptor)
             }
         }
     }
@@ -159,22 +172,16 @@ struct KaminoEarnView<EmptyState: View>: View {
         }
     }
 
+    /// The amount rides INSIDE the label and the fiat sits opposite it, which is
+    /// how the design draws both figure rows — and it is what lets the deposited
+    /// and earned lines read as a pair rather than as two stacked columns.
     @ViewBuilder
     private func depositedRow(for row: KaminoEarnRow) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text("kaminoEarnDeposited".localized)
-                .font(Theme.fonts.bodySMedium)
-                .foregroundStyle(Theme.colors.textTertiary)
-            Spacer()
-            VStack(alignment: .trailing, spacing: 2) {
-                HiddenBalanceText("\(formatAmount(row.tokenAmount)) \(row.coin?.ticker ?? "")")
-                    .font(Theme.fonts.priceBodyL)
-                    .foregroundStyle(Theme.colors.textPrimary)
-                HiddenBalanceText(fiatString(for: row))
-                    .font(Theme.fonts.priceBodyS)
-                    .foregroundStyle(Theme.colors.textTertiary)
-            }
-        }
+        figureRow(
+            label: String(format: "kaminoEarnDeposited".localized, tokenString(row.tokenAmount, in: row)),
+            fiat: fiatString(fiatValue(for: row)),
+            valueColor: Theme.colors.textPrimary
+        )
     }
 
     @ViewBuilder
@@ -206,20 +213,45 @@ struct KaminoEarnView<EmptyState: View>: View {
             .accessibilityHidden(true)
     }
 
+    /// What the position has made, in the underlying token and in fiat.
+    ///
+    /// The figure is the vault's lifetime profit and loss — on a lending vault
+    /// that is the interest it has accrued, which is what "earned" means here.
+    /// It is still SIGNED: a vault that has lost value says so in red rather
+    /// than reporting a loss as something earned.
     @ViewBuilder
-    private func pnlRow(for row: KaminoEarnRow) -> some View {
-        HStack(spacing: 4) {
-            Text("kaminoEarnPnl".localized)
-                .font(Theme.fonts.bodySMedium)
-                .foregroundStyle(Theme.colors.textTertiary)
-            Spacer()
-            if let pnl = row.pnlToken {
-                HiddenBalanceText("\(formatAmount(pnl)) \(row.coin?.ticker ?? "")")
-                    .font(Theme.fonts.priceBodyS)
-                    .foregroundStyle(pnlColor(pnl))
-            } else {
-                valuePlaceholder(width: 72)
+    private func earnedRow(for row: KaminoEarnRow) -> some View {
+        if let pnl = row.pnlToken {
+            figureRow(
+                label: String(format: "kaminoEarnEarned".localized, tokenString(pnl, in: row)),
+                fiat: fiatString(fiatValue(pnl, in: row)),
+                valueColor: pnlColor(pnl)
+            )
+        } else {
+            HStack(alignment: .firstTextBaseline) {
+                valuePlaceholder(width: 120)
+                Spacer()
+                valuePlaceholder(width: 64)
             }
+        }
+    }
+
+    /// One labelled figure with its fiat value opposite. The label carries the
+    /// token amount, so it is hidden along with the value when balances are
+    /// hidden — a row reading "Earned: 200 USDC" beside a masked fiat figure
+    /// would defeat the point of hiding it.
+    @ViewBuilder
+    private func figureRow(label: String, fiat: String, valueColor: Color) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            HiddenBalanceText(label)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(valueColor)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            HiddenBalanceText(fiat)
+                .font(Theme.fonts.priceBodyS)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .lineLimit(1)
         }
     }
 
@@ -236,12 +268,22 @@ struct KaminoEarnView<EmptyState: View>: View {
     }
 
     private func fiatValue(for row: KaminoEarnRow) -> Decimal {
-        guard let coin = row.coin else { return .zero }
-        return RateProvider.shared.fiatBalance(value: row.tokenAmount, coin: coin)
+        fiatValue(row.tokenAmount, in: row)
     }
 
-    private func fiatString(for row: KaminoEarnRow) -> String {
-        fiatValue(for: row).formatToFiat(includeCurrencySymbol: true)
+    /// Any token amount of this row's asset, in fiat. Used for the deposit and
+    /// for what it has earned, which are the same asset at the same rate.
+    private func fiatValue(_ amount: Decimal, in row: KaminoEarnRow) -> Decimal {
+        guard let coin = row.coin else { return .zero }
+        return RateProvider.shared.fiatBalance(value: amount, coin: coin)
+    }
+
+    private func fiatString(_ value: Decimal) -> String {
+        value.formatToFiat(includeCurrencySymbol: true)
+    }
+
+    private func tokenString(_ amount: Decimal, in row: KaminoEarnRow) -> String {
+        "\(formatAmount(amount)) \(row.coin?.ticker ?? "")"
     }
 
     /// Green means the position made money, red means it lost some. Exactly zero

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Earn/KaminoEarnView.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/View/Earn/KaminoEarnView.swift
@@ -108,9 +108,10 @@ struct KaminoEarnView<EmptyState: View>: View {
         .overlay(cardBorder)
     }
 
-    /// The withdraw button appears only once the vault holds something, and
-    /// deposit takes the whole width until it does — there is nothing to put
-    /// beside it, and a half-width button next to empty space reads as a missing
+    /// The withdraw button appears once the vault is known to hold something —
+    /// or while that is still unknown, because a position must never be made
+    /// unreachable by a read that failed. Deposit takes the whole width when it
+    /// is alone: a half-width button beside empty space reads as a missing
     /// control rather than an absent one.
     ///
     /// Whether the position can actually be withdrawn is the withdraw form's
@@ -122,7 +123,7 @@ struct KaminoEarnView<EmptyState: View>: View {
         // takes an equal share of the row: two side by side when there is a
         // position, one across the full width when there is not.
         HStack(spacing: 16) {
-            if row.hasPosition {
+            if row.offersWithdraw {
                 PrimaryButton(title: "kaminoEarnWithdraw".localized, type: .secondary, size: .smallFixed) {
                     onWithdraw(row.descriptor)
                 }
@@ -216,15 +217,19 @@ struct KaminoEarnView<EmptyState: View>: View {
     /// What the position has made, in the underlying token and in fiat.
     ///
     /// The figure is the vault's lifetime profit and loss — on a lending vault
-    /// that is the interest it has accrued, which is what "earned" means here.
-    /// It is still SIGNED: a vault that has lost value says so in red rather
-    /// than reporting a loss as something earned.
+    /// that is the interest it has accrued, which is what "earned" means. A
+    /// NEGATIVE one is not, so it changes the label rather than only the colour:
+    /// "Earned: -3 USDC" in red still asserts the loss was earned, and the
+    /// figure is rendered unsigned beside a label that names it.
     @ViewBuilder
     private func earnedRow(for row: KaminoEarnRow) -> some View {
         if let pnl = row.pnlToken {
             figureRow(
-                label: String(format: "kaminoEarnEarned".localized, tokenString(pnl, in: row)),
-                fiat: fiatString(fiatValue(pnl, in: row)),
+                label: String(
+                    format: (pnl < 0 ? "kaminoEarnLost" : "kaminoEarnEarned").localized,
+                    tokenString(abs(pnl), in: row)
+                ),
+                fiat: fiatString(abs(fiatValue(pnl, in: row))),
                 valueColor: pnlColor(pnl)
             )
         } else {

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
@@ -197,10 +197,15 @@ final class DefiChainMainViewModel: ObservableObject {
             // TON nominator-pool staking only — no bond / LP segments.
             [.stake]
         case .solana:
-            // Native (Stake program) staking plus the Kamino Earn yield vaults —
-            // routed to `SolanaStakeDefiView` and `KaminoEarnView` respectively
-            // (see `DefiChainMainScreen`).
-            [.stake, .earn]
+            // Kamino Earn yield vaults first, then native (Stake program)
+            // staking — routed to `KaminoEarnView` and `SolanaStakeDefiView`
+            // respectively (see `DefiChainMainScreen`).
+            //
+            // Earn leads, which also makes it the segment the screen opens on:
+            // `onLoad` selects the first type. That is what the design asks for,
+            // and the order here is presentational only — the picker files a
+            // selection by `selectionIndex`, which Earn does not have at all.
+            [.earn, .stake]
         default:
             []
         }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/DefiChainMainViewModel.swift
@@ -95,12 +95,12 @@ final class DefiChainMainViewModel: ObservableObject {
     /// the pool fetch left the picker rendering its "no positions" empty state
     /// for the duration of the request, with nothing to enable.
     ///
-    /// The first three sections are always present and always in this order: the
-    /// picker maps a tapped cell back to a selection bucket by section type, and
-    /// the persisted `DefiPositions` record has one field per type. Earn is
-    /// appended only on the chain that has yield vaults, and is deliberately
-    /// last — it has no `DefiPositions` bucket at all (its enablement lives on
-    /// `KaminoPosition`), so it can neither shift nor claim one of the three.
+    /// Section ORDER here is presentational, and only that. The picker maps a
+    /// tapped cell back to a selection bucket through `selectionIndex`, which
+    /// each position type carries itself, so a section can move without filing a
+    /// selection under the wrong type — the reason that index exists rather than
+    /// being derived from this array. Earn appears only on a chain with yield
+    /// vaults, and leads there to match the segment order on the chain screen.
     func setupSelectablePositions() {
         let supportsLiquidityPools = positionsService.supportsLiquidityPools(for: chain)
         var sections: [AssetSection<DefiChainPositionType, DefiSelectableAsset>] = [
@@ -126,12 +126,21 @@ final class DefiChainMainViewModel: ObservableObject {
 
         let earnVaults = positionsService.earnVaults(for: chain)
         if !earnVaults.isEmpty {
-            sections.append(
+            // FIRST, matching the segment order on the chain screen — the two
+            // lists describe the same thing and disagreeing about which comes
+            // first is how a user hunts for a section they were just looking at.
+            //
+            // Safe to put anywhere: the picker maps a tapped cell to a bucket
+            // through `selectionIndex`, which each type carries itself, and Earn
+            // has none — its selection is a set of vault addresses kept beside
+            // the coin buckets. Nothing here is addressed by array position.
+            sections.insert(
                 AssetSection(
                     title: DefiChainPositionType.earn.sectionTitle,
                     type: .earn,
                     assets: earnVaults.map { .kaminoVault($0) }
-                )
+                ),
+                at: 0
             )
         }
         availablePositions = sections

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/KaminoEarnViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/KaminoEarnViewModel.swift
@@ -87,7 +87,11 @@ final class KaminoEarnViewModel: ObservableObject {
                 name: descriptor.fallbackName,
                 tokenAmount: position.tokenAmountDecimal,
                 apy30d: position.apy30d,
-                pnlToken: position.pnlToken
+                pnlToken: position.pnlToken,
+                // The store cannot tell a balance that was read from the zero
+                // that enabling a vault writes, so a seeded row never claims to
+                // be a confirmed one.
+                isPositionConfirmed: false
             )
         }
     }
@@ -222,7 +226,8 @@ final class KaminoEarnViewModel: ObservableObject {
                     name: info.name,
                     tokenAmount: tokenAmount.decimalValue,
                     apy30d: info.apy30d,
-                    pnlToken: pnlToken
+                    pnlToken: pnlToken,
+                    isPositionConfirmed: true
                 )
             )
             snapshots.append(
@@ -345,6 +350,19 @@ struct KaminoEarnRow: Identifiable, Equatable {
     /// it offers the rate and a deposit and says nothing about figures it would
     /// only be reporting as zeros.
     var hasPosition: Bool { tokenAmount > 0 }
+
+    /// Whether a successful read produced these figures, as opposed to the zero
+    /// placeholder enabling a vault writes.
+    ///
+    /// The two are not the same claim and only one of them is "holds nothing".
+    /// A user who deposited on another device, or whose refresh failed straight
+    /// after depositing, has a real position sitting behind an unconfirmed zero
+    /// — so the WAY OUT of it may not be hidden on the strength of that zero.
+    /// The figures stay off the card either way, because a zero is all there is
+    /// to show; the withdraw form reads the position itself and is the thing
+    /// that can say "nothing to withdraw" truthfully.
+    var isPositionConfirmed: Bool
+    var offersWithdraw: Bool { hasPosition || !isPositionConfirmed }
 
     var curator: String { descriptor.curator }
     var riskTier: KaminoRiskTier { descriptor.riskTier }

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/KaminoEarnViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/ViewModel/KaminoEarnViewModel.swift
@@ -340,6 +340,12 @@ struct KaminoEarnRow: Identifiable, Equatable {
     /// Lifetime profit and loss in the underlying token, or `nil` to hide the row.
     let pnlToken: Decimal?
 
+    /// Whether the user holds anything in this vault. What the card shows turns
+    /// on it: an enabled vault with no deposit has no position to describe, so
+    /// it offers the rate and a deposit and says nothing about figures it would
+    /// only be reporting as zeros.
+    var hasPosition: Bool { tokenAmount > 0 }
+
     var curator: String { descriptor.curator }
     var riskTier: KaminoRiskTier { descriptor.riskTier }
     /// The wallet coin the amount is denominated in — its ticker, logo and rate.

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 enum VaultBannerType: String, CarouselBannerType, CaseIterable {
-    case upgradeVault, backupVault, buyVult, followVultisig
+    case upgradeVault, backupVault, buyVult, followVultisig, kaminoEarn
 
     var id: String {
         rawValue
@@ -28,6 +28,8 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
             return "buy_vult_swap"
         case .followVultisig:
             return "follow_x_vultisig"
+        case .kaminoEarn:
+            return "kamino_earn_solana"
         }
     }
 
@@ -41,7 +43,7 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
             return .ttl(.days(7))
         case .backupVault:
             return .session
-        case .upgradeVault, .followVultisig:
+        case .upgradeVault, .followVultisig, .kaminoEarn:
             return .ttl(.days(15))
         }
     }
@@ -56,6 +58,8 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
             "buyVultBannerTitle".localized
         case .followVultisig:
             "followVultisigBannerTitle".localized
+        case .kaminoEarn:
+            "kaminoBannerTitle".localized
         }
     }
     var subtitle: String {
@@ -68,6 +72,8 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
             "buyVultBannerSubtitle".localized
         case .followVultisig:
             "followVultisigBannerSubtitle".localized
+        case .kaminoEarn:
+            "kaminoBannerSubtitle".localized
         }
     }
 
@@ -81,12 +87,14 @@ enum VaultBannerType: String, CarouselBannerType, CaseIterable {
             .logoOutline
         case .followVultisig:
             .iconX
+        case .kaminoEarn:
+            .circleDollar
         }
     }
 
     var iconColor: Color {
         switch self {
-        case .upgradeVault:
+        case .upgradeVault, .kaminoEarn:
             Theme.colors.alertInfo
         case .backupVault, .buyVult, .followVultisig:
             Theme.colors.textPrimary

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/Model/VaultBannerType.swift
@@ -9,7 +9,12 @@ import Foundation
 import SwiftUI
 
 enum VaultBannerType: String, CarouselBannerType, CaseIterable {
-    case upgradeVault, backupVault, buyVult, followVultisig, kaminoEarn
+    /// Declaration order is the carousel's order: `setupBanners` filters
+    /// `allCases` and keeps this sequence, so `kaminoEarn` leading is what puts
+    /// it on the first page. Nothing else depends on it — `rawValue` is the case
+    /// name and `dismissalID` is spelled out separately, so moving a case can
+    /// neither rename a banner nor invalidate a stored dismissal.
+    case kaminoEarn, upgradeVault, backupVault, buyVult, followVultisig
 
     var id: String {
         rawValue

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -109,13 +109,6 @@ struct VaultMainScreen: View {
                     )
                 }
                 .throttledOnAppear(interval: 15.0, action: refresh)
-                // Banner eligibility otherwise only moves on `refresh`, which
-                // is throttled to 15s — so tapping the Kamino promo, enabling a
-                // vault and coming straight back would leave the promo on
-                // screen advertising something the user had just done.
-                .onReceive(NotificationCenter.default.publisher(for: .defiPositionsDidChange)) { _ in
-                    viewModel.setupBanners(for: vault)
-                }
                 .refreshable { refresh() }
                 .onChange(of: settingsViewModel.selectedCurrency) {
                     refresh()

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -109,6 +109,13 @@ struct VaultMainScreen: View {
                     )
                 }
                 .throttledOnAppear(interval: 15.0, action: refresh)
+                // Banner eligibility otherwise only moves on `refresh`, which
+                // is throttled to 15s — so tapping the Kamino promo, enabling a
+                // vault and coming straight back would leave the promo on
+                // screen advertising something the user had just done.
+                .onReceive(NotificationCenter.default.publisher(for: .defiPositionsDidChange)) { _ in
+                    viewModel.setupBanners(for: vault)
+                }
                 .refreshable { refresh() }
                 .onChange(of: settingsViewModel.selectedCurrency) {
                     refresh()

--- a/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/VaultMain/VaultMainScreen.swift
@@ -333,6 +333,11 @@ struct VaultMainScreen: View {
             openSwapToVult()
         case .followVultisig:
             openURL(StaticURL.XVultisigURL)
+        case .kaminoEarn:
+            // Straight to Solana's DeFi screen, which opens on Earn — that is
+            // the first segment there, so the banner lands on the vaults it
+            // advertises rather than one tab away from them.
+            router.navigate(to: VaultRoute.defiChain(chain: .solana, vault: vault))
         }
     }
 

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -288,6 +288,14 @@ struct VaultDetailLogic {
                     return !vault.isBackedUp
                 case .upgradeVault:
                     return vault.libType == .GG20
+                case .kaminoEarn:
+                    // Two conditions, and the second is what stops it being an
+                    // advertisement: the vault has to be able to reach Solana
+                    // at all — the banner opens the Solana DeFi screen — and
+                    // the user has to not already be earning, since a promo for
+                    // something you are doing is just noise on your own screen.
+                    return vault.nativeCoin(for: .solana) != nil
+                        && !vault.kaminoPositions.contains(where: \.isEnabled)
                 case .buyVult, .followVultisig:
                     return true
                 }

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -294,7 +294,15 @@ struct VaultDetailLogic {
                     // at all — the banner opens the Solana DeFi screen — and
                     // the user has to not already be earning, since a promo for
                     // something you are doing is just noise on your own screen.
+                    //
+                    // "Already earning" is read from BOTH records because they
+                    // arrive at different times. `enabledKaminoVaults` is what a
+                    // backup encodes and what an import restores; the position
+                    // rows are materialised later, on the first visit to the
+                    // DeFi screen. Reading only the rows would promote the
+                    // feature to a restored user who had already turned it on.
                     return vault.nativeCoin(for: .solana) != nil
+                        && vault.enabledKaminoVaults.isEmpty
                         && !vault.kaminoPositions.contains(where: \.isEnabled)
                 case .buyVult, .followVultisig:
                     return true

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/VaultDetailViewModel.swift
@@ -289,21 +289,15 @@ struct VaultDetailLogic {
                 case .upgradeVault:
                     return vault.libType == .GG20
                 case .kaminoEarn:
-                    // Two conditions, and the second is what stops it being an
-                    // advertisement: the vault has to be able to reach Solana
-                    // at all — the banner opens the Solana DeFi screen — and
-                    // the user has to not already be earning, since a promo for
-                    // something you are doing is just noise on your own screen.
+                    // Solana only, because the banner opens the Solana DeFi
+                    // screen and there would be nowhere for it to go otherwise.
                     //
-                    // "Already earning" is read from BOTH records because they
-                    // arrive at different times. `enabledKaminoVaults` is what a
-                    // backup encodes and what an import restores; the position
-                    // rows are materialised later, on the first visit to the
-                    // DeFi screen. Reading only the rows would promote the
-                    // feature to a restored user who had already turned it on.
+                    // Deliberately NOT gated on whether the user already has a
+                    // position: someone earning in one vault is a good audience
+                    // for the other two, and the banner is a route into the
+                    // segment rather than a one-time announcement. Dismissal is
+                    // what makes it go away, for the usual fifteen days.
                     return vault.nativeCoin(for: .solana) != nil
-                        && vault.enabledKaminoVaults.isEmpty
-                        && !vault.kaminoPositions.contains(where: \.isEnabled)
                 case .buyVult, .followVultisig:
                     return true
                 }

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainMainViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainMainViewModelTests.swift
@@ -248,10 +248,17 @@ final class DefiChainMainViewModelTests: XCTestCase {
 
     // MARK: - Earn section
 
-    func testSolanaOffersStakeAndEarnSegments() {
+    /// Earn leads on Solana, which is also what makes it the segment the screen
+    /// opens on — `onLoad` selects the first type. Both halves are asserted
+    /// because the second is the one a reader would not expect from the first.
+    func testSolanaOffersEarnFirstThenStake() {
         let vm = makeViewModel(chain: .solana)
 
-        XCTAssertEqual(vm.getDefiPositionTypes(), [.stake, .earn])
+        XCTAssertEqual(vm.getDefiPositionTypes(), [.earn, .stake])
+
+        vm.onLoad()
+        XCTAssertEqual(vm.selectedPosition, .earn)
+        XCTAssertEqual(vm.positions.map(\.value), [.earn, .stake])
     }
 
     func testEarnSectionIsAppendedLastAndNeverDisturbsTheCoinBuckets() {

--- a/VultisigApp/VultisigAppTests/Defi/DefiChainMainViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/DefiChainMainViewModelTests.swift
@@ -261,7 +261,7 @@ final class DefiChainMainViewModelTests: XCTestCase {
         XCTAssertEqual(vm.positions.map(\.value), [.earn, .stake])
     }
 
-    func testEarnSectionIsAppendedLastAndNeverDisturbsTheCoinBuckets() {
+    func testEarnSectionLeadsAndNeverDisturbsTheCoinBuckets() {
         service.supportsLPs = false
         service.earnStub = KaminoVaultRegistry.allowList
         let vm = makeViewModel(chain: .solana)
@@ -270,9 +270,15 @@ final class DefiChainMainViewModelTests: XCTestCase {
 
         XCTAssertEqual(
             vm.availablePositions.map(\.type),
-            [.bond, .stake, .liquidityPool, .earn],
-            "Earn is appended after the three DefiPositions buckets, whose order the picker depends on."
+            [.earn, .bond, .stake, .liquidityPool],
+            "Earn leads the picker, matching the segment order on the chain screen."
         )
+        // The buckets keep their own indices whatever the section order is —
+        // that decoupling is what makes reordering safe, so it is asserted here
+        // rather than assumed.
+        XCTAssertEqual(DefiChainPositionType.bond.selectionIndex, 0)
+        XCTAssertEqual(DefiChainPositionType.stake.selectionIndex, 1)
+        XCTAssertEqual(DefiChainPositionType.liquidityPool.selectionIndex, 2)
         XCTAssertEqual(
             section(.earn, in: vm)?.assets,
             KaminoVaultRegistry.allowList.map { .kaminoVault($0) }

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoEarnViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoEarnViewModelTests.swift
@@ -333,6 +333,44 @@ final class KaminoEarnViewModelTests: XCTestCase {
         )
     }
 
+    // MARK: - What the card is allowed to conclude from a zero
+
+    /// Enabling a vault writes a zero placeholder, and a zero that was never
+    /// read is not the same claim as a zero that was. A user who deposited on
+    /// another device — or whose refresh failed right after depositing — has a
+    /// real position sitting behind that placeholder, and the way OUT of it may
+    /// not be hidden on the strength of it.
+    func testAnUnreadPositionStillOffersWithdraw() async throws {
+        try storage.setEnabled(true, descriptor: steakhouse, for: vault)
+        let viewModel = makeViewModel()
+
+        let seeded = try XCTUnwrap(viewModel.rows.first)
+        XCTAssertFalse(seeded.hasPosition, "The placeholder holds nothing to show.")
+        XCTAssertFalse(seeded.isPositionConfirmed)
+        XCTAssertTrue(seeded.offersWithdraw, "An unread zero must not take away the exit.")
+
+        // A confirmed empty response is the other claim, and it is allowed to.
+        service.positions = []
+        await viewModel.refresh(owner: owner)
+
+        let confirmed = try XCTUnwrap(viewModel.rows.first)
+        XCTAssertTrue(confirmed.isPositionConfirmed)
+        XCTAssertFalse(confirmed.offersWithdraw, "A vault read as empty offers nothing to withdraw.")
+    }
+
+    func testARefreshedPositionIsConfirmedAndOffersWithdraw() async throws {
+        try storage.setEnabled(true, descriptor: steakhouse, for: vault)
+        service.positions = [KaminoFixtures.position(vault: steakhouse.address, shares: "1000")]
+        let viewModel = makeViewModel()
+
+        await viewModel.refresh(owner: owner)
+
+        let row = try XCTUnwrap(viewModel.rows.first)
+        XCTAssertTrue(row.hasPosition)
+        XCTAssertTrue(row.isPositionConfirmed)
+        XCTAssertTrue(row.offersWithdraw)
+    }
+
     // MARK: - Rates
 
     /// Fiat is read from `RateProvider`'s cache, which is populated from the

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
@@ -436,6 +436,20 @@ final class KaminoTransactionValidatorTests: XCTestCase {
 
     // MARK: - Attribution memo
 
+    /// The tag and the program are an INTERFACE, not an implementation detail:
+    /// Kamino's own attribution and the public Dune queries filter on these
+    /// exact bytes, and iOS, Android and Windows all have to write the same
+    /// ones. Pinned as literals because everything else in the suite — the
+    /// fixtures, the injector, the validator, the decoder — derives from the
+    /// constants. If `memoTag` drifted to another valid two-byte string, every
+    /// one of those would still agree with itself, the live simulation would
+    /// still pass, and the attribution would silently stop matching anything.
+    func testTheAttributionTagAndProgramArePinnedToTheirLiterals() {
+        XCTAssertEqual(KaminoAttribution.memoTag, "vs")
+        XCTAssertEqual(KaminoAttribution.memoTagBytes, [0x76, 0x73])
+        XCTAssertEqual(SolanaV0Transaction.memoProgramId, "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr")
+    }
+
     /// The validator runs again on its own output, so the tagged form — budget
     /// pair in front, attribution memo behind — has to pass. If it did not, the
     /// memo could never be injected before the final gate.

--- a/VultisigApp/VultisigAppTests/Views/BannersCarouselIndexTests.swift
+++ b/VultisigApp/VultisigAppTests/Views/BannersCarouselIndexTests.swift
@@ -81,4 +81,32 @@ final class BannersCarouselIndexTests: XCTestCase {
             0
         )
     }
+
+    // MARK: - Clamping an externally replaced array
+
+    /// The array can shrink from outside the carousel — a promo the user has
+    /// just satisfied stops being eligible — and `afterRemoval` cannot describe
+    /// that, because it needs the index that went away and a replacement only
+    /// says what is left.
+    ///
+    /// This is the case that strands the carousel: the auto-advance declines to
+    /// move at one banner, so an index left past the end is never corrected.
+    func testClampPullsAnOutOfBoundsIndexBackInside() {
+        XCTAssertEqual(BannersCarouselIndex.clamped(1, count: 1), 0)
+        XCTAssertEqual(BannersCarouselIndex.clamped(2, count: 1), 0)
+        XCTAssertEqual(BannersCarouselIndex.clamped(3, count: 2), 1)
+    }
+
+    func testClampLeavesAValidIndexAlone() {
+        XCTAssertEqual(BannersCarouselIndex.clamped(0, count: 3), 0)
+        XCTAssertEqual(BannersCarouselIndex.clamped(2, count: 3), 2)
+    }
+
+    /// An empty array has no valid index, and the carousel hides itself — so
+    /// zero is the only answer that cannot be read out of bounds when it
+    /// reappears.
+    func testClampOnAnEmptyArrayIsZero() {
+        XCTAssertEqual(BannersCarouselIndex.clamped(4, count: 0), 0)
+        XCTAssertEqual(BannersCarouselIndex.clamped(-1, count: 0), 0)
+    }
 }

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -452,9 +452,8 @@ final class VaultDetailViewModelTests: XCTestCase {
     // MARK: - The Kamino Earn promo
 
     /// It opens the Solana DeFi screen, so a vault that cannot reach Solana has
-    /// nowhere for it to go — and a user already earning is being advertised
-    /// something they are doing.
-    func testKaminoBanner_showsOnlyForASolanaVaultThatIsNotEarningYet() {
+    /// nowhere for it to go. That is the only condition — see the next test.
+    func testKaminoBanner_needsASolanaVault() {
         let store = makeStore()
         let logic = VaultDetailLogic()
 
@@ -463,35 +462,46 @@ final class VaultDetailViewModelTests: XCTestCase {
 
         let solana = makeVault(pubKey: "solana", chains: [.solana])
         XCTAssertTrue(logic.setupBanners(for: solana, store: store, now: fixedNow).contains(.kaminoEarn))
+    }
 
-        solana.kaminoPositions = [
+    /// Deliberately NOT gated on having a position. Someone earning in one
+    /// vault is a good audience for the other two, and the banner is a route
+    /// into the segment rather than a one-time announcement — dismissal is what
+    /// makes it go away.
+    func testKaminoBanner_staysForAVaultThatIsAlreadyEarning() {
+        let store = makeStore()
+        let logic = VaultDetailLogic()
+        let vault = makeVault(pubKey: "earning", chains: [.solana])
+
+        vault.enabledKaminoVaults = [KaminoVaultRegistry.steakhouseUSDC.address]
+        vault.kaminoPositions = [
             KaminoPosition(
                 vaultAddress: KaminoVaultRegistry.steakhouseUSDC.address,
                 isEnabled: true,
-                shares: KaminoShareAmount(baseUnits: 0, decimals: 6),
-                tokenAmount: KaminoTokenAmount(baseUnits: 0, decimals: 6),
-                vault: solana
+                shares: KaminoShareAmount(baseUnits: 1_000_000, decimals: 6),
+                tokenAmount: KaminoTokenAmount(baseUnits: 1_000_000, decimals: 6),
+                vault: vault
             )
         ]
-        XCTAssertFalse(
-            logic.setupBanners(for: solana, store: store, now: fixedNow).contains(.kaminoEarn),
-            "A promo for something the user has already enabled is noise on their own screen."
-        )
+
+        XCTAssertTrue(logic.setupBanners(for: vault, store: store, now: fixedNow).contains(.kaminoEarn))
     }
 
-    /// A backup encodes `enabledKaminoVaults`, not the position rows — those are
-    /// materialised on the first visit to the DeFi screen. So a restored vault
-    /// arrives already enabled with no rows at all, and a gate that only reads
-    /// rows would advertise the feature back to the user who turned it on.
-    func testKaminoBanner_isHiddenForARestoredVaultBeforeItsRowsExist() {
+    /// The carousel renders `setupBanners` in order, so leading the list is what
+    /// puts the promo on the first page rather than behind whatever else the
+    /// vault happens to qualify for.
+    func testKaminoBanner_leadsTheCarousel() {
         let store = makeStore()
         let logic = VaultDetailLogic()
-        let restored = makeVault(pubKey: "restored", chains: [.solana])
+        // A fresh vault qualifies for several — it is un-backed-up, and the two
+        // always-on promos apply — so "first" is a real position here rather
+        // than the only one available.
+        let vault = makeVault(pubKey: "many-banners", chains: [.solana])
 
-        restored.enabledKaminoVaults = [KaminoVaultRegistry.steakhouseUSDC.address]
-        XCTAssertTrue(restored.kaminoPositions.isEmpty, "The import restores the choice, not the cache.")
+        let banners = logic.setupBanners(for: vault, store: store, now: fixedNow)
 
-        XCTAssertFalse(logic.setupBanners(for: restored, store: store, now: fixedNow).contains(.kaminoEarn))
+        XCTAssertGreaterThan(banners.count, 1, "This vault should qualify for more than the promo alone.")
+        XCTAssertEqual(banners.first, .kaminoEarn)
     }
 
     /// AC: different intents are independent — dismissing one banner does not

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -449,6 +449,36 @@ final class VaultDetailViewModelTests: XCTestCase {
                        "A dismissal must hold across vaults — the store has no vault key")
     }
 
+    // MARK: - The Kamino Earn promo
+
+    /// It opens the Solana DeFi screen, so a vault that cannot reach Solana has
+    /// nowhere for it to go — and a user already earning is being advertised
+    /// something they are doing.
+    func testKaminoBanner_showsOnlyForASolanaVaultThatIsNotEarningYet() {
+        let store = makeStore()
+        let logic = VaultDetailLogic()
+
+        let noSolana = makeVault(pubKey: "no-solana", chains: [.bitcoin])
+        XCTAssertFalse(logic.setupBanners(for: noSolana, store: store, now: fixedNow).contains(.kaminoEarn))
+
+        let solana = makeVault(pubKey: "solana", chains: [.solana])
+        XCTAssertTrue(logic.setupBanners(for: solana, store: store, now: fixedNow).contains(.kaminoEarn))
+
+        solana.kaminoPositions = [
+            KaminoPosition(
+                vaultAddress: KaminoVaultRegistry.steakhouseUSDC.address,
+                isEnabled: true,
+                shares: KaminoShareAmount(baseUnits: 0, decimals: 6),
+                tokenAmount: KaminoTokenAmount(baseUnits: 0, decimals: 6),
+                vault: solana
+            )
+        ]
+        XCTAssertFalse(
+            logic.setupBanners(for: solana, store: store, now: fixedNow).contains(.kaminoEarn),
+            "A promo for something the user has already enabled is noise on their own screen."
+        )
+    }
+
     /// AC: different intents are independent — dismissing one banner does not
     /// suppress another.
     func testDismiss_isPerIntent_doesNotSuppressOtherBanners() {

--- a/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Wallet/VaultDetailViewModelTests.swift
@@ -479,6 +479,21 @@ final class VaultDetailViewModelTests: XCTestCase {
         )
     }
 
+    /// A backup encodes `enabledKaminoVaults`, not the position rows — those are
+    /// materialised on the first visit to the DeFi screen. So a restored vault
+    /// arrives already enabled with no rows at all, and a gate that only reads
+    /// rows would advertise the feature back to the user who turned it on.
+    func testKaminoBanner_isHiddenForARestoredVaultBeforeItsRowsExist() {
+        let store = makeStore()
+        let logic = VaultDetailLogic()
+        let restored = makeVault(pubKey: "restored", chains: [.solana])
+
+        restored.enabledKaminoVaults = [KaminoVaultRegistry.steakhouseUSDC.address]
+        XCTAssertTrue(restored.kaminoPositions.isEmpty, "The import restores the choice, not the cache.")
+
+        XCTAssertFalse(logic.setupBanners(for: restored, store: store, now: fixedNow).contains(.kaminoEarn))
+    }
+
     /// AC: different intents are independent — dismissing one banner does not
     /// suppress another.
     func testDismiss_isPerIntent_doesNotSuppressOtherBanners() {


### PR DESCRIPTION
## Description

Layer 6 of the stacked change adding **Kamino Earn vaults (kVaults)** to the Solana DeFi surface. This layer brings the Earn UI to the design — the segment itself, and the promo that points at it from the main screen.

Part of #5017 — the [UI design filed as a comment](https://github.com/vultisig/vultisig-ios/issues/5017#issuecomment-5249982356). Figma: [DeFi Page — Earn — Kamino Vaults](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=79469-243134). The issue closes when the whole stack lands.

> **Stacked PR.** Base is `feat/kamino-memo-5017` (#5104), so this diff is only layer 6. Review #5053 → #5055 → #5056 → #5057 → #5104 first.

### What the design asked for

**1. Earn leads — everywhere.** On the Solana segments, and in the select-positions picker too: two lists describing the same thing and disagreeing about which comes first is how a user hunts for a section they were just looking at. The picker's order turned out to be presentational only — a tapped cell is filed through `selectionIndex`, which each type carries itself, so nothing there is addressed by array position; the test pins the new order *and* those indices, since their independence is what makes the move safe.

**1a. Segment order.** The design's segmented control reads `Earn  Staked`; the app had it the other way round. This also makes Earn the segment the screen opens on — `onLoad` selects the first type. The order is presentational only: the position picker files a selection by `selectionIndex`, which Earn does not have, so nothing about persistence or routing depends on it.

**2. Each vault says what it has earned.** This was not on screen. The figure existed — the card carried a "Profit & Loss" row — but only in the underlying token and only as a label beside a number. It now reads `Earned: 200 USDC` with its fiat value opposite, matching the `Deposited: 1,000 USDC → $1,000.23` line above it, which is the pair the design draws rather than two stacked columns.

A vault holding nothing drops both figure rows and takes a full-width Deposit, as the design draws its empty cards: there is no position to describe, and rows of zeros describe nothing.

**3. The main screen promotes it.** The design puts *"New on Solana / Start earning with Kamino"* in the main screen's banner carousel, and it was the one piece of that Figma with nothing behind it. Everything it needed already existed — `VaultBannerType` carries copy, icon and dismissal rule, `CarouselBannerView` already renders title-in-tertiary above subtitle-in-primary, and `PromoBannerDismissalStore` already honours a per-banner TTL — so this is one enum case, not a new surface. It shows for any vault that holds Solana — deliberately not gated on already having a position, since someone earning in one vault is a good audience for the other two, and dismissal is what retires it. It leads the carousel, and tapping it lands on Earn directly, since that is now Solana's first segment.

### What review caught

**A zero is two different claims.** Enabling a vault writes a zero placeholder, and the card was reading it as "holds nothing" — which hid **Withdraw** from a user who had deposited on another device, or whose refresh failed right after depositing. A row now records whether its figures were read or seeded, and the way out of a position is never removed on the strength of a read that has not happened. (The figures stay off the card either way; the withdraw form reads the position itself and is the thing that can say "nothing to withdraw" truthfully.)

**The carousel could strand itself.** `BannersCarousel` never clamped its index when the banner array is replaced from outside, so dropping the page the user was on left `currentIndex` and `scrollPosition` past the end — and the auto-advance declines to move at one banner, so nothing corrected it. Reachable today (back up a vault while the backup banner is showing); fixed here with a `clamped(_:count:)` beside the existing removal math, and unit-tested.

**A loss is not something earned.** The source is `totalPnl`, which goes negative. `Earned: -3 USDC` in red still asserts the loss was earned and leaves the colour to correct it, so below zero the label reads `Lost: 3 USDC` with the figure unsigned beside it.

### Three design points deliberately NOT followed

Flagged rather than changed, because each one would cost something the issue or the app already established:

| Design | This PR | Why |
|---|---|---|
| Subtitle `Kamino · Solana` | `Curated by <curator>` + risk tier | #5017 **requires** risk labeling — "show RWA one risk tier above the conservative vault, not as T-bill backed". A static string would undo an explicit acceptance criterion. |
| Third vault is `JLP Vault` | `RWA USDC` (RockawayX) | The issue's launch table names the three vaults; the registry is the source of truth. The design appears to predate it. |
| No total card | "Kamino Earn" total across vaults | Removing it loses the aggregate the DeFi total is built from. |

Happy to take any of these the other way if the design is the newer decision.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [x] New Chain / Chain related feature

## Parity

- Android: `linked: vultisig-android#5485`
- Windows + extension: `linked: vultisig-windows#4541`
- SDK: `n/a` — presentation only, no SDK surface.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

Gate: **5746 tests, 11 skipped, 0 failures**. SwiftLint 0 violations across the touched sources and tests. New strings (`kaminoEarnDeposited` as a format, `kaminoEarnEarned`, `kaminoEarnLost`, `kaminoBannerTitle`, `kaminoBannerSubtitle`) are in all **8** shipping locales, sorted, entry counts equal at 1,785.

## Screenshots (if applicable):

_To add: the Earn segment with a funded vault and an empty one, plus the main-screen banner, against the Figma frames._

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5017
- **Confidence**: high
- **Needs human review for**: the three design deviations above — they are judgement calls between the Figma and the issue text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Kamino Earn promotional banner for eligible Solana vaults, with direct navigation to DeFi.
  * Improved Kamino Earn cards with clearer deposited, earned, and lost amounts, position-aware actions, and loading states.
  * Added attribution memos to supported Kamino Solana transactions.

* **Bug Fixes**
  * Prevented banner carousel positions from exceeding available banners.
  * Improved withdrawal availability handling for confirmed and unconfirmed positions.
  * Updated Kamino messaging across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->