### PR TITLE
fix(swap): mark high-fee THORChain/Maya routes in the Select-route picker

### DIFF
--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -656,6 +656,92 @@ private extension SwapService {
     }
 }
 
+// MARK: - High-fee route marking
+
+extension SwapService {
+    /// Route-fee share, in basis points, at or above which a candidate route is
+    /// marked "high fee" in the Select-route picker. 1000 bps = 10% of the swap.
+    ///
+    /// This marks; it never filters. Of these two mechanisms only the
+    /// below-minimum guard (`belowRecommendedMinimumError`) removes a candidate
+    /// — a quote can of course also drop out by failing outright or by having no
+    /// rankable output — and the two are independent: a route can be marked and
+    /// still be selectable, and a route can clear the node's floor while charging
+    /// a fee worth flagging, which is precisely the case that motivated this.
+    ///
+    /// 10% was chosen against live quotes rather than picked for roundness.
+    /// Sampling THORChain and MAYAChain across BTC/ETH/LTC/DOGE/BCH pairs at
+    /// sizes spanning three orders of magnitude, healthy routes sit far below:
+    /// the same BTC→ETH pair reads 284 bps at 0.00014844 BTC on THORChain and
+    /// falls to 25 bps as the size grows. Routes that are genuinely not worth
+    /// taking cluster well above: 1503, 1448, 2162 bps, up to 4436 bps on a dust
+    /// -sized LTC→BTC. Nothing observed between 972 and 1051 bps changes
+    /// character, so the line sits in the quietest part of the distribution
+    /// while still catching every route a user would be upset to have taken.
+    static let highRouteFeeThresholdBps = 1000
+
+    /// What share of the swap this route's own fees consume, in basis points, or
+    /// `nil` when the quote exposes no fee breakdown (every aggregator route).
+    ///
+    /// **The Vultisig affiliate cut is deliberately excluded, and that is load
+    /// bearing.** The affiliate bps the app sends varies with the user's VULT
+    /// tier (`max(0, 50 − discount)`), and it lands inside the node's own
+    /// `fees.total`. Measured across 36 quote pairs at the two ends of that
+    /// range, the node's `fees.total_bps` moves **34–50 bps** purely from the
+    /// tier — enough to push a route across any threshold and make the badge
+    /// blink on and off for reasons that have nothing to do with the route. With
+    /// the affiliate backed out, the same 36 pairs move by **exactly 0 bps**. So
+    /// this measures the route, not the user's tier.
+    ///
+    /// Computed locally rather than read from `fees.total_bps` for a second
+    /// reason: the node's field is not the same quantity as the ratio below and
+    /// the gap is provider-dependent — for one BTC→ETH quote MAYAChain reported
+    /// `total_bps` 1306 where the fee is 1502 bps of gross, while THORChain
+    /// reported 277 against 284. Mixing the two would put rows in the same list
+    /// on different scales.
+    static func routeFeeBps(for quote: SwapQuote) -> Int? {
+        // Every field must parse and be individually sane. A malformed affiliate
+        // must NOT be treated as zero: that would silently fold the Vultisig cut
+        // back into the figure and could mark a route on the strength of our own
+        // fee. No measurement beats a wrong one, so anything unexpected yields
+        // `nil` and the row simply goes unmarked.
+        guard let native = quote.nativeQuote,
+              let totalFee = Decimal(string: native.fees.total),
+              let expectedOut = Decimal(string: native.expectedAmountOut),
+              let affiliateFee = Decimal(string: native.fees.affiliate),
+              totalFee >= 0,
+              expectedOut >= 0,
+              affiliateFee >= 0,
+              affiliateFee <= totalFee else {
+            return nil
+        }
+
+        // `expected_amount_out` is already net of `fees.total`, so their sum is
+        // what the swap would have delivered fee-free — the honest denominator
+        // for "what share did this cost".
+        let gross = expectedOut + totalFee
+        guard gross > 0 else { return nil }
+
+        // Divide before scaling. The guards above put `routeFee / gross` in
+        // [0, 1], so the intermediate cannot overflow `Decimal` no matter how
+        // large the node's figures are; multiplying first could overflow to NaN
+        // on an absurd payload and silently read as 0 bps.
+        let routeFee = totalFee - affiliateFee
+        return NSDecimalNumber(
+            decimal: (routeFee / gross * 10_000).truncated(toPlaces: 0)
+        ).intValue
+    }
+
+    /// Whether this route's fees are large enough a share of the swap to warrant
+    /// marking it in the picker. Unmeasurable routes (aggregators) are never
+    /// marked — the badge claims a measurement, so it must not be shown without
+    /// one.
+    static func isHighFeeRoute(_ quote: SwapQuote) -> Bool {
+        guard let bps = routeFeeBps(for: quote) else { return false }
+        return bps >= highRouteFeeThresholdBps
+    }
+}
+
 // MARK: - Recommended-minimum guard
 
 extension SwapService {

--- a/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
+++ b/VultisigApp/VultisigApp/Blockchain/Swaps/Common/SwapService.swift
@@ -473,9 +473,12 @@ private extension SwapService {
                 throw SwapError.swapAmountTooSmall
             }
 
-            if let minSwapAmountDecimal = Decimal(string: rapidQuote.recommendedMinAmountIn), normalizedAmount < minSwapAmountDecimal {
-                let recommendedAmount = "\(minSwapAmountDecimal / fromCoin.thorswapMultiplier) \(fromCoin.ticker)"
-                throw SwapError.lessThenMinSwapAmount(amount: recommendedAmount)
+            if let belowMinimum = Self.belowRecommendedMinimumError(
+                normalizedAmount: normalizedAmount,
+                recommendedMinAmountIn: rapidQuote.recommendedMinAmountIn,
+                fromCoin: fromCoin
+            ) {
+                throw belowMinimum
             }
 
             let quote = await maybeUpgradeToStreaming(
@@ -650,6 +653,49 @@ private extension SwapService {
             slippageBps: slippageBps
         )
         return .jupiter(quote, fee: fee, platformFee: platformFee, feeOnInput: feeOnInput)
+    }
+}
+
+// MARK: - Recommended-minimum guard
+
+extension SwapService {
+    /// The per-candidate "below the node's own recommended floor" verdict for a
+    /// native THORChain/MAYAChain quote, or `nil` when the amount clears it.
+    ///
+    /// Two contracts this encodes, both easy to break silently:
+    ///
+    /// 1. **The comparison is in node scale, not human scale.** Both sides are
+    ///    the node's fixed-point integer units: `normalizedAmount` is
+    ///    `amount × fromCoin.thorswapMultiplier`, and `recommended_min_amount_in`
+    ///    is quoted in the same units. Comparing the human-decimal amount
+    ///    against the node's integer would make the guard fire on essentially
+    ///    every swap; comparing the other way would never fire.
+    /// 2. **The multiplier is the from-coin's, so it is not always 1e8.** THORChain
+    ///    fixed-point is 1e8 for every off-chain asset, but a MAYAChain-native
+    ///    input (CACAO, 10 decimals) is quoted at 1e10 — `thorswapMultiplier`
+    ///    already switches on the coin's chain, and the user-facing recommended
+    ///    amount must be scaled back down by that same multiplier.
+    ///
+    /// Fails **open**: a minimum that does not parse as a `Decimal` yields `nil`
+    /// (quote allowed), so a malformed value cannot block an otherwise fine swap.
+    /// Note this covers only a *present* value — `recommendedMinAmountIn` is a
+    /// required property on `ThorchainSwapQuote`, so a response omitting the field
+    /// fails decoding upstream and that provider is dropped before reaching here.
+    ///
+    /// Because each provider is fetched independently and a throwing provider is
+    /// dropped from the candidate pool, a verdict here removes only that one
+    /// route from the ranked set — it never fails the whole fan-out.
+    static func belowRecommendedMinimumError(
+        normalizedAmount: Decimal,
+        recommendedMinAmountIn: String,
+        fromCoin: Coin
+    ) -> SwapError? {
+        guard let minimum = Decimal(string: recommendedMinAmountIn),
+              normalizedAmount < minimum else {
+            return nil
+        }
+        let recommendedAmount = "\(minimum / fromCoin.thorswapMultiplier) \(fromCoin.ticker)"
+        return .lessThenMinSwapAmount(amount: recommendedAmount)
     }
 }
 

--- a/VultisigApp/VultisigApp/Components/Swap/HighFeeRouteBadge.swift
+++ b/VultisigApp/VultisigApp/Components/Swap/HighFeeRouteBadge.swift
@@ -1,0 +1,26 @@
+//
+//  HighFeeRouteBadge.swift
+//  VultisigApp
+//
+
+import SwiftUI
+
+/// Small pill marking a Select-route row whose own fees take a large share of
+/// the swap. It marks the row without disabling it — the route stays selectable,
+/// and it is still ranked purely on net output.
+struct HighFeeRouteBadge: View {
+    var body: some View {
+        Text("swapRouteHighFee".localized)
+            .font(Theme.fonts.caption10)
+            .foregroundStyle(Theme.colors.alertWarning)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Theme.colors.alertWarning.opacity(0.12))
+            .clipShape(Capsule())
+            .overlay(Capsule().stroke(Theme.colors.bgSurface2, lineWidth: 1))
+    }
+}
+
+#Preview {
+    HighFeeRouteBadge()
+}

