### PR TITLE
fix(passcode): show a recovery screen when sealed shares outlive their key

### DIFF
--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import SwiftData
 
+private let logger = Log.app.other
+
 enum RootRoute {
     case home(showingVaultSelector: Bool)
     case createVault
@@ -147,13 +149,13 @@ struct ContentView: View {
             guard isPending else { return }
             appViewModel.handOffToKeyshareRecoveryImport {
                 appViewModel.showSplashView = false
-                // Dropped rather than drained. The queue exists for a cover
-                // that lasts seconds; this one lasts the session, so a link
-                // held behind it would arrive an arbitrary time later — right
-                // on top of the one screen the user has just asked for. A link
-                // that arrives once the app is showing itself again is handled
-                // normally.
-                pendingDeeplinks = []
+                // A `.vult` opened from Files while the recovery screen was up
+                // is pending this very route, and its hold runs the moment the
+                // cover comes down. Claimed here so that becomes a no-op rather
+                // than a second copy of the import screen on the stack — the
+                // document itself is still on the view model, and the import
+                // screen picks it up when it appears.
+                _ = vultExtensionViewModel.consumeDocumentImport()
                 // Without animation, and that is not a style choice: the push
                 // slides for a third of a second, and the recovery screen comes
                 // off as soon as this returns. Animated, that third of a second
@@ -364,9 +366,20 @@ struct ContentView: View {
     ///
     /// Acting on one behind a cover would navigate, present sheets and mutate
     /// state where nobody can see it — a cover has to apply to what the app
-    /// *does*, not only to what it shows. Either cover: the lock screen, and
-    /// the key-share recovery screen.
+    /// *does*, not only to what it shows.
+    ///
+    /// **Held behind the lock screen, dropped behind the recovery screen**, and
+    /// the difference is how long each one lasts. A gate is seconds, so a link
+    /// is worth keeping. The recovery screen stands for the rest of the session
+    /// and comes down onto the import flow, so a link kept there would arrive an
+    /// arbitrary time later, on top of the one screen the user asked for. The
+    /// queue is also `@State`, so it is per scene — dropping needs no
+    /// co-ordination between them, where draining would.
     private func handleDeeplink(_ incomingURL: URL) {
+        guard !appViewModel.isKeyshareRecoveryRequired else {
+            logger.info("Ignoring a deeplink that arrived while the key-share recovery screen was up")
+            return
+        }
         guard !appViewModel.isCoveredByAppLock else {
             // Queued rather than replaced: a single slot silently drops every
             // link but the last, and each one is a user action.

--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -81,8 +81,12 @@ struct ContentView: View {
         .onOpenURL { incomingURL in
             handleDeeplink(incomingURL)
         }
-        .onChange(of: appViewModel.isPasscodeLocked) { _, isLocked in
-            guard !isLocked else { return }
+        // Either cover, not just the gate: a deeplink acted on behind the
+        // recovery screen navigates and presents where nobody can see it, and
+        // then lands the user somewhere other than the import flow the moment
+        // that screen comes down.
+        .onChange(of: appViewModel.isCoveredByAppLock) { _, isCovered in
+            guard !isCovered else { return }
             drainPendingDeeplinks()
         }
         // The document scene's hand-off is owned here rather than by `HomeScreen`,
@@ -122,14 +126,47 @@ struct ContentView: View {
         .withForegroundNotificationBanner()
         .overlay(appViewModel.showCover ? CoverView() : nil)
         .overlay(passcodeGate.animation(.easeInOut(duration: 0.25), value: appViewModel.isPasscodeLocked))
-        // Additive to the two overlays above, not a replacement for them. The
+        // Above the gate's overlay, matching the order `appLockPresentation`
+        // derives: the two are mutually exclusive today, and if that ever stops
+        // being true the screen a passcode cannot dismiss must not be the one
+        // underneath.
+        .overlay(keyshareRecoveryFloor)
+        // Additive to the overlays above, not a replacement for them. The
         // overlays are what the app draws; the window is what reaches the layer
         // sheets and alerts are presented in, which no overlay can.
         .hostsAppLock(
             appLockPresentation,
             onUnlocked: { appViewModel.markPasscodeUnlocked() },
-            onAttemptFailed: { appViewModel.lowerPasscodeGateIfNoLongerRequired() }
+            onAttemptFailed: { appViewModel.lowerPasscodeGateIfNoLongerRequired() },
+            onRestoreFromBackup: { appViewModel.beginKeyshareRecoveryImport() }
         )
+        // The recovery screen points at the import flow, and the import flow is
+        // a screen in this navigation stack — which the recovery screen is
+        // drawn over, in a window it cannot reach. So it asks, and this routes.
+        .onChange(of: appViewModel.isKeyshareRecoveryImportPending) { _, isPending in
+            guard isPending else { return }
+            appViewModel.handOffToKeyshareRecoveryImport {
+                appViewModel.showSplashView = false
+                // Dropped rather than drained. The queue exists for a cover
+                // that lasts seconds; this one lasts the session, so a link
+                // held behind it would arrive an arbitrary time later — right
+                // on top of the one screen the user has just asked for. A link
+                // that arrives once the app is showing itself again is handled
+                // normally.
+                pendingDeeplinks = []
+                // Without animation, and that is not a style choice: the push
+                // slides for a third of a second, and the recovery screen comes
+                // off as soon as this returns. Animated, that third of a second
+                // is the wallet on screen behind a transition — which is the
+                // silent open this state exists to prevent, arriving by the one
+                // door left open.
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    navigationRouter.navigate(to: OnboardingRoute.importVaultShare)
+                }
+            }
+        }
         .onLoad {
             // The cold-start gate is not decided here. It is decided in
             // `VultisigApp.init()`, because this modifier runs *after* the
@@ -174,6 +211,9 @@ struct ContentView: View {
     /// What the app is covering itself with, as one value — see
     /// ``AppLockPresentation``.
     private var appLockPresentation: AppLockPresentation {
+        if appViewModel.isKeyshareRecoveryRequired {
+            return .recovery
+        }
         if appViewModel.isPasscodeLocked {
             return .gate(generation: appViewModel.passcodeGateGeneration)
         }
@@ -240,6 +280,30 @@ struct ContentView: View {
         }
     }
 
+    /// Covers the app when this device holds sealed key shares and the key that
+    /// opens them is confirmed gone.
+    ///
+    /// The same floor-and-window split as ``passcodeGate``, and for the same
+    /// reason: the window reaches the layer sheets are presented in and the
+    /// overlay covers the cold start, where the recovery state is decided
+    /// before any scene — and so any window — exists. Exactly one of them
+    /// mounts the live screen, and which one is the host's to say.
+    ///
+    /// No transition and no identity. It is derived once at launch rather than
+    /// raised and re-raised, so there is nothing for either to disambiguate.
+    @ViewBuilder
+    var keyshareRecoveryFloor: some View {
+        if appViewModel.isKeyshareRecoveryRequired {
+            if appLockHost.hostsLockScreen {
+                VultisigBrandScreen()
+            } else {
+                KeyshareRecoveryScreen(
+                    onRestoreFromBackup: { appViewModel.beginKeyshareRecoveryImport() }
+                )
+            }
+        }
+    }
+
     func navigateToHome() {
         appViewModel.showSplashView = false
         rootRoute = .home(showingVaultSelector: appViewModel.showingVaultSelector)
@@ -296,13 +360,14 @@ struct ContentView: View {
         appViewModel.authenticateUser()
     }
 
-    /// Deeplinks are held until the app is unlocked.
+    /// Deeplinks are held until the app is showing itself again.
     ///
-    /// Acting on one while locked would navigate, present sheets and mutate
-    /// state behind the lock screen — the gate has to apply to what the app
-    /// *does*, not only to what it shows.
+    /// Acting on one behind a cover would navigate, present sheets and mutate
+    /// state where nobody can see it — a cover has to apply to what the app
+    /// *does*, not only to what it shows. Either cover: the lock screen, and
+    /// the key-share recovery screen.
     private func handleDeeplink(_ incomingURL: URL) {
-        guard !appViewModel.isPasscodeLocked else {
+        guard !appViewModel.isCoveredByAppLock else {
             // Queued rather than replaced: a single slot silently drops every
             // link but the last, and each one is a user action.
             pendingDeeplinks.append(incomingURL)

--- a/VultisigApp/VultisigApp/Components/AppLock/AppLockHosting.swift
+++ b/VultisigApp/VultisigApp/Components/AppLock/AppLockHosting.swift
@@ -20,7 +20,42 @@ enum AppLockPresentation: Equatable {
     /// The lock screen. The generation is the lock screen's identity — see
     /// ``AppViewModel/passcodeGateGeneration``.
     case gate(generation: Int)
+    /// The store holds sealed key shares and the key that opens them is
+    /// confirmed gone, so nothing on this device can read them.
+    ///
+    /// It is here rather than in the app's own hierarchy for the reason the
+    /// gate is: the wallet underneath renders names, addresses and balances
+    /// perfectly well and only fails at signing, so anything short of covering
+    /// it — sheets and full-screen covers included — is the silent open this
+    /// state exists to stop.
+    ///
+    /// No generation, because there is nothing to re-raise it over: it is
+    /// derived once at launch and stands until the user leaves it for the
+    /// import flow.
+    case recovery
 
+    /// Whether this presentation carries a screen the user acts on.
+    ///
+    /// The distinction the hosts need, and it is not "is it the gate": an
+    /// interactive screen has to be in the key window to receive input, exactly
+    /// one scene may hold it, and the root overlay must not draw a second live
+    /// copy of it. The gate and the recovery screen both want all three.
+    var isInteractive: Bool {
+        switch self {
+        case .gate, .recovery:
+            return true
+        case .uncovered, .cover:
+            return false
+        }
+    }
+
+    /// Kept apart from ``isInteractive`` because only the gate may fade away.
+    ///
+    /// The gate fades because by then the app is unlocked and there is nothing
+    /// left to hide. The recovery screen comes down onto a screen the app has
+    /// *just pushed underneath it*, and a quarter second of translucency there
+    /// is a quarter second of the wallet showing through on the way to the
+    /// import flow. It goes at once instead.
     var isGate: Bool {
         if case .gate = self { return true }
         return false
@@ -29,13 +64,17 @@ enum AppLockPresentation: Equatable {
 
 /// What the raised window draws.
 ///
-/// Two states in one root rather than a window each: see ``AppLockPresentation``
-/// for why the two must not be able to disagree.
+/// Every state in one root rather than a window each: see ``AppLockPresentation``
+/// for why they must not be able to disagree.
 struct AppLockHostedScreen: View {
 
     let presentation: AppLockPresentation
     let onUnlocked: () -> Void
     let onAttemptFailed: () -> Void
+    /// Hands the user to the app's import flow from the recovery screen. The
+    /// window is outside the app's navigation, so the route is a closure the
+    /// app supplies rather than something this view can reach.
+    let onRestoreFromBackup: () -> Void
 
     var body: some View {
         content
@@ -59,6 +98,8 @@ struct AppLockHostedScreen: View {
             // A raise is a new screen, never a reused one. See
             // ``AppViewModel/passcodeGateGeneration``.
             .id(generation)
+        case .recovery:
+            KeyshareRecoveryScreen(onRestoreFromBackup: onRestoreFromBackup)
         }
     }
 }
@@ -76,6 +117,7 @@ private struct HostsAppLockModifier: ViewModifier {
     let presentation: AppLockPresentation
     let onUnlocked: () -> Void
     let onAttemptFailed: () -> Void
+    let onRestoreFromBackup: () -> Void
 
     func body(content: Content) -> some View {
         content
@@ -87,16 +129,18 @@ private struct HostsAppLockModifier: ViewModifier {
         AppLockHost.shared.update(
             to: presentation,
             onUnlocked: onUnlocked,
-            onAttemptFailed: onAttemptFailed
+            onAttemptFailed: onAttemptFailed,
+            onRestoreFromBackup: onRestoreFromBackup
         )
     }
 }
 
 extension View {
 
-    /// Hosts the privacy cover and the lock screen in a window above the app's
-    /// own, so that a sheet, a full-screen cover or an alert already on screen is
-    /// covered rather than left drawn on top.
+    /// Hosts the privacy cover, the lock screen and the key-share recovery
+    /// screen in a window above the app's own, so that a sheet, a full-screen
+    /// cover or an alert already on screen is covered rather than left drawn on
+    /// top.
     ///
     /// A sheet is presented in a layer a SwiftUI `.overlay` does not reach, which
     /// is why the root overlay alone was never enough. Window order is by level
@@ -106,13 +150,15 @@ extension View {
     func hostsAppLock(
         _ presentation: AppLockPresentation,
         onUnlocked: @escaping () -> Void,
-        onAttemptFailed: @escaping () -> Void
+        onAttemptFailed: @escaping () -> Void,
+        onRestoreFromBackup: @escaping () -> Void
     ) -> some View {
         modifier(
             HostsAppLockModifier(
                 presentation: presentation,
                 onUnlocked: onUnlocked,
-                onAttemptFailed: onAttemptFailed
+                onAttemptFailed: onAttemptFailed,
+                onRestoreFromBackup: onRestoreFromBackup
             )
         )
     }

--- a/VultisigApp/VultisigApp/Components/ViewModifiers/PresentsWhenUnlocked.swift
+++ b/VultisigApp/VultisigApp/Components/ViewModifiers/PresentsWhenUnlocked.swift
@@ -65,8 +65,11 @@ private struct PresentsWhenUnlockedModifier<Trigger: Equatable>: ViewModifier {
         content
             .onLoad { request() }
             .onChange(of: trigger) { _, _ in request() }
-            .onChange(of: appViewModel.isPasscodeLocked) { _, isLocked in
-                guard hold.lockChanged(isLocked: isLocked) else { return }
+            // Either cover, not just the gate: a sheet raised behind the
+            // key-share recovery screen is a sheet the user finds instead of
+            // the import flow they were sent to.
+            .onChange(of: appViewModel.isCoveredByAppLock) { _, isCovered in
+                guard hold.lockChanged(isLocked: isCovered) else { return }
                 check()
             }
     }
@@ -83,7 +86,7 @@ private struct PresentsWhenUnlockedModifier<Trigger: Equatable>: ViewModifier {
     }
 
     private func runIfUnlocked() {
-        guard hold.requested(whileLocked: appViewModel.isPasscodeLocked) else { return }
+        guard hold.requested(whileLocked: appViewModel.isCoveredByAppLock) else { return }
         check()
     }
 }
@@ -101,15 +104,15 @@ private struct HoldsPresentationWhileLockedModifier: ViewModifier {
         content
             .onLoad { holdIfLocked() }
             .onChange(of: isPresented) { _, _ in holdIfLocked() }
-            .onChange(of: appViewModel.isPasscodeLocked) { _, isLocked in
-                guard hold.lockChanged(isLocked: isLocked) else { return }
+            .onChange(of: appViewModel.isCoveredByAppLock) { _, isCovered in
+                guard hold.lockChanged(isLocked: isCovered) else { return }
                 isPresented = true
             }
     }
 
     private func holdIfLocked() {
         guard isPresented else { return }
-        guard !hold.requested(whileLocked: appViewModel.isPasscodeLocked) else { return }
+        guard !hold.requested(whileLocked: appViewModel.isCoveredByAppLock) else { return }
         isPresented = false
     }
 }

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -658,6 +658,12 @@
 "keygenInstructionsCar7DescriptionPart3" = " zu und verbessere so die Flexibilität, ohne die Sicherheit zu vernachlässigen.";
 "keygenInstructionsCar7Title" = "Funktionshighlight";
 "keys" = "Schlüssel";
+"keyshareRecoveryBackupMessage" = "Ihr .vult-Backup ist der Weg zurück. Importieren Sie es, und diese Vaults funktionieren wieder.";
+"keyshareRecoveryImportButton" = ".vult-Backup importieren";
+"keyshareRecoveryMessage" = "Ihre Key Shares sind verschlüsselt, und der Schlüssel, der sie entsperrt, kam bei dieser Wiederherstellung nicht mit. Auf diesem Gerät kann sie nichts lesen, also kann es mit diesen Vaults nicht signieren.";
+"keyshareRecoveryNoBackupMessage" = "Ohne .vult-Backup lassen sich die Key Shares auf diesem Gerät nicht mehr entsperren — dieser Teil ist nicht wiederherstellbar. Der Vault selbst kann es sein: Wenn Ihre anderen Geräte ihre eigenen Shares halten und damit weiterhin den Signaturschwellenwert erreichen, funktioniert er ohne dieses Gerät weiter.";
+"keyshareRecoveryNoBackupTitle" = "Ich habe kein Backup";
+"keyshareRecoveryTitle" = "Diese Vaults lassen sich auf diesem Gerät nicht öffnen";
 "keysharesUnreadableVaultNotSaved" = "Die Key Shares dieses Tresors konnten nicht gelesen werden, daher wurde er nicht gespeichert. Entsperren Sie die App und versuchen Sie es erneut — bleibt das Problem bestehen, erstellen Sie den Tresor neu.";
 "keysharesUnsealableVaultNotSaved" = "Die Key Shares dieses Tresors konnten nicht für die Speicherung geschützt werden, daher wurde er nicht gespeichert. Entsperren Sie die App und versuchen Sie es erneut.";
 "keysign" = "Schlüsselsignatur";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -658,6 +658,12 @@
 "keygenInstructionsCar7DescriptionPart3" = ", enhancing flexibility without compromising security.";
 "keygenInstructionsCar7Title" = "Feature Highlight";
 "keys" = "Keys";
+"keyshareRecoveryBackupMessage" = "Your .vult backup is the way back. Import it and these vaults work again.";
+"keyshareRecoveryImportButton" = "Import .vult backup";
+"keyshareRecoveryMessage" = "Their key shares are encrypted, and the key that unlocks them did not come across with this restore. Nothing on this device can read them, so it cannot sign with these vaults.";
+"keyshareRecoveryNoBackupMessage" = "Without a .vult backup, the key shares on this device cannot be unlocked again — that part is not recoverable. The vault itself may still be: if your other devices hold their own shares and still reach its signing threshold, it keeps working without this one.";
+"keyshareRecoveryNoBackupTitle" = "I don't have a backup";
+"keyshareRecoveryTitle" = "These vaults can't be opened on this device";
 "keysharesUnreadableVaultNotSaved" = "This vault's key shares could not be read, so it was not saved. Unlock the app and try again — if this keeps happening, create the vault again.";
 "keysharesUnsealableVaultNotSaved" = "This vault's key shares could not be protected for storage, so it was not saved. Unlock the app and try again.";
 "keysign" = "Keysign";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -658,6 +658,12 @@
 "keygenInstructionsCar7DescriptionPart3" = ", mejorando la flexibilidad sin comprometer la seguridad.";
 "keygenInstructionsCar7Title" = "Destacado de funciones";
 "keys" = "Llaves";
+"keyshareRecoveryBackupMessage" = "Tu copia de seguridad .vult es el camino de vuelta. Impórtala y estos vaults volverán a funcionar.";
+"keyshareRecoveryImportButton" = "Importar copia .vult";
+"keyshareRecoveryMessage" = "Sus key shares están cifrados y la clave que los descifra no llegó con esta restauración. Nada en este dispositivo puede leerlos, así que no puede firmar con estos vaults.";
+"keyshareRecoveryNoBackupMessage" = "Sin una copia .vult, los key shares de este dispositivo ya no se pueden descifrar: esa parte no es recuperable. El vault en sí puede seguir siéndolo: si tus otros dispositivos conservan sus propios shares y siguen alcanzando el umbral de firma, seguirá funcionando sin este.";
+"keyshareRecoveryNoBackupTitle" = "No tengo copia de seguridad";
+"keyshareRecoveryTitle" = "Estos vaults no se pueden abrir en este dispositivo";
 "keysharesUnreadableVaultNotSaved" = "No se pudieron leer las key shares de esta bóveda, por lo que no se guardó. Desbloquea la app e inténtalo de nuevo; si sigue fallando, crea la bóveda otra vez.";
 "keysharesUnsealableVaultNotSaved" = "No se pudieron proteger las key shares de esta bóveda para su almacenamiento, por lo que no se guardó. Desbloquea la app e inténtalo de nuevo.";
 "keysign" = "Firma de Clave";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -658,6 +658,12 @@
 "keygenInstructionsCar7DescriptionPart3" = ", povećavajući fleksibilnost bez ugrožavanja sigurnosti.";
 "keygenInstructionsCar7Title" = "Istaknuta značajka";
 "keys" = "Ključ";
+"keyshareRecoveryBackupMessage" = "Vaša .vult sigurnosna kopija je put natrag. Uvezite je i ovi će vaultovi ponovno raditi.";
+"keyshareRecoveryImportButton" = "Uvezi .vult kopiju";
+"keyshareRecoveryMessage" = "Njihovi su key shareovi šifrirani, a ključ koji ih otključava nije prenesen ovom obnovom. Ništa na ovom uređaju ne može ih pročitati, pa njime ne možete potpisivati ovim vaultovima.";
+"keyshareRecoveryNoBackupMessage" = "Bez .vult sigurnosne kopije key shareovi na ovom uređaju više se ne mogu dešifrirati — taj dio nije moguće obnoviti. Sam vault možda jest: ako vaši drugi uređaji čuvaju vlastite shareove i i dalje dosežu prag za potpisivanje, nastavlja raditi i bez ovoga.";
+"keyshareRecoveryNoBackupTitle" = "Nemam sigurnosnu kopiju";
+"keyshareRecoveryTitle" = "Ovi se vaultovi ne mogu otvoriti na ovom uređaju";
 "keysharesUnreadableVaultNotSaved" = "Key shareovi ovog trezora nisu se mogli pročitati pa trezor nije spremljen. Otključajte aplikaciju i pokušajte ponovno; ako se nastavi, stvorite trezor iznova.";
 "keysharesUnsealableVaultNotSaved" = "Key shareovi ovog trezora nisu se mogli zaštititi za pohranu pa trezor nije spremljen. Otključajte aplikaciju i pokušajte ponovno.";
 "keysign" = "Potpis ključa";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -658,6 +658,12 @@
 "keygenInstructionsCar7DescriptionPart3" = ", migliorando la flessibilità senza compromettere la sicurezza.";
 "keygenInstructionsCar7Title" = "In evidenza";
 "keys" = "Chiavi";
+"keyshareRecoveryBackupMessage" = "Il tuo backup .vult è la via del ritorno. Importalo e questi vault torneranno a funzionare.";
+"keyshareRecoveryImportButton" = "Importa backup .vult";
+"keyshareRecoveryMessage" = "I loro key share sono cifrati e la chiave che li sblocca non è arrivata con questo ripristino. Nulla su questo dispositivo può leggerli, quindi non può firmare con questi vault.";
+"keyshareRecoveryNoBackupMessage" = "Senza un backup .vult i key share su questo dispositivo non possono più essere decifrati: questa parte non è recuperabile. Il vault stesso potrebbe esserlo ancora: se i tuoi altri dispositivi conservano i propri share e raggiungono ancora la soglia di firma, continua a funzionare senza questo.";
+"keyshareRecoveryNoBackupTitle" = "Non ho un backup";
+"keyshareRecoveryTitle" = "Questi vault non possono essere aperti su questo dispositivo";
 "keysharesUnreadableVaultNotSaved" = "Non è stato possibile leggere le key share di questo vault, quindi non è stato salvato. Sblocca l'app e riprova; se continua a fallire, crea di nuovo il vault.";
 "keysharesUnsealableVaultNotSaved" = "Non è stato possibile proteggere le key share di questo vault per l'archiviazione, quindi non è stato salvato. Sblocca l'app e riprova.";
 "keysign" = "Firma Chiave";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -658,6 +658,12 @@
 "keygenInstructionsCar7DescriptionPart3" = " Vultisig 볼트에 액세스하여 보안을 유지하면서 유연성을 높입니다.";
 "keygenInstructionsCar7Title" = "기능 하이라이트";
 "keys" = "키";
+"keyshareRecoveryBackupMessage" = ".vult 백업이 돌아가는 길입니다. 백업을 가져오면 이 볼트를 다시 사용할 수 있습니다.";
+"keyshareRecoveryImportButton" = ".vult 백업 가져오기";
+"keyshareRecoveryMessage" = "이 볼트의 키 셰어는 암호화되어 있는데, 이를 여는 키가 이번 복원에 함께 오지 않았습니다. 이 기기에서는 아무것도 키 셰어를 읽을 수 없으므로 이 볼트로 서명할 수 없습니다.";
+"keyshareRecoveryNoBackupMessage" = ".vult 백업이 없으면 이 기기의 키 셰어는 다시 복호화할 수 없으며, 그 부분은 복구되지 않습니다. 볼트 자체는 아직 살아 있을 수 있습니다. 다른 기기들이 각자의 셰어를 가지고 있고 서명 임계값을 여전히 충족한다면, 이 기기 없이도 볼트는 계속 동작합니다.";
+"keyshareRecoveryNoBackupTitle" = "백업이 없습니다";
+"keyshareRecoveryTitle" = "이 기기에서는 이 볼트를 열 수 없습니다";
 "keysharesUnreadableVaultNotSaved" = "이 볼트의 키 셰어를 읽을 수 없어 저장되지 않았습니다. 앱을 잠금 해제한 후 다시 시도하세요. 계속 실패하면 볼트를 다시 생성하세요.";
 "keysharesUnsealableVaultNotSaved" = "이 볼트의 키 셰어를 저장용으로 보호할 수 없어 저장되지 않았습니다. 앱을 잠금 해제한 후 다시 시도하세요.";
 "keysign" = "키사인";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -661,7 +661,7 @@
 "keyshareRecoveryBackupMessage" = "A sua cópia de segurança .vult é o caminho de volta. Importe-a e estes vaults voltam a funcionar.";
 "keyshareRecoveryImportButton" = "Importar cópia .vult";
 "keyshareRecoveryMessage" = "Os seus key shares estão encriptados e a chave que os desbloqueia não veio com este restauro. Nada neste dispositivo os consegue ler, por isso não pode assinar com estes vaults.";
-"keyshareRecoveryNoBackupMessage" = "Sem uma cópia .vult, os key shares deste dispositivo já não podem ser desencriptados — essa parte não é recuperável. O vault em si ainda pode ser: se os seus outros dispositivos guardarem os próprios shares e continuarem a atingir o limiar de assinatura, ele continua a funcionar sem este.";
+"keyshareRecoveryNoBackupMessage" = "Sem uma cópia .vult, os key shares deste dispositivo já não podem ser desencriptados — essa parte não é recuperável. O vault em si ainda pode ser: se os seus outros dispositivos guardarem os próprios shares e continuarem a atingir o limiar de assinatura, ele continua a funcionar sem este dispositivo.";
 "keyshareRecoveryNoBackupTitle" = "Não tenho cópia de segurança";
 "keyshareRecoveryTitle" = "Estes vaults não podem ser abertos neste dispositivo";
 "keysharesUnreadableVaultNotSaved" = "Não foi possível ler as key shares deste cofre, por isso não foi guardado. Desbloqueie a app e tente novamente; se continuar a falhar, crie o cofre de novo.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -658,6 +658,12 @@
 "keygenInstructionsCar7DescriptionPart3" = ", aumentando a flexibilidade sem comprometer a segurança.";
 "keygenInstructionsCar7Title" = "Destaque de recursos";
 "keys" = "Chaves";
+"keyshareRecoveryBackupMessage" = "A sua cópia de segurança .vult é o caminho de volta. Importe-a e estes vaults voltam a funcionar.";
+"keyshareRecoveryImportButton" = "Importar cópia .vult";
+"keyshareRecoveryMessage" = "Os seus key shares estão encriptados e a chave que os desbloqueia não veio com este restauro. Nada neste dispositivo os consegue ler, por isso não pode assinar com estes vaults.";
+"keyshareRecoveryNoBackupMessage" = "Sem uma cópia .vult, os key shares deste dispositivo já não podem ser desencriptados — essa parte não é recuperável. O vault em si ainda pode ser: se os seus outros dispositivos guardarem os próprios shares e continuarem a atingir o limiar de assinatura, ele continua a funcionar sem este.";
+"keyshareRecoveryNoBackupTitle" = "Não tenho cópia de segurança";
+"keyshareRecoveryTitle" = "Estes vaults não podem ser abertos neste dispositivo";
 "keysharesUnreadableVaultNotSaved" = "Não foi possível ler as key shares deste cofre, por isso não foi guardado. Desbloqueie a app e tente novamente; se continuar a falhar, crie o cofre de novo.";
 "keysharesUnsealableVaultNotSaved" = "Não foi possível proteger as key shares deste cofre para armazenamento, por isso não foi guardado. Desbloqueie a app e tente novamente.";
 "keysign" = "Assinatura de Chave";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -658,6 +658,12 @@
 "keygenInstructionsCar7DescriptionPart3" = "访问您的 Vultisig 保险库，在不影响安全性的情况下增强灵活性";
 "keygenInstructionsCar7Title" = "功能亮点";
 "keys" = "密钥";
+"keyshareRecoveryBackupMessage" = "您的 .vult 备份就是找回的途径。导入备份后，这些 vault 即可恢复使用。";
+"keyshareRecoveryImportButton" = "导入 .vult 备份";
+"keyshareRecoveryMessage" = "它们的 key share 已加密，而解锁所需的密钥并没有随本次恢复一起带过来。本设备上没有任何东西能读取它们，因此无法用这些 vault 签名。";
+"keyshareRecoveryNoBackupMessage" = "没有 .vult 备份，本设备上的 key share 将无法再解密——这部分无法恢复。但 vault 本身可能仍然可用：如果您的其他设备仍持有各自的 share 并且达到签名门限，即使没有本设备，vault 也能继续工作。";
+"keyshareRecoveryNoBackupTitle" = "我没有备份";
+"keyshareRecoveryTitle" = "本设备无法打开这些 vault";
 "keysharesUnreadableVaultNotSaved" = "无法读取此保险库的密钥分片，因此未保存。请解锁应用后重试；若仍然失败，请重新创建保险库。";
 "keysharesUnsealableVaultNotSaved" = "无法为存储保护此保险库的密钥分片，因此未保存。请解锁应用后重试。";
 "keysign" = "密钥签名";

--- a/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
+++ b/VultisigApp/VultisigApp/Core/Notifications/PushNotificationManager.swift
@@ -426,12 +426,18 @@ enum ForegroundNotificationPresentationPolicy {
     /// Center is the same disclosure a swipe later.
     static let lockedOptions: UNNotificationPresentationOptions = [.sound]
 
-    /// Read off the app's own gate flag rather than
+    /// Read off the app's own cover flag rather than
     /// ``PasscodeService/isPasscodeGateRequired``. The predicate is true for
     /// every install that *has* a passcode, gate up or not, so using it here
     /// would silence notifications for those users the entire time they are
     /// using the app.
-    static var isAppLocked: Bool { AppViewModel.shared.isPasscodeLocked }
+    ///
+    /// Either cover counts. The key-share recovery screen is hosted in the same
+    /// raised window the lock screen is, and the reasoning above applies to it
+    /// unchanged: the system banner is drawn above every window the app owns,
+    /// carrying a vault name and a transaction summary over a screen the user
+    /// cannot dismiss.
+    static var isAppLocked: Bool { AppViewModel.shared.isCoveredByAppLock }
 
     static func options(handled: Bool) -> UNNotificationPresentationOptions {
         guard !isAppLocked else { return lockedOptions }

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
@@ -41,9 +41,9 @@ final class AppLockWindowHost: ObservableObject {
 
     static let shared = AppLockWindowHost()
 
-    /// Whether the raised window is the thing carrying the lock screen, so the
-    /// root overlay knows to draw an opaque floor rather than a second copy of
-    /// it.
+    /// Whether the raised window is the thing carrying the interactive screen —
+    /// the lock screen, or the key-share recovery screen — so the root overlay
+    /// knows to draw an opaque floor rather than a second copy of it.
     ///
     /// It starts `true` — **assumed, not observed**, and that is the only
     /// ordering that works. A raise happens on the view's first appearance, one
@@ -74,6 +74,7 @@ final class AppLockWindowHost: ObservableObject {
     private struct Callbacks {
         let onUnlocked: () -> Void
         let onAttemptFailed: () -> Void
+        let onRestoreFromBackup: () -> Void
     }
 
     private final class WeakWindow {
@@ -88,21 +89,28 @@ final class AppLockWindowHost: ObservableObject {
     func update(
         to presentation: AppLockPresentation,
         onUnlocked: @escaping () -> Void,
-        onAttemptFailed: @escaping () -> Void
+        onAttemptFailed: @escaping () -> Void,
+        onRestoreFromBackup: @escaping () -> Void
     ) {
         guard presentation != .uncovered else {
             // Asymmetric, and the insertion side is the point: a lock that fades
             // in is a lock you can see through while it arrives. Going up is
             // instant; coming down fades, because by then the app is unlocked and
             // there is nothing left to hide. The privacy cover never faded and
-            // still does not, so only a gate animates away.
+            // still does not, and neither does the recovery screen — see
+            // ``AppLockPresentation/isGate``. Only a gate animates away.
             lower(animated: current.isGate)
             current = .uncovered
             callbacks = nil
             return
         }
 
-        raise(presentation, onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
+        raise(
+            presentation,
+            onUnlocked: onUnlocked,
+            onAttemptFailed: onAttemptFailed,
+            onRestoreFromBackup: onRestoreFromBackup
+        )
     }
 
     // MARK: - Raising
@@ -110,7 +118,8 @@ final class AppLockWindowHost: ObservableObject {
     private func raise(
         _ presentation: AppLockPresentation,
         onUnlocked: @escaping () -> Void,
-        onAttemptFailed: @escaping () -> Void
+        onAttemptFailed: @escaping () -> Void,
+        onRestoreFromBackup: @escaping () -> Void
     ) {
         let scenes = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
@@ -121,7 +130,7 @@ final class AppLockWindowHost: ObservableObject {
             // the gate is decided in `VultisigApp.init()`, before any exists. The
             // root overlay carries the lock screen itself, which is what it is
             // there for.
-            if presentation.isGate {
+            if presentation.isInteractive {
                 hostsLockScreen = false
             }
             return
@@ -131,7 +140,7 @@ final class AppLockWindowHost: ObservableObject {
         // torn down by the completion of the lowering it interrupted.
         lowerToken += 1
 
-        if presentation.isGate {
+        if presentation.isInteractive {
             // The keyboard is in a window of its own, far above `.alert`, so a
             // field that was first responder under a sheet would go on drawing
             // its keyboard over the lock screen.
@@ -167,11 +176,16 @@ final class AppLockWindowHost: ObservableObject {
                 scene === elected ? presentation : .cover,
                 in: scene,
                 onUnlocked: onUnlocked,
-                onAttemptFailed: onAttemptFailed
+                onAttemptFailed: onAttemptFailed,
+                onRestoreFromBackup: onRestoreFromBackup
             )
         }
 
-        callbacks = Callbacks(onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
+        callbacks = Callbacks(
+            onUnlocked: onUnlocked,
+            onAttemptFailed: onAttemptFailed,
+            onRestoreFromBackup: onRestoreFromBackup
+        )
         current = presentation
     }
 
@@ -188,13 +202,14 @@ final class AppLockWindowHost: ObservableObject {
         _ presentation: AppLockPresentation,
         in scene: UIWindowScene,
         onUnlocked: @escaping () -> Void,
-        onAttemptFailed: @escaping () -> Void
+        onAttemptFailed: @escaping () -> Void,
+        onRestoreFromBackup: @escaping () -> Void
     ) {
         let key = ObjectIdentifier(scene)
         let window = windows[key] ?? makeWindow(for: scene)
         windows[key] = window
 
-        if presentation.isGate,
+        if presentation.isInteractive,
            previousKeyWindows[key] == nil,
            let previous = scene.keyWindow,
            !(previous is AppLockWindow) {
@@ -207,7 +222,7 @@ final class AppLockWindowHost: ObservableObject {
         window.alpha = 1
         window.isUserInteractionEnabled = true
 
-        if presentation.isGate {
+        if presentation.isInteractive {
             window.makeKeyAndVisible()
         } else {
             window.isHidden = false
@@ -216,14 +231,20 @@ final class AppLockWindowHost: ObservableObject {
         window.host.rootView = AppLockHostedScreen(
             presentation: presentation,
             onUnlocked: onUnlocked,
-            onAttemptFailed: onAttemptFailed
+            onAttemptFailed: onAttemptFailed,
+            onRestoreFromBackup: onRestoreFromBackup
         )
     }
 
     private func makeWindow(for scene: UIWindowScene) -> AppLockWindow {
         let window = AppLockWindow(
             scene: scene,
-            screen: AppLockHostedScreen(presentation: .cover, onUnlocked: {}, onAttemptFailed: {})
+            screen: AppLockHostedScreen(
+                presentation: .cover,
+                onUnlocked: {},
+                onAttemptFailed: {},
+                onRestoreFromBackup: {}
+            )
         )
         window.windowLevel = UIWindow.Level(rawValue: UIWindow.Level.alert.rawValue + 1)
         window.overrideUserInterfaceStyle = .dark
@@ -326,11 +347,12 @@ final class AppLockWindowHost: ObservableObject {
         guard scene !== interactiveScene else { return }
         interactiveScene = scene
 
-        guard current.isGate, let callbacks else { return }
+        guard current.isInteractive, let callbacks else { return }
         raise(
             current,
             onUnlocked: callbacks.onUnlocked,
-            onAttemptFailed: callbacks.onAttemptFailed
+            onAttemptFailed: callbacks.onAttemptFailed,
+            onRestoreFromBackup: callbacks.onRestoreFromBackup
         )
     }
 
@@ -351,12 +373,13 @@ final class AppLockWindowHost: ObservableObject {
             dismantle(window)
         }
 
-        guard current.isGate, heldTheKeypad, let callbacks else { return }
+        guard current.isInteractive, heldTheKeypad, let callbacks else { return }
         interactiveScene = nil
         raise(
             current,
             onUnlocked: callbacks.onUnlocked,
-            onAttemptFailed: callbacks.onAttemptFailed
+            onAttemptFailed: callbacks.onAttemptFailed,
+            onRestoreFromBackup: callbacks.onRestoreFromBackup
         )
     }
 }

--- a/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/macOS/Native/AppLockPanelHost.swift
@@ -81,6 +81,7 @@ final class AppLockPanelHost: ObservableObject {
     private struct Callbacks {
         let onUnlocked: () -> Void
         let onAttemptFailed: () -> Void
+        let onRestoreFromBackup: () -> Void
     }
 
     init() {
@@ -90,7 +91,8 @@ final class AppLockPanelHost: ObservableObject {
     func update(
         to presentation: AppLockPresentation,
         onUnlocked: @escaping () -> Void,
-        onAttemptFailed: @escaping () -> Void
+        onAttemptFailed: @escaping () -> Void,
+        onRestoreFromBackup: @escaping () -> Void
     ) {
         guard presentation != .uncovered else {
             lower(animated: current.isGate)
@@ -99,7 +101,12 @@ final class AppLockPanelHost: ObservableObject {
             return
         }
 
-        raise(presentation, onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
+        raise(
+            presentation,
+            onUnlocked: onUnlocked,
+            onAttemptFailed: onAttemptFailed,
+            onRestoreFromBackup: onRestoreFromBackup
+        )
     }
 
     // MARK: - Raising
@@ -107,12 +114,13 @@ final class AppLockPanelHost: ObservableObject {
     private func raise(
         _ presentation: AppLockPresentation,
         onUnlocked: @escaping () -> Void,
-        onAttemptFailed: @escaping () -> Void
+        onAttemptFailed: @escaping () -> Void,
+        onRestoreFromBackup: @escaping () -> Void
     ) {
         let hosts = coverableWindows
 
         guard !hosts.isEmpty else {
-            if presentation.isGate {
+            if presentation.isInteractive {
                 hostsLockScreen = false
             }
             return
@@ -127,7 +135,7 @@ final class AppLockPanelHost: ObservableObject {
         // torn down by the completion of the lowering it interrupted.
         lowerToken += 1
 
-        if presentation.isGate {
+        if presentation.isInteractive {
             hostsLockScreen = true
         }
 
@@ -144,12 +152,17 @@ final class AppLockPanelHost: ObservableObject {
                 window === interactive ? presentation : .cover,
                 over: window,
                 onUnlocked: onUnlocked,
-                onAttemptFailed: onAttemptFailed
+                onAttemptFailed: onAttemptFailed,
+                onRestoreFromBackup: onRestoreFromBackup
             )
         }
 
         applyPanelLevel()
-        callbacks = Callbacks(onUnlocked: onUnlocked, onAttemptFailed: onAttemptFailed)
+        callbacks = Callbacks(
+            onUnlocked: onUnlocked,
+            onAttemptFailed: onAttemptFailed,
+            onRestoreFromBackup: onRestoreFromBackup
+        )
         current = presentation
     }
 
@@ -187,11 +200,17 @@ final class AppLockPanelHost: ObservableObject {
         _ presentation: AppLockPresentation,
         over window: NSWindow,
         onUnlocked: @escaping () -> Void,
-        onAttemptFailed: @escaping () -> Void
+        onAttemptFailed: @escaping () -> Void,
+        onRestoreFromBackup: @escaping () -> Void
     ) {
         let key = ObjectIdentifier(window)
         let panel = panels[key] ?? AppLockPanel(
-            screen: AppLockHostedScreen(presentation: .cover, onUnlocked: {}, onAttemptFailed: {})
+            screen: AppLockHostedScreen(
+                presentation: .cover,
+                onUnlocked: {},
+                onAttemptFailed: {},
+                onRestoreFromBackup: {}
+            )
         )
         panels[key] = panel
 
@@ -209,14 +228,15 @@ final class AppLockPanelHost: ObservableObject {
         panel.ignoresMouseEvents = false
         panel.orderFront(nil)
 
-        if presentation.isGate {
+        if presentation.isInteractive {
             panel.makeKey()
         }
 
         panel.host.rootView = AppLockHostedScreen(
             presentation: presentation,
             onUnlocked: onUnlocked,
-            onAttemptFailed: onAttemptFailed
+            onAttemptFailed: onAttemptFailed,
+            onRestoreFromBackup: onRestoreFromBackup
         )
     }
 
@@ -385,12 +405,13 @@ final class AppLockPanelHost: ObservableObject {
     /// A no-op when it is already there, which is what keeps the `makeKey` inside
     /// the re-raise from electing its way round in a circle.
     private func elect(_ window: NSWindow) {
-        guard current.isGate, let callbacks, window !== interactiveWindow else { return }
+        guard current.isInteractive, let callbacks, window !== interactiveWindow else { return }
         interactiveWindow = window
         raise(
             current,
             onUnlocked: callbacks.onUnlocked,
-            onAttemptFailed: callbacks.onAttemptFailed
+            onAttemptFailed: callbacks.onAttemptFailed,
+            onRestoreFromBackup: callbacks.onRestoreFromBackup
         )
     }
 

--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/KeyshareInstallReconciler.swift
@@ -61,6 +61,7 @@ struct KeyshareInstallReconciler {
     private let biometrics: BiometricUnlockStore
     private let lockService: AppLockService
     private let coordinator: KeyshareWriteCoordinator
+    private let sweeper: KeyshareSweeping
     private let defaults: UserDefaults
 
     init(
@@ -69,6 +70,7 @@ struct KeyshareInstallReconciler {
         biometrics: BiometricUnlockStore = .shared,
         lockService: AppLockService = .shared,
         coordinator: KeyshareWriteCoordinator = .shared,
+        sweeper: KeyshareSweeping = KeyshareSweeper.shared,
         defaults: UserDefaults = .standard
     ) {
         self.keychain = keychain
@@ -76,6 +78,7 @@ struct KeyshareInstallReconciler {
         self.biometrics = biometrics
         self.lockService = lockService
         self.coordinator = coordinator
+        self.sweeper = sweeper
         self.defaults = defaults
     }
 
@@ -92,9 +95,45 @@ struct KeyshareInstallReconciler {
         case unknown
     }
 
+    /// Whether the store holds a key share that is sealed.
+    ///
+    /// Three cases for the same reason ``StoreOccupancy`` has three: the answer
+    /// licenses a *state*, and "the store could not be read" is neither of the
+    /// other two. Read as `.sealed` it would raise a recovery screen over a
+    /// perfectly healthy install; read as `.nothingSealed` it would let the
+    /// orphaned state carry on opening silently.
+    ///
+    /// Named `nothingSealed` rather than `none` so it cannot be read as
+    /// `Optional`'s case at a call site — the same reason
+    /// ``InheritedKeyMaterial`` avoids `none`/`some`.
+    enum SealedShareCensus {
+        case sealed
+        case nothingSealed
+        case unknown
+    }
+
+    /// What reconciliation found that somebody above it has to act on.
+    ///
+    /// Only one thing so far, and it is deliberately not expressed as a `Bool`:
+    /// the compiler points at every call site when another is added, which is
+    /// the forcing function this feature prefers.
+    enum Outcome: Equatable {
+        /// Nothing for the app to raise.
+        case nothing
+        /// The store holds at least one sealed key share and the key that opens
+        /// it is **confirmed** gone. Nothing on this device can read those
+        /// shares again, so the app must say so rather than open over them.
+        case sealedSharesWithoutTheirKey
+    }
+
     @MainActor
-    func reconcile() {
-        reconcile(occupancy: storeOccupancy())
+    @discardableResult
+    func reconcile() -> Outcome {
+        // Both are computed here, on the main actor, and handed down as values.
+        // `Vault` is a main-actor-only `@Model` and the work below is not
+        // isolated, so the alternative would be isolating the whole type — see
+        // `storeOccupancy()`, which has solved this once already.
+        reconcile(occupancy: storeOccupancy(), census: sealedShareCensus())
     }
 
     @MainActor
@@ -106,11 +145,35 @@ struct KeyshareInstallReconciler {
         return count == 0 ? .empty : .occupied
     }
 
-    func reconcile(isStoreEmpty: Bool) {
-        reconcile(occupancy: isStoreEmpty ? .empty : .occupied)
+    /// Safe to ask here: it takes no lease of its own, needs no data key —
+    /// `isSealed` is a prefix check — and the model context is installed before
+    /// `VultisigApp.init()` runs this.
+    ///
+    /// It refuses a context carrying unsaved work, which at launch it never is.
+    /// That refusal is `.unknown`, not an error to report: a census that cannot
+    /// be taken decides nothing, and the condition does not depend on the lock
+    /// mode, so the next launch that can read the store still finds it.
+    @MainActor
+    private func sealedShareCensus() -> SealedShareCensus {
+        do {
+            return try sweeper.hasSealedShare() ? .sealed : .nothingSealed
+        } catch {
+            logger.info("The sealed-share census could not be taken: \(String(describing: error), privacy: .public)")
+            return .unknown
+        }
     }
 
-    func reconcile(occupancy: StoreOccupancy) {
+    /// - Parameter census: defaults to `.unknown`, which is the answer that
+    ///   changes nothing — a caller that cannot take the census must not be
+    ///   able to assert either of the other two by omission.
+    @discardableResult
+    func reconcile(isStoreEmpty: Bool, census: SealedShareCensus = .unknown) -> Outcome {
+        reconcile(occupancy: isStoreEmpty ? .empty : .occupied, census: census)
+    }
+
+    /// - Parameter census: see ``reconcile(isStoreEmpty:census:)``.
+    @discardableResult
+    func reconcile(occupancy: StoreOccupancy, census: SealedShareCensus = .unknown) -> Outcome {
         // Both halves read the wrapped key and act on what they read, so both
         // have to be indivisible against a passcode transition. Without this a
         // launch could clear a wrapper `setPasscode` had just made durable, or
@@ -118,12 +181,12 @@ struct KeyshareInstallReconciler {
         // invalidated.
         guard let lease = try? coordinator.beginTransition() else {
             logger.info("Reconciliation skipped: a passcode transition or key-share write is in progress")
-            return
+            return .nothing
         }
         defer { coordinator.end(lease) }
 
         clearInheritedKeyMaterialIfContainerIsNew(occupancy: occupancy)
-        alignLockModeWithTheWrappedKey()
+        return alignLockModeWithTheWrappedKey(census: census)
     }
 
     // MARK: - Inherited key material
@@ -282,18 +345,42 @@ struct KeyshareInstallReconciler {
     ///   persisted `.passcode` — a reinstall clear, or the crash order the
     ///   disable deliberately avoids. `unlock` has nothing to verify a passcode
     ///   against, so that gate could never be opened.
-    private func alignLockModeWithTheWrappedKey() {
+    ///
+    /// A confirmed-absent wrapper over a store that still holds a **sealed**
+    /// share is a third thing, and it is not a lock-mode problem at all: the
+    /// shares are ciphertext whose key is gone, so no mode repair makes them
+    /// readable. It is reported instead, and the mode is left exactly as it is —
+    /// there is nothing to repair, and moving it would erase the only remaining
+    /// evidence that a passcode was ever set here.
+    ///
+    /// The condition deliberately does **not** consult the lock mode. Anyone who
+    /// already hit this has `.deviceAuth` persisted, because this method wrote
+    /// it on their first launch; a check gated on `.passcode` would miss exactly
+    /// the installs that need reporting.
+    private func alignLockModeWithTheWrappedKey(census: SealedShareCensus) -> Outcome {
         switch keyStore.loadWrappedDataKey() {
         case .present:
-            guard lockService.mode != .passcode else { return }
+            guard lockService.mode != .passcode else { return .nothing }
             logger.warning("A wrapped data key exists but the lock mode was \(lockService.mode.rawValue, privacy: .public); restoring passcode mode")
             lockService.mode = .passcode
+            return .nothing
         case .absent:
-            guard lockService.mode == .passcode else { return }
+            if case .sealed = census {
+                logger.error("Sealed key shares with no wrapped data key to open them; this device cannot sign with them")
+                return .sealedSharesWithoutTheirKey
+            }
+            // `.unknown` keeps the repair rather than deferring it, and that is
+            // the safe side here: a persisted `.passcode` over an absent wrapper
+            // is a gate no passcode can open, which is the lockout this branch
+            // exists to prevent. Nothing is lost by repairing — the report above
+            // does not depend on the mode, so the next launch that can read the
+            // store still makes it.
+            guard lockService.mode == .passcode else { return .nothing }
             logger.warning("The lock mode was passcode with no wrapped data key behind it; falling back to device auth")
             lockService.mode = .deviceAuth
+            return .nothing
         case .unavailable:
-            return
+            return .nothing
         }
     }
 }

--- a/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
@@ -34,6 +34,9 @@ enum AccessibilityID {
         static let deleteKey = "passcode.deleteKey"
         static let enterScreen = "passcode.enterScreen"
         static let awaitingBiometrics = "passcode.awaitingBiometrics"
+        static let keyshareRecoveryScreen = "passcode.keyshareRecoveryScreen"
+        static let keyshareRecoveryImportButton = "passcode.keyshareRecoveryImportButton"
+        static let keyshareRecoveryNoBackupToggle = "passcode.keyshareRecoveryNoBackupToggle"
 
         static func digitKey(_ digit: String) -> String {
             "passcode.digit.\(digit)"

--- a/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
@@ -39,6 +39,42 @@ class AppViewModel: ObservableObject {
     @Published var isAuthenticated = false
     /// Whether the passcode lock screen should be covering the app.
     @Published var isPasscodeLocked = false
+    /// Whether this device holds sealed key shares with no key left to open
+    /// them, so the recovery screen has to cover the app.
+    ///
+    /// Derived at launch from ``KeyshareInstallReconciler``'s outcome and not
+    /// from the lock mode: anyone who has already hit this has `.deviceAuth`
+    /// persisted, because reconciliation wrote it on their first launch.
+    ///
+    /// It is not re-derived while the app is running. The state cannot appear
+    /// mid-session — the key does not go missing while the app is open — and
+    /// the one way out of it, importing the `.vult`, is a screen in the app
+    /// that this would be covering.
+    @Published private(set) var isKeyshareRecoveryRequired = false
+    /// Set for exactly as long as it takes ``ContentView`` to route to the
+    /// import flow, then consumed.
+    ///
+    /// A trigger rather than a destination, and consumed rather than merely
+    /// read, because every mounted scene sees it: two scenes acting on one tap
+    /// would push the import route twice.
+    @Published private(set) var isKeyshareRecoveryImportPending = false
+
+    /// Whether anything the app raises over itself is currently up.
+    ///
+    /// The question every *other* part of the app is really asking when it looks
+    /// at ``isPasscodeLocked``: may I present, navigate, or draw a banner right
+    /// now? Both covers answer no, and for the same reason — a deeplink acted on
+    /// behind one navigates and presents where nobody can see it, a foreground
+    /// push banner is drawn by the system above every window the app owns, and a
+    /// sheet raised behind one is a sheet the user finds instead of the screen
+    /// they were sent to.
+    ///
+    /// Computed rather than stored, so it cannot go stale: both halves are
+    /// `@Published`, so anything observing this object re-reads it when either
+    /// moves.
+    var isCoveredByAppLock: Bool {
+        isPasscodeLocked || isKeyshareRecoveryRequired
+    }
     /// Bumped every time the gate goes up, and used as the lock screen's
     /// identity so each raise gets a brand new one.
     ///
@@ -73,7 +109,7 @@ class AppViewModel: ObservableObject {
     private let passcodeService: PasscodeService
     /// Injected rather than called directly so a test can prove it runs *before*
     /// the launch gate reads the lock mode, which is the whole property.
-    private let reconcileInstall: @MainActor () -> Void
+    private let reconcileInstall: @MainActor () -> KeyshareInstallReconciler.Outcome
     private var didTriggerAuthThisSession = false
     /// Whether the app has actually been to the background since the last time
     /// it came forward.
@@ -94,7 +130,9 @@ class AppViewModel: ObservableObject {
     init(
         lockService: AppLockService = .shared,
         passcodeService: PasscodeService = .shared,
-        reconcileInstall: @escaping @MainActor () -> Void = { KeyshareInstallReconciler().reconcile() }
+        reconcileInstall: @escaping @MainActor () -> KeyshareInstallReconciler.Outcome = {
+            KeyshareInstallReconciler().reconcile()
+        }
     ) {
         self.lockService = lockService
         self.passcodeService = passcodeService
@@ -177,7 +215,12 @@ class AppViewModel: ObservableObject {
         // again would be a second read that a transition on `PasscodeService`'s
         // executor could answer differently — the two disagreeing is how the app
         // ends up open behind no gate at all.
-        guard !isPasscodeLocked else {
+        //
+        // The recovery screen counts the same way. It covers the app for the
+        // same reason and is dismissed by no authentication of any kind, so a
+        // system Face ID sheet in front of it would be a prompt with nothing
+        // behind it.
+        guard !isPasscodeLocked, !isKeyshareRecoveryRequired else {
             showSplashView = false
             didUserCancelAuthentication = false
             return
@@ -353,15 +396,71 @@ class AppViewModel: ObservableObject {
     /// with a persisted `.passcode` and a confirmed-absent wrapper therefore
     /// opens the app rather than presenting a lock screen no passcode can
     /// satisfy, and one whose Keychain merely did not answer still presents it.
+    ///
+    /// Reconciliation now also answers whether this device holds sealed key
+    /// shares with no key left to open them, and that answer is taken **first**.
+    /// The two cannot both be true — the orphaned state is only reported over a
+    /// *confirmed absent* wrapper, which is exactly the reading that makes
+    /// `isPasscodeGateRequired` false — so the ordering is not a race being
+    /// resolved. It states which screen wins if that ever stops holding, and a
+    /// lock screen no passcode can open is the wrong one.
     @MainActor
     func restorePasscodeLockOnLaunch() {
-        reconcileInstall()
+        let outcome = reconcileInstall()
+
+        isKeyshareRecoveryRequired = outcome == .sealedSharesWithoutTheirKey
+        guard !isKeyshareRecoveryRequired else {
+            isPasscodeLocked = false
+            return
+        }
 
         guard passcodeService.isPasscodeGateRequired else {
             isPasscodeLocked = false
             return
         }
         raisePasscodeGate()
+    }
+
+    /// Asks to be sent from the recovery screen to the app's import flow.
+    ///
+    /// It only *asks*. The screen is hosted in a window above the app and has no
+    /// access to its navigation, so the route is pushed by whoever owns the
+    /// navigation stack — see ``handOffToKeyshareRecoveryImport(routingWith:)``.
+    func beginKeyshareRecoveryImport() {
+        guard isKeyshareRecoveryRequired else { return }
+        isKeyshareRecoveryImportPending = true
+    }
+
+    /// Pushes the import route and only then takes the recovery screen down.
+    ///
+    /// **The order is the whole method.** Lowering first uncovers the app while
+    /// the push is still on its way, so the wallet — the very thing this state
+    /// exists to stop being shown as healthy — is what the user sees between the
+    /// tap and the import screen. Routing first means the cover comes off a
+    /// stack whose top is already where they were sent.
+    ///
+    /// **The screen does not come back if the user backs out of the import**,
+    /// and that is a decision rather than an oversight. Re-raising it on the way
+    /// out of that route would need the census taken again to tell a successful
+    /// import from an abandoned one — and until the import path stops refusing
+    /// the orphaned vault as a duplicate, "still orphaned" is the only answer it
+    /// can give, which is a screen with no way out at all. This state is not a
+    /// security boundary either: nothing behind it is protected, the app renders
+    /// the same wallet with or without it and can sign in neither case. It is
+    /// derived again on the next launch from the same census, so an import that
+    /// succeeds no longer qualifies and one the user walked away from is put
+    /// back in front of them.
+    ///
+    /// - Returns: whether this caller was the one that claimed the hand-off.
+    ///   Every mounted scene sees the request, and two of them pushing the route
+    ///   is two import screens.
+    @discardableResult
+    func handOffToKeyshareRecoveryImport(routingWith route: () -> Void) -> Bool {
+        guard isKeyshareRecoveryImportPending else { return false }
+        isKeyshareRecoveryImportPending = false
+        route()
+        isKeyshareRecoveryRequired = false
+        return true
     }
 
     /// The foreground hook, and so the first place a transition that completed

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/KeyshareRecoveryScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/KeyshareRecoveryScreen.swift
@@ -1,0 +1,123 @@
+//
+//  KeyshareRecoveryScreen.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Shown when this device holds sealed key shares and the key that opens them is
+/// confirmed gone.
+///
+/// The state is real and legitimate: an iOS restore from an *unencrypted*
+/// computer backup carries the SwiftData store but not the Keychain item, so the
+/// vaults arrive without the key that unseals them. Names, addresses and
+/// balances all still render, and only signing fails — which is why this screen
+/// exists rather than a silent open.
+///
+/// Three rules shape the copy, and each one is a way of making it worse:
+///
+/// 1. **No blame and no alarm.** Nothing the user did caused this, and telling
+///    them their funds are gone when a `.vult` would bring them straight back is
+///    the wrong instruction at the worst moment.
+/// 2. **The `.vult` is named, and importing it is one tap away.** It is the only
+///    route back for a device that has lost the key, so it is the primary action
+///    rather than a sentence someone has to interpret.
+/// 3. **No reinstall or clear-data advice, anywhere.** That is the one action
+///    that turns a recoverable vault into an unrecoverable one — it removes the
+///    stored shares as well, so a user who later finds their backup has nothing
+///    left to reconcile it against.
+struct KeyshareRecoveryScreen: View {
+
+    /// Hands the user to the app's import flow. Held as a closure because this
+    /// screen is mounted in a window above the app's own hierarchy, which
+    /// carries none of its navigation.
+    let onRestoreFromBackup: () -> Void
+
+    /// Whether the honest statement for the user with no backup is showing.
+    ///
+    /// Behind a disclosure rather than on the face of the screen: it is the one
+    /// genuinely bad outcome, and leading with it would tell everyone their
+    /// vaults are gone when most of them are one file away from having them
+    /// back.
+    @State private var isShowingNoBackupHelp = false
+
+    var body: some View {
+        Screen {
+            VStack(spacing: 24) {
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 16) {
+                        header
+                        noBackupSection
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+
+                PrimaryButton(title: "keyshareRecoveryImportButton".localized) {
+                    onRestoreFromBackup()
+                }
+                .accessibilityIdentifier(AccessibilityID.Passcode.keyshareRecoveryImportButton)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .screenNavigationBarHidden(true)
+        .screenBackground(.gradient)
+        .accessibilityIdentifier(AccessibilityID.Passcode.keyshareRecoveryScreen)
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Icon(.folderLock, color: Theme.colors.alertWarning, size: 48)
+                .padding(.bottom, 8)
+
+            Text("keyshareRecoveryTitle".localized)
+                .font(Theme.fonts.title2)
+                .foregroundStyle(Theme.colors.textPrimary)
+
+            Text("keyshareRecoveryMessage".localized)
+                .font(Theme.fonts.bodyMRegular)
+                .foregroundStyle(Theme.colors.textTertiary)
+
+            Text("keyshareRecoveryBackupMessage".localized)
+                .font(Theme.fonts.bodyMMedium)
+                .foregroundStyle(Theme.colors.textPrimary)
+                .padding(.top, 8)
+        }
+        .multilineTextAlignment(.center)
+        // The paragraphs wrap to whatever height they need instead of being
+        // compressed into one truncated line: the sentence naming the `.vult` is
+        // the last thing on this screen that should end in an ellipsis.
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.top, 24)
+    }
+
+    private var noBackupSection: some View {
+        VStack(spacing: 12) {
+            Button {
+                withAnimation { isShowingNoBackupHelp.toggle() }
+            } label: {
+                Text("keyshareRecoveryNoBackupTitle".localized)
+                    .font(Theme.fonts.bodySMedium)
+                    .foregroundStyle(Theme.colors.primaryAccent4)
+                    .underline()
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(AccessibilityID.Passcode.keyshareRecoveryNoBackupToggle)
+
+            if isShowingNoBackupHelp {
+                Text("keyshareRecoveryNoBackupMessage".localized)
+                    .font(Theme.fonts.bodySRegular)
+                    .foregroundStyle(Theme.colors.textTertiary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(16)
+                    .frame(maxWidth: .infinity)
+                    .background(Theme.radius.md.shape.fill(Theme.colors.bgSurface2))
+            }
+        }
+        .padding(.top, 16)
+    }
+}
+
+#Preview {
+    KeyshareRecoveryScreen(onRestoreFromBackup: {})
+}

--- a/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/KeyshareInstallReconcilerTests.swift
@@ -273,6 +273,152 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
         XCTAssertEqual(lockService.mode, .deviceAuth)
     }
 
+    // MARK: - Sealed shares with no key
+
+    /// The whole matrix, because the interesting cell is the one nothing used to
+    /// look at: a confirmed-absent wrapper over a store that still holds sealed
+    /// shares. Every other cell has to keep behaving exactly as it did, or the
+    /// census has changed something it was not supposed to.
+    func testTheCensusOnlyChangesTheConfirmedAbsentSealedCell() {
+        let wrappers: [(name: String, result: KeychainReadResult<Data>)] = [
+            ("present", .present(wrappedBlob)),
+            ("absent", .absent),
+            ("unavailable", .unavailable(errSecInteractionNotAllowed))
+        ]
+        let censuses: [KeyshareInstallReconciler.SealedShareCensus] = [.sealed, .nothingSealed, .unknown]
+
+        for wrapper in wrappers {
+            for census in censuses {
+                keychain.wrappedKeyshareDataKeyResult = wrapper.result
+                // Restated per cell rather than left where the previous one put
+                // it: the alignment writes the mode, so an assertion run against
+                // whatever the last cell happened to leave behind is not the
+                // cell it claims to be.
+                lockService.mode = .passcode
+
+                let outcome = sut.reconcile(isStoreEmpty: false, census: census)
+
+                let expected: KeyshareInstallReconciler.Outcome
+                if case .absent = wrapper.result, case .sealed = census {
+                    expected = .sealedSharesWithoutTheirKey
+                } else {
+                    expected = .nothing
+                }
+
+                XCTAssertEqual(
+                    outcome,
+                    expected,
+                    "census \(census) over a \(wrapper.name) wrapper"
+                )
+            }
+        }
+    }
+
+    /// The cell above, stated as the state it actually is: the shares are
+    /// ciphertext and the key is gone, so there is no mode repair to make. The
+    /// mode is left alone deliberately — moving it would erase the only evidence
+    /// left on the device that a passcode was ever set.
+    func testSealedSharesWithNoWrappedKeyAreReportedAndTheModeIsLeftAlone() {
+        lockService.mode = .passcode
+
+        let outcome = sut.reconcile(isStoreEmpty: false, census: .sealed)
+
+        XCTAssertEqual(outcome, .sealedSharesWithoutTheirKey)
+        XCTAssertEqual(lockService.mode, .passcode, "there is nothing behind this gate to repair towards")
+    }
+
+    /// The reason the check keys on the census rather than on the lock mode.
+    /// Anyone who has already hit this bug has `.deviceAuth` persisted — this
+    /// very method wrote it on their first launch — so a condition gated on
+    /// `.passcode` would miss exactly the installs that need reporting.
+    func testSealedSharesAreReportedEvenWhenTheModeHasAlreadyBeenRepaired() {
+        lockService.mode = .deviceAuth
+
+        let outcome = sut.reconcile(isStoreEmpty: false, census: .sealed)
+
+        XCTAssertEqual(outcome, .sealedSharesWithoutTheirKey)
+    }
+
+    /// An unreadable store must not raise it. The screen it drives is not
+    /// dismissible, so raising one on a guess strands a user whose vaults are
+    /// perfectly fine — and the condition does not depend on the mode, so the
+    /// next launch that can read the store still finds it.
+    func testAnUnreadableCensusReportsNothingAndStillRepairsTheMode() {
+        lockService.mode = .passcode
+
+        let outcome = sut.reconcile(isStoreEmpty: false, census: .unknown)
+
+        XCTAssertEqual(outcome, .nothing)
+        XCTAssertEqual(
+            lockService.mode,
+            .deviceAuth,
+            "a gate no passcode can open is the lockout this branch exists to prevent; deferring is not the safe side"
+        )
+    }
+
+    /// A store with nothing sealed in it is the interrupted-disable case the
+    /// `.absent` branch has always repaired, and it must go on repairing it.
+    func testAStoreWithNothingSealedStillFallsBackToDeviceAuth() {
+        lockService.mode = .passcode
+
+        let outcome = sut.reconcile(isStoreEmpty: false, census: .nothingSealed)
+
+        XCTAssertEqual(outcome, .nothing)
+        XCTAssertEqual(lockService.mode, .deviceAuth)
+    }
+
+    /// The census is taken from the store, and a store that answers "yes" has to
+    /// reach the outcome. Asserted through `reconcile()` — the entry point the
+    /// app actually calls — rather than through the seam, so a census that is
+    /// computed but never passed down would fail here.
+    @MainActor
+    func testReconcileTakesTheCensusFromTheStore() {
+        let sut = KeyshareInstallReconciler(
+            keychain: keychain,
+            keyStore: keyStore,
+            biometrics: biometrics,
+            lockService: lockService,
+            coordinator: coordinator,
+            sweeper: StubSweeper(answer: .success(true)),
+            defaults: defaults
+        )
+
+        XCTAssertEqual(sut.reconcile(), .sealedSharesWithoutTheirKey)
+    }
+
+    @MainActor
+    func testReconcileReportsNothingWhenTheStoreHoldsNoSealedShare() {
+        let sut = KeyshareInstallReconciler(
+            keychain: keychain,
+            keyStore: keyStore,
+            biometrics: biometrics,
+            lockService: lockService,
+            coordinator: coordinator,
+            sweeper: StubSweeper(answer: .success(false)),
+            defaults: defaults
+        )
+
+        XCTAssertEqual(sut.reconcile(), .nothing)
+    }
+
+    /// A census that throws is not an answer. `hasSealedShare()` refuses a
+    /// context carrying unsaved work, and that refusal must not be read as
+    /// either "sealed" or "nothing sealed".
+    @MainActor
+    func testACensusThatThrowsReportsNothing() {
+        let sut = KeyshareInstallReconciler(
+            keychain: keychain,
+            keyStore: keyStore,
+            biometrics: biometrics,
+            lockService: lockService,
+            coordinator: coordinator,
+            sweeper: StubSweeper(answer: .failure(KeyshareSweeperError.busy)),
+            defaults: defaults
+        )
+
+        XCTAssertEqual(sut.reconcile(), .nothing)
+    }
+
     // MARK: - Serialization
 
     /// Launch reconciliation deletes and re-decides exactly the state a passcode
@@ -395,6 +541,22 @@ final class KeyshareInstallReconcilerTests: XCTestCase {
 
         XCTAssertFalse(biometrics.isEnabled)
     }
+}
+
+/// Answers the census and nothing else. Reconciliation never sweeps — it reads
+/// the store and repairs Keychain-held state — so a sweep here fails loudly
+/// rather than silently doing nothing.
+private final class StubSweeper: KeyshareSweeping {
+
+    private let answer: Result<Bool, Error>
+
+    init(answer: Result<Bool, Error>) {
+        self.answer = answer
+    }
+
+    @MainActor func sealAll() throws { XCTFail("reconciliation must not sweep") }
+    @MainActor func unsealAll() throws { XCTFail("reconciliation must not sweep") }
+    @MainActor func hasSealedShare() throws -> Bool { try answer.get() }
 }
 
 /// In-memory stand-in for the biometry-protected Keychain item — the real one

--- a/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
@@ -126,7 +126,7 @@ final class PasscodeGateWiringTests: XCTestCase {
         AppViewModel(
             lockService: lockService,
             passcodeService: service,
-            reconcileInstall: { }
+            reconcileInstall: { .nothing }
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Security/PasscodeLaunchGateTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeLaunchGateTests.swift
@@ -81,11 +81,23 @@ final class PasscodeLaunchGateTests: XCTestCase {
         super.tearDown()
     }
 
-    private func makeViewModel(reconcile: @escaping @MainActor () -> Void) -> AppViewModel {
+    /// - Parameters:
+    ///   - outcome: what reconciliation reports back. Separate from the closure
+    ///     below so a test can state the outcome without also having to model a
+    ///     side effect, and vice versa.
+    ///   - reconcile: reconciliation's side effect on the lock mode, run at the
+    ///     moment the real one would run it.
+    private func makeViewModel(
+        outcome: KeyshareInstallReconciler.Outcome = .nothing,
+        reconcile: @escaping @MainActor () -> Void = {}
+    ) -> AppViewModel {
         AppViewModel(
             lockService: lockService,
             passcodeService: passcodeService,
-            reconcileInstall: reconcile
+            reconcileInstall: {
+                reconcile()
+                return outcome
+            }
         )
     }
 
@@ -156,6 +168,147 @@ final class PasscodeLaunchGateTests: XCTestCase {
         sut.restorePasscodeLockOnLaunch()
 
         XCTAssertTrue(sut.isPasscodeLocked)
+    }
+
+    // MARK: - Sealed shares with no key
+
+    /// The launch this whole change exists for: the store came across in a
+    /// restore and the Keychain wrapper did not, so the shares are ciphertext
+    /// nothing on this device can read. The app must say so instead of opening.
+    func testTheRecoveryScreenIsRaisedOverAnOrphanedInstall() {
+        lockService.mode = .deviceAuth
+        keychain.wrappedKeyshareDataKey = nil
+
+        let sut = makeViewModel(outcome: .sealedSharesWithoutTheirKey)
+        sut.restorePasscodeLockOnLaunch()
+
+        XCTAssertTrue(sut.isKeyshareRecoveryRequired)
+        XCTAssertFalse(sut.isPasscodeLocked, "there is no passcode behind this, and nothing to type")
+    }
+
+    /// A healthy install raises nothing, whichever gate it has. Without this the
+    /// pair above would pass against a flag that is simply always true.
+    func testTheRecoveryScreenIsNotRaisedOverAHealthyInstall() {
+        lockService.mode = .passcode
+
+        let sut = makeViewModel()
+        sut.restorePasscodeLockOnLaunch()
+
+        XCTAssertFalse(sut.isKeyshareRecoveryRequired)
+        XCTAssertTrue(sut.isPasscodeLocked, "the ordinary passcode gate still goes up")
+    }
+
+    /// Reconciliation reports the orphaned state without touching the mode, so a
+    /// stale `.passcode` can still be sitting there. The recovery screen wins:
+    /// a lock screen whose only exit is an unlock that can answer nothing but
+    /// `notSet` is the worse of the two to present.
+    func testTheRecoveryScreenWinsOverAStalePasscodeMode() {
+        lockService.mode = .passcode
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+
+        let sut = makeViewModel(outcome: .sealedSharesWithoutTheirKey)
+        sut.restorePasscodeLockOnLaunch()
+
+        XCTAssertTrue(sut.isKeyshareRecoveryRequired)
+        XCTAssertFalse(sut.isPasscodeLocked)
+    }
+
+    /// The screen points at the import flow, and the import flow is a screen in
+    /// the app — which this is drawn over. So the route goes in **first** and
+    /// the screen comes down after: lowering first uncovers the wallet while the
+    /// push is still on its way, which is the silent open this state exists to
+    /// prevent arriving by the one door left open.
+    func testTheImportRouteIsPushedBeforeTheRecoveryScreenComesDown() {
+        keychain.wrappedKeyshareDataKey = nil
+
+        let sut = makeViewModel(outcome: .sealedSharesWithoutTheirKey)
+        sut.restorePasscodeLockOnLaunch()
+
+        sut.beginKeyshareRecoveryImport()
+        XCTAssertTrue(sut.isKeyshareRecoveryRequired, "asking must not be enough to uncover the app")
+        XCTAssertTrue(sut.isKeyshareRecoveryImportPending)
+
+        var wasStillCoveredWhileRouting = false
+        let claimed = sut.handOffToKeyshareRecoveryImport {
+            wasStillCoveredWhileRouting = sut.isKeyshareRecoveryRequired
+        }
+
+        XCTAssertTrue(claimed)
+        XCTAssertTrue(wasStillCoveredWhileRouting, "the push happens under the cover, not after it")
+        XCTAssertFalse(sut.isKeyshareRecoveryRequired)
+        XCTAssertFalse(sut.isKeyshareRecoveryImportPending)
+    }
+
+    /// Every mounted scene sees the request, and two of them routing is two
+    /// import screens.
+    func testOnlyOneSceneClaimsTheImportHandOff() {
+        keychain.wrappedKeyshareDataKey = nil
+
+        let sut = makeViewModel(outcome: .sealedSharesWithoutTheirKey)
+        sut.restorePasscodeLockOnLaunch()
+        sut.beginKeyshareRecoveryImport()
+
+        var routes = 0
+        XCTAssertTrue(sut.handOffToKeyshareRecoveryImport { routes += 1 })
+        XCTAssertFalse(sut.handOffToKeyshareRecoveryImport { routes += 1 })
+
+        XCTAssertEqual(routes, 1)
+    }
+
+    /// The cover predicate the rest of the app reads. A deeplink, a held sheet
+    /// and a foreground push banner all have to treat this screen the way they
+    /// treat the lock screen — otherwise they act, and are seen, behind it.
+    func testTheRecoveryScreenCountsAsAnAppLockCover() {
+        keychain.wrappedKeyshareDataKey = nil
+
+        let sut = makeViewModel(outcome: .sealedSharesWithoutTheirKey)
+        sut.restorePasscodeLockOnLaunch()
+
+        XCTAssertFalse(sut.isPasscodeLocked, "precondition: it is not the gate that is up")
+        XCTAssertTrue(sut.isCoveredByAppLock)
+
+        sut.beginKeyshareRecoveryImport()
+        sut.handOffToKeyshareRecoveryImport { }
+
+        XCTAssertFalse(sut.isCoveredByAppLock)
+    }
+
+    /// And nothing else may start it. The hand-off lowers a screen the user is
+    /// meant to be looking at, so a stray call would open the app over key
+    /// shares it cannot read.
+    func testTheImportHandOffDoesNothingWithoutARecoveryScreenUp() {
+        let sut = makeViewModel()
+        sut.restorePasscodeLockOnLaunch()
+
+        sut.beginKeyshareRecoveryImport()
+
+        XCTAssertFalse(sut.isKeyshareRecoveryImportPending)
+
+        var routed = false
+        XCTAssertFalse(sut.handOffToKeyshareRecoveryImport { routed = true })
+        XCTAssertFalse(routed)
+    }
+
+    /// The same rule the passcode gate has: with the recovery screen up, the
+    /// legacy device-auth path must not run. It is dismissed by no
+    /// authentication of any kind, so a system biometric sheet in front of it
+    /// is a prompt with nothing behind it.
+    func testTheLegacyDeviceAuthIsNotRunWhileTheRecoveryScreenIsUp() {
+        keychain.wrappedKeyshareDataKey = nil
+
+        let sut = makeViewModel(outcome: .sealedSharesWithoutTheirKey)
+        sut.didAskForAuthentication = false
+        sut.restorePasscodeLockOnLaunch()
+        XCTAssertTrue(sut.isKeyshareRecoveryRequired, "precondition: the recovery screen is up")
+
+        sut.authenticateUser()
+
+        XCTAssertTrue(sut.isKeyshareRecoveryRequired, "the recovery screen survives the splash's authentication")
+        XCTAssertFalse(sut.showSplashView, "the splash comes down; the recovery screen is what covers the app")
+        XCTAssertFalse(
+            sut.didAskForAuthentication,
+            "reaching the device-auth branch is what sets this, and it must not be reached"
+        )
     }
 
     // MARK: - The splash, and the legacy gate behind it

--- a/VultisigApp/VultisigAppTests/Security/VaultBackupExportTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/VaultBackupExportTests.swift
@@ -1,0 +1,142 @@
+//
+//  VaultBackupExportTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import VultisigCommonData
+import XCTest
+@testable import VultisigApp
+
+/// Pins the one property the whole recovery design leans on: **`.vult` export
+/// opens every share, or it throws.**
+///
+/// A device whose key shares are sealed with a key it no longer holds is told to
+/// restore from its `.vult`. That advice is only true while the backups people
+/// already hold are real backups — and the way this stops being true is quiet.
+/// An export that skipped a share it could not open, or wrote the ciphertext
+/// instead, produces a file that has the right name, the right size, imports
+/// without complaint, and restores to a vault that cannot sign. Nothing on
+/// either side reports anything.
+///
+/// These are **pins, not fail-first regressions.** `Vault.mapToProtobuff` is
+/// already correct; the point is that it stays that way, so each test names the
+/// specific plausible edit it would fail against rather than a bug that exists.
+/// ``KeyshareAccessorTests`` covers the round trip and the locked case; what is
+/// here is the granularity that survives a refactor — partial failure, and every
+/// share rather than the first one.
+final class VaultBackupExportTests: XCTestCase {
+
+    private let shares = [
+        ("02aaa", "eyJrZXlzaGFyZSI6ImVjZHNhIn0="),
+        ("03bbb", #"{"PubKey":"03bbb","ShareID":{"value":"9"}}"#),
+        ("04ccc", #"{"PubKey":"04ccc","ShareID":{"value":"11"}}"#)
+    ]
+
+    /// One key, made once. A closure that minted a fresh key on every `state()`
+    /// read would seal and open under different keys and fail for a reason that
+    /// has nothing to do with what is being pinned.
+    private func makeUnlockedProtector() throws -> KeyshareProtector {
+        let key = try VaultCryptoEnvelope.randomKey()
+        return KeyshareProtector(state: { .unlocked(key) })
+    }
+
+    private func makeVault(keyshares: [KeyShare]) -> Vault {
+        let vault = Vault(name: "Test Vault")
+        vault.pubKeyECDSA = shares[0].0
+        vault.pubKeyEdDSA = shares[1].0
+        vault.hexChainCode = "abcd"
+        vault.localPartyID = "iPhone-1"
+        vault.signers = ["iPhone-1", "iPad-2"]
+        vault.libType = .DKLS
+        vault.keyshares = keyshares
+        return vault
+    }
+
+    /// Every share reaches the file, in the clear, with its own public key.
+    ///
+    /// The edit this fails against is any rewrite that opens the first share and
+    /// reuses the result, or that maps over a subset — both of which produce a
+    /// file that passes a "does it contain plaintext?" check on its first entry.
+    func testExportOpensEveryShareRatherThanOnlyTheFirst() throws {
+        let protector = try makeUnlockedProtector()
+        let vault = makeVault(
+            keyshares: try shares.map {
+                try KeyShare.sealed(pubkey: $0.0, keyshare: $0.1, protector: protector)
+            }
+        )
+
+        let proto = try vault.mapToProtobuff(protector: protector)
+
+        XCTAssertEqual(proto.keyShares.count, shares.count)
+        for (index, expected) in shares.enumerated() {
+            XCTAssertEqual(proto.keyShares[index].publicKey, expected.0)
+            XCTAssertEqual(proto.keyShares[index].keyshare, expected.1)
+        }
+    }
+
+    /// A share sealed under a key this device does not hold is exactly the
+    /// orphaned state, and the export has to refuse rather than write the
+    /// envelope it cannot open.
+    func testExportThrowsRatherThanWritingAShareItCannotOpen() throws {
+        let sealing = try makeUnlockedProtector()
+        let vault = makeVault(
+            keyshares: try shares.map {
+                try KeyShare.sealed(pubkey: $0.0, keyshare: $0.1, protector: sealing)
+            }
+        )
+
+        // A different data key — the same thing a restore onto another device
+        // produces, and the one case where a silently-written backup would be
+        // ciphertext nobody can ever open.
+        let otherDevice = try makeUnlockedProtector()
+
+        XCTAssertThrowsError(try vault.mapToProtobuff(protector: otherDevice)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .cipherFailure)
+        }
+    }
+
+    /// The partial case, and the one a `try?` or a `compactMap` would turn into
+    /// a backup that looks complete.
+    ///
+    /// Plaintext passes through `open` in every state, so a vault part-way
+    /// through a sweep exports its readable shares perfectly well. One share it
+    /// cannot open has to take the whole export down with it — a `.vult` missing
+    /// a share restores to a vault that cannot sign, and says nothing.
+    func testOneUnopenableShareRefusesTheWholeExport() throws {
+        let sealing = try makeUnlockedProtector()
+        let vault = makeVault(
+            keyshares: [
+                KeyShare(pubkey: shares[0].0, keyshare: shares[0].1),
+                try KeyShare.sealed(pubkey: shares[1].0, keyshare: shares[1].1, protector: sealing),
+                KeyShare(pubkey: shares[2].0, keyshare: shares[2].1)
+            ]
+        )
+
+        let locked = KeyshareProtector(state: { .locked })
+
+        // Precondition, so the assertion below cannot pass because nothing was
+        // readable: the two plaintext shares open under the same locked
+        // protector that refuses the sealed one.
+        XCTAssertEqual(try locked.open(shares[0].1), shares[0].1)
+        XCTAssertEqual(try locked.open(shares[2].1), shares[2].1)
+
+        XCTAssertThrowsError(try vault.mapToProtobuff(protector: locked)) { error in
+            XCTAssertEqual(error as? KeyshareProtectionError, .locked)
+        }
+    }
+
+    /// And the same rule with nothing sealed at all: a vault with no passcode
+    /// exports byte-for-byte, which is the acceptance test this feature is held
+    /// to for every user who never turns a passcode on.
+    func testAVaultWithNoPasscodeExportsItsSharesUnchanged() throws {
+        let disabled = KeyshareProtector(state: { .disabled })
+        let vault = makeVault(
+            keyshares: shares.map { KeyShare(pubkey: $0.0, keyshare: $0.1) }
+        )
+
+        let proto = try vault.mapToProtobuff(protector: disabled)
+
+        XCTAssertEqual(proto.keyShares.map(\.keyshare), shares.map(\.1))
+    }
+}

--- a/VultisigApp/VultisigAppTests/Security/VaultBackupExportTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/VaultBackupExportTests.swift
@@ -25,6 +25,11 @@ import XCTest
 /// ``KeyshareAccessorTests`` covers the round trip and the locked case; what is
 /// here is the granularity that survives a refactor — partial failure, and every
 /// share rather than the first one.
+/// `@MainActor` because every test here builds a `Vault`, which is a SwiftData
+/// `@Model` and must not be touched off the main actor. The sibling Security
+/// tests that construct one — `BackupImportProtectionTests`, `KeyshareSweeperTests`
+/// — are isolated for the same reason.
+@MainActor
 final class VaultBackupExportTests: XCTestCase {
 
     private let shares = [
@@ -137,6 +142,11 @@ final class VaultBackupExportTests: XCTestCase {
 
         let proto = try vault.mapToProtobuff(protector: disabled)
 
+        // Both fields, not just the share. A mapping that dropped or reordered
+        // the public keys would still produce the right plaintext in the right
+        // order, and a share exported under the wrong key is a backup that
+        // restores into a vault that cannot sign.
         XCTAssertEqual(proto.keyShares.map(\.keyshare), shares.map(\.1))
+        XCTAssertEqual(proto.keyShares.map(\.publicKey), shares.map(\.0))
     }
 }


### PR DESCRIPTION
## What

A device restored from an **unencrypted** computer backup gets the SwiftData store but not the Keychain wrapper, so every sealed key share is ciphertext with no key. The app opened anyway: names, addresses and balances all rendered, and the failure only surfaced at signing as `fail to get local keyshare`.

`alignLockModeWithTheWrappedKey` saw the wrapper confirmed absent, flipped the lock mode to device auth, and returned — without ever asking whether the store still held shares sealed under the key that had just gone missing. `hasSealedShare()` already existed and would have caught it; it had one caller, `setPasscode`, and never ran at launch.

This PR detects the state at launch and puts an explicit recovery screen in front of the app. Making the recovery route actually work is the stacked PR that follows.

Closes #5086.

## How

**The census keys on the state, not on the lock mode.** The orphaned condition is *wrapper confirmed absent* **and** *the store holds a sealed share*. That second clause matters more than it looks: anyone who has already hit this bug has `mode = .deviceAuth` persisted, because today's code wrote it on their first launch. A check gated on `mode == .passcode` would miss exactly the users who need it.

`SealedShareCensus` is the third input, computed by `reconcile()` on the main actor alongside `storeOccupancy()` — the same shape the file already uses, with the same "only a confirmed answer moves state" rule:

| Census | Wrapper `.absent` | Action |
|---|---|---|
| `.sealed` | yes | **Orphaned.** Report it; do not touch the mode. |
| `.nothingSealed` | yes | Today's behaviour: repair `mode` → `.deviceAuth`. |
| `.unknown` | yes | Today's behaviour: repair `mode` → `.deviceAuth`, report nothing. |

`.unknown` keeps the existing repair rather than deferring. Leaving a persisted `.passcode` over an absent wrapper is a gate no passcode can open — the exact lockout that branch exists to prevent — so deferring is not the safe side here. Nothing is lost: the condition does not depend on the mode, so the next launch that gets a readable census still reports it.

**`AppLockPresentation` gets a third case.** The recovery state has to cover sheets and full-screen covers the way the gate now does, because the wallet underneath renders perfectly well and only fails at signing — anything short of covering it is the silent open. `.recovery` in the hosted window is that.

`isGate` splits in two along the way. Everything the hosts used it for except one meant "this screen takes input" — key window, one scene only, no second live copy in the root overlay — and the recovery screen wants all three, so those become `isInteractive`. The exception is the fade on the way down, which stays gate-only.

**`isCoveredByAppLock`** is the predicate the rest of the app was really asking for when it read `isPasscodeLocked`. Held presentations and the foreground push-notification policy now treat the recovery screen the way they treat the lock screen — a foreground push falling through to the system banner is drawn above every window the app owns, vault name and transaction summary included.

**The screen** is built to the copy spec in vultisig/vultisig-sdk#1845 screen 2: what happened without blame or alarm, the `.vult` named as the route back with the import one tap away, a distinct state for the user with no backup saying what is and is not recoverable, and no reinstall or clear-data advice anywhere — that last one is what actually destroys a recoverable vault. Design system only, localised into all 8 shipping locales.

**Export is pinned.** iOS export was already correct; these are characterisation tests so it stays that way. Each names the plausible edit it would fail against: an open of the first share reused for the rest, a `try?`/`compactMap` that drops the one share that will not open, and the wrong-key case a restore onto another device produces. The partial vault is the one worth having — plaintext passes through `open` in every state, so a vault part-way through a sweep exports its readable shares perfectly well, and one unopenable share has to take the whole export down with it.

## Deliberate, and worth a reviewer's eye

- **The screen hands off to the app's import flow rather than hosting it.** The screen lives in a window above the app's own hierarchy, which carries none of its navigation or model container. So it asks, and `ContentView` routes — the push first, without animation, and only then the cover down, so the cover comes off a stack whose top is already where the user was sent.
- **Backing out of the import route reaches the wallet.** This is a deviation from the plan's "not dismissible into the app", taken knowingly. Re-raising the screen on the way out of that route needs the census taken again to tell a successful import from an abandoned one, and until the stacked PR lands "still orphaned" is the only answer it can give — a screen with no way out at all, on a PR that may merge first. This state is also not a security boundary: nothing behind it is protected, the app renders the same wallet either way and can sign in neither case. It is derived again at the next launch, so a user who backs out is put back in front of it.
- **The state is derived at launch only.** It cannot appear mid-session — the key does not go missing while the app is open — and the one way out of it is a screen this would be covering.
- **Deeplinks are dropped behind the recovery screen, not queued.** The queue exists for a cover that lasts seconds; this one lasts the session, so a link kept there arrives an arbitrary time later on top of the import screen.
- **Other held presentations** (monthly backup warning, biweekly password verification, push-notification setup) still fire when the cover comes down and present over the import screen. Suppressing them needs a notion of "the import flow exited", which is the same machinery rejected above.

## Testing

- `KeyshareInstallReconcilerTests`: all nine census × wrapper-state cells, the mode-independence case that proves detection does not need `.passcode`, and the census taken through `reconcile()` itself rather than only through the test seam.
- `PasscodeLaunchGateTests`: the screen raised over an orphaned install and not over a healthy one, the recovery screen winning over a stale `.passcode` mode, the route pushed while the cover is still up, one scene only claiming the hand-off, and the legacy device-auth path not running behind it.
- `VaultBackupExportTests`: the export pins above.

Gate, on a dedicated `iPhone 17 Pro Max` / iOS 26.5 simulator:

```
Executed 5485 tests, with 1 test skipped and 0 failures (0 unexpected)
** TEST SUCCEEDED **
```

macOS build (step 3 adds cross-platform SwiftUI the iOS build never compiles):

```
** BUILD SUCCEEDED **
```

`swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 22 violations, unchanged from `main`. 0 new.

Every commit was gated by a read-only `codex exec` review before the next step started, plus a whole-branch pass; ledger in the wiki at `pages/projects/vultisig/passcode-app-lock/codex-review-ledger-5086.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added key-share recovery when vault shares cannot be opened.
  - Added recovery guidance, backup import, and no-backup help.
  - Added support for importing `.vult` backups directly into recovery.
- **Bug Fixes**
  - Deferred deeplinks and notifications while the app is locked or recovering.
  - Recovery now takes priority over passcode locking.
  - Improved app-lock handling across supported platforms.
- **Localization**
  - Added recovery translations in English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.
- **Accessibility**
  - Added identifiers for recovery actions and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->