### PR TITLE
fix(passcode): stop the privacy cover appearing over the app's own Face ID prompt

### DIFF
--- a/VultisigApp/VultisigApp/Core/Security/AppLock/AppLockService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/AppLock/AppLockService.swift
@@ -70,6 +70,94 @@ final class AppLockService {
         mode != .off
     }
 
+    // MARK: - The app's own system prompts
+
+    /// How many system authentication prompts the app itself currently has on
+    /// screen.
+    ///
+    /// Main-thread only, and not persisted: it describes what is on the display
+    /// right now, and a launch has none of them up by definition.
+    private var systemAuthPromptCount = 0
+    /// Bumped whenever the count is dropped wholesale, so that a completion
+    /// belonging to a prompt from before the drop cannot decrement a prompt
+    /// raised after it.
+    ///
+    /// Without it the pairing is by count alone, and a count cannot tell whose
+    /// completion it is: a prompt outstanding when the app backgrounds has its
+    /// completion delivered *later*, by which time ``forgetSystemAuthPrompts()``
+    /// has reset everything and the user may have raised a new one. The stale
+    /// completion would decrement the new prompt's count to zero and the cover
+    /// would go up over it — the exact flash this exists to prevent, arriving by
+    /// the back door.
+    private var systemAuthPromptGeneration = 0
+
+    /// A prompt's claim on the count, handed out by ``beginSystemAuthPrompt()``
+    /// and spent by ``endSystemAuthPrompt(_:)``.
+    ///
+    /// Opaque on purpose: the only correct thing a caller can do with it is give
+    /// it back exactly once, so it carries nothing else.
+    struct SystemAuthPromptTicket {
+        fileprivate let generation: Int
+    }
+
+    /// Whether an `.inactive` arriving now is one the app caused by raising a
+    /// prompt, rather than the app going anywhere.
+    ///
+    /// The privacy cover goes up on `.inactive`, which is right for a departure
+    /// and wrong for this: a `LAContext` prompt makes the app inactive without
+    /// it leaving, and covering there paints the logo over the very screen the
+    /// user is authenticating *for* — on the fast-signing path, a cover
+    /// appearing between Verify and Signing, over a Face ID sheet the app raised
+    /// itself.
+    ///
+    /// It is the same distinction `AppViewModel`'s `didBackgroundSinceForeground`
+    /// draws for the re-lock half of this family — an activation that followed
+    /// no departure is not a return — reaching the cover half, which that flag
+    /// never covered.
+    ///
+    /// This is deliberately **not** consulted for a real backgrounding. That
+    /// arrives as `.background`, where the cover goes up unconditionally.
+    var isPresentingSystemAuthPrompt: Bool {
+        systemAuthPromptCount > 0
+    }
+
+    /// Called immediately before a prompt is raised rather than after, because
+    /// the `.inactive` it causes can arrive before the call that raised it has
+    /// returned.
+    ///
+    /// A count rather than a flag because prompts can overlap, and because a
+    /// balanced pair is the most a caller can honestly promise.
+    func beginSystemAuthPrompt() -> SystemAuthPromptTicket {
+        systemAuthPromptCount += 1
+        return SystemAuthPromptTicket(generation: systemAuthPromptGeneration)
+    }
+
+    /// The other half, required on **every** path out of a prompt — success,
+    /// failure and cancellation alike. A prompt the user dismissed is still a
+    /// prompt that is gone.
+    ///
+    /// A ticket from before the last ``forgetSystemAuthPrompts()`` is spent
+    /// silently: the prompt it belonged to was already accounted for when the
+    /// app left, and the count it would decrement now belongs to somebody else.
+    func endSystemAuthPrompt(_ ticket: SystemAuthPromptTicket) {
+        guard ticket.generation == systemAuthPromptGeneration else { return }
+        systemAuthPromptCount = max(0, systemAuthPromptCount - 1)
+    }
+
+    /// Drops the count on the floor, for the one caller that knows better than
+    /// it does: a real backgrounding took the app and every prompt over it away
+    /// together.
+    ///
+    /// Balanced calls are never trusted to be balanced. A completion that never
+    /// arrives would otherwise leave the app permanently uncoverable, which is
+    /// the one failure this must not have — and every ticket outstanding at this
+    /// moment is invalidated with the count, so the completions that *do* arrive
+    /// late cannot spend themselves against whatever comes next.
+    func forgetSystemAuthPrompts() {
+        systemAuthPromptCount = 0
+        systemAuthPromptGeneration &+= 1
+    }
+
     // MARK: - Scene transitions
 
     /// Records that the app left the foreground.

