### PR TITLE
chore(debug): add a DEBUG-only synthetic vault seeder

### DIFF
--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -62,6 +62,13 @@ struct VultisigApp: App {
         // and documents. And because the flag is already `true` when the first
         // body is evaluated, there is no false-to-true transition for the
         // overlay's animation to fade: the app's first frame is the lock screen.
+#if DEBUG
+        // DEBUG-only, and additionally behind an explicit launch argument, so an
+        // ordinary debug run is unaffected. Runs before the launch gate because
+        // the gate and the reconciler both read the vault store.
+        MainActor.assumeIsolated { SyntheticVaultSeeder.runIfRequested() }
+#endif
+
         AppViewModel.shared.restorePasscodeLockOnLaunch()
 
         // Register every swap-tracking provider with the shared registry so

--- a/VultisigApp/VultisigApp/Debug/SyntheticVaultSeeder.swift
+++ b/VultisigApp/VultisigApp/Debug/SyntheticVaultSeeder.swift
@@ -1,0 +1,207 @@
+//
+//  SyntheticVaultSeeder.swift
+//  VultisigApp
+//
+//  DEBUG-ONLY investigation scaffold. Seeds a fully synthetic vault into the
+//  SwiftData store so the wallet home screen renders on a machine that has no
+//  real vault — which is the standing blocker on reproducing the macOS layout
+//  loop (see the #4470 recurrence investigation).
+//
+//  TWO LOCKS, deliberately:
+//    1. `#if DEBUG` — never compiled into a Release build.
+//    2. `-seedSyntheticVault` launch argument — never fires on an ordinary
+//       debug run, only when explicitly asked for.
+//
+//  It writes ONLY to SwiftData. No keychain, no network, no real key shares,
+//  no real addresses. `keyshares` is left empty on purpose: this vault exists
+//  to make views lay out, not to sign anything, and an empty keyshare list
+//  keeps it structurally incapable of being mistaken for a usable wallet.
+//
+//  REMOVE IT AGAIN with `-removeSyntheticVault` (deletes by pubKeyECDSA and
+//  nothing else), or delete the whole container:
+//    rm -rf ~/Library/Containers/com.vultisig.wallet
+//
+
+#if DEBUG
+import Foundation
+import SwiftData
+
+enum SyntheticVaultSeeder {
+    /// Marker that identifies everything this seeder created. Nothing else in
+    /// the app can produce this value, so removal is exact.
+    static let syntheticPubKeyECDSA = "SYNTHETIC-REPRO-VAULT-DO-NOT-SIGN"
+    private static let syntheticName = "Synthetic Repro Vault"
+
+    static var isSeedRequested: Bool {
+        CommandLine.arguments.contains("-seedSyntheticVault")
+    }
+
+    static var isRemovalRequested: Bool {
+        CommandLine.arguments.contains("-removeSyntheticVault")
+    }
+
+    @MainActor
+    static func runIfRequested() {
+        if isRemovalRequested { remove(); return }
+        guard isSeedRequested else { return }
+        seed()
+    }
+
+    // MARK: - Seed
+
+    @MainActor
+    private static func seed() {
+        let context = Storage.shared.modelContext!
+
+        if let existing = fetchSynthetic(in: context) {
+            note("synthetic vault already present (\(existing.coins.count) coins) — leaving it alone")
+            return
+        }
+
+        let vault = Vault(name: syntheticName, libType: .DKLS)
+        vault.pubKeyECDSA = syntheticPubKeyECDSA
+        vault.pubKeyEdDSA = "SYNTHETIC-EDDSA"
+        vault.hexChainCode = String(repeating: "ab", count: 32)
+        vault.localPartyID = "synthetic-mac"
+        vault.signers = ["synthetic-mac", "synthetic-peer"]
+        vault.isBackedUp = true          // suppresses the backup banner/nag
+        vault.keyshares = []             // deliberately empty — cannot sign
+        context.insert(vault)
+
+        // Native coins across several chains, including the DeFi-capable ones,
+        // so the chain list, the balance header and the DeFi tab all populate.
+        for meta in nativeMetas() {
+            let coin = Coin(
+                asset: meta,
+                address: syntheticAddress(for: meta),
+                hexPublicKey: String(repeating: "cd", count: 33)
+            )
+            coin.rawBalance = syntheticRawBalance(for: meta)
+            coin.vault = vault
+            context.insert(coin)
+        }
+
+        // DeFi rows. These are the @Model types under suspicion elsewhere, so
+        // the repro needs them to actually exist rather than be implied.
+        seedDefiPositions(vault: vault, context: context)
+
+        do {
+            try context.save()
+            // Make the app select it directly on the next launch instead of
+            // opening the vault picker — a returning user, which is what the
+            // capture shows (the window was restored, not freshly created).
+            UserDefaults.standard.set(syntheticName, forKey: "vaultName")
+            UserDefaults.standard.set(syntheticPubKeyECDSA, forKey: "selectedPubKeyECDSA")
+            UserDefaults.standard.set(false, forKey: "showOnboarding")
+            note("seeded synthetic vault: \(vault.coins.count) coins, "
+                 + "\(vault.stakePositions.count) stake, \(vault.lpPositions.count) LP")
+        } catch {
+            note("SEED FAILED: \(error)")
+        }
+    }
+
+    @MainActor
+    private static func seedDefiPositions(vault: Vault, context: ModelContext) {
+        let rune = TokensStore.rune
+        let tcy = TokensStore.tcy
+
+        vault.defiChains = [.thorChain]
+
+        let stake = StakePosition(
+            coin: tcy,
+            type: .stake,
+            amount: 1234.5678,
+            availableToUnstake: 1234.5678,
+            apr: 0.0912,
+            estimatedReward: 12.34,
+            rewards: 5.67,
+            rewardCoin: rune,
+            poolName: "TCY Staking",
+            vault: vault
+        )
+        context.insert(stake)
+
+        let lp = LPPosition(
+            LPPositionData(
+                coin1: rune,
+                coin1Amount: 42.5,
+                coin2: btcMeta,
+                coin2Amount: 0.0125,
+                poolName: "BTC.BTC",
+                poolUnits: "1234567",
+                apr: 0.0731
+            ),
+            vault: vault
+        )
+        context.insert(lp)
+    }
+
+    // MARK: - Remove
+
+    @MainActor
+    static func remove() {
+        let context = Storage.shared.modelContext!
+        guard let vault = fetchSynthetic(in: context) else {
+            note("no synthetic vault to remove")
+            return
+        }
+        // The relationships are `.cascade`, so deleting the vault takes its
+        // coins and positions with it.
+        context.delete(vault)
+        do {
+            try context.save()
+            UserDefaults.standard.removeObject(forKey: "vaultName")
+            UserDefaults.standard.removeObject(forKey: "selectedPubKeyECDSA")
+            note("removed synthetic vault")
+        } catch {
+            note("REMOVE FAILED: \(error)")
+        }
+    }
+
+    @MainActor
+    private static func fetchSynthetic(in context: ModelContext) -> Vault? {
+        let key = syntheticPubKeyECDSA
+        let descriptor = FetchDescriptor<Vault>(
+            predicate: #Predicate { $0.pubKeyECDSA == key }
+        )
+        return try? context.fetch(descriptor).first
+    }
+
+    // MARK: - Fixtures
+
+    private static let btcMeta = CoinMeta(
+        chain: .bitcoin, ticker: "BTC", logo: "btc", decimals: 8,
+        priceProviderId: "bitcoin", contractAddress: "", isNativeToken: true
+    )
+
+    private static func nativeMetas() -> [CoinMeta] {
+        var metas: [CoinMeta] = [btcMeta, TokensStore.rune]
+        // Pull the remaining natives out of the bundled store so tickers,
+        // logos and decimals are the real ones and the rows render normally.
+        let wanted: [Chain] = [.ethereum, .solana, .thorChain, .bitcoin]
+        for chain in wanted {
+            if let meta = TokensStore.TokenSelectionAssets.first(where: {
+                $0.chain == chain && $0.isNativeToken
+            }), !metas.contains(where: { $0.chain == meta.chain && $0.ticker == meta.ticker }) {
+                metas.append(meta)
+            }
+        }
+        return metas
+    }
+
+    /// Deterministic, obviously-fake, and never a valid address on any chain.
+    private static func syntheticAddress(for meta: CoinMeta) -> String {
+        "synthetic-\(meta.chain.rawValue.lowercased())-\(meta.ticker.lowercased())"
+    }
+
+    private static func syntheticRawBalance(for meta: CoinMeta) -> String {
+        // A few whole units in the chain's smallest denomination.
+        let units = Decimal(sign: .plus, exponent: meta.decimals, significand: 1)
+        return NSDecimalNumber(decimal: units * 3).stringValue
+    }
+
+    private static func note(_ message: String) {
+        FileHandle.standardError.write("[SyntheticVaultSeeder] \(message)\n".data(using: .utf8)!)
+    }
+}
+#endif


### PR DESCRIPTION
## Description

A `#if DEBUG` synthetic-vault seeder, so a developer machine with no vault can reach the home screen and the DeFi/staking rows.

This exists because investigating the macOS render-cycle report (#4470) was blocked on it: the diagnostics that would settle it — a subtractive root-`@Query` build, `sample` of the wedged process, Instruments' View Body lane — all need a populated home screen, and there is no `.vult` fixture and no seeding launch argument in the repo. The alternative was provisioning a real server-side FastVault against a real email address to look at a rendering question.

**It is a developer tool, not a product change.** No product behaviour is altered on any build that ships.

### Safety

- **Two locks:** `#if DEBUG` **and** an explicit `-seedSyntheticVault` launch argument. An ordinary debug run is unaffected.
- **SwiftData only.** No keychain writes, no network, no real key shares or addresses.
- **`keyshares` is deliberately empty**, so the vault is structurally incapable of signing.
- **Reversible:** `-removeSyntheticVault` matches on `pubKeyECDSA == "SYNTHETIC-REPRO-VAULT-DO-NOT-SIGN"`; the cascade takes its coins and positions.

Two files, 214 lines: `Debug/SyntheticVaultSeeder.swift` plus a 7-line hook in `VultisigApp.swift`.

### Usage

```
…/VultisigApp.app/Contents/MacOS/VultisigApp -seedSyntheticVault    # idempotent
…/VultisigApp.app/Contents/MacOS/VultisigApp -removeSyntheticVault
```

Seeds 1 vault, 4 coins, 1 stake position, 1 LP position.

> ⚠️ Useful gotcha found while building it: the Debug build runs **unsandboxed**, so its store is `~/Library/Application Support/default.store`, *not* the app container. That is also why it cannot collide with a real sandboxed vault.

### What it bought, and what it didn't

With it, every launch condition from the #4470 capture reproduces — `shouldRestoreState=1 hasPersistentStateToRestore=1`, AppKit restores the saved `ContentView` window, the home screen renders, and the capture's exact SwiftUI fault fires:

> `Update NavigationRequestObserver tried to update multiple times per frame.`

That **confirms the `ContentView.swift:151-159` double-`navigateToHome()` diagnosis**, which could never surface before because it needs a vault to load.

The layout loop itself **did not** reproduce — zero `has continued for … iterations` warnings across 150s on macOS 26.5.2, against the reporter's 15.7.7 (where `#available(macOS 26.0, *)` puts `CrossPlatformSheet`, `VultiTabBar` and the tab pill on different code). A macOS-26 non-repro discriminates between "macOS-15 framework bug" and "app trigger not yet found" not at all.

**Which is the main reason to merge this:** for anyone on the team running macOS 15.x, it turns that investigation from blocked into a 15-minute check. It also makes each future experiment minutes rather than hours.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None of the above — debug-only tooling, compiled out of release. No parity section.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

No tests: this is `#if DEBUG` tooling behind a launch argument, with no product code path. Verified by running it — `1 vault, 4 coins, 1 stake, 1 LP` — and by confirming an ordinary debug launch without the argument is unaffected.

Reviewers should weigh whether debug-only tooling belongs on `main` at all; the alternative is that it lives on a branch and rots. Happy to close this if the team would rather keep it out of the tree.
