### PR TITLE
test: stop TestStore vault fixtures collapsing into one row

### DIFF
--- a/VultisigApp/VultisigAppTests/Helpers/TestStore.swift
+++ b/VultisigApp/VultisigAppTests/Helpers/TestStore.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import SwiftData
+import XCTest
 @testable import VultisigApp
 
 /// Token returned by `TestStore.installInMemoryContainer()`. Holds the previous
@@ -143,20 +144,92 @@ enum TestStore {
 
     /// Insert a populated Vault matching `pubKeyECDSA` so position upserts have a
     /// parent to attach via inverse relationships.
-    static func makeVault(pubKey: String = "test-pub-ecdsa") -> Vault {
+    ///
+    /// Every unique `String` attribute `Vault` declares — `name`, `pubKeyECDSA`
+    /// and `pubKeyEdDSA` — is derived from `pubKey`, so two fixtures built with
+    /// different keys are two rows. Hard-coding any one of them is not cosmetic:
+    /// SwiftData answers a duplicate unique value with an **upsert**, not an
+    /// error, so each insert silently replaces the last and the store ends up
+    /// holding one survivor. Assertions shaped `for vault in fetch() { … }`, and
+    /// any expectation about ordering or count, then pass vacuously.
+    ///
+    /// `publicKeyMLDSA44` is unique too and deliberately stays `nil`: a unique
+    /// index treats NULLs as distinct, so nil fixtures never collapse, while
+    /// giving it a value would flip every product branch that reads the field as
+    /// "this is a quantum vault" — QBTC coin creation, the MLDSA keysign key,
+    /// the advanced-settings gate — for callers that only wanted a parent row.
+    ///
+    /// Fails the calling test if the fixture would land on top of a vault
+    /// already in the store, so a future hard-coded unique field cannot regress
+    /// into a silent upsert.
+    static func makeVault(
+        pubKey: String = "test-pub-ecdsa",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> Vault {
         let vault = Vault(
             name: "Test Vault \(pubKey)",
             signers: [],
             pubKeyECDSA: pubKey,
-            pubKeyEdDSA: "test-pub-eddsa",
+            pubKeyEdDSA: "test-pub-eddsa-\(pubKey)",
             keyshares: [],
             localPartyID: "party",
             hexChainCode: "hex",
             resharePrefix: nil,
             libType: .DKLS
         )
+        assertNoUniqueCollision(for: vault, file: file, line: line)
         Storage.shared.modelContext.insert(vault)
         return vault
+    }
+
+    /// Fails the running test when `candidate` shares a `@Attribute(.unique)`
+    /// value with a vault already in `Storage.shared`.
+    ///
+    /// Asked *before* the insert rather than by counting rows after it. The
+    /// collapse itself only lands when the context saves, so a post-insert count
+    /// reads one-more even for a duplicate and would report the collision at
+    /// whatever unrelated place happened to save next. A pre-insert lookup
+    /// answers the precise question — is there already a row this insert would
+    /// replace — and can only fire on a real collision.
+    private static func assertNoUniqueCollision(
+        for candidate: Vault,
+        file: StaticString,
+        line: UInt
+    ) {
+        let stored: [Vault]
+        do {
+            stored = try Storage.shared.modelContext.fetch(FetchDescriptor<Vault>())
+        } catch {
+            XCTFail("TestStore.makeVault could not read the vault store: \(error)", file: file, line: line)
+            return
+        }
+
+        for existing in stored {
+            var collided: [String] = []
+            if existing.name == candidate.name { collided.append("name") }
+            if existing.pubKeyECDSA == candidate.pubKeyECDSA { collided.append("pubKeyECDSA") }
+            if existing.pubKeyEdDSA == candidate.pubKeyEdDSA { collided.append("pubKeyEdDSA") }
+            // A nil MLDSA key is not a duplicate — a unique index treats NULLs
+            // as distinct, which is why the fixture is allowed to leave it nil.
+            if let mldsa = candidate.publicKeyMLDSA44, existing.publicKeyMLDSA44 == mldsa {
+                collided.append("publicKeyMLDSA44")
+            }
+            guard collided.isEmpty else {
+                XCTFail(
+                    """
+                    TestStore.makeVault(pubKey: "\(candidate.pubKeyECDSA)") duplicates a vault already \
+                    in the store on \(collided.joined(separator: ", ")). SwiftData resolves a unique \
+                    collision by upserting, so this insert would replace that row and leave the test \
+                    asserting over a single survivor. Give each fixture its own `pubKey:`, and install \
+                    a fresh in-memory container per test so nothing leaks in from the previous one.
+                    """,
+                    file: file,
+                    line: line
+                )
+                return
+            }
+        }
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Helpers/TestStoreTests.swift
+++ b/VultisigApp/VultisigAppTests/Helpers/TestStoreTests.swift
@@ -1,0 +1,74 @@
+//
+//  TestStoreTests.swift
+//  VultisigAppTests
+//
+//  Guards the fixture helper itself. `Vault` declares four
+//  `@Attribute(.unique)` fields and SwiftData answers a duplicate with an
+//  upsert rather than an error, so a helper that hard-codes one of them
+//  collapses every fixture it builds into a single row — silently, with every
+//  `for vault in fetch() { … }` assertion still passing over the survivor.
+//
+
+import SwiftData
+import XCTest
+@testable import VultisigApp
+
+@MainActor
+final class TestStoreTests: XCTestCase {
+    private var token: TestContextToken!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        token = try TestStore.installInMemoryContainer()
+    }
+
+    override func tearDown() async throws {
+        TestStore.restore(token)
+        token = nil
+        try await super.tearDown()
+    }
+
+    /// The regression this file exists for: three fixtures must survive a save
+    /// as three rows. While `pubKeyEdDSA` was hard-coded they collapsed into
+    /// one, and a count assertion was the only thing that could see it.
+    func testMakeVaultKeepsEveryFixtureAsItsOwnRow() throws {
+        _ = TestStore.makeVault(pubKey: "vault-a")
+        _ = TestStore.makeVault(pubKey: "vault-b")
+        _ = TestStore.makeVault(pubKey: "vault-c")
+
+        let context: ModelContext = Storage.shared.modelContext
+        try context.save()
+
+        let stored = try context.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(stored.count, 3, "fixtures collapsed on a unique attribute")
+        XCTAssertEqual(Set(stored.map(\.name)).count, 3, "`name` is unique and must vary per fixture")
+        XCTAssertEqual(Set(stored.map(\.pubKeyECDSA)).count, 3, "`pubKeyECDSA` is unique and must vary per fixture")
+        XCTAssertEqual(Set(stored.map(\.pubKeyEdDSA)).count, 3, "`pubKeyEdDSA` is unique and must vary per fixture")
+    }
+
+    /// Proves the guard fires rather than being decorative. The same `pubKey`
+    /// twice is exactly the shape that used to upsert in silence, and this also
+    /// pins that the pre-insert lookup sees a still-unsaved fixture.
+    func testMakeVaultFailsOnADuplicateFixture() {
+        _ = TestStore.makeVault(pubKey: "duplicate")
+
+        XCTExpectFailure("makeVault must flag a fixture that would upsert over an existing row")
+        _ = TestStore.makeVault(pubKey: "duplicate")
+    }
+
+    /// A nil `publicKeyMLDSA44` is not a collision — a unique index treats NULLs
+    /// as distinct. That is why the fixture leaves it nil rather than inventing
+    /// a value, which would flip every `publicKeyMLDSA44 == nil` product branch
+    /// for callers that only wanted a parent row.
+    func testMakeVaultLeavesTheMLDSAKeyNilWithoutCollapsing() throws {
+        _ = TestStore.makeVault(pubKey: "mldsa-a")
+        _ = TestStore.makeVault(pubKey: "mldsa-b")
+
+        let context: ModelContext = Storage.shared.modelContext
+        try context.save()
+
+        let stored = try context.fetch(FetchDescriptor<Vault>())
+        XCTAssertEqual(stored.count, 2)
+        XCTAssertTrue(stored.allSatisfy { $0.publicKeyMLDSA44 == nil })
+    }
+}

--- a/VultisigApp/VultisigAppTests/Keysign/SendPreviewOverrideTests.swift
+++ b/VultisigApp/VultisigAppTests/Keysign/SendPreviewOverrideTests.swift
@@ -18,6 +18,29 @@ import XCTest
 @MainActor
 final class SendPreviewOverrideTests: XCTestCase {
 
+    /// Fixtures here go through `TestStore.makeVault`, which inserts into
+    /// `Storage.shared.modelContext`. Without a container of its own the class
+    /// wrote into whichever context the previous test class left behind — or the
+    /// app's real store — so vaults accumulated across cases and, because every
+    /// `@Attribute(.unique)` field on `Vault` matched, SwiftData upserted them
+    /// into a single shared row. One vault per test, in a store that starts
+    /// empty and is handed back on teardown.
+    private var storeToken: TestContextToken!
+    private var vault: Vault!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+        vault = TestStore.makeVault()
+    }
+
+    override func tearDown() async throws {
+        vault = nil
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
     func testOverrideSurfacesDisplayUsdcWhenSignedCoinDiffers() throws {
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
         let vaultRecipient = "0x1111111111111111111111111111111111111111"
@@ -59,7 +82,6 @@ final class SendPreviewOverrideTests: XCTestCase {
     }
 
     private func makeTransaction(coin: Coin, toAddress: String, amount: String) throws -> SendTransaction {
-        let vault = try TestStore.makeVault()
         return SendTransaction(
             coin: coin, vault: vault, fromAddress: coin.address,
             toAddress: toAddress, toAddressLabel: nil,

--- a/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendCryptoVerifyViewModelTests.swift
@@ -20,6 +20,29 @@ import VultisigCommonData
 @MainActor
 final class SendCryptoVerifyViewModelTests: XCTestCase {
 
+    /// Fixtures here go through `TestStore.makeVault`, which inserts into
+    /// `Storage.shared.modelContext`. Without a container of its own the class
+    /// wrote into whichever context the previous test class left behind — or the
+    /// app's real store — so vaults accumulated across cases and, because every
+    /// `@Attribute(.unique)` field on `Vault` matched, SwiftData upserted them
+    /// into a single shared row. One vault per test, in a store that starts
+    /// empty and is handed back on teardown.
+    private var storeToken: TestContextToken!
+    private var vault: Vault!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+        vault = TestStore.makeVault()
+    }
+
+    override func tearDown() async throws {
+        vault = nil
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
     // MARK: - Init
 
     func testInitWithTransactionSetsTransactionField() throws {
@@ -285,7 +308,6 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
                             contractAddress: "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26")
         let lunc = makeCoin(.terraClassic, ticker: "LUNC", decimals: 6, isNative: true,
                             rawBalance: "1000000000")
-        let vault = try TestStore.makeVault()
         vault.coins = [lunc, cw20]
         let tx = SendTransaction(
             coin: cw20, vault: vault, fromAddress: cw20.address,
@@ -316,7 +338,6 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
                             contractAddress: "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26")
         let lunc = makeCoin(.terraClassic, ticker: "LUNC", decimals: 6, isNative: true,
                             rawBalance: "1000") // not enough LUNC for the gas fee
-        let vault = try TestStore.makeVault()
         vault.coins = [lunc, cw20]
         let tx = SendTransaction(
             coin: cw20, vault: vault, fromAddress: cw20.address,
@@ -420,7 +441,6 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         // here would re-introduce the bug where user-pinned EVM gas got
         // dropped on the 60s refresh.
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
-        let vault = try TestStore.makeVault()
         let originalTx = SendTransaction(
             coin: eth, vault: vault, fromAddress: eth.address,
             toAddress: "0xabc", toAddressLabel: nil,
@@ -557,7 +577,6 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
                            isNative: true, rawBalance: "1000000000000000000")
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6,
                             isNative: false, rawBalance: "5000000")
-        let vault = try TestStore.makeVault()
         vault.coins = [eth, usdc]
         let tx = SendTransaction(
             coin: usdc, vault: vault, fromAddress: usdc.address,
@@ -590,7 +609,6 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         }
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18,
                            isNative: true, rawBalance: "1000000000000000000")  // 1 ETH
-        let vault = try TestStore.makeVault()
         vault.coins = [eth]
         let tx = SendTransaction(
             coin: eth, vault: vault, fromAddress: eth.address,
@@ -621,7 +639,6 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         }
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18,
                            isNative: true, rawBalance: "1000000000000000000")
-        let vault = try TestStore.makeVault()
         let tx = SendTransaction(
             coin: eth, vault: vault, fromAddress: eth.address,
             toAddress: "0x0000000000000000000000000000000000000001", toAddressLabel: nil,
@@ -1104,7 +1121,7 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
             memo: "0xb61d27f6",
             chainSpecific: .Ethereum(maxFeePerGasWei: BigInt(1), priorityFeeWei: BigInt(1), nonce: 0, gasLimit: BigInt(21_000)),
             wasmExecuteContractPayload: nil,
-            vault: try TestStore.makeVault()
+            vault: vault
         )
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false, rawBalance: "1000000")
         let vm = SendCryptoVerifyViewModel(
@@ -1660,7 +1677,6 @@ final class SendCryptoVerifyViewModelTests: XCTestCase {
         sendMaxAmount: Bool = false,
         amountWasAutoAdjusted: Bool = false
     ) throws -> SendTransaction {
-        let vault = try TestStore.makeVault()
         let coinToUse = coin ?? makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true,
                                          rawBalance: "1000000000000000000")
         return SendTransaction(

--- a/VultisigApp/VultisigAppTests/Send/SendPhaseDRegressionTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendPhaseDRegressionTests.swift
@@ -23,6 +23,29 @@ import VultisigCommonData
 @MainActor
 final class SendPhaseDRegressionTests: XCTestCase {
 
+    /// Fixtures here go through `TestStore.makeVault`, which inserts into
+    /// `Storage.shared.modelContext`. Without a container of its own the class
+    /// wrote into whichever context the previous test class left behind — or the
+    /// app's real store — so vaults accumulated across cases and, because every
+    /// `@Attribute(.unique)` field on `Vault` matched, SwiftData upserted them
+    /// into a single shared row. One vault per test, in a store that starts
+    /// empty and is handed back on teardown.
+    private var storeToken: TestContextToken!
+    private var vault: Vault!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+        vault = TestStore.makeVault()
+    }
+
+    override func tearDown() async throws {
+        vault = nil
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
     // MARK: - Lesson 1 — fiat conversion reads tx.fee, not tx.gas
 
     /// Sites covered: `CryptoAmountFormatter.feesInReadable(tx:)`,
@@ -33,7 +56,6 @@ final class SendPhaseDRegressionTests: XCTestCase {
     /// except `tx.gas`, and assert the readable output is the SAME (because
     /// only `tx.fee` should influence the fiat-fee display for non-UTXO chains).
     func testFeesInReadableReflectsTxFeeNotGas() throws {
-        let vault = try TestStore.makeVault()
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true, rawBalance: "1000000000000000000")
 
         let txLowFee = try makeTx(

--- a/VultisigApp/VultisigAppTests/Send/SendTransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Send/SendTransactionTests.swift
@@ -14,10 +14,32 @@ import VultisigCommonData
 @MainActor
 final class SendTransactionTests: XCTestCase {
 
+    /// Fixtures here go through `TestStore.makeVault`, which inserts into
+    /// `Storage.shared.modelContext`. Without a container of its own the class
+    /// wrote into whichever context the previous test class left behind — or the
+    /// app's real store — so vaults accumulated across cases and, because every
+    /// `@Attribute(.unique)` field on `Vault` matched, SwiftData upserted them
+    /// into a single shared row. One vault per test, in a store that starts
+    /// empty and is handed back on teardown.
+    private var storeToken: TestContextToken!
+    private var vault: Vault!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        storeToken = try TestStore.installInMemoryContainer()
+        vault = TestStore.makeVault()
+    }
+
+    override func tearDown() async throws {
+        vault = nil
+        TestStore.restore(storeToken)
+        storeToken = nil
+        try await super.tearDown()
+    }
+
     // MARK: - empty seed
 
     func testEmptySeedDefaultsAreZeroOrEmpty() throws {
-        let vault = try TestStore.makeVault()
         let coin = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
         let tx = SendTransaction.empty(coin: coin, vault: vault)
 
@@ -34,7 +56,6 @@ final class SendTransactionTests: XCTestCase {
     }
 
     func testEmptySeedFromAddressMirrorsCoinAddress() throws {
-        let vault = try TestStore.makeVault()
         let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
         let tx = SendTransaction.empty(coin: coin, vault: vault)
         XCTAssertEqual(tx.fromAddress, coin.address)
@@ -43,7 +64,6 @@ final class SendTransactionTests: XCTestCase {
     // MARK: - Decision 1: plain [String: String] dictionary
 
     func testMemoFunctionDictionaryIsPlainDict() throws {
-        let vault = try TestStore.makeVault()
         let coin = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
         let tx = SendTransaction.empty(coin: coin, vault: vault)
         // Type assertion: not a ThreadSafeDictionary — directly subscriptable.
@@ -55,7 +75,6 @@ final class SendTransactionTests: XCTestCase {
     func testVaultIsNonOptional() throws {
         // If the type system enforces non-optional, this just compiles. Belt-and-
         // braces: read .vault and verify it isn't nil at runtime.
-        let vault = try TestStore.makeVault()
         let coin = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
         let tx = SendTransaction.empty(coin: coin, vault: vault)
         XCTAssertEqual(tx.vault.pubKeyECDSA, vault.pubKeyECDSA)
@@ -64,14 +83,12 @@ final class SendTransactionTests: XCTestCase {
     // MARK: - feeCoin resolution
 
     func testFeeCoinForNativeSourceIsSelf() throws {
-        let vault = try TestStore.makeVault()
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
         let tx = SendTransaction.empty(coin: eth, vault: vault)
         XCTAssertEqual(tx.feeCoin, eth)
     }
 
     func testFeeCoinForERC20FallsBackToCoinWhenVaultHasNoNative() throws {
-        let vault = try TestStore.makeVault()
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
         let tx = SendTransaction.empty(coin: usdc, vault: vault)
         // Empty vault — no ETH sibling — falls back to coin.
@@ -81,7 +98,6 @@ final class SendTransactionTests: XCTestCase {
     // MARK: - Builder
 
     func testWithUpdatesGasAndFeePreservingIdentity() throws {
-        let vault = try TestStore.makeVault()
         let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
         let original = SendTransaction.empty(coin: coin, vault: vault)
         let updated = original.with(gas: BigInt(50_000_000_000), fee: BigInt(1_500_000_000_000_000))
@@ -94,7 +110,6 @@ final class SendTransactionTests: XCTestCase {
     // MARK: - Decision 3: with(...) preserves custom gas pin
 
     func testWithDoesNotClearCustomGasLimitOnRefresh() throws {
-        let vault = try TestStore.makeVault()
         let coin = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
         let pinned = SendTransaction(
             coin: coin,
@@ -126,7 +141,6 @@ final class SendTransactionTests: XCTestCase {
     }
 
     func testERC20DefaultGasLimitUsesTokenTransferLimit() throws {
-        let vault = try TestStore.makeVault()
         let usdc = makeCoin(.ethereum, ticker: "USDC", decimals: 6, isNative: false)
         let tx = SendTransaction.empty(coin: usdc, vault: vault)
 
@@ -134,7 +148,6 @@ final class SendTransactionTests: XCTestCase {
     }
 
     func testWithDoesNotClearCustomByteFeeOnRefresh() throws {
-        let vault = try TestStore.makeVault()
         let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8, isNative: true)
         let pinned = SendTransaction(
             coin: btc,
@@ -307,7 +320,6 @@ final class SendTransactionTests: XCTestCase {
         sendMaxAmount: Bool = false,
         isStakingOperation: Bool = false
     ) throws -> SendTransaction {
-        let vault = try TestStore.makeVault()
         let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18, isNative: true)
         return SendTransaction(
             coin: eth, vault: vault, fromAddress: eth.address,


### PR DESCRIPTION
## Description

`TestStore.makeVault(pubKey:)` varied `name` and `pubKeyECDSA` but **hard-coded `pubKeyEdDSA: "test-pub-eddsa"`**. `Model/Vault.swift:12-15` marks `name`, `pubKeyECDSA`, `pubKeyEdDSA` and `publicKeyMLDSA44` **each independently** `@Attribute(.unique)`, and SwiftData resolves a unique collision by **upserting** — each insert silently replaces the previous row, with no error.

So every vault built by this helper collided. Any test creating more than one got one, per-case isolation was fiction, and assertions shaped `for vault in fetch() { … }` or checking ordering **passed vacuously** over the single survivor. 68 call sites across 27 files.

**Fixing it turned 98 test cases red.** Every one had been green for the wrong reason.

### The repair

| File | Cases | What it was silently doing |
|---|---|---|
| `Send/SendCryptoVerifyViewModelTests` | 72 | Never installed an in-memory container — inserted into whatever context the previous test class left behind, accumulating rows that all upserted into one. One test built a *payload* vault and a *transaction* vault that were the same row. |
| `Send/SendTransactionTests` | 23 | Same — **all 23** failed, so the store was already contaminated before the class started |
| `Keysign/SendPreviewOverrideTests` | 2 | Same |
| `Send/SendPhaseDRegressionTests` | 1 | Same (cross-class leakage from a vault left by an earlier class) |

All four now install a per-test container with one shared vault in `setUp` — one vault, many transactions, which is what these tests always meant. Every case was "relying on cross-case leakage"; **no product bugs surfaced**, and nothing outside `VultisigAppTests/` is touched.

> ⚠️ **Side effect worth knowing:** because those four classes had no container at all, the unit-test suite was writing `Vault` rows into the **app's real SwiftData store** in the simulator. Every `TestStore.makeVault` caller now installs one, so that's closed.

The repair is isolated in its own commit (`test: give the Send fixture classes their own in-memory store`) so it can be dropped and split if reviewers prefer.

### Two details worth review attention

**`publicKeyMLDSA44` is deliberately left `nil`, not varied.** A unique index treats NULLs as distinct, so nil fixtures never collapse (the repo already relied on this — `KeygenVaultCommitTests.swift:45`), and giving it a value would flip every product branch that reads the field as "this is a quantum vault": `CoinFactory+QBTC`, the MLDSA keysign key at `KeysignViewModel.swift:548,633`, `CoinSelectionViewModel.swift:66,83`, `VaultAdvancedSettingsScreen.swift:62,68`. That reasoning is in the doc comment and pinned by a test.

**Collision detection is *pre*-insert, not a post-insert row count.** SwiftData resolves the collision at **save**, so counting after the insert reads +1 even for a duplicate and would surface the problem at whatever unrelated place saved next. `assertNoUniqueCollision` fetches first and `XCTFail`s naming the exact colliding fields, with `file:`/`line:` defaulted to the call site.

### Still latent, reported not changed

`Send/SendFormFixture.swift:83-92` and `FunctionCall/FunctionCallFixture.swift:22-33` hard-code all three unique fields but never insert into a context — they collapse the moment a caller inserts two. `ReferralFormFixture` delegates to the former. Every other `@Model` with a unique attribute (`BondPosition`, `StakePosition`, `LPPosition`, `CirclePosition`, `YieldPosition`, `LimitOrder`, `DatabaseRate`, `CustomRPCOverride`, `ChainPublicKey`, `PendingTransaction`) was surveyed: all test constructions are ad-hoc with ids derived from real inputs, no shared helper hard-codes one.

One pre-existing vacuous assertion is **deferred, not fixed**: `SendPhaseDRegressionTests.testFeesInReadableReflectsTxFeeNotGas` — `feesInReadable` returns `.empty` when the vault has no native coin and the test's own escape hatch then skips the assertion. Verified pre-existing on `e20272b86`; making it real requires seeding the shared `RateProvider` singleton, which deserves its own change.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None of the above — test infrastructure only. No product code changed.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`Helpers/TestStoreTests.swift` — three fixtures survive a `save()` as three rows; the guard fires on a duplicate (via `XCTExpectFailure`, which also proves the fetch sees still-unsaved fixtures); nil MLDSA keys don't collapse.

Gate, quoted from the log markers:

- Baseline, unmodified worktree — `** TEST SUCCEEDED **`, `Executed 5465 tests, with 1 test skipped and 0 failures (0 unexpected)`
- Helper fix only — `** TEST FAILED **`, `Executed 5468 tests, with 1 test skipped and 105 failures (0 unexpected)` (98 cases)
- Final — `** TEST SUCCEEDED **`, `Executed 5468 tests, with 1 test skipped and 0 failures (0 unexpected)`
- SwiftLint 22 → 22, no regression.

Staleness explicitly ruled out: disk stayed at 21–22 GiB free throughout (a full volume can make `xcodebuild` emit `** TEST SUCCEEDED **` from a stale run), the count moved 5465 → 5468, and the helper-fix-only run went red with failures originating in the edited helper — which a stale run cannot fake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by using fresh in-memory storage for each test.
  * Added validation that test vault fixtures remain distinct and reject duplicate data.
  * Updated send and transaction tests to reuse consistent fixtures, improving reliability across fee, payload, balance, and transaction scenarios.
  * Added regression coverage for vault data integrity, including optional key fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->