--- a/VultisigApp/VultisigApp/Core/Security/Biometry/BiometryService.swift
+++ b/VultisigApp/VultisigApp/Core/Security/Biometry/BiometryService.swift
@@ -12,20 +12,56 @@ struct BiometryService {
 
     static let shared = BiometryService()
 
+    /// Held so the privacy cover can tell a prompt this raised from the app
+    /// actually leaving — see ``AppLockService/isPresentingSystemAuthPrompt``.
+    private let lockService: AppLockService
+    /// Injected so a test can reach the one branch that matters here.
+    ///
+    /// The prompting path is unreachable in a simulator by construction —
+    /// ``isRunningOnPhysicalDevice()`` is false there and the call short-circuits
+    /// to success — so without a seam the bracketing around the prompt, which is
+    /// the whole point of this type knowing about the lock service at all, is
+    /// exactly the part no test can run.
+    private let makeContext: () -> LAContext
+    private let isPhysicalDevice: () -> Bool
+
+    init(
+        lockService: AppLockService = .shared,
+        makeContext: @escaping () -> LAContext = { LAContext() },
+        isPhysicalDevice: @escaping () -> Bool = { BiometryService.runningOnPhysicalDevice }
+    ) {
+        self.lockService = lockService
+        self.makeContext = makeContext
+        self.isPhysicalDevice = isPhysicalDevice
+    }
+
     func authenticate(
         reason: String,
         onSuccess: @escaping () -> Void,
         onError: ((Error) -> Void)?
     ) {
-        let context = LAContext()
+        let context = makeContext()
         var error: NSError?
 
         if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
-            if isRunningOnPhysicalDevice() {
+            if isPhysicalDevice() {
                 switch context.biometryType {
                 case .touchID, .faceID, .opticID:
+                    // Bracketed around the prompt, and only around the branch
+                    // that actually raises one — the app is about to be made
+                    // inactive by its own sheet, and the privacy cover must not
+                    // read that as the app leaving. See
+                    // ``AppLockService/isPresentingSystemAuthPrompt``.
+                    //
+                    // Before `evaluatePolicy` rather than after: the `.inactive`
+                    // can arrive before that call returns.
+                    let ticket = lockService.beginSystemAuthPrompt()
                     context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, error in
                         DispatchQueue.main.async {
+                            // First, and outside the branches below: a cancelled
+                            // prompt is as gone as a successful one, and either
+                            // way the app is about to be told it is active again.
+                            lockService.endSystemAuthPrompt(ticket)
                             if let error, !success {
                                 onError?(error)
                             } else if success {
@@ -51,8 +87,11 @@ private extension BiometryService {
         case cantEvaluatePolicy
         case wrongBiometryType
     }
+}
 
-    func isRunningOnPhysicalDevice() -> Bool {
+extension BiometryService {
+
+    static var runningOnPhysicalDevice: Bool {
         #if targetEnvironment(simulator)
         return false
         #else

--- a/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
+++ b/VultisigApp/VultisigApp/Core/ViewModels/AppViewModel.swift
@@ -305,6 +305,12 @@ class AppViewModel: ObservableObject {
         // down again before it finished arriving — is a foreground that never
         // happened. The next one is entitled to its own decision.
         didEvaluateForeground = false
+        // Whatever the app believed about its own prompts, it has now actually
+        // left, and anything the system was showing over it went with it. This
+        // is what keeps an unbalanced count from outliving the moment it
+        // described — the cover above is raised first and unconditionally, so
+        // forgetting them can never uncover anything.
+        lockService.forgetSystemAuthPrompts()
         lockService.noteBackgrounded()
     }
 
@@ -321,7 +327,18 @@ class AppViewModel: ObservableObject {
     /// `noteBackgrounded()` starts the auto-lock clock, and starting it because
     /// somebody glanced at Control Centre would re-lock people who never left
     /// the app.
+    ///
+    /// The exception is an `.inactive` the app *caused*, by putting a system
+    /// authentication prompt up itself. Covering there hides the screen the user
+    /// is authenticating for behind the logo, which on the fast-signing path is
+    /// a cover appearing between Verify and Signing. Nothing has gone anywhere
+    /// and nobody else can see the screen: the person the cover would be hiding
+    /// it from is the one looking at the prompt. See
+    /// ``AppLockService/isPresentingSystemAuthPrompt`` — and note that a genuine
+    /// departure during a prompt still covers, because that arrives as
+    /// `.background` and ``revokeAuth()`` does not consult it at all.
     func coverForPrivacy() {
+        guard !lockService.isPresentingSystemAuthPrompt else { return }
         showCover = true
     }
 

--- a/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
+++ b/VultisigApp/VultisigAppTests/Security/PasscodeGateWiringTests.swift
@@ -5,6 +5,7 @@
 
 import Combine
 import CryptoKit
+import LocalAuthentication
 import Security
 import SwiftData
 import SwiftUI
@@ -363,6 +364,185 @@ final class PasscodeGateWiringTests: XCTestCase {
             defaults.string(forKey: "lastRecordedTime"),
             "covering is not leaving; the interval must not start here"
         )
+    }
+
+    /// The app's own Face ID sheet makes it `.inactive` without it going
+    /// anywhere, and covering there puts the logo over the screen the user is
+    /// authenticating *for* — on the fast-signing path, a cover between Verify
+    /// and Signing.
+    func testAPromptTheAppRaisedItselfDoesNotCover() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        _ = lockService.beginSystemAuthPrompt()
+        sut.coverForPrivacy()
+
+        XCTAssertFalse(sut.showCover, "nothing has left; the prompt is the app's own")
+    }
+
+    /// And the suppression lasts exactly as long as the prompt does, so the very
+    /// next departure covers normally.
+    func testCoveringResumesOnceThePromptIsGone() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        let ticket = lockService.beginSystemAuthPrompt()
+        lockService.endSystemAuthPrompt(ticket)
+        sut.coverForPrivacy()
+
+        XCTAssertTrue(sut.showCover)
+    }
+
+    /// Overlapping prompts must not have the first one to finish uncover the
+    /// app while the second is still on screen.
+    func testCoveringStaysSuppressedWhileASecondPromptIsStillUp() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        let first = lockService.beginSystemAuthPrompt()
+        _ = lockService.beginSystemAuthPrompt()
+        lockService.endSystemAuthPrompt(first)
+        sut.coverForPrivacy()
+
+        XCTAssertFalse(sut.showCover)
+    }
+
+    /// The safety property, and the one that makes the suppression affordable: a
+    /// real departure covers whatever the app believes about its own prompts.
+    /// Leaving arrives as `.background`, which does not consult them at all —
+    /// so a prompt whose completion never came cannot leave the wallet on
+    /// display in the app switcher.
+    func testARealBackgroundingCoversEvenWithAPromptOutstanding() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        _ = lockService.beginSystemAuthPrompt()
+        sut.revokeAuth()
+
+        XCTAssertTrue(sut.showCover, "leaving covers; the prompt went with the app")
+        XCTAssertFalse(
+            lockService.isPresentingSystemAuthPrompt,
+            "and the stale count is forgotten, or the next departure would not cover either"
+        )
+    }
+
+    /// A prompt outstanding when the app leaves has its completion delivered
+    /// later — by which time the count has been dropped and the user may have
+    /// raised a new prompt. Paired by count alone, that stale completion would
+    /// decrement the *new* prompt's claim and let the cover go up over it.
+    func testAStaleCompletionCannotEndAPromptRaisedAfterIt() {
+        let sut = makeViewModel()
+        sut.showCover = false
+
+        let leftBehind = lockService.beginSystemAuthPrompt()
+        sut.revokeAuth()
+        sut.showCover = false
+
+        let fresh = lockService.beginSystemAuthPrompt()
+        lockService.endSystemAuthPrompt(leftBehind)
+        sut.coverForPrivacy()
+
+        XCTAssertFalse(
+            sut.showCover,
+            "the late completion belonged to a prompt that is already gone"
+        )
+
+        // The other half, and it is what stops the guard being "ignore every end
+        // after a backgrounding": that would pass the assertion above and leave
+        // the app permanently uncoverable instead, which is the worse failure of
+        // the two.
+        lockService.endSystemAuthPrompt(fresh)
+        sut.coverForPrivacy()
+
+        XCTAssertTrue(sut.showCover, "the current prompt's own ticket still ends it")
+    }
+
+    // MARK: - Bracketing the real prompt
+
+    /// The tests above drive `AppLockService` directly, so every one of them
+    /// would still pass if `BiometryService` bracketed nothing at all — and the
+    /// bracketing is the fix. These two run the service itself.
+    ///
+    /// The prompting branch is unreachable in a simulator by construction, which
+    /// is exactly why the seam exists.
+    func testRaisingAPromptMarksItBeforeTheSheetGoesUp() {
+        var reply: ((Bool, Error?) -> Void)?
+        var markedWhenTheSheetWentUp: Bool?
+        let service = BiometryService(
+            lockService: lockService,
+            makeContext: { [lockService] in
+                StubLAContext(biometry: .faceID, canEvaluate: true) { captured in
+                    // Read *inside* `evaluatePolicy`, not after `authenticate`
+                    // returns. On a device the `.inactive` the sheet causes
+                    // arrives during this call, so a claim staked afterwards is
+                    // staked too late — and asserting only at the end would let
+                    // that reordering pass.
+                    markedWhenTheSheetWentUp = lockService?.isPresentingSystemAuthPrompt
+                    reply = captured
+                }
+            },
+            isPhysicalDevice: { true }
+        )
+        let finished = expectation(description: "prompt resolved")
+
+        service.authenticate(reason: "test", onSuccess: { finished.fulfill() }, onError: nil)
+
+        XCTAssertEqual(markedWhenTheSheetWentUp, true, "claimed before the sheet, not after")
+
+        reply?(true, nil)
+        wait(for: [finished], timeout: 1)
+
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt, "and released when it resolves")
+    }
+
+    /// The release must not live in the success branch. A prompt the user
+    /// cancelled is as gone as one they satisfied, and a claim left behind by
+    /// the cancel path would leave the app uncoverable for the rest of the
+    /// session.
+    func testACancelledPromptIsReleasedToo() {
+        var reply: ((Bool, Error?) -> Void)?
+        let service = BiometryService(
+            lockService: lockService,
+            makeContext: { StubLAContext(biometry: .faceID, canEvaluate: true) { reply = $0 } },
+            isPhysicalDevice: { true }
+        )
+        let failed = expectation(description: "error delivered")
+
+        service.authenticate(reason: "test", onSuccess: {}, onError: { _ in failed.fulfill() })
+        XCTAssertTrue(lockService.isPresentingSystemAuthPrompt, "precondition: the prompt is up")
+
+        reply?(false, LAError(.userCancel))
+        wait(for: [failed], timeout: 1)
+
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt)
+    }
+
+    /// The branches that never raise a prompt must never claim one either, or
+    /// the first one taken would leave the app uncoverable for the session.
+    func testTheBranchesThatRaiseNoPromptClaimNothing() {
+        let cannotEvaluate = BiometryService(
+            lockService: lockService,
+            makeContext: { StubLAContext(biometry: .faceID, canEvaluate: false) { _ in } },
+            isPhysicalDevice: { true }
+        )
+        cannotEvaluate.authenticate(reason: "test", onSuccess: {}, onError: { _ in })
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt)
+
+        let noBiometry = BiometryService(
+            lockService: lockService,
+            makeContext: { StubLAContext(biometry: .none, canEvaluate: true) { _ in } },
+            isPhysicalDevice: { true }
+        )
+        noBiometry.authenticate(reason: "test", onSuccess: {}, onError: { _ in })
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt)
+
+        let simulator = BiometryService(
+            lockService: lockService,
+            makeContext: { StubLAContext(biometry: .faceID, canEvaluate: true) { _ in } },
+            isPhysicalDevice: { false }
+        )
+        simulator.authenticate(reason: "test", onSuccess: {}, onError: { _ in })
+        XCTAssertFalse(lockService.isPresentingSystemAuthPrompt)
     }
 
     /// The other half, so the pair is not just "cover does nothing": a real
@@ -779,4 +959,43 @@ private final class InMemoryBiometricKeychain: BiometricKeychainProtecting {
     func delete(account _: String) throws { stored = nil }
 
     func exists(account _: String) -> Bool { stored != nil }
+}
+
+/// An `LAContext` that answers however a test needs and hands the reply block
+/// back instead of raising anything.
+///
+/// A subclass rather than a protocol, because `BiometryService` is bracketing a
+/// real system prompt and the seam has to be the smallest thing that makes that
+/// branch reachable — anything wider would be testing a different shape of code
+/// than the one that ships.
+private final class StubLAContext: LAContext {
+
+    private let biometry: LABiometryType
+    private let canEvaluate: Bool
+    private let capture: (@escaping (Bool, Error?) -> Void) -> Void
+
+    init(
+        biometry: LABiometryType,
+        canEvaluate: Bool,
+        capture: @escaping (@escaping (Bool, Error?) -> Void) -> Void
+    ) {
+        self.biometry = biometry
+        self.canEvaluate = canEvaluate
+        self.capture = capture
+        super.init()
+    }
+
+    override var biometryType: LABiometryType { biometry }
+
+    override func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
+        canEvaluate
+    }
+
+    override func evaluatePolicy(
+        _ policy: LAPolicy,
+        localizedReason: String,
+        reply: @escaping (Bool, Error?) -> Void
+    ) {
+        capture(reply)
+    }
 }


