### PR TITLE
fix(passcode): take the privacy cover down as the app returns, and make it a blurred wallet

### DIFF
--- a/VultisigApp/VultisigApp/App/ContentView.swift
+++ b/VultisigApp/VultisigApp/App/ContentView.swift
@@ -127,7 +127,11 @@ struct ContentView: View {
         // keysign summary in the space it vacated. Applied before, the overlays
         // cover it like anything else.
         .withForegroundNotificationBanner()
-        .overlay(appViewModel.showCover ? CoverView() : nil)
+        // The same picture the raised window shows, not a second opinion. This
+        // overlay renders in the pass that raises the cover and the window is put
+        // up after it, so anything different here is a frame of something else
+        // on the way out — which is how a logo came to flash over the wallet.
+        .overlay(appViewModel.showCover ? CoverView(backdrop: privacyBackdrop) : nil)
         .overlay(passcodeGate.animation(.easeInOut(duration: 0.25), value: appViewModel.isPasscodeLocked))
         // Above the gate's overlay, matching the order `appLockPresentation`
         // derives: the two are mutually exclusive today, and if that ever stops
@@ -209,6 +213,24 @@ struct ContentView: View {
             // Retry action - clear error to allow user to try again
             deeplinkError = nil
         }
+    }
+
+    /// The blurred picture of the app that the privacy cover shows, where there
+    /// is one to show.
+    ///
+    /// Read rather than observed, and that is sound because of when it is
+    /// written: the picture is taken one step *ahead* of `showCover`, so by the
+    /// time this body runs in response to the flag it is already there. Nothing
+    /// changes it while the cover is up.
+    ///
+    /// The Mac has none — no app switcher zooms a stale card up there, so the
+    /// cover stays the brand screen.
+    private var privacyBackdrop: Image? {
+        #if os(iOS)
+        return PrivacyBackdrop.latest
+        #else
+        return nil
+        #endif
     }
 
     /// What the app is covering itself with, as one value — see

--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -222,6 +222,14 @@ extension VultisigApp {
                         await SwapTrackingRegistry.shared.resumeAllInFlight()
                     }
                 case .inactive:
+                    // The picture is taken one step ahead of the cover that
+                    // shows it, so that the first covered frame already has it
+                    // — see `PrivacyBackdrop.take()`. Only on the way out: a
+                    // return is about to uncover, and photographing the app
+                    // there would be work thrown away.
+                    if previousPhase == .active {
+                        PrivacyBackdrop.take()
+                    }
                     // Leaving and returning are the same phase, and which one
                     // this is decides whether the cover goes up or comes down —
                     // see `AppViewModel.sceneBecameInactive(comingFrom:)`.

