### PR TITLE
feat(defi): tag every Kamino transaction with the vs attribution memo

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Solana/Signing/SolanaV0Transaction.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Solana/Signing/SolanaV0Transaction.swift
@@ -30,6 +30,8 @@ enum SolanaV0TransactionError: Error, LocalizedError, Equatable {
     case oversizedTransaction(Int)
     case computeBudgetAlreadyPresent
     case computeUnitLimitOutOfRange(UInt32)
+    case memoAlreadyPresent
+    case memoOutOfRange(Int)
     case unknownLookupTable(String)
     case lookupIndexOutOfRange(table: String, index: Int, tableSize: Int)
 
@@ -75,6 +77,10 @@ enum SolanaV0TransactionError: Error, LocalizedError, Equatable {
             return "Transaction already carries a Compute Budget instruction"
         case .computeUnitLimitOutOfRange(let limit):
             return "Compute unit limit \(limit) is outside the range the network accepts"
+        case .memoAlreadyPresent:
+            return "Transaction already carries a Memo instruction"
+        case .memoOutOfRange(let count):
+            return "Memo of \(count) bytes is outside the range this app injects"
         case .unknownLookupTable(let address):
             return "No contents supplied for address lookup table \(address)"
         case .lookupIndexOutOfRange(let table, let index, let size):
@@ -111,6 +117,16 @@ struct SolanaV0Transaction: Equatable {
 
     static let computeBudgetProgramId = "ComputeBudget111111111111111111111111111111"
 
+    /// SPL Memo v3. The program writes nothing and owns nothing; it logs its
+    /// instruction data, which is what makes an on-chain attribution tag
+    /// readable by an indexer without changing what the transaction does.
+    static let memoProgramId = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+
+    /// Bound on an injected memo. Nothing here needs a long one — the tag this
+    /// app writes is two bytes — and the ceiling keeps a caller from spending
+    /// the transaction's remaining size budget on a note.
+    static let maxMemoByteCount = 64
+
     /// The 32 raw bytes of `computeBudgetProgramId`, decoded once. The input is
     /// a compile-time constant, so a decode failure would mean the base58
     /// decoder itself is broken rather than that the data is bad — hence the
@@ -119,6 +135,15 @@ struct SolanaV0Transaction: Equatable {
     static let computeBudgetProgramKey: [UInt8] = {
         guard let data = Base58.decodeNoCheck(string: computeBudgetProgramId), data.count == 32 else {
             preconditionFailure("ComputeBudget program id must decode to 32 bytes")
+        }
+        return [UInt8](data)
+    }()
+
+    /// The 32 raw bytes of `memoProgramId`, decoded once — same compile-time
+    /// constant argument as `computeBudgetProgramKey`, pinned by the same tests.
+    static let memoProgramKey: [UInt8] = {
+        guard let data = Base58.decodeNoCheck(string: memoProgramId), data.count == 32 else {
+            preconditionFailure("Memo program id must decode to 32 bytes")
         }
         return [UInt8](data)
     }()
@@ -182,6 +207,10 @@ struct SolanaV0Transaction: Equatable {
 
     var hasComputeBudgetInstruction: Bool {
         instructions.contains { staticAccountKeys[Int($0.programIdIndex)] == Self.computeBudgetProgramKey }
+    }
+
+    var hasMemoInstruction: Bool {
+        instructions.contains { staticAccountKeys[Int($0.programIdIndex)] == Self.memoProgramKey }
     }
 
     // MARK: - Parsing
@@ -368,6 +397,78 @@ struct SolanaV0Transaction: Equatable {
     /// Prepends `SetComputeUnitLimit` + `SetComputeUnitPrice`, appending the
     /// ComputeBudget program as a new **static, read-only, unsigned** account key.
     ///
+    /// See `injecting(programKey:leading:trailing:)` for the account-key and
+    /// index-drift mechanics both injections share.
+    func injectingComputeBudget(price: UInt64, limit: UInt32) throws -> SolanaV0Transaction {
+        guard limit > 0, limit <= Self.maxComputeUnitLimit else {
+            throw SolanaV0TransactionError.computeUnitLimitOutOfRange(limit)
+        }
+        // Both checks matter. A stray ComputeBudget key with no instruction would
+        // make the append a duplicate account; an instruction with no static key
+        // is impossible, but checking it keeps the guard honest if the key ever
+        // arrives through a lookup table.
+        guard !staticAccountKeys.contains(Self.computeBudgetProgramKey), !hasComputeBudgetInstruction else {
+            throw SolanaV0TransactionError.computeBudgetAlreadyPresent
+        }
+
+        return try injecting(
+            programKey: Self.computeBudgetProgramKey,
+            leading: { programIdIndex in
+                [
+                    Instruction(
+                        programIdIndex: programIdIndex,
+                        accountIndexes: [],
+                        data: [ComputeBudgetInstruction.setUnitLimit] + Self.littleEndianBytes(limit)
+                    ),
+                    Instruction(
+                        programIdIndex: programIdIndex,
+                        accountIndexes: [],
+                        data: [ComputeBudgetInstruction.setUnitPrice] + Self.littleEndianBytes(price)
+                    )
+                ]
+            },
+            trailing: { _ in [] }
+        )
+    }
+
+    /// Appends one SPL Memo instruction carrying `text`, with the Memo program as
+    /// a new **static, read-only, unsigned** account key.
+    ///
+    /// Appended rather than prepended: the memo records who originated the
+    /// transaction and takes no part in what it does, so it belongs after the
+    /// instructions that move the money — and putting it last keeps every
+    /// existing instruction at the position the template already expects, with
+    /// only the two compute-budget instructions ahead of them.
+    ///
+    /// The memo has no accounts and no signer of its own. A memo instruction
+    /// listing signer accounts is how the Memo program attests to them, and
+    /// attesting is not what this is for.
+    func injectingMemo(_ text: String) throws -> SolanaV0Transaction {
+        let data = [UInt8](Data(text.utf8))
+        guard !data.isEmpty, data.count <= Self.maxMemoByteCount else {
+            throw SolanaV0TransactionError.memoOutOfRange(data.count)
+        }
+        // Same pair of checks as the budget injection, for the same reason: the
+        // key and the instruction are two ways for a memo to already be here, and
+        // appending a second one would both duplicate the account and leave the
+        // transaction carrying two attributions.
+        guard !staticAccountKeys.contains(Self.memoProgramKey), !hasMemoInstruction else {
+            throw SolanaV0TransactionError.memoAlreadyPresent
+        }
+
+        return try injecting(
+            programKey: Self.memoProgramKey,
+            leading: { _ in [] },
+            trailing: { programIdIndex in
+                [Instruction(programIdIndex: programIdIndex, accountIndexes: [], data: data)]
+            }
+        )
+    }
+
+    /// Appends `programKey` as a new **static, read-only, unsigned** account key
+    /// and re-serializes the message with `leading` instructions in front of the
+    /// existing ones and `trailing` behind them.
+    ///
     /// Static keys are ordered by privilege — writable signers, read-only
     /// signers, writable non-signers, read-only non-signers — so the read-only
     /// unsigned block is the tail, and appending there plus incrementing
@@ -381,18 +482,14 @@ struct SolanaV0Transaction: Equatable {
     /// so every program is already a static key below the insertion point. The
     /// indexes *inside* each `AddressTableLookup` are positions in the table
     /// itself, not in this message, so they are untouched too.
-    func injectingComputeBudget(price: UInt64, limit: UInt32) throws -> SolanaV0Transaction {
-        guard limit > 0, limit <= Self.maxComputeUnitLimit else {
-            throw SolanaV0TransactionError.computeUnitLimitOutOfRange(limit)
-        }
-        // Both checks matter. A stray ComputeBudget key with no instruction would
-        // make the append a duplicate account; an instruction with no static key
-        // is impossible, but checking it keeps the guard honest if the key ever
-        // arrives through a lookup table.
-        guard !staticAccountKeys.contains(Self.computeBudgetProgramKey), !hasComputeBudgetInstruction else {
-            throw SolanaV0TransactionError.computeBudgetAlreadyPresent
-        }
-
+    ///
+    /// Both closures receive the index the new key lands at, which is the only
+    /// thing an injected instruction needs that it cannot know beforehand.
+    private func injecting(
+        programKey: [UInt8],
+        leading: (UInt8) -> [Instruction],
+        trailing: (UInt8) -> [Instruction]
+    ) throws -> SolanaV0Transaction {
         // Checked before any index arithmetic: with the new key the message must
         // still address at most 256 accounts, which bounds both the appended
         // key's own index and every shifted index below `UInt8.max`.
@@ -403,7 +500,7 @@ struct SolanaV0Transaction: Equatable {
 
         let oldStaticCount = staticAccountKeys.count
         let programIdIndex = UInt8(oldStaticCount)
-        let keys = staticAccountKeys + [Self.computeBudgetProgramKey]
+        let keys = staticAccountKeys + [programKey]
 
         let shifted = instructions.map { instruction in
             Instruction(
@@ -415,26 +512,13 @@ struct SolanaV0Transaction: Equatable {
             )
         }
 
-        let budgetInstructions = [
-            Instruction(
-                programIdIndex: programIdIndex,
-                accountIndexes: [],
-                data: [ComputeBudgetInstruction.setUnitLimit] + Self.littleEndianBytes(limit)
-            ),
-            Instruction(
-                programIdIndex: programIdIndex,
-                accountIndexes: [],
-                data: [ComputeBudgetInstruction.setUnitPrice] + Self.littleEndianBytes(price)
-            )
-        ]
-
         var message: [UInt8] = [0x80, numRequiredSignatures, numReadonlySignedAccounts]
         message.append(numReadonlyUnsignedAccounts + 1)
         message += try Self.encodeCompactLength(keys.count)
         for key in keys { message += key }
         message += wire[blockhashRange]
 
-        let allInstructions = budgetInstructions + shifted
+        let allInstructions = leading(programIdIndex) + shifted + trailing(programIdIndex)
         message += try Self.encodeCompactLength(allInstructions.count)
         for instruction in allInstructions {
             message.append(instruction.programIdIndex)

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoInstructionSequence.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoInstructionSequence.swift
@@ -41,6 +41,7 @@ enum KaminoInstructionSequence {
         case farmsStake
         case farmsUnstake
         case farmsWithdrawUnstakedDeposits
+        case attributionMemo
 
         var name: String {
             switch self {
@@ -56,6 +57,7 @@ enum KaminoInstructionSequence {
             case .farmsStake: return "farm stake"
             case .farmsUnstake: return "farm unstake"
             case .farmsWithdrawUnstakedDeposits: return "farm unstaked share withdrawal"
+            case .attributionMemo: return "attribution memo"
             }
         }
     }
@@ -138,6 +140,11 @@ enum KaminoInstructionSequence {
     /// - Parameter hasPriorityFee: whether the app's ComputeBudget pair has been
     ///   injected. The API emits none, so before injection their presence is a
     ///   refusal and after it their absence is.
+    /// - Parameter hasAttributionMemo: whether the app's attribution memo has
+    ///   been appended. Same contract as `hasPriorityFee`, and for the same
+    ///   reason: the API emits no memo, so one arriving before injection came
+    ///   from somewhere else, and one missing after injection means the tag this
+    ///   app claims to write is not in the bytes it is about to sign.
     /// - Parameter farmUnstake: whether this withdraw has to release shares from
     ///   the vault's farm first. Ignored for a deposit.
     static func expected(
@@ -145,6 +152,7 @@ enum KaminoInstructionSequence {
         isWrappedSolVault: Bool,
         hasFarm: Bool,
         hasPriorityFee: Bool,
+        hasAttributionMemo: Bool = false,
         farmUnstake: FarmUnstake = .unknown
     ) -> [Step] {
         var steps: [Step] = []
@@ -230,6 +238,14 @@ enum KaminoInstructionSequence {
             steps.append(Step(.closeTokenAccount, required: isWrappedSolVault, repeatable: true))
         }
 
+        // Last, because that is where the injector appends it: the memo records
+        // who originated the transaction and takes no part in what it does, so
+        // it sits behind every instruction that moves money rather than in
+        // front of them.
+        if hasAttributionMemo {
+            steps.append(Step(.attributionMemo, required: true, repeatable: false))
+        }
+
         return steps
     }
 
@@ -260,6 +276,13 @@ enum KaminoInstructionSequence {
             if Array(data.prefix(8)) == KaminoInstructionDiscriminator.kvaultDeposit { return .kvaultDeposit }
             if Array(data.prefix(8)) == KaminoInstructionDiscriminator.kvaultWithdraw { return .kvaultWithdraw }
             return nil
+        case .memo:
+            // The tag is matched WHOLE, not as a prefix. A memo is free-form
+            // bytes, so "vs" followed by anything else is a different memo —
+            // and the one thing this app is willing to sign under the Memo
+            // program is its own attribution tag, exactly.
+            return data == KaminoAttribution.memoTagBytes ? .attributionMemo : nil
+
         case .farms:
             if Array(data.prefix(8)) == KaminoInstructionDiscriminator.farmsInitializeUser {
                 return .farmsInitializeUser

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoSolanaInstructions.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoSolanaInstructions.swift
@@ -22,6 +22,10 @@ enum KaminoSolanaProgram: String, CaseIterable {
     case computeBudget = "ComputeBudget111111111111111111111111111111"
     case kvault = "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd"
     case farms = "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+    /// SPL Memo v3, carrying this app's attribution tag. Never present in what
+    /// Kamino builds — the app appends it, which is why a memo arriving from the
+    /// API is a refusal rather than something to pass through.
+    case memo = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
 
     init?(programId: String) {
         self.init(rawValue: programId)
@@ -39,7 +43,7 @@ enum KaminoSolanaProgram: String, CaseIterable {
         switch self {
         case .system, .token, .token2022, .associatedToken:
             return true
-        case .computeBudget, .kvault, .farms:
+        case .computeBudget, .kvault, .farms, .memo:
             return false
         }
     }
@@ -47,6 +51,23 @@ enum KaminoSolanaProgram: String, CaseIterable {
     var isTokenProgram: Bool {
         self == .token || self == .token2022
     }
+}
+
+/// The attribution tag this app writes into every Kamino transaction it builds.
+///
+/// Kamino's kvault API takes no referrer or partner parameter, so attribution is
+/// client-side: one SPL Memo instruction carrying this literal, appended after
+/// the API has built the transaction and before it is validated and signed.
+///
+/// The bytes are the whole point. This tag is the filter every downstream
+/// measurement of Vultisig-originated deposits keys on — Kamino's own
+/// attribution and the public Dune queries alike — and it has to be
+/// byte-identical here, on Android and on Windows. So it is written once, and
+/// the injector, the validator and the verify-screen decoder all read it from
+/// here rather than each spelling it out.
+enum KaminoAttribution {
+    static let memoTag = "vs"
+    static let memoTagBytes = [UInt8](Data(memoTag.utf8))
 }
 
 /// Instruction discriminators for the programs a Kamino Earn transaction uses.

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoTransactionDecoder.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoTransactionDecoder.swift
@@ -269,6 +269,12 @@ enum KaminoTransactionDecoder {
             // never leaves the preparer, but a relayed transaction is whatever
             // it is, and the template has to describe the one in hand.
             hasPriorityFee: kinds.contains(.computeUnitLimit) || kinds.contains(.computeUnitPrice),
+            // Read from the bytes for the same reason as the fee above: this
+            // device did not build the transaction, so what it holds is whatever
+            // arrived. The memo's CONTENT is not read leniently — `kind` matches
+            // the tag whole, so any other memo is already `nil` here and the
+            // template refuses it as an instruction it cannot name.
+            hasAttributionMemo: kinds.contains(.attributionMemo),
             // Which of the two withdraw shapes this is depends on how the
             // signer's position was split when the request was built, and a
             // co-signer holds no position at all. So both shapes are accepted
@@ -490,6 +496,15 @@ enum KaminoTransactionDecoder {
                       staticAddress(accounts, indexes[KaminoInstructionAccounts.CloseAccount.destination]) == signer,
                       staticAddress(accounts, indexes[KaminoInstructionAccounts.CloseAccount.authority]) == signer
                 else { return nil }
+
+            case .attributionMemo:
+                // The tag itself was matched whole by `KaminoInstructionSequence`
+                // — nothing else reaches here under the Memo program. What is
+                // left to check is that it attests to nobody: a memo carrying
+                // account indexes is the Memo program asserting those accounts
+                // signed, which is a claim this screen would be showing without
+                // saying so.
+                guard indexes.isEmpty else { return nil }
 
             case .syncNative:
                 guard !indexes.isEmpty else { return nil }

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoTransactionPreparer.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoTransactionPreparer.swift
@@ -359,15 +359,23 @@ struct KaminoTransactionPreparer: KaminoDepositPreparing, KaminoWithdrawPreparin
         unitPrice: UInt64
     ) async throws -> KaminoPreparedTransaction {
         let fee = KaminoPriorityFee(limit: unitLimit, price: unitPrice)
-        let budgeted = try transaction.injectingComputeBudget(price: fee.price, limit: fee.limit)
+        // Both edits happen here, before the injected form is validated and
+        // simulated, so what gets proven is what gets signed. The memo goes on
+        // last and adds no accounts of its own, which is why it cannot disturb
+        // the budget instructions' indexes ahead of it.
+        let budgeted = try transaction
+            .injectingComputeBudget(price: fee.price, limit: fee.limit)
+            .injectingMemo(KaminoAttribution.memoTag)
 
         // Phase two, and the opposite contract: both ComputeBudget instructions
-        // are now required, in order, carrying exactly the values above.
+        // and the attribution memo are now required, in order, carrying exactly
+        // the values above.
         let injected = KaminoTransactionIntent(
             operation: operation,
             vault: vault,
             owner: owner,
-            priorityFee: fee
+            priorityFee: fee,
+            carriesAttributionMemo: true
         )
         try await validator.validate(transaction: budgeted, intent: injected)
 

--- a/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoTransactionValidator.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/Protocols/Kamino/KaminoTransactionValidator.swift
@@ -82,17 +82,24 @@ struct KaminoTransactionIntent {
     /// case any ComputeBudget instruction at all is a refusal, because Kamino's
     /// builder emits none and a fee we did not choose is SOL leaving the wallet.
     let priorityFee: KaminoPriorityFee?
+    /// Whether the app has appended its attribution memo. `false` before
+    /// injection, where a memo can only have come from the response — and the
+    /// Memo program logs whatever it is handed, so a memo we did not write is
+    /// text this app would be signing on somebody else's behalf.
+    let carriesAttributionMemo: Bool
 
     init(
         operation: KaminoOperation,
         vault: KaminoVaultInfo,
         owner: String,
-        priorityFee: KaminoPriorityFee? = nil
+        priorityFee: KaminoPriorityFee? = nil,
+        carriesAttributionMemo: Bool = false
     ) {
         self.operation = operation
         self.vault = vault
         self.owner = owner
         self.priorityFee = priorityFee
+        self.carriesAttributionMemo = carriesAttributionMemo
     }
 }
 
@@ -116,6 +123,7 @@ enum KaminoValidationError: Error, LocalizedError, Equatable {
     case amountMismatch(role: String, expected: String, actual: String)
     case amountOutOfRange(String)
     case unexpectedPriorityFee(index: Int)
+    case unexpectedMemo(index: Int)
     case unattributableWritableAccount(program: String, account: String)
     case unreferencedWritableAccount(String)
     case addressDerivationFailed(String)
@@ -152,6 +160,8 @@ enum KaminoValidationError: Error, LocalizedError, Equatable {
             return "Amount cannot be expressed on chain: \(detail)"
         case .unexpectedPriorityFee(let index):
             return "Instruction \(index) sets a priority fee this app did not choose"
+        case .unexpectedMemo(let index):
+            return "Instruction \(index) writes a memo this app did not choose"
         case .unattributableWritableAccount(let program, let account):
             return "Instruction from \(program) writes to \(account), which this operation does not explain"
         case .unreferencedWritableAccount(let account):
@@ -258,6 +268,7 @@ struct KaminoTransactionValidator {
         let context = try Context(intent: intent, accounts: accounts, transaction: transaction)
         try validatePrograms(context)
         try validatePriorityFeePresence(context)
+        try validateAttributionMemoPresence(context)
         try validateSequence(context)
         try validateWritableAccounts(context)
     }
@@ -303,6 +314,18 @@ struct KaminoTransactionValidator {
         }
     }
 
+    /// Before injection the app has written no memo, so one in the response came
+    /// from the builder — and a memo is arbitrary text logged on chain under the
+    /// user's signature. Named separately for the same reason as the fee: the
+    /// sequence would report it as a position error, which says nothing about
+    /// what is wrong with it.
+    private static func validateAttributionMemoPresence(_ context: Context) throws {
+        guard !context.intent.carriesAttributionMemo else { return }
+        for (position, program) in context.programs.enumerated() where program == .memo {
+            throw KaminoValidationError.unexpectedMemo(index: position)
+        }
+    }
+
     // MARK: - Instruction sequence
 
     /// Matches the transaction against the shape this operation produces, then
@@ -318,6 +341,7 @@ struct KaminoTransactionValidator {
             isWrappedSolVault: context.intent.vault.isWrappedSolVault,
             hasFarm: context.intent.vault.hasFarm,
             hasPriorityFee: context.intent.priorityFee != nil,
+            hasAttributionMemo: context.intent.carriesAttributionMemo,
             // This device read the position, so it knows which of the two
             // withdraw shapes it asked for and says so. Never `.unknown` here:
             // accepting either shape would let a transaction that unstakes
@@ -395,6 +419,9 @@ struct KaminoTransactionValidator {
                 position: position,
                 context
             )
+
+        case .attributionMemo:
+            try validateAttributionMemo(data: data, accounts: accounts, position: position)
         }
     }
 
@@ -442,6 +469,28 @@ struct KaminoTransactionValidator {
                 expected: String(fee.price),
                 actual: String(price)
             )
+        }
+    }
+
+    /// The memo must be this app's tag and nothing else.
+    ///
+    /// `KaminoInstructionSequence.kind` already refuses any other payload under
+    /// the Memo program, so reaching here with different bytes is impossible —
+    /// which is exactly why it is asserted rather than assumed: the tag is the
+    /// only reason this program is allow-listed at all, and the check that
+    /// enforces it should live beside the one that says so.
+    ///
+    /// No accounts, either. A memo listing accounts is the Memo program
+    /// attesting that they signed, and attribution is not an attestation.
+    private static func validateAttributionMemo(data: [UInt8], accounts: [String], position: Int) throws {
+        guard accounts.isEmpty else {
+            throw KaminoValidationError.malformedInstruction(
+                index: position,
+                detail: "attribution memo takes no accounts"
+            )
+        }
+        guard data == KaminoAttribution.memoTagBytes else {
+            throw KaminoValidationError.malformedInstruction(index: position, detail: "attribution memo")
         }
     }
 

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/KaminoTransactionFixtures.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/KaminoTransactionFixtures.swift
@@ -14,6 +14,7 @@
 //
 
 import Foundation
+@testable import VultisigApp
 
 enum KaminoTransactionFixtures {
 
@@ -30,6 +31,23 @@ enum KaminoTransactionFixtures {
         let unitLimit: UInt32
         let feePayer: String
         let lookupTable: String
+
+        /// `injected`, plus the attribution memo the preparer appends last —
+        /// i.e. the exact bytes the app now hands to keysign.
+        ///
+        /// DERIVED rather than pasted, on purpose. `injected` is the artifact
+        /// that was produced by the reference implementation and simulated on
+        /// mainnet; the memo is a byte edit whose exactness is proven on its own
+        /// in `SolanaV0TransactionTests`. A second frozen base64 blob here would
+        /// have no provenance of its own — it could only be this same edit,
+        /// recorded — so it would assert the edit against itself and pin nothing.
+        var tagged: String {
+            get throws {
+                try SolanaV0Transaction(base64Transaction: injected)
+                    .injectingMemo(KaminoAttribution.memoTag)
+                    .base64EncodedTransaction
+            }
+        }
     }
 
     static let usdcDeposit = Vector(

--- a/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaV0TransactionTests.swift
+++ b/VultisigApp/VultisigAppTests/Blockchain/Solana/SolanaV0TransactionTests.swift
@@ -400,6 +400,88 @@ final class SolanaV0TransactionTests: XCTestCase {
         )
     }
 
+    func testMemoProgramKeyIsTheDecodedProgramId() {
+        XCTAssertEqual(SolanaV0Transaction.memoProgramKey.count, 32)
+        XCTAssertEqual(
+            Base58.encodeNoCheck(data: Data(SolanaV0Transaction.memoProgramKey)),
+            SolanaV0Transaction.memoProgramId
+        )
+    }
+
+    // MARK: - Memo injection
+
+    /// The memo goes on the END, carries its text verbatim and attests to
+    /// nobody. Position matters as much as content: everything ahead of it keeps
+    /// the index it already had, which is what lets the shared instruction
+    /// template describe the tagged transaction by appending one step.
+    func testMemoInjectionAppendsOneAccountlessInstructionCarryingTheText() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
+
+        let tagged = try transaction.injectingMemo("vs")
+
+        XCTAssertEqual(tagged.instructions.count, transaction.instructions.count + 1)
+        let memo = try XCTUnwrap(tagged.instructions.last)
+        XCTAssertEqual(memo.data, [UInt8]("vs".utf8))
+        XCTAssertTrue(memo.accountIndexes.isEmpty)
+        XCTAssertEqual(tagged.staticAccountKeys[Int(memo.programIdIndex)], SolanaV0Transaction.memoProgramKey)
+        // Appended to the read-only unsigned block, exactly like the budget key.
+        XCTAssertEqual(tagged.staticAccountKeys.count, transaction.staticAccountKeys.count + 1)
+        XCTAssertEqual(tagged.numReadonlyUnsignedAccounts, transaction.numReadonlyUnsignedAccounts + 1)
+        // And the instruction that was already there is untouched.
+        XCTAssertEqual(tagged.instructions[0], transaction.instructions[0])
+    }
+
+    /// The whole point of the injection is that it does not disturb which
+    /// account any existing instruction addresses — the lookup-loaded ones move
+    /// one slot later, and their indexes have to move with them.
+    func testMemoInjectionPreservesResolvedAccountsAcrossMultipleLookupTables() throws {
+        let source = try SolanaV0Transaction(wireBytes: try Self.twoTableBuilder().bytes())
+        let tagged = try source.injectingMemo("vs")
+
+        let before = try source.resolvedAccountAddresses(forInstructionAt: 0, lookupTables: Self.twoTables)
+        let after = try tagged.resolvedAccountAddresses(forInstructionAt: 0, lookupTables: Self.twoTables)
+
+        XCTAssertEqual(before, after)
+    }
+
+    /// Both injections on one transaction: the budget pair in front, the memo
+    /// behind, and the original instruction between them still addressing the
+    /// same accounts after being shifted twice.
+    func testBudgetAndMemoComposeWithoutDisturbingTheOriginalInstruction() throws {
+        let source = try SolanaV0Transaction(wireBytes: try Self.twoTableBuilder().bytes())
+
+        let both = try source
+            .injectingComputeBudget(price: 20_000, limit: 200_000)
+            .injectingMemo("vs")
+
+        XCTAssertEqual(both.instructions.count, source.instructions.count + 3)
+        XCTAssertEqual(both.instructions.last?.data, [UInt8]("vs".utf8))
+        XCTAssertEqual(
+            try source.resolvedAccountAddresses(forInstructionAt: 0, lookupTables: Self.twoTables),
+            try both.resolvedAccountAddresses(forInstructionAt: 2, lookupTables: Self.twoTables)
+        )
+    }
+
+    func testASecondMemoIsRefused() throws {
+        let tagged = try SolanaV0Transaction(wireBytes: try Builder().bytes()).injectingMemo("vs")
+
+        XCTAssertThrowsError(try tagged.injectingMemo("vs")) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .memoAlreadyPresent)
+        }
+    }
+
+    func testAnEmptyOrOversizedMemoIsRefused() throws {
+        let transaction = try SolanaV0Transaction(wireBytes: try Builder().bytes())
+
+        XCTAssertThrowsError(try transaction.injectingMemo("")) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .memoOutOfRange(0))
+        }
+        let oversized = String(repeating: "x", count: SolanaV0Transaction.maxMemoByteCount + 1)
+        XCTAssertThrowsError(try transaction.injectingMemo(oversized)) { error in
+            XCTAssertEqual(error as? SolanaV0TransactionError, .memoOutOfRange(oversized.utf8.count))
+        }
+    }
+
     // MARK: - Builder
 
     private static let tableAKey = key(200)

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoLiveAPITests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoLiveAPITests.swift
@@ -154,6 +154,94 @@ final class KaminoLiveAPITests: XCTestCase {
         }
     }
 
+    /// The attribution memo, against the live API and the live chain.
+    ///
+    /// Two things could only be assumed offline, and both are the kind of
+    /// assumption that ships a broken deposit:
+    ///
+    /// 1. **Size.** A Solana transaction is capped at 1,232 bytes. The memo adds
+    ///    the program key plus a small instruction, and the vectors it was
+    ///    developed against are the ones the API happened to return in August —
+    ///    a vault whose transaction grows (another account creation, a longer
+    ///    lookup) could put the tagged form over the line, and the injection
+    ///    would start throwing on a path the user cannot avoid.
+    /// 2. **Compute.** The pinned unit limits were measured on untagged
+    ///    transactions. The Memo program costs compute of its own, so the tagged
+    ///    form has to still fit under the same limit — with the margin, not by
+    ///    landing exactly on it.
+    ///
+    /// So this simulates the tagged transaction and asserts `err: null`, then
+    /// reports the two numbers with their headroom. A failure here means the
+    /// tag as shipped cannot execute, which no offline test can tell us.
+    func testTheTaggedDepositStillFitsAndStillExecutes() async throws {
+        for descriptor in KaminoVaultRegistry.allowList {
+            let vault = try await service.fetchVaultInfo(descriptor: descriptor)
+            let amount = vault.minDeposit
+
+            let built = try await service.buildDepositTransaction(
+                owner: Self.probeOwner,
+                vault: descriptor,
+                amount: amount
+            )
+            let fee = KaminoPriorityFee(
+                limit: KaminoComputeBudget.depositUnitLimit(for: vault),
+                price: KaminoComputeBudget.fallbackUnitPriceMicroLamports
+            )
+            let tagged = try SolanaV0Transaction(base64Transaction: built)
+                .injectingComputeBudget(price: fee.price, limit: fee.limit)
+                .injectingMemo(KaminoAttribution.memoTag)
+
+            try await validator.validate(
+                transaction: tagged,
+                intent: KaminoTransactionIntent(
+                    operation: .deposit(amount),
+                    vault: vault,
+                    owner: Self.probeOwner,
+                    priorityFee: fee,
+                    carriesAttributionMemo: true
+                )
+            )
+            XCTAssertLessThanOrEqual(
+                tagged.wireSize,
+                SolanaV0Transaction.maxWireSize,
+                "\(vault.name): the tagged transaction does not fit in a Solana packet"
+            )
+
+            let result = try await solana.simulateTransaction(
+                base64Transaction: tagged.base64EncodedTransaction,
+                replaceRecentBlockhash: true,
+                accountAddresses: []
+            )
+
+            if let failure = result.failure {
+                // The probe wallet holds no USDC, so a deposit it cannot fund is
+                // not this app's behaviour — same rule as the minimum test above.
+                // A refusal that names the AMOUNT is a skip; anything else is the
+                // memo breaking a transaction that would otherwise have executed.
+                let fundingProblem = result.logs.contains {
+                    $0.contains("insufficient funds") || $0.contains("InsufficientFunds")
+                }
+                XCTAssertTrue(
+                    fundingProblem,
+                    "\(vault.name): the tagged deposit failed for a reason that is not the probe's balance — \(failure)"
+                )
+                note("SKIP \(vault.name): probe wallet cannot fund the deposit — \(failure)")
+                continue
+            }
+
+            let consumed = result.unitsConsumed ?? 0
+            XCTAssertLessThanOrEqual(
+                consumed,
+                UInt64(fee.limit),
+                "\(vault.name): the tagged deposit consumes more than the limit this app pins"
+            )
+            note(
+                "\(vault.name): tagged deposit → \(tagged.wireSize)/\(SolanaV0Transaction.maxWireSize) B, "
+                + "\(consumed)/\(fee.limit) CU"
+            )
+        }
+    }
+
     /// The deposit half of the same defect, and the reason the suite's earlier
     /// claim that "no test here simulates a deposit" was a gap worth closing:
     /// the form advertised `minDepositAmount` and the program refused it with

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionPreparerTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionPreparerTests.swift
@@ -41,7 +41,7 @@ final class KaminoTransactionPreparerTests: XCTestCase {
             unitPrice: KaminoTransactionFixtures.unitPriceMicroLamports
         )
 
-        XCTAssertEqual(prepared.base64, KaminoTransactionFixtures.usdcDeposit.injected)
+        XCTAssertEqual(prepared.base64, try KaminoTransactionFixtures.usdcDeposit.tagged)
         XCTAssertEqual(prepared.priorityFee.limit, KaminoComputeBudget.tokenDepositUnitLimit)
         XCTAssertEqual(prepared.priorityFee.price, KaminoTransactionFixtures.unitPriceMicroLamports)
     }
@@ -59,7 +59,7 @@ final class KaminoTransactionPreparerTests: XCTestCase {
             unitPrice: KaminoTransactionFixtures.unitPriceMicroLamports
         )
 
-        XCTAssertEqual(prepared.base64, KaminoTransactionFixtures.solDeposit.injected)
+        XCTAssertEqual(prepared.base64, try KaminoTransactionFixtures.solDeposit.tagged)
         XCTAssertEqual(prepared.priorityFee.limit, KaminoComputeBudget.nativeDepositUnitLimit)
         XCTAssertGreaterThan(
             KaminoComputeBudget.nativeDepositUnitLimit,
@@ -92,7 +92,7 @@ final class KaminoTransactionPreparerTests: XCTestCase {
             unitPrice: KaminoTransactionFixtures.unitPriceMicroLamports
         )
 
-        XCTAssertEqual(prepared.base64, KaminoTransactionFixtures.usdcWithdraw.injected)
+        XCTAssertEqual(prepared.base64, try KaminoTransactionFixtures.usdcWithdraw.tagged)
         XCTAssertEqual(prepared.priorityFee.limit, KaminoComputeBudget.withdrawUnitLimit)
         XCTAssertEqual(prepared.priorityFee.price, KaminoTransactionFixtures.unitPriceMicroLamports)
     }
@@ -220,7 +220,7 @@ final class KaminoTransactionPreparerTests: XCTestCase {
 
         XCTAssertEqual(harness.solana.simulatedTransactions.count, 2)
         XCTAssertEqual(harness.solana.simulatedTransactions[0], KaminoTransactionFixtures.usdcDeposit.source)
-        XCTAssertEqual(harness.solana.simulatedTransactions[1], KaminoTransactionFixtures.usdcDeposit.injected)
+        XCTAssertEqual(harness.solana.simulatedTransactions[1], try KaminoTransactionFixtures.usdcDeposit.tagged)
     }
 
     /// Phase one's contract, exercised end to end: a response that already

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoTransactionValidatorTests.swift
@@ -434,6 +434,82 @@ final class KaminoTransactionValidatorTests: XCTestCase {
 
     // MARK: - Priority fee
 
+    // MARK: - Attribution memo
+
+    /// The validator runs again on its own output, so the tagged form — budget
+    /// pair in front, attribution memo behind — has to pass. If it did not, the
+    /// memo could never be injected before the final gate.
+    func testAcceptsTheTaggedTransactions() throws {
+        try assertValid(
+            try KaminoTransactionFixtures.usdcDeposit.tagged,
+            intent: Self.usdcDepositIntent
+                .replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit))
+                .expectingAttributionMemo()
+        )
+        try assertValid(
+            try KaminoTransactionFixtures.usdcWithdraw.tagged,
+            intent: Self.usdcWithdrawIntent
+                .replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcWithdraw))
+                .expectingAttributionMemo()
+        )
+    }
+
+    /// Kamino emits no memo, so one arriving with the response is text this app
+    /// would be logging on chain under the user's signature without having
+    /// written it.
+    func testRejectsAMemoTheAppDidNotWrite() throws {
+        let tagged = try KaminoTransactionFixtures.usdcDeposit.tagged
+        let memoIndex = try SolanaV0Transaction(base64Transaction: tagged).instructions.count - 1
+
+        assertRefused(
+            tagged,
+            intent: Self.usdcDepositIntent
+                .replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit)),
+            expected: .unexpectedMemo(index: memoIndex)
+        )
+    }
+
+    /// The tag is the whole reason the Memo program is allow-listed, and it is
+    /// matched whole. A memo that merely STARTS with the tag is a different
+    /// memo — and the attribution filter downstream keys on the exact bytes.
+    func testRejectsAMemoCarryingAnythingButTheTag() throws {
+        for text in ["v", "vsx", "VS", "vs "] {
+            var mutable = try MutableTransaction(base64: try KaminoTransactionFixtures.usdcDeposit.tagged)
+            mutable.instructions[mutable.instructions.count - 1].data = [UInt8](Data(text.utf8))
+
+            assertRefused(
+                try mutable.base64(),
+                intent: Self.usdcDepositIntent
+                    .replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit))
+                    .expectingAttributionMemo(),
+                // The template names the memo as a REQUIRED last step, and this
+                // is not it — `kind` refuses the payload before the walk can
+                // match it — so the refusal is the missing step rather than an
+                // extra instruction. Either way the transaction does not pass.
+                expected: .missingInstruction("attribution memo")
+            )
+        }
+    }
+
+    /// A memo listing accounts is the Memo program attesting that they signed.
+    /// Attribution is not an attestation, and the accounts it would name are the
+    /// user's.
+    func testRejectsAMemoThatNamesAccounts() throws {
+        var mutable = try MutableTransaction(base64: try KaminoTransactionFixtures.usdcDeposit.tagged)
+        mutable.instructions[mutable.instructions.count - 1].accounts = [0]
+
+        assertRefused(
+            try mutable.base64(),
+            intent: Self.usdcDepositIntent
+                .replacing(priorityFee: Self.fee(KaminoTransactionFixtures.usdcDeposit))
+                .expectingAttributionMemo(),
+            expected: .malformedInstruction(
+                index: mutable.instructions.count - 1,
+                detail: "attribution memo takes no accounts"
+            )
+        )
+    }
+
     /// The fee is `limit × price` lamports out of the user's balance and Kamino
     /// emits no ComputeBudget instruction at all, so one arriving with the
     /// response is a spend nobody asked for.
@@ -892,7 +968,23 @@ private extension KaminoTransactionIntent {
     }
 
     func replacing(priorityFee: KaminoPriorityFee?) -> KaminoTransactionIntent {
-        KaminoTransactionIntent(operation: operation, vault: vault, owner: owner, priorityFee: priorityFee)
+        KaminoTransactionIntent(
+            operation: operation,
+            vault: vault,
+            owner: owner,
+            priorityFee: priorityFee,
+            carriesAttributionMemo: carriesAttributionMemo
+        )
+    }
+
+    func expectingAttributionMemo() -> KaminoTransactionIntent {
+        KaminoTransactionIntent(
+            operation: operation,
+            vault: vault,
+            owner: owner,
+            priorityFee: priorityFee,
+            carriesAttributionMemo: true
+        )
     }
 
     func replacing(descriptor: KaminoVaultDescriptor) -> KaminoTransactionIntent {
@@ -900,7 +992,8 @@ private extension KaminoTransactionIntent {
             operation: operation,
             vault: vault.replacing(descriptor: descriptor),
             owner: owner,
-            priorityFee: priorityFee
+            priorityFee: priorityFee,
+            carriesAttributionMemo: carriesAttributionMemo
         )
     }
 

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoVerifyPresentationTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoVerifyPresentationTests.swift
@@ -91,6 +91,45 @@ final class KaminoVerifyPresentationTests: XCTestCase {
         }
     }
 
+    /// And the tagged form — the exact bytes keysign receives — describes the
+    /// same transaction as the untagged one. The attribution memo takes no part
+    /// in what the transaction does, so nothing on the screen may move because
+    /// of it; what it must not do is make the decode fail, which would show a
+    /// co-signer "unreadable" for every deposit this app originates.
+    func testTheTaggedFormDescribesTheSameTransactionAsTheInjectedOne() throws {
+        for vector in KaminoTransactionFixtures.all {
+            let injected = try decode(vector.injected)
+            let tagged = try decode(try vector.tagged)
+
+            XCTAssertEqual(injected.operation, tagged.operation, vector.name)
+            XCTAssertEqual(injected.descriptor, tagged.descriptor, vector.name)
+            XCTAssertEqual(injected.amountBaseUnits, tagged.amountBaseUnits, vector.name)
+            XCTAssertEqual(injected.signer, tagged.signer, vector.name)
+            XCTAssertEqual(injected.strandsWrappedSolRent, tagged.strandsWrappedSolRent, vector.name)
+            XCTAssertEqual(injected.priorityFee?.limit, tagged.priorityFee?.limit, vector.name)
+            XCTAssertEqual(injected.priorityFee?.price, tagged.priorityFee?.price, vector.name)
+        }
+    }
+
+    /// A memo carrying anything but this app's tag is an instruction the
+    /// template cannot name, so the whole transaction becomes unreadable rather
+    /// than being summarised with the memo quietly ignored. The Memo program
+    /// logs its data on chain, and text the user was never shown is exactly what
+    /// this screen exists to prevent them signing.
+    func testAMemoOtherThanTheAttributionTagIsUnreadable() throws {
+        var mutable = try MutableTransaction(base64: try KaminoTransactionFixtures.usdcDeposit.tagged)
+        mutable.instructions[mutable.instructions.count - 1].data = [UInt8]("drained by".utf8)
+        let base64 = try mutable.base64()
+
+        let transaction = try SolanaV0Transaction(base64Transaction: base64)
+        XCTAssertTrue(KaminoTransactionDecoder.invokesKaminoVault(transaction))
+        XCTAssertNil(KaminoTransactionDecoder.decode(transaction))
+        XCTAssertEqual(
+            KaminoVerifyPresentation.state(for: payload(transaction: base64, marker: nil)),
+            .unreadable
+        )
+    }
+
     // MARK: - What the decoder refuses to describe
 
     /// The vault is identified by deriving each curated vault's share account for


### PR DESCRIPTION
## Description

Tags every Kamino transaction this app originates with a single SPL Memo instruction carrying the literal `vs`, so deposits it drives can be attributed. Kamino's kvault API takes no referrer/partner parameter, so attribution has to live in the transaction itself — one Memo instruction, appended after the API builds the transaction and before it is validated and signed, byte-identical across iOS/Android/Windows via a shared `KaminoAttribution` constant.

Injection happens alongside the existing ComputeBudget edit in `KaminoTransactionPreparer`, sharing one private byte editor (`injecting(programKey:leading:trailing:)`) rather than duplicating the key-append/index-shift arithmetic. The memo goes last, after every instruction that moves money, so it doesn't shift the indices the shared template expects.

`KaminoInstructionSequence` (shared by the validator and the offline decoder) admits exactly one memo carrying exactly `vs`: a memo present before injection, carrying any other bytes, or naming accounts is refused.

Supersedes #5104, which was auto-closed by the merge queue when its base branch (`feat/kamino-flows-5017`, merged as #5056) was deleted — GitHub's automatic base-change didn't stick before the queue closed it. This PR carries the same single commit, rebased cleanly onto current `main` (all earlier stack layers — #5053, #5055, #5056, #5057 — are already merged).

## Test plan

- [x] `KaminoTransactionPreparerTests` / `KaminoTransactionValidatorTests` — memo injection and validation golden vectors
- [x] `SolanaV0TransactionTests` — shared byte-editor refactor is byte-identical for both ComputeBudget and memo injection
- [x] `KaminoVerifyPresentationTests` — verify-screen decoding of the memo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for adding text memos to Solana transactions.
  * Added memo size limits and protection against duplicate memos.
  * Kamino transactions now include a required attribution memo when prepared.
* **Bug Fixes**
  * Improved validation to reject unexpected, malformed, or incorrectly formatted memos.
  * Preserved transaction account references when adding memos and compute-budget settings.
* **Tests**
  * Expanded coverage for memo injection, validation, transaction decoding, signing restrictions, and Kamino transaction preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->