### PR DESCRIPTION
## Description

Fixes #5120.

**Stacked on #5128** — base branch is `fix/passcode-foreground-cover`, review that one first.

> ⚠️ Because this targets the stack base rather than `main`, GitHub does **not** register the `Fixes #5120` link while it is stacked — the sidebar will show no linked issue. It starts working once #5128 merges and this is retargeted to `main`; until then #5120 has to be closed by hand if this merges first.

Fast Sign raises a biometric prompt to fill the fast-vault password. That prompt makes the app `.inactive`, the privacy cover treats every `.inactive` as a departure, and so a cover went up over the Verify screen — between Verify and Signing, behind a sheet the app had raised itself.

Nothing has gone anywhere in that moment, and the person the cover would hide the screen from is the one looking at the prompt. So the app now knows when a prompt is its own: `AppLockService` counts them, and `coverForPrivacy()` declines while one is up.

It is the same distinction `didBackgroundSinceForeground` already draws for the re-lock half of this family — an activation that followed no departure is not a return — reaching the cover half, which that flag never covered.

### Claims are ticketed, not just counted

`beginSystemAuthPrompt()` hands back an opaque ticket and `forgetSystemAuthPrompts()` bumps a generation that invalidates every ticket outstanding.

Counted alone, this sequence puts the flash straight back: prompt A is up when the app backgrounds → the count is dropped → the app returns and the user raises prompt B → **A's** completion finally arrives and decrements **B's** claim to zero → the cover goes up over B. Found by the cross-model review, and covered by a test.