--- a/VultisigApp/VultisigApp/App/VultisigApp.swift
+++ b/VultisigApp/VultisigApp/App/VultisigApp.swift
@@ -209,21 +209,23 @@ extension VultisigApp {
             .environmentObject(coinSelectionViewModel)
             .environmentObject(deeplinkViewModel)
             .environmentObject(pushNotificationManager)
-            .onChange(of: scenePhase) {
-                switch scenePhase {
+            .onChange(of: scenePhase) { previousPhase, newPhase in
+                switch newPhase {
                 case .active:
-                    continueLogin()
+                    // Not `continueLogin()` directly: a return was decided at
+                    // `.inactive` and must not be decided again here — see
+                    // `AppViewModel.sceneBecameActive()`.
+                    appViewModel.sceneBecameActive()
                     appViewModel.refreshFastVaultEligibilityIfNeeded()
                     Task { @MainActor in
                         SwapTrackingRegistry.shared.setActiveOnAll(true)
                         await SwapTrackingRegistry.shared.resumeAllInFlight()
                     }
                 case .inactive:
-                    // Before `.background`, and that is the whole reason it is
-                    // here: the app-switcher snapshot is taken around this
-                    // phase, so a cover raised at `.background` is raised after
-                    // the picture of the wallet has been taken.
-                    appViewModel.coverForPrivacy()
+                    // Leaving and returning are the same phase, and which one
+                    // this is decides whether the cover goes up or comes down —
+                    // see `AppViewModel.sceneBecameInactive(comingFrom:)`.
+                    appViewModel.sceneBecameInactive(comingFrom: previousPhase)
                 case .background:
                     resetLogin()
                     Task { @MainActor in

--- a/VultisigApp/VultisigApp/Components/AppLock/AppLockHosting.swift
+++ b/VultisigApp/VultisigApp/Components/AppLock/AppLockHosting.swift
@@ -69,6 +69,16 @@ enum AppLockPresentation: Equatable {
 struct AppLockHostedScreen: View {
 
     let presentation: AppLockPresentation
+    /// A picture of the app taken as it left, blurred, for the privacy cover to
+    /// show — see ``PrivacyBackdrop``.
+    ///
+    /// Carried alongside the presentation rather than inside it, because it is
+    /// not part of the decision: ``AppLockPresentation`` is what the app has
+    /// concluded about itself and is compared for equality on every change,
+    /// whereas this is one host's material for drawing one of those cases. The
+    /// root overlay has no capture to offer and passes nothing, which is exactly
+    /// the case ``CoverView`` falls back for.
+    var backdrop: Image?
     let onUnlocked: () -> Void
     let onAttemptFailed: () -> Void
     /// Hands the user to the app's import flow from the recovery screen. The
@@ -89,7 +99,7 @@ struct AppLockHostedScreen: View {
     private var content: some View {
         switch presentation {
         case .uncovered, .cover:
-            CoverView()
+            CoverView(backdrop: backdrop)
         case .gate(let generation):
             EnterPasscodeScreen(
                 onUnlocked: onUnlocked,

--- a/VultisigApp/VultisigApp/Components/CoverView.swift
+++ b/VultisigApp/VultisigApp/Components/CoverView.swift
@@ -37,6 +37,11 @@ struct CoverView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .clipped()
                 .ignoresSafeArea()
+                // A photograph of the screen, not content. VoiceOver reading its
+                // way into a blurred picture of the wallet would be announcing
+                // the very thing this is hiding, and there is nothing here to
+                // act on in any case.
+                .accessibilityHidden(true)
         } else {
             VultisigBrandScreen()
         }

--- a/VultisigApp/VultisigApp/Components/CoverView.swift
+++ b/VultisigApp/VultisigApp/Components/CoverView.swift
@@ -8,11 +8,38 @@
 import SwiftUI
 
 /// What the app shows instead of itself while it is leaving, away, or coming
-/// back. Named for that job; the screen it draws is shared with the splash and
-/// with the lock screen's biometric wait — see ``VultisigBrandScreen``.
+/// back. Named for that job.
+///
+/// Given a picture it draws the app's own screen, blurred past reading — and
+/// that is a decision about the *return* rather than the departure. What the
+/// user sees coming back is the app-switcher card, drawn as they left and zoomed
+/// to full screen by the system: a picture, settled before the app has any say
+/// in it. A card carrying a different screen than the one behind it cannot be
+/// dissolved on the way in, however early the app uncovers — it reads as a cut.
+/// A blurred copy keeps the layout, so the same animation reads as the app
+/// coming into focus. See ``PrivacyBackdrop`` for how it is taken.
+///
+/// Given nothing it draws ``VultisigBrandScreen``, which is every case where no
+/// picture could be had: the Mac, where there is no app switcher zooming a stale
+/// card up and so no transition to solve; the root overlay, which holds no
+/// capture of its own; and a capture that failed. That fallback is the more
+/// concealing of the two, which is the right way round for one.
 struct CoverView: View {
+
+    var backdrop: Image?
+
+    @ViewBuilder
     var body: some View {
-        VultisigBrandScreen()
+        if let backdrop {
+            backdrop
+                .resizable()
+                .scaledToFill()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
+                .ignoresSafeArea()
+        } else {
+            VultisigBrandScreen()
+        }
     }
 }
 

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
@@ -227,6 +227,14 @@ final class AppLockWindowHost: ObservableObject {
         // itself. Only the privacy cover carries it: the gate and the recovery
         // screen are screens in their own right, and a blurred wallet behind
         // either of them would be the wallet on display.
+        //
+        // Capturing while still hidden does not leave the app uncovered for the
+        // duration. This runs to the end of `show` without returning to the run
+        // loop, so no frame is committed between the picture being taken and the
+        // window being raised over it, and a snapshot can only ever be of a
+        // committed frame. Ordering it the other way round would buy nothing and
+        // cost a raise the picture it is being raised to show.
+
         let backdrop = presentation == .cover
             ? contentWindow(in: scene).flatMap(PrivacyBackdrop.picture).map(Image.init(uiImage:))
             : nil

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
@@ -222,6 +222,15 @@ final class AppLockWindowHost: ObservableObject {
         window.alpha = 1
         window.isUserInteractionEnabled = true
 
+        // Taken before this window goes up, and of the app's own window rather
+        // than this one — this one is about to be, or already is, the cover
+        // itself. Only the privacy cover carries it: the gate and the recovery
+        // screen are screens in their own right, and a blurred wallet behind
+        // either of them would be the wallet on display.
+        let backdrop = presentation == .cover
+            ? contentWindow(in: scene).flatMap(PrivacyBackdrop.picture).map(Image.init(uiImage:))
+            : nil
+
         if presentation.isInteractive {
             window.makeKeyAndVisible()
         } else {
@@ -230,10 +239,23 @@ final class AppLockWindowHost: ObservableObject {
 
         window.host.rootView = AppLockHostedScreen(
             presentation: presentation,
+            backdrop: backdrop,
             onUnlocked: onUnlocked,
             onAttemptFailed: onAttemptFailed,
             onRestoreFromBackup: onRestoreFromBackup
         )
+    }
+
+    /// The window the app itself draws into, as opposed to the raised one this
+    /// puts over it.
+    ///
+    /// Level rather than type is what tells them apart, because a sheet is
+    /// presented into the app's own window and so is exactly what a cover has to
+    /// take a picture of. `.normal` is where the app lives; everything raised
+    /// over it — this host's windows, the keyboard — sits above.
+    private func contentWindow(in scene: UIWindowScene) -> UIWindow? {
+        scene.windows.first { $0.isKeyWindow && $0.windowLevel == .normal }
+            ?? scene.windows.first { !($0 is AppLockWindow) && $0.windowLevel == .normal }
     }
 
     private func makeWindow(for scene: UIWindowScene) -> AppLockWindow {

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
@@ -178,6 +178,7 @@ final class AppLockWindowHost: ObservableObject {
             show(
                 scene === elected ? presentation : .cover,
                 in: scene,
+                requested: presentation,
                 onUnlocked: onUnlocked,
                 onAttemptFailed: onAttemptFailed,
                 onRestoreFromBackup: onRestoreFromBackup
@@ -201,9 +202,16 @@ final class AppLockWindowHost: ObservableObject {
     /// over. A new window opens on the brand screen instead, which is exactly
     /// what the lock screen itself draws while that attempt runs, so there is no
     /// seam between the two.
+    /// `requested` is what the *app* concluded; `presentation` is what this
+    /// particular scene gets, which is not always the same thing — only one
+    /// scene may carry an interactive screen, and the rest are covered instead.
+    /// The two must not be confused when deciding what a cover may contain: a
+    /// scene covered *because a gate went up elsewhere* is part of a locked app,
+    /// and a blurred wallet is the last thing it should be showing.
     private func show(
         _ presentation: AppLockPresentation,
         in scene: UIWindowScene,
+        requested: AppLockPresentation,
         onUnlocked: @escaping () -> Void,
         onAttemptFailed: @escaping () -> Void,
         onRestoreFromBackup: @escaping () -> Void
@@ -227,10 +235,14 @@ final class AppLockWindowHost: ObservableObject {
 
         // Read rather than taken here, and shared with the app's own overlay so
         // the two cannot draw different things — see ``PrivacyBackdrop/latest``.
-        // Only the privacy cover carries it: the gate and the recovery screen
-        // are screens in their own right, and a blurred wallet behind either of
-        // them would be the wallet on display.
-        let backdrop = presentation == .cover ? PrivacyBackdrop.latest : nil
+        //
+        // Gated on what the app asked for, not on what this scene got. Only a
+        // privacy cover may carry a picture of the app: the gate and the
+        // recovery screen are screens in their own right, and the scenes covered
+        // *alongside* one of them belong to an app that is locked. Reading the
+        // per-scene value here put a blurred wallet on every non-elected scene
+        // of a gated iPad.
+        let backdrop = requested == .cover ? PrivacyBackdrop.latest : nil
 
         if presentation.isInteractive {
             window.makeKeyAndVisible()

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/AppLockWindowHost.swift
@@ -102,6 +102,9 @@ final class AppLockWindowHost: ObservableObject {
             lower(animated: current.isGate)
             current = .uncovered
             callbacks = nil
+            // The photograph of the wallet outlives nothing: there is no longer
+            // anything to cover, and the next departure takes a fresh one.
+            PrivacyBackdrop.discard()
             return
         }
 
@@ -222,22 +225,12 @@ final class AppLockWindowHost: ObservableObject {
         window.alpha = 1
         window.isUserInteractionEnabled = true
 
-        // Taken before this window goes up, and of the app's own window rather
-        // than this one — this one is about to be, or already is, the cover
-        // itself. Only the privacy cover carries it: the gate and the recovery
-        // screen are screens in their own right, and a blurred wallet behind
-        // either of them would be the wallet on display.
-        //
-        // Capturing while still hidden does not leave the app uncovered for the
-        // duration. This runs to the end of `show` without returning to the run
-        // loop, so no frame is committed between the picture being taken and the
-        // window being raised over it, and a snapshot can only ever be of a
-        // committed frame. Ordering it the other way round would buy nothing and
-        // cost a raise the picture it is being raised to show.
-
-        let backdrop = presentation == .cover
-            ? contentWindow(in: scene).flatMap(PrivacyBackdrop.picture).map(Image.init(uiImage:))
-            : nil
+        // Read rather than taken here, and shared with the app's own overlay so
+        // the two cannot draw different things — see ``PrivacyBackdrop/latest``.
+        // Only the privacy cover carries it: the gate and the recovery screen
+        // are screens in their own right, and a blurred wallet behind either of
+        // them would be the wallet on display.
+        let backdrop = presentation == .cover ? PrivacyBackdrop.latest : nil
 
         if presentation.isInteractive {
             window.makeKeyAndVisible()
@@ -252,18 +245,6 @@ final class AppLockWindowHost: ObservableObject {
             onAttemptFailed: onAttemptFailed,
             onRestoreFromBackup: onRestoreFromBackup
         )
-    }
-
-    /// The window the app itself draws into, as opposed to the raised one this
-    /// puts over it.
-    ///
-    /// Level rather than type is what tells them apart, because a sheet is
-    /// presented into the app's own window and so is exactly what a cover has to
-    /// take a picture of. `.normal` is where the app lives; everything raised
-    /// over it — this host's windows, the keyboard — sits above.
-    private func contentWindow(in scene: UIWindowScene) -> UIWindow? {
-        scene.windows.first { $0.isKeyWindow && $0.windowLevel == .normal }
-            ?? scene.windows.first { !($0 is AppLockWindow) && $0.windowLevel == .normal }
     }
 
     private func makeWindow(for scene: UIWindowScene) -> AppLockWindow {

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
@@ -30,11 +30,10 @@ enum PrivacyBackdrop {
     /// How much of the screen's resolution survives the capture.
     ///
     /// Low enough that a balance is a smudge before a blur is applied at all,
-    /// which is what makes this cheap enough to run on the way out: the render is
-    /// a small fraction of the screen's pixels. The gaussian pass afterwards is
-    /// for smoothness — it takes the stair-stepping off the upscale — and not for
-    /// the hiding, so that no part of the privacy rests on a filter that might
-    /// fail.
+    /// which is also what makes this cheap enough to run on the way out: the
+    /// render is a small fraction of the screen's pixels. The two steps are
+    /// belt and braces rather than a division of labour — neither is trusted
+    /// alone, and if either fails there is no picture at all.
     private static let captureScale: CGFloat = 0.12
     /// Applied to the *downscaled* picture, so it goes a long way: at an eighth
     /// of the resolution this is worth eight times as much as it would be at
@@ -64,7 +63,18 @@ enum PrivacyBackdrop {
             window.drawHierarchy(in: bounds, afterScreenUpdates: false)
         }
 
-        guard let source = CIImage(image: small) else { return small }
+        // Nothing partial is ever returned. A failure here answers `nil` and
+        // ``CoverView`` shows the brand screen instead, which conceals more than
+        // this ever does.
+        //
+        // The downscaled picture on its own is *not* the fallback, tempting as it
+        // is to treat "too small to read" as good enough. It is not a
+        // confidentiality boundary: a balance set in a display face, and a
+        // receive-address QR at iPad size, both survive an eighth-scale
+        // reduction better than intuition suggests, and this picture is what
+        // becomes the app-switcher card — the one artefact here that outlives
+        // the moment.
+        guard let source = CIImage(image: small) else { return nil }
         // Clamped first, or the blur samples transparent black from beyond the
         // edges and leaves a dark vignette all the way round.
         let blurred = source
@@ -72,11 +82,7 @@ enum PrivacyBackdrop {
             .applyingGaussianBlur(sigma: blurSigma)
             .cropped(to: source.extent)
 
-        guard let rendered = context.createCGImage(blurred, from: blurred.extent) else {
-            // The downscale alone already hid everything; a failed filter is a
-            // rougher cover, not a leaking one.
-            return small
-        }
+        guard let rendered = context.createCGImage(blurred, from: blurred.extent) else { return nil }
         return UIImage(cgImage: rendered)
     }
 }

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
@@ -5,6 +5,7 @@
 
 #if os(iOS)
 import CoreImage
+import SwiftUI
 import UIKit
 
 /// A picture of the app blurred past reading — what the privacy cover shows over
@@ -43,6 +44,41 @@ enum PrivacyBackdrop {
     private static let blurSigma: Double = 1.6
 
     private static let context = CIContext(options: [.useSoftwareRenderer: false])
+
+    /// The picture the cover is currently showing, or `nil` when there is none
+    /// and ``CoverView`` should fall back to the brand screen.
+    ///
+    /// Shared state rather than each host taking its own, because the app draws
+    /// the cover in two places — its own overlay and the raised window — and the
+    /// two must not be able to draw *different things*. They could: the overlay
+    /// renders in the same pass that raises the cover, while the window is put up
+    /// afterwards and, the first time, has a whole `UIWindow` to build and lay
+    /// out first. With a picture each, the overlay's brand-screen fallback landed
+    /// first and the window's blur replaced it a frame or two later — a logo
+    /// flashing over the wallet on the way out, which is precisely what the blur
+    /// exists to stop.
+    private(set) static var latest: Image?
+
+    /// Takes the picture, **before** the cover goes up.
+    ///
+    /// The ordering is the whole point and it is not an optimisation: the first
+    /// frame in which anything is covered must already have this to draw, or the
+    /// fallback shows for that frame and the flash is back. Called from the
+    /// scene-phase hook, one step ahead of the flag.
+    ///
+    /// Answers `nil` on any failure, which is the safe direction: no picture
+    /// means the brand screen, in both hosts at once.
+    static func take() {
+        latest = UIApplication.shared.activeContentWindow
+            .flatMap(picture(of:))
+            .map(Image.init(uiImage:))
+    }
+
+    /// Dropped as soon as the app is uncovered — this is a photograph of a
+    /// wallet, and nothing needs it once there is nothing to cover.
+    static func discard() {
+        latest = nil
+    }
 
     static func picture(of window: UIWindow) -> UIImage? {
         let bounds = window.bounds

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
@@ -1,0 +1,83 @@
+//
+//  PrivacyBackdrop.swift
+//  VultisigApp
+//
+
+#if os(iOS)
+import CoreImage
+import UIKit
+
+/// A picture of the app blurred past reading — what the privacy cover shows over
+/// the app while it is away.
+///
+/// It exists for the *return*, not the departure. What the user sees coming back
+/// is the app-switcher card, drawn as they left and zoomed to full screen by the
+/// system: a picture, settled before the app has any say in it. A card carrying a
+/// different screen than the one behind it cannot be dissolved on the way in,
+/// however early the app uncovers — it reads as a cut. A blurred copy of the
+/// screen keeps the layout, so the same animation reads as the app coming into
+/// focus.
+///
+/// A captured bitmap rather than a `UIVisualEffectView`, and that is not a
+/// preference. A visual-effect view samples the backdrop *of its own window*, and
+/// the cover is carried in a window raised above the app's precisely so that it
+/// covers sheets and alerts too. There is nothing behind it there to sample: it
+/// paints its material over an empty backdrop and comes out a flat slab, with the
+/// layout — the whole reason for blurring the screen rather than replacing it —
+/// gone. That was measured, not assumed.
+enum PrivacyBackdrop {
+
+    /// How much of the screen's resolution survives the capture.
+    ///
+    /// Low enough that a balance is a smudge before a blur is applied at all,
+    /// which is what makes this cheap enough to run on the way out: the render is
+    /// a small fraction of the screen's pixels. The gaussian pass afterwards is
+    /// for smoothness — it takes the stair-stepping off the upscale — and not for
+    /// the hiding, so that no part of the privacy rests on a filter that might
+    /// fail.
+    private static let captureScale: CGFloat = 0.12
+    /// Applied to the *downscaled* picture, so it goes a long way: at an eighth
+    /// of the resolution this is worth eight times as much as it would be at
+    /// full size. Enough to take the stair-stepping off the upscale, and no more
+    /// — past that the cards and rows dissolve into a wash, and a wash is the
+    /// scene change the blur exists to avoid.
+    private static let blurSigma: Double = 1.6
+
+    private static let context = CIContext(options: [.useSoftwareRenderer: false])
+
+    static func picture(of window: UIWindow) -> UIImage? {
+        let bounds = window.bounds
+        guard bounds.width > 0, bounds.height > 0 else { return nil }
+
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.scale = captureScale
+        format.opaque = true
+
+        let small = UIGraphicsImageRenderer(bounds: bounds, format: format).image { _ in
+            // `afterScreenUpdates: false`, and it is load bearing. The cover this
+            // picture is *for* has just been raised, so the app's own overlay copy
+            // of it is already pending in this very hierarchy; waiting for the
+            // screen to update would capture that logo instead of the wallet the
+            // card is supposed to show. Drawing what is currently on screen takes
+            // the frame from before the cover, which is the one wanted — and costs
+            // no render pass on the way out.
+            window.drawHierarchy(in: bounds, afterScreenUpdates: false)
+        }
+
+        guard let source = CIImage(image: small) else { return small }
+        // Clamped first, or the blur samples transparent black from beyond the
+        // edges and leaves a dark vignette all the way round.
+        let blurred = source
+            .clampedToExtent()
+            .applyingGaussianBlur(sigma: blurSigma)
+            .cropped(to: source.extent)
+
+        guard let rendered = context.createCGImage(blurred, from: blurred.extent) else {
+            // The downscale alone already hid everything; a failed filter is a
+            // rougher cover, not a leaking one.
+            return small
+        }
+        return UIImage(cgImage: rendered)
+    }
+}
+#endif

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
@@ -26,6 +26,7 @@ import UIKit
 /// paints its material over an empty backdrop and comes out a flat slab, with the
 /// layout — the whole reason for blurring the screen rather than replacing it —
 /// gone. That was measured, not assumed.
+@MainActor
 enum PrivacyBackdrop {
 
     /// How much of the screen's resolution survives the capture.
@@ -69,7 +70,14 @@ enum PrivacyBackdrop {
     /// Answers `nil` on any failure, which is the safe direction: no picture
     /// means the brand screen, in both hosts at once.
     static func take() {
-        latest = UIApplication.shared.activeContentWindow
+        // `activeContentWindow` answers the key window at `.normal`, and this
+        // host's windows sit at `.alert + 1`, so one cannot be returned here
+        // today. Asserted anyway rather than relied upon: a cover that
+        // photographed *itself* would blur a blur, once per departure, until
+        // there was nothing left of the screen — and the level is a constant in
+        // another file that nothing stops anyone changing.
+        let content = UIApplication.shared.activeContentWindow
+        latest = (content is AppLockWindow ? nil : content)
             .flatMap(picture(of:))
             .map(Image.init(uiImage:))
     }

--- a/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
+++ b/VultisigApp/VultisigApp/Core/Platform/iOS/Native/PrivacyBackdrop.swift
@@ -70,16 +70,32 @@ enum PrivacyBackdrop {
     /// Answers `nil` on any failure, which is the safe direction: no picture
     /// means the brand screen, in both hosts at once.
     static func take() {
-        // `activeContentWindow` answers the key window at `.normal`, and this
-        // host's windows sit at `.alert + 1`, so one cannot be returned here
-        // today. Asserted anyway rather than relied upon: a cover that
-        // photographed *itself* would blur a blur, once per departure, until
-        // there was nothing left of the screen — and the level is a constant in
-        // another file that nothing stops anyone changing.
-        let content = UIApplication.shared.activeContentWindow
-        latest = (content is AppLockWindow ? nil : content)
-            .flatMap(picture(of:))
-            .map(Image.init(uiImage:))
+        latest = contentWindow.flatMap(picture(of:)).map(Image.init(uiImage:))
+    }
+
+    /// The window the app draws itself into, found without requiring the scene
+    /// to be *active*.
+    ///
+    /// Deliberately not `UIApplication.activeContentWindow`, and this is the
+    /// whole reason the lookup is written out here: that one keeps only scenes
+    /// at `.foregroundActive`, and by the moment the app knows it is leaving the
+    /// scene has already moved to `.foregroundInactive`. Asking it for a window
+    /// here answers `nil` on every single departure, which does not fail loudly
+    /// — it quietly leaves the cover with no picture and falls back to the brand
+    /// screen, i.e. removes the blur entirely while every test still passes.
+    ///
+    /// `AppLockWindow` is excluded by type as well as by level. It cannot match
+    /// `.normal` today, but a cover that photographed itself would blur a blur
+    /// once per departure until nothing of the screen was left, and the level
+    /// that prevents it is a constant in another file.
+    private static var contentWindow: UIWindow? {
+        let windows = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .filter { $0.activationState != .unattached }
+            .flatMap(\.windows)
+            .filter { !($0 is AppLockWindow) && $0.windowLevel == .normal }
+
+        return windows.first(where: \.isKeyWindow) ?? windows.first
     }
 
     /// Dropped as soon as the app is uncovered — this is a photograph of a

--- a/VultisigApp/VultisigApp/Core/Security/AppLock/AppLockService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/AppLock/AppLockService.swift
@@ -70,6 +70,94 @@ final class AppLockService {
         mode != .off
     }
 
+    // MARK: - The app's own system prompts
+
+    /// How many system authentication prompts the app itself currently has on
+    /// screen.
+    ///
+    /// Main-thread only, and not persisted: it describes what is on the display
+    /// right now, and a launch has none of them up by definition.
+    private var systemAuthPromptCount = 0
+    /// Bumped whenever the count is dropped wholesale, so that a completion
+    /// belonging to a prompt from before the drop cannot decrement a prompt
+    /// raised after it.
+    ///
+    /// Without it the pairing is by count alone, and a count cannot tell whose
+    /// completion it is: a prompt outstanding when the app backgrounds has its
+    /// completion delivered *later*, by which time ``forgetSystemAuthPrompts()``
+    /// has reset everything and the user may have raised a new one. The stale
+    /// completion would decrement the new prompt's count to zero and the cover
+    /// would go up over it — the exact flash this exists to prevent, arriving by
+    /// the back door.
+    private var systemAuthPromptGeneration = 0
+
+    /// A prompt's claim on the count, handed out by ``beginSystemAuthPrompt()``
+    /// and spent by ``endSystemAuthPrompt(_:)``.
+    ///
+    /// Opaque on purpose: the only correct thing a caller can do with it is give
+    /// it back exactly once, so it carries nothing else.
+    struct SystemAuthPromptTicket {
+        fileprivate let generation: Int
+    }
+
+    /// Whether an `.inactive` arriving now is one the app caused by raising a
+    /// prompt, rather than the app going anywhere.
+    ///
+    /// The privacy cover goes up on `.inactive`, which is right for a departure
+    /// and wrong for this: a `LAContext` prompt makes the app inactive without
+    /// it leaving, and covering there paints the logo over the very screen the
+    /// user is authenticating *for* — on the fast-signing path, a cover
+    /// appearing between Verify and Signing, over a Face ID sheet the app raised
+    /// itself.
+    ///
+    /// It is the same distinction `AppViewModel`'s `didBackgroundSinceForeground`
+    /// draws for the re-lock half of this family — an activation that followed
+    /// no departure is not a return — reaching the cover half, which that flag
+    /// never covered.
+    ///
+    /// This is deliberately **not** consulted for a real backgrounding. That
+    /// arrives as `.background`, where the cover goes up unconditionally.
+    var isPresentingSystemAuthPrompt: Bool {
+        systemAuthPromptCount > 0
+    }
+
+    /// Called immediately before a prompt is raised rather than after, because
+    /// the `.inactive` it causes can arrive before the call that raised it has
+    /// returned.
+    ///
+    /// A count rather than a flag because prompts can overlap, and because a
+    /// balanced pair is the most a caller can honestly promise.
+    func beginSystemAuthPrompt() -> SystemAuthPromptTicket {
+        systemAuthPromptCount += 1
+        return SystemAuthPromptTicket(generation: systemAuthPromptGeneration)
+    }
+
+    /// The other half, required on **every** path out of a prompt — success,
+    /// failure and cancellation alike. A prompt the user dismissed is still a
+    /// prompt that is gone.
+    ///
+    /// A ticket from before the last ``forgetSystemAuthPrompts()`` is spent
+    /// silently: the prompt it belonged to was already accounted for when the
+    /// app left, and the count it would decrement now belongs to somebody else.
+    func endSystemAuthPrompt(_ ticket: SystemAuthPromptTicket) {
+        guard ticket.generation == systemAuthPromptGeneration else { return }
+        systemAuthPromptCount = max(0, systemAuthPromptCount - 1)
+    }
+
+    /// Drops the count on the floor, for the one caller that knows better than
+    /// it does: a real backgrounding took the app and every prompt over it away
+    /// together.
+    ///
+    /// Balanced calls are never trusted to be balanced. A completion that never
+    /// arrives would otherwise leave the app permanently uncoverable, which is
+    /// the one failure this must not have — and every ticket outstanding at this
+    /// moment is invalidated with the count, so the completions that *do* arrive
+    /// late cannot spend themselves against whatever comes next.
+    func forgetSystemAuthPrompts() {
+        systemAuthPromptCount = 0
+        systemAuthPromptGeneration &+= 1
+    }
+
     // MARK: - Scene transitions
 
     /// Records that the app left the foreground.

--- a/VultisigApp/VultisigApp/Core/Security/Biometry/BiometryService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Biometry/BiometryService.swift
@@ -12,20 +12,56 @@ struct BiometryService {
 
     static let shared = BiometryService()
 
+    /// Held so the privacy cover can tell a prompt this raised from the app
+    /// actually leaving — see ``AppLockService/isPresentingSystemAuthPrompt``.
+    private let lockService: AppLockService
+    /// Injected so a test can reach the one branch that matters here.
+    ///
+    /// The prompting path is unreachable in a simulator by construction —
+    /// ``isRunningOnPhysicalDevice()`` is false there and the call short-circuits
+    /// to success — so without a seam the bracketing around the prompt, which is
+    /// the whole point of this type knowing about the lock service at all, is
+    /// exactly the part no test can run.
+    private let makeContext: () -> LAContext
+    private let isPhysicalDevice: () -> Bool
+
+    init(
+        lockService: AppLockService = .shared,
+        makeContext: @escaping () -> LAContext = { LAContext() },
+        isPhysicalDevice: @escaping () -> Bool = { BiometryService.runningOnPhysicalDevice }
+    ) {
+        self.lockService = lockService
+        self.makeContext = makeContext
+        self.isPhysicalDevice = isPhysicalDevice
+    }
+
     func authenticate(
         reason: String,
         onSuccess: @escaping () -> Void,
         onError: ((Error) -> Void)?
     ) {
-        let context = LAContext()
+        let context = makeContext()
         var error: NSError?
 
         if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-            if isRunningOnPhysicalDevice() {
+            if isPhysicalDevice() {
                 switch context.biometryType {
                 case .touchID, .faceID, .opticID:
+                    // Bracketed around the prompt, and only around the branch
+                    // that actually raises one — the app is about to be made
+                    // inactive by its own sheet, and the privacy cover must not
+                    // read that as the app leaving. See
+                    // ``AppLockService/isPresentingSystemAuthPrompt``.
+                    //
+                    // Before `evaluatePolicy` rather than after: the `.inactive`
+                    // can arrive before that call returns.
+                    let ticket = lockService.beginSystemAuthPrompt()
                     context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, error in
                         DispatchQueue.main.async {
+                            // First, and outside the branches below: a cancelled
+                            // prompt is as gone as a successful one, and either
+                            // way the app is about to be told it is active again.
+                            lockService.endSystemAuthPrompt(ticket)
                             if let error, !success {
                                 onError?(error)
                             } else if success {
@@ -51,8 +87,11 @@ private extension BiometryService {
         case cantEvaluatePolicy
         case wrongBiometryType
     }
+}
 
-    func isRunningOnPhysicalDevice() -> Bool {
+extension BiometryService {
+
+    static var runningOnPhysicalDevice: Bool {
         #if targetEnvironment(simulator)
         return false
         #else

--- a/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
@@ -305,6 +305,12 @@ class AppViewModel: ObservableObject {
         // down again before it finished arriving — is a foreground that never
         // happened. The next one is entitled to its own decision.
         didEvaluateForeground = false
+        // Whatever the app believed about its own prompts, it has now actually
+        // left, and anything the system was showing over it went with it. This
+        // is what keeps an unbalanced count from outliving the moment it
+        // described — the cover above is raised first and unconditionally, so
+        // forgetting them can never uncover anything.
+        lockService.forgetSystemAuthPrompts()
         lockService.noteBackgrounded()
     }
 
@@ -321,7 +327,18 @@ class AppViewModel: ObservableObject {
     /// `noteBackgrounded()` starts the auto-lock clock, and starting it because
     /// somebody glanced at Control Centre would re-lock people who never left
     /// the app.
+    ///
+    /// The exception is an `.inactive` the app *caused*, by putting a system
+    /// authentication prompt up itself. Covering there hides the screen the user
+    /// is authenticating for behind the logo, which on the fast-signing path is
+    /// a cover appearing between Verify and Signing. Nothing has gone anywhere
+    /// and nobody else can see the screen: the person the cover would be hiding
+    /// it from is the one looking at the prompt. See
+    /// ``AppLockService/isPresentingSystemAuthPrompt`` — and note that a genuine
+    /// departure during a prompt still covers, because that arrives as
+    /// `.background` and ``revokeAuth()`` does not consult it at all.
     func coverForPrivacy() {
+        guard !lockService.isPresentingSystemAuthPrompt else { return }
         showCover = true
     }
 

--- a/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
@@ -126,6 +126,22 @@ class AppViewModel: ObservableObject {
     /// rebuilt the lock screen, which raised the sheet again. Requiring a real
     /// backgrounding is the fix for the whole family, not just the one case.
     private var didBackgroundSinceForeground = false
+    /// Whether the return currently under way has already been evaluated.
+    ///
+    /// A return crosses two phases — `.inactive` as the zoom begins, `.active`
+    /// when it ends — and ``enableAuth()`` is answered at the first of them.
+    /// Letting the second run it again would not be a harmless repeat: the first
+    /// consumes ``didBackgroundSinceForeground``, so the second reads the lock
+    /// state afresh but can no longer act on most of what it finds. A
+    /// `disablePasscode` completing in the third of a second between them would
+    /// be read as "no gate required", lower the gate the first call raised, and
+    /// then skip the device-auth fallback that is supposed to replace it —
+    /// leaving the app open behind neither.
+    ///
+    /// One foreground, one decision, every branch acting on that one answer. It
+    /// is the same rule ``enableAuth()`` keeps internally, extended to the pair
+    /// of phases the decision now spans.
+    private var didEvaluateForeground = false
 
     init(
         lockService: AppLockService = .shared,
@@ -285,6 +301,10 @@ class AppViewModel: ObservableObject {
         showCover = true
         didTriggerAuthThisSession = false
         didBackgroundSinceForeground = true
+        // A return that began and then turned back — the app was tapped and put
+        // down again before it finished arriving — is a foreground that never
+        // happened. The next one is entitled to its own decision.
+        didEvaluateForeground = false
         lockService.noteBackgrounded()
     }
 
@@ -303,6 +323,55 @@ class AppViewModel: ObservableObject {
     /// the app.
     func coverForPrivacy() {
         showCover = true
+    }
+
+    /// Routes the one phase that means two opposite things.
+    ///
+    /// `.inactive` is the app leaving *and* the app coming back. It is what the
+    /// system reports as the app-switcher snapshot is taken, and it is also what
+    /// it reports the instant a return begins — a good third of a second before
+    /// `.active` arrives at the end of the zoom. Nothing in the phase itself
+    /// tells the two apart; only where it came from does.
+    ///
+    /// Both used to cover, and the return is why the app came forward oddly: the
+    /// cover stayed up for the whole of the zoom and the wallet replaced it in a
+    /// jump at the end, having been absent from the transition it was the
+    /// destination of. Handing the return to ``enableAuth()`` here instead means
+    /// the animation shows what the user is coming back to — the wallet, or the
+    /// lock screen when the interval says it is time for one, since that is the
+    /// same call that decides it and it raises the gate before it drops the
+    /// cover. Nothing about the departure changes: the picture the app switcher
+    /// keeps is still taken over the logo.
+    /// What is given up for it is a window the width of an abandoned launch: the
+    /// app is uncovered from here, so tapping the icon and putting the phone down
+    /// again before the zoom finishes renders the wallet for those frames. The
+    /// app reaches `.background` on that path like any other departure, and
+    /// `revokeAuth()` covers it there — which is before the snapshot that
+    /// actually outlives the moment is taken. What is bought with it is every
+    /// ordinary return, of which there are thousands.
+    func sceneBecameInactive(comingFrom previousPhase: ScenePhase) {
+        guard previousPhase == .background else {
+            coverForPrivacy()
+            return
+        }
+        didEvaluateForeground = true
+        enableAuth()
+    }
+
+    /// The end of the return, and by then usually nothing is left to do.
+    ///
+    /// `.active` is the only foreground signal an activation that never left
+    /// gets — a Control Centre pull, an incoming call, a biometric sheet — so it
+    /// still asks. A real return has already been answered a third of a second
+    /// ago at `.inactive`, and asking again would be a second reading of the lock
+    /// state that can only act on part of what it sees; see
+    /// ``didEvaluateForeground``.
+    func sceneBecameActive() {
+        guard !didEvaluateForeground else {
+            didEvaluateForeground = false
+            return
+        }
+        enableAuth()
     }
 
     /// Engages the passcode lock: forgets the data key, then raises the overlay.

--- a/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
@@ -473,6 +473,32 @@ final class PasscodeGateWiringTests: XCTestCase {
         )
     }
 
+    /// A return that began and then turned back — the app tapped and put down
+    /// again before it finished arriving — must not spend the *next* return's
+    /// decision. The marker is cleared by leaving, so the activation that
+    /// follows a second departure decides afresh.
+    func testAnAbandonedReturnDoesNotSpendTheNextOnesDecision() async throws {
+        try await service.setPasscode(passcode)
+        lockService.autoLockInterval = .immediate
+
+        let sut = makeViewModel()
+        sut.revokeAuth()
+        sut.sceneBecameInactive(comingFrom: .background)
+        _ = try await service.unlock(with: passcode)
+        sut.markPasscodeUnlocked()
+        XCTAssertFalse(sut.isPasscodeLocked, "precondition: the return unlocked the app")
+
+        // The app turns round and leaves again without ever reaching `.active`.
+        sut.revokeAuth()
+
+        sut.sceneBecameActive()
+
+        XCTAssertTrue(
+            sut.isPasscodeLocked,
+            "the second departure is a new foreground to decide, not the first one's leftovers"
+        )
+    }
+
     // MARK: - A foreground that lands mid-unlock
 
     /// The Face ID loop. A biometric prompt drives the app `.inactive` and then

--- a/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
@@ -5,6 +5,7 @@
 
 import Combine
 import CryptoKit
+import LocalAuthentication
 import Security
 import SwiftData
 import SwiftUI
@@ -363,6 +364,185 @@ final class PasscodeGateWiringTests: XCTestCase {
             defaults.string(forKey: "lastRecordedTime"),
             "covering is not leaving; the interval must not start here"
         )
+    }
+
+    /// The app's own Face ID sheet makes it `.inactive` without it going
+    /// anywhere, and covering there puts the logo over the screen the user is
+    /// authenticating *for* — on the fast-signing path, a cover between Verify
+    /// and Signing.
+    func testAPromptTheAppRaisedItselfDoesNotCover() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        _ = lockService.beginSystemAuthPrompt()
+        sut.coverForPrivacy()
+
+        XCTAssertFalse(sut.showCover, "nothing has left; the prompt is the app's own")
+    }
+
+    /// And the suppression lasts exactly as long as the prompt does, so the very
+    /// next departure covers normally.
+    func testCoveringResumesOnceThePromptIsGone() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        let ticket = lockService.beginSystemAuthPrompt()
+        lockService.endSystemAuthPrompt(ticket)
+        sut.coverForPrivacy()
+
+        XCTAssertTrue(sut.showCover)
+    }
+
+    /// Overlapping prompts must not have the first one to finish uncover the
+    /// app while the second is still on screen.
+    func testCoveringStaysSuppressedWhileASecondPromptIsStillUp() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        let first = lockService.beginSystemAuthPrompt()
+        _ = lockService.beginSystemAuthPrompt()
+        lockService.endSystemAuthPrompt(first)
+        sut.coverForPrivacy()
+
+        XCTAssertFalse(sut.showCover)
+    }
+
+    /// The safety property, and the one that makes the suppression affordable: a
+    /// real departure covers whatever the app believes about its own prompts.
+    /// Leaving arrives as `.background`, which does not consult them at all —
+    /// so a prompt whose completion never came cannot leave the wallet on
+    /// display in the app switcher.
+    func testARealBackgroundingCoversEvenWithAPromptOutstanding() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        _ = lockService.beginSystemAuthPrompt()
+        sut.revokeAuth()
+
+        XCTAssertTrue(sut.showCover, "leaving covers; the prompt went with the app")
+        XCTAssertFalse(
+            lockService.isPresentingSystemAuthPrompt,
+            "and the stale count is forgotten, or the next departure would not cover either"
+        )
+    }
+
+    /// A prompt outstanding when the app leaves has its completion delivered
+    /// later — by which time the count has been dropped and the user may have
+    /// raised a new prompt. Paired by count alone, that stale completion would
+    /// decrement the *new* prompt's claim and let the cover go up over it.
+    func testAStaleCompletionCannotEndAPromptRaisedAfterIt() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        let leftBehind = lockService.beginSystemAuthPrompt()
+        sut.revokeAuth()
+        sut.showCover = false
+
+        let fresh = lockService.beginSystemAuthPrompt()
+        lockService.endSystemAuthPrompt(leftBehind)
+        sut.coverForPrivacy()
+
+        XCTAssertFalse(
+            sut.showCover,
+            "the late completion belonged to a prompt that is already gone"
+        )
+
+        // The other half, and it is what stops the guard being "ignore every end
+        // after a backgrounding": that would pass the assertion above and leave
+        // the app permanently uncoverable instead, which is the worse failure of
+        // the two.
+        lockService.endSystemAuthPrompt(fresh)
+        sut.coverForPrivacy()
+
+        XCTAssertTrue(sut.showCover, "the current prompt's own ticket still ends it")
+    }
+
+    // MARK: - Bracketing the real prompt
+
+    /// The tests above drive `AppLockService` directly, so every one of them
+    /// would still pass if `BiometryService` bracketed nothing at all — and the
+    /// bracketing is the fix. These two run the service itself.
+    ///
+    /// The prompting branch is unreachable in a simulator by construction, which
+    /// is exactly why the seam exists.
+    func testRaisingAPromptMarksItBeforeTheSheetGoesUp() {
+        var reply: ((Bool, Error?) -> Void)?
+        var markedWhenTheSheetWentUp: Bool?
+        let service = BiometryService(
+            lockService: lockService,
+            makeContext: { [lockService] in
+                StubLAContext(biometry: .faceID, canEvaluate: true) { captured in
+                    // Read *inside* `evaluatePolicy`, not after `authenticate`
+                    // returns. On a device the `.inactive` the sheet causes
+                    // arrives during this call, so a claim staked afterwards is
+                    // staked too late — and asserting only at the end would let
+                    // that reordering pass.
+                    markedWhenTheSheetWentUp = lockService?.isPresentingSystemAuthPrompt
+                    reply = captured
+                }
+            },
+            isPhysicalDevice: { true }
+        )
+        let finished = expectation(description: "prompt resolved")
+
+        service.authenticate(reason: "test", onSuccess: { finished.fulfill() }, onError: nil)
+
+        XCTAssertEqual(markedWhenTheSheetWentUp, true, "claimed before the sheet, not after")
+
+        reply?(true, nil)
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt, "and released when it resolves")
+    }
+
+    /// The release must not live in the success branch. A prompt the user
+    /// cancelled is as gone as one they satisfied, and a claim left behind by
+    /// the cancel path would leave the app uncoverable for the rest of the
+    /// session.
+    func testACancelledPromptIsReleasedToo() {
+        var reply: ((Bool, Error?) -> Void)?
+        let service = BiometryService(
+            lockService: lockService,
+            makeContext: { StubLAContext(biometry: .faceID, canEvaluate: true) { reply = $0 } },
+            isPhysicalDevice: { true }
+        )
+        let failed = expectation(description: "error delivered")
+
+        service.authenticate(reason: "test", onSuccess: {}, onError: { _ in failed.fulfill() })
+        XCTAssertTrue(lockService.isPresentingSystemAuthPrompt, "precondition: the prompt is up")
+
+        reply?(false, LAError(.userCancel))
+        wait(for: [failed], timeout: 1)
+
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt)
+    }
+
+    /// The branches that never raise a prompt must never claim one either, or
+    /// the first one taken would leave the app uncoverable for the session.
+    func testTheBranchesThatRaiseNoPromptClaimNothing() {
+        let cannotEvaluate = BiometryService(
+            lockService: lockService,
+            makeContext: { StubLAContext(biometry: .faceID, canEvaluate: false) { _ in } },
+            isPhysicalDevice: { true }
+        )
+        cannotEvaluate.authenticate(reason: "test", onSuccess: {}, onError: { _ in })
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt)
+
+        let noBiometry = BiometryService(
+            lockService: lockService,
+            makeContext: { StubLAContext(biometry: .none, canEvaluate: true) { _ in } },
+            isPhysicalDevice: { true }
+        )
+        noBiometry.authenticate(reason: "test", onSuccess: {}, onError: { _ in })
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt)
+
+        let simulator = BiometryService(
+            lockService: lockService,
+            makeContext: { StubLAContext(biometry: .faceID, canEvaluate: true) { _ in } },
+            isPhysicalDevice: { false }
+        )
+        simulator.authenticate(reason: "test", onSuccess: {}, onError: { _ in })
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt)
     }
 
     /// The other half, so the pair is not just "cover does nothing": a real
@@ -779,4 +959,43 @@ private final class InMemoryBiometricKeychain: BiometricKeychainProtecting {
     func delete(account _: String) throws { stored = nil }
 
     func exists(account _: String) -> Bool { stored != nil }
+}
+
+/// An `LAContext` that answers however a test needs and hands the reply block
+/// back instead of raising anything.
+///
+/// A subclass rather than a protocol, because `BiometryService` is bracketing a
+/// real system prompt and the seam has to be the smallest thing that makes that
+/// branch reachable — anything wider would be testing a different shape of code
+/// than the one that ships.
+private final class StubLAContext: LAContext {
+
+    private let biometry: LABiometryType
+    private let canEvaluate: Bool
+    private let capture: (@escaping (Bool, Error?) -> Void) -> Void
+
+    init(
+        biometry: LABiometryType,
+        canEvaluate: Bool,
+        capture: @escaping (@escaping (Bool, Error?) -> Void) -> Void
+    ) {
+        self.biometry = biometry
+        self.canEvaluate = canEvaluate
+        self.capture = capture
+        super.init()
+    }
+
+    override var biometryType: LABiometryType { biometry }
+
+    override func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
+        canEvaluate
+    }
+
+    override func evaluatePolicy(
+        _ policy: LAPolicy,
+        localizedReason: String,
+        reply: @escaping (Bool, Error?) -> Void
+    ) {
+        capture(reply)
+    }
 }

--- a/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
@@ -3,9 +3,11 @@
 //  VultisigAppTests
 //
 
+import Combine
 import CryptoKit
 import Security
 import SwiftData
+import SwiftUI
 import XCTest
 @testable import VultisigApp
 
@@ -374,6 +376,101 @@ final class PasscodeGateWiringTests: XCTestCase {
 
         XCTAssertTrue(sut.showCover)
         XCTAssertNotNil(defaults.string(forKey: "lastRecordedTime"))
+    }
+
+    /// The departure. `.inactive` reached from `.active` is the app on its way
+    /// out — a swipe to the switcher, a Control Centre pull — and the snapshot is
+    /// taken there, so it still covers.
+    func testAnInactiveOnTheWayOutCovers() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        sut.sceneBecameInactive(comingFrom: .active)
+
+        XCTAssertTrue(sut.showCover)
+    }
+
+    /// The return, and the reason the pair exists. `.inactive` reached from
+    /// `.background` is the start of the zoom back in, not a departure: covering
+    /// again there is what kept the logo on screen for the whole animation and
+    /// made the wallet arrive as a jump at the end of it.
+    func testAnInactiveOnTheWayBackUncovers() {
+        let sut = makeViewModel()
+        sut.revokeAuth()
+        XCTAssertTrue(sut.showCover, "precondition: leaving covered the app")
+
+        sut.sceneBecameInactive(comingFrom: .background)
+
+        XCTAssertFalse(sut.showCover)
+    }
+
+    /// Uncovering early must not be *opening* early. When the interval says
+    /// relock, the return has to hand the animation a lock screen rather than the
+    /// wallet — which is the same order `enableAuth()` keeps at `.active`, moved
+    /// to the moment the user can first see through it.
+    ///
+    /// The order is what is asserted, not the end state: both flags settle the
+    /// same way whichever way round they are written, and it is the frames in
+    /// between that decide whether the home screen shows through.
+    func testAReturnThatRelocksRaisesTheGateBeforeItUncovers() async throws {
+        try await service.setPasscode(passcode)
+        lockService.autoLockInterval = .immediate
+
+        let sut = makeViewModel()
+        sut.revokeAuth()
+        XCTAssertFalse(sut.isPasscodeLocked, "precondition: nothing is up")
+        XCTAssertTrue(sut.showCover, "precondition: leaving covered the app")
+
+        // `@Published` publishes from `willSet`, so this runs as the gate goes up
+        // with every other property still holding the value it had — which is
+        // what makes it an ordering assertion rather than a second look at the
+        // end state.
+        var coverWhenTheGateWentUp: Bool?
+        let subscription = sut.$isPasscodeLocked
+            .filter { $0 }
+            .sink { [weak sut] _ in coverWhenTheGateWentUp = sut?.showCover }
+        defer { subscription.cancel() }
+
+        sut.sceneBecameInactive(comingFrom: .background)
+
+        XCTAssertTrue(sut.isPasscodeLocked, "the gate is what the return animation shows")
+        XCTAssertFalse(sut.showCover, "and the cover comes off it")
+        XCTAssertEqual(
+            coverWhenTheGateWentUp,
+            true,
+            "cover first, gate second is the home screen on display for the frames the lock screen takes to mount"
+        )
+    }
+
+    /// The return is two phases, and the decision belongs to the first of them.
+    ///
+    /// `.active` arriving a third of a second later must not take it again. The
+    /// first call consumed the backgrounding, so a second reading of the lock
+    /// state could act on only part of what it found: a `disablePasscode` landing
+    /// in between reads as "no gate required", lowers the gate the return raised,
+    /// and then skips the device-auth fallback meant to replace it — the app open
+    /// behind neither. The gate stays instead, and the lock screen's own
+    /// `lowerPasscodeGateIfNoLongerRequired()` is what retires it if the passcode
+    /// really is gone.
+    func testTheActivationAfterAReturnDoesNotDecideItAgain() async throws {
+        try await service.setPasscode(passcode)
+        lockService.autoLockInterval = .immediate
+
+        let sut = makeViewModel()
+        sut.revokeAuth()
+        sut.sceneBecameInactive(comingFrom: .background)
+        XCTAssertTrue(sut.isPasscodeLocked, "precondition: the return raised the gate")
+
+        // What a second evaluation would read differently.
+        try await service.disablePasscode(current: passcode)
+        XCTAssertFalse(service.isPasscodeGateRequired, "precondition: the answer has changed")
+
+        sut.sceneBecameActive()
+
+        XCTAssertTrue(
+            sut.isPasscodeLocked,
+            "the second phase of one return is not a second decision about it"
+        )
     }
 
     // MARK: - A foreground that lands mid-unlock


### PR DESCRIPTION
## Description

The privacy cover occupied the whole foreground transition, and the wallet arrived as a jump at the end of it.

`.inactive` is reported **twice** per round trip — once as the app leaves, and once the instant a return begins, ~400 ms before `.active` — and both were covering. Measured on device-equivalent (simulator), before this change:

```
willResignActive         cover up      (app-switcher snapshot taken over it)
...
willEnterForeground      still covered
didBecomeActive  +437ms  cover down    <- the wallet appears here, as a cut
```

Five commits.

**1. Take the cover down as the app returns, not after.** The previous phase is what tells the two `.inactive`s apart, so the scene-phase hook routes on it. An `.inactive` from `.active` still covers; one from `.background` hands the return to `enableAuth()` — already the call that decides whether a lock screen is due, and one that raises the gate *before* it drops the cover, so the earlier moment is not an earlier glimpse. After this change `showCover` is false 424 ms before `didBecomeActive`, i.e. for the whole zoom.

That decision is now taken **once per foreground rather than once per phase**. The first call consumes the backgrounding, so a second reading at `.active` could act on only part of what it found: a `disablePasscode` landing in the third of a second between them would read as "no gate required", lower the gate the return had raised, and then skip the device-auth fallback meant to replace it — leaving the app open behind neither. Caught by the cross-model review, and covered by a test.

**2. The cover is now a blurred picture of the wallet (iOS).** Uncovering early does not remove the logo you see coming back, because that logo is not the app's — it is the app-switcher card, drawn as you left and zoomed up by the system. A card carrying a different screen than the one behind it cannot be dissolved on the way in; it reads as a cut. So the card now carries the wallet, blurred past reading: the layout survives, and the same system animation reads as the app coming into focus.

Captured rather than composed with a `UIVisualEffectView` — **measured, not assumed**. An effect view samples the backdrop of its *own window*, and the cover is carried in a window raised above the app's precisely so it covers sheets and alerts too. There is nothing behind it there to sample; it renders a flat slab, layout gone.

Downscaling (0.12) and blurring are belt-and-braces rather than a division of labour. Neither is trusted alone — an eighth-scale balance, and a receive-address QR at iPad size, survive reduction better than intuition suggests — and if either step fails there is no picture at all and the brand screen stands in.

macOS is unchanged: no app switcher zooms a stale card up there, so the transition does not exist, and the logo conceals more.

**3. One cover, not two that disagree.** The cover is drawn in two places — the app's own overlay and the raised window — and each was taking its own picture. The overlay renders in the pass that raises the cover; the window goes up afterwards and, the first time, has a whole `UIWindow` to build and lay out first. So the overlay's fallback landed first: the **logo**, flashing over the wallet for a frame or two on the way out, then replaced by the blur. Visible in the wild on slow gestures like swipe-up-and-hold.

The picture is now taken one step ahead of the cover flag and both hosts read that one. Not less likely — impossible: there is no second thing to flash to, and a failed capture leaves both on the brand screen together. It also means the photograph does not outlive the cover, and the return no longer photographs a screen it is about to reveal.

**4. The blurred wallet is kept off scenes covered beside a gate.** From review: only one scene may carry the lock screen and the rest get `.cover`, but the cover was deciding what it may contain from its *own* value — so on an iPad with two scenes and the passcode gate up, the elected scene showed the keypad and the other showed a blurred wallet. An app that is locked, displaying the thing the lock is for. `show` now reads what the app concluded rather than what one scene was handed.

**5. The capture finds the app's window without requiring an active scene.** A regression introduced by commit 3 and caught in testing, not in review. The lookup went through `UIApplication.activeContentWindow`, which keeps only scenes at `.foregroundActive` — but the capture runs the instant the app knows it is leaving, when the scene has already moved to `.foregroundInactive`. It answered nil on every departure, so the cover had no picture and fell back to the brand screen: **the blur was silently absent everywhere.**

It survived a green suite because no-picture is a legitimate state here — the fallback is deliberate, so nothing threw and nothing failed. The lookup is written out in `PrivacyBackdrop` now, over scenes that are merely *attached*, with the reason not to reach for the shared helper recorded beside it. Verified by logging the capture across a real background cycle: `window=true picture=true` at `.inactive`, where before it was neither.

### #5120 is fixed separately

An earlier revision of this PR took #5120 as a side effect, on the grounds that a blurred Verify is not an interruption the way a logo is. That is no longer the plan — #5120 has its own PR stacked on this branch, which suppresses the cover outright for prompts the app raised itself, so Verify stays crisp behind Face ID. See that PR for the trade it makes.

### Note on the other linked issue

Referenced rather than closed, deliberately. #5121 reports that the **lock screen** appears on every brief backgrounding with the Auto-lock interval ignored. There are two readings:

- The reporter saw the brand-screen cover — which is pixel-identical to the lock screen's biometric-wait state — occupying the return. **This PR fixes that.**
- There is a genuine relock bug and the reporter is landing on the passcode keypad, needing to type it. **This PR does not fix that**, and it should stay open.

Worth confirming which before closing it. `AutoLockInterval.default` is `.fiveMinutes` and `shouldRelock()` only short-circuits on `.immediate`, so nothing obvious falls out of a read of the policy code.

### Known limitation: iPad Split View

The capture is one shared picture rather than one per scene, because the overlay half cannot cheaply know its own scene and re-scoping it reintroduces the flash commit 3 removes. So with two Vultisig scenes side by side, a covered scene can show a blurred picture of the *other* scene's screen, and a `discard()` from one means a later re-raise in the other falls back to the brand screen.

Both windows belong to the same user on the same device and both pictures are blurred past reading, so nothing crosses a trust boundary — a fidelity regression on a rare configuration, traded against a guaranteed logo flash on every departure on every device.

### Privacy trade worth a conscious decision

The app-switcher card previously leaked nothing. It now carries a blurred wallet: unreadable, but its shape reveals that there is a wallet with a balance and roughly how many holdings are listed. That is inherent to blurring rather than replacing, not a defect — but it is a real change in what the multitasking UI exposes.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None of the above — app-lock / privacy-cover presentation only. No keysign, broadcast, or fee code touched.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- `make test` — **5947 tests, 0 failures**, 11 skipped, on the committed HEAD
- macOS `xcodebuild build` — **BUILD SUCCEEDED** (`CoverView` / `AppLockHosting` are shared)
- `swiftlint` — no new violations
- CI green — iOS and macOS jobs both pass
- **Confirmed on device**, which is the verification that matters here: the blur appears on backgrounding and the logo no longer flashes on the way out. Two of the five commits exist because device testing found what the simulator and a green suite could not.
- Runtime-verified in the simulator as well, not in theory: instrumented the scene phases to confirm the cover comes down at `willEnterForeground`, screenshotted the raised cover to confirm the blur renders and the numbers are unreadable, and logged the capture across a real background cycle after the commit-5 fix. Every instrumentation pass was stripped before committing.

Five new tests in `PasscodeGateWiringTests`: an `.inactive` on the way out covers; one on the way back uncovers; a return that relocks raises the gate **before** it uncovers (asserted on ordering via `$isPasscodeLocked`, not on end state, so reversing the two writes fails it); the activation after a return does not decide it again; and an abandoned return does not spend the next one's decision.

## Screenshots

| Cover, before | Cover, after |
|---|---|
| Logo on gradient — a different screen from the one behind it | The wallet, blurred: layout recognisable, every number a smear |

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a privacy-preserving blurred backdrop when the app is covered or moved to the background.
  * The app now restores the captured screen appearance when returning, with a branded fallback when unavailable.
* **Bug Fixes**
  * Improved biometric authentication handling across inactive, active, and background transitions.
  * Prevented duplicate authentication prompts, stale results, and unnecessary repeated relocking.
  * Improved privacy-cover behavior while system authentication prompts are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->