### PR TITLE
fix(swap): stop a failed VULT tier read dropping the discount for the whole session

### DIFF
--- a/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BalanceService.swift
@@ -481,8 +481,18 @@ class BalanceService {
         try Storage.shared.save()
     }
 
+    /// Best-effort balance refresh. Returns whether a live **raw balance**
+    /// actually landed, so a caller that stamps its own freshness cache can tell
+    /// a failed fetch from a genuine zero — the two are otherwise
+    /// indistinguishable here, because a failure leaves the last known balance in
+    /// place rather than zeroing it. Only the raw balance counts: a price fetch,
+    /// a persistence error, or a failed auxiliary read that happens *after* the
+    /// balance (RUNE's bonded nodes, staked balances) leaves a live number on the
+    /// coin, and reporting those as a failure would make the caller refetch a
+    /// balance it already has.
     @MainActor
-    func updateBalance(for coin: Coin) async {
+    @discardableResult
+    func updateBalance(for coin: Coin) async -> Bool {
         // Fetch price
         do {
             try await cryptoPriceService.fetchPrice(coin: coin)
@@ -522,6 +532,8 @@ class BalanceService {
                 logger.warning("Update Balance error: \(error.localizedDescription)")
             }
         }
+
+        return update.rawBalance != nil
     }
 
     /// Fail-closed spendable-balance refresh: fetches the live raw balance and

--- a/VultisigApp/VultisigApp/Core/Services/BalanceServiceProtocol.swift
+++ b/VultisigApp/VultisigApp/Core/Services/BalanceServiceProtocol.swift
@@ -10,7 +10,11 @@
 import Foundation
 
 protocol BalanceServiceProtocol {
-    func updateBalance(for coin: Coin) async
+    /// Best-effort refresh. Returns whether a live balance actually landed, so a
+    /// caller stamping its own freshness cache can tell a failed fetch from a
+    /// genuine zero. Discardable — most callers only want the side effect.
+    @discardableResult
+    func updateBalance(for coin: Coin) async -> Bool
     /// Fail-closed refresh — throws if the live balance fetch fails. See
     /// `BalanceService.refreshSpendableBalanceOrThrow`.
     func refreshSpendableBalanceOrThrow(for coin: Coin) async throws

--- a/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Defi/DefiChain/DefiChainMainScreen.swift
@@ -517,7 +517,7 @@ private extension DefiChainMainScreen {
             owner: nativeCoin.address,
             decimals: nativeCoin.decimals
         )
-        async let balance: Void = BalanceService.shared.updateBalance(for: nativeCoin)
+        async let balance: Bool = BalanceService.shared.updateBalance(for: nativeCoin)
         _ = await (rows, balance)
     }
 

--- a/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
+++ b/VultisigApp/VultisigApp/Features/Send/Views/Screens/SendDetailsScreen.swift
@@ -355,7 +355,7 @@ struct SendDetailsScreen: View {
     }
 
     private func onRefresh() async {
-        async let bal: Void = BalanceService.shared.updateBalance(for: viewModel.coin)
+        async let bal: Bool = BalanceService.shared.updateBalance(for: viewModel.coin)
         async let pendingCheck: Void = viewModel.forceCheckPendingTransactions()
         _ = await (bal, pendingCheck)
     }

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/DefaultSwapInteractor.swift
@@ -45,11 +45,12 @@ struct DefaultSwapInteractor: SwapInteractor {
             throw SwapCryptoLogic.Errors.sameAsset
         }
 
-        // Read the per-session cached tier. The first call resolves it once
-        // (VULT balance + Thorguard NFT eth_call) and caches it for the wallet;
-        // every later quote reads the cached value, keeping the Thorguard
-        // eth_call off the per-quote critical path. The screen warms this cache
-        // on load, so by the time quotes run it's usually already populated.
+        // Resolve the tier fresh for this quote. The VULT balance is re-read
+        // every time, so a balance that arrives late — or a first read that
+        // failed — is reflected in the very next quote instead of costing the
+        // user their discount for the whole session. Only the Thorguard NFT
+        // eth_call behind it is session-cached, keeping it off the per-quote
+        // critical path; the screen warms that cache on load.
         let vultTier = await tierResolver.resolveTierForSession(for: vault)
         let vultDiscountBps = vultTier?.bpsDiscount ?? 0
         let referralDiscountBps = referredCode.isEmpty

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/SwapDiscountTierResolving.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/SwapDiscountTierResolving.swift
@@ -3,16 +3,19 @@
 //  VultisigApp
 //
 //  Test seam over the VULT discount-tier resolution used by the swap quote
-//  path. Lets the interactor read a per-session cached tier instead of
-//  resolving it (VULT balance + Thorguard NFT eth_call) on every quote fetch.
+//  path. Lets the interactor resolve the tier without the Thorguard NFT
+//  eth_call on every quote fetch.
 //
 
 import Foundation
 
 protocol SwapDiscountTierResolving {
-    /// Resolves the discount tier for the vault once and caches it for the
-    /// session. Subsequent calls return the cached value without touching the
-    /// network (no Thorguard eth_call). Safe to call repeatedly.
+    /// Resolves the discount tier for the vault. The VULT balance half is
+    /// re-read every call, so a balance that lands late is honoured by the next
+    /// quote; only the Thorguard NFT ownership behind it is session-cached, so
+    /// the eth_call stays off the per-quote critical path. Safe to call
+    /// repeatedly.
+    @MainActor
     func resolveTierForSession(for vault: Vault) async -> VultDiscountTier?
 }
 

--- a/VultisigApp/VultisigApp/Features/Swap/Interactor/SwapInteractor.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/Interactor/SwapInteractor.swift
@@ -61,9 +61,10 @@ protocol SwapInteractor {
     /// non-throwing `updateBalance` for test seams; production overrides it.
     func refreshBalanceOrThrow(for coin: Coin) async throws
 
-    /// Resolve and cache the VULT discount tier (VULT balance + Thorguard NFT) for the
-    /// wallet once per session. Called on screen load to warm the cache so the per-quote
-    /// path reads the cached tier instead of re-running the Thorguard eth_call each time.
+    /// Resolve the VULT discount tier once on screen load. Its purpose is to warm
+    /// the session cache of Thorguard NFT ownership so the per-quote path doesn't
+    /// re-run the eth_call; the VULT balance half is re-read on every quote, so a
+    /// balance that lands after this warm-up is still honoured.
     func warmDiscountTier(for vault: Vault) async
 }
 

--- a/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
+++ b/VultisigApp/VultisigApp/Features/Swap/ViewModels/SwapDetailsViewModel.swift
@@ -181,10 +181,10 @@ final class SwapDetailsViewModel {
         }
     }
 