### The trade this makes, stated plainly

While a prompt is up the scene is **already** `.inactive`, so leaving from there produces no second `.inactive` and the cover is not raised until `.background`. Swiping to the app switcher mid-prompt can therefore put the Verify screen — amount and destination address — in the switcher card until `.background` catches it.

That is not a race; it is guaranteed by the phase model, and it cannot be closed while also keeping Verify visible during the prompt, because the app's own prompt and the user leaving are the same signal. It was weighed against the alternative — covering, and showing a screen the user did not ask for over the one they are authenticating for — and this is the side that was chosen deliberately.

The safety property that makes it affordable: a real departure arrives as `.background`, where `revokeAuth()` covers unconditionally and forgets every claim. An outstanding prompt cannot leave the app uncoverable, and an unbalanced pair cannot survive a backgrounding.

### On the `BiometryService` seam

It now takes its `LAContext` and its device check by injection. Not gratuitous: the prompting branch is unreachable in a simulator by construction (`isRunningOnPhysicalDevice()` is false there and the call short-circuits to success), so the bracketing — the entire point of this type knowing about the lock service — was the one part no test could run.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [ ] Swap
- [ ] New Chain / Chain related feature

None of the above — app-lock / privacy-cover presentation only. No keysign, broadcast, or fee code touched. The Fast Sign *password* path is read-only here: what changed is whether a cover is drawn over it.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- `make test` — **5955 tests, 0 failures**, 11 skipped
- `swiftlint` — no new violations
- Two cross-model review passes; the stale-completion defect and the missing test seam both came from them.

Eight tests. Five drive the suppression (a prompt does not cover; covering resumes once it is gone; overlapping prompts do not uncover early; a stale completion cannot end a newer prompt **while the current one's own ticket still can**; a real backgrounding covers with a prompt outstanding). Three drive `BiometryService` itself through a `StubLAContext`: the claim is staked **inside** `evaluatePolicy` rather than after `authenticate` returns — read from within the stub, so reordering the two fails the test — a cancelled prompt is released just as a satisfied one is, and all three non-prompting branches claim nothing, since the first one that wrongly claimed would leave the app uncoverable for the session.

**Confirmed on device.** The simulator cannot exercise this at all — `isRunningOnPhysicalDevice()` is false there, so the prompt is skipped and `onSuccess` fires directly — so a Debug build on a device with Face ID enrolled was the only way to check it, and Fast Sign now stays on Verify with only the Face ID sheet over it.

Everything above the device check is unit-level: the eight tests, and two cross-model review passes. The switcher trade in "The trade this makes" is *by construction* rather than observed, and follows from the phase model rather than from a run.

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>
