### PR TITLE
fix(import): let a .vult replace the vault this device can no longer open

### DIFF
--- a/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Keyshare/ProtectedVaultImporter.swift
@@ -10,9 +10,10 @@ import SwiftData
 private let logger = Log.app.store
 
 enum ProtectedVaultImportError: Error, Equatable {
-    /// A passcode transition is in progress. The import is refused rather than
-    /// queued: the transition is about to rewrite every stored share, and a
-    /// vault inserted underneath it would never be seen.
+    /// A passcode transition is in progress, or a *replacement* was asked for
+    /// over a store carrying somebody else's unsaved work. The import is refused
+    /// rather than queued: the transition is about to rewrite every stored
+    /// share, and a vault inserted underneath it would never be seen.
     case busy
     /// An incoming share is sealed and does not open here — the wrong key, or a
     /// value that is not a share at all.
@@ -111,9 +112,15 @@ struct ProtectedVaultImporter {
     ///   that exists, and it is aimed at rows this method can still take back —
     ///   so the caller starts it once `commit` has returned, never from inside
     ///   `prepare`.
+    ///
+    /// - Parameter orphaned: stored vaults the incoming ones replace, deleted in
+    ///   the same save that stores their replacements. See below for why this is
+    ///   an explicit delete and why it refuses a context that is carrying
+    ///   anything else.
     @MainActor
     func commit(
         _ vaults: [Vault],
+        replacing orphaned: [Vault] = [],
         into context: ModelContext,
         prepare: (Vault) -> Bool = { _ in true }
     ) throws {
@@ -127,6 +134,9 @@ struct ProtectedVaultImporter {
         }
         defer { coordinator.end(episode) }
 
+        // Ahead of the deletion, and that ordering is the whole safety of a
+        // replacement: a backup whose shares this device cannot open must be
+        // refused while the row it would have replaced is still there.
         let normalized = try statedAsAnImportFailure {
             try vaults.map { try normalizer.normalizedShares(of: $0) }
         }
@@ -134,6 +144,30 @@ struct ProtectedVaultImporter {
         // Whatever the context was already carrying decides how a failure is
         // undone below, and it has to be sampled before anything is inserted.
         let wasCarryingOtherWork = context.hasChanges
+
+        // A deletion cannot be taken back except by `rollback()`, and
+        // `rollback()` is only this method's to call when the context was clean
+        // on the way in — otherwise it would discard another flow's work. So
+        // rather than leave a failed save able to flush the deletion by the next
+        // autosave *without* the replacement that justified it, a replacement
+        // over a busy context is refused and the user retries. Nothing has moved
+        // at this point.
+        guard orphaned.isEmpty || !wasCarryingOtherWork else {
+            logger.warning("Vault replacement refused: the store is carrying unsaved work")
+            throw ProtectedVaultImportError.busy
+        }
+
+        // Explicit, and never SwiftData's `@Attribute(.unique)` upsert. An
+        // insert that collides on a unique attribute resolves by overwriting the
+        // stored row with the incoming values — no error, no log — so relying on
+        // it would make "the replacement was stored" and "the original was
+        // destroyed and nothing replaced it" the same code path. Deleting names
+        // what is being removed, and it is the same save that stores what
+        // replaces it.
+        for vault in orphaned {
+            logger.info("Replacing a stored vault whose key shares this device can no longer open")
+            context.delete(vault)
+        }
 
         for (vault, shares) in zip(vaults, normalized) {
             // Whole-array assignment, never element assignment: assigning into
@@ -224,6 +258,11 @@ struct ProtectedVaultImporter {
     /// while an import runs. So it is only used when the context was clean on
     /// the way in and the pending changes are provably ours; otherwise the
     /// imported vaults are withdrawn one by one and the rest is left alone.
+    ///
+    /// A replacement always takes the first branch, and that is why it refuses a
+    /// context carrying anything else: a pending *deletion* cannot be withdrawn
+    /// row by row, so the per-row path would leave the orphan on its way out
+    /// with nothing arriving in its place.
     @MainActor
     private func withdraw(_ vaults: [Vault], from context: ModelContext, rollingBack: Bool) {
         guard !rollingBack else {

--- a/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Wallet/ViewModels/EncryptedBackupViewModel.swift
@@ -32,6 +32,16 @@ enum VaultImportDecision: Equatable {
     /// key), so it cannot be called a duplicate either. Storing it would
     /// overwrite a stored vault, so it is refused.
     case unsafeCollision
+    /// The device already holds this vault, and holds it in a form it can no
+    /// longer open: every one of its key shares is sealed and the key that
+    /// unseals them is confirmed gone. Skipping it as a duplicate is what makes
+    /// the recovery advice — "restore from your `.vult`" — a dead end, so the
+    /// stored row is replaced instead.
+    ///
+    /// `name` is the backup's own name, disambiguated against every stored
+    /// vault **except** the one being replaced: that one is on its way out, so
+    /// its name is not taken.
+    case replaceOrphaned(name: String)
 }
 
 @MainActor
@@ -69,9 +79,22 @@ class EncryptedBackupViewModel: ObservableObject {
     /// the JSON paths would otherwise write plaintext shares into a store that
     /// has a passcode set.
     private let importer: ProtectedVaultImporter
+    /// Only ``KeyshareProtecting/isSealed(_:)`` is used, which reads the stored
+    /// form and consults no state — so this cannot disagree with the importer's
+    /// own protector about what a sealed value looks like.
+    private let protector: KeyshareProtecting
+    /// Read to tell "this device is locked" from "the key is gone", which is the
+    /// difference between refusing an import and completing a recovery.
+    private let keyStore: KeyshareKeyStoring
 
-    init(importer: ProtectedVaultImporter = ProtectedVaultImporter()) {
+    init(
+        importer: ProtectedVaultImporter = ProtectedVaultImporter(),
+        protector: KeyshareProtecting = KeyshareProtector.shared,
+        keyStore: KeyshareKeyStoring = DefaultKeyshareKeyStore.shared
+    ) {
         self.importer = importer
+        self.protector = protector
+        self.keyStore = keyStore
     }
 
     func resetData() {
@@ -604,6 +627,7 @@ class EncryptedBackupViewModel: ObservableObject {
 
     private func importVaults(_ vaultsToImport: [Vault], to modelContext: ModelContext, existing: [Vault]) throws -> ImportResults {
         var imported: [Vault] = []
+        var replacing: [Vault] = []
         var duplicates = 0
         var skippedNames: [String] = []
         var unsafeNames: [String] = []
@@ -611,10 +635,30 @@ class EncryptedBackupViewModel: ObservableObject {
         for vault in vaultsToImport {
             // `imported` carries the already-resolved names, so a batch that
             // contains two vaults called "Savings" disambiguates the second
-            // against the first rather than upserting it.
-            switch insertIfSafe(vault, existing: existing + imported) {
+            // against the first rather than upserting it. It also means a second
+            // copy of the *same* vault in one ZIP now collides with the first
+            // copy as well as with the orphan, so it is skipped as a duplicate
+            // rather than asking to replace a row that is already being
+            // replaced.
+            let plan = insertIfSafe(vault, existing: existing + imported)
+            switch plan.decision {
             case .insert:
                 imported.append(vault)
+            case .replaceOrphaned where plan.replacing.contains(where: { orphan in
+                replacing.contains { $0 === orphan }
+            }):
+                // One incoming vault per orphan. An ordinary second copy of the
+                // same vault already collides with the first through
+                // `existing + imported` — but two *incomplete* backups can each
+                // match a different public key of the same orphan without
+                // matching each other, and one row replaced by two vaults is
+                // not a replacement.
+                unsafeNames.append(vault.name)
+                logger.error("Refused a vault during zip import: another vault in this zip already replaces the same stored vault")
+            case .replaceOrphaned:
+                imported.append(vault)
+                replacing.append(contentsOf: plan.replacing)
+                logger.info("A vault in this zip replaces a stored one whose key shares can no longer be opened")
             case .duplicate:
                 duplicates += 1
                 skippedNames.append(vault.name)
@@ -630,7 +674,7 @@ class EncryptedBackupViewModel: ObservableObject {
         // Default coins are added inside it, because they insert rows of their
         // own and doing that first strands them when the import is refused.
         let coinService = VaultDefaultCoinService(context: modelContext)
-        try importer.commit(imported, into: modelContext) { vault in
+        try importer.commit(imported, replacing: replacing, into: modelContext) { vault in
             coinService.setDefaultCoinsOnce(vault: vault)
         }
         // Outside the commit, because the commit is what stores the rows that
@@ -746,10 +790,11 @@ class EncryptedBackupViewModel: ObservableObject {
                 vault.libType = LibType.DKLS
             }
 
-            switch insertIfSafe(vault, existing: vaults) {
-            case .insert:
+            let plan = insertIfSafe(vault, existing: vaults)
+            switch plan.decision {
+            case .insert, .replaceOrphaned:
                 let coinService = VaultDefaultCoinService(context: modelContext)
-                try importer.commit([vault], into: modelContext) { vault in
+                try importer.commit([vault], replacing: plan.replacing, into: modelContext) { vault in
                     coinService.setDefaultCoinsOnce(vault: vault)
                 }
                 // Outside the commit, because the commit is what stores the rows
@@ -807,20 +852,21 @@ class EncryptedBackupViewModel: ObservableObject {
             }
         }
 
-        switch insertIfSafe(decoded, existing: vaults) {
+        let plan = insertIfSafe(decoded, existing: vaults)
+        switch plan.decision {
         case .duplicate:
             showError("vaultAlreadyExists")
             return
         case .unsafeCollision:
             showError("vaultImportWouldOverwriteExisting")
             return
-        case .insert:
+        case .insert, .replaceOrphaned:
             break
         }
 
         do {
             let coinService = VaultDefaultCoinService(context: modelContext)
-            try importer.commit([decoded], into: modelContext) { vault in
+            try importer.commit([decoded], replacing: plan.replacing, into: modelContext) { vault in
                 coinService.setDefaultCoinsOnce(vault: vault)
             }
             // Outside the commit, because the commit is what stores the rows
@@ -865,28 +911,158 @@ class EncryptedBackupViewModel: ObservableObject {
     /// A name collision between two genuinely different vaults is resolved, not
     /// rejected — the name is user-chosen and `Main`/`Savings`/`Test` are exactly
     /// the names people reuse across devices. Anything still colliding after that
-    /// is refused: `pubKeyECDSA`/`pubKeyEdDSA` default to `""`, and `""` is a
-    /// real value in the unique index, so two key-less backups would upsert each
-    /// other. The final check restates the raw index semantics — one clause per
-    /// `@Attribute(.unique)` field on `Vault` — rather than reusing the duplicate
-    /// rule, whose empty/`nil` tolerance is exactly what would let those through.
-    /// It is the single place to extend when a unique attribute is added.
+    /// is refused by ``collides(_:named:with:)``, which restates the raw index
+    /// semantics rather than reusing the duplicate rule.
+    ///
+    /// A vault this device can no longer open is the one exception, and it is a
+    /// narrow one: see ``orphanedVault(collidingWith:in:)``. Even then the
+    /// collision check still runs — against everything the replacement is *not*
+    /// displacing.
     func importDecision(for backupVault: Vault, existing: [Vault]) -> VaultImportDecision {
+        plan(for: backupVault, existing: existing).decision
+    }
+
+    /// The decision, plus the stored row it displaces.
+    ///
+    /// The row is resolved here rather than carried on ``VaultImportDecision``
+    /// so that decision stays a plain value the tests can compare — a live
+    /// `@Model` travelling through one would make it neither comparable nor
+    /// safe to hold.
+    private struct ImportPlan {
+        let decision: VaultImportDecision
+        /// At most one, and only ever a vault this device can no longer open.
+        /// ``ProtectedVaultImporter/commit(_:replacing:into:prepare:)`` deletes
+        /// it in the same save that stores the replacement.
+        let replacing: [Vault]
+    }
+
+    private func plan(for backupVault: Vault, existing: [Vault]) -> ImportPlan {
         guard isVaultUnique(backupVault: backupVault, vaults: existing) else {
-            return .duplicate
+            guard let orphaned = orphanedVault(collidingWith: backupVault, in: existing) else {
+                return ImportPlan(decision: .duplicate, replacing: [])
+            }
+
+            // The row being replaced is on its way out, so its name is not taken
+            // — otherwise every recovery would come back as "Main (2)". It is
+            // the *only* row a replacement excuses, though: everything else on
+            // the device still has to survive the insert.
+            let others = existing.filter { $0 !== orphaned }
+            let name = availableVaultName(basedOn: backupVault.name, taken: Set(others.map(\.name)))
+            guard !collides(backupVault, named: name, with: others) else {
+                return ImportPlan(decision: .unsafeCollision, replacing: [])
+            }
+
+            return ImportPlan(decision: .replaceOrphaned(name: name), replacing: [orphaned])
         }
 
         let name = availableVaultName(basedOn: backupVault.name, taken: Set(existing.map(\.name)))
+        guard !collides(backupVault, named: name, with: existing) else {
+            return ImportPlan(decision: .unsafeCollision, replacing: [])
+        }
 
-        let collides = existing.contains { vault in
+        return ImportPlan(decision: .insert(name: name), replacing: [])
+    }
+
+    /// The raw `@Attribute(.unique)` index semantics — one clause per unique
+    /// field on `Vault` — rather than the duplicate rule, whose empty/`nil`
+    /// tolerance is exactly what would let a collision through.
+    ///
+    /// It is asked on the replacement path too. There it is defence in depth
+    /// rather than the load-bearing guard — a replacement already has to declare
+    /// every identity the row it displaces holds, which is what keeps an
+    /// incomplete backup from matching the orphan on the one key it carries and
+    /// upserting over a **healthy** vault on an empty one. Deleting the orphan
+    /// would do nothing about that, so both checks stay.
+    ///
+    /// This is the single place to extend when a unique attribute is added.
+    private func collides(_ backupVault: Vault, named name: String, with existing: [Vault]) -> Bool {
+        existing.contains { vault in
             vault.name == name
                 || vault.pubKeyECDSA == backupVault.pubKeyECDSA
                 || vault.pubKeyEdDSA == backupVault.pubKeyEdDSA
                 || (vault.publicKeyMLDSA44 != nil && vault.publicKeyMLDSA44 == backupVault.publicKeyMLDSA44)
         }
-        guard !collides else { return .unsafeCollision }
+    }
 
-        return .insert(name: name)
+    /// The one stored vault an incoming backup is allowed to replace.
+    ///
+    /// This deliberately re-enables, in one tightly bounded path, the
+    /// replacement the import gate was hardened against — so every clause below
+    /// is the difference between a recovery and a loss, and none of them is a
+    /// convenience.
+    ///
+    /// - **Exactly one colliding vault.** A backup that matches two stored
+    ///   vaults is a question this cannot answer, and answering it by picking
+    ///   one destroys the other's key material.
+    /// - **The wrapper is *confirmed* absent.** `.unavailable` must not qualify:
+    ///   a Keychain that merely went quiet may well still hold the key, and the
+    ///   shares would open again on the next launch. Deleting a working vault
+    ///   over a momentary read failure is the one mistake available here that
+    ///   destroys something.
+    /// - **Every share sealed, and at least one.** A vault with no shares has
+    ///   nothing to be orphaned about. A partly-sealed one is not a state this
+    ///   app can produce — the sweep is all-or-nothing — so it is a state to
+    ///   refuse rather than to guess about.
+    /// - **The backup *is* the stored vault, not merely overlapping with it.**
+    ///   Matching on one public key is what makes something a duplicate; it is
+    ///   not enough to make it a replacement. Every signing identity the stored
+    ///   row carries has to be declared identically by the backup, or the
+    ///   replacement drops key material — a file naming a different EdDSA key
+    ///   would swap a vault that cannot sign for one that still cannot, and the
+    ///   ciphertext that was there would be gone. An identity the *backup* adds
+    ///   is fine; one it leaves out is not.
+    /// - **The backup carries a share for every key — its own and the stored
+    ///   row's.** `ProtectedVaultImporter` proves that whatever the backup does
+    ///   carry opens here, and it proves it before the deletion, but a file
+    ///   carrying an empty `keyshares` array normalizes perfectly well and would
+    ///   buy the deletion with nothing.
+    ///
+    /// What is deliberately *not* done: nothing here parses a share to confirm
+    /// its bytes really derive the public key it is labelled with. That is TSS
+    /// work behind a critical boundary, and the ordinary import path extends a
+    /// backup the same trust. The checks above are what keep this path from
+    /// extending it any *further* than that one does.
+    func orphanedVault(collidingWith backupVault: Vault, in existing: [Vault]) -> Vault? {
+        let colliding = existing.filter { !isVaultUnique(backupVault: backupVault, vaults: [$0]) }
+        guard colliding.count == 1, let stored = colliding.first else { return nil }
+
+        guard case .absent = keyStore.loadWrappedDataKey() else { return nil }
+
+        guard !stored.keyshares.isEmpty,
+              stored.keyshares.allSatisfy({ protector.isSealed($0.keyshare) }) else {
+            return nil
+        }
+
+        guard preserves(stored.pubKeyECDSA, in: backupVault.pubKeyECDSA),
+              preserves(stored.pubKeyEdDSA, in: backupVault.pubKeyEdDSA),
+              preserves(stored.publicKeyMLDSA44, in: backupVault.publicKeyMLDSA44) else {
+            return nil
+        }
+
+        let carried = Set(backupVault.keyshares.map(\.pubkey))
+        let declared = Set(
+            [backupVault.pubKeyECDSA, backupVault.pubKeyEdDSA, backupVault.publicKeyMLDSA44 ?? ""]
+                .compactMap(\.nilIfEmpty)
+        )
+        guard !backupVault.keyshares.isEmpty,
+              backupVault.keyshares.allSatisfy({ !$0.keyshare.isEmpty }),
+              carried.isSuperset(of: declared),
+              carried.isSuperset(of: Set(stored.keyshares.map(\.pubkey))) else {
+            return nil
+        }
+
+        return stored
+    }
+
+    /// Whether a signing identity the stored vault holds survives the
+    /// replacement unchanged.
+    ///
+    /// An identity the stored row does not have is nothing to preserve. One it
+    /// has and the backup does not — or declares differently — is key material
+    /// the replacement would take away with the row.
+    private func preserves(_ stored: String?, in backup: String?) -> Bool {
+        guard let stored = stored?.nilIfEmpty else { return true }
+        return stored == backup?.nilIfEmpty
     }
 
     /// A vault name no stored vault holds, derived from the backup's own name
@@ -906,20 +1082,27 @@ class EncryptedBackupViewModel: ObservableObject {
     }
 
     /// Runs the import gate and renames `vault` to an available name when it is
-    /// safe to store. Returns the decision so the caller can surface the
-    /// outcome. Storage itself never happens here: it must go through
-    /// ``ProtectedVaultImporter/commit(_:into:prepare:)``, which normalizes,
-    /// inserts and saves inside a single passcode-transition-safe lease — a
-    /// direct `modelContext.insert` here would land outside that lease.
-    private func insertIfSafe(_ vault: Vault, existing: [Vault]) -> VaultImportDecision {
-        let decision = importDecision(for: vault, existing: existing)
-        guard case .insert(let name) = decision else { return decision }
+    /// safe to store. Returns the plan so the caller can surface the outcome and
+    /// hand the displaced row on. Storage itself never happens here: it must go
+    /// through ``ProtectedVaultImporter/commit(_:replacing:into:prepare:)``,
+    /// which normalizes, deletes, inserts and saves inside a single
+    /// passcode-transition-safe lease — a direct `modelContext.insert` here
+    /// would land outside that lease, and a direct `delete` outside the save
+    /// that justifies it.
+    private func insertIfSafe(_ vault: Vault, existing: [Vault]) -> ImportPlan {
+        let plan = plan(for: vault, existing: existing)
 
-        if vault.name != name {
-            logger.info("Renamed an imported vault to avoid colliding with a stored vault's name")
-            vault.name = name
+        switch plan.decision {
+        case .insert(let name), .replaceOrphaned(let name):
+            if vault.name != name {
+                logger.info("Renamed an imported vault to avoid colliding with a stored vault's name")
+                vault.name = name
+            }
+        case .duplicate, .unsafeCollision:
+            break
         }
-        return decision
+
+        return plan
     }
 
     private func isValidFormat(_ url: URL) -> Bool {

--- a/VultisigApp/VultisigAppTests/Security/OrphanedVaultReplacementTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/OrphanedVaultReplacementTests.swift
@@ -1,0 +1,516 @@
+//
+//  OrphanedVaultReplacementTests.swift
+//  VultisigAppTests
+//
+
+import CryptoKit
+import SwiftData
+import XCTest
+@testable import VultisigApp
+
+/// The recovery route, end to end.
+///
+/// A device restored without its Keychain holds every key share sealed under a
+/// key that is gone. It is told to restore from its `.vult` — and the import
+/// gate answered `.duplicate` and skipped it, so the advice was a dead end and
+/// the recovery screen came back on every launch forever.
+///
+/// This re-enables, in one tightly bounded path, the replacement the import gate
+/// was hardened against. So the tests here are as much about what must **not**
+/// be replaced as about what must: a stored vault holding openable shares, one
+/// this device merely cannot read *right now*, and one the import cannot prove
+/// it has a working copy of are each a vault that would be destroyed by a
+/// looser predicate.
+///
+/// Every fixture carries real key shares. A suite built on share-less vaults
+/// passes while refusing every vault a user actually has — the predicate
+/// requires at least one sealed share, so an empty `keyshares` array never
+/// qualifies.
+@MainActor
+final class OrphanedVaultReplacementTests: XCTestCase {
+
+    private var token: TestContextToken!
+    private var context: ModelContext!
+    private var keychain: MockKeychainService!
+    private var keyStore: DefaultKeyshareKeyStore!
+    private var lostKey: SymmetricKey!
+
+    /// What the vault's shares really are, and what a good `.vult` carries.
+    private let ecdsaShare = "eyJrZXlzaGFyZSI6ImRrbHMtZWNkc2EifQ=="
+    private let eddsaShare = "eyJrZXlzaGFyZSI6ImRrbHMtZWRkc2EifQ=="
+
+    private let ecdsaPubKey = "ecdsa-recovered-vault"
+    private let eddsaPubKey = "eddsa-recovered-vault"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        token = try TestStore.installInMemoryContainer()
+        TestStore.retain(token.container)
+        context = token.container.mainContext
+        keychain = MockKeychainService()
+        keyStore = DefaultKeyshareKeyStore(keychain: keychain)
+        // The key the previous device held and this one did not inherit. It is
+        // never given to anything under test — that is the whole state.
+        lostKey = SymmetricKey(size: .bits256)
+    }
+
+    override func tearDown() {
+        lostKey = nil
+        keyStore = nil
+        keychain = nil
+        context = nil
+        TestStore.restore(token)
+        token = nil
+        super.tearDown()
+    }
+
+    // MARK: - The replacement
+
+    /// The route the recovery screen points at, working. The stored row is
+    /// replaced by the backup in one save, and what comes back is readable.
+    func testAnOrphanedVaultIsReplacedByItsBackup() throws {
+        let orphan = try storeOrphanedVault()
+        // Captured before the import, because it is what tells an explicit
+        // delete-and-insert apart from the upsert this must never rely on: an
+        // upsert keeps the stored row and overwrites its values, so the row
+        // count and the shares would look exactly the same either way.
+        let orphanRow = orphan.persistentModelID
+        let sut = makeViewModel()
+        sut.decryptedContent = try backupHex()
+
+        sut.restoreVault(modelContext: context, vaults: [orphan])
+
+        XCTAssertTrue(sut.isVaultImported)
+        XCTAssertFalse(sut.showAlert)
+
+        // Read back through a context that never saw the objects: the point is
+        // what is on disk, and one row rather than two.
+        let fresh = ModelContext(token.container)
+        let stored = try fresh.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(stored.count, 1, "the orphan is replaced, not joined")
+        let replacement = try XCTUnwrap(stored.first)
+        XCTAssertEqual(
+            Set(replacement.keyshares.map(\.keyshare)),
+            Set([ecdsaShare, eddsaShare]),
+            "the shares on disk are the backup's, in a form this device can read"
+        )
+        XCTAssertNotEqual(
+            replacement.persistentModelID, orphanRow,
+            "the stored row was deleted and a new one inserted, not upserted over"
+        )
+    }
+
+    /// The name is the backup's own. The row being replaced is on its way out,
+    /// so its name is not taken — otherwise every recovery would come back as
+    /// "Main (2)".
+    func testTheReplacementKeepsTheBackupsName() throws {
+        let orphan = try storeOrphanedVault()
+        let sut = makeViewModel()
+        sut.decryptedContent = try backupHex()
+
+        sut.restoreVault(modelContext: context, vaults: [orphan])
+
+        let fresh = ModelContext(token.container)
+        XCTAssertEqual(try XCTUnwrap(try fresh.fetch(FetchDescriptor<Vault>()).first).name, "Main")
+    }
+
+    // MARK: - What must not be replaced
+
+    /// The ordinary duplicate, unchanged. A stored vault whose shares open is
+    /// not orphaned, and re-importing it must still be skipped rather than
+    /// silently rewriting the row.
+    func testAnOrdinaryDuplicateIsStillSkipped() throws {
+        let stored = try storeVault(shares: [ecdsaShare, eddsaShare])
+        let sut = makeViewModel()
+        sut.decryptedContent = try backupHex()
+
+        sut.restoreVault(modelContext: context, vaults: [stored])
+
+        XCTAssertFalse(sut.isVaultImported)
+        XCTAssertEqual(sut.alertTitle, "vaultAlreadyExists")
+        XCTAssertEqual(try ModelContext(token.container).fetchCount(FetchDescriptor<Vault>()), 1)
+    }
+
+    /// The one that would destroy a working vault. An unreadable Keychain is not
+    /// evidence the key is gone — the item may well be there and open the shares
+    /// again on the next launch — so `.unavailable` must not qualify.
+    func testAnUnreadableWrapperDoesNotQualify() throws {
+        let orphan = try storeOrphanedVault()
+        keychain.wrappedKeyshareDataKeyResult = .unavailable(errSecInteractionNotAllowed)
+        let sut = makeViewModel()
+
+        XCTAssertNil(sut.orphanedVault(collidingWith: backupVault(), in: [orphan]))
+        XCTAssertEqual(sut.importDecision(for: backupVault(), existing: [orphan]), .duplicate)
+    }
+
+    /// A wrapper that is present means the shares are sealed behind a passcode
+    /// this device still has. Nothing is orphaned; the app is merely locked.
+    func testAPresentWrapperDoesNotQualify() throws {
+        let orphan = try storeOrphanedVault()
+        keychain.wrappedKeyshareDataKey = Data("wrapped-data-key".utf8)
+        let sut = makeViewModel()
+
+        XCTAssertEqual(sut.importDecision(for: backupVault(), existing: [orphan]), .duplicate)
+    }
+
+    /// Not a state the app can produce — the sweep is all-or-nothing — so it is
+    /// one to refuse rather than to guess about.
+    func testAPartlySealedVaultDoesNotQualify() throws {
+        let cipher = AesGcmKeyshareCipher()
+        let stored = try storeVault(shares: [try cipher.seal(ecdsaShare, with: lostKey), eddsaShare])
+        let sut = makeViewModel()
+
+        XCTAssertEqual(sut.importDecision(for: backupVault(), existing: [stored]), .duplicate)
+    }
+
+    /// A vault with no shares has nothing to be orphaned about, and treating one
+    /// as replaceable is how a suite of share-less fixtures passes while every
+    /// real vault is refused.
+    func testAVaultWithNoSharesDoesNotQualify() throws {
+        let stored = try storeVault(shares: [])
+        let sut = makeViewModel()
+
+        XCTAssertEqual(sut.importDecision(for: backupVault(), existing: [stored]), .duplicate)
+    }
+
+    /// Matching on one public key is what makes something a duplicate. It is
+    /// not enough to make it a replacement: a backup declaring a different
+    /// EdDSA key swaps a vault that cannot sign for one that still cannot, and
+    /// the ciphertext that was there is gone.
+    func testABackupDeclaringADifferentSigningKeyCannotReplaceTheStoredVault() throws {
+        let orphan = try storeOrphanedVault()
+        let reshared = makeVault(shares: [ecdsaShare, eddsaShare])
+        reshared.pubKeyEdDSA = "eddsa-somebody-elses"
+
+        let sut = makeViewModel()
+
+        XCTAssertNil(sut.orphanedVault(collidingWith: reshared, in: [orphan]))
+        XCTAssertEqual(sut.importDecision(for: reshared, existing: [orphan]), .duplicate)
+    }
+
+    /// The same rule stated where it costs the most, end to end.
+    ///
+    /// `pubKeyECDSA` and `pubKeyEdDSA` default to `""`, and `""` is a real value
+    /// in the unique index. So an incomplete backup matching the orphan on the
+    /// one key it carries would, if it qualified, be inserted next to a
+    /// perfectly **healthy** vault that also declares no EdDSA key — and
+    /// SwiftData would resolve that by upserting over the healthy row, taking
+    /// its key shares with it. Deleting the orphan does nothing about that.
+    func testAnIncompleteBackupCannotUpsertOverAHealthyVault() throws {
+        let orphan = try storeOrphanedVault()
+        let healthy = Vault(
+            name: "Savings",
+            signers: [],
+            pubKeyECDSA: "ecdsa-healthy",
+            pubKeyEdDSA: "",
+            keyshares: [KeyShare(pubkey: "ecdsa-healthy", keyshare: ecdsaShare)],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        context.insert(healthy)
+        try context.save()
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Vault>()), 2)
+
+        let incomplete = Vault(
+            name: "Main",
+            signers: [],
+            pubKeyECDSA: ecdsaPubKey,
+            pubKeyEdDSA: "",
+            keyshares: [
+                KeyShare(pubkey: ecdsaPubKey, keyshare: ecdsaShare),
+                KeyShare(pubkey: eddsaPubKey, keyshare: eddsaShare)
+            ],
+            localPartyID: "iPhone-1",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        let sut = makeViewModel()
+        sut.decryptedContent = try JSONEncoder()
+            .encode(BackupVault(version: .v1, vault: incomplete))
+            .hexString
+
+        sut.restoreVault(modelContext: context, vaults: [orphan, healthy])
+
+        XCTAssertFalse(sut.isVaultImported)
+        let fresh = ModelContext(token.container)
+        XCTAssertEqual(
+            try fresh.fetchCount(FetchDescriptor<Vault>()), 2,
+            "both stored vaults survive — the orphan and the one that had nothing to do with it"
+        )
+    }
+
+    /// A backup declaring a key it carries no share for cannot sign with it, so
+    /// it is not a replacement for anything either.
+    func testABackupWithNoShareForOneOfItsOwnKeysCannotReplace() throws {
+        let orphan = try storeOrphanedVault()
+        let overclaiming = makeVault(shares: [ecdsaShare, eddsaShare])
+        overclaiming.publicKeyMLDSA44 = "mldsa-with-no-share"
+
+        let sut = makeViewModel()
+
+        XCTAssertNil(sut.orphanedVault(collidingWith: overclaiming, in: [orphan]))
+    }
+
+    /// A backup matching two stored vaults is a question this cannot answer, and
+    /// answering it by picking one destroys the other's key material.
+    func testABackupCollidingWithTwoStoredVaultsDoesNotQualify() throws {
+        let cipher = AesGcmKeyshareCipher()
+        let onEcdsa = Vault(
+            name: "Main",
+            signers: [],
+            pubKeyECDSA: ecdsaPubKey,
+            pubKeyEdDSA: "eddsa-other",
+            keyshares: [KeyShare(pubkey: ecdsaPubKey, keyshare: try cipher.seal(ecdsaShare, with: lostKey))],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        let onEddsa = Vault(
+            name: "Spare",
+            signers: [],
+            pubKeyECDSA: "ecdsa-other",
+            pubKeyEdDSA: eddsaPubKey,
+            keyshares: [KeyShare(pubkey: eddsaPubKey, keyshare: try cipher.seal(eddsaShare, with: lostKey))],
+            localPartyID: "party",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+        context.insert(onEcdsa)
+        context.insert(onEddsa)
+        try context.save()
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Vault>()), 2, "distinct key material, so two rows")
+
+        let sut = makeViewModel()
+
+        XCTAssertNil(sut.orphanedVault(collidingWith: backupVault(), in: [onEcdsa, onEddsa]))
+    }
+
+    /// The other side of the trade, and the one a replacement makes newly
+    /// dangerous. `ProtectedVaultImporter` proves that whatever the backup
+    /// *carries* opens here — but a file carrying nothing at all normalizes
+    /// perfectly well, so without this it would delete the orphan in exchange
+    /// for a vault that can sign nothing.
+    func testABackupWithNoKeySharesCannotReplaceAnything() throws {
+        let orphan = try storeOrphanedVault()
+        let empty = makeVault(shares: [])
+        XCTAssertTrue(empty.keyshares.isEmpty, "precondition: the backup carries no key material")
+
+        let sut = makeViewModel()
+
+        XCTAssertNil(sut.orphanedVault(collidingWith: empty, in: [orphan]))
+        XCTAssertEqual(sut.importDecision(for: empty, existing: [orphan]), .duplicate)
+    }
+
+    /// Less key material than the row it displaces is not a replacement for it.
+    /// A backup holding only the ECDSA share would take the EdDSA one with the
+    /// orphan, and nothing would ever bring it back.
+    func testABackupMissingOneOfTheStoredSharesCannotReplaceIt() throws {
+        let orphan = try storeOrphanedVault()
+        let partial = makeVault(shares: [ecdsaShare])
+        XCTAssertEqual(partial.keyshares.count, 1, "precondition: one share where the stored vault holds two")
+
+        let sut = makeViewModel()
+
+        XCTAssertNil(sut.orphanedVault(collidingWith: partial, in: [orphan]))
+    }
+
+    /// An empty string is a share the store will happily hold and nothing can
+    /// ever sign with.
+    func testABackupCarryingAnEmptyShareCannotReplaceAnything() throws {
+        let orphan = try storeOrphanedVault()
+        let blank = makeVault(shares: [ecdsaShare, ""])
+
+        let sut = makeViewModel()
+
+        XCTAssertNil(sut.orphanedVault(collidingWith: blank, in: [orphan]))
+    }
+
+    /// One incoming vault per orphan, across a whole ZIP.
+    ///
+    /// A ZIP holding the same vault twice is the shape a user actually produces
+    /// — two exports of the same vault, or the same file under two names. The
+    /// first replaces the orphan; the second must be skipped as a duplicate
+    /// rather than replacing a row that is already being replaced.
+    func testTwoCopiesOfTheSameVaultInOneZipReplaceTheOrphanOnce() throws {
+        let orphan = try storeOrphanedVault()
+
+        let sut = makeViewModel()
+        sut.multipleVaultsToImport = [backupVault(), backupVault()]
+
+        sut.restoreMultipleVaults(modelContext: context, vaults: [orphan])
+
+        let fresh = ModelContext(token.container)
+        XCTAssertEqual(
+            try fresh.fetchCount(FetchDescriptor<Vault>()), 1,
+            "the orphan is gone and exactly one replacement took its place"
+        )
+        XCTAssertTrue(sut.showAlert, "the skipped copy is reported rather than silently dropped")
+    }
+
+    // MARK: - When the replacement does not land
+
+    /// The deletion and the insert are one save, so a save that fails leaves the
+    /// orphan exactly where it was. Losing it here would take the user's only
+    /// remaining copy of that key material with it — and they would not have a
+    /// working vault to show for it.
+    func testAFailedSaveLeavesTheOrphanInPlace() throws {
+        let orphan = try storeOrphanedVault()
+        let sealedBefore = orphan.keyshares.map(\.keyshare)
+
+        let sut = makeViewModel(save: { _ in throw SaveFailure.refused })
+        sut.decryptedContent = try backupHex()
+
+        sut.restoreVault(modelContext: context, vaults: [orphan])
+
+        XCTAssertFalse(sut.isVaultImported)
+        XCTAssertEqual(sut.alertTitle, "vaultRestoreFailed")
+
+        let fresh = ModelContext(token.container)
+        let stored = try fresh.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(
+            try XCTUnwrap(stored.first).keyshares.map(\.keyshare), sealedBefore,
+            "the orphan survives the failure with its own shares, not the backup's"
+        )
+    }
+
+    /// A pending deletion cannot be withdrawn row by row, so a replacement over
+    /// a context carrying somebody else's work would leave the orphan on its way
+    /// out with nothing arriving in its place the moment that save fails. It is
+    /// refused instead, and the user retries.
+    func testAReplacementIsRefusedWhileTheStoreCarriesOtherWork() throws {
+        let orphan = try storeOrphanedVault()
+        let importer = ProtectedVaultImporter(
+            protector: KeyshareProtector(state: { .disabled }),
+            coordinator: KeyshareWriteCoordinator()
+        )
+
+        // Somebody else's unsaved work, which `rollback()` would throw away.
+        context.insert(
+            Vault(
+                name: "Somebody else's half-finished keygen",
+                signers: [],
+                pubKeyECDSA: "ecdsa-unrelated",
+                pubKeyEdDSA: "eddsa-unrelated",
+                keyshares: [],
+                localPartyID: "party",
+                hexChainCode: "hex",
+                resharePrefix: nil,
+                libType: .DKLS
+            )
+        )
+        XCTAssertTrue(context.hasChanges)
+
+        XCTAssertThrowsError(
+            try importer.commit([backupVault()], replacing: [orphan], into: context)
+        ) { error in
+            XCTAssertEqual(error as? ProtectedVaultImportError, .busy)
+        }
+
+        context.rollback()
+        let fresh = ModelContext(token.container)
+        XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Vault>()), 1, "the orphan is untouched")
+    }
+
+    /// A backup this device cannot open must be refused **while the row it would
+    /// have replaced is still there**. Normalization runs ahead of the deletion
+    /// precisely so a wrong file cannot cost the user the only copy they had.
+    func testABackupThatCannotBeOpenedIsRefusedWithoutTouchingTheOrphan() throws {
+        let orphan = try storeOrphanedVault()
+        let foreign = try AesGcmKeyshareCipher().seal(ecdsaShare, with: SymmetricKey(size: .bits256))
+        let importer = ProtectedVaultImporter(
+            protector: KeyshareProtector(state: { .disabled }),
+            coordinator: KeyshareWriteCoordinator()
+        )
+
+        XCTAssertThrowsError(
+            try importer.commit([backupVault(shares: [foreign])], replacing: [orphan], into: context)
+        )
+
+        let fresh = ModelContext(token.container)
+        XCTAssertEqual(try fresh.fetchCount(FetchDescriptor<Vault>()), 1)
+        XCTAssertEqual(try XCTUnwrap(try fresh.fetch(FetchDescriptor<Vault>()).first).keyshares.count, 2)
+    }
+
+    // MARK: - Helpers
+
+    private enum SaveFailure: Error {
+        case refused
+    }
+
+    private func makeViewModel(
+        save: @escaping @MainActor (ModelContext) throws -> Void = { try $0.save() }
+    ) -> EncryptedBackupViewModel {
+        // `.disabled` is the protection state of a device with no wrapper, which
+        // is the state this whole path is about — and the only one the test
+        // bundle can drive, since it holds no Keychain entitlement.
+        let protector = KeyshareProtector(state: { .disabled })
+        return EncryptedBackupViewModel(
+            importer: ProtectedVaultImporter(
+                protector: protector,
+                coordinator: KeyshareWriteCoordinator(),
+                save: save
+            ),
+            protector: protector,
+            keyStore: keyStore
+        )
+    }
+
+    /// One vault's worth of key material, however its shares are stored.
+    private func makeVault(shares: [String]) -> Vault {
+        Vault(
+            name: "Main",
+            signers: ["iPhone-1", "iPad-2"],
+            pubKeyECDSA: ecdsaPubKey,
+            pubKeyEdDSA: eddsaPubKey,
+            keyshares: zip([ecdsaPubKey, eddsaPubKey], shares).map { KeyShare(pubkey: $0, keyshare: $1) },
+            localPartyID: "iPhone-1",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+    }
+
+    /// The vault as the backup carries it: same key material, shares in the
+    /// clear, which is what `Vault.mapToProtobuff` writes.
+    private func backupVault(shares: [String]? = nil) -> Vault {
+        makeVault(shares: shares ?? [ecdsaShare, eddsaShare])
+    }
+
+    private func backupHex() throws -> String {
+        try JSONEncoder().encode(BackupVault(version: .v1, vault: backupVault())).hexString
+    }
+
+    /// The state a restore without the Keychain leaves behind: the vault is
+    /// there, every share is `vlt2:` ciphertext, and nothing on the device holds
+    /// the key.
+    @discardableResult
+    private func storeOrphanedVault() throws -> Vault {
+        let cipher = AesGcmKeyshareCipher()
+        let vault = try storeVault(
+            shares: [
+                try cipher.seal(ecdsaShare, with: lostKey),
+                try cipher.seal(eddsaShare, with: lostKey)
+            ]
+        )
+        XCTAssertEqual(keyStore.loadWrappedDataKey(), .absent, "precondition: the key really is gone")
+        return vault
+    }
+
+    @discardableResult
+    private func storeVault(shares: [String]) throws -> Vault {
+        let vault = makeVault(shares: shares)
+        context.insert(vault)
+        try context.save()
+        // A SwiftData `@Attribute(.unique)` collision upserts rather than
+        // failing, so a fixture that silently collapsed to one row would pass
+        // assertions it never actually exercised.
+        XCTAssertEqual(try context.fetchCount(FetchDescriptor<Vault>()), 1)
+        return vault
+    }
+}


### PR DESCRIPTION
> Stacked on #5106. Review that one first — this PR's diff is the single commit on top of it.

## What

#5106 puts a recovery screen in front of a device whose key shares are sealed with a key it no longer holds, and tells the user to restore from their `.vult`. That advice was a dead end: `importDecision` sends the same vault to `.duplicate` via `isVaultUnique` — it *is* the same vault, by key material — and the import path skips duplicates. So a user following the screen imported nothing, and the screen returned on every launch, forever.

This PR makes the route work.

Part of #5086.

## How

**A fourth decision, returned only when the stored row is provably unopenable.** `.replaceOrphaned` requires the colliding stored vault to have **every** share sealed and the wrapper to be **confirmed** absent. `ProtectedVaultImporter.commit` takes the row it displaces, deletes it inside the lease it already holds, and saves it in the same transaction as the insert.

**Remove-then-import was the other shape, and it was rejected.** It puts a destructive step ahead of the recovery, so a user with the wrong file or the wrong password loses the row and gains nothing — and "delete this to fix it" is the exact register vultisig/vultisig-sdk#1845 rules out.

### The predicate, clause by clause

Each one is the difference between a recovery and a loss, so none of them is a convenience:

- **Exactly one colliding stored vault.** A backup matching two is a question this cannot answer, and answering it by picking one destroys the other's key material.
- **A *confirmed* absent wrapper**, never `.unavailable`. A Keychain that merely went quiet may still hold the key, and the shares would open again on the next launch.
- **Every stored share sealed, and at least one.** A partly-sealed vault is not a state the sweep can produce, and an empty one has nothing to be orphaned about.
- **The backup *is* that vault.** Every non-empty signing identity the stored row carries — `pubKeyECDSA`, `pubKeyEdDSA`, `publicKeyMLDSA44` — has to be declared identically by the backup. Matching on one public key is what makes something a duplicate; it is not enough to make it a replacement. A file naming a different EdDSA key would swap a vault that cannot sign for one that still cannot. An identity the backup *adds* is fine; one it drops is not.
- **The backup carries a share for every key** — its own declared ones and the stored row's — with no empty share values. `ProtectedVaultImporter` proves that whatever the backup carries opens here, and it proves it before the deletion; but a file with an empty `keyshares` array normalizes perfectly well and would buy the deletion with nothing.
- **The raw unique-index check still runs**, against everything the replacement is *not* displacing. `pubKeyECDSA`/`pubKeyEdDSA` default to `""`, and `""` is a real value in the index.

### The two orderings

- **Normalization runs ahead of the deletion**, so a backup this device cannot open is refused while the row it would have replaced is still there.
- **A replacement over a context carrying somebody else's unsaved work is refused outright.** A pending deletion cannot be withdrawn row by row, and `rollback()` is only this method's to call when the context was clean on the way in — so the per-row failure path would leave the orphan on its way out with nothing arriving in its place. `.busy`, and the user retries.

### Never the upsert

The deletion is explicit. SwiftData resolves a duplicate `@Attribute(.unique)` insert by overwriting the stored row with the incoming values, with nothing thrown and nothing logged — which would make "the replacement was stored" and "the original was destroyed and nothing replaced it" the same code path. The success test captures the orphan's `persistentModelID` before the import and asserts the persisted row has a different one, so it cannot pass against an implementation that leans on the upsert.

## Known limits, for a reviewer to weigh

- **Nothing parses a share to confirm its bytes really derive the public key it is labelled with.** That is TSS work behind a critical boundary, and the ordinary import path extends a backup the same trust. The checks above are what keep this path from extending it any *further*.
- **The recovery screen is not re-raised when the user backs out of the import.** Inherited from #5106 and documented there; it is derived again at the next launch. Cross-model review flagged it twice and it is left as a deliberate product call rather than being resolved inside a fix PR — worth a decision.

## Testing

`OrphanedVaultReplacementTests`, 18 cases, every fixture carrying real key shares — a suite of share-less vaults would pass while refusing every vault a user actually has:

- the orphan replaced end to end through `EncryptedBackupViewModel.restoreVault`, asserted on a fresh `ModelContext` and on the row identity;
- the replacement keeping the backup's own name;
- an ordinary duplicate still skipped; a present wrapper, an unreadable wrapper, a partly-sealed vault, a share-less vault, and a backup colliding with two stored vaults all refused;
- a backup declaring a different EdDSA key, one declaring a key it has no share for, one carrying no shares, one carrying an empty share, and one missing a share the stored row holds, all refused;
- an incomplete backup that would otherwise have upserted over an unrelated healthy vault — both stored vaults survive;
- two copies of the same vault in one ZIP replacing the orphan exactly once;
- a failed save leaving the orphan in place with its own shares, a replacement refused over a busy context, and a backup this device cannot open refused without touching the orphan.

Gate, on a dedicated `iPhone 17 Pro Max` / iOS 26.5 simulator:

```
Executed 5503 tests, with 1 test skipped and 0 failures (0 unexpected)
** TEST SUCCEEDED **
```

macOS:

```
** BUILD SUCCEEDED **
```

`swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 22 violations, unchanged from `main`. 0 new.

Two rounds of read-only `codex exec` review on the commit plus two whole-branch rounds; ledger in the wiki at `pages/projects/vultisig/passcode-app-lock/codex-review-ledger-5086.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
