### PR TITLE
fix(networking): suppress body logging for password-carrying requests

### DIFF
--- a/VultisigApp/VultisigApp/Core/Networking/HTTPClient.swift
+++ b/VultisigApp/VultisigApp/Core/Networking/HTTPClient.swift
@@ -40,7 +40,7 @@ final class HTTPClient: HTTPClientProtocol {
         try Task.checkCancellation()
 
         let urlRequest = try buildURLRequest(from: target)
-        let shouldSuppressBodyLogging = containsSensitiveHeaders(in: urlRequest.allHTTPHeaderFields)
+        let shouldSuppressBodyLogging = target.isSensitive || containsSensitiveHeaders(in: urlRequest.allHTTPHeaderFields)
 
         // Log the request
         logRequest(urlRequest, target: target, suppressBodyLogging: shouldSuppressBodyLogging)
@@ -358,14 +358,14 @@ private extension HTTPClient {
 
     func containsSensitiveHeaders(in headers: [String: String]?) -> Bool {
         guard let headers else { return false }
-        let sensitiveHeaders = ["authorization", "cookie", "set-cookie", "x-api-key"]
+        let sensitiveHeaders = ["authorization", "cookie", "set-cookie", "x-api-key", "x-password"]
         return headers.keys.contains { key in
             sensitiveHeaders.contains(key.lowercased())
         }
     }
 
     func formatHeaders(_ headers: [String: String]) -> String {
-        let sensitiveHeaders = ["authorization", "cookie", "set-cookie", "x-api-key"]
+        let sensitiveHeaders = ["authorization", "cookie", "set-cookie", "x-api-key", "x-password"]
         return headers
             .sorted { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }
             .map { key, value in

--- a/VultisigApp/VultisigApp/Core/Networking/TargetType.swift
+++ b/VultisigApp/VultisigApp/Core/Networking/TargetType.swift
@@ -45,6 +45,9 @@ public protocol TargetType {
 
     /// The timeout interval for the request
     var timeoutInterval: TimeInterval { get }
+
+    /// Whether the request body carries sensitive data (e.g. a password) and must never be logged
+    var isSensitive: Bool { get }
 }
 
 /// Validation type for SSL certificate validation
@@ -66,5 +69,9 @@ public extension TargetType {
 
     var headers: [String: String]? {
         return ["Content-Type": "application/json"]
+    }
+
+    var isSensitive: Bool {
+        return false
     }
 }

--- a/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultAPI.swift
+++ b/VultisigApp/VultisigApp/Core/Services/FastVault/FastVaultAPI.swift
@@ -110,4 +110,14 @@ enum FastVaultAPI: TargetType {
             return .successCodes
         }
     }
+
+    var isSensitive: Bool {
+        switch self {
+        case .create, .batchCreate, .keyImport, .batchKeyImport,
+             .reshare, .batchReshare, .sign, .migrate, .singleKeygen:
+            return true
+        case .validateAccess, .exists, .verifyBackupOTP:
+            return false
+        }
+    }
 }

--- a/VultisigApp/VultisigApp/Core/Services/VultiServer/VultiServerAPI.swift
+++ b/VultisigApp/VultisigApp/Core/Services/VultiServer/VultiServerAPI.swift
@@ -34,4 +34,11 @@ enum VultiServerAPI: TargetType {
             return .requestCodable(request, .jsonEncoding)
         }
     }
+
+    var isSensitive: Bool {
+        switch self {
+        case .resendVaultShare:
+            return true
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- FastVault sign requests logged `vault_password` in plaintext at debug level: `HTTPClient` only suppressed body logging when it saw sensitive *headers*, so a password inside a JSON *body* had no way to trigger suppression.
- Added `isSensitive: Bool` to `TargetType` (default `false`) and had `HTTPClient` suppress body logging whenever `target.isSensitive` is true, in addition to the existing header check.
- Marked every FastVault request that carries `encryption_password`/`vault_password` as sensitive (`create`, `batchCreate`, `keyImport`, `batchKeyImport`, `reshare`, `batchReshare`, `sign`, `migrate`, `singleKeygen`) — not just the keysign request named in the issue.
- Found and fixed the same class of leak on `VultiServerAPI.resendVaultShare`, which also ships a plaintext `password`.
- Added `x-password` to `HTTPClient`'s header-redaction lists, since `FastVaultAPI.validateAccess` sends its password via that header and it wasn't being redacted in logs either.

## Issue
Closes #5123

## Test Plan
- [x] `swiftlint lint --config VultisigApp/.swiftlint.yml VultisigApp/` — 0 violations in changed files
- [x] `make generate` + `xcodebuild build` succeeds
- [ ] Manual: trigger a FastVault sign/keygen/reshare request in a debug build with log streaming and confirm the body log line reads "Body logging skipped for sensitive request" instead of the raw JSON

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for sensitive request data by suppressing sensitive body content in network logs.
  * Added password-header detection and redaction to prevent accidental exposure.
  * Sensitive vault creation, import, signing, migration, reshare, and key-generation requests are now excluded from body logging.
  * Sensitive vault-share resend requests receive the same protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->