### PR TITLE
fix(defi,rates): stop YieldPosition and DatabaseRate churning the store on no-op refreshes

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
+++ b/VultisigApp/VultisigApp/Core/Services/Rates/RateProvider.swift
@@ -97,18 +97,34 @@ final class RateProvider {
         // Defer fetch to avoid re-entrant SwiftData calls during init.
         // Must run on MainActor — ModelContext is MainActor-isolated.
         Task { @MainActor [weak self] in
-            guard let self else { return }
-            let descriptor = FetchDescriptor<DatabaseRate>()
-            do {
-                let objects = try Storage.shared.modelContext.fetch(descriptor)
-                self.replaceRates(with: objects.map { Rate(object: $0) })
-                // Persisted rates make fiat renderable immediately on a warm
-                // start; announce them so views that cached a pre-load fiat
-                // value recompute instead of waiting on a network refresh.
-                self.ratesDidChange.send()
-            } catch {
-                Log.chain.service.error("Failed to load rates: \(error.localizedDescription, privacy: .public)")
-            }
+            self?.loadPersistedRates()
+        }
+    }
+
+    /// Populates the cache from the persisted rates.
+    ///
+    /// Called once, from `init`. Not `private` because the initializer of a
+    /// process-wide singleton cannot be re-entered from a test, and the
+    /// non-finite filter below is worth verifying rather than asserting.
+    @MainActor
+    func loadPersistedRates() {
+        let descriptor = FetchDescriptor<DatabaseRate>()
+        do {
+            let objects = try Storage.shared.modelContext.fetch(descriptor)
+            // The same non-finite filter `save(rates:)` applies, on the way back
+            // in: a build predating that filter could have persisted an infinity,
+            // and this is the one path that would put it back into the cache
+            // every fiat render reads. Filtered rather than deleted — a
+            // launch-time store write is exactly the kind of gratuitous mutation
+            // these guards exist to stop making, and the row is overwritten by
+            // the next finite quote for that coin anyway.
+            replaceRates(with: objects.map { Rate(object: $0) }.filter { $0.value.isFinite })
+            // Persisted rates make fiat renderable immediately on a warm
+            // start; announce them so views that cached a pre-load fiat
+            // value recompute instead of waiting on a network refresh.
+            ratesDidChange.send()
+        } catch {
+            Log.chain.service.error("Failed to load rates: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -159,8 +175,21 @@ final class RateProvider {
     }
 
     @MainActor func save(rates newRates: [Rate]) throws {
+        // A non-finite rate is never a usable price, and admitting one poisons
+        // the cache every fiat render reads. NaN is worse still: `NaN != NaN`, so
+        // no equality guard can ever suppress it, and the attribute coerces it to
+        // `0` on save (infinities persist as they are), so the stored value never
+        // compares equal to the incoming one either — one NaN quote re-dirties
+        // its row on every refresh from then on, notifying every observer, and
+        // through the save every `@Query` in the app, about a price that never
+        // changed. Nothing upstream rejects one: the MAYAChain pool-derived price
+        // is `Double(String)` arithmetic over API-supplied balances, and
+        // `Double("nan")` parses. Dropped at the door so the last usable price
+        // survives in both the cache and the store.
+        let rates = newRates.filter { $0.value.isFinite }
+
         // if a rate is newer , we use the newer one
-        mergeRates(newRates)
+        mergeRates(rates)
 
         // The in-memory cache is what rendering reads, and it has already
         // changed — announce it even if the persistence below throws, or a
@@ -169,17 +198,14 @@ final class RateProvider {
         defer { ratesDidChange.send() }
 
         // Update existing or insert new rates
-        for rate in newRates {
+        for rate in rates {
             let rateId = rate.id // Capture the value outside the predicate
             let descriptor = FetchDescriptor<DatabaseRate>(
                 predicate: #Predicate { $0.id == rateId }
             )
 
             if let existingRate = try Storage.shared.modelContext.fetch(descriptor).first {
-                // Update existing rate
-                existingRate.fiat = rate.fiat
-                existingRate.crypto = rate.crypto
-                existingRate.value = rate.value
+                update(existingRate, from: rate)
             } else {
                 // Insert new rate
                 Storage.shared.insert(rate.mapToObject())
@@ -187,5 +213,32 @@ final class RateProvider {
         }
 
         try Storage.shared.modelContext.save()
+    }
+
+    /// Copies a refreshed rate onto its persisted row, or leaves the row entirely
+    /// alone when nothing differs.
+    ///
+    /// The equality guard is load-bearing, not an optimization. SwiftData's
+    /// `@Model` setter wraps each store in `withMutation(of:)`, which notifies
+    /// observers **without comparing** the new value to the old, and a save then
+    /// posts a store-change notification that re-evaluates every `@Query` in the
+    /// app — including queries over entirely unrelated types. So "nothing reads
+    /// `DatabaseRate`" is not a defence: a blind re-assignment here invalidates
+    /// the whole window, and this is the app's largest write burst — one row per
+    /// held coin, on every price refresh, most of them unchanged.
+    ///
+    /// The guard is all-or-nothing over every write below, and it must compare
+    /// **every** field that is assigned, or an uncompared field re-opens the same
+    /// hole. Add to both lists together.
+    @MainActor
+    private func update(_ object: DatabaseRate, from rate: Rate) {
+        guard object.fiat != rate.fiat
+            || object.crypto != rate.crypto
+            || object.value != rate.value
+        else { return }
+
+        object.fiat = rate.fiat
+        object.crypto = rate.crypto
+        object.value = rate.value
     }
 }

--- a/VultisigApp/VultisigApp/Features/Defi/Common/Yield/YieldPositionStorageService.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Common/Yield/YieldPositionStorageService.swift
@@ -25,9 +25,7 @@ struct YieldPositionStorageService {
     ) throws {
         let target: YieldPosition
         if let existing = position(for: vault, providerID: providerID) {
-            existing.depositedBalance = depositedBalance
-            existing.nativeGasBalance = nativeGasBalance
-            existing.lastUpdated = .now
+            applyBalances(depositedBalance: depositedBalance, nativeGasBalance: nativeGasBalance, to: existing)
             target = existing
         } else {
             let position = YieldPosition(
@@ -64,20 +62,125 @@ struct YieldPositionStorageService {
 
     // MARK: - Private
 
-    /// Replaces the position's redemption rows with the supplied snapshot.
+    /// Copies the refreshed balances onto `position`, or leaves it entirely alone
+    /// when neither moved.
+    ///
+    /// The equality guard is load-bearing, not an optimization. SwiftData's
+    /// `@Model` setter wraps each store in `withMutation(of:)`, which notifies
+    /// observers **without comparing** the new value to the old — so re-assigning a
+    /// value that is already there still invalidates every SwiftUI view reading
+    /// this position. A plain `@Observable` class does not behave this way, which is
+    /// why the habit of assigning blind is safe elsewhere and not here. A refresh
+    /// re-supplies the same balances whenever nothing moved on-chain, so an
+    /// unguarded copy re-dirties its readers on every single call.
+    ///
+    /// Two properties of the guard matter: it must cover **every** write below,
+    /// the `lastUpdated` stamp included — a stamp left outside re-notifies by
+    /// itself and defeats the guard entirely — and it must compare **every** field
+    /// that is assigned, or an uncompared field re-opens the same hole. Add to both
+    /// lists together.
+    ///
+    /// `lastUpdated` has no readers: nothing checks this position for staleness,
+    /// expires it, sorts on it, or filters on it, so declining to re-stamp a no-op
+    /// refresh is not observable behaviour.
+    @MainActor
+    private func applyBalances(
+        depositedBalance: Decimal,
+        nativeGasBalance: Decimal,
+        to position: YieldPosition
+    ) {
+        guard position.depositedBalance != depositedBalance
+            || position.nativeGasBalance != nativeGasBalance
+        else { return }
+
+        position.depositedBalance = depositedBalance
+        position.nativeGasBalance = nativeGasBalance
+        position.lastUpdated = .now
+    }
+
+    /// Reconciles the position's redemption rows against `redemptions`, matching
+    /// stored rows to incoming ones by `id`.
+    ///
+    /// This is a diff rather than the obvious delete-everything-and-recreate,
+    /// because an equality guard cannot rescue the latter: deleting and
+    /// re-inserting rows that did not change is itself a store mutation, so it
+    /// invalidates every reader — and, once the caller saves, every `@Query` in
+    /// the app — on every refresh, however little actually moved. Only touching
+    /// what genuinely differs is what stops that.
+    ///
+    /// `id` is the identity: it is the provider's own redemption-request
+    /// identifier, it is what `YieldRedemptionRecord` already persists
+    /// `@Attribute(.unique)`, and it is the key the read path maps back out on.
+    /// It is deliberately not derived from the mutable fields — a redemption
+    /// keeps its identity precisely while it moves `pending -> claimable ->
+    /// settled`, which is the update this diff has to recognize as an update
+    /// rather than as a delete plus an insert.
+    ///
+    /// Row order is not a contract and is not maintained here. A SwiftData
+    /// to-many relationship is unordered, so the wholesale assignment this
+    /// replaced did not preserve the snapshot's order either; imposing one would
+    /// need a persisted sort index, and rewriting the relationship whenever the
+    /// provider reorders its list would put back exactly the churn this removes.
+    /// Readers that need a specific redemption should select it, not index into
+    /// the array.
     @MainActor
     private func syncRedemptions(_ redemptions: [YieldRedemption], on position: YieldPosition) {
-        for stale in position.redemptions {
-            Storage.shared.delete(stale)
+        // `id` is `@Attribute(.unique)`, so two incoming rows sharing one would
+        // collapse into a single stored row anyway; keep the first and drop the
+        // rest here, where it is explicit.
+        var seen = Set<String>()
+        let incoming = redemptions.filter { seen.insert($0.id).inserted }
+        let incomingByID = Dictionary(uniqueKeysWithValues: incoming.map { ($0.id, $0) })
+        var matched: [String: YieldRedemptionRecord] = [:]
+
+        // Keep the first stored row per incoming id; delete the rest. A row whose
+        // id is absent from the snapshot is genuinely gone, and a second row
+        // carrying an already-matched id is a duplicate the store should not hold.
+        for stored in position.redemptions {
+            if incomingByID[stored.id] != nil, matched[stored.id] == nil {
+                matched[stored.id] = stored
+            } else {
+                Storage.shared.delete(stored)
+            }
         }
-        position.redemptions = redemptions.map { redemption in
-            YieldRedemptionRecord(
+
+        for redemption in incoming {
+            guard let record = matched[redemption.id] else { continue }
+            apply(redemption, to: record)
+        }
+
+        // New rows are attached through the inverse rather than by appending to
+        // `position.redemptions`: appending is a get-modify-set of the whole
+        // relationship, and the rows deleted just above may still be in the array
+        // the getter hands back, which would write them straight back in.
+        for redemption in incoming where matched[redemption.id] == nil {
+            let record = YieldRedemptionRecord(
                 id: redemption.id,
                 amount: redemption.amount,
                 requestedAt: redemption.requestedAt,
                 claimableAt: redemption.claimableAt,
                 status: redemption.status
             )
+            Storage.shared.insert(record)
+            record.position = position
         }
+    }
+
+    /// Copies a refreshed redemption onto its stored row, or leaves the row
+    /// entirely alone when nothing differs — same all-or-nothing guard, and same
+    /// reason, as ``applyBalances(depositedBalance:nativeGasBalance:to:)``.
+    /// `id` is the match key and is never written.
+    @MainActor
+    private func apply(_ redemption: YieldRedemption, to record: YieldRedemptionRecord) {
+        guard record.amount != redemption.amount
+            || record.requestedAt != redemption.requestedAt
+            || record.claimableAt != redemption.claimableAt
+            || record.status != redemption.status
+        else { return }
+
+        record.amount = redemption.amount
+        record.requestedAt = redemption.requestedAt
+        record.claimableAt = redemption.claimableAt
+        record.status = redemption.status
     }
 }

--- a/VultisigApp/VultisigAppTests/Defi/YieldPositionWriteGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/YieldPositionWriteGuardTests.swift
@@ -1,0 +1,366 @@
+//
+//  YieldPositionWriteGuardTests.swift
+//  VultisigAppTests
+//
+//  `YieldPositionStorageService.upsert(...)` must leave the store completely
+//  alone when the refreshed snapshot already matches what is persisted — both
+//  halves of it: the position's own balances, and its redemption rows.
+//
+//  Asserting on the resulting VALUES cannot show that. A blind re-assignment of
+//  an identical value leaves the values identical, and a delete-then-recreate of
+//  identical rows leaves the rows looking identical too, so a test written that
+//  way passes against the unguarded implementation as happily as against this
+//  one. What separates them is the mutation: SwiftData's `@Model` setter routes
+//  through the Observation registrar and notifies WITHOUT comparing new to old,
+//  and a deleted-and-reinserted row is a genuine store change no equality guard
+//  can suppress. Both invalidate every SwiftUI reader — and, once the caller
+//  saves, every `@Query` in the app, whatever type it queries — on every refresh
+//  however little actually moved.
+//
+//  So these tests observe with `withObservationTracking` and assert on whether a
+//  change was published, and — for the redemption diff — on OBJECT IDENTITY:
+//  a row that survived a refresh untouched is the same instance afterwards, and
+//  a recreated one is not. That is the assertion the delete-recreate fails.
+//
+//  The per-field sweeps are the other half. The failure they prevent is a field
+//  that is written but not compared: the guard returns early, the write never
+//  runs, and a real update is silently dropped. Every field either guard assigns
+//  gets its own case.
+//
+
+@testable import VultisigApp
+import Observation
+import SwiftData
+import XCTest
+
+/// Reference box so the `@Sendable` `onChange` closure can report back without
+/// capturing a mutable local. Every access is main-actor and synchronous —
+/// `onChange` fires from inside the mutating call, on the same thread.
+private final class ChangeRecorder: @unchecked Sendable {
+    private(set) var didChange = false
+    func record() { didChange = true }
+}
+
+private func redemption(
+    id: String = "req-1",
+    amount: Decimal = 95,
+    requestedAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+    claimableAt: Date? = Date(timeIntervalSince1970: 1_700_600_000),
+    status: YieldRedemption.Status = .pending
+) -> YieldRedemption {
+    YieldRedemption(
+        id: id,
+        amount: amount,
+        requestedAt: requestedAt,
+        claimableAt: claimableAt,
+        status: status
+    )
+}
+
+@MainActor
+final class YieldPositionWriteGuardTests: XCTestCase {
+
+    private var token: TestContextToken!
+    private let service = YieldPositionStorageService()
+    private var vault: Vault!
+
+    override func setUpWithError() throws {
+        token = try TestStore.installInMemoryContainer()
+        vault = TestStore.makeVault(pubKey: "yield-guard")
+    }
+
+    override func tearDown() {
+        vault = nil
+        TestStore.restore(token)
+        token = nil
+    }
+
+    // MARK: - Helpers
+
+    /// Runs `mutate` while observing everything `read` touches, and reports
+    /// whether the Observation registrar published a change.
+    private func changePublished(reading read: () -> Void, during mutate: () throws -> Void) rethrows -> Bool {
+        let recorder = ChangeRecorder()
+        withObservationTracking { read() } onChange: { recorder.record() }
+        try mutate()
+        return recorder.didChange
+    }
+
+    /// Reads every property the balance guard can write. All of them have to be
+    /// observed: a property written but not read here could be mutated without
+    /// the probe noticing, and the test would pass vacuously.
+    private func readPositionFields(_ position: YieldPosition) {
+        _ = position.depositedBalance
+        _ = position.nativeGasBalance
+        _ = position.lastUpdated
+        _ = position.redemptions
+    }
+
+    /// Reads every property the redemption guard can write. `id` is the match
+    /// key and is never written, so it is deliberately absent.
+    private func readRecordFields(_ record: YieldRedemptionRecord) {
+        _ = record.amount
+        _ = record.requestedAt
+        _ = record.claimableAt
+        _ = record.statusRawValue
+    }
+
+    @discardableResult
+    private func upsert(
+        deposited: Decimal = 100,
+        gas: Decimal = 0.2,
+        redemptions: [YieldRedemption] = []
+    ) throws -> YieldPosition {
+        try service.upsert(
+            providerID: .circle,
+            depositedBalance: deposited,
+            nativeGasBalance: gas,
+            redemptions: redemptions,
+            for: vault
+        )
+        return try XCTUnwrap(service.position(for: vault, providerID: .circle))
+    }
+
+    /// Row identity as the STORE sees it. Deliberately not `ObjectIdentifier`:
+    /// SwiftData re-materializes fresh Swift instances for the same persisted row
+    /// after a save, so instance identity changes for reasons that have nothing
+    /// to do with the row being deleted and recreated. `persistentModelID`
+    /// survives that and does not survive a delete plus an insert.
+    private func identities(of position: YieldPosition) -> Set<PersistentIdentifier> {
+        Set(position.redemptions.map(\.persistentModelID))
+    }
+
+    private func record(_ position: YieldPosition, id: String) throws -> YieldRedemptionRecord {
+        try XCTUnwrap(position.redemptions.first { $0.id == id })
+    }
+
+    /// Every redemption row in the store, not just the ones still hanging off the
+    /// position — a row dropped from the relationship but left behind in the
+    /// store is an orphan, and the delete has to be asserted where it happens.
+    /// `isDeleted` cannot be used for this: it goes back to `false` once the
+    /// delete is saved.
+    private func storedRedemptionIDs() throws -> Set<String> {
+        let rows = try Storage.shared.modelContext.fetch(FetchDescriptor<YieldRedemptionRecord>())
+        return Set(rows.map(\.id))
+    }
+
+    // MARK: - Balances: the no-op case
+
+    func testUpsertWithIdenticalSnapshotPublishesNoChange() throws {
+        let position = try upsert()
+
+        let published = try changePublished(reading: { readPositionFields(position) }, during: {
+            try upsert()
+        })
+
+        XCTAssertFalse(
+            published,
+            "An identical snapshot must not mutate the position. SwiftData notifies without comparing, "
+                + "so any blind re-assignment re-invalidates every SwiftUI reader."
+        )
+    }
+
+    /// The stamp has to sit INSIDE the guard. Left outside it re-notifies on its
+    /// own on every call and the guard buys nothing, so this is asserted
+    /// separately rather than folded into the probe above.
+    func testUpsertWithIdenticalSnapshotLeavesLastUpdatedUntouched() async throws {
+        let position = try upsert()
+        let stampBefore = position.lastUpdated
+
+        // Enough of a gap that a re-stamp would be unambiguous rather than a
+        // sub-microsecond tie.
+        try await Task.sleep(for: .milliseconds(20))
+        try upsert()
+
+        XCTAssertEqual(position.lastUpdated, stampBefore, "A no-op refresh must not refresh lastUpdated.")
+    }
+
+    // MARK: - Balances: the real-update case
+
+    func testUpsertPublishesChangeForEveryBalanceFieldDifference() async throws {
+        let cases: [(field: String, deposited: Decimal, gas: Decimal)] = [
+            ("depositedBalance", 101, 0.2),
+            ("nativeGasBalance", 100, 0.9)
+        ]
+
+        for testCase in cases {
+            let position = try upsert(deposited: 100, gas: 0.2)
+            let stampBefore = position.lastUpdated
+            try await Task.sleep(for: .milliseconds(20))
+
+            let published = try changePublished(reading: { readPositionFields(position) }, during: {
+                try upsert(deposited: testCase.deposited, gas: testCase.gas)
+            })
+
+            XCTAssertTrue(
+                published,
+                "\(testCase.field) differs from the stored value — upsert must write it"
+            )
+            XCTAssertEqual(position.depositedBalance, testCase.deposited)
+            XCTAssertEqual(position.nativeGasBalance, testCase.gas)
+            XCTAssertGreaterThan(position.lastUpdated, stampBefore, "A real update must refresh lastUpdated.")
+        }
+    }
+
+    // MARK: - Redemptions: the unchanged set
+
+    /// The decisive test for the diff. Under a delete-and-recreate every row is
+    /// a new instance on every refresh, so the identity set cannot survive.
+    func testUnchangedRedemptionSnapshotKeepsTheSameRowInstances() throws {
+        let rows = [redemption(id: "req-1"), redemption(id: "req-2", amount: 5, status: .claimable)]
+        let position = try upsert(redemptions: rows)
+        let before = identities(of: position)
+        XCTAssertEqual(before.count, 2)
+
+        try upsert(redemptions: rows)
+
+        XCTAssertEqual(
+            identities(of: position),
+            before,
+            "An unchanged snapshot must reuse the stored rows, not delete and recreate them."
+        )
+        XCTAssertEqual(position.redemptions.count, 2)
+        XCTAssertEqual(try storedRedemptionIDs(), ["req-1", "req-2"])
+    }
+
+    func testUnchangedRedemptionSnapshotPublishesNoChange() throws {
+        let rows = [redemption(id: "req-1"), redemption(id: "req-2", amount: 5, status: .claimable)]
+        let position = try upsert(redemptions: rows)
+        let stored = position.redemptions
+
+        let published = try changePublished(reading: {
+            readPositionFields(position)
+            stored.forEach { readRecordFields($0) }
+        }, during: {
+            try upsert(redemptions: rows)
+        })
+
+        XCTAssertFalse(published, "An unchanged redemption snapshot must not mutate anything.")
+    }
+
+    // MARK: - Redemptions: one row changed
+
+    func testChangedRedemptionUpdatesOnlyThatRow() throws {
+        let untouched = redemption(id: "req-1")
+        let position = try upsert(redemptions: [untouched, redemption(id: "req-2", amount: 5, status: .pending)])
+        let before = identities(of: position)
+        let stableRow = try record(position, id: "req-1")
+
+        let stablePublished = try changePublished(reading: { readRecordFields(stableRow) }, during: {
+            try upsert(redemptions: [untouched, redemption(id: "req-2", amount: 5, status: .claimable)])
+        })
+
+        XCTAssertFalse(stablePublished, "The row that did not change must not be written.")
+        XCTAssertEqual(identities(of: position), before, "Neither row may be recreated.")
+        XCTAssertEqual(try record(position, id: "req-2").status, .claimable)
+        XCTAssertEqual(try record(position, id: "req-1").status, .pending)
+    }
+
+    /// One case per field the redemption guard assigns. Catches a field that is
+    /// assigned but missing from the comparison, which would make the early
+    /// return swallow a real update.
+    func testRedemptionPublishesChangeForEverySingleFieldDifference() throws {
+        let baseline = redemption()
+        let cases: [(field: String, changed: YieldRedemption, verify: (YieldRedemptionRecord) -> Void)] = [
+            ("amount", redemption(amount: 96), { XCTAssertEqual($0.amount, 96) }),
+            ("requestedAt", redemption(requestedAt: Date(timeIntervalSince1970: 1_700_000_500)),
+             { XCTAssertEqual($0.requestedAt, Date(timeIntervalSince1970: 1_700_000_500)) }),
+            ("claimableAt", redemption(claimableAt: Date(timeIntervalSince1970: 1_700_700_000)),
+             { XCTAssertEqual($0.claimableAt, Date(timeIntervalSince1970: 1_700_700_000)) }),
+            ("claimableAt→nil", redemption(claimableAt: nil), { XCTAssertNil($0.claimableAt) }),
+            ("status", redemption(status: .settled), { XCTAssertEqual($0.status, .settled) })
+        ]
+
+        for testCase in cases {
+            let position = try upsert(redemptions: [baseline])
+            let stored = try record(position, id: baseline.id)
+
+            let published = try changePublished(reading: { readRecordFields(stored) }, during: {
+                try upsert(redemptions: [testCase.changed])
+            })
+
+            XCTAssertTrue(published, "\(testCase.field) differs from the stored value — the sync must write it")
+            XCTAssertEqual(
+                identities(of: position),
+                [stored.persistentModelID],
+                "\(testCase.field): the row must be updated in place, not replaced"
+            )
+            testCase.verify(stored)
+
+            // Reset for the next case: the position is keyed on the vault, so
+            // every case shares it.
+            try upsert(redemptions: [])
+        }
+    }
+
+    // MARK: - Redemptions: membership changes
+
+    func testUpsertInsertsAddedRowAndDeletesRemovedRowOnly() throws {
+        let kept = redemption(id: "req-1")
+        let position = try upsert(redemptions: [kept, redemption(id: "req-2", amount: 5)])
+        let keptRowID = try record(position, id: "req-1").persistentModelID
+
+        try upsert(redemptions: [kept, redemption(id: "req-3", amount: 7)])
+
+        XCTAssertEqual(Set(position.redemptions.map(\.id)), ["req-1", "req-3"])
+        XCTAssertTrue(
+            identities(of: position).contains(keptRowID),
+            "The row present in both snapshots must survive as the same stored row."
+        )
+        XCTAssertEqual(
+            try storedRedemptionIDs(),
+            ["req-1", "req-3"],
+            "The row absent from the snapshot must be deleted from the store, not just detached."
+        )
+        XCTAssertEqual(try record(position, id: "req-3").amount, 7)
+    }
+
+    func testUpsertPopulatesRedemptionsFromEmpty() throws {
+        let position = try upsert(redemptions: [])
+        XCTAssertTrue(position.redemptions.isEmpty)
+
+        try upsert(redemptions: [redemption(id: "req-1"), redemption(id: "req-2", amount: 5)])
+
+        XCTAssertEqual(Set(position.redemptions.map(\.id)), ["req-1", "req-2"])
+        XCTAssertEqual(try record(position, id: "req-1").amount, 95)
+    }
+
+    func testUpsertClearsEveryRedemptionWhenSnapshotIsEmpty() throws {
+        let position = try upsert(redemptions: [redemption(id: "req-1"), redemption(id: "req-2", amount: 5)])
+        XCTAssertEqual(try storedRedemptionIDs().count, 2)
+
+        try upsert(redemptions: [])
+
+        XCTAssertTrue(position.redemptions.isEmpty)
+        XCTAssertTrue(
+            try storedRedemptionIDs().isEmpty,
+            "Rows dropped from the snapshot must be deleted, not orphaned in the store."
+        )
+    }
+
+    /// The empty-to-empty transition is the one production actually runs today —
+    /// Circle is instant and always supplies no redemptions — so it is the case
+    /// that must not churn.
+    func testEmptySnapshotOverEmptyRowsPublishesNoChange() throws {
+        let position = try upsert(redemptions: [])
+
+        let published = try changePublished(reading: { readPositionFields(position) }, during: {
+            try upsert(redemptions: [])
+        })
+
+        XCTAssertFalse(published, "An empty snapshot over no rows must not touch the relationship.")
+    }
+
+    /// Two incoming rows sharing an id would collide on `@Attribute(.unique)`;
+    /// the sync keeps the first and drops the rest rather than letting SwiftData
+    /// silently upsert them into one.
+    func testDuplicateIncomingRedemptionIdsCollapseToOneRow() throws {
+        let position = try upsert(redemptions: [
+            redemption(id: "req-1", amount: 95),
+            redemption(id: "req-1", amount: 42)
+        ])
+
+        XCTAssertEqual(position.redemptions.count, 1)
+        XCTAssertEqual(try record(position, id: "req-1").amount, 95)
+    }
+}

--- a/VultisigApp/VultisigAppTests/Rates/RateProviderWriteGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Rates/RateProviderWriteGuardTests.swift
@@ -1,0 +1,295 @@
+//
+//  RateProviderWriteGuardTests.swift
+//  VultisigAppTests
+//
+//  `RateProvider.save(rates:)` must leave a persisted `DatabaseRate` untouched
+//  when the refreshed rate already matches it.
+//
+//  Asserting on the resulting VALUES cannot show that — a blind re-assignment of
+//  an identical value leaves the values identical, so a test written that way
+//  passes against the unguarded implementation too. What separates them is the
+//  mutation: SwiftData's `@Model` setter routes through the Observation
+//  registrar and notifies WITHOUT comparing new to old, and the `save()` that
+//  follows posts a store-change notification which re-evaluates every `@Query`
+//  in the app — including queries over entirely unrelated types. That is why
+//  "no view reads `DatabaseRate`" does not make this site safe, and why these
+//  tests observe with `withObservationTracking` and assert on whether a change
+//  was published rather than on values.
+//
+//  The per-field sweep is the other half: a field written but not compared makes
+//  the early return swallow a real update. `fiat` and `crypto` are reachable
+//  because `Rate.id` lowercases both, so a differently-cased pair resolves to the
+//  same persisted row.
+//
+//  `RateProvider` is a process-wide singleton whose in-memory cache outlives the
+//  per-test model container, so — as in `RateProviderTests` — every test keys its
+//  rates off a UUID and cannot contaminate another.
+//
+
+@testable import VultisigApp
+import Observation
+import SwiftData
+import XCTest
+
+/// Reference box so the `@Sendable` `onChange` closure can report back without
+/// capturing a mutable local. Every access is main-actor and synchronous.
+private final class ChangeRecorder: @unchecked Sendable {
+    private(set) var didChange = false
+    func record() { didChange = true }
+}
+
+@MainActor
+final class RateProviderWriteGuardTests: XCTestCase {
+
+    private var token: TestContextToken!
+
+    override func setUpWithError() throws {
+        token = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() {
+        TestStore.restore(token)
+        token = nil
+    }
+
+    // MARK: - Helpers
+
+    private func changePublished(reading read: () -> Void, during mutate: () throws -> Void) rethrows -> Bool {
+        let recorder = ChangeRecorder()
+        withObservationTracking { read() } onChange: { recorder.record() }
+        try mutate()
+        return recorder.didChange
+    }
+
+    /// Reads every property the guard can write. All of them have to be observed
+    /// or the probe could miss a write and the test would pass vacuously. `id` is
+    /// the lookup key and is never written.
+    private func readFields(_ object: DatabaseRate) {
+        _ = object.fiat
+        _ = object.crypto
+        _ = object.value
+    }
+
+    private func storedRate(id: String) throws -> DatabaseRate {
+        let descriptor = FetchDescriptor<DatabaseRate>(predicate: #Predicate { $0.id == id })
+        return try XCTUnwrap(Storage.shared.modelContext.fetch(descriptor).first)
+    }
+
+    /// Keeps each test's rates out of the singleton's process-wide cache.
+    private func uniqueCryptoId() -> String {
+        "rate-guard-test-\(UUID().uuidString.lowercased())"
+    }
+
+    /// A coin whose `RateProvider.cryptoId` is `priceProviderId`, so the cache
+    /// can be read back through the same lookup the app uses.
+    private func makeCoin(priceProviderId: String) -> CoinMeta {
+        CoinMeta(
+            chain: .bitcoin,
+            ticker: "TST",
+            logo: "",
+            decimals: 8,
+            priceProviderId: priceProviderId,
+            contractAddress: "",
+            isNativeToken: true
+        )
+    }
+
+    // MARK: - The no-op case
+
+    func testSavingAnIdenticalRatePublishesNoChange() throws {
+        let rate = Rate(fiat: "usd", crypto: uniqueCryptoId(), value: 42)
+        try RateProvider.shared.save(rates: [rate])
+        let stored = try storedRate(id: rate.id)
+
+        let published = try changePublished(reading: { readFields(stored) }, during: {
+            try RateProvider.shared.save(rates: [rate])
+        })
+
+        XCTAssertFalse(
+            published,
+            "An identical rate must not mutate the row. SwiftData notifies without comparing, and the save "
+                + "that follows re-evaluates every @Query in the app — whatever type it queries."
+        )
+        XCTAssertEqual(stored.value, 42)
+    }
+
+    /// Neither a NaN nor an infinity is a usable price. NaN is additionally the
+    /// one value an equality guard cannot suppress at all: `NaN != NaN`, and the
+    /// attribute coerces it to `0` on persist (infinities persist as they are),
+    /// so the stored value never compares equal to the incoming one and the row
+    /// would be re-dirtied on every single refresh.
+    func testSavingANonFiniteRateOverAStoredRatePublishesNoChange() throws {
+        for value in [Double.nan, .infinity, -.infinity] {
+            let crypto = uniqueCryptoId()
+            try RateProvider.shared.save(rates: [Rate(fiat: "usd", crypto: crypto, value: 5)])
+            let stored = try storedRate(id: Rate.identifier(fiat: "usd", crypto: crypto))
+
+            let published = try changePublished(reading: { readFields(stored) }, during: {
+                try RateProvider.shared.save(rates: [Rate(fiat: "usd", crypto: crypto, value: value)])
+            })
+
+            XCTAssertFalse(published, "\(value): a non-finite rate must not be written.")
+            XCTAssertEqual(stored.value, 5, "\(value): the last usable price must survive.")
+        }
+    }
+
+    /// The cache is what every fiat render reads, and it is merged before any
+    /// persistence happens — so the non-finite filter has to sit ahead of it,
+    /// not inside the row update.
+    func testNonFiniteRateDoesNotEvictTheCachedPrice() throws {
+        let providerId = uniqueCryptoId()
+        let coin = makeCoin(priceProviderId: providerId)
+        let fiat = SettingsCurrency.current.rawValue
+        try RateProvider.shared.save(rates: [Rate(fiat: fiat, crypto: providerId, value: 5)])
+        XCTAssertEqual(RateProvider.shared.rate(for: coin)?.value, 5)
+
+        try RateProvider.shared.save(rates: [Rate(fiat: fiat, crypto: providerId, value: .nan)])
+
+        XCTAssertEqual(
+            RateProvider.shared.rate(for: coin)?.value,
+            5,
+            "A non-finite rate must not replace the cached price every fiat render reads."
+        )
+    }
+
+    /// The insert branch is the other half the row-update guard cannot reach: a
+    /// coin priced for the first time by a non-finite rate must not get a row at
+    /// all, rather than a row the next refresh can never leave alone.
+    func testNonFiniteRateIsNotPersistedAsANewRow() throws {
+        let crypto = uniqueCryptoId()
+        let id = Rate.identifier(fiat: "usd", crypto: crypto)
+
+        try RateProvider.shared.save(rates: [Rate(fiat: "usd", crypto: crypto, value: .nan)])
+
+        let descriptor = FetchDescriptor<DatabaseRate>(predicate: #Predicate { $0.id == id })
+        XCTAssertTrue(try Storage.shared.modelContext.fetch(descriptor).isEmpty)
+    }
+
+    /// The warm-start load is the one path that could put a non-finite rate back
+    /// into the cache: a build predating the filter could have persisted an
+    /// infinity (NaN could not — it is coerced to `0` on save). The finite row in
+    /// the same load has to survive, or the filter would be passing by loading
+    /// nothing at all.
+    func testWarmStartLoadsFinitePersistedRatesAndSkipsNonFiniteOnes() throws {
+        let fiat = SettingsCurrency.current.rawValue
+        let goodCrypto = uniqueCryptoId()
+        let poisonedCrypto = uniqueCryptoId()
+        Storage.shared.insert(DatabaseRate(
+            id: Rate.identifier(fiat: fiat, crypto: goodCrypto), fiat: fiat, crypto: goodCrypto, value: 3
+        ))
+        Storage.shared.insert(DatabaseRate(
+            id: Rate.identifier(fiat: fiat, crypto: poisonedCrypto),
+            fiat: fiat,
+            crypto: poisonedCrypto,
+            value: .infinity
+        ))
+        try Storage.shared.save()
+
+        RateProvider.shared.loadPersistedRates()
+
+        XCTAssertEqual(RateProvider.shared.rate(for: makeCoin(priceProviderId: goodCrypto))?.value, 3)
+        XCTAssertNil(
+            RateProvider.shared.rate(for: makeCoin(priceProviderId: poisonedCrypto)),
+            "A persisted non-finite rate must not reach the cache every fiat render reads."
+        )
+    }
+
+    /// The guard declines only non-finite values; a real price still lands.
+    func testSavingAFiniteRateAfterANonFiniteOnePublishesChange() throws {
+        let crypto = uniqueCryptoId()
+        try RateProvider.shared.save(rates: [Rate(fiat: "usd", crypto: crypto, value: 5)])
+        let stored = try storedRate(id: Rate.identifier(fiat: "usd", crypto: crypto))
+        try RateProvider.shared.save(rates: [Rate(fiat: "usd", crypto: crypto, value: .nan)])
+
+        let published = try changePublished(reading: { readFields(stored) }, during: {
+            try RateProvider.shared.save(rates: [Rate(fiat: "usd", crypto: crypto, value: 9)])
+        })
+
+        XCTAssertTrue(published, "A finite rate arriving after a rejected one is a real update.")
+        XCTAssertEqual(stored.value, 9)
+    }
+
+    /// One row per coin, and a refresh usually moves only some of them. The rows
+    /// that did not move must not be written just because their neighbours were.
+    func testSavingABatchOnlyMutatesTheRatesThatMoved() throws {
+        let stable = Rate(fiat: "usd", crypto: uniqueCryptoId(), value: 1)
+        let movingCrypto = uniqueCryptoId()
+        let moving = Rate(fiat: "usd", crypto: movingCrypto, value: 2)
+        try RateProvider.shared.save(rates: [stable, moving])
+        let stableRow = try storedRate(id: stable.id)
+
+        let published = try changePublished(reading: { readFields(stableRow) }, during: {
+            try RateProvider.shared.save(rates: [stable, Rate(fiat: "usd", crypto: movingCrypto, value: 3)])
+        })
+
+        XCTAssertFalse(published, "The unchanged rate in the batch must not be written.")
+        XCTAssertEqual(try storedRate(id: moving.id).value, 3, "The changed rate still has to be written.")
+    }
+
+    // MARK: - The real-update case
+
+    /// One case per field the guard assigns. `fiat` and `crypto` differ from the
+    /// stored row while resolving to the same `Rate.id`, because the identifier
+    /// lowercases both.
+    func testSavePublishesChangeForEverySingleFieldDifference() throws {
+        let cases: [(
+            field: String,
+            seed: (String) -> Rate,
+            updated: (String) -> Rate,
+            verify: (DatabaseRate, String) -> Void
+        )] = [
+            (
+                "value",
+                { Rate(fiat: "usd", crypto: $0, value: 1) },
+                { Rate(fiat: "usd", crypto: $0, value: 9) },
+                { row, _ in XCTAssertEqual(row.value, 9) }
+            ),
+            (
+                "fiat",
+                { Rate(fiat: "usd", crypto: $0, value: 1) },
+                { Rate(fiat: "USD", crypto: $0, value: 1) },
+                { row, _ in XCTAssertEqual(row.fiat, "USD") }
+            ),
+            (
+                "crypto",
+                { Rate(fiat: "usd", crypto: $0, value: 1) },
+                { Rate(fiat: "usd", crypto: $0.uppercased(), value: 1) },
+                { row, crypto in XCTAssertEqual(row.crypto, crypto.uppercased()) }
+            )
+        ]
+
+        for testCase in cases {
+            let crypto = uniqueCryptoId()
+            let seed = testCase.seed(crypto)
+            let updated = testCase.updated(crypto)
+            XCTAssertEqual(seed.id, updated.id, "\(testCase.field): both must hit the same row")
+
+            try RateProvider.shared.save(rates: [seed])
+            let stored = try storedRate(id: seed.id)
+
+            let published = try changePublished(reading: { readFields(stored) }, during: {
+                try RateProvider.shared.save(rates: [updated])
+            })
+
+            XCTAssertTrue(
+                published,
+                "\(testCase.field) differs from the stored value — save(rates:) must write it"
+            )
+            testCase.verify(stored, crypto)
+        }
+    }
+
+    /// A rate with no persisted row still has to be inserted; the guard only
+    /// covers the update branch.
+    func testSaveInsertsARateThatHasNoStoredRow() throws {
+        let crypto = uniqueCryptoId()
+        let rate = Rate(fiat: "usd", crypto: crypto, value: 7)
+
+        try RateProvider.shared.save(rates: [rate])
+
+        let stored = try storedRate(id: rate.id)
+        XCTAssertEqual(stored.fiat, "usd")
+        XCTAssertEqual(stored.crypto, crypto)
+        XCTAssertEqual(stored.value, 7)
+    }
+}


### PR DESCRIPTION
## Description

Two independent sites where SwiftData `@Model` state is written without comparing first, so every refresh re-invalidates SwiftUI readers even when nothing changed.

SwiftData's `@Model` setter calls `withMutation` **without comparing** old and new, so assigning an identical value still publishes a change. Measured against the app's own shipping types in an `NSWindow` + `NSHostingView` harness: an unguarded `apply(_:)` called with an identical DTO produced **344,063** body evaluations in 8s (~44,000/s); guarded, **1**. It is amplified app-wide by the root `@Query` at `ContentView.swift:17`, and the amplification is **cross-type** whenever a `save()` follows — which every storage service here does.

Guard shape follows #5109: an all-or-nothing early return covering every write in the method, including any timestamp.

### `YieldPositionStorageService`

- `:26-30` — three unguarded writes including `lastUpdated = .now`. Standard equality guard.
- `:69-81` — `syncRedemptions` **deleted and recreated every redemption row on every refresh**. No equality guard can fix that: the delete+insert is itself store churn that fires the amplifier unconditionally. Replaced with a diff/merge.

**Identity key: `YieldRedemption.id`.** It is the provider's own request identifier, it is already what `YieldRedemptionRecord` persists as `@Attribute(.unique)`, and it is already the key the read path (`YieldViewModel.seed`) maps back out on. Deliberately **not** derived from the mutable fields — a redemption keeps its identity precisely while it moves `pending → claimable → settled`, and that transition must read as an update, not a delete plus an insert.

The delete-recreate was **not** load-bearing: the existing `testUpsertReplacesStaleRedemptionRows` already asserts the same-id/changed-status semantics the merge preserves. New rows attach via the inverse (`record.position = position`) rather than by appending to `position.redemptions` — appending is a get-modify-set of the whole relationship, and rows deleted earlier in the same pass can still appear in the array the getter returns.

> ⚠️ Worth knowing when weighting this: **`syncRedemptions` is currently dead in production.** The only `DefiYieldProvider` is Circle, which passes `redemptions: []` unconditionally (`CircleYieldProvider.swift:100`). Today its only cost is the unconditional `position.redemptions = []` relationship write; the diff/merge is prophylactic for the first windowed provider.

### `RateProvider` — needed more than a guard

`:178-187` was the app's largest unguarded write burst. Its previous defence — "no view reads `DatabaseRate`" — is refuted by the cross-type amplification above.

But an equality guard alone **cannot** fix it. `NaN != NaN`, so `guard stored != incoming else { return }` always falls through for a non-finite rate. Worse, SwiftData **coerces NaN to `0` on persist** (measured; infinities survive), so the stored value never compares equal to the incoming NaN either. **A single NaN quote would have re-dirtied its row on every refresh, forever, silently defeating the guard.**

Non-finite rates are therefore dropped at the entry to `save(rates:)`, ahead of both the cache merge and the persistence loop. Flagging this as a real scope extension beyond "guard the writes".

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None of the above — DeFi yield persistence and the rate cache. SwiftUI/SwiftData-specific, no analogue on the other platforms, so no parity section.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`YieldPositionWriteGuardTests` (12) and `RateProviderWriteGuardTests` (9). All assert via `withObservationTracking` rather than on values — identical values cannot distinguish guarded from unguarded — plus per-field sweeps.

The redemption diff additionally asserts on `persistentModelID`. `ObjectIdentifier` was tried first and is **unsound**: SwiftData re-materializes fresh instances for the same row after a save, so instance identity changes for reasons unrelated to deletion.

**Verified non-vacuous**, each guard reverted then restored: balance guard → 4 fail; redemption diff → 8 fail; rate equality guard → 2 fail; non-finite filter → 6 fail; warm-start filter → 1 fail.

Gate: `Executed 5486 tests, with 1 test skipped and 0 failures (0 unexpected)`, `** TEST SUCCEEDED **`. SwiftLint 22 — identical to `main`'s baseline.

## Review notes

One finding was **rejected with reason** and documented in code: a suggestion to preserve redemption ordering. A SwiftData to-many is unordered, so the wholesale assignment this replaces did not preserve order either; imposing one needs a sort index and would restore the churn this PR removes.

A later round raised deleting rows at warm-start load; the **filtering** half was taken and the **deleting** half rejected — a launch-time store write is precisely the mutation class this branch exists to remove.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate persistence by ignoring invalid values and avoiding unnecessary updates.
  * Improved yield position synchronization, preventing duplicate records and preserving unchanged data.
  * Ensured stale redemption records are removed during synchronization.

* **Tests**
  * Added coverage for rate caching, validation, persistence, and update behavior.
  * Added coverage for yield balance and redemption updates, duplicates, deletions, and no-op saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->