--- a/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/de.lproj/Localizable.strings
@@ -1493,6 +1493,7 @@
 "swapRecipientRouteNotAvailable" = "Für dieses Paar ist keine Route zu einem externen Empfänger verfügbar. Entfernen Sie den Empfänger oder wählen Sie ein anderes Paar.";
 "swapRecipientVerificationFailed" = "Es konnte nicht bestätigt werden, dass der Swap an den gewählten Empfänger geht; er wurde vor dem Signieren gestoppt. Bitte versuchen Sie es erneut.";
 "swapRouteEta" = "~%lds";
+"swapRouteHighFee" = "Hohe Gebühr";
 "swapRouteNotAvailable" = "Tauschroute nicht verfügbar";
 "swaps" = "Swaps";
 "swapSecuredAssetBadge" = "Secured";

--- a/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/en.lproj/Localizable.strings
@@ -1493,6 +1493,7 @@
 "swapRecipientRouteNotAvailable" = "No route to an external recipient is available for this pair. Remove the recipient or choose a different pair.";
 "swapRecipientVerificationFailed" = "The swap could not be confirmed to deliver to your chosen recipient and was stopped before signing. Please try again.";
 "swapRouteEta" = "~%lds";
+"swapRouteHighFee" = "High fee";
 "swapRouteNotAvailable" = "Swap route not available";
 "swaps" = "Swaps";
 "swapSecuredAssetBadge" = "Secured";

--- a/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/es.lproj/Localizable.strings
@@ -1493,6 +1493,7 @@
 "swapRecipientRouteNotAvailable" = "No hay ninguna ruta hacia un destinatario externo disponible para este par. Quita el destinatario o elige otro par.";
 "swapRecipientVerificationFailed" = "No se pudo confirmar que el intercambio se entregue al destinatario elegido y se detuvo antes de firmar. Inténtalo de nuevo.";
 "swapRouteEta" = "~%lds";
+"swapRouteHighFee" = "Comisión alta";
 "swapRouteNotAvailable" = "Ruta de intercambio no disponible";
 "swaps" = "Intercambios";
 "swapSecuredAssetBadge" = "Secured";

--- a/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/hr.lproj/Localizable.strings
@@ -1493,6 +1493,7 @@
 "swapRecipientRouteNotAvailable" = "Za ovaj par nije dostupna ruta do vanjskog primatelja. Uklonite primatelja ili odaberite drugi par.";
 "swapRecipientVerificationFailed" = "Nije se moglo potvrditi da će zamjena biti isporučena odabranom primatelju te je zaustavljena prije potpisivanja. Pokušajte ponovno.";
 "swapRouteEta" = "~%lds";
+"swapRouteHighFee" = "Visoka naknada";
 "swapRouteNotAvailable" = "Ruta zamjene nije dostupna";
 "swaps" = "Zamjene";
 "swapSecuredAssetBadge" = "Secured";

--- a/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/it.lproj/Localizable.strings
@@ -1493,6 +1493,7 @@
 "swapRecipientRouteNotAvailable" = "Nessun percorso verso un destinatario esterno è disponibile per questa coppia. Rimuovi il destinatario o scegli un'altra coppia.";
 "swapRecipientVerificationFailed" = "Non è stato possibile confermare che lo swap venga consegnato al destinatario scelto ed è stato interrotto prima della firma. Riprova.";
 "swapRouteEta" = "~%lds";
