### PR TITLE
feat(passcode): ask for a backup before the passcode goes on

### DIFF
--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -943,6 +943,10 @@
 "partOf" = "Teil %d von %d";
 "passcodeAlreadySet" = "Auf diesem Gerät ist bereits ein Passcode gesetzt. Gehen Sie zurück, um ihn zu ändern oder zu entfernen.";
 "passcodeAutoLockTitle" = "Automatische Sperre";
+"passcodeBackupPromptBackUpNow" = "Jetzt sichern";
+"passcodeBackupPromptHasBackup" = "Ich habe bereits ein Backup";
+"passcodeBackupPromptSubtitle" = "Ein Passcode verschlüsselt Ihre Key-Shares mit einem Schlüssel, der auf diesem Gerät liegt. Geht dieser Schlüssel verloren, ist Ihr .vult-Backup der einzige Weg zurück – der Passcode selbst lässt sich nicht wiederherstellen.";
+"passcodeBackupPromptTitle" = "Erstellen Sie ein Backup, bevor Sie einen Passcode festlegen";
 "passcodeBiometricDisableFailed" = "Die biometrische Entsperrung konnte nicht deaktiviert werden. Versuchen Sie es erneut.";
 "passcodeBiometricEnableFailed" = "Die biometrische Entsperrung konnte nicht aktiviert werden. Ihr Passcode funktioniert weiterhin.";
 "passcodeBiometricNotAvailable" = "Dieses Gerät kann die biometrische Entsperrung nicht verwenden.";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -943,6 +943,10 @@
 "partOf" = "part %d of %d";
 "passcodeAlreadySet" = "A passcode is already set on this device. Go back to change or remove it.";
 "passcodeAutoLockTitle" = "Auto-lock";
+"passcodeBackupPromptBackUpNow" = "Back up now";
+"passcodeBackupPromptHasBackup" = "I already have a backup";
+"passcodeBackupPromptSubtitle" = "A passcode encrypts your key shares with a key held on this device. If that key is ever lost, your .vult backup is the only way back — the passcode itself cannot be recovered.";
+"passcodeBackupPromptTitle" = "Back up before you set a passcode";
 "passcodeBiometricDisableFailed" = "Biometric unlock could not be turned off. Try again.";
 "passcodeBiometricEnableFailed" = "Biometric unlock could not be turned on. Your passcode still works.";
 "passcodeBiometricNotAvailable" = "This device cannot use biometric unlock.";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -943,6 +943,10 @@
 "partOf" = "Parte %d de %d";
 "passcodeAlreadySet" = "Ya hay un código establecido en este dispositivo. Vuelve atrás para cambiarlo o quitarlo.";
 "passcodeAutoLockTitle" = "Bloqueo automático";
+"passcodeBackupPromptBackUpNow" = "Crear copia ahora";
+"passcodeBackupPromptHasBackup" = "Ya tengo una copia de seguridad";
+"passcodeBackupPromptSubtitle" = "Un código cifra tus key shares con una clave guardada en este dispositivo. Si esa clave se pierde, tu copia .vult es la única forma de recuperarlos: el código en sí no se puede recuperar.";
+"passcodeBackupPromptTitle" = "Haz una copia de seguridad antes de establecer un código";
 "passcodeBiometricDisableFailed" = "No se pudo desactivar el desbloqueo biométrico. Inténtalo de nuevo.";
 "passcodeBiometricEnableFailed" = "No se pudo activar el desbloqueo biométrico. Tu código sigue funcionando.";
 "passcodeBiometricNotAvailable" = "Este dispositivo no puede usar el desbloqueo biométrico.";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -943,6 +943,10 @@
 "partOf" = "dio %d od %d";
 "passcodeAlreadySet" = "Na ovom uređaju već je postavljena zaporka. Vratite se natrag da biste je promijenili ili uklonili.";
 "passcodeAutoLockTitle" = "Automatsko zaključavanje";
+"passcodeBackupPromptBackUpNow" = "Napravi kopiju sada";
+"passcodeBackupPromptHasBackup" = "Već imam sigurnosnu kopiju";
+"passcodeBackupPromptSubtitle" = "Zaporka šifrira vaše key shareove ključem koji se nalazi na ovom uređaju. Ako se taj ključ izgubi, vaša .vult sigurnosna kopija jedini je način povratka — sama zaporka ne može se vratiti.";
+"passcodeBackupPromptTitle" = "Napravite sigurnosnu kopiju prije postavljanja zaporke";
 "passcodeBiometricDisableFailed" = "Otključavanje biometrijom nije se moglo isključiti. Pokušajte ponovno.";
 "passcodeBiometricEnableFailed" = "Otključavanje biometrijom nije se moglo uključiti. Vaša zaporka i dalje radi.";
 "passcodeBiometricNotAvailable" = "Ovaj uređaj ne može koristiti otključavanje biometrijom.";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -943,6 +943,10 @@
 "partOf" = "parte %d di %d";
 "passcodeAlreadySet" = "Su questo dispositivo è già impostato un codice. Torna indietro per cambiarlo o rimuoverlo.";
 "passcodeAutoLockTitle" = "Blocco automatico";