-    /// Warm the per-session VULT discount-tier cache once on screen load so the
-    /// quote path reads the cached tier (VULT balance + Thorguard NFT) instead of
-    /// re-resolving it — and re-running the Thorguard eth_call — on every fetch.
-    /// This feeds the VULT fee-discount applied on the quote path.
+    /// Resolve the VULT discount tier once on screen load, warming the session
+    /// cache of Thorguard NFT ownership so the quote path doesn't re-run the
+    /// eth_call on every fetch. Each quote still re-reads the VULT balance, so a
+    /// balance arriving after this warm-up still reaches the fee discount.
     func warmDiscountTier(vault: Vault) {
         Task { [weak self] in
             guard let self else { return }

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
@@ -13,7 +13,11 @@ import SwiftUI
 private let logger = Log.app.service
 
 struct VultTierService {
-    let vultTicker = "VULT"
+    /// VULT's ERC-20 contract on Ethereum. The tier is matched on this rather
+    /// than on the "VULT" ticker: any address can deploy a token under any
+    /// symbol and a user can add it to their vault, and a look-alike must not
+    /// buy a real trading-fee discount.
+    static let vultContractAddress = "0xb788144DF611029C60b859DF47e79B7726C4DEBa"
     let thorguardContractAddress = "0xa98b29a8f5a247802149c268ecf860b8308b7291"
 
     @AppStorage("vult_balance_cache") private var cacheEntries: [CacheEntry] = []
@@ -99,7 +103,21 @@ struct VultTierService {
     }
 
     func getVultToken(for vault: Vault) -> Coin? {
-        vault.coins.first(where: { $0.chain == .ethereum && $0.ticker == vultTicker })
+        vault.coins.first { Self.isVult($0) }
+    }
+
+    /// Whether `coin` is the real VULT, matched on chain + contract address.
+    /// Contract addresses are compared case-insensitively: EIP-55 checksums a
+    /// hex address by letter case, so the same token legitimately arrives in
+    /// different casings depending on where its metadata came from.
+    private static func isVult(_ coin: Coin) -> Bool {
+        coin.chain == .ethereum
+            && coin.contractAddress.caseInsensitiveCompare(vultContractAddress) == .orderedSame
+    }
+
+    private static func isVult(_ meta: CoinMeta) -> Bool {
+        meta.chain == .ethereum
+            && meta.contractAddress.caseInsensitiveCompare(vultContractAddress) == .orderedSame
     }
 
     /// Checks if we recently fetched the balance (within cache validity duration)
@@ -238,7 +256,7 @@ private extension VultTierService {
 
     @MainActor
     func addVultToken(to vault: Vault) async {
-        let vultTokenMeta = TokensStore.TokenSelectionAssets.first(where: { $0.chain == .ethereum && $0.ticker == vultTicker })
+        let vultTokenMeta = TokensStore.TokenSelectionAssets.first { Self.isVult($0) }
         guard let vultTokenMeta else { return }
         try? await CoinService.addToChain(assets: [vultTokenMeta], to: vault)
     }

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
@@ -31,6 +31,12 @@ struct VultTierService {
     /// swap for the rest of the session.
     private static let thorguardCache = ThorguardOwnershipCache()
 
+    /// One in-flight VULT balance refresh per vault. The swap screen warms the
+    /// tier on load while the first debounced quote resolves it again moments
+    /// later; without this they'd each pay for their own round trip.
+    @MainActor
+    private static var refreshesInFlight: [String: Task<Bool, Never>] = [:]
+
     // MARK: - Tier resolution
 
     /// Resolves the tier with a live Thorguard check. `cached` selects the VULT
@@ -185,19 +191,38 @@ private extension VultTierService {
     func fetchVultBalance(for vault: Vault) async -> Decimal {
         // Check if we need to fetch fresh balance
         if shouldFetchBalance(for: vault) {
-            // Fetch fresh balance
-            await addEthChainIfNeeded(for: vault)
-            let vultToken = await getOrAddVultTokenIfNeeded(to: vault)
-            if let vultToken {
-                await BalanceService.shared.updateBalance(for: vultToken)
+            let vaultId = vault.pubKeyEdDSA
+            let didLand: Bool
+            if let inFlight = Self.refreshesInFlight[vaultId] {
+                didLand = await inFlight.value
+            } else {
+                let refresh = Task { @MainActor in await refreshVultBalance(for: vault) }
+                Self.refreshesInFlight[vaultId] = refresh
+                didLand = await refresh.value
+                Self.refreshesInFlight[vaultId] = nil
             }
 
-            // Update the cache entry
-            cacheEntries.removeAll { $0.vaultId == vault.pubKeyEdDSA }
-            cacheEntries.append(CacheEntry(vaultId: vault.pubKeyEdDSA, lastFetchDate: Date()))
+            // Stamp the freshness cache only when a live balance actually
+            // landed. Stamping after a failed fetch would suppress every retry
+            // for the next three minutes, leaving the tier resolved from a
+            // balance that was never read.
+            if didLand {
+                cacheEntries.removeAll { $0.vaultId == vaultId }
+                cacheEntries.append(CacheEntry(vaultId: vaultId, lastFetchDate: Date()))
+            }
         }
 
         return storedVultBalance(for: vault)
+    }
+
+    /// Refreshes the vault's VULT balance from the network, adding the Ethereum
+    /// chain and the VULT token first if the vault doesn't carry them yet.
+    /// Returns whether a live balance landed.
+    @MainActor
+    func refreshVultBalance(for vault: Vault) async -> Bool {
+        await addEthChainIfNeeded(for: vault)
+        guard let vultToken = await getOrAddVultTokenIfNeeded(to: vault) else { return false }
+        return await BalanceService.shared.updateBalance(for: vultToken)
     }
 
     @MainActor

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
@@ -60,15 +60,16 @@ struct VultTierService {
 
     /// Quote-path resolution. The VULT balance is re-read on every call, so a
     /// balance that lands late — or a first read that failed — is picked up by
-    /// the very next quote instead of being pinned for the session. Only the
-    /// Thorguard `eth_call` behind it is session-cached, which is what keeps it
-    /// off the per-quote critical path.
+    /// the very next quote instead of being pinned for the session. Neither half
+    /// puts a network round trip on the quote's critical path once it has an
+    /// answer: the Thorguard `eth_call` is session-cached, and a stale balance is
+    /// refreshed in the background rather than waited on.
     @MainActor
     func resolveTierForSession(for vault: Vault) async -> VultDiscountTier? {
         await Self.resolveSessionTier(
             cache: Self.thorguardCache,
             vaultId: vault.pubKeyEdDSA,
-            balance: { await fetchVultBalance(for: vault) },
+            balance: { await sessionVultBalance(for: vault) },
             ownership: { await checkThorguardBalance(for: vault) }
         )
     }
@@ -207,30 +208,61 @@ private extension VultTierService {
 
     @MainActor
     func fetchVultBalance(for vault: Vault) async -> Decimal {
-        // Check if we need to fetch fresh balance
         if shouldFetchBalance(for: vault) {
-            let vaultId = vault.pubKeyEdDSA
-            let didLand: Bool
-            if let inFlight = Self.refreshesInFlight[vaultId] {
-                didLand = await inFlight.value
-            } else {
-                let refresh = Task { @MainActor in await refreshVultBalance(for: vault) }
-                Self.refreshesInFlight[vaultId] = refresh
-                didLand = await refresh.value
-                Self.refreshesInFlight[vaultId] = nil
-            }
+            await refreshVultBalanceIfNeeded(for: vault)
+        }
+        return storedVultBalance(for: vault)
+    }
 
-            // Stamp the freshness cache only when a live balance actually
-            // landed. Stamping after a failed fetch would suppress every retry
-            // for the next three minutes, leaving the tier resolved from a
-            // balance that was never read.
-            if didLand {
-                cacheEntries.removeAll { $0.vaultId == vaultId }
-                cacheEntries.append(CacheEntry(vaultId: vaultId, lastFetchDate: Date()))
-            }
+    /// VULT balance for the quote path, which must not pay for a network round
+    /// trip it can avoid: quotes are debounced per keystroke and auto-refresh on
+    /// a timer, and the caller holds the loading spinner while this runs.
+    ///
+    /// A balance that has already landed is answered from memory and any
+    /// staleness is refreshed in the background, so the *next* quote sees the new
+    /// number. Only a vault with no landed balance at all — a cold start, or one
+    /// where every attempt so far failed — waits, because there is nothing to
+    /// answer with otherwise and a wrong zero costs the user their fee discount.
+    @MainActor
+    func sessionVultBalance(for vault: Vault) async -> Decimal {
+        guard shouldFetchBalance(for: vault) else {
+            return storedVultBalance(for: vault)
+        }
+        guard hasLandedBalance(for: vault) else {
+            return await fetchVultBalance(for: vault)
+        }
+        Task { @MainActor in await refreshVultBalanceIfNeeded(for: vault) }
+        return storedVultBalance(for: vault)
+    }
+
+    /// Whether a VULT balance has ever landed for this vault. The freshness stamp
+    /// is written only after a refresh that actually returned one, so its
+    /// presence is exactly that question.
+    func hasLandedBalance(for vault: Vault) -> Bool {
+        cacheEntries.contains { $0.vaultId == vault.pubKeyEdDSA }
+    }
+
+    /// Runs — or joins — the single in-flight VULT balance refresh for this
+    /// vault, stamping the freshness cache only when a live balance landed.
+    /// Stamping after a failed fetch would suppress every retry for the next
+    /// three minutes, leaving the tier resolved from a balance never read.
+    @MainActor
+    func refreshVultBalanceIfNeeded(for vault: Vault) async {
+        let vaultId = vault.pubKeyEdDSA
+        let didLand: Bool
+        if let inFlight = Self.refreshesInFlight[vaultId] {
+            didLand = await inFlight.value
+        } else {
+            let refresh = Task { @MainActor in await refreshVultBalance(for: vault) }
+            Self.refreshesInFlight[vaultId] = refresh
+            didLand = await refresh.value
+            Self.refreshesInFlight[vaultId] = nil
         }
 
-        return storedVultBalance(for: vault)
+        if didLand {
+            cacheEntries.removeAll { $0.vaultId == vaultId }
+            cacheEntries.append(CacheEntry(vaultId: vaultId, lastFetchDate: Date()))
+        }
     }
 
     /// Refreshes the vault's VULT balance from the network, adding the Ethereum

--- a/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
+++ b/VultisigApp/VultisigApp/Features/VultDiscountTiers/Service/VultTierService.swift
@@ -19,42 +19,77 @@ struct VultTierService {
     @AppStorage("vult_balance_cache") private var cacheEntries: [CacheEntry] = []
     private static let cacheValidityDuration: TimeInterval = 3 * 60 // 3 minutes
 
-    /// Per-wallet cache of the fully-resolved discount tier (VULT balance result
-    /// + Thorguard boost), keyed by vault id and held for the process lifetime.
-    /// The tier doesn't change during a swap session, so once resolved it's read
-    /// back without re-running the Thorguard NFT `eth_call` on every quote fetch.
-    /// Switching vaults resolves fresh because the cache is keyed per vault; a
-    /// VULT/Thorguard balance change for the *same* vault isn't reflected until
-    /// the next app launch, which is acceptable for a discount-tier hint.
-    private static let sessionCache = SessionTierCache()
+    /// Per-vault session cache of Thorguard NFT ownership — and *only* that.
+    ///
+    /// Ownership is the expensive half of a tier resolution (an Ethereum
+    /// `eth_call` that would otherwise fire on every debounced keystroke) and
+    /// the half that cannot change without the user leaving the app, so it is
+    /// the only half worth pinning for the process lifetime. The VULT balance
+    /// half is deliberately *not* cached: it arrives late, can fail, and is
+    /// refreshed by unrelated screens, so caching a fully-resolved tier meant a
+    /// single balance read of zero cost the user their fee discount on every
+    /// swap for the rest of the session.
+    private static let thorguardCache = ThorguardOwnershipCache()
 
+    // MARK: - Tier resolution
+
+    /// Resolves the tier with a live Thorguard check. `cached` selects the VULT
+    /// balance source: `true` reads the balance already stored on the vault,
+    /// `false` refreshes it from the network first (throttled to once per
+    /// `cacheValidityDuration`).
+    ///
+    /// `@MainActor` because it reads and writes the `@Model` vault and its coins.
+    @MainActor
     func fetchDiscountTier(for vault: Vault, cached: Bool = false) async -> VultDiscountTier? {
-        let balance = cached ? (getVultToken(for: vault)?.balanceDecimal ?? 0) : await fetchVultBalance(for: vault)
-        var tier = VultDiscountTier.allCases
-            .sorted { $0.balanceToUnlock > $1.balanceToUnlock }
-            .first { balance >= $0.balanceToUnlock }
-
-        // Check for Thorguard boost (upgrade tier by one level if eligible)
-        if canUpgrade(tier) {
-            let hasThorguard = await checkThorguardBalance(for: vault)
-            if hasThorguard {
-                tier = upgradeTier(tier)
-                logger.info("Upgraded VULT Tier to \(tier?.name ?? "", privacy: .public)")
-            }
-        }
-
-        return tier
+        let balance = cached ? storedVultBalance(for: vault) : await fetchVultBalance(for: vault)
+        let base = Self.baseTier(forBalance: balance)
+        // Skip the eth_call entirely when the boost couldn't lift the tier anyway.
+        guard Self.canUpgrade(base) else { return base }
+        return Self.applyThorguardBoost(to: base, hasThorguard: await checkThorguardBalance(for: vault))
     }
 
-    /// Resolves the discount tier once per wallet for the session and caches the
-    /// fully-resolved value (post-Thorguard). Subsequent calls return the cached
-    /// tier without any network access, keeping the Thorguard `eth_call` off the
-    /// per-quote critical path.
+    /// Quote-path resolution. The VULT balance is re-read on every call, so a
+    /// balance that lands late — or a first read that failed — is picked up by
+    /// the very next quote instead of being pinned for the session. Only the
+    /// Thorguard `eth_call` behind it is session-cached, which is what keeps it
+    /// off the per-quote critical path.
+    @MainActor
     func resolveTierForSession(for vault: Vault) async -> VultDiscountTier? {
-        let vaultId = vault.pubKeyEdDSA
-        return await Self.sessionCache.resolve(for: vaultId) {
-            await fetchDiscountTier(for: vault)
-        }
+        await Self.resolveSessionTier(
+            cache: Self.thorguardCache,
+            vaultId: vault.pubKeyEdDSA,
+            balance: { await fetchVultBalance(for: vault) },
+            ownership: { await checkThorguardBalance(for: vault) }
+        )
+    }
+
+    /// The session-scoped composition, kept free of vault plumbing so it can be
+    /// exercised without a network: `balance` is asked on every call, while
+    /// ownership goes through `cache`, which remembers only a determined answer.
+    @MainActor
+    static func resolveSessionTier(
+        cache: ThorguardOwnershipCache,
+        vaultId: String,
+        balance: @MainActor () async -> Decimal,
+        ownership: @MainActor @escaping () async -> Bool?
+    ) async -> VultDiscountTier? {
+        let base = baseTier(forBalance: await balance())
+        guard canUpgrade(base) else { return base }
+        let hasThorguard = await cache.ownsThorguard(for: vaultId, ownership)
+        return applyThorguardBoost(to: base, hasThorguard: hasThorguard)
+    }
+
+    /// Highest tier unlocked by `balance` alone, before any Thorguard boost.
+    static func baseTier(forBalance balance: Decimal) -> VultDiscountTier? {
+        VultDiscountTier.allCases
+            .sorted { $0.balanceToUnlock > $1.balanceToUnlock }
+            .first { balance >= $0.balanceToUnlock }
+    }
+
+    /// Tier for a VULT balance combined with Thorguard ownership. Pass `nil` for
+    /// `hasThorguard` when ownership could not be determined.
+    static func tier(forBalance balance: Decimal, hasThorguard: Bool?) -> VultDiscountTier? {
+        applyThorguardBoost(to: baseTier(forBalance: balance), hasThorguard: hasThorguard)
     }
 
     func getVultToken(for vault: Vault) -> Coin? {
@@ -72,8 +107,22 @@ struct VultTierService {
         return shouldFetch
     }
 
+    /// Applies the one-level Thorguard boost. `hasThorguard == nil` means
+    /// ownership couldn't be determined; it is treated as "no boost" for this
+    /// resolution only and deliberately never remembered, so the next
+    /// resolution retries instead of locking the user out of the upgrade.
+    private static func applyThorguardBoost(
+        to base: VultDiscountTier?,
+        hasThorguard: Bool?
+    ) -> VultDiscountTier? {
+        guard hasThorguard == true, canUpgrade(base) else { return base }
+        let upgraded = upgradeTier(base)
+        logger.info("Upgraded VULT Tier to \(upgraded.name, privacy: .public)")
+        return upgraded
+    }
+
     /// Upgrades a tier to the next level (capped at Platinum for Thorguard boost)
-    private func upgradeTier(_ tier: VultDiscountTier?) -> VultDiscountTier {
+    private static func upgradeTier(_ tier: VultDiscountTier?) -> VultDiscountTier {
         guard let tier else { return .bronze }
         let tiers = VultDiscountTier.allCases
         let index = tiers.firstIndex(of: tier)
@@ -84,7 +133,7 @@ struct VultTierService {
         }
     }
 
-    private func canUpgrade(_ tier: VultDiscountTier?) -> Bool {
+    private static func canUpgrade(_ tier: VultDiscountTier?) -> Bool {
         switch tier {
         case .bronze, .silver, .gold, .none:
             logger.debug("Can upgrade VULT Tier, currently \(tier?.name ?? "", privacy: .public)")
@@ -95,11 +144,15 @@ struct VultTierService {
         }
     }
 
-    /// Checks if the vault holds at least one Thorguard NFT
-    private func checkThorguardBalance(for vault: Vault) async -> Bool {
+    /// Whether the vault holds at least one Thorguard NFT. Returns `nil` when
+    /// ownership could not be determined — no Ethereum address on the vault yet,
+    /// or a failed `eth_call`. Callers must not remember `nil` as "no NFT".
+    @MainActor
+    private func checkThorguardBalance(for vault: Vault) async -> Bool? {
         // Find Ethereum address in the vault
         guard let ethCoin = vault.coins.first(where: { $0.chain == .ethereum }) else {
-            return false
+            logger.debug("No Ethereum address on the vault, THORGuard ownership unknown")
+            return nil
         }
 
         do {
@@ -112,7 +165,7 @@ struct VultTierService {
             return balance > 0
         } catch {
             logger.error("Error fetching Thorguard balance: \(error.localizedDescription, privacy: .public)")
-            return false
+            return nil
         }
     }
 }
@@ -123,6 +176,12 @@ private extension VultTierService {
         let lastFetchDate: Date
     }
 
+    /// VULT balance already stored on the vault — an in-memory read, no network.
+    func storedVultBalance(for vault: Vault) -> Decimal {
+        getVultToken(for: vault)?.balanceDecimal ?? 0
+    }
+
+    @MainActor
     func fetchVultBalance(for vault: Vault) async -> Decimal {
         // Check if we need to fetch fresh balance
         if shouldFetchBalance(for: vault) {
@@ -138,11 +197,10 @@ private extension VultTierService {
             cacheEntries.append(CacheEntry(vaultId: vault.pubKeyEdDSA, lastFetchDate: Date()))
         }
 
-        // Return the balance from the coin (fresh or cached)
-        guard let vultToken = getVultToken(for: vault) else { return .zero }
-        return vultToken.balanceDecimal
+        return storedVultBalance(for: vault)
     }
 
+    @MainActor
     func getOrAddVultTokenIfNeeded(to vault: Vault) async -> Coin? {
         var vultToken = getVultToken(for: vault)
         if vultToken == nil {
@@ -153,12 +211,14 @@ private extension VultTierService {
         return vultToken
     }
 
+    @MainActor
     func addVultToken(to vault: Vault) async {
         let vultTokenMeta = TokensStore.TokenSelectionAssets.first(where: { $0.chain == .ethereum && $0.ticker == vultTicker })
         guard let vultTokenMeta else { return }
         try? await CoinService.addToChain(assets: [vultTokenMeta], to: vault)
     }
 
+    @MainActor
     func addEthChainIfNeeded(for vault: Vault) async {
         guard !vault.coins.contains(where: { $0.chain == .ethereum && $0.isNativeToken }) else {
             return
@@ -170,43 +230,44 @@ private extension VultTierService {
     }
 }
 
-/// Thread-safe, in-memory cache of resolved discount tiers keyed by vault id.
-/// `Box` lets us distinguish "not yet resolved" (no entry) from "resolved to
-/// nil" (entry holding nil) so a genuinely tier-less wallet isn't re-resolved.
+/// Thread-safe, in-memory record of whether a vault holds a Thorguard NFT,
+/// keyed by vault id and held for the process lifetime.
 ///
-/// Resolution is single-flight: concurrent callers for the same vault (e.g. the
-/// fire-and-forget warm-up on screen load racing the first debounced quote
-/// fetch) await one shared `Task` instead of each launching their own
-/// `fetchDiscountTier` — so the underlying Thorguard `eth_call` runs at most
-/// once per vault per session.
-actor SessionTierCache {
-    struct Box {
-        let value: VultDiscountTier?
-    }
+/// Only a *determined* answer is stored. "Couldn't check" — a failed `eth_call`,
+/// or a vault with no Ethereum address yet — is returned to the caller as `nil`
+/// but never cached, so the next resolution retries instead of pinning a wrong
+/// "no NFT" for the rest of the session.
+///
+/// Lookups are single-flight: concurrent callers for the same vault (e.g. the
+/// fire-and-forget warm-up on swap-screen load racing the first debounced quote
+/// fetch) await one shared `Task` instead of each firing their own `eth_call` —
+/// so the call runs at most once per vault per session.
+actor ThorguardOwnershipCache {
+    private var owned: [String: Bool] = [:]
+    private var inFlight: [String: Task<Bool?, Never>] = [:]
 
-    private var tiers: [String: Box] = [:]
-    private var inFlight: [String: Task<VultDiscountTier?, Never>] = [:]
-
-    /// Returns the cached tier if resolved; otherwise runs `work` once, sharing
-    /// the in-flight `Task` with any concurrent caller for the same vault.
-    /// `work` is `@MainActor`-isolated so it can safely read the `@Model` vault
-    /// it resolves the tier from — nothing non-Sendable crosses the actor's
+    /// Returns the cached ownership flag, or runs `check` once and shares its
+    /// in-flight `Task` with any concurrent caller for the same vault.
+    /// `check` is `@MainActor`-isolated so it can safely read the `@Model` vault
+    /// it resolves ownership from — nothing non-Sendable crosses the actor's
     /// executor boundary.
-    func resolve(
+    func ownsThorguard(
         for vaultId: String,
-        _ work: @MainActor @escaping () async -> VultDiscountTier?
-    ) async -> VultDiscountTier? {
-        if let box = tiers[vaultId] {
-            return box.value
+        _ check: @MainActor @escaping () async -> Bool?
+    ) async -> Bool? {
+        if let owned = owned[vaultId] {
+            return owned
         }
         if let task = inFlight[vaultId] {
             return await task.value
         }
-        let task = Task { @MainActor in await work() }
+        let task = Task { @MainActor in await check() }
         inFlight[vaultId] = task
         let value = await task.value
-        tiers[vaultId] = Box(value: value)
         inFlight[vaultId] = nil
+        if let value {
+            owned[vaultId] = value
+        }
         return value
     }
 }

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoDepositViewModelTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoDepositViewModelTests.swift
@@ -600,10 +600,12 @@ private final class CountingBalanceService: BalanceServiceProtocol, @unchecked S
 
     var refreshedTickers: [String] { lock.withLock { _refreshed } }
 
-    func updateBalance(for coin: Coin) async {
+    @discardableResult
+    func updateBalance(for coin: Coin) async -> Bool {
         await Task.yield()
         let ticker = coin.ticker
         lock.withLock { _refreshed.append(ticker) }
+        return true
     }
 
     func refreshSpendableBalanceOrThrow(for coin: Coin) async throws {

--- a/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoHostileResponseTests.swift
+++ b/VultisigApp/VultisigAppTests/Defi/Kamino/KaminoHostileResponseTests.swift
@@ -436,7 +436,7 @@ private struct FixtureLookupTables: SolanaAddressLookupTableFetching {
 }
 
 private struct HostileBalanceService: BalanceServiceProtocol {
-    func updateBalance(for coin: Coin) async {}
+    func updateBalance(for coin: Coin) async -> Bool { true }
     func refreshSpendableBalanceOrThrow(for coin: Coin) async throws {}
 }
 

--- a/VultisigApp/VultisigAppTests/Features/VultTierResolutionTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/VultTierResolutionTests.swift
@@ -62,20 +62,28 @@ final class VultTierResolutionTests: XCTestCase {
 
     /// The warm-up on swap-screen load races the first debounced quote fetch;
     /// they must share one `eth_call` rather than each firing their own.
+    ///
+    /// The gate parks the first lookup *inside* the cache's in-flight window
+    /// rather than racing a fixed sleep, so the later lookups can only be served
+    /// by joining it — a broken single-flight would run the probe again and be
+    /// counted.
     func testConcurrentLookupsShareOneCheck() async {
         let cache = ThorguardOwnershipCache()
-        let probe = ThorguardProbe(answers: [true], delayNanoseconds: 50_000_000)
+        let gate = ProbeGate()
+        let probe = ThorguardProbe(answers: [true], gate: gate)
 
-        await withTaskGroup(of: Bool?.self) { group in
-            for _ in 0..<5 {
-                group.addTask {
-                    await cache.ownsThorguard(for: "vault-a") { await probe.check() }
-                }
-            }
-            for await owned in group {
-                XCTAssertEqual(owned, true)
-            }
-        }
+        async let first = cache.ownsThorguard(for: "vault-a") { await probe.check() }
+        await gate.waitUntilEntered()
+        async let second = cache.ownsThorguard(for: "vault-a") { await probe.check() }
+        async let third = cache.ownsThorguard(for: "vault-a") { await probe.check() }
+        await gate.open()
+
+        let firstAnswer = await first
+        let secondAnswer = await second
+        let thirdAnswer = await third
+        XCTAssertEqual(firstAnswer, true)
+        XCTAssertEqual(secondAnswer, true, "Joining callers must get the shared answer")
+        XCTAssertEqual(thirdAnswer, true)
 
         let callCount = await probe.callCount
         XCTAssertEqual(callCount, 1, "Concurrent callers for the same vault must share one in-flight check")
@@ -309,21 +317,55 @@ private actor BalanceScript {
 /// counting how many times it was actually run.
 private actor ThorguardProbe {
     private let answers: [Bool?]
-    private let delayNanoseconds: UInt64
+    private let gate: ProbeGate?
     private(set) var callCount = 0
 
-    init(answers: [Bool?], delayNanoseconds: UInt64 = 0) {
+    init(answers: [Bool?], gate: ProbeGate? = nil) {
         self.answers = answers
-        self.delayNanoseconds = delayNanoseconds
+        self.gate = gate
     }
 
     func check() async -> Bool? {
         guard !answers.isEmpty else { return nil }
         let index = min(callCount, answers.count - 1)
         callCount += 1
-        if delayNanoseconds > 0 {
-            try? await Task.sleep(nanoseconds: delayNanoseconds)
+        if let gate {
+            await gate.markEntered()
+            await gate.waitUntilOpen()
         }
         return answers[index]
+    }
+}
+
+/// Holds a probe open inside the cache's in-flight window until the test lets go,
+/// so concurrency is expressed as a happens-before rather than as a sleep.
+private actor ProbeGate {
+    private var isEntered = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var isOpen = false
+    private var openWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func markEntered() {
+        isEntered = true
+        let waiters = enteredWaiters
+        enteredWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func waitUntilEntered() async {
+        guard !isEntered else { return }
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        let waiters = openWaiters
+        openWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func waitUntilOpen() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { openWaiters.append($0) }
     }
 }

--- a/VultisigApp/VultisigAppTests/Features/VultTierResolutionTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/VultTierResolutionTests.swift
@@ -1,0 +1,246 @@
+//
+//  VultTierResolutionTests.swift
+//  VultisigAppTests
+//
+//  Covers how a VULT discount tier is put together: the balance half is
+//  recomputed on every resolution, while the Thorguard NFT half is the only
+//  thing pinned for the session — and only when it was actually determined.
+//
+
+import XCTest
+@testable import VultisigApp
+
+final class VultTierResolutionTests: XCTestCase {
+
+    // MARK: - Thorguard ownership cache
+
+    /// Pins the optimization the session cache exists for: the Thorguard
+    /// `eth_call` must stay off the per-quote critical path.
+    func testThorguardOwnershipIsCheckedOncePerVaultPerSession() async {
+        let cache = ThorguardOwnershipCache()
+        let probe = ThorguardProbe(answers: [true])
+
+        for _ in 0..<5 {
+            let owned = await cache.ownsThorguard(for: "vault-a") { await probe.check() }
+            XCTAssertEqual(owned, true)
+        }
+
+        let callCount = await probe.callCount
+        XCTAssertEqual(callCount, 1, "A determined ownership answer must be resolved once per vault per session")
+    }
+
+    /// A determined "no NFT" is a real answer and is cached like any other.
+    func testDeterminedAbsenceOfTheNftIsCached() async {
+        let cache = ThorguardOwnershipCache()
+        let probe = ThorguardProbe(answers: [false])
+
+        let first = await cache.ownsThorguard(for: "vault-a") { await probe.check() }
+        let second = await cache.ownsThorguard(for: "vault-a") { await probe.check() }
+
+        XCTAssertEqual(first, false)
+        XCTAssertEqual(second, false)
+        let callCount = await probe.callCount
+        XCTAssertEqual(callCount, 1)
+    }
+
+    /// A failed `eth_call` is "unknown", not "no NFT". Caching it would strip a
+    /// Thorguard holder of their boost for the rest of the session.
+    func testUndeterminedOwnershipIsNotCachedAndIsRetried() async {
+        let cache = ThorguardOwnershipCache()
+        let probe = ThorguardProbe(answers: [nil, true])
+
+        let first = await cache.ownsThorguard(for: "vault-a") { await probe.check() }
+        let second = await cache.ownsThorguard(for: "vault-a") { await probe.check() }
+        let third = await cache.ownsThorguard(for: "vault-a") { await probe.check() }
+
+        XCTAssertNil(first, "A failed check must surface as unknown")
+        XCTAssertEqual(second, true, "The retry's answer must be honoured")
+        XCTAssertEqual(third, true, "and then cached like any other determined answer")
+        let callCount = await probe.callCount
+        XCTAssertEqual(callCount, 2, "Only the failed check is retried")
+    }
+
+    /// The warm-up on swap-screen load races the first debounced quote fetch;
+    /// they must share one `eth_call` rather than each firing their own.
+    func testConcurrentLookupsShareOneCheck() async {
+        let cache = ThorguardOwnershipCache()
+        let probe = ThorguardProbe(answers: [true], delayNanoseconds: 50_000_000)
+
+        await withTaskGroup(of: Bool?.self) { group in
+            for _ in 0..<5 {
+                group.addTask {
+                    await cache.ownsThorguard(for: "vault-a") { await probe.check() }
+                }
+            }
+            for await owned in group {
+                XCTAssertEqual(owned, true)
+            }
+        }
+
+        let callCount = await probe.callCount
+        XCTAssertEqual(callCount, 1, "Concurrent callers for the same vault must share one in-flight check")
+    }
+
+    func testOwnershipIsCachedPerVault() async {
+        let cache = ThorguardOwnershipCache()
+        let probe = ThorguardProbe(answers: [true, false])
+
+        let vaultA = await cache.ownsThorguard(for: "vault-a") { await probe.check() }
+        let vaultB = await cache.ownsThorguard(for: "vault-b") { await probe.check() }
+
+        XCTAssertEqual(vaultA, true)
+        XCTAssertEqual(vaultB, false, "Switching vaults must resolve fresh, not read the other vault's answer")
+        let callCount = await probe.callCount
+        XCTAssertEqual(callCount, 2)
+    }
+
+    // MARK: - Tier from balance + Thorguard
+
+    func testTierTracksTheBalanceOnEveryResolution() {
+        // The first resolution saw nothing, a later one sees the balance that
+        // finally landed. Nothing about the first is sticky.
+        XCTAssertNil(VultTierService.tier(forBalance: 0, hasThorguard: false))
+        XCTAssertEqual(VultTierService.tier(forBalance: 7_500, hasThorguard: false), .gold)
+    }
+
+    func testTierUsesTheHighestThresholdMetByTheBalance() {
+        XCTAssertNil(VultTierService.tier(forBalance: 1_499, hasThorguard: false))
+        XCTAssertEqual(VultTierService.tier(forBalance: 1_500, hasThorguard: false), .bronze)
+        XCTAssertEqual(VultTierService.tier(forBalance: 7_499, hasThorguard: false), .silver)
+        XCTAssertEqual(VultTierService.tier(forBalance: 7_500, hasThorguard: false), .gold)
+        XCTAssertEqual(VultTierService.tier(forBalance: 1_000_000, hasThorguard: false), .ultimate)
+    }
+
+    func testThorguardBoostsOneTierAndIsCappedAtPlatinum() {
+        XCTAssertEqual(VultTierService.tier(forBalance: 0, hasThorguard: true), .bronze)
+        XCTAssertEqual(VultTierService.tier(forBalance: 7_500, hasThorguard: true), .platinum)
+        XCTAssertEqual(
+            VultTierService.tier(forBalance: 15_000, hasThorguard: true), .platinum,
+            "Platinum and above must not be boosted"
+        )
+        XCTAssertEqual(VultTierService.tier(forBalance: 100_000, hasThorguard: true), .diamond)
+    }
+
+    func testUndeterminedOwnershipDoesNotBoostTheTier() {
+        XCTAssertEqual(
+            VultTierService.tier(forBalance: 7_500, hasThorguard: nil), .gold,
+            "An unknown NFT answer must resolve as no boost — the retry lives in the cache, not here"
+        )
+    }
+
+    // MARK: - Session-scoped composition
+
+    /// The regression this whole change exists for: the balance half must be
+    /// asked again on every resolution while the expensive ownership half is
+    /// reused. Caching a resolved tier instead made the first zero balance
+    /// permanent, silently dropping the user's fee discount for the session.
+    func testSessionResolutionRereadsTheBalanceButChecksOwnershipOnce() async {
+        let cache = ThorguardOwnershipCache()
+        let ownership = ThorguardProbe(answers: [false])
+        let balances = BalanceScript(values: [0, 7_500])
+
+        let first = await VultTierService.resolveSessionTier(
+            cache: cache,
+            vaultId: "vault-a",
+            balance: { await balances.next() },
+            ownership: { await ownership.check() }
+        )
+        let second = await VultTierService.resolveSessionTier(
+            cache: cache,
+            vaultId: "vault-a",
+            balance: { await balances.next() },
+            ownership: { await ownership.check() }
+        )
+
+        XCTAssertNil(first, "Precondition: the first resolution saw no balance")
+        XCTAssertEqual(second, .gold, "A balance that lands late must not be shadowed by the first resolution")
+        let reads = await balances.readCount
+        XCTAssertEqual(reads, 2, "The balance must be re-read on every resolution")
+        let checks = await ownership.callCount
+        XCTAssertEqual(checks, 1, "A determined ownership answer must be reused, not re-fetched")
+    }
+
+    func testSessionResolutionRetriesAnUndeterminedOwnershipCheck() async {
+        let cache = ThorguardOwnershipCache()
+        let ownership = ThorguardProbe(answers: [nil, true])
+        let balances = BalanceScript(values: [7_500])
+
+        let first = await VultTierService.resolveSessionTier(
+            cache: cache,
+            vaultId: "vault-a",
+            balance: { await balances.next() },
+            ownership: { await ownership.check() }
+        )
+        let second = await VultTierService.resolveSessionTier(
+            cache: cache,
+            vaultId: "vault-a",
+            balance: { await balances.next() },
+            ownership: { await ownership.check() }
+        )
+
+        XCTAssertEqual(first, .gold, "An undetermined NFT answer must not boost the tier")
+        XCTAssertEqual(second, .platinum, "The retried check must be honoured on the next resolution")
+        let checks = await ownership.callCount
+        XCTAssertEqual(checks, 2)
+    }
+
+    /// A vault already at Platinum or above can't be boosted, so the resolution
+    /// must not pay for the eth_call at all.
+    func testSessionResolutionSkipsTheOwnershipCheckWhenNoBoostIsPossible() async {
+        let cache = ThorguardOwnershipCache()
+        let ownership = ThorguardProbe(answers: [true])
+        let balances = BalanceScript(values: [15_000])
+
+        let tier = await VultTierService.resolveSessionTier(
+            cache: cache,
+            vaultId: "vault-a",
+            balance: { await balances.next() },
+            ownership: { await ownership.check() }
+        )
+
+        XCTAssertEqual(tier, .platinum)
+        let checks = await ownership.callCount
+        XCTAssertEqual(checks, 0, "Platinum and above can't be boosted, so no eth_call should be made")
+    }
+}
+
+/// Stand-in for the VULT balance read, answering a scripted sequence and
+/// counting how many times the resolution actually asked for it.
+private actor BalanceScript {
+    private let values: [Decimal]
+    private(set) var readCount = 0
+
+    init(values: [Decimal]) {
+        self.values = values
+    }
+
+    func next() -> Decimal {
+        guard !values.isEmpty else { return 0 }
+        let value = values[min(readCount, values.count - 1)]
+        readCount += 1
+        return value
+    }
+}
+
+/// Stand-in for the Thorguard `eth_call`, answering a scripted sequence and
+/// counting how many times it was actually run.
+private actor ThorguardProbe {
+    private let answers: [Bool?]
+    private let delayNanoseconds: UInt64
+    private(set) var callCount = 0
+
+    init(answers: [Bool?], delayNanoseconds: UInt64 = 0) {
+        self.answers = answers
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func check() async -> Bool? {
+        guard !answers.isEmpty else { return nil }
+        let index = min(callCount, answers.count - 1)
+        callCount += 1
+        if delayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
+        }
+        return answers[index]
+    }
+}

--- a/VultisigApp/VultisigAppTests/Features/VultTierResolutionTests.swift
+++ b/VultisigApp/VultisigAppTests/Features/VultTierResolutionTests.swift
@@ -128,6 +128,55 @@ final class VultTierResolutionTests: XCTestCase {
         )
     }
 
+    // MARK: - Which token counts as VULT
+
+    /// Any address can deploy an ERC-20 under the "VULT" symbol and a user can
+    /// add it to their vault. Matching on the ticker let that buy a real
+    /// trading-fee discount; the contract address is what actually identifies it.
+    @MainActor
+    func testImpostorTokenTickeredVultGrantsNoTier() {
+        let service = VultTierService()
+        let vault = makeVault()
+        vault.coins = [makeEthereumToken(ticker: "VULT", contract: "0xdeadbeef00000000000000000000000000000000", balance: 100_000)]
+
+        XCTAssertNil(service.getVultToken(for: vault), "A different contract is a different token, whatever it calls itself")
+        let balance = service.getVultToken(for: vault)?.balanceDecimal ?? 0
+        XCTAssertNil(
+            VultTierService.tier(forBalance: balance, hasThorguard: false),
+            "An impostor balance must not unlock any tier"
+        )
+    }
+
+    @MainActor
+    func testRealVultIsMatchedRegardlessOfAddressCasing() {
+        let service = VultTierService()
+        let vault = makeVault()
+        vault.coins = [
+            makeEthereumToken(
+                ticker: "VULT",
+                contract: VultTierService.vultContractAddress.lowercased(),
+                balance: 7_500
+            )
+        ]
+
+        // EIP-55 checksums an address by letter case, so the same token
+        // legitimately arrives in different casings.
+        let vult = service.getVultToken(for: vault)
+        XCTAssertNotNil(vult)
+        XCTAssertEqual(VultTierService.tier(forBalance: vult?.balanceDecimal ?? 0, hasThorguard: false), .gold)
+    }
+
+    @MainActor
+    func testRealVultIsMatchedEvenUnderADifferentTicker() {
+        let service = VultTierService()
+        let vault = makeVault()
+        vault.coins = [
+            makeEthereumToken(ticker: "vult", contract: VultTierService.vultContractAddress, balance: 3_000)
+        ]
+
+        XCTAssertNotNil(service.getVultToken(for: vault), "The contract is the identity, not the displayed symbol")
+    }
+
     // MARK: - Session-scoped composition
 
     /// The regression this whole change exists for: the balance half must be
@@ -201,6 +250,40 @@ final class VultTierResolutionTests: XCTestCase {
         XCTAssertEqual(tier, .platinum)
         let checks = await ownership.callCount
         XCTAssertEqual(checks, 0, "Platinum and above can't be boosted, so no eth_call should be made")
+    }
+
+    // MARK: - Fixtures
+
+    @MainActor
+    private func makeVault() -> Vault {
+        Vault(
+            name: "Test Vault",
+            signers: [],
+            pubKeyECDSA: "test-pub-ecdsa",
+            pubKeyEdDSA: "test-pub-eddsa",
+            keyshares: [],
+            localPartyID: "iPhone-12345",
+            hexChainCode: "hex",
+            resharePrefix: nil,
+            libType: .DKLS
+        )
+    }
+
+    @MainActor
+    private func makeEthereumToken(ticker: String, contract: String, balance: Int) -> Coin {
+        let meta = CoinMeta(
+            chain: .ethereum,
+            ticker: ticker,
+            logo: "logo",
+            decimals: 18,
+            priceProviderId: ticker.lowercased(),
+            contractAddress: contract,
+            isNativeToken: false
+        )
+        let coin = Coin(asset: meta, address: "0xwallet", hexPublicKey: "")
+        // 18 decimals, so the whole-token balance is the value followed by 18 zeros.
+        coin.rawBalance = "\(balance)" + String(repeating: "0", count: 18)
+        return coin
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Mocks/MockBalanceService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockBalanceService.swift
@@ -12,9 +12,14 @@ final class MockBalanceService: BalanceServiceProtocol {
     private(set) var updateBalanceCallCount = 0
     private(set) var lastUpdatedCoin: Coin?
 
-    func updateBalance(for coin: Coin) async {
+    /// Whether the stubbed refresh reports that a live balance landed.
+    var updateBalanceSucceeds = true
+
+    @discardableResult
+    func updateBalance(for coin: Coin) async -> Bool {
         updateBalanceCallCount += 1
         lastUpdatedCoin = coin
+        return updateBalanceSucceeds
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Mocks/MockBalanceService.swift
+++ b/VultisigApp/VultisigAppTests/Mocks/MockBalanceService.swift
@@ -12,14 +12,12 @@ final class MockBalanceService: BalanceServiceProtocol {
     private(set) var updateBalanceCallCount = 0
     private(set) var lastUpdatedCoin: Coin?
 
-    /// Whether the stubbed refresh reports that a live balance landed.
-    var updateBalanceSucceeds = true
-
+    /// Reports that a live balance landed — the stub always "succeeds".
     @discardableResult
     func updateBalance(for coin: Coin) async -> Bool {
         updateBalanceCallCount += 1
         lastUpdatedCoin = coin
-        return updateBalanceSucceeds
+        return true
     }
 }
 

--- a/VultisigApp/VultisigAppTests/Swap/DefaultSwapInteractorTests.swift
+++ b/VultisigApp/VultisigAppTests/Swap/DefaultSwapInteractorTests.swift
@@ -158,6 +158,65 @@ final class DefaultSwapInteractorTests: XCTestCase {
         XCTAssertEqual(quoteService.lastVultTierDiscount, VultDiscountTier.gold.bpsDiscount)
     }
 
+    /// The first resolution saw a VULT balance of zero — a failed or
+    /// not-yet-landed fetch — and produced no tier. The tier must be re-resolved
+    /// for the next quote, not pinned: a pinned nil silently overcharged the user
+    /// on every later swap of the session.
+    func testFetchQuoteHonoursATierThatOnlyResolvesOnTheSecondCall() async throws {
+        let tierResolver = SequencedDiscountTierResolver(tiers: [nil, .gold])
+        let quoteService = MockQuoteService(stubbedResult: .success(.thorchain(makeThorQuote())))
+        let interactor = makeInteractor(quote: quoteService, tierResolver: tierResolver)
+        let vault = makeVault()
+        let from = makeCoin(.ethereum, ticker: "ETH")
+        let to = makeCoin(.bitcoin, ticker: "BTC")
+
+        let first = try await interactor.fetchQuote(
+            amount: 1, fromCoin: from, toCoin: to, vault: vault, referredCode: "", slippageBps: nil, recipientAddress: nil
+        )
+        XCTAssertEqual(first?.vultDiscountBps, 0, "Precondition: the first quote resolved no tier")
+
+        let second = try await interactor.fetchQuote(
+            amount: 1, fromCoin: from, toCoin: to, vault: vault, referredCode: "", slippageBps: nil, recipientAddress: nil
+        )
+
+        XCTAssertEqual(tierResolver.resolveCallCount, 2, "Every quote must re-resolve the tier")
+        XCTAssertEqual(
+            second?.vultDiscountBps, VultDiscountTier.gold.bpsDiscount,
+            "A tier that resolves late must be honoured by the next quote"
+        )
+        XCTAssertEqual(quoteService.lastVultTierDiscount, VultDiscountTier.gold.bpsDiscount)
+    }
+
+    /// Ties the fix to the observable symptom: a Gold vault must send
+    /// `affiliate_bps = 30`, not the undiscounted 50. Mayanode's
+    /// `recommended_min_amount_in` is inversely proportional to the affiliate
+    /// bps, so sending 50 raised the minimum the reporter's route was measured
+    /// against and changed which routes were offered.
+    func testGoldTierYieldsThirtyAffiliateBps() async throws {
+        let tierResolver = MockDiscountTierResolver(tier: .gold)
+        let quoteService = MockQuoteService(stubbedResult: .success(.thorchain(makeThorQuote())))
+        let interactor = makeInteractor(quote: quoteService, tierResolver: tierResolver)
+
+        let result = try await interactor.fetchQuote(
+            amount: 1,
+            fromCoin: makeCoin(.ethereum, ticker: "ETH"),
+            toCoin: makeCoin(.bitcoin, ticker: "BTC"),
+            vault: makeVault(),
+            referredCode: "",
+            slippageBps: nil,
+            recipientAddress: nil
+        )
+
+        // The release affiliate rate is 50 bps; DEBUG builds force
+        // `affiliateFeeRateBp` to 0, so the shipping base is spelled out here.
+        let releaseAffiliateBps = 50
+        let discount = try XCTUnwrap(result?.vultDiscountBps)
+        XCTAssertEqual(
+            THORChainSwaps.discountedAffiliateBps(baseBps: releaseAffiliateBps, discountBps: discount), 30,
+            "A Gold vault must send affiliate_bps=30"
+        )
+    }
+
     // MARK: - Slippage + recipient threading
 
     func testFetchQuoteThreadsCustomSlippageToQuoteService() async throws {
@@ -280,8 +339,8 @@ private enum StubError: Error, Equatable {
 // swiftlint:disable async_without_await unused_parameter
 
 /// Instrumented tier resolver mirroring `VultTierService`'s session-cache
-/// behaviour: the underlying (network) resolve runs once and is cached, while
-/// `resolveTierForSession` may be *called* many times.
+/// behaviour: the expensive half (the Thorguard eth_call) runs once and is
+/// cached, while `resolveTierForSession` may be *called* many times.
 private final class MockDiscountTierResolver: SwapDiscountTierResolving, @unchecked Sendable {
     private let tier: VultDiscountTier?
     private(set) var resolveCallCount = 0
@@ -292,15 +351,34 @@ private final class MockDiscountTierResolver: SwapDiscountTierResolving, @unchec
         self.tier = tier
     }
 
+    @MainActor
     func resolveTierForSession(for vault: Vault) async -> VultDiscountTier? {
         resolveCallCount += 1
         if let cached {
             return cached
         }
-        // Stand-in for the uncached VULT balance + Thorguard eth_call.
+        // Stand-in for the session-cached Thorguard eth_call.
         networkResolveCount += 1
         cached = tier
         return tier
+    }
+}
+
+/// Tier resolver that answers a different tier each call, standing in for a
+/// vault whose VULT balance lands after the first quote has already gone out.
+private final class SequencedDiscountTierResolver: SwapDiscountTierResolving, @unchecked Sendable {
+    private var tiers: [VultDiscountTier?]
+    private(set) var resolveCallCount = 0
+
+    init(tiers: [VultDiscountTier?]) {
+        self.tiers = tiers
+    }
+
+    @MainActor
+    func resolveTierForSession(for vault: Vault) async -> VultDiscountTier? {
+        resolveCallCount += 1
+        guard !tiers.isEmpty else { return nil }
+        return tiers.removeFirst()
     }
 }
 


### PR DESCRIPTION
## Description

Fixes #5131

A vault's VULT discount tier was resolved **once per app launch** and cached for the whole process — and a resolution that *failed* was cached as "no tier" and never retried. Every swap for the rest of that session then sent the undiscounted `affiliate_bps`: a Gold-tier holder charged **50 bps instead of 30**, with no tier badge, recoverable only by relaunching.

`SessionTierCache`'s `Box` type existed specifically so a `nil` result was remembered as final. The file said so: *"a VULT/Thorguard balance change for the same vault isn't reflected until the next app launch."* Nothing anywhere distinguished *"this wallet holds no VULT"* from *"we could not find out"*.

### Why it looked like a route-picker bug

The `affiliate_bps` we send moves Mayanode's `recommended_min_amount_in`, which is an **affiliate-dust floor inversely proportional to that bps** — measured over a 5→50 bps sweep, `min_in × bps / 10000 = 72.71`, constant to two decimals. Higher bps ⇒ lower floor. For the swap in #5099 (BTC→ETH, 14844 sat):

| `affiliate_bps` sent | Maya `recommended_min_amount_in` | below floor? |
|---|---|---|
| 30 (Gold, correct) | 24236 | yes — candidate dropped |
| 50 (tier lost) | 14541 | no — candidate offered |

So #5099's "iOS offers a 14.97% Maya route that Android drops" was this bug, seen from the far end. The below-minimum filter is correct on both platforms and is **not touched here**.

## The fix

**Cache the thing that can't change, not the answer that can.** #4457 asked for the session cache to keep the Thorguard `eth_call` off the per-quote path; that intent is preserved.

- `SessionTierCache` (keyed `VultDiscountTier?`) → `ThorguardOwnershipCache` (keyed `Bool`, single-flight, **never stores an undetermined answer**). `checkThorguardBalance` returns `Bool?`. The tier is recomputed per quote from the in-memory balance, so a late balance is picked up by the next quote — the same self-healing Android gets by recomputing.
- `BalanceService.updateBalance(for:)` now reports whether a refresh landed, so the 3-minute freshness stamp is only written on a real fetch. It previously stamped unconditionally, so one failed refresh suppressed the next three minutes of retries.
- VULT is matched by **contract address** (`0xb788144DF611029C60b859DF47e79B7726C4DEBa`), not by ticker — an impostor ERC-20 tickered "VULT" could previously grant a tier.

The NFT cache is scoped to the quote path only, so the $VULT Tiers screen and `TierGate` keep their live `eth_call` — buying a Thorguard NFT still takes effect without relaunching.

**Not changed:** the tier thresholds and bps values (they match spec #3451), the balance source (#4589's sVULT migration was closed won't-do), and the below-minimum guard.

## Which feature is affected?
- [ ] Create vault ( Secure / Fast)
- [ ] Sending
- [x] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature

**No swap tx link — deliberate, not an omission.** This changes which `affiliate_bps` value is sent, not how any payload is built, signed or broadcast. Reproducing it on-chain would mean signing a real swap from a tier-holding vault twice; the evidence is the quote-fetch measurement above, taken against live Mayanode/THORNode.

## Parity

- Android: `n/a: no equivalent defect` — `GetDiscountBpsUseCase.invoke(vaultId, provider)` runs fresh on every quote fetch (`SwapQuotePipeline.kt:226`), so there is no session cache to pin a failed resolution. Verified against `vultisig-android@main`.
- Windows + extension: `first: VULT tier discount resolution` — a code search for the discount surface returned no equivalent resolver; if one exists it was not audited here.
- SDK: `first: clients/cli/src/commands/discount.ts` — a discount surface exists; its caching behaviour was not audited in this PR.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

`make test`: `** TEST SUCCEEDED **` — **6069 tests, 11 skipped, 0 failures**. SwiftLint 26, identical to `origin/main` (zero introduced).

## Additional context

Cross-model review, 3 Codex passes. The whole-branch pass caught what both per-commit passes cleared: the first cut kept the balance refresh *awaited*, so every quote past the 3-minute expiry blocked on a price fetch plus an Ethereum balance RPC **with the loading spinner held**. The shipped version answers from the already-landed balance and refreshes staleness in the background; only a vault with no landed balance waits. It also caught that annotating `resolveTierForSession` `@MainActor` bought nothing, because the nonisolated `async` helpers still read the SwiftData `@Model` vault off the main actor.

**Deferred:** full dependency injection into `VultTierService` so the real resolver is under test. It reaches `BalanceService.shared`, `EvmService`, `CoinService.addToChain` and a process-global `@AppStorage` stamp, so a test around it would be suite-order-dependent across 6069 tests — a worse outcome than the gap.

**Separately flagged, not fixed:** spec #3451 says the Ultimate tier "will also clear referral", but `ThorchainService.affiliateParams` sends `"10/0"`, so an Ultimate-tier referred swap still pays the referrer 10 bps. Same on Android. Cross-platform fee policy — needs product sign-off, so it is deliberately out of scope here.

## Agent Metadata
- **Agent**: Claude Code
- **Issue**: #5131
- **Needs human review for**: the `BalanceService.updateBalance` signature change (it ripples through the protocol and three test doubles), and on-device confirmation that a tier-holding vault shows its badge and sends the discounted bps after a cold start on a flaky connection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VULT discount tiers now use the latest available balance when determining eligibility.
  * Thorguard ownership checks are cached during a session for faster quote updates.
  * Balance refreshes are coordinated to avoid duplicate requests and can retry when results are unavailable.

* **Bug Fixes**
  * Improved handling of stale or failed balance updates while preserving the most recent known balance.
  * More accurate tier boosts and affiliate discounts based on token identity and ownership status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->