+"swapRouteHighFee" = "Commissione alta";
 "swapRouteNotAvailable" = "Percorso di scambio non disponibile";
 "swaps" = "Scambi";
 "swapSecuredAssetBadge" = "Garantito";

--- a/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/ko.lproj/Localizable.strings
@@ -1493,6 +1493,7 @@
 "swapRecipientRouteNotAvailable" = "이 쌍에 대해 외부 수신자로 가는 경로를 사용할 수 없습니다. 수신자를 제거하거나 다른 쌍을 선택하세요.";
 "swapRecipientVerificationFailed" = "스왑이 선택한 수신자에게 전달되는지 확인할 수 없어 서명 전에 중단되었습니다. 다시 시도해 주세요.";
 "swapRouteEta" = "~%ld초";
+"swapRouteHighFee" = "높은 수수료";
 "swapRouteNotAvailable" = "스왑 경로를 사용할 수 없습니다";
 "swaps" = "스왑";
 "swapSecuredAssetBadge" = "보안";

--- a/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/pt.lproj/Localizable.strings
@@ -1493,6 +1493,7 @@
 "swapRecipientRouteNotAvailable" = "Nenhuma rota para um destinatário externo está disponível para este par. Remova o destinatário ou escolha outro par.";
 "swapRecipientVerificationFailed" = "Não foi possível confirmar que a troca seria entregue ao destinatário escolhido e ela foi interrompida antes da assinatura. Tente novamente.";
 "swapRouteEta" = "~%lds";
+"swapRouteHighFee" = "Taxa alta";
 "swapRouteNotAvailable" = "Rota de troca não disponível";
 "swaps" = "Trocas";
 "swapSecuredAssetBadge" = "Secured";

--- a/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
+++ b/VultisigApp/VultisigApp/Core/Localizables/zh-Hans.lproj/Localizable.strings
@@ -1493,6 +1493,7 @@
 "swapRecipientRouteNotAvailable" = "此交易对没有可用的外部接收方路由。请移除接收方或选择其他交易对。";
 "swapRecipientVerificationFailed" = "无法确认此交换会发送至你选择的接收方，已在签名前停止。请重试。";
 "swapRouteEta" = "~%ld秒";
+"swapRouteHighFee" = "高手续费";
 "swapRouteNotAvailable" = "交换路由不可用";
 "swaps" = "兑换";
 "swapSecuredAssetBadge" = "担保";

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -244,6 +244,13 @@ final class SwapDetailsViewModel {
         return String(format: "swapRouteEta".localized, seconds)
     }
 