+"passcodeBackupPromptBackUpNow" = "Fai il backup ora";
+"passcodeBackupPromptHasBackup" = "Ho già un backup";
+"passcodeBackupPromptSubtitle" = "Un codice cifra i tuoi key share con una chiave conservata su questo dispositivo. Se quella chiave va persa, il tuo backup .vult è l'unico modo per recuperarli: il codice stesso non può essere recuperato.";
+"passcodeBackupPromptTitle" = "Fai un backup prima di impostare un codice";
 "passcodeBiometricDisableFailed" = "Non è stato possibile disattivare lo sblocco con la biometria. Riprova.";
 "passcodeBiometricEnableFailed" = "Non è stato possibile attivare lo sblocco con la biometria. Il codice continua a funzionare.";
 "passcodeBiometricNotAvailable" = "Questo dispositivo non può usare lo sblocco con la biometria.";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -943,6 +943,10 @@
 "partOf" = "%d/%d 공유";
 "passcodeAlreadySet" = "이 기기에는 이미 패스코드가 설정되어 있습니다. 뒤로 돌아가 변경하거나 삭제하세요.";
 "passcodeAutoLockTitle" = "자동 잠금";
+"passcodeBackupPromptBackUpNow" = "지금 백업";
+"passcodeBackupPromptHasBackup" = "이미 백업이 있습니다";
+"passcodeBackupPromptSubtitle" = "패스코드는 이 기기에 보관된 키로 키 셰어를 암호화합니다. 그 키를 잃어버리면 .vult 백업이 유일한 복구 방법이며, 패스코드 자체는 복구할 수 없습니다.";
+"passcodeBackupPromptTitle" = "패스코드를 설정하기 전에 백업하세요";
 "passcodeBiometricDisableFailed" = "생체 인식 잠금 해제를 끄지 못했습니다. 다시 시도하세요.";
 "passcodeBiometricEnableFailed" = "생체 인식 잠금 해제를 켜지 못했습니다. 패스코드는 계속 사용할 수 있습니다.";
 "passcodeBiometricNotAvailable" = "이 기기에서는 생체 인식 잠금 해제를 사용할 수 없습니다.";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -943,6 +943,10 @@
 "partOf" = "parte %d de %d";
 "passcodeAlreadySet" = "Já existe um código definido neste dispositivo. Volte atrás para o alterar ou remover.";
 "passcodeAutoLockTitle" = "Bloqueio automático";
+"passcodeBackupPromptBackUpNow" = "Fazer cópia agora";
+"passcodeBackupPromptHasBackup" = "Já tenho uma cópia de segurança";
+"passcodeBackupPromptSubtitle" = "Um código encripta os seus key shares com uma chave guardada neste dispositivo. Se essa chave se perder, a sua cópia .vult é a única forma de os recuperar — o próprio código não pode ser recuperado.";
+"passcodeBackupPromptTitle" = "Faça uma cópia de segurança antes de definir um código";
 "passcodeBiometricDisableFailed" = "Não foi possível desativar o desbloqueio biométrico. Tente novamente.";
 "passcodeBiometricEnableFailed" = "Não foi possível ativar o desbloqueio biométrico. O seu código continua a funcionar.";
 "passcodeBiometricNotAvailable" = "Este dispositivo não pode usar o desbloqueio biométrico.";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -943,6 +943,10 @@
 "partOf" = "第 %d 部分，共 %d 部分";
 "passcodeAlreadySet" = "本设备已设置密码。请返回上一页以修改或移除。";
 "passcodeAutoLockTitle" = "自动锁定";
