### PR TITLE
fix(thorchain): price bRUNE at RUNE parity instead of a nonexistent pool

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/TokenPriceSource.swift
+++ b/VultisigApp/VultisigApp/Core/Services/TokenPriceSource.swift
@@ -237,37 +237,150 @@ struct MayaChainTokenPriceSource: TokenPriceSource {
 /// Prices THORChain assets from THORChain pools, with special-casing for the
 /// yield tokens (yRUNE / yTCY / ybRUNE) and sanitisation of `x/` and `STAKING-`
 /// prefixes before the pool lookup.
+///
+/// A pool lookup only answers for an asset that actually has an L1 pool.
+/// THORChain *derived* assets have none — `/thorchain/pool/THOR.BRUNE` replies
+/// `"asset: THOR.BRUNE is a derived asset"` and `getAssetPriceInUSD` reports
+/// `0.0` — so when the pool has no price this falls back to the CoinGecko feed
+/// the token's curated `TokensStore` entry declares via `priceProviderId`.
+/// bRUNE names RUNE's own feed, which is what prices it at RUNE parity, the
+/// same result vultisig-android reaches by pricing every `priceProviderID`
+/// -bearing token from CoinGecko and never asking the pool. The pool stays
+/// first so every asset that does have one (TCY, RUJI and their staking
+/// receipts) keeps pricing exactly as it does today.
+///
+/// This path is only reached for a coin whose stored `priceProviderId` is
+/// empty: `RateProvider.cryptoId(for:)` routes a coin that carries one to the
+/// provider-id price fetch instead. A coin auto-discovered before its curated
+/// entry existed was persisted without one and is never re-synced, which is how
+/// a held bRUNE ends up priced from a pool that cannot exist.
 struct ThorChainTokenPriceSource: TokenPriceSource {
+    /// NAV-derived USD price for a yield token's contract denom.
+    typealias YieldPrice = (Chain, String) async -> Double?
+    /// USD price for a fully qualified THORChain pool asset (e.g. `THOR.TCY`).
+    typealias PoolPrice = (Chain, String) async -> Double
+    /// Cached USD rate for a curated token's declared CoinGecko feed.
+    typealias ProviderRate = (CoinMeta) -> Double?
+    /// Fetches and persists one CoinGecko provider id's rates.
+    typealias ProviderFeedFetch = (String) async -> Void
+
     let chain: Chain
+    private let yieldPrice: YieldPrice
+    private let poolPrice: PoolPrice
+    private let providerRate: ProviderRate
+    private let fetchProviderFeed: ProviderFeedFetch
+    private let logger = Log.chain.service
+
+    init(
+        chain: Chain,
+        yieldPrice: @escaping YieldPrice = { chain, contract in
+            await ThorchainServiceFactory.getService(for: chain).fetchYieldTokenPrice(for: contract)
+        },
+        poolPrice: @escaping PoolPrice = { chain, assetName in
+            await ThorchainServiceFactory.getService(for: chain).getAssetPriceInUSD(assetName: assetName)
+        },
+        providerRate: @escaping ProviderRate = { coin in
+            RateProvider.shared.rate(for: coin, currency: .USD)?.value
+        },
+        fetchProviderFeed: @escaping ProviderFeedFetch = { providerId in
+            _ = try? await CoinGeckoRates.fetchAndSaveByIds(
+                [providerId],
+                httpClient: HTTPClient(),
+                logger: Log.chain.service
+            )
+        }
+    ) {
+        self.chain = chain
+        self.yieldPrice = yieldPrice
+        self.poolPrice = poolPrice
+        self.providerRate = providerRate
+        self.fetchProviderFeed = fetchProviderFeed
+    }
 
     func prices(contracts: [String], coins _: [CoinMeta]) async throws -> [Rate] {
-        let thorService = ThorchainServiceFactory.getService(for: chain)
+        let yieldTokens = TokensStore.TokenSelectionAssets
+            .filter { $0.chain == chain && ($0.ticker == "yRUNE" || $0.ticker == "yTCY" || $0.ticker == "ybRUNE") }
+            .map { $0.contractAddress }
+
+        // Two contracts can name the same declared feed (a stale TCY and sTCY both
+        // name `tcy`), so remember which feeds this batch already tried to fetch
+        // and don't issue the same request twice. A later refresh retries.
+        var attemptedFeeds: Set<String> = []
         var rates: [Rate] = []
         for contract in contracts {
-
-            let yieldTokens = TokensStore.TokenSelectionAssets.filter({ $0.chain == chain && ( $0.ticker == "yRUNE" || $0.ticker == "yTCY" || $0.ticker == "ybRUNE") }).map({$0.contractAddress})
-
             if yieldTokens.contains(contract) {
-                let price = await thorService.fetchYieldTokenPrice(for: contract)
-                let rate: Rate = .init(fiat: "usd", crypto: contract, value: price ?? 0.0)
-                rates.append(rate)
+                let price = await yieldPrice(chain, contract)
+                rates.append(Rate(fiat: "usd", crypto: contract, value: price ?? 0.0))
+                continue
+            }
+
+            let poolPriceUSD = await poolPrice(chain, Self.poolAssetName(for: contract))
+            if poolPriceUSD.isFinite, poolPriceUSD > 0 {
+                rates.append(Rate(fiat: "usd", crypto: contract, value: poolPriceUSD))
+                continue
+            }
+
+            if let declaredRate = await declaredFeedRate(for: contract, attemptedFeeds: &attemptedFeeds) {
+                rates.append(declaredRate)
             } else {
-                var sanitisedContract = contract.uppercased().replacingOccurrences(of: "X/", with: "")
-
-                // Handle staking assets mappings to their underlying asset for price
-                if sanitisedContract.starts(with: "STAKING-") {
-                    sanitisedContract = sanitisedContract.replacingOccurrences(of: "STAKING-", with: "")
-                }
-
-                // Ensure we have the THOR. prefix for the pool lookup
-                let assetName = sanitisedContract.contains(".") ? sanitisedContract : "THOR.\(sanitisedContract)"
-
-                let poolPrice = await thorService.getAssetPriceInUSD(assetName: assetName)
-                let poolRate: Rate = .init(fiat: "usd", crypto: contract, value: poolPrice)
-                rates.append(poolRate)
+                // No pool and no declared feed to fall back on: keep reporting the
+                // pool's zero so the caller's behaviour is unchanged for assets
+                // that have never had a price (e.g. LQDY, whose pool doesn't exist).
+                rates.append(Rate(fiat: "usd", crypto: contract, value: poolPriceUSD))
             }
         }
         return rates
+    }
+
+    /// The pool asset a THORChain token denom is priced from: `x/` and a leading
+    /// `STAKING-` are stripped (a staking receipt prices off its underlying
+    /// asset's pool) and a bare symbol is qualified with the `THOR.` prefix.
+    static func poolAssetName(for contract: String) -> String {
+        var sanitisedContract = contract.uppercased().replacingOccurrences(of: "X/", with: "")
+
+        // Handle staking assets mappings to their underlying asset for price
+        if sanitisedContract.starts(with: "STAKING-") {
+            sanitisedContract = sanitisedContract.replacingOccurrences(of: "STAKING-", with: "")
+        }
+
+        // Ensure we have the THOR. prefix for the pool lookup
+        return sanitisedContract.contains(".") ? sanitisedContract : "THOR.\(sanitisedContract)"
+    }
+
+    /// The USD rate for `contract` read off the CoinGecko feed its curated
+    /// `TokensStore` entry declares. `nil` when the token isn't curated, declares
+    /// no feed, or that feed can't be resolved at all.
+    ///
+    /// The feed is usually already cached: `CryptoPriceService` resolves
+    /// provider-id prices before contract prices, and any vault holding bRUNE also
+    /// holds native RUNE, which names the same feed. A *single-coin* refresh
+    /// (`BalanceService.updateBalance(for:)`, behind a coin-detail screen) carries
+    /// no such coin, so on a cold cache the feed is fetched here first — the same
+    /// pre-fetch `MayaChainTokenPriceSource` performs for CACAO.
+    ///
+    /// USD only, matching the pool price it stands in for. Emitting the feed's
+    /// other currencies would leave them stranded the moment an asset went back to
+    /// pool pricing, since the pool path has no per-currency rates to refresh them
+    /// with — the wider non-USD gap in every contract-keyed price source is its own
+    /// problem, not this one's.
+    private func declaredFeedRate(for contract: String, attemptedFeeds: inout Set<String>) async -> Rate? {
+        guard let curated = TokensStore.findTokenMeta(chain: chain, contractAddress: contract),
+              !curated.priceProviderId.isEmpty else {
+            return nil
+        }
+
+        var feedRate = providerRate(curated)
+        if feedRate == nil, attemptedFeeds.insert(curated.priceProviderId).inserted {
+            await fetchProviderFeed(curated.priceProviderId)
+            feedRate = providerRate(curated)
+        }
+
+        guard let value = feedRate, value.isFinite, value > 0 else {
+            logger.warning("No \(curated.priceProviderId, privacy: .public) rate to price \(curated.ticker, privacy: .public) from")
+            return nil
+        }
+
+        return Rate(fiat: "usd", crypto: contract, value: value)
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Services/ThorChainTokenPriceSourceTests.swift
+++ b/VultisigApp/VultisigAppTests/Services/ThorChainTokenPriceSourceTests.swift
@@ -1,0 +1,279 @@
+//
+//  ThorChainTokenPriceSourceTests.swift
+//  VultisigAppTests
+//
+//  THORChain *derived* assets have no L1 pool, so the pool lookup that prices
+//  every other THORChain token reports 0 for them ("asset: THOR.BRUNE is a
+//  derived asset"). These tests pin the fallback that reads the CoinGecko feed
+//  the curated `TokensStore` entry declares — bRUNE names RUNE's feed, so it
+//  prices at RUNE parity — and pin that every asset which does have a pool
+//  (TCY, RUJI and their staking receipts) still prices from it.
+//
+//  Every case here deliberately drives the source directly, which is the shape
+//  of the only coins that reach it in production: `RateProvider.cryptoId(for:)`
+//  routes a THORChain coin that carries a `priceProviderId` to the provider-id
+//  fetch instead, so a curated coin never asks for a pool price. What lands here
+//  is a coin persisted *without* one — auto-discovered before its curated entry
+//  existed and never re-synced. `testRoutingSendsOnlyAStaleCoinDownThisPath`
+//  pins that precondition against `RateProvider` itself.
+//
+
+@testable import VultisigApp
+import XCTest
+
+final class ThorChainTokenPriceSourceTests: XCTestCase {
+
+    private static let runeUSD = 1.75
+
+    // MARK: - The routing precondition
+
+    func testRoutingSendsOnlyAStaleCoinDownThisPath() {
+        // Curated bRUNE declares RUNE's feed, so it never reaches this source.
+        guard case .priceProvider(let id) = RateProvider.cryptoId(for: TokensStore.brune) else {
+            return XCTFail("Curated bRUNE should price from its declared feed, not its contract")
+        }
+        XCTAssertEqual(id, TokensStore.rune.priceProviderId)
+
+        // A bRUNE persisted before that entry existed carries no feed, so its
+        // rate is keyed by the contract denom and priced by this source.
+        guard case .contract(let contract) = RateProvider.cryptoId(for: staleBRune) else {
+            return XCTFail("A bRUNE without a declared feed should price from its contract")
+        }
+        XCTAssertEqual(contract, TokensStore.brune.contractAddress)
+    }
+
+    // MARK: - bRUNE: RUNE parity
+
+    func testBRunePricesAtRuneParityWhenPoolReportsNoPrice() async throws {
+        let feed = FeedStore(cached: Self.runeUSD)
+        let source = makeSource(pool: PoolPriceRecorder(price: 0), feed: feed)
+
+        let rates = try await source.prices(contracts: [TokensStore.brune.contractAddress], coins: [])
+
+        XCTAssertEqual(rates, [
+            Rate(fiat: "usd", crypto: TokensStore.brune.contractAddress, value: Self.runeUSD)
+        ])
+        // Parity comes from the feed the curated entry declares, which is RUNE's.
+        XCTAssertEqual(feed.queriedProviderIds, [TokensStore.rune.priceProviderId])
+        XCTAssertEqual(feed.fetchedProviderIds, [])
+    }
+
+    func testBRunePoolLookupTargetsTheDerivedAssetNameBeforeFallingBack() async throws {
+        let poolRecorder = PoolPriceRecorder(price: 0)
+        let source = makeSource(pool: poolRecorder, feed: FeedStore(cached: Self.runeUSD))
+
+        _ = try await source.prices(contracts: [TokensStore.brune.contractAddress], coins: [])
+
+        let assetNames = await poolRecorder.assetNames
+        XCTAssertEqual(assetNames, ["THOR.BRUNE"])
+    }
+
+    func testBRuneFetchesTheRuneFeedWhenItIsNotCachedYet() async throws {
+        // A single-coin refresh carries no coin that names RUNE's feed, so on a
+        // cold cache the feed has to be fetched here or bRUNE stays at $0.
+        let feed = FeedStore(cached: nil, afterFetch: Self.runeUSD)
+        let source = makeSource(pool: PoolPriceRecorder(price: 0), feed: feed)
+
+        let rates = try await source.prices(contracts: [TokensStore.brune.contractAddress], coins: [])
+
+        XCTAssertEqual(rates, [
+            Rate(fiat: "usd", crypto: TokensStore.brune.contractAddress, value: Self.runeUSD)
+        ])
+        XCTAssertEqual(feed.fetchedProviderIds, [TokensStore.rune.priceProviderId])
+    }
+
+    func testBRuneReportsZeroWhenTheRuneFeedCannotBeResolved() async throws {
+        let feed = FeedStore(cached: nil)
+        let source = makeSource(pool: PoolPriceRecorder(price: 0), feed: feed)
+
+        let rates = try await source.prices(contracts: [TokensStore.brune.contractAddress], coins: [])
+
+        XCTAssertEqual(rates, [
+            Rate(fiat: "usd", crypto: TokensStore.brune.contractAddress, value: 0)
+        ])
+        XCTAssertEqual(feed.fetchedProviderIds, [TokensStore.rune.priceProviderId])
+    }
+
+    func testAnUnresolvableFeedIsFetchedOncePerBatchNotOncePerContract() async throws {
+        // A stale TCY and sTCY both name the `tcy` feed; one failed fetch per
+        // refresh is enough, and a later refresh gets to retry.
+        let feed = FeedStore(cached: nil)
+        let source = makeSource(pool: PoolPriceRecorder(price: 0), feed: feed)
+
+        let rates = try await source.prices(
+            contracts: [TokensStore.tcy.contractAddress, TokensStore.stcy.contractAddress],
+            coins: []
+        )
+
+        XCTAssertEqual(rates, [
+            Rate(fiat: "usd", crypto: TokensStore.tcy.contractAddress, value: 0),
+            Rate(fiat: "usd", crypto: TokensStore.stcy.contractAddress, value: 0)
+        ])
+        XCTAssertEqual(feed.fetchedProviderIds, [TokensStore.tcy.priceProviderId])
+    }
+
+    // MARK: - ybRUNE keeps the yield path
+
+    func testYbRuneStillResolvesThroughTheYieldPath() async throws {
+        let poolRecorder = PoolPriceRecorder(price: 9.99)
+        let yieldRecorder = YieldPriceRecorder(price: 2.5)
+        let feed = FeedStore(cached: Self.runeUSD)
+        let source = makeSource(pool: poolRecorder, yield: yieldRecorder, feed: feed)
+
+        let rates = try await source.prices(contracts: [TokensStore.ybrune.contractAddress], coins: [])
+
+        XCTAssertEqual(rates, [
+            Rate(fiat: "usd", crypto: TokensStore.ybrune.contractAddress, value: 2.5)
+        ])
+        let yieldContracts = await yieldRecorder.contracts
+        XCTAssertEqual(yieldContracts, [TokensStore.ybrune.contractAddress])
+        // A naive `x/` strip would turn `x/staking-x/brune` into the same
+        // nonexistent THOR.BRUNE pool, so the yield branch must win outright.
+        let poolAssetNames = await poolRecorder.assetNames
+        XCTAssertTrue(poolAssetNames.isEmpty)
+        XCTAssertEqual(feed.queriedProviderIds, [])
+    }
+
+    // MARK: - Regression guards: assets that do have a pool
+
+    func testTcyKeepsItsPoolPriceAndIgnoresTheDeclaredFeed() async throws {
+        // TCY has an Available THOR.TCY pool and is deliberately priced from it.
+        let feed = FeedStore(cached: 999)
+        let source = makeSource(pool: PoolPriceRecorder(price: 3.0), feed: feed)
+
+        let rates = try await source.prices(contracts: [TokensStore.tcy.contractAddress], coins: [])
+
+        XCTAssertEqual(rates, [
+            Rate(fiat: "usd", crypto: TokensStore.tcy.contractAddress, value: 3.0)
+        ])
+        XCTAssertEqual(feed.queriedProviderIds, [])
+    }
+
+    func testRujiAndStakedRujiKeepTheirPoolPrice() async throws {
+        let poolRecorder = PoolPriceRecorder(price: 1.1)
+        let feed = FeedStore(cached: 999)
+        let source = makeSource(pool: poolRecorder, feed: feed)
+
+        let rates = try await source.prices(
+            contracts: [TokensStore.ruji.contractAddress, TokensStore.sruji.contractAddress],
+            coins: []
+        )
+
+        XCTAssertEqual(rates, [
+            Rate(fiat: "usd", crypto: TokensStore.ruji.contractAddress, value: 1.1),
+            Rate(fiat: "usd", crypto: TokensStore.sruji.contractAddress, value: 1.1)
+        ])
+        let assetNames = await poolRecorder.assetNames
+        XCTAssertEqual(assetNames, ["THOR.RUJI", "THOR.RUJI"])
+        XCTAssertEqual(feed.queriedProviderIds, [])
+    }
+
+    func testAssetWithNeitherPoolNorDeclaredFeedStillReportsZero() async throws {
+        // LQDY has no pool and no `priceProviderId`; it reported $0 before and must
+        // keep doing so rather than silently dropping out of the rate cache.
+        let feed = FeedStore(cached: 999)
+        let source = makeSource(pool: PoolPriceRecorder(price: 0), feed: feed)
+
+        let rates = try await source.prices(contracts: ["thor.lqdy"], coins: [])
+
+        XCTAssertEqual(rates, [Rate(fiat: "usd", crypto: "thor.lqdy", value: 0)])
+        XCTAssertEqual(feed.queriedProviderIds, [])
+    }
+
+    // MARK: - Pool asset name mapping
+
+    func testPoolAssetNameStripsXAndStakingPrefixes() {
+        let name = ThorChainTokenPriceSource.poolAssetName
+        XCTAssertEqual(name(TokensStore.brune.contractAddress), "THOR.BRUNE")
+        XCTAssertEqual(name(TokensStore.ruji.contractAddress), "THOR.RUJI")
+        XCTAssertEqual(name(TokensStore.sruji.contractAddress), "THOR.RUJI")
+        XCTAssertEqual(name(TokensStore.stcy.contractAddress), "THOR.TCY")
+        XCTAssertEqual(name(TokensStore.tcy.contractAddress), "THOR.TCY")
+        XCTAssertEqual(name("thor.lvn"), "THOR.LVN")
+    }
+
+    // MARK: - Helpers
+
+    /// bRUNE as a vault that auto-discovered it before the curated entry existed
+    /// persisted it: the real denom, but no declared price feed.
+    private var staleBRune: CoinMeta {
+        CoinMeta(
+            chain: .thorChain,
+            ticker: "BRUNE",
+            logo: .empty,
+            decimals: 8,
+            priceProviderId: .empty,
+            contractAddress: TokensStore.brune.contractAddress,
+            isNativeToken: false
+        )
+    }
+
+    private func makeSource(
+        pool: PoolPriceRecorder,
+        yield: YieldPriceRecorder = YieldPriceRecorder(price: nil),
+        feed: FeedStore
+    ) -> ThorChainTokenPriceSource {
+        ThorChainTokenPriceSource(
+            chain: .thorChain,
+            yieldPrice: { _, contract in await yield.price(contract: contract) },
+            poolPrice: { _, assetName in await pool.price(assetName: assetName) },
+            providerRate: { coin in feed.cachedRate(providerId: coin.priceProviderId) },
+            fetchProviderFeed: { providerId in feed.fetch(providerId: providerId) }
+        )
+    }
+}
+
+/// Stands in for the cached CoinGecko rates a token's declared feed resolves to,
+/// recording which feeds were read and which were fetched. Not thread-safe by
+/// design — the source reads it serially from one task.
+private final class FeedStore {
+    private(set) var queriedProviderIds: [String] = []
+    private(set) var fetchedProviderIds: [String] = []
+    private var rate: Double?
+    private let rateAfterFetch: Double?
+
+    init(cached: Double?, afterFetch: Double? = nil) {
+        self.rate = cached
+        self.rateAfterFetch = afterFetch
+    }
+
+    func cachedRate(providerId: String) -> Double? {
+        queriedProviderIds.append(providerId)
+        return rate
+    }
+
+    func fetch(providerId: String) {
+        fetchedProviderIds.append(providerId)
+        if let rateAfterFetch {
+            rate = rateAfterFetch
+        }
+    }
+}
+
+private actor PoolPriceRecorder {
+    private(set) var assetNames: [String] = []
+    private let priceValue: Double
+
+    init(price: Double) {
+        self.priceValue = price
+    }
+
+    func price(assetName: String) -> Double {
+        assetNames.append(assetName)
+        return priceValue
+    }
+}
+
+private actor YieldPriceRecorder {
+    private(set) var contracts: [String] = []
+    private let priceValue: Double?
+
+    init(price: Double?) {
+        self.priceValue = price
+    }
+
+    func price(contract: String) -> Double? {
+        contracts.append(contract)
+        return priceValue
+    }
+}


### PR DESCRIPTION
## Description

bRUNE renders **$0** in the wallet. `ThorChainTokenPriceSource` prices a THORChain token by stripping `x/` from its denom and asking `/thorchain/pool/THOR.<SYMBOL>` — but bRUNE is a THORChain *derived* asset and has no pool. Verified live against the node:

```
GET /thorchain/pool/THOR.BRUNE
→ {"code":2,"message":"asset: THOR.BRUNE is a derived asset","details":[]}
```

`getAssetPriceInUSD` reports `0.0` for that, so the rate cached under the denom is zero and the row renders $0.

Rather than hardcode bRUNE, this reads the intent `TokensStore` already declares: **when the pool has no usable price, fall back to the CoinGecko feed the curated entry names via `priceProviderId`.** bRUNE declares `thorchain` — RUNE's own feed — so it lands at RUNE parity with bRUNE named nowhere in the pricing code.

### The pool stays *first*, deliberately

Porting Android's feed-first ordering would have moved tokens that price correctly today. `TCY` declares `priceProviderId: "tcy"` but is **deliberately** priced from the Available `THOR.TCY` pool (commit `67a4f85`, "tcy price from the pool"), and RUJI/sRUJI from `THOR.RUJI`. Pool-first leaves every working price byte-identical and only fills the gap where the pool has nothing to say. Regression tests pin TCY, RUJI and sRUJI to their pool prices and assert the declared feed is never even consulted for them.

### ⚠️ How to reproduce — the issue's premise needs one correction

**A freshly-added bRUNE will not show $0, so a reviewer testing on a clean vault will not reproduce the bug.** `RateProvider.cryptoId(for:)` routes any THORChain coin that *carries* a `priceProviderId` to the provider-id fetch, so a curated bRUNE never reaches the pool lookup at all.

What is actually broken is a `Coin` **persisted before the curated entry landed** (#4799). bRUNE existed on Rujira first, so auto-discovery stored it with ticker `BRUNE` and an empty `priceProviderId` — and `CoinService.addToChain` returns early for an existing coin, so that empty id is never re-synced. Those coins fall to the contract path, hit `THOR.BRUNE`, and are pinned at $0 forever.

To reproduce: a vault that held bRUNE before upgrading past #4799 (or set an existing bRUNE coin's `priceProviderId` to `""`).

This is also why the fix **keys off the contract denom, not the ticker** — the broken coins stored `BRUNE`, not `bRUNE` (the lowercase-preserving guard shipped *with* the curated entry), so a ticker-keyed special case would have missed exactly the coins that are broken.

### Siblings, verified live against `/thorchain/pool/…`

| Denom | Pool asset | Result | Priced today? |
|---|---|---|---|
| `x/brune` | `THOR.BRUNE` | **derived asset** | **$0 — this PR** |
| `x/ruji`, `x/staking-x/ruji` | `THOR.RUJI` | `Available` | ✅ pool price — untouched |
| `x/staking-tcy`, `tcy` | `THOR.TCY` | `Available` | ✅ pool price — untouched |
| `x/nami-…-rcpt`, `x/staking-x/brune` | — | never reaches the strip | ✅ yield NAV path — untouched |
| `thor.lvn`, `thor.rkuji` | `THOR.LVN` / `THOR.RKUJI` | **derived asset** | ⚠️ repaired for free by the same rule |
| `thor.lqdy` | `THOR.LQDY` | **pool doesn't exist** | ❌ still $0 — no feed declared, unchanged |

None of the four assets the issue implied might share the cause actually do. **LVN and RKUJI *are* the identical root cause** (derived, no pool) under the same stale-coin precondition, and the general rule repairs them at **no extra code** — a consequence of reading the declared feed, not scope expansion.

### Deliberately out of scope

- **The real root cause: a stored `Coin.priceProviderId` is never re-synced from its curated `TokensStore` entry.** That is a cross-chain data migration and is why bRUNE, LVN and RKUJI can go stale at all. **Not filed** — flagging it here for a maintainer to raise.
- NAV-exact pricing for sRUJI/sTCY (both currently price at their underlying's value; Android does the liquid-bond NAV for `x/staking-tcy`).
- Mapping secured-asset denoms to their real pool asset (`btc-btc` → `btc.btc`), which Android does and iOS does not.
- Per-currency rates for contract-keyed sources. The fallback emits **USD only**, symmetric with the pool price it replaces: emitting the feed's other currencies would strand them once an asset returned to pool pricing, since the pool path has no per-currency rates to refresh them with. `SolanaTokenPriceSource` has the same USD-only shape — systemic, its own change.

### Implementation notes

- The declared feed is normally already cached (provider-id prices resolve before contract prices, and any vault holding bRUNE also holds native RUNE). A *single-coin* refresh — `BalanceService.updateBalance(for:)` behind a coin-detail screen — carries no such coin, so on a cold cache the feed is fetched once before it is read, mirroring the CACAO pre-fetch `MayaChainTokenPriceSource` already performs. Deduped per refresh so two contracts naming the same feed don't issue the same request twice.
- When there is no declared feed at all (LQDY), the pool's zero is still reported — behaviour unchanged.
- `ThorChainTokenPriceSource` gains injected yield/pool/feed closures defaulting to `ThorchainServiceFactory`, `RateProvider.shared` and `CoinGeckoRates`, mirroring how `SuiTokenPriceSource` is already structured; the `x/` + `STAKING-` sanitisation moves to a static `poolAssetName(for:)` so the (unchanged) mapping can be pinned directly.

Fixes #5101

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [x] New Chain / Chain related feature  -  Please attach tx link here

> No tx link: this is a THORChain **price-display** fix. It changes no transaction, memo, fee or keysign path — only which source a cached USD rate is read from.

## Parity

- Android: `n/a:` already correct — `TokenPriceRepositoryImpl.refresh` buckets every `priceProviderID`-bearing token to CoinGecko and never asks a pool, and `mapThorPoolAsset("x/brune")` matches no pool so nothing overwrites it. bRUNE prices at RUNE parity there by construction; iOS is the platform catching up, so there is no Android defect to link or file.
- Windows + extension: `n/a:` no separate implementation — both consume `@vultisig/core-chain`, whose token registry carries the same `priceProviderId: 'thorchain'` for `x/brune` (see the SDK verdict). Verified read-only from the SDK registry the app imports, **not** by running the desktop app; if a maintainer knows of a Windows-side pool lookup that bypasses the registry, that would be worth a second look.
- SDK: `n/a:` already correct — `packages/core/chain/coin/knownTokens/cosmos.ts` registers `'x/brune'` with `priceProviderId: 'thorchain'`, and vultisig-sdk#1317's changelog states bRUNE "is auto-discovered as a normal wallet token priced against RUNE (`priceProviderId: 'thorchain'`)". Nothing to fix there.

> The iOS-only defect is the **pool-first contract path**, which no sibling has: the others price straight from the declared feed. This PR brings iOS's fallback in line with that intent without giving up the pool prices iOS deliberately uses for TCY/RUJI.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if applicable):

None. Reproducing the $0 row requires a vault holding a bRUNE coin auto-discovered before #4799 (an empty stored `priceProviderId`), which I could not construct on a simulator without a funded mainnet THORChain vault. The behaviour is pinned by unit tests instead — see below.

## Additional context

**Gate:** `make test` on a dedicated en_US simulator, judged by the log marker:

```
** TEST SUCCEEDED **
Executed 5953 tests, with 11 tests skipped and 0 failures (0 unexpected) in 93.321 seconds
```

SwiftLint clean on both touched files. 11 new tests in `ThorChainTokenPriceSourceTests`: bRUNE → RUNE parity; the pool lookup targets `THOR.BRUNE` before falling back; cold-cache feed fetch; feed fetched once per batch not once per contract; bRUNE still reports 0 when the feed can't be resolved at all; ybRUNE still takes the yield path and the pool is never consulted; TCY/RUJI/sRUJI pool-price regression guards; LQDY still zero; `poolAssetName` mapping; and a routing test asserting against `RateProvider.cryptoId` that only a coin *without* a declared feed reaches this source.

**Review:** three read-only `codex exec` passes (two during implementation, one whole-branch before pushing). Four findings across the first two rounds, all fixed — the cold-cache single-coin refresh, the stranded non-USD rates, the per-contract duplicate feed fetch, and a test that bypassed production routing. The final whole-branch pass returned no findings.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5101
- **Confidence**: high on the fix and the blast radius (pool-priced assets are provably untouched, and the live pool probes are in the table above); medium on the *reproduction story* — the stale-`priceProviderId` explanation is derived by reading the code paths, not by observing a real affected vault.
- **Needs human review for**: (1) confirmation from someone with an affected vault that bRUNE now shows ~RUNE instead of $0; (2) whether the stale-`priceProviderId` re-sync deserves its own issue — I was not authorized to file it; (3) the deliberate USD-only choice, if anyone wants non-USD wallets covered sooner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved THORChain token price resolution with fallback pricing when pool data is unavailable or invalid.
  * Preserved valid zero-price results and improved handling for derived assets and yield tokens.
  * Added more reliable pricing for bRUNE, RUNE, TCY, and RUJI assets.

* **Tests**
  * Expanded coverage for token routing, fallback behavior, asset mapping, and price-fetching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->