+    /// Whether a route row should carry the "high fee" mark. Marking only; the
+    /// row stays fully selectable, and this has no bearing on which candidates
+    /// reach the picker in the first place.
+    func isHighFeeRoute(_ candidate: SwapQuote) -> Bool {
+        SwapService.isHighFeeRoute(candidate)
+    }
+
     func updateCoinLists() {
         let (resolvedToCoins, resolvedToCoin) = SwapCoinsResolver.resolveToCoins(
             fromCoin: fromCoin,

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SelectRouteSettingsView.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SelectRouteSettingsView.swift
@@ -56,6 +56,7 @@ struct SelectRouteSettingsView: View {
 
     private func routeRow(for quote: SwapQuote) -> some View {
         let selected = isSelected(quote)
+        let isHighFee = vm.isHighFeeRoute(quote)
         return Button {
             vm.selectProvider(quote)
             onBack()
@@ -69,9 +70,24 @@ struct SelectRouteSettingsView: View {
                 )
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(quote.displayName ?? "")
-                        .font(Theme.fonts.bodySMedium)
-                        .foregroundStyle(Theme.colors.textPrimary)
+                    // Only a badged row constrains the name. The badge holds its
+                    // intrinsic width and the name yields first, so a long name
+                    // (e.g. "THORChain-Stagenet") on a narrow row cannot squeeze
+                    // the badge into an unreadable sliver or push it off the row.
+                    // An unbadged row keeps its original free-wrapping name, so
+                    // rows without a badge render exactly as they did before.
+                    HStack(spacing: 6) {
+                        Text(quote.displayName ?? "")
+                            .font(Theme.fonts.bodySMedium)
+                            .foregroundStyle(Theme.colors.textPrimary)
+                            .lineLimit(isHighFee ? 1 : nil)
+                            .truncationMode(.tail)
+
+                        if isHighFee {
+                            HighFeeRouteBadge()
+                                .fixedSize()
+                        }
+                    }
 
                     feeSubtitle(for: quote, highlightFee: selected)
                 }

--- a/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Views/SwapQuote.swift
@@ -80,6 +80,18 @@ enum SwapQuote: Hashable {
         }
     }
 
+    /// The native THORChain/MAYAChain payload backing this quote, or `nil` for an
+    /// aggregator route. Aggregators expose no gross-vs-net fee breakdown, so
+    /// anything derived from the node's `fees` block is only defined here.
+    var nativeQuote: ThorchainSwapQuote? {
+        switch self {
+        case .thorchain(let quote), .thorchainChainnet(let quote), .thorchainStagenet(let quote), .mayachain(let quote):
+            return quote
+        case .oneinch, .kyberswap, .lifi, .swapkit, .jupiter:
+            return nil
+        }
+    }
+
     var router: String? {
         switch self {
         case .thorchain(let quote), .thorchainChainnet(let quote), .thorchainStagenet(let quote), .mayachain(let quote):

--- a/VultisigApp/VultisigAppTests/Swap/SwapHighFeeRouteMarkingTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapHighFeeRouteMarkingTests.swift
@@ -1,0 +1,287 @@
+//
+//  SwapHighFeeRouteMarkingTests.swift
+//  VultisigAppTests
+//
+//  Pins the "high fee" mark on Select-route rows: which routes get it, which
+//  never do, and — most importantly — that it depends only on the route.
+//
+//  Every numeric fixture below is a real THORChain/MAYAChain response captured
+//  for BTC.BTC -> ETH.ETH at 14844 sat, at both ends of the affiliate range the
+//  app can send (0 bps in DEBUG, 50 bps un-discounted in Release).
+//
+
+import BigInt
+import XCTest
+@testable import VultisigApp
+
+final class SwapHighFeeRouteMarkingTests: XCTestCase {
+
+    // Live MAYAChain quote, affiliate_bps=0 -> route fee is 1502 bps of gross.
+    private let mayaNoAffiliate = (out: "424259", total: "75008", affiliate: "0")
+    // The same MAYAChain quote at affiliate_bps=50. The affiliate cut grew and
+    // the output shrank by exactly that much; the route itself did not change.
+    private let mayaWithAffiliate = (out: "421763", total: "77504", affiliate: "2496")
+
+    // Live THORChain quote for the same swap -> 284 bps, a healthy route.
+    private let thorNoAffiliate = (out: "485317", total: "14234", affiliate: "0")
+    private let thorWithAffiliate = (out: "482824", total: "16727", affiliate: "2493")
+
+    // MARK: - Above / below the threshold
+
+    func testRouteAboveThresholdIsMarked() {
+        let quote = SwapQuote.mayachain(makeQuote(mayaNoAffiliate))
+
+        XCTAssertEqual(SwapService.routeFeeBps(for: quote), 1502)
+        XCTAssertTrue(
+            SwapService.isHighFeeRoute(quote),
+            "A route taking 15% of the swap must be marked"
+        )
+    }
+
+    func testRouteBelowThresholdIsNotMarked() {
+        let quote = SwapQuote.thorchain(makeQuote(thorNoAffiliate))
+
+        XCTAssertEqual(SwapService.routeFeeBps(for: quote), 284)
+        XCTAssertFalse(
+            SwapService.isHighFeeRoute(quote),
+            "A 2.8% route is a normal swap and must not be marked"
+        )
+    }
+
+    /// Both sides of the line, on the same pair and amount, so the test fails if
+    /// the threshold ever moves far enough to reclassify real routes.
+    func testThresholdSeparatesTheTwoLiveRoutesForTheSameSwap() {
+        XCTAssertTrue(SwapService.isHighFeeRoute(.mayachain(makeQuote(mayaNoAffiliate))))
+        XCTAssertFalse(SwapService.isHighFeeRoute(.thorchain(makeQuote(thorNoAffiliate))))
+    }
+
+    func testThresholdIsInclusiveAtItsBoundary() {
+        // gross = 10_000, so the fee IS the bps figure.
+        let atThreshold = SwapQuote.thorchain(makeQuote((out: "9000", total: "1000", affiliate: "0")))
+        let justUnder = SwapQuote.thorchain(makeQuote((out: "9001", total: "999", affiliate: "0")))
+
+        XCTAssertEqual(SwapService.routeFeeBps(for: atThreshold), SwapService.highRouteFeeThresholdBps)
+        XCTAssertTrue(SwapService.isHighFeeRoute(atThreshold), "The boundary itself is marked")
+        XCTAssertFalse(SwapService.isHighFeeRoute(justUnder), "One bps under is not")
+    }
+
+    // MARK: - Tier invariance (the reason the affiliate cut is excluded)
+
+    /// The headline property. The affiliate bps the app sends moves with the
+    /// user's VULT tier, and it sits inside `fees.total`. If the mark were driven
+    /// off the node's `fees.total_bps` it would move 34-50 bps with the tier and
+    /// could flip a row. With the affiliate backed out the figure is identical.
+    func testAffiliateCutIsExcludedSoTheTierCannotChangeTheMark() {
+        let withoutAffiliate = SwapQuote.mayachain(makeQuote(mayaNoAffiliate))
+        let withAffiliate = SwapQuote.mayachain(makeQuote(mayaWithAffiliate))
+
+        XCTAssertEqual(
+            SwapService.routeFeeBps(for: withAffiliate),
+            SwapService.routeFeeBps(for: withoutAffiliate),
+            "The same route at two VULT tiers must measure identically"
+        )
+        XCTAssertEqual(SwapService.routeFeeBps(for: withAffiliate), 1502)
+    }
+
+    func testTierInvarianceAlsoHoldsForAHealthyRoute() {
+        XCTAssertEqual(
+            SwapService.routeFeeBps(for: .thorchain(makeQuote(thorWithAffiliate))),
+            SwapService.routeFeeBps(for: .thorchain(makeQuote(thorNoAffiliate))),
+            "Tier invariance is a property of the metric, not of high-fee routes"
+        )
+        XCTAssertFalse(SwapService.isHighFeeRoute(.thorchain(makeQuote(thorWithAffiliate))))
+    }
+
+    /// The node's own `fees.total_bps` is a different quantity from this ratio,
+    /// and the gap is provider-dependent (MAYAChain reported 1306 where the fee
+    /// is 1502 bps of gross). Reading the node's field would put rows in one list
+    /// on two scales, so it must not influence the mark.
+    func testNodeReportedTotalBpsDoesNotDriveTheMark() {
+        let quote = SwapQuote.mayachain(
+            makeQuote(mayaNoAffiliate, totalBps: 10)
+        )
+
+        XCTAssertEqual(SwapService.routeFeeBps(for: quote), 1502)
+        XCTAssertTrue(
+            SwapService.isHighFeeRoute(quote),
+            "A low total_bps on the payload must not suppress the mark"
+        )
+    }
+
+    // MARK: - Independence from the below-minimum filter
+
+    /// Marking and filtering are separate mechanisms. The filter
+    /// (`belowRecommendedMinimumError`) decides whether a candidate reaches the
+    /// picker at all; the mark describes a candidate that already did. Neither
+    /// may read the other's input.
+    func testMarkingIgnoresTheRecommendedMinimum() {
+        let clearsFloor = SwapQuote.mayachain(
+            makeQuote(mayaNoAffiliate, recommendedMinAmountIn: "0")
+        )
+        let farBelowFloor = SwapQuote.mayachain(
+            makeQuote(mayaNoAffiliate, recommendedMinAmountIn: "999999999")
+        )
+
+        XCTAssertEqual(
+            SwapService.routeFeeBps(for: clearsFloor),
+            SwapService.routeFeeBps(for: farBelowFloor),
+            "The node's floor must not affect the fee measurement"
+        )
+        XCTAssertTrue(SwapService.isHighFeeRoute(clearsFloor))
+        XCTAssertTrue(SwapService.isHighFeeRoute(farBelowFloor))
+    }
+
+    /// The converse: clearing the floor is not a clean bill of health. This is
+    /// exactly the reported case — the amount clears MAYAChain's own recommended
+    /// minimum and the route still charges 15%.
+    func testARouteThatClearsTheFloorCanStillBeMarked() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC")
+        let normalizedAmount = Decimal(14844)
+
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedAmount,
+                recommendedMinAmountIn: "14455",
+                fromCoin: btc
+            ),
+            "14844 clears the 14455 floor, so the candidate is not filtered out"
+        )
+        XCTAssertTrue(
+            SwapService.isHighFeeRoute(.mayachain(makeQuote(mayaNoAffiliate))),
+            "...and it is still a 15% route, so it is marked"
+        )
+    }
+
+    // MARK: - Routes that cannot be measured
+
+    /// Aggregators expose no gross-vs-net breakdown. The badge asserts a
+    /// measurement, so an unmeasurable route must never carry it.
+    func testAggregatorRoutesAreNeverMarked() throws {
+        let swapKitResponse = try SwapKitFixtureLoader.decode(
+            SwapKitSwapResponse.self,
+            from: "v3-real-btc-all-swap"
+        )
+        let aggregators: [SwapQuote] = [
+            .oneinch(makeEVMQuote(), fee: nil),
+            .kyberswap(makeEVMQuote(), fee: nil),
+            .lifi(makeEVMQuote(), fee: nil, integratorFee: nil),
+            .swapkit(swapKitResponse, fee: nil, subProvider: swapKitResponse.subProvider),
+            .jupiter(makeEVMQuote(), fee: nil, platformFee: 0, feeOnInput: false)
+        ]
+
+        for quote in aggregators {
+            XCTAssertNil(
+                SwapService.routeFeeBps(for: quote),
+                "\(quote.displayName ?? "?") exposes no fee breakdown"
+            )
+            XCTAssertFalse(SwapService.isHighFeeRoute(quote))
+        }
+    }
+
+    func testUnparseableFeeFieldsAreNotMarked() {
+        let badTotal = SwapQuote.mayachain(makeQuote((out: "424259", total: "n/a", affiliate: "0")))
+        let badOut = SwapQuote.mayachain(makeQuote((out: "", total: "75008", affiliate: "0")))
+
+        XCTAssertNil(SwapService.routeFeeBps(for: badTotal))
+        XCTAssertNil(SwapService.routeFeeBps(for: badOut))
+        XCTAssertFalse(SwapService.isHighFeeRoute(badTotal))
+        XCTAssertFalse(SwapService.isHighFeeRoute(badOut))
+    }
+
+    /// An unreadable affiliate must not default to zero. Doing so would fold the
+    /// Vultisig cut back into the figure and could mark a route on the strength
+    /// of our own fee — the one number this metric exists to exclude.
+    func testUnparseableAffiliateYieldsNoMeasurementRatherThanZero() {
+        let quote = SwapQuote.mayachain(makeQuote((out: "424259", total: "75008", affiliate: "n/a")))
+
+        XCTAssertNil(
+            SwapService.routeFeeBps(for: quote),
+            "A missing affiliate must not be silently treated as 0"
+        )
+        XCTAssertFalse(SwapService.isHighFeeRoute(quote))
+    }
+
+    /// Nonsense sign combinations produce no measurement rather than a plausible
+    /// looking number. Each of these would otherwise yield a value in or beyond
+    /// the normal bps range and could mark, or fail to mark, a row on garbage.
+    func testImpossibleFeeShapesYieldNoMeasurement() {
+        let shapes: [(String, (out: String, total: String, affiliate: String))] = [
+            ("negative output", (out: "-100", total: "50", affiliate: "0")),
+            ("negative total", (out: "100", total: "-50", affiliate: "0")),
+            ("negative affiliate", (out: "1000", total: "500", affiliate: "-100")),
+            ("affiliate exceeding total", (out: "1000", total: "500", affiliate: "600"))
+        ]
+
+        for (label, fees) in shapes {
+            let quote = SwapQuote.mayachain(makeQuote(fees))
+            XCTAssertNil(SwapService.routeFeeBps(for: quote), "\(label) must not measure")
+            XCTAssertFalse(SwapService.isHighFeeRoute(quote), "\(label) must not be marked")
+        }
+    }
+
+    func testZeroGrossIsNotMarked() {
+        let quote = SwapQuote.mayachain(makeQuote((out: "0", total: "0", affiliate: "0")))
+
+        XCTAssertNil(SwapService.routeFeeBps(for: quote), "A zero-value swap has no fee share")
+        XCTAssertFalse(SwapService.isHighFeeRoute(quote))
+    }
+
+    /// An affiliate-only fee means the route itself charged nothing, which is a
+    /// measurement of zero rather than an absent measurement.
+    func testAffiliateOnlyFeeMeasuresZeroAndIsNotMarked() {
+        let quote = SwapQuote.mayachain(makeQuote((out: "100000", total: "2496", affiliate: "2496")))
+
+        XCTAssertEqual(SwapService.routeFeeBps(for: quote), 0)
+        XCTAssertFalse(SwapService.isHighFeeRoute(quote))
+    }
+
+    // MARK: - Helpers
+
+    private func makeQuote(
+        _ fees: (out: String, total: String, affiliate: String),
+        totalBps: Int? = nil,
+        recommendedMinAmountIn: String = "0"
+    ) -> ThorchainSwapQuote {
+        ThorchainSwapQuote(
+            dustThreshold: nil,
+            expectedAmountOut: fees.out,
+            expiry: 0,
+            fees: Fees(
+                affiliate: fees.affiliate,
+                asset: "ETH.ETH",
+                outbound: "75000",
+                total: fees.total,
+                liquidity: "8",
+                slippageBps: 0,
+                totalBps: totalBps
+            ),
+            inboundAddress: nil,
+            inboundConfirmationBlocks: nil,
+            inboundConfirmationSeconds: nil,
+            memo: "memo",
+            notes: "",
+            outboundDelayBlocks: 0,
+            outboundDelaySeconds: 0,
+            recommendedMinAmountIn: recommendedMinAmountIn,
+            slippageBps: nil,
+            totalSwapSeconds: nil,
+            warning: "",
+            router: nil,
+            maxStreamingQuantity: nil
+        )
+    }
+
+    private func makeEVMQuote() -> EVMQuote {
+        EVMQuote(
+            dstAmount: "1000",
+            tx: EVMQuote.Transaction(
+                from: "0xfrom", to: "0xto", data: "0x", value: "0", gasPrice: "0", gas: 0
+            )
+        )
+    }
+
+    private func makeCoin(_ chain: Chain, ticker: String) -> Coin {
+        let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: 8, isNativeToken: true)
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+}

--- a/VultisigApp/VultisigAppTests/Swap/SwapRecommendedMinimumGuardTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/SwapRecommendedMinimumGuardTests.swift
@@ -1,0 +1,225 @@
+//
+//  SwapRecommendedMinimumGuardTests.swift
+//  VultisigAppTests
+//
+//  Pins the per-candidate "below the node's recommended minimum" guard that
+//  keeps a THORChain/MAYAChain route out of the ranked candidate set (and
+//  therefore out of the Select-route picker).
+//
+//  The guard is the only thing standing between a below-floor native route and
+//  a user manually selecting it, and every assertion here encodes a contract
+//  that a refactor could break without any visible symptom:
+//
+//   * the comparison happens in the node's fixed-point scale, not human scale;
+//   * the scale comes from the FROM-coin, so it is 1e10 for a Maya-native input
+//     and 1e8 for everything else;
+//   * a present-but-unparseable minimum fails OPEN (the quote is allowed through);
+//   * when every provider fails, the minimum-amount verdict outranks a SwapKit
+//     failure and relayed upstream text, so it is not demoted behind either.
+//
+//  The numeric fixtures are real Mayanode/THORNode responses captured for
+//  BTC.BTC → ETH.ETH at 14844 sat, which is why the same amount both clears and
+//  fails the floor depending only on the affiliate bps the app sent.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class SwapRecommendedMinimumGuardTests: XCTestCase {
+
+    /// 0.00014844 BTC in THORChain 1e8 fixed point.
+    private let normalizedBtcAmount = Decimal(14844)
+
+    // MARK: - Live-captured Mayanode floors
+
+    /// Mayanode returned this floor when the request carried `affiliate_bps=30`
+    /// (a vault on the 20 bps VULT tier). Above the amount, so Maya is dropped.
+    func testBelowRecommendedMinimumFiresWhenNodeFloorExceedsAmount() {
+        let verdict = SwapService.belowRecommendedMinimumError(
+            normalizedAmount: normalizedBtcAmount,
+            recommendedMinAmountIn: "24092",
+            fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+        )
+
+        guard case .lessThenMinSwapAmount(let amount)? = verdict else {
+            return XCTFail("A node floor above the swap amount must produce the minimum-amount verdict")
+        }
+        XCTAssertEqual(
+            amount,
+            "0.00024092 BTC",
+            "The recommended amount must be scaled back out of node fixed point for display"
+        )
+    }
+
+    /// Same swap, same node, `affiliate_bps=50` (the un-discounted Release rate):
+    /// Mayanode's floor drops BELOW the amount, so the guard legitimately passes
+    /// and the route stays in the candidate set. This is the behaviour that makes
+    /// a below-economic-sense Maya route selectable, and it is a property of the
+    /// node's answer rather than of this comparison.
+    func testBelowRecommendedMinimumClearsWhenNodeFloorDropsBelowAmount() {
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedBtcAmount,
+                recommendedMinAmountIn: "14455",
+                fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+            ),
+            "A node floor below the swap amount must not drop the candidate"
+        )
+    }
+
+    /// `affiliate_bps=0` (DEBUG builds send no affiliate fee) — floor lower again.
+    func testBelowRecommendedMinimumClearsWithoutAffiliateFee() {
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedBtcAmount,
+                recommendedMinAmountIn: "8944",
+                fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+            )
+        )
+    }
+
+    // MARK: - Scale contract
+
+    /// The guard must compare node fixed point against node fixed point. Feeding
+    /// it the human-scale amount instead flips the verdict on a swap that is
+    /// three orders of magnitude ABOVE the floor, which is exactly the kind of
+    /// mistake that would silently delete THORChain/Maya from every picker.
+    func testBelowRecommendedMinimumComparesInNodeScaleNotHumanScale() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+        let oneBitcoin = Decimal(1)
+
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: oneBitcoin * btc.thorswapMultiplier,
+                recommendedMinAmountIn: "24092",
+                fromCoin: btc
+            ),
+            "1 BTC is far above the floor once normalized into node scale"
+        )
+        XCTAssertNotNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: oneBitcoin,
+                recommendedMinAmountIn: "24092",
+                fromCoin: btc
+            ),
+            "Skipping the multiplier must be observable — it wrongly rejects 1 BTC"
+        )
+    }
+
+    /// THORChain quotes every off-chain asset in 1e8 regardless of the asset's
+    /// own decimals, but a MAYAChain-native input is quoted at 1e10.
+    /// `thorswapMultiplier` switches on the coin's chain, and the displayed
+    /// recommended amount has to come back down by that same multiplier.
+    func testBelowRecommendedMinimumUsesMayaNativeScaleForMayaSourceCoin() {
+        let cacao = makeCoin(.mayaChain, ticker: "CACAO", decimals: 10)
+        XCTAssertEqual(cacao.thorswapMultiplier, Decimal(10_000_000_000))
+
+        let verdict = SwapService.belowRecommendedMinimumError(
+            normalizedAmount: Decimal(10) * cacao.thorswapMultiplier,
+            recommendedMinAmountIn: "246000000000",
+            fromCoin: cacao
+        )
+
+        guard case .lessThenMinSwapAmount(let amount)? = verdict else {
+            return XCTFail("A Maya-native input below the floor must still be dropped")
+        }
+        XCTAssertEqual(amount, "24.6 CACAO", "Maya-native amounts scale by 1e10, not 1e8")
+    }
+
+    /// An 18-decimal EVM input is still quoted in THORChain's 1e8, so the
+    /// multiplier must NOT follow the coin's own decimals here.
+    func testBelowRecommendedMinimumUsesThorchainScaleForEighteenDecimalCoin() {
+        let eth = makeCoin(.ethereum, ticker: "ETH", decimals: 18)
+        XCTAssertEqual(eth.thorswapMultiplier, Decimal(100_000_000))
+
+        let verdict = SwapService.belowRecommendedMinimumError(
+            normalizedAmount: Decimal(string: "0.001")! * eth.thorswapMultiplier,
+            recommendedMinAmountIn: "1000000",
+            fromCoin: eth
+        )
+
+        guard case .lessThenMinSwapAmount(let amount)? = verdict else {
+            return XCTFail("0.001 ETH is below a 0.01 ETH floor")
+        }
+        XCTAssertEqual(amount, "0.01 ETH")
+    }
+
+    // MARK: - Boundary and fail-open behaviour
+
+    /// The floor is *recommended*, so an amount exactly at it is allowed.
+    func testBelowRecommendedMinimumAllowsAmountExactlyAtTheFloor() {
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedBtcAmount,
+                recommendedMinAmountIn: "14844",
+                fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+            ),
+            "An amount equal to the floor clears it — the comparison is strict"
+        )
+    }
+
+    /// A malformed floor must not be able to block a swap. An *omitted* field
+    /// never reaches here — `recommendedMinAmountIn` is required by
+    /// `ThorchainSwapQuote`, so its absence fails decoding and drops the provider.
+    func testBelowRecommendedMinimumFailsOpenOnUnparseableFloor() {
+        let btc = makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+        for floor in ["", "n/a", "null"] {
+            XCTAssertNil(
+                SwapService.belowRecommendedMinimumError(
+                    normalizedAmount: normalizedBtcAmount,
+                    recommendedMinAmountIn: floor,
+                    fromCoin: btc
+                ),
+                "An unparseable floor (\(floor)) must fail open"
+            )
+        }
+    }
+
+    /// A zero floor is the shape every node uses for "no minimum".
+    func testBelowRecommendedMinimumClearsOnZeroFloor() {
+        XCTAssertNil(
+            SwapService.belowRecommendedMinimumError(
+                normalizedAmount: normalizedBtcAmount,
+                recommendedMinAmountIn: "0",
+                fromCoin: makeCoin(.bitcoin, ticker: "BTC", decimals: 8)
+            )
+        )
+    }
+
+    // MARK: - Surfacing when every candidate failed
+
+    /// The guard drops one candidate; the other providers still rank. Only when
+    /// EVERY provider failed does an error reach the user, and the minimum-amount
+    /// verdict must not lose that selection to a SwapKit failure or to relayed
+    /// upstream text — it is the one failure that tells the user what to change.
+    /// (Among other *classified* core-provider errors the order is still
+    /// task-completion order; this pins only the two demotions that exist.)
+    func testMinimumAmountErrorIsSurfacedAheadOfSwapKitAndUnclassifiedFailures() {
+        let minimumError = SwapError.lessThenMinSwapAmount(amount: "0.00024092 BTC")
+
+        let overSwapKit = SwapService.surfacedQuoteError(
+            from: [SwapKitError.providerNotEnabled, minimumError]
+        )
+        XCTAssertEqual(
+            overSwapKit as? SwapError,
+            minimumError,
+            "A core-provider minimum verdict must outrank a SwapKit failure"
+        )
+
+        let overRelayedText = SwapService.surfacedQuoteError(
+            from: [SwapError.serverError(message: "raw node text"), minimumError]
+        )
+        XCTAssertEqual(
+            overRelayedText as? SwapError,
+            minimumError,
+            "A typed minimum verdict must outrank relayed upstream text"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoin(_ chain: Chain, ticker: String, decimals: Int) -> Coin {
+        let asset = CoinMeta.make(chain: chain, ticker: ticker, decimals: decimals, isNativeToken: true)
+        return Coin(asset: asset, address: "test-address-\(ticker)", hexPublicKey: "")
+    }
+}


### PR DESCRIPTION
## Description

**This PR does not fix the bug as reported, because there is no such bug.** Please read this section before the diff — the change looks unrelated to the issue title otherwise.

Fixes #5099

### The reported bug does not reproduce

The issue claims the Select-route picker lists THORChain/Maya routes below the node's `recommended_min_amount_in`, and that Android drops them. Both claims are wrong, verified at runtime against live Mayanode/THORNode through the real `SwapService.fetchQuotes` path:

- The guard in `fetchCrossChainQuote` already runs **per candidate** for both `.thorchain` and `.mayachain`, `fetchQuotes` drops the throwing provider via `compactMap { try? $0.get() }`, and the picker reads that same filtered list. It also **predates the picker** — `git log -S lessThenMinSwapAmount` reaches `9b3d53d68` (2024-06-06); `SelectRouteSettingsView.swift` was added by `e9d3d5d6b` (2026-06-19).
- **Android does the same thing.** `SwapQuoteManager.fetchThorMayaQuote` throws `SwapException.SmallSwapAmount` inside its per-candidate `async { runCatching { … } }`, `ranked` is built from `successes`, and Maya's `affiliate_bps` is `max(0, 50 − discount)` on both platforms. No divergence exists on the reported scenario.
- **The reporter's `affiliate_bps=30` curl is not the request the app makes.** At 30 bps the floor is 24092 and Maya *is* dropped. The app sends 50 bps (Release, un-discounted), where the floor is 14455 — below the 14844 sat amount — so the guard legitimately passes.

Measured for the issue's own swap (BTC→ETH, 14844 sat), `normalizedAmount = 14844`:

| requested `affiliate_bps` | Maya `recommended_min_amount_in` | guard fires | in `allQuotes` | Maya `total_bps` |
|---|---|---|---|---|
| 0 (DEBUG default) | 8944 | no | **yes** | 1309 |
| 30 (reporter's curl) | 24092 | **yes** | no | 1331 |
| 50 (Release default) | 14455 | no | **yes** | 1346 |

### What is actually wrong

`recommended_min_amount_in` is **not an economic minimum on Mayanode when an affiliate is present** — it is an affiliate-dust floor, inversely proportional to `affiliate_bps`. Sweeping 5→50 bps, `min_in × bps / 10000 = 72.28 sat`, constant to two decimals, while `fees.total_bps` stays **1309–1346 bps (13.1–13.5%) throughout**. The floor tracks whether the affiliate's cut clears ~72 sat of dust; it says nothing about whether the swap is worth doing. So the existing guard is weakest at exactly the bps the app sends.

THORChain, by contrast, returns 6057–6087 for the same swap — essentially bps-invariant — at 277–324 bps of fees. That is what a real economic floor looks like.

### What shipped instead

A **high-fee mark on the picker row. It marks; it does not filter.** The below-minimum guard is untouched and still matches Android. Marking rather than hiding, because the ranker already puts THORChain first here — a bad route is never auto-selected; a user has to open Advanced → Select route and pick it deliberately, and hiding would also remove a route that may be the only one available.

**The metric is not `fees.total_bps`.** Two live measurements ruled that out:

1. **It moves with the user's VULT tier.** The affiliate bps (`max(0, 50 − discount)`) lands *inside* `fees.total`. Across 36 (pair, node, amount) triples quoted at both ends of that range, `total_bps` moved **34–50 bps** from the tier alone. Real routes form a continuum as size varies — observed adjacent: 887, 929, 951, 991, 1003, 1043 — so no threshold has 50 bps of clearance on both sides, and a tier change would flip rows on and off.
2. **It is a different quantity from fee-share-of-gross, with a provider-dependent gap.** For one BTC→ETH quote MAYAChain reported `total_bps` 1306 where the fee is 1502 bps of gross; THORChain reported 277 against 285. The natural fallback, `SwapService.rapidSlippageBps`, computes the *second* form — mixing them would put rows in one list on two scales.

So `SwapService.routeFeeBps` computes, identically for every native quote:

```
(fees.total − fees.affiliate) × 10⁴ / (expected_amount_out + fees.total)
```

Across those same 36 triples this moves by **exactly 0 bps** between affiliate 0 and 50. Tier-invariance is a property of the metric, not a margin. Excluding our own affiliate cut is also the right product answer: it is roughly constant across candidate rows, so it cannot differentiate routes; protocol and liquidity cost can.

**Threshold: 1000 bps (10%), measured rather than picked for roundness.** Sampling THORChain and MAYAChain across BTC/ETH/LTC/DOGE/BCH over three orders of magnitude of size:

| route class | observed `routeFeeBps` |
|---|---|
| healthy, any size | 25 – 744 |
| the quiet band | 972, 1051 (nothing changes character between) |
| not worth taking | 1116, 1448, 1503, 2162, up to 4436 (dust-sized LTC→BTC) |

The reported swap measures **1502 bps on Maya and 284 on THORChain**, so it marks exactly one of the two rows.

Unmeasurable routes are never marked — aggregators expose no gross-vs-net breakdown, and the badge asserts a measurement. `routeFeeBps` also returns `nil` unless all three fee fields parse and are individually sane (`total ≥ 0`, `out ≥ 0`, `0 ≤ affiliate ≤ total`); a malformed `fees.affiliate` defaulting to 0 would fold our own fee back in and could mark a route on the strength of it.

### Commits

- `5549878c9` — regression test pinning the below-minimum guard (comparison in node fixed point, from-coin multiplier 1e10 for Maya-native / 1e8 otherwise, inclusive floor, fail-open). Extracts the existing comparison into `belowRecommendedMinimumError` to make it reachable; **no behaviour change**.
- `b4d12233b` — the high-fee mark.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

**No swap tx link — deliberately, not an omission.** This is a display-only marking change plus tests. No signing, payload-building, or broadcast path is touched, and the candidate set, ranking, ordering, and selection are all byte-identical to `main`. There is no transaction this PR could produce to link. The runtime evidence is quote-fetch measurement against live Mayanode/THORNode, quoted inline above.

## Parity

<!-- One verdict per surface. No sibling issues filed — see note below. -->

- Android: `first: Android swap route picker` — no equivalent high-fee marking exists. Its below-minimum filter already matches iOS's (verified in `SwapQuoteManager.fetchThorMayaQuote` — same per-candidate throw, same `successes` set feeding the picker, same `max(0, 50 − discount)` affiliate bps for Maya), so only the *mark* needs porting, not the filter.
- Windows + extension: `first: core/ui/vault/swap/form/info/SwapFees.tsx` — no high-fee marking. `total_bps` is read there only to render a fee percentage (`totalBps / 100`); no `recommended_min_amount_in` handling was found at all.
- SDK: `first: packages/core/chain/swap/native` — no high-fee marking. `total_bps` is used only for the THORChain streaming-slippage threshold (`NativeSwapChain.ts`, `getNativeSwapQuote.ts`).

> Sibling issues were **not** filed: this agent is not authorized to create issues in any repo. Each verdict names the exact surface so the tickets can be raised from it.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`make test`: `** TEST SUCCEEDED **` — 5967 tests, 11 skipped, **0 failures** (5952 on `main`; +15 new across two suites). SwiftLint at its unchanged 22-violation baseline. New key `swapRouteHighFee` added to **all 8** locales including `ko`, verified at 1803 entries each.

## Screenshots (if applicable):

**None attached.** The badge only renders on a live Select-route sheet, which needs a seeded vault plus live quotes for a below-threshold pair; this agent has no vault on its machine. The visual is a pill following the existing `VultTierBadge` convention (`caption10`, capsule, 12% tint) in `Theme.colors.alertWarning`, placed beside the provider name. Worth a human eyeballing before merge — see below.

## Additional context

The threshold and the mark-vs-hide choice are product judgments backed by the measurements above, not derived facts; both are cheap to change (`SwapService.highRouteFeeThresholdBps`).

Cross-model review: four read-only Codex passes — two per-commit, a confirmation pass, and a whole-branch pass over the complete diff vs `main`. Every finding was accepted and fixed; none rejected or deferred. The substantive ones were input validation on `routeFeeBps` (a malformed `fees.affiliate` must not default to 0), row-layout robustness, and one the whole-branch view caught that neither per-commit pass could: `.lineLimit(1)` had been applied to *every* route row, quietly truncating long provider names on rows with no badge. It is now scoped to badged rows only, so an unbadged row renders exactly as it does on `main`.

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5099
- **Confidence**: high — for the measurements and the mechanism, both runtime-verified and reproducible from the tables above. Medium for the product calls (10% threshold, mark rather than hide).
- **Needs human review for**: the 1000 bps threshold and the decision to mark rather than filter; and a visual check of the badge in the Select-route sheet, since no screenshot is attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added high-fee route detection for swaps, with clear warning badges in route selection.
  * Added localized high-fee messaging across supported languages.
  * Improved recommended minimum amount validation and user-facing error handling.
* **Bug Fixes**
  * Preserved accurate fee comparisons and amount conversions across swap routes.
  * Improved handling of invalid minimum amount data without blocking valid swaps.
* **Tests**
  * Added coverage for high-fee thresholds, affiliate fees, route types, and minimum amount validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->