+"passcodeBackupPromptBackUpNow" = "立即备份";
+"passcodeBackupPromptHasBackup" = "我已有备份";
+"passcodeBackupPromptSubtitle" = "密码会使用保存在本设备上的密钥加密您的 key share。如果该密钥丢失，您的 .vult 备份是唯一的恢复途径——密码本身无法找回。";
+"passcodeBackupPromptTitle" = "设置密码前请先备份";
 "passcodeBiometricDisableFailed" = "无法关闭生物识别解锁。请重试。";
 "passcodeBiometricEnableFailed" = "无法开启生物识别解锁。密码仍然可用。";
 "passcodeBiometricNotAvailable" = "本设备无法使用生物识别解锁。";

--- a/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
+++ b/VultisigApp/VultisigApp/Core/Utils/AccessibilityID.swift
@@ -27,6 +27,8 @@ enum AccessibilityID {
         static let autoLockCell = "settings.autoLockCell"
         static let biometricUnlockToggle = "settings.biometricUnlockToggle"
         static let biometricUnlockNote = "settings.biometricUnlockNote"
+        static let passcodeBackupPromptBackUpNow = "settings.passcodeBackupPromptBackUpNow"
+        static let passcodeBackupPromptHasBackup = "settings.passcodeBackupPromptHasBackup"
     }
 
     enum Passcode {

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/BackUpBeforePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/BackUpBeforePasscodeScreen.swift
@@ -1,0 +1,96 @@
+//
+//  BackUpBeforePasscodeScreen.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Asks for a backup before the passcode goes on.
+///
+/// Setting a passcode encrypts every stored key share under a key this device
+/// holds. Nothing about that is reversible from the outside: if the key goes and
+/// the shares stay — a restore that did not carry the Keychain across is the
+/// ordinary way — the `.vult` is what brings the vault back, and there is no
+/// support path that substitutes for it.
+///
+/// So this is a prompt rather than a warning banner, and it is deliberately not
+/// a gate: the app cannot actually tell whether a backup exists or is current.
+/// ``Vault/isBackedUp`` is a flag set by any export or import and never cleared
+/// by a later change, so treating it as proof would let a stale backup through
+/// silently while nagging someone who has a perfectly good one on disk. Asking,
+/// and taking the answer, is the honest version of a check the app cannot make.
+struct BackUpBeforePasscodeScreen: View {
+
+    /// Closing is done by the presenter's flag rather than `@Environment(\.dismiss)`.
+    ///
+    /// Below macOS 26 `crossPlatformSheet` is not a presentation at all — it
+    /// renders this view as a sibling inside the presenter's own `ZStack` — so
+    /// there is nothing there for `dismiss()` to close, and it would reach past
+    /// this screen to the enclosing navigation stack instead. The flag is the
+    /// one thing both sheet implementations agree on.
+    @Binding var isPresented: Bool
+
+    /// Takes the user to the backup flow instead of the passcode.
+    let onBackUpNow: () -> Void
+    /// Proceeds to set the passcode on the user's word that a backup exists.
+    let onContinue: () -> Void
+
+    var body: some View {
+        Screen {
+            VStack(spacing: 24) {
+                Spacer()
+                header
+                Spacer()
+                buttons
+            }
+        }
+        .screenBackButtonHidden()
+        .screenIgnoresTopEdge()
+        .screenToolbar {
+            CustomToolbarItem(placement: .leading) {
+                ToolbarButton(image: .xmark) {
+                    isPresented = false
+                }
+            }
+        }
+        .applySheetSize(650, 400)
+        .sheetStyle()
+        .presentationDetents([.height(325)])
+    }
+
+    var header: some View {
+        VStack(spacing: 12) {
+            Text("passcodeBackupPromptTitle".localized)
+                .font(Theme.fonts.title2)
+                .foregroundStyle(Theme.colors.textPrimary)
+
+            Text("passcodeBackupPromptSubtitle".localized)
+                .font(Theme.fonts.bodySMedium)
+                .foregroundStyle(Theme.colors.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .multilineTextAlignment(.center)
+    }
+
+    var buttons: some View {
+        VStack(spacing: 12) {
+            PrimaryButton(title: "passcodeBackupPromptBackUpNow", action: onBackUpNow)
+                .accessibilityIdentifier(AccessibilityID.Settings.passcodeBackupPromptBackUpNow)
+
+            PrimaryButton(
+                title: "passcodeBackupPromptHasBackup",
+                type: .secondary,
+                action: onContinue
+            )
+            .accessibilityIdentifier(AccessibilityID.Settings.passcodeBackupPromptHasBackup)
+        }
+    }
+}
+
+#Preview {
+    BackUpBeforePasscodeScreen(
+        isPresented: .constant(true),
+        onBackUpNow: {},
+        onContinue: {}
+    )
+}

--- a/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Settings/Views/Passcode/ManagePasscodeScreen.swift
@@ -10,7 +10,18 @@ import SwiftUI
 struct ManagePasscodeScreen: View {
 
     @Environment(\.router) var router
+    @EnvironmentObject var appViewModel: AppViewModel
     @State private var isSet: Bool = false
+    /// Raised by "Set passcode" instead of navigating, so the backup prompt is
+    /// answered before the passcode screen is reached at all.
+    ///
+    /// An *item* rather than a flag, because both answers end in a navigation
+    /// push and only `crossPlatformSheet(item:onDismiss:)` can run one after the
+    /// dismissal has settled. Pushing while the sheet is still on screen races
+    /// the dismissal animation and the destination can be dropped.
+    @State private var backupPrompt: BackupPrompt?
+    /// Which button was pressed, held until the sheet is off screen.
+    @State private var backupPromptAnswer: BackupPromptAnswer?
     @State private var isBiometricEnabled: Bool = false
     @State private var biometricAvailability: BiometricAvailability = .available
     @State private var biometricError: String?
@@ -67,6 +78,23 @@ struct ManagePasscodeScreen: View {
         .crossPlatformSheet(isPresented: $showDisable, isDismissable: !isRemoving) {
             DisablePasscodeScreen(isPresented: $showDisable, isRemoving: $isRemoving)
                 .presentationDragIndicator(.visible)
+        }
+        // Dismissable on purpose. Backing out of it is backing out of setting a
+        // passcode at all, which leaves the key shares exactly as they are — the
+        // one outcome here that cannot cost anyone their funds, and it answers
+        // nothing so `onDismiss` has nothing to carry out.
+        .crossPlatformSheet(item: $backupPrompt, onDismiss: actOnBackupPromptAnswer) { _ in
+            BackUpBeforePasscodeScreen(
+                isPresented: Binding(
+                    get: { backupPrompt != nil },
+                    set: { isPresented in
+                        guard !isPresented else { return }
+                        backupPrompt = nil
+                    }
+                ),
+                onBackUpNow: { answerBackupPrompt(with: .backUp) },
+                onContinue: { answerBackupPrompt(with: .alreadyHasBackup) }
+            )
         }
         // `.onAppear` as well as `.task`: returning from the pushed set/change
         // screens does not re-run `.task`, and a stale `isSet` would keep
@@ -130,6 +158,17 @@ struct ManagePasscodeScreen: View {
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    /// Presence is what presents the backup prompt; it carries nothing, because
+    /// the answer travels separately and outlives the dismissal.
+    struct BackupPrompt: Identifiable, Equatable {
+        let id = UUID()
+    }
+
+    enum BackupPromptAnswer {
+        case backUp
+        case alreadyHasBackup
+    }
+
     enum Row: Hashable {
         case set
         case change
@@ -186,7 +225,7 @@ struct ManagePasscodeScreen: View {
     private func handle(_ row: Row) {
         switch row {
         case .set:
-            router.navigate(to: SettingsRoute.setPasscode)
+            backupPrompt = BackupPrompt()
         case .change:
             router.navigate(to: SettingsRoute.changePasscode)
         case .autoLock:
@@ -196,6 +235,47 @@ struct ManagePasscodeScreen: View {
         case .biometrics:
             // Rendered as a toggle, never as a tappable destination.
             break
+        }
+    }
+
+    /// Records the answer and closes the sheet. Acting on it waits for
+    /// ``actOnBackupPromptAnswer()``.
+    private func answerBackupPrompt(with answer: BackupPromptAnswer) {
+        backupPromptAnswer = answer
+        backupPrompt = nil
+    }
+
+    /// Carries out the answer, once the sheet is actually off screen.
+    ///
+    /// Both destinations are navigation pushes, and a push issued while the
+    /// sheet is still dismissing can be dropped — which is why the prompt is an
+    /// item-based sheet at all.
+    private func actOnBackupPromptAnswer() {
+        guard let answer = backupPromptAnswer else { return }
+        backupPromptAnswer = nil
+
+        switch answer {
+        case .backUp:
+            // The passcode seals the key shares of *every* stored vault, not
+            // just the selected one, so the destination is the backup
+            // **selection** screen — the one entry point that can export more
+            // than the current vault. Which vaults to take is left to the user
+            // there rather than decided here.
+            guard let vault = appViewModel.selectedVault else {
+                // No vault means nothing to export and nothing to lose, so the
+                // prompt has nothing to offer. Falling through to the passcode
+                // screen beats a button that does nothing.
+                router.navigate(to: SettingsRoute.setPasscode)
+                return
+            }
+            router.navigate(to: VaultRoute.backupSelection(vault: vault))
+        case .alreadyHasBackup:
+            // Taken at face value deliberately: `Vault.isBackedUp` is set by any
+            // export or import and never cleared when the vault changes
+            // afterwards, so it can neither confirm this answer nor contradict
+            // it. Recording it as if it could would put a claim in the store
+            // that later code might trust.
+            router.navigate(to: SettingsRoute.setPasscode)
         }
     }
 


### PR DESCRIPTION
## Description

Setting a passcode encrypts every stored key share under a key this device holds. If that key is later lost while the shares remain — a restore that did not carry the Keychain across is the ordinary way — the `.vult` backup is the only route back, and nothing substitutes for it.

Until now **Set passcode** navigated straight to the entry screen and said none of that. The only mention was a line of caption text further down the settings list (`passcodeManageExplanation`), which is a warning you read after deciding, if at all.

Tapping it now raises a sheet first, offering the backup flow or a way past on the user's word that a backup already exists.

No issue — filed straight from a conversation about the recovery side of the same problem (#5086).

### Three decisions worth reviewing

**It is a prompt, not a gate.** The app cannot tell whether a backup exists or is current. `Vault.isBackedUp` is a plain `Bool` set by any export *or import* and never cleared when the vault changes afterwards, so treating it as proof would wave a stale backup through while nagging someone whose backup is fine. It is therefore neither read to skip the prompt nor written when the user answers — recording the answer would put a claim in the store that later code might trust.

**"Back up now" goes to the backup *selection* screen**, not an export of the current vault. A passcode seals the key shares of *every* stored vault, and `VaultBackupSelectionScreen` is the only entry point that can export more than one.

**The prompt is an item-based sheet rather than a boolean one.** Both answers end in a navigation push, and only `crossPlatformSheet(item:onDismiss:)` can run one after the dismissal has settled — pushing while the sheet is still on screen races the animation and the destination can be dropped. That hazard is documented on the overload itself (`CrossPlatformSheet.swift:15-19`); `TransactionHistoryScreen` uses it for the same reason.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None of the above — Settings only, no keysign/broadcast/fee surface touched.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

**No tests.** The change is a presentation decision inside a SwiftUI view — which sheet is raised and where each answer navigates. The unit-test target has no view-hosting harness, and the one piece of logic worth pinning (the answer surviving the dismissal) lives in `@State` on the view. Verified by running it instead; see below.

## Screenshots (if applicable):

None attached — verified on-device by @gastonm5, who also made the final sheet sizing and detent adjustments.

## Additional context

**Gate**
- iOS: `Executed 5465 tests, with 1 test skipped and 0 failures (0 unexpected)` → `** TEST SUCCEEDED **`
- macOS: `** BUILD SUCCEEDED **` (the iOS target never compiles `#if os(macOS)`, and this sheet has a macOS-only path below macOS 26 where `crossPlatformSheet` renders as a `ZStack` sibling rather than a real presentation)
- SwiftLint: 22 violations, identical to `main` — 0 new
- Localisation: 4 new keys across all 8 shipping locales, each file at 1745 entries

**Relationship to the shared design work.** vultisig/vultisig-sdk#1845 specifies two passcode screens for all three clients. This is a lighter take on its *screen 1*: that issue asks for a **blocking** gate requiring a current backup, whereas the "I already have a backup" button here makes this a speed bump. If that design lands, this is the surface it would replace.

Two things it deliberately does not attempt, both of which #1845 wants and neither of which is currently expressible: a **"your backup is old"** state — `isBackedUp` is a bool with no export timestamp or vault-version marker behind it, so staleness cannot be detected — and any blocking behaviour.

The recovery side of the same problem is #5086 → #5106 / #5107.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: none
- **Confidence**: medium — gate green and confirmed working on device, but no second-model review pass and no automated test coverage
- **Needs human review for**: the copy (it says "a key held on this device" and deliberately **not** that the key never leaves it — the wrapper is `kSecAttrAccessibleWhenUnlocked`, not `ThisDeviceOnly`, so it does travel in encrypted backups and device migration), and the item-based sheet plumbing in `ManagePasscodeScreen`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a backup prompt before passcode setup, allowing users to back up immediately or confirm an existing backup.
  * Added localized prompt content in English, German, Spanish, Croatian, Italian, Korean, Portuguese, and Simplified Chinese.
  * Improved navigation based on the selected vault and backup choice.
* **Accessibility**
  * Added accessibility identifiers for backup